### PR TITLE
Add arithmetic support for interval type

### DIFF
--- a/common/functions/src/scalars/arithmetics/arithmetic.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic.rs
@@ -14,6 +14,7 @@
 
 use std::fmt;
 
+use common_datavalues::chrono::*;
 use common_datavalues::columns::DataColumn;
 use common_datavalues::prelude::*;
 use common_datavalues::DataSchema;
@@ -79,22 +80,21 @@ impl Function for ArithmeticFunction {
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {
+        let result: DataColumn = {
+            // Some logic type need DateType information, try arithmetic on column with field first.
+            if let Some(r) = self.try_evaluate_on_column_field(columns) {
+                r?
+            } else {
+                match columns.len() {
+                    1 => columns[0].column().unary_arithmetic(self.op.clone()),
+                    _ => columns[0]
+                        .column()
+                        .arithmetic(self.op.clone(), columns[1].column()),
+                }?
+            }
+        };
+
         let has_date_or_date_time = columns.iter().any(|c| is_date_or_date_time(c.data_type()));
-        let has_interval = columns.iter().any(|c| is_interval(c.data_type()));
-
-        if has_date_or_date_time && has_interval {
-            //TODO(Jun): implement data/datatime +/- interval
-            return Err(ErrorCode::UnImplement(
-                "Arithmetic operation between date and interval is not implemented yet.".to_owned(),
-            ));
-        }
-
-        let result = match columns.len() {
-            1 => columns[0].column().unary_arithmetic(self.op.clone()),
-            _ => columns[0]
-                .column()
-                .arithmetic(self.op.clone(), columns[1].column()),
-        }?;
 
         if has_date_or_date_time {
             let args = columns
@@ -120,5 +120,193 @@ impl Function for ArithmeticFunction {
 impl fmt::Display for ArithmeticFunction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.op)
+    }
+}
+
+impl ArithmeticFunction {
+    // This is an arithmetic support for DataColumnWithField. Maybe we should move it into to "impl DataColumnWithField",
+    // thus we can do it like "columns[0].arithmetic(columns[1])".
+    // Currently only apply for Plus/Minus operation between Date/DateTime and Interval
+    pub fn try_evaluate_on_column_field(
+        &self,
+        columns: &DataColumnsWithField,
+    ) -> Option<Result<DataColumn>> {
+        if columns.len() != 2 {
+            return None;
+        }
+
+        match (columns[0].data_type(), columns[1].data_type()) {
+            (&DataType::Interval(_), &DataType::Date16)
+            | (&DataType::Interval(_), &DataType::Date32)
+            | (&DataType::Interval(_), &DataType::DateTime32(_))
+            | (&DataType::Date16, &DataType::Interval(_))
+            | (&DataType::Date32, &DataType::Interval(_))
+            | (&DataType::DateTime32(_), &DataType::Interval(_)) => match self.op {
+                DataValueArithmeticOperator::Plus | DataValueArithmeticOperator::Minus => {
+                    Some(self.datetime_plus_minus_interval(columns))
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    pub fn datetime_plus_minus_interval(
+        &self,
+        columns: &DataColumnsWithField,
+    ) -> Result<DataColumn> {
+        let days_to_datetime = |days: i64| -> Result<DateTime<Utc>> {
+            let naive =
+                NaiveDateTime::from_timestamp(0, 0).checked_add_signed(Duration::days(days));
+            if naive.is_none() {
+                return Err(ErrorCode::Overflow(format!(
+                    "Overflow on date with days {}.",
+                    days,
+                )));
+            }
+            Ok(DateTime::<Utc>::from_utc(naive.unwrap(), Utc))
+        };
+
+        let seconds_to_datetime = |seconds: i64| -> Result<DateTime<Utc>> {
+            let naive = NaiveDateTime::from_timestamp_opt(seconds, 0);
+            if naive.is_none() {
+                return Err(ErrorCode::Overflow(format!(
+                    "Overflow on datetime with seconds {}.",
+                    seconds
+                )));
+            }
+            Ok(DateTime::<Utc>::from_utc(naive.unwrap(), Utc))
+        };
+
+        let (interval_column, date_column) = match columns[0].data_type() {
+            DataType::Interval(_) => (&columns[0], &columns[1]),
+            _ => (&columns[1], &columns[0]),
+        };
+
+        let interval_series = interval_column.column().to_array()?;
+        let date_series = date_column.column().to_array()?;
+        let len = date_series.len();
+        let mut dt_vec = Vec::<DateTime<Utc>>::with_capacity(len);
+
+        for i in 0..len {
+            // Convert Date16, Date32 or DateTime32 to chrono::DateTime
+            let date = date_series.try_get(i)?;
+            let dt = match date_column.data_type() {
+                DataType::DateTime32(_) => {
+                    let seconds = date.as_i64()?;
+                    seconds_to_datetime(seconds)
+                }
+                DataType::Date32 | DataType::Date16 => {
+                    let days = date.as_u64()?;
+                    days_to_datetime(days as i64)
+                }
+                _ => unreachable!(),
+            }?;
+
+            // Add interval to DateTime, the interval could be YearMonth or DayTime
+            let interval = interval_series.try_get(i)?.as_i64()?;
+            let new_dt = match interval_column.data_type() {
+                DataType::Interval(IntervalUnit::YearMonth) => {
+                    let months = match self.op {
+                        DataValueArithmeticOperator::Plus => interval,
+                        DataValueArithmeticOperator::Minus => -interval,
+                        _ => unreachable!(),
+                    };
+                    Self::datetime_add_signed_months(&dt, months)?
+                }
+                DataType::Interval(IntervalUnit::DayTime) => {
+                    let mut days: i64 = interval.abs() >> 32; //higher 32 bits as number of days
+                    let mut milliseconds: i64 = interval.abs() & 0x0000_0000_FFFF_FFFF; //lower 32 bits as milliseconds
+                    if interval < 0 {
+                        days = -days;
+                        milliseconds = -milliseconds;
+                    }
+
+                    let updated = match self.op {
+                        DataValueArithmeticOperator::Plus => dt.checked_add_signed(
+                            Duration::days(days) + Duration::milliseconds(milliseconds as i64),
+                        ),
+                        DataValueArithmeticOperator::Minus => dt.checked_sub_signed(
+                            Duration::days(days) + Duration::milliseconds(milliseconds as i64),
+                        ),
+                        _ => unreachable!(),
+                    };
+                    if updated.is_none() {
+                        return Err(ErrorCode::Overflow(format!(
+                            "Overflow on datetime with days {}, milliseconds {}.",
+                            days, milliseconds
+                        )));
+                    }
+                    updated.unwrap()
+                }
+                _ => unreachable!(),
+            };
+
+            dt_vec.push(new_dt);
+        }
+
+        match date_column.data_type() {
+            DataType::Date16 | DataType::Date32 => {
+                // convert datetime to elapsed days with UInt32 type
+                let arr = DFUInt32Array::new_from_iter(
+                    dt_vec
+                        .iter()
+                        .map(|dt| (dt.timestamp() / (24 * 3600)) as u32),
+                );
+                Ok(arr.into())
+            }
+            DataType::DateTime32(_) => {
+                // convert datetime to elapsed seconds with UInt32 type
+                let arr =
+                    DFUInt32Array::new_from_iter(dt_vec.iter().map(|dt| dt.timestamp() as u32));
+                Ok(arr.into())
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn datetime_add_signed_months(dt: &DateTime<Utc>, months: i64) -> Result<DateTime<Utc>> {
+        let total_months = (dt.month() as i64) + months;
+        let mut new_year = dt.year() + (total_months / 12) as i32;
+        let mut new_month = total_months % 12;
+        if new_month < 0 {
+            new_year -= 1;
+            new_month += 12;
+        }
+
+        let (_y, _m, d, h, m, s) = (
+            dt.year(),
+            dt.month(),
+            dt.day(),
+            dt.hour(),
+            dt.minute(),
+            dt.second(),
+        );
+
+        // Handle month last day overflow, "2020-2-29" + "1 year" should be "2020-2-28", or "1990-1-31" + "3 month" should be "1990-4-31".
+        let new_day =
+            std::cmp::min::<u32>(d, Self::last_day_of_year_month(new_year, new_month as u32));
+
+        let new_date = NaiveDate::from_ymd_opt(new_year, new_month as u32, new_day);
+        if new_date.is_none() {
+            return Err(ErrorCode::Overflow(format!(
+                "Overflow on date YMD {}-{}-{}.",
+                new_year, new_month, new_day
+            )));
+        }
+        Ok(DateTime::<Utc>::from_utc(
+            new_date.unwrap().and_hms(h, m, s),
+            Utc,
+        ))
+    }
+
+    // Get the last day of the year month, could be 28(non leap Feb), 29(leap year Feb), 30 or 31
+    fn last_day_of_year_month(year: i32, month: u32) -> u32 {
+        let is_leap_year = NaiveDate::from_ymd_opt(year, 2, 29).is_some();
+        if month == 2 && is_leap_year {
+            return 29;
+        }
+        let last_day_lookup = [0u32, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+        last_day_lookup[month as usize]
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_test.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_test.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_datavalues::chrono;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use pretty_assertions::assert_eq;
@@ -163,6 +164,259 @@ fn test_arithmetic_function() -> Result<()> {
         let actual_type = v.data_type().clone();
         assert_eq!(expect_type, actual_type);
 
+        assert_eq!(v, &t.expect);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_arithmetic_date_interval() -> Result<()> {
+    let to_seconds = |y: i32, m: u32, d: u32, h: u32, min: u32, s: u32| -> u32 {
+        let date_time = chrono::NaiveDate::from_ymd(y, m, d).and_hms(h, min, s);
+        date_time.timestamp() as u32
+    };
+
+    let to_days = |y: i32, m: u32, d: u32| -> u32 {
+        let date_time = chrono::NaiveDate::from_ymd(y, m, d).and_hms(0, 0, 1);
+        (date_time.timestamp() / (24 * 3600)) as u32
+    };
+
+    #[allow(dead_code)]
+    struct Test {
+        name: &'static str,
+        display: &'static str,
+        nullable: bool,
+        arg_names: Vec<&'static str>,
+        columns: Vec<DataColumn>,
+        expect: DataColumn,
+        error: &'static str,
+        func: Box<dyn Function>,
+    }
+
+    let schema = DataSchemaRefExt::create(vec![
+        DataField::new(
+            "interval-day-time",
+            DataType::Interval(IntervalUnit::DayTime),
+            false,
+        ),
+        DataField::new(
+            "interval-year-month",
+            DataType::Interval(IntervalUnit::YearMonth),
+            false,
+        ),
+        DataField::new("datetime32", DataType::DateTime32(None), false),
+        DataField::new("date32", DataType::Date32, false),
+        DataField::new("date16", DataType::Date32, false),
+    ]);
+
+    let tests = vec![
+        Test {
+            name: "datetime-add-year-month-passed",
+            display: "plus",
+            nullable: false,
+            arg_names: vec!["datetime32", "interval-year-month"],
+            func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Plus)?,
+            columns: vec![
+                Series::new(vec![
+                    to_seconds(2020, 2, 29, 10, 30, 00), /* 2020-2-29-10:30:00 */
+                    to_seconds(2000, 1, 31, 15, 00, 00),
+                ])
+                .into(),
+                Series::new(vec![
+                    12i64,       /* 1 year */
+                    20 * 12 + 1, /* 20 years and 1 month */
+                ])
+                .into(),
+            ],
+            expect: Series::new(vec![
+                to_seconds(2021, 2, 28, 10, 30, 00), /* 2021-2-28-10:30:00 */
+                to_seconds(2020, 2, 29, 15, 00, 00),
+            ])
+            .into(),
+            error: "",
+        },
+        Test {
+            name: "datetime-add-year-month-passed",
+            display: "plus",
+            nullable: false,
+            arg_names: vec!["datetime32", "interval-year-month"],
+            func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Plus)?,
+            columns: vec![
+                Series::new(vec![
+                    to_seconds(2021, 2, 28, 10, 30, 00),
+                    to_seconds(2020, 2, 29, 15, 00, 00),
+                ])
+                .into(),
+                Series::new(vec![-12i64 /* -1 year */, -1 /* -1 month */]).into(),
+            ],
+            expect: Series::new(vec![
+                to_seconds(2020, 2, 28, 10, 30, 00),
+                to_seconds(2020, 1, 29, 15, 00, 00),
+            ])
+            .into(),
+            error: "",
+        },
+        Test {
+            name: "datetime-add-day-time-passed",
+            display: "plus",
+            nullable: false,
+            arg_names: vec!["datetime32", "interval-day-time"],
+            func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Plus)?,
+            columns: vec![
+                Series::new(vec![
+                    to_seconds(2020, 3, 1, 10, 30, 00),
+                    to_seconds(2020, 3, 1, 10, 30, 00),
+                ])
+                .into(),
+                Series::new(vec![
+                    -(1i64 << 32),     /* -1 day */
+                    -25 * 3600 * 1000, /* -25 hours */
+                ])
+                .into(),
+            ],
+            expect: Series::new(vec![
+                to_seconds(2020, 2, 29, 10, 30, 00),
+                to_seconds(2020, 2, 29, 9, 30, 00),
+            ])
+            .into(),
+            error: "",
+        },
+        Test {
+            name: "datetime-minus-day-time-passed",
+            display: "minus",
+            nullable: false,
+            arg_names: vec!["datetime32", "interval-day-time"],
+            func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Minus)?,
+            columns: vec![
+                Series::new(vec![
+                    to_seconds(2020, 2, 29, 10, 30, 00),
+                    to_seconds(2020, 2, 29, 9, 30, 00),
+                ])
+                .into(),
+                Series::new(vec![
+                    -(1i64 << 32),     /* -1 day */
+                    -25 * 3600 * 1000, /* -25 hours */
+                ])
+                .into(),
+            ],
+            expect: Series::new(vec![
+                to_seconds(2020, 3, 1, 10, 30, 00),
+                to_seconds(2020, 3, 1, 10, 30, 00),
+            ])
+            .into(),
+            error: "",
+        },
+        Test {
+            name: "date32-plus-year-month",
+            display: "plus",
+            nullable: false,
+            arg_names: vec!["date32", "interval-year-month"],
+            func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Plus)?,
+            columns: vec![
+                Series::new(vec![to_days(2020, 2, 29), to_days(2000, 1, 31)]).into(),
+                Series::new(vec![
+                    12i64,       /* 1 year */
+                    20 * 12 + 1, /* 20 years and 1 month */
+                ])
+                .into(),
+            ],
+            expect: Series::new(vec![to_days(2021, 2, 28), to_days(2020, 2, 29)]).into(),
+            error: "",
+        },
+        Test {
+            name: "date32-minus-year-month",
+            display: "minus",
+            nullable: false,
+            arg_names: vec!["date32", "interval-year-month"],
+            func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Minus)?,
+            columns: vec![
+                Series::new(vec![to_days(2020, 2, 29), to_days(2000, 1, 31)]).into(),
+                Series::new(vec![
+                    -12i64,         /* 1 year */
+                    -(20 * 12 + 1), /* 20 years and 1 month */
+                ])
+                .into(),
+            ],
+            expect: Series::new(vec![to_days(2021, 2, 28), to_days(2020, 2, 29)]).into(),
+            error: "",
+        },
+        Test {
+            name: "date32-plus-day-time",
+            display: "plus",
+            nullable: false,
+            arg_names: vec!["date32", "interval-day-time"],
+            func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Plus)?,
+            columns: vec![
+                Series::new(vec![to_days(2020, 3, 1), to_days(2020, 3, 1)]).into(),
+                Series::new(vec![
+                    -(1i64 << 32),     /* -1 day */
+                    -25 * 3600 * 1000, /* -25 hours */
+                ])
+                .into(),
+            ],
+            expect: Series::new(vec![to_days(2020, 2, 29), to_days(2020, 2, 28)]).into(),
+            error: "",
+        },
+        Test {
+            name: "date16-plus-year-month",
+            display: "plus",
+            nullable: false,
+            arg_names: vec!["date16", "interval-year-month"],
+            func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Plus)?,
+            columns: vec![
+                Series::new(vec![
+                    to_days(2020, 2, 29) as u16,
+                    to_days(2000, 1, 31) as u16,
+                ])
+                .into(),
+                Series::new(vec![
+                    12i64,       /* 1 year */
+                    20 * 12 + 1, /* 20 years and 1 month */
+                ])
+                .into(),
+            ],
+            expect: Series::new(vec![
+                to_days(2021, 2, 28) as u16,
+                to_days(2020, 2, 29) as u16,
+            ])
+            .into(),
+            error: "",
+        },
+    ];
+
+    for t in tests {
+        let rows = t.columns[0].len();
+        // Type check.
+        let mut args = vec![];
+        let mut fields = vec![];
+        for name in t.arg_names {
+            args.push(schema.field_with_name(name)?.data_type().clone());
+            fields.push(schema.field_with_name(name)?.clone());
+        }
+
+        let columns: Vec<DataColumnWithField> = t
+            .columns
+            .iter()
+            .zip(fields.iter())
+            .map(|(c, f)| DataColumnWithField::new(c.clone(), f.clone()))
+            .collect();
+
+        let func = t.func;
+        if let Err(e) = func.eval(&columns, rows) {
+            assert_eq!(t.error, e.to_string());
+        }
+
+        // Display check.
+        let expect_display = t.display.to_string();
+        let actual_display = format!("{}", func);
+        assert_eq!(expect_display, actual_display);
+
+        // Nullable check.
+        let expect_null = t.nullable;
+        let actual_null = func.nullable(&schema)?;
+        assert_eq!(expect_null, actual_null);
+
+        let ref v = func.eval(&columns, rows)?;
         assert_eq!(v, &t.expect);
     }
     Ok(())

--- a/common/functions/src/scalars/arithmetics/arithmetic_test.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_test.rs
@@ -181,6 +181,10 @@ fn test_arithmetic_date_interval() -> Result<()> {
         (date_time.timestamp() / (24 * 3600)) as u32
     };
 
+    let daytime_to_ms = |days: i64, hour: i64, minute: i64, second: i64| -> i64 {
+        (days * 24 * 3600 * 1000) + (hour * 3600 * 1000) + (minute * 60 * 1000) + (second * 1000)
+    };
+
     #[allow(dead_code)]
     struct Test {
         name: &'static str,
@@ -269,8 +273,8 @@ fn test_arithmetic_date_interval() -> Result<()> {
                 ])
                 .into(),
                 Series::new(vec![
-                    -(1i64 << 32),                   /* -1 day */
-                    -(1i64 << 32 | 1 * 3600 * 1000), /* - 1 day and 1 hours */
+                    daytime_to_ms(-1, 0, 0, 0),
+                    daytime_to_ms(-1, -1, 0, 0),
                 ])
                 .into(),
             ],
@@ -294,8 +298,8 @@ fn test_arithmetic_date_interval() -> Result<()> {
                 ])
                 .into(),
                 Series::new(vec![
-                    -(1i64 << 32),                   /* -1 day */
-                    -(1i64 << 32 | 1 * 3600 * 1000), /* - 1 day and 1 hours */
+                    daytime_to_ms(-1, 0, 0, 0),
+                    daytime_to_ms(-1, -1, 0, 0),
                 ])
                 .into(),
             ],
@@ -349,8 +353,8 @@ fn test_arithmetic_date_interval() -> Result<()> {
             columns: vec![
                 Series::new(vec![to_days(2020, 3, 1), to_days(2021, 3, 1)]).into(),
                 Series::new(vec![
-                    -(1i64 << 32),                   /* -1 day */
-                    -(1i64 << 32 | 1 * 3600 * 1000), /* - 1 day and 1 hour */
+                    daytime_to_ms(-1, 0, 0, 0),
+                    daytime_to_ms(-1, -1, 0, 0),
                 ])
                 .into(),
             ],
@@ -365,11 +369,7 @@ fn test_arithmetic_date_interval() -> Result<()> {
             func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Minus)?,
             columns: vec![
                 Series::new(vec![to_days(2020, 3, 1), to_days(2021, 3, 1)]).into(),
-                Series::new(vec![
-                    1i64 << 32,                   /* 1 day */
-                    1i64 << 32 | 1 * 3600 * 1000, /* 1 day and 1 hour */
-                ])
-                .into(),
+                Series::new(vec![daytime_to_ms(1, 0, 0, 0), daytime_to_ms(1, 1, 0, 0)]).into(),
             ],
             expect: Series::new(vec![to_days(2020, 2, 29), to_days(2021, 2, 28)]).into(),
             error: "",
@@ -407,11 +407,7 @@ fn test_arithmetic_date_interval() -> Result<()> {
             func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Plus)?,
             columns: vec![
                 Series::new(vec![to_days(2020, 2, 29), to_days(2021, 2, 28)]).into(),
-                Series::new(vec![
-                    1i64 << 32,                   /* 1 day */
-                    1i64 << 32 | 1 * 3600 * 1000, /* 1 day and 1 hour */
-                ])
-                .into(),
+                Series::new(vec![daytime_to_ms(1, 0, 0, 0), daytime_to_ms(1, 1, 0, 0)]).into(),
             ],
             expect: Series::new(vec![to_days(2020, 3, 1), to_days(2021, 3, 1)]).into(),
             error: "",

--- a/common/functions/src/scalars/arithmetics/arithmetic_test.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_test.rs
@@ -206,7 +206,7 @@ fn test_arithmetic_date_interval() -> Result<()> {
         ),
         DataField::new("datetime32", DataType::DateTime32(None), false),
         DataField::new("date32", DataType::Date32, false),
-        DataField::new("date16", DataType::Date32, false),
+        DataField::new("date16", DataType::Date16, false),
     ]);
 
     let tests = vec![
@@ -269,8 +269,8 @@ fn test_arithmetic_date_interval() -> Result<()> {
                 ])
                 .into(),
                 Series::new(vec![
-                    -(1i64 << 32),     /* -1 day */
-                    -25 * 3600 * 1000, /* -25 hours */
+                    -(1i64 << 32),                   /* -1 day */
+                    -(1i64 << 32 | 1 * 3600 * 1000), /* - 1 day and 1 hours */
                 ])
                 .into(),
             ],
@@ -294,8 +294,8 @@ fn test_arithmetic_date_interval() -> Result<()> {
                 ])
                 .into(),
                 Series::new(vec![
-                    -(1i64 << 32),     /* -1 day */
-                    -25 * 3600 * 1000, /* -25 hours */
+                    -(1i64 << 32),                   /* -1 day */
+                    -(1i64 << 32 | 1 * 3600 * 1000), /* - 1 day and 1 hours */
                 ])
                 .into(),
             ],
@@ -332,8 +332,8 @@ fn test_arithmetic_date_interval() -> Result<()> {
             columns: vec![
                 Series::new(vec![to_days(2020, 2, 29), to_days(2000, 1, 31)]).into(),
                 Series::new(vec![
-                    -12i64,         /* 1 year */
-                    -(20 * 12 + 1), /* 20 years and 1 month */
+                    -12i64,         /* - 1 year */
+                    -(20 * 12 + 1), /* - 20 years and 1 month */
                 ])
                 .into(),
             ],
@@ -347,14 +347,31 @@ fn test_arithmetic_date_interval() -> Result<()> {
             arg_names: vec!["date32", "interval-day-time"],
             func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Plus)?,
             columns: vec![
-                Series::new(vec![to_days(2020, 3, 1), to_days(2020, 3, 1)]).into(),
+                Series::new(vec![to_days(2020, 3, 1), to_days(2021, 3, 1)]).into(),
                 Series::new(vec![
-                    -(1i64 << 32),     /* -1 day */
-                    -25 * 3600 * 1000, /* -25 hours */
+                    -(1i64 << 32),                   /* -1 day */
+                    -(1i64 << 32 | 1 * 3600 * 1000), /* - 1 day and 1 hour */
                 ])
                 .into(),
             ],
-            expect: Series::new(vec![to_days(2020, 2, 29), to_days(2020, 2, 28)]).into(),
+            expect: Series::new(vec![to_days(2020, 2, 29), to_days(2021, 2, 28)]).into(),
+            error: "",
+        },
+        Test {
+            name: "date32-minus-day-time",
+            display: "minus",
+            nullable: false,
+            arg_names: vec!["date32", "interval-day-time"],
+            func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Minus)?,
+            columns: vec![
+                Series::new(vec![to_days(2020, 3, 1), to_days(2021, 3, 1)]).into(),
+                Series::new(vec![
+                    1i64 << 32,                   /* 1 day */
+                    1i64 << 32 | 1 * 3600 * 1000, /* 1 day and 1 hour */
+                ])
+                .into(),
+            ],
+            expect: Series::new(vec![to_days(2020, 2, 29), to_days(2021, 2, 28)]).into(),
             error: "",
         },
         Test {
@@ -380,6 +397,23 @@ fn test_arithmetic_date_interval() -> Result<()> {
                 to_days(2020, 2, 29) as u16,
             ])
             .into(),
+            error: "",
+        },
+        Test {
+            name: "date16-plus-day-time",
+            display: "plus",
+            nullable: false,
+            arg_names: vec!["date16", "interval-day-time"],
+            func: ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Plus)?,
+            columns: vec![
+                Series::new(vec![to_days(2020, 2, 29), to_days(2021, 2, 28)]).into(),
+                Series::new(vec![
+                    1i64 << 32,                   /* 1 day */
+                    1i64 << 32 | 1 * 3600 * 1000, /* 1 day and 1 hour */
+                ])
+                .into(),
+            ],
+            expect: Series::new(vec![to_days(2020, 3, 1), to_days(2021, 3, 1)]).into(),
             error: "",
         },
     ];

--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -893,15 +893,13 @@ impl PlanParser {
     }
 
     fn interval_to_day_time(days: i32, ms: i32) -> Result<Expression> {
-        let milliseconds_per_day = 24 * 3600 * 1000;
-        let wrapped_days = days + ms / milliseconds_per_day;
-        let wrapped_ms = ms % milliseconds_per_day;
-        let num = (wrapped_days as i64) << 32 | (wrapped_ms as i64);
         let data_type = DataType::Interval(IntervalUnit::DayTime);
+        let milliseconds_per_day = 24 * 3600 * 1000;
+        let total_ms = days as i64 * milliseconds_per_day + ms as i64;
 
         Ok(Expression::Literal {
-            value: DataValue::Int64(Some(num)),
-            column_name: Some(num.to_string()),
+            value: DataValue::Int64(Some(total_ms)),
+            column_name: Some(total_ms.to_string()),
             data_type,
         })
     }

--- a/query/src/sql/plan_parser_test.rs
+++ b/query/src/sql/plan_parser_test.rs
@@ -126,7 +126,7 @@ fn test_plan_parser() -> Result<()> {
         Test {
             name: "interval-passed",
             sql: "SELECT INTERVAL '1' year, INTERVAL '1' month, INTERVAL '1' day, INTERVAL '1' hour, INTERVAL '1' minute, INTERVAL '1' second",
-            expect: "Projection: 12:Interval(YearMonth), 1:Interval(YearMonth), 4294967296:Interval(DayTime), 3600000:Interval(DayTime), 60000:Interval(DayTime), 1000:Interval(DayTime)\n  Expression: 12:Interval(YearMonth), 1:Interval(YearMonth), 4294967296:Interval(DayTime), 3600000:Interval(DayTime), 60000:Interval(DayTime), 1000:Interval(DayTime) (Before Projection)\n    ReadDataSource: scan partitions: [1], scan schema: [dummy:UInt8], statistics: [read_rows: 1, read_bytes: 1]",
+            expect: "Projection: 12:Interval(YearMonth), 1:Interval(YearMonth), 86400000:Interval(DayTime), 3600000:Interval(DayTime), 60000:Interval(DayTime), 1000:Interval(DayTime)\n  Expression: 12:Interval(YearMonth), 1:Interval(YearMonth), 86400000:Interval(DayTime), 3600000:Interval(DayTime), 60000:Interval(DayTime), 1000:Interval(DayTime) (Before Projection)\n    ReadDataSource: scan partitions: [1], scan schema: [dummy:UInt8], statistics: [read_rows: 1, read_bytes: 1]",
             error: "",
         },
         // Test {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add arithemetic support for interval type
>      Date16  [+|-] Interval
>      Date32  [+|-] Interval
>      DateTime32 [+|-] Interval

## Changelog

- New Feature

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

