### PR TITLE
COMMON: apply member same order as trait

### DIFF
--- a/common/datavalues/src/types/serializations/boolean.rs
+++ b/common/datavalues/src/types/serializations/boolean.rs
@@ -60,10 +60,6 @@ impl TypeSerializer for BooleanSerializer {
         Ok(())
     }
 
-    fn finish_to_series(&mut self) -> Series {
-        self.builder.finish().into_series()
-    }
-
     fn de_text(&mut self, reader: &[u8]) -> Result<()> {
         let v = if reader.eq_ignore_ascii_case(b"false") {
             Some(false)
@@ -80,5 +76,9 @@ impl TypeSerializer for BooleanSerializer {
 
     fn de_null(&mut self) {
         self.builder.append_null()
+    }
+
+    fn finish_to_series(&mut self) -> Series {
+        self.builder.finish().into_series()
     }
 }

--- a/common/datavalues/src/types/serializations/date.rs
+++ b/common/datavalues/src/types/serializations/date.rs
@@ -73,10 +73,6 @@ where
         Ok(())
     }
 
-    fn finish_to_series(&mut self) -> Series {
-        self.builder.finish().into_series()
-    }
-
     fn de_text(&mut self, reader: &[u8]) -> Result<()> {
         if reader.eq_ignore_ascii_case(b"null") {
             self.builder.append_null();
@@ -104,6 +100,10 @@ where
 
     fn de_null(&mut self) {
         self.builder.append_null()
+    }
+
+    fn finish_to_series(&mut self) -> Series {
+        self.builder.finish().into_series()
     }
 }
 

--- a/common/datavalues/src/types/serializations/date_time.rs
+++ b/common/datavalues/src/types/serializations/date_time.rs
@@ -71,10 +71,6 @@ where
         Ok(())
     }
 
-    fn finish_to_series(&mut self) -> Series {
-        self.builder.finish().into_series()
-    }
-
     fn de_text(&mut self, reader: &[u8]) -> Result<()> {
         if reader.eq_ignore_ascii_case(b"null") {
             self.builder.append_null();
@@ -103,5 +99,9 @@ where
 
     fn de_null(&mut self) {
         self.builder.append_null()
+    }
+
+    fn finish_to_series(&mut self) -> Series {
+        self.builder.finish().into_series()
     }
 }

--- a/common/datavalues/src/types/serializations/number.rs
+++ b/common/datavalues/src/types/serializations/number.rs
@@ -60,10 +60,6 @@ where
         Ok(())
     }
 
-    fn finish_to_series(&mut self) -> Series {
-        self.builder.finish().into_series()
-    }
-
     fn de_text(&mut self, reader: &[u8]) -> Result<()> {
         if reader.eq_ignore_ascii_case(b"null") {
             self.builder.append_null();
@@ -84,5 +80,9 @@ where
 
     fn de_null(&mut self) {
         self.builder.append_null()
+    }
+
+    fn finish_to_series(&mut self) -> Series {
+        self.builder.finish().into_series()
     }
 }

--- a/common/datavalues/src/types/serializations/string.rs
+++ b/common/datavalues/src/types/serializations/string.rs
@@ -54,10 +54,6 @@ impl TypeSerializer for StringSerializer {
         Ok(())
     }
 
-    fn finish_to_series(&mut self) -> Series {
-        self.builder.finish().into_series()
-    }
-
     fn de_text(&mut self, reader: &[u8]) -> Result<()> {
         self.builder.append_value(reader);
         Ok(())
@@ -65,5 +61,9 @@ impl TypeSerializer for StringSerializer {
 
     fn de_null(&mut self) {
         self.builder.append_null()
+    }
+
+    fn finish_to_series(&mut self) -> Series {
+        self.builder.finish().into_series()
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Apply member same order as trait

## Changelog

- Improvement


## Related Issues

Fixes N/A

## Test Plan

Unit Tests

Stateless Tests

