### PR TITLE
Add mysql progress output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "msql-srv"
 version = "0.9.6"
-source = "git+https://github.com/datafuse-extras/msql-srv?rev=bb7ba7b#bb7ba7b1fb2c1e27d60cf905752e189e0aaa050b"
+source = "git+https://github.com/datafuse-extras/msql-srv?rev=60e369b#60e369b78fa092c95177428fda1c756342733064"
 dependencies = [
  "byteorder",
  "chrono",

--- a/common/io/src/lib.rs
+++ b/common/io/src/lib.rs
@@ -21,6 +21,7 @@ mod buf_read;
 mod marshal;
 mod stat_buffer;
 mod unmarshal;
+mod utils;
 
 #[cfg(test)]
 mod binary_read_test;
@@ -30,3 +31,6 @@ mod binary_write_test;
 mod buf_read_test;
 #[cfg(test)]
 mod marshal_test;
+
+#[cfg(test)]
+mod utils_test;

--- a/common/io/src/utils.rs
+++ b/common/io/src/utils.rs
@@ -1,0 +1,63 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp;
+
+pub fn convert_byte_size(num: f64) -> String {
+    let negative = if num.is_sign_positive() { "" } else { "-" };
+    let num = num.abs();
+    let units = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+    if num < 1_f64 {
+        return format!("{}{} {}", negative, num, "B");
+    }
+    let delimiter = 1000_f64;
+    let exponent = cmp::min(
+        (num.ln() / delimiter.ln()).floor() as i32,
+        (units.len() - 1) as i32,
+    );
+    let pretty_bytes = format!("{:.2}", num / delimiter.powi(exponent))
+        .parse::<f64>()
+        .unwrap()
+        * 1_f64;
+    let unit = units[exponent as usize];
+    format!("{}{} {}", negative, pretty_bytes, unit)
+}
+
+pub fn convert_number_size(num: f64) -> String {
+    let negative = if num.is_sign_positive() { "" } else { "-" };
+    let num = num.abs();
+    let units = [
+        "",
+        " thousand",
+        " million",
+        " billion",
+        " trillion",
+        " quadrillion",
+    ];
+
+    if num < 1_f64 {
+        return format!("{}{}", negative, num);
+    }
+    let delimiter = 1000_f64;
+    let exponent = cmp::min(
+        (num.ln() / delimiter.ln()).floor() as i32,
+        (units.len() - 1) as i32,
+    );
+    let pretty_bytes = format!("{:.2}", num / delimiter.powi(exponent))
+        .parse::<f64>()
+        .unwrap()
+        * 1_f64;
+    let unit = units[exponent as usize];
+    format!("{}{}{}", negative, pretty_bytes, unit)
+}

--- a/common/io/src/utils_test.rs
+++ b/common/io/src/utils_test.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use bytes::BufMut;
-pub use bytes::BytesMut;
+use crate::utils::convert_byte_size;
+use crate::utils::convert_number_size;
 
-pub use crate::binary_de::BinaryDe;
-pub use crate::binary_read::BinaryRead;
-pub use crate::binary_ser::BinarySer;
-pub use crate::binary_write::BinaryWrite;
-pub use crate::binary_write::BinaryWriteBuf;
-pub use crate::buf_read::BufReadExt;
-pub use crate::marshal::Marshal;
-pub use crate::stat_buffer::StatBuffer;
-pub use crate::unmarshal::Unmarshal;
-pub use crate::utils::*;
+#[test]
+fn convert_test() {
+    assert_eq!(convert_byte_size(1_f64), "1 B");
+    assert_eq!(convert_byte_size(1022_f64), "1.02 KB");
+    assert_eq!(convert_byte_size(1022_f64 * 10000000f64), "10.22 GB");
+
+    assert_eq!(convert_number_size(1_f64), "1");
+    assert_eq!(convert_number_size(1022_f64), "1.02 thousand");
+    assert_eq!(convert_number_size(10222_f64), "10.22 thousand");
+}

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -42,7 +42,7 @@ common-metatypes = { path = "../common/metatypes" }
 common-clickhouse-srv = { path = "../common/clickhouse-srv" }
 
 # Github dependencies
-msql-srv = { git = "https://github.com/datafuse-extras/msql-srv", rev = "bb7ba7b" }
+msql-srv = { git = "https://github.com/datafuse-extras/msql-srv", rev = "60e369b" }
 clickhouse-rs = { git = "https://github.com/datafuse-extras/clickhouse-rs", rev = "c4743a9" }
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "77f6ae5" }
 

--- a/query/src/servers/mysql/writers/query_result_writer.rs
+++ b/query/src/servers/mysql/writers/query_result_writer.rs
@@ -50,8 +50,10 @@ impl<'a, W: std::io::Write> DFQueryResultWriter<'a, W> {
         dataset_writer: QueryResultWriter<'a, W>,
     ) -> Result<()> {
         // XXX: num_columns == 0 may is error?
-        let mut default_response = OkResponse::default();
-        default_response.info = extra_info;
+        let default_response = OkResponse {
+            info: extra_info,
+            ..Default::default()
+        };
 
         if blocks.is_empty() || (blocks[0].num_columns() == 0) {
             dataset_writer.completed(default_response)?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add mysql progress output

```
mysql> select avg(number) from numbers(100000);
+-------------+
| avg(number) |
+-------------+
|     49999.5 |
+-------------+
1 row in set (0.01 sec)
Read 100000 rows, 800 KB in 0.004 sec., 25 million rows/sec., 200 MB/sec.
```

## Changelog

- New Feature



## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

