### PR TITLE
[common/uniq-di] feature: make unique-id generating a common lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-uniq-id"
+version = "0.1.0"
+
+[[package]]
 name = "console"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1505,7 @@ dependencies = [
  "common-profling",
  "common-runtime",
  "common-tracing",
+ "common-uniq-id",
  "env_logger 0.9.0",
  "flaky_test",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "common/management",
     "common/io",
     "common/cache",
+    "common/uniq_id",
     "common/clickhouse-srv",
 
     # Query

--- a/common/uniq_id/Cargo.toml
+++ b/common/uniq_id/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "common-uniq-id"
+version = "0.1.0"
+authors = ["Databend Authors <opensource@datafuselabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+

--- a/common/uniq_id/src/lib.rs
+++ b/common/uniq_id/src/lib.rs
@@ -12,25 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Deref;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
-static GLOBAL_SEQ: AtomicUsize = AtomicUsize::new(0);
+pub fn uniq_usize() -> usize {
+    static GLOBAL_SEQ: AtomicUsize = AtomicUsize::new(0);
 
-#[derive(Debug)]
-pub struct Seq(usize);
-
-impl Default for Seq {
-    fn default() -> Self {
-        Seq(GLOBAL_SEQ.fetch_add(1, Ordering::SeqCst))
-    }
-}
-
-impl Deref for Seq {
-    type Target = usize;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+    GLOBAL_SEQ.fetch_add(1, Ordering::SeqCst)
 }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -29,6 +29,7 @@ common-planners = {path = "../common/planners"}
 common-profling = { path = "../common/profiling" }
 common-runtime = {path = "../common/runtime"}
 common-tracing = {path = "../common/tracing"}
+common-uniq-id = {path = "../common/uniq_id"}
 
 # Github dependencies
 

--- a/store/src/tests/mod.rs
+++ b/store/src/tests/mod.rs
@@ -14,10 +14,8 @@
 
 #[macro_use]
 pub mod service;
-pub mod seq;
 pub(crate) mod tls_constants;
 
-pub use seq::Seq;
 pub use service::assert_meta_connection;
 pub use service::next_port;
 pub use service::start_store_server;

--- a/store/src/tests/service.rs
+++ b/store/src/tests/service.rs
@@ -29,7 +29,6 @@ use crate::meta_service::raft_db::get_sled_db;
 use crate::meta_service::GetReq;
 use crate::meta_service::MetaNode;
 use crate::meta_service::MetaServiceClient;
-use crate::tests::Seq;
 
 // Start one random service and get the session manager.
 #[tracing::instrument(level = "info")]
@@ -56,7 +55,7 @@ pub async fn start_store_server_with_context(tc: &mut StoreTestContext) -> Resul
 }
 
 pub fn next_port() -> u32 {
-    19000u32 + (*Seq::default() as u32)
+    19000u32 + (common_uniq_id::uniq_usize() as u32)
 }
 
 pub struct StoreTestContext {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/uniq-di] feature: make unique-id generating a common lib

## Changelog

- New Feature





## Related Issues

#1855 