### PR TITLE
[store] refactor: remove Config::default().

### DIFF
--- a/common/functions/src/scalars/dates/date_test.rs
+++ b/common/functions/src/scalars/dates/date_test.rs
@@ -52,7 +52,7 @@ fn test_round_function() -> Result<()> {
 }
 
 #[test]
-fn test_toStartOf_function() -> Result<()> {
+fn test_to_start_of_function() -> Result<()> {
     let test = Test {
         name: "test-timeSlot-now",
         display: "toStartOfQuarter()",

--- a/store/src/api/http/v1/config_test.rs
+++ b/store/src/api/http/v1/config_test.rs
@@ -31,7 +31,7 @@ async fn test_config() -> common_exception::Result<()> {
     use crate::api::http::v1::config::config_handler;
     use crate::configs::Config; // for `app.oneshot()`
 
-    let conf = Config::default();
+    let conf = Config::empty();
     let cluster_router = Router::new()
         .route("/v1/config", get(config_handler))
         .layer(AddExtensionLayer::new(conf.clone()));

--- a/store/src/api/http_service_test.rs
+++ b/store/src/api/http_service_test.rs
@@ -28,7 +28,7 @@ use crate::tests::tls_constants::TEST_SERVER_KEY;
 // TODO(zhihanz) add tls fail case
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_http_service_tls_server() -> Result<()> {
-    let mut conf = Config::default();
+    let mut conf = Config::empty();
     let addr_str = "127.0.0.1:0";
 
     conf.tls_server_key = TEST_SERVER_KEY.to_owned();

--- a/store/src/configs/config.rs
+++ b/store/src/configs/config.rs
@@ -228,32 +228,4 @@ impl Config {
     pub fn tree_name(&self, name: impl std::fmt::Display) -> String {
         format!("{}{}", self.sled_tree_prefix, name)
     }
-
-    /// Defaulting values similar to query config
-    pub fn default() -> Self {
-        Config {
-            config_id: "".to_string(),
-            log_level: "INFO".to_string(),
-            log_dir: "./_logs".to_string(),
-            metric_api_address: "127.0.0.1:7171".to_string(),
-            http_api_address: "127.0.0.1:8181".to_string(),
-            tls_server_cert: "".to_string(),
-            tls_server_key: "".to_string(),
-            flight_api_address: "127.0.0.1:9191".to_string(),
-            meta_api_host: "127.0.0.1".to_string(),
-            meta_api_port: 9291,
-            meta_dir: "./_meta".to_string(),
-            meta_no_sync: false,
-            snapshot_logs_since_last: 1024,
-            heartbeat_interval: 500,
-            install_snapshot_timeout: 4000,
-            boot: false,
-            rpc_tls_server_cert: "".to_string(),
-            rpc_tls_server_key: "".to_string(),
-            single: false,
-            id: 0,
-            local_fs_dir: "./_local_fs".to_string(),
-            sled_tree_prefix: "".to_string(),
-        }
-    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [store] refactor: remove Config::default().
Since it overrides the `default()` provided by StructOptToml, there could be unexpected side effect.
Use `Config::empty()` to create a default instance without reading CLI
arguments.

## Changelog




- Improvement


## Related Issues

- #271
- #1834
