### PR TITLE
[ci] refactor: limit number of test running thread to 2.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,6 +43,7 @@ jobs:
           components: rustfmt
           args: --all-features --no-fail-fast
         env:
+          RUST_TEST_THREADS: 2
           RUST_LOG: debug
           RUST_BACKTRACE: full
           CARGO_INCREMENTAL: '0'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [ci] refactor: limit number of test running thread to 2.
Raft that is used in meta service is sensitive to time.
In a CI a unit test sometimes is delayed by one or two minutes and then fails due to timeout.

To reduce the max number of parallel test to run, may reduce the chance unit test delays each other.

## Changelog


- Improvement


## Related Issues

#1881