### PR TITLE
Fix protocol seq in AuthSwitchRequest 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,7 +3177,7 @@ dependencies = [
 [[package]]
 name = "msql-srv"
 version = "0.9.6"
-source = "git+https://github.com/datafuse-extras/msql-srv?rev=60e369b#60e369b78fa092c95177428fda1c756342733064"
+source = "git+https://github.com/datafuse-extras/msql-srv?rev=9c706a3#9c706a3fbc210f3b49c06a06e0ce9518b2cfa38e"
 dependencies = [
  "byteorder",
  "chrono",

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -42,7 +42,7 @@ common-metatypes = { path = "../common/metatypes" }
 common-clickhouse-srv = { path = "../common/clickhouse-srv" }
 
 # Github dependencies
-msql-srv = { git = "https://github.com/datafuse-extras/msql-srv", rev = "60e369b" }
+msql-srv = { git = "https://github.com/datafuse-extras/msql-srv", rev = "9c706a3" }
 clickhouse-rs = { git = "https://github.com/datafuse-extras/clickhouse-rs", rev = "c4743a9" }
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "77f6ae5" }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Fix protocol seq in AuthSwitchRequest 


```
❯ mysql --version
mysql  Ver 8.0.19 for osx10.14 on x86_64 (Homebrew)


❯ mysql --host 192.168.101.40 --user default --port 3307
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 8
Server version: DatabendQuery v-0.1.0-13d03b2-simd(1.57.0-nightly-2021-09-20T03:42:02.090437433+00:00) 0

Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> select 1;
+------+
| 1    |
+------+
|    1 |
+------+
1 row in set (0.01 sec)
Read 0 rows, 0 B in 0.003 sec., 0 rows/sec., 0 B/sec.

mysql>
```

## Changelog


- Bug Fix



## Related Issues

https://github.com/datafuse-extras/msql-srv/pull/9

Fixes #1878 

## Test Plan

Unit Tests

Stateless Tests

