### PR TITLE
bug fix: incorrect err-code returned for create db

### DIFF
--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -74,7 +74,7 @@ impl MetaStoreCatalog {
         };
 
         let plan = CreateDatabasePlan {
-            if_not_exists: false,
+            if_not_exists: true,
             db: "default".to_string(),
             engine: DEFAULT_DB_ENGINE.to_string(),
             options: Default::default(),

--- a/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
+++ b/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
@@ -289,7 +289,7 @@ impl MetaBackend for RemoteMeteStoreClient {
         let _r = self.do_block(async move {
             let cli = cli_provider.try_get_meta_client().await?;
             cli.create_database(plan).await
-        })?;
+        })??;
         Ok(())
     }
 
@@ -298,7 +298,7 @@ impl MetaBackend for RemoteMeteStoreClient {
         let _r = self.do_block(async move {
             let cli = cli_provider.try_get_meta_client().await?;
             cli.drop_database(plan).await
-        })?;
+        })??;
         Ok(())
     }
 

--- a/tests/suites/0_stateless/05_0001_ddl_create_database.sql
+++ b/tests/suites/0_stateless/05_0001_ddl_create_database.sql
@@ -5,7 +5,7 @@ CREATE TABLE db.t(c1 int) ENGINE = Null;
 SELECT COUNT(1) from system.tables where name = 't' and database = 'db';
 
 CREATE DATABASE IF NOT EXISTS db ENGINE = default;
-CREATE DATABASE db ENGINE = default; -- {ErrorCode 3}
+CREATE DATABASE db ENGINE = default; -- {ErrorCode 4001}
 
 DROP DATABASE IF EXISTS db;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

- EmbededMetaBackend should return DatabaseAlreadyExists instead
  of UnknownDatabase if database already exist

- RemoteMetabackend should evaluate the inner result returned from
  `do_block`

- `create_database` of EmbeddedMetaBackend should acquire a lock
   for both checking and inserting, not a read lock for checking and a
   write lock for inserting

 - enable `if_not_exists`, when creating `default` db

    currently, there is no pre built db in the remote meta backend.
    instead,  a `default` database is registered by EACH query node.

    To avoid the conflicts of creating the same "default" database,
    we enable the if_not_exists flag when registering the default db.

Thank @zhang2014 for reminding me that the err code is incorrect, (and for remote meta cases, errors are not detected correctly) 

## Changelog

- Bug Fix


## Related Issues



## Test Plan

Unit Tests

Stateless Tests

