### PR TITLE
[metasrv] refactor: rename MetaServer to FlightServer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,6 +1407,8 @@ dependencies = [
  "colored",
  "comfy-table",
  "common-building",
+ "databend-query",
+ "databend-store",
  "dirs",
  "dyn-clone",
  "flate2",

--- a/metasrv/src/api/flight_server.rs
+++ b/metasrv/src/api/flight_server.rs
@@ -30,11 +30,11 @@ use crate::api::rpc::MetaFlightImpl;
 use crate::configs::Config;
 use crate::meta_service::MetaNode;
 
-pub struct MetaServer {
+pub struct FlightServer {
     conf: Config,
 }
 
-impl MetaServer {
+impl FlightServer {
     pub fn create(conf: Config) -> Self {
         Self { conf }
     }

--- a/metasrv/src/api/mod.rs
+++ b/metasrv/src/api/mod.rs
@@ -14,13 +14,13 @@
 
 // The api module only used for internal communication, such as GRPC between cluster and the managed HTTP REST API.
 
+mod flight_server;
 mod http;
 mod http_service;
 pub mod rpc;
-mod rpc_service;
 
 #[cfg(test)]
 mod http_service_test;
 
+pub use flight_server::FlightServer;
 pub use http_service::HttpService;
-pub use rpc_service::MetaServer;

--- a/metasrv/src/bin/metasrv.rs
+++ b/metasrv/src/bin/metasrv.rs
@@ -15,8 +15,8 @@
 use common_runtime::tokio;
 use common_tracing::init_tracing_with_file;
 use log::info;
+use metasrv::api::FlightServer;
 use metasrv::api::HttpService;
-use metasrv::api::MetaServer;
 use metasrv::configs::Config;
 use metasrv::meta_service::raft_db::init_sled_db;
 use metasrv::metrics::MetricService;
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // RPC API service.
     {
-        let srv = MetaServer::create(conf.clone());
+        let srv = FlightServer::create(conf.clone());
         info!(
             "Databend-Metasrv API server listening on {}",
             conf.flight_api_address

--- a/metasrv/src/tests/service.rs
+++ b/metasrv/src/tests/service.rs
@@ -23,7 +23,7 @@ use tempfile::tempdir;
 use tempfile::TempDir;
 
 // use tracing_appender::non_blocking::WorkerGuard;
-use crate::api::MetaServer;
+use crate::api::FlightServer;
 use crate::configs;
 use crate::meta_service::raft_db::get_sled_db;
 use crate::meta_service::GetReq;
@@ -43,7 +43,7 @@ pub async fn start_metasrv() -> Result<(MetaSrvTestContext, String)> {
 }
 
 pub async fn start_metasrv_with_context(tc: &mut MetaSrvTestContext) -> Result<()> {
-    let srv = MetaServer::create(tc.config.clone());
+    let srv = FlightServer::create(tc.config.clone());
     let (stop_tx, fin_rx) = srv.start().await?;
 
     tc.channels = Some((stop_tx, fin_rx));


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: rename MetaServer to FlightServer

## Changelog




- Improvement


## Related Issues