### PR TITLE
[metasrv] refactor: organized integration test in the rust-crate style: move flight api test into metasrv/tests/

### DIFF
--- a/metasrv/src/lib.rs
+++ b/metasrv/src/lib.rs
@@ -17,7 +17,6 @@ pub mod protobuf {
     include!(concat!(env!("OUT_DIR"), concat!("/meta.rs")));
 }
 
-#[cfg(test)]
 #[macro_use]
 pub mod tests;
 

--- a/metasrv/src/tests/mod.rs
+++ b/metasrv/src/tests/mod.rs
@@ -14,7 +14,7 @@
 
 #[macro_use]
 pub mod service;
-pub(crate) mod tls_constants;
+pub mod tls_constants;
 
 pub use service::assert_meta_connection;
 pub use service::next_port;

--- a/metasrv/src/tests/service.rs
+++ b/metasrv/src/tests/service.rs
@@ -161,10 +161,11 @@ pub async fn assert_meta_connection(addr: &str) -> anyhow::Result<()> {
 /// 1. Open a temp sled::Db for all tests.
 /// 2. Initialize a global tracing.
 /// 3. Create a span for a test case. One needs to enter it by `span.enter()` and keeps the guard held.
+#[macro_export]
 macro_rules! init_meta_ut {
     () => {{
         let t = tempfile::tempdir().expect("create temp dir to sled db");
-        crate::meta_service::raft_db::init_temp_sled_db(t);
+        $crate::meta_service::raft_db::init_temp_sled_db(t);
 
         // common_tracing::init_tracing(&format!("ut-{}", name), "./_logs")
         common_tracing::init_default_ut_tracing();

--- a/metasrv/src/tests/tls_constants.rs
+++ b/metasrv/src/tests/tls_constants.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Datafuse Labs.
+// Copyright 2021 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 pub const TEST_CA_CERT: &str = "../tests/certs/ca.pem";
 pub const TEST_SERVER_CERT: &str = "../tests/certs/server.pem";

--- a/metasrv/tests/flight/main.rs
+++ b/metasrv/tests/flight/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Datafuse Labs.
+// Copyright 2021 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod flight_service;
-
-pub use flight_service::FlightStream;
-pub use flight_service::MetaFlightImpl;
+pub mod metasrv_flight_api;
+pub mod metasrv_flight_tls;

--- a/metasrv/tests/flight/metasrv_flight_api.rs
+++ b/metasrv/tests/flight/metasrv_flight_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Datafuse Labs.
+// Copyright 2021 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Test arrow-flight API of metasrv
+
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -23,11 +25,12 @@ use common_store_api_sdk::kv_api_impl::UpsertKVActionResult;
 use common_store_api_sdk::KVApi;
 use common_store_api_sdk::StoreClient;
 use common_tracing::tracing;
+use metasrv::init_meta_ut;
 use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_flight_restart() -> anyhow::Result<()> {
-    // Issue 1134  https://github.com/datafuselabs/databend/issues/1134
+async fn test_restart() -> anyhow::Result<()> {
+    // Fix: Issue 1134  https://github.com/datafuselabs/databend/issues/1134
     // - Start a metasrv server.
     // - create db and create table
     // - restart
@@ -36,7 +39,7 @@ async fn test_flight_restart() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let (mut tc, addr) = crate::tests::start_metasrv().await?;
+    let (mut tc, addr) = metasrv::tests::start_metasrv().await?;
 
     let client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -91,7 +94,7 @@ async fn test_flight_restart() -> anyhow::Result<()> {
 
         // restart by opening existent meta db
         tc.config.meta_config.boot = false;
-        crate::tests::start_metasrv_with_context(&mut tc).await?;
+        metasrv::tests::start_metasrv_with_context(&mut tc).await?;
     }
 
     tokio::time::sleep(tokio::time::Duration::from_millis(10_000)).await;
@@ -118,14 +121,14 @@ async fn test_flight_restart() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_flight_generic_kv_mget() -> anyhow::Result<()> {
+async fn test_generic_kv_mget() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
     {
-        let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
+        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_list");
         let _ent = span.enter();
 
-        let (_tc, addr) = crate::tests::start_metasrv().await?;
+        let (_tc, addr) = metasrv::tests::start_metasrv().await?;
 
         let client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -166,14 +169,14 @@ async fn test_flight_generic_kv_mget() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_flight_generic_kv_list() -> anyhow::Result<()> {
+async fn test_generic_kv_list() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
     {
-        let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
+        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_list");
         let _ent = span.enter();
 
-        let (_tc, addr) = crate::tests::start_metasrv().await?;
+        let (_tc, addr) = metasrv::tests::start_metasrv().await?;
 
         let client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -214,14 +217,14 @@ async fn test_flight_generic_kv_list() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_flight_generic_kv_delete() -> anyhow::Result<()> {
+async fn test_generic_kv_delete() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
     {
-        let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
+        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_list");
         let _ent = span.enter();
 
-        let (_tc, addr) = crate::tests::start_metasrv().await?;
+        let (_tc, addr) = metasrv::tests::start_metasrv().await?;
 
         let client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -282,14 +285,14 @@ async fn test_flight_generic_kv_delete() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_flight_generic_kv_update() -> anyhow::Result<()> {
+async fn test_generic_kv_update() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
     {
-        let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
+        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_list");
         let _ent = span.enter();
 
-        let (_tc, addr) = crate::tests::start_metasrv().await?;
+        let (_tc, addr) = metasrv::tests::start_metasrv().await?;
 
         let client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -386,16 +389,16 @@ async fn test_flight_generic_kv_update() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_flight_generic_kv_update_meta() -> anyhow::Result<()> {
+async fn test_generic_kv_update_meta() -> anyhow::Result<()> {
     // Only update meta, do not touch the value part.
 
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
     {
-        let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_update_meta");
+        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_update_meta");
         let _ent = span.enter();
 
-        let (_tc, addr) = crate::tests::start_metasrv().await?;
+        let (_tc, addr) = metasrv::tests::start_metasrv().await?;
 
         let client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -489,7 +492,7 @@ async fn test_flight_generic_kv_update_meta() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_flight_generic_kv_timeout() -> anyhow::Result<()> {
+async fn test_generic_kv_timeout() -> anyhow::Result<()> {
     // - Test get  expired and non-expired.
     // - Test mget expired and non-expired.
     // - Test list expired and non-expired.
@@ -498,10 +501,10 @@ async fn test_flight_generic_kv_timeout() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
     {
-        let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_timeout");
+        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_timeout");
         let _ent = span.enter();
 
-        let (_tc, addr) = crate::tests::start_metasrv().await?;
+        let (_tc, addr) = metasrv::tests::start_metasrv().await?;
 
         let client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -607,15 +610,15 @@ async fn test_flight_generic_kv_timeout() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_flight_generic_kv() -> anyhow::Result<()> {
+async fn test_generic_kv() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
     {
-        let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv");
+        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv");
         let _ent = span.enter();
 
-        let (_tc, addr) = crate::tests::start_metasrv().await?;
+        let (_tc, addr) = metasrv::tests::start_metasrv().await?;
 
         let client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 

--- a/metasrv/tests/flight/metasrv_flight_tls.rs
+++ b/metasrv/tests/flight/metasrv_flight_tls.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Datafuse Labs.
+// Copyright 2021 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,18 +17,17 @@ use common_runtime::tokio;
 use common_store_api_sdk::MetaApi;
 use common_store_api_sdk::RpcClientTlsConfig;
 use common_store_api_sdk::StoreClient;
+use metasrv::init_meta_ut;
+use metasrv::tests::service::new_test_context;
+use metasrv::tests::start_metasrv_with_context;
+use metasrv::tests::tls_constants::TEST_CA_CERT;
+use metasrv::tests::tls_constants::TEST_CN_NAME;
+use metasrv::tests::tls_constants::TEST_SERVER_CERT;
+use metasrv::tests::tls_constants::TEST_SERVER_KEY;
 use pretty_assertions::assert_eq;
 
-use crate::tests::service::new_test_context;
-use crate::tests::start_metasrv_with_context;
-
-const TEST_CA_CERT: &str = "../tests/certs/ca.pem";
-const TEST_SERVER_CERT: &str = "../tests/certs/server.pem";
-const TEST_SERVER_KEY: &str = "../tests/certs/server.key";
-const TEST_CN_NAME: &str = "localhost";
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_flight_tls() -> anyhow::Result<()> {
+async fn test_tls_server() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
@@ -58,7 +57,7 @@ async fn test_flight_tls() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_flight_tls_server_config_failure() -> anyhow::Result<()> {
+async fn test_tls_server_config_failure() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
@@ -73,7 +72,7 @@ async fn test_flight_tls_server_config_failure() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_flight_tls_client_config_failure() -> anyhow::Result<()> {
+async fn test_tls_client_config_failure() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: organized integration test in the rust-crate style: move flight api test into metasrv/tests/

## Changelog




- Improvement


## Related Issues

- According to #1866

Rust-crate-style tests guide: https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html