### PR TITLE
[kv] refactor: move local kv into standalone crate /kvlocal to break potential cyclic dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,8 +880,8 @@ dependencies = [
  "common-store-api",
  "common-store-api-sdk",
  "common-tracing",
+ "kvlocal",
  "lazy_static",
- "metasrv",
  "mockall",
  "serde",
  "serde_json",
@@ -959,7 +959,6 @@ dependencies = [
  "common-datablocks",
  "common-datavalues",
  "common-exception",
- "common-management",
  "common-metatypes",
  "common-planners",
  "common-runtime",
@@ -2701,6 +2700,21 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2",
+]
+
+[[package]]
+name = "kvlocal"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "common-exception",
+ "common-metatypes",
+ "common-runtime",
+ "common-store-api",
+ "common-tracing",
+ "metasrv",
+ "pretty_assertions",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "query",
 
     "metasrv",
+    "kvlocal",
 
     # Store
     "store",

--- a/common/management/Cargo.toml
+++ b/common/management/Cargo.toml
@@ -16,7 +16,7 @@ common-store-api-sdk= {path = "../store-api-sdk"}
 common-store-api= {path = "../store-api"}
 common-tracing= {path = "../tracing"}
 
-metasrv = {path = "../../metasrv"}
+kvlocal = {path = "../../kvlocal" }
 
 async-trait = "0.1"
 lazy_static = "1.4.0"
@@ -28,5 +28,4 @@ sha1 = "0.6.0"
 [dev-dependencies]
 tempfile = "3.2.0"
 common-runtime = { path = "../runtime"}
-common-store-api-sdk= {path = "../store-api-sdk"}
 mockall = "0.10.2"

--- a/common/store-api/Cargo.toml
+++ b/common/store-api/Cargo.toml
@@ -24,4 +24,3 @@ thiserror = "1.0.29"
 [dev-dependencies]
 common-runtime = { path = "../runtime"}
 common-tracing= {path = "../tracing"}
-common-management = {path = "../management"}

--- a/kvlocal/Cargo.toml
+++ b/kvlocal/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "kvlocal"
+version = "0.1.0"
+description = "distributed meta data service"
+authors = ["Databend Authors <opensource@datafuselabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+
+[features]
+
+[dependencies]
+# Workspace dependencies
+common-exception = {path = "../common/exception"}
+common-metatypes = {path = "../common/metatypes"}
+common-runtime = {path = "../common/runtime"}
+common-tracing = {path = "../common/tracing"}
+common-store-api = {path = "../common/store-api"}
+
+metasrv = {path = "../metasrv"}
+
+
+# Crates.io dependencies
+async-trait = "0.1"
+tempfile = "3.2.0"
+
+
+[dev-dependencies]
+pretty_assertions = "0.7"
+

--- a/kvlocal/src/lib.rs
+++ b/kvlocal/src/lib.rs
@@ -13,11 +13,7 @@
 // limitations under the License.
 //
 
-pub use namespace_api::NamespaceApi;
-pub use namespace_api::NodeInfo;
+mod local_kv_store;
 
 #[cfg(test)]
-mod namespace_mgr_test;
-
-mod namespace_api;
-mod namespace_mgr;
+mod local_kv_store_test;

--- a/kvlocal/src/local_kv_store.rs
+++ b/kvlocal/src/local_kv_store.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Datafuse Labs.
+// Copyright 2021 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,17 +22,18 @@ use common_metatypes::KVMeta;
 use common_metatypes::MatchSeq;
 use common_metatypes::Operation;
 use common_runtime::tokio::sync::Mutex;
+use common_store_api::kv_apis::kv_api::MGetKVActionResult;
 use common_store_api::GetKVActionResult;
 use common_store_api::KVApi;
 use common_store_api::PrefixListReply;
 use common_store_api::UpsertKVActionResult;
-use common_store_api_sdk::kv_api_impl::MGetKVActionResult;
 use common_tracing::tracing;
 use metasrv::configs;
 use metasrv::meta_service::AppliedState;
 use metasrv::meta_service::Cmd;
 use metasrv::meta_service::LogEntry;
 use metasrv::raft::state_machine::StateMachine;
+pub use metasrv::sled_store::init_temp_sled_db;
 
 /// Local storage that provides the API defined by `KVApi`.
 /// It is just a wrapped `StateMachine`, which is the same one used by raft driven meta-store service.

--- a/kvlocal/src/local_kv_store_test.rs
+++ b/kvlocal/src/local_kv_store_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Datafuse Labs.
+// Copyright 2021 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -25,85 +24,10 @@ use common_store_api::kv_apis::kv_api::MGetKVActionResult;
 use common_store_api::GetKVActionResult;
 use common_store_api::KVApi;
 use common_store_api::UpsertKVActionResult;
-use common_store_api_sdk::StoreApiProvider;
-use common_store_api_sdk::StoreClientConf;
 use common_tracing::tracing;
 use metasrv::sled_store::init_temp_sled_db;
 
-use crate::namespace::local_kv_store::LocalKVStore;
-use crate::namespace::namespace_mgr::NamespaceMgr;
-use crate::namespace::NamespaceApi;
-use crate::namespace::NodeInfo;
-
-#[allow(dead_code)]
-async fn new_kv_api_with_store_api_provider() -> Result<Arc<dyn KVApi>> {
-    // this is for Api(compilation) testing only
-    //
-
-    // StoreAiProvider::new accepts a arg which can be converted
-    // into StoreClientConf, which query::configs::Conf implemented
-    // like this:
-    //
-    // - the constructor of StoreApiProvider
-    //
-    // ```
-    // pub fn new(conf: impl Into<StoreClientConf>) -> Self
-    // ```
-    // - the converter in crate `query`
-    //
-    // ```
-    //
-    // impl From<&Config> for StoreClientConf {
-    //  ...
-    // }
-    // ```
-    //
-    // since this crate is not supposed to be depended on crate `query`
-    // we can not demo it. instead we passes in a default StoreClientConf
-    //
-    // please DO NOT use the bare default config, which will lead to runtime error
-
-    let conf = StoreClientConf::default();
-    let api_provider = StoreApiProvider::new(conf);
-    api_provider.try_get_kv_client().await
-}
-
-#[tokio::test]
-async fn test_mgr_backed_with_local_kv_store() -> Result<()> {
-    init_testing_sled_db();
-
-    let tenant_id = "tenant1";
-    let namespace_id = "cluster1";
-    let node_id = "node1";
-    let node = NodeInfo {
-        id: node_id.to_string(),
-        cpu_nums: 0,
-        version: 0,
-        ip: "".to_string(),
-        port: 0,
-    };
-
-    let api = LocalKVStore::new_temp().await?;
-
-    let mgr = NamespaceMgr::new(Arc::new(api));
-    let res = mgr
-        .add_node(
-            tenant_id.to_string(),
-            namespace_id.to_string(),
-            node.clone(),
-        )
-        .await?;
-
-    assert_eq!(1, res, "the seq of the first added node");
-
-    let got = mgr
-        .get_nodes(tenant_id.to_string(), namespace_id.to_string(), None)
-        .await?;
-
-    assert_eq!(vec![(1, node.clone())], got, "fetch added nodes");
-
-    Ok(())
-}
+use crate::local_kv_store::LocalKVStore;
 
 #[tokio::test]
 async fn test_local_kv_store() -> Result<()> {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [kv] refactor: move local kv into standalone crate /kvlocal to break potential cyclic dependency
Currently the dependency graph is:

```
.----- common/management
|      |
|      v
|  .-- kvlocal
|  |   |
|  |   v
|  |   metasrv
|  |   |
|  |   v
+--|-> common/store-api-sdk
|  |   |
|  |   v
`--+-> common/store-api
```

```
cargo tree -i kvlocal

kvlocal v0.1.0
└── common-management v0.1.0
    └── databend-query v0.1.0
        ├── databend-cli v0.1.0
        └── fuzz v0.1.0

cargo tree -i common-store-api

common-store-api v0.1.0
├── common-management v0.1.0
│   └── databend-query v0.1.0
│       ├── databend-cli v0.1.0
│       └── fuzz v0.1.0
├── common-store-api-sdk v0.1.0
│   ├── common-management v0.1.0
│   ├── databend-query v0.1.0
│   ├── databend-store v0.1.0
│   │   └── databend-cli v0.1.0
│   └── metasrv v0.1.0
│       ├── databend-store v0.1.0
│       └── kvlocal v0.1.0
│           └── common-management v0.1.0
│   [dev-dependencies]
│   └── common-management v0.1.0
├── databend-query v0.1.0
└── kvlocal v0.1.0

cargo tree -i common-store-api-sdk

common-store-api-sdk v0.1.0
├── common-management v0.1.0
│   └── databend-query v0.1.0
│       ├── databend-cli v0.1.0
│       └── fuzz v0.1.0
├── databend-query v0.1.0
├── databend-store v0.1.0
│   └── databend-cli v0.1.0
└── metasrv v0.1.0
    ├── databend-store v0.1.0
    └── kvlocal v0.1.0
        └── common-management v0.1.0

cargo tree -i common-management

common-management v0.1.0
└── databend-query v0.1.0
    ├── databend-cli v0.1.0
    └── fuzz v0.1.0
```

## Changelog




- Improvement


## Related Issues