### PR TITLE
[common/runtime] fix: extend duration to test timeout, hoping it may fix the flaky failure of test block_on

### DIFF
--- a/common/runtime/src/runtime_test.rs
+++ b/common/runtime/src/runtime_test.rs
@@ -70,12 +70,6 @@ fn test_block_on() -> Result<()> {
         Ok(5)
     }
 
-    async fn sleep() -> Result<()> {
-        let deadline = Instant::now() + Duration::from_millis(100);
-        sleep_until(deadline).await;
-        Ok(())
-    }
-
     // Ok.
     {
         let rt = Runtime::with_default_worker_threads().unwrap();
@@ -92,8 +86,14 @@ fn test_block_on() -> Result<()> {
 
     // Timeout error.
     {
+        async fn sleep() -> Result<()> {
+            let deadline = Instant::now() + Duration::from_millis(10_000);
+            sleep_until(deadline).await;
+            Ok(())
+        }
+
         let rt = Runtime::with_default_worker_threads().unwrap();
-        let r = rt.block_on(sleep(), Some(Duration::from_millis(50)));
+        let r = rt.block_on(sleep(), Some(Duration::from_millis(500)));
 
         assert!(r.is_err());
         if let Err(e) = r {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/runtime] fix: extend duration to test timeout, hoping it may fix the flaky failure of test block_on

## Changelog


- Bug Fix




## Related Issues

- maybe fix: #1917 