### PR TITLE
StoreApiProvider uses local kv store if conf.meta.address is empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ dependencies = [
  "headers",
  "hyper",
  "indexmap",
+ "kvlocal",
  "lazy_static",
  "log",
  "metrics",

--- a/common/store-api-sdk/src/lib.rs
+++ b/common/store-api-sdk/src/lib.rs
@@ -23,7 +23,6 @@ pub use flight_token::FlightToken;
 pub use impl_flights::kv_api_impl;
 pub use impl_flights::meta_api_impl;
 pub use impl_flights::storage_api_impl;
-pub use store_api_provider::StoreApiProvider;
 pub use store_client::StoreClient;
 pub use store_client_conf::ClientConf;
 pub use store_client_conf::StoreClientConf;
@@ -38,7 +37,6 @@ mod impl_flights;
 mod store_client;
 #[macro_use]
 mod store_do_action;
-mod store_api_provider;
 mod store_client_conf;
 mod store_do_get;
 

--- a/kvlocal/src/lib.rs
+++ b/kvlocal/src/lib.rs
@@ -17,3 +17,5 @@ mod local_kv_store;
 
 #[cfg(test)]
 mod local_kv_store_test;
+
+pub use local_kv_store::LocalKVStore;

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -40,7 +40,7 @@ common-store-api-sdk= {path = "../common/store-api-sdk" }
 common-io = { path = "../common/io" }
 common-metatypes = { path = "../common/metatypes" }
 common-clickhouse-srv = { path = "../common/clickhouse-srv" }
-
+kvlocal = { path = "../kvlocal"}
 # Github dependencies
 msql-srv = { git = "https://github.com/datafuse-extras/msql-srv", rev = "9c706a3" }
 clickhouse-rs = { git = "https://github.com/datafuse-extras/clickhouse-rs", rev = "c4743a9" }

--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -23,7 +23,6 @@ use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
 use common_planners::CreateDatabasePlan;
 use common_planners::DropDatabasePlan;
-use common_store_api_sdk::StoreApiProvider;
 
 use crate::catalogs::catalog::Catalog;
 use crate::catalogs::impls::meta_backends::EmbeddedMetaBackend;
@@ -33,6 +32,7 @@ use crate::catalogs::meta_backend::MetaBackend;
 use crate::catalogs::Database;
 use crate::catalogs::TableFunctionMeta;
 use crate::catalogs::TableMeta;
+use crate::common::StoreApiProvider;
 use crate::configs::Config;
 use crate::datasources::database::prelude::register_prelude_db_engines;
 use crate::datasources::database_engine::DatabaseEngine;

--- a/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
+++ b/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
@@ -35,11 +35,11 @@ use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
 use common_planners::DropTablePlan;
 use common_runtime::Runtime;
-use common_store_api_sdk::StoreApiProvider;
 
 use crate::catalogs::meta_backend::DatabaseInfo;
 use crate::catalogs::meta_backend::MetaBackend;
 use crate::catalogs::meta_backend::TableInfo;
+use crate::common::StoreApiProvider;
 
 type CatalogTable = common_metatypes::Table;
 type TableMetaCache = LruCache<(MetaId, MetaVersion), Arc<TableInfo>>;

--- a/query/src/common/config_converter.rs
+++ b/query/src/common/config_converter.rs
@@ -56,8 +56,8 @@ impl From<&Config> for StoreClientConf {
         };
 
         StoreClientConf {
-            // kv service config are not separated yet, we use configs::Config.store as it
-            kv_service_config: config.clone(),
+            // kv service is configured by conf.meta
+            kv_service_config: meta_config.clone(),
             block_service_config: config,
             // copy meta config from query config
             meta_service_config: meta_config,

--- a/query/src/common/mod.rs
+++ b/query/src/common/mod.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use hash_table::HashTable;
+pub use hash_table_entity::HashTableEntity;
+pub use hash_table_entity::KeyValueEntity;
+pub use hash_table_iter::HashTableIter;
+pub use hash_table_key::HashTableKeyable;
+
 #[cfg(test)]
 mod hash_table_grower_test;
 
@@ -22,12 +28,8 @@ mod hash_table_entity;
 mod hash_table_grower;
 mod hash_table_iter;
 mod hash_table_key;
-
-pub use hash_table::HashTable;
-pub use hash_table_entity::HashTableEntity;
-pub use hash_table_entity::KeyValueEntity;
-pub use hash_table_iter::HashTableIter;
-pub use hash_table_key::HashTableKeyable;
+mod store_api_provider;
 
 pub type HashMap<Key, Value> = HashTable<Key, KeyValueEntity<Key, Value>>;
 pub type HashMapIterator<Key, Value> = HashTableIter<Key, KeyValueEntity<Key, Value>>;
+pub use store_api_provider::StoreApiProvider;

--- a/query/src/datasources/database/default/default_database.rs
+++ b/query/src/datasources/database/default/default_database.rs
@@ -21,7 +21,6 @@ use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
 use common_planners::CreateTablePlan;
 use common_planners::DropTablePlan;
-use common_store_api_sdk::StoreApiProvider;
 
 use crate::catalogs::impls::util::in_memory_metas::InMemoryMetas;
 use crate::catalogs::meta_backend::MetaBackend;
@@ -29,6 +28,7 @@ use crate::catalogs::meta_backend::TableInfo;
 use crate::catalogs::Database;
 use crate::catalogs::TableFunctionMeta;
 use crate::catalogs::TableMeta;
+use crate::common::StoreApiProvider;
 use crate::datasources::table_engine_registry::TableEngineRegistry;
 
 pub struct DefaultDatabase {

--- a/query/src/datasources/database/default/default_database_factory.rs
+++ b/query/src/datasources/database/default/default_database_factory.rs
@@ -16,12 +16,12 @@
 use std::sync::Arc;
 
 use common_exception::Result;
-use common_store_api_sdk::StoreApiProvider;
 
 use crate::catalogs::meta_backend::DatabaseInfo;
 use crate::catalogs::meta_backend::MetaBackend;
 use crate::catalogs::Database;
 use crate::catalogs::DatabaseEngine;
+use crate::common::StoreApiProvider;
 use crate::configs::Config;
 use crate::datasources::database::default::default_database::DefaultDatabase;
 use crate::datasources::table_engine_registry::TableEngineRegistry;

--- a/query/src/datasources/table/remote/remote_table.rs
+++ b/query/src/datasources/table/remote/remote_table.rs
@@ -28,10 +28,10 @@ use common_planners::Statistics;
 use common_planners::TableOptions;
 use common_planners::TruncateTablePlan;
 use common_store_api::ReadPlanResult;
-use common_store_api_sdk::StoreApiProvider;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
+use crate::common::StoreApiProvider;
 use crate::datasources::table_engine::TableEngine;
 use crate::sessions::DatabendQueryContextRef;
 

--- a/query/src/datasources/table_engine.rs
+++ b/query/src/datasources/table_engine.rs
@@ -16,9 +16,9 @@
 use common_datavalues::DataSchemaRef;
 use common_exception::Result;
 use common_planners::TableOptions;
-use common_store_api_sdk::StoreApiProvider;
 
 use crate::catalogs::Table;
+use crate::common::StoreApiProvider;
 
 pub trait TableEngine: Send + Sync {
     fn try_create(


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

- StoreApiProvider is moved to databend-query
  It is a temp workaround (otherwise, we should merge all the api sdk
  into query) of the dependency issues.
- While returning KVApi from StoreApiProvider, if conf.meta.address is
empty, an instance of LocalKVStore is provided

## Changelog


- Improvement


## Related Issues

## Test Plan

Unit Tests

Stateless Tests

