### PR TITLE
[metasrv] refactor: move key space impl into metasrv/raft

### DIFF
--- a/metasrv/src/meta_service/log_entry.rs
+++ b/metasrv/src/meta_service/log_entry.rs
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::TryFrom;
-
 use async_raft::AppData;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::meta_service::Cmd;
-use crate::meta_service::RaftMes;
 use crate::raft::types::RaftTxId;
 
 /// The application data request type which the `Metasrv` works with.
@@ -37,23 +34,3 @@ pub struct LogEntry {
 }
 
 impl AppData for LogEntry {}
-
-impl tonic::IntoRequest<RaftMes> for LogEntry {
-    fn into_request(self) -> tonic::Request<RaftMes> {
-        let mes = RaftMes {
-            data: serde_json::to_string(&self).expect("fail to serialize"),
-            error: "".to_string(),
-        };
-        tonic::Request::new(mes)
-    }
-}
-
-impl TryFrom<RaftMes> for LogEntry {
-    type Error = tonic::Status;
-
-    fn try_from(mes: RaftMes) -> Result<Self, Self::Error> {
-        let req: LogEntry =
-            serde_json::from_str(&mes.data).map_err(|e| tonic::Status::internal(e.to_string()))?;
-        Ok(req)
-    }
-}

--- a/metasrv/src/meta_service/network.rs
+++ b/metasrv/src/meta_service/network.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 use async_raft::async_trait::async_trait;
@@ -31,6 +32,27 @@ use crate::meta_service::MetaServiceClient;
 use crate::meta_service::RaftMes;
 use crate::meta_service::RetryableError;
 use crate::raft::types::NodeId;
+
+/// Impl grpc method `write`
+impl tonic::IntoRequest<RaftMes> for LogEntry {
+    fn into_request(self) -> tonic::Request<RaftMes> {
+        let mes = RaftMes {
+            data: serde_json::to_string(&self).expect("fail to serialize"),
+            error: "".to_string(),
+        };
+        tonic::Request::new(mes)
+    }
+}
+
+impl TryFrom<RaftMes> for LogEntry {
+    type Error = tonic::Status;
+
+    fn try_from(mes: RaftMes) -> Result<Self, Self::Error> {
+        let req: LogEntry =
+            serde_json::from_str(&mes.data).map_err(|e| tonic::Status::internal(e.to_string()))?;
+        Ok(req)
+    }
+}
 
 impl tonic::IntoRequest<RaftMes> for AppendEntriesRequest<LogEntry> {
     fn into_request(self) -> tonic::Request<RaftMes> {

--- a/metasrv/src/raft/log/raft_log.rs
+++ b/metasrv/src/raft/log/raft_log.rs
@@ -19,8 +19,8 @@ use common_tracing::tracing;
 
 use crate::configs;
 use crate::meta_service::LogEntry;
+use crate::raft::sled_key_spaces::Logs;
 use crate::raft::types::LogIndex;
-use crate::sled_store::sled_key_space;
 use crate::sled_store::AsKeySpace;
 use crate::sled_store::SledSerde;
 use crate::sled_store::SledTree;
@@ -129,7 +129,7 @@ impl RaftLog {
     }
 
     /// Returns a borrowed key space in sled::Tree for logs
-    fn logs(&self) -> AsKeySpace<sled_key_space::Logs> {
+    fn logs(&self) -> AsKeySpace<Logs> {
         self.inner.key_space()
     }
 }

--- a/metasrv/src/raft/sled_impl.rs
+++ b/metasrv/src/raft/sled_impl.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod log;
-pub mod state;
-pub mod state_machine;
-pub mod types;
+use crate::sled_store::SeqNum;
+use crate::sled_store::SledSerde;
 
-mod sled_impl;
-pub mod sled_key_spaces;
+impl SledSerde for SeqNum {}

--- a/metasrv/src/raft/sled_key_spaces.rs
+++ b/metasrv/src/raft/sled_key_spaces.rs
@@ -1,0 +1,95 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_raft::raft::Entry;
+use common_metatypes::KVValue;
+use common_metatypes::SeqValue;
+
+use crate::meta_service::LogEntry;
+use crate::raft::state::RaftStateKey;
+use crate::raft::state::RaftStateValue;
+use crate::raft::state_machine::StateMachineMetaKey;
+use crate::raft::state_machine::StateMachineMetaValue;
+use crate::raft::types::LogIndex;
+use crate::raft::types::Node;
+use crate::raft::types::NodeId;
+use crate::sled_store::sled_key_space::SledKeySpace;
+use crate::sled_store::SeqNum;
+
+/// Types for raft log in SledTree
+pub struct Logs {}
+impl SledKeySpace for Logs {
+    const PREFIX: u8 = 1;
+    const NAME: &'static str = "log";
+    type K = LogIndex;
+    type V = Entry<LogEntry>;
+}
+
+/// Types for Node in SledTree
+pub struct Nodes {}
+impl SledKeySpace for Nodes {
+    const PREFIX: u8 = 2;
+    const NAME: &'static str = "node";
+    type K = NodeId;
+    type V = Node;
+}
+
+/// Key-Value Types for storing meta data of a raft state machine in sled::Tree, e.g. the last applied log id.
+pub struct StateMachineMeta {}
+impl SledKeySpace for StateMachineMeta {
+    const PREFIX: u8 = 3;
+    const NAME: &'static str = "sm-meta";
+    type K = StateMachineMetaKey;
+    type V = StateMachineMetaValue;
+}
+
+/// Key-Value Types for storing meta data of a raft in sled::Tree:
+/// id: NodeId,
+/// hard_state:
+///      current_term,
+///      voted_for,
+pub struct RaftStateKV {}
+impl SledKeySpace for RaftStateKV {
+    const PREFIX: u8 = 4;
+    const NAME: &'static str = "raft-state";
+    type K = RaftStateKey;
+    type V = RaftStateValue;
+}
+
+/// Key-Value Types for storing DFS files in sled::Tree:
+pub struct Files {}
+impl SledKeySpace for Files {
+    const PREFIX: u8 = 5;
+    const NAME: &'static str = "files";
+    type K = String;
+    type V = String;
+}
+
+/// Key-Value Types for storing general purpose kv in sled::Tree:
+pub struct GenericKV {}
+impl SledKeySpace for GenericKV {
+    const PREFIX: u8 = 6;
+    const NAME: &'static str = "generic-kv";
+    type K = String;
+    type V = SeqValue<KVValue<Vec<u8>>>;
+}
+
+/// Key-Value Types for sequence number generator in sled::Tree:
+pub struct Sequences {}
+impl SledKeySpace for Sequences {
+    const PREFIX: u8 = 7;
+    const NAME: &'static str = "sequences";
+    type K = String;
+    type V = SeqNum;
+}

--- a/metasrv/src/raft/state/raft_state.rs
+++ b/metasrv/src/raft/state/raft_state.rs
@@ -17,10 +17,10 @@ use common_exception::ErrorCode;
 use common_tracing::tracing;
 
 use crate::configs;
+use crate::raft::sled_key_spaces::RaftStateKV;
 use crate::raft::state::RaftStateKey;
 use crate::raft::state::RaftStateValue;
 use crate::raft::types::NodeId;
-use crate::sled_store::sled_key_space::RaftStateKV;
 use crate::sled_store::AsKeySpace;
 use crate::sled_store::SledSerde;
 use crate::sled_store::SledTree;

--- a/metasrv/src/raft/state_machine/sm.rs
+++ b/metasrv/src/raft/state_machine/sm.rs
@@ -41,6 +41,11 @@ use sled::IVec;
 use crate::configs;
 use crate::meta_service::Cmd;
 use crate::meta_service::LogEntry;
+use crate::raft::sled_key_spaces::Files;
+use crate::raft::sled_key_spaces::GenericKV;
+use crate::raft::sled_key_spaces::Nodes;
+use crate::raft::sled_key_spaces::Sequences;
+use crate::raft::sled_key_spaces::StateMachineMeta;
 use crate::raft::state_machine::placement::rand_n_from_m;
 use crate::raft::state_machine::AppliedState;
 use crate::raft::state_machine::Placement;
@@ -54,8 +59,6 @@ use crate::raft::types::Node;
 use crate::raft::types::NodeId;
 use crate::raft::types::Slot;
 use crate::sled_store::get_sled_db;
-use crate::sled_store::sled_key_space;
-use crate::sled_store::sled_key_space::StateMachineMeta;
 use crate::sled_store::AsKeySpace;
 use crate::sled_store::SledSerde;
 use crate::sled_store::SledTree;
@@ -913,24 +916,24 @@ impl StateMachine {
         self.sm_tree.key_space()
     }
 
-    pub fn nodes(&self) -> AsKeySpace<sled_key_space::Nodes> {
+    pub fn nodes(&self) -> AsKeySpace<Nodes> {
         self.sm_tree.key_space()
     }
 
     /// The file names stored in this cluster
-    pub fn files(&self) -> AsKeySpace<sled_key_space::Files> {
+    pub fn files(&self) -> AsKeySpace<Files> {
         self.sm_tree.key_space()
     }
 
     /// A kv store of all other general purpose information.
     /// The value is tuple of a monotonic sequence number and userdata value in string.
     /// The sequence number is guaranteed to increment(by some value greater than 0) everytime the record changes.
-    pub fn kvs(&self) -> AsKeySpace<sled_key_space::GenericKV> {
+    pub fn kvs(&self) -> AsKeySpace<GenericKV> {
         self.sm_tree.key_space()
     }
 
     /// storage of auto-incremental number.
-    pub fn sequences(&self) -> AsKeySpace<sled_key_space::Sequences> {
+    pub fn sequences(&self) -> AsKeySpace<Sequences> {
         self.sm_tree.key_space()
     }
 }

--- a/metasrv/src/sled_store/seq_num.rs
+++ b/metasrv/src/sled_store/seq_num.rs
@@ -17,8 +17,6 @@ use std::fmt;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::sled_store::SledSerde;
-
 /// Sequence number that is used in SledTree
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct SeqNum(pub(crate) u64);
@@ -42,5 +40,3 @@ impl From<SeqNum> for u64 {
         sn.0
     }
 }
-
-impl SledSerde for SeqNum {}

--- a/metasrv/src/sled_store/sled_key_space.rs
+++ b/metasrv/src/sled_store/sled_key_space.rs
@@ -19,21 +19,9 @@ use std::fmt::Display;
 use std::ops::Bound;
 use std::ops::RangeBounds;
 
-use async_raft::raft::Entry;
 use common_exception::ErrorCode;
-use common_metatypes::KVValue;
-use common_metatypes::SeqValue;
 use sled::IVec;
 
-use crate::meta_service::LogEntry;
-use crate::raft::state::RaftStateKey;
-use crate::raft::state::RaftStateValue;
-use crate::raft::state_machine::StateMachineMetaKey;
-use crate::raft::state_machine::StateMachineMetaValue;
-use crate::raft::types::LogIndex;
-use crate::raft::types::Node;
-use crate::raft::types::NodeId;
-use crate::sled_store::SeqNum;
 use crate::sled_store::SledOrderedSerde;
 use crate::sled_store::SledSerde;
 
@@ -109,71 +97,4 @@ pub trait SledKeySpace {
         };
         Ok(res)
     }
-}
-
-/// Types for raft log in SledTree
-pub struct Logs {}
-impl SledKeySpace for Logs {
-    const PREFIX: u8 = 1;
-    const NAME: &'static str = "log";
-    type K = LogIndex;
-    type V = Entry<LogEntry>;
-}
-
-/// Types for Node in SledTree
-pub struct Nodes {}
-impl SledKeySpace for Nodes {
-    const PREFIX: u8 = 2;
-    const NAME: &'static str = "node";
-    type K = NodeId;
-    type V = Node;
-}
-
-/// Key-Value Types for storing meta data of a raft state machine in sled::Tree, e.g. the last applied log id.
-pub struct StateMachineMeta {}
-impl SledKeySpace for StateMachineMeta {
-    const PREFIX: u8 = 3;
-    const NAME: &'static str = "sm-meta";
-    type K = StateMachineMetaKey;
-    type V = StateMachineMetaValue;
-}
-
-/// Key-Value Types for storing meta data of a raft in sled::Tree:
-/// id: NodeId,
-/// hard_state:
-///      current_term,
-///      voted_for,
-pub struct RaftStateKV {}
-impl SledKeySpace for RaftStateKV {
-    const PREFIX: u8 = 4;
-    const NAME: &'static str = "raft-state";
-    type K = RaftStateKey;
-    type V = RaftStateValue;
-}
-
-/// Key-Value Types for storing DFS files in sled::Tree:
-pub struct Files {}
-impl SledKeySpace for Files {
-    const PREFIX: u8 = 5;
-    const NAME: &'static str = "files";
-    type K = String;
-    type V = String;
-}
-
-/// Key-Value Types for storing general purpose kv in sled::Tree:
-pub struct GenericKV {}
-impl SledKeySpace for GenericKV {
-    const PREFIX: u8 = 6;
-    const NAME: &'static str = "generic-kv";
-    type K = String;
-    type V = SeqValue<KVValue<Vec<u8>>>;
-}
-
-/// Key-Value Types for sequence number generator in sled::Tree:
-pub struct Sequences {}
-impl SledKeySpace for Sequences {
-    const PREFIX: u8 = 7;
-    const NAME: &'static str = "sequences";
-    type K = String;
-    type V = SeqNum;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: move key space impl into metasrv/raft
`sled_store` should just provide key space trait.
The key spaces that `metasrv` need should not be inside `sled_store`.


##### [metasrv] refactor: move trait impl for network to network.rs

## Changelog




- Improvement


## Related Issues

- #1877 