### PR TITLE
[metasrv] refactor: reorganize config and testing utils

### DIFF
--- a/metasrv/src/configs/mod.rs
+++ b/metasrv/src/configs/mod.rs
@@ -18,5 +18,3 @@ pub mod config;
 mod config_test;
 
 pub use config::Config;
-
-pub use crate::raft::config::RaftConfig;

--- a/metasrv/src/raft/log/raft_log.rs
+++ b/metasrv/src/raft/log/raft_log.rs
@@ -21,7 +21,7 @@ use common_sled_store::AsKeySpace;
 use common_sled_store::SledTree;
 use common_tracing::tracing;
 
-use crate::configs;
+use crate::raft::config::RaftConfig;
 use crate::raft::sled_key_spaces::Logs;
 
 const TREE_RAFT_LOG: &str = "raft_log";
@@ -35,10 +35,7 @@ pub struct RaftLog {
 impl RaftLog {
     /// Open RaftLog
     #[tracing::instrument(level = "info", skip(db))]
-    pub async fn open(
-        db: &sled::Db,
-        config: &configs::RaftConfig,
-    ) -> common_exception::Result<RaftLog> {
+    pub async fn open(db: &sled::Db, config: &RaftConfig) -> common_exception::Result<RaftLog> {
         let tree_name = config.tree_name(TREE_RAFT_LOG);
         let inner = SledTree::open(db, &tree_name, config.is_sync())?;
         let rl = RaftLog { inner };

--- a/metasrv/src/raft/log/raft_log_test.rs
+++ b/metasrv/src/raft/log/raft_log_test.rs
@@ -21,7 +21,7 @@ use common_metatypes::LogEntry;
 use common_runtime::tokio;
 
 use crate::raft::log::RaftLog;
-use crate::tests::service::new_raft_test_context;
+use crate::raft::testing::new_raft_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_open() -> anyhow::Result<()> {

--- a/metasrv/src/raft/log/raft_log_test.rs
+++ b/metasrv/src/raft/log/raft_log_test.rs
@@ -21,15 +21,15 @@ use common_metatypes::LogEntry;
 use common_runtime::tokio;
 
 use crate::raft::log::RaftLog;
-use crate::tests::service::new_sled_test_context;
+use crate::tests::service::new_raft_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_open() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    let tc = new_sled_test_context();
+    let tc = new_raft_test_context();
     let db = &tc.db;
-    RaftLog::open(db, &tc.config.raft_config).await?;
+    RaftLog::open(db, &tc.raft_config).await?;
 
     Ok(())
 }
@@ -38,9 +38,9 @@ async fn test_raft_log_open() -> anyhow::Result<()> {
 async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    let tc = new_sled_test_context();
+    let tc = new_raft_test_context();
     let db = &tc.db;
-    let rl = RaftLog::open(db, &tc.config.raft_config).await?;
+    let rl = RaftLog::open(db, &tc.raft_config).await?;
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -113,9 +113,9 @@ async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
 async fn test_raft_log_insert() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    let tc = new_sled_test_context();
+    let tc = new_raft_test_context();
     let db = &tc.db;
-    let rl = RaftLog::open(db, &tc.config.raft_config).await?;
+    let rl = RaftLog::open(db, &tc.raft_config).await?;
 
     assert_eq!(None, rl.get(&5)?);
 
@@ -150,9 +150,9 @@ async fn test_raft_log_insert() -> anyhow::Result<()> {
 async fn test_raft_log_get() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    let tc = new_sled_test_context();
+    let tc = new_raft_test_context();
     let db = &tc.db;
-    let rl = RaftLog::open(db, &tc.config.raft_config).await?;
+    let rl = RaftLog::open(db, &tc.raft_config).await?;
 
     assert_eq!(None, rl.get(&5)?);
 
@@ -189,9 +189,9 @@ async fn test_raft_log_get() -> anyhow::Result<()> {
 async fn test_raft_log_last() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    let tc = new_sled_test_context();
+    let tc = new_raft_test_context();
     let db = &tc.db;
-    let rl = RaftLog::open(db, &tc.config.raft_config).await?;
+    let rl = RaftLog::open(db, &tc.raft_config).await?;
 
     assert_eq!(None, rl.last()?);
 
@@ -223,9 +223,9 @@ async fn test_raft_log_last() -> anyhow::Result<()> {
 async fn test_raft_log_range_remove() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    let tc = new_sled_test_context();
+    let tc = new_raft_test_context();
     let db = &tc.db;
-    let rl = RaftLog::open(db, &tc.config.raft_config).await?;
+    let rl = RaftLog::open(db, &tc.raft_config).await?;
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {

--- a/metasrv/src/raft/state/raft_state.rs
+++ b/metasrv/src/raft/state/raft_state.rs
@@ -19,7 +19,7 @@ use common_sled_store::AsKeySpace;
 use common_sled_store::SledTree;
 use common_tracing::tracing;
 
-use crate::configs;
+use crate::raft::config::RaftConfig;
 use crate::raft::sled_key_spaces::RaftStateKV;
 use crate::raft::state::RaftStateKey;
 use crate::raft::state::RaftStateValue;
@@ -57,7 +57,7 @@ impl RaftState {
     #[tracing::instrument(level = "info", skip(db))]
     pub async fn open_create(
         db: &sled::Db,
-        config: &configs::RaftConfig,
+        config: &RaftConfig,
         open: Option<()>,
         create: Option<()>,
     ) -> common_exception::Result<RaftState> {

--- a/metasrv/src/raft/state/raft_state_test.rs
+++ b/metasrv/src/raft/state/raft_state_test.rs
@@ -15,7 +15,7 @@ use async_raft::storage::HardState;
 use common_runtime::tokio;
 
 use crate::raft::state::RaftState;
-use crate::tests::service::new_raft_test_context;
+use crate::raft::testing::new_raft_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_state_create() -> anyhow::Result<()> {

--- a/metasrv/src/raft/state/raft_state_test.rs
+++ b/metasrv/src/raft/state/raft_state_test.rs
@@ -15,7 +15,7 @@ use async_raft::storage::HardState;
 use common_runtime::tokio;
 
 use crate::raft::state::RaftState;
-use crate::tests::service::new_sled_test_context;
+use crate::tests::service::new_raft_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_state_create() -> anyhow::Result<()> {
@@ -25,25 +25,25 @@ async fn test_raft_state_create() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut tc = new_sled_test_context();
+    let mut tc = new_raft_test_context();
     let db = &tc.db;
-    tc.config.raft_config.id = 3;
-    let rs = RaftState::open_create(db, &tc.config.raft_config, None, Some(())).await?;
+    tc.raft_config.id = 3;
+    let rs = RaftState::open_create(db, &tc.raft_config, None, Some(())).await?;
     let is_open = rs.is_open();
 
     assert_eq!(3, rs.id);
     assert!(!is_open);
 
-    tc.config.raft_config.id = 4;
-    let res = RaftState::open_create(db, &tc.config.raft_config, None, Some(())).await;
+    tc.raft_config.id = 4;
+    let res = RaftState::open_create(db, &tc.raft_config, None, Some(())).await;
     assert!(res.is_err());
     assert_eq!(
         "Code: 2402, displayText = raft state present id=3, can not create.",
         res.unwrap_err().to_string()
     );
 
-    tc.config.raft_config.id = 3;
-    let res = RaftState::open_create(db, &tc.config.raft_config, None, Some(())).await;
+    tc.raft_config.id = 3;
+    let res = RaftState::open_create(db, &tc.raft_config, None, Some(())).await;
     assert!(res.is_err());
     assert_eq!(
         "Code: 2402, displayText = raft state present id=3, can not create.",
@@ -60,17 +60,17 @@ async fn test_raft_state_open() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut tc = new_sled_test_context();
+    let mut tc = new_raft_test_context();
     let db = &tc.db;
-    tc.config.raft_config.id = 3;
-    let rs = RaftState::open_create(db, &tc.config.raft_config, None, Some(())).await?;
+    tc.raft_config.id = 3;
+    let rs = RaftState::open_create(db, &tc.raft_config, None, Some(())).await?;
     let is_open = rs.is_open();
 
     assert_eq!(3, rs.id);
     assert!(!is_open);
 
-    tc.config.raft_config.id = 1000;
-    let rs = RaftState::open_create(db, &tc.config.raft_config, Some(()), None).await?;
+    tc.raft_config.id = 1000;
+    let rs = RaftState::open_create(db, &tc.raft_config, Some(()), None).await?;
     let is_open = rs.is_open();
     assert_eq!(3, rs.id);
     assert!(is_open);
@@ -82,10 +82,10 @@ async fn test_raft_state_open_or_create() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut tc = new_sled_test_context();
+    let mut tc = new_raft_test_context();
     let db = &tc.db;
-    tc.config.raft_config.id = 3;
-    let rs = RaftState::open_create(db, &tc.config.raft_config, Some(()), Some(())).await?;
+    tc.raft_config.id = 3;
+    let rs = RaftState::open_create(db, &tc.raft_config, Some(()), Some(())).await?;
     let is_open = rs.is_open();
 
     assert_eq!(3, rs.id);
@@ -101,10 +101,10 @@ async fn test_raft_state_write_read_hard_state() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut tc = new_sled_test_context();
+    let mut tc = new_raft_test_context();
     let db = &tc.db;
-    tc.config.raft_config.id = 3;
-    let rs = RaftState::open_create(db, &tc.config.raft_config, None, Some(())).await?;
+    tc.raft_config.id = 3;
+    let rs = RaftState::open_create(db, &tc.raft_config, None, Some(())).await?;
 
     assert_eq!(3, rs.id);
 
@@ -136,10 +136,10 @@ async fn test_raft_state_write_read_state_machine_id() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut tc = new_sled_test_context();
+    let mut tc = new_raft_test_context();
     let db = &tc.db;
-    tc.config.raft_config.id = 3;
-    let rs = RaftState::open_create(db, &tc.config.raft_config, None, Some(())).await?;
+    tc.raft_config.id = 3;
+    let rs = RaftState::open_create(db, &tc.raft_config, None, Some(())).await?;
 
     // read got a None
 

--- a/metasrv/src/raft/state_machine/sm.rs
+++ b/metasrv/src/raft/state_machine/sm.rs
@@ -47,7 +47,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use sled::IVec;
 
-use crate::configs;
+use crate::raft::config::RaftConfig;
 use crate::raft::sled_key_spaces::Files;
 use crate::raft::sled_key_spaces::GenericKV;
 use crate::raft::sled_key_spaces::Nodes;
@@ -95,7 +95,7 @@ impl Default for Replication {
 #[derive(Debug)]
 pub struct StateMachine {
     // TODO(xp): config is not required. Remove it after snapshot is done.
-    config: configs::RaftConfig,
+    config: RaftConfig,
 
     /// The dedicated sled db to store everything about a state machine.
     /// A state machine has several trees opened on this db.
@@ -196,12 +196,12 @@ impl StateMachine {
     }
 
     #[tracing::instrument(level = "debug", skip(config), fields(config_id=%config.config_id, prefix=%config.sled_tree_prefix))]
-    pub fn tree_name(config: &configs::RaftConfig, sm_id: u64) -> String {
+    pub fn tree_name(config: &RaftConfig, sm_id: u64) -> String {
         config.tree_name(format!("{}/{}", TREE_STATE_MACHINE, sm_id))
     }
 
     #[tracing::instrument(level = "debug", skip(config), fields(config_id=config.config_id.as_str()))]
-    pub fn clean(config: &configs::RaftConfig, sm_id: u64) -> common_exception::Result<()> {
+    pub fn clean(config: &RaftConfig, sm_id: u64) -> common_exception::Result<()> {
         let tree_name = StateMachine::tree_name(config, sm_id);
 
         let db = get_sled_db();
@@ -214,10 +214,7 @@ impl StateMachine {
     }
 
     #[tracing::instrument(level = "debug", skip(config), fields(config_id=config.config_id.as_str()))]
-    pub async fn open(
-        config: &configs::RaftConfig,
-        sm_id: u64,
-    ) -> common_exception::Result<StateMachine> {
+    pub async fn open(config: &RaftConfig, sm_id: u64) -> common_exception::Result<StateMachine> {
         let db = get_sled_db();
 
         let tree_name = StateMachine::tree_name(config, sm_id);

--- a/metasrv/src/raft/state_machine/state_machine_test.rs
+++ b/metasrv/src/raft/state_machine/state_machine_test.rs
@@ -42,7 +42,7 @@ use crate::raft::state_machine::AppliedState;
 use crate::raft::state_machine::Replication;
 use crate::raft::state_machine::SerializableSnapshot;
 use crate::raft::state_machine::StateMachine;
-use crate::tests::service::new_test_context;
+use crate::tests::service::new_raft_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_assign_rand_nodes_to_slot() -> anyhow::Result<()> {
@@ -52,8 +52,8 @@ async fn test_state_machine_assign_rand_nodes_to_slot() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
-    let mut sm = StateMachine::open(&tc.config.raft_config, 1).await?;
+    let tc = new_raft_test_context();
+    let mut sm = StateMachine::open(&tc.raft_config, 1).await?;
     sm.nodes()
         .append(&[
             (1, Node::default()),
@@ -93,8 +93,8 @@ async fn test_state_machine_init_slots() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
-    let mut sm = StateMachine::open(&tc.config.raft_config, 1).await?;
+    let tc = new_raft_test_context();
+    let mut sm = StateMachine::open(&tc.raft_config, 1).await?;
     sm.nodes()
         .append(&[
             (1, Node::default()),
@@ -126,8 +126,8 @@ async fn test_state_machine_builder() -> anyhow::Result<()> {
     let _ent = ut_span.enter();
 
     {
-        let tc = new_test_context();
-        let sm = StateMachine::open(&tc.config.raft_config, 1).await?;
+        let tc = new_raft_test_context();
+        let sm = StateMachine::open(&tc.raft_config, 1).await?;
 
         assert_eq!(3, sm.slots.len());
         let Replication::Mirror(n) = sm.replication;
@@ -135,8 +135,8 @@ async fn test_state_machine_builder() -> anyhow::Result<()> {
     }
 
     {
-        let tc = new_test_context();
-        let sm = StateMachine::open(&tc.config.raft_config, 1).await?;
+        let tc = new_raft_test_context();
+        let sm = StateMachine::open(&tc.raft_config, 1).await?;
 
         let sm = StateMachine::initializer()
             .slots(5)
@@ -156,8 +156,8 @@ async fn test_state_machine_apply_non_dup_incr_seq() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
-    let mut sm = StateMachine::open(&tc.config.raft_config, 1).await?;
+    let tc = new_raft_test_context();
+    let mut sm = StateMachine::open(&tc.raft_config, 1).await?;
 
     for i in 0..3 {
         // incr "foo"
@@ -187,8 +187,8 @@ async fn test_state_machine_apply_incr_seq() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
-    let mut sm = StateMachine::open(&tc.config.raft_config, 1).await?;
+    let tc = new_raft_test_context();
+    let mut sm = StateMachine::open(&tc.raft_config, 1).await?;
 
     let cases = crate::raft::state_machine::testing::cases_incr_seq();
 
@@ -215,8 +215,8 @@ async fn test_state_machine_apply_add_database() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
-    let mut m = StateMachine::open(&tc.config.raft_config, 1).await?;
+    let tc = new_raft_test_context();
+    let mut m = StateMachine::open(&tc.raft_config, 1).await?;
 
     struct T {
         name: &'static str,
@@ -288,8 +288,8 @@ async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Res
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
-    let mut sm = StateMachine::open(&tc.config.raft_config, 1).await?;
+    let tc = new_raft_test_context();
+    let mut sm = StateMachine::open(&tc.raft_config, 1).await?;
 
     struct T {
         // input:
@@ -442,8 +442,8 @@ async fn test_state_machine_apply_non_dup_generic_kv_value_meta() -> anyhow::Res
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
-    let mut sm = StateMachine::open(&tc.config.raft_config, 1).await?;
+    let tc = new_raft_test_context();
+    let mut sm = StateMachine::open(&tc.raft_config, 1).await?;
 
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -570,8 +570,8 @@ async fn test_state_machine_apply_non_dup_generic_kv_delete() -> anyhow::Result<
     for (i, c) in cases.iter().enumerate() {
         let mes = format!("{}-th: {}({})", i, c.key, c.seq);
 
-        let tc = new_test_context();
-        let mut sm = StateMachine::open(&tc.config.raft_config, 1).await?;
+        let tc = new_raft_test_context();
+        let mut sm = StateMachine::open(&tc.raft_config, 1).await?;
 
         // prepare an record
         sm.apply_cmd(&Cmd::UpsertKV {
@@ -615,8 +615,8 @@ async fn test_state_machine_apply_add_file() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
-    let mut sm = StateMachine::open(&tc.config.raft_config, 1).await?;
+    let tc = new_raft_test_context();
+    let mut sm = StateMachine::open(&tc.raft_config, 1).await?;
 
     let cases = crate::raft::state_machine::testing::cases_add_file();
 
@@ -654,8 +654,8 @@ async fn test_state_machine_apply_set_file() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
-    let mut sm = StateMachine::open(&tc.config.raft_config, 1).await?;
+    let tc = new_raft_test_context();
+    let mut sm = StateMachine::open(&tc.raft_config, 1).await?;
 
     let cases = crate::raft::state_machine::testing::cases_set_file();
 
@@ -696,8 +696,8 @@ async fn test_state_machine_snapshot() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
-    let mut sm = StateMachine::open(&tc.config.raft_config, 0).await?;
+    let tc = new_raft_test_context();
+    let mut sm = StateMachine::open(&tc.raft_config, 0).await?;
 
     let (logs, want) = snapshot_logs();
     // TODO(xp): following logs are not saving to sled yet:

--- a/metasrv/src/raft/state_machine/state_machine_test.rs
+++ b/metasrv/src/raft/state_machine/state_machine_test.rs
@@ -42,7 +42,7 @@ use crate::raft::state_machine::AppliedState;
 use crate::raft::state_machine::Replication;
 use crate::raft::state_machine::SerializableSnapshot;
 use crate::raft::state_machine::StateMachine;
-use crate::tests::service::new_raft_test_context;
+use crate::raft::testing::new_raft_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_assign_rand_nodes_to_slot() -> anyhow::Result<()> {

--- a/metasrv/src/raft/testing.rs
+++ b/metasrv/src/raft/testing.rs
@@ -14,7 +14,7 @@
 
 use common_sled_store::get_sled_db;
 
-use crate::configs::RaftConfig;
+use crate::raft::config::RaftConfig;
 
 pub struct RaftTestContext {
     pub raft_config: RaftConfig,

--- a/metasrv/src/raft/testing.rs
+++ b/metasrv/src/raft/testing.rs
@@ -12,14 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod config;
-pub mod log;
-pub mod sled_key_spaces;
-pub mod state;
-pub mod state_machine;
+use common_sled_store::get_sled_db;
 
-#[cfg(test)]
-mod raft_types_test;
+use crate::configs::RaftConfig;
 
-#[cfg(test)]
-mod testing;
+pub struct RaftTestContext {
+    pub raft_config: RaftConfig,
+    pub db: sled::Db,
+}
+
+/// Create a new context for testing sled
+pub fn new_raft_test_context() -> RaftTestContext {
+    // config for unit test of sled db, meta_sync() is true by default.
+    let mut config = RaftConfig::empty();
+
+    config.sled_tree_prefix = format!("test-{}-", 30900 + common_uniq_id::uniq_usize());
+
+    RaftTestContext {
+        raft_config: config,
+        db: get_sled_db(),
+    }
+}

--- a/metasrv/src/tests/service.rs
+++ b/metasrv/src/tests/service.rs
@@ -29,6 +29,7 @@ use crate::configs;
 use crate::meta_service::GetReq;
 use crate::meta_service::MetaNode;
 use crate::meta_service::MetaServiceClient;
+use crate::raft::config::RaftConfig;
 
 // Start one random service and get the session manager.
 #[tracing::instrument(level = "info")]
@@ -128,20 +129,20 @@ pub fn new_test_context() -> MetaSrvTestContext {
     }
 }
 
-pub struct SledTestContext {
-    pub config: configs::Config,
+pub struct RaftTestContext {
+    pub raft_config: RaftConfig,
     pub db: sled::Db,
 }
 
 /// Create a new context for testing sled
-pub fn new_sled_test_context() -> SledTestContext {
+pub fn new_raft_test_context() -> RaftTestContext {
     // config for unit test of sled db, meta_sync() is true by default.
-    let mut config = configs::Config::empty();
+    let mut config = RaftConfig::empty();
 
-    config.raft_config.sled_tree_prefix = format!("test-{}-", next_port());
+    config.sled_tree_prefix = format!("test-{}-", next_port());
 
-    SledTestContext {
-        config,
+    RaftTestContext {
+        raft_config: config,
         db: get_sled_db(),
     }
 }

--- a/metasrv/src/tests/service.rs
+++ b/metasrv/src/tests/service.rs
@@ -17,19 +17,15 @@ use std::sync::Arc;
 use anyhow::Result;
 use common_runtime::tokio;
 use common_runtime::tokio::sync::oneshot;
-use common_sled_store::get_sled_db;
 use common_tracing::tracing;
-// use common_tracing::tracing::Span;
 use tempfile::tempdir;
 use tempfile::TempDir;
 
-// use tracing_appender::non_blocking::WorkerGuard;
 use crate::api::FlightServer;
 use crate::configs;
 use crate::meta_service::GetReq;
 use crate::meta_service::MetaNode;
 use crate::meta_service::MetaServiceClient;
-use crate::raft::config::RaftConfig;
 
 // Start one random service and get the session manager.
 #[tracing::instrument(level = "info")]
@@ -126,24 +122,6 @@ pub fn new_test_context() -> MetaSrvTestContext {
         meta_nodes: vec![],
 
         channels: None,
-    }
-}
-
-pub struct RaftTestContext {
-    pub raft_config: RaftConfig,
-    pub db: sled::Db,
-}
-
-/// Create a new context for testing sled
-pub fn new_raft_test_context() -> RaftTestContext {
-    // config for unit test of sled db, meta_sync() is true by default.
-    let mut config = RaftConfig::empty();
-
-    config.sled_tree_prefix = format!("test-{}-", next_port());
-
-    RaftTestContext {
-        raft_config: config,
-        db: get_sled_db(),
     }
 }
 

--- a/store/src/configs/config.rs
+++ b/store/src/configs/config.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use lazy_static::lazy_static;
+use metasrv::raft::config::RaftConfig;
 use structopt::StructOpt;
 use structopt_toml::StructOptToml;
 
@@ -82,7 +83,7 @@ pub struct Config {
 
     /// Config for the embedded metasrv.
     #[structopt(flatten)]
-    pub meta_config: metasrv::configs::RaftConfig,
+    pub meta_config: RaftConfig,
 
     #[structopt(
         long,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: config should not re-export RaftConfig

##### [metasrv] refactor: move raft test supporting utils into metasrv/raft/testing.rs

##### [metasrv] refactor: rename SledTestContext to RaftTestContext since it just support raft store tests

## Changelog




- Improvement


## Related Issues

- fix: #1877 