### PR TITLE
[improvement] add Apache 2.0 license to common-io

### DIFF
--- a/common/io/Cargo.toml
+++ b/common/io/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "common-io"
 version = "0.1.0"
+authors = ["Databend Authors <opensource@datafuselabs.com>"]
+license = "Apache-2.0"
+publish = false
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

add Apache 2.0 license to common-io

## Changelog

- Improvement

## Related Issues

Fixes #1956

## Test Plan

None

