### PR TITLE
add `row_count` to struct `ColStats`

### DIFF
--- a/query/src/datasources/table/fuse/io/block_appender.rs
+++ b/query/src/datasources/table/fuse/io/block_appender.rs
@@ -112,6 +112,8 @@ impl FuseTable {
 pub fn block_stats(data_block: &DataBlock) -> Result<HashMap<ColumnId, (DataType, ColStats)>> {
     // TODO column id is FAKED, this is OK as long as table schema is NOT changed, which is not realistic
     // we should extend DataField with column_id ...
+
+    let row_count = data_block.num_rows();
     (0..).into_iter().zip(data_block.columns().iter()).try_fold(
         HashMap::new(),
         |mut res, (idx, col)| {
@@ -136,11 +138,14 @@ pub fn block_stats(data_block: &DataBlock) -> Result<HashMap<ColumnId, (DataType
                     }
                 }
             };
+
             let col_stats = ColStats {
                 min,
                 max,
                 null_count,
+                row_count,
             };
+
             res.insert(idx, (data_type, col_stats));
             Ok(res)
         },

--- a/query/src/datasources/table/fuse/meta/table_snapshot.rs
+++ b/query/src/datasources/table/fuse/meta/table_snapshot.rs
@@ -83,6 +83,7 @@ pub struct ColStats {
     pub min: DataValue,
     pub max: DataValue,
     pub null_count: usize,
+    pub row_count: usize,
 }
 
 #[allow(dead_code)]

--- a/query/src/datasources/table/fuse/util/statistic_helper.rs
+++ b/query/src/datasources/table/fuse/util/statistic_helper.rs
@@ -51,11 +51,13 @@ pub fn column_stats_reduce(
             let mut min_stats = Vec::with_capacity(stats.len());
             let mut max_stats = Vec::with_capacity(stats.len());
             let mut null_count = 0;
+            let mut row_count = 0;
 
             for col_stats in stats {
                 min_stats.push(col_stats.min.clone());
                 max_stats.push(col_stats.max.clone());
                 null_count += col_stats.null_count;
+                row_count += col_stats.row_count;
             }
 
             let min =
@@ -70,6 +72,7 @@ pub fn column_stats_reduce(
                 min,
                 max,
                 null_count,
+                row_count,
             });
             Ok(acc)
         },


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add new attribute `row_count` to struct `ColStats`.

cc @zhyass, if anything does not meet the requirements of the indexing layer, pls inform me 

## Changelog


- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues
None

## Test Plan

Unit Tests

Stateless Tests

