### PR TITLE
CONFIG-1987: storage config

### DIFF
--- a/common/store-api-sdk/src/store_client_conf.rs
+++ b/common/store-api-sdk/src/store_client_conf.rs
@@ -19,8 +19,6 @@ use crate::RpcClientTlsConfig;
 pub struct StoreClientConf {
     pub meta_service_config: ClientConf,
     pub kv_service_config: ClientConf,
-    // deprecated, should be replace by FuseDFS config
-    pub block_service_config: ClientConf,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -83,7 +83,7 @@ structopt = "0.3"
 structopt-toml = "0.5.0"
 threadpool = "1.8.1"
 tokio-stream = { version = "0.1", features = ["net"] }
-toml = "0.5.6"
+toml = "0.5.8"
 tonic = "0.5.2"
 walkdir = "2.3.2"
 axum = {version = "0.2.5", features=["headers"] }

--- a/query/src/bin/databend-query.rs
+++ b/query/src/bin/databend-query.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("{:?}", conf);
     info!(
         "DatabendQuery v-{}",
-        *databend_query::configs::config::DATABEND_COMMIT_VERSION,
+        *databend_query::configs::DATABEND_COMMIT_VERSION,
     );
 
     // User manager and init the default users.

--- a/query/src/common/storeapi/config_converter.rs
+++ b/query/src/common/storeapi/config_converter.rs
@@ -23,22 +23,6 @@ use crate::configs::Config;
 // we provide a converter for it -- just copy things around
 impl From<&Config> for StoreClientConf {
     fn from(conf: &Config) -> Self {
-        let tls_conf = if conf.tls_store_cli_enabled() {
-            Some(RpcClientTlsConfig {
-                rpc_tls_server_root_ca_cert: conf.store.rpc_tls_store_server_root_ca_cert.clone(),
-                domain_name: conf.store.rpc_tls_store_service_domain_name.clone(),
-            })
-        } else {
-            None
-        };
-
-        let config = ClientConf {
-            address: conf.store.store_address.clone(),
-            username: conf.store.store_username.clone(),
-            password: conf.store.store_password.clone(),
-            tls_conf,
-        };
-
         let meta_tls_conf = if conf.tls_meta_cli_enabled() {
             Some(RpcClientTlsConfig {
                 rpc_tls_server_root_ca_cert: conf.meta.rpc_tls_meta_server_root_ca_cert.clone(),
@@ -58,7 +42,6 @@ impl From<&Config> for StoreClientConf {
         StoreClientConf {
             // kv service is configured by conf.meta
             kv_service_config: meta_config.clone(),
-            block_service_config: config,
             // copy meta config from query config
             meta_service_config: meta_config,
         }

--- a/query/src/configs/config.rs
+++ b/query/src/configs/config.rs
@@ -21,12 +21,8 @@ use lazy_static::lazy_static;
 use structopt::StructOpt;
 use structopt_toml::StructOptToml;
 
+use crate::configs::QueryConfig;
 use crate::configs::StorageConfig;
-use crate::configs::DFS_STORAGE_ADDRESS;
-use crate::configs::DFS_STORAGE_PASSWORD;
-use crate::configs::DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT;
-use crate::configs::DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME;
-use crate::configs::DFS_STORAGE_USERNAME;
 
 lazy_static! {
     pub static ref DATABEND_COMMIT_VERSION: String = {
@@ -48,42 +44,9 @@ lazy_static! {
     };
 }
 
-macro_rules! env_helper {
-    ($config:expr, $struct: tt, $field:tt, $field_type: ty, $env:expr) => {
-        let env_var = std::env::var_os($env)
-            .unwrap_or($config.$struct.$field.to_string().into())
-            .into_string()
-            .expect(format!("cannot convert {} to string", $env).as_str());
-        $config.$struct.$field = env_var
-            .parse::<$field_type>()
-            .expect(format!("cannot convert {} to {}", $env, stringify!($field_type)).as_str());
-    };
-}
-
 // Log env.
 const LOG_LEVEL: &str = "LOG_LEVEL";
 const LOG_DIR: &str = "LOG_DIR";
-
-// Query env.
-const QUERY_TENANT: &str = "QUERY_TENANT";
-const QUERY_NAMESPACE: &str = "QUERY_NAMESPACE";
-const QUERY_NUM_CPUS: &str = "QUERY_NUM_CPUS";
-const QUERY_MYSQL_HANDLER_HOST: &str = "QUERY_MYSQL_HANDLER_HOST";
-const QUERY_MYSQL_HANDLER_PORT: &str = "QUERY_MYSQL_HANDLER_PORT";
-const QUERY_MAX_ACTIVE_SESSIONS: &str = "QUERY_MAX_ACTIVE_SESSIONS";
-const QUERY_CLICKHOUSE_HANDLER_HOST: &str = "QUERY_CLICKHOUSE_HANDLER_HOST";
-const QUERY_CLICKHOUSE_HANDLER_PORT: &str = "QUERY_CLICKHOUSE_HANDLER_PORT";
-const QUERY_FLIGHT_API_ADDRESS: &str = "QUERY_FLIGHT_API_ADDRESS";
-const QUERY_HTTP_API_ADDRESS: &str = "QUERY_HTTP_API_ADDRESS";
-const QUERY_METRICS_API_ADDRESS: &str = "QUERY_METRIC_API_ADDRESS";
-const QUERY_API_TLS_SERVER_CERT: &str = "QUERY_API_TLS_SERVER_CERT";
-const QUERY_API_TLS_SERVER_KEY: &str = "QUERY_API_TLS_SERVER_KEY";
-const QUERY_API_TLS_SERVER_ROOT_CA_CERT: &str = "QUERY_API_TLS_SERVER_ROOT_CA_CERT";
-
-const QUERY_RPC_TLS_SERVER_CERT: &str = "QUERY_RPC_TLS_SERVER_CERT";
-const QUERY_RPC_TLS_SERVER_KEY: &str = "QUERY_RPC_TLS_SERVER_KEY";
-const QUERY_RPC_TLS_SERVER_ROOT_CA_CERT: &str = "QUERY_RPC_TLS_SERVER_ROOT_CA_CERT";
-const QUERY_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "QUERY_RPC_TLS_SERVICE_DOMAIN_NAME";
 
 // Meta env.
 const META_ADDRESS: &str = "META_ADDRESS";
@@ -172,156 +135,6 @@ impl fmt::Debug for MetaConfig {
         write!(f, "meta_user: \"{}\", ", self.meta_username)?;
         write!(f, "meta_password: \"******\"")?;
         write!(f, "}}")
-    }
-}
-
-/// Query config group.
-/// serde(default) make the toml de to default working.
-#[derive(
-    Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
-)]
-pub struct QueryConfig {
-    #[structopt(long, env = QUERY_TENANT, default_value = "", help = "Tenant id for get the information from the MetaStore")]
-    #[serde(default)]
-    pub tenant: String,
-
-    #[structopt(long, env = QUERY_NAMESPACE, default_value = "", help = "Namespace for construct the cluster")]
-    #[serde(default)]
-    pub namespace: String,
-
-    #[structopt(long, env = QUERY_NUM_CPUS, default_value = "0")]
-    #[serde(default)]
-    pub num_cpus: u64,
-
-    #[structopt(
-    long,
-    env = QUERY_MYSQL_HANDLER_HOST,
-    default_value = "127.0.0.1"
-    )]
-    #[serde(default)]
-    pub mysql_handler_host: String,
-
-    #[structopt(long, env = QUERY_MYSQL_HANDLER_PORT, default_value = "3307")]
-    #[serde(default)]
-    pub mysql_handler_port: u16,
-
-    #[structopt(
-    long,
-    env = QUERY_MAX_ACTIVE_SESSIONS,
-    default_value = "256"
-    )]
-    #[serde(default)]
-    pub max_active_sessions: u64,
-
-    #[structopt(
-    long,
-    env = QUERY_CLICKHOUSE_HANDLER_HOST,
-    default_value = "127.0.0.1"
-    )]
-    #[serde(default)]
-    pub clickhouse_handler_host: String,
-
-    #[structopt(
-    long,
-    env = QUERY_CLICKHOUSE_HANDLER_PORT,
-    default_value = "9000"
-    )]
-    #[serde(default)]
-    pub clickhouse_handler_port: u16,
-
-    #[structopt(
-    long,
-    env = QUERY_FLIGHT_API_ADDRESS,
-    default_value = "127.0.0.1:9090"
-    )]
-    #[serde(default)]
-    pub flight_api_address: String,
-
-    #[structopt(
-    long,
-    env = QUERY_HTTP_API_ADDRESS,
-    default_value = "127.0.0.1:8080"
-    )]
-    #[serde(default)]
-    pub http_api_address: String,
-
-    #[structopt(
-    long,
-    env = QUERY_METRICS_API_ADDRESS,
-    default_value = "127.0.0.1:7070"
-    )]
-    #[serde(default)]
-    pub metric_api_address: String,
-
-    #[structopt(long, env = QUERY_API_TLS_SERVER_CERT, default_value = "")]
-    #[serde(default)]
-    pub api_tls_server_cert: String,
-
-    #[structopt(long, env = QUERY_API_TLS_SERVER_KEY, default_value = "")]
-    #[serde(default)]
-    pub api_tls_server_key: String,
-
-    #[structopt(long, env = QUERY_API_TLS_SERVER_ROOT_CA_CERT, default_value = "")]
-    #[serde(default)]
-    pub api_tls_server_root_ca_cert: String,
-
-    #[structopt(
-        long,
-        env = "QUERY_RPC_TLS_SERVER_CERT",
-        default_value = "",
-        help = "rpc server cert"
-    )]
-    #[serde(default)]
-    pub rpc_tls_server_cert: String,
-
-    #[structopt(
-        long,
-        env = "QUERY_RPC_TLS_SERVER_KEY",
-        default_value = "key for rpc server cert"
-    )]
-    #[serde(default)]
-    pub rpc_tls_server_key: String,
-
-    #[structopt(
-        long,
-        env = "QUERY_RPC_TLS_SERVER_ROOT_CA_CERT",
-        default_value = "",
-        help = "Certificate for client to identify query rpc server"
-    )]
-    #[serde(default)]
-    pub rpc_tls_query_server_root_ca_cert: String,
-
-    #[structopt(
-        long,
-        env = "QUERY_RPC_TLS_SERVICE_DOMAIN_NAME",
-        default_value = "localhost"
-    )]
-    #[serde(default)]
-    pub rpc_tls_query_service_domain_name: String,
-}
-
-impl QueryConfig {
-    pub fn default() -> Self {
-        QueryConfig {
-            tenant: "".to_string(),
-            namespace: "".to_string(),
-            num_cpus: 8,
-            mysql_handler_host: "127.0.0.1".to_string(),
-            mysql_handler_port: 3307,
-            max_active_sessions: 256,
-            clickhouse_handler_host: "127.0.0.1".to_string(),
-            clickhouse_handler_port: 9000,
-            flight_api_address: "127.0.0.1:9090".to_string(),
-            http_api_address: "127.0.0.1:8080".to_string(),
-            metric_api_address: "127.0.0.1:7070".to_string(),
-            api_tls_server_cert: "".to_string(),
-            api_tls_server_key: "".to_string(),
-            api_tls_server_root_ca_cert: "".to_string(),
-            rpc_tls_server_cert: "".to_string(),
-            rpc_tls_server_key: "".to_string(),
-            rpc_tls_query_server_root_ca_cert: "".to_string(),
-            rpc_tls_query_service_domain_name: "localhost".to_string(),
-        }
     }
 }
 
@@ -417,152 +230,10 @@ impl Config {
         );
 
         // Storage.
-        env_helper!(
-            mut_config.storage,
-            dfs,
-            address,
-            String,
-            DFS_STORAGE_ADDRESS
-        );
-        env_helper!(
-            mut_config.storage,
-            dfs,
-            username,
-            String,
-            DFS_STORAGE_USERNAME
-        );
-        env_helper!(
-            mut_config.storage,
-            dfs,
-            password,
-            String,
-            DFS_STORAGE_PASSWORD
-        );
-        env_helper!(
-            mut_config.storage,
-            dfs,
-            rpc_tls_storage_server_root_ca_cert,
-            String,
-            DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT
-        );
-        env_helper!(
-            mut_config.storage,
-            dfs,
-            rpc_tls_storage_service_domain_name,
-            String,
-            DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME
-        );
+        StorageConfig::load_from_env(&mut mut_config);
 
         // Query.
-        env_helper!(mut_config, query, tenant, String, QUERY_TENANT);
-        env_helper!(mut_config, query, namespace, String, QUERY_NAMESPACE);
-        env_helper!(mut_config, query, num_cpus, u64, QUERY_NUM_CPUS);
-        env_helper!(
-            mut_config,
-            query,
-            mysql_handler_host,
-            String,
-            QUERY_MYSQL_HANDLER_HOST
-        );
-        env_helper!(
-            mut_config,
-            query,
-            mysql_handler_port,
-            u16,
-            QUERY_MYSQL_HANDLER_PORT
-        );
-        env_helper!(
-            mut_config,
-            query,
-            max_active_sessions,
-            u64,
-            QUERY_MAX_ACTIVE_SESSIONS
-        );
-        env_helper!(
-            mut_config,
-            query,
-            clickhouse_handler_host,
-            String,
-            QUERY_CLICKHOUSE_HANDLER_HOST
-        );
-        env_helper!(
-            mut_config,
-            query,
-            clickhouse_handler_port,
-            u16,
-            QUERY_CLICKHOUSE_HANDLER_PORT
-        );
-        env_helper!(
-            mut_config,
-            query,
-            flight_api_address,
-            String,
-            QUERY_FLIGHT_API_ADDRESS
-        );
-        env_helper!(
-            mut_config,
-            query,
-            http_api_address,
-            String,
-            QUERY_HTTP_API_ADDRESS
-        );
-        env_helper!(
-            mut_config,
-            query,
-            metric_api_address,
-            String,
-            QUERY_METRICS_API_ADDRESS
-        );
-
-        // for api http service
-        env_helper!(
-            mut_config,
-            query,
-            api_tls_server_cert,
-            String,
-            QUERY_API_TLS_SERVER_CERT
-        );
-
-        env_helper!(
-            mut_config,
-            query,
-            api_tls_server_key,
-            String,
-            QUERY_API_TLS_SERVER_KEY
-        );
-
-        // for query rpc server
-        env_helper!(
-            mut_config,
-            query,
-            rpc_tls_server_cert,
-            String,
-            QUERY_RPC_TLS_SERVER_CERT
-        );
-
-        env_helper!(
-            mut_config,
-            query,
-            rpc_tls_server_key,
-            String,
-            QUERY_RPC_TLS_SERVER_KEY
-        );
-
-        // for query rpc client
-        env_helper!(
-            mut_config,
-            query,
-            rpc_tls_query_server_root_ca_cert,
-            String,
-            QUERY_RPC_TLS_SERVER_ROOT_CA_CERT
-        );
-        env_helper!(
-            mut_config,
-            query,
-            rpc_tls_query_service_domain_name,
-            String,
-            QUERY_RPC_TLS_SERVICE_DOMAIN_NAME
-        );
+        QueryConfig::load_from_env(&mut mut_config);
 
         Ok(mut_config)
     }

--- a/query/src/configs/config.rs
+++ b/query/src/configs/config.rs
@@ -52,6 +52,13 @@ const CONFIG_FILE: &str = "CONFIG_FILE";
 )]
 #[serde(default)]
 pub struct Config {
+    #[structopt(long, short = "c", env = CONFIG_FILE, default_value = "")]
+    pub config_file: String,
+
+    // Query engine config.
+    #[structopt(flatten)]
+    pub query: QueryConfig,
+
     #[structopt(flatten)]
     pub log: LogConfig,
 
@@ -62,24 +69,17 @@ pub struct Config {
     // Storage backend config.
     #[structopt(flatten)]
     pub storage: StorageConfig,
-
-    // Query engine config.
-    #[structopt(flatten)]
-    pub query: QueryConfig,
-
-    #[structopt(long, short = "c", env = CONFIG_FILE, default_value = "")]
-    pub config_file: String,
 }
 
 impl Config {
     /// Default configs.
     pub fn default() -> Self {
         Config {
+            config_file: "".to_string(),
+            query: QueryConfig::default(),
             log: LogConfig::default(),
             meta: MetaConfig::default(),
             storage: StorageConfig::default(),
-            query: QueryConfig::default(),
-            config_file: "".to_string(),
         }
     }
 

--- a/query/src/configs/config_log.rs
+++ b/query/src/configs/config_log.rs
@@ -1,0 +1,51 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use structopt::StructOpt;
+use structopt_toml::StructOptToml;
+
+use crate::configs::Config;
+
+// Log env.
+const LOG_LEVEL: &str = "LOG_LEVEL";
+const LOG_DIR: &str = "LOG_DIR";
+
+/// Log config group.
+/// serde(default) make the toml de to default working.
+#[derive(
+    Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
+)]
+pub struct LogConfig {
+    #[structopt(long, env = LOG_LEVEL, default_value = "INFO" , help = "Log level <DEBUG|INFO|ERROR>")]
+    #[serde(default)]
+    pub log_level: String,
+
+    #[structopt(required = false, long, env = LOG_DIR, default_value = "./_logs", help = "Log file dir")]
+    #[serde(default)]
+    pub log_dir: String,
+}
+
+impl LogConfig {
+    pub fn default() -> Self {
+        LogConfig {
+            log_level: "INFO".to_string(),
+            log_dir: "./_logs".to_string(),
+        }
+    }
+
+    pub fn load_from_env(mut_config: &mut Config) {
+        env_helper!(mut_config, log, log_level, String, LOG_LEVEL);
+        env_helper!(mut_config, log, log_dir, String, LOG_DIR);
+    }
+}

--- a/query/src/configs/config_meta.rs
+++ b/query/src/configs/config_meta.rs
@@ -1,0 +1,103 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use structopt::StructOpt;
+use structopt_toml::StructOptToml;
+
+use crate::configs::Config;
+
+// Meta env.
+const META_ADDRESS: &str = "META_ADDRESS";
+const META_USERNAME: &str = "META_USERNAME";
+const META_PASSWORD: &str = "META_PASSWORD";
+const META_RPC_TLS_SERVER_ROOT_CA_CERT: &str = "META_RPC_TLS_SERVER_ROOT_CA_CERT";
+const META_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "META_RPC_TLS_SERVICE_DOMAIN_NAME";
+
+/// Meta config group.
+/// serde(default) make the toml de to default working.
+#[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
+pub struct MetaConfig {
+    #[structopt(long, env = META_ADDRESS, default_value = "", help = "MetaStore backend address")]
+    #[serde(default)]
+    pub meta_address: String,
+
+    #[structopt(long, env = META_USERNAME, default_value = "", help = "MetaStore backend user name")]
+    #[serde(default)]
+    pub meta_username: String,
+
+    #[structopt(long, env = META_PASSWORD, default_value = "", help = "MetaStore backend user password")]
+    #[serde(default)]
+    pub meta_password: String,
+
+    #[structopt(
+        long,
+        env = "META_RPC_TLS_SERVER_ROOT_CA_CERT",
+        default_value = "",
+        help = "Certificate for client to identify meta rpc server"
+    )]
+    #[serde(default)]
+    pub rpc_tls_meta_server_root_ca_cert: String,
+
+    #[structopt(
+        long,
+        env = "META_RPC_TLS_SERVICE_DOMAIN_NAME",
+        default_value = "localhost"
+    )]
+    #[serde(default)]
+    pub rpc_tls_meta_service_domain_name: String,
+}
+
+impl MetaConfig {
+    pub fn default() -> Self {
+        MetaConfig {
+            meta_address: "".to_string(),
+            meta_username: "root".to_string(),
+            meta_password: "".to_string(),
+            rpc_tls_meta_server_root_ca_cert: "".to_string(),
+            rpc_tls_meta_service_domain_name: "localhost".to_string(),
+        }
+    }
+
+    pub fn load_from_env(mut_config: &mut Config) {
+        env_helper!(mut_config, meta, meta_address, String, META_ADDRESS);
+        env_helper!(mut_config, meta, meta_username, String, META_USERNAME);
+        env_helper!(mut_config, meta, meta_password, String, META_PASSWORD);
+        env_helper!(
+            mut_config,
+            meta,
+            rpc_tls_meta_server_root_ca_cert,
+            String,
+            META_RPC_TLS_SERVER_ROOT_CA_CERT
+        );
+        env_helper!(
+            mut_config,
+            meta,
+            rpc_tls_meta_service_domain_name,
+            String,
+            META_RPC_TLS_SERVICE_DOMAIN_NAME
+        );
+    }
+}
+
+impl fmt::Debug for MetaConfig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, "meta_address: \"{}\", ", self.meta_address)?;
+        write!(f, "meta_user: \"{}\", ", self.meta_username)?;
+        write!(f, "meta_password: \"******\"")?;
+        write!(f, "}}")
+    }
+}

--- a/query/src/configs/config_query.rs
+++ b/query/src/configs/config_query.rs
@@ -1,0 +1,301 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use structopt::StructOpt;
+use structopt_toml::StructOptToml;
+
+use crate::configs::Config;
+
+// Query env.
+const QUERY_TENANT: &str = "QUERY_TENANT";
+const QUERY_NAMESPACE: &str = "QUERY_NAMESPACE";
+const QUERY_NUM_CPUS: &str = "QUERY_NUM_CPUS";
+const QUERY_MYSQL_HANDLER_HOST: &str = "QUERY_MYSQL_HANDLER_HOST";
+const QUERY_MYSQL_HANDLER_PORT: &str = "QUERY_MYSQL_HANDLER_PORT";
+const QUERY_MAX_ACTIVE_SESSIONS: &str = "QUERY_MAX_ACTIVE_SESSIONS";
+const QUERY_CLICKHOUSE_HANDLER_HOST: &str = "QUERY_CLICKHOUSE_HANDLER_HOST";
+const QUERY_CLICKHOUSE_HANDLER_PORT: &str = "QUERY_CLICKHOUSE_HANDLER_PORT";
+const QUERY_FLIGHT_API_ADDRESS: &str = "QUERY_FLIGHT_API_ADDRESS";
+const QUERY_HTTP_API_ADDRESS: &str = "QUERY_HTTP_API_ADDRESS";
+const QUERY_METRICS_API_ADDRESS: &str = "QUERY_METRIC_API_ADDRESS";
+const QUERY_API_TLS_SERVER_CERT: &str = "QUERY_API_TLS_SERVER_CERT";
+const QUERY_API_TLS_SERVER_KEY: &str = "QUERY_API_TLS_SERVER_KEY";
+const QUERY_API_TLS_SERVER_ROOT_CA_CERT: &str = "QUERY_API_TLS_SERVER_ROOT_CA_CERT";
+
+const QUERY_RPC_TLS_SERVER_CERT: &str = "QUERY_RPC_TLS_SERVER_CERT";
+const QUERY_RPC_TLS_SERVER_KEY: &str = "QUERY_RPC_TLS_SERVER_KEY";
+const QUERY_RPC_TLS_SERVER_ROOT_CA_CERT: &str = "QUERY_RPC_TLS_SERVER_ROOT_CA_CERT";
+const QUERY_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "QUERY_RPC_TLS_SERVICE_DOMAIN_NAME";
+
+/// Query config group.
+/// serde(default) make the toml de to default working.
+#[derive(
+    Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
+)]
+pub struct QueryConfig {
+    #[structopt(long, env = QUERY_TENANT, default_value = "", help = "Tenant id for get the information from the MetaStore")]
+    #[serde(default)]
+    pub tenant: String,
+
+    #[structopt(long, env = QUERY_NAMESPACE, default_value = "", help = "Namespace for construct the cluster")]
+    #[serde(default)]
+    pub namespace: String,
+
+    #[structopt(long, env = QUERY_NUM_CPUS, default_value = "0")]
+    #[serde(default)]
+    pub num_cpus: u64,
+
+    #[structopt(
+    long,
+    env = QUERY_MYSQL_HANDLER_HOST,
+    default_value = "127.0.0.1"
+    )]
+    #[serde(default)]
+    pub mysql_handler_host: String,
+
+    #[structopt(long, env = QUERY_MYSQL_HANDLER_PORT, default_value = "3307")]
+    #[serde(default)]
+    pub mysql_handler_port: u16,
+
+    #[structopt(
+    long,
+    env = QUERY_MAX_ACTIVE_SESSIONS,
+    default_value = "256"
+    )]
+    #[serde(default)]
+    pub max_active_sessions: u64,
+
+    #[structopt(
+    long,
+    env = QUERY_CLICKHOUSE_HANDLER_HOST,
+    default_value = "127.0.0.1"
+    )]
+    #[serde(default)]
+    pub clickhouse_handler_host: String,
+
+    #[structopt(
+    long,
+    env = QUERY_CLICKHOUSE_HANDLER_PORT,
+    default_value = "9000"
+    )]
+    #[serde(default)]
+    pub clickhouse_handler_port: u16,
+
+    #[structopt(
+    long,
+    env = QUERY_FLIGHT_API_ADDRESS,
+    default_value = "127.0.0.1:9090"
+    )]
+    #[serde(default)]
+    pub flight_api_address: String,
+
+    #[structopt(
+    long,
+    env = QUERY_HTTP_API_ADDRESS,
+    default_value = "127.0.0.1:8080"
+    )]
+    #[serde(default)]
+    pub http_api_address: String,
+
+    #[structopt(
+    long,
+    env = QUERY_METRICS_API_ADDRESS,
+    default_value = "127.0.0.1:7070"
+    )]
+    #[serde(default)]
+    pub metric_api_address: String,
+
+    #[structopt(long, env = QUERY_API_TLS_SERVER_CERT, default_value = "")]
+    #[serde(default)]
+    pub api_tls_server_cert: String,
+
+    #[structopt(long, env = QUERY_API_TLS_SERVER_KEY, default_value = "")]
+    #[serde(default)]
+    pub api_tls_server_key: String,
+
+    #[structopt(long, env = QUERY_API_TLS_SERVER_ROOT_CA_CERT, default_value = "")]
+    #[serde(default)]
+    pub api_tls_server_root_ca_cert: String,
+
+    #[structopt(
+        long,
+        env = "QUERY_RPC_TLS_SERVER_CERT",
+        default_value = "",
+        help = "rpc server cert"
+    )]
+    #[serde(default)]
+    pub rpc_tls_server_cert: String,
+
+    #[structopt(
+        long,
+        env = "QUERY_RPC_TLS_SERVER_KEY",
+        default_value = "key for rpc server cert"
+    )]
+    #[serde(default)]
+    pub rpc_tls_server_key: String,
+
+    #[structopt(
+        long,
+        env = "QUERY_RPC_TLS_SERVER_ROOT_CA_CERT",
+        default_value = "",
+        help = "Certificate for client to identify query rpc server"
+    )]
+    #[serde(default)]
+    pub rpc_tls_query_server_root_ca_cert: String,
+
+    #[structopt(
+        long,
+        env = "QUERY_RPC_TLS_SERVICE_DOMAIN_NAME",
+        default_value = "localhost"
+    )]
+    #[serde(default)]
+    pub rpc_tls_query_service_domain_name: String,
+}
+
+impl QueryConfig {
+    pub fn default() -> Self {
+        QueryConfig {
+            tenant: "".to_string(),
+            namespace: "".to_string(),
+            num_cpus: 8,
+            mysql_handler_host: "127.0.0.1".to_string(),
+            mysql_handler_port: 3307,
+            max_active_sessions: 256,
+            clickhouse_handler_host: "127.0.0.1".to_string(),
+            clickhouse_handler_port: 9000,
+            flight_api_address: "127.0.0.1:9090".to_string(),
+            http_api_address: "127.0.0.1:8080".to_string(),
+            metric_api_address: "127.0.0.1:7070".to_string(),
+            api_tls_server_cert: "".to_string(),
+            api_tls_server_key: "".to_string(),
+            api_tls_server_root_ca_cert: "".to_string(),
+            rpc_tls_server_cert: "".to_string(),
+            rpc_tls_server_key: "".to_string(),
+            rpc_tls_query_server_root_ca_cert: "".to_string(),
+            rpc_tls_query_service_domain_name: "localhost".to_string(),
+        }
+    }
+
+    pub fn load_from_env(mut_config: &mut Config) {
+        env_helper!(mut_config, query, tenant, String, QUERY_TENANT);
+        env_helper!(mut_config, query, namespace, String, QUERY_NAMESPACE);
+        env_helper!(mut_config, query, num_cpus, u64, QUERY_NUM_CPUS);
+        env_helper!(
+            mut_config,
+            query,
+            mysql_handler_host,
+            String,
+            QUERY_MYSQL_HANDLER_HOST
+        );
+        env_helper!(
+            mut_config,
+            query,
+            mysql_handler_port,
+            u16,
+            QUERY_MYSQL_HANDLER_PORT
+        );
+        env_helper!(
+            mut_config,
+            query,
+            max_active_sessions,
+            u64,
+            QUERY_MAX_ACTIVE_SESSIONS
+        );
+        env_helper!(
+            mut_config,
+            query,
+            clickhouse_handler_host,
+            String,
+            QUERY_CLICKHOUSE_HANDLER_HOST
+        );
+        env_helper!(
+            mut_config,
+            query,
+            clickhouse_handler_port,
+            u16,
+            QUERY_CLICKHOUSE_HANDLER_PORT
+        );
+        env_helper!(
+            mut_config,
+            query,
+            flight_api_address,
+            String,
+            QUERY_FLIGHT_API_ADDRESS
+        );
+        env_helper!(
+            mut_config,
+            query,
+            http_api_address,
+            String,
+            QUERY_HTTP_API_ADDRESS
+        );
+        env_helper!(
+            mut_config,
+            query,
+            metric_api_address,
+            String,
+            QUERY_METRICS_API_ADDRESS
+        );
+
+        // for api http service
+        env_helper!(
+            mut_config,
+            query,
+            api_tls_server_cert,
+            String,
+            QUERY_API_TLS_SERVER_CERT
+        );
+
+        env_helper!(
+            mut_config,
+            query,
+            api_tls_server_key,
+            String,
+            QUERY_API_TLS_SERVER_KEY
+        );
+
+        // for query rpc server
+        env_helper!(
+            mut_config,
+            query,
+            rpc_tls_server_cert,
+            String,
+            QUERY_RPC_TLS_SERVER_CERT
+        );
+
+        env_helper!(
+            mut_config,
+            query,
+            rpc_tls_server_key,
+            String,
+            QUERY_RPC_TLS_SERVER_KEY
+        );
+
+        // for query rpc client
+        env_helper!(
+            mut_config,
+            query,
+            rpc_tls_query_server_root_ca_cert,
+            String,
+            QUERY_RPC_TLS_SERVER_ROOT_CA_CERT
+        );
+        env_helper!(
+            mut_config,
+            query,
+            rpc_tls_query_service_domain_name,
+            String,
+            QUERY_RPC_TLS_SERVICE_DOMAIN_NAME
+        );
+    }
+}

--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -1,0 +1,108 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use structopt::StructOpt;
+use structopt_toml::StructOptToml;
+
+const DEFAULT_STORAGE_TYPE: &str = "DEFAULT_STORAGE_TYPE";
+
+// DFS Storage env.
+const DFS_STORAGE_ADDRESS: &str = "DFS_STORAGE_ADDRESS";
+const DFS_STORAGE_USERNAME: &str = "DFS_STORAGE_USERNAME";
+const DFS_STORAGE_PASSWORD: &str = "DFS_STORAGE_PASSWORD";
+const DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT: &str = "DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT";
+const DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME";
+
+#[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub enum StorageType {
+    Dfs,
+    Disk,
+    S3,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
+pub struct DfsStorageConfig {
+    #[structopt(long, env = DFS_STORAGE_ADDRESS, default_value = "", help = "DFS storage backend address")]
+    #[serde(default)]
+    pub address: String,
+
+    #[structopt(long, env = DFS_STORAGE_USERNAME, default_value = "", help = "DFS storage backend user name")]
+    #[serde(default)]
+    pub username: String,
+
+    #[structopt(long, env = DFS_STORAGE_PASSWORD, default_value = "", help = "DFS storage backend user password")]
+    #[serde(default)]
+    pub password: String,
+
+    #[structopt(
+        long,
+        env = "DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT",
+        default_value = "",
+        help = "Certificate for client to identify dfs storage rpc server"
+    )]
+    #[serde(default)]
+    pub rpc_tls_storage_server_root_ca_cert: String,
+
+    #[structopt(
+        long,
+        env = "DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME",
+        default_value = "localhost"
+    )]
+    #[serde(default)]
+    pub rpc_tls_storage_service_domain_name: String,
+}
+
+impl DfsStorageConfig {
+    pub fn default() -> Self {
+        DfsStorageConfig {
+            address: "".to_string(),
+            username: "".to_string(),
+            password: "".to_string(),
+            rpc_tls_storage_server_root_ca_cert: "".to_string(),
+            rpc_tls_storage_service_domain_name: "".to_string(),
+        }
+    }
+}
+
+impl fmt::Debug for DfsStorageConfig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, "dfs.storage.address: \"{}\", ", self.address)?;
+        write!(f, "}}")
+    }
+}
+
+/// Storage config group.
+/// serde(default) make the toml de to default working.
+#[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
+pub struct StorageConfig {
+    #[structopt(long, env = DEFAULT_STORAGE_TYPE, default_value = "", help = "Default storage type: dfs|disk|s3")]
+    #[serde(default)]
+    pub default_storage: String,
+
+    // DFS storage backend config.
+    #[structopt(flatten)]
+    pub dfs: DfsStorageConfig,
+}
+
+impl StorageConfig {
+    pub fn default() -> Self {
+        StorageConfig {
+            default_storage: "disk".to_string(),
+            dfs: DfsStorageConfig::default(),
+        }
+    }
+}

--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -99,6 +99,7 @@ pub struct StorageConfig {
 
     // DFS storage backend config.
     #[structopt(flatten)]
+    #[serde(rename = "storage.dfs")]
     pub dfs: DfsStorageConfig,
 }
 

--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -33,8 +33,8 @@ const DISK_STORAGE_DATA_PATH: &str = "DISK_STORAGE_DATA_PATH";
 
 // S3 Storage env.
 const S3_STORAGE_REGION: &str = "S3_STORAGE_REGION";
-const S3_STORAGE_KEY: &str = "S3_STORAGE_KEY";
-const S3_STORAGE_SECRET: &str = "S3_STORAGE_SECRET";
+const S3_STORAGE_ACCESS_KEY_ID: &str = "S3_STORAGE_ACCESS_KEY_ID";
+const S3_STORAGE_SECRET_ACCESS_KEY: &str = "S3_STORAGE_SECRET_ACCESS_KEY";
 const S3_STORAGE_BUCKET: &str = "S3_STORAGE_BUCKET";
 
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq)]
@@ -119,13 +119,13 @@ pub struct S3StorageConfig {
     #[serde(default)]
     pub region: String,
 
-    #[structopt(long, env = S3_STORAGE_KEY, default_value = "", help = "Access key for S3 storage")]
+    #[structopt(long, env = S3_STORAGE_ACCESS_KEY_ID, default_value = "", help = "Access key for S3 storage")]
     #[serde(default)]
-    pub key: String,
+    pub access_key_id: String,
 
-    #[structopt(long, env = S3_STORAGE_SECRET, default_value = "", help = "Secret key for S3 storage")]
+    #[structopt(long, env = S3_STORAGE_SECRET_ACCESS_KEY, default_value = "", help = "Secret key for S3 storage")]
     #[serde(default)]
-    pub secret: String,
+    pub secret_access_key: String,
 
     #[structopt(long, env = S3_STORAGE_BUCKET, default_value = "", help = "S3 Bucket to use for storage")]
     #[serde(default)]
@@ -136,8 +136,8 @@ impl S3StorageConfig {
     pub fn default() -> Self {
         S3StorageConfig {
             region: "".to_string(),
-            key: "".to_string(),
-            secret: "".to_string(),
+            access_key_id: "".to_string(),
+            secret_access_key: "".to_string(),
             bucket: "".to_string(),
         }
     }
@@ -235,8 +235,20 @@ impl StorageConfig {
 
         // S3.
         env_helper!(mut_config.storage, s3, region, String, S3_STORAGE_REGION);
-        env_helper!(mut_config.storage, s3, key, String, S3_STORAGE_KEY);
-        env_helper!(mut_config.storage, s3, secret, String, S3_STORAGE_SECRET);
+        env_helper!(
+            mut_config.storage,
+            s3,
+            access_key_id,
+            String,
+            S3_STORAGE_ACCESS_KEY_ID
+        );
+        env_helper!(
+            mut_config.storage,
+            s3,
+            secret_access_key,
+            String,
+            S3_STORAGE_SECRET_ACCESS_KEY
+        );
         env_helper!(mut_config.storage, s3, bucket, String, S3_STORAGE_BUCKET);
     }
 }

--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -17,14 +17,16 @@ use std::fmt;
 use structopt::StructOpt;
 use structopt_toml::StructOptToml;
 
+use crate::configs::Config;
+
 const DEFAULT_STORAGE_TYPE: &str = "DEFAULT_STORAGE_TYPE";
 
 // DFS Storage env.
-pub const DFS_STORAGE_ADDRESS: &str = "DFS_STORAGE_ADDRESS";
-pub const DFS_STORAGE_USERNAME: &str = "DFS_STORAGE_USERNAME";
-pub const DFS_STORAGE_PASSWORD: &str = "DFS_STORAGE_PASSWORD";
-pub const DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT: &str = "DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT";
-pub const DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME";
+const DFS_STORAGE_ADDRESS: &str = "DFS_STORAGE_ADDRESS";
+const DFS_STORAGE_USERNAME: &str = "DFS_STORAGE_USERNAME";
+const DFS_STORAGE_PASSWORD: &str = "DFS_STORAGE_PASSWORD";
+const DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT: &str = "DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT";
+const DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME";
 
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub enum StorageType {
@@ -106,5 +108,43 @@ impl StorageConfig {
             default_storage: "disk".to_string(),
             dfs: DfsStorageConfig::default(),
         }
+    }
+
+    pub fn load_from_env(mut_config: &mut Config) {
+        env_helper!(
+            mut_config.storage,
+            dfs,
+            address,
+            String,
+            DFS_STORAGE_ADDRESS
+        );
+        env_helper!(
+            mut_config.storage,
+            dfs,
+            username,
+            String,
+            DFS_STORAGE_USERNAME
+        );
+        env_helper!(
+            mut_config.storage,
+            dfs,
+            password,
+            String,
+            DFS_STORAGE_PASSWORD
+        );
+        env_helper!(
+            mut_config.storage,
+            dfs,
+            rpc_tls_storage_server_root_ca_cert,
+            String,
+            DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT
+        );
+        env_helper!(
+            mut_config.storage,
+            dfs,
+            rpc_tls_storage_service_domain_name,
+            String,
+            DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME
+        );
     }
 }

--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -20,11 +20,11 @@ use structopt_toml::StructOptToml;
 const DEFAULT_STORAGE_TYPE: &str = "DEFAULT_STORAGE_TYPE";
 
 // DFS Storage env.
-const DFS_STORAGE_ADDRESS: &str = "DFS_STORAGE_ADDRESS";
-const DFS_STORAGE_USERNAME: &str = "DFS_STORAGE_USERNAME";
-const DFS_STORAGE_PASSWORD: &str = "DFS_STORAGE_PASSWORD";
-const DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT: &str = "DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT";
-const DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME";
+pub const DFS_STORAGE_ADDRESS: &str = "DFS_STORAGE_ADDRESS";
+pub const DFS_STORAGE_USERNAME: &str = "DFS_STORAGE_USERNAME";
+pub const DFS_STORAGE_PASSWORD: &str = "DFS_STORAGE_PASSWORD";
+pub const DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT: &str = "DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT";
+pub const DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME";
 
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub enum StorageType {
@@ -87,7 +87,9 @@ impl fmt::Debug for DfsStorageConfig {
 
 /// Storage config group.
 /// serde(default) make the toml de to default working.
-#[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
+#[derive(
+    Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
+)]
 pub struct StorageConfig {
     #[structopt(long, env = DEFAULT_STORAGE_TYPE, default_value = "", help = "Default storage type: dfs|disk|s3")]
     #[serde(default)]

--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -19,7 +19,7 @@ use structopt_toml::StructOptToml;
 
 use crate::configs::Config;
 
-const DEFAULT_STORAGE_TYPE: &str = "DEFAULT_STORAGE_TYPE";
+const STORAGE_TYPE: &str = "STORAGE_TYPE";
 
 // DFS Storage env.
 const DFS_STORAGE_ADDRESS: &str = "DFS_STORAGE_ADDRESS";
@@ -157,9 +157,9 @@ impl fmt::Debug for S3StorageConfig {
     Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
 )]
 pub struct StorageConfig {
-    #[structopt(long, env = DEFAULT_STORAGE_TYPE, default_value = "", help = "Default storage type: dfs|disk|s3")]
+    #[structopt(long, env = STORAGE_TYPE, default_value = "", help = "Current storage type: dfs|disk|s3")]
     #[serde(default)]
-    pub default_storage: String,
+    pub storage_type: String,
 
     // DFS storage backend config.
     #[structopt(flatten)]
@@ -177,7 +177,7 @@ pub struct StorageConfig {
 impl StorageConfig {
     pub fn default() -> Self {
         StorageConfig {
-            default_storage: "disk".to_string(),
+            storage_type: "disk".to_string(),
             dfs: DfsStorageConfig::default(),
             disk: DiskStorageConfig::default(),
             s3: S3StorageConfig::default(),
@@ -185,6 +185,8 @@ impl StorageConfig {
     }
 
     pub fn load_from_env(mut_config: &mut Config) {
+        env_helper!(mut_config, storage, storage_type, String, STORAGE_TYPE);
+
         // DFS.
         env_helper!(
             mut_config.storage,

--- a/query/src/configs/config_test.rs
+++ b/query/src/configs/config_test.rs
@@ -19,7 +19,7 @@ use crate::configs::Config;
 use crate::configs::LogConfig;
 use crate::configs::MetaConfig;
 use crate::configs::QueryConfig;
-use crate::configs::StoreConfig;
+use crate::configs::StorageConfig;
 
 // Default.
 #[test]
@@ -27,7 +27,7 @@ fn test_default_config() -> Result<()> {
     let expect = Config {
         log: LogConfig::default(),
         meta: MetaConfig::default(),
-        store: StoreConfig::default(),
+        storage: StorageConfig::default(),
         query: QueryConfig::default(),
         config_file: "".to_string(),
     };
@@ -50,9 +50,9 @@ fn test_env_config() -> Result<()> {
     std::env::set_var("QUERY_FLIGHT_API_ADDRESS", "1.2.3.4:9091");
     std::env::set_var("QUERY_HTTP_API_ADDRESS", "1.2.3.4:8081");
     std::env::set_var("QUERY_METRIC_API_ADDRESS", "1.2.3.4:7071");
-    std::env::set_var("STORE_ADDRESS", "1.2.3.4:1234");
-    std::env::set_var("STORE_USERNAME", "admin");
-    std::env::set_var("STORE_PASSWORD", "password!");
+    std::env::set_var("DFS_STORAGE_ADDRESS", "1.2.3.4:1234");
+    std::env::set_var("DFS_STORAGE_USERNAME", "admin");
+    std::env::set_var("DFS_STORAGE_PASSWORD", "password!");
     std::env::remove_var("CONFIG_FILE");
 
     let default = Config::default();
@@ -71,9 +71,9 @@ fn test_env_config() -> Result<()> {
     assert_eq!("1.2.3.4:8081", configured.query.http_api_address);
     assert_eq!("1.2.3.4:7071", configured.query.metric_api_address);
 
-    assert_eq!("1.2.3.4:1234", configured.store.store_address);
-    assert_eq!("admin", configured.store.store_username);
-    assert_eq!("password!", configured.store.store_password);
+    assert_eq!("1.2.3.4:1234", configured.storage.dfs.address);
+    assert_eq!("admin", configured.storage.dfs.username);
+    assert_eq!("password!", configured.storage.dfs.password);
 
     // clean up
     std::env::remove_var("LOG_LEVEL");
@@ -88,9 +88,9 @@ fn test_env_config() -> Result<()> {
     std::env::remove_var("QUERY_FLIGHT_API_ADDRESS");
     std::env::remove_var("QUERY_HTTP_API_ADDRESS");
     std::env::remove_var("QUERY_METRIC_API_ADDRESS");
-    std::env::remove_var("STORE_ADDRESS");
-    std::env::remove_var("STORE_USERNAME");
-    std::env::remove_var("STORE_PASSWORD");
+    std::env::remove_var("DFS_STORAGE_ADDRESS");
+    std::env::remove_var("DFS_STORAGE_USERNAME");
+    std::env::remove_var("DFS_STORAGE_PASSWORD");
     Ok(())
 }
 

--- a/query/src/configs/config_test.rs
+++ b/query/src/configs/config_test.rs
@@ -82,8 +82,8 @@ data_path = \"\"
 
 [storage.s3]
 region = \"\"
-key = \"\"
-secret = \"\"
+access_key_id = \"\"
+secret_access_key = \"\"
 bucket = \"\"
 ";
 
@@ -112,8 +112,8 @@ fn test_env_config() -> Result<()> {
     std::env::set_var("DFS_STORAGE_PASSWORD", "password!");
     std::env::set_var("DISK_STORAGE_DATA_PATH", "/tmp/test");
     std::env::set_var("S3_STORAGE_REGION", "us.region");
-    std::env::set_var("S3_STORAGE_KEY", "us.key");
-    std::env::set_var("S3_STORAGE_SECRET", "us.secret");
+    std::env::set_var("S3_STORAGE_ACCESS_KEY_ID", "us.key.id");
+    std::env::set_var("S3_STORAGE_SECRET_ACCESS_KEY", "us.key");
     std::env::set_var("S3_STORAGE_BUCKET", "us.bucket");
     std::env::remove_var("CONFIG_FILE");
 
@@ -142,8 +142,8 @@ fn test_env_config() -> Result<()> {
     assert_eq!("/tmp/test", configured.storage.disk.data_path);
 
     assert_eq!("us.region", configured.storage.s3.region);
-    assert_eq!("us.key", configured.storage.s3.key);
-    assert_eq!("us.secret", configured.storage.s3.secret);
+    assert_eq!("us.key.id", configured.storage.s3.access_key_id);
+    assert_eq!("us.key", configured.storage.s3.secret_access_key);
     assert_eq!("us.bucket", configured.storage.s3.bucket);
 
     // clean up
@@ -165,8 +165,8 @@ fn test_env_config() -> Result<()> {
     std::env::remove_var("DFS_STORAGE_PASSWORD");
     std::env::remove_var("DISK_STORAGE_DATA_PATH");
     std::env::remove_var("S3_STORAGE_REGION");
-    std::env::remove_var("S3_STORAGE_KEY");
-    std::env::remove_var("S3_STORAGE_SECRET");
+    std::env::remove_var("S3_STORAGE_ACCESS_KEY_ID");
+    std::env::remove_var("S3_STORAGE_SECRET_ACCESS_KEY");
     std::env::remove_var("S3_STORAGE_BUCKET");
     Ok(())
 }

--- a/query/src/configs/config_test.rs
+++ b/query/src/configs/config_test.rs
@@ -68,7 +68,7 @@ rpc_tls_meta_server_root_ca_cert = \"\"
 rpc_tls_meta_service_domain_name = \"localhost\"
 
 [storage]
-default_storage = \"disk\"
+storage_type = \"disk\"
 
 [storage.dfs]
 address = \"\"
@@ -106,6 +106,7 @@ fn test_env_config() -> Result<()> {
     std::env::set_var("QUERY_FLIGHT_API_ADDRESS", "1.2.3.4:9091");
     std::env::set_var("QUERY_HTTP_API_ADDRESS", "1.2.3.4:8081");
     std::env::set_var("QUERY_METRIC_API_ADDRESS", "1.2.3.4:7071");
+    std::env::set_var("STORAGE_TYPE", "s3");
     std::env::set_var("DFS_STORAGE_ADDRESS", "1.2.3.4:1234");
     std::env::set_var("DFS_STORAGE_USERNAME", "admin");
     std::env::set_var("DFS_STORAGE_PASSWORD", "password!");
@@ -132,6 +133,8 @@ fn test_env_config() -> Result<()> {
     assert_eq!("1.2.3.4:8081", configured.query.http_api_address);
     assert_eq!("1.2.3.4:7071", configured.query.metric_api_address);
 
+    assert_eq!("s3", configured.storage.storage_type);
+
     assert_eq!("1.2.3.4:1234", configured.storage.dfs.address);
     assert_eq!("admin", configured.storage.dfs.username);
     assert_eq!("password!", configured.storage.dfs.password);
@@ -156,6 +159,7 @@ fn test_env_config() -> Result<()> {
     std::env::remove_var("QUERY_FLIGHT_API_ADDRESS");
     std::env::remove_var("QUERY_HTTP_API_ADDRESS");
     std::env::remove_var("QUERY_METRIC_API_ADDRESS");
+    std::env::remove_var("STORAGE_TYPE");
     std::env::remove_var("DFS_STORAGE_ADDRESS");
     std::env::remove_var("DFS_STORAGE_USERNAME");
     std::env::remove_var("DFS_STORAGE_PASSWORD");

--- a/query/src/configs/config_test.rs
+++ b/query/src/configs/config_test.rs
@@ -33,6 +33,53 @@ fn test_default_config() -> Result<()> {
     };
     let actual = Config::default();
     assert_eq!(actual, expect);
+
+    let tom_expect = "config_file = \"\"
+
+[query]
+tenant = \"\"
+namespace = \"\"
+num_cpus = 8
+mysql_handler_host = \"127.0.0.1\"
+mysql_handler_port = 3307
+max_active_sessions = 256
+clickhouse_handler_host = \"127.0.0.1\"
+clickhouse_handler_port = 9000
+flight_api_address = \"127.0.0.1:9090\"
+http_api_address = \"127.0.0.1:8080\"
+metric_api_address = \"127.0.0.1:7070\"
+api_tls_server_cert = \"\"
+api_tls_server_key = \"\"
+api_tls_server_root_ca_cert = \"\"
+rpc_tls_server_cert = \"\"
+rpc_tls_server_key = \"\"
+rpc_tls_query_server_root_ca_cert = \"\"
+rpc_tls_query_service_domain_name = \"localhost\"
+
+[log]
+log_level = \"INFO\"
+log_dir = \"./_logs\"
+
+[meta]
+meta_address = \"\"
+meta_username = \"root\"
+meta_password = \"\"
+rpc_tls_meta_server_root_ca_cert = \"\"
+rpc_tls_meta_service_domain_name = \"localhost\"
+
+[storage]
+default_storage = \"disk\"
+
+[storage.\"storage.dfs\"]
+address = \"\"
+username = \"\"
+password = \"\"
+rpc_tls_storage_server_root_ca_cert = \"\"
+rpc_tls_storage_service_domain_name = \"\"
+";
+
+    let tom_actual = toml::to_string(&actual).unwrap();
+    assert_eq!(tom_actual, tom_expect);
     Ok(())
 }
 
@@ -91,64 +138,6 @@ fn test_env_config() -> Result<()> {
     std::env::remove_var("DFS_STORAGE_ADDRESS");
     std::env::remove_var("DFS_STORAGE_USERNAME");
     std::env::remove_var("DFS_STORAGE_PASSWORD");
-    Ok(())
-}
-
-// From Args.
-#[test]
-#[ignore]
-fn test_args_config() -> Result<()> {
-    let actual = Config::load_from_args();
-    assert_eq!("INFO", actual.log.log_level);
-    Ok(())
-}
-
-// From file NotFound.
-#[test]
-#[ignore]
-fn test_config_file_not_found() -> Result<()> {
-    if let Err(e) = Config::load_from_toml("xx.toml") {
-        let expect = "Code: 23, displayText = File: xx.toml, err: Os { code: 2, kind: NotFound, message: \"No such file or directory\" }.";
-        assert_eq!(expect, format!("{}", e));
-    }
-    Ok(())
-}
-
-// From file.
-#[test]
-#[ignore]
-fn test_file_config() -> Result<()> {
-    let toml_str = r#"
-[log_config]
-log_level = "ERROR"
-log_dir = "./_logs"
- "#;
-
-    let actual = Config::load_from_toml_str(toml_str)?;
-    assert_eq!("INFO", actual.log.log_level);
-
-    std::env::set_var("QUERY_LOG_LEVEL", "DEBUG");
-    let env = Config::load_from_env(&actual)?;
-    assert_eq!("INFO", env.log.log_level);
-    std::env::remove_var("QUERY_LOG_LEVEL");
-    Ok(())
-}
-
-// From env, load config file and ignore the rest settings.
-#[test]
-#[ignore]
-fn test_env_file_config() -> Result<()> {
-    std::env::set_var("QUERY_LOG_LEVEL", "DEBUG");
-    let config_path = std::env::current_dir()
-        .unwrap()
-        .join("../scripts/deploy/config/databend-query-node-1.toml")
-        .display()
-        .to_string();
-    std::env::set_var("CONFIG_FILE", config_path);
-    let config = Config::load_from_env(&Config::default())?;
-    assert_eq!(config.log.log_level, "INFO");
-    std::env::remove_var("QUERY_LOG_LEVEL");
-    std::env::remove_var("CONFIG_FILE");
     Ok(())
 }
 

--- a/query/src/configs/config_test.rs
+++ b/query/src/configs/config_test.rs
@@ -70,12 +70,21 @@ rpc_tls_meta_service_domain_name = \"localhost\"
 [storage]
 default_storage = \"disk\"
 
-[storage.\"storage.dfs\"]
+[storage.dfs]
 address = \"\"
 username = \"\"
 password = \"\"
 rpc_tls_storage_server_root_ca_cert = \"\"
 rpc_tls_storage_service_domain_name = \"\"
+
+[storage.disk]
+data_path = \"\"
+
+[storage.s3]
+region = \"\"
+key = \"\"
+secret = \"\"
+bucket = \"\"
 ";
 
     let tom_actual = toml::to_string(&actual).unwrap();
@@ -100,6 +109,11 @@ fn test_env_config() -> Result<()> {
     std::env::set_var("DFS_STORAGE_ADDRESS", "1.2.3.4:1234");
     std::env::set_var("DFS_STORAGE_USERNAME", "admin");
     std::env::set_var("DFS_STORAGE_PASSWORD", "password!");
+    std::env::set_var("DISK_STORAGE_DATA_PATH", "/tmp/test");
+    std::env::set_var("S3_STORAGE_REGION", "us.region");
+    std::env::set_var("S3_STORAGE_KEY", "us.key");
+    std::env::set_var("S3_STORAGE_SECRET", "us.secret");
+    std::env::set_var("S3_STORAGE_BUCKET", "us.bucket");
     std::env::remove_var("CONFIG_FILE");
 
     let default = Config::default();
@@ -122,6 +136,13 @@ fn test_env_config() -> Result<()> {
     assert_eq!("admin", configured.storage.dfs.username);
     assert_eq!("password!", configured.storage.dfs.password);
 
+    assert_eq!("/tmp/test", configured.storage.disk.data_path);
+
+    assert_eq!("us.region", configured.storage.s3.region);
+    assert_eq!("us.key", configured.storage.s3.key);
+    assert_eq!("us.secret", configured.storage.s3.secret);
+    assert_eq!("us.bucket", configured.storage.s3.bucket);
+
     // clean up
     std::env::remove_var("LOG_LEVEL");
     std::env::remove_var("QUERY_TENANT");
@@ -138,6 +159,11 @@ fn test_env_config() -> Result<()> {
     std::env::remove_var("DFS_STORAGE_ADDRESS");
     std::env::remove_var("DFS_STORAGE_USERNAME");
     std::env::remove_var("DFS_STORAGE_PASSWORD");
+    std::env::remove_var("DISK_STORAGE_DATA_PATH");
+    std::env::remove_var("S3_STORAGE_REGION");
+    std::env::remove_var("S3_STORAGE_KEY");
+    std::env::remove_var("S3_STORAGE_SECRET");
+    std::env::remove_var("S3_STORAGE_BUCKET");
     Ok(())
 }
 

--- a/query/src/configs/macros.rs
+++ b/query/src/configs/macros.rs
@@ -12,19 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
-mod macros;
-
-#[cfg(test)]
-mod config_test;
-
-pub mod config;
-mod config_query;
-mod config_storage;
-
-pub use common_store_api_sdk::RpcClientTlsConfig;
-pub use config::Config;
-pub use config::LogConfig;
-pub use config::MetaConfig;
-pub use config_query::*;
-pub use config_storage::*;
+macro_rules! env_helper {
+    ($config:expr, $struct: tt, $field:tt, $field_type: ty, $env:expr) => {
+        let env_var = std::env::var_os($env)
+            .unwrap_or($config.$struct.$field.to_string().into())
+            .into_string()
+            .expect(format!("cannot convert {} to string", $env).as_str());
+        $config.$struct.$field = env_var
+            .parse::<$field_type>()
+            .expect(format!("cannot convert {} to {}", $env, stringify!($field_type)).as_str());
+    };
+}

--- a/query/src/configs/mod.rs
+++ b/query/src/configs/mod.rs
@@ -23,4 +23,4 @@ pub use config::Config;
 pub use config::LogConfig;
 pub use config::MetaConfig;
 pub use config::QueryConfig;
-pub use config::StoreConfig;
+pub use config_storage::*;

--- a/query/src/configs/mod.rs
+++ b/query/src/configs/mod.rs
@@ -18,13 +18,16 @@ mod macros;
 #[cfg(test)]
 mod config_test;
 
-pub mod config;
+mod config;
+mod config_log;
+mod config_meta;
 mod config_query;
 mod config_storage;
 
 pub use common_store_api_sdk::RpcClientTlsConfig;
 pub use config::Config;
-pub use config::LogConfig;
-pub use config::MetaConfig;
-pub use config_query::*;
-pub use config_storage::*;
+pub use config::DATABEND_COMMIT_VERSION;
+pub use config_log::LogConfig;
+pub use config_meta::MetaConfig;
+pub use config_query::QueryConfig;
+pub use config_storage::StorageConfig;

--- a/query/src/configs/mod.rs
+++ b/query/src/configs/mod.rs
@@ -16,6 +16,7 @@
 mod config_test;
 
 pub mod config;
+mod config_storage;
 
 pub use common_store_api_sdk::RpcClientTlsConfig;
 pub use config::Config;

--- a/query/src/datasources/database/system/configs_table.rs
+++ b/query/src/datasources/database/system/configs_table.rs
@@ -156,17 +156,6 @@ impl Table for ConfigsTable {
             meta_config_value,
         );
 
-        let store_config = config.store;
-        let store_config_value = serde_json::to_value(store_config)?;
-        ConfigsTable::extract_config(
-            &mut names,
-            &mut values,
-            &mut groups,
-            &mut descs,
-            "dfs".to_string(),
-            store_config_value,
-        );
-
         let names: Vec<&str> = names.iter().map(|x| x.as_str()).collect();
         let values: Vec<&str> = values.iter().map(|x| x.as_str()).collect();
         let groups: Vec<&str> = groups.iter().map(|x| x.as_str()).collect();

--- a/query/src/datasources/database/system/configs_table_test.rs
+++ b/query/src/datasources/database/system/configs_table_test.rs
@@ -40,7 +40,7 @@ async fn test_configs_table() -> Result<()> {
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 4);
-    assert_eq!(block.num_rows(), 30);
+    assert_eq!(block.num_rows(), 25);
 
     let expected = vec![
         "+-----------------------------------+----------------+-------+-------------+",
@@ -70,11 +70,6 @@ async fn test_configs_table() -> Result<()> {
         "| rpc_tls_query_service_domain_name | localhost      | query |             |",
         "| rpc_tls_server_cert               |                | query |             |",
         "| rpc_tls_server_key                |                | query |             |",
-        "| rpc_tls_store_server_root_ca_cert |                | dfs   |             |",
-        "| rpc_tls_store_service_domain_name | localhost      | dfs   |             |",
-        "| store_address                     |                | dfs   |             |",
-        "| store_password                    |                | dfs   |             |",
-        "| store_username                    | root           | dfs   |             |",
         "| tenant                            |                | query |             |",
         "+-----------------------------------+----------------+-------+-------------+",
     ];

--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -340,7 +340,7 @@ impl<W: std::io::Write> InteractiveWorker<W> {
             },
             salt: scramble,
             // TODO: version
-            version: crate::configs::config::DATABEND_COMMIT_VERSION.to_string(),
+            version: crate::configs::DATABEND_COMMIT_VERSION.to_string(),
         }
     }
 }

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -71,7 +71,7 @@ impl DatabendQueryContext {
             partition_queue: Arc::new(RwLock::new(VecDeque::new())),
             version: format!(
                 "DatabendQuery v-{}",
-                *crate::configs::config::DATABEND_COMMIT_VERSION
+                *crate::configs::DATABEND_COMMIT_VERSION
             ),
             shared,
         })

--- a/scripts/deploy/config/databend-query-node-1.toml
+++ b/scripts/deploy/config/databend-query-node-1.toml
@@ -38,7 +38,7 @@ meta_password = "root"
 
 # Storage config.
 [storage]
-default_storage = "disk|dfs|s3"
+storage_type = "disk|dfs|s3"
 
 # DFS storage.
 [storage.dfs]

--- a/scripts/deploy/config/databend-query-node-1.toml
+++ b/scripts/deploy/config/databend-query-node-1.toml
@@ -38,7 +38,8 @@ meta_password = "root"
 
 # Storage config.
 [storage]
-storage_type = "disk|dfs|s3"
+# dfs|disk|s3
+storage_type = ""
 
 # DFS storage.
 [storage.dfs]

--- a/scripts/deploy/config/databend-query-node-1.toml
+++ b/scripts/deploy/config/databend-query-node-1.toml
@@ -1,23 +1,6 @@
 # Usage:
 # databend-query -c databend_query_config_spec.toml
 
-# Log
-[log]
-log_level = "ERROR"
-log_dir = "./_logs"
-
-# Meta
-[meta]
-meta_address = "0.0.0.0:9191"
-meta_username = "root"
-meta_password = "root"
-
-# Store
-[store]
-store_address = "0.0.0.0:9191"
-store_username = "root"
-store_password = "root"
-
 # Query
 [query]
 max_active_sessions = 256
@@ -41,3 +24,27 @@ clickhouse_handler_host = "0.0.0.0"
 clickhouse_handler_port = 9001
 
 namespace = "test_cluster"
+
+# Log
+[log]
+log_level = "ERROR"
+log_dir = "./_logs"
+
+# Meta service.
+[meta]
+meta_address = "0.0.0.0:9191"
+meta_username = "root"
+meta_password = "root"
+
+# Storage config.
+[storage]
+default_storage = "disk|dfs|s3"
+
+# DFS storage.
+[storage.dfs]
+
+# DISK storage.
+[storage.disk]
+
+# S3 storage.
+[storage.s3]

--- a/scripts/deploy/config/databend-query-node-2.toml
+++ b/scripts/deploy/config/databend-query-node-2.toml
@@ -36,7 +36,7 @@ meta_password = "root"
 
 # Storage config.
 [storage]
-default_storage = "disk|dfs|s3"
+storage_type = "disk|dfs|s3"
 
 # DFS storage.
 [storage.dfs]

--- a/scripts/deploy/config/databend-query-node-2.toml
+++ b/scripts/deploy/config/databend-query-node-2.toml
@@ -1,22 +1,6 @@
 # Usage:
 # databend-query -c databend_query_config_spec.toml
 
-[log]
-log_level = "ERROR"
-log_dir = "./_logs"
-
-# Meta
-[meta]
-meta_address = "0.0.0.0:9191"
-meta_username = "root"
-meta_password = "root"
-
-# Store
-[store]
-store_address = "0.0.0.0:9191"
-store_username = "root"
-store_password = "root"
-
 [query]
 max_active_sessions = 256
 
@@ -39,3 +23,26 @@ clickhouse_handler_host = "0.0.0.0"
 clickhouse_handler_port = 9002
 
 namespace = "test_cluster"
+
+[log]
+log_level = "ERROR"
+log_dir = "./_logs"
+
+# Meta service.
+[meta]
+meta_address = "0.0.0.0:9191"
+meta_username = "root"
+meta_password = "root"
+
+# Storage config.
+[storage]
+default_storage = "disk|dfs|s3"
+
+# DFS storage.
+[storage.dfs]
+
+# DISK storage.
+[storage.disk]
+
+# S3 storage.
+[storage.s3]

--- a/scripts/deploy/config/databend-query-node-2.toml
+++ b/scripts/deploy/config/databend-query-node-2.toml
@@ -36,7 +36,8 @@ meta_password = "root"
 
 # Storage config.
 [storage]
-storage_type = "disk|dfs|s3"
+# dfs|disk|s3
+storage_type = ""
 
 # DFS storage.
 [storage.dfs]

--- a/scripts/deploy/config/databend-query-node-3.toml
+++ b/scripts/deploy/config/databend-query-node-3.toml
@@ -1,22 +1,6 @@
 # Usage:
 # databend-query -c databend_query_config_spec.toml
 
-[log]
-log_level = "ERROR"
-log_dir = "./_logs"
-
-# Meta
-[meta]
-meta_address = "0.0.0.0:9191"
-meta_username = "root"
-meta_password = "root"
-
-# Store
-[store]
-store_address = "0.0.0.0:9191"
-store_username = "root"
-store_password = "root"
-
 [query]
 max_active_sessions = 256
 
@@ -39,3 +23,26 @@ clickhouse_handler_host = "0.0.0.0"
 clickhouse_handler_port = 9003
 
 namespace = "test_cluster"
+
+[log]
+log_level = "ERROR"
+log_dir = "./_logs"
+
+# Meta service.
+[meta]
+meta_address = "0.0.0.0:9191"
+meta_username = "root"
+meta_password = "root"
+
+# Storage config.
+[storage]
+default_storage = "disk|dfs|s3"
+
+# DFS storage.
+[storage.dfs]
+
+# DISK storage.
+[storage.disk]
+
+# S3 storage.
+[storage.s3]

--- a/scripts/deploy/config/databend-query-node-3.toml
+++ b/scripts/deploy/config/databend-query-node-3.toml
@@ -36,7 +36,7 @@ meta_password = "root"
 
 # Storage config.
 [storage]
-default_storage = "disk|dfs|s3"
+storage_type = "disk|dfs|s3"
 
 # DFS storage.
 [storage.dfs]

--- a/scripts/deploy/config/databend-query-node-3.toml
+++ b/scripts/deploy/config/databend-query-node-3.toml
@@ -36,7 +36,8 @@ meta_password = "root"
 
 # Storage config.
 [storage]
-storage_type = "disk|dfs|s3"
+# dfs|disk|s3
+storage_type = ""
 
 # DFS storage.
 [storage.dfs]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR:
1. Split config one file into: config_meta.rs, config_log.rs, config_storage.rs
2. Add `storage` config group, remove `store` config group
3. Add `DFS/DISK/S3` sub config group
4. Update stateless config toml
5. Remove block_service_config from common/store-api-sdk/src/store_client_conf.rs
6. Remove unused config tests

## Changelog

- Improvement

## Related Issues

Fixes #1987

## Test Plan

Unit Tests

Stateless Tests

