### PR TITLE
Make date32 physical type to be int32

### DIFF
--- a/common/datavalues/src/types/data_type.rs
+++ b/common/datavalues/src/types/data_type.rs
@@ -37,7 +37,7 @@ pub enum DataType {
     /// in days (16 bits), it's physical type is UInt16
     Date16,
     /// A 32-bit date representing the elapsed time since UNIX epoch (1970-01-01)
-    /// in days (32 bits), it's physical type is UInt32
+    /// in days (32 bits), it's physical type is Int32
     Date32,
 
     /// A 32-bit datetime representing the elapsed time since UNIX epoch (1970-01-01)
@@ -91,7 +91,7 @@ impl DataType {
             Float32 => ArrowDataType::Float32,
             Float64 => ArrowDataType::Float64,
             Date16 => ArrowDataType::UInt16,
-            Date32 => ArrowDataType::UInt32,
+            Date32 => ArrowDataType::Int32,
             // we don't use DataType::Extension because extension types are not supported in parquet
             DateTime32(_) => ArrowDataType::UInt32,
             List(dt) => ArrowDataType::LargeList(Box::new(dt.to_arrow())),

--- a/common/functions/src/scalars/arithmetics/arithmetic_test.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_test.rs
@@ -176,9 +176,9 @@ fn test_arithmetic_date_interval() -> Result<()> {
         date_time.timestamp() as u32
     };
 
-    let to_days = |y: i32, m: u32, d: u32| -> u32 {
+    let to_days = |y: i32, m: u32, d: u32| -> i32 {
         let date_time = chrono::NaiveDate::from_ymd(y, m, d).and_hms(0, 0, 1);
-        (date_time.timestamp() / (24 * 3600)) as u32
+        (date_time.timestamp() / (24 * 3600)) as i32
     };
 
     let daytime_to_ms = |days: i64, hour: i64, minute: i64, second: i64| -> i64 {

--- a/common/functions/src/scalars/dates/date_function_test.rs
+++ b/common/functions/src/scalars/dates/date_function_test.rs
@@ -76,7 +76,7 @@ fn test_toyyyymm_date16_function() -> Result<()> {
 #[test]
 fn test_toyyyymm_date32_function() -> Result<()> {
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date32, false)]);
-    let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![0u32])]);
+    let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![0i32])]);
 
     {
         let col = ToYYYYMMFunction::try_create("a")?;
@@ -96,9 +96,7 @@ fn test_toyyyymm_date32_function() -> Result<()> {
     }
 
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date32, false)]);
-    let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![
-        0u32, 1u32, 2u32, 3u32,
-    ])]);
+    let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![0i32, 1, 2, 3])]);
 
     {
         let toyyyymm = ToYYYYMMFunction::try_create("a")?;
@@ -204,7 +202,7 @@ fn test_toyyyymm_constant_function() -> Result<()> {
     // date32
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date32, false)]);
     let block = DataBlock::create(schema.clone(), vec![DataColumn::Constant(
-        DataValue::UInt32(Some(0u32)),
+        DataValue::Int32(Some(0i32)),
         10,
     )]);
     {
@@ -275,7 +273,7 @@ fn test_toyyyymmdd_function() -> Result<()> {
 
     // date32
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date32, false)]);
-    let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![0u32])]);
+    let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![0i32])]);
 
     {
         let col = ToYYYYMMDDFunction::try_create("a")?;
@@ -348,7 +346,7 @@ fn test_toyyyymmdd_constant_function() -> Result<()> {
     // date32
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date32, false)]);
     let block = DataBlock::create(schema.clone(), vec![DataColumn::Constant(
-        DataValue::UInt32(Some(0u32)),
+        DataValue::Int32(Some(0i32)),
         10,
     )]);
     {
@@ -420,7 +418,7 @@ fn test_toyyyymmddhhmmss_function() -> Result<()> {
 
     // date32
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date32, false)]);
-    let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![0u32])]);
+    let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![0i32])]);
 
     {
         let col = ToYYYYMMDDhhmmssFunction::try_create("a")?;
@@ -493,7 +491,7 @@ fn test_toyyyymmhhmmss_constant_function() -> Result<()> {
     // date32
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date32, false)]);
     let block = DataBlock::create(schema.clone(), vec![DataColumn::Constant(
-        DataValue::UInt32(Some(0u32)),
+        DataValue::Int32(Some(0i32)),
         10,
     )]);
     {

--- a/common/functions/src/scalars/dates/date_test.rs
+++ b/common/functions/src/scalars/dates/date_test.rs
@@ -93,9 +93,6 @@ fn do_test(t: Test) -> Result<()> {
     //Eq check
     let v = func.eval(&columns, rows)?;
     let expect: DataColumn = t.expect.into();
-    for val in v.to_values()? {
-        println!("{}", val);
-    }
     assert_eq!(&expect, &v);
     Ok(())
 }

--- a/common/functions/src/scalars/dates/interval_function.rs
+++ b/common/functions/src/scalars/dates/interval_function.rs
@@ -294,14 +294,14 @@ impl IntervalFunctionFactory {
         let milliseconds_per_day = 24 * 3600 * 1000;
         let res = Self::interval_operation(
             interval.column().to_array()?.i64()?,
-            date32.column().to_array()?.u32()?,
-            |ms: &i64, days: &u32| {
+            date32.column().to_array()?.i32()?,
+            |ms: &i64, days: &i32| {
                 let r = match op {
                     DataValueArithmeticOperator::Plus => {
-                        (*days as i64 + *ms / milliseconds_per_day) as u32
+                        (*days as i64 + *ms / milliseconds_per_day) as i32
                     }
                     DataValueArithmeticOperator::Minus => {
-                        (*days as i64 - *ms / milliseconds_per_day) as u32
+                        (*days as i64 - *ms / milliseconds_per_day) as i32
                     }
                     _ => unreachable!(),
                 };
@@ -420,14 +420,14 @@ impl IntervalFunctionFactory {
     crate::define_month_plus_minus_date!(month_u8_plus_minus_date16, u8, u16);
 
     // date32 functions
-    crate::define_month_plus_minus_date!(month_i64_plus_minus_date32, i64, u32);
-    crate::define_month_plus_minus_date!(month_i32_plus_minus_date32, i32, u32);
-    crate::define_month_plus_minus_date!(month_i16_plus_minus_date32, i16, u32);
-    crate::define_month_plus_minus_date!(month_i8_plus_minus_date32, i8, u32);
-    crate::define_month_plus_minus_date!(month_u64_plus_minus_date32, u64, u32);
-    crate::define_month_plus_minus_date!(month_u32_plus_minus_date32, u32, u32);
-    crate::define_month_plus_minus_date!(month_u16_plus_minus_date32, u16, u32);
-    crate::define_month_plus_minus_date!(month_u8_plus_minus_date32, u8, u32);
+    crate::define_month_plus_minus_date!(month_i64_plus_minus_date32, i64, i32);
+    crate::define_month_plus_minus_date!(month_i32_plus_minus_date32, i32, i32);
+    crate::define_month_plus_minus_date!(month_i16_plus_minus_date32, i16, i32);
+    crate::define_month_plus_minus_date!(month_i8_plus_minus_date32, i8, i32);
+    crate::define_month_plus_minus_date!(month_u64_plus_minus_date32, u64, i32);
+    crate::define_month_plus_minus_date!(month_u32_plus_minus_date32, u32, i32);
+    crate::define_month_plus_minus_date!(month_u16_plus_minus_date32, u16, i32);
+    crate::define_month_plus_minus_date!(month_u8_plus_minus_date32, u8, i32);
 
     crate::define_month_plus_minus_datetime32!(month_i64_plus_minus_datetime32, i64);
     crate::define_month_plus_minus_datetime32!(month_i32_plus_minus_datetime32, i32);
@@ -499,14 +499,14 @@ impl IntervalFunctionFactory {
     crate::define_time_secs_plus_minus_date!(time_secs_u8_plus_minus_date16, u8, u16);
 
     // date32 functions
-    crate::define_time_secs_plus_minus_date!(time_secs_i64_plus_minus_date32, i64, u32);
-    crate::define_time_secs_plus_minus_date!(time_secs_i32_plus_minus_date32, i32, u32);
-    crate::define_time_secs_plus_minus_date!(time_secs_i16_plus_minus_date32, i16, u32);
-    crate::define_time_secs_plus_minus_date!(time_secs_i8_plus_minus_date32, i8, u32);
-    crate::define_time_secs_plus_minus_date!(time_secs_u64_plus_minus_date32, u64, u32);
-    crate::define_time_secs_plus_minus_date!(time_secs_u32_plus_minus_date32, u32, u32);
-    crate::define_time_secs_plus_minus_date!(time_secs_u16_plus_minus_date32, u16, u32);
-    crate::define_time_secs_plus_minus_date!(time_secs_u8_plus_minus_date32, u8, u32);
+    crate::define_time_secs_plus_minus_date!(time_secs_i64_plus_minus_date32, i64, i32);
+    crate::define_time_secs_plus_minus_date!(time_secs_i32_plus_minus_date32, i32, i32);
+    crate::define_time_secs_plus_minus_date!(time_secs_i16_plus_minus_date32, i16, i32);
+    crate::define_time_secs_plus_minus_date!(time_secs_i8_plus_minus_date32, i8, i32);
+    crate::define_time_secs_plus_minus_date!(time_secs_u64_plus_minus_date32, u64, i32);
+    crate::define_time_secs_plus_minus_date!(time_secs_u32_plus_minus_date32, u32, i32);
+    crate::define_time_secs_plus_minus_date!(time_secs_u16_plus_minus_date32, u16, i32);
+    crate::define_time_secs_plus_minus_date!(time_secs_u8_plus_minus_date32, u8, i32);
 
     crate::define_time_secs_plus_minus_datetime32!(time_secs_i64_plus_minus_datetime32, i64);
     crate::define_time_secs_plus_minus_datetime32!(time_secs_i32_plus_minus_datetime32, i32);

--- a/common/functions/src/scalars/dates/interval_function_test.rs
+++ b/common/functions/src/scalars/dates/interval_function_test.rs
@@ -44,7 +44,7 @@ fn test_add_months() -> Result<()> {
 
     let blocks = DataBlock::create_by_array(schema.clone(), vec![
         Series::new(vec![dt_to_days("2020-02-29T10:00:00Z") as u16]),
-        Series::new(vec![dt_to_days("2020-02-29T10:00:00Z") as u32]),
+        Series::new(vec![dt_to_days("2020-02-29T10:00:00Z") as i32]),
         Series::new(vec![dt_to_seconds("2020-02-29T01:02:03Z") as u32]),
         Series::new(vec![12_u8]),
         Series::new(vec![12_u16]),
@@ -89,24 +89,24 @@ fn test_add_months() -> Result<()> {
     }
 
     {
-        let mut expects: Vec<u32> = Vec::new();
+        let mut expects: Vec<i32> = Vec::new();
         expects.reserve(8);
         for c in ["u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64"] {
             let col = add_months.eval(&[column("date32"), column(c)], 1)?;
-            let raw = col.to_array()?.u32()?.inner().values().as_slice().to_vec();
+            let raw = col.to_array()?.i32()?.inner().values().as_slice().to_vec();
             assert_eq!(raw.len(), 1);
-            assert_eq!(col.data_type(), DataType::UInt32);
+            assert_eq!(col.data_type(), DataType::Int32);
             expects.push(raw[0]);
         }
         assert_eq!(expects, vec![
-            dt_to_days("2021-02-28T10:00:00Z") as u32,
-            dt_to_days("2021-02-28T10:00:00Z") as u32,
-            dt_to_days("2021-02-28T10:00:00Z") as u32,
-            dt_to_days("2021-02-28T10:00:00Z") as u32,
-            dt_to_days("2019-01-29T10:00:00Z") as u32,
-            dt_to_days("2019-01-29T10:00:00Z") as u32,
-            dt_to_days("2019-01-29T10:00:00Z") as u32,
-            dt_to_days("2019-01-29T10:00:00Z") as u32,
+            dt_to_days("2021-02-28T10:00:00Z") as i32,
+            dt_to_days("2021-02-28T10:00:00Z") as i32,
+            dt_to_days("2021-02-28T10:00:00Z") as i32,
+            dt_to_days("2021-02-28T10:00:00Z") as i32,
+            dt_to_days("2019-01-29T10:00:00Z") as i32,
+            dt_to_days("2019-01-29T10:00:00Z") as i32,
+            dt_to_days("2019-01-29T10:00:00Z") as i32,
+            dt_to_days("2019-01-29T10:00:00Z") as i32,
         ]);
     }
 

--- a/common/functions/src/scalars/dates/number_function.rs
+++ b/common/functions/src/scalars/dates/number_function.rs
@@ -209,7 +209,7 @@ where
         let number_array: DataColumn = match data_type {
             DataType::Date16 => {
                 if let DataColumn::Constant(v, _) = columns[0].column() {
-                    let date_time = Utc.timestamp(v.as_u64().unwrap() as i64 * 24 * 3600, 0_u32);
+                    let date_time = Utc.timestamp(v.as_u64()? as i64 * 24 * 3600, 0_u32);
                     let constant_result = T::to_constant_value(date_time);
                     Ok(DataColumn::Constant(constant_result, input_rows))
                 } else {
@@ -226,7 +226,7 @@ where
             },
             DataType::Date32 => {
                 if let DataColumn::Constant(v, _) = columns[0].column() {
-                    let date_time = Utc.timestamp(v.as_u64().unwrap() as i64 * 24 * 3600, 0_u32);
+                    let date_time = Utc.timestamp(v.as_i64()? * 24 * 3600, 0_u32);
                     let constant_result = T::to_constant_value(date_time);
                     Ok(DataColumn::Constant(constant_result, input_rows))
                 } else {
@@ -243,7 +243,7 @@ where
             },
             DataType::DateTime32(_) => {
                 if let DataColumn::Constant(v, _) = columns[0].column() {
-                    let date_time = Utc.timestamp(v.as_u64().unwrap() as i64, 0_u32);
+                    let date_time = Utc.timestamp(v.as_u64()? as i64, 0_u32);
                     let constant_result = T::to_constant_value(date_time);
                     Ok(DataColumn::Constant(constant_result, input_rows))
                 } else {

--- a/common/functions/src/scalars/dates/number_function.rs
+++ b/common/functions/src/scalars/dates/number_function.rs
@@ -96,13 +96,13 @@ impl NumberResultFunction<u64> for ToYYYYMMDDhhmmss {
 #[derive(Clone)]
 pub struct ToStartOfYear;
 
-impl NumberResultFunction<u32> for ToStartOfYear {
+impl NumberResultFunction<u16> for ToStartOfYear {
     fn return_type() -> Result<DataType> {
         Ok(DataType::Date16)
     }
-    fn to_number(value: DateTime<Utc>) -> u32 {
+    fn to_number(value: DateTime<Utc>) -> u16 {
         let end: DateTime<Utc> = Utc.ymd(value.year(), 1, 1).and_hms(0, 0, 0);
-        get_day(end)
+        get_day(end) as u16
     }
 
     fn to_constant_value(value: DateTime<Utc>) -> DataValue {
@@ -113,18 +113,18 @@ impl NumberResultFunction<u32> for ToStartOfYear {
 #[derive(Clone)]
 pub struct ToStartOfISOYear;
 
-impl NumberResultFunction<u32> for ToStartOfISOYear {
+impl NumberResultFunction<u16> for ToStartOfISOYear {
     fn return_type() -> Result<DataType> {
         Ok(DataType::Date16)
     }
-    fn to_number(value: DateTime<Utc>) -> u32 {
+    fn to_number(value: DateTime<Utc>) -> u16 {
         let week_day = value.weekday().num_days_from_monday();
         let iso_week = value.iso_week();
         let iso_week_num = iso_week.week();
         let sub_days = (iso_week_num - 1) * 7 + week_day;
         let result = value.timestamp_millis() - sub_days as i64 * 24 * 3600 * 1000;
         let end: DateTime<Utc> = Utc.timestamp_millis(result);
-        get_day(end)
+        get_day(end) as u16
     }
 
     fn to_constant_value(value: DateTime<Utc>) -> DataValue {
@@ -135,14 +135,14 @@ impl NumberResultFunction<u32> for ToStartOfISOYear {
 #[derive(Clone)]
 pub struct ToStartOfQuarter;
 
-impl NumberResultFunction<u32> for ToStartOfQuarter {
+impl NumberResultFunction<u16> for ToStartOfQuarter {
     fn return_type() -> Result<DataType> {
         Ok(DataType::Date16)
     }
-    fn to_number(value: DateTime<Utc>) -> u32 {
+    fn to_number(value: DateTime<Utc>) -> u16 {
         let new_month = value.month0() / 3 * 3 + 1;
         let date = Utc.ymd(value.year(), new_month, 1).and_hms(0, 0, 0);
-        get_day(date)
+        get_day(date) as u16
     }
 
     fn to_constant_value(value: DateTime<Utc>) -> DataValue {
@@ -153,13 +153,13 @@ impl NumberResultFunction<u32> for ToStartOfQuarter {
 #[derive(Clone)]
 pub struct ToStartOfMonth;
 
-impl NumberResultFunction<u32> for ToStartOfMonth {
+impl NumberResultFunction<u16> for ToStartOfMonth {
     fn return_type() -> Result<DataType> {
         Ok(DataType::Date16)
     }
-    fn to_number(value: DateTime<Utc>) -> u32 {
+    fn to_number(value: DateTime<Utc>) -> u16 {
         let date = Utc.ymd(value.year(), value.month(), 1).and_hms(0, 0, 0);
-        get_day(date)
+        get_day(date) as u16
     }
 
     fn to_constant_value(value: DateTime<Utc>) -> DataValue {
@@ -232,7 +232,7 @@ where
                 } else {
                     let result = columns[0].column()
                         .to_array()?
-                        .u32()?
+                        .i32()?
                         .apply_cast_numeric(|v| {
                             let date_time = Utc.timestamp(v as i64 * 24 * 3600, 0_u32);
                             T::to_number(date_time)
@@ -282,7 +282,8 @@ fn get_day(date: DateTime<Utc>) -> u32 {
 pub type ToYYYYMMFunction = NumberFunction<ToYYYYMM, u32>;
 pub type ToYYYYMMDDFunction = NumberFunction<ToYYYYMMDD, u32>;
 pub type ToYYYYMMDDhhmmssFunction = NumberFunction<ToYYYYMMDDhhmmss, u64>;
-pub type ToStartOfISOYearFunction = NumberFunction<ToStartOfISOYear, u32>;
-pub type ToStartOfYearFunction = NumberFunction<ToStartOfYear, u32>;
-pub type ToStartOfQuarterFunction = NumberFunction<ToStartOfQuarter, u32>;
-pub type ToStartOfMonthFunction = NumberFunction<ToStartOfMonth, u32>;
+
+pub type ToStartOfISOYearFunction = NumberFunction<ToStartOfISOYear, u16>;
+pub type ToStartOfYearFunction = NumberFunction<ToStartOfYear, u16>;
+pub type ToStartOfQuarterFunction = NumberFunction<ToStartOfQuarter, u16>;
+pub type ToStartOfMonthFunction = NumberFunction<ToStartOfMonth, u16>;

--- a/common/functions/src/scalars/dates/round_function.rs
+++ b/common/functions/src/scalars/dates/round_function.rs
@@ -15,6 +15,7 @@
 use std::fmt;
 
 use common_datavalues::prelude::*;
+use common_exception::ErrorCode;
 use common_exception::Result;
 
 use crate::scalars::Function;
@@ -49,8 +50,14 @@ impl Function for RoundFunction {
         self.display_name.as_str()
     }
 
-    fn return_type(&self, _args: &[DataType]) -> Result<DataType> {
-        Ok(DataType::DateTime32(None))
+    fn return_type(&self, args: &[DataType]) -> Result<DataType> {
+        match args[0] {
+            DataType::DateTime32(_) => Ok(DataType::DateTime32(None)),
+            _ => Err(ErrorCode::BadDataValueType(format!(
+                "Function {} must have a DateTime type as argument, but got {}",
+                self.display_name, args[0],
+            ))),
+        }
     }
 
     fn nullable(&self, _input_schema: &DataSchema) -> Result<bool> {

--- a/common/functions/src/scalars/dates/week_date.rs
+++ b/common/functions/src/scalars/dates/week_date.rs
@@ -140,7 +140,7 @@ where
                 } else {
                     let result = columns[0].column()
                         .to_array()?
-                        .u32()?
+                        .i32()?
                         .apply_cast_numeric(|v| {
                             let date_time = Utc.timestamp(v as i64 * 24 * 3600, 0_u32);
                             T::to_number(date_time, mode)

--- a/common/functions/src/scalars/dates/week_date.rs
+++ b/common/functions/src/scalars/dates/week_date.rs
@@ -134,7 +134,7 @@ where
             },
             DataType::Date32 => {
                 if let DataColumn::Constant(v, _) = columns[0].column() {
-                    let date_time = Utc.timestamp(v.as_u64()? as i64 * 24 * 3600, 0_u32);
+                    let date_time = Utc.timestamp(v.as_i64()?  * 24 * 3600, 0_u32);
                     let constant_result = T::to_constant_value(date_time, mode);
                     Ok(DataColumn::Constant(constant_result, input_rows))
                 } else {
@@ -151,7 +151,7 @@ where
             },
             DataType::DateTime32(_) => {
                 if let DataColumn::Constant(v, _) = columns[0].column() {
-                    let date_time = Utc.timestamp(v.as_u64()? as i64, 0_u32);
+                    let date_time = Utc.timestamp(v.as_i64()?, 0_u32);
                     let constant_result = T::to_constant_value(date_time, mode);
                     Ok(DataColumn::Constant(constant_result, input_rows))
                 } else {

--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -286,9 +286,9 @@ impl<W: std::io::Write> InteractiveWorkerBase<W> {
 
     fn extra_info(context: &DatabendQueryContextRef, instant: Instant) -> String {
         let progress = context.get_progress_value();
-        let seconds = instant.elapsed().as_millis() as f64 / 1000f64;
+        let seconds = instant.elapsed().as_nanos() as f64 / 1e9f64;
         format!(
-            "Read {} rows, {} in {} sec., {} rows/sec., {}/sec.",
+            "Read {} rows, {} in {:.3} sec., {} rows/sec., {}/sec.",
             progress.read_rows,
             convert_byte_size(progress.read_bytes as f64),
             seconds,

--- a/query/src/sql/sql_common.rs
+++ b/query/src/sql/sql_common.rs
@@ -54,6 +54,10 @@ impl SQLCommon {
                     "FLOAT32" => Ok(DataType::Float32),
                     "FLOAT64" => Ok(DataType::Float64),
                     "STRING" => Ok(DataType::String),
+                    "DATE16" => Ok(DataType::Date16),
+                    "DATE32" => Ok(DataType::Date32),
+                    "DATETIME" => Ok(DataType::DateTime32(None)),
+                    "DATETIME32" => Ok(DataType::DateTime32(None)),
 
                     _ => Result::Err(ErrorCode::IllegalDataType(format!(
                         "The SQL data type {:?} is not implemented",

--- a/website/databend/docs/sqlstatement/data-types/data-type-time-date-types.md
+++ b/website/databend/docs/sqlstatement/data-types/data-type-time-date-types.md
@@ -3,27 +3,30 @@ id: data-type-time-date-types
 title: Time and Date Types
 
 ---
-| Data Type  | Size    |  Resolution | Min Value           | Max Value           | Precision           |
-| -----------| ------- |  ---------- | ------------------- |-------------------- | ------------------- |
-| DATE       | 4 byte  |  day        | 1000-01-01          | 9999-12-31          | YYYY-MM-DD          |
-| TIMESTAMP  | 4 byte  |  second     | 1970-01-01 00:00:00 | 2105-12-31 23:59:59 | YYYY-MM-DD hh:mm:ss |
+| Data Type             | Size    |  Resolution | Min Value           | Max Value           | Precision           |
+| ----------------------| ------- |  ---------- | ------------------- |-------------------- | ------------------- |
+| Date                  | 2 byte  |  day        | 1000-01-01          | 9999-12-31          | YYYY-MM-DD          |
+| Date32                | 4 byte  |  day        | 1000-01-01          | 9999-12-31          | YYYY-MM-DD          |
+| DateTime/DateTime32   | 4 byte  |  second     | 1970-01-01 00:00:00 | 2105-12-31 23:59:59 | YYYY-MM-DD hh:mm:ss |
+| DateTime/DateTime32   | 4 byte  |  second     | 1970-01-01 00:00:00 | 2105-12-31 23:59:59 | YYYY-MM-DD hh:mm:ss |
 
 
 For example:
 ```
 CREATE TABLE dt
 (
-    `timestamp` Date,
-    `event_id` UInt8
+    d Date,
+    t DateTime,
+    event_id UInt8
 )
 ENGINE = Memory;
 
-INSERT INTO dt VALUES ('2021-09-09', 1);
+INSERT INTO dt VALUES ('2021-09-09', '2021-09-09 01:01:01', 1);
 
-mysql> SELECT * FROM dt;
-+------------+----------+
-| timestamp  | event_id |
-+------------+----------+
-| 2021-09-09 |        1 |
-+------------+----------+
+mysql> select * from dt;
++------------+---------------------+----------+
+| d          | t                   | event_id |
++------------+---------------------+----------+
+| 2021-09-09 | 2021-09-09 01:01:01 |        1 |
++------------+---------------------+----------+
 ```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

- To be compatible with ClickHouse's [Date32](https://clickhouse.com/docs/en/sql-reference/data-types/date32/), it supports negative numbers.

- Add new aliases for SQL datatypes:
   "DATE16" => Ok(DataType::Date16),
    "DATE32" => Ok(DataType::Date32),
    "DATETIME" => Ok(DataType::DateTime32(None)),
    "DATETIME32" => Ok(DataType::DateTime32(None)),

## Changelog


related cc @ygf11  @dust1  @junli1026 

- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

