### PR TITLE
TEST-1995: databend-test --skip support regex rule

### DIFF
--- a/docker/stateless/run.sh
+++ b/docker/stateless/run.sh
@@ -9,7 +9,7 @@ function run_tests()
 {
   cd tests
   mkdir -p test_output
-  ./databend-test --print-time  --jobs 4   
+  ./databend-test --print-time  --jobs 4 --skip '^09_*'
 }
 
 export -f run_tests

--- a/scripts/ci/ci-run-stateless-tests-cluster.sh
+++ b/scripts/ci/ci-run-stateless-tests-cluster.sh
@@ -9,4 +9,4 @@ SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 cd "$SCRIPT_PATH/../../tests" || exit
 
 echo "Starting databend-test"
-./databend-test '^0[^4]_' --mode 'cluster'
+./databend-test '^0[^4]_' --mode 'cluster' --skip '^09_*'

--- a/scripts/ci/ci-run-stateless-tests-standalone.sh
+++ b/scripts/ci/ci-run-stateless-tests-standalone.sh
@@ -9,4 +9,4 @@ SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 cd "$SCRIPT_PATH/../../tests" || exit
 
 echo "Starting databend-test"
-./databend-test --mode 'standalone'
+./databend-test --mode 'standalone' --skip '^09_*'

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -184,7 +184,7 @@ def run_tests_array(all_tests_with_params):
             else:
                 status = "{0:72}".format(name + ": ")
 
-            if args.skip and any(s in name for s in args.skip):
+            if args.skip and any([re.search(r, case) for r in args.skip]):
                 status += MSG_SKIPPED + " - skip\n"
                 skipped_total += 1
             else:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR:
1. ./databend-test --mode 'standalone' --skip '^09_*' 
2. Skip the remote stateless test, for #1994 

## Changelog

- Build/Testing/CI


## Related Issues

Fixes #1995 

## Test Plan

Unit Tests

Stateless Tests

