### PR TITLE
CONFIG-2003: Remove dfs storage type

### DIFF
--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -21,13 +21,6 @@ use crate::configs::Config;
 
 const STORAGE_TYPE: &str = "STORAGE_TYPE";
 
-// DFS Storage env.
-const DFS_STORAGE_ADDRESS: &str = "DFS_STORAGE_ADDRESS";
-const DFS_STORAGE_USERNAME: &str = "DFS_STORAGE_USERNAME";
-const DFS_STORAGE_PASSWORD: &str = "DFS_STORAGE_PASSWORD";
-const DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT: &str = "DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT";
-const DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME";
-
 // Disk Storage env.
 const DISK_STORAGE_DATA_PATH: &str = "DISK_STORAGE_DATA_PATH";
 
@@ -39,68 +32,15 @@ const S3_STORAGE_BUCKET: &str = "S3_STORAGE_BUCKET";
 
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub enum StorageType {
-    Dfs,
     Disk,
     S3,
-}
-
-#[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
-pub struct DfsStorageConfig {
-    #[structopt(long, env = DFS_STORAGE_ADDRESS, default_value = "", help = "DFS storage backend address")]
-    #[serde(default)]
-    pub address: String,
-
-    #[structopt(long, env = DFS_STORAGE_USERNAME, default_value = "", help = "DFS storage backend user name")]
-    #[serde(default)]
-    pub username: String,
-
-    #[structopt(long, env = DFS_STORAGE_PASSWORD, default_value = "", help = "DFS storage backend user password")]
-    #[serde(default)]
-    pub password: String,
-
-    #[structopt(
-        long,
-        env = "DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT",
-        default_value = "",
-        help = "Certificate for client to identify dfs storage rpc server"
-    )]
-    #[serde(default)]
-    pub rpc_tls_storage_server_root_ca_cert: String,
-
-    #[structopt(
-        long,
-        env = "DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME",
-        default_value = "localhost"
-    )]
-    #[serde(default)]
-    pub rpc_tls_storage_service_domain_name: String,
-}
-
-impl DfsStorageConfig {
-    pub fn default() -> Self {
-        DfsStorageConfig {
-            address: "".to_string(),
-            username: "".to_string(),
-            password: "".to_string(),
-            rpc_tls_storage_server_root_ca_cert: "".to_string(),
-            rpc_tls_storage_service_domain_name: "".to_string(),
-        }
-    }
-}
-
-impl fmt::Debug for DfsStorageConfig {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{")?;
-        write!(f, "dfs.storage.address: \"{}\", ", self.address)?;
-        write!(f, "}}")
-    }
 }
 
 #[derive(
     Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
 )]
 pub struct DiskStorageConfig {
-    #[structopt(long, env = DFS_STORAGE_ADDRESS, default_value = "", help = "Disk storage backend address")]
+    #[structopt(long, env = DISK_STORAGE_DATA_PATH, default_value = "", help = "Disk storage backend address")]
     #[serde(default)]
     pub data_path: String,
 }
@@ -161,10 +101,6 @@ pub struct StorageConfig {
     #[serde(default)]
     pub storage_type: String,
 
-    // DFS storage backend config.
-    #[structopt(flatten)]
-    pub dfs: DfsStorageConfig,
-
     // Disk storage backend config.
     #[structopt(flatten)]
     pub disk: DiskStorageConfig,
@@ -178,7 +114,6 @@ impl StorageConfig {
     pub fn default() -> Self {
         StorageConfig {
             storage_type: "disk".to_string(),
-            dfs: DfsStorageConfig::default(),
             disk: DiskStorageConfig::default(),
             s3: S3StorageConfig::default(),
         }
@@ -186,43 +121,6 @@ impl StorageConfig {
 
     pub fn load_from_env(mut_config: &mut Config) {
         env_helper!(mut_config, storage, storage_type, String, STORAGE_TYPE);
-
-        // DFS.
-        env_helper!(
-            mut_config.storage,
-            dfs,
-            address,
-            String,
-            DFS_STORAGE_ADDRESS
-        );
-        env_helper!(
-            mut_config.storage,
-            dfs,
-            username,
-            String,
-            DFS_STORAGE_USERNAME
-        );
-        env_helper!(
-            mut_config.storage,
-            dfs,
-            password,
-            String,
-            DFS_STORAGE_PASSWORD
-        );
-        env_helper!(
-            mut_config.storage,
-            dfs,
-            rpc_tls_storage_server_root_ca_cert,
-            String,
-            DFS_STORAGE_RPC_TLS_SERVER_ROOT_CA_CERT
-        );
-        env_helper!(
-            mut_config.storage,
-            dfs,
-            rpc_tls_storage_service_domain_name,
-            String,
-            DFS_STORAGE_RPC_TLS_SERVICE_DOMAIN_NAME
-        );
 
         // DISK.
         env_helper!(

--- a/query/src/configs/config_test.rs
+++ b/query/src/configs/config_test.rs
@@ -70,13 +70,6 @@ rpc_tls_meta_service_domain_name = \"localhost\"
 [storage]
 storage_type = \"disk\"
 
-[storage.dfs]
-address = \"\"
-username = \"\"
-password = \"\"
-rpc_tls_storage_server_root_ca_cert = \"\"
-rpc_tls_storage_service_domain_name = \"\"
-
 [storage.disk]
 data_path = \"\"
 
@@ -107,9 +100,6 @@ fn test_env_config() -> Result<()> {
     std::env::set_var("QUERY_HTTP_API_ADDRESS", "1.2.3.4:8081");
     std::env::set_var("QUERY_METRIC_API_ADDRESS", "1.2.3.4:7071");
     std::env::set_var("STORAGE_TYPE", "s3");
-    std::env::set_var("DFS_STORAGE_ADDRESS", "1.2.3.4:1234");
-    std::env::set_var("DFS_STORAGE_USERNAME", "admin");
-    std::env::set_var("DFS_STORAGE_PASSWORD", "password!");
     std::env::set_var("DISK_STORAGE_DATA_PATH", "/tmp/test");
     std::env::set_var("S3_STORAGE_REGION", "us.region");
     std::env::set_var("S3_STORAGE_ACCESS_KEY_ID", "us.key.id");
@@ -135,10 +125,6 @@ fn test_env_config() -> Result<()> {
 
     assert_eq!("s3", configured.storage.storage_type);
 
-    assert_eq!("1.2.3.4:1234", configured.storage.dfs.address);
-    assert_eq!("admin", configured.storage.dfs.username);
-    assert_eq!("password!", configured.storage.dfs.password);
-
     assert_eq!("/tmp/test", configured.storage.disk.data_path);
 
     assert_eq!("us.region", configured.storage.s3.region);
@@ -160,9 +146,6 @@ fn test_env_config() -> Result<()> {
     std::env::remove_var("QUERY_HTTP_API_ADDRESS");
     std::env::remove_var("QUERY_METRIC_API_ADDRESS");
     std::env::remove_var("STORAGE_TYPE");
-    std::env::remove_var("DFS_STORAGE_ADDRESS");
-    std::env::remove_var("DFS_STORAGE_USERNAME");
-    std::env::remove_var("DFS_STORAGE_PASSWORD");
     std::env::remove_var("DISK_STORAGE_DATA_PATH");
     std::env::remove_var("S3_STORAGE_REGION");
     std::env::remove_var("S3_STORAGE_ACCESS_KEY_ID");

--- a/scripts/deploy/config/databend-query-node-1.toml
+++ b/scripts/deploy/config/databend-query-node-1.toml
@@ -38,11 +38,8 @@ meta_password = "root"
 
 # Storage config.
 [storage]
-# dfs|disk|s3
+# disk|s3
 storage_type = ""
-
-# DFS storage.
-[storage.dfs]
 
 # DISK storage.
 [storage.disk]

--- a/scripts/deploy/config/databend-query-node-2.toml
+++ b/scripts/deploy/config/databend-query-node-2.toml
@@ -36,11 +36,8 @@ meta_password = "root"
 
 # Storage config.
 [storage]
-# dfs|disk|s3
+# disk|s3
 storage_type = ""
-
-# DFS storage.
-[storage.dfs]
 
 # DISK storage.
 [storage.disk]

--- a/scripts/deploy/config/databend-query-node-3.toml
+++ b/scripts/deploy/config/databend-query-node-3.toml
@@ -36,11 +36,8 @@ meta_password = "root"
 
 # Storage config.
 [storage]
-# dfs|disk|s3
+# disk|s3
 storage_type = ""
-
-# DFS storage.
-[storage.dfs]
 
 # DISK storage.
 [storage.disk]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR:
1. Remove the dfs storage type from config

## Changelog

- Improvement


## Related Issues

Fixes #2003 

## Test Plan

Unit Tests

Stateless Tests

