### PR TITLE
[query] refactor: rename get_table_ext to get_table_by_id; They are the same

### DIFF
--- a/common/meta-apis/api/src/meta_api.rs
+++ b/common/meta-apis/api/src/meta_api.rs
@@ -51,7 +51,7 @@ pub trait MetaApi: Send + Sync {
         table: String,
     ) -> common_exception::Result<GetTableActionResult>;
 
-    async fn get_table_ext(
+    async fn get_table_by_id(
         &self,
         table_id: MetaId,
         db_ver: Option<MetaVersion>,

--- a/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
+++ b/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
@@ -75,7 +75,7 @@ impl MetaApi for StoreClient {
         self.do_action(GetTableAction { db, table }).await
     }
 
-    async fn get_table_ext(
+    async fn get_table_by_id(
         &self,
         tbl_id: MetaId,
         tbl_ver: Option<MetaVersion>,

--- a/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
+++ b/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
@@ -133,7 +133,7 @@ impl MetaBackend for RemoteMeteStoreClient {
         let reply = self.rt.block_on(
             async move {
                 let client = cli.try_get_meta_client().await?;
-                client.get_table_ext(table_id, table_version).await
+                client.get_table_by_id(table_id, table_version).await
             },
             self.rpc_time_out,
         )??;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor: rename get_table_ext to get_table_by_id; They are the same

## Changelog




- Improvement


## Related Issues