### PR TITLE
[query] refactor: merge GetTableActionResult and TableInfo into one struct TableInfo; fix: #2015

### DIFF
--- a/common/meta-apis/api/src/meta_api.rs
+++ b/common/meta-apis/api/src/meta_api.rs
@@ -45,17 +45,13 @@ pub trait MetaApi: Send + Sync {
         plan: DropTablePlan,
     ) -> common_exception::Result<DropTableActionResult>;
 
-    async fn get_table(
-        &self,
-        db: String,
-        table: String,
-    ) -> common_exception::Result<GetTableActionResult>;
+    async fn get_table(&self, db: String, table: String) -> common_exception::Result<TableInfo>;
 
     async fn get_table_by_id(
         &self,
         table_id: MetaId,
         db_ver: Option<MetaVersion>,
-    ) -> common_exception::Result<GetTableActionResult>;
+    ) -> common_exception::Result<TableInfo>;
 
     async fn get_database_meta(
         &self,

--- a/common/meta-apis/vo/src/lib.rs
+++ b/common/meta-apis/vo/src/lib.rs
@@ -43,7 +43,7 @@ pub struct CreateTableActionResult {
 pub struct DropTableActionResult {}
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct GetTableActionResult {
+pub struct TableInfo {
     pub table_id: u64,
     pub db: String,
     pub name: String,

--- a/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
+++ b/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
@@ -67,11 +67,7 @@ impl MetaApi for StoreClient {
     }
 
     /// Get table.
-    async fn get_table(
-        &self,
-        db: String,
-        table: String,
-    ) -> common_exception::Result<GetTableActionResult> {
+    async fn get_table(&self, db: String, table: String) -> common_exception::Result<TableInfo> {
         self.do_action(GetTableAction { db, table }).await
     }
 
@@ -79,7 +75,7 @@ impl MetaApi for StoreClient {
         &self,
         tbl_id: MetaId,
         tbl_ver: Option<MetaVersion>,
-    ) -> common_exception::Result<GetTableActionResult> {
+    ) -> common_exception::Result<TableInfo> {
         self.do_action(GetTableExtReq { tbl_id, tbl_ver }).await
     }
 
@@ -150,22 +146,14 @@ pub struct GetTableAction {
     pub db: String,
     pub table: String,
 }
-action_declare!(
-    GetTableAction,
-    GetTableActionResult,
-    StoreDoAction::GetTable
-);
+action_declare!(GetTableAction, TableInfo, StoreDoAction::GetTable);
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct GetTableExtReq {
     pub tbl_id: MetaId,
     pub tbl_ver: Option<MetaVersion>,
 }
-action_declare!(
-    GetTableExtReq,
-    GetTableActionResult,
-    StoreDoAction::GetTableExt
-);
+action_declare!(GetTableExtReq, TableInfo, StoreDoAction::GetTableExt);
 
 // - get database meta
 

--- a/dfs/src/api/rpc/flight_service_test.rs
+++ b/dfs/src/api/rpc/flight_service_test.rs
@@ -99,7 +99,7 @@ async fn test_flight_restart() -> anyhow::Result<()> {
             assert_eq!(1, res.table_id, "table id is 1");
 
             let got = client.get_table(db_name.into(), table_name.into()).await?;
-            let want = GetTableActionResult {
+            let want = TableInfo {
                 table_id: 1,
                 db: db_name.into(),
                 name: table_name.into(),
@@ -297,7 +297,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
                 .get_table(db_name.into(), tbl_name.into())
                 .await
                 .unwrap();
-            let want = GetTableActionResult {
+            let want = TableInfo {
                 table_id: 1,
                 db: db_name.into(),
                 name: tbl_name.into(),
@@ -318,7 +318,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
                 .get_table(db_name.into(), tbl_name.into())
                 .await
                 .unwrap();
-            let want = GetTableActionResult {
+            let want = TableInfo {
                 table_id: 1,
                 db: db_name.into(),
                 name: tbl_name.into(),
@@ -345,7 +345,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
             // get_table returns the old table
 
             let got = client.get_table("db1".into(), "tb2".into()).await.unwrap();
-            let want = GetTableActionResult {
+            let want = TableInfo {
                 table_id: 1,
                 db: db_name.into(),
                 name: tbl_name.into(),
@@ -427,7 +427,7 @@ async fn test_flight_drop_table() -> anyhow::Result<()> {
                 .get_table(db_name.into(), tbl_name.into())
                 .await
                 .unwrap();
-            let want = GetTableActionResult {
+            let want = TableInfo {
                 table_id: 1,
                 db: db_name.into(),
                 name: tbl_name.into(),

--- a/dfs/src/executor/action_handler_test.rs
+++ b/dfs/src/executor/action_handler_test.rs
@@ -437,7 +437,7 @@ async fn test_action_handler_get_table() -> anyhow::Result<()> {
     struct T {
         db_name: &'static str,
         table_name: &'static str,
-        want: Result<GetTableActionResult, ErrorCode>,
+        want: Result<TableInfo, ErrorCode>,
     }
 
     /// helper to build a T
@@ -449,7 +449,7 @@ async fn test_action_handler_get_table() -> anyhow::Result<()> {
         )]));
 
         let want = match want {
-            Ok(want_table_id) => Ok(GetTableActionResult {
+            Ok(want_table_id) => Ok(TableInfo {
                 table_id: want_table_id,
                 db: db_name.to_string(),
                 name: table_name.to_string(),

--- a/dfs/src/executor/meta_handlers.rs
+++ b/dfs/src/executor/meta_handlers.rs
@@ -264,7 +264,7 @@ impl RequestHandler<DropTableAction> for ActionHandler {
 
 #[async_trait::async_trait]
 impl RequestHandler<GetTableAction> for ActionHandler {
-    async fn handle(&self, act: GetTableAction) -> common_exception::Result<GetTableActionResult> {
+    async fn handle(&self, act: GetTableAction) -> common_exception::Result<TableInfo> {
         let db_name = &act.db;
         let table_name = &act.table;
 
@@ -288,7 +288,7 @@ impl RequestHandler<GetTableAction> for ActionHandler {
                 .map_err(|e| {
                     ErrorCode::IllegalSchema(format!("invalid schema: {:}", e.to_string()))
                 })?;
-                let rst = GetTableActionResult {
+                let rst = TableInfo {
                     table_id: table.table_id,
                     db: db_name.clone(),
                     name: table_name.clone(),
@@ -305,7 +305,7 @@ impl RequestHandler<GetTableAction> for ActionHandler {
 
 #[async_trait::async_trait]
 impl RequestHandler<GetTableExtReq> for ActionHandler {
-    async fn handle(&self, act: GetTableExtReq) -> common_exception::Result<GetTableActionResult> {
+    async fn handle(&self, act: GetTableExtReq) -> common_exception::Result<TableInfo> {
         // TODO duplicated code
         let table_id = act.tbl_id;
         let result = self.meta_node.get_table(&table_id).await;
@@ -318,7 +318,7 @@ impl RequestHandler<GetTableExtReq> for ActionHandler {
                 .map_err(|e| {
                     ErrorCode::IllegalSchema(format!("invalid schema: {:}", e.to_string()))
                 })?;
-                let rst = GetTableActionResult {
+                let rst = TableInfo {
                     table_id: table.table_id,
                     // TODO rm these filed
                     db: "".to_owned(),

--- a/query/src/catalogs/impls/meta_backends/embedded_meta_backend.rs
+++ b/query/src/catalogs/impls/meta_backends/embedded_meta_backend.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use common_exception::ErrorCode;
 use common_infallible::RwLock;
 use common_meta_api_vo::DatabaseInfo;
+use common_meta_api_vo::TableInfo;
 use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
 use common_planners::CreateDatabasePlan;
@@ -28,7 +29,6 @@ use common_planners::DropTablePlan;
 
 use crate::catalogs::meta_backend::MetaBackend;
 use crate::catalogs::meta_id_ranges::LOCAL_TBL_ID_BEGIN;
-use crate::catalogs::TableInfo;
 
 struct InMemoryTableInfo {
     pub(crate) name2meta: HashMap<String, Arc<TableInfo>>,
@@ -173,7 +173,7 @@ impl MetaBackend for EmbeddedMetaBackend {
             table_id: self.next_db_id(),
             name: plan.table,
             schema: plan.schema,
-            table_option: plan.options,
+            options: plan.options,
             engine: plan.engine,
         };
 

--- a/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
+++ b/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
@@ -28,6 +28,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_infallible::Mutex;
 use common_meta_api_vo::DatabaseInfo;
+use common_meta_api_vo::TableInfo;
 use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
 use common_planners::CreateDatabasePlan;
@@ -36,7 +37,6 @@ use common_planners::DropDatabasePlan;
 use common_planners::DropTablePlan;
 
 use crate::catalogs::meta_backend::MetaBackend;
-use crate::catalogs::TableInfo;
 use crate::common::StoreApiProvider;
 
 type CatalogTable = common_metatypes::Table;
@@ -83,7 +83,7 @@ impl RemoteMeteStoreClient {
             table_id: t_id,
             name: t_name.to_owned(),
             schema: Arc::new(schema),
-            table_option: tbl.table_options.clone(),
+            options: tbl.table_options.clone(),
             engine: tbl.table_engine.clone(),
         };
         Ok(info)
@@ -111,7 +111,7 @@ impl MetaBackend for RemoteMeteStoreClient {
             name: reply.name.clone(),
             schema: reply.schema,
             engine: reply.engine,
-            table_option: reply.options,
+            options: reply.options,
         };
         Ok(Arc::new(table_info))
     }
@@ -144,7 +144,7 @@ impl MetaBackend for RemoteMeteStoreClient {
             name: reply.name.clone(),
             schema: reply.schema.clone(),
             engine: reply.engine.clone(),
-            table_option: reply.options.clone(),
+            options: reply.options.clone(),
         };
 
         let mut cache = self.table_meta_cache.lock();

--- a/query/src/catalogs/meta_backend.rs
+++ b/query/src/catalogs/meta_backend.rs
@@ -17,14 +17,13 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_meta_api_vo::DatabaseInfo;
+use common_meta_api_vo::TableInfo;
 use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
 use common_planners::DropTablePlan;
-
-use crate::catalogs::TableInfo;
 
 pub trait MetaBackend: Send + Sync {
     fn get_table(&self, db_name: &str, table_name: &str) -> Result<Arc<TableInfo>>;

--- a/query/src/catalogs/mod.rs
+++ b/query/src/catalogs/mod.rs
@@ -14,8 +14,6 @@
 //
 
 pub use catalog::Catalog;
-use common_datavalues::DataSchemaRef;
-use common_planners::TableOptions;
 pub use database::Database;
 pub use impls::util::in_memory_metas::InMemoryMetas;
 pub use meta_id_ranges::*;
@@ -39,13 +37,3 @@ mod table_meta;
 
 pub mod impls;
 pub mod meta_backend;
-
-#[derive(Debug, Clone)]
-pub struct TableInfo {
-    pub db: String,
-    pub table_id: u64,
-    pub name: String,
-    pub schema: DataSchemaRef,
-    pub engine: String,
-    pub table_option: TableOptions,
-}

--- a/query/src/datasources/database/default/default_database.rs
+++ b/query/src/datasources/database/default/default_database.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_infallible::RwLock;
+use common_meta_api_vo::TableInfo;
 use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
 use common_planners::CreateTablePlan;
@@ -25,7 +26,6 @@ use common_planners::DropTablePlan;
 use crate::catalogs::impls::util::in_memory_metas::InMemoryMetas;
 use crate::catalogs::meta_backend::MetaBackend;
 use crate::catalogs::Database;
-use crate::catalogs::TableInfo;
 use crate::catalogs::TableMeta;
 use crate::common::StoreApiProvider;
 use crate::datasources::table_engine_registry::TableEngineRegistry;

--- a/query/src/datasources/database/example/example_database.rs
+++ b/query/src/datasources/database/example/example_database.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_api_vo::TableInfo;
 use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
 use common_planners::CreateTablePlan;
@@ -23,7 +24,6 @@ use common_planners::DropTablePlan;
 
 use crate::catalogs::meta_backend::MetaBackend;
 use crate::catalogs::Database;
-use crate::catalogs::TableInfo;
 use crate::catalogs::TableMeta;
 use crate::datasources::database::example::ExampleTable;
 
@@ -63,7 +63,7 @@ impl ExampleDatabase {
             table_info.db.clone(),
             table_info.name.clone(),
             table_info.schema.clone(),
-            table_info.table_option.clone(),
+            table_info.options.clone(),
             table_info.table_id,
         )?;
         let tbl_meta = TableMeta::create(tbl.into(), table_info.table_id);

--- a/query/src/datasources/table/csv/csv_table.rs
+++ b/query/src/datasources/table/csv/csv_table.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_api_vo::TableInfo;
 use common_planners::Extras;
 use common_planners::ReadDataSourcePlan;
 use common_planners::ScanPlan;
@@ -27,7 +28,6 @@ use common_planners::Statistics;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::catalogs::TableInfo;
 use crate::datasources::common::count_lines;
 use crate::datasources::common::generate_parts;
 use crate::datasources::table::csv::csv_table_stream::CsvTableStream;
@@ -41,7 +41,7 @@ pub struct CsvTable {
 
 impl CsvTable {
     pub fn try_create(tbl_info: TableInfo) -> Result<Box<dyn Table>> {
-        let options = &tbl_info.table_option;
+        let options = &tbl_info.options;
         let has_header = options.get("has_header").is_some();
         let file = match options.get("location") {
             None => {

--- a/query/src/datasources/table/csv/csv_table_test.rs
+++ b/query/src/datasources/table/csv/csv_table_test.rs
@@ -19,10 +19,10 @@ use common_base::tokio;
 use common_datablocks::assert_blocks_sorted_eq;
 use common_datavalues::prelude::*;
 use common_exception::Result;
+use common_meta_api_vo::TableInfo;
 use common_planners::*;
 use futures::TryStreamExt;
 
-use crate::catalogs::TableInfo;
 use crate::datasources::table::csv::csv_table::CsvTable;
 
 #[tokio::test]
@@ -44,7 +44,7 @@ async fn test_csv_table() -> Result<()> {
         name: "test_csv".into(),
         schema: DataSchemaRefExt::create(vec![DataField::new("column1", DataType::UInt64, false)]),
         engine: "Csv".to_string(),
-        table_option: options,
+        options: options,
         table_id: 0,
     })?;
 
@@ -116,7 +116,7 @@ async fn test_csv_table_parse_error() -> Result<()> {
             DataField::new("column4", DataType::UInt64, false),
         ]),
         engine: "Csv".to_string(),
-        table_option: options,
+        options: options,
         table_id: 0,
     })?;
 

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_api_vo::TableInfo;
 use common_planners::Extras;
 use common_planners::InsertIntoPlan;
 use common_planners::Partitions;
@@ -31,7 +32,6 @@ use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
 use crate::catalogs::Table;
-use crate::catalogs::TableInfo;
 use crate::datasources::dal::DataAccessor;
 use crate::datasources::table::fuse::range_filter;
 use crate::datasources::table::fuse::read_part;

--- a/query/src/datasources/table/memory/memory_table.rs
+++ b/query/src/datasources/table/memory/memory_table.rs
@@ -21,6 +21,7 @@ use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_infallible::RwLock;
+use common_meta_api_vo::TableInfo;
 use common_planners::Extras;
 use common_planners::ReadDataSourcePlan;
 use common_planners::Statistics;
@@ -29,7 +30,6 @@ use common_streams::SendableDataBlockStream;
 use futures::stream::StreamExt;
 
 use crate::catalogs::Table;
-use crate::catalogs::TableInfo;
 use crate::datasources::common::generate_parts;
 use crate::datasources::table::memory::memory_table_stream::MemoryTableStream;
 use crate::sessions::DatabendQueryContextRef;

--- a/query/src/datasources/table/memory/memory_table_test.rs
+++ b/query/src/datasources/table/memory/memory_table_test.rs
@@ -21,10 +21,10 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_infallible::Mutex;
+use common_meta_api_vo::TableInfo;
 use common_planners::*;
 use futures::TryStreamExt;
 
-use crate::catalogs::TableInfo;
 use crate::datasources::table::memory::memory_table::MemoryTable;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -39,7 +39,7 @@ async fn test_memorytable() -> Result<()> {
         name: "a".into(),
         schema: schema.clone(),
         engine: "Memory".to_string(),
-        table_option: TableOptions::default(),
+        options: TableOptions::default(),
         table_id: 0,
     })?;
 

--- a/query/src/datasources/table/null/null_table.rs
+++ b/query/src/datasources/table/null/null_table.rs
@@ -18,6 +18,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_api_vo::TableInfo;
 use common_planners::Extras;
 use common_planners::Part;
 use common_planners::ReadDataSourcePlan;
@@ -29,7 +30,6 @@ use common_tracing::tracing::info;
 use futures::stream::StreamExt;
 
 use crate::catalogs::Table;
-use crate::catalogs::TableInfo;
 use crate::sessions::DatabendQueryContextRef;
 
 pub struct NullTable {

--- a/query/src/datasources/table/null/null_table_test.rs
+++ b/query/src/datasources/table/null/null_table_test.rs
@@ -20,10 +20,10 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_infallible::Mutex;
+use common_meta_api_vo::TableInfo;
 use common_planners::*;
 use futures::TryStreamExt;
 
-use crate::catalogs::TableInfo;
 use crate::datasources::table::null::null_table::NullTable;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -38,7 +38,7 @@ async fn test_null_table() -> Result<()> {
         name: "a".into(),
         schema: DataSchemaRefExt::create(vec![DataField::new("a", DataType::UInt64, false)]),
         engine: "Null".to_string(),
-        table_option: TableOptions::default(),
+        options: TableOptions::default(),
         table_id: 0,
     })?;
 

--- a/query/src/datasources/table/parquet/parquet_table.rs
+++ b/query/src/datasources/table/parquet/parquet_table.rs
@@ -22,6 +22,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_api_vo::TableInfo;
 use common_planners::Extras;
 use common_planners::Part;
 use common_planners::ReadDataSourcePlan;
@@ -33,7 +34,6 @@ use crossbeam::channel::Receiver;
 use crossbeam::channel::Sender;
 
 use crate::catalogs::Table;
-use crate::catalogs::TableInfo;
 use crate::sessions::DatabendQueryContextRef;
 
 pub struct ParquetTable {
@@ -43,7 +43,7 @@ pub struct ParquetTable {
 
 impl ParquetTable {
     pub fn try_create(tbl_info: TableInfo) -> Result<Box<dyn Table>> {
-        let options = &tbl_info.table_option;
+        let options = &tbl_info.options;
         let file = options.get("location").cloned();
         return match file {
             Some(file) => {

--- a/query/src/datasources/table/parquet/parquet_table_test.rs
+++ b/query/src/datasources/table/parquet/parquet_table_test.rs
@@ -18,10 +18,10 @@ use std::env;
 use common_base::tokio;
 use common_datavalues::prelude::*;
 use common_exception::Result;
+use common_meta_api_vo::TableInfo;
 use common_planners::*;
 use futures::TryStreamExt;
 
-use crate::catalogs::TableInfo;
 use crate::datasources::table::parquet::parquet_table::ParquetTable;
 
 #[tokio::test]
@@ -44,7 +44,7 @@ async fn test_parquet_table() -> Result<()> {
         name: "test_parquet".to_string(),
         schema: DataSchemaRefExt::create(vec![DataField::new("id", DataType::Int32, false)]),
         engine: "test_parquet".into(),
-        table_option: options,
+        options: options,
     };
     let table = ParquetTable::try_create(tbl_info)?;
 

--- a/query/src/datasources/table/remote/remote_table.rs
+++ b/query/src/datasources/table/remote/remote_table.rs
@@ -20,6 +20,7 @@ use common_datavalues::DataSchemaRef;
 use common_dfs_api_vo::ReadPlanResult;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_api_vo::TableInfo;
 use common_planners::Extras;
 use common_planners::InsertIntoPlan;
 use common_planners::Part;
@@ -29,7 +30,6 @@ use common_planners::TruncateTablePlan;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::catalogs::TableInfo;
 use crate::common::StoreApiProvider;
 use crate::datasources::table_engine::TableEngine;
 use crate::sessions::DatabendQueryContextRef;

--- a/query/src/datasources/table_engine.rs
+++ b/query/src/datasources/table_engine.rs
@@ -13,8 +13,9 @@
 //  limitations under the License.
 //
 
+use common_meta_api_vo::TableInfo;
+
 use crate::catalogs::Table;
-use crate::catalogs::TableInfo;
 use crate::common::StoreApiProvider;
 
 // TODO maybe we should introduce a


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor: merge GetTableActionResult and TableInfo into one struct TableInfo; fix: #2015

## Changelog


- Bug Fix

- Improvement


## Related Issues