### PR TITLE
Move meta handlers to crate kvsrv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,6 +2837,7 @@ dependencies = [
  "common-kv-api",
  "common-kv-api-vo",
  "common-meta-api",
+ "common-meta-api-vo",
  "common-metatypes",
  "common-planners",
  "common-raft-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
     "kvsrv",
 
     # distributed file system
-    "dfs",
+    #"dfs",
 
     # SQL Fuzz
     "query/fuzz",

--- a/kvsrv/Cargo.toml
+++ b/kvsrv/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 edition = "2021"
 
 [[bin]]
-name = "kvsrv"
-path = "src/bin/kvsrv.rs"
+name = "databend-meta"
+path = "src/bin/metasrv.rs"
 
 [features]
 default = ["simd"]
@@ -31,6 +31,7 @@ common-sled-store = {path = "../common/sled-store"}
 common-store-api-sdk = {path = "../common/store-api-sdk"}
 common-tracing = {path = "../common/tracing"}
 common-kv-api-vo = {path = "../common/kv-apis/vo" }
+common-meta-api-vo = {path = "../common/meta-apis/vo" }
 
 # Github dependencies
 

--- a/kvsrv/src/bin/metasrv.rs
+++ b/kvsrv/src/bin/metasrv.rs
@@ -31,14 +31,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .init();
 
     let _guards = init_tracing_with_file(
-        "databend-kvsrv",
+        "databend-meta",
         conf.log_dir.as_str(),
         conf.log_level.as_str(),
     );
 
     info!("{:?}", conf.clone());
     info!(
-        "Databend-kvsrv v-{}",
+        "Databend-meta v-{}",
         *kvsrv::configs::config::DATABEND_COMMIT_VERSION
     );
 
@@ -66,10 +66,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let srv = FlightServer::create(conf.clone());
         info!(
-            "Databend-kvsrv API server listening on {}",
+            "Databend-meta API server listening on {}",
             conf.flight_api_address
         );
-        let (_stop_tx, fin_rx) = srv.start().await.expect("Databend-kvsrv service error");
+        let (_stop_tx, fin_rx) = srv.start().await.expect("Databend-meta service error");
         fin_rx.await?;
     }
 

--- a/kvsrv/src/configs/config.rs
+++ b/kvsrv/src/configs/config.rs
@@ -66,7 +66,7 @@ pub struct Config {
     #[structopt(
         long,
         env = "METASRV_FLIGHT_API_ADDRESS",
-        default_value = "127.0.0.1:28003"
+        default_value = "127.0.0.1:9191"
     )]
     pub flight_api_address: String,
 

--- a/kvsrv/src/configs/config.rs
+++ b/kvsrv/src/configs/config.rs
@@ -41,15 +41,15 @@ lazy_static! {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, StructOpt, StructOptToml)]
 pub struct Config {
-    #[structopt(long, env = "KVSRV_LOG_LEVEL", default_value = "INFO")]
+    #[structopt(long, env = "METASRV_LOG_LEVEL", default_value = "INFO")]
     pub log_level: String,
 
-    #[structopt(long, env = "KVSRV_LOG_DIR", default_value = "./_logs")]
+    #[structopt(long, env = "METASRV_LOG_DIR", default_value = "./_logs")]
     pub log_dir: String,
 
     #[structopt(
         long,
-        env = "KVSRV_METRIC_API_ADDRESS",
+        env = "METASRV_METRIC_API_ADDRESS",
         default_value = "127.0.0.1:28001"
     )]
     pub metric_api_address: String,
@@ -65,7 +65,7 @@ pub struct Config {
 
     #[structopt(
         long,
-        env = "KVSRV_FLIGHT_API_ADDRESS",
+        env = "METASRV_FLIGHT_API_ADDRESS",
         default_value = "127.0.0.1:28003"
     )]
     pub flight_api_address: String,

--- a/kvsrv/src/executor/action_handler.rs
+++ b/kvsrv/src/executor/action_handler.rs
@@ -54,9 +54,19 @@ impl ActionHandler {
             StoreDoAction::GetKV(a) => s.serialize(self.handle(a).await?),
             StoreDoAction::MGetKV(a) => s.serialize(self.handle(a).await?),
             StoreDoAction::PrefixListKV(a) => s.serialize(self.handle(a).await?),
-            _ => {
-                unimplemented!("non-kv API are no longer supported by kvsrv. Although they will be maintained for a while in databend-dfs")
-            }
+
+            // database
+            StoreDoAction::CreateDatabase(a) => s.serialize(self.handle(a).await?),
+            StoreDoAction::GetDatabase(a) => s.serialize(self.handle(a).await?),
+            StoreDoAction::DropDatabase(a) => s.serialize(self.handle(a).await?),
+            StoreDoAction::GetDatabases(a) => s.serialize(self.handle(a).await?),
+
+            // table
+            StoreDoAction::CreateTable(a) => s.serialize(self.handle(a).await?),
+            StoreDoAction::DropTable(a) => s.serialize(self.handle(a).await?),
+            StoreDoAction::GetTable(a) => s.serialize(self.handle(a).await?),
+            StoreDoAction::GetTables(a) => s.serialize(self.handle(a).await?),
+            StoreDoAction::GetTableExt(a) => s.serialize(self.handle(a).await?),
         }
     }
 }

--- a/kvsrv/src/executor/meta_handlers.rs
+++ b/kvsrv/src/executor/meta_handlers.rs
@@ -1,0 +1,391 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::sync::Arc;
+
+use common_arrow::arrow::datatypes::Schema as ArrowSchema;
+use common_arrow::arrow::io::ipc::write::common::IpcWriteOptions;
+use common_arrow::arrow_flight::utils::flight_data_from_arrow_schema;
+use common_arrow::arrow_flight::FlightData;
+use common_exception::ErrorCode;
+use common_meta_api_vo::*;
+use common_metatypes::Cmd::CreateDatabase;
+use common_metatypes::Cmd::CreateTable;
+use common_metatypes::Cmd::DropDatabase;
+use common_metatypes::Cmd::DropTable;
+use common_metatypes::Database;
+use common_metatypes::LogEntry;
+use common_metatypes::Table;
+use common_raft_store::state_machine::AppliedState;
+use common_store_api_sdk::meta_api_impl::CreateDatabaseAction;
+use common_store_api_sdk::meta_api_impl::CreateTableAction;
+use common_store_api_sdk::meta_api_impl::DropDatabaseAction;
+use common_store_api_sdk::meta_api_impl::DropTableAction;
+use common_store_api_sdk::meta_api_impl::GetDatabaseAction;
+use common_store_api_sdk::meta_api_impl::GetDatabasesAction;
+use common_store_api_sdk::meta_api_impl::GetTableAction;
+use common_store_api_sdk::meta_api_impl::GetTableExtReq;
+use common_store_api_sdk::meta_api_impl::GetTablesAction;
+use log::info;
+
+use crate::executor::action_handler::RequestHandler;
+use crate::executor::ActionHandler;
+
+// Db
+#[async_trait::async_trait]
+impl RequestHandler<CreateDatabaseAction> for ActionHandler {
+    async fn handle(
+        &self,
+        act: CreateDatabaseAction,
+    ) -> common_exception::Result<CreateDatabaseActionResult> {
+        let plan = act.plan;
+        let db_name = &plan.db;
+        let if_not_exists = plan.if_not_exists;
+
+        let cr = LogEntry {
+            txid: None,
+            cmd: CreateDatabase {
+                name: db_name.clone(),
+                if_not_exists,
+                db: Database {
+                    database_id: 0,
+                    database_engine: plan.engine.clone(),
+                    tables: HashMap::new(),
+                },
+            },
+        };
+
+        let rst = self
+            .meta_node
+            .write(cr)
+            .await
+            .map_err(|e| ErrorCode::MetaNodeInternalError(e.to_string()))?;
+
+        match rst {
+            AppliedState::DataBase { prev, result } => {
+                if let Some(prev) = prev {
+                    if if_not_exists {
+                        Ok(CreateDatabaseActionResult {
+                            database_id: prev.database_id,
+                        })
+                    } else {
+                        Err(ErrorCode::DatabaseAlreadyExists(format!(
+                            "{} database exists",
+                            db_name
+                        )))
+                    }
+                } else {
+                    Ok(CreateDatabaseActionResult {
+                        database_id: result.unwrap().database_id,
+                    })
+                }
+            }
+
+            _ => Err(ErrorCode::MetaNodeInternalError("not a Database result")),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestHandler<GetDatabaseAction> for ActionHandler {
+    async fn handle(&self, act: GetDatabaseAction) -> common_exception::Result<DatabaseInfo> {
+        let db_name = act.db;
+        let db = self.meta_node.get_database(&db_name).await;
+
+        match db {
+            Some(db) => {
+                let rst = DatabaseInfo {
+                    database_id: db.database_id,
+                    db: db_name,
+                    engine: db.database_engine,
+                };
+                Ok(rst)
+            }
+            None => Err(ErrorCode::UnknownDatabase(db_name)),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestHandler<DropDatabaseAction> for ActionHandler {
+    async fn handle(
+        &self,
+        act: DropDatabaseAction,
+    ) -> common_exception::Result<DropDatabaseActionResult> {
+        let db_name = &act.plan.db;
+        let if_exists = act.plan.if_exists;
+        let cr = LogEntry {
+            txid: None,
+            cmd: DropDatabase {
+                name: db_name.clone(),
+            },
+        };
+
+        let rst = self
+            .meta_node
+            .write(cr)
+            .await
+            .map_err(|e| ErrorCode::MetaNodeInternalError(e.to_string()))?;
+
+        match rst {
+            AppliedState::DataBase { prev, .. } => {
+                if prev.is_some() || if_exists {
+                    Ok(DropDatabaseActionResult {})
+                } else {
+                    Err(ErrorCode::UnknownDatabase(format!(
+                        "database not found: {:}",
+                        db_name
+                    )))
+                }
+            }
+            _ => Err(ErrorCode::MetaNodeInternalError("not a Database result")),
+        }
+    }
+}
+
+// table
+#[async_trait::async_trait]
+impl RequestHandler<CreateTableAction> for ActionHandler {
+    async fn handle(
+        &self,
+        act: CreateTableAction,
+    ) -> common_exception::Result<CreateTableActionResult> {
+        let plan = act.plan;
+        let db_name = &plan.db;
+        let table_name = &plan.table;
+        let if_not_exists = plan.if_not_exists;
+
+        info!("create table: {:}: {:?}", &db_name, &table_name);
+
+        let options = IpcWriteOptions::default();
+        let flight_data = flight_data_from_arrow_schema(&plan.schema.to_arrow(), &options);
+
+        let table = Table {
+            table_id: 0,
+            schema: flight_data.data_header,
+            table_engine: plan.engine.clone(),
+            table_options: plan.options.clone(),
+            parts: Default::default(),
+        };
+
+        let cr = LogEntry {
+            txid: None,
+            cmd: CreateTable {
+                db_name: db_name.clone(),
+                table_name: table_name.clone(),
+                if_not_exists,
+                table,
+            },
+        };
+
+        let rst = self
+            .meta_node
+            .write(cr)
+            .await
+            .map_err(|e| ErrorCode::MetaNodeInternalError(e.to_string()))?;
+
+        match rst {
+            AppliedState::Table { prev, result } => {
+                if let Some(prev) = prev {
+                    if if_not_exists {
+                        Ok(CreateTableActionResult {
+                            table_id: prev.table_id,
+                        })
+                    } else {
+                        Err(ErrorCode::TableAlreadyExists(format!(
+                            "table exists: {}",
+                            table_name
+                        )))
+                    }
+                } else {
+                    Ok(CreateTableActionResult {
+                        table_id: result.unwrap().table_id,
+                    })
+                }
+            }
+            _ => Err(ErrorCode::MetaNodeInternalError("not a Table result")),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestHandler<DropTableAction> for ActionHandler {
+    async fn handle(
+        &self,
+        act: DropTableAction,
+    ) -> common_exception::Result<DropTableActionResult> {
+        let db_name = &act.plan.db;
+        let table_name = &act.plan.table;
+        let if_exists = act.plan.if_exists;
+
+        let cr = LogEntry {
+            txid: None,
+            cmd: DropTable {
+                db_name: db_name.clone(),
+                table_name: table_name.clone(),
+                if_exists,
+            },
+        };
+
+        let rst = self
+            .meta_node
+            .write(cr)
+            .await
+            .map_err(|e| ErrorCode::MetaNodeInternalError(e.to_string()))?;
+
+        match rst {
+            AppliedState::Table { prev, .. } => {
+                if prev.is_some() || if_exists {
+                    Ok(DropTableActionResult {})
+                } else {
+                    Err(ErrorCode::UnknownTable(format!(
+                        "table not found: {:}",
+                        table_name
+                    )))
+                }
+            }
+            _ => Err(ErrorCode::MetaNodeInternalError("not a Table result")),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestHandler<GetTableAction> for ActionHandler {
+    async fn handle(&self, act: GetTableAction) -> common_exception::Result<TableInfo> {
+        let db_name = &act.db;
+        let table_name = &act.table;
+
+        let db = self.meta_node.get_database(db_name).await.ok_or_else(|| {
+            ErrorCode::UnknownDatabase(format!("get table: database not found {:}", db_name))
+        })?;
+
+        let table_id = db
+            .tables
+            .get(table_name)
+            .ok_or_else(|| ErrorCode::UnknownTable(format!("table not found: {:}", table_name)))?;
+
+        let result = self.meta_node.get_table(table_id).await;
+
+        match result {
+            Some(table) => {
+                let arrow_schema = ArrowSchema::try_from(&FlightData {
+                    data_header: table.schema,
+                    ..Default::default()
+                })
+                .map_err(|e| {
+                    ErrorCode::IllegalSchema(format!("invalid schema: {:}", e.to_string()))
+                })?;
+                let rst = TableInfo {
+                    table_id: table.table_id,
+                    db: db_name.clone(),
+                    name: table_name.clone(),
+                    schema: Arc::new(arrow_schema.into()),
+                    engine: table.table_engine.clone(),
+                    options: table.table_options,
+                };
+                Ok(rst)
+            }
+            None => Err(ErrorCode::UnknownTable(table_name)),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestHandler<GetTableExtReq> for ActionHandler {
+    async fn handle(&self, act: GetTableExtReq) -> common_exception::Result<TableInfo> {
+        // TODO duplicated code
+        let table_id = act.tbl_id;
+        let result = self.meta_node.get_table(&table_id).await;
+        match result {
+            Some(table) => {
+                let arrow_schema = ArrowSchema::try_from(&FlightData {
+                    data_header: table.schema,
+                    ..Default::default()
+                })
+                .map_err(|e| {
+                    ErrorCode::IllegalSchema(format!("invalid schema: {:}", e.to_string()))
+                })?;
+                let rst = TableInfo {
+                    table_id: table.table_id,
+                    // TODO rm these filed
+                    db: "".to_owned(),
+                    name: "".to_owned(), // TODO for each version of table, we duplicates the name at present
+                    schema: Arc::new(arrow_schema.into()),
+                    engine: table.table_engine.clone(),
+                    options: table.table_options,
+                };
+                Ok(rst)
+            }
+            None => Err(ErrorCode::UnknownTable(format!(
+                "table of id {} not found",
+                act.tbl_id
+            ))),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestHandler<GetDatabasesAction> for ActionHandler {
+    async fn handle(
+        &self,
+        _req: GetDatabasesAction,
+    ) -> common_exception::Result<GetDatabasesReply> {
+        let res = self.meta_node.get_databases().await;
+        Ok(res
+            .iter()
+            .map(|(name, db)| DatabaseInfo {
+                database_id: db.database_id,
+                db: name.to_string(),
+                engine: db.database_engine.to_string(),
+            })
+            .collect::<Vec<_>>())
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestHandler<GetTablesAction> for ActionHandler {
+    async fn handle(&self, req: GetTablesAction) -> common_exception::Result<GetTablesReply> {
+        let res = self.meta_node.get_tables(req.db.as_str()).await?;
+        Ok(res
+            .iter()
+            .try_fold(Vec::new(), |mut acc, (id, name, tbl)| {
+                let arrow_schema = ArrowSchema::try_from(&FlightData {
+                    data_header: tbl.schema.clone(),
+                    ..Default::default()
+                })
+                .map_err(|e| {
+                    ErrorCode::IllegalSchema(format!(
+                        "invalid schema of table id {}, error: {}",
+                        *id,
+                        e.to_string()
+                    ))
+                })?;
+
+                let tbl_info = TableInfo {
+                    db: req.db.to_string(),
+                    table_id: *id,
+                    name: name.to_string(),
+                    schema: Arc::new(arrow_schema.into()),
+                    engine: tbl.table_engine.to_string(),
+                    options: tbl.table_options.clone(),
+                };
+
+                acc.push(tbl_info);
+                Ok::<_, ErrorCode>(acc)
+            })?)
+    }
+}

--- a/kvsrv/src/executor/mod.rs
+++ b/kvsrv/src/executor/mod.rs
@@ -14,6 +14,7 @@
 
 mod action_handler;
 mod kv_handlers;
+mod meta_handlers;
 
 pub use action_handler::ActionHandler;
 pub use action_handler::ReplySerializer;

--- a/scripts/deploy/databend-query-cluster-3-nodes.sh
+++ b/scripts/deploy/databend-query-cluster-3-nodes.sh
@@ -6,12 +6,12 @@ SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 cd "$SCRIPT_PATH/../.." || exit
 
 killall databend-query
-killall databend-dfs
+killall databend-meta
 sleep 1
 
 echo 'Start one DatabendStore...'
-nohup target/debug/databend-dfs  --single=true --log-level=ERROR &
-echo "Waiting on databend-dfs 10 seconds..."
+nohup target/debug/databend-meta  --single=true --log-level=ERROR &
+echo "Waiting on databend-meta 10 seconds..."
 python scripts/ci/wait_tcp.py --timeout 5 --port 9191
 
 echo 'Start DatabendQuery node-1'

--- a/scripts/deploy/databend-query-standalone.sh
+++ b/scripts/deploy/databend-query-standalone.sh
@@ -6,14 +6,14 @@ SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 cd "$SCRIPT_PATH/../.." || exit
 
 killall databend-dfs
-killall databend-query
+killall databend-meta
 sleep 1
 
 BIN=${1:-debug}
 
 echo 'Start DatabendStore...'
-nohup target/${BIN}/databend-dfs --single=true --log-level=ERROR &
-echo "Waiting on databend-dfs 10 seconds..."
+nohup target/${BIN}/databend-meta --single=true --log-level=ERROR &
+echo "Waiting on databend-meta 10 seconds..."
 python scripts/ci/wait_tcp.py --timeout 5 --port 9191
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

- add database metadata action handlers to crate `kvsrv`
- change the binary of crate `kvsrv` to `databend-meta`
   default flight service port of `databend-meta` changed to 9191
- adapts scripts to `databend-meta`

-----------------



- crate `dfs` is removed from cargo workspaces, but codes are left there
- crate `kvsrv` is NOT renamed (to `meta` or something else which I am not sure)

these two items are left to subsequent PRs

## Changelog


- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

