### PR TITLE
[common/meta-api] Refactor: MetaApi always use `&str` as argument type instead of `String`

### DIFF
--- a/common/meta-apis/api/src/meta_api.rs
+++ b/common/meta-apis/api/src/meta_api.rs
@@ -36,21 +36,21 @@ pub trait MetaApi: Send + Sync {
     async fn create_database(&self, plan: CreateDatabasePlan)
         -> Result<CreateDatabaseActionResult>;
 
+    async fn drop_database(&self, plan: DropDatabasePlan) -> Result<DropDatabaseActionResult>;
+
     async fn get_database(&self, db: &str) -> Result<DatabaseInfo>;
 
-    async fn drop_database(&self, plan: DropDatabasePlan) -> Result<DropDatabaseActionResult>;
+    async fn get_databases(&self) -> Result<GetDatabasesReply>;
 
     // table
 
     async fn create_table(&self, plan: CreateTablePlan) -> Result<CreateTableActionResult>;
 
-    async fn get_databases(&self) -> common_exception::Result<GetDatabasesReply>;
-
-    async fn get_tables(&self, db: String) -> common_exception::Result<GetTablesReply>;
-
     async fn drop_table(&self, plan: DropTablePlan) -> Result<DropTableActionResult>;
 
-    async fn get_table(&self, db: String, table: String) -> Result<TableInfo>;
+    async fn get_table(&self, db: &str, table: &str) -> Result<TableInfo>;
+
+    async fn get_tables(&self, db: &str) -> Result<GetTablesReply>;
 
     async fn get_table_by_id(
         &self,

--- a/common/meta-apis/vo/src/lib.rs
+++ b/common/meta-apis/vo/src/lib.rs
@@ -16,8 +16,6 @@
 use std::collections::HashMap;
 
 use common_datavalues::DataSchemaRef;
-use common_metatypes::Database;
-use common_metatypes::Table;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct CreateDatabaseActionResult {
@@ -52,13 +50,5 @@ pub struct TableInfo {
     pub options: HashMap<String, String>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub struct DatabaseMetaSnapshot {
-    pub meta_ver: u64,
-    pub db_metas: Vec<(String, Database)>,
-    pub tbl_metas: Vec<(u64, Table)>,
-}
-
-pub type DatabaseMetaReply = Option<DatabaseMetaSnapshot>;
 pub type GetDatabasesReply = Vec<DatabaseInfo>;
 pub type GetTablesReply = Vec<TableInfo>;

--- a/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
+++ b/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
@@ -67,8 +67,12 @@ impl MetaApi for StoreClient {
     }
 
     /// Get table.
-    async fn get_table(&self, db: String, table: String) -> common_exception::Result<TableInfo> {
-        self.do_action(GetTableAction { db, table }).await
+    async fn get_table(&self, db: &str, table: &str) -> common_exception::Result<TableInfo> {
+        self.do_action(GetTableAction {
+            db: db.to_string(),
+            table: table.to_string(),
+        })
+        .await
     }
 
     async fn get_table_by_id(
@@ -84,8 +88,8 @@ impl MetaApi for StoreClient {
     }
 
     /// Get tables.
-    async fn get_tables(&self, db: String) -> common_exception::Result<GetTablesReply> {
-        self.do_action(GetTablesAction { db }).await
+    async fn get_tables(&self, db: &str) -> common_exception::Result<GetTablesReply> {
+        self.do_action(GetTablesAction { db: db.to_string() }).await
     }
 }
 

--- a/dfs/src/api/rpc/flight_service_test.rs
+++ b/dfs/src/api/rpc/flight_service_test.rs
@@ -98,7 +98,7 @@ async fn test_flight_restart() -> anyhow::Result<()> {
             let res = client.create_table(plan.clone()).await?;
             assert_eq!(1, res.table_id, "table id is 1");
 
-            let got = client.get_table(db_name.into(), table_name.into()).await?;
+            let got = client.get_table(db_name, table_name).await?;
             let want = TableInfo {
                 table_id: 1,
                 db: db_name.into(),
@@ -293,10 +293,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
             let res = client.create_table(plan.clone()).await.unwrap();
             assert_eq!(1, res.table_id, "table id is 1");
 
-            let got = client
-                .get_table(db_name.into(), tbl_name.into())
-                .await
-                .unwrap();
+            let got = client.get_table(db_name, tbl_name).await.unwrap();
             let want = TableInfo {
                 table_id: 1,
                 db: db_name.into(),
@@ -314,10 +311,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
             let res = client.create_table(plan.clone()).await.unwrap();
             assert_eq!(1, res.table_id, "new table id");
 
-            let got = client
-                .get_table(db_name.into(), tbl_name.into())
-                .await
-                .unwrap();
+            let got = client.get_table(db_name, tbl_name).await.unwrap();
             let want = TableInfo {
                 table_id: 1,
                 db: db_name.into(),
@@ -344,7 +338,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
 
             // get_table returns the old table
 
-            let got = client.get_table("db1".into(), "tb2".into()).await.unwrap();
+            let got = client.get_table("db1", "tb2").await.unwrap();
             let want = TableInfo {
                 table_id: 1,
                 db: db_name.into(),
@@ -423,10 +417,7 @@ async fn test_flight_drop_table() -> anyhow::Result<()> {
             let res = client.create_table(plan.clone()).await.unwrap();
             assert_eq!(1, res.table_id, "table id is 1");
 
-            let got = client
-                .get_table(db_name.into(), tbl_name.into())
-                .await
-                .unwrap();
+            let got = client.get_table(db_name, tbl_name).await.unwrap();
             let want = TableInfo {
                 table_id: 1,
                 db: db_name.into(),
@@ -450,7 +441,7 @@ async fn test_flight_drop_table() -> anyhow::Result<()> {
         }
 
         {
-            let res = client.get_table(db_name.into(), tbl_name.into()).await;
+            let res = client.get_table(db_name, tbl_name).await;
             let status = res.err().unwrap();
             assert_eq!(
                 format!("Code: 25, displayText = table not found: {}.", tbl_name),
@@ -1190,7 +1181,7 @@ async fn test_flight_get_tables() -> anyhow::Result<()> {
     let client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
     // not such db
-    let res = client.get_tables("none".to_string()).await;
+    let res = client.get_tables("none").await;
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().code(),
@@ -1207,7 +1198,7 @@ async fn test_flight_get_tables() -> anyhow::Result<()> {
 
     client.create_database(plan).await?;
 
-    let res = client.get_tables("db1".to_string()).await?;
+    let res = client.get_tables("db1").await?;
     assert!(res.is_empty());
 
     // with tables
@@ -1227,7 +1218,7 @@ async fn test_flight_get_tables() -> anyhow::Result<()> {
     };
     client.create_table(plan.clone()).await?;
 
-    let tbls = client.get_tables("db1".to_string()).await;
+    let tbls = client.get_tables("db1").await;
     assert!(tbls.is_ok());
     let tbls = tbls?;
     assert_eq!(1, tbls.len());

--- a/dfs/src/api/rpc/tls_flight_service_test.rs
+++ b/dfs/src/api/rpc/tls_flight_service_test.rs
@@ -49,9 +49,7 @@ async fn test_flight_tls() -> anyhow::Result<()> {
 
     let client = StoreClient::with_tls_conf(addr.as_str(), "root", "xxx", Some(tls_conf)).await?;
 
-    let r = client
-        .get_table("do not care".to_owned(), "do not care".to_owned())
-        .await;
+    let r = client.get_table("do not care", "do not care").await;
     assert!(r.is_err());
     let e = r.unwrap_err();
     assert_eq!(e.code(), ErrorCode::UnknownDatabase("").code());

--- a/kvsrv/tests/flight/kvsrv_flight_tls.rs
+++ b/kvsrv/tests/flight/kvsrv_flight_tls.rs
@@ -48,9 +48,7 @@ async fn test_tls_server() -> anyhow::Result<()> {
 
     let client = StoreClient::with_tls_conf(addr.as_str(), "root", "xxx", Some(tls_conf)).await?;
 
-    let r = client
-        .get_table("do not care".to_owned(), "do not care".to_owned())
-        .await;
+    let r = client.get_table("do not care", "do not care").await;
     assert!(r.is_err());
 
     Ok(())

--- a/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
+++ b/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
@@ -72,7 +72,7 @@ impl MetaBackend for RemoteMeteStoreClient {
             self.rt.block_on(
                 async move {
                     let client = cli_provider.try_get_meta_client().await?;
-                    client.get_table(db_name, tbl_name).await
+                    client.get_table(&db_name, &tbl_name).await
                 },
                 self.rpc_time_out,
             )??
@@ -167,7 +167,7 @@ impl MetaBackend for RemoteMeteStoreClient {
         let tbls = self.rt.block_on(
             async move {
                 let client = cli.try_get_meta_client().await?;
-                client.get_tables(db_name).await
+                client.get_tables(&db_name).await
             },
             self.rpc_time_out,
         )??;

--- a/query/src/catalogs/meta_backend.rs
+++ b/query/src/catalogs/meta_backend.rs
@@ -38,7 +38,13 @@ pub trait MetaBackend: Send + Sync {
 
     // table
 
+    fn create_table(&self, plan: CreateTablePlan) -> Result<()>;
+
+    fn drop_table(&self, plan: DropTablePlan) -> Result<()>;
+
     fn get_table(&self, db_name: &str, table_name: &str) -> Result<Arc<TableInfo>>;
+
+    fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<TableInfo>>>;
 
     fn get_table_by_id(
         &self,
@@ -46,12 +52,6 @@ pub trait MetaBackend: Send + Sync {
         table_id: MetaId,
         table_version: Option<MetaVersion>,
     ) -> Result<Arc<TableInfo>>;
-
-    fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<TableInfo>>>;
-
-    fn create_table(&self, plan: CreateTablePlan) -> Result<()>;
-
-    fn drop_table(&self, plan: DropTablePlan) -> Result<()>;
 
     fn name(&self) -> String;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta-api] Refactor: MetaApi always use `&str` as argument type instead of `String`

## Changelog







## Related Issues

- fix: #2032 