### PR TITLE
[common/meta-api] refactor: MetaApi::drop_table() does not need a return value type. use () for it

### DIFF
--- a/common/meta-apis/api/src/meta_api.rs
+++ b/common/meta-apis/api/src/meta_api.rs
@@ -17,7 +17,6 @@ use common_exception::Result;
 use common_meta_api_vo::CreateDatabaseReply;
 use common_meta_api_vo::CreateTableReply;
 use common_meta_api_vo::DatabaseInfo;
-use common_meta_api_vo::DropTableReply;
 use common_meta_api_vo::GetDatabasesReply;
 use common_meta_api_vo::GetTablesReply;
 use common_meta_api_vo::TableInfo;
@@ -44,7 +43,7 @@ pub trait MetaApi: Send + Sync {
 
     async fn create_table(&self, plan: CreateTablePlan) -> Result<CreateTableReply>;
 
-    async fn drop_table(&self, plan: DropTablePlan) -> Result<DropTableReply>;
+    async fn drop_table(&self, plan: DropTablePlan) -> Result<()>;
 
     async fn get_table(&self, db: &str, table: &str) -> Result<TableInfo>;
 

--- a/common/meta-apis/api/src/meta_api.rs
+++ b/common/meta-apis/api/src/meta_api.rs
@@ -17,7 +17,6 @@ use common_exception::Result;
 use common_meta_api_vo::CreateDatabaseReply;
 use common_meta_api_vo::CreateTableReply;
 use common_meta_api_vo::DatabaseInfo;
-use common_meta_api_vo::DropDatabaseReply;
 use common_meta_api_vo::DropTableReply;
 use common_meta_api_vo::GetDatabasesReply;
 use common_meta_api_vo::GetTablesReply;
@@ -35,7 +34,7 @@ pub trait MetaApi: Send + Sync {
 
     async fn create_database(&self, plan: CreateDatabasePlan) -> Result<CreateDatabaseReply>;
 
-    async fn drop_database(&self, plan: DropDatabasePlan) -> Result<DropDatabaseReply>;
+    async fn drop_database(&self, plan: DropDatabasePlan) -> Result<()>;
 
     async fn get_database(&self, db: &str) -> Result<DatabaseInfo>;
 

--- a/common/meta-apis/api/src/meta_api.rs
+++ b/common/meta-apis/api/src/meta_api.rs
@@ -14,11 +14,11 @@
 //
 
 use common_exception::Result;
-use common_meta_api_vo::CreateDatabaseActionResult;
-use common_meta_api_vo::CreateTableActionResult;
+use common_meta_api_vo::CreateDatabaseReply;
+use common_meta_api_vo::CreateTableReply;
 use common_meta_api_vo::DatabaseInfo;
-use common_meta_api_vo::DropDatabaseActionResult;
-use common_meta_api_vo::DropTableActionResult;
+use common_meta_api_vo::DropDatabaseReply;
+use common_meta_api_vo::DropTableReply;
 use common_meta_api_vo::GetDatabasesReply;
 use common_meta_api_vo::GetTablesReply;
 use common_meta_api_vo::TableInfo;
@@ -33,10 +33,9 @@ use common_planners::DropTablePlan;
 pub trait MetaApi: Send + Sync {
     // database
 
-    async fn create_database(&self, plan: CreateDatabasePlan)
-        -> Result<CreateDatabaseActionResult>;
+    async fn create_database(&self, plan: CreateDatabasePlan) -> Result<CreateDatabaseReply>;
 
-    async fn drop_database(&self, plan: DropDatabasePlan) -> Result<DropDatabaseActionResult>;
+    async fn drop_database(&self, plan: DropDatabasePlan) -> Result<DropDatabaseReply>;
 
     async fn get_database(&self, db: &str) -> Result<DatabaseInfo>;
 
@@ -44,9 +43,9 @@ pub trait MetaApi: Send + Sync {
 
     // table
 
-    async fn create_table(&self, plan: CreateTablePlan) -> Result<CreateTableActionResult>;
+    async fn create_table(&self, plan: CreateTablePlan) -> Result<CreateTableReply>;
 
-    async fn drop_table(&self, plan: DropTablePlan) -> Result<DropTableActionResult>;
+    async fn drop_table(&self, plan: DropTablePlan) -> Result<DropTableReply>;
 
     async fn get_table(&self, db: &str, table: &str) -> Result<TableInfo>;
 

--- a/common/meta-apis/vo/src/lib.rs
+++ b/common/meta-apis/vo/src/lib.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use common_datavalues::DataSchemaRef;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct CreateDatabaseActionResult {
+pub struct CreateDatabaseReply {
     pub database_id: u64,
 }
 
@@ -30,15 +30,15 @@ pub struct DatabaseInfo {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct DropDatabaseActionResult {}
+pub struct DropDatabaseReply {}
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct CreateTableActionResult {
+pub struct CreateTableReply {
     pub table_id: u64,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct DropTableActionResult {}
+pub struct DropTableReply {}
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct TableInfo {

--- a/common/meta-apis/vo/src/lib.rs
+++ b/common/meta-apis/vo/src/lib.rs
@@ -35,9 +35,6 @@ pub struct CreateTableReply {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct DropTableReply {}
-
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct TableInfo {
     pub table_id: u64,
     pub db: String,

--- a/common/meta-apis/vo/src/lib.rs
+++ b/common/meta-apis/vo/src/lib.rs
@@ -30,9 +30,6 @@ pub struct DatabaseInfo {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct DropDatabaseReply {}
-
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct CreateTableReply {
     pub table_id: u64,
 }

--- a/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
+++ b/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
@@ -43,10 +43,7 @@ impl MetaApi for StoreClient {
     }
 
     /// Drop database call.
-    async fn drop_database(
-        &self,
-        plan: DropDatabasePlan,
-    ) -> common_exception::Result<DropDatabaseReply> {
+    async fn drop_database(&self, plan: DropDatabasePlan) -> common_exception::Result<()> {
         self.do_action(DropDatabaseAction { plan }).await
     }
 
@@ -113,11 +110,7 @@ action_declare!(GetDatabaseAction, DatabaseInfo, StoreDoAction::GetDatabase);
 pub struct DropDatabaseAction {
     pub plan: DropDatabasePlan,
 }
-action_declare!(
-    DropDatabaseAction,
-    DropDatabaseReply,
-    StoreDoAction::DropDatabase
-);
+action_declare!(DropDatabaseAction, (), StoreDoAction::DropDatabase);
 
 // == table actions ==
 // - create table

--- a/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
+++ b/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
@@ -33,7 +33,7 @@ impl MetaApi for StoreClient {
     async fn create_database(
         &self,
         plan: CreateDatabasePlan,
-    ) -> common_exception::Result<CreateDatabaseActionResult> {
+    ) -> common_exception::Result<CreateDatabaseReply> {
         self.do_action(CreateDatabaseAction { plan }).await
     }
 
@@ -46,7 +46,7 @@ impl MetaApi for StoreClient {
     async fn drop_database(
         &self,
         plan: DropDatabasePlan,
-    ) -> common_exception::Result<DropDatabaseActionResult> {
+    ) -> common_exception::Result<DropDatabaseReply> {
         self.do_action(DropDatabaseAction { plan }).await
     }
 
@@ -54,15 +54,12 @@ impl MetaApi for StoreClient {
     async fn create_table(
         &self,
         plan: CreateTablePlan,
-    ) -> common_exception::Result<CreateTableActionResult> {
+    ) -> common_exception::Result<CreateTableReply> {
         self.do_action(CreateTableAction { plan }).await
     }
 
     /// Drop table call.
-    async fn drop_table(
-        &self,
-        plan: DropTablePlan,
-    ) -> common_exception::Result<DropTableActionResult> {
+    async fn drop_table(&self, plan: DropTablePlan) -> common_exception::Result<DropTableReply> {
         self.do_action(DropTableAction { plan }).await
     }
 
@@ -101,7 +98,7 @@ pub struct CreateDatabaseAction {
 }
 action_declare!(
     CreateDatabaseAction,
-    CreateDatabaseActionResult,
+    CreateDatabaseReply,
     StoreDoAction::CreateDatabase
 );
 
@@ -118,7 +115,7 @@ pub struct DropDatabaseAction {
 }
 action_declare!(
     DropDatabaseAction,
-    DropDatabaseActionResult,
+    DropDatabaseReply,
     StoreDoAction::DropDatabase
 );
 
@@ -130,7 +127,7 @@ pub struct CreateTableAction {
 }
 action_declare!(
     CreateTableAction,
-    CreateTableActionResult,
+    CreateTableReply,
     StoreDoAction::CreateTable
 );
 
@@ -139,11 +136,7 @@ action_declare!(
 pub struct DropTableAction {
     pub plan: DropTablePlan,
 }
-action_declare!(
-    DropTableAction,
-    DropTableActionResult,
-    StoreDoAction::DropTable
-);
+action_declare!(DropTableAction, DropTableReply, StoreDoAction::DropTable);
 
 // - get table
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]

--- a/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
+++ b/common/store-api-sdk/src/impl_flights/meta_api_impl.rs
@@ -56,7 +56,7 @@ impl MetaApi for StoreClient {
     }
 
     /// Drop table call.
-    async fn drop_table(&self, plan: DropTablePlan) -> common_exception::Result<DropTableReply> {
+    async fn drop_table(&self, plan: DropTablePlan) -> common_exception::Result<()> {
         self.do_action(DropTableAction { plan }).await
     }
 
@@ -129,7 +129,7 @@ action_declare!(
 pub struct DropTableAction {
     pub plan: DropTablePlan,
 }
-action_declare!(DropTableAction, DropTableReply, StoreDoAction::DropTable);
+action_declare!(DropTableAction, (), StoreDoAction::DropTable);
 
 // - get table
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]

--- a/common/store-api-sdk/src/store_do_action.rs
+++ b/common/store-api-sdk/src/store_do_action.rs
@@ -42,7 +42,7 @@ pub trait RequestFor {
 
 #[macro_export]
 macro_rules! action_declare {
-    ($req:ident, $reply:ident, $enum_ctor:expr) => {
+    ($req:ident, $reply:tt, $enum_ctor:expr) => {
         impl RequestFor for $req {
             type Reply = $reply;
         }

--- a/dfs/src/api/rpc/flight_service_test.rs
+++ b/dfs/src/api/rpc/flight_service_test.rs
@@ -437,7 +437,7 @@ async fn test_flight_drop_table() -> anyhow::Result<()> {
                 table: tbl_name.to_string(),
             };
             let res = client.drop_table(plan.clone()).await.unwrap();
-            assert_eq!(DropTableReply {}, res, "drop table {}", tbl_name)
+            assert_eq!((), res, "drop table {}", tbl_name)
         }
 
         {

--- a/dfs/src/api/rpc/flight_service_test.rs
+++ b/dfs/src/api/rpc/flight_service_test.rs
@@ -437,7 +437,7 @@ async fn test_flight_drop_table() -> anyhow::Result<()> {
                 table: tbl_name.to_string(),
             };
             let res = client.drop_table(plan.clone()).await.unwrap();
-            assert_eq!(DropTableActionResult {}, res, "drop table {}", tbl_name)
+            assert_eq!(DropTableReply {}, res, "drop table {}", tbl_name)
         }
 
         {

--- a/dfs/src/executor/action_handler_test.rs
+++ b/dfs/src/executor/action_handler_test.rs
@@ -90,7 +90,7 @@ async fn test_action_handler_add_database() -> anyhow::Result<()> {
 
     struct D {
         plan: CreateDatabasePlan,
-        want: common_exception::Result<CreateDatabaseActionResult>,
+        want: common_exception::Result<CreateDatabaseReply>,
     }
 
     /// helper to build a D
@@ -102,7 +102,7 @@ async fn test_action_handler_add_database() -> anyhow::Result<()> {
             options: Default::default(),
         };
         let want = match want {
-            Ok(want_db_id) => Ok(CreateDatabaseActionResult {
+            Ok(want_db_id) => Ok(CreateDatabaseReply {
                 database_id: want_db_id,
             }),
             Err(err) => Err(err), // Result<i64,_> to Result<StoreDoActionResult, _>
@@ -231,13 +231,13 @@ async fn test_action_handler_drop_database() -> anyhow::Result<()> {
     struct T {
         db_name: &'static str,
         if_exists: bool,
-        want: Result<DropDatabaseActionResult, ErrorCode>,
+        want: Result<DropDatabaseReply, ErrorCode>,
     }
 
     /// helper to build a T
     fn case(db_name: &'static str, if_exists: bool, want: Result<(), &str>) -> T {
         let want = match want {
-            Ok(..) => Ok(DropDatabaseActionResult {}),
+            Ok(..) => Ok(DropDatabaseReply {}),
             Err(err_str) => Err(ErrorCode::UnknownDatabase(err_str)),
         };
 
@@ -310,7 +310,7 @@ async fn test_action_handler_create_table() -> anyhow::Result<()> {
 
     struct D {
         plan: CreateDatabasePlan,
-        want: common_exception::Result<CreateDatabaseActionResult>,
+        want: common_exception::Result<CreateDatabaseReply>,
     }
 
     /// helper to build a D
@@ -322,7 +322,7 @@ async fn test_action_handler_create_table() -> anyhow::Result<()> {
             options: Default::default(),
         };
         let want = match want {
-            Ok(want_db_id) => Ok(CreateDatabaseActionResult {
+            Ok(want_db_id) => Ok(CreateDatabaseReply {
                 database_id: want_db_id,
             }),
             Err(err) => Err(err), // Result<i64,_> to Result<StoreDoActionResult, _>
@@ -333,7 +333,7 @@ async fn test_action_handler_create_table() -> anyhow::Result<()> {
 
     struct T {
         plan: CreateTablePlan,
-        want: common_exception::Result<CreateTableActionResult>,
+        want: common_exception::Result<CreateTableReply>,
     }
 
     /// helper to build a T
@@ -357,7 +357,7 @@ async fn test_action_handler_create_table() -> anyhow::Result<()> {
             options: Default::default(),
         };
         let want = match want {
-            Ok(want_table_id) => Ok(CreateTableActionResult {
+            Ok(want_table_id) => Ok(CreateTableReply {
                 table_id: want_table_id,
             }),
             Err(err) => Err(err),
@@ -548,7 +548,7 @@ async fn test_action_handler_drop_table() -> anyhow::Result<()> {
         db_name: &'static str,
         table_name: &'static str,
         if_exists: bool,
-        want: Result<DropTableActionResult, ErrorCode>,
+        want: Result<DropTableReply, ErrorCode>,
     }
 
     /// helper to build a T
@@ -559,7 +559,7 @@ async fn test_action_handler_drop_table() -> anyhow::Result<()> {
         want: Result<(), &str>,
     ) -> T {
         let want = match want {
-            Ok(..) => Ok(DropTableActionResult {}),
+            Ok(..) => Ok(DropTableReply {}),
             Err(err_str) => Err(ErrorCode::UnknownTable(err_str)),
         };
 

--- a/dfs/src/executor/action_handler_test.rs
+++ b/dfs/src/executor/action_handler_test.rs
@@ -548,7 +548,7 @@ async fn test_action_handler_drop_table() -> anyhow::Result<()> {
         db_name: &'static str,
         table_name: &'static str,
         if_exists: bool,
-        want: Result<DropTableReply, ErrorCode>,
+        want: Result<(), ErrorCode>,
     }
 
     /// helper to build a T
@@ -559,7 +559,7 @@ async fn test_action_handler_drop_table() -> anyhow::Result<()> {
         want: Result<(), &str>,
     ) -> T {
         let want = match want {
-            Ok(..) => Ok(DropTableReply {}),
+            Ok(..) => Ok(()),
             Err(err_str) => Err(ErrorCode::UnknownTable(err_str)),
         };
 

--- a/dfs/src/executor/action_handler_test.rs
+++ b/dfs/src/executor/action_handler_test.rs
@@ -231,13 +231,13 @@ async fn test_action_handler_drop_database() -> anyhow::Result<()> {
     struct T {
         db_name: &'static str,
         if_exists: bool,
-        want: Result<DropDatabaseReply, ErrorCode>,
+        want: Result<(), ErrorCode>,
     }
 
     /// helper to build a T
     fn case(db_name: &'static str, if_exists: bool, want: Result<(), &str>) -> T {
         let want = match want {
-            Ok(..) => Ok(DropDatabaseReply {}),
+            Ok(..) => Ok(()),
             Err(err_str) => Err(ErrorCode::UnknownDatabase(err_str)),
         };
 

--- a/dfs/src/executor/meta_handlers.rs
+++ b/dfs/src/executor/meta_handlers.rs
@@ -122,7 +122,7 @@ impl RequestHandler<GetDatabaseAction> for ActionHandler {
 
 #[async_trait::async_trait]
 impl RequestHandler<DropDatabaseAction> for ActionHandler {
-    async fn handle(&self, act: DropDatabaseAction) -> common_exception::Result<DropDatabaseReply> {
+    async fn handle(&self, act: DropDatabaseAction) -> common_exception::Result<()> {
         let db_name = &act.plan.db;
         let if_exists = act.plan.if_exists;
         let cr = LogEntry {
@@ -141,7 +141,7 @@ impl RequestHandler<DropDatabaseAction> for ActionHandler {
         match rst {
             AppliedState::DataBase { prev, .. } => {
                 if prev.is_some() || if_exists {
-                    Ok(DropDatabaseReply {})
+                    Ok(())
                 } else {
                     Err(ErrorCode::UnknownDatabase(format!(
                         "database not found: {:}",

--- a/dfs/src/executor/meta_handlers.rs
+++ b/dfs/src/executor/meta_handlers.rs
@@ -218,7 +218,7 @@ impl RequestHandler<CreateTableAction> for ActionHandler {
 
 #[async_trait::async_trait]
 impl RequestHandler<DropTableAction> for ActionHandler {
-    async fn handle(&self, act: DropTableAction) -> common_exception::Result<DropTableReply> {
+    async fn handle(&self, act: DropTableAction) -> common_exception::Result<()> {
         let db_name = &act.plan.db;
         let table_name = &act.plan.table;
         let if_exists = act.plan.if_exists;
@@ -241,7 +241,7 @@ impl RequestHandler<DropTableAction> for ActionHandler {
         match rst {
             AppliedState::Table { prev, .. } => {
                 if prev.is_some() || if_exists {
-                    Ok(DropTableReply {})
+                    Ok(())
                 } else {
                     Err(ErrorCode::UnknownTable(format!(
                         "table not found: {:}",

--- a/dfs/src/executor/meta_handlers.rs
+++ b/dfs/src/executor/meta_handlers.rs
@@ -51,7 +51,7 @@ impl RequestHandler<CreateDatabaseAction> for ActionHandler {
     async fn handle(
         &self,
         act: CreateDatabaseAction,
-    ) -> common_exception::Result<CreateDatabaseActionResult> {
+    ) -> common_exception::Result<CreateDatabaseReply> {
         let plan = act.plan;
         let db_name = &plan.db;
         let if_not_exists = plan.if_not_exists;
@@ -79,7 +79,7 @@ impl RequestHandler<CreateDatabaseAction> for ActionHandler {
             AppliedState::DataBase { prev, result } => {
                 if let Some(prev) = prev {
                     if if_not_exists {
-                        Ok(CreateDatabaseActionResult {
+                        Ok(CreateDatabaseReply {
                             database_id: prev.database_id,
                         })
                     } else {
@@ -89,7 +89,7 @@ impl RequestHandler<CreateDatabaseAction> for ActionHandler {
                         )))
                     }
                 } else {
-                    Ok(CreateDatabaseActionResult {
+                    Ok(CreateDatabaseReply {
                         database_id: result.unwrap().database_id,
                     })
                 }
@@ -122,10 +122,7 @@ impl RequestHandler<GetDatabaseAction> for ActionHandler {
 
 #[async_trait::async_trait]
 impl RequestHandler<DropDatabaseAction> for ActionHandler {
-    async fn handle(
-        &self,
-        act: DropDatabaseAction,
-    ) -> common_exception::Result<DropDatabaseActionResult> {
+    async fn handle(&self, act: DropDatabaseAction) -> common_exception::Result<DropDatabaseReply> {
         let db_name = &act.plan.db;
         let if_exists = act.plan.if_exists;
         let cr = LogEntry {
@@ -144,7 +141,7 @@ impl RequestHandler<DropDatabaseAction> for ActionHandler {
         match rst {
             AppliedState::DataBase { prev, .. } => {
                 if prev.is_some() || if_exists {
-                    Ok(DropDatabaseActionResult {})
+                    Ok(DropDatabaseReply {})
                 } else {
                     Err(ErrorCode::UnknownDatabase(format!(
                         "database not found: {:}",
@@ -160,10 +157,7 @@ impl RequestHandler<DropDatabaseAction> for ActionHandler {
 // table
 #[async_trait::async_trait]
 impl RequestHandler<CreateTableAction> for ActionHandler {
-    async fn handle(
-        &self,
-        act: CreateTableAction,
-    ) -> common_exception::Result<CreateTableActionResult> {
+    async fn handle(&self, act: CreateTableAction) -> common_exception::Result<CreateTableReply> {
         let plan = act.plan;
         let db_name = &plan.db;
         let table_name = &plan.table;
@@ -202,7 +196,7 @@ impl RequestHandler<CreateTableAction> for ActionHandler {
             AppliedState::Table { prev, result } => {
                 if let Some(prev) = prev {
                     if if_not_exists {
-                        Ok(CreateTableActionResult {
+                        Ok(CreateTableReply {
                             table_id: prev.table_id,
                         })
                     } else {
@@ -212,7 +206,7 @@ impl RequestHandler<CreateTableAction> for ActionHandler {
                         )))
                     }
                 } else {
-                    Ok(CreateTableActionResult {
+                    Ok(CreateTableReply {
                         table_id: result.unwrap().table_id,
                     })
                 }
@@ -224,10 +218,7 @@ impl RequestHandler<CreateTableAction> for ActionHandler {
 
 #[async_trait::async_trait]
 impl RequestHandler<DropTableAction> for ActionHandler {
-    async fn handle(
-        &self,
-        act: DropTableAction,
-    ) -> common_exception::Result<DropTableActionResult> {
+    async fn handle(&self, act: DropTableAction) -> common_exception::Result<DropTableReply> {
         let db_name = &act.plan.db;
         let table_name = &act.plan.table;
         let if_exists = act.plan.if_exists;
@@ -250,7 +241,7 @@ impl RequestHandler<DropTableAction> for ActionHandler {
         match rst {
             AppliedState::Table { prev, .. } => {
                 if prev.is_some() || if_exists {
-                    Ok(DropTableActionResult {})
+                    Ok(DropTableReply {})
                 } else {
                     Err(ErrorCode::UnknownTable(format!(
                         "table not found: {:}",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta-api] refactor: MetaApi::drop_table() does not need a return value type. use () for it

##### [common/meta-api] refactor: drop database does not need a return value type

##### [common/meta-api] refactor: rename xxxActionResult to xxxReply

## Changelog




- Improvement


## Related Issues
- #2017