### PR TITLE
[query] refactor: remove trait method `Table::database`

### DIFF
--- a/query/src/catalogs/table.rs
+++ b/query/src/catalogs/table.rs
@@ -30,7 +30,6 @@ use crate::sessions::DatabendQueryContextRef;
 #[async_trait::async_trait]
 pub trait Table: Sync + Send {
     fn name(&self) -> &str;
-    fn database(&self) -> &str;
     fn engine(&self) -> &str;
     fn as_any(&self) -> &dyn Any;
     fn schema(&self) -> Result<DataSchemaRef>;

--- a/query/src/datasources/database/example/example_table.rs
+++ b/query/src/datasources/database/example/example_table.rs
@@ -61,10 +61,6 @@ impl Table for ExampleTable {
         &self.name
     }
 
-    fn database(&self) -> &str {
-        self.db.as_str()
-    }
-
     fn engine(&self) -> &str {
         "ExampleNull"
     }

--- a/query/src/datasources/database/system/clusters_table.rs
+++ b/query/src/datasources/database/system/clusters_table.rs
@@ -31,15 +31,13 @@ use crate::sessions::DatabendQueryContextRef;
 
 pub struct ClustersTable {
     table_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl ClustersTable {
-    pub fn create(table_id: u64, db_name: &str) -> Self {
+    pub fn create(table_id: u64) -> Self {
         ClustersTable {
             table_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![
                 DataField::new("name", DataType::String, false),
                 DataField::new("host", DataType::String, false),
@@ -53,10 +51,6 @@ impl ClustersTable {
 impl Table for ClustersTable {
     fn name(&self) -> &str {
         "clusters"
-    }
-
-    fn database(&self) -> &str {
-        &self.db_name
     }
 
     fn engine(&self) -> &str {

--- a/query/src/datasources/database/system/clusters_table_test.rs
+++ b/query/src/datasources/database/system/clusters_table_test.rs
@@ -22,7 +22,7 @@ use crate::datasources::database::system::ClustersTable;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_clusters_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
-    let table = ClustersTable::create(1, "system");
+    let table = ClustersTable::create(1);
     let source_plan = table.read_plan(
         ctx.clone(),
         None,

--- a/query/src/datasources/database/system/configs_table.rs
+++ b/query/src/datasources/database/system/configs_table.rs
@@ -30,15 +30,13 @@ use crate::sessions::DatabendQueryContextRef;
 
 pub struct ConfigsTable {
     table_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl ConfigsTable {
-    pub fn create(table_id: u64, db_name: &str) -> Self {
+    pub fn create(table_id: u64) -> Self {
         ConfigsTable {
             table_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![
                 DataField::new("name", DataType::String, false),
                 DataField::new("value", DataType::String, false),
@@ -73,10 +71,6 @@ impl ConfigsTable {
 impl Table for ConfigsTable {
     fn name(&self) -> &str {
         "configs"
-    }
-
-    fn database(&self) -> &str {
-        &self.db_name
     }
 
     fn engine(&self) -> &str {

--- a/query/src/datasources/database/system/configs_table_test.rs
+++ b/query/src/datasources/database/system/configs_table_test.rs
@@ -28,7 +28,7 @@ async fn test_configs_table() -> Result<()> {
     let ctx = try_create_context_with_config(config)?;
     ctx.get_settings().set_max_threads(8)?;
 
-    let table = ConfigsTable::create(1, "system");
+    let table = ConfigsTable::create(1);
     let source_plan = table.read_plan(
         ctx.clone(),
         None,

--- a/query/src/datasources/database/system/contributors_table.rs
+++ b/query/src/datasources/database/system/contributors_table.rs
@@ -29,15 +29,13 @@ use crate::sessions::DatabendQueryContextRef;
 
 pub struct ContributorsTable {
     table_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl ContributorsTable {
-    pub fn create(table_id: u64, db_name: &str) -> Self {
+    pub fn create(table_id: u64) -> Self {
         ContributorsTable {
             table_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![DataField::new("name", DataType::String, false)]),
         }
     }
@@ -47,10 +45,6 @@ impl ContributorsTable {
 impl Table for ContributorsTable {
     fn name(&self) -> &str {
         "contributors"
-    }
-
-    fn database(&self) -> &str {
-        self.db_name.as_str()
     }
 
     fn engine(&self) -> &str {

--- a/query/src/datasources/database/system/contributors_table_test.rs
+++ b/query/src/datasources/database/system/contributors_table_test.rs
@@ -22,7 +22,7 @@ use crate::datasources::database::system::ContributorsTable;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_contributors_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
-    let table = ContributorsTable::create(1, "system");
+    let table = ContributorsTable::create(1);
     let source_plan = table.read_plan(
         ctx.clone(),
         None,

--- a/query/src/datasources/database/system/credits_table.rs
+++ b/query/src/datasources/database/system/credits_table.rs
@@ -29,15 +29,13 @@ use crate::sessions::DatabendQueryContextRef;
 
 pub struct CreditsTable {
     table_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl CreditsTable {
-    pub fn create(table_id: u64, db_name: &str) -> Self {
+    pub fn create(table_id: u64) -> Self {
         CreditsTable {
             table_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![
                 DataField::new("name", DataType::String, false),
                 DataField::new("version", DataType::String, false),
@@ -51,10 +49,6 @@ impl CreditsTable {
 impl Table for CreditsTable {
     fn name(&self) -> &str {
         "credits"
-    }
-
-    fn database(&self) -> &str {
-        self.db_name.as_str()
     }
 
     fn engine(&self) -> &str {

--- a/query/src/datasources/database/system/credits_table_test.rs
+++ b/query/src/datasources/database/system/credits_table_test.rs
@@ -22,7 +22,7 @@ use crate::datasources::database::system::CreditsTable;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_credits_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
-    let table = CreditsTable::create(1, "system");
+    let table = CreditsTable::create(1);
     let source_plan = table.read_plan(
         ctx.clone(),
         None,

--- a/query/src/datasources/database/system/databases_table.rs
+++ b/query/src/datasources/database/system/databases_table.rs
@@ -30,15 +30,13 @@ use crate::sessions::DatabendQueryContextRef;
 
 pub struct DatabasesTable {
     table_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl DatabasesTable {
-    pub fn create(table_id: u64, db_name: &str) -> Self {
+    pub fn create(table_id: u64) -> Self {
         DatabasesTable {
             table_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![DataField::new("name", DataType::String, false)]),
         }
     }
@@ -50,9 +48,6 @@ impl Table for DatabasesTable {
         "databases"
     }
 
-    fn database(&self) -> &str {
-        self.db_name.as_str()
-    }
     fn engine(&self) -> &str {
         "SystemDatabases"
     }

--- a/query/src/datasources/database/system/databases_table_test.rs
+++ b/query/src/datasources/database/system/databases_table_test.rs
@@ -22,7 +22,7 @@ use crate::datasources::database::system::DatabasesTable;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_tables_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
-    let table = DatabasesTable::create(1, "system");
+    let table = DatabasesTable::create(1);
     let source_plan = table.read_plan(
         ctx.clone(),
         None,

--- a/query/src/datasources/database/system/engines_table.rs
+++ b/query/src/datasources/database/system/engines_table.rs
@@ -30,15 +30,13 @@ use crate::sessions::DatabendQueryContextRef;
 
 pub struct EnginesTable {
     table_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl EnginesTable {
-    pub fn create(table_id: u64, db_name: &str) -> Self {
+    pub fn create(table_id: u64) -> Self {
         EnginesTable {
             table_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![
                 DataField::new("name", DataType::String, false),
                 DataField::new("description", DataType::String, false),
@@ -51,10 +49,6 @@ impl EnginesTable {
 impl Table for EnginesTable {
     fn name(&self) -> &str {
         "engines"
-    }
-
-    fn database(&self) -> &str {
-        self.db_name.as_str()
     }
 
     fn engine(&self) -> &str {

--- a/query/src/datasources/database/system/engines_table_test.rs
+++ b/query/src/datasources/database/system/engines_table_test.rs
@@ -25,7 +25,7 @@ async fn test_engines_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
     ctx.get_settings().set_max_threads(2)?;
 
-    let table = EnginesTable::create(1, "system");
+    let table = EnginesTable::create(1);
     let source_plan = table.read_plan(
         ctx.clone(),
         None,

--- a/query/src/datasources/database/system/functions_table.rs
+++ b/query/src/datasources/database/system/functions_table.rs
@@ -31,15 +31,13 @@ use crate::sessions::DatabendQueryContextRef;
 
 pub struct FunctionsTable {
     table_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl FunctionsTable {
-    pub fn create(table_id: u64, db_name: &str) -> Self {
+    pub fn create(table_id: u64) -> Self {
         FunctionsTable {
             table_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![
                 DataField::new("name", DataType::String, false),
                 DataField::new("is_aggregate", DataType::Boolean, false),
@@ -52,10 +50,6 @@ impl FunctionsTable {
 impl Table for FunctionsTable {
     fn name(&self) -> &str {
         "functions"
-    }
-
-    fn database(&self) -> &str {
-        self.db_name.as_str()
     }
 
     fn engine(&self) -> &str {

--- a/query/src/datasources/database/system/functions_table_test.rs
+++ b/query/src/datasources/database/system/functions_table_test.rs
@@ -22,7 +22,7 @@ use crate::datasources::database::system::FunctionsTable;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_functions_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
-    let table = FunctionsTable::create(1, "system");
+    let table = FunctionsTable::create(1);
     let source_plan = table.read_plan(
         ctx.clone(),
         None,

--- a/query/src/datasources/database/system/one_table.rs
+++ b/query/src/datasources/database/system/one_table.rs
@@ -29,15 +29,13 @@ use crate::sessions::DatabendQueryContextRef;
 
 pub struct OneTable {
     tbl_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl OneTable {
-    pub fn create(tbl_id: u64, db_name: &str) -> Self {
+    pub fn create(tbl_id: u64) -> Self {
         OneTable {
             tbl_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![DataField::new("dummy", DataType::UInt8, false)]),
         }
     }
@@ -47,10 +45,6 @@ impl OneTable {
 impl Table for OneTable {
     fn name(&self) -> &str {
         "one"
-    }
-
-    fn database(&self) -> &str {
-        self.db_name.as_str()
     }
 
     fn engine(&self) -> &str {

--- a/query/src/datasources/database/system/processes_table.rs
+++ b/query/src/datasources/database/system/processes_table.rs
@@ -35,15 +35,13 @@ use crate::sessions::ProcessInfo;
 
 pub struct ProcessesTable {
     table_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl ProcessesTable {
-    pub fn create(table_id: u64, db_name: &str) -> Self {
+    pub fn create(table_id: u64) -> Self {
         ProcessesTable {
             table_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![
                 DataField::new("id", DataType::String, false),
                 DataField::new("type", DataType::String, false),
@@ -72,10 +70,6 @@ impl ProcessesTable {
 impl Table for ProcessesTable {
     fn name(&self) -> &str {
         "processes"
-    }
-
-    fn database(&self) -> &str {
-        self.db_name.as_str()
     }
 
     fn engine(&self) -> &str {

--- a/query/src/datasources/database/system/settings_table.rs
+++ b/query/src/datasources/database/system/settings_table.rs
@@ -29,15 +29,13 @@ use crate::sessions::DatabendQueryContextRef;
 
 pub struct SettingsTable {
     table_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl SettingsTable {
-    pub fn create(table_id: u64, db_name: &str) -> Self {
+    pub fn create(table_id: u64) -> Self {
         SettingsTable {
             table_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![
                 DataField::new("name", DataType::String, false),
                 DataField::new("value", DataType::String, false),
@@ -52,10 +50,6 @@ impl SettingsTable {
 impl Table for SettingsTable {
     fn name(&self) -> &str {
         "settings"
-    }
-
-    fn database(&self) -> &str {
-        self.db_name.as_str()
     }
 
     fn engine(&self) -> &str {

--- a/query/src/datasources/database/system/settings_table_test.rs
+++ b/query/src/datasources/database/system/settings_table_test.rs
@@ -25,7 +25,7 @@ async fn test_settings_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
     ctx.get_settings().set_max_threads(2)?;
 
-    let table = SettingsTable::create(1, "system");
+    let table = SettingsTable::create(1);
     let source_plan = table.read_plan(
         ctx.clone(),
         None,

--- a/query/src/datasources/database/system/system_database.rs
+++ b/query/src/datasources/database/system/system_database.rs
@@ -53,18 +53,18 @@ impl SystemDatabase {
 
         // Table list.
         let table_list: Vec<Arc<dyn Table>> = vec![
-            Arc::new(system::OneTable::create(next_id(), &name)),
-            Arc::new(system::FunctionsTable::create(next_id(), &name)),
-            Arc::new(system::ContributorsTable::create(next_id(), &name)),
-            Arc::new(system::CreditsTable::create(next_id(), &name)),
-            Arc::new(system::EnginesTable::create(next_id(), &name)),
-            Arc::new(system::SettingsTable::create(next_id(), &name)),
-            Arc::new(system::TablesTable::create(next_id(), &name)),
-            Arc::new(system::ClustersTable::create(next_id(), &name)),
-            Arc::new(system::DatabasesTable::create(next_id(), &name)),
-            Arc::new(system::TracingTable::create(next_id(), &name)),
-            Arc::new(system::ProcessesTable::create(next_id(), &name)),
-            Arc::new(system::ConfigsTable::create(next_id(), &name)),
+            Arc::new(system::OneTable::create(next_id())),
+            Arc::new(system::FunctionsTable::create(next_id())),
+            Arc::new(system::ContributorsTable::create(next_id())),
+            Arc::new(system::CreditsTable::create(next_id())),
+            Arc::new(system::EnginesTable::create(next_id())),
+            Arc::new(system::SettingsTable::create(next_id())),
+            Arc::new(system::TablesTable::create(next_id())),
+            Arc::new(system::ClustersTable::create(next_id())),
+            Arc::new(system::DatabasesTable::create(next_id())),
+            Arc::new(system::TracingTable::create(next_id())),
+            Arc::new(system::ProcessesTable::create(next_id())),
+            Arc::new(system::ConfigsTable::create(next_id())),
         ];
 
         let tbl_meta_list = table_list.into_iter().map(|t| {

--- a/query/src/datasources/database/system/tables_table.rs
+++ b/query/src/datasources/database/system/tables_table.rs
@@ -30,15 +30,13 @@ use crate::sessions::DatabendQueryContextRef;
 
 pub struct TablesTable {
     table_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl TablesTable {
-    pub fn create(table_id: u64, db_name: &str) -> Self {
+    pub fn create(table_id: u64) -> Self {
         TablesTable {
             table_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![
                 DataField::new("database", DataType::String, false),
                 DataField::new("name", DataType::String, false),
@@ -52,10 +50,6 @@ impl TablesTable {
 impl Table for TablesTable {
     fn name(&self) -> &str {
         "tables"
-    }
-
-    fn database(&self) -> &str {
-        self.db_name.as_str()
     }
 
     fn engine(&self) -> &str {

--- a/query/src/datasources/database/system/tables_table_test.rs
+++ b/query/src/datasources/database/system/tables_table_test.rs
@@ -22,7 +22,7 @@ use crate::datasources::database::system::TablesTable;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_tables_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
-    let table = TablesTable::create(1, "system");
+    let table = TablesTable::create(1);
     let source_plan = table.read_plan(
         ctx.clone(),
         None,

--- a/query/src/datasources/database/system/tracing_table.rs
+++ b/query/src/datasources/database/system/tracing_table.rs
@@ -34,16 +34,14 @@ use crate::sessions::DatabendQueryContextRef;
 
 pub struct TracingTable {
     table_id: u64,
-    db_name: String,
     schema: DataSchemaRef,
 }
 
 impl TracingTable {
-    pub fn create(table_id: u64, db_name: &str) -> Self {
+    pub fn create(table_id: u64) -> Self {
         // {"v":0,"name":"databend-query","msg":"Group by partial cost: 9.071158ms","level":20,"hostname":"databend","pid":56776,"time":"2021-06-24T02:17:28.679642889+00:00"}
         TracingTable {
             table_id,
-            db_name: db_name.to_string(),
             schema: DataSchemaRefExt::create(vec![
                 DataField::new("v", DataType::Int64, false),
                 DataField::new("name", DataType::String, false),
@@ -61,10 +59,6 @@ impl TracingTable {
 impl Table for TracingTable {
     fn name(&self) -> &str {
         "tracing"
-    }
-
-    fn database(&self) -> &str {
-        self.db_name.as_str()
     }
 
     fn engine(&self) -> &str {

--- a/query/src/datasources/database/system/tracing_table_test.rs
+++ b/query/src/datasources/database/system/tracing_table_test.rs
@@ -22,7 +22,7 @@ use crate::datasources::database::system::TracingTable;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_tracing_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
-    let table = TracingTable::create(1, "system");
+    let table = TracingTable::create(1);
     let source_plan = table.read_plan(
         ctx.clone(),
         None,

--- a/query/src/datasources/table/csv/csv_table.rs
+++ b/query/src/datasources/table/csv/csv_table.rs
@@ -66,10 +66,6 @@ impl Table for CsvTable {
         &self.tbl_info.name
     }
 
-    fn database(&self) -> &str {
-        &self.tbl_info.db
-    }
-
     fn engine(&self) -> &str {
         &self.tbl_info.engine
     }

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -82,10 +82,6 @@ impl Table for FuseTable {
         &self.tbl_info.name
     }
 
-    fn database(&self) -> &str {
-        &self.tbl_info.db
-    }
-
     fn engine(&self) -> &str {
         &self.tbl_info.engine
     }

--- a/query/src/datasources/table/memory/memory_table.rs
+++ b/query/src/datasources/table/memory/memory_table.rs
@@ -55,10 +55,6 @@ impl Table for MemoryTable {
         &self.tbl_info.name
     }
 
-    fn database(&self) -> &str {
-        &self.tbl_info.db
-    }
-
     fn engine(&self) -> &str {
         &self.tbl_info.engine
     }

--- a/query/src/datasources/table/null/null_table.rs
+++ b/query/src/datasources/table/null/null_table.rs
@@ -48,10 +48,6 @@ impl Table for NullTable {
         &self.tbl_info.name
     }
 
-    fn database(&self) -> &str {
-        &self.tbl_info.db
-    }
-
     fn engine(&self) -> &str {
         &self.tbl_info.engine
     }

--- a/query/src/datasources/table/parquet/parquet_table.rs
+++ b/query/src/datasources/table/parquet/parquet_table.rs
@@ -96,10 +96,6 @@ impl Table for ParquetTable {
         &self.tbl_info.name
     }
 
-    fn database(&self) -> &str {
-        &self.tbl_info.db
-    }
-
     fn engine(&self) -> &str {
         &self.tbl_info.engine
     }

--- a/query/src/datasources/table/remote/remote_table.rs
+++ b/query/src/datasources/table/remote/remote_table.rs
@@ -42,10 +42,6 @@ impl Table for RemoteTable {
         &self.tbl_info.name
     }
 
-    fn database(&self) -> &str {
-        &self.tbl_info.db
-    }
-
     fn engine(&self) -> &str {
         &self.tbl_info.engine
     }

--- a/query/src/datasources/table_func/numbers_table.rs
+++ b/query/src/datasources/table_func/numbers_table.rs
@@ -89,10 +89,6 @@ impl Table for NumbersTable {
         &self.table_name
     }
 
-    fn database(&self) -> &str {
-        &self.db_name
-    }
-
     fn get_id(&self) -> u64 {
         self.table_id
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor: remove trait method `Table::database`

This method is not used at all and a `table` object should not be aware of the `database`.
I.e. a table itself does not change even when its belonging database is renamed.



## Changelog




- Improvement


## Related Issues