### PR TITLE
[common/catalog] refactor: move TableSnapshot into crate common/catalog, so that a plan could have a reference to table info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-catalog"
+version = "0.1.0"
+dependencies = [
+ "common-arrow",
+ "common-base",
+ "common-datavalues",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "common-clickhouse-srv"
 version = "0.3.2"
 dependencies = [
@@ -1615,6 +1627,7 @@ dependencies = [
  "common-base",
  "common-building",
  "common-cache",
+ "common-catalog",
  "common-clickhouse-srv",
  "common-datablocks",
  "common-datavalues",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "common/base",
     "common/building",
     "common/cache",
+    "common/catalog",
     "common/clickhouse-srv",
     "common/datablocks",
     "common/datavalues",

--- a/common/base/Cargo.toml
+++ b/common/base/Cargo.toml
@@ -14,12 +14,12 @@ common-exception = { path = "../exception" }
 # Github dependencies
 
 # Crates.io dependencies
-futures = "0.3"
 async-trait = "0.1"
-uuid = { version = "0.8", features = ["serde", "v4"] }
 ctrlc = { version = "3.1.9", features = ["termination"] }
+futures = "0.3"
 pprof = { version = "0.5", features = ["flamegraph", "protobuf"] }
 tokio = { version = "1.12.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
 pretty_assertions = "1.0"

--- a/common/catalog/Cargo.toml
+++ b/common/catalog/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "common-catalog"
+version = "0.1.0"
+authors = ["Databend Authors <opensource@datafuselabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+common-base = {path = "../base"}
+common-arrow = {path = "../arrow"}
+common-datavalues = {path = "../datavalues"}
+
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+pretty_assertions = "1.0"

--- a/common/catalog/src/lib.rs
+++ b/common/catalog/src/lib.rs
@@ -12,33 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(test)]
-mod runtime_test;
+//! `catalog` defines catalog related data types, such as table or database.
 
-#[cfg(test)]
-mod progress_test;
+mod table_snapshot;
 
-#[cfg(test)]
-mod stoppable_test;
-
-mod profiling;
-mod progress;
-mod runtime;
-
-pub use profiling::Profiling;
-pub use progress::Progress;
-pub use progress::ProgressCallback;
-pub use progress::ProgressValues;
-pub use runtime::Dropper;
-pub use runtime::Runtime;
-pub use tokio;
-pub use uuid;
-
-mod stop_handle;
-mod stoppable;
-mod uniq_id;
-
-pub use stop_handle::StopHandle;
-pub use stoppable::Stoppable;
-pub use uniq_id::GlobalSequence;
-pub use uniq_id::GlobalUniqName;
+pub use table_snapshot::BlockLocation;
+pub use table_snapshot::BlockMeta;
+pub use table_snapshot::ColStats;
+pub use table_snapshot::ColumnId;
+pub use table_snapshot::Location;
+pub use table_snapshot::RawBlockStats;
+pub use table_snapshot::SegmentInfo;
+pub use table_snapshot::SnapshotId;
+pub use table_snapshot::Stats;
+pub use table_snapshot::TableSnapshot;

--- a/common/catalog/src/table_snapshot.rs
+++ b/common/catalog/src/table_snapshot.rs
@@ -1,37 +1,43 @@
-//  Copyright 2021 Datafuse Labs.
+// Copyright 2020 Datafuse Labs.
 //
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use std::collections::HashMap;
 
 use common_arrow::parquet::statistics::Statistics;
+use common_base::uuid;
 use common_datavalues::DataSchema;
 use common_datavalues::DataValue;
+use serde::Deserialize;
+use serde::Serialize;
 use uuid::Uuid;
 
 pub type SnapshotId = Uuid;
 pub type ColumnId = u32;
 pub type Location = String;
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TableSnapshot {
     pub snapshot_id: SnapshotId,
+
     pub prev_snapshot_id: Option<SnapshotId>,
+
     /// For each snapshot, we keep a schema for it (in case of schema evolution)
     pub schema: DataSchema,
+
     /// Summary Statistics
     pub summary: Stats,
+
     /// Pointers to SegmentInfos
     ///
     /// We rely on background merge tasks to keep merging segments, so that
@@ -45,6 +51,12 @@ impl TableSnapshot {
     }
 }
 
+impl Default for TableSnapshot {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A segment comprised of one or more blocks
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct SegmentInfo {
@@ -52,7 +64,7 @@ pub struct SegmentInfo {
     pub summary: Stats,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Stats {
     pub row_count: u64,
     pub block_count: u64,

--- a/common/functions/src/aggregates/aggregate_combinator_test.rs
+++ b/common/functions/src/aggregates/aggregate_combinator_test.rs
@@ -18,7 +18,6 @@ use common_exception::Result;
 use pretty_assertions::assert_eq;
 
 use crate::aggregates::aggregate_function_factory::AggregateFunctionFactory;
-use crate::aggregates::*;
 
 #[test]
 fn test_aggregate_combinator_function() -> Result<()> {

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -25,6 +25,7 @@ common-arrow = { path = "../common/arrow" }
 common-base = { path = "../common/base" }
 common-management = { path = "../common/management" }
 common-cache = { path = "../common/cache"}
+common-catalog = { path = "../common/catalog"}
 common-datablocks = { path = "../common/datablocks" }
 common-datavalues = { path = "../common/datavalues" }
 common-exception = { path = "../common/exception" }

--- a/query/src/datasources/table/fuse/io/block_appender.rs
+++ b/query/src/datasources/table/fuse/io/block_appender.rs
@@ -19,6 +19,12 @@ use common_arrow::arrow::datatypes::Schema as ArrowSchema;
 use common_arrow::arrow::io::parquet::write::WriteOptions;
 use common_arrow::arrow::io::parquet::write::*;
 use common_arrow::arrow::record_batch::RecordBatch;
+use common_catalog::BlockLocation;
+use common_catalog::BlockMeta;
+use common_catalog::ColStats;
+use common_catalog::ColumnId;
+use common_catalog::SegmentInfo;
+use common_catalog::Stats;
 use common_datablocks::DataBlock;
 use common_datavalues::columns::DataColumn;
 use common_datavalues::DataType;
@@ -31,13 +37,7 @@ use uuid::Uuid;
 use crate::datasources::dal::DataAccessor;
 use crate::datasources::table::fuse::block_location;
 use crate::datasources::table::fuse::column_stats_reduce;
-use crate::datasources::table::fuse::BlockLocation;
-use crate::datasources::table::fuse::BlockMeta;
-use crate::datasources::table::fuse::ColStats;
-use crate::datasources::table::fuse::ColumnId;
 use crate::datasources::table::fuse::FuseTable;
-use crate::datasources::table::fuse::SegmentInfo;
-use crate::datasources::table::fuse::Stats;
 use crate::sessions::DatabendQueryContextRef;
 
 impl FuseTable {

--- a/query/src/datasources/table/fuse/io/segment_reader.rs
+++ b/query/src/datasources/table/fuse/io/segment_reader.rs
@@ -15,12 +15,12 @@
 
 use std::sync::Arc;
 
+use common_catalog::SegmentInfo;
 use common_exception::Result;
 
 use crate::datasources::dal::DataAccessor;
 use crate::datasources::table::fuse::do_read_obj;
 use crate::datasources::table::fuse::do_read_obj_async;
-use crate::datasources::table::fuse::SegmentInfo;
 use crate::sessions::DatabendQueryContextRef;
 
 #[allow(dead_code)]

--- a/query/src/datasources/table/fuse/io/snapshot_reader.rs
+++ b/query/src/datasources/table/fuse/io/snapshot_reader.rs
@@ -15,12 +15,12 @@
 
 use std::sync::Arc;
 
+use common_catalog::TableSnapshot;
 use common_exception::Result;
 
 use crate::datasources::dal::DataAccessor;
 use crate::datasources::table::fuse::do_read_obj;
 use crate::datasources::table::fuse::do_read_obj_async;
-use crate::datasources::table::fuse::TableSnapshot;
 use crate::sessions::DatabendQueryContextRef;
 
 pub fn read_table_snapshot(

--- a/query/src/datasources/table/fuse/meta/meta_info_reader.rs
+++ b/query/src/datasources/table/fuse/meta/meta_info_reader.rs
@@ -16,13 +16,13 @@
 use std::sync::Arc;
 
 use common_arrow::parquet::read::read_metadata;
+use common_catalog::RawBlockStats;
+use common_catalog::SegmentInfo;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
 use crate::datasources::dal::DataAccessor;
 use crate::datasources::table::fuse::read_segment;
-use crate::datasources::table::fuse::RawBlockStats;
-use crate::datasources::table::fuse::SegmentInfo;
 use crate::sessions::DatabendQueryContextRef;
 
 // TODO cache

--- a/query/src/datasources/table/fuse/meta/mod.rs
+++ b/query/src/datasources/table/fuse/meta/mod.rs
@@ -14,7 +14,5 @@
 //
 
 mod meta_info_reader;
-mod table_snapshot;
 
 pub use meta_info_reader::MetaInfoReader;
-pub use table_snapshot::*;

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -16,6 +16,9 @@
 use std::any::Any;
 use std::sync::Arc;
 
+use common_catalog::BlockLocation;
+use common_catalog::SegmentInfo;
+use common_catalog::TableSnapshot;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -38,10 +41,7 @@ use crate::datasources::table::fuse::read_part;
 use crate::datasources::table::fuse::read_table_snapshot;
 use crate::datasources::table::fuse::segment_info_location;
 use crate::datasources::table::fuse::snapshot_location;
-use crate::datasources::table::fuse::BlockLocation;
 use crate::datasources::table::fuse::MetaInfoReader;
-use crate::datasources::table::fuse::SegmentInfo;
-use crate::datasources::table::fuse::TableSnapshot;
 use crate::datasources::table::fuse::TableStorageScheme;
 use crate::sessions::DatabendQueryContextRef;
 

--- a/query/src/datasources/table/fuse/util/index_helpers.rs
+++ b/query/src/datasources/table/fuse/util/index_helpers.rs
@@ -13,12 +13,12 @@
 //  limitations under the License.
 //
 
+use common_catalog::BlockLocation;
+use common_catalog::TableSnapshot;
 use common_exception::Result;
 use common_planners::Extras;
 
-use crate::datasources::table::fuse::BlockLocation;
 use crate::datasources::table::fuse::MetaInfoReader;
-use crate::datasources::table::fuse::TableSnapshot;
 
 struct TableSparseIndex {}
 struct CacheMgr;

--- a/query/src/datasources/table/fuse/util/statistic_helper.rs
+++ b/query/src/datasources/table/fuse/util/statistic_helper.rs
@@ -16,11 +16,10 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
+use common_catalog::ColStats;
+use common_catalog::ColumnId;
 use common_datavalues::DataType;
 use common_exception::Result;
-
-use crate::datasources::table::fuse::ColStats;
-use crate::datasources::table::fuse::ColumnId;
 
 pub fn column_stats_reduce(
     stats: Vec<HashMap<ColumnId, (DataType, ColStats)>>,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/catalog] refactor: move TableSnapshot into crate common/catalog, so that a plan could have a reference to table info

## Changelog




- Improvement


## Related Issues

- #2055 
- #2059
- fix: #2060