### PR TITLE
[common/base] feature: introduce trait `TrySpawn` to define methods to spawn an async task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,7 @@ name = "common-kv-api"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "common-base",
  "common-exception",
  "common-kv-api-util",
  "common-kv-api-vo",

--- a/common/base/src/lib.rs
+++ b/common/base/src/lib.rs
@@ -31,6 +31,7 @@ pub use progress::ProgressCallback;
 pub use progress::ProgressValues;
 pub use runtime::Dropper;
 pub use runtime::Runtime;
+pub use runtime::TrySpawn;
 pub use tokio;
 pub use uuid;
 

--- a/common/kv-apis/api/Cargo.toml
+++ b/common/kv-apis/api/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [dependencies]
 
+common-base = {path= "../../base" }
 common-metatypes = {path= "../../metatypes" }
 common-exception = {path = "../../exception" }
 common-kv-api-util= { path = "../util" }

--- a/common/kv-apis/api/src/kv_api_sync.rs
+++ b/common/kv-apis/api/src/kv_api_sync.rs
@@ -16,6 +16,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use common_base::TrySpawn;
 use common_kv_api_vo::GetKVActionResult;
 use common_kv_api_vo::MGetKVActionResult;
 use common_kv_api_vo::PrefixListReply;

--- a/common/kv/src/kv.rs
+++ b/common/kv/src/kv.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use common_base::tokio::sync::Mutex;
+use common_base::TrySpawn;
 use common_exception::Result;
 use common_kv_api::KVApi;
 use common_kv_api_util::STORE_RUNTIME;

--- a/common/store-api-sdk/Cargo.toml
+++ b/common/store-api-sdk/Cargo.toml
@@ -9,23 +9,23 @@ edition = "2021"
 [dependencies] # In alphabetical order
 # Workspace dependencies
 common-arrow = {path = "../arrow"}
+common-base = {path = "../base" }
 common-datablocks= {path = "../datablocks"}
 common-datavalues = {path = "../datavalues"}
-common-exception= {path = "../exception"}
-common-metatypes = {path = "../metatypes"}
-common-planners = {path = "../planners"}
-common-base = {path = "../base" }
-common-streams = {path = "../streams"}
-common-tracing = {path = "../tracing"}
-common-kv-api = {path = "../kv-apis/api" }
-common-kv-api-vo = {path = "../kv-apis/vo" }
-common-kv-api-util = {path = "../kv-apis/util" }
-common-meta-api = {path = "../meta-apis/api" }
-common-meta-api-vo = {path = "../meta-apis/vo" }
 common-dfs-api = {path = "../dfs-apis/api" }
 common-dfs-api-vo = {path = "../dfs-apis/vo" }
+common-exception= {path = "../exception"}
 common-infallible = {path = "../infallible"}
+common-kv-api = {path = "../kv-apis/api" }
+common-kv-api-util = {path = "../kv-apis/util" }
+common-kv-api-vo = {path = "../kv-apis/vo" }
+common-meta-api = {path = "../meta-apis/api" }
+common-meta-api-vo = {path = "../meta-apis/vo" }
+common-metatypes = {path = "../metatypes"}
+common-planners = {path = "../planners"}
 common-store-api-sdk-util = {path = "./util"}
+common-streams = {path = "../streams"}
+common-tracing = {path = "../tracing"}
 
 # Github dependencies
 

--- a/common/store-api-sdk/src/store_client.rs
+++ b/common/store-api-sdk/src/store_client.rs
@@ -19,6 +19,7 @@ use common_arrow::arrow_flight::flight_service_client::FlightServiceClient;
 use common_arrow::arrow_flight::Action;
 use common_arrow::arrow_flight::BasicAuth;
 use common_arrow::arrow_flight::HandshakeRequest;
+use common_base::TrySpawn;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_kv_api_util::STORE_RUNTIME;

--- a/query/src/api/rpc/flight_dispatcher.rs
+++ b/query/src/api/rpc/flight_dispatcher.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use common_base::tokio::sync::mpsc::Sender;
 use common_base::tokio::sync::*;
+use common_base::TrySpawn;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
@@ -137,7 +138,7 @@ impl DatabendQueryFlightDispatcher {
         let tx_ref = self.streams.read().get(&stream_name).map(|x| x.tx.clone());
         let tx = tx_ref.ok_or_else(|| ErrorCode::NotFoundStream("Not found stream"))?;
 
-        query_context.execute_task(async move {
+        query_context.try_spawn(async move {
             let _session = session;
             wait_start(stage_name, stages_notify).await;
 
@@ -211,7 +212,7 @@ impl DatabendQueryFlightDispatcher {
             action.get_sinks().len(),
         )?;
 
-        query_context.execute_task(async move {
+        query_context.try_spawn(async move {
             let _session = session;
             wait_start(stage_name, stages_notify).await;
 

--- a/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
+++ b/query/src/catalogs/impls/meta_backends/remote_meta_backend.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common_base::Runtime;
+use common_base::TrySpawn;
 use common_cache::Cache;
 use common_cache::LruCache;
 use common_exception::Result;

--- a/query/src/datasources/dal/blob_accessor.rs
+++ b/query/src/datasources/dal/blob_accessor.rs
@@ -37,6 +37,7 @@ impl<T> SeekableReader for T where T: Read + Seek {}
 #[async_trait::async_trait]
 pub trait DataAccessor: Send + Sync {
     fn get_reader(&self, path: &str, len: Option<u64>) -> Result<Box<dyn SeekableReader>>;
+
     fn get_writer(&self, path: &str) -> Result<Box<dyn Write>>;
 
     async fn get_input_stream(&self, path: &str, stream_len: Option<u64>) -> Result<InputStream>;

--- a/query/src/datasources/table/fuse/io/reader_util.rs
+++ b/query/src/datasources/table/fuse/io/reader_util.rs
@@ -15,6 +15,7 @@
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 
+use common_base::TrySpawn;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use futures::AsyncReadExt;
@@ -30,7 +31,7 @@ pub fn do_read(
 ) -> Result<Vec<u8>> {
     let (tx, rx) = channel();
     let location = loc.to_string();
-    ctx.execute_task(async move {
+    ctx.try_spawn(async move {
         let input_stream = da.get_input_stream(&location, None);
         match input_stream.await {
             Ok(mut input) => {

--- a/query/src/pipelines/processors/processor_merge.rs
+++ b/query/src/pipelines/processors/processor_merge.rs
@@ -16,6 +16,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use common_base::tokio::sync::mpsc;
+use common_base::TrySpawn;
 use common_datablocks::DataBlock;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -52,7 +53,7 @@ impl MergeProcessor {
         for i in 0..len {
             let processor = self.inputs[i].clone();
             let sender = sender.clone();
-            self.ctx.execute_task(async move {
+            self.ctx.try_spawn(async move {
                 let mut stream = match processor.execute().await {
                     Err(e) => {
                         if let Err(error) = sender.send(Result::Err(e)).await {

--- a/query/src/pipelines/processors/processor_mixed.rs
+++ b/query/src/pipelines/processors/processor_mixed.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use common_base::tokio::sync::mpsc;
+use common_base::TrySpawn;
 use common_datablocks::DataBlock;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -59,7 +60,7 @@ impl MixedWorker {
         }
 
         let mut stream = self.merger.merge()?;
-        self.ctx.execute_task(async move {
+        self.ctx.try_spawn(async move {
             let index = AtomicUsize::new(0);
             while let Some(item) = stream.next().await {
                 let i = index.fetch_add(1, Ordering::Relaxed) % outputs_len;

--- a/query/src/pipelines/transforms/transform_create_sets.rs
+++ b/query/src/pipelines/transforms/transform_create_sets.rs
@@ -16,6 +16,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use common_base::tokio::task::JoinHandle;
+use common_base::TrySpawn;
 use common_datavalues::DataSchemaRef;
 use common_datavalues::DataValue;
 use common_exception::ErrorCode;
@@ -92,7 +93,7 @@ impl CreateSetsTransform {
         let mut join_tasks = vec![];
         for index in 0..data_puller.sub_queries_num() {
             let future = data_puller.take_subquery_data(index)?;
-            join_tasks.push(context.execute_task(future)?);
+            join_tasks.push(context.try_spawn(future)?);
         }
 
         Ok(join_all(join_tasks))

--- a/query/src/servers/clickhouse/clickhouse_handler.rs
+++ b/query/src/servers/clickhouse/clickhouse_handler.rs
@@ -19,6 +19,7 @@ use common_base::tokio;
 use common_base::tokio::net::TcpStream;
 use common_base::tokio::task::JoinHandle;
 use common_base::Runtime;
+use common_base::TrySpawn;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use futures::future::AbortHandle;

--- a/query/src/servers/clickhouse/clickhouse_session.rs
+++ b/query/src/servers/clickhouse/clickhouse_session.rs
@@ -16,6 +16,7 @@ use std::net::Shutdown;
 
 use common_base::tokio::net::TcpStream;
 use common_base::Runtime;
+use common_base::TrySpawn;
 use common_clickhouse_srv::ClickHouseServer;
 use common_exception::ErrorCode;
 use common_exception::Result;

--- a/query/src/servers/clickhouse/interactive_worker_base.rs
+++ b/query/src/servers/clickhouse/interactive_worker_base.rs
@@ -22,6 +22,7 @@ use common_base::tokio;
 use common_base::tokio::sync::mpsc::channel;
 use common_base::tokio::time::interval;
 use common_base::ProgressValues;
+use common_base::TrySpawn;
 use common_clickhouse_srv::types::Block as ClickHouseBlock;
 use common_clickhouse_srv::CHContext;
 use common_datablocks::DataBlock;
@@ -94,7 +95,7 @@ impl InteractiveWorkerBase {
                     }
                 });
 
-                ctx.execute_task(async move {
+                ctx.try_spawn(async move {
                     while let Some(block) = data_stream.next().await {
                         tx2.send(BlockItem::Block(block)).await.ok();
                     }
@@ -132,7 +133,7 @@ impl InteractiveWorkerBase {
         // the data is comming in async mode
         let sent_all_data = ch_ctx.state.sent_all_data.clone();
         let start = Instant::now();
-        ctx.execute_task(async move {
+        ctx.try_spawn(async move {
             interpreter.execute().await.unwrap();
             sent_all_data.notify_one();
         })?;

--- a/query/src/servers/mysql/mysql_handler.rs
+++ b/query/src/servers/mysql/mysql_handler.rs
@@ -20,6 +20,7 @@ use common_base::tokio;
 use common_base::tokio::net::TcpStream;
 use common_base::tokio::task::JoinHandle;
 use common_base::Runtime;
+use common_base::TrySpawn;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use futures::future::AbortHandle;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/base] feature: introduce trait `TrySpawn` to define methods to spawn an async task
Rename DatabendQueryContext::execute_task to `try_spawn` and let
DatabendQueryContext impl `TrySpawn` so that a crate that just needs
`DatabendQueryContext` to spawn a task for it does not need to depend
on databend-query any more.

## Changelog

- New Feature





## Related Issues

- #2046
- #2059
- fix: #2061