### PR TITLE
[query] refactor: define table with associated type: PushDown and ReadPlan, to decouple dependency on common/planner

### DIFF
--- a/query/src/catalogs/table.rs
+++ b/query/src/catalogs/table.rs
@@ -28,6 +28,9 @@ use common_streams::SendableDataBlockStream;
 
 #[async_trait::async_trait]
 pub trait Table: Sync + Send {
+    type PushDown;
+    type ReadPlan;
+
     fn name(&self) -> &str;
     fn engine(&self) -> &str;
     fn as_any(&self) -> &dyn Any;
@@ -45,15 +48,15 @@ pub trait Table: Sync + Send {
     fn read_plan(
         &self,
         io_ctx: Arc<TableIOContext>,
-        push_downs: Option<Extras>,
+        push_downs: Option<Self::PushDown>,
         partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan>;
+    ) -> Result<Self::ReadPlan>;
 
     // Read block data from the underling.
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream>;
 
     // temporary added, pls feel free to rm it
@@ -80,4 +83,4 @@ pub trait Table: Sync + Send {
     }
 }
 
-pub type TablePtr = Arc<dyn Table>;
+pub type TablePtr = Arc<dyn Table<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>;

--- a/query/src/catalogs/table_function.rs
+++ b/query/src/catalogs/table_function.rs
@@ -14,12 +14,17 @@
 
 use std::sync::Arc;
 
+use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
+
 use crate::catalogs::Table;
 
 pub trait TableFunction: Sync + Send + Table {
     fn function_name(&self) -> &str;
     fn db(&self) -> &str;
 
-    fn as_table<'a>(self: Arc<Self>) -> Arc<dyn Table + 'a>
+    fn as_table<'a>(
+        self: Arc<Self>,
+    ) -> Arc<dyn Table<PushDown = Extras, ReadPlan = ReadDataSourcePlan> + 'a>
     where Self: 'a;
 }

--- a/query/src/catalogs/table_meta.rs
+++ b/query/src/catalogs/table_meta.rs
@@ -17,12 +17,15 @@ use std::sync::Arc;
 
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 
 use crate::catalogs::Table;
 use crate::catalogs::TableFunction;
 
-pub type TableMeta = Meta<Arc<dyn Table>>;
-pub type TableFunctionMeta = Meta<Arc<dyn TableFunction>>;
+pub type TableMeta = Meta<Arc<dyn Table<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>>;
+pub type TableFunctionMeta =
+    Meta<Arc<dyn TableFunction<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>>;
 
 /// The wrapper of the T with meta version.
 #[derive(Debug, Clone)]

--- a/query/src/datasources/database/example/example_table.rs
+++ b/query/src/datasources/database/example/example_table.rs
@@ -46,7 +46,7 @@ impl ExampleTable {
         schema: DataSchemaRef,
         _options: TableOptions,
         table_id: u64,
-    ) -> Result<Box<dyn Table>> {
+    ) -> Result<Box<dyn Table<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>> {
         let table = Self {
             db,
             name,
@@ -59,6 +59,9 @@ impl ExampleTable {
 
 #[async_trait::async_trait]
 impl Table for ExampleTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         &self.name
     }
@@ -86,9 +89,9 @@ impl Table for ExampleTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: self.db.clone(),
             table: self.name().to_string(),
@@ -113,7 +116,7 @@ impl Table for ExampleTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let block = DataBlock::empty_with_schema(self.schema.clone());
 

--- a/query/src/datasources/database/system/clusters_table.rs
+++ b/query/src/datasources/database/system/clusters_table.rs
@@ -49,6 +49,9 @@ impl ClustersTable {
 
 #[async_trait::async_trait]
 impl Table for ClustersTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "clusters"
     }
@@ -76,9 +79,9 @@ impl Table for ClustersTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -100,7 +103,7 @@ impl Table for ClustersTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let cluster_nodes = io_ctx.get_query_nodes();
 

--- a/query/src/datasources/database/system/configs_table.rs
+++ b/query/src/datasources/database/system/configs_table.rs
@@ -72,6 +72,9 @@ impl ConfigsTable {
 
 #[async_trait::async_trait]
 impl Table for ConfigsTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "configs"
     }
@@ -99,9 +102,9 @@ impl Table for ConfigsTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -123,7 +126,7 @@ impl Table for ConfigsTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/contributors_table.rs
+++ b/query/src/datasources/database/system/contributors_table.rs
@@ -44,6 +44,9 @@ impl ContributorsTable {
 
 #[async_trait::async_trait]
 impl Table for ContributorsTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "contributors"
     }
@@ -71,9 +74,9 @@ impl Table for ContributorsTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -95,7 +98,7 @@ impl Table for ContributorsTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let contributors: Vec<&[u8]> = env!("DATABEND_COMMIT_AUTHORS")
             .split_terminator(',')

--- a/query/src/datasources/database/system/credits_table.rs
+++ b/query/src/datasources/database/system/credits_table.rs
@@ -48,6 +48,9 @@ impl CreditsTable {
 
 #[async_trait::async_trait]
 impl Table for CreditsTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "credits"
     }
@@ -75,9 +78,9 @@ impl Table for CreditsTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -99,7 +102,7 @@ impl Table for CreditsTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let metadata_command = cargo_metadata::MetadataCommand::new();
 

--- a/query/src/datasources/database/system/databases_table.rs
+++ b/query/src/datasources/database/system/databases_table.rs
@@ -47,6 +47,9 @@ impl DatabasesTable {
 
 #[async_trait::async_trait]
 impl Table for DatabasesTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "databases"
     }
@@ -74,9 +77,9 @@ impl Table for DatabasesTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -98,7 +101,7 @@ impl Table for DatabasesTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/engines_table.rs
+++ b/query/src/datasources/database/system/engines_table.rs
@@ -50,6 +50,9 @@ impl EnginesTable {
 
 #[async_trait::async_trait]
 impl Table for EnginesTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "engines"
     }
@@ -77,9 +80,9 @@ impl Table for EnginesTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -101,7 +104,7 @@ impl Table for EnginesTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/functions_table.rs
+++ b/query/src/datasources/database/system/functions_table.rs
@@ -49,6 +49,9 @@ impl FunctionsTable {
 
 #[async_trait::async_trait]
 impl Table for FunctionsTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "functions"
     }
@@ -76,9 +79,9 @@ impl Table for FunctionsTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -100,7 +103,7 @@ impl Table for FunctionsTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let function_factory = FunctionFactory::instance();
         let aggregate_function_factory = AggregateFunctionFactory::instance();

--- a/query/src/datasources/database/system/one_table.rs
+++ b/query/src/datasources/database/system/one_table.rs
@@ -44,6 +44,9 @@ impl OneTable {
 
 #[async_trait::async_trait]
 impl Table for OneTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "one"
     }
@@ -71,9 +74,9 @@ impl Table for OneTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -95,7 +98,7 @@ impl Table for OneTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let block = DataBlock::create_by_array(self.schema.clone(), vec![Series::new(vec![1u8])]);
         Ok(Box::pin(DataBlockStream::create(

--- a/query/src/datasources/database/system/processes_table.rs
+++ b/query/src/datasources/database/system/processes_table.rs
@@ -71,6 +71,9 @@ impl ProcessesTable {
 
 #[async_trait::async_trait]
 impl Table for ProcessesTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "processes"
     }
@@ -98,9 +101,9 @@ impl Table for ProcessesTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -122,7 +125,7 @@ impl Table for ProcessesTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/settings_table.rs
+++ b/query/src/datasources/database/system/settings_table.rs
@@ -51,6 +51,9 @@ impl SettingsTable {
 
 #[async_trait::async_trait]
 impl Table for SettingsTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "settings"
     }
@@ -78,9 +81,9 @@ impl Table for SettingsTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -102,7 +105,7 @@ impl Table for SettingsTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/system_database.rs
+++ b/query/src/datasources/database/system/system_database.rs
@@ -20,6 +20,8 @@ use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 use common_planners::CreateTablePlan;
 use common_planners::DropTablePlan;
+use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 
 use crate::catalogs::impls::util::in_memory_metas::InMemoryMetas;
 use crate::catalogs::Database;
@@ -52,7 +54,7 @@ impl SystemDatabase {
         let name = name.into();
 
         // Table list.
-        let table_list: Vec<Arc<dyn Table>> = vec![
+        let table_list: Vec<Arc<dyn Table<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>> = vec![
             Arc::new(system::OneTable::create(next_id())),
             Arc::new(system::FunctionsTable::create(next_id())),
             Arc::new(system::ContributorsTable::create(next_id())),

--- a/query/src/datasources/database/system/tables_table.rs
+++ b/query/src/datasources/database/system/tables_table.rs
@@ -51,6 +51,9 @@ impl TablesTable {
 
 #[async_trait::async_trait]
 impl Table for TablesTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "tables"
     }
@@ -78,9 +81,9 @@ impl Table for TablesTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -102,7 +105,7 @@ impl Table for TablesTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/tracing_table.rs
+++ b/query/src/datasources/database/system/tracing_table.rs
@@ -60,6 +60,9 @@ impl TracingTable {
 
 #[async_trait::async_trait]
 impl Table for TracingTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         "tracing"
     }
@@ -87,9 +90,9 @@ impl Table for TracingTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         Ok(ReadDataSourcePlan {
             db: "system".to_string(),
             table: self.name().to_string(),
@@ -111,7 +114,7 @@ impl Table for TracingTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let mut log_files = vec![];
 
@@ -130,9 +133,9 @@ impl Table for TracingTable {
 
         // Default limit.
         let mut limit = 100000000_usize;
-        tracing::debug!("read push_down:{:?}", push_downs);
+        tracing::debug!("read push_down:{:?}", _push_downs);
 
-        if let Some(extras) = push_downs {
+        if let Some(extras) = _push_downs {
             if let Some(limit_push_down) = extras.limit {
                 limit = limit_push_down;
             }

--- a/query/src/datasources/table/null/null_table.rs
+++ b/query/src/datasources/table/null/null_table.rs
@@ -39,13 +39,18 @@ pub struct NullTable {
 }
 
 impl NullTable {
-    pub fn try_create(tbl_info: TableInfo) -> Result<Box<dyn Table>> {
+    pub fn try_create(
+        tbl_info: TableInfo,
+    ) -> Result<Box<dyn Table<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>> {
         Ok(Box::new(Self { tbl_info }))
     }
 }
 
 #[async_trait::async_trait]
 impl Table for NullTable {
+    type PushDown = Extras;
+    type ReadPlan = ReadDataSourcePlan;
+
     fn name(&self) -> &str {
         &self.tbl_info.name
     }
@@ -73,9 +78,9 @@ impl Table for NullTable {
     fn read_plan(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: Option<Extras>,
+        _push_downs: Option<Self::PushDown>,
         _partition_num_hint: Option<usize>,
-    ) -> Result<ReadDataSourcePlan> {
+    ) -> Result<Self::ReadPlan> {
         let tbl_info = &self.tbl_info;
         let db = &tbl_info.db;
         Ok(ReadDataSourcePlan {
@@ -99,7 +104,7 @@ impl Table for NullTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _push_downs: &Option<Self::PushDown>,
     ) -> Result<SendableDataBlockStream> {
         let block = DataBlock::empty_with_schema(self.tbl_info.schema.clone());
 

--- a/query/src/datasources/table_engine.rs
+++ b/query/src/datasources/table_engine.rs
@@ -14,6 +14,8 @@
 //
 
 use common_meta_flight::meta_flight_reply::TableInfo;
+use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 
 use crate::catalogs::Table;
 use crate::common::StoreApiProvider;
@@ -27,19 +29,24 @@ pub trait TableEngine: Send + Sync {
         &self,
         tbl_info: TableInfo,
         store_provider: StoreApiProvider,
-    ) -> common_exception::Result<Box<dyn Table>>;
+    ) -> common_exception::Result<Box<dyn Table<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>>;
 }
 
 impl<T> TableEngine for T
 where
-    T: Fn(TableInfo) -> common_exception::Result<Box<dyn Table>>,
+    T: Fn(
+        TableInfo,
+    ) -> common_exception::Result<
+        Box<dyn Table<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>,
+    >,
     T: Send + Sync,
 {
     fn try_create(
         &self,
         tbl_info: TableInfo,
         _store_provider: StoreApiProvider,
-    ) -> common_exception::Result<Box<dyn Table>> {
+    ) -> common_exception::Result<Box<dyn Table<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>>
+    {
         self(tbl_info)
     }
 }

--- a/query/src/datasources/table_func_engine.rs
+++ b/query/src/datasources/table_func_engine.rs
@@ -17,6 +17,8 @@ use std::sync::Arc;
 
 use common_meta_types::MetaId;
 use common_planners::Expression;
+use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 
 use crate::catalogs::TableFunction;
 
@@ -29,12 +31,21 @@ pub trait TableFuncEngine: Send + Sync {
         tbl_func_name: &str,
         tbl_id: MetaId,
         arg: TableArgs,
-    ) -> common_exception::Result<Arc<dyn TableFunction>>;
+    ) -> common_exception::Result<
+        Arc<dyn TableFunction<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>,
+    >;
 }
 
 impl<T> TableFuncEngine for T
 where
-    T: Fn(&str, &str, MetaId, TableArgs) -> common_exception::Result<Arc<dyn TableFunction>>,
+    T: Fn(
+        &str,
+        &str,
+        MetaId,
+        TableArgs,
+    ) -> common_exception::Result<
+        Arc<dyn TableFunction<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>,
+    >,
     T: Send + Sync,
 {
     fn try_create(
@@ -43,7 +54,9 @@ where
         tbl_func_name: &str,
         tbl_id: MetaId,
         arg: TableArgs,
-    ) -> common_exception::Result<Arc<dyn TableFunction>> {
+    ) -> common_exception::Result<
+        Arc<dyn TableFunction<PushDown = Extras, ReadPlan = ReadDataSourcePlan>>,
+    > {
         self(db_name, tbl_func_name, tbl_id, arg)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor: define table with associated type: PushDown and ReadPlan, to decouple dependency on common/planner

## Changelog




- Improvement


## Related Issues

- #2046
- #2059
- fix: #2140