### PR TITLE
[DO NOT MERGE]ISSUE-2385: changing the type of `Extras::filters`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.3",
+ "instant",
+ "pin-project",
+ "rand 0.8.4",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2043,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-server",
+ "backoff",
  "bumpalo",
  "byteorder",
  "bytes",

--- a/common/planners/src/plan_builder_scan.rs
+++ b/common/planners/src/plan_builder_scan.rs
@@ -61,7 +61,7 @@ impl PlanBuilder {
             table_args: table_scan_info.table_args,
             push_downs: Extras {
                 projection,
-                filters: vec![],
+                filters: None,
                 limit,
             },
         })))

--- a/common/planners/src/plan_extras.rs
+++ b/common/planners/src/plan_extras.rs
@@ -20,7 +20,7 @@ pub struct Extras {
     /// Optional column indices to use as a projection
     pub projection: Option<Vec<usize>>,
     /// Optional filter expression plan
-    pub filters: Vec<Expression>,
+    pub filters: Option<Expression>,
     /// Optional limit to skip read
     pub limit: Option<usize>,
 }
@@ -29,7 +29,7 @@ impl Extras {
     pub fn default() -> Self {
         Extras {
             projection: None,
-            filters: vec![],
+            filters: None,
             limit: None,
         }
     }

--- a/common/planners/src/plan_extras_test.rs
+++ b/common/planners/src/plan_extras_test.rs
@@ -20,7 +20,7 @@ use crate::*;
 #[test]
 fn test_plan_extras() -> Result<()> {
     let extras = Extras::default();
-    let expect = "Extras { projection: None, filters: [], limit: None }";
+    let expect = "Extras { projection: None, filters: None, limit: None }";
     let actual = format!("{:?}", extras);
     assert_eq!(expect, actual);
     Ok(())

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -96,6 +96,7 @@ cargo-license = "0.4.2"
 cargo_metadata = "0.14.0"
 sha2 = "0.9.8"
 sha1 = "0.6.0"
+backoff = {version = "0.3.0", features = ["futures", "tokio"] }
 
 [dependencies.parquet-format-async-temp]
 version = "0.2.0"

--- a/query/src/catalogs/backends/impls/embedded_backend.rs
+++ b/query/src/catalogs/backends/impls/embedded_backend.rs
@@ -340,7 +340,7 @@ impl MetaApiSync for MetaEmbeddedSync {
                         tbl_idx.insert(new_tbl_info);
                         return Ok(());
                     } else {
-                        return Err(ErrorCode::CommitTableError(format!(
+                        return Err(ErrorCode::TableVersionMissMatch(format!(
                             "expecting table version: [{}], but got [{}]. (table_id {})",
                             tbl.version, table_version, table_id
                         )));

--- a/query/src/datasources/table/fuse/index/min_max.rs
+++ b/query/src/datasources/table/fuse/index/min_max.rs
@@ -54,12 +54,11 @@ impl MinMaxIndex {
         let pred_true: fn() -> Pred = || Box::new(|_: &BlockStats| Ok(true));
 
         let block_pred: Pred = if let Some(exprs) = push_down {
-            if exprs.filters.is_empty() {
-                pred_true()
-            } else {
-                // for the time being, we only handle the first expr
-                let verifiable_expression = RangeFilter::try_create(&exprs.filters[0], schema)?;
+            if let Some(expr) = exprs.filters {
+                let verifiable_expression = RangeFilter::try_create(&expr, schema)?;
                 Box::new(move |v: &BlockStats| verifiable_expression.eval(v))
+            } else {
+                pred_true()
             }
         } else {
             pred_true()

--- a/query/src/datasources/table/fuse/index/min_max_test.rs
+++ b/query/src/datasources/table/fuse/index/min_max_test.rs
@@ -114,7 +114,7 @@ async fn test_min_max_index() -> Result<()> {
     // fully pruned
     let mut extra = Extras::default();
     let pred = col("a").gt(lit(30));
-    extra.filters = vec![pred];
+    extra.filters = Some(pred);
 
     let blocks = range_filter(
         &snapshot,
@@ -127,7 +127,7 @@ async fn test_min_max_index() -> Result<()> {
     // one block pruned
     let mut extra = Extras::default();
     let pred = col("a").gt(lit(3)).and(col("b").gt(lit(3)));
-    extra.filters = vec![pred];
+    extra.filters = Some(pred);
 
     let blocks = range_filter(
         &snapshot,

--- a/query/src/datasources/table/fuse/mod.rs
+++ b/query/src/datasources/table/fuse/mod.rs
@@ -24,6 +24,10 @@ mod table_do_truncate;
 pub(crate) mod util;
 
 #[cfg(test)]
+mod table_do_append_test;
+#[cfg(test)]
+mod table_do_truncate_test;
+#[cfg(test)]
 mod table_test;
 #[cfg(test)]
 mod table_test_fixture;

--- a/query/src/datasources/table/fuse/table_do_append_test.rs
+++ b/query/src/datasources/table/fuse/table_do_append_test.rs
@@ -1,0 +1,73 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_base::tokio;
+use common_exception::Result;
+
+use crate::catalogs::Catalog;
+use crate::datasources::table::fuse::table_test_fixture::TestFixture;
+
+#[tokio::test]
+async fn test_fuse_table_append_retry() -> Result<()> {
+    let fixture = TestFixture::new();
+    let ctx = fixture.ctx();
+
+    let crate_table_plan = fixture.default_crate_table_plan();
+    let catalog = ctx.get_catalog();
+    catalog.create_table(crate_table_plan)?;
+
+    let table = catalog.get_table(
+        fixture.default_db().as_str(),
+        fixture.default_table().as_str(),
+    )?;
+
+    let retried_appender = table.clone();
+    assert_eq!(0, retried_appender.get_table_info().version);
+
+    let io_ctx = Arc::new(ctx.get_single_node_table_io_context()?);
+
+    // "insert" a append operation before we truncate the table with an old version
+    {
+        let insert_into_plan = fixture.insert_plan_of_table(table.as_ref(), 10);
+        table.append_data(io_ctx.clone(), insert_into_plan).await?;
+    }
+
+    // append data with staled version
+    let insert_into_plan = fixture.insert_plan_of_table(table.as_ref(), 10);
+    let r = retried_appender
+        .append_data(io_ctx.clone(), insert_into_plan)
+        .await;
+    assert!(r.is_ok());
+
+    // get the latest table
+    let table = catalog.get_table(
+        fixture.default_db().as_str(),
+        fixture.default_table().as_str(),
+    )?;
+    let latest_version = table.get_table_info().version;
+
+    // version has been bumped to 2
+    assert_eq!(
+        latest_version,
+        retried_appender.get_table_info().version + 2
+    );
+    let (stats, parts) = table.read_partitions(io_ctx.clone(), None, None)?;
+    assert_eq!(parts.len(), 2 * 10);
+    assert_eq!(stats.read_rows, 3 * (10 + 10));
+
+    Ok(())
+}

--- a/query/src/datasources/table/fuse/table_do_truncate.rs
+++ b/query/src/datasources/table/fuse/table_do_truncate.rs
@@ -15,9 +15,12 @@
 
 use std::sync::Arc;
 
+use backoff::ExponentialBackoff;
 use common_context::IOContext;
 use common_context::TableIOContext;
+use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::MetaVersion;
 use common_planners::TruncateTablePlan;
 use uuid::Uuid;
 
@@ -26,6 +29,7 @@ use crate::catalogs::Table;
 use crate::datasources::table::fuse::util;
 use crate::datasources::table::fuse::util::TBL_OPT_KEY_SNAPSHOT_LOC;
 use crate::datasources::table::fuse::FuseTable;
+use crate::datasources::table::fuse::TableSnapshot;
 use crate::sessions::DatabendQueryContext;
 
 impl FuseTable {
@@ -35,33 +39,59 @@ impl FuseTable {
         io_ctx: Arc<TableIOContext>,
         _truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
-        if let Some(prev_snapshot) = self.table_snapshot(&io_ctx)? {
-            let prev_id = prev_snapshot.snapshot_id;
-            let mut new_snapshot = prev_snapshot;
-            new_snapshot.segments = vec![];
-            new_snapshot.prev_snapshot_id = Some(prev_id);
-            new_snapshot.summary = Default::default();
-            let ctx: Arc<DatabendQueryContext> = io_ctx
-                .get_user_data()?
-                .expect("DatabendQueryContext should not be None");
-            new_snapshot.snapshot_id = Uuid::new_v4();
-            let new_snapshot_loc =
-                util::snapshot_location(new_snapshot.snapshot_id.to_simple().to_string().as_str()); // TODO refine this
-            let da = io_ctx.get_data_accessor()?;
-            let bytes = serde_json::to_vec(&new_snapshot)?;
-            da.put(&new_snapshot_loc, bytes).await?;
-
-            let catalog = ctx.get_catalog();
-            let table_id = self.get_id();
-            // TODO backoff retry
-            catalog.upsert_table_option(
-                table_id,
-                self.table_info.version,
-                TBL_OPT_KEY_SNAPSHOT_LOC.to_string(),
-                new_snapshot_loc,
-            )?
-        }
-
+        let version_wrapper = common_base::tokio::sync::Mutex::new(self.table_info.version);
+        let backoff = ExponentialBackoff::default();
+        backoff::future::retry(backoff, || self.commit_truncate(&version_wrapper, &io_ctx)).await?;
         Ok(())
+    }
+
+    async fn commit_truncate(
+        &self,
+        version_wrapper: &common_base::tokio::sync::Mutex<MetaVersion>,
+        io_ctx: &Arc<TableIOContext>,
+    ) -> std::result::Result<(), backoff::Error<ErrorCode>> {
+        let mut version = version_wrapper.lock().await;
+        let prev_snapshot = self.table_snapshot_with_version(*version, io_ctx)?;
+        let prev_id = prev_snapshot.map_or_else(|| None, |s| Some(s.snapshot_id));
+        // "clear" segments and stats
+        let new_snapshot = TableSnapshot {
+            snapshot_id: Uuid::new_v4(),
+            prev_snapshot_id: prev_id,
+            schema: self.table_info.schema.as_ref().clone(),
+            summary: Default::default(),
+            segments: vec![],
+        };
+
+        // save new snapshot
+        let ctx: Arc<DatabendQueryContext> = io_ctx
+            .get_user_data()?
+            .expect("DatabendQueryContext should not be None");
+        let new_snapshot_loc =
+            util::snapshot_location(new_snapshot.snapshot_id.to_simple().to_string());
+        let da = io_ctx.get_data_accessor()?;
+        let bytes = serde_json::to_vec(&new_snapshot).map_err(ErrorCode::from_std_error)?;
+        da.put(&new_snapshot_loc, bytes).await?;
+
+        // update table snapshot location
+        let catalog = ctx.get_catalog();
+        let table_id = self.get_id();
+        match catalog.upsert_table_option(
+            table_id,
+            *version,
+            TBL_OPT_KEY_SNAPSHOT_LOC.to_string(),
+            new_snapshot_loc,
+        ) {
+            Err(err) => {
+                if err.code() == ErrorCode::TableVersionMissMatch("").code() {
+                    let table = catalog
+                        .get_table(self.table_info.db.as_str(), self.table_info.name.as_str())?;
+                    *version = table.get_table_info().version;
+                    Err(backoff::Error::Transient(err))
+                } else {
+                    Err(backoff::Error::Permanent(err))
+                }
+            }
+            Ok(_) => Ok(()),
+        }
     }
 }

--- a/query/src/datasources/table/fuse/table_do_truncate_test.rs
+++ b/query/src/datasources/table/fuse/table_do_truncate_test.rs
@@ -1,0 +1,87 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_base::tokio;
+use common_exception::Result;
+use common_planners::TruncateTablePlan;
+
+use crate::catalogs::Catalog;
+use crate::datasources::table::fuse::table_test_fixture::TestFixture;
+
+#[tokio::test]
+async fn test_fuse_table_truncate_retry() -> Result<()> {
+    let fixture = TestFixture::new();
+    let ctx = fixture.ctx();
+
+    let crate_table_plan = fixture.default_crate_table_plan();
+    let catalog = ctx.get_catalog();
+    catalog.create_table(crate_table_plan)?;
+
+    let table = catalog.get_table(
+        fixture.default_db().as_str(),
+        fixture.default_table().as_str(),
+    )?;
+
+    let retried_truncator = table.clone();
+    assert_eq!(0, retried_truncator.get_table_info().version);
+
+    let io_ctx = Arc::new(ctx.get_single_node_table_io_context()?);
+    let truncate_plan = TruncateTablePlan {
+        db: "".to_string(),
+        table: "".to_string(),
+    };
+
+    // "insert" a truncation operation before we truncate the table with an old version
+    {
+        let insert_into_plan = fixture.insert_plan_of_table(table.as_ref(), 10);
+        table.append_data(io_ctx.clone(), insert_into_plan).await?;
+
+        // get the lasted table
+        let table = catalog.get_table(
+            fixture.default_db().as_str(),
+            fixture.default_table().as_str(),
+        )?;
+        // no retry here, since we are using the latest table
+        table
+            .truncate(io_ctx.clone(), truncate_plan.clone())
+            .await?;
+    }
+
+    // truncate with test table, retry do occur
+    let r = retried_truncator
+        .truncate(io_ctx.clone(), truncate_plan)
+        .await;
+    assert!(r.is_ok());
+
+    // get the latest table
+    let table = catalog.get_table(
+        fixture.default_db().as_str(),
+        fixture.default_table().as_str(),
+    )?;
+    let latest_version = table.get_table_info().version;
+
+    // version has been bumped to 3 : one "insert", one "truncate" and another "truncate"
+    assert_eq!(
+        latest_version,
+        retried_truncator.get_table_info().version + 3
+    );
+    let (stats, parts) = table.read_partitions(io_ctx.clone(), None, None)?;
+    assert_eq!(parts.len(), 0);
+    assert_eq!(stats.read_rows, 0);
+
+    Ok(())
+}

--- a/query/src/datasources/table/fuse/table_test.rs
+++ b/query/src/datasources/table/fuse/table_test.rs
@@ -131,8 +131,8 @@ async fn test_fuse_table_truncate() -> Result<()> {
         fixture.default_db().as_str(),
         fixture.default_table().as_str(),
     )?;
-    // no side effects
-    assert_eq!(prev_version, table.get_table_info().version);
+
+    assert_eq!(prev_version + 1, table.get_table_info().version);
     assert!(r.is_ok());
 
     // 2. truncate table which has data

--- a/query/src/datasources/table/fuse/util/col_encoding.rs
+++ b/query/src/datasources/table/fuse/util/col_encoding.rs
@@ -37,16 +37,13 @@ use common_arrow::parquet::encoding::Encoding;
 ///  ~~~
 ///
 ///
-pub fn col_encoding(_data_type: &ArrowDataType) -> Encoding {
-    // Although encoding does work, parquet2 has not implemented decoding of DeltaLengthByteArray yet, we fallback to Plain
-    // From parquet2: Decoding "DeltaLengthByteArray"-encoded required V2 pages is not yet implemented for Binary.
-    //
-    //match data_type {
-    //    ArrowDataType::Binary
-    //    | ArrowDataType::LargeBinary
-    //    | ArrowDataType::Utf8
-    //    | ArrowDataType::LargeUtf8 => Encoding::DeltaLengthByteArray,
-    //    _ => Encoding::Plain,
-    //}
-    Encoding::Plain
+pub fn col_encoding(data_type: &ArrowDataType) -> Encoding {
+    // Although encoding does work, parquet2 has not implemented decoding of DeltaLengthByteArray for Binary yet, we fallback to Plain
+    // From parquet2 error message : Decoding "DeltaLengthByteArray"-encoded required V2 pages is not yet implemented for Binary.
+
+    match data_type {
+        ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 => Encoding::DeltaLengthByteArray,
+        ArrowDataType::Dictionary(_, _) => Encoding::RleDictionary,
+        _ => Encoding::Plain,
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

changing the type of Extras::filters to Option<Expression>

## Changelog

- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2385

## Test Plan

Unit Tests

Stateless Tests

