### PR TITLE
[bendctl] introduce fn subcommands() to the Command trait

### DIFF
--- a/cli/src/cmds/clusters/cluster.rs
+++ b/cli/src/cmds/clusters/cluster.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -34,7 +33,6 @@ use crate::error::Result;
 #[derive(Clone)]
 pub struct ClusterCommand {
     conf: Config,
-    clap: App<'static>,
 }
 
 // Support to up and run databend cluster on different platforms
@@ -62,31 +60,13 @@ impl FromStr for ClusterProfile {
 
 impl ClusterCommand {
     pub fn create(conf: Config) -> Self {
-        let clap = ClusterCommand::generate();
-        ClusterCommand { conf, clap }
+        ClusterCommand { conf }
     }
 
-    pub fn generate() -> App<'static> {
-        let app = App::new("cluster")
-            .setting(AppSettings::DisableVersionFlag)
-            .about("Cluster life cycle management")
-            .subcommand(CreateCommand::generate())
-            .subcommand(StopCommand::generate())
-            .subcommand(ViewCommand::generate());
-        app
-    }
-
-    pub async fn exec(&self, writer: &mut Writer, args: String) -> Result<()> {
-        match self.clap.clone().try_get_matches_from(args.split(' ')) {
-            Ok(matches) => {
-                return self.exec_matches(writer, Some(matches.borrow())).await;
-            }
-            Err(err) => {
-                println!("Cannot get subcommand matches: {}", err);
-            }
-        }
-
-        Ok(())
+    pub fn default() -> Self {
+        // TODO: this function is a hack to avoid the dependency cycle on the Config struct
+        // the dependency cycle is avoidable, but we need some work to work around it
+        ClusterCommand::create(Config::default())
     }
 }
 
@@ -97,12 +77,21 @@ impl Command for ClusterCommand {
     }
 
     fn clap(&self) -> App<'static> {
-        self.clap.clone()
+        let subcommands = self.subcommands();
+        let app = App::new("cluster")
+            .setting(AppSettings::DisableVersionFlag)
+            .about("Cluster life cycle management")
+            .subcommand(subcommands[0].clap())
+            .subcommand(subcommands[1].clap())
+            .subcommand(subcommands[2].clap());
+        app
     }
 
     fn subcommands(&self) -> Vec<Arc<dyn Command>> {
         vec![
             Arc::new(CreateCommand::create(self.conf.clone())),
+            Arc::new(StopCommand::create(self.conf.clone())),
+            Arc::new(ViewCommand::create(self.conf.clone())),
         ]
     }
 
@@ -114,37 +103,7 @@ impl Command for ClusterCommand {
         s.contains(self.name())
     }
 
-    async fn exec_matches(
-        &self,
-        writer: &mut Writer,
-        args: Option<&ArgMatches>,
-    ) -> Result<()> {
-        match args {
-            Some(matches) => match matches.subcommand_name() {
-                Some("create") => {
-                    let create = CreateCommand::create(self.conf.clone());
-                    create
-                        .exec_matches(writer, matches.subcommand_matches("create"))
-                        .await?;
-                }
-                Some("delete") => {
-                    let stop = StopCommand::create(self.conf.clone());
-                    stop
-                        .exec_match(writer, matches.subcommand_matches("delete"))
-                        .await?;
-                }
-                Some("view") => {
-                    let view = ViewCommand::create(self.conf.clone());
-                    view.exec_match(writer, matches.subcommand_matches("view"))
-                        .await?;
-                }
-                _ => writer.write_err("unknown command, usage: cluster -h"),
-            },
-            None => {
-                println!("None")
-            }
-        }
-
-        Ok(())
+    async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
+        self.exec_subcommand(writer, args).await
     }
 }

--- a/cli/src/cmds/clusters/create.rs
+++ b/cli/src/cmds/clusters/create.rs
@@ -19,7 +19,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use crate::cmds::command::Command;
 use clap::App;
 use clap::AppSettings;
 use clap::Arg;
@@ -35,6 +34,7 @@ use sysinfo::SystemExt;
 
 use crate::cmds::clusters::cluster::ClusterProfile;
 use crate::cmds::clusters::stop::StopCommand;
+use crate::cmds::command::Command;
 use crate::cmds::packages::fetch::get_version;
 use crate::cmds::status::LocalMetaConfig;
 use crate::cmds::status::LocalQueryConfig;
@@ -103,105 +103,6 @@ async fn reconcile_local(status: &mut Status) -> Result<()> {
 impl CreateCommand {
     pub fn create(conf: Config) -> Self {
         CreateCommand { conf }
-    }
-    pub fn generate() -> App<'static> {
-        App::new("create")
-            .setting(AppSettings::DisableVersionFlag)
-            .about("Create a databend cluster based on profile")
-            .arg(
-                Arg::new("profile")
-                    .long("profile")
-                    .about("Profile for deployment, support local and cluster")
-                    .required(false)
-                    .takes_value(true)
-                    .possible_values(&["local"]).default_value("local"),
-            )
-            .arg(
-                Arg::new("meta_address")
-                    .long("meta-address")
-                    .about("Set endpoint to provide metastore service")
-                    .takes_value(true)
-                    .env(databend_query::configs::config_meta::META_ADDRESS),
-            )
-            .arg(
-                Arg::new("log_level")
-                    .long("log-level")
-                    .about("Set logging level")
-                    .takes_value(true)
-                    .env(databend_query::configs::config_log::LOG_LEVEL)
-                    .default_value("INFO"),
-            )
-            .arg(
-                Arg::new("version")
-                    .long("version")
-                    .takes_value(true)
-                    .about("Set databend version to run")
-                    .default_value("latest"),
-            )
-            .arg(
-                Arg::new("num_cpus")
-                    .long("num-cpus")
-                    .env(databend_query::configs::config_query::QUERY_NUM_CPUS)
-                    .takes_value(true)
-                    .about("Set number of cpus for query instance to use")
-                    .default_value(""),
-            )
-            .arg(
-                Arg::new("query_namespace")
-                    .long("query-namespace")
-                    .env(databend_query::configs::config_query::QUERY_NAMESPACE)
-                    .takes_value(true)
-                    .about("Set the namespace for query to work on")
-                    .default_value("test_cluster"),
-            )
-            .arg(
-                Arg::new("query_tenant")
-                    .long("query-tenant")
-                    .env(databend_query::configs::config_query::QUERY_TENANT)
-                    .takes_value(true)
-                    .about("Set the tenant for query to work on")
-                    .default_value("test"),
-            )
-            .arg(
-                Arg::new("mysql_handler_port")
-                    .long("mysql-handler-port")
-                    .takes_value(true)
-                    .env(databend_query::configs::config_query::QUERY_MYSQL_HANDLER_PORT)
-                    .about("Configure the port for mysql endpoint to run queries in mysql client")
-                    .default_value("3307"),
-            )
-            .arg(
-                Arg::new("clickhouse_handler_port")
-                    .long("clickhouse-handler-port")
-                    .env(databend_query::configs::config_query::QUERY_CLICKHOUSE_HANDLER_HOST)
-                    .takes_value(true)
-                    .about("Configure the port clickhouse endpoint to run queries in clickhouse client")
-                    .default_value("9000"),
-            )
-            .arg(
-                Arg::new("storage_type")
-                    .long("storage-type")
-                    .takes_value(true)
-                    .env(databend_query::configs::config_storage::STORAGE_TYPE)
-                    .about("Set the storage medium to store datasets, support disk or s3 object storage ")
-                    .possible_values(&["disk", "s3"]).default_value("disk"),
-            )
-            .arg(
-                Arg::new("disk_path")
-                    .long("disk-path")
-                    .takes_value(true)
-                    // .env(databend_query::configs::config_storage::DISK_STORAGE_DATA_PATH)
-                    .about("Set the root directory to store all datasets")
-                    .value_hint(ValueHint::DirPath),
-            )
-            .arg(
-                Arg::new("force")
-                    .long("force")
-                    // .env(databend_query::configs::config_storage::DISK_STORAGE_DATA_PATH)
-                    .about("Delete existing cluster and install new cluster without check")
-                    .takes_value(false)
-                    ,
-            )
     }
 
     fn binary_path(&self, dir: String, version: String, name: String) -> Result<String> {
@@ -784,7 +685,102 @@ impl Command for CreateCommand {
     }
 
     fn clap(&self) -> App<'static> {
-        CreateCommand::generate()
+        App::new("create")
+            .setting(AppSettings::DisableVersionFlag)
+            .about("Create a databend cluster based on profile")
+            .arg(
+                Arg::new("profile")
+                    .long("profile")
+                    .about("Profile for deployment, support local and cluster")
+                    .required(false)
+                    .takes_value(true)
+                    .possible_values(&["local"]).default_value("local"),
+            )
+            .arg(
+                Arg::new("meta_address")
+                    .long("meta-address")
+                    .about("Set endpoint to provide metastore service")
+                    .takes_value(true)
+                    .env(databend_query::configs::config_meta::META_ADDRESS),
+            )
+            .arg(
+                Arg::new("log_level")
+                    .long("log-level")
+                    .about("Set logging level")
+                    .takes_value(true)
+                    .env(databend_query::configs::config_log::LOG_LEVEL)
+                    .default_value("INFO"),
+            )
+            .arg(
+                Arg::new("version")
+                    .long("version")
+                    .takes_value(true)
+                    .about("Set databend version to run")
+                    .default_value("latest"),
+            )
+            .arg(
+                Arg::new("num_cpus")
+                    .long("num-cpus")
+                    .env(databend_query::configs::config_query::QUERY_NUM_CPUS)
+                    .takes_value(true)
+                    .about("Set number of cpus for query instance to use")
+                    .default_value(""),
+            )
+            .arg(
+                Arg::new("query_namespace")
+                    .long("query-namespace")
+                    .env(databend_query::configs::config_query::QUERY_NAMESPACE)
+                    .takes_value(true)
+                    .about("Set the namespace for query to work on")
+                    .default_value("test_cluster"),
+            )
+            .arg(
+                Arg::new("query_tenant")
+                    .long("query-tenant")
+                    .env(databend_query::configs::config_query::QUERY_TENANT)
+                    .takes_value(true)
+                    .about("Set the tenant for query to work on")
+                    .default_value("test"),
+            )
+            .arg(
+                Arg::new("mysql_handler_port")
+                    .long("mysql-handler-port")
+                    .takes_value(true)
+                    .env(databend_query::configs::config_query::QUERY_MYSQL_HANDLER_PORT)
+                    .about("Configure the port for mysql endpoint to run queries in mysql client")
+                    .default_value("3307"),
+            )
+            .arg(
+                Arg::new("clickhouse_handler_port")
+                    .long("clickhouse-handler-port")
+                    .env(databend_query::configs::config_query::QUERY_CLICKHOUSE_HANDLER_HOST)
+                    .takes_value(true)
+                    .about("Configure the port clickhouse endpoint to run queries in clickhouse client")
+                    .default_value("9000"),
+            )
+            .arg(
+                Arg::new("storage_type")
+                    .long("storage-type")
+                    .takes_value(true)
+                    .env(databend_query::configs::config_storage::STORAGE_TYPE)
+                    .about("Set the storage medium to store datasets, support disk or s3 object storage ")
+                    .possible_values(&["disk", "s3"]).default_value("disk"),
+            )
+            .arg(
+                Arg::new("disk_path")
+                    .long("disk-path")
+                    .takes_value(true)
+                    // .env(databend_query::configs::config_storage::DISK_STORAGE_DATA_PATH)
+                    .about("Set the root directory to store all datasets")
+                    .value_hint(ValueHint::DirPath),
+            )
+            .arg(
+                Arg::new("force")
+                    .long("force")
+                    // .env(databend_query::configs::config_storage::DISK_STORAGE_DATA_PATH)
+                    .about("Delete existing cluster and install new cluster without check")
+                    .takes_value(false),
+            )
     }
 
     fn subcommands(&self) -> Vec<Arc<dyn Command>> {
@@ -820,5 +816,4 @@ impl Command for CreateCommand {
 
         Ok(())
     }
-
 }

--- a/cli/src/cmds/clusters/create.rs
+++ b/cli/src/cmds/clusters/create.rs
@@ -16,7 +16,10 @@ use std::fs;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::Arc;
 
+use async_trait::async_trait;
+use crate::cmds::command::Command;
 use clap::App;
 use clap::AppSettings;
 use clap::Arg;
@@ -772,8 +775,31 @@ impl CreateCommand {
 
         Ok(())
     }
+}
 
-    pub async fn exec_match(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
+#[async_trait]
+impl Command for CreateCommand {
+    fn name(&self) -> &str {
+        "create"
+    }
+
+    fn clap(&self) -> App<'static> {
+        CreateCommand::generate()
+    }
+
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![]
+    }
+
+    fn about(&self) -> &str {
+        "create" // TODO
+    }
+
+    fn is(&self, s: &str) -> bool {
+        s.contains(self.name())
+    }
+
+    async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
         match args {
             Some(matches) => {
                 let profile = matches.value_of_t("profile");
@@ -794,4 +820,5 @@ impl CreateCommand {
 
         Ok(())
     }
+
 }

--- a/cli/src/cmds/clusters/create_test.rs
+++ b/cli/src/cmds/clusters/create_test.rs
@@ -17,6 +17,7 @@ use std::fs;
 use tempfile::tempdir;
 
 use crate::cmds::clusters::create::LocalBinaryPaths;
+use crate::cmds::command::Command;
 use crate::cmds::config::GithubMirror;
 use crate::cmds::config::MirrorAsset;
 use crate::cmds::config::Mode;
@@ -35,7 +36,7 @@ fn test_generate_local_meta_config() -> Result<()> {
     };
     let t = tempdir()?;
     conf.databend_dir = t.path().to_str().unwrap().to_string();
-    let args = CreateCommand::generate();
+    let args = CreateCommand::create(conf.clone()).clap();
     // test on default bahavior
     {
         let matches = args
@@ -123,7 +124,7 @@ fn test_generate_local_query_config() -> Result<()> {
     };
     let t = tempdir()?;
     conf.databend_dir = t.path().to_str().unwrap().to_string();
-    let args = CreateCommand::generate();
+    let args = CreateCommand::create(conf.clone()).clap();
     // test on default bahavior
     {
         let matches = args

--- a/cli/src/cmds/command.rs
+++ b/cli/src/cmds/command.rs
@@ -80,7 +80,10 @@ pub trait Command: DynClone + Send + Sync {
             }
         }
 
-        writer.write_err("unknown command");
+        // show help on not founding subcommand
+        self.clap()
+            .print_help()
+            .map_err(|err| CliError::Unknown(format!("unexpected err: {:?}", err)))?;
         Ok(())
     }
 }

--- a/cli/src/cmds/comments/comment.rs
+++ b/cli/src/cmds/comments/comment.rs
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_trait::async_trait;
 use colored::Colorize;
-use std::sync::Arc;
 
-use clap::App;
-use clap::ArgMatches;
-use crate::cmds::command::Command;
 use crate::cmds::Writer;
 use crate::error::Result;
 
@@ -29,33 +24,21 @@ impl CommentCommand {
     pub fn create() -> Self {
         CommentCommand {}
     }
-}
 
-#[async_trait]
-impl Command for CommentCommand {
-    fn name(&self) -> &str {
+    pub fn name(&self) -> &str {
         "comment"
     }
 
-    fn about(&self) -> &str {
+    pub fn about(&self) -> &str {
         "# your comments"
     }
 
-    fn clap(&self) -> App<'static> {
-        App::new("#").about("your comments")
-    }
-
-    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
-        vec![]
-    }
-
-    fn is(&self, s: &str) -> bool {
+    pub fn is(&self, s: &str) -> bool {
         s.starts_with('#')
     }
 
-    async fn exec_matches(&self, writer: &mut Writer, _matches: Option<&ArgMatches>) -> Result<()> {
-        // TODO writer.writeln(format!("{}", args.green()).as_str());
+    pub async fn exec(&self, writer: &mut Writer, args: String) -> Result<()> {
+        writer.writeln(format!("{}", args.green()).as_str());
         Ok(())
     }
-
 }

--- a/cli/src/cmds/comments/comment.rs
+++ b/cli/src/cmds/comments/comment.rs
@@ -14,7 +14,10 @@
 
 use async_trait::async_trait;
 use colored::Colorize;
+use std::sync::Arc;
 
+use clap::App;
+use clap::ArgMatches;
 use crate::cmds::command::Command;
 use crate::cmds::Writer;
 use crate::error::Result;
@@ -38,12 +41,21 @@ impl Command for CommentCommand {
         "# your comments"
     }
 
+    fn clap(&self) -> App<'static> {
+        App::new("#").about("your comments")
+    }
+
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![]
+    }
+
     fn is(&self, s: &str) -> bool {
         s.starts_with('#')
     }
 
-    async fn exec(&self, writer: &mut Writer, args: String) -> Result<()> {
-        writer.writeln(format!("{}", args.green()).as_str());
+    async fn exec_matches(&self, writer: &mut Writer, _matches: Option<&ArgMatches>) -> Result<()> {
+        // TODO writer.writeln(format!("{}", args.green()).as_str());
         Ok(())
     }
+
 }

--- a/cli/src/cmds/config.rs
+++ b/cli/src/cmds/config.rs
@@ -25,6 +25,7 @@ use colored::Colorize;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::cmds::command::Command;
 use crate::cmds::queries::query::QueryCommand;
 use crate::cmds::ups::up::UpCommand;
 use crate::cmds::ClusterCommand;
@@ -44,6 +45,7 @@ const REPO_BASE_URL: &str = "https://repo.databend.rs/databend/tags.json";
 const REPO_DATABEND_URL: &str = "https://repo.databend.rs/databend";
 const REPO_DATABEND_TAG_URL: &str = "https://repo.databend.rs/databend/tags.json";
 const REPO_PLAYGROUND_URL: &str = "https://repo.databend.rs/databend";
+
 #[derive(Clone, Debug)]
 pub struct Config {
     //(TODO(zhihanz) remove those field as they already mentioned in Clap global flag)
@@ -53,6 +55,7 @@ pub struct Config {
     pub mirror: CustomMirror,
     pub clap: ArgMatches,
 }
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum Mode {
     Sql,
@@ -308,10 +311,11 @@ impl Config {
             )
             .subcommand(PackageCommand::generate())
             .subcommand(VersionCommand::generate())
-            .subcommand(ClusterCommand::generate())
+            .subcommand(ClusterCommand::default().clap())
             .subcommand(QueryCommand::generate())
             .subcommand(UpCommand::generate())
     }
+
     pub fn create() -> Self {
         let clap = Config::build_cli().get_matches();
         let config = Config {
@@ -346,6 +350,22 @@ impl Config {
         };
         Config::build(config)
     }
+
+    pub fn default() -> Self {
+        Config {
+            group: "".into(),
+            mode: Mode::Sql,
+            databend_dir: "~/.databend".into(),
+            clap: Default::default(),
+            mirror: CustomMirror {
+                base_url: "".into(),
+                databend_url: "".into(),
+                databend_tag_url: "".into(),
+                playground_url: "".into(),
+            },
+        }
+    }
+
     fn build(mut conf: Config) -> Self {
         let home_dir = dirs::home_dir().unwrap();
         let databend_dir = home_dir.join(".databend");

--- a/cli/src/cmds/helps/help.rs
+++ b/cli/src/cmds/helps/help.rs
@@ -15,11 +15,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use clap::App;
+use clap::ArgMatches;
 use comfy_table::Cell;
 use comfy_table::Row;
 use comfy_table::Table;
-use clap::ArgMatches;
-use clap::App;
 
 use crate::cmds::command::Command;
 use crate::cmds::Writer;

--- a/cli/src/cmds/helps/help.rs
+++ b/cli/src/cmds/helps/help.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use comfy_table::Cell;
 use comfy_table::Row;
 use comfy_table::Table;
+use clap::ArgMatches;
+use clap::App;
 
 use crate::cmds::command::Command;
 use crate::cmds::Writer;
@@ -38,6 +42,14 @@ impl Command for HelpCommand {
         "help"
     }
 
+    fn clap(&self) -> App<'static> {
+        App::new("help").about("show help")
+    }
+
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![]
+    }
+
     fn about(&self) -> &str {
         "help"
     }
@@ -46,7 +58,7 @@ impl Command for HelpCommand {
         self.name() == s
     }
 
-    async fn exec(&self, writer: &mut Writer, _args: String) -> Result<()> {
+    async fn exec_matches(&self, writer: &mut Writer, _args: Option<&ArgMatches>) -> Result<()> {
         let mut table = Table::new();
         table.load_preset("||--+-++|    ++++++");
         // Title.

--- a/cli/src/cmds/packages/package.rs
+++ b/cli/src/cmds/packages/package.rs
@@ -40,19 +40,6 @@ impl PackageCommand {
         PackageCommand { conf, clap }
     }
 
-    async fn exec(&self, writer: &mut Writer, args: String) -> Result<()> {
-        match self.clap.clone().try_get_matches_from(args.split(' ')) {
-            Ok(matches) => {
-                return self.exec_matches(writer, Some(matches.borrow())).await;
-            }
-            Err(err) => {
-                println!("Cannot get subcommand matches: {}", err);
-            }
-        }
-
-        Ok(())
-    }
-
     pub fn generate() -> App<'static> {
         return App::new("package")
             .about("Package manage databend binary releases")
@@ -96,29 +83,9 @@ impl Command for PackageCommand {
     fn is(&self, s: &str) -> bool {
         s.contains(self.name())
     }
-    async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
-        match args {
-            Some(matches) => match matches.subcommand_name() {
-                Some("fetch") => {
-                    let fetch = FetchCommand::create(self.conf.clone());
-                    fetch.exec_match(writer, matches.subcommand_matches("fetch"))?;
-                }
-                Some("list") => {
-                    let list = ListCommand::create(self.conf.clone());
-                    list.exec_match(writer, matches.subcommand_matches("list"))?;
-                }
-                Some("switch") => {
-                    let switch = SwitchCommand::create(self.conf.clone());
-                    switch.exec_match(writer, matches.subcommand_matches("switch"))?;
-                }
-                _ => writer.write_err("unknown command, usage: package -h"),
-            },
-            None => {
-                println!("None")
-            }
-        }
 
-        Ok(())
+    async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
+        self.exec_subcommand(writer, args).await
     }
 
 }

--- a/cli/src/cmds/packages/package.rs
+++ b/cli/src/cmds/packages/package.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::borrow::Borrow;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use clap::App;
@@ -38,6 +39,20 @@ impl PackageCommand {
         let clap = PackageCommand::generate();
         PackageCommand { conf, clap }
     }
+
+    async fn exec(&self, writer: &mut Writer, args: String) -> Result<()> {
+        match self.clap.clone().try_get_matches_from(args.split(' ')) {
+            Ok(matches) => {
+                return self.exec_matches(writer, Some(matches.borrow())).await;
+            }
+            Err(err) => {
+                println!("Cannot get subcommand matches: {}", err);
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn generate() -> App<'static> {
         return App::new("package")
             .about("Package manage databend binary releases")
@@ -58,8 +73,30 @@ impl PackageCommand {
                     ))
             );
     }
+}
 
-    pub(crate) fn exec_match(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
+#[async_trait]
+impl Command for PackageCommand {
+    fn name(&self) -> &str {
+        "package"
+    }
+
+    fn about(&self) -> &str {
+        "Package command"
+    }
+
+    fn clap(&self) -> App<'static> {
+        self.clap.clone()
+    }
+
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![]
+    }
+
+    fn is(&self, s: &str) -> bool {
+        s.contains(self.name())
+    }
+    async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
         match args {
             Some(matches) => match matches.subcommand_name() {
                 Some("fetch") => {
@@ -83,32 +120,5 @@ impl PackageCommand {
 
         Ok(())
     }
-}
 
-#[async_trait]
-impl Command for PackageCommand {
-    fn name(&self) -> &str {
-        "package"
-    }
-
-    fn about(&self) -> &str {
-        "Package command"
-    }
-
-    fn is(&self, s: &str) -> bool {
-        s.contains(self.name())
-    }
-
-    async fn exec(&self, writer: &mut Writer, args: String) -> Result<()> {
-        match self.clap.clone().try_get_matches_from(args.split(' ')) {
-            Ok(matches) => {
-                return self.exec_match(writer, Some(matches.borrow()));
-            }
-            Err(err) => {
-                println!("Cannot get subcommand matches: {}", err);
-            }
-        }
-
-        Ok(())
-    }
 }

--- a/cli/src/cmds/packages/package.rs
+++ b/cli/src/cmds/packages/package.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -85,7 +84,27 @@ impl Command for PackageCommand {
     }
 
     async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
-        self.exec_subcommand(writer, args).await
-    }
+        match args {
+            Some(matches) => match matches.subcommand_name() {
+                Some("fetch") => {
+                    let fetch = FetchCommand::create(self.conf.clone());
+                    fetch.exec_match(writer, matches.subcommand_matches("fetch"))?;
+                }
+                Some("list") => {
+                    let list = ListCommand::create(self.conf.clone());
+                    list.exec_match(writer, matches.subcommand_matches("list"))?;
+                }
+                Some("switch") => {
+                    let switch = SwitchCommand::create(self.conf.clone());
+                    switch.exec_match(writer, matches.subcommand_matches("switch"))?;
+                }
+                _ => writer.write_err("unknown command, usage: package -h"),
+            },
+            None => {
+                println!("None")
+            }
+        }
 
+        Ok(())
+    }
 }

--- a/cli/src/cmds/processor.rs
+++ b/cli/src/cmds/processor.rs
@@ -89,19 +89,19 @@ impl Processor {
         match self.env.conf.clone().clap.subcommand_name() {
             Some("package") => {
                 let cmd = PackageCommand::create(self.env.conf.clone());
-                return cmd.exec_match(
+                return cmd.exec_matches(
                     &mut writer,
                     self.env.conf.clone().clap.subcommand_matches("package"),
-                );
+                ).await;
             }
             Some("version") => {
                 let cmd = VersionCommand::create();
-                cmd.exec(&mut writer, "".parse().unwrap()).await
+                cmd.exec_matches(&mut writer, None).await
             }
             Some("cluster") => {
                 let cmd = ClusterCommand::create(self.env.conf.clone());
                 return cmd
-                    .exec_match(
+                    .exec_matches(
                         &mut writer,
                         self.env.conf.clone().clap.subcommand_matches("cluster"),
                     )
@@ -109,7 +109,7 @@ impl Processor {
             }
             Some("query") => {
                 let cmd = QueryCommand::create(self.env.conf.clone());
-                cmd.exec_match(
+                cmd.exec_matches(
                     &mut writer,
                     self.env.conf.clone().clap.subcommand_matches("query"),
                 )
@@ -137,7 +137,7 @@ impl Processor {
             }
             Some("up") => {
                 let cmd = UpCommand::create(self.env.conf.clone());
-                cmd.exec_match(
+                cmd.exec_matches(
                     &mut writer,
                     self.env.conf.clone().clap.subcommand_matches("up"),
                 )

--- a/cli/src/cmds/processor.rs
+++ b/cli/src/cmds/processor.rs
@@ -89,10 +89,12 @@ impl Processor {
         match self.env.conf.clone().clap.subcommand_name() {
             Some("package") => {
                 let cmd = PackageCommand::create(self.env.conf.clone());
-                return cmd.exec_matches(
-                    &mut writer,
-                    self.env.conf.clone().clap.subcommand_matches("package"),
-                ).await;
+                return cmd
+                    .exec_matches(
+                        &mut writer,
+                        self.env.conf.clone().clap.subcommand_matches("package"),
+                    )
+                    .await;
             }
             Some("version") => {
                 let cmd = VersionCommand::create();

--- a/cli/src/cmds/queries/query.rs
+++ b/cli/src/cmds/queries/query.rs
@@ -295,8 +295,6 @@ async fn execute_query(
         }
         Ok(("".to_string(), ans.stats))
     }
-
-
 }
 
 #[async_trait]
@@ -321,11 +319,7 @@ impl Command for QueryCommand {
         s.contains(self.name())
     }
 
-    async fn exec_matches(
-        &self,
-        writer: &mut Writer,
-        args: Option<&ArgMatches>,
-    ) -> Result<()> {
+    async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
         match args {
             Some(matches) => {
                 let profile = matches.value_of_t("profile");
@@ -345,6 +339,4 @@ impl Command for QueryCommand {
         }
         Ok(())
     }
-
-
 }

--- a/cli/src/cmds/queries/query.rs
+++ b/cli/src/cmds/queries/query.rs
@@ -16,6 +16,7 @@ use std::borrow::Borrow;
 use std::io::Read;
 use std::net::SocketAddr;
 use std::path::Path;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use clap::App;
@@ -70,32 +71,6 @@ impl QueryCommand {
             );
         app
     }
-
-    pub(crate) async fn exec_match(
-        &self,
-        writer: &mut Writer,
-        args: Option<&ArgMatches>,
-    ) -> Result<()> {
-        match args {
-            Some(matches) => {
-                let profile = matches.value_of_t("profile");
-                match profile {
-                    Ok(ClusterProfile::Local) => {
-                        return self.local_exec_match(writer, matches).await;
-                    }
-                    Ok(ClusterProfile::Cluster) => {
-                        todo!()
-                    }
-                    Err(_) => writer.write_err("currently profile only support cluster or local"),
-                }
-            }
-            None => {
-                println!("none ");
-            }
-        }
-        Ok(())
-    }
-
     async fn local_exec_match(&self, writer: &mut Writer, args: &ArgMatches) -> Result<()> {
         match self.local_exec_precheck(args) {
             Ok(_) => {
@@ -175,6 +150,23 @@ impl QueryCommand {
                 "Query command error: cannot find local configs in {}, please run `bendctl cluster create --profile local` to create a new local cluster",
                 status.local_config_dir
             )));
+        }
+
+        Ok(())
+    }
+
+    pub async fn exec(&self, writer: &mut Writer, args: String) -> Result<()> {
+        match self
+            .clap
+            .clone()
+            .try_get_matches_from(vec!["query", args.as_str()])
+        {
+            Ok(matches) => {
+                return self.exec_matches(writer, Some(matches.borrow())).await;
+            }
+            Err(err) => {
+                println!("Cannot get subcommand matches: {}", err);
+            }
         }
 
         Ok(())
@@ -303,6 +295,8 @@ async fn execute_query(
         }
         Ok(("".to_string(), ans.stats))
     }
+
+
 }
 
 #[async_trait]
@@ -311,28 +305,46 @@ impl Command for QueryCommand {
         "query"
     }
 
+    fn clap(&self) -> App<'static> {
+        self.clap.clone()
+    }
+
     fn about(&self) -> &str {
         "Query on databend cluster"
+    }
+
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![]
     }
 
     fn is(&self, s: &str) -> bool {
         s.contains(self.name())
     }
 
-    async fn exec(&self, writer: &mut Writer, args: String) -> Result<()> {
-        match self
-            .clap
-            .clone()
-            .try_get_matches_from(vec!["query", args.as_str()])
-        {
-            Ok(matches) => {
-                return self.exec_match(writer, Some(matches.borrow())).await;
+    async fn exec_matches(
+        &self,
+        writer: &mut Writer,
+        args: Option<&ArgMatches>,
+    ) -> Result<()> {
+        match args {
+            Some(matches) => {
+                let profile = matches.value_of_t("profile");
+                match profile {
+                    Ok(ClusterProfile::Local) => {
+                        return self.local_exec_match(writer, matches).await;
+                    }
+                    Ok(ClusterProfile::Cluster) => {
+                        todo!()
+                    }
+                    Err(_) => writer.write_err("currently profile only support cluster or local"),
+                }
             }
-            Err(err) => {
-                println!("Cannot get subcommand matches: {}", err);
+            None => {
+                println!("none ");
             }
         }
-
         Ok(())
     }
+
+
 }

--- a/cli/src/cmds/ups/up.rs
+++ b/cli/src/cmds/ups/up.rs
@@ -15,6 +15,7 @@
 use std::borrow::Borrow;
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use clap::App;
@@ -248,60 +249,18 @@ impl UpCommand {
             );
         app
     }
-
-    pub(crate) async fn exec_match(
-        &self,
-        writer: &mut Writer,
-        args: Option<&ArgMatches>,
-    ) -> Result<()> {
-        match args {
-            Some(matches) => {
-                let profile = matches.value_of_t("profile");
-                match profile {
-                    Ok(ClusterProfile::Local) => {
-                        return self.local_exec_match(writer, matches).await;
-                    }
-                    Ok(ClusterProfile::Cluster) => {
-                        todo!()
-                    }
-                    Err(_) => writer.write_err("currently profile only support cluster or local"),
-                }
+ 
+    async fn exec(&self, writer: &mut Writer, args: String) -> Result<()> {
+        match self.clap.clone().try_get_matches_from(args.split(' ')) {
+            Ok(matches) => {
+                return self.exec_matches(writer, Some(matches.borrow())).await;
             }
-            None => {
-                println!("none ");
+            Err(err) => {
+                println!("Cannot get subcommand matches: {}", err);
             }
         }
+
         Ok(())
-    }
-    async fn download_dataset(&self, dataset: DataSets) -> Result<String> {
-        return match dataset {
-            DataSets::OntimeMini(url, _) => {
-                let status = Status::read(self.conf.clone())?;
-                let cfgs = status.get_local_query_configs();
-                let (_, query_config) = cfgs.get(0).expect("cannot get local query config");
-                let dataset_dir = query_config.config.storage.disk.data_path.as_str();
-                let dataset_location = format!("{}/ontime_2019_2021.csv", dataset_dir);
-                let download_location = format!(
-                    "{}/downloads/datasets/ontime_mini.tar.gz",
-                    self.conf.databend_dir
-                );
-                std::fs::create_dir_all(Path::new(
-                    format!("{}/downloads/datasets/", self.conf.databend_dir).as_str(),
-                ))?;
-                if let Err(e) = download_and_unpack(
-                    url,
-                    &*download_location,
-                    dataset_dir,
-                    Some(dataset_location.clone()),
-                ) {
-                    return Err(CliError::Unknown(format!(
-                        "Cannot download/unpack dataset {:?}",
-                        e
-                    )));
-                }
-                Ok::<String, CliError>(dataset_location)
-            }
-        };
     }
 
     async fn download_playground(&self) -> Result<String> {
@@ -498,11 +457,49 @@ impl UpCommand {
     fn local_exec_precheck(&self, _args: &ArgMatches) -> Result<()> {
         Ok(())
     }
+
+   async fn download_dataset(&self, dataset: DataSets) -> Result<String> {
+        return match dataset {
+            DataSets::OntimeMini(url, _) => {
+                let status = Status::read(self.conf.clone())?;
+                let cfgs = status.get_local_query_configs();
+                let (_, query_config) = cfgs.get(0).expect("cannot get local query config");
+                let dataset_dir = query_config.config.storage.disk.data_path.as_str();
+                let dataset_location = format!("{}/ontime_2019_2021.csv", dataset_dir);
+                let download_location = format!(
+                    "{}/downloads/datasets/ontime_mini.tar.gz",
+                    self.conf.databend_dir
+                );
+                std::fs::create_dir_all(Path::new(
+                    format!("{}/downloads/datasets/", self.conf.databend_dir).as_str(),
+                ))?;
+                if let Err(e) = download_and_unpack(
+                    url,
+                    &*download_location,
+                    dataset_dir,
+                    Some(dataset_location.clone()),
+                ) {
+                    return Err(CliError::Unknown(format!(
+                        "Cannot download/unpack dataset {:?}",
+                        e
+                    )));
+                }
+                Ok::<String, CliError>(dataset_location)
+            }
+        };
+    }
+
+
 }
+
 #[async_trait]
 impl Command for UpCommand {
     fn name(&self) -> &str {
         "up"
+    }
+
+    fn clap(&self) -> App<'static> {
+        self.clap.clone()
     }
 
     fn about(&self) -> &str {
@@ -513,16 +510,33 @@ impl Command for UpCommand {
         s.contains(self.name())
     }
 
-    async fn exec(&self, writer: &mut Writer, args: String) -> Result<()> {
-        match self.clap.clone().try_get_matches_from(args.split(' ')) {
-            Ok(matches) => {
-                return self.exec_match(writer, Some(matches.borrow())).await;
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![]
+    }
+
+    async fn exec_matches(
+        &self,
+        writer: &mut Writer,
+        args: Option<&ArgMatches>,
+    ) -> Result<()> {
+        match args {
+            Some(matches) => {
+                let profile = matches.value_of_t("profile");
+                match profile {
+                    Ok(ClusterProfile::Local) => {
+                        return self.local_exec_match(writer, matches).await;
+                    }
+                    Ok(ClusterProfile::Cluster) => {
+                        todo!()
+                    }
+                    Err(_) => writer.write_err("currently profile only support cluster or local"),
+                }
             }
-            Err(err) => {
-                println!("Cannot get subcommand matches: {}", err);
+            None => {
+                println!("none ");
             }
         }
-
         Ok(())
     }
+
 }

--- a/cli/src/cmds/ups/up.rs
+++ b/cli/src/cmds/ups/up.rs
@@ -474,8 +474,6 @@ impl UpCommand {
     fn local_exec_precheck(&self, _args: &ArgMatches) -> Result<()> {
         Ok(())
     }
-
-
 }
 
 #[async_trait]

--- a/cli/src/cmds/versions/version.rs
+++ b/cli/src/cmds/versions/version.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use clap::App;
+use clap::ArgMatches;
 use sha2::Digest;
 use sha2::Sha256;
 use sysinfo::SystemExt;
-use clap::ArgMatches;
-use std::sync::Arc;
 
 use crate::cmds::command::Command;
 use crate::cmds::Writer;
@@ -107,5 +108,4 @@ impl Command for VersionCommand {
 
         Ok(())
     }
-
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

this PR tries make a re-org on the Command trait:

1) add fn subcommands(): allowing a command nests multiple subcommands, easier to make the `clap::App` and dispatch the subcommand

2) add two template methods exec() and exec_subcommand()

currently this PR only changed the `cluster` command and its subcommands, if the idea is ok, i'd continue work on other commands like `package`. 

before: https://github.com/datafuselabs/databend/blob/ba278730fd2a5d95e0a223bcbd3482bde7c15cd5/cli/src/cmds/clusters/cluster.rs
after: https://github.com/datafuselabs/databend/blob/c18100d1a46e9ec17e131803ca55c57398e4bf16/cli/src/cmds/clusters/cluster.rs

benefits:

- we could seperate the concerns on "parsing cmdline" (in the Command trait impl part) with the "command execution" logic (in the concrete impl part)
- maybe reduced some duplication on parsing the cmdline (from an exec() fn in each command to a reused exec() template method in the trait)
- may simplify the nested command combination (replace the manual dispatch logic by subcommand name to a reusable search logic)

the cons of this re-org:

- introduces more abstraction on Command, maybe make things harder to understand.

i'm not quite sure whether this re-org could make things easier or worse, thank you for comments!  

## Changelog

- Improvement

## Related Issues

## Test Plan

Unit Tests

Stateless Tests

