### PR TITLE
CI: fix embedded config missing field azure_storage_blob

### DIFF
--- a/scripts/deploy/config/databend-query-embedded-meta.toml
+++ b/scripts/deploy/config/databend-query-embedded-meta.toml
@@ -53,4 +53,4 @@ data_path = "stateless_test_data"
 [storage.s3]
 
 # Azure storage
-[storage.asb]
+[storage.azure_storage_blob]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

This is a CI bug:
Step1: Merge #2528
Step2: Merge #2534
Step3: #2534 's new file scripts/deploy/config/databend-query-embedded-meta.toml missing the config field `azure_storage_blob` who refined in the #2528  

CI failed:
https://github.com/datafuselabs/databend/runs/4052571595?check_suite_focus=true

## Changelog

- Build/Testing/CI


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

