### PR TITLE
CLI: Refine the writer format and the message hints

### DIFF
--- a/cli/src/cmds/clusters/cluster.rs
+++ b/cli/src/cmds/clusters/cluster.rs
@@ -87,20 +87,20 @@ impl Command for ClusterCommand {
         app
     }
 
-    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
-        vec![
-            Arc::new(CreateCommand::create(self.conf.clone())),
-            Arc::new(StopCommand::create(self.conf.clone())),
-            Arc::new(ViewCommand::create(self.conf.clone())),
-        ]
-    }
-
     fn about(&self) -> &str {
         "Cluster life cycle management"
     }
 
     fn is(&self, s: &str) -> bool {
         s.contains(self.name())
+    }
+
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![
+            Arc::new(CreateCommand::create(self.conf.clone())),
+            Arc::new(StopCommand::create(self.conf.clone())),
+            Arc::new(ViewCommand::create(self.conf.clone())),
+        ]
     }
 
     async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {

--- a/cli/src/cmds/clusters/stop.rs
+++ b/cli/src/cmds/clusters/stop.rs
@@ -44,49 +44,49 @@ impl StopCommand {
         status: &mut Status,
         writer: &mut Writer,
     ) -> Result<()> {
-        writer.write_ok("⚠️  start to clean up local services");
+        writer.write_warn("Start to clean up local services".to_string());
         for (fs, query) in status.get_local_query_configs() {
             if query.kill().await.is_err() {
                 if Status::delete_local_config(status, "query".to_string(), fs.clone()).is_err() {
-                    writer.write_err(&*format!("cannot clean query config in {}", fs.clone()))
+                    writer.write_err(format!("Cannot clean query config in {}", fs.clone()))
                 }
-                writer.write_err(&*format!(
-                    "cannot kill query service with config in {}",
+                writer.write_err(format!(
+                    "Cannot kill query service with config in {}",
                     fs.clone()
                 ))
             }
 
             if Status::delete_local_config(status, "query".to_string(), fs.clone()).is_err() {
-                writer.write_err(&*format!("cannot clean query config in {}", fs.clone()))
+                writer.write_err(format!("cannot clean query config in {}", fs.clone()))
             }
-            writer.write_ok(format!("⚠️  stopped query service with config in {}", fs).as_str());
+            writer.write_warn(format!("Stopped query service with config in {}", fs));
         }
         if status.get_local_meta_config().is_some() {
             let (fs, meta) = status.get_local_meta_config().unwrap();
             if meta.kill().await.is_err() {
-                writer.write_err(&*format!("cannot kill meta service with config in {}", fs));
+                writer.write_err(format!("Cannot kill meta service with config in {}", fs));
                 if Status::delete_local_config(status, "meta".to_string(), fs.clone()).is_err() {
-                    writer.write_err(&*format!("cannot clean meta config in {}", fs))
+                    writer.write_err(format!("Cannot clean meta config in {}", fs))
                 }
             }
             Status::delete_local_config(status, "meta".to_string(), fs.clone())
                 .expect("cannot clean meta config");
-            writer.write_ok(format!("⚠️  stopped meta service with config in {}", fs).as_str());
+            writer.write_warn(format!("Stopped meta service with config in {}", fs));
         }
         if status.get_local_dashboard_config().is_some() {
             let (fs, dash) = status.get_local_dashboard_config().unwrap();
             if dash.kill().await.is_err() {
-                writer.write_err(&*format!(
-                    "cannot kill dashboard service with config in {}",
+                writer.write_err(format!(
+                    "Cannot kill dashboard service with config in {}",
                     fs
                 ));
                 if Status::delete_local_config(status, "meta".to_string(), fs.clone()).is_err() {
-                    writer.write_err(&*format!("cannot clean meta config in {}", fs))
+                    writer.write_err(format!("Cannot clean meta config in {}", fs))
                 }
             }
             Status::delete_local_config(status, "dashboard".to_string(), fs.clone())
                 .expect("cannot clean meta config");
-            writer.write_ok(format!("⚠️ stopped meta service with config in {}", fs).as_str());
+            writer.write_warn(format!("Stopped meta service with config in {}", fs));
         }
         Ok(())
     }
@@ -97,14 +97,14 @@ impl StopCommand {
                 let mut status = Status::read(self.conf.clone())?;
                 if let Err(e) = StopCommand::stop_current_local_services(&mut status, writer).await
                 {
-                    writer.write_err(format!("{:?}", e).as_str());
+                    writer.write_err(format!("{:?}", e));
                 };
                 status.current_profile = None;
                 status.write()?;
-                writer.write_ok("🚀 stopped services");
+                writer.write_rocket("Stopped all services".to_string());
             }
             Err(e) => {
-                writer.write_err(format!("{:?}", e).as_str());
+                writer.write_err(format!("{:?}", e));
             }
         }
         //(TODO) purge semantics
@@ -156,16 +156,16 @@ impl Command for StopCommand {
             )
     }
 
-    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
-        vec![]
-    }
-
     fn about(&self) -> &str {
         "stop" // TODO
     }
 
     fn is(&self, s: &str) -> bool {
         s.contains(self.name())
+    }
+
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![]
     }
 
     async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
@@ -180,11 +180,11 @@ impl Command for StopCommand {
                     Ok(ClusterProfile::Cluster) => {
                         todo!()
                     }
-                    Err(e) => writer.write_err(format!("cannot parse profile, {:?}", e).as_str()),
+                    Err(e) => writer.write_err(format!("Cannot parse profile, {:?}", e)),
                 }
             }
             None => {
-                writer.write_err(&*"cannot find matches for cluster delete");
+                writer.write_err("Cannot find matches for cluster delete".to_string());
             }
         }
 

--- a/cli/src/cmds/clusters/view.rs
+++ b/cli/src/cmds/clusters/view.rs
@@ -70,17 +70,14 @@ impl ViewCommand {
                 if let Ok(t) = table {
                     writer.writeln(&t.trim_fmt());
                 } else {
-                    writer.write_err(
-                        format!(
-                            "cannot retrieve view table, error: {:?}",
-                            table.unwrap_err()
-                        )
-                        .as_str(),
-                    );
+                    writer.write_err(format!(
+                        "Cannot retrieve view table, error: {:?}",
+                        table.unwrap_err()
+                    ));
                 }
             }
             Err(e) => {
-                writer.write_err(format!("View precheck failed: {:?}", e).as_str());
+                writer.write_err(format!("View precheck failed: {:?}", e));
             }
         }
         Ok(())
@@ -193,16 +190,16 @@ impl Command for ViewCommand {
             )
     }
 
-    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
-        vec![]
-    }
-
     fn about(&self) -> &str {
         "create" // TODO
     }
 
     fn is(&self, s: &str) -> bool {
         s.contains(self.name())
+    }
+
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![]
     }
 
     async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
@@ -217,11 +214,11 @@ impl Command for ViewCommand {
                     Ok(ClusterProfile::Cluster) => {
                         todo!()
                     }
-                    Err(e) => writer.write_err(format!("cannot parse profile, {:?}", e).as_str()),
+                    Err(e) => writer.write_err(format!("cannot parse profile, {:?}", e)),
                 }
             }
             None => {
-                writer.write_err(&*"cannot find available profile to view");
+                writer.write_err("cannot find available profile to view".to_string());
             }
         }
         Ok(())

--- a/cli/src/cmds/config.rs
+++ b/cli/src/cmds/config.rs
@@ -206,7 +206,7 @@ pub fn choose_mirror(conf: &Config) -> Result<CustomMirror, CliError> {
     if let Some(mirror) = status.mirrors {
         let custom: CustomMirror = mirror.clone();
         if !custom.is_ok() {
-            writer.write_err(&*format!(
+            writer.write_err(format!(
                 "Mirror error: cannot connect to current mirror {:?}",
                 mirror
             ))

--- a/cli/src/cmds/helps/help.rs
+++ b/cli/src/cmds/helps/help.rs
@@ -67,7 +67,7 @@ impl Command for HelpCommand {
         for cmd in self.commands.iter() {
             table.add_row(Row::from([cmd.name(), cmd.about()]));
         }
-        writer.write_ok("Mode switch commands:");
+        writer.write_ok("Mode switch commands:".to_string());
         writer.writeln_width(
             "\\sql",
             "Switch to query mode, you could run query directly under this mode",
@@ -76,7 +76,7 @@ impl Command for HelpCommand {
             "\\admin",
             "Switch to cluster administration mode, you could profile/view/update databend cluster",
         );
-        writer.write_ok("Admin commands:");
+        writer.write_ok("Admin commands:".to_string());
         writer.writeln(&table.trim_fmt());
         Ok(())
     }

--- a/cli/src/cmds/packages/fetch.rs
+++ b/cli/src/cmds/packages/fetch.rs
@@ -187,7 +187,7 @@ impl FetchCommand {
             &*bin_unpack_dir,
             Some(bin_file),
         ) {
-            writer.write_err(format!("Cannot download or unpack error: {:?}", e).as_str())
+            writer.write_err(format!("Cannot download or unpack error: {:?}", e))
         }
         let switch = SwitchCommand::create(self.conf.clone());
         switch.exec_match(writer, args)
@@ -198,19 +198,19 @@ impl FetchCommand {
             Some(matches) => {
                 let arch = get_rust_architecture();
                 if let Ok(arch) = arch {
-                    writer.write_ok(format!("Arch {}", arch).as_str());
+                    writer.write_ok(format!("Arch {}", arch));
                     let current_tag = get_version(
                         &self.conf,
                         matches.value_of("version").map(|e| e.to_string()),
                     )?;
-                    writer.write_ok(format!("Tag {}", current_tag).as_str());
+                    writer.write_ok(format!("Tag {}", current_tag));
                     if let Err(e) =
                         self.download_databend(&arch, current_tag.as_str(), writer, args)
                     {
-                        writer.write_err(format!("{:?}", e).as_str());
+                        writer.write_err(format!("{:?}", e));
                     }
                 } else {
-                    writer.write_err(format!("{:?}", arch.unwrap_err()).as_str());
+                    writer.write_err(format!("{:?}", arch.unwrap_err()));
                 }
             }
             None => {

--- a/cli/src/cmds/packages/package.rs
+++ b/cli/src/cmds/packages/package.rs
@@ -98,7 +98,7 @@ impl Command for PackageCommand {
                     let switch = SwitchCommand::create(self.conf.clone());
                     switch.exec_match(writer, matches.subcommand_matches("switch"))?;
                 }
-                _ => writer.write_err("unknown command, usage: package -h"),
+                _ => writer.write_err("Unknown command, usage: package -h".to_string()),
             },
             None => {
                 println!("None")

--- a/cli/src/cmds/packages/switch.rs
+++ b/cli/src/cmds/packages/switch.rs
@@ -65,18 +65,16 @@ impl SwitchCommand {
                 }
 
                 if !exists {
-                    writer.write_err(
-                        format!("Can't found version: {}, package list:", current_tag).as_str(),
-                    );
+                    writer.write_err(format!(
+                        "Can't found version: {}, package list:",
+                        current_tag
+                    ));
                     let list = ListCommand::create(self.conf.clone());
                     list.exec_match(writer, args)?;
-                    writer.write_err(
-                        format!(
-                            "Use command bendctl package fetch {} to retrieve this version",
-                            current_tag
-                        )
-                        .as_str(),
-                    );
+                    writer.write_err(format!(
+                        "Use command bendctl package fetch {} to retrieve this version",
+                        current_tag
+                    ));
                     return Ok(());
                 }
 
@@ -85,7 +83,7 @@ impl SwitchCommand {
                 status.version = current_tag;
                 status.write()?;
 
-                writer.write_ok(format!("Package switch to {}", status.version).as_str());
+                writer.write_ok(format!("Package switch to {}", status.version));
 
                 Ok(())
             }

--- a/cli/src/cmds/processor.rs
+++ b/cli/src/cmds/processor.rs
@@ -278,7 +278,7 @@ impl Processor {
         if self.env.conf.mode == Mode::Sql {
             let res = self.query.exec(&mut writer, line.trim().to_string()).await;
             if let Err(e) = res {
-                writer.write_err(format!("Cannot exeuction query, if you want to manage databend cluster or check its status, please change to admin mode(type \\admin), error: {:?}", e).as_str())
+                writer.write_err(format!("Cannot exeuction query, if you want to manage databend cluster or check its status, please change to admin mode(type \\admin), error: {:?}", e))
             }
             writer.flush()?;
         } else {

--- a/cli/src/cmds/queries/query.rs
+++ b/cli/src/cmds/queries/query.rs
@@ -74,7 +74,7 @@ impl QueryCommand {
     async fn local_exec_match(&self, writer: &mut Writer, args: &ArgMatches) -> Result<()> {
         match self.local_exec_precheck(args) {
             Ok(_) => {
-                writer.write_debug("Query precheck passed!");
+                writer.write_ok("Query precheck passed!".to_string());
                 let status = Status::read(self.conf.clone())?;
                 let queries = match args.value_of("query") {
                     Some(val) => {
@@ -112,31 +112,24 @@ impl QueryCommand {
                         .map(|elem| format!("{};", elem))
                         .collect::<Vec<String>>()
                     {
-                        writer.write_debug(
-                            format!("Execute query {} on {}", query.clone(), url).as_str(),
-                        );
+                        writer.write_debug(format!("Execute query {} on {}", query.clone(), url));
                         if let Err(e) =
                             query_writer(&cli, url.as_str(), query.clone(), writer).await
                         {
-                            writer.write_err(
-                                format!("query {} execution error: {:?}", query, e).as_str(),
-                            );
+                            writer.write_err(format!("Query {} execution error: {:?}", query, e));
                         }
                     }
                 } else {
-                    writer.write_err(
-                        format!(
-                            "Query command error: cannot parse query url with error: {:?}",
-                            res.unwrap_err()
-                        )
-                        .as_str(),
-                    );
+                    writer.write_err(format!(
+                        "Query command error: cannot parse query url with error: {:?}",
+                        res.unwrap_err()
+                    ));
                 }
 
                 Ok(())
             }
             Err(e) => {
-                writer.write_err(&*format!("Query command precheck failed, error {:?}", e));
+                writer.write_err(format!("Query command precheck failed, error {:?}", e));
                 Ok(())
             }
         }
@@ -147,7 +140,7 @@ impl QueryCommand {
         let status = Status::read(self.conf.clone())?;
         if !status.has_local_configs() {
             return Err(CliError::Unknown(format!(
-                "Query command error: cannot find local configs in {}, please run `bendctl cluster create --profile local` to create a new local cluster",
+                "Query command error: cannot find local configs in {}, please run `bendctl cluster create` to create a new local cluster or '\\admin' switch to the admin mode",
                 status.local_config_dir
             )));
         }
@@ -203,18 +196,14 @@ async fn query_writer(
                         byte_per_sec.get_value(),
                         byte_per_sec.get_unit().to_string()
                     )
-                        .as_str(),
                 );
             }
         }
         Err(e) => {
-            writer.write_err(
-                format!(
-                    "Query command error: cannot execute query with error: {:?}",
-                    e
-                )
-                .as_str(),
-            );
+            writer.write_err(format!(
+                "Query command error: cannot execute query with error: {:?}",
+                e
+            ));
         }
     }
     Ok(())
@@ -311,12 +300,12 @@ impl Command for QueryCommand {
         "Query on databend cluster"
     }
 
-    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
-        vec![]
-    }
-
     fn is(&self, s: &str) -> bool {
         s.contains(self.name())
+    }
+
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![]
     }
 
     async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
@@ -330,7 +319,8 @@ impl Command for QueryCommand {
                     Ok(ClusterProfile::Cluster) => {
                         todo!()
                     }
-                    Err(_) => writer.write_err("currently profile only support cluster or local"),
+                    Err(_) => writer
+                        .write_err("Currently profile only support cluster or local".to_string()),
                 }
             }
             None => {

--- a/cli/src/cmds/ups/up.rs
+++ b/cli/src/cmds/ups/up.rs
@@ -311,7 +311,7 @@ impl UpCommand {
 
     async fn local_up(&self, dataset: DataSets, writer: &mut Writer) -> Result<()> {
         // bootstrap cluster
-        writer.write_ok("Welcome to use our databend product 🎉🎉🎉");
+        writer.write_ok("Welcome to use our databend product 🎉🎉🎉".to_string());
         let cluster = ClusterCommand::create(self.conf.clone());
         if let Err(e) = cluster
             .exec(writer, ["cluster", "create", "--force"].join(" "))
@@ -322,9 +322,10 @@ impl UpCommand {
                 e
             )));
         }
-        writer.write_ok("Start to download dataset");
+        writer.write_ok("Start to download dataset".to_string());
         match self.download_dataset(dataset.clone()).await {
             Ok(dataset_location) => {
+                writer.write_ok(format!("Download dataset to {}", dataset_location));
                 match dataset {
                     DataSets::OntimeMini(_, ddl) => {
                         if let Err(e) = self
@@ -335,7 +336,7 @@ impl UpCommand {
                         }
                     }
                 }
-                writer.write_ok("Start to download playground");
+                writer.write_ok("Start to download playground".to_string());
 
                 match self.download_playground().await {
                     Ok(path) => {
@@ -387,15 +388,12 @@ impl UpCommand {
                     "dashboard_config_0.yaml".to_string(),
                     &dash_config.clone(),
                 )?;
-                writer.write_ok(
-                    format!(
-                        "👏 successfully started meta service listen on {}",
-                        dash_config
-                            .listen_addr
-                            .expect("dashboard config has no listen address")
-                    )
-                    .as_str(),
-                );
+                writer.write_ok(format!(
+                    "👏 Successfully started meta service listen on {}",
+                    dash_config
+                        .listen_addr
+                        .expect("dashboard config has no listen address")
+                ));
                 Ok(())
             }
             Err(e) => Err(e),
@@ -448,23 +446,23 @@ impl UpCommand {
                 match dataset {
                     Ok(d) => {
                         if let Err(e) = self.local_up(d, writer).await {
-                            writer.write_err(&*format!("{:?}", e));
+                            writer.write_err(format!("{:?}", e));
                             let mut status = Status::read(self.conf.clone())?;
                             if let Err(e) =
                                 StopCommand::stop_current_local_services(&mut status, writer).await
                             {
-                                writer.write_err(&*format!("{:?}", e));
+                                writer.write_err(format!("{:?}", e));
                             }
                         }
                     }
                     Err(e) => {
-                        writer.write_err(&*format!("Cannot find public dataset, error {:?}", e));
+                        writer.write_err(format!("Cannot find public dataset, error {:?}", e));
                     }
                 }
                 Ok(())
             }
             Err(e) => {
-                writer.write_err(&*format!("Query command precheck failed, error {:?}", e));
+                writer.write_err(format!("Query command precheck failed, error {:?}", e));
                 Ok(())
             }
         }
@@ -509,7 +507,8 @@ impl Command for UpCommand {
                     Ok(ClusterProfile::Cluster) => {
                         todo!()
                     }
-                    Err(_) => writer.write_err("currently profile only support cluster or local"),
+                    Err(_) => writer
+                        .write_err("Currently profile only support cluster or local".to_string()),
                 }
             }
             None => {

--- a/cli/src/cmds/writer.rs
+++ b/cli/src/cmds/writer.rs
@@ -43,17 +43,26 @@ impl Writer {
         writeln!(self, "{}", value).unwrap();
     }
 
-    pub fn write_ok(&mut self, msg: &str) {
-        writeln!(self, "{} {}", "[ok]".bold().green(), msg).unwrap();
+    pub fn write_ok(&mut self, msg: String) {
+        writeln!(self, "{} ✅ {}", "[ok]".bold().green(), msg).unwrap();
     }
-    pub fn write_debug(&mut self, msg: &str) {
+
+    pub fn write_warn(&mut self, msg: String) {
+        writeln!(self, "{} ⚠ {}", "[ok]".bold().green(), msg).unwrap();
+    }
+
+    pub fn write_rocket(&mut self, msg: String) {
+        writeln!(self, "{} 🚀 {}", "[ok]".bold().green(), msg).unwrap();
+    }
+
+    pub fn write_debug(&mut self, msg: String) {
         if self.debug {
             writeln!(self, "{} {}", "[debug]".bold().yellow(), msg).unwrap();
         }
     }
 
-    pub fn write_err(&mut self, msg: &str) {
-        writeln!(self, "{} {}", "[failed]".bold().red(), msg.red()).unwrap();
+    pub fn write_err(&mut self, msg: String) {
+        writeln!(self, "{} ❌ {}", "[failed]".bold().red(), msg.red()).unwrap();
     }
 }
 

--- a/website/databend/docs/cli/cli.md
+++ b/website/databend/docs/cli/cli.md
@@ -4,10 +4,8 @@ title: Databend CLI Reference
 ---
 
 `bendctl` is a command-line tool for creating, listing, logging,
-deleting databend running instances on local or
-on cloud.
-It also supports to port forward webUI, monitoring dashboard on local
-and run SQL queries from command line.
+deleting databend running instances on local or on cloud.
+It also supports to port forward webUI, monitoring dashboard on local and run SQL queries from command line.
 
 
 ## 1. Install
@@ -20,25 +18,44 @@ curl -fsS https://repo.databend.rs/databend/install-bendctl.sh | bash
 export PATH="${HOME}/.databend/bin:${PATH}"
 ```
 
-## 2. Setting up a cluster
+## 2. Help
 
 ```markdown
 $ bendctl
+[local] [sql]> help
+[ok] ✅ Mode switch commands:
+\sql                 Switch to query mode, you could run query directly under this mode
+\admin               Switch to cluster administration mode, you could profile/view/update databend cluster
+[ok] ✅ Admin commands:
++---------+-------------------------------------------+
+| Name    | About                                     |
++---------+-------------------------------------------+
+| version | Databend CLI version                      |
+| package | Package command                           |
+| cluster | Cluster life cycle management             |
+| up      | Bootstrap a single cluster with dashboard |
++---------+-------------------------------------------+
+```
+
+## 3. Setting up a cluster
+
+```markdown
 [local] [sql]> \admin
 Mode switched to admin mode
 [local] [admin]> cluster create
-[ok] databend cluster precheck passed!
-[ok] 👏 successfully started meta service with rpc endpoint 127.0.0.1:9191
-[ok] local data would be stored in /home/ubuntu/.databend/local/data
-[ok] 👏 successfully started query service.
-[ok] ✅  To run queries through RESTful api, run: bendctl query 'SQL statement'
-[ok] ✅  For example: bendctl query 'SELECT sum(number), avg(number) FROM numbers(100);'
-[ok] ✅ To process mysql queries, run: mysql -h 127.0.0.1 -P 3307 -uroot
+[ok] ✅ Databend cluster pre-check passed!
+[ok] ✅ Successfully started meta service with rpc endpoint 127.0.0.1:9191
+[ok] ✅ Local data would be stored in /home/bohu/.databend/local/data
+[ok] ✅ Successfully started query service.
+[ok] ✅ To run queries through bendctl, run: bendctl query 'your SQL'
+[ok] ✅ For example: bendctl query 'SELECT sum(number), avg(number) FROM numbers(100)'
+[ok] ✅ To process mysql queries, run: mysql -h127.0.0.1 -P3307 -uroot
 [ok] ✅ To process clickhouse queries, run: clickhouse client --host 127.0.0.1 --port 9000 --user root
-[local] [admin]>
+[ok] ✅ To process HTTP REST queries, run: curl --location --request POST '127.0.0.1:24974/v1/statement/' --header 'Content-Type: text/plain' --data-raw 'your SQL'
+[local] [admin]> 
 ```
 
-## 3. Query Example
+## 4. Query Example
 
 === "bendctl"
 
@@ -64,7 +81,7 @@ Mode switched to admin mode
         numbers(N) – A table for test with the single `number` column (UInt64) that contains integers from 0 to N-1.
 
     ```
-    $ mysql -h127.0.0.1 -uroot -P3307
+    mysql -h127.0.0.1 -uroot -P3307
     ```
     ```markdown
     mysql> SELECT avg(number) FROM numbers(1000000000);
@@ -82,7 +99,7 @@ Mode switched to admin mode
         numbers(N) – A table for test with the single `number` column (UInt64) that contains integers from 0 to N-1.
 
     ```
-    $ clickhouse client --host 0.0.0.0 --port 9001
+    clickhouse client --host 0.0.0.0 --port 9001
     ```
 
     ```
@@ -99,3 +116,27 @@ Mode switched to admin mode
 
     1 rows in set. Elapsed: 0.062 sec. Processed 1.00 billion rows, 8.01 GB (16.16 billion rows/s., 129.38 GB/s.)
     ```
+
+=== "HTTP Client"
+
+    !!! note
+        numbers(N) – A table for test with the single `number` column (UInt64) that contains integers from 0 to N-1.
+
+    ```
+    curl --location --request POST '127.0.0.1:8001/v1/statement/' --header 'Content-Type: text/plain' --data-raw 'SELECT avg(number) FROM numbers(1000000000)'
+    ```
+
+    ```
+    {"id":"efca332b-13f4-4b8c-982d-cebf91626214","nextUri":null,"data":[[499999999.5]],"columns":{"fields":[{"name":"avg(number)","data_type":"Float64","nullable":false}],"metadata":{}},"error":null,"stats":{"read_rows":1000000000,"read_bytes":8000000000,"total_rows_to_read":0}}
+    ```
+
+## 5. Stop a cluster
+
+```markdown
+[local] [admin]> cluster stop
+[ok] ⚠ Start to clean up local services
+[ok] ⚠ Stopped query service with config in /home/bohu/.databend/local/configs/local/query_config_0.yaml
+[ok] ⚠ Stopped meta service with config in /home/bohu/.databend/local/configs/local/meta_config_0.yaml
+[ok] 🚀 Stopped all services
+[local] [admin]> 
+```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR:
1. Refine the message hints
2. Introduce more writers: write_ok/write_err/write_rocket/write_warn
3. Apply the same order as `Command` trait order

## Changelog


- Improvement


## Related Issues


## Test Plan

Unit Tests

Stateless Tests

