### PR TITLE
[bendctl] continue #2530 on the package subcommands

### DIFF
--- a/cli/src/cmds/clusters/cluster.rs
+++ b/cli/src/cmds/clusters/cluster.rs
@@ -80,7 +80,7 @@ impl Command for ClusterCommand {
         let subcommands = self.subcommands();
         let app = App::new("cluster")
             .setting(AppSettings::DisableVersionFlag)
-            .about("Cluster life cycle management")
+            .about(self.about())
             .subcommand(subcommands[0].clap())
             .subcommand(subcommands[1].clap())
             .subcommand(subcommands[2].clap());
@@ -95,7 +95,7 @@ impl Command for ClusterCommand {
         ]
     }
 
-    fn about(&self) -> &str {
+    fn about(&self) -> &'static str {
         "Cluster life cycle management"
     }
 

--- a/cli/src/cmds/clusters/create.rs
+++ b/cli/src/cmds/clusters/create.rs
@@ -149,9 +149,13 @@ impl CreateCommand {
                 "Cannot find databend binary path in version {}, start to download",
                 args.value_of("version").unwrap()
             ));
-            FetchCommand::create(self.conf.clone()).exec_matches(writer, Some(args)).await?;
+            FetchCommand::create(self.conf.clone())
+                .exec_matches(writer, Some(args))
+                .await?;
         }
-        SwitchCommand::create(self.conf.clone()).exec_matches(writer, Some(args)).await?;
+        SwitchCommand::create(self.conf.clone())
+            .exec_matches(writer, Some(args))
+            .await?;
         let status = Status::read(self.conf.clone())?;
         paths.query = self
             .binary_path(

--- a/cli/src/cmds/clusters/create.rs
+++ b/cli/src/cmds/clusters/create.rs
@@ -688,7 +688,7 @@ impl Command for CreateCommand {
     fn clap(&self) -> App<'static> {
         App::new("create")
             .setting(AppSettings::DisableVersionFlag)
-            .about("Create a databend cluster based on profile")
+            .about(self.about())
             .arg(
                 Arg::new("profile")
                     .long("profile")
@@ -788,8 +788,8 @@ impl Command for CreateCommand {
         vec![]
     }
 
-    fn about(&self) -> &str {
-        "create" // TODO
+    fn about(&self) -> &'static str {
+        "Create a databend cluster based on profile"
     }
 
     fn is(&self, s: &str) -> bool {

--- a/cli/src/cmds/clusters/create.rs
+++ b/cli/src/cmds/clusters/create.rs
@@ -125,7 +125,7 @@ impl CreateCommand {
             .to_string())
     }
 
-    fn ensure_bin(&self, writer: &mut Writer, args: &ArgMatches) -> Result<LocalBinaryPaths> {
+    async fn ensure_bin(&self, writer: &mut Writer, args: &ArgMatches) -> Result<LocalBinaryPaths> {
         let mut status = Status::read(self.conf.clone())?;
 
         let mut paths = LocalBinaryPaths {
@@ -149,9 +149,9 @@ impl CreateCommand {
                 "Cannot find databend binary path in version {}, start to download",
                 args.value_of("version").unwrap()
             ));
-            FetchCommand::create(self.conf.clone()).exec_match(writer, Some(args))?;
+            FetchCommand::create(self.conf.clone()).exec_matches(writer, Some(args)).await?;
         }
-        SwitchCommand::create(self.conf.clone()).exec_match(writer, Some(args))?;
+        SwitchCommand::create(self.conf.clone()).exec_matches(writer, Some(args)).await?;
         let status = Status::read(self.conf.clone())?;
         paths.query = self
             .binary_path(
@@ -517,6 +517,7 @@ impl CreateCommand {
                 // ensuring needed dependencies
                 let bin_path = self
                     .ensure_bin(writer, args)
+                    .await
                     .expect("cannot find binary path");
                 let meta_config = self
                     .generate_local_meta_config(args, bin_path.clone())

--- a/cli/src/cmds/clusters/stop.rs
+++ b/cli/src/cmds/clusters/stop.rs
@@ -140,7 +140,7 @@ impl Command for StopCommand {
     fn clap(&self) -> App<'static> {
         App::new("stop")
             .setting(AppSettings::DisableVersionFlag)
-            .about("Delete a databend cluster (delete current cluster by default) ")
+            .about(self.about())
             .arg(
                 Arg::new("profile")
                     .long("profile")
@@ -160,8 +160,8 @@ impl Command for StopCommand {
         vec![]
     }
 
-    fn about(&self) -> &str {
-        "stop" // TODO
+    fn about(&self) -> &'static str {
+        "Delete a databend cluster (delete current cluster by default)"
     }
 
     fn is(&self, s: &str) -> bool {

--- a/cli/src/cmds/clusters/view.rs
+++ b/cli/src/cmds/clusters/view.rs
@@ -183,7 +183,7 @@ impl Command for ViewCommand {
     fn clap(&self) -> App<'static> {
         App::new("view")
             .setting(AppSettings::DisableVersionFlag)
-            .about("View health status of current profile")
+            .about(self.about())
             .arg(
                 Arg::new("profile")
                     .long("profile")
@@ -197,8 +197,8 @@ impl Command for ViewCommand {
         vec![]
     }
 
-    fn about(&self) -> &str {
-        "create" // TODO
+    fn about(&self) -> &'static str {
+        "View health status of current profile"
     }
 
     fn is(&self, s: &str) -> bool {

--- a/cli/src/cmds/command.rs
+++ b/cli/src/cmds/command.rs
@@ -28,7 +28,7 @@ pub trait Command: DynClone + Send + Sync {
 
     fn clap(&self) -> clap::App<'static>;
 
-    fn about(&self) -> &str;
+    fn about(&self) -> &'static str;
 
     fn is(&self, s: &str) -> bool;
 

--- a/cli/src/cmds/config.rs
+++ b/cli/src/cmds/config.rs
@@ -309,7 +309,7 @@ impl Config {
                             .possible_values(&["bash", "zsh"]),
                     ),
             )
-            .subcommand(PackageCommand::generate())
+            .subcommand(PackageCommand::default().clap())
             .subcommand(VersionCommand::generate())
             .subcommand(ClusterCommand::default().clap())
             .subcommand(QueryCommand::generate())

--- a/cli/src/cmds/helps/help.rs
+++ b/cli/src/cmds/helps/help.rs
@@ -43,15 +43,15 @@ impl Command for HelpCommand {
     }
 
     fn clap(&self) -> App<'static> {
-        App::new("help").about("show help")
+        App::new("help").about(self.about())
     }
 
     fn subcommands(&self) -> Vec<Arc<dyn Command>> {
         vec![]
     }
 
-    fn about(&self) -> &str {
-        "help"
+    fn about(&self) -> &'static str {
+        "show help"
     }
 
     fn is(&self, s: &str) -> bool {

--- a/cli/src/cmds/packages/fetch.rs
+++ b/cli/src/cmds/packages/fetch.rs
@@ -18,6 +18,9 @@ use std::io;
 use std::path::Path;
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use clap::App;
+use clap::Arg;
 use clap::ArgMatches;
 use flate2::read::GzDecoder;
 use fs_extra::dir;
@@ -25,9 +28,6 @@ use fs_extra::move_items;
 use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
 use tar::Archive;
-use async_trait::async_trait;
-use clap::App;
-use clap::Arg;
 
 use crate::cmds::command::Command;
 use crate::cmds::Config;
@@ -206,9 +206,11 @@ impl Command for FetchCommand {
     }
 
     fn clap(&self) -> App<'static> {
-        App::new("fetch")
-            .about(self.about())
-            .arg(Arg::new("version").about("Version of databend package to fetch").default_value("latest"))
+        App::new("fetch").about(self.about()).arg(
+            Arg::new("version")
+                .about("Version of databend package to fetch")
+                .default_value("latest"),
+        )
     }
 
     fn subcommands(&self) -> Vec<Arc<dyn Command>> {
@@ -234,8 +236,9 @@ impl Command for FetchCommand {
                         matches.value_of("version").map(|e| e.to_string()),
                     )?;
                     writer.write_ok(format!("Tag {}", current_tag).as_str());
-                    if let Err(e) =
-                        self.download_databend(&arch, current_tag.as_str(), writer, args).await
+                    if let Err(e) = self
+                        .download_databend(&arch, current_tag.as_str(), writer, args)
+                        .await
                     {
                         writer.write_err(format!("{:?}", e).as_str());
                     }
@@ -249,6 +252,5 @@ impl Command for FetchCommand {
         }
 
         Ok(())
-
     }
 }

--- a/cli/src/cmds/packages/fetch.rs
+++ b/cli/src/cmds/packages/fetch.rs
@@ -207,7 +207,7 @@ impl Command for FetchCommand {
 
     fn clap(&self) -> App<'static> {
         App::new("fetch")
-            .about("Fetch the given version binary package")
+            .about(self.about())
             .arg(Arg::new("version").about("Version of databend package to fetch").default_value("latest"))
     }
 
@@ -215,7 +215,7 @@ impl Command for FetchCommand {
         vec![]
     }
 
-    fn about(&self) -> &str {
+    fn about(&self) -> &'static str {
         "Fetch the given version binary package"
     }
 

--- a/cli/src/cmds/packages/list.rs
+++ b/cli/src/cmds/packages/list.rs
@@ -13,13 +13,16 @@
 // limitations under the License.
 
 use std::fs;
+use std::sync::Arc;
 
 use clap::ArgMatches;
 use comfy_table::Cell;
 use comfy_table::CellAlignment;
 use comfy_table::Color;
 use comfy_table::Table;
+use clap::App;
 
+use crate::cmds::command::Command;
 use crate::cmds::Config;
 use crate::cmds::Status;
 use crate::cmds::Writer;
@@ -34,7 +37,32 @@ impl ListCommand {
     pub fn create(conf: Config) -> Self {
         ListCommand { conf }
     }
-    pub fn exec_match(&self, writer: &mut Writer, _args: Option<&ArgMatches>) -> Result<()> {
+}
+
+#[async_trait::async_trait]
+impl Command for ListCommand {
+    fn name(&self) -> &str {
+        "list"
+    }
+
+    fn clap(&self) -> App<'static> {
+        App::new("list")
+            .about("List all the packages")
+    }
+
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![]
+    }
+
+    fn about(&self) -> &str {
+        "list all the packages"
+    }
+
+    fn is(&self, s: &str) -> bool {
+        s.contains(self.name())
+    }
+
+    async fn exec_matches(&self, writer: &mut Writer, _args: Option<&ArgMatches>) -> Result<()> {
         let bin_dir = format!("{}/bin", self.conf.databend_dir.clone());
         let paths = fs::read_dir(bin_dir)?;
 

--- a/cli/src/cmds/packages/list.rs
+++ b/cli/src/cmds/packages/list.rs
@@ -15,12 +15,12 @@
 use std::fs;
 use std::sync::Arc;
 
+use clap::App;
 use clap::ArgMatches;
 use comfy_table::Cell;
 use comfy_table::CellAlignment;
 use comfy_table::Color;
 use comfy_table::Table;
-use clap::App;
 
 use crate::cmds::command::Command;
 use crate::cmds::Config;
@@ -46,8 +46,7 @@ impl Command for ListCommand {
     }
 
     fn clap(&self) -> App<'static> {
-        App::new("list")
-            .about(self.about())
+        App::new("list").about(self.about())
     }
 
     fn subcommands(&self) -> Vec<Arc<dyn Command>> {

--- a/cli/src/cmds/packages/list.rs
+++ b/cli/src/cmds/packages/list.rs
@@ -47,15 +47,15 @@ impl Command for ListCommand {
 
     fn clap(&self) -> App<'static> {
         App::new("list")
-            .about("List all the packages")
+            .about(self.about())
     }
 
     fn subcommands(&self) -> Vec<Arc<dyn Command>> {
         vec![]
     }
 
-    fn about(&self) -> &str {
-        "list all the packages"
+    fn about(&self) -> &'static str {
+        "List all the packages"
     }
 
     fn is(&self, s: &str) -> bool {

--- a/cli/src/cmds/packages/package.rs
+++ b/cli/src/cmds/packages/package.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use clap::App;
-use clap::Arg;
 use clap::ArgMatches;
 
 use crate::cmds::command::Command;
@@ -30,34 +29,15 @@ use crate::error::Result;
 #[derive(Clone)]
 pub struct PackageCommand {
     conf: Config,
-    clap: App<'static>,
 }
 
 impl PackageCommand {
     pub fn create(conf: Config) -> Self {
-        let clap = PackageCommand::generate();
-        PackageCommand { conf, clap }
+        PackageCommand { conf }
     }
 
-    pub fn generate() -> App<'static> {
-        return App::new("package")
-            .about("Package manage databend binary releases")
-            .subcommand(
-                App::new("fetch")
-                    .about("Fetch the given version binary package")
-                    .arg(Arg::new("version").about("Version of databend package to fetch").default_value("latest")),
-            )
-            .subcommand(
-                App::new("list")
-                    .about("List all the packages"),
-            )
-            .subcommand(
-                App::new("switch")
-                    .about("Switch the active databend to a specified version")
-                    .arg(Arg::new("version").required(true).about(
-                        "Version of databend package, e.g. v0.4.69-nightly. Check the versions: package list"
-                    ))
-            );
+    pub fn default() -> Self {
+        PackageCommand::create(Config::default())
     }
 }
 
@@ -68,15 +48,25 @@ impl Command for PackageCommand {
     }
 
     fn about(&self) -> &str {
-        "Package command"
+        "Package manage databend binary releases"
     }
 
     fn clap(&self) -> App<'static> {
-        self.clap.clone()
+        let subcommands = self.subcommands();
+        let app = App::new("package")
+            .about("Package manage databend binary releases")
+            .subcommand(subcommands[0].clap())
+            .subcommand(subcommands[1].clap())
+            .subcommand(subcommands[2].clap());
+        app
     }
 
     fn subcommands(&self) -> Vec<Arc<dyn Command>> {
-        vec![]
+        vec![
+            Arc::new(ListCommand::create(self.conf.clone())),
+            Arc::new(FetchCommand::create(self.conf.clone())),
+            Arc::new(SwitchCommand::create(self.conf.clone())),
+        ]
     }
 
     fn is(&self, s: &str) -> bool {
@@ -84,27 +74,6 @@ impl Command for PackageCommand {
     }
 
     async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
-        match args {
-            Some(matches) => match matches.subcommand_name() {
-                Some("fetch") => {
-                    let fetch = FetchCommand::create(self.conf.clone());
-                    fetch.exec_match(writer, matches.subcommand_matches("fetch"))?;
-                }
-                Some("list") => {
-                    let list = ListCommand::create(self.conf.clone());
-                    list.exec_match(writer, matches.subcommand_matches("list"))?;
-                }
-                Some("switch") => {
-                    let switch = SwitchCommand::create(self.conf.clone());
-                    switch.exec_match(writer, matches.subcommand_matches("switch"))?;
-                }
-                _ => writer.write_err("unknown command, usage: package -h"),
-            },
-            None => {
-                println!("None")
-            }
-        }
-
-        Ok(())
+        self.exec_subcommand(writer, args).await
     }
 }

--- a/cli/src/cmds/packages/package.rs
+++ b/cli/src/cmds/packages/package.rs
@@ -47,14 +47,14 @@ impl Command for PackageCommand {
         "package"
     }
 
-    fn about(&self) -> &str {
+    fn about(&self) -> &'static str {
         "Package manage databend binary releases"
     }
 
     fn clap(&self) -> App<'static> {
         let subcommands = self.subcommands();
         let app = App::new("package")
-            .about("Package manage databend binary releases")
+            .about(self.about())
             .subcommand(subcommands[0].clap())
             .subcommand(subcommands[1].clap())
             .subcommand(subcommands[2].clap());

--- a/cli/src/cmds/packages/switch.rs
+++ b/cli/src/cmds/packages/switch.rs
@@ -15,13 +15,13 @@
 use std::fs;
 use std::sync::Arc;
 
-use clap::ArgMatches;
-use clap::Arg;
 use clap::App;
+use clap::Arg;
+use clap::ArgMatches;
 
+use crate::cmds::command::Command;
 use crate::cmds::Config;
 use crate::cmds::ListCommand;
-use crate::cmds::command::Command;
 use crate::cmds::Status;
 use crate::cmds::Writer;
 use crate::error::Result;
@@ -55,8 +55,8 @@ impl Command for SwitchCommand {
         App::new("switch")
             .about(self.about())
             .arg(Arg::new("version").required(true).about(
-                "Version of databend package, e.g. v0.4.69-nightly. Check the versions: package list"
-            ))
+            "Version of databend package, e.g. v0.4.69-nightly. Check the versions: package list",
+        ))
     }
 
     fn subcommands(&self) -> Vec<Arc<dyn Command>> {

--- a/cli/src/cmds/packages/switch.rs
+++ b/cli/src/cmds/packages/switch.rs
@@ -13,11 +13,15 @@
 // limitations under the License.
 
 use std::fs;
+use std::sync::Arc;
 
 use clap::ArgMatches;
+use clap::Arg;
+use clap::App;
 
 use crate::cmds::Config;
 use crate::cmds::ListCommand;
+use crate::cmds::command::Command;
 use crate::cmds::Status;
 use crate::cmds::Writer;
 use crate::error::Result;
@@ -39,8 +43,35 @@ impl SwitchCommand {
 
         Ok(format!("{}", json[0]["name"]).replace("\"", ""))
     }
+}
 
-    pub fn exec_match(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
+#[async_trait::async_trait]
+impl Command for SwitchCommand {
+    fn name(&self) -> &str {
+        "switch"
+    }
+
+    fn clap(&self) -> App<'static> {
+        App::new("switch")
+            .about("Switch the active databend to a specified version")
+            .arg(Arg::new("version").required(true).about(
+                "Version of databend package, e.g. v0.4.69-nightly. Check the versions: package list"
+            ))
+    }
+
+    fn subcommands(&self) -> Vec<Arc<dyn Command>> {
+        vec![]
+    }
+
+    fn about(&self) -> &str {
+        "Fetch the given version binary package"
+    }
+
+    fn is(&self, s: &str) -> bool {
+        s.contains(self.name())
+    }
+
+    async fn exec_matches(&self, writer: &mut Writer, args: Option<&ArgMatches>) -> Result<()> {
         match args {
             Some(matches) => {
                 let bin_dir = format!("{}/bin", self.conf.databend_dir.clone());
@@ -69,7 +100,7 @@ impl SwitchCommand {
                         format!("Can't found version: {}, package list:", current_tag).as_str(),
                     );
                     let list = ListCommand::create(self.conf.clone());
-                    list.exec_match(writer, args)?;
+                    list.exec_matches(writer, args).await?;
                     writer.write_err(
                         format!(
                             "Use command bendctl package fetch {} to retrieve this version",

--- a/cli/src/cmds/packages/switch.rs
+++ b/cli/src/cmds/packages/switch.rs
@@ -53,7 +53,7 @@ impl Command for SwitchCommand {
 
     fn clap(&self) -> App<'static> {
         App::new("switch")
-            .about("Switch the active databend to a specified version")
+            .about(self.about())
             .arg(Arg::new("version").required(true).about(
                 "Version of databend package, e.g. v0.4.69-nightly. Check the versions: package list"
             ))
@@ -63,8 +63,8 @@ impl Command for SwitchCommand {
         vec![]
     }
 
-    fn about(&self) -> &str {
-        "Fetch the given version binary package"
+    fn about(&self) -> &'static str {
+        "Switch the active databend to a specified version"
     }
 
     fn is(&self, s: &str) -> bool {

--- a/cli/src/cmds/queries/query.rs
+++ b/cli/src/cmds/queries/query.rs
@@ -307,7 +307,7 @@ impl Command for QueryCommand {
         self.clap.clone()
     }
 
-    fn about(&self) -> &str {
+    fn about(&self) -> &'static str {
         "Query on databend cluster"
     }
 

--- a/cli/src/cmds/ups/up.rs
+++ b/cli/src/cmds/ups/up.rs
@@ -486,7 +486,7 @@ impl Command for UpCommand {
         self.clap.clone()
     }
 
-    fn about(&self) -> &str {
+    fn about(&self) -> &'static str {
         "Bootstrap a single cluster with dashboard"
     }
 

--- a/cli/src/cmds/versions/version.rs
+++ b/cli/src/cmds/versions/version.rs
@@ -74,7 +74,7 @@ impl Command for VersionCommand {
         VersionCommand::generate()
     }
 
-    fn about(&self) -> &str {
+    fn about(&self) -> &'static str {
         "Databend CLI version"
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

this PR continue the work from #2530 on the package commands.

- make the package subcommands impl the Command trait
- change the return value of `about()` to `&'static str`, removes duplicated description string in the `about` fn and the clap definition 

## Changelog

- Improvement

## Related Issues

## Test Plan

Unit Tests

Stateless Tests

