### PR TITLE
[fix]: resolve ulimit error in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ cli-test:
 	bash ./scripts/ci/ci-run-cli-unit-tests.sh
 
 unit-test:
-	ulimit -c 1024 bash ./scripts/ci/ci-run-unit-tests.sh
+	ulimit -n 10000; bash ./scripts/ci/ci-run-unit-tests.sh
 
 embedded-meta-test: build-debug
 	rm -rf ./_meta_embedded
@@ -69,7 +69,7 @@ embedded-meta-test: build-debug
 
 stateless-test: build-debug
 	rm -rf ./_meta/
-	ulimit -c 1024 bash ./scripts/ci/ci-run-stateless-tests-standalone.sh
+	ulimit -n 10000; bash ./scripts/ci/ci-run-stateless-tests-standalone.sh
 
 stateless-cluster-test: build-debug
 	rm -rf ./_meta/


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

fix `ulimit: too many arguments` 

## Changelog


- Bug Fix


## Related Issues

Fixes #2551

## Test Plan

Unit Tests

Stateless Tests

