### PR TITLE
[ci] work around grcov build break

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,11 +42,7 @@ jobs:
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
 
       - name: Install grcov
-        uses: actions-rs/install@v0.1
-        with:
-          crate: grcov
-          version: latest
-          use-tool-cache: true
+        run: cargo install --locked grcov
 
       - name: Run code coverage
         uses: actions-rs/grcov@v0.1.5


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

use locked deps when installing grcov

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2583 

## Test Plan

Unit Tests

Stateless Tests

