### PR TITLE
ISSUE-2601: add scripts/ci/ci-run-stateless-tests-standalone-s3.sh

### DIFF
--- a/.github/workflows/stateless-tests-standalone.yml
+++ b/.github/workflows/stateless-tests-standalone.yml
@@ -61,13 +61,7 @@ jobs:
       - name: Run Stateless Tests with Standalone mode (ubuntu-latest only)
         if: matrix.config.os == 'ubuntu-latest'
         run: |
-          export STORAGE_TYPE=s3
-          export S3_STORAGE_BUCKET=testbucket
-          export S3_STORAGE_REGION=us-east-1
-          export S3_STORAGE_ENDPOINT_URL=http://127.0.0.1:9000
-          export S3_STORAGE_ACCESS_KEY_ID=minioadmin
-          export S3_STORAGE_SECRET_ACCESS_KEY=minioadmin
-          bash ./scripts/ci/ci-run-stateless-tests-standalone.sh
+          bash ./scripts/ci/ci-run-stateless-tests-standalone-s3.sh
 
       - name: Run Stateless Tests with Standalone mode
         if: matrix.config.os != 'ubuntu-latest'

--- a/scripts/ci/ci-run-stateless-tests-standalone-s3.sh
+++ b/scripts/ci/ci-run-stateless-tests-standalone-s3.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2020-2021 The Databend Authors.
+# SPDX-License-Identifier: Apache-2.0.
+
+echo "*************************************"
+echo "* Setting STORAGE_TYPE to S3.       *"
+echo "*                                   *"
+echo "* Please make sure that S3 backend  *"
+echo "* is ready, and configured properly.*"
+echo "*************************************"
+export STORAGE_TYPE=s3
+export S3_STORAGE_BUCKET=testbucket
+export S3_STORAGE_REGION=us-east-1
+export S3_STORAGE_ENDPOINT_URL=http://127.0.0.1:9000
+export S3_STORAGE_ACCESS_KEY_ID=minioadmin
+export S3_STORAGE_SECRET_ACCESS_KEY=minioadmin
+echo "calling test suite"
+bash ./scripts/ci/ci-run-stateless-tests-standalone.sh
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

- add ci script "scripts/ci/ci-run-stateless-tests-standalone-s3.sh".
- devs can also use this script to launch a local stateless-test 

## Changelog

- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2601

## Test Plan

Unit Tests

Stateless Tests

