### PR TITLE
[function] add trigonometric func

### DIFF
--- a/common/datavalues/src/series/series_impl.rs
+++ b/common/datavalues/src/series/series_impl.rs
@@ -154,7 +154,7 @@ pub trait SeriesTrait: Send + Sync + fmt::Debug {
     /// Unpack to DFArray of data_type u64
     fn u64(&self) -> Result<&DFUInt64Array> {
         Err(ErrorCode::IllegalDataType(format!(
-            "{:?} != u32",
+            "{:?} != u64",
             self.data_type()
         )))
     }

--- a/common/functions/src/scalars/maths/math.rs
+++ b/common/functions/src/scalars/maths/math.rs
@@ -14,11 +14,19 @@
 
 use crate::scalars::function_factory::FunctionFactory;
 use crate::scalars::PiFunction;
+use crate::scalars::TrigonometricCosFunction;
+use crate::scalars::TrigonometricCotFunction;
+use crate::scalars::TrigonometricSinFunction;
+use crate::scalars::TrigonometricTanFunction;
 
 pub struct MathsFunction;
 
 impl MathsFunction {
     pub fn register(factory: &mut FunctionFactory) {
         factory.register("pi", PiFunction::desc());
+        factory.register("sin", TrigonometricSinFunction::desc());
+        factory.register("cos", TrigonometricCosFunction::desc());
+        factory.register("tan", TrigonometricTanFunction::desc());
+        factory.register("cot", TrigonometricCotFunction::desc());
     }
 }

--- a/common/functions/src/scalars/maths/mod.rs
+++ b/common/functions/src/scalars/maths/mod.rs
@@ -14,9 +14,17 @@
 
 #[cfg(test)]
 mod pi_test;
+#[cfg(test)]
+mod trigonometric_test;
 
 mod math;
 mod pi;
+mod trigonometric;
 
 pub use math::MathsFunction;
 pub use pi::PiFunction;
+pub use trigonometric::Trigonometric;
+pub use trigonometric::TrigonometricCosFunction;
+pub use trigonometric::TrigonometricCotFunction;
+pub use trigonometric::TrigonometricSinFunction;
+pub use trigonometric::TrigonometricTanFunction;

--- a/common/functions/src/scalars/maths/trigonometric.rs
+++ b/common/functions/src/scalars/maths/trigonometric.rs
@@ -1,0 +1,147 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use common_datavalues::prelude::*;
+use common_datavalues::DataSchema;
+use common_datavalues::DataType;
+use common_exception::Result;
+
+use crate::scalars::function_factory::FunctionDescription;
+use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::Function;
+
+#[derive(Clone)]
+pub struct TrigonometricFunction {
+    t: Trigonometric,
+}
+
+#[derive(Clone, Debug)]
+pub enum Trigonometric {
+    SIN,
+    COS,
+    COT,
+    TAN,
+}
+
+impl fmt::Display for Trigonometric {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let display = match &self {
+            Trigonometric::SIN => "sin",
+            Trigonometric::COS => "cos",
+            Trigonometric::TAN => "tan",
+            Trigonometric::COT => "cot",
+        };
+        write!(f, "{}", display)
+    }
+}
+
+impl TrigonometricFunction {
+    pub fn try_create_func(t: Trigonometric) -> Result<Box<dyn Function>> {
+        Ok(Box::new(TrigonometricFunction { t }))
+    }
+}
+
+impl Function for TrigonometricFunction {
+    fn name(&self) -> &str {
+        "TrigonometricFunction"
+    }
+
+    fn num_arguments(&self) -> usize {
+        1
+    }
+
+    fn return_type(&self, _args: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Float64)
+    }
+
+    fn nullable(&self, _input_schema: &DataSchema) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {
+        let result = columns[0]
+            .column()
+            .to_minimal_array()?
+            .cast_with_type(&DataType::Float64)?
+            .f64()?
+            .apply_cast_numeric(|v| match self.t {
+                Trigonometric::COS => v.cos(),
+                Trigonometric::SIN => v.sin(),
+                Trigonometric::COT => 1.0 / v.tan(),
+                Trigonometric::TAN => v.tan(),
+            });
+        let column: DataColumn = result.into();
+        Ok(column.resize_constant(columns[0].column().len()))
+    }
+}
+
+impl fmt::Display for TrigonometricFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.t)
+    }
+}
+
+pub struct TrigonometricSinFunction;
+
+impl TrigonometricSinFunction {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
+        TrigonometricFunction::try_create_func(Trigonometric::SIN)
+    }
+
+    pub fn desc() -> FunctionDescription {
+        FunctionDescription::creator(Box::new(Self::try_create_func))
+            .features(FunctionFeatures::default().deterministic())
+    }
+}
+
+pub struct TrigonometricCosFunction;
+
+impl TrigonometricCosFunction {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
+        TrigonometricFunction::try_create_func(Trigonometric::COS)
+    }
+
+    pub fn desc() -> FunctionDescription {
+        FunctionDescription::creator(Box::new(Self::try_create_func))
+            .features(FunctionFeatures::default().deterministic())
+    }
+}
+
+pub struct TrigonometricTanFunction;
+
+impl TrigonometricTanFunction {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
+        TrigonometricFunction::try_create_func(Trigonometric::TAN)
+    }
+
+    pub fn desc() -> FunctionDescription {
+        FunctionDescription::creator(Box::new(Self::try_create_func))
+            .features(FunctionFeatures::default().deterministic())
+    }
+}
+
+pub struct TrigonometricCotFunction;
+
+impl TrigonometricCotFunction {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
+        TrigonometricFunction::try_create_func(Trigonometric::COT)
+    }
+
+    pub fn desc() -> FunctionDescription {
+        FunctionDescription::creator(Box::new(Self::try_create_func))
+            .features(FunctionFeatures::default().deterministic())
+    }
+}

--- a/common/functions/src/scalars/maths/trigonometric_test.rs
+++ b/common/functions/src/scalars/maths/trigonometric_test.rs
@@ -1,0 +1,159 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::f64::consts::PI;
+
+use common_datavalues::prelude::*;
+use common_exception::Result;
+
+use crate::scalars::*;
+
+#[test]
+fn test_trigonometic_function() -> Result<()> {
+    #[allow(dead_code)]
+    struct Test {
+        name: &'static str,
+        display: &'static str,
+        nullable: bool,
+        columns: DataColumn,
+        expect: DataColumn,
+        error: &'static str,
+        func: Box<dyn Function>,
+    }
+
+    let tests = vec![
+        Test {
+            name: "sin-u8-passed",
+            display: "sin",
+            nullable: false,
+            columns: Series::new(vec![0_u8, 1, 3]).into(),
+            func: TrigonometricSinFunction::try_create_func("sin")?,
+            expect: Series::new(vec![0f64, 0.8414709848078965, 0.1411200080598672]).into(),
+            error: "",
+        },
+        Test {
+            name: "sin-u16-passed",
+            display: "sin",
+            nullable: false,
+            columns: Series::new(vec![0_u16, 1, 3]).into(),
+            func: TrigonometricSinFunction::try_create_func("sin")?,
+            expect: Series::new(vec![0f64, 0.8414709848078965, 0.1411200080598672]).into(),
+            error: "",
+        },
+        Test {
+            name: "sin-u32-passed",
+            display: "sin",
+            nullable: false,
+            columns: Series::new(vec![0_u32, 1, 3]).into(),
+            func: TrigonometricSinFunction::try_create_func("sin")?,
+            expect: Series::new(vec![0f64, 0.8414709848078965, 0.1411200080598672]).into(),
+            error: "",
+        },
+        Test {
+            name: "sin-u64-passed",
+            display: "sin",
+            nullable: false,
+            columns: Series::new(vec![0_u64, 1, 3]).into(),
+            func: TrigonometricSinFunction::try_create_func("sin")?,
+            expect: Series::new(vec![0f64, 0.8414709848078965, 0.1411200080598672]).into(),
+            error: "",
+        },
+        Test {
+            name: "sin-str-passed",
+            display: "sin",
+            nullable: false,
+            columns: Series::new(vec!["0", "1", "3"]).into(),
+            func: TrigonometricSinFunction::try_create_func("sin")?,
+            expect: Series::new(vec![0f64, 0.8414709848078965, 0.1411200080598672]).into(),
+            error: "",
+        },
+        Test {
+            name: "sin-bool-passed",
+            display: "sin",
+            nullable: false,
+            columns: Series::new(vec![true]).into(),
+            func: TrigonometricSinFunction::try_create_func("sin")?,
+            expect: Series::new(vec![0.8414709848078965]).into(),
+            error: "",
+        },
+        Test {
+            name: "sin-f64-passed",
+            display: "sin",
+            nullable: false,
+            columns: Series::new(vec![0_f64, 1.0, 3.0]).into(),
+            func: TrigonometricSinFunction::try_create_func("sin")?,
+            expect: Series::new(vec![0f64, 0.8414709848078965, 0.1411200080598672]).into(),
+            error: "",
+        },
+        Test {
+            name: "cos-f64-passed",
+            display: "cos",
+            nullable: false,
+            columns: Series::new(vec![0_f64, 1.0, 3.0]).into(),
+            func: TrigonometricCosFunction::try_create_func("cos")?,
+            expect: Series::new(vec![1f64, 0.5403023058681398, -0.9899924966004454]).into(),
+            error: "",
+        },
+        Test {
+            name: "tan-pi4-passed",
+            display: "tan",
+            nullable: false,
+            columns: Series::new(vec![0_f64, PI / 4.0]).into(),
+            func: TrigonometricTanFunction::try_create_func("tan")?,
+            expect: Series::new(vec![0f64, 0.9999999999999999]).into(),
+            error: "",
+        },
+        Test {
+            name: "cot-pi4-passed",
+            display: "cot",
+            nullable: false,
+            columns: Series::new(vec![PI / 4.0]).into(),
+            func: TrigonometricCotFunction::try_create_func("cot")?,
+            expect: Series::new(vec![1.0000000000000002]).into(),
+            error: "",
+        },
+        Test {
+            name: "cot-0-passed",
+            display: "cot",
+            nullable: false,
+            columns: Series::new(vec![0_f64]).into(),
+            func: TrigonometricCotFunction::try_create_func("cot")?,
+            expect: Series::new(vec![f64::INFINITY]).into(),
+            error: "",
+        },
+    ];
+
+    for t in tests {
+        let func = t.func;
+        let rows = t.columns.len();
+
+        let columns = vec![DataColumnWithField::new(
+            t.columns.clone(),
+            DataField::new("dummpy", t.columns.data_type(), false),
+        )];
+
+        if let Err(e) = func.eval(&columns, rows) {
+            assert_eq!(t.error, e.to_string(), "{}", t.name);
+        }
+
+        // Display check.
+        let expect_display = t.display.to_string();
+        let actual_display = format!("{}", func);
+        assert_eq!(expect_display, actual_display);
+
+        let v = &(func.eval(&columns, rows)?);
+        assert_eq!(v, &t.expect, "{}", t.name);
+    }
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add trigonometric func.

```
mysql> SELECT SIN(PI());
+------------------------------------+
| SIN(PI())                          |
+------------------------------------+
| 0.00000000000000012246467991473532 |
+------------------------------------+
1 row in set (0.01 sec)
Read 1 rows, 1 B in 0.000 sec., 2.46 thousand rows/sec., 2.46 KB/sec.

mysql> SELECT TAN(PI());
+-------------------------------------+
| TAN(PI())                           |
+-------------------------------------+
| -0.00000000000000012246467991473532 |
+-------------------------------------+
1 row in set (0.01 sec)
Read 1 rows, 1 B in 0.000 sec., 2.44 thousand rows/sec., 2.44 KB/sec.

mysql> SELECT TAN(PI()+1);
+--------------------+
| TAN((PI() + 1))    |
+--------------------+
| 1.5574077246549016 |
+--------------------+
1 row in set (0.00 sec)
Read 1 rows, 1 B in 0.001 sec., 1.3 thousand rows/sec., 1.3 KB/sec.

mysql> SELECT COS(PI());
+-----------+
| COS(PI()) |
+-----------+
|        -1 |
+-----------+
1 row in set (0.00 sec)
Read 1 rows, 1 B in 0.000 sec., 2.64 thousand rows/sec., 2.64 KB/sec.

mysql> SELECT COT(12);
+---------------------+
| COT(12)             |
+---------------------+
| -1.5726734063976895 |
+---------------------+
1 row in set (0.00 sec)
Read 1 rows, 1 B in 0.000 sec., 2.58 thousand rows/sec., 2.58 KB/sec.
```

## Changelog

- New Feature

## Related Issues

https://github.com/datafuselabs/databend/issues/2563

## Test Plan

Unit Tests

Stateless Tests

