### PR TITLE
[function] add crc32 function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,6 +1343,7 @@ dependencies = [
  "common-datavalues",
  "common-exception",
  "common-io",
+ "crc32fast",
  "dyn-clone",
  "float-cmp 0.9.0",
  "indexmap",

--- a/common/functions/Cargo.toml
+++ b/common/functions/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0"
 bytes = "1.1.0"
 num = "^0.4"
 ordered-float = "2.8"
+crc32fast = "1.2.1"
 
 [dev-dependencies]
 bumpalo = "3.8.0"

--- a/common/functions/src/scalars/maths/crc32.rs
+++ b/common/functions/src/scalars/maths/crc32.rs
@@ -1,0 +1,82 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use common_datavalues::prelude::*;
+use common_datavalues::DataSchema;
+use common_datavalues::DataType;
+use common_exception::Result;
+use crc32fast::Hasher;
+
+use crate::scalars::function_factory::FunctionDescription;
+use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::Function;
+
+#[derive(Clone)]
+pub struct CRC32Function {
+    _display_name: String,
+}
+
+impl CRC32Function {
+    pub fn try_create(_display_name: &str) -> Result<Box<dyn Function>> {
+        Ok(Box::new(CRC32Function {
+            _display_name: _display_name.to_string(),
+        }))
+    }
+
+    pub fn desc() -> FunctionDescription {
+        FunctionDescription::creator(Box::new(Self::try_create))
+            .features(FunctionFeatures::default().deterministic())
+    }
+}
+
+impl Function for CRC32Function {
+    fn name(&self) -> &str {
+        &*self._display_name
+    }
+
+    fn num_arguments(&self) -> usize {
+        1
+    }
+
+    fn return_type(&self, _args: &[DataType]) -> Result<DataType> {
+        Ok(DataType::UInt32)
+    }
+
+    fn nullable(&self, _input_schema: &DataSchema) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {
+        let result = columns[0]
+            .column()
+            .to_minimal_array()?
+            .cast_with_type(&DataType::String)?
+            .string()?
+            .apply_cast_numeric(|v| {
+                let mut hasher = Hasher::new();
+                hasher.update(v);
+                hasher.finalize()
+            });
+        let column: DataColumn = result.into();
+        Ok(column.resize_constant(columns[0].column().len()))
+    }
+}
+
+impl fmt::Display for CRC32Function {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CRC")
+    }
+}

--- a/common/functions/src/scalars/maths/crc32_test.rs
+++ b/common/functions/src/scalars/maths/crc32_test.rs
@@ -1,0 +1,83 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_datavalues::prelude::*;
+use common_exception::Result;
+
+use crate::scalars::*;
+
+#[test]
+fn test_crc32_function() -> Result<()> {
+    #[allow(dead_code)]
+    struct Test {
+        name: &'static str,
+        display: &'static str,
+        nullable: bool,
+        columns: DataColumn,
+        expect: DataColumn,
+        error: &'static str,
+        func: Box<dyn Function>,
+    }
+    let tests = vec![
+        Test {
+            name: "crc-MySQL-passed",
+            display: "CRC",
+            nullable: false,
+            columns: Series::new(vec!["MySQL"]).into(),
+            func: CRC32Function::try_create("crc")?,
+            expect: Series::new(vec![3259397556u32]).into(),
+            error: "",
+        },
+        Test {
+            name: "crc-mysql-passed",
+            display: "CRC",
+            nullable: false,
+            columns: Series::new(vec!["mysql"]).into(),
+            func: CRC32Function::try_create("crc")?,
+            expect: Series::new(vec![2501908538u32]).into(),
+            error: "",
+        },
+        Test {
+            name: "crc-1-passed",
+            display: "CRC",
+            nullable: true,
+            columns: Series::new(vec![1]).into(),
+            func: CRC32Function::try_create("crc")?,
+            expect: Series::new(vec![2212294583u32]).into(),
+            error: "",
+        },
+    ];
+    for t in tests {
+        let func = t.func;
+        let rows = t.columns.len();
+
+        let columns = vec![DataColumnWithField::new(
+            t.columns.clone(),
+            DataField::new("dummpy", t.columns.data_type(), false),
+        )];
+
+        if let Err(e) = func.eval(&columns, rows) {
+            assert_eq!(t.error, e.to_string(), "{}", t.name);
+        }
+
+        // Display check.
+        let expect_display = t.display.to_string();
+        let actual_display = format!("{}", func);
+        assert_eq!(expect_display, actual_display);
+
+        let v = &(func.eval(&columns, rows)?);
+        assert_eq!(v, &t.expect);
+    }
+    Ok(())
+}

--- a/common/functions/src/scalars/maths/math.rs
+++ b/common/functions/src/scalars/maths/math.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::scalars::function_factory::FunctionFactory;
+use crate::scalars::CRC32Function;
 use crate::scalars::PiFunction;
 use crate::scalars::TrigonometricCosFunction;
 use crate::scalars::TrigonometricCotFunction;
@@ -28,5 +29,6 @@ impl MathsFunction {
         factory.register("cos", TrigonometricCosFunction::desc());
         factory.register("tan", TrigonometricTanFunction::desc());
         factory.register("cot", TrigonometricCotFunction::desc());
+        factory.register("crc32", CRC32Function::desc());
     }
 }

--- a/common/functions/src/scalars/maths/mod.rs
+++ b/common/functions/src/scalars/maths/mod.rs
@@ -13,14 +13,18 @@
 // limitations under the License.
 
 #[cfg(test)]
+mod crc32_test;
+#[cfg(test)]
 mod pi_test;
 #[cfg(test)]
 mod trigonometric_test;
 
+mod crc32;
 mod math;
 mod pi;
 mod trigonometric;
 
+pub use crc32::CRC32Function;
 pub use math::MathsFunction;
 pub use pi::PiFunction;
 pub use trigonometric::Trigonometric;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary
Add crc32 function.

```
mysql> SELECT CRC32('MySQL');
+----------------+
| CRC32('MySQL') |
+----------------+
|     3259397556 |
+----------------+
1 row in set (0.09 sec)
Read 1 rows, 1 B in 0.001 sec., 953.33 rows/sec., 953.33 B/sec.

mysql> SELECT CRC32('mysql');
+----------------+
| CRC32('mysql') |
+----------------+
|     2501908538 |
+----------------+
1 row in set (0.01 sec)
Read 1 rows, 1 B in 0.000 sec., 2.06 thousand rows/sec., 2.06 KB/sec.

mysql> SELECT CRC32(NULL);
+-------------+
| CRC32(NULL) |
+-------------+
|        NULL |
+-------------+
1 row in set (0.00 sec)
Read 1 rows, 1 B in 0.001 sec., 1.79 thousand rows/sec., 1.79 KB/sec.

mysql> SELECT CRC32(12);
+------------+
| CRC32(12)  |
+------------+
| 1330857165 |
+------------+
1 row in set (0.01 sec)
Read 1 rows, 1 B in 0.001 sec., 1.17 thousand rows/sec., 1.17 KB/sec.

```

## Changelog
- New Feature

## Related Issues

https://github.com/datafuselabs/databend/issues/2563

## Test Plan

Unit Tests

Stateless Tests

