### PR TITLE
Try to remove PlanScan in PlanReadSource

### DIFF
--- a/common/datavalues/src/data_schema.rs
+++ b/common/datavalues/src/data_schema.rs
@@ -116,7 +116,12 @@ impl DataSchema {
     }
 
     /// project will do column pruning.
-    pub fn project(&self, fields: Vec<DataField>) -> Self {
+    pub fn project(&self, project_indexes: &[usize]) -> Self {
+        let fields = project_indexes
+            .iter()
+            .map(|i| self.fields[*i].clone())
+            .collect::<Vec<_>>();
+
         Self::new_from(fields, self.meta().clone())
     }
 

--- a/common/planners/src/plan_builder_scan.rs
+++ b/common/planners/src/plan_builder_scan.rs
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
-use common_datavalues::DataSchemaRefExt;
 use common_exception::Result;
 
 use crate::Expression;
-use crate::Extras;
 use crate::PlanBuilder;
 use crate::PlanNode;
 use crate::ScanPlan;
@@ -35,36 +31,15 @@ pub struct TableScanInfo<'a> {
 
 impl PlanBuilder {
     /// Scan a data source
-    pub fn scan(
-        schema_name: &str,
-        table_scan_info: TableScanInfo,
-        projection: Option<Vec<usize>>,
-        limit: Option<usize>,
-    ) -> Result<PlanBuilder> {
+    pub fn scan(schema_name: &str, table_scan_info: TableScanInfo) -> Result<PlanBuilder> {
         let table_schema = DataSchemaRef::new(table_scan_info.table_schema.clone());
-        let projected_schema = projection.clone().map(|p| {
-            DataSchemaRefExt::create(p.iter().map(|i| table_schema.field(*i).clone()).collect())
-                .as_ref()
-                .clone()
-        });
-        let projected_schema = match projected_schema {
-            None => table_schema.clone(),
-            Some(v) => Arc::new(v),
-        };
 
         Ok(PlanBuilder::from(&PlanNode::Scan(ScanPlan {
             schema_name: schema_name.to_owned(),
             table_id: table_scan_info.table_id,
             table_version: table_scan_info.table_version,
             table_schema,
-            projected_schema,
             table_args: table_scan_info.table_args,
-            push_downs: Extras {
-                projection,
-                filters: vec![],
-                limit,
-                order_by: vec![],
-            },
         })))
     }
 }

--- a/common/planners/src/plan_read_datasource.rs
+++ b/common/planners/src/plan_read_datasource.rs
@@ -49,9 +49,7 @@ impl ReadDataSourcePlan {
             self.push_downs
                 .clone()
                 .and_then(|x| x.projection)
-                .and_then(|project_indexes| {
-                    Some(Arc::new(self.table_info.schema().project(&project_indexes)))
-                })
+                .map(|project_indexes| Arc::new(self.table_info.schema().project(&project_indexes)))
                 .unwrap_or_else(|| self.table_info.schema())
         }
     }
@@ -64,12 +62,12 @@ impl ReadDataSourcePlan {
             self.push_downs
                 .clone()
                 .and_then(|x| x.projection)
-                .and_then(|project_indexes| {
+                .map(|project_indexes| {
                     let fields = project_indexes
                         .iter()
                         .map(|i| self.table_info.schema().field(*i).clone());
 
-                    Some((project_indexes.iter().cloned().zip(fields)).collect::<BTreeMap<_, _>>())
+                    (project_indexes.iter().cloned().zip(fields)).collect::<BTreeMap<_, _>>()
                 })
                 .unwrap_or_else(|| self.table_info.schema().fields_map())
         }

--- a/common/planners/src/plan_rewriter.rs
+++ b/common/planners/src/plan_rewriter.rs
@@ -283,18 +283,7 @@ pub trait PlanRewriter {
     }
 
     fn rewrite_read_data_source(&mut self, plan: &ReadDataSourcePlan) -> Result<PlanNode> {
-        let need_rewrite_plan = PlanNode::Scan(plan.scan_plan.as_ref().clone());
-        let new_scan = self.rewrite_plan_node(&need_rewrite_plan)?;
-        match new_scan {
-            PlanNode::Scan(new_scan) => {
-                let mut rewrite_plan = plan.clone();
-                rewrite_plan.scan_plan = Arc::new(new_scan);
-                Ok(PlanNode::ReadSource(rewrite_plan))
-            }
-            _ => Err(ErrorCode::BadPlanInputs(
-                "Rewrite ReadDataSource need scan plan.",
-            )),
-        }
+        Ok(PlanNode::ReadSource(plan.clone()))
     }
 
     fn rewrite_select(&mut self, plan: &SelectPlan) -> Result<PlanNode> {

--- a/common/planners/src/plan_scan.rs
+++ b/common/planners/src/plan_scan.rs
@@ -20,7 +20,6 @@ use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 
 use crate::Expression;
-use crate::Extras;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct ScanPlan {
@@ -31,14 +30,11 @@ pub struct ScanPlan {
     // The schema of the source data
     pub table_schema: DataSchemaRef,
     pub table_args: Option<Expression>,
-    pub projected_schema: DataSchemaRef,
-    // Extras.
-    pub push_downs: Extras,
 }
 
 impl ScanPlan {
     pub fn schema(&self) -> DataSchemaRef {
-        self.projected_schema.clone()
+        self.table_schema.clone()
     }
 
     pub fn with_table_id(table_id: u64, table_version: Option<u64>) -> ScanPlan {
@@ -47,9 +43,7 @@ impl ScanPlan {
             table_id,
             table_version,
             table_schema: Arc::new(DataSchema::empty()),
-            projected_schema: Arc::new(DataSchema::empty()),
             table_args: None,
-            push_downs: Extras::default(),
         }
     }
 
@@ -59,9 +53,7 @@ impl ScanPlan {
             table_id: 0,
             table_version: None,
             table_schema: Arc::new(DataSchema::empty()),
-            projected_schema: Arc::new(DataSchema::empty()),
             table_args: None,
-            push_downs: Extras::default(),
         }
     }
 }

--- a/common/planners/src/plan_scan_test.rs
+++ b/common/planners/src/plan_scan_test.rs
@@ -27,12 +27,6 @@ fn test_scan_plan() -> Result<()> {
         table_version: None,
         table_schema: DataSchemaRefExt::create(vec![DataField::new("a", DataType::String, false)]),
         table_args: None,
-        projected_schema: DataSchemaRefExt::create(vec![DataField::new(
-            "a",
-            DataType::String,
-            false,
-        )]),
-        push_downs: Extras::default(),
     });
 
     let _ = scan.schema();

--- a/common/planners/src/test.rs
+++ b/common/planners/src/test.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use common_datavalues::DataField;
 use common_datavalues::DataSchemaRefExt;
 use common_datavalues::DataType;
@@ -24,7 +22,6 @@ use crate::Part;
 use crate::Partitions;
 use crate::PlanNode;
 use crate::ReadDataSourcePlan;
-use crate::ScanPlan;
 use crate::Statistics;
 
 pub struct Test {}
@@ -46,7 +43,6 @@ impl Test {
 
         Ok(PlanNode::ReadSource(ReadDataSourcePlan {
             table_info: TableInfo::simple("system", "numbers_mt", schema),
-            scan_fields: None,
             parts: Self::generate_partitions(8, total as u64),
             statistics: statistics.clone(),
             description: format!(
@@ -55,6 +51,7 @@ impl Test {
             ),
             tbl_args: None,
             push_downs: None,
+            benefit_column_prune: false,
         }))
     }
 

--- a/common/planners/src/test.rs
+++ b/common/planners/src/test.rs
@@ -53,7 +53,6 @@ impl Test {
                 "(Read from system.numbers_mt table, Exactly Read Rows:{}, Read Bytes:{})",
                 statistics.read_rows, statistics.read_bytes
             ),
-            scan_plan: Arc::new(ScanPlan::empty()),
             tbl_args: None,
             push_downs: None,
         }))

--- a/query/src/catalogs/table.rs
+++ b/query/src/catalogs/table.rs
@@ -57,6 +57,11 @@ pub trait Table: Sync + Send {
 
     fn get_table_info(&self) -> &TableInfo;
 
+    /// whether column prune(projection) can help in table read
+    fn benefit_column_prune(&self) -> bool {
+        false
+    }
+
     // defaults to generate one single part and empty statistics
     fn read_partitions(
         &self,
@@ -145,14 +150,12 @@ impl ToReadDataSourcePlan for dyn Table {
 
         Ok(ReadDataSourcePlan {
             table_info: table_info.clone(),
-
-            scan_fields: None,
             parts,
             statistics,
             description,
-            scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
             tbl_args: self.table_args(),
             push_downs,
+            benefit_column_prune: self.benefit_column_prune(),
         })
     }
 }

--- a/query/src/datasources/table/csv/csv_table_test.rs
+++ b/query/src/datasources/table/csv/csv_table_test.rs
@@ -61,27 +61,10 @@ async fn test_csv_table() -> Result<()> {
         Arc::new(TableDataContext::default()),
     )?;
 
-    let scan_plan = &ScanPlan {
-        schema_name: "".to_string(),
-        table_schema: DataSchemaRefExt::create(vec![]),
-        table_id: 0,
-        table_version: None,
-        table_args: None,
-        projected_schema: DataSchemaRefExt::create(vec![DataField::new(
-            "column1",
-            DataType::UInt64,
-            false,
-        )]),
-        push_downs: Extras::default(),
-    };
     let partitions = ctx.get_settings().get_max_threads()? as usize;
     let io_ctx = ctx.get_single_node_table_io_context()?;
     let io_ctx = Arc::new(io_ctx);
-    let source_plan = table.read_plan(
-        io_ctx.clone(),
-        Some(scan_plan.push_downs.clone()),
-        Some(partitions),
-    )?;
+    let source_plan = table.read_plan(io_ctx.clone(), None, Some(partitions))?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
 
     let stream = table.read(io_ctx, &source_plan).await?;
@@ -140,27 +123,10 @@ async fn test_csv_table_parse_error() -> Result<()> {
         Arc::new(TableDataContext::default()),
     )?;
 
-    let scan_plan = &ScanPlan {
-        schema_name: "".to_string(),
-        table_id: 0,
-        table_version: None,
-        table_schema: DataSchemaRefExt::create(vec![]),
-        table_args: None,
-        projected_schema: DataSchemaRefExt::create(vec![DataField::new(
-            "column2",
-            DataType::UInt64,
-            false,
-        )]),
-        push_downs: Extras::default(),
-    };
     let partitions = ctx.get_settings().get_max_threads()? as usize;
     let io_ctx = ctx.get_single_node_table_io_context()?;
     let io_ctx = Arc::new(io_ctx);
-    let source_plan = table.read_plan(
-        io_ctx.clone(),
-        Some(scan_plan.push_downs.clone()),
-        Some(partitions),
-    )?;
+    let source_plan = table.read_plan(io_ctx.clone(), None, Some(partitions))?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
 
     let stream = table.read(io_ctx, &source_plan).await?;

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -63,6 +63,10 @@ impl Table for FuseTable {
         &self.table_info
     }
 
+    fn benefit_column_prune(&self) -> bool {
+        true
+    }
+
     fn read_partitions(
         &self,
         io_ctx: Arc<TableIOContext>,

--- a/query/src/datasources/table/fuse/table_test.rs
+++ b/query/src/datasources/table/fuse/table_test.rs
@@ -69,12 +69,12 @@ async fn test_fuse_table_simple_case() -> Result<()> {
     let stream = table
         .read(io_ctx, &ReadDataSourcePlan {
             table_info: Default::default(),
-            scan_fields: None,
             parts: Default::default(),
             statistics: Default::default(),
             description: "".to_string(),
             tbl_args: None,
             push_downs: None,
+            benefit_column_prune: false,
         })
         .await?;
     let blocks = stream.try_collect::<Vec<_>>().await?;

--- a/query/src/datasources/table/fuse/table_test.rs
+++ b/query/src/datasources/table/fuse/table_test.rs
@@ -73,7 +73,6 @@ async fn test_fuse_table_simple_case() -> Result<()> {
             parts: Default::default(),
             statistics: Default::default(),
             description: "".to_string(),
-            scan_plan: Arc::new(Default::default()),
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/table_func/numbers_table_test.rs
+++ b/query/src/datasources/table_func/numbers_table_test.rs
@@ -30,27 +30,13 @@ async fn test_number_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
     let table = NumbersTable::create("system", "numbers_mt", 1, tbl_args)?;
 
-    let scan = &ScanPlan {
-        schema_name: "scan_test".to_string(),
-        table_id: 0,
-        table_version: None,
-        table_schema: DataSchemaRefExt::create(vec![]),
-        table_args: Some(Expression::create_literal(DataValue::UInt64(Some(8)))),
-        projected_schema: DataSchemaRefExt::create(vec![DataField::new(
-            "number",
-            DataType::UInt64,
-            false,
-        )]),
-        push_downs: Extras::default(),
-    };
     let partitions = ctx.get_settings().get_max_threads()? as usize;
     let io_ctx = ctx.get_single_node_table_io_context()?;
     let io_ctx = Arc::new(io_ctx);
-    let source_plan = table.clone().as_table().read_plan(
-        io_ctx.clone(),
-        Some(scan.push_downs.clone()),
-        Some(partitions),
-    )?;
+    let source_plan = table
+        .clone()
+        .as_table()
+        .read_plan(io_ctx.clone(), None, Some(partitions))?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
 
     let stream = table.read(io_ctx, &source_plan).await?;

--- a/query/src/interpreters/plan_scheduler.rs
+++ b/query/src/interpreters/plan_scheduler.rs
@@ -857,7 +857,7 @@ impl PlanScheduler {
 
         table.read_plan(
             io_ctx.clone(),
-            push_downs.clone(),
+            push_downs,
             Some(io_ctx.get_max_threads() * io_ctx.get_query_node_ids().len()),
         )
     }

--- a/query/src/interpreters/plan_scheduler.rs
+++ b/query/src/interpreters/plan_scheduler.rs
@@ -28,6 +28,7 @@ use common_planners::EmptyPlan;
 use common_planners::Expression;
 use common_planners::ExpressionPlan;
 use common_planners::Expressions;
+use common_planners::Extras;
 use common_planners::FilterPlan;
 use common_planners::HavingPlan;
 use common_planners::LimitByPlan;
@@ -37,7 +38,6 @@ use common_planners::PlanNode;
 use common_planners::ProjectionPlan;
 use common_planners::ReadDataSourcePlan;
 use common_planners::RemotePlan;
-use common_planners::ScanPlan;
 use common_planners::SelectPlan;
 use common_planners::SortPlan;
 use common_planners::StageKind;
@@ -796,7 +796,7 @@ impl PlanScheduler {
         match table.is_local() {
             true => self.visit_local_data_source(plan),
             false => {
-                let cluster_source = self.cluster_source(&plan.scan_plan, table.clone())?;
+                let cluster_source = self.cluster_source(plan.push_downs.clone(), table.clone())?;
                 self.visit_cluster_data_source(&cluster_source)
             }
         }
@@ -846,14 +846,18 @@ impl PlanScheduler {
 }
 
 impl PlanScheduler {
-    fn cluster_source(&mut self, node: &ScanPlan, table: TablePtr) -> Result<ReadDataSourcePlan> {
+    fn cluster_source(
+        &mut self,
+        push_downs: Option<Extras>,
+        table: TablePtr,
+    ) -> Result<ReadDataSourcePlan> {
         let io_ctx = self.query_context.get_cluster_table_io_context()?;
 
         let io_ctx = Arc::new(io_ctx);
 
         table.read_plan(
             io_ctx.clone(),
-            Some(node.push_downs.clone()),
+            push_downs.clone(),
             Some(io_ctx.get_max_threads() * io_ctx.get_query_node_ids().len()),
         )
     }

--- a/query/src/optimizers/optimizer_expression_transform.rs
+++ b/query/src/optimizers/optimizer_expression_transform.rs
@@ -244,7 +244,6 @@ impl PlanRewriter for ExprTransformImpl {
             // then we overwrites the ReadDataSourcePlan to an empty one.
             let node = PlanNode::ReadSource(ReadDataSourcePlan {
                 table_info: plan.table_info.clone(),
-                scan_fields: plan.scan_fields.clone(),
                 parts: vec![], // set parts to empty vector, read_table should return None immediately
                 statistics: Statistics {
                     read_rows: 0,
@@ -252,9 +251,9 @@ impl PlanRewriter for ExprTransformImpl {
                     is_exact: true,
                 },
                 description: format!("(Read from {} table)", plan.table_info.desc),
-                scan_plan: plan.scan_plan.clone(),
                 tbl_args: plan.tbl_args.clone(),
                 push_downs: plan.push_downs.clone(),
+                benefit_column_prune: plan.benefit_column_prune,
             });
             return Ok(node);
         }

--- a/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/query/src/optimizers/optimizer_projection_push_down.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
 use std::collections::HashSet;
 
-use common_datavalues::DataField;
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
@@ -25,6 +23,7 @@ use common_planners::AggregatorPartialPlan;
 use common_planners::EmptyPlan;
 use common_planners::Expression;
 use common_planners::ExpressionPlan;
+use common_planners::Extras;
 use common_planners::FilterPlan;
 use common_planners::PlanBuilder;
 use common_planners::PlanNode;
@@ -117,19 +116,22 @@ impl PlanRewriter for ProjectionPushDownImpl {
     }
 
     fn rewrite_read_data_source(&mut self, plan: &ReadDataSourcePlan) -> Result<PlanNode> {
-        // TODO: rewrite scan
-        self.get_projected_fields(plan.table_info.schema().as_ref())
-            .map(|projected_fields| {
-                PlanNode::ReadSource(ReadDataSourcePlan {
-                    table_info: plan.table_info.clone(),
-                    scan_fields: Some(projected_fields),
-                    parts: plan.parts.clone(),
-                    statistics: plan.statistics.clone(),
-                    description: plan.description.to_string(),
-                    scan_plan: plan.scan_plan.clone(),
-                    tbl_args: plan.tbl_args.clone(),
-                    push_downs: plan.push_downs.clone(),
-                })
+        self.get_projection(plan.table_info.schema().as_ref())
+            .map(|projection| {
+                let mut new_plan = plan.clone();
+                new_plan.push_downs = match &plan.push_downs {
+                    Some(extras) => {
+                        let mut new_extras = extras.clone();
+                        new_extras.projection = Some(projection);
+                        Some(new_extras)
+                    }
+                    None => {
+                        let mut extras = Extras::default();
+                        extras.projection = Some(projection);
+                        Some(extras)
+                    }
+                };
+                PlanNode::ReadSource(new_plan)
             })
     }
 }
@@ -164,9 +166,8 @@ impl ProjectionPushDownImpl {
         Ok(())
     }
 
-    fn get_projected_fields(&self, schema: &DataSchema) -> Result<BTreeMap<usize, DataField>> {
+    fn get_projection(&self, schema: &DataSchema) -> Result<Vec<usize>> {
         // Discard non-existing columns, e.g. when the column derives from aggregation
-
         let mut projection: Vec<usize> = self
             .required_columns
             .iter()
@@ -181,17 +182,11 @@ impl ProjectionPushDownImpl {
             } else {
                 // for table scan without projection
                 // just return all columns
-                return Ok(schema.fields_map());
+                return Ok((0..schema.fields().len()).collect());
             }
         }
 
-        let mut res = BTreeMap::new();
-
-        for i in &projection {
-            res.insert(*i, schema.fields()[*i].clone());
-        }
-
-        Ok(res)
+        Ok(projection)
     }
 }
 

--- a/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/query/src/optimizers/optimizer_projection_push_down.rs
@@ -118,6 +118,11 @@ impl PlanRewriter for ProjectionPushDownImpl {
     fn rewrite_read_data_source(&mut self, plan: &ReadDataSourcePlan) -> Result<PlanNode> {
         self.get_projection(plan.table_info.schema().as_ref())
             .map(|projection| {
+                // No need to rewrite projection if it is full
+                if projection.len() == plan.table_info.schema().fields().len() {
+                    return PlanNode::ReadSource(plan.clone());
+                }
+
                 let mut new_plan = plan.clone();
                 new_plan.push_downs = match &plan.push_downs {
                     Some(extras) => {

--- a/query/src/optimizers/optimizer_projection_push_down_test.rs
+++ b/query/src/optimizers/optimizer_projection_push_down_test.rs
@@ -101,7 +101,6 @@ fn test_projection_push_down_optimizer_2() -> Result<()> {
                 DataField::new("c", DataType::String, false),
             ]),
         ),
-        scan_fields: None,
         parts: generate_partitions(8, total as u64),
         statistics: statistics.clone(),
         description: format!(
@@ -112,6 +111,7 @@ fn test_projection_push_down_optimizer_2() -> Result<()> {
         ),
         tbl_args: None,
         push_downs: None,
+        benefit_column_prune: false,
     });
 
     let filter_plan = PlanBuilder::from(&source_plan)
@@ -159,7 +159,6 @@ fn test_projection_push_down_optimizer_3() -> Result<()> {
                 DataField::new("g", DataType::String, false),
             ]),
         ),
-        scan_fields: None,
         parts: generate_partitions(8, total as u64),
         statistics: statistics.clone(),
         description: format!(
@@ -170,6 +169,7 @@ fn test_projection_push_down_optimizer_3() -> Result<()> {
         ),
         tbl_args: None,
         push_downs: None,
+        benefit_column_prune: false,
     });
 
     let group_exprs = &[col("a"), col("c")];

--- a/query/src/optimizers/optimizer_projection_push_down_test.rs
+++ b/query/src/optimizers/optimizer_projection_push_down_test.rs
@@ -110,7 +110,6 @@ fn test_projection_push_down_optimizer_2() -> Result<()> {
             statistics.read_rows,
             statistics.read_bytes
         ),
-        scan_plan: Arc::new(ScanPlan::empty()),
         tbl_args: None,
         push_downs: None,
     });
@@ -169,7 +168,6 @@ fn test_projection_push_down_optimizer_3() -> Result<()> {
             statistics.read_rows,
             statistics.read_bytes
         ),
-        scan_plan: Arc::new(ScanPlan::empty()),
         tbl_args: None,
         push_downs: None,
     });

--- a/query/src/optimizers/optimizer_statistics_exact.rs
+++ b/query/src/optimizers/optimizer_statistics_exact.rs
@@ -73,16 +73,16 @@ impl PlanRewriter for StatisticsExactImpl<'_> {
                                 table_schema: &table.schema(),
                                 table_args: None,
                             };
-                            PlanBuilder::scan(db_name, tbl_scan_info, None, None)
+                            PlanBuilder::scan(db_name, tbl_scan_info)
                                 .and_then(|builder| builder.build())
                                 .and_then(|dummy_scan_plan| match dummy_scan_plan {
-                                    PlanNode::Scan(ref dummy_scan_plan) => {
+                                    PlanNode::Scan(_) => {
                                         //
                                         let io_ctx = self.ctx.get_single_node_table_io_context()?;
                                         table
                                             .read_plan(
                                                 Arc::new(io_ctx),
-                                                Some(dummy_scan_plan.push_downs.clone()),
+                                                None,
                                                 Some(self.ctx.get_settings().get_max_threads()?
                                                     as usize),
                                             )

--- a/query/src/optimizers/optimizer_statistics_exact_test.rs
+++ b/query/src/optimizers/optimizer_statistics_exact_test.rs
@@ -53,7 +53,6 @@ mod tests {
                 statistics.read_rows,
                 statistics.read_bytes
             ),
-            scan_plan: Arc::new(ScanPlan::empty()),
             tbl_args: None,
             push_downs: None,
         });

--- a/query/src/optimizers/optimizer_statistics_exact_test.rs
+++ b/query/src/optimizers/optimizer_statistics_exact_test.rs
@@ -15,7 +15,6 @@
 #[cfg(test)]
 mod tests {
     use std::mem::size_of;
-    use std::sync::Arc;
 
     use common_datavalues::*;
     use common_exception::Result;
@@ -44,7 +43,6 @@ mod tests {
                     DataField::new("c", DataType::String, false),
                 ]),
             ),
-            scan_fields: None,
             parts: generate_partitions(8, total as u64),
             statistics: statistics.clone(),
             description: format!(
@@ -55,6 +53,7 @@ mod tests {
             ),
             tbl_args: None,
             push_downs: None,
+            benefit_column_prune: false,
         });
 
         let aggr_expr = Expression::AggregateFunction {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR

- Try to remove PlanScan in PlanReadSource
- Make pushdowns work for fuse table
- Add benefit_column_prune in table trait

## Changelog

 
- Bug Fix
 

## Related Issues

Fixes #2632

## Test Plan

Unit Tests

Stateless Tests

