### PR TITLE
[common/planners] refactor: remove unused fields: TableScanInfo::{table_name, table_args} ScanPlan::table_args

### DIFF
--- a/common/planners/src/plan_builder_scan.rs
+++ b/common/planners/src/plan_builder_scan.rs
@@ -19,18 +19,15 @@ use common_datavalues::DataSchemaRef;
 use common_datavalues::DataSchemaRefExt;
 use common_exception::Result;
 
-use crate::Expression;
 use crate::Extras;
 use crate::PlanBuilder;
 use crate::PlanNode;
 use crate::ScanPlan;
 
 pub struct TableScanInfo<'a> {
-    pub table_name: &'a str,
     pub table_id: u64,
     pub table_version: Option<u64>,
     pub table_schema: &'a DataSchema,
-    pub table_args: Option<Expression>,
 }
 
 impl PlanBuilder {
@@ -58,7 +55,6 @@ impl PlanBuilder {
             table_version: table_scan_info.table_version,
             table_schema,
             projected_schema,
-            table_args: table_scan_info.table_args,
             push_downs: Extras {
                 projection,
                 filters: vec![],

--- a/common/planners/src/plan_node.rs
+++ b/common/planners/src/plan_node.rs
@@ -49,6 +49,7 @@ use crate::StagePlan;
 use crate::TruncateTablePlan;
 use crate::UseDatabasePlan;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub enum PlanNode {
     Empty(EmptyPlan),

--- a/common/planners/src/plan_scan.rs
+++ b/common/planners/src/plan_scan.rs
@@ -19,7 +19,6 @@ use common_datavalues::DataSchemaRef;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 
-use crate::Expression;
 use crate::Extras;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
@@ -30,7 +29,6 @@ pub struct ScanPlan {
     pub table_version: Option<MetaVersion>,
     // The schema of the source data
     pub table_schema: DataSchemaRef,
-    pub table_args: Option<Expression>,
     pub projected_schema: DataSchemaRef,
     // Extras.
     pub push_downs: Extras,
@@ -48,7 +46,6 @@ impl ScanPlan {
             table_version,
             table_schema: Arc::new(DataSchema::empty()),
             projected_schema: Arc::new(DataSchema::empty()),
-            table_args: None,
             push_downs: Extras::default(),
         }
     }
@@ -60,7 +57,6 @@ impl ScanPlan {
             table_version: None,
             table_schema: Arc::new(DataSchema::empty()),
             projected_schema: Arc::new(DataSchema::empty()),
-            table_args: None,
             push_downs: Extras::default(),
         }
     }

--- a/common/planners/src/plan_scan_test.rs
+++ b/common/planners/src/plan_scan_test.rs
@@ -26,7 +26,6 @@ fn test_scan_plan() -> Result<()> {
         table_id: 0,
         table_version: None,
         table_schema: DataSchemaRefExt::create(vec![DataField::new("a", DataType::String, false)]),
-        table_args: None,
         projected_schema: DataSchemaRefExt::create(vec![DataField::new(
             "a",
             DataType::String,

--- a/query/src/datasources/table/csv/csv_table_test.rs
+++ b/query/src/datasources/table/csv/csv_table_test.rs
@@ -66,7 +66,6 @@ async fn test_csv_table() -> Result<()> {
         table_schema: DataSchemaRefExt::create(vec![]),
         table_id: 0,
         table_version: None,
-        table_args: None,
         projected_schema: DataSchemaRefExt::create(vec![DataField::new(
             "column1",
             DataType::UInt64,
@@ -145,7 +144,6 @@ async fn test_csv_table_parse_error() -> Result<()> {
         table_id: 0,
         table_version: None,
         table_schema: DataSchemaRefExt::create(vec![]),
-        table_args: None,
         projected_schema: DataSchemaRefExt::create(vec![DataField::new(
             "column2",
             DataType::UInt64,

--- a/query/src/datasources/table_func/numbers_table_test.rs
+++ b/query/src/datasources/table_func/numbers_table_test.rs
@@ -35,7 +35,6 @@ async fn test_number_table() -> Result<()> {
         table_id: 0,
         table_version: None,
         table_schema: DataSchemaRefExt::create(vec![]),
-        table_args: Some(Expression::create_literal(DataValue::UInt64(Some(8)))),
         projected_schema: DataSchemaRefExt::create(vec![DataField::new(
             "number",
             DataType::UInt64,

--- a/query/src/optimizers/optimizer_statistics_exact.rs
+++ b/query/src/optimizers/optimizer_statistics_exact.rs
@@ -67,11 +67,9 @@ impl PlanRewriter for StatisticsExactImpl<'_> {
                             let table_version = Some(table.get_table_info().ident.version);
 
                             let tbl_scan_info = TableScanInfo {
-                                table_name,
                                 table_id,
                                 table_version,
                                 table_schema: &table.schema(),
-                                table_args: None,
                             };
                             PlanBuilder::scan(db_name, tbl_scan_info, None, None)
                                 .and_then(|builder| builder.build())

--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -722,11 +722,9 @@ impl PlanParser {
             let table_version = Some(table.get_table_info().ident.version);
 
             let tbl_scan_info = TableScanInfo {
-                table_name,
                 table_id,
                 table_version,
                 table_schema: &table.schema(),
-                table_args: None,
             };
 
             PlanBuilder::scan(db_name, tbl_scan_info, None, None)
@@ -761,7 +759,6 @@ impl PlanParser {
                     db_name = name.0[0].to_string();
                     table_name = name.0[1].to_string();
                 }
-                let table_args = None;
                 let meta_id;
                 let meta_version;
                 let table;
@@ -794,7 +791,6 @@ impl PlanParser {
                     let table_func = self.ctx.get_table_function(&table_name, Some(table_args))?;
                     meta_id = table_func.get_id();
                     meta_version = table_func.get_table_info().ident.version;
-                    table_name = table_func.name().to_string();
                     table = table_func.as_table();
                 } else {
                     table = self.ctx.get_table(&db_name, &table_name)?;
@@ -804,11 +800,9 @@ impl PlanParser {
 
                 let scan = {
                     let tbl_scan_info = TableScanInfo {
-                        table_name: &table_name,
                         table_id: meta_id,
                         table_version: Some(meta_version),
                         table_schema: &table.schema(),
-                        table_args,
                     };
                     PlanBuilder::scan(&db_name, tbl_scan_info, None, None)
                         .and_then(|builder| builder.build())


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/planners] refactor: remove unused fields: TableScanInfo::{table_name, table_args} ScanPlan::table_args

## Changelog




- Improvement


## Related Issues