### PR TITLE
[function] add angle function for math

### DIFF
--- a/common/functions/src/scalars/maths/angle.rs
+++ b/common/functions/src/scalars/maths/angle.rs
@@ -1,0 +1,109 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::marker::PhantomData;
+
+use common_datavalues::prelude::*;
+use common_datavalues::DataSchema;
+use common_datavalues::DataType;
+use common_exception::Result;
+
+use crate::scalars::function_factory::FunctionDescription;
+use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::Function;
+
+#[derive(Clone)]
+pub struct AngleFunction<T> {
+    _display_name: String,
+    t: PhantomData<T>,
+}
+
+pub trait AngleConvertFunction {
+    fn convert(v: f64) -> f64;
+}
+
+impl<T> AngleFunction<T>
+where T: AngleConvertFunction + Clone + Sync + Send + 'static
+{
+    pub fn try_create(display_name: &str) -> Result<Box<dyn Function>> {
+        Ok(Box::new(AngleFunction::<T> {
+            _display_name: display_name.to_string(),
+            t: PhantomData,
+        }))
+    }
+
+    pub fn desc() -> FunctionDescription {
+        FunctionDescription::creator(Box::new(Self::try_create))
+            .features(FunctionFeatures::default().deterministic())
+    }
+}
+
+impl<T> Function for AngleFunction<T>
+where T: AngleConvertFunction + Clone + Sync + Send + 'static
+{
+    fn name(&self) -> &str {
+        "AngleFunction"
+    }
+
+    fn num_arguments(&self) -> usize {
+        1
+    }
+
+    fn return_type(&self, _args: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Float64)
+    }
+
+    fn nullable(&self, _input_schema: &DataSchema) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {
+        let result = columns[0]
+            .column()
+            .to_minimal_array()?
+            .cast_with_type(&DataType::Float64)?
+            .f64()?
+            .apply_cast_numeric(T::convert);
+        let column: DataColumn = result.into();
+        Ok(column.resize_constant(columns[0].column().len()))
+    }
+}
+
+impl<T> fmt::Display for AngleFunction<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self._display_name)
+    }
+}
+
+#[derive(Clone)]
+pub struct ToDegrees;
+
+impl AngleConvertFunction for ToDegrees {
+    fn convert(v: f64) -> f64 {
+        v.to_degrees()
+    }
+}
+
+#[derive(Clone)]
+pub struct ToRadians;
+
+impl AngleConvertFunction for ToRadians {
+    fn convert(v: f64) -> f64 {
+        v.to_radians()
+    }
+}
+
+pub type DegressFunction = AngleFunction<ToDegrees>;
+pub type RadiansFunction = AngleFunction<ToRadians>;

--- a/common/functions/src/scalars/maths/math.rs
+++ b/common/functions/src/scalars/maths/math.rs
@@ -15,7 +15,9 @@
 use crate::scalars::function_factory::FunctionFactory;
 use crate::scalars::AbsFunction;
 use crate::scalars::CRC32Function;
+use crate::scalars::DegressFunction;
 use crate::scalars::PiFunction;
+use crate::scalars::RadiansFunction;
 use crate::scalars::TrigonometricCosFunction;
 use crate::scalars::TrigonometricCotFunction;
 use crate::scalars::TrigonometricSinFunction;
@@ -32,5 +34,7 @@ impl MathsFunction {
         factory.register("tan", TrigonometricTanFunction::desc());
         factory.register("cot", TrigonometricCotFunction::desc());
         factory.register("crc32", CRC32Function::desc());
+        factory.register("degrees", DegressFunction::desc());
+        factory.register("radians", RadiansFunction::desc());
     }
 }

--- a/common/functions/src/scalars/maths/mod.rs
+++ b/common/functions/src/scalars/maths/mod.rs
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 mod abs;
+mod angle;
 mod crc32;
 mod math;
 mod pi;
 mod trigonometric;
 
 pub use abs::AbsFunction;
+pub use angle::DegressFunction;
+pub use angle::RadiansFunction;
 pub use crc32::CRC32Function;
 pub use math::MathsFunction;
 pub use pi::PiFunction;

--- a/common/functions/tests/it/scalars/maths/angle.rs
+++ b/common/functions/tests/it/scalars/maths/angle.rs
@@ -1,0 +1,77 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::f64::consts::PI;
+
+use common_datavalues::prelude::*;
+use common_exception::Result;
+use common_functions::scalars::*;
+
+#[test]
+fn test_angle_function() -> Result<()> {
+    #[allow(dead_code)]
+    struct Test {
+        name: &'static str,
+        display: &'static str,
+        nullable: bool,
+        columns: DataColumn,
+        expect: DataColumn,
+        error: &'static str,
+        func: Box<dyn Function>,
+    }
+
+    let tests = vec![
+        Test {
+            name: "degress-passed",
+            display: "degrees",
+            nullable: false,
+            columns: Series::new(vec![PI, PI / 2.0]).into(),
+            func: DegressFunction::try_create("degrees")?,
+            expect: Series::new(vec![180_f64, 90.0]).into(),
+            error: "",
+        },
+        Test {
+            name: "radians-passed",
+            display: "radians",
+            nullable: false,
+            columns: Series::new(vec![180]).into(),
+            func: RadiansFunction::try_create("radians")?,
+            expect: Series::new(vec![PI]).into(),
+            error: "",
+        },
+    ];
+
+    for t in tests {
+        let func = t.func;
+        let rows = t.columns.len();
+
+        let columns = vec![DataColumnWithField::new(
+            t.columns.clone(),
+            DataField::new("dummpy", t.columns.data_type(), false),
+        )];
+
+        if let Err(e) = func.eval(&columns, rows) {
+            assert_eq!(t.error, e.to_string(), "{}", t.name);
+        }
+
+        // Display check.
+        let expect_display = t.display.to_string();
+        let actual_display = format!("{}", func);
+        assert_eq!(expect_display, actual_display);
+
+        let v = &(func.eval(&columns, rows)?);
+        assert_eq!(v, &t.expect, "{}", t.name);
+    }
+    Ok(())
+}

--- a/common/functions/tests/it/scalars/maths/mod.rs
+++ b/common/functions/tests/it/scalars/maths/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod abs;
+mod angle;
 mod crc32;
 mod pi;
 mod trigonometric;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add angle function for math.

```
mysql> SELECT DEGREES(PI());
+---------------+
| DEGREES(PI()) |
+---------------+
|           180 |
+---------------+
1 row in set (0.01 sec)
Read 1 rows, 1 B in 0.000 sec., 3.22 thousand rows/sec., 3.22 KB/sec.

mysql> SELECT DEGREES(PI() / 2);
+---------------------+
| DEGREES((PI() / 2)) |
+---------------------+
|                  90 |
+---------------------+
1 row in set (0.00 sec)
Read 1 rows, 1 B in 0.001 sec., 1.94 thousand rows/sec., 1.94 KB/sec.

+--------------------+
| RADIANS(90)        |
+--------------------+
| 1.5707963267948966 |
+--------------------+
1 row in set (0.08 sec)
Read 1 rows, 1 B in 0.001 sec., 867.02 rows/sec., 867.02 B/sec.

mysql> SELECT RADIANS(180);
+-------------------+
| RADIANS(180)      |
+-------------------+
| 3.141592653589793 |
+-------------------+
1 row in set (0.01 sec)
Read 1 rows, 1 B in 0.001 sec., 1.78 thousand rows/sec., 1.78 KB/sec.
```

## Changelog

- New Feature

## Related Issues

https://github.com/datafuselabs/databend/issues/2563

## Test Plan

Unit Tests

Stateless Tests

