### PR TITLE
USER-2630: create user

### DIFF
--- a/common/management/src/user/user_api.rs
+++ b/common/management/src/user/user_api.rs
@@ -17,15 +17,8 @@ use std::convert::TryFrom;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::AuthType;
 use common_meta_types::SeqV;
-
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub enum AuthType {
-    None = 0,
-    PlainText = 1,
-    DoubleSha1 = 2,
-    Sha256 = 3,
-}
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct UserInfo {

--- a/common/management/src/user/user_mgr.rs
+++ b/common/management/src/user/user_mgr.rs
@@ -20,12 +20,12 @@ use common_exception::Result;
 use common_exception::ToErrorCode;
 use common_meta_api::KVApi;
 use common_meta_types::AddResult;
+use common_meta_types::AuthType;
 use common_meta_types::IntoSeqV;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::SeqV;
 
-use super::user_api::AuthType;
 use crate::user::user_api::UserInfo;
 use crate::user::user_api::UserMgrApi;
 

--- a/common/management/src/user/user_mgr_test.rs
+++ b/common/management/src/user/user_mgr_test.rs
@@ -29,7 +29,6 @@ use common_meta_types::UpsertKVActionReply;
 use mockall::predicate::*;
 use mockall::*;
 
-use crate::user::user_api::AuthType;
 use crate::user::user_api::UserInfo;
 use crate::user::user_api::UserMgrApi;
 use crate::UserMgr;
@@ -66,6 +65,7 @@ mock! {
 }
 
 mod add {
+    use common_meta_types::AuthType;
 
     use super::*;
 
@@ -177,6 +177,7 @@ mod add {
 }
 
 mod get {
+    use common_meta_types::AuthType;
 
     use super::*;
 
@@ -309,6 +310,7 @@ mod get {
 }
 
 mod get_users {
+    use common_meta_types::AuthType;
 
     use super::*;
 
@@ -438,6 +440,7 @@ mod drop {
 }
 
 mod update {
+    use common_meta_types::AuthType;
 
     use super::*;
 

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -14,6 +14,11 @@
 
 //! This crate defines data types used in meta data storage service.
 
+#[cfg(test)]
+mod cluster_test;
+#[cfg(test)]
+mod match_seq_test;
+
 pub use change::AddResult;
 pub use change::Change;
 pub use cluster::Node;
@@ -47,6 +52,7 @@ pub use table_info::TableIdent;
 pub use table_info::TableInfo;
 pub use table_info::TableMeta;
 pub use table_reply::CreateTableReply;
+pub use user::AuthType;
 
 mod change;
 mod cluster;
@@ -65,8 +71,4 @@ mod seq_num;
 mod seq_value;
 mod table_info;
 mod table_reply;
-
-#[cfg(test)]
-mod cluster_test;
-#[cfg(test)]
-mod match_seq_test;
+mod user;

--- a/common/meta/types/src/user.rs
+++ b/common/meta/types/src/user.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Datafuse Labs.
+// Copyright 2021 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,13 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
-mod namespace;
-mod user;
-
-pub use namespace::NamespaceApi;
-pub use namespace::NamespaceMgr;
-pub use user::user_api::UserInfo;
-pub use user::user_api::UserMgrApi;
-pub use user::user_mgr::UserMgr;
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum AuthType {
+    None = 0,
+    PlainText = 1,
+    DoubleSha1 = 2,
+    Sha256 = 3,
+}

--- a/common/planners/src/plan_user_create.rs
+++ b/common/planners/src/plan_user_create.rs
@@ -16,10 +16,14 @@ use std::sync::Arc;
 
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
+use common_meta_types::AuthType;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct CreateUserPlan {
     pub name: String,
+    pub password: Vec<u8>,
+    pub host_name: String,
+    pub auth_type: AuthType,
 }
 
 impl CreateUserPlan {

--- a/query/src/interpreters/interpreter_factory.rs
+++ b/query/src/interpreters/interpreter_factory.rs
@@ -19,6 +19,7 @@ use common_exception::Result;
 use common_planners::PlanNode;
 
 use crate::interpreters::interpreter_kill::KillInterpreter;
+use crate::interpreters::CreatUserInterpreter;
 use crate::interpreters::CreateDatabaseInterpreter;
 use crate::interpreters::CreateTableInterpreter;
 use crate::interpreters::DescribeTableInterpreter;
@@ -52,6 +53,7 @@ impl InterpreterFactory {
             PlanNode::InsertInto(v) => InsertIntoInterpreter::try_create(ctx, v),
             PlanNode::ShowCreateTable(v) => ShowCreateTableInterpreter::try_create(ctx, v),
             PlanNode::Kill(v) => KillInterpreter::try_create(ctx, v),
+            PlanNode::CreateUser(v) => CreatUserInterpreter::try_create(ctx, v),
             _ => Result::Err(ErrorCode::UnknownTypeOfQuery(format!(
                 "Can't get the interpreter by plan:{}",
                 plan.name()

--- a/query/src/interpreters/interpreter_user_create.rs
+++ b/query/src/interpreters/interpreter_user_create.rs
@@ -1,0 +1,66 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_exception::Result;
+use common_management::UserInfo;
+use common_planners::CreateUserPlan;
+use common_streams::DataBlockStream;
+use common_streams::SendableDataBlockStream;
+use common_tracing::tracing;
+
+use crate::interpreters::Interpreter;
+use crate::interpreters::InterpreterPtr;
+use crate::sessions::DatabendQueryContextRef;
+
+#[derive(Debug)]
+pub struct CreatUserInterpreter {
+    ctx: DatabendQueryContextRef,
+    plan: CreateUserPlan,
+}
+
+impl CreatUserInterpreter {
+    pub fn try_create(
+        ctx: DatabendQueryContextRef,
+        plan: CreateUserPlan,
+    ) -> Result<InterpreterPtr> {
+        Ok(Arc::new(CreatUserInterpreter { ctx, plan }))
+    }
+}
+
+#[async_trait::async_trait]
+impl Interpreter for CreatUserInterpreter {
+    fn name(&self) -> &str {
+        "CreateUserInterpreter"
+    }
+
+    #[tracing::instrument(level = "info", skip(self), fields(ctx.id = self.ctx.get_id().as_str()))]
+    async fn execute(&self) -> Result<SendableDataBlockStream> {
+        let plan = self.plan.clone();
+        let user_mgr = self.ctx.get_sessions_manager().get_user_manager();
+        let user_info = UserInfo {
+            name: plan.name,
+            password: plan.password,
+            auth_type: plan.auth_type,
+        };
+        user_mgr.add_user(user_info).await?;
+
+        Ok(Box::pin(DataBlockStream::create(
+            self.plan.schema(),
+            None,
+            vec![],
+        )))
+    }
+}

--- a/query/src/interpreters/interpreter_user_create_test.rs
+++ b/query/src/interpreters/interpreter_user_create_test.rs
@@ -1,0 +1,42 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_base::tokio;
+use common_exception::Result;
+use common_planners::*;
+use futures::stream::StreamExt;
+use pretty_assertions::assert_eq;
+
+use crate::interpreters::*;
+use crate::sql::*;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_create_user_interpreter() -> Result<()> {
+    common_tracing::init_default_ut_tracing();
+
+    let ctx = crate::tests::try_create_context()?;
+
+    if let PlanNode::CreateUser(plan) = PlanParser::create(ctx.clone())
+        .build_from_sql("CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'")?
+    {
+        let executor = CreatUserInterpreter::try_create(ctx, plan.clone())?;
+        assert_eq!(executor.name(), "CreateUserInterpreter");
+        let mut stream = executor.execute().await?;
+        while let Some(_block) = stream.next().await {}
+    } else {
+        panic!()
+    }
+
+    Ok(())
+}

--- a/query/src/interpreters/mod.rs
+++ b/query/src/interpreters/mod.rs
@@ -35,6 +35,8 @@ mod interpreter_truncate_table_test;
 #[cfg(test)]
 mod interpreter_use_database_test;
 #[cfg(test)]
+mod interpreter_user_create_test;
+#[cfg(test)]
 mod plan_scheduler_test;
 
 mod interpreter;
@@ -52,6 +54,7 @@ mod interpreter_table_create;
 mod interpreter_table_drop;
 mod interpreter_truncate_table;
 mod interpreter_use_database;
+mod interpreter_user_create;
 #[allow(clippy::needless_range_loop)]
 mod plan_scheduler;
 
@@ -70,3 +73,4 @@ pub use interpreter_table_create::CreateTableInterpreter;
 pub use interpreter_table_drop::DropTableInterpreter;
 pub use interpreter_truncate_table::TruncateTableInterpreter;
 pub use interpreter_use_database::UseDatabaseInterpreter;
+pub use interpreter_user_create::CreatUserInterpreter;

--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -337,6 +337,9 @@ impl PlanParser {
     pub fn sql_create_user_to_plan(&self, create: &DfCreateUser) -> Result<PlanNode> {
         Ok(PlanNode::CreateUser(CreateUserPlan {
             name: create.name.clone(),
+            password: Vec::from(create.password.clone()),
+            host_name: create.host_name.clone(),
+            auth_type: create.auth_type.clone(),
         }))
     }
 

--- a/query/src/sql/sql_parser.rs
+++ b/query/src/sql/sql_parser.rs
@@ -18,7 +18,7 @@
 use std::time::Instant;
 
 use common_exception::ErrorCode;
-use common_management::AuthType;
+use common_meta_types::AuthType;
 use common_planners::ExplainType;
 use metrics::histogram;
 use sqlparser::ast::BinaryOperator;

--- a/query/src/sql/sql_parser_test.rs
+++ b/query/src/sql/sql_parser_test.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_exception::Result;
-use common_management::AuthType;
+use common_meta_types::AuthType;
 use sqlparser::ast::*;
 
 use crate::sql::sql_statement::DfDropDatabase;

--- a/query/src/sql/sql_statement.rs
+++ b/query/src/sql/sql_statement.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_management::AuthType;
+use common_meta_types::AuthType;
 use common_planners::ExplainType;
 use nom::bytes::complete::tag;
 use nom::bytes::complete::take_till1;

--- a/query/src/users/user.rs
+++ b/query/src/users/user.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 
-use common_management::AuthType;
 use common_management::UserInfo;
+use common_meta_types::AuthType;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct User {

--- a/query/src/users/user_mgr.rs
+++ b/query/src/users/user_mgr.rs
@@ -15,11 +15,11 @@
 use std::sync::Arc;
 
 use common_exception::Result;
-use common_management::AuthType;
 use common_management::UserInfo;
 use common_management::UserMgr;
 use common_management::UserMgrApi;
 use common_meta_api::KVApi;
+use common_meta_types::AuthType;
 use sha2::Digest;
 
 use crate::common::MetaClientProvider;

--- a/query/src/users/user_mgr_test.rs
+++ b/query/src/users/user_mgr_test.rs
@@ -14,7 +14,7 @@
 
 use common_base::tokio;
 use common_exception::Result;
-use common_management::AuthType;
+use common_meta_types::AuthType;
 use pretty_assertions::assert_eq;
 
 use crate::configs::Config;

--- a/tests/suites/0_stateless/05_0004_ddl_create_user.sql
+++ b/tests/suites/0_stateless/05_0004_ddl_create_user.sql
@@ -1,0 +1,6 @@
+CREATE USER 'test'@'localhost' IDENTIFIED BY 'password';
+CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'; -- {ErrorCode 3001}
+CREATE USER 'test-a'@'localhost' IDENTIFIED WITH plaintext_password BY 'password';
+CREATE USER 'test-b'@'localhost' IDENTIFIED WITH sha256_password BY 'password';
+CREATE USER 'test-c'@'localhost' IDENTIFIED WITH double_sha1_password BY 'password';
+CREATE USER 'test-d@localhost' IDENTIFIED WITH sha256_password BY 'password';


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

1. `CREATE USER 'test'@'localhost' IDENTIFIED BY 'password';`
2. The `host` should add to user info in another PR

## Changelog

- New Feature


## Related Issues

Fixes #2630 

## Test Plan

Unit Tests

Stateless Tests

