### PR TITLE
feat: add reviewers automatically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,41 @@
+# Global rule
+*    @BohuTANG
+
+# Query rule
+/query/                  @datafuselabs/query-guys
+/common/array/           @datafuselabs/query-guys
+/common/cache/           @datafuselabs/query-guys
+/common/clickhouse-srv/  @datafuselabs/query-guys
+/common/context/         @datafuselabs/query-guys
+/common/datablocks/      @datafuselabs/query-guys
+/common/datavalues/      @datafuselabs/query-guys
+/common/flight-rpc/      @datafuselabs/query-guys
+/common/functions/       @datafuselabs/query-guys
+/common/infallible/      @datafuselabs/query-guys
+/common/io/              @datafuselabs/query-guys
+/common/management/      @datafuselabs/query-guys
+/common/mem-allocator/   @datafuselabs/query-guys
+/common/metrics/         @datafuselabs/query-guys
+/common/planners/        @datafuselabs/query-guys
+/common/streams/         @datafuselabs/query-guys
+/common/tracing/         @datafuselabs/query-guys
+
+# Meta rule
+/metasrv                 @datafuselabs/meta-guys
+/kvsrv                   @datafuselabs/meta-guys
+/dfs                     @datafuselabs/meta-guys
+/common/dal/             @datafuselabs/meta-guys
+/common/meta/            @datafuselabs/meta-guys
+/common/raft-store/      @datafuselabs/meta-guys
+/common/sled-store/      @datafuselabs/meta-guys
+
+# Cli rule
+/docker                  @datafuselabs/cli-guys
+/cli                     @datafuselabs/cli-guys
+/common/base/            @datafuselabs/cli-guys
+/common/building/        @datafuselabs/cli-guys
+
+# Tests rule
+
+# Website rule
+/website  @Chasen-Zhang  @wubx


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Use the [Github feature](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax) to add reviewers automatically when a PR is created.

Teams are listed at [here](https://github.com/orgs/datafuselabs/teams), also you can drop you in multiple teams if you need.

## Changelog


- Build/Testing/CI


## Related Issues


## Test Plan

Unit Tests

Stateless Tests

