### PR TITLE
[test] apply the new test style to common_cache

### DIFF
--- a/common/cache/Cargo.toml
+++ b/common/cache/Cargo.toml
@@ -6,6 +6,10 @@ license = "Apache-2.0"
 publish = false
 edition = "2021"
 
+[lib]
+doctest = false
+test = false
+
 [features]
 heapsize = ["heapsize_"]
 amortized = ["ritelinked/ahash-amortized", "ritelinked/inline-more-amortized"]

--- a/common/cache/src/cache.rs
+++ b/common/cache/src/cache.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 pub mod lru;
-#[cfg(test)]
-mod lru_test;
 
 use std::borrow::Borrow;
 use std::hash::BuildHasher;

--- a/common/cache/tests/it/cache.rs
+++ b/common/cache/tests/it/cache.rs
@@ -1,0 +1,15 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod lru;

--- a/common/cache/tests/it/cache/lru.rs
+++ b/common/cache/tests/it/cache/lru.rs
@@ -14,9 +14,9 @@
 
 use std::borrow::Borrow;
 
-use crate::Cache;
-use crate::LruCache;
-use crate::Meter;
+use common_cache::Cache;
+use common_cache::LruCache;
+use common_cache::Meter;
 
 #[test]
 fn test_put_and_get() {

--- a/common/cache/tests/it/cache/lru.rs
+++ b/common/cache/tests/it/cache/lru.rs
@@ -211,7 +211,7 @@ fn test_metered_cache_oversize() {
 #[cfg(not(target_os = "macos"))]
 #[test]
 fn test_heapsize_cache() {
-    use crate::HeapSize;
+    use common_cache::HeapSize;
 
     let mut cache = LruCache::<&str, (u8, u8, u8), _, _>::with_meter(8, HeapSize);
     cache.put("foo1", (1, 2, 3));

--- a/common/cache/tests/it/disk_cache.rs
+++ b/common/cache/tests/it/disk_cache.rs
@@ -20,12 +20,11 @@ use std::io::{self};
 use std::path::Path;
 use std::path::PathBuf;
 
+use common_cache::DiskCacheError;
+use common_cache::LruDiskCache;
 use filetime::set_file_times;
 use filetime::FileTime;
 use tempfile::TempDir;
-
-use crate::DiskCacheError;
-use crate::LruDiskCache;
 
 struct TestFixture {
     /// Temp directory.

--- a/common/cache/tests/it/main.rs
+++ b/common/cache/tests/it/main.rs
@@ -12,27 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
-extern crate log;
-#[cfg(feature = "heapsize")]
-#[cfg(not(target_os = "macos"))]
-extern crate heapsize_;
-
 mod cache;
-#[allow(dead_code)]
 mod disk_cache;
-mod meter;
-
-pub use cache::lru::LruCache;
-pub use cache::Cache;
-pub use disk_cache::result::Error as DiskCacheError;
-pub use disk_cache::result::Result as DiskCacheResult;
-pub use disk_cache::DiskCache;
-pub use disk_cache::LruDiskCache;
-pub use meter::count_meter::Count;
-pub use meter::count_meter::CountableMeter;
-pub use meter::file_meter::FileSize;
-#[cfg(feature = "heapsize")]
-#[cfg(not(target_os = "macos"))]
-pub use meter::heap_meter::HeapSize;
-pub use meter::Meter;


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

apply the new test style to common_cache

## Changelog

- Build/Testing/CI
- Not for changelog (changelog entry is not required)

## Related Issues

Part of  #1866

## Test Plan

Unit Tests

Stateless Tests

