### PR TITLE
number table apply top-n (order-by and limit)

### DIFF
--- a/query/src/pipelines/transforms/mod.rs
+++ b/query/src/pipelines/transforms/mod.rs
@@ -27,6 +27,7 @@ pub use transform_limit_by::LimitByTransform;
 pub use transform_projection::ProjectionTransform;
 pub use transform_remote::RemoteTransform;
 pub use transform_sort_merge::SortMergeTransform;
+pub use transform_sort_partial::get_sort_descriptions;
 pub use transform_sort_partial::SortPartialTransform;
 pub use transform_source::SourceTransform;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

When order-by and limit are set, we just return top-n rows for every scan part.

## Changelog

- Improvement

## Related Issues

Fixes #2617

## Test Plan

Unit Tests

Stateless Tests

