### PR TITLE
Migrate to Poem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,53 +401,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "axum"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f08f95a202e827209db1491047aa57c18c8adb4c5efcfcfd4a2da4838ee3a72"
-dependencies = [
- "async-trait",
- "bitflags",
- "bytes",
- "futures-util",
- "headers",
- "http",
- "http-body",
- "hyper",
- "pin-project-lite",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-server"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269f4732d25f53214f81364220e033b991154aa0afae8d9acede67b74ed16b89"
-dependencies = [
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "parking_lot",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "azure_core_mirror"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,8 +1978,6 @@ dependencies = [
  "anyhow",
  "async-raft",
  "async-trait",
- "axum",
- "axum-server",
  "byteorder",
  "common-arrow",
  "common-base",
@@ -2056,6 +2007,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "num",
  "num_cpus",
+ "poem",
  "pretty_assertions",
  "prost",
  "rand 0.8.4",
@@ -2073,7 +2025,6 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
- "tower",
  "uuid",
 ]
 
@@ -2084,8 +2035,6 @@ dependencies = [
  "ahash",
  "async-compat",
  "async-trait",
- "axum",
- "axum-server",
  "bumpalo",
  "byteorder",
  "bytes",
@@ -2140,6 +2089,7 @@ dependencies = [
  "num_cpus",
  "parquet-format-async-temp",
  "paste",
+ "poem",
  "pretty_assertions",
  "prost",
  "quantiles",
@@ -2160,7 +2110,6 @@ dependencies = [
  "tokio-stream",
  "toml",
  "tonic",
- "tower",
  "uuid",
  "walkdir",
 ]
@@ -3944,6 +3893,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4850,6 +4809,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "poem"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70978aaae37dc18bbd43e5ed31cfd665a79a07bba612477eb808520eb5b1dde"
+dependencies = [
+ "async-trait",
+ "base64 0.13.0",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "mime",
+ "mime_guess",
+ "nom 7.0.0",
+ "parking_lot",
+ "percent-encoding",
+ "pin-project-lite",
+ "poem-derive",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha1",
+ "smallvec",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "poem-derive"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3795975cfc1663ca3932a2fc341b77ace2d81c0f2e1e4ea22348b6767d9d9b75"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "polling"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4957,6 +4961,16 @@ dependencies = [
  "ctor",
  "diff",
  "output_vt100",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -6316,12 +6330,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
-
-[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6775,22 +6783,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b56efe69aa0ad2b5da6b942e57ea9f6fe683b7a314d4ff48662e2c8838de1"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "pin-project",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -65,8 +65,7 @@ tonic = { version = "0.5.2", features = ["tls"]}
 
 sha2 = "0.9.8"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-axum = {version = "0.2.8", features=["headers"] }
-axum-server = { version = "0.2", features = ["tls-rustls"] }
+poem = { version = "1.0.21", features = ["tls"] }
 
 [dev-dependencies]
 common-meta-api = {path = "../common/meta/api" }
@@ -74,7 +73,6 @@ common-meta-api = {path = "../common/meta/api" }
 pretty_assertions = "1.0"
 test-env-log = "0.2.7"
 flaky_test = "0.1"
-tower = { version = "0.4", default-features = false, features = ["util", "buffer", "make"] }
 reqwest = { version = "0.11", features = ["json"] }
 
 [build-dependencies]

--- a/metasrv/src/api/http/debug/home.rs
+++ b/metasrv/src/api/http/debug/home.rs
@@ -14,8 +14,8 @@
 
 use std::num::NonZeroI32;
 
-use axum::response::Html;
-use axum::response::IntoResponse;
+use poem::web::Html;
+use poem::IntoResponse;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct PProfRequest {
@@ -35,10 +35,10 @@ impl PProfRequest {
 }
 
 // return home page for default pprof results
+#[poem::handler]
 pub async fn debug_home_handler() -> impl IntoResponse {
-    return Html(format!(
+    Html(format!(
         r#"<a href="/debug/pprof/profile?seconds={}">pprof/profile</a>"#,
         PProfRequest::default_seconds()
     ))
-    .into_response();
 }

--- a/metasrv/src/api/http/debug/pprof.rs
+++ b/metasrv/src/api/http/debug/pprof.rs
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use axum::body::Body;
-use axum::extract::Query;
-use axum::response::IntoResponse;
 use common_base::tokio::time::Duration;
 use common_base::Profiling;
 use common_tracing::tracing;
+use poem::web::Query;
+use poem::IntoResponse;
 
 use crate::api::http::debug::PProfRequest;
 
 // run pprof
 // example: /debug/pprof/profile?seconds=5&frequency=99
 // req query contains pprofrequest information
+#[poem::handler]
 pub async fn debug_pprof_handler(req: Option<Query<PProfRequest>>) -> impl IntoResponse {
     let profile = match req {
         Some(query) => {
@@ -48,5 +48,5 @@ pub async fn debug_pprof_handler(req: Option<Query<PProfRequest>>) -> impl IntoR
     let body = profile.dump_flamegraph().await.unwrap();
 
     tracing::info!("finished pprof request");
-    Body::from(body).into_response()
+    body
 }

--- a/metasrv/src/api/http/v1/config.rs
+++ b/metasrv/src/api/http/v1/config.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use axum::extract::Extension;
+use poem::web::Data;
 
 use crate::configs::Config;
 
-pub async fn config_handler(cfg: Extension<Config>) -> String {
+#[poem::handler]
+pub async fn config_handler(cfg: Data<&Config>) -> String {
     format!("{:?}", cfg.0)
 }

--- a/metasrv/src/api/http/v1/config_test.rs
+++ b/metasrv/src/api/http/v1/config_test.rs
@@ -14,16 +14,16 @@
  * limitations under the License.
  *
  */
-use axum::body::Body;
-use axum::handler::get;
-use axum::http;
-use axum::http::Request;
-use axum::http::StatusCode;
-use axum::AddExtensionLayer;
-use axum::Router;
 use common_base::tokio;
+use poem::get;
+use poem::http::Method;
+use poem::http::StatusCode;
+use poem::http::Uri;
+use poem::Endpoint;
+use poem::EndpointExt;
+use poem::Request;
+use poem::Route;
 use pretty_assertions::assert_eq;
-use tower::ServiceExt;
 
 use crate::api::http::v1::config::config_handler;
 use crate::configs::Config;
@@ -31,21 +31,18 @@ use crate::configs::Config;
 #[tokio::test]
 async fn test_config() -> common_exception::Result<()> {
     let conf = Config::empty();
-    let cluster_router = Router::new()
-        .route("/v1/config", get(config_handler))
-        .layer(AddExtensionLayer::new(conf.clone()));
+    let cluster_router = Route::new()
+        .at("/v1/config", get(config_handler))
+        .data(conf.clone());
 
     let response = cluster_router
-        .clone()
-        .oneshot(
+        .call(
             Request::builder()
-                .uri("/v1/config")
-                .method(http::Method::GET)
-                .body(Body::empty())
-                .unwrap(),
+                .uri(Uri::from_static("/v1/config"))
+                .method(Method::GET)
+                .finish(),
         )
-        .await
-        .unwrap();
+        .await;
 
     assert_eq!(response.status(), StatusCode::OK);
     Ok(())

--- a/metasrv/src/api/http/v1/health.rs
+++ b/metasrv/src/api/http/v1/health.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
-use axum::response::Json;
+use poem::http::StatusCode;
+use poem::web::Json;
+use poem::IntoResponse;
 
 #[derive(serde::Serialize)]
 pub struct HealthCheckResponse {
@@ -27,10 +27,10 @@ pub enum HealthCheckStatus {
     Pass,
 }
 
+#[poem::handler]
 pub async fn health_handler() -> impl IntoResponse {
     let check = HealthCheckResponse {
         status: HealthCheckStatus::Pass,
     };
-
     (StatusCode::OK, Json(check))
 }

--- a/metasrv/src/api/http/v1/health_test.rs
+++ b/metasrv/src/api/http/v1/health_test.rs
@@ -14,33 +14,30 @@
  * limitations under the License.
  *
  */
-use axum::body::Body;
-use axum::handler::get;
-use axum::http;
-use axum::http::Request;
-use axum::http::StatusCode;
-use axum::Router;
 use common_base::tokio;
+use poem::get;
+use poem::http::Method;
+use poem::http::StatusCode;
+use poem::http::Uri;
+use poem::Endpoint;
+use poem::Request;
+use poem::Route;
 use pretty_assertions::assert_eq;
-use tower::ServiceExt;
 
 use crate::api::http::v1::health::health_handler;
 
 #[tokio::test]
 async fn test_health() -> common_exception::Result<()> {
-    let cluster_router = Router::new().route("/v1/health", get(health_handler));
+    let cluster_router = Route::new().at("/v1/health", get(health_handler));
     // health check
     let response = cluster_router
-        .clone()
-        .oneshot(
+        .call(
             Request::builder()
-                .uri("/v1/health")
-                .method(http::Method::GET)
-                .body(Body::empty())
-                .unwrap(),
+                .uri(Uri::from_static("/v1/health"))
+                .method(Method::GET)
+                .finish(),
         )
-        .await
-        .unwrap();
+        .await;
 
     assert_eq!(response.status(), StatusCode::OK);
 

--- a/metasrv/src/api/http_service.rs
+++ b/metasrv/src/api/http_service.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use axum::handler::get;
-use axum::AddExtensionLayer;
-use axum::Router;
 use common_exception::Result;
+use poem::get;
+use poem::listener::Listener;
+use poem::listener::TcpListener;
+use poem::listener::TlsConfig;
+use poem::Endpoint;
+use poem::EndpointExt;
+use poem::Route;
 
 use crate::configs::Config;
 
@@ -23,31 +27,28 @@ pub struct HttpService {
     cfg: Config,
 }
 
-// build axum router
-macro_rules! build_router {
-    ($cfg: expr) => {
-        Router::new()
-            .route("/v1/health", get(super::http::v1::health::health_handler))
-            .route("/v1/config", get(super::http::v1::config::config_handler))
-            .route(
-                "/debug/home",
-                get(super::http::debug::home::debug_home_handler),
-            )
-            .route(
-                "/debug/pprof/profile",
-                get(super::http::debug::pprof::debug_pprof_handler),
-            )
-            .layer(AddExtensionLayer::new($cfg.clone()))
-    };
-}
-
 impl HttpService {
     pub fn create(cfg: Config) -> Box<Self> {
         Box::new(HttpService { cfg })
     }
 
+    fn build_router(&self) -> impl Endpoint {
+        Route::new()
+            .at("/v1/health", get(super::http::v1::health::health_handler))
+            .at("/v1/config", get(super::http::v1::config::config_handler))
+            .at(
+                "/debug/home",
+                get(super::http::debug::home::debug_home_handler),
+            )
+            .at(
+                "/debug/pprof/profile",
+                get(super::http::debug::pprof::debug_pprof_handler),
+            )
+            .data(self.cfg.clone())
+    }
+
     pub async fn start(&mut self) -> Result<()> {
-        let app = build_router!(self.cfg.clone());
+        let app = self.build_router();
 
         let conf = self.cfg.clone();
         let tls_cert = conf.admin_tls_server_cert;
@@ -57,14 +58,18 @@ impl HttpService {
 
         if !tls_cert.is_empty() && !tls_key.is_empty() {
             log::info!("Http API TLS enabled");
-            axum_server::bind_rustls(address)
-                .private_key_file(tls_key)
-                .certificate_file(tls_cert)
-                .serve(app)
-                .await?;
+            poem::Server::new(
+                TcpListener::bind(address).tls(TlsConfig::new().key(tls_key).cert(tls_cert)),
+            )
+            .await?
+            .run(app)
+            .await?;
         } else {
             log::warn!("Http API TLS not set");
-            axum_server::bind(address).serve(app).await?;
+            poem::Server::new(TcpListener::bind(address))
+                .await?
+                .run(app)
+                .await?;
         }
         Ok(())
     }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -23,7 +23,7 @@ simd = ["common-arrow/simd"]
 # Workspace dependencies
 common-arrow = { path = "../common/arrow" }
 common-base = { path = "../common/base" }
-common-cache = { path = "../common/cache"}
+common-cache = { path = "../common/cache" }
 common-clickhouse-srv = { path = "../common/clickhouse-srv" }
 common-context = { path = "../common/context" }
 common-dal = { path = "../common/dal" }
@@ -38,9 +38,9 @@ common-management = { path = "../common/management" }
 common-mem-allocator = { path = "../common/mem-allocator" }
 common-meta-api = { path = "../common/meta/api" }
 common-meta-embedded = { path = "../common/meta/embedded" }
-common-meta-flight = {path = "../common/meta/flight" }
+common-meta-flight = { path = "../common/meta/flight" }
 common-meta-sled-store = { path = "../common/meta/sled-store" }
-common-meta-types = {path = "../common/meta/types"}
+common-meta-types = { path = "../common/meta/types" }
 common-macros = { path = "../common/macros" }
 common-metrics = { path = "../common/metrics" }
 common-planners = { path = "../common/planners" }
@@ -56,14 +56,13 @@ sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "cd
 ahash = "0.7.6"
 async-compat = "0.2.1"
 async-trait = "0.1"
-axum = {version = "0.2.8", features=["headers"] }
-axum-server = { version = "0.2", features = ["tls-rustls"] }
+poem = { version = "1.0.21", features = ["tls"] }
 bumpalo = "3.8.0"
 byteorder = "1"
 bytes = "1"
 cargo-license = "0.4.2"
 cargo_metadata = "0.14.1"
-chrono =  "0.4.0"
+chrono = "0.4.0"
 chrono-tz = "0.6"
 crossbeam = "0.8"
 crossbeam-queue = "0.3.2"
@@ -109,10 +108,9 @@ mysql = "21.0.1"
 pretty_assertions = "1.0"
 reqwest = { version = "0.11", features = ["json", "native-tls"] }
 tempfile = "3.2.0"
-tower = { version = "0.4", default-features = false, features = ["util", "buffer", "make"] }
 
 [build-dependencies]
-common-building = {path = "../common/building"}
+common-building = { path = "../common/building" }
 
 [[bench]]
 name = "bench_main"

--- a/query/src/api/http/debug/home.rs
+++ b/query/src/api/http/debug/home.rs
@@ -14,8 +14,8 @@
 
 use std::num::NonZeroI32;
 
-use axum::response::Html;
-use axum::response::IntoResponse;
+use poem::web::Html;
+use poem::IntoResponse;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct PProfRequest {
@@ -35,6 +35,7 @@ impl PProfRequest {
 }
 
 // return home page for default pprof results
+#[poem::handler]
 pub async fn debug_home_handler() -> impl IntoResponse {
     return Html(format!(
         r#"<a href="/debug/pprof/profile?seconds={}">pprof/profile</a>"#,

--- a/query/src/api/http/debug/pprof.rs
+++ b/query/src/api/http/debug/pprof.rs
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use axum::body::Body;
-use axum::extract::Query;
-use axum::response::IntoResponse;
 use common_base::tokio::time::Duration;
 use common_base::Profiling;
 use common_tracing::tracing;
+use poem::web::IntoResponse;
+use poem::web::Query;
+use poem::Body;
 
 use crate::api::http::debug::PProfRequest;
 
 // run pprof
 // example: /debug/pprof/profile?seconds=5&frequency=99
 // req query contains pprofrequest information
+#[poem::handler]
 pub async fn debug_pprof_handler(req: Option<Query<PProfRequest>>) -> impl IntoResponse {
     let profile = match req {
         Some(query) => {

--- a/query/src/api/http/v1/cluster_test.rs
+++ b/query/src/api/http/v1/cluster_test.rs
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use axum::body::Body;
-use axum::handler::get;
-use axum::http::Request;
-use axum::http::StatusCode;
-use axum::http::{self};
-use axum::AddExtensionLayer;
-use axum::Router;
 use common_base::tokio;
 use common_exception::Result;
 use common_meta_types::NodeInfo;
+use poem::get;
+use poem::http::header;
+use poem::http::Method;
+use poem::http::StatusCode;
+use poem::http::Uri;
+use poem::Endpoint;
+use poem::EndpointExt;
+use poem::Request;
+use poem::Route;
 use pretty_assertions::assert_eq;
-use tower::ServiceExt;
 
 use crate::api::http::v1::cluster::*;
 use crate::tests::SessionManagerBuilder;
@@ -31,29 +32,25 @@ use crate::tests::SessionManagerBuilder;
 #[tokio::test]
 async fn test_cluster() -> Result<()> {
     let sessions = SessionManagerBuilder::create().build()?;
-    let cluster_router = Router::new()
-        .route("/v1/cluster/list", get(cluster_list_handler))
-        .layer(AddExtensionLayer::new(sessions));
+    let cluster_router = Route::new()
+        .at("/v1/cluster/list", get(cluster_list_handler))
+        .data(sessions);
 
     // List Node
     {
         let response = cluster_router
-            .clone()
-            .oneshot(
+            .call(
                 Request::builder()
-                    .uri("/v1/cluster/list")
-                    .header(http::header::CONTENT_TYPE, "application/json")
-                    .method(http::Method::GET)
-                    .body(Body::empty())
-                    .unwrap(),
+                    .uri(Uri::from_static("/v1/cluster/list"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .method(Method::GET)
+                    .finish(),
             )
-            .await
-            .unwrap();
+            .await;
         assert_eq!(response.status(), StatusCode::OK);
 
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
-        let nodes =
-            serde_json::from_str::<Vec<NodeInfo>>(&String::from_utf8_lossy(&*body.to_vec()))?;
+        let body = response.into_body().into_vec().await.unwrap();
+        let nodes = serde_json::from_str::<Vec<NodeInfo>>(&String::from_utf8_lossy(&body))?;
         assert_eq!(nodes.len(), 1);
     }
 

--- a/query/src/api/http/v1/config.rs
+++ b/query/src/api/http/v1/config.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use axum::extract::Extension;
+use poem::web::Data;
 
 use crate::configs::Config;
 
-pub async fn config_handler(cfg: Extension<Config>) -> String {
+#[poem::handler]
+pub async fn config_handler(cfg: Data<&Config>) -> String {
     format!("{:?}", cfg.0)
 }

--- a/query/src/api/http/v1/health.rs
+++ b/query/src/api/http/v1/health.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
-use axum::response::Json;
+use poem::http::StatusCode;
+use poem::web::Json;
+use poem::IntoResponse;
 
 #[derive(serde::Serialize)]
 pub struct HealthCheckResponse {
@@ -27,6 +27,7 @@ pub enum HealthCheckStatus {
     Pass,
 }
 
+#[poem::handler]
 pub async fn health_handler() -> impl IntoResponse {
     let check = HealthCheckResponse {
         status: HealthCheckStatus::Pass,

--- a/query/src/api/http/v1/health_test.rs
+++ b/query/src/api/http/v1/health_test.rs
@@ -15,32 +15,29 @@
  *
  */
 use common_base::tokio;
+use poem::get;
+use poem::http::Method;
+use poem::http::StatusCode;
+use poem::http::Uri;
+use poem::Endpoint;
+use poem::Request;
+use poem::Route;
+use pretty_assertions::assert_eq;
 
 #[tokio::test]
 async fn test_health() -> common_exception::Result<()> {
-    use axum::body::Body;
-    use axum::handler::get;
-    use axum::http::Request;
-    use axum::http::StatusCode;
-    use axum::http::{self};
-    use axum::Router;
-    use pretty_assertions::assert_eq;
-    use tower::ServiceExt;
-
     use crate::api::http::v1::health::health_handler;
-    let cluster_router = Router::new().route("/v1/health", get(health_handler));
+
+    let cluster_router = Route::new().at("/v1/health", get(health_handler));
     // health check
     let response = cluster_router
-        .clone()
-        .oneshot(
+        .call(
             Request::builder()
-                .uri("/v1/health")
-                .method(http::Method::GET)
-                .body(Body::empty())
-                .unwrap(),
+                .uri(Uri::from_static("/v1/health"))
+                .method(Method::GET)
+                .finish(),
         )
-        .await
-        .unwrap();
+        .await;
 
     assert_eq!(response.status(), StatusCode::OK);
 

--- a/query/src/api/http_service.rs
+++ b/query/src/api/http_service.rs
@@ -12,30 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::BorrowMut;
-use std::fs::File;
-use std::io::BufReader;
 use std::net::SocketAddr;
 use std::path::Path;
-use std::sync::Arc;
 
-use axum::handler::get;
-use axum::routing::BoxRoute;
-use axum::AddExtensionLayer;
-use axum::Router;
-use axum_server;
-use axum_server::tls::TlsLoader;
-use common_base::tokio;
-use common_exception::ErrorCode;
 use common_exception::Result;
-use tokio_rustls::rustls::internal::pemfile::certs;
-use tokio_rustls::rustls::internal::pemfile::pkcs8_private_keys;
-use tokio_rustls::rustls::AllowAnyAuthenticatedClient;
-use tokio_rustls::rustls::Certificate;
-use tokio_rustls::rustls::NoClientAuth;
-use tokio_rustls::rustls::PrivateKey;
-use tokio_rustls::rustls::RootCertStore;
-use tokio_rustls::rustls::ServerConfig;
+use poem::get;
+use poem::listener::TlsConfig;
+use poem::Endpoint;
+use poem::EndpointExt;
+use poem::Route;
 
 use crate::common::service::HttpShutdownHandler;
 use crate::configs::Config;
@@ -55,127 +40,58 @@ impl HttpService {
         })
     }
 
-    fn build_tls(config: &Config) -> Result<ServerConfig> {
-        let tls_key = Path::new(config.query.api_tls_server_key.as_str());
-        let tls_cert = Path::new(config.query.api_tls_server_cert.as_str());
-
-        let key = HttpService::load_keys(tls_key)?.remove(0);
-        let certs = HttpService::load_certs(tls_cert)?;
-
-        let mut tls_config = ServerConfig::new(NoClientAuth::new());
-        if let Err(cause) = tls_config.set_single_cert(certs, key) {
-            return Err(ErrorCode::TLSConfigurationFailure(format!(
-                "Cannot build TLS config for http service, cause {}",
-                cause
-            )));
-        }
-
-        HttpService::add_tls_pem_files(config, tls_config)
-    }
-
-    fn add_tls_pem_files(config: &Config, mut tls_config: ServerConfig) -> Result<ServerConfig> {
-        let pem_path = &config.query.api_tls_server_root_ca_cert;
-        if let Some(pem_path) = HttpService::load_ca(pem_path) {
-            log::info!("Client Authentication for http service.");
-
-            let pem_file = File::open(pem_path.as_str())?;
-            let mut root_cert_store = RootCertStore::empty();
-
-            if root_cert_store
-                .add_pem_file(BufReader::new(pem_file).borrow_mut())
-                .is_err()
-            {
-                return Err(ErrorCode::TLSConfigurationFailure(
-                    "Cannot add client ca in for http service",
-                ));
-            }
-
-            let authenticated_client = AllowAnyAuthenticatedClient::new(root_cert_store);
-            tls_config.set_client_certificate_verifier(authenticated_client);
-        }
-
-        Ok(tls_config)
-    }
-
-    fn load_certs(path: &Path) -> Result<Vec<Certificate>> {
-        match certs(&mut BufReader::new(File::open(path)?)) {
-            Ok(certs) => Ok(certs),
-            Err(_) => Err(ErrorCode::TLSConfigurationFailure("invalid cert")),
-        }
-    }
-
-    // currently only PKCS8 key supports for TLS setup
-    fn load_keys(path: &Path) -> Result<Vec<PrivateKey>> {
-        match pkcs8_private_keys(&mut BufReader::new(File::open(path)?)) {
-            Ok(keys) => Ok(keys),
-            Err(_) => Err(ErrorCode::TLSConfigurationFailure("invalid key")),
-        }
-    }
-
-    // Client Auth(mTLS) CA certificate configuration
-    fn load_ca(ca_path: &str) -> Option<String> {
-        match Path::new(ca_path).exists() {
-            false => None,
-            true => Some(ca_path.to_string()),
-        }
-    }
-
-    fn build_router(&self) -> Router<BoxRoute> {
-        Router::new()
-            .route("/v1/health", get(super::http::v1::health::health_handler))
-            .route("/v1/config", get(super::http::v1::config::config_handler))
-            .route("/v1/logs", get(super::http::v1::logs::logs_handler))
-            .route(
+    fn build_router(&self) -> impl Endpoint {
+        Route::new()
+            .at("/v1/health", get(super::http::v1::health::health_handler))
+            .at("/v1/config", get(super::http::v1::config::config_handler))
+            .at("/v1/logs", get(super::http::v1::logs::logs_handler))
+            .at(
                 "/v1/cluster/list",
                 get(super::http::v1::cluster::cluster_list_handler),
             )
-            .route(
+            .at(
                 "/debug/home",
                 get(super::http::debug::home::debug_home_handler),
             )
-            .route(
+            .at(
                 "/debug/pprof/profile",
                 get(super::http::debug::pprof::debug_pprof_handler),
             )
-            .layer(AddExtensionLayer::new(self.sessions.clone()))
-            .layer(AddExtensionLayer::new(self.sessions.get_conf().clone()))
-            .boxed()
+            .data(self.sessions.clone())
+            .data(self.sessions.get_conf().clone())
+    }
+
+    fn build_tls(config: &Config) -> Result<TlsConfig> {
+        let mut cfg = TlsConfig::new()
+            .cert(std::fs::read(&config.query.api_tls_server_cert.as_str())?)
+            .key(std::fs::read(&config.query.api_tls_server_key.as_str())?);
+        if Path::new(&config.query.api_tls_server_root_ca_cert).exists() {
+            cfg = cfg.client_auth_required(std::fs::read(
+                &config.query.api_tls_server_root_ca_cert.as_str(),
+            )?);
+        }
+        Ok(cfg)
     }
 
     async fn start_with_tls(&mut self, listening: SocketAddr) -> Result<SocketAddr> {
         log::info!("Http API TLS enabled");
 
-        let loader = Self::tls_loader(self.sessions.get_conf());
-
-        let server = axum_server::bind_rustls(listening.to_string())
-            .handle(self.shutdown_handler.abort_handle.clone())
-            .loader(loader.await?)
-            .serve(self.build_router());
-
-        self.shutdown_handler.try_listen(tokio::spawn(server)).await
-    }
-
-    async fn tls_loader(config: &Config) -> Result<TlsLoader> {
-        let mut tls_loader = TlsLoader::new();
-        tls_loader.config(Arc::new(Self::build_tls(config)?));
-
-        match tls_loader.load().await {
-            Ok(_) => Ok(tls_loader),
-            Err(cause) => Err(ErrorCode::TLSConfigurationFailure(format!(
-                "Cannot load tls config, cause {}",
-                cause
-            ))),
-        }
+        let tls_config = Self::build_tls(self.sessions.get_conf())?;
+        let addr = self
+            .shutdown_handler
+            .start_service(listening, Some(tls_config), self.build_router())
+            .await?;
+        Ok(addr)
     }
 
     async fn start_without_tls(&mut self, listening: SocketAddr) -> Result<SocketAddr> {
         log::warn!("Http API TLS not set");
 
-        let server = axum_server::bind(listening.to_string())
-            .handle(self.shutdown_handler.abort_handle.clone())
-            .serve(self.build_router());
-
-        self.shutdown_handler.try_listen(tokio::spawn(server)).await
+        let addr = self
+            .shutdown_handler
+            .start_service(listening, None, self.build_router())
+            .await?;
+        Ok(addr)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Migrate `databend-query` and `databend-metasrv` from `axum` to `poem`

## Changelog

- Improvement

## Related Issues

Fixes #2666 

## Test Plan

Unit Tests

Stateless Tests
