### PR TITLE
[metasrv] refactor: remove redundant method MetaNode::boot_non_voter()

### DIFF
--- a/metasrv/src/meta_service/meta_service_impl_test.rs
+++ b/metasrv/src/meta_service/meta_service_impl_test.rs
@@ -20,6 +20,7 @@ use common_meta_types::Cmd;
 use common_meta_types::LogEntry;
 use common_meta_types::MatchSeq;
 use common_meta_types::Operation;
+use common_tracing::tracing;
 #[allow(unused_imports)]
 use log::info;
 use pretty_assertions::assert_eq;
@@ -130,8 +131,12 @@ async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
     assert_meta_connection(&addr0).await?;
 
     {
-        // add node 1 as non-voter
-        let mn1 = MetaNode::boot_non_voter(1, &tc1.config.raft_config).await?;
+        tracing::info!("--- add node 1 as non-voter");
+
+        let mut config = tc1.config.raft_config.clone();
+        config.id = 1;
+        let (mn1, _is_open) = MetaNode::open_create_boot(&config, None, Some(()), None).await?;
+
         assert_meta_connection(&addr0).await?;
 
         let resp = mn0.add_node(1, addr1.clone()).await?;

--- a/metasrv/src/meta_service/raftmeta_test.rs
+++ b/metasrv/src/meta_service/raftmeta_test.rs
@@ -615,7 +615,12 @@ async fn setup_non_voter(
     let mut tc = new_test_context();
     let addr = tc.config.raft_config.raft_api_addr();
 
-    let mn = MetaNode::boot_non_voter(id, &tc.config.raft_config).await?;
+    let mut config = tc.config.raft_config.clone();
+    config.id = id;
+
+    let (mn, is_open) = MetaNode::open_create_boot(&config, None, Some(()), None).await?;
+    assert!(!is_open);
+
     tc.meta_nodes.push(mn.clone());
 
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: remove redundant method MetaNode::boot_non_voter()

## Changelog




- Improvement


## Related Issues