### PR TITLE
[query/server/http] Add /v1/query.

### DIFF
--- a/common/base/src/progress.rs
+++ b/common/base/src/progress.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 /// Progress callback is called with progress about the stream read progress.
 pub type ProgressCallback = Box<dyn FnMut(&ProgressValues) + Send + Sync + 'static>;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ProgressValues {
     pub read_rows: usize,
     pub read_bytes: usize,

--- a/query/src/servers/http/http_services.rs
+++ b/query/src/servers/http/http_services.rs
@@ -21,8 +21,8 @@ use poem::EndpointExt;
 use poem::Route;
 
 use crate::common::service::HttpShutdownHandler;
-use crate::servers::http::v1::http_query_handlers::query_route;
-use crate::servers::http::v1::statement::statement_router;
+use crate::servers::http::v1::query_route;
+use crate::servers::http::v1::statement_router;
 use crate::servers::Server;
 use crate::sessions::SessionManagerRef;
 

--- a/query/src/servers/http/http_services.rs
+++ b/query/src/servers/http/http_services.rs
@@ -21,6 +21,7 @@ use poem::EndpointExt;
 use poem::Route;
 
 use crate::common::service::HttpShutdownHandler;
+use crate::servers::http::v1::http_query_handlers::query_route;
 use crate::servers::http::v1::statement::statement_router;
 use crate::servers::Server;
 use crate::sessions::SessionManagerRef;
@@ -44,7 +45,9 @@ impl HttpHandler {
                 get(poem::endpoint::make_sync(|_| "This is http handler.")),
             )
             .nest("/v1/statement", statement_router())
+            .nest("/v1/query", query_route())
             .data(self.session_manager.clone())
+            .boxed()
     }
     async fn start_without_tls(&mut self, listening: SocketAddr) -> Result<SocketAddr> {
         let addr = self

--- a/query/src/servers/http/mod.rs
+++ b/query/src/servers/http/mod.rs
@@ -16,3 +16,5 @@ mod http_services;
 pub mod v1;
 
 pub use http_services::HttpHandler;
+pub use v1::query::http_query_manager::HttpQueryManager;
+pub use v1::query::http_query_manager::HttpQueryManagerRef;

--- a/query/src/servers/http/mod.rs
+++ b/query/src/servers/http/mod.rs
@@ -14,7 +14,4 @@
 
 mod http_services;
 pub mod v1;
-
 pub use http_services::HttpHandler;
-pub use v1::query::http_query_manager::HttpQueryManager;
-pub use v1::query::http_query_manager::HttpQueryManagerRef;

--- a/query/src/servers/http/v1/block_to_json_test.rs
+++ b/query/src/servers/http/v1/block_to_json_test.rs
@@ -27,7 +27,6 @@ where T: Serialize {
     to_value(v).unwrap()
 }
 
-// TODO(youngsofun): test null, Int8, dates
 fn test_data_block(is_nullable: bool) -> Result<()> {
     let schema = DataSchemaRefExt::create(vec![
         DataField::new("c1", DataType::Int32, is_nullable),
@@ -46,7 +45,7 @@ fn test_data_block(is_nullable: bool) -> Result<()> {
             .cast_with_type(&DataType::Date16)
             .unwrap(),
     ]);
-    let json_block = block_to_json(block)?;
+    let json_block = block_to_json(&block)?;
     let expect = vec![
         vec![val(1), val("a"), val(true), val(1.1), val("1970-01-02")],
         vec![val(2), val("b"), val(true), val(2.2), val("1970-01-03")],

--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -1,0 +1,242 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use common_base::ProgressValues;
+use common_datavalues::DataSchemaRef;
+use common_exception::Result;
+use hyper::http::header;
+use poem::get;
+use poem::http::StatusCode;
+use poem::post;
+use poem::web::Data;
+use poem::web::Json;
+use poem::web::Path;
+use poem::web::Query;
+use poem::IntoResponse;
+use poem::Response;
+use poem::Route;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::servers::http::v1::block_to_json::JsonBlockRef;
+use crate::servers::http::v1::query::execute_state::HttpQueryRequest;
+use crate::servers::http::v1::query::http_query::HttpQueryResponseInternal;
+use crate::servers::http::v1::query::result_data_manager::Wait;
+use crate::sessions::SessionManagerRef;
+
+pub fn make_page_uri(query_id: &str, page_no: usize) -> String {
+    format!("/v1/query/{}/page/{}", query_id, page_no)
+}
+
+pub fn make_state_uri(query_id: &str) -> String {
+    format!("/v1/query/{}", query_id)
+}
+
+pub fn make_delete_uri(query_id: &str) -> String {
+    format!("/v1/query/{}/kill?delete=true", query_id)
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct QueryResponse {
+    pub id: Option<String>,
+    pub columns: Option<DataSchemaRef>,
+    pub data: JsonBlockRef,
+    pub next_uri: Option<String>,
+    pub state_uri: Option<String>,
+    pub delete_uri: Option<String>,
+    // TODO(youngsofun): consider better response for error
+    // 1. another json format for request error
+    // 2. return 400 for some situation
+    // 3. more detail from ErrorCode (does not support Serialization))
+    // 4. use error code to ease the handling in client program
+    pub request_error: Option<String>,
+    pub query_error: Option<String>,
+    pub query_state: Option<String>,
+    pub query_progress: Option<ProgressValues>,
+}
+
+impl QueryResponse {
+    fn from_internal(id: String, result: &Result<HttpQueryResponseInternal>) -> QueryResponse {
+        match result {
+            Ok(r) => {
+                let (data, next_url) = match &r.data {
+                    Some(d) => (
+                        d.page.data.clone(),
+                        d.next_page_no.map(|n| make_page_uri(&id, n)),
+                    ),
+                    None => (Arc::new(vec![]), None),
+                };
+                let columns = match &r.initial_state {
+                    Some(v) => v.schema.clone(),
+                    None => None,
+                };
+                QueryResponse {
+                    data,
+                    columns,
+                    id: Some(id.clone()),
+                    next_uri: next_url,
+                    state_uri: Some(make_state_uri(&id)),
+                    delete_uri: Some(make_delete_uri(&id)),
+                    query_error: r.state.error.clone(),
+                    query_progress: r.state.progress.clone(),
+                    query_state: Some(r.state.state.to_string()),
+                    request_error: None,
+                }
+            }
+            Err(e) => QueryResponse::simple_error(Some(id), e.message()),
+        }
+    }
+
+    fn not_found(query_id: String) -> QueryResponse {
+        QueryResponse::simple_error(None, format!("query id not found {}", query_id))
+    }
+
+    fn simple_error(id: Option<String>, message: String) -> QueryResponse {
+        QueryResponse {
+            id,
+            data: Arc::new(vec![]),
+            query_error: None,
+            columns: None,
+            query_progress: None,
+            next_uri: None,
+            state_uri: None,
+            delete_uri: None,
+            query_state: None,
+            request_error: Some(message),
+        }
+    }
+}
+
+impl IntoResponse for QueryResponse {
+    fn into_response(self) -> Response {
+        let body = serde_json::to_vec(&self).unwrap();
+        // TODO(youngsofun): when should we return other status code here?
+        let status = StatusCode::OK;
+        let content_type = "application/json";
+        Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, content_type)
+            .body(body)
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct CancelParams {
+    delete: Option<bool>,
+}
+
+#[poem::handler]
+async fn query_cancel_handler(
+    sessions_extension: Data<&SessionManagerRef>,
+    Query(params): Query<CancelParams>,
+    Path(query_id): Path<String>,
+) -> impl IntoResponse {
+    let session_manager = sessions_extension.0;
+    let http_query_manager = session_manager.get_http_query_manager();
+    match http_query_manager.get_query_by_id(&query_id).await {
+        Some(query) => {
+            query.kill().await;
+            if params.delete.unwrap_or(false) {
+                http_query_manager.remove_query_by_id(&query_id).await;
+            }
+            StatusCode::OK
+        }
+        None => StatusCode::NOT_FOUND,
+    }
+}
+
+#[poem::handler]
+async fn query_state_handler(
+    sessions_extension: Data<&SessionManagerRef>,
+    Path(query_id): Path<String>,
+) -> impl IntoResponse {
+    let session_manager = sessions_extension.0;
+    let http_query_manager = session_manager.get_http_query_manager();
+    match http_query_manager.get_query_by_id(&query_id).await {
+        Some(query) => {
+            let response = query.get_response_state_only().await;
+            QueryResponse::from_internal(query_id, &Ok(response))
+        }
+        None => QueryResponse::not_found(query_id),
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct PageParams {
+    // for now, only used for test
+    wait_time: Option<i32>,
+}
+
+impl PageParams {
+    fn get_wait_type(&self) -> Wait {
+        let t = self.wait_time.unwrap_or(10);
+        match t.cmp(&0) {
+            Ordering::Greater => Wait::Deadline(Instant::now() + Duration::from_secs(t as u64)),
+            Ordering::Equal => Wait::Async,
+            Ordering::Less => Wait::Sync,
+        }
+    }
+}
+
+#[poem::handler]
+async fn query_page_handler(
+    sessions_extension: Data<&SessionManagerRef>,
+    Query(params): Query<PageParams>,
+    Path((query_id, page_no)): Path<(String, usize)>,
+) -> impl IntoResponse {
+    let session_manager = sessions_extension.0;
+    let http_query_manager = session_manager.get_http_query_manager();
+    match http_query_manager.get_query_by_id(&query_id).await {
+        Some(query) => {
+            let wait_type = params.get_wait_type();
+            let result = query.get_response_page(page_no, &wait_type, false).await;
+            QueryResponse::from_internal(query_id, &result)
+        }
+        None => QueryResponse::not_found(query_id),
+    }
+}
+
+#[poem::handler]
+pub(crate) async fn query_handler(
+    sessions_extension: Data<&SessionManagerRef>,
+    Query(params): Query<PageParams>,
+    Json(req): Json<HttpQueryRequest>,
+) -> impl IntoResponse {
+    log::info!("receive http query: {:?} {:?}", req, params);
+    let session_manager = sessions_extension.0;
+    let http_query_manager = session_manager.get_http_query_manager();
+    let query = http_query_manager.create_query(req, session_manager).await;
+    match query {
+        Ok(query) => {
+            let wait_type = params.get_wait_type();
+            let result = query.get_response_page(0, &wait_type, true).await;
+            QueryResponse::from_internal(query.id.to_string(), &result)
+        }
+        Err(e) => QueryResponse::simple_error(None, e.message()),
+    }
+}
+
+pub fn query_route() -> Route {
+    // Note: endpoints except /v1/query may change without notice, use uris in response instead
+    Route::new()
+        .at("/", post(query_handler))
+        .at("/:id", get(query_state_handler))
+        .at("/:id/page/:page_no", get(query_page_handler))
+        .at("/:id/kill", get(query_cancel_handler))
+}

--- a/query/src/servers/http/v1/http_query_handlers_test.rs
+++ b/query/src/servers/http/v1/http_query_handlers_test.rs
@@ -1,0 +1,252 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_base::tokio;
+use common_exception::Result;
+use hyper::header;
+use poem::http::Method;
+use poem::http::StatusCode;
+use poem::middleware::AddDataEndpoint;
+use poem::Endpoint;
+use poem::EndpointExt;
+use poem::Request;
+use poem::Response;
+use poem::Route;
+use pretty_assertions::assert_eq;
+use serde_json;
+
+use crate::servers::http::v1::http_query_handlers::make_delete_uri;
+use crate::servers::http::v1::http_query_handlers::make_page_uri;
+use crate::servers::http::v1::http_query_handlers::make_state_uri;
+use crate::servers::http::v1::http_query_handlers::query_route;
+use crate::servers::http::v1::http_query_handlers::QueryResponse;
+use crate::servers::http::v1::query::execute_state::STATE_RUNNING;
+use crate::servers::http::v1::query::execute_state::STATE_STOPPED;
+use crate::sessions::SessionManagerRef;
+use crate::tests::SessionManagerBuilder;
+
+// TODO(youngsofun): add test for
+// 1. kill without delete
+// 2. query fail after started
+// 3. get old page other than the last
+
+type RouteWithData = AddDataEndpoint<Route, SessionManagerRef>;
+
+#[tokio::test]
+async fn test_simple_sql() -> Result<()> {
+    let sql = "select * from system.tables limit 10";
+    let (status, result) = post_sql(sql, 1).await?;
+    assert_eq!(status, StatusCode::OK, "{:?}", result);
+    assert_eq!(result.data.len(), 10);
+    assert!(result.next_uri.is_none(), "{:?}", result);
+    assert_eq!(result.query_state, Some(STATE_STOPPED.to_string()));
+    assert!(result.query_error.is_none());
+    assert!(result.query_progress.is_some());
+    assert!(result.columns.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_bad_sql() -> Result<()> {
+    let (status, result) = post_sql("bad sql", 1).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(result.data.len(), 0);
+    assert!(result.next_uri.is_none());
+    assert!(result.query_state.is_none());
+    assert!(result.query_error.is_none());
+    assert!(result.request_error.is_some());
+    assert!(result.query_progress.is_none());
+    assert!(result.columns.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_async() -> Result<()> {
+    let sessions = SessionManagerBuilder::create().build().unwrap();
+    let route = Route::new().nest("/v1/query", query_route()).data(sessions);
+    let sql = "select sum(number+1) from numbers(1000000) where number>0 group by number%3";
+    let json = serde_json::json!({"sql": sql.to_string()});
+
+    let (status, result) = post_json_to_router(&route, &json, 0).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert!(result.id.is_some());
+    let query_id = result.id.unwrap();
+    let next_uri = make_page_uri(&query_id, 0);
+    assert_eq!(result.data.len(), 0, "should no data when async");
+    assert_eq!(result.next_uri, Some(next_uri));
+    assert!(result.query_progress.is_some());
+    assert!(result.columns.is_some());
+    assert!(result.query_error.is_none());
+    assert!(result.request_error.is_none());
+    assert_eq!(
+        result.query_state,
+        Some(STATE_RUNNING.to_string()),
+        "query should be running"
+    );
+
+    // get page, support retry
+    for _ in 1..2 {
+        let (status, result) = get_page(&route, query_id.clone(), 0, 3).await?;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(result.data.len(), 3);
+        assert!(result.next_uri.is_none());
+        assert!(result.columns.is_none());
+        assert!(result.query_error.is_none());
+        assert!(result.query_progress.is_some());
+        assert!(result.request_error.is_none());
+        assert_eq!(
+            result.query_state,
+            Some(STATE_STOPPED.to_string()),
+            "query should be stopped"
+        );
+    }
+
+    // get state
+    let (status, result) = get_state(&route, query_id.clone()).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(result.data.len(), 0);
+    assert!(result.next_uri.is_none());
+    assert!(result.columns.is_none());
+    assert!(result.query_error.is_none());
+    assert!(result.query_progress.is_some());
+    assert!(result.request_error.is_none());
+    assert_eq!(
+        result.query_state,
+        Some(STATE_STOPPED.to_string()),
+        "query should be stopped"
+    );
+
+    // get page not expected
+    let (status, result) = get_page(&route, query_id.clone(), 1, 3).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(result.data.len(), 0);
+    assert!(result.next_uri.is_none());
+    assert!(result.columns.is_none());
+    assert!(result.query_error.is_none());
+    assert!(result.request_error.is_some());
+    assert!(result.query_state.is_none());
+
+    // delete
+    let status = delete_query(&route, query_id.clone()).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // get state fail because query is deleted
+    let (status, result) = get_state(&route, query_id.clone()).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(result.data.len(), 0);
+    assert!(result.next_uri.is_none());
+    assert!(result.columns.is_none());
+    assert!(result.query_error.is_none());
+    assert!(result.query_progress.is_none());
+    assert!(result.request_error.is_some());
+
+    Ok(())
+}
+
+async fn get_state(route: &RouteWithData, query_id: String) -> Result<(StatusCode, QueryResponse)> {
+    let uri = make_state_uri(&query_id);
+    get_uri_checked(route, uri).await
+}
+
+async fn delete_query(route: &RouteWithData, query_id: String) -> StatusCode {
+    let uri = make_delete_uri(&query_id);
+    let resp = get_uri(route, uri).await;
+    resp.status()
+}
+
+async fn check_response(response: Response) -> Result<(StatusCode, QueryResponse)> {
+    let status = response.status();
+    let body = response.into_body().into_string().await.unwrap();
+    let result = serde_json::from_str::<QueryResponse>(&body);
+    assert!(
+        result.is_ok(),
+        "body ='{}', result='{:?}'",
+        &body,
+        result.err()
+    );
+    Ok((status, result.unwrap()))
+}
+
+async fn get_uri(route: &RouteWithData, uri: String) -> Response {
+    route
+        .call(
+            Request::builder()
+                .uri(uri.parse().unwrap())
+                .method(Method::GET)
+                .finish(),
+        )
+        .await
+}
+async fn get_uri_checked(
+    route: &RouteWithData,
+    uri: String,
+) -> Result<(StatusCode, QueryResponse)> {
+    let response = get_uri(route, uri).await;
+    check_response(response).await
+}
+
+async fn get_page(
+    route: &RouteWithData,
+    query_id: String,
+    page_no: usize,
+    wait_time: u32,
+) -> Result<(StatusCode, QueryResponse)> {
+    let uri = format!(
+        "{}?wait_time={}",
+        make_page_uri(&query_id, page_no),
+        wait_time
+    );
+    get_uri_checked(route, uri).await
+}
+
+async fn post_sql(sql: &'static str, wait_time: i32) -> Result<(StatusCode, QueryResponse)> {
+    let json = serde_json::json!({"sql": sql.to_string()});
+    post_json(&json, wait_time).await
+}
+
+pub fn create_router() -> RouteWithData {
+    let sessions = SessionManagerBuilder::create().build().unwrap();
+    Route::new().nest("/v1/query", query_route()).data(sessions)
+}
+
+async fn post_json(
+    json: &serde_json::Value,
+    wait_time: i32,
+) -> Result<(StatusCode, QueryResponse)> {
+    let router = create_router();
+    post_json_to_router(&router, json, wait_time).await
+}
+
+async fn post_json_to_router(
+    route: &RouteWithData,
+    json: &serde_json::Value,
+    wait_time: i32,
+) -> Result<(StatusCode, QueryResponse)> {
+    let path = "/v1/query";
+    let uri = format!("{}?wait_time={}", path, wait_time);
+    let content_type = "application/json";
+    let body = serde_json::to_vec(&json).unwrap();
+
+    let response = route
+        .call(
+            Request::builder()
+                .uri(uri.parse().unwrap())
+                .method(Method::POST)
+                .header(header::CONTENT_TYPE, content_type)
+                .body(body),
+        )
+        .await;
+
+    check_response(response).await
+}

--- a/query/src/servers/http/v1/http_query_handlers_test.rs
+++ b/query/src/servers/http/v1/http_query_handlers_test.rs
@@ -49,8 +49,8 @@ async fn test_simple_sql() -> Result<()> {
     let (status, result) = post_sql(sql, 1).await?;
     assert_eq!(status, StatusCode::OK, "{:?}", result);
     assert_eq!(result.data.len(), 10);
-    assert!(result.next_uri.is_none(), "{:?}", result);
     assert_eq!(result.query_state, Some(STATE_STOPPED.to_string()));
+    assert!(result.next_uri.is_none(), "{:?}", result);
     assert!(result.query_error.is_none());
     assert!(result.query_progress.is_some());
     assert!(result.columns.is_some());
@@ -64,7 +64,7 @@ async fn test_bad_sql() -> Result<()> {
     assert_eq!(result.data.len(), 0);
     assert!(result.next_uri.is_none());
     assert!(result.query_state.is_none());
-    assert!(result.query_error.is_none());
+    assert!(result.query_error.is_some());
     assert!(result.request_error.is_some());
     assert!(result.query_progress.is_none());
     assert!(result.columns.is_none());

--- a/query/src/servers/http/v1/mod.rs
+++ b/query/src/servers/http/v1/mod.rs
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod block_to_json;
+mod block_to_json;
+
 #[cfg(test)]
 mod block_to_json_test;
-pub mod http_query_handlers;
+mod http_query_handlers;
 #[cfg(test)]
 mod http_query_handlers_test;
 pub(crate) mod query;
 pub mod statement;
 #[cfg(test)]
 mod statement_test;
+
+pub(super) use http_query_handlers::query_route;
+pub(super) use statement::statement_router;

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -1,0 +1,174 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_base::tokio;
+use common_base::tokio::sync::mpsc;
+use common_base::tokio::sync::RwLock;
+use common_base::ProgressValues;
+use common_base::TrySpawn;
+use common_datablocks::DataBlock;
+use common_datavalues::DataSchemaRef;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_planners::PlanNode;
+use futures::StreamExt;
+use serde::Deserialize;
+
+use crate::interpreters::InterpreterFactory;
+use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionRef;
+use crate::sql::PlanParser;
+
+#[derive(Deserialize, Debug)]
+pub struct HttpQueryRequest {
+    pub sql: String,
+}
+
+pub(crate) enum ExecuteState {
+    Running(ExecuteRunning),
+    Stopped(ExecuteStopped),
+}
+
+use ExecuteState::*;
+
+pub(crate) type ExecuteStateRef = Arc<RwLock<ExecuteStateWrapper>>;
+
+pub(crate) struct ExecuteStopped {
+    progress: Option<ProgressValues>,
+    #[allow(dead_code)]
+    reason: Result<()>,
+}
+
+pub(crate) struct ExecuteStateWrapper {
+    pub(crate) state: ExecuteState,
+}
+
+pub const STATE_RUNNING: &str = "running";
+pub const STATE_STOPPED: &str = "stopped";
+
+impl ExecuteStateWrapper {
+    pub(crate) fn get_state(&self) -> &str {
+        match &self.state {
+            Running(_) => STATE_RUNNING,
+            Stopped(_) => STATE_STOPPED,
+        }
+    }
+    pub(crate) fn get_schema(&self) -> DataSchemaRef {
+        match &self.state {
+            Running(r) => r.plan.schema(),
+            Stopped(_) => unreachable!(),
+        }
+    }
+    pub(crate) fn get_progress(&self) -> Option<ProgressValues> {
+        match &self.state {
+            Running(r) => Some(r.context.get_progress_value()),
+            Stopped(f) => f.progress.clone(),
+        }
+    }
+}
+
+pub struct HttpQueryHandle {
+    pub abort_sender: mpsc::Sender<()>,
+}
+
+impl HttpQueryHandle {
+    pub fn abort(&self) {
+        let sender = self.abort_sender.clone();
+        tokio::spawn(async move {
+            sender.send(()).await.ok();
+        });
+    }
+}
+
+pub(crate) struct ExecuteRunning {
+    // used to kill query
+    session: SessionRef,
+    // mainly used to get progress for now
+    context: DatabendQueryContextRef,
+    plan: PlanNode,
+}
+
+impl ExecuteState {
+    pub(crate) async fn try_create(
+        request: &HttpQueryRequest,
+        session_manager: &SessionManagerRef,
+        block_tx: mpsc::Sender<DataBlock>,
+    ) -> Result<ExecuteStateRef> {
+        let sql = &request.sql;
+        let session = session_manager.create_session("http-statement")?;
+        let context = session.create_context().await?;
+        context.attach_query_str(sql);
+
+        let plan = PlanParser::create(context.clone()).build_from_sql(sql)?;
+
+        let interpreter = InterpreterFactory::get(context.clone(), plan.clone())?;
+        let data_stream = interpreter.execute().await?;
+        let mut data_stream = context.try_create_abortable(data_stream).unwrap();
+
+        let (abort_tx, mut abort_rx) = mpsc::channel(2);
+        context.attach_http_query(HttpQueryHandle {
+            abort_sender: abort_tx,
+        });
+
+        let running_state = ExecuteRunning {
+            session,
+            context: context.clone(),
+            plan,
+        };
+        let state = Arc::new(RwLock::new(ExecuteStateWrapper {
+            state: Running(running_state),
+        }));
+        let state_clone = state.clone();
+
+        context
+            .try_spawn(async move {
+                loop {
+                    if let Some(block_r) = data_stream.next().await {
+                        match block_r {
+                            Ok(block) => tokio::select! {
+                                _ = block_tx.send(block) => { },
+                                _ = abort_rx.recv() => {
+                                    ExecuteState::stop(&state, Err(ErrorCode::AbortedQuery("query aborted"))).await;
+                                    break;
+                                },
+                            },
+                            Err(err) => {
+                                ExecuteState::stop(&state, Err(err)).await;
+                                break
+                            }
+                        };
+                    } else {
+                        ExecuteState::stop(&state, Ok(())).await;
+                        break;
+                    }
+                }
+                log::debug!("drop block sender!");
+            })
+            .unwrap();
+        Ok(state_clone)
+    }
+
+    pub(crate) async fn stop(this: &ExecuteStateRef, reason: Result<()>) {
+        let mut guard = this.write().await;
+        if let Running(r) = &guard.state {
+            // release session
+            let progress = Some(r.context.get_progress_value());
+            r.session.force_kill_session();
+            guard.state = Stopped(ExecuteStopped { progress, reason });
+        };
+    }
+}

--- a/query/src/servers/http/v1/query/http_query.rs
+++ b/query/src/servers/http/v1/query/http_query.rs
@@ -1,0 +1,135 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_base::tokio::sync::mpsc;
+use common_base::tokio::sync::Mutex as TokioMutex;
+use common_base::ProgressValues;
+use common_datavalues::DataSchemaRef;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::servers::http::v1::query::execute_state::ExecuteState;
+use crate::servers::http::v1::query::execute_state::ExecuteStateRef;
+use crate::servers::http::v1::query::execute_state::HttpQueryRequest;
+use crate::servers::http::v1::query::result_data_manager::ResponseData;
+use crate::servers::http::v1::query::result_data_manager::ResultDataManager;
+use crate::servers::http::v1::query::result_data_manager::Wait;
+use crate::sessions::SessionManagerRef;
+
+pub struct ResponseInitialState {
+    pub schema: Option<DataSchemaRef>,
+}
+
+pub struct ResponseState {
+    pub progress: Option<ProgressValues>,
+    pub state: String,
+    pub error: Option<String>,
+}
+
+pub struct HttpQueryResponseInternal {
+    pub data: Option<ResponseData>,
+    pub initial_state: Option<ResponseInitialState>,
+    pub state: ResponseState,
+}
+
+pub struct HttpQuery {
+    pub(crate) id: String,
+    #[allow(dead_code)]
+    request: HttpQueryRequest,
+    state: ExecuteStateRef,
+    data: Arc<TokioMutex<ResultDataManager>>,
+}
+
+pub type HttpQueryRef = Arc<HttpQuery>;
+
+impl HttpQuery {
+    pub(crate) async fn try_create(
+        id: String,
+        request: HttpQueryRequest,
+        session_manager: &SessionManagerRef,
+    ) -> Result<HttpQueryRef> {
+        //TODO(youngsofun): support config/set channel size
+        let (block_tx, block_rx) = mpsc::channel(10);
+
+        let state = ExecuteState::try_create(&request, session_manager, block_tx).await?;
+        let schema = state.read().await.get_schema();
+        let data = Arc::new(TokioMutex::new(ResultDataManager::new(schema, block_rx)));
+        let query = HttpQuery {
+            id,
+            request,
+            state,
+            data,
+        };
+        let query = Arc::new(query);
+        Ok(query)
+    }
+
+    pub async fn get_response_page(
+        &self,
+        page_no: usize,
+        wait: &Wait,
+        init: bool,
+    ) -> Result<HttpQueryResponseInternal> {
+        Ok(HttpQueryResponseInternal {
+            data: Some(self.get_page(page_no, wait).await?),
+            initial_state: if init {
+                Some(self.get_initial_state().await)
+            } else {
+                None
+            },
+            state: self.get_state().await,
+        })
+    }
+
+    pub async fn get_response_state_only(&self) -> HttpQueryResponseInternal {
+        HttpQueryResponseInternal {
+            data: None,
+            initial_state: None,
+            state: self.get_state().await,
+        }
+    }
+
+    pub async fn get_initial_state(&self) -> ResponseInitialState {
+        let data = self.data.lock().await;
+        ResponseInitialState {
+            schema: Some(data.schema.clone()),
+        }
+    }
+
+    pub async fn get_state(&self) -> ResponseState {
+        let state = self.state.read().await;
+        ResponseState {
+            progress: state.get_progress(),
+            state: state.get_state().to_string(),
+            error: None, // todo
+        }
+    }
+
+    pub async fn get_page(&self, page_no: usize, tp: &Wait) -> Result<ResponseData> {
+        let mut data = self.data.lock().await;
+        let page = data.get_a_page(page_no, tp).await?;
+        let response = ResponseData {
+            page,
+            next_page_no: data.next_page_no(),
+        };
+        Ok(response)
+    }
+
+    pub async fn kill(&self) {
+        ExecuteState::stop(&self.state, Err(ErrorCode::Ok("killed by http"))).await;
+        self.data.lock().await.block_rx.close();
+    }
+}

--- a/query/src/servers/http/v1/query/http_query_manager.rs
+++ b/query/src/servers/http/v1/query/http_query_manager.rs
@@ -1,0 +1,67 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common_base::tokio::sync::RwLock;
+use common_exception::Result;
+
+use crate::configs::Config;
+use crate::servers::http::v1::query::execute_state::HttpQueryRequest;
+use crate::servers::http::v1::query::http_query::HttpQuery;
+use crate::servers::http::v1::query::http_query::HttpQueryRef;
+use crate::sessions::SessionManagerRef;
+
+pub struct HttpQueryManager {
+    pub(crate) queries: Arc<RwLock<HashMap<String, HttpQueryRef>>>,
+}
+
+pub type HttpQueryManagerRef = Arc<HttpQueryManager>;
+
+impl HttpQueryManager {
+    pub async fn create_global(_cfg: Config) -> Result<HttpQueryManagerRef> {
+        Ok(Arc::new(HttpQueryManager {
+            queries: Arc::new(RwLock::new(HashMap::new())),
+        }))
+    }
+
+    fn next_query_id(self: &Arc<Self>) -> String {
+        uuid::Uuid::new_v4().to_string()
+    }
+
+    pub(crate) async fn create_query(
+        self: &Arc<Self>,
+        req: HttpQueryRequest,
+        session_manager: &SessionManagerRef,
+    ) -> Result<HttpQueryRef> {
+        let query_id = self.next_query_id();
+        let query = HttpQuery::try_create(query_id.clone(), req, session_manager).await?;
+        self.queries
+            .write()
+            .await
+            .insert(query_id.clone(), query.clone());
+        Ok(query)
+    }
+
+    pub(crate) async fn get_query_by_id(self: &Arc<Self>, query_id: &str) -> Option<HttpQueryRef> {
+        let queries = self.queries.read().await;
+        queries.get(query_id).map(|q| q.to_owned())
+    }
+
+    pub(crate) async fn remove_query_by_id(self: &Arc<Self>, query_id: &str) {
+        let mut queries = self.queries.write().await;
+        queries.remove(query_id);
+    }
+}

--- a/query/src/servers/http/v1/query/mod.rs
+++ b/query/src/servers/http/v1/query/mod.rs
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod block_to_json;
-#[cfg(test)]
-mod block_to_json_test;
-pub mod http_query_handlers;
-#[cfg(test)]
-mod http_query_handlers_test;
-pub(crate) mod query;
-pub mod statement;
-#[cfg(test)]
-mod statement_test;
+pub use execute_state::HttpQueryHandle;
+
+pub(crate) mod execute_state;
+pub(crate) mod http_query;
+pub(crate) mod http_query_manager;
+pub(crate) mod result_data_manager;

--- a/query/src/servers/http/v1/query/mod.rs
+++ b/query/src/servers/http/v1/query/mod.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use execute_state::HttpQueryHandle;
+pub(super) mod execute_state;
+pub(super) mod http_query;
+mod http_query_manager;
+pub(super) mod result_data_manager;
 
-pub(crate) mod execute_state;
-pub(crate) mod http_query;
-pub(crate) mod http_query_manager;
-pub(crate) mod result_data_manager;
+pub use execute_state::HttpQueryHandle;
+pub use http_query_manager::HttpQueryManager;
+pub use http_query_manager::HttpQueryManagerRef;

--- a/query/src/servers/http/v1/query/result_data_manager.rs
+++ b/query/src/servers/http/v1/query/result_data_manager.rs
@@ -1,0 +1,147 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use common_base::tokio;
+use common_base::tokio::sync::mpsc;
+use common_base::tokio::sync::mpsc::error::TryRecvError;
+use common_datablocks::DataBlock;
+use common_datavalues::DataSchemaRef;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::servers::http::v1::block_to_json::block_to_json;
+use crate::servers::http::v1::block_to_json::JsonBlock;
+use crate::servers::http::v1::block_to_json::JsonBlockRef;
+
+#[derive(Debug)]
+pub enum Wait {
+    Async,
+    Sync,
+    Deadline(Instant),
+}
+
+#[derive(Clone)]
+pub struct Page {
+    pub data: JsonBlockRef,
+    pub total_rows: usize,
+}
+
+pub struct ResponseData {
+    pub page: Page,
+    pub next_page_no: Option<usize>,
+}
+
+pub struct ResultDataManager {
+    pub(crate) schema: DataSchemaRef,
+    total_rows: usize,
+    total_pages: usize,
+    last_page: Option<Page>,
+    pub(crate) block_rx: mpsc::Receiver<DataBlock>,
+    end: bool,
+}
+
+impl ResultDataManager {
+    pub fn new(schema: DataSchemaRef, block_rx: mpsc::Receiver<DataBlock>) -> ResultDataManager {
+        ResultDataManager {
+            schema,
+            block_rx,
+            total_rows: 0,
+            last_page: None,
+            total_pages: 0,
+            end: false,
+        }
+    }
+
+    pub fn next_page_no(&mut self) -> Option<usize> {
+        if self.end {
+            None
+        } else {
+            Some(self.total_pages)
+        }
+    }
+
+    pub async fn get_a_page(&mut self, page_no: usize, tp: &Wait) -> Result<Page> {
+        let next_no = self.total_pages;
+        if page_no == next_no && !self.end {
+            let (block, end) = self.collect_new_page(tp).await;
+            let num_row = block.len();
+            self.total_rows += num_row;
+            let page = Page {
+                data: Arc::new(block),
+                total_rows: self.total_rows,
+            };
+            if num_row > 0 {
+                self.total_pages += 1;
+                self.last_page = Some(page.clone());
+            }
+            self.end = end;
+            Ok(page)
+        } else if page_no == next_no - 1 {
+            // later, there may be other ways to ack and drop the last page except collect_new_page.
+            // but for now, last_page always exists in this branch, since page_no is unsigned.
+            Ok(self.last_page.as_ref().unwrap().clone())
+        } else {
+            Err(ErrorCode::LogicalError("page no too large"))
+        }
+    }
+
+    pub async fn receive(
+        block_rx: &mut mpsc::Receiver<DataBlock>,
+        tp: &Wait,
+    ) -> std::result::Result<DataBlock, TryRecvError> {
+        use Wait::*;
+        match tp {
+            Async => block_rx.try_recv(),
+            Sync => match block_rx.recv().await {
+                Some(block) => Ok(block),
+                None => Err(TryRecvError::Disconnected),
+            },
+            Deadline(t) => {
+                let sleep = tokio::time::sleep_until(tokio::time::Instant::from_std(*t));
+                tokio::select! {
+                    biased;
+                    block = block_rx.recv() => {
+                         match block {
+                            Some(block) => Ok(block),
+                            None => Err(TryRecvError::Disconnected)
+                        }
+                    }
+                    _ = sleep => Err(TryRecvError::Empty)
+                }
+            }
+        }
+    }
+
+    pub async fn collect_new_page(&mut self, tp: &Wait) -> (JsonBlock, bool) {
+        let mut results: Vec<JsonBlock> = Vec::new();
+        let block_rx = &mut self.block_rx;
+
+        let mut end = false;
+        loop {
+            match ResultDataManager::receive(block_rx, tp).await {
+                Ok(block) => results.push(block_to_json(&block).unwrap()),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    log::debug!("no more data");
+                    end = true;
+                    break;
+                }
+            }
+        }
+        (results.concat(), end)
+    }
+}

--- a/query/src/servers/http/v1/statement.rs
+++ b/query/src/servers/http/v1/statement.rs
@@ -150,7 +150,7 @@ impl HttpQueryState {
     async fn collect_all(&mut self) -> Result<Vec<Vec<JsonValue>>> {
         let mut results: Vec<Vec<Vec<JsonValue>>> = Vec::new();
         while let Some(block) = self.data_stream.next().await {
-            results.push(block_to_json(block.unwrap())?);
+            results.push(block_to_json(&block.unwrap())?);
         }
         Ok(results.concat())
     }

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -43,6 +43,7 @@ use crate::catalogs::Table;
 use crate::clusters::ClusterRef;
 use crate::configs::Config;
 use crate::datasources::common::ContextDalBuilder;
+use crate::servers::http::v1::query::HttpQueryHandle;
 use crate::sessions::context_shared::DatabendQueryContextShared;
 use crate::sessions::SessionManagerRef;
 use crate::sessions::Settings;
@@ -184,6 +185,10 @@ impl DatabendQueryContext {
         let (abort_handle, abort_stream) = AbortStream::try_create(input)?;
         self.shared.add_source_abort_handle(abort_handle);
         Ok(abort_stream)
+    }
+
+    pub fn attach_http_query(&self, handle: HttpQueryHandle) {
+        self.shared.attach_http_query(handle);
     }
 
     pub fn get_current_database(&self) -> String {

--- a/query/src/sessions/sessions.rs
+++ b/query/src/sessions/sessions.rs
@@ -32,8 +32,8 @@ use crate::catalogs::impls::DatabaseCatalog;
 use crate::clusters::ClusterDiscovery;
 use crate::clusters::ClusterDiscoveryRef;
 use crate::configs::Config;
-use crate::servers::http::HttpQueryManager;
-use crate::servers::http::HttpQueryManagerRef;
+use crate::servers::http::v1::query::HttpQueryManager;
+use crate::servers::http::v1::query::HttpQueryManagerRef;
 use crate::sessions::session::Session;
 use crate::sessions::session_ref::SessionRef;
 use crate::users::UserManager;
@@ -87,6 +87,7 @@ impl SessionManager {
     pub fn get_http_query_manager(self: &Arc<Self>) -> HttpQueryManagerRef {
         self.http_query_manager.clone()
     }
+
     // Get the user api provider.
     pub fn get_user_manager(self: &Arc<Self>) -> UserManagerRef {
         self.user.clone()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add new endpoint /v1/query to support sql.



# handler usage

1. post query with JSON with format HttpQueryRequest, and return JSON with format QueryResponse
2. Pagination with long polling.
3. result data is embedded in QueryResponse.
4. return the following  4 URIs,   the client should rely on the endpoint  /v1/query and URIs returned in the response. the other endpoints may change without notices.
   1. next: get the next page (together with progress) with long polling.   page N is released when Page N+1 is requested. 
   2. state: return struct like QueryResponse,  but the data field is empty. short polling.
   3. kill: kill running query
   4. delete: kill running query and delete it

[test_async](https://github.com/datafuselabs/databend/blob/aeeffa6e9a582d5073745b5b7b446da0c5166880/query/src/servers/http/v1/http_query_handlers_test.rs#L75) can be a demo for their usage.  


``` rust
pub struct HttpQueryRequest {
    pub sql: String,
}
```



```rust
pub struct QueryResponse {
    pub id: Option<String>,
    pub columns: Option<DataSchemaRef>,
    pub data: JsonBlockRef,
    pub next_uri: Option<String>,
    pub state_uri: Option<String>,
    pub kill_uri: Option<String>,
    pub delete_uri: Option<String>,
    pub query_state: Option<String>,
    pub request_error: Option<String>,
    pub query_error: Option<String>,
    pub query_progress: Option<ProgressValues>,
}

```


## internal 




1. The web layer (query_handlers.rs)  is separated from a more structured internal implementation in mod v1/query. 
     2. /v1/statement is kept to post raw SQL, may reuse the internal implementation, this will be done some others changes in another PR.
     3.   hope it may event be used to support GRPC if need later?
3. make sure the internal tokio task stop fast when the query is killed by SQL command or HTTP request



## TODO



soon( new PR in 1 week or so)：

1. classification and organization of Errors returned will be polished later.
2. more tests.
3. rewrite /v1/statements.



Long term:

1. Add client session support.
2. Adjust the handler interface to a stable version with a formal doc.  only necessary fields are added currently.  including 2 JSON formats and optional URL parameters and headers.
3. better control of memory.




## Changelog

- New Feature

## Related Issues

Fixes #2604 

## Test Plan

Unit Tests


