### PR TITLE
[common/exception] feature: add AnyError as a representation of std error for transmit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,6 +1980,7 @@ dependencies = [
  "anyhow",
  "async-raft",
  "async-trait",
+ "backtrace",
  "byteorder",
  "common-arrow",
  "common-base",

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -39,6 +39,7 @@ common-macros = { path = "../common/macros" }
 anyhow = "1.0.45"
 async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.14" }
 async-trait = "0.1"
+backtrace = "0.3.63"
 byteorder = "1.1.0"
 env_logger = "0.9"
 futures = "0.3"

--- a/metasrv/src/any_error/any_error_impl.rs
+++ b/metasrv/src/any_error/any_error_impl.rs
@@ -1,0 +1,140 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use backtrace::Backtrace;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// AnyError is a serializable wrapper `Error`.
+///
+/// It is can be used to convert other `Error` into a serializable Error for transmission,
+/// with most necessary info kept.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Default)]
+pub struct AnyError {
+    typ: Option<String>,
+    msg: String,
+    source: Option<Box<AnyError>>,
+    backtrace: Option<String>,
+}
+
+impl Display for AnyError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        if let Some(t) = &self.typ {
+            write!(f, "{}: ", t)?;
+        }
+
+        write!(f, "{}", self.msg)?;
+
+        if let Some(ref s) = self.source {
+            write!(f, " source: {}", s)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for AnyError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        <Self as Display>::fmt(self, f)?;
+
+        if let Some(ref b) = self.backtrace {
+            write!(f, "\nbacktrace:\n{}", b)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for AnyError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self.source {
+            Some(x) => Some(x.as_ref()),
+            None => None,
+        }
+    }
+}
+
+impl From<anyhow::Error> for AnyError {
+    fn from(a: anyhow::Error) -> Self {
+        AnyError::from_dyn(a.as_ref(), None)
+    }
+}
+
+impl AnyError {
+    /// Convert some `Error` to AnyError.
+    ///
+    /// - If there is a `source()` in the input error, it is also converted to AnyError, recursively.
+    /// - A new backtrace will be built if there is not.
+    /// TODO(xp): remove allow(dead_code)
+    #[allow(dead_code)]
+    pub fn new<E>(e: &E) -> Self
+    where E: Error + 'static {
+        let q: &(dyn Error + 'static) = e;
+
+        let x = q.downcast_ref::<AnyError>();
+        let typ = match x {
+            Some(ae) => ae.typ.clone(),
+            None => Some(std::any::type_name::<E>().to_string()),
+        };
+
+        Self::from_dyn(e, typ)
+    }
+
+    pub fn from_dyn(e: &(dyn Error + 'static), typ: Option<String>) -> Self {
+        let x = e.downcast_ref::<AnyError>();
+
+        return match x {
+            Some(ae) => {
+                let mut res = ae.clone();
+                if res.backtrace.is_none() {
+                    res.backtrace = Some(format!("{:?}", Backtrace::new()));
+                }
+                res
+            }
+            None => {
+                let bt = match e.backtrace() {
+                    Some(b) => Some(format!("{:?}", b)),
+                    None => Some(format!("{:?}", Backtrace::new())),
+                };
+
+                let source = e.source().map(|x| Box::new(AnyError::from_dyn(x, None)));
+
+                Self {
+                    typ,
+                    msg: e.to_string(),
+                    source,
+                    backtrace: bt,
+                }
+            }
+        };
+    }
+
+    // TODO(xp): it is useful but not yet been used.
+    #[allow(dead_code)]
+    pub fn get_type(&self) -> Option<&str> {
+        match &self.typ {
+            Some(v) => Some(v),
+            None => None,
+        }
+    }
+
+    // TODO(xp): it is useful but not yet been used.
+    #[allow(dead_code)]
+    pub fn backtrace(&self) -> Option<&str> {
+        self.backtrace.as_ref().map(|x| x as _)
+    }
+}

--- a/metasrv/src/any_error/any_error_test.rs
+++ b/metasrv/src/any_error/any_error_test.rs
@@ -1,0 +1,65 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use anyhow::Context;
+
+use crate::any_error::AnyError;
+
+#[test]
+fn test_any_error() -> anyhow::Result<()> {
+    // build from std Error
+
+    let fmt_err = fmt::Error {};
+
+    let ae = AnyError::new(&fmt_err);
+
+    let want_str = "core::fmt::Error: an error occurred when formatting an argument";
+    assert_eq!(want_str, ae.to_string());
+    assert!(ae.source().is_none());
+    assert!(!ae.backtrace().unwrap().is_empty());
+
+    // debug output with backtrace
+
+    let debug_str = format!("{:?}", ae);
+
+    assert!(debug_str.starts_with(want_str));
+    assert!(debug_str.contains("test_any_error"));
+
+    // chained errors
+
+    let err1 = anyhow::anyhow!("err1");
+    let err2 = Err::<(), anyhow::Error>(err1).context("err2");
+
+    let ae = AnyError::from(err2.unwrap_err());
+
+    assert_eq!("err2 source: err1", ae.to_string());
+    let src = ae.source().unwrap();
+    assert_eq!("err1", src.to_string());
+    assert!(!ae.backtrace().unwrap().is_empty());
+
+    // build AnyError from AnyError
+
+    let ae2 = AnyError::new(&ae);
+    assert_eq!("err2 source: err1", ae.to_string());
+
+    let ser = serde_json::to_string(&ae2)?;
+    let de: AnyError = serde_json::from_str(&ser)?;
+
+    assert_eq!("err2 source: err1", de.to_string());
+
+    Ok(())
+}

--- a/metasrv/src/any_error/mod.rs
+++ b/metasrv/src/any_error/mod.rs
@@ -12,18 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(backtrace)]
+mod any_error_impl;
 
-#[allow(clippy::all)]
-pub mod proto;
+#[cfg(test)]
+mod any_error_test;
 
-#[macro_use]
-pub mod tests;
-
-pub mod api;
-pub mod configs;
-pub mod executor;
-pub mod meta_service;
-pub mod metrics;
-
-mod any_error;
+pub use any_error_impl::AnyError;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/exception] feature: add AnyError as a representation of std error for transmit
By converting std::Error to AnyError, structured error can be serialized
and transferred.
The **type** of an error is not kept. However, AnyError stores the
`description`, `source` and `backtrace` info.

E.g., to define a structured error:

```rust
pub enum MetaError {
    #[error(transparent)]
    ConnectionError(#[from] ConnectionError),
    ...
}
pub struct ConnectionError {
    msg: String,
    #[source]
    source: AnyError,
}

impl ConnectionError {
    pub fn new(source: tonic::transport::Error, msg: String) -> Self {
        Self { msg, source: AnyError::new(&source), }
    }
}

// Usage:
let err:MetaError = ConnectionError::new(tonic_err, "when connecting to 1.2.3.4").into()
```

## Changelog

- New Feature





## Related Issues