### PR TITLE
[query] add show uses statement

### DIFF
--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -175,6 +175,7 @@ impl PlanParser {
             DfStatement::KillQuery(v) => self.sql_kill_query_to_plan(v),
             DfStatement::KillConn(v) => self.sql_kill_connection_to_plan(v),
             DfStatement::CreateUser(v) => self.sql_create_user_to_plan(v),
+            DfStatement::ShowUsers(_) => self.build_from_sql("SELECT * FROM system.users"),
         }
     }
 

--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -175,7 +175,9 @@ impl PlanParser {
             DfStatement::KillQuery(v) => self.sql_kill_query_to_plan(v),
             DfStatement::KillConn(v) => self.sql_kill_connection_to_plan(v),
             DfStatement::CreateUser(v) => self.sql_create_user_to_plan(v),
-            DfStatement::ShowUsers(_) => self.build_from_sql("SELECT * FROM system.users"),
+            DfStatement::ShowUsers(_) => {
+                self.build_from_sql("SELECT * FROM system.users ORDER BY name")
+            }
         }
     }
 

--- a/query/src/sql/sql_parser.rs
+++ b/query/src/sql/sql_parser.rs
@@ -53,6 +53,7 @@ use crate::sql::DfShowMetrics;
 use crate::sql::DfShowProcessList;
 use crate::sql::DfShowSettings;
 use crate::sql::DfShowTables;
+use crate::sql::DfShowUsers;
 use crate::sql::DfStatement;
 use crate::sql::DfTruncateTable;
 use crate::sql::DfUseDatabase;
@@ -200,6 +201,8 @@ impl<'a> DfParser<'a> {
                             Ok(DfStatement::ShowProcessList(DfShowProcessList))
                         } else if self.consume_token("METRICS") {
                             Ok(DfStatement::ShowMetrics(DfShowMetrics))
+                        } else if self.consume_token("USERS") {
+                            Ok(DfStatement::ShowUsers(DfShowUsers))
                         } else {
                             self.expected("tables or settings", self.parser.peek_token())
                         }

--- a/query/src/sql/sql_statement.rs
+++ b/query/src/sql/sql_statement.rs
@@ -119,6 +119,9 @@ pub struct DfCreateUser {
     pub password: String,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct DfShowUsers;
+
 /// Tokens parsed by `DFParser` are converted into these values.
 #[derive(Debug, Clone, PartialEq)]
 pub enum DfStatement {
@@ -153,7 +156,9 @@ pub enum DfStatement {
     KillQuery(DfKillStatement),
     KillConn(DfKillStatement),
 
+    // User
     CreateUser(DfCreateUser),
+    ShowUsers(DfShowUsers),
 }
 
 /// Comment hints from SQL.

--- a/website/databend/docs/sqlstatement/show-commands/show-users.md
+++ b/website/databend/docs/sqlstatement/show-commands/show-users.md
@@ -1,0 +1,23 @@
+---
+id: show-users
+title: SHOW USERS
+---
+
+Shows the list of user accounts.
+
+## Syntax
+
+```
+SHOW USERS
+```
+
+## Examples
+
+```
+mysql> SHOW USERS;
++------+-----------+----------+-----------+
+| name | hostname  | password | auth_type |
++------+-----------+----------+-----------+
+| test | localhost | password |         3 |
++------+-----------+----------+-----------+
+```

--- a/website/databend/mkdocs.yml
+++ b/website/databend/mkdocs.yml
@@ -153,6 +153,7 @@ nav:
           - SHOW TABLES: sqlstatement/show-commands/show-tables.md
           - SHOW SETTINGS: sqlstatement/show-commands/show-settings.md
           - SHOW METRICS: sqlstatement/show-commands/show-metrics.md
+          - SHOW USERS: sqlstatement/show-commands/show-users.md
       - Kill Commands:
           - KILL QUERY: sqlstatement/kill-commands/kill-query.md
       - Aggregate Functions:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add `show users` statement.

```
mysql> SHOW USERS;
+------+-----------+----------+-----------+
| name | hostname  | password | auth_type |
+------+-----------+----------+-----------+
| test | localhost | password |         3 |
+------+-----------+----------+-----------+
1 row in set (0.00 sec)
```

## Changelog

- Improvement

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/2687

## Test Plan

Unit Tests

Stateless Tests

