### PR TITLE
ISSUE-2672:  statistics returned by `Table::read_partitions` should take push-down projections into account

### DIFF
--- a/query/src/datasources/index/range_filter_test.rs
+++ b/query/src/datasources/index/range_filter_test.rs
@@ -36,16 +36,19 @@ fn test_range_filter() -> Result<()> {
         min: DataValue::Int64(Some(1)),
         max: DataValue::Int64(Some(20)),
         null_count: 1,
+        in_memory_size: 0,
     });
     stats.insert(1u32, ColStats {
         min: DataValue::Int32(Some(3)),
         max: DataValue::Int32(Some(10)),
         null_count: 0,
+        in_memory_size: 0,
     });
     stats.insert(2u32, ColStats {
         min: DataValue::String(Some("abc".as_bytes().to_vec())),
         max: DataValue::String(Some("bcd".as_bytes().to_vec())),
         null_count: 0,
+        in_memory_size: 0,
     });
 
     #[allow(dead_code)]

--- a/query/src/datasources/table/fuse/meta/table_snapshot.rs
+++ b/query/src/datasources/table/fuse/meta/table_snapshot.rs
@@ -79,7 +79,7 @@ pub struct Stats {
 }
 
 /// Meta information of a block (currently, the parquet file)
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct BlockMeta {
     /// Pointer of the data Block
     pub row_count: u64,
@@ -88,7 +88,7 @@ pub struct BlockMeta {
     pub location: BlockLocation,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct BlockLocation {
     pub location: Location,
     // for parquet, this filed can be used to fetch the meta data without seeking around
@@ -99,5 +99,6 @@ pub struct BlockLocation {
 pub struct ColStats {
     pub min: DataValue,
     pub max: DataValue,
-    pub null_count: usize,
+    pub null_count: u64,
+    pub in_memory_size: u64,
 }

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -14,6 +14,8 @@
 //
 
 use std::any::Any;
+use std::collections::HashSet;
+use std::iter::FromIterator;
 use std::sync::Arc;
 
 use common_context::DataContext;
@@ -121,27 +123,32 @@ impl FuseTable {
     }
 
     pub(crate) fn to_partitions(
-        &self,
         blocks_metas: &[BlockMeta],
-        _push_downs: Option<Extras>,
+        push_downs: Option<Extras>,
     ) -> (Statistics, Partitions) {
+        let proj_cols =
+            push_downs.and_then(|extras| extras.projection.map(HashSet::<usize>::from_iter));
         blocks_metas.iter().fold(
             (Statistics::default(), Partitions::default()),
-            |(mut stats, mut parts), item| {
+            |(mut stats, mut parts), block_meta| {
                 parts.push(Part {
-                    name: item.location.location.clone(),
+                    name: block_meta.location.location.clone(),
                     version: 0,
                 });
 
-                stats.read_rows += item.row_count as usize;
-                stats.read_bytes += item.block_size as usize;
+                stats.read_rows += block_meta.row_count as usize;
 
-                // todo: @zhaobr add column stats
-                // if let Some(Extras {
-                //     projection: Some(_),
-                //     ..
-                // }) = &push_downs
-                // {}
+                match &proj_cols {
+                    Some(proj) => {
+                        stats.read_bytes += block_meta
+                            .col_stats
+                            .iter()
+                            .filter(|(cid, _)| proj.contains(&(**cid as usize)))
+                            .map(|(_, col_stats)| col_stats.in_memory_size)
+                            .sum::<u64>() as usize
+                    }
+                    None => stats.read_bytes += block_meta.block_size as usize,
+                }
 
                 (stats, parts)
             },

--- a/query/src/datasources/table/fuse/table_do_read.rs
+++ b/query/src/datasources/table/fuse/table_do_read.rs
@@ -43,12 +43,12 @@ impl FuseTable {
                 .collect::<Vec<usize>>()
         };
 
-        let projection = if let Some(push_down) = push_downs {
-            if let Some(prj) = &push_down.projection {
-                prj.clone()
-            } else {
-                default_proj()
-            }
+        let projection = if let Some(Extras {
+            projection: Some(prj),
+            ..
+        }) = push_downs
+        {
+            prj.clone()
         } else {
             default_proj()
         };

--- a/query/src/datasources/table/fuse/table_do_read_partitions.rs
+++ b/query/src/datasources/table/fuse/table_do_read_partitions.rs
@@ -43,7 +43,7 @@ impl FuseTable {
             }
             .wait_in(&io_ctx.get_runtime(), None)??;
 
-            let (statistics, parts) = self.to_partitions(&block_metas, push_downs);
+            let (statistics, parts) = Self::to_partitions(&block_metas, push_downs);
             Ok((statistics, parts))
         } else {
             Ok((Statistics::default(), vec![]))

--- a/query/src/datasources/table/fuse/util/statistic_helper.rs
+++ b/query/src/datasources/table/fuse/util/statistic_helper.rs
@@ -121,12 +121,15 @@ pub(super) fn block_stats(data_block: &DataBlock) -> Result<BlockStats> {
                         0
                     }
                 }
-            };
+            } as u64;
+
+            let in_memory_size = col.get_array_memory_size() as u64;
 
             let col_stats = ColStats {
                 min,
                 max,
                 null_count,
+                in_memory_size,
             };
 
             Ok((idx, col_stats))
@@ -165,6 +168,7 @@ pub fn column_stats_reduce_with_schema(
             let mut min_stats = Vec::with_capacity(stats.len());
             let mut max_stats = Vec::with_capacity(stats.len());
             let mut null_count = 0;
+            let mut in_memory_size = 0;
 
             for col_stats in stats {
                 // to be optimized, with DataType and the value of data, we may
@@ -173,6 +177,7 @@ pub fn column_stats_reduce_with_schema(
                 max_stats.push(col_stats.max.clone());
 
                 null_count += col_stats.null_count;
+                in_memory_size += col_stats.in_memory_size;
             }
 
             // TODO panic
@@ -193,6 +198,7 @@ pub fn column_stats_reduce_with_schema(
                 min,
                 max,
                 null_count,
+                in_memory_size,
             });
             Ok(acc)
         })


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Statistics returned by `Table::read_partitions` should take push-down projections into account

- add field `in_memory_size` to `ColStats`
   the value of this field is obtained by using `DataColunm::get_array_memory_size`
   @sundy-li please take a look, is this method supposed to be used in this case?

- `Statistics` returned by `Table::to_partitions` takes `Extras::projection` into account
   bytes of pruned columns will NOT be accumulated into `Statistics::read_bytes`

## Changelog


- Bug Fix
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2672

## Test Plan

Unit Tests

Stateless Tests

