### PR TITLE
[metasrv] feature: add `join` API to join a node to cluster.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,6 +1999,7 @@ dependencies = [
  "common-meta-types",
  "common-planners",
  "common-tracing",
+ "derive_more",
  "env_logger 0.9.0",
  "flaky_test",
  "futures",

--- a/common/meta/raft-store/src/config.rs
+++ b/common/meta/raft-store/src/config.rs
@@ -111,6 +111,12 @@ pub struct RaftConfig {
     )]
     pub single: bool,
 
+    /// Bring up a metasrv node and join a cluster.
+    ///
+    /// The value is one or more addresses of a node in the cluster, to which this node sends a `join` request.
+    #[structopt(long, env = "METASRV_JOIN")]
+    pub join: Vec<String>,
+
     #[structopt(
     long,
     env = KVSRV_ID,

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -41,6 +41,7 @@ async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.
 async-trait = "0.1"
 backtrace = "0.3.63"
 byteorder = "1.1.0"
+derive_more = "0.99.16"
 env_logger = "0.9"
 futures = "0.3"
 indexmap = "1.7.0"

--- a/metasrv/proto/meta.proto
+++ b/metasrv/proto/meta.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-// meta data types for DatabendStore
+// meta data types for Databend meta server
 package meta;
 
 // TODO(zbr): keep it or remove
@@ -76,6 +76,9 @@ service MetaService {
 
   rpc Write(RaftMes) returns (RaftMes) {}
   rpc Get(GetReq) returns (GetReply) {}
+
+  /// Forward a request to other
+  rpc Forward(RaftMes) returns (RaftMes) {}
 
   // raft RPC
 

--- a/metasrv/src/meta_service/message.rs
+++ b/metasrv/src/meta_service/message.rs
@@ -1,0 +1,59 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_meta_types::NodeId;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::proto::RaftMes;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct JoinRequest {
+    pub node_id: NodeId,
+    pub address: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, derive_more::TryInto)]
+pub enum AdminRequestInner {
+    Join(JoinRequest),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct AdminRequest {
+    /// Forward the request to leader if the node received this request is not leader.
+    pub forward_to_leader: bool,
+
+    pub req: AdminRequestInner,
+}
+
+impl AdminRequest {
+    pub fn set_forward(&mut self, allow: bool) {
+        self.forward_to_leader = allow;
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, derive_more::TryInto)]
+pub enum AdminResponse {
+    Join(()),
+}
+
+impl tonic::IntoRequest<RaftMes> for AdminRequest {
+    fn into_request(self) -> tonic::Request<RaftMes> {
+        let mes = RaftMes {
+            data: serde_json::to_string(&self).expect("fail to serialize"),
+            error: "".to_string(),
+        };
+        tonic::Request::new(mes)
+    }
+}

--- a/metasrv/src/meta_service/meta_leader.rs
+++ b/metasrv/src/meta_service/meta_leader.rs
@@ -1,0 +1,141 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+
+use async_raft::error::ResponseError;
+use async_raft::ChangeConfigError;
+use common_meta_types::Cmd;
+use common_meta_types::LogEntry;
+use common_meta_types::Node;
+use common_meta_types::NodeId;
+use common_tracing::tracing;
+
+use crate::meta_service::message::AdminRequest;
+use crate::meta_service::message::AdminResponse;
+use crate::meta_service::AdminRequestInner;
+use crate::meta_service::ForwardToLeader;
+use crate::meta_service::InvalidMembership;
+use crate::meta_service::JoinRequest;
+use crate::meta_service::MetaError;
+use crate::meta_service::MetaNode;
+use crate::meta_service::RetryableError;
+
+/// The container of APIs of a metasrv leader in a metasrv cluster.
+///
+/// A meta leader does not imply it is actually the leader granted by the cluster.
+/// It just means it believes it is the leader an have not yet perceived there is other newer leader.
+pub struct MetaLeader<'a> {
+    meta_node: &'a MetaNode,
+}
+
+impl<'a> MetaLeader<'a> {
+    pub fn new(meta_node: &'a MetaNode) -> MetaLeader {
+        MetaLeader { meta_node }
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn handle_admin_req(&self, req: AdminRequest) -> Result<AdminResponse, MetaError> {
+        match req.req {
+            AdminRequestInner::Join(join_req) => {
+                self.join(join_req).await?;
+                Ok(AdminResponse::Join(()))
+            }
+        }
+    }
+
+    /// Join a new node to the cluster.
+    ///
+    /// - Adds the node to cluster as a non-voter persistently and starts replication.
+    /// - Adds the node to membership to let it become a voter.
+    ///
+    /// If the node is already in cluster membership, it still returns Ok.
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn join(&self, req: JoinRequest) -> Result<(), MetaError> {
+        let node_id = req.node_id;
+        let addr = req.address;
+        let metrics = self.meta_node.metrics_rx.borrow().clone();
+        let mut membership = metrics.membership_config.members.clone();
+
+        if membership.contains(&node_id) {
+            return Ok(());
+        }
+
+        membership.insert(node_id);
+
+        let ent = LogEntry {
+            txid: None,
+            cmd: Cmd::AddNode {
+                node_id,
+                node: Node {
+                    name: "".to_string(),
+                    address: addr,
+                },
+            },
+        };
+
+        let res = self
+            .meta_node
+            .write_to_local_leader(ent.clone())
+            .await
+            .map_err(|e| MetaError::UnknownError(e.to_string()))?;
+        match res {
+            Ok(_applied_state) => {}
+            Err(retryable_error) => {
+                // TODO(xp): remove retryable error.
+                let leader_id = match retryable_error {
+                    RetryableError::ForwardToLeader { leader } => leader,
+                };
+                return Err(MetaError::ForwardToLeader(ForwardToLeader {
+                    leader: Some(leader_id),
+                }));
+            }
+        }
+
+        self.change_membership(membership).await
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn change_membership(&self, membership: BTreeSet<NodeId>) -> Result<(), MetaError> {
+        let res = self.meta_node.raft.change_membership(membership).await;
+
+        let err = match res {
+            Ok(_) => return Ok(()),
+            Err(e) => e,
+        };
+
+        match err {
+            ResponseError::ChangeConfig(e) => match e {
+                // TODO(xp): enable MetaNode::RaftError when RaftError impl Serialized
+                ChangeConfigError::RaftError(raft_error) => {
+                    Err(MetaError::UnknownError(raft_error.to_string()))
+                }
+                ChangeConfigError::ConfigChangeInProgress => {
+                    Err(MetaError::MembershipChangeInProgress)
+                }
+                ChangeConfigError::InoperableConfig => {
+                    Err(MetaError::InvalidMembership(InvalidMembership {}))
+                }
+                ChangeConfigError::NodeNotLeader(leader) => {
+                    Err(MetaError::ForwardToLeader(ForwardToLeader { leader }))
+                }
+                ChangeConfigError::Noop => Ok(()),
+                _ => Err(MetaError::UnknownError("uncovered error".to_string())),
+            },
+            // TODO(xp): enable MetaNode::RaftError when RaftError impl Serialized
+            ResponseError::Raft(raft_error) => Err(MetaError::UnknownError(raft_error.to_string())),
+            _ => Err(MetaError::UnknownError("uncovered error".to_string())),
+        }
+    }
+}

--- a/metasrv/src/meta_service/meta_service_impl.rs
+++ b/metasrv/src/meta_service/meta_service_impl.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use common_meta_types::LogEntry;
 use common_tracing::tracing;
 
+use crate::meta_service::message::AdminRequest;
 use crate::meta_service::MetaNode;
 use crate::proto::meta_service_server::MetaService;
 use crate::proto::GetReply;
@@ -78,6 +79,25 @@ impl MetaService for MetaServiceImpl {
         };
 
         Ok(tonic::Response::new(rst))
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn forward(
+        &self,
+        request: tonic::Request<RaftMes>,
+    ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
+        common_tracing::extract_remote_span_as_parent(&request);
+
+        let req = request.into_inner();
+
+        let admin_req: AdminRequest = serde_json::from_str(&req.data)
+            .map_err(|x| tonic::Status::invalid_argument(x.to_string()))?;
+
+        let res = self.meta_node.handle_admin_req(admin_req).await;
+
+        let raft_mes: RaftMes = res.into();
+
+        Ok(tonic::Response::new(raft_mes))
     }
 
     #[tracing::instrument(level = "info", skip(self, request))]

--- a/metasrv/src/meta_service/mod.rs
+++ b/metasrv/src/meta_service/mod.rs
@@ -12,14 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use errors::ForwardToLeader;
+pub use errors::InvalidMembership;
+pub use errors::MetaError;
 pub use errors::RetryableError;
 pub use errors::ShutdownError;
+pub use message::AdminRequest;
+pub use message::AdminRequestInner;
+pub use message::JoinRequest;
 pub use meta_service_impl::MetaServiceImpl;
 pub use network::Network;
 pub use raftmeta::MetaNode;
 pub use raftmeta::MetaRaftStore;
 
 pub mod errors;
+mod message;
+mod meta_leader;
 pub mod meta_service_impl;
 pub mod network;
 pub mod raftmeta;

--- a/metasrv/src/meta_service/network.rs
+++ b/metasrv/src/meta_service/network.rs
@@ -27,6 +27,8 @@ use common_meta_raft_store::state_machine::AppliedState;
 use common_meta_types::LogEntry;
 use common_meta_types::NodeId;
 use common_tracing::tracing;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use tonic::transport::channel::Channel;
 
 use crate::meta_service::MetaRaftStore;
@@ -189,24 +191,43 @@ impl From<AppliedState> for RaftMes {
     }
 }
 
-impl From<Result<AppliedState, RetryableError>> for RaftMes {
-    fn from(rst: Result<AppliedState, RetryableError>) -> Self {
-        match rst {
-            Ok(resp) => resp.into(),
-            Err(err) => err.into(),
+impl<T, E> From<RaftMes> for Result<T, E>
+where
+    T: DeserializeOwned,
+    E: DeserializeOwned,
+{
+    fn from(msg: RaftMes) -> Self {
+        if !msg.data.is_empty() {
+            let resp: T = serde_json::from_str(&msg.data).expect("fail to deserialize");
+            Ok(resp)
+        } else {
+            let err: E = serde_json::from_str(&msg.error).expect("fail to deserialize");
+            Err(err)
         }
     }
 }
 
-impl From<RaftMes> for Result<AppliedState, RetryableError> {
-    fn from(msg: RaftMes) -> Self {
-        if !msg.data.is_empty() {
-            let resp: AppliedState = serde_json::from_str(&msg.data).expect("fail to deserialize");
-            Ok(resp)
-        } else {
-            let err: RetryableError =
-                serde_json::from_str(&msg.error).expect("fail to deserialize");
-            Err(err)
+impl<T, E> From<Result<T, E>> for RaftMes
+where
+    T: Serialize,
+    E: Serialize,
+{
+    fn from(r: Result<T, E>) -> Self {
+        match r {
+            Ok(x) => {
+                let data = serde_json::to_string(&x).expect("fail to serialize");
+                RaftMes {
+                    data,
+                    error: Default::default(),
+                }
+            }
+            Err(e) => {
+                let error = serde_json::to_string(&e).expect("fail to serialize");
+                RaftMes {
+                    data: Default::default(),
+                    error,
+                }
+            }
         }
     }
 }

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -62,6 +62,12 @@ use common_meta_types::TableMeta;
 use common_tracing::tracing;
 use common_tracing::tracing::Instrument;
 
+use crate::meta_service::errors::ConnectionError;
+use crate::meta_service::message::AdminRequest;
+use crate::meta_service::message::AdminResponse;
+use crate::meta_service::meta_leader::MetaLeader;
+use crate::meta_service::ForwardToLeader;
+use crate::meta_service::MetaError;
 use crate::meta_service::MetaServiceImpl;
 use crate::meta_service::Network;
 use crate::meta_service::RetryableError;
@@ -943,6 +949,58 @@ impl MetaNode {
         sm.get_node(node_id)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn handle_admin_req(&self, req: AdminRequest) -> Result<AdminResponse, MetaError> {
+        let forward = req.forward_to_leader;
+
+        let l = self.as_leader().await;
+        let res = match l {
+            Ok(l) => l.handle_admin_req(req.clone()).await,
+            Err(e) => Err(MetaError::ForwardToLeader(e)),
+        };
+
+        let e = match res {
+            Ok(x) => return Ok(x),
+            Err(e) => e,
+        };
+
+        let e = match e {
+            MetaError::ForwardToLeader(e) => e,
+            _ => return Err(e),
+        };
+
+        if !forward {
+            return Err(MetaError::ForwardToLeader(e));
+        }
+
+        let leader_id = match e.leader {
+            Some(leader_id) => leader_id,
+            None => return Err(MetaError::ForwardToLeader(e)),
+        };
+
+        let mut r2 = req.clone();
+        // Avoid infinite forward
+        r2.set_forward(false);
+
+        let res: AdminResponse = self.forward(&leader_id, r2).await?;
+
+        Ok(res)
+    }
+
+    /// Return a MetaLeader if `self` believes it is the leader.
+    ///
+    /// Otherwise it returns the leader in a ForwardToLeader error.
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn as_leader(&self) -> Result<MetaLeader<'_>, ForwardToLeader> {
+        let curr_leader = self.get_leader().await;
+        if curr_leader == self.sto.id {
+            return Ok(MetaLeader::new(self));
+        }
+        Err(ForwardToLeader {
+            leader: Some(curr_leader),
+        })
+    }
+
     /// Add a new node into this cluster.
     /// The node info is committed with raft, thus it must be called on an initialized node.
     #[tracing::instrument(level = "debug", skip(self))]
@@ -952,7 +1010,7 @@ impl MetaNode {
         addr: String,
     ) -> common_exception::Result<AppliedState> {
         // TODO: use txid?
-        let _resp = self
+        let resp = self
             .write(LogEntry {
                 txid: None,
                 cmd: Cmd::AddNode {
@@ -964,7 +1022,7 @@ impl MetaNode {
                 },
             })
             .await?;
-        Ok(_resp)
+        Ok(resp)
     }
 
     pub async fn get_state_machine(&self) -> RwLockReadGuard<'_, StateMachine> {
@@ -1092,6 +1150,32 @@ impl MetaNode {
                 return 0;
             }
         }
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    pub async fn forward(
+        &self,
+        node_id: &NodeId,
+        req: AdminRequest,
+    ) -> Result<AdminResponse, MetaError> {
+        let addr = self
+            .sto
+            .get_node_addr(node_id)
+            .await
+            .map_err(|e| MetaError::UnknownError(e.to_string()))?;
+
+        let mut client = MetaServiceClient::connect(format!("http://{}", addr))
+            .await
+            .map_err(|e| ConnectionError::new(e, format!("address: {}", addr)))?;
+
+        let resp = client
+            .forward(req)
+            .await
+            .map_err(|e| MetaError::UnknownError(e.to_string()))?;
+        let raft_mes = resp.into_inner();
+
+        let res: Result<AdminResponse, MetaError> = raft_mes.into();
+        res
     }
 
     /// Write a meta log through local raft node.

--- a/metasrv/src/meta_service/raftmeta_test.rs
+++ b/metasrv/src/meta_service/raftmeta_test.rs
@@ -31,8 +31,12 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::configs;
+use crate::meta_service::message::AdminRequest;
+use crate::meta_service::AdminRequestInner;
+use crate::meta_service::JoinRequest;
 use crate::meta_service::MetaNode;
 use crate::meta_service::RetryableError;
+use crate::proto::meta_service_client::MetaServiceClient;
 use crate::tests::assert_meta_connection;
 use crate::tests::service::new_test_context;
 use crate::tests::service::KVSrvTestContext;
@@ -373,6 +377,95 @@ async fn test_meta_node_cluster_1_2_2() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+async fn test_meta_node_join() -> anyhow::Result<()> {
+    // - Bring up a cluster
+    // - Join a new node by sending a Join request to leader.
+    // - Join a new node by sending a Join request to a non-voter.
+
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    let span = tracing::span!(tracing::Level::INFO, "test_meta_node_join");
+    let _ent = span.enter();
+
+    let (mut _nlog, tcs) = setup_cluster(btreeset![0], btreeset![1]).await?;
+    let mut all = test_context_nodes(&tcs);
+
+    tracing::info!("--- bring up non-voter 2");
+
+    let node_id = 2;
+    let tc2 = new_test_context();
+    let mut raft_config = tc2.config.raft_config.clone();
+    raft_config.id = node_id;
+    let addr2 = raft_config.raft_api_addr();
+
+    let (mn2, is_open) = MetaNode::open_create_boot(&raft_config, None, Some(()), None).await?;
+    assert!(!is_open);
+
+    tracing::info!("--- join non-voter 2 to cluster by leader");
+
+    let leader_id = all[0].get_leader().await;
+    let leader = all[leader_id as usize].clone();
+    leader
+        .handle_admin_req(AdminRequest {
+            forward_to_leader: false,
+            req: AdminRequestInner::Join(JoinRequest {
+                node_id,
+                address: addr2,
+            }),
+        })
+        .await?;
+
+    all.push(mn2.clone());
+    for mn in all.iter() {
+        mn.raft
+            .wait(timeout())
+            .members(btreeset! {0,2}, format!("node-2 is joined: {}", mn.sto.id))
+            .await?;
+    }
+
+    tracing::info!("--- bring up non-voter 3");
+
+    let node_id = 3;
+    let tc3 = new_test_context();
+    let mut raft_config = tc3.config.raft_config.clone();
+    raft_config.id = node_id;
+    let addr3 = raft_config.raft_api_addr();
+
+    let (mn3, is_open) = MetaNode::open_create_boot(&raft_config, None, Some(()), None).await?;
+    assert!(!is_open);
+
+    tracing::info!("--- join node-3 by sending rpc `join`");
+
+    let to_addr = tcs[1].config.raft_config.raft_api_addr();
+
+    let mut client = MetaServiceClient::connect(format!("http://{}", to_addr)).await?;
+    let admin_req = AdminRequest {
+        forward_to_leader: true,
+        req: AdminRequestInner::Join(JoinRequest {
+            node_id,
+            address: addr3,
+        }),
+    };
+    client.forward(admin_req).await?;
+
+    tracing::info!("--- check all nodes has node-3 joined");
+
+    all.push(mn3.clone());
+    for mn in all.iter() {
+        mn.raft
+            .wait(timeout())
+            .members(
+                btreeset! {0,2,3},
+                format!("node-2 is joined: {}", mn.sto.id),
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
 async fn test_meta_node_restart() -> anyhow::Result<()> {
     // TODO check restarted follower.
     // - Start a leader and a non-voter;
@@ -483,7 +576,10 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
     }
 
     tracing::info!("--- reopen MetaNode");
-    let leader = MetaNode::open(&tc.config.raft_config).await?;
+
+    let (leader, _is_open) =
+        MetaNode::open_create_boot(&tc.config.raft_config, Some(()), None, None).await?;
+
     log_cnt += 1;
 
     wait_for_state(&leader, State::Leader).await?;
@@ -615,10 +711,10 @@ async fn setup_non_voter(
     let mut tc = new_test_context();
     let addr = tc.config.raft_config.raft_api_addr();
 
-    let mut config = tc.config.raft_config.clone();
-    config.id = id;
+    let mut raft_config = tc.config.raft_config.clone();
+    raft_config.id = id;
 
-    let (mn, is_open) = MetaNode::open_create_boot(&config, None, Some(()), None).await?;
+    let (mn, is_open) = MetaNode::open_create_boot(&raft_config, None, Some(()), None).await?;
     assert!(!is_open);
 
     tc.meta_nodes.push(mn.clone());


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] feature: add `join` API to join a node to cluster.
- Feature: add cli arg `--join addr1,addr2...` to join a new node to a
  metasrv cluster.

- Feature: add RPC `forward` to forward a request to other metasrv node.
  It is used to proxy an admin request to a known leader.

- Refactor: add `MetaError` which is serializable and structured, to
  express errors a meta server emits.

  `MetaErro` can be transmitted between metasrv nodes.

- Refactor: add `MetaLeader` as a container of admin API.

- Refactor: simplify From/Into for `RaftMes`

- Test: add unit test of `join`ing node to cluster.

- part of #2668

## Changelog

- New Feature





## Related Issues