### PR TITLE
USER-2704: Add user quota to user info

### DIFF
--- a/common/management/src/user/user_api.rs
+++ b/common/management/src/user/user_api.rs
@@ -20,6 +20,7 @@ use common_exception::Result;
 use common_meta_types::AuthType;
 use common_meta_types::SeqV;
 use common_meta_types::UserPrivilege;
+use common_meta_types::UserQuota;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct UserInfo {
@@ -28,6 +29,7 @@ pub struct UserInfo {
     pub password: Vec<u8>,
     pub auth_type: AuthType,
     pub privileges: UserPrivilege,
+    pub quota: UserQuota,
 }
 
 impl UserInfo {
@@ -39,12 +41,15 @@ impl UserInfo {
     ) -> Self {
         // Default is no privileges.
         let privileges = UserPrivilege::empty();
+        let quota = UserQuota::no_limit();
+
         UserInfo {
             name,
             hostname,
             password,
             auth_type,
             privileges,
+            quota,
         }
     }
 }

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -20,6 +20,8 @@ mod cluster_test;
 mod match_seq_test;
 #[cfg(test)]
 mod user_privilege_test;
+#[cfg(test)]
+mod user_quota_test;
 
 pub use change::AddResult;
 pub use change::Change;
@@ -57,6 +59,7 @@ pub use table_reply::CreateTableReply;
 pub use user_auth::AuthType;
 pub use user_privilege::UserPrivilege;
 pub use user_privilege::UserPrivilegeType;
+pub use user_quota::UserQuota;
 
 mod change;
 mod cluster;
@@ -77,3 +80,4 @@ mod table_info;
 mod table_reply;
 mod user_auth;
 mod user_privilege;
+mod user_quota;

--- a/common/meta/types/src/user_quota.rs
+++ b/common/meta/types/src/user_quota.rs
@@ -1,0 +1,38 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct UserQuota {
+    // The max cpu can be used (0 is no limited).
+    #[serde(default)]
+    pub max_cpu: u64,
+
+    // The max memory(bytes) can be used(0 is no limited).
+    #[serde(default)]
+    pub max_memory_in_bytes: u64,
+
+    // The max storage(bytes) can be used(0 is no limited).
+    #[serde(default)]
+    pub max_storage_in_bytes: u64,
+}
+
+impl UserQuota {
+    pub fn no_limit() -> Self {
+        UserQuota {
+            max_cpu: 0,
+            max_memory_in_bytes: 0,
+            max_storage_in_bytes: 0,
+        }
+    }
+}

--- a/common/meta/types/src/user_quota_test.rs
+++ b/common/meta/types/src/user_quota_test.rs
@@ -1,0 +1,27 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::exception::Result;
+
+use crate::UserQuota;
+
+#[test]
+fn test_user_quota() -> Result<()> {
+    let quota = UserQuota::no_limit();
+    assert_eq!(quota.max_cpu, 0);
+    assert_eq!(quota.max_memory_in_bytes, 0);
+    assert_eq!(quota.max_storage_in_bytes, 0);
+
+    Ok(())
+}

--- a/query/src/datasources/database/system/users_table_test.rs
+++ b/query/src/datasources/database/system/users_table_test.rs
@@ -19,6 +19,7 @@ use common_exception::Result;
 use common_management::UserInfo;
 use common_meta_types::AuthType;
 use common_meta_types::UserPrivilege;
+use common_meta_types::UserQuota;
 use futures::TryStreamExt;
 use pretty_assertions::assert_eq;
 
@@ -38,6 +39,7 @@ async fn test_users_table() -> Result<()> {
             password: Vec::from(""),
             auth_type: AuthType::None,
             privileges: UserPrivilege::empty(),
+            quota: UserQuota::no_limit(),
         })
         .await?;
     ctx.get_sessions_manager()
@@ -48,6 +50,7 @@ async fn test_users_table() -> Result<()> {
             password: Vec::from("123456789"),
             auth_type: AuthType::PlainText,
             privileges: UserPrivilege::empty(),
+            quota: UserQuota::no_limit(),
         })
         .await?;
 

--- a/query/src/interpreters/interpreter_user_create.rs
+++ b/query/src/interpreters/interpreter_user_create.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_management::UserInfo;
 use common_meta_types::UserPrivilege;
+use common_meta_types::UserQuota;
 use common_planners::CreateUserPlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -57,6 +58,7 @@ impl Interpreter for CreatUserInterpreter {
             password: plan.password,
             auth_type: plan.auth_type,
             privileges: UserPrivilege::empty(),
+            quota: UserQuota::no_limit(),
         };
         user_mgr.add_user(user_info).await?;
 

--- a/query/src/users/user.rs
+++ b/query/src/users/user.rs
@@ -16,6 +16,7 @@
 use common_management::UserInfo;
 use common_meta_types::AuthType;
 use common_meta_types::UserPrivilege;
+use common_meta_types::UserQuota;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct User {
@@ -44,12 +45,15 @@ impl User {
 impl From<&User> for UserInfo {
     fn from(user: &User) -> Self {
         let privileges = UserPrivilege::empty();
+        let quota = UserQuota::no_limit();
+
         UserInfo {
             name: user.name.clone(),
             hostname: user.hostname.clone(),
             password: Vec::from(user.password.clone()),
             auth_type: user.auth_type.clone(),
             privileges,
+            quota,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR:
1. Only add `quota` to a user, it's no limited for now.

## Changelog

- New Feature


## Related Issues

Fixes #2704 

## Test Plan

Unit Tests

Stateless Tests

