### PR TITLE
[metasrv] refactor: use RaftRequest as a request type, use RaftReply as reply type for raft communication

### DIFF
--- a/metasrv/proto/meta.proto
+++ b/metasrv/proto/meta.proto
@@ -67,22 +67,22 @@ message GetReply {
   string value = 3;
 }
 
-message RaftMes {
+message RaftReply {
   string data = 1;
   string error = 2;
 }
 
 service MetaService {
 
-  rpc Write(RaftMes) returns (RaftMes) {}
+  rpc Write(RaftReply) returns (RaftReply) {}
   rpc Get(GetReq) returns (GetReply) {}
 
   /// Forward a request to other
-  rpc Forward(RaftMes) returns (RaftMes) {}
+  rpc Forward(RaftReply) returns (RaftReply) {}
 
   // raft RPC
 
-  rpc AppendEntries(RaftMes) returns (RaftMes);
-  rpc InstallSnapshot(RaftMes) returns (RaftMes);
-  rpc vote(RaftMes) returns (RaftMes);
+  rpc AppendEntries(RaftReply) returns (RaftReply);
+  rpc InstallSnapshot(RaftReply) returns (RaftReply);
+  rpc vote(RaftReply) returns (RaftReply);
 }

--- a/metasrv/proto/meta.proto
+++ b/metasrv/proto/meta.proto
@@ -67,6 +67,10 @@ message GetReply {
   string value = 3;
 }
 
+message RaftRequest {
+  string data = 1;
+}
+
 message RaftReply {
   string data = 1;
   string error = 2;
@@ -74,15 +78,15 @@ message RaftReply {
 
 service MetaService {
 
-  rpc Write(RaftReply) returns (RaftReply) {}
+  rpc Write(RaftRequest) returns (RaftReply) {}
   rpc Get(GetReq) returns (GetReply) {}
 
   /// Forward a request to other
-  rpc Forward(RaftReply) returns (RaftReply) {}
+  rpc Forward(RaftRequest) returns (RaftReply) {}
 
   // raft RPC
 
-  rpc AppendEntries(RaftReply) returns (RaftReply);
-  rpc InstallSnapshot(RaftReply) returns (RaftReply);
-  rpc vote(RaftReply) returns (RaftReply);
+  rpc AppendEntries(RaftRequest) returns (RaftReply);
+  rpc InstallSnapshot(RaftRequest) returns (RaftReply);
+  rpc vote(RaftRequest) returns (RaftReply);
 }

--- a/metasrv/src/meta_service/message.rs
+++ b/metasrv/src/meta_service/message.rs
@@ -24,6 +24,7 @@ use serde::Serialize;
 
 use crate::errors::RetryableError;
 use crate::proto::RaftReply;
+use crate::proto::RaftRequest;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct JoinRequest {
@@ -55,71 +56,66 @@ pub enum AdminResponse {
     Join(()),
 }
 
-impl tonic::IntoRequest<RaftReply> for AdminRequest {
-    fn into_request(self) -> tonic::Request<RaftReply> {
-        let mes = RaftReply {
+impl tonic::IntoRequest<RaftRequest> for AdminRequest {
+    fn into_request(self) -> tonic::Request<RaftRequest> {
+        let mes = RaftRequest {
             data: serde_json::to_string(&self).expect("fail to serialize"),
-            error: "".to_string(),
         };
         tonic::Request::new(mes)
     }
 }
 
-impl TryFrom<RaftReply> for AdminRequest {
+impl TryFrom<RaftRequest> for AdminRequest {
     type Error = tonic::Status;
 
-    fn try_from(mes: RaftReply) -> Result<Self, Self::Error> {
+    fn try_from(mes: RaftRequest) -> Result<Self, Self::Error> {
         let req = serde_json::from_str(&mes.data)
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
         Ok(req)
     }
 }
 
-impl tonic::IntoRequest<RaftReply> for LogEntry {
-    fn into_request(self) -> tonic::Request<RaftReply> {
-        let mes = RaftReply {
+impl tonic::IntoRequest<RaftRequest> for LogEntry {
+    fn into_request(self) -> tonic::Request<RaftRequest> {
+        let mes = RaftRequest {
             data: serde_json::to_string(&self).expect("fail to serialize"),
-            error: "".to_string(),
         };
         tonic::Request::new(mes)
     }
 }
 
-impl TryFrom<RaftReply> for LogEntry {
+impl TryFrom<RaftRequest> for LogEntry {
     type Error = tonic::Status;
 
-    fn try_from(mes: RaftReply) -> Result<Self, Self::Error> {
+    fn try_from(mes: RaftRequest) -> Result<Self, Self::Error> {
         let req: LogEntry = serde_json::from_str(&mes.data)
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
         Ok(req)
     }
 }
 
-impl tonic::IntoRequest<RaftReply> for AppendEntriesRequest<LogEntry> {
-    fn into_request(self) -> tonic::Request<RaftReply> {
-        let mes = RaftReply {
+impl tonic::IntoRequest<RaftRequest> for AppendEntriesRequest<LogEntry> {
+    fn into_request(self) -> tonic::Request<RaftRequest> {
+        let mes = RaftRequest {
             data: serde_json::to_string(&self).expect("fail to serialize"),
-            error: "".to_string(),
         };
         tonic::Request::new(mes)
     }
 }
 
-impl tonic::IntoRequest<RaftReply> for InstallSnapshotRequest {
-    fn into_request(self) -> tonic::Request<RaftReply> {
-        let mes = RaftReply {
+impl tonic::IntoRequest<RaftRequest> for InstallSnapshotRequest {
+    fn into_request(self) -> tonic::Request<RaftRequest> {
+        let mes = RaftRequest {
             data: serde_json::to_string(&self).expect("fail to serialize"),
-            error: "".to_string(),
         };
         tonic::Request::new(mes)
     }
 }
 
-impl tonic::IntoRequest<RaftReply> for VoteRequest {
-    fn into_request(self) -> tonic::Request<RaftReply> {
-        let mes = RaftReply {
+impl tonic::IntoRequest<RaftRequest> for VoteRequest {
+    fn into_request(self) -> tonic::Request<RaftRequest> {
+        let mes = RaftRequest {
             data: serde_json::to_string(&self).expect("fail to serialize"),
-            error: "".to_string(),
         };
         tonic::Request::new(mes)
     }

--- a/metasrv/src/meta_service/message.rs
+++ b/metasrv/src/meta_service/message.rs
@@ -23,7 +23,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::errors::RetryableError;
-use crate::proto::RaftMes;
+use crate::proto::RaftReply;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct JoinRequest {
@@ -55,9 +55,9 @@ pub enum AdminResponse {
     Join(()),
 }
 
-impl tonic::IntoRequest<RaftMes> for AdminRequest {
-    fn into_request(self) -> tonic::Request<RaftMes> {
-        let mes = RaftMes {
+impl tonic::IntoRequest<RaftReply> for AdminRequest {
+    fn into_request(self) -> tonic::Request<RaftReply> {
+        let mes = RaftReply {
             data: serde_json::to_string(&self).expect("fail to serialize"),
             error: "".to_string(),
         };
@@ -65,19 +65,19 @@ impl tonic::IntoRequest<RaftMes> for AdminRequest {
     }
 }
 
-impl TryFrom<RaftMes> for AdminRequest {
+impl TryFrom<RaftReply> for AdminRequest {
     type Error = tonic::Status;
 
-    fn try_from(mes: RaftMes) -> Result<Self, Self::Error> {
+    fn try_from(mes: RaftReply) -> Result<Self, Self::Error> {
         let req = serde_json::from_str(&mes.data)
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
         Ok(req)
     }
 }
 
-impl tonic::IntoRequest<RaftMes> for LogEntry {
-    fn into_request(self) -> tonic::Request<RaftMes> {
-        let mes = RaftMes {
+impl tonic::IntoRequest<RaftReply> for LogEntry {
+    fn into_request(self) -> tonic::Request<RaftReply> {
+        let mes = RaftReply {
             data: serde_json::to_string(&self).expect("fail to serialize"),
             error: "".to_string(),
         };
@@ -85,19 +85,19 @@ impl tonic::IntoRequest<RaftMes> for LogEntry {
     }
 }
 
-impl TryFrom<RaftMes> for LogEntry {
+impl TryFrom<RaftReply> for LogEntry {
     type Error = tonic::Status;
 
-    fn try_from(mes: RaftMes) -> Result<Self, Self::Error> {
+    fn try_from(mes: RaftReply) -> Result<Self, Self::Error> {
         let req: LogEntry = serde_json::from_str(&mes.data)
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
         Ok(req)
     }
 }
 
-impl tonic::IntoRequest<RaftMes> for AppendEntriesRequest<LogEntry> {
-    fn into_request(self) -> tonic::Request<RaftMes> {
-        let mes = RaftMes {
+impl tonic::IntoRequest<RaftReply> for AppendEntriesRequest<LogEntry> {
+    fn into_request(self) -> tonic::Request<RaftReply> {
+        let mes = RaftReply {
             data: serde_json::to_string(&self).expect("fail to serialize"),
             error: "".to_string(),
         };
@@ -105,9 +105,9 @@ impl tonic::IntoRequest<RaftMes> for AppendEntriesRequest<LogEntry> {
     }
 }
 
-impl tonic::IntoRequest<RaftMes> for InstallSnapshotRequest {
-    fn into_request(self) -> tonic::Request<RaftMes> {
-        let mes = RaftMes {
+impl tonic::IntoRequest<RaftReply> for InstallSnapshotRequest {
+    fn into_request(self) -> tonic::Request<RaftReply> {
+        let mes = RaftReply {
             data: serde_json::to_string(&self).expect("fail to serialize"),
             error: "".to_string(),
         };
@@ -115,9 +115,9 @@ impl tonic::IntoRequest<RaftMes> for InstallSnapshotRequest {
     }
 }
 
-impl tonic::IntoRequest<RaftMes> for VoteRequest {
-    fn into_request(self) -> tonic::Request<RaftMes> {
-        let mes = RaftMes {
+impl tonic::IntoRequest<RaftReply> for VoteRequest {
+    fn into_request(self) -> tonic::Request<RaftReply> {
+        let mes = RaftReply {
             data: serde_json::to_string(&self).expect("fail to serialize"),
             error: "".to_string(),
         };
@@ -125,32 +125,32 @@ impl tonic::IntoRequest<RaftMes> for VoteRequest {
     }
 }
 
-impl From<RetryableError> for RaftMes {
+impl From<RetryableError> for RaftReply {
     fn from(err: RetryableError) -> Self {
         let error = serde_json::to_string(&err).expect("fail to serialize");
-        RaftMes {
+        RaftReply {
             data: "".to_string(),
             error,
         }
     }
 }
 
-impl From<AppliedState> for RaftMes {
+impl From<AppliedState> for RaftReply {
     fn from(msg: AppliedState) -> Self {
         let data = serde_json::to_string(&msg).expect("fail to serialize");
-        RaftMes {
+        RaftReply {
             data,
             error: "".to_string(),
         }
     }
 }
 
-impl<T, E> From<RaftMes> for Result<T, E>
+impl<T, E> From<RaftReply> for Result<T, E>
 where
     T: DeserializeOwned,
     E: DeserializeOwned,
 {
-    fn from(msg: RaftMes) -> Self {
+    fn from(msg: RaftReply) -> Self {
         if !msg.data.is_empty() {
             let resp: T = serde_json::from_str(&msg.data).expect("fail to deserialize");
             Ok(resp)
@@ -161,7 +161,7 @@ where
     }
 }
 
-impl<T, E> From<Result<T, E>> for RaftMes
+impl<T, E> From<Result<T, E>> for RaftReply
 where
     T: Serialize,
     E: Serialize,
@@ -170,14 +170,14 @@ where
         match r {
             Ok(x) => {
                 let data = serde_json::to_string(&x).expect("fail to serialize");
-                RaftMes {
+                RaftReply {
                     data,
                     error: Default::default(),
                 }
             }
             Err(e) => {
                 let error = serde_json::to_string(&e).expect("fail to serialize");
-                RaftMes {
+                RaftReply {
                     data: Default::default(),
                     error,
                 }

--- a/metasrv/src/meta_service/meta_service_impl.rs
+++ b/metasrv/src/meta_service/meta_service_impl.rs
@@ -27,6 +27,7 @@ use crate::proto::meta_service_server::MetaService;
 use crate::proto::GetReply;
 use crate::proto::GetReq;
 use crate::proto::RaftReply;
+use crate::proto::RaftRequest;
 
 pub struct MetaServiceImpl {
     pub meta_node: Arc<MetaNode>,
@@ -45,7 +46,7 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self))]
     async fn write(
         &self,
-        request: tonic::Request<RaftReply>,
+        request: tonic::Request<RaftRequest>,
     ) -> Result<tonic::Response<RaftReply>, tonic::Status> {
         common_tracing::extract_remote_span_as_parent(&request);
 
@@ -84,7 +85,7 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self))]
     async fn forward(
         &self,
-        request: tonic::Request<RaftReply>,
+        request: tonic::Request<RaftRequest>,
     ) -> Result<tonic::Response<RaftReply>, tonic::Status> {
         common_tracing::extract_remote_span_as_parent(&request);
 
@@ -103,7 +104,7 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self, request))]
     async fn append_entries(
         &self,
-        request: tonic::Request<RaftReply>,
+        request: tonic::Request<RaftRequest>,
     ) -> Result<tonic::Response<RaftReply>, tonic::Status> {
         common_tracing::extract_remote_span_as_parent(&request);
 
@@ -130,7 +131,7 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self, request))]
     async fn install_snapshot(
         &self,
-        request: tonic::Request<RaftReply>,
+        request: tonic::Request<RaftRequest>,
     ) -> Result<tonic::Response<RaftReply>, tonic::Status> {
         common_tracing::extract_remote_span_as_parent(&request);
 
@@ -157,7 +158,7 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self, request))]
     async fn vote(
         &self,
-        request: tonic::Request<RaftReply>,
+        request: tonic::Request<RaftRequest>,
     ) -> Result<tonic::Response<RaftReply>, tonic::Status> {
         common_tracing::extract_remote_span_as_parent(&request);
 

--- a/metasrv/src/meta_service/meta_service_impl.rs
+++ b/metasrv/src/meta_service/meta_service_impl.rs
@@ -26,7 +26,7 @@ use crate::meta_service::MetaNode;
 use crate::proto::meta_service_server::MetaService;
 use crate::proto::GetReply;
 use crate::proto::GetReq;
-use crate::proto::RaftMes;
+use crate::proto::RaftReply;
 
 pub struct MetaServiceImpl {
     pub meta_node: Arc<MetaNode>,
@@ -45,8 +45,8 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self))]
     async fn write(
         &self,
-        request: tonic::Request<RaftMes>,
-    ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
+        request: tonic::Request<RaftReply>,
+    ) -> Result<tonic::Response<RaftReply>, tonic::Status> {
         common_tracing::extract_remote_span_as_parent(&request);
 
         let mes = request.into_inner();
@@ -84,8 +84,8 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self))]
     async fn forward(
         &self,
-        request: tonic::Request<RaftMes>,
-    ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
+        request: tonic::Request<RaftReply>,
+    ) -> Result<tonic::Response<RaftReply>, tonic::Status> {
         common_tracing::extract_remote_span_as_parent(&request);
 
         let req = request.into_inner();
@@ -95,7 +95,7 @@ impl MetaService for MetaServiceImpl {
 
         let res = self.meta_node.handle_admin_req(admin_req).await;
 
-        let raft_mes: RaftMes = res.into();
+        let raft_mes: RaftReply = res.into();
 
         Ok(tonic::Response::new(raft_mes))
     }
@@ -103,8 +103,8 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self, request))]
     async fn append_entries(
         &self,
-        request: tonic::Request<RaftMes>,
-    ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
+        request: tonic::Request<RaftReply>,
+    ) -> Result<tonic::Response<RaftReply>, tonic::Status> {
         common_tracing::extract_remote_span_as_parent(&request);
 
         let req = request.into_inner();
@@ -119,7 +119,7 @@ impl MetaService for MetaServiceImpl {
             .await
             .map_err(|x| tonic::Status::internal(x.to_string()))?;
         let data = serde_json::to_string(&resp).expect("fail to serialize resp");
-        let mes = RaftMes {
+        let mes = RaftReply {
             data,
             error: "".to_string(),
         };
@@ -130,8 +130,8 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self, request))]
     async fn install_snapshot(
         &self,
-        request: tonic::Request<RaftMes>,
-    ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
+        request: tonic::Request<RaftReply>,
+    ) -> Result<tonic::Response<RaftReply>, tonic::Status> {
         common_tracing::extract_remote_span_as_parent(&request);
 
         let req = request.into_inner();
@@ -146,7 +146,7 @@ impl MetaService for MetaServiceImpl {
             .await
             .map_err(|x| tonic::Status::internal(x.to_string()))?;
         let data = serde_json::to_string(&resp).expect("fail to serialize resp");
-        let mes = RaftMes {
+        let mes = RaftReply {
             data,
             error: "".to_string(),
         };
@@ -157,8 +157,8 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self, request))]
     async fn vote(
         &self,
-        request: tonic::Request<RaftMes>,
-    ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
+        request: tonic::Request<RaftReply>,
+    ) -> Result<tonic::Response<RaftReply>, tonic::Status> {
         common_tracing::extract_remote_span_as_parent(&request);
 
         let req = request.into_inner();
@@ -173,7 +173,7 @@ impl MetaService for MetaServiceImpl {
             .await
             .map_err(|x| tonic::Status::internal(x.to_string()))?;
         let data = serde_json::to_string(&resp).expect("fail to serialize resp");
-        let mes = RaftMes {
+        let mes = RaftReply {
             data,
             error: "".to_string(),
         };

--- a/metasrv/src/proto/meta.rs
+++ b/metasrv/src/proto/meta.rs
@@ -70,6 +70,11 @@ pub struct GetReply {
     pub value: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RaftRequest {
+    #[prost(string, tag = "1")]
+    pub data: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RaftReply {
     #[prost(string, tag = "1")]
     pub data: ::prost::alloc::string::String,
@@ -138,7 +143,7 @@ pub mod meta_service_client {
         }
         pub async fn write(
             &mut self,
-            request: impl tonic::IntoRequest<super::RaftReply>,
+            request: impl tonic::IntoRequest<super::RaftRequest>,
         ) -> Result<tonic::Response<super::RaftReply>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
@@ -167,7 +172,7 @@ pub mod meta_service_client {
         #[doc = "/ Forward a request to other"]
         pub async fn forward(
             &mut self,
-            request: impl tonic::IntoRequest<super::RaftReply>,
+            request: impl tonic::IntoRequest<super::RaftRequest>,
         ) -> Result<tonic::Response<super::RaftReply>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
@@ -181,7 +186,7 @@ pub mod meta_service_client {
         }
         pub async fn append_entries(
             &mut self,
-            request: impl tonic::IntoRequest<super::RaftReply>,
+            request: impl tonic::IntoRequest<super::RaftRequest>,
         ) -> Result<tonic::Response<super::RaftReply>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
@@ -195,7 +200,7 @@ pub mod meta_service_client {
         }
         pub async fn install_snapshot(
             &mut self,
-            request: impl tonic::IntoRequest<super::RaftReply>,
+            request: impl tonic::IntoRequest<super::RaftRequest>,
         ) -> Result<tonic::Response<super::RaftReply>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
@@ -209,7 +214,7 @@ pub mod meta_service_client {
         }
         pub async fn vote(
             &mut self,
-            request: impl tonic::IntoRequest<super::RaftReply>,
+            request: impl tonic::IntoRequest<super::RaftRequest>,
         ) -> Result<tonic::Response<super::RaftReply>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
@@ -232,7 +237,7 @@ pub mod meta_service_server {
     pub trait MetaService: Send + Sync + 'static {
         async fn write(
             &self,
-            request: tonic::Request<super::RaftReply>,
+            request: tonic::Request<super::RaftRequest>,
         ) -> Result<tonic::Response<super::RaftReply>, tonic::Status>;
         async fn get(
             &self,
@@ -241,19 +246,19 @@ pub mod meta_service_server {
         #[doc = "/ Forward a request to other"]
         async fn forward(
             &self,
-            request: tonic::Request<super::RaftReply>,
+            request: tonic::Request<super::RaftRequest>,
         ) -> Result<tonic::Response<super::RaftReply>, tonic::Status>;
         async fn append_entries(
             &self,
-            request: tonic::Request<super::RaftReply>,
+            request: tonic::Request<super::RaftRequest>,
         ) -> Result<tonic::Response<super::RaftReply>, tonic::Status>;
         async fn install_snapshot(
             &self,
-            request: tonic::Request<super::RaftReply>,
+            request: tonic::Request<super::RaftRequest>,
         ) -> Result<tonic::Response<super::RaftReply>, tonic::Status>;
         async fn vote(
             &self,
-            request: tonic::Request<super::RaftReply>,
+            request: tonic::Request<super::RaftRequest>,
         ) -> Result<tonic::Response<super::RaftReply>, tonic::Status>;
     }
     #[derive(Debug)]
@@ -296,12 +301,12 @@ pub mod meta_service_server {
                 "/meta.MetaService/Write" => {
                     #[allow(non_camel_case_types)]
                     struct WriteSvc<T: MetaService>(pub Arc<T>);
-                    impl<T: MetaService> tonic::server::UnaryService<super::RaftReply> for WriteSvc<T> {
+                    impl<T: MetaService> tonic::server::UnaryService<super::RaftRequest> for WriteSvc<T> {
                         type Response = super::RaftReply;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::RaftReply>,
+                            request: tonic::Request<super::RaftRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).write(request).await };
@@ -355,12 +360,12 @@ pub mod meta_service_server {
                 "/meta.MetaService/Forward" => {
                     #[allow(non_camel_case_types)]
                     struct ForwardSvc<T: MetaService>(pub Arc<T>);
-                    impl<T: MetaService> tonic::server::UnaryService<super::RaftReply> for ForwardSvc<T> {
+                    impl<T: MetaService> tonic::server::UnaryService<super::RaftRequest> for ForwardSvc<T> {
                         type Response = super::RaftReply;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::RaftReply>,
+                            request: tonic::Request<super::RaftRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).forward(request).await };
@@ -386,12 +391,12 @@ pub mod meta_service_server {
                 "/meta.MetaService/AppendEntries" => {
                     #[allow(non_camel_case_types)]
                     struct AppendEntriesSvc<T: MetaService>(pub Arc<T>);
-                    impl<T: MetaService> tonic::server::UnaryService<super::RaftReply> for AppendEntriesSvc<T> {
+                    impl<T: MetaService> tonic::server::UnaryService<super::RaftRequest> for AppendEntriesSvc<T> {
                         type Response = super::RaftReply;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::RaftReply>,
+                            request: tonic::Request<super::RaftRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).append_entries(request).await };
@@ -417,12 +422,12 @@ pub mod meta_service_server {
                 "/meta.MetaService/InstallSnapshot" => {
                     #[allow(non_camel_case_types)]
                     struct InstallSnapshotSvc<T: MetaService>(pub Arc<T>);
-                    impl<T: MetaService> tonic::server::UnaryService<super::RaftReply> for InstallSnapshotSvc<T> {
+                    impl<T: MetaService> tonic::server::UnaryService<super::RaftRequest> for InstallSnapshotSvc<T> {
                         type Response = super::RaftReply;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::RaftReply>,
+                            request: tonic::Request<super::RaftRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).install_snapshot(request).await };
@@ -448,12 +453,12 @@ pub mod meta_service_server {
                 "/meta.MetaService/vote" => {
                     #[allow(non_camel_case_types)]
                     struct voteSvc<T: MetaService>(pub Arc<T>);
-                    impl<T: MetaService> tonic::server::UnaryService<super::RaftReply> for voteSvc<T> {
+                    impl<T: MetaService> tonic::server::UnaryService<super::RaftRequest> for voteSvc<T> {
                         type Response = super::RaftReply;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::RaftReply>,
+                            request: tonic::Request<super::RaftRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).vote(request).await };

--- a/metasrv/src/proto/meta.rs
+++ b/metasrv/src/proto/meta.rs
@@ -70,7 +70,7 @@ pub struct GetReply {
     pub value: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RaftMes {
+pub struct RaftReply {
     #[prost(string, tag = "1")]
     pub data: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
@@ -138,8 +138,8 @@ pub mod meta_service_client {
         }
         pub async fn write(
             &mut self,
-            request: impl tonic::IntoRequest<super::RaftMes>,
-        ) -> Result<tonic::Response<super::RaftMes>, tonic::Status> {
+            request: impl tonic::IntoRequest<super::RaftReply>,
+        ) -> Result<tonic::Response<super::RaftReply>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
@@ -167,8 +167,8 @@ pub mod meta_service_client {
         #[doc = "/ Forward a request to other"]
         pub async fn forward(
             &mut self,
-            request: impl tonic::IntoRequest<super::RaftMes>,
-        ) -> Result<tonic::Response<super::RaftMes>, tonic::Status> {
+            request: impl tonic::IntoRequest<super::RaftReply>,
+        ) -> Result<tonic::Response<super::RaftReply>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
@@ -181,8 +181,8 @@ pub mod meta_service_client {
         }
         pub async fn append_entries(
             &mut self,
-            request: impl tonic::IntoRequest<super::RaftMes>,
-        ) -> Result<tonic::Response<super::RaftMes>, tonic::Status> {
+            request: impl tonic::IntoRequest<super::RaftReply>,
+        ) -> Result<tonic::Response<super::RaftReply>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
@@ -195,8 +195,8 @@ pub mod meta_service_client {
         }
         pub async fn install_snapshot(
             &mut self,
-            request: impl tonic::IntoRequest<super::RaftMes>,
-        ) -> Result<tonic::Response<super::RaftMes>, tonic::Status> {
+            request: impl tonic::IntoRequest<super::RaftReply>,
+        ) -> Result<tonic::Response<super::RaftReply>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
@@ -209,8 +209,8 @@ pub mod meta_service_client {
         }
         pub async fn vote(
             &mut self,
-            request: impl tonic::IntoRequest<super::RaftMes>,
-        ) -> Result<tonic::Response<super::RaftMes>, tonic::Status> {
+            request: impl tonic::IntoRequest<super::RaftReply>,
+        ) -> Result<tonic::Response<super::RaftReply>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
@@ -232,8 +232,8 @@ pub mod meta_service_server {
     pub trait MetaService: Send + Sync + 'static {
         async fn write(
             &self,
-            request: tonic::Request<super::RaftMes>,
-        ) -> Result<tonic::Response<super::RaftMes>, tonic::Status>;
+            request: tonic::Request<super::RaftReply>,
+        ) -> Result<tonic::Response<super::RaftReply>, tonic::Status>;
         async fn get(
             &self,
             request: tonic::Request<super::GetReq>,
@@ -241,20 +241,20 @@ pub mod meta_service_server {
         #[doc = "/ Forward a request to other"]
         async fn forward(
             &self,
-            request: tonic::Request<super::RaftMes>,
-        ) -> Result<tonic::Response<super::RaftMes>, tonic::Status>;
+            request: tonic::Request<super::RaftReply>,
+        ) -> Result<tonic::Response<super::RaftReply>, tonic::Status>;
         async fn append_entries(
             &self,
-            request: tonic::Request<super::RaftMes>,
-        ) -> Result<tonic::Response<super::RaftMes>, tonic::Status>;
+            request: tonic::Request<super::RaftReply>,
+        ) -> Result<tonic::Response<super::RaftReply>, tonic::Status>;
         async fn install_snapshot(
             &self,
-            request: tonic::Request<super::RaftMes>,
-        ) -> Result<tonic::Response<super::RaftMes>, tonic::Status>;
+            request: tonic::Request<super::RaftReply>,
+        ) -> Result<tonic::Response<super::RaftReply>, tonic::Status>;
         async fn vote(
             &self,
-            request: tonic::Request<super::RaftMes>,
-        ) -> Result<tonic::Response<super::RaftMes>, tonic::Status>;
+            request: tonic::Request<super::RaftReply>,
+        ) -> Result<tonic::Response<super::RaftReply>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MetaServiceServer<T: MetaService> {
@@ -296,12 +296,12 @@ pub mod meta_service_server {
                 "/meta.MetaService/Write" => {
                     #[allow(non_camel_case_types)]
                     struct WriteSvc<T: MetaService>(pub Arc<T>);
-                    impl<T: MetaService> tonic::server::UnaryService<super::RaftMes> for WriteSvc<T> {
-                        type Response = super::RaftMes;
+                    impl<T: MetaService> tonic::server::UnaryService<super::RaftReply> for WriteSvc<T> {
+                        type Response = super::RaftReply;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::RaftMes>,
+                            request: tonic::Request<super::RaftReply>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).write(request).await };
@@ -355,12 +355,12 @@ pub mod meta_service_server {
                 "/meta.MetaService/Forward" => {
                     #[allow(non_camel_case_types)]
                     struct ForwardSvc<T: MetaService>(pub Arc<T>);
-                    impl<T: MetaService> tonic::server::UnaryService<super::RaftMes> for ForwardSvc<T> {
-                        type Response = super::RaftMes;
+                    impl<T: MetaService> tonic::server::UnaryService<super::RaftReply> for ForwardSvc<T> {
+                        type Response = super::RaftReply;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::RaftMes>,
+                            request: tonic::Request<super::RaftReply>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).forward(request).await };
@@ -386,12 +386,12 @@ pub mod meta_service_server {
                 "/meta.MetaService/AppendEntries" => {
                     #[allow(non_camel_case_types)]
                     struct AppendEntriesSvc<T: MetaService>(pub Arc<T>);
-                    impl<T: MetaService> tonic::server::UnaryService<super::RaftMes> for AppendEntriesSvc<T> {
-                        type Response = super::RaftMes;
+                    impl<T: MetaService> tonic::server::UnaryService<super::RaftReply> for AppendEntriesSvc<T> {
+                        type Response = super::RaftReply;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::RaftMes>,
+                            request: tonic::Request<super::RaftReply>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).append_entries(request).await };
@@ -417,12 +417,12 @@ pub mod meta_service_server {
                 "/meta.MetaService/InstallSnapshot" => {
                     #[allow(non_camel_case_types)]
                     struct InstallSnapshotSvc<T: MetaService>(pub Arc<T>);
-                    impl<T: MetaService> tonic::server::UnaryService<super::RaftMes> for InstallSnapshotSvc<T> {
-                        type Response = super::RaftMes;
+                    impl<T: MetaService> tonic::server::UnaryService<super::RaftReply> for InstallSnapshotSvc<T> {
+                        type Response = super::RaftReply;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::RaftMes>,
+                            request: tonic::Request<super::RaftReply>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).install_snapshot(request).await };
@@ -448,12 +448,12 @@ pub mod meta_service_server {
                 "/meta.MetaService/vote" => {
                     #[allow(non_camel_case_types)]
                     struct voteSvc<T: MetaService>(pub Arc<T>);
-                    impl<T: MetaService> tonic::server::UnaryService<super::RaftMes> for voteSvc<T> {
-                        type Response = super::RaftMes;
+                    impl<T: MetaService> tonic::server::UnaryService<super::RaftReply> for voteSvc<T> {
+                        type Response = super::RaftReply;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::RaftMes>,
+                            request: tonic::Request<super::RaftReply>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).vote(request).await };


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: use RaftRequest as a request type, use RaftReply as reply type for raft communication

##### [metasrv] refactor: rename RaftMes to RaftReply

## Changelog




- Improvement


## Related Issues