### PR TITLE
[common/meta/api] refactor: remove api update_kv_meta(), upsert_kv() is quite enough

### DIFF
--- a/common/management/src/namespace/namespace_mgr.rs
+++ b/common/management/src/namespace/namespace_mgr.rs
@@ -25,6 +25,7 @@ use common_meta_types::AddResult;
 use common_meta_types::KVMeta;
 use common_meta_types::MatchSeq;
 use common_meta_types::NodeInfo;
+use common_meta_types::Operation;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKVActionReply;
 
@@ -136,7 +137,7 @@ impl NamespaceApi for NamespaceMgr {
         // Only when there are no record, i.e. seq=0
         let seq = MatchSeq::Exact(0);
         let meta = Some(self.new_lift_time());
-        let value = Some(serde_json::to_vec(&node)?);
+        let value = Operation::Update(serde_json::to_vec(&node)?);
         let node_key = format!(
             "{}/{}",
             self.namespace_prefix,
@@ -176,7 +177,9 @@ impl NamespaceApi for NamespaceMgr {
             self.namespace_prefix,
             Self::escape_for_key(&node_id)?
         );
-        let upsert_node = self.kv_api.upsert_kv(&node_key, seq.into(), None, None);
+        let upsert_node = self
+            .kv_api
+            .upsert_kv(&node_key, seq.into(), Operation::Delete, None);
 
         match upsert_node.await? {
             UpsertKVActionReply {

--- a/common/management/src/namespace/namespace_mgr.rs
+++ b/common/management/src/namespace/namespace_mgr.rs
@@ -205,7 +205,7 @@ impl NamespaceApi for NamespaceMgr {
             Some(exact) => MatchSeq::Exact(exact),
         };
 
-        let upsert_meta = self.kv_api.update_kv_meta(&node_key, seq, meta);
+        let upsert_meta = self.kv_api.upsert_kv(&node_key, seq, Operation::AsIs, meta);
 
         match upsert_meta.await? {
             UpsertKVActionReply {

--- a/common/management/src/user/user_mgr.rs
+++ b/common/management/src/user/user_mgr.rs
@@ -24,6 +24,7 @@ use common_meta_types::AuthType;
 use common_meta_types::IntoSeqV;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
+use common_meta_types::Operation;
 use common_meta_types::SeqV;
 
 use crate::user::user_api::UserInfo;
@@ -53,7 +54,7 @@ impl UserMgrApi for UserMgr {
         let value = serde_json::to_vec(&user_info)?;
 
         let kv_api = self.kv_api.clone();
-        let upsert_kv = kv_api.upsert_kv(&key, match_seq, Some(value), None);
+        let upsert_kv = kv_api.upsert_kv(&key, match_seq, Operation::Update(value), None);
         let res = upsert_kv.await?.into_add_result()?;
         match res {
             AddResult::Ok(v) => Ok(v.seq),
@@ -136,7 +137,11 @@ impl UserMgrApi for UserMgr {
         };
 
         let kv_api = self.kv_api.clone();
-        let upsert_kv = async move { kv_api.upsert_kv(&key, match_seq, Some(value), None).await };
+        let upsert_kv = async move {
+            kv_api
+                .upsert_kv(&key, match_seq, Operation::Update(value), None)
+                .await
+        };
         let res = upsert_kv.await?;
         match res.result {
             Some(SeqV { seq: s, .. }) => Ok(Some(s)),
@@ -150,7 +155,11 @@ impl UserMgrApi for UserMgr {
     async fn drop_user(&self, username: String, seq: Option<u64>) -> Result<()> {
         let key = format!("{}/{}", self.user_prefix, username);
         let kv_api = self.kv_api.clone();
-        let upsert_kv = async move { kv_api.upsert_kv(&key, seq.into(), None, None).await };
+        let upsert_kv = async move {
+            kv_api
+                .upsert_kv(&key, seq.into(), Operation::Delete, None)
+                .await
+        };
         let res = upsert_kv.await?;
         if res.prev.is_some() && res.result.is_none() {
             Ok(())

--- a/common/management/src/user/user_mgr_test.rs
+++ b/common/management/src/user/user_mgr_test.rs
@@ -47,13 +47,6 @@ mock! {
             value_meta: Option<KVMeta>
         ) -> common_exception::Result<UpsertKVActionReply>;
 
-        async fn update_kv_meta(
-            &self,
-            key: &str,
-            seq: MatchSeq,
-            value_meta: Option<KVMeta>
-        ) -> common_exception::Result<UpsertKVActionReply>;
-
         async fn get_kv(&self, key: &str) -> common_exception::Result<GetKVActionReply>;
 
         async fn mget_kv(

--- a/common/management/src/user/user_mgr_test.rs
+++ b/common/management/src/user/user_mgr_test.rs
@@ -23,6 +23,7 @@ use common_meta_types::GetKVActionReply;
 use common_meta_types::KVMeta;
 use common_meta_types::MGetKVActionReply;
 use common_meta_types::MatchSeq;
+use common_meta_types::Operation;
 use common_meta_types::PrefixListReply;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKVActionReply;
@@ -42,7 +43,7 @@ mock! {
             &self,
             key: &str,
             seq: MatchSeq,
-            value: Option<Vec<u8>>,
+            value: Operation<Vec<u8>>,
             value_meta: Option<KVMeta>
         ) -> common_exception::Result<UpsertKVActionReply>;
 
@@ -66,6 +67,7 @@ mock! {
 
 mod add {
     use common_meta_types::AuthType;
+    use common_meta_types::Operation;
 
     use super::*;
 
@@ -81,7 +83,7 @@ mod add {
             Vec::from(test_password),
             auth_type.clone(),
         );
-        let value = Some(serde_json::to_vec(&user_info)?);
+        let value = Operation::Update(serde_json::to_vec(&user_info)?);
 
         let test_key = format!("__fd_users/tenant1/{}", test_user_name);
         let test_seq = MatchSeq::Exact(0);
@@ -411,7 +413,7 @@ mod drop {
             .with(
                 predicate::function(move |v| v == test_key),
                 predicate::eq(MatchSeq::Any),
-                predicate::eq(None),
+                predicate::eq(Operation::Delete),
                 predicate::eq(None),
             )
             .times(1)
@@ -434,7 +436,7 @@ mod drop {
             .with(
                 predicate::function(move |v| v == test_key),
                 predicate::eq(MatchSeq::Any),
-                predicate::eq(None),
+                predicate::eq(Operation::Delete),
                 predicate::eq(None),
             )
             .times(1)
@@ -502,7 +504,7 @@ mod update {
             .with(
                 predicate::function(move |v| v == test_key.as_str()),
                 predicate::eq(MatchSeq::GE(1)),
-                predicate::eq(Some(new_value_with_old_salt)),
+                predicate::eq(Operation::Update(new_value_with_old_salt)),
                 predicate::eq(None),
             )
             .times(1)
@@ -551,7 +553,7 @@ mod update {
             .with(
                 predicate::function(move |v| v == test_key.as_str()),
                 predicate::eq(MatchSeq::GE(1)),
-                predicate::eq(Some(new_value)),
+                predicate::eq(Operation::Update(new_value)),
                 predicate::eq(None),
             )
             .times(1)

--- a/common/meta/api/src/kv_api.rs
+++ b/common/meta/api/src/kv_api.rs
@@ -20,6 +20,7 @@ use common_meta_types::GetKVActionReply;
 use common_meta_types::KVMeta;
 use common_meta_types::MGetKVActionReply;
 use common_meta_types::MatchSeq;
+use common_meta_types::Operation;
 use common_meta_types::PrefixListReply;
 use common_meta_types::UpsertKVActionReply;
 
@@ -29,7 +30,7 @@ pub trait KVApi: Send + Sync {
         &self,
         key: &str,
         seq: MatchSeq,
-        value: Option<Vec<u8>>,
+        value: Operation<Vec<u8>>,
         value_meta: Option<KVMeta>,
     ) -> common_exception::Result<UpsertKVActionReply>;
 
@@ -54,7 +55,7 @@ impl KVApi for Arc<dyn KVApi> {
         &self,
         key: &str,
         seq: MatchSeq,
-        value: Option<Vec<u8>>,
+        value: Operation<Vec<u8>>,
         value_meta: Option<KVMeta>,
     ) -> common_exception::Result<UpsertKVActionReply> {
         self.as_ref().upsert_kv(key, seq, value, value_meta).await

--- a/common/meta/api/src/kv_api.rs
+++ b/common/meta/api/src/kv_api.rs
@@ -34,13 +34,6 @@ pub trait KVApi: Send + Sync {
         value_meta: Option<KVMeta>,
     ) -> common_exception::Result<UpsertKVActionReply>;
 
-    async fn update_kv_meta(
-        &self,
-        key: &str,
-        seq: MatchSeq,
-        value_meta: Option<KVMeta>,
-    ) -> common_exception::Result<UpsertKVActionReply>;
-
     async fn get_kv(&self, key: &str) -> common_exception::Result<GetKVActionReply>;
 
     // mockall complains about AsRef... so we use String here
@@ -59,15 +52,6 @@ impl KVApi for Arc<dyn KVApi> {
         value_meta: Option<KVMeta>,
     ) -> common_exception::Result<UpsertKVActionReply> {
         self.as_ref().upsert_kv(key, seq, value, value_meta).await
-    }
-
-    async fn update_kv_meta(
-        &self,
-        key: &str,
-        seq: MatchSeq,
-        value_meta: Option<KVMeta>,
-    ) -> common_exception::Result<UpsertKVActionReply> {
-        self.as_ref().update_kv_meta(key, seq, value_meta).await
     }
 
     async fn get_kv(&self, key: &str) -> common_exception::Result<GetKVActionReply> {

--- a/common/meta/api/src/kv_api_test_suite.rs
+++ b/common/meta/api/src/kv_api_test_suite.rs
@@ -346,9 +346,10 @@ impl KVApiTestSuite {
         tracing::info!("--- mismatching seq does nothing");
 
         let r = client
-            .update_kv_meta(
+            .upsert_kv(
                 test_key,
                 MatchSeq::Exact(seq + 1),
+                Operation::AsIs,
                 Some(KVMeta {
                     expire_at: Some(now + 20),
                 }),
@@ -360,9 +361,10 @@ impl KVApiTestSuite {
         tracing::info!("--- matching seq only update meta");
 
         let r = client
-            .update_kv_meta(
+            .upsert_kv(
                 test_key,
                 MatchSeq::Exact(seq),
+                Operation::AsIs,
                 Some(KVMeta {
                     expire_at: Some(now + 20),
                 }),

--- a/common/meta/api/src/lib.rs
+++ b/common/meta/api/src/lib.rs
@@ -13,6 +13,8 @@
 //  limitations under the License.
 //
 
+extern crate common_meta_types;
+
 mod kv_api;
 mod kv_api_test_suite;
 mod meta_api;

--- a/common/meta/embedded/src/kv_api_impl.rs
+++ b/common/meta/embedded/src/kv_api_impl.rs
@@ -34,9 +34,9 @@ impl KVApi for MetaEmbedded {
         &self,
         key: &str,
         seq: MatchSeq,
-        value: Option<Vec<u8>>,
+        value: Operation<Vec<u8>>,
         value_meta: Option<KVMeta>,
-    ) -> Result<UpsertKVActionReply> {
+    ) -> common_exception::Result<UpsertKVActionReply> {
         let cmd = Cmd::UpsertKV {
             key: key.to_string(),
             seq,

--- a/common/meta/embedded/src/kv_api_impl.rs
+++ b/common/meta/embedded/src/kv_api_impl.rs
@@ -40,31 +40,7 @@ impl KVApi for MetaEmbedded {
         let cmd = Cmd::UpsertKV {
             key: key.to_string(),
             seq,
-            value: value.into(),
-            value_meta,
-        };
-
-        let mut sm = self.inner.lock().await;
-        let res = sm.apply_cmd(&cmd).await?;
-
-        match res {
-            AppliedState::KV(x) => Ok(x),
-            _ => {
-                panic!("expect AppliedState::KV");
-            }
-        }
-    }
-
-    async fn update_kv_meta(
-        &self,
-        key: &str,
-        seq: MatchSeq,
-        value_meta: Option<KVMeta>,
-    ) -> Result<UpsertKVActionReply> {
-        let cmd = Cmd::UpsertKV {
-            key: key.to_string(),
-            seq,
-            value: Operation::AsIs,
+            value,
             value_meta,
         };
 

--- a/common/meta/flight/src/flight_action.rs
+++ b/common/meta/flight/src/flight_action.rs
@@ -77,7 +77,6 @@ pub enum MetaFlightAction {
 
     // general purpose kv
     UpsertKV(UpsertKVAction),
-    UpdateKVMeta(KVMetaAction),
     GetKV(GetKVAction),
     MGetKV(MGetKVAction),
     PrefixListKV(PrefixListReq),
@@ -174,19 +173,6 @@ action_declare!(
     UpsertKVAction,
     UpsertKVActionReply,
     MetaFlightAction::UpsertKV
-);
-
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub struct KVMetaAction {
-    pub key: String,
-    pub seq: MatchSeq,
-    pub value_meta: Option<KVMeta>,
-}
-
-action_declare!(
-    KVMetaAction,
-    UpsertKVActionReply,
-    MetaFlightAction::UpdateKVMeta
 );
 
 // == database actions ==

--- a/common/meta/flight/src/flight_action.rs
+++ b/common/meta/flight/src/flight_action.rs
@@ -27,6 +27,7 @@ use common_meta_types::MGetKVActionReply;
 use common_meta_types::MatchSeq;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_meta_types::Operation;
 use common_meta_types::PrefixListReply;
 use common_meta_types::TableInfo;
 use common_meta_types::UpsertKVActionReply;
@@ -165,7 +166,7 @@ action_declare!(
 pub struct UpsertKVAction {
     pub key: String,
     pub seq: MatchSeq,
-    pub value: Option<Vec<u8>>,
+    pub value: Operation<Vec<u8>>,
     pub value_meta: Option<KVMeta>,
 }
 

--- a/common/meta/flight/src/impls/kv_api_impl.rs
+++ b/common/meta/flight/src/impls/kv_api_impl.rs
@@ -24,7 +24,6 @@ use common_meta_types::UpsertKVActionReply;
 use common_tracing::tracing;
 
 use crate::GetKVAction;
-use crate::KVMetaAction;
 use crate::MGetKVAction;
 use crate::MetaFlightClient;
 use crate::PrefixListReq;
@@ -44,20 +43,6 @@ impl KVApi for MetaFlightClient {
             key: key.to_string(),
             seq,
             value,
-            value_meta,
-        })
-        .await
-    }
-
-    async fn update_kv_meta(
-        &self,
-        key: &str,
-        seq: MatchSeq,
-        value_meta: Option<KVMeta>,
-    ) -> Result<UpsertKVActionReply> {
-        self.do_action(KVMetaAction {
-            key: key.to_string(),
-            seq,
             value_meta,
         })
         .await

--- a/common/meta/flight/src/impls/kv_api_impl.rs
+++ b/common/meta/flight/src/impls/kv_api_impl.rs
@@ -18,6 +18,7 @@ use common_meta_types::GetKVActionReply;
 use common_meta_types::KVMeta;
 use common_meta_types::MGetKVActionReply;
 use common_meta_types::MatchSeq;
+use common_meta_types::Operation;
 use common_meta_types::PrefixListReply;
 use common_meta_types::UpsertKVActionReply;
 use common_tracing::tracing;
@@ -36,9 +37,9 @@ impl KVApi for MetaFlightClient {
         &self,
         key: &str,
         seq: MatchSeq,
-        value: Option<Vec<u8>>,
+        value: Operation<Vec<u8>>,
         value_meta: Option<KVMeta>,
-    ) -> Result<UpsertKVActionReply> {
+    ) -> common_exception::Result<UpsertKVActionReply> {
         self.do_action(UpsertKVAction {
             key: key.to_string(),
             seq,

--- a/metasrv/src/executor/action_handler.rs
+++ b/metasrv/src/executor/action_handler.rs
@@ -56,7 +56,6 @@ impl ActionHandler {
 
         match action {
             MetaFlightAction::UpsertKV(a) => s.serialize(self.handle(a).await?),
-            MetaFlightAction::UpdateKVMeta(a) => s.serialize(self.handle(a).await?),
             MetaFlightAction::GetKV(a) => s.serialize(self.handle(a).await?),
             MetaFlightAction::MGetKV(a) => s.serialize(self.handle(a).await?),
             MetaFlightAction::PrefixListKV(a) => s.serialize(self.handle(a).await?),

--- a/metasrv/src/executor/kv_handlers.rs
+++ b/metasrv/src/executor/kv_handlers.rs
@@ -15,7 +15,6 @@
 
 use common_exception::ErrorCode;
 use common_meta_flight::GetKVAction;
-use common_meta_flight::KVMetaAction;
 use common_meta_flight::MGetKVAction;
 use common_meta_flight::PrefixListReq;
 use common_meta_flight::UpsertKVAction;
@@ -24,7 +23,6 @@ use common_meta_types::Cmd;
 use common_meta_types::GetKVActionReply;
 use common_meta_types::LogEntry;
 use common_meta_types::MGetKVActionReply;
-use common_meta_types::Operation;
 use common_meta_types::PrefixListReply;
 use common_meta_types::UpsertKVActionReply;
 
@@ -39,32 +37,7 @@ impl RequestHandler<UpsertKVAction> for ActionHandler {
             cmd: Cmd::UpsertKV {
                 key: act.key,
                 seq: act.seq,
-                value: act.value.into(),
-                value_meta: act.value_meta,
-            },
-        };
-        let rst = self
-            .meta_node
-            .write(cr)
-            .await
-            .map_err(|e| ErrorCode::MetaNodeInternalError(e.to_string()))?;
-
-        match rst {
-            AppliedState::KV(x) => Ok(x),
-            _ => Err(ErrorCode::MetaNodeInternalError("not a KV result")),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl RequestHandler<KVMetaAction> for ActionHandler {
-    async fn handle(&self, act: KVMetaAction) -> common_exception::Result<UpsertKVActionReply> {
-        let cr = LogEntry {
-            txid: None,
-            cmd: Cmd::UpsertKV {
-                key: act.key,
-                seq: act.seq,
-                value: Operation::AsIs,
+                value: act.value,
                 value_meta: act.value_meta,
             },
         };

--- a/metasrv/tests/flight/metasrv_flight_api.rs
+++ b/metasrv/tests/flight/metasrv_flight_api.rs
@@ -18,6 +18,7 @@ use common_base::tokio;
 use common_meta_api::KVApi;
 use common_meta_flight::MetaFlightClient;
 use common_meta_types::MatchSeq;
+use common_meta_types::Operation;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKVActionReply;
 use common_tracing::tracing;
@@ -45,7 +46,12 @@ async fn test_restart() -> anyhow::Result<()> {
     tracing::info!("--- upsert kv");
     {
         let res = client
-            .upsert_kv("foo", MatchSeq::Any, Some(b"bar".to_vec()), None)
+            .upsert_kv(
+                "foo",
+                MatchSeq::Any,
+                Operation::Update(b"bar".to_vec()),
+                None,
+            )
             .await;
 
         tracing::debug!("set kv res: {:?}", res);
@@ -160,7 +166,7 @@ async fn test_join() -> anyhow::Result<()> {
                 .upsert_kv(
                     k.as_str(),
                     MatchSeq::Any,
-                    Some(k.clone().into_bytes()),
+                    Operation::Update(k.clone().into_bytes()),
                     None,
                 )
                 .await;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/api] refactor: remove api update_kv_meta(), upsert_kv() is quite enough

##### [common/meta/api]: refactor: upsert_kv replace Option<T> with Operation<T>; Operation provides 3 ops: update, delete and as-is

## Changelog




- Improvement


## Related Issues