### PR TITLE
[metasrv] refactor: move write_to_local_leader() to MetaLeader

### DIFF
--- a/metasrv/src/meta_service/message.rs
+++ b/metasrv/src/meta_service/message.rs
@@ -35,6 +35,7 @@ pub struct JoinRequest {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, derive_more::TryInto)]
 pub enum AdminRequestInner {
     Join(JoinRequest),
+    Write(LogEntry),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -52,8 +53,10 @@ impl AdminRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, derive_more::TryInto)]
+#[allow(clippy::large_enum_variant)]
 pub enum AdminResponse {
     Join(()),
+    AppliedState(AppliedState),
 }
 
 impl tonic::IntoRequest<RaftRequest> for AdminRequest {

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -16,8 +16,6 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use async_raft::config::Config;
-use async_raft::raft::ClientWriteRequest;
-use async_raft::ClientWriteError;
 use async_raft::Raft;
 use async_raft::RaftMetrics;
 use async_raft::SnapshotPolicy;
@@ -46,10 +44,10 @@ use common_tracing::tracing::Instrument;
 use crate::errors::ConnectionError;
 use crate::errors::ForwardToLeader;
 use crate::errors::MetaError;
-use crate::errors::RetryableError;
 use crate::meta_service::message::AdminRequest;
 use crate::meta_service::message::AdminResponse;
 use crate::meta_service::meta_leader::MetaLeader;
+use crate::meta_service::AdminRequestInner;
 use crate::meta_service::MetaServiceImpl;
 use crate::meta_service::Network;
 use crate::proto::meta_service_client::MetaServiceClient;
@@ -532,31 +530,16 @@ impl MetaNode {
     /// Submit a write request to the known leader. Returns the response after applying the request.
     #[tracing::instrument(level = "info", skip(self))]
     pub async fn write(&self, req: LogEntry) -> common_exception::Result<AppliedState> {
-        let mut curr_leader = self.get_leader().await;
-        loop {
-            let rst = if curr_leader == self.sto.id {
-                self.write_to_local_leader(req.clone()).await?
-            } else {
-                // forward to leader
+        let res = self
+            .handle_admin_req(AdminRequest {
+                forward_to_leader: true,
+                req: AdminRequestInner::Write(req.clone()),
+            })
+            .await?;
 
-                let addr = self.sto.get_node_addr(&curr_leader).await?;
+        let res: AppliedState = res.try_into().expect("expect AppliedState");
 
-                // TODO: retry
-                let mut client = MetaServiceClient::connect(format!("http://{}", addr))
-                    .await
-                    .map_err(|e| ErrorCode::CannotConnectNode(e.to_string()))?;
-                let resp = client.write(req.clone()).await?;
-                let rst: Result<AppliedState, RetryableError> = resp.into_inner().into();
-                rst
-            };
-
-            match rst {
-                Ok(resp) => return Ok(resp),
-                Err(write_err) => match write_err {
-                    RetryableError::ForwardToLeader { leader } => curr_leader = leader,
-                },
-            }
-        }
+        Ok(res)
     }
 
     /// Try to get the leader from the latest metrics of the local raft node.
@@ -615,35 +598,5 @@ impl MetaNode {
 
         let res: Result<AdminResponse, MetaError> = raft_mes.into();
         res
-    }
-
-    /// Write a meta log through local raft node.
-    /// It works only when this node is the leader,
-    /// otherwise it returns ClientWriteError::ForwardToLeader error indicating the latest leader.
-    #[tracing::instrument(level = "info", skip(self))]
-    pub async fn write_to_local_leader(
-        &self,
-        req: LogEntry,
-    ) -> common_exception::Result<Result<AppliedState, RetryableError>> {
-        let write_rst = self.raft.client_write(ClientWriteRequest::new(req)).await;
-
-        tracing::debug!("raft.client_write rst: {:?}", write_rst);
-
-        match write_rst {
-            Ok(resp) => Ok(Ok(resp.data)),
-            Err(cli_write_err) => match cli_write_err {
-                // fatal error
-                ClientWriteError::RaftError(raft_err) => {
-                    Err(ErrorCode::MetaServiceError(raft_err.to_string()))
-                }
-                // retryable error
-                ClientWriteError::ForwardToLeader(_, leader) => match leader {
-                    Some(id) => Ok(Err(RetryableError::ForwardToLeader { leader: id })),
-                    None => Err(ErrorCode::MetaServiceUnavailable(
-                        "no leader to write".to_string(),
-                    )),
-                },
-            },
-        }
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: move write_to_local_leader() to MetaLeader

## Changelog




- Improvement


## Related Issues