### PR TITLE
Add monotonicity check visitor

### DIFF
--- a/common/functions/src/scalars/arithmetics/arithmetic.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic.rs
@@ -21,6 +21,7 @@ use common_datavalues::DataValueArithmeticOperator;
 use common_exception::Result;
 
 use crate::scalars::dates::IntervalFunctionFactory;
+use crate::scalars::function::MonotonicityNode;
 use crate::scalars::function_factory::FunctionFactory;
 use crate::scalars::ArithmeticDivFunction;
 use crate::scalars::ArithmeticMinusFunction;
@@ -111,6 +112,16 @@ impl Function for ArithmeticFunction {
 
     fn variadic_arguments(&self) -> Option<(usize, usize)> {
         Some((1, 2))
+    }
+
+    fn get_monotonicity(&self, args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
+        match self.op {
+            Plus => ArithmeticPlusFunction::get_monotonicity(args),
+            Minus => ArithmeticMinusFunction::get_monotonicity(args),
+            Mul => ArithmeticMulFunction::get_monotonicity(args),
+            Div => ArithmeticDivFunction::get_monotonicity(args),
+            Modulo => ArithmeticModuloFunction::get_monotonicity(args),
+        }
     }
 }
 

--- a/common/functions/src/scalars/arithmetics/arithmetic_div.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_div.rs
@@ -19,6 +19,8 @@ use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
+use crate::scalars::Monotonicity;
+use crate::scalars::MonotonicityNode;
 
 pub struct ArithmeticDivFunction;
 
@@ -30,5 +32,10 @@ impl ArithmeticDivFunction {
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create_func))
             .features(FunctionFeatures::default().deterministic())
+    }
+
+    pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
+        //TODO: implement
+        Ok(MonotonicityNode::Function(Monotonicity::default()))
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_div.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_div.rs
@@ -36,6 +36,6 @@ impl ArithmeticDivFunction {
 
     pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
         //TODO: implement
-        Ok(MonotonicityNode::Function(Monotonicity::default()))
+        Ok(MonotonicityNode::Function(Monotonicity::default(), None))
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
@@ -19,6 +19,8 @@ use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
+use crate::scalars::Monotonicity;
+use crate::scalars::MonotonicityNode;
 
 pub struct ArithmeticMinusFunction;
 
@@ -30,5 +32,10 @@ impl ArithmeticMinusFunction {
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create_func))
             .features(FunctionFeatures::default().deterministic())
+    }
+
+    pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
+        //TODO: implement
+        Ok(MonotonicityNode::Function(Monotonicity::default()))
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
@@ -36,6 +36,6 @@ impl ArithmeticMinusFunction {
 
     pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
         //TODO: implement
-        Ok(MonotonicityNode::Function(Monotonicity::default()))
+        Ok(MonotonicityNode::Function(Monotonicity::default(), None))
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_modulo.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_modulo.rs
@@ -19,6 +19,8 @@ use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
+use crate::scalars::Monotonicity;
+use crate::scalars::MonotonicityNode;
 
 pub struct ArithmeticModuloFunction;
 
@@ -30,5 +32,10 @@ impl ArithmeticModuloFunction {
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create_func))
             .features(FunctionFeatures::default().deterministic())
+    }
+
+    pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
+        //TODO: implement
+        Ok(MonotonicityNode::Function(Monotonicity::default()))
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_modulo.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_modulo.rs
@@ -36,6 +36,6 @@ impl ArithmeticModuloFunction {
 
     pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
         //TODO: implement
-        Ok(MonotonicityNode::Function(Monotonicity::default()))
+        Ok(MonotonicityNode::Function(Monotonicity::default(), None))
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
@@ -19,6 +19,8 @@ use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
+use crate::scalars::Monotonicity;
+use crate::scalars::MonotonicityNode;
 
 pub struct ArithmeticMulFunction;
 
@@ -30,5 +32,10 @@ impl ArithmeticMulFunction {
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create_func))
             .features(FunctionFeatures::default().deterministic())
+    }
+
+    pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
+        //TODO: implement
+        Ok(MonotonicityNode::Function(Monotonicity::default()))
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
@@ -36,6 +36,6 @@ impl ArithmeticMulFunction {
 
     pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
         //TODO: implement
-        Ok(MonotonicityNode::Function(Monotonicity::default()))
+        Ok(MonotonicityNode::Function(Monotonicity::default(), None))
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
@@ -47,60 +47,71 @@ impl ArithmeticPlusFunction {
             return Ok(args[0].clone());
         }
 
+        // TODO: handle input with data range
         match (&args[0], &args[1]) {
             // a constant value plus a function, like 12 + f(x), the monotonicity should be the same as f
-            (MonotonicityNode::Function(mono), MonotonicityNode::Constant(_))
-            | (MonotonicityNode::Constant(_), MonotonicityNode::Function(mono)) => {
-                Ok(MonotonicityNode::Function(mono.clone()))
+            (MonotonicityNode::Function(mono, None), MonotonicityNode::Constant(_))
+            | (MonotonicityNode::Constant(_), MonotonicityNode::Function(mono, None)) => {
+                Ok(MonotonicityNode::Function(mono.clone(), None))
             }
 
             // a constant value plus a variable, like x + 12 should be monotonically increasing
-            (MonotonicityNode::Constant(_), MonotonicityNode::Variable(_))
-            | (MonotonicityNode::Variable(_), MonotonicityNode::Constant(_)) => {
-                Ok(MonotonicityNode::Function(Monotonicity {
-                    is_monotonic: true,
-                    is_positive: true,
-                    is_always_monotonic: true,
-                }))
+            (MonotonicityNode::Constant(_), MonotonicityNode::Variable(_, None))
+            | (MonotonicityNode::Variable(_, None), MonotonicityNode::Constant(_)) => {
+                Ok(MonotonicityNode::Function(
+                    Monotonicity {
+                        is_monotonic: true,
+                        is_positive: true,
+                        is_always_monotonic: true,
+                    },
+                    None,
+                ))
             }
 
             // two function plus, f(x) + g(x) , if they have same monotonicity, then should return that monotonicity
-            (MonotonicityNode::Function(mono1), MonotonicityNode::Function(mono2)) => {
+            (MonotonicityNode::Function(mono1, None), MonotonicityNode::Function(mono2, None)) => {
                 if mono1.is_monotonic
                     && mono2.is_monotonic
                     && mono1.is_positive == mono2.is_positive
                 {
-                    return Ok(MonotonicityNode::Function(Monotonicity {
-                        is_monotonic: true,
-                        is_positive: mono1.is_positive,
-                        is_always_monotonic: mono1.is_always_monotonic && mono2.is_always_monotonic,
-                    }));
+                    return Ok(MonotonicityNode::Function(
+                        Monotonicity {
+                            is_monotonic: true,
+                            is_positive: mono1.is_positive,
+                            is_always_monotonic: mono1.is_always_monotonic
+                                && mono2.is_always_monotonic,
+                        },
+                        None,
+                    ));
                 }
-                Ok(MonotonicityNode::Function(Monotonicity::default()))
+                Ok(MonotonicityNode::Function(Monotonicity::default(), None))
             }
 
             // two variable plus(we assume only one variable exists), like x+x, should be monotonically increasing
-            (MonotonicityNode::Variable(var1), MonotonicityNode::Variable(var2)) => {
+            (MonotonicityNode::Variable(var1, None), MonotonicityNode::Variable(var2, None)) => {
                 if var1 == var2 {
-                    return Ok(MonotonicityNode::Function(Monotonicity {
-                        is_monotonic: true,
-                        is_positive: true,
-                        is_always_monotonic: true,
-                    }));
+                    return Ok(MonotonicityNode::Function(
+                        Monotonicity {
+                            is_monotonic: true,
+                            is_positive: true,
+                            is_always_monotonic: true,
+                        },
+                        None,
+                    ));
                 }
-                Ok(MonotonicityNode::Function(Monotonicity::default()))
+                Ok(MonotonicityNode::Function(Monotonicity::default(), None))
             }
 
             // a function plus the variable, like f(x) + x, if f(x) is monotonically increasing, return it.
-            (MonotonicityNode::Function(mono), MonotonicityNode::Variable(_))
-            | (MonotonicityNode::Variable(_), MonotonicityNode::Function(mono)) => {
+            (MonotonicityNode::Function(mono, None), MonotonicityNode::Variable(_, None))
+            | (MonotonicityNode::Variable(_, None), MonotonicityNode::Function(mono, None)) => {
                 if mono.is_monotonic && mono.is_positive {
-                    return Ok(MonotonicityNode::Function(mono.clone()));
+                    return Ok(MonotonicityNode::Function(mono.clone(), None));
                 }
-                Ok(MonotonicityNode::Function(Monotonicity::default()))
+                Ok(MonotonicityNode::Function(Monotonicity::default(), None))
             }
 
-            _ => Ok(MonotonicityNode::Function(Monotonicity::default())),
+            _ => Ok(MonotonicityNode::Function(Monotonicity::default(), None)),
         }
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 use common_datavalues::DataValueArithmeticOperator;
+use common_exception::ErrorCode;
 use common_exception::Result;
 
+use crate::scalars::function::MonotonicityNode;
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
+use crate::scalars::Monotonicity;
 
 pub struct ArithmeticPlusFunction;
 
@@ -30,5 +33,74 @@ impl ArithmeticPlusFunction {
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create_func))
             .features(FunctionFeatures::default().deterministic())
+    }
+
+    pub fn get_monotonicity(args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
+        if args.is_empty() || args.len() > 2 {
+            return Err(ErrorCode::BadArguments(format!(
+                "Invalid argument lengths {} for get_monotonicity",
+                args.len()
+            )));
+        }
+
+        if args.len() == 1 {
+            return Ok(args[0].clone());
+        }
+
+        match (&args[0], &args[1]) {
+            // a constant value plus a function, like 12 + f(x), the monotonicity should be the same as f
+            (MonotonicityNode::Function(mono), MonotonicityNode::Constant(_))
+            | (MonotonicityNode::Constant(_), MonotonicityNode::Function(mono)) => {
+                Ok(MonotonicityNode::Function(mono.clone()))
+            }
+
+            // a constant value plus a variable, like x + 12 should be monotonically increasing
+            (MonotonicityNode::Constant(_), MonotonicityNode::Variable(_))
+            | (MonotonicityNode::Variable(_), MonotonicityNode::Constant(_)) => {
+                Ok(MonotonicityNode::Function(Monotonicity {
+                    is_monotonic: true,
+                    is_positive: true,
+                    is_always_monotonic: true,
+                }))
+            }
+
+            // two function plus, f(x) + g(x) , if they have same monotonicity, then should return that monotonicity
+            (MonotonicityNode::Function(mono1), MonotonicityNode::Function(mono2)) => {
+                if mono1.is_monotonic
+                    && mono2.is_monotonic
+                    && mono1.is_positive == mono2.is_positive
+                {
+                    return Ok(MonotonicityNode::Function(Monotonicity {
+                        is_monotonic: true,
+                        is_positive: mono1.is_positive,
+                        is_always_monotonic: mono1.is_always_monotonic && mono2.is_always_monotonic,
+                    }));
+                }
+                Ok(MonotonicityNode::Function(Monotonicity::default()))
+            }
+
+            // two variable plus(we assume only one variable exists), like x+x, should be monotonically increasing
+            (MonotonicityNode::Variable(var1), MonotonicityNode::Variable(var2)) => {
+                if var1 == var2 {
+                    return Ok(MonotonicityNode::Function(Monotonicity {
+                        is_monotonic: true,
+                        is_positive: true,
+                        is_always_monotonic: true,
+                    }));
+                }
+                Ok(MonotonicityNode::Function(Monotonicity::default()))
+            }
+
+            // a function plus the variable, like f(x) + x, if f(x) is monotonically increasing, return it.
+            (MonotonicityNode::Function(mono), MonotonicityNode::Variable(_))
+            | (MonotonicityNode::Variable(_), MonotonicityNode::Function(mono)) => {
+                if mono.is_monotonic && mono.is_positive {
+                    return Ok(MonotonicityNode::Function(mono.clone()));
+                }
+                Ok(MonotonicityNode::Function(Monotonicity::default()))
+            }
+
+            _ => Ok(MonotonicityNode::Function(Monotonicity::default())),
+        }
     }
 }

--- a/common/functions/src/scalars/function.rs
+++ b/common/functions/src/scalars/function.rs
@@ -18,8 +18,52 @@ use common_datavalues::columns::DataColumn;
 use common_datavalues::prelude::DataColumnsWithField;
 use common_datavalues::DataSchema;
 use common_datavalues::DataType;
+use common_datavalues::DataValue;
 use common_exception::Result;
 use dyn_clone::DynClone;
+
+// Represents the node of function tree for calculating monotonicity.
+// For example, a function of Add(Neg(number), 5) will have a tree like this:
+//
+// .                   MonotonicityNode::Function --> Add
+//                         /                       \
+//                        /                         \
+//      MonotonicityNode::Function --> Neg        Monotonicity::Constant --> 5
+//                     /
+//                    /
+//     MonotonicityNode::Variable --> number
+//
+// The structure of the tree is basically the structure of the expression.
+// Simple depth first search visit the expression tree and gete monotonicity from
+// every function. Each function is responsible to implement its own monotonicity
+// function.
+// Notice!! the mechanism doesn't solve multiple variables case.
+#[derive(Clone)]
+pub enum MonotonicityNode {
+    Function(Monotonicity),
+    Constant(DataValue),
+    Variable(String),
+}
+
+#[derive(Clone)]
+pub struct Monotonicity {
+    // Is the function monotonous (nondecreasing or nonincreasing).
+    pub is_monotonic: bool,
+    // true if the function is nondecreasing, false, if notincreasing. If is_monotonic = false, then it does not matter.
+    pub is_positive: bool,
+    // Is true if function is monotonic on the whole input range
+    pub is_always_monotonic: bool,
+}
+
+impl Monotonicity {
+    pub fn default() -> Self {
+        Monotonicity {
+            is_monotonic: false,
+            is_positive: false,
+            is_always_monotonic: false,
+        }
+    }
+}
 
 pub trait Function: fmt::Display + Sync + Send + DynClone {
     fn name(&self) -> &str;
@@ -32,6 +76,11 @@ pub trait Function: fmt::Display + Sync + Send + DynClone {
     // None means it's not variadic function
     fn variadic_arguments(&self) -> Option<(usize, usize)> {
         None
+    }
+
+    // return monotonicity node, should always return MonotonicityNode::Function
+    fn get_monotonicity(&self, _args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
+        Ok(MonotonicityNode::Function(Monotonicity::default()))
     }
 
     fn return_type(&self, args: &[DataType]) -> Result<DataType>;

--- a/common/functions/src/scalars/mod.rs
+++ b/common/functions/src/scalars/mod.rs
@@ -36,6 +36,8 @@ pub use conditionals::*;
 pub use dates::*;
 pub use expressions::*;
 pub use function::Function;
+pub use function::Monotonicity;
+pub use function::MonotonicityNode;
 pub use function_alias::AliasFunction;
 pub use function_column::ColumnFunction;
 pub use function_factory::FunctionFactory;

--- a/common/functions/src/scalars/mod.rs
+++ b/common/functions/src/scalars/mod.rs
@@ -38,6 +38,7 @@ pub use expressions::*;
 pub use function::Function;
 pub use function::Monotonicity;
 pub use function::MonotonicityNode;
+pub use function::Range;
 pub use function_alias::AliasFunction;
 pub use function_column::ColumnFunction;
 pub use function_factory::FunctionFactory;

--- a/common/planners/src/plan_expression.rs
+++ b/common/planners/src/plan_expression.rs
@@ -96,6 +96,10 @@ pub enum Expression {
         asc: bool,
         /// Whether to put Nulls before all other data values
         nulls_first: bool,
+        /// The original expression from parser. Because sort 'expr' field maybe overwritten by a Column expression, like
+        /// from BinaryExpression { +, number, number} to Column(number+number), the orig_expr is for keeping the original
+        /// one that is before overwritten. This field is mostly for function monotonicity optimization purpose.
+        origin_expr: Box<Expression>,
     },
     /// All fields(*) in a schema.
     Wildcard,

--- a/common/planners/src/plan_expression_common.rs
+++ b/common/planners/src/plan_expression_common.rs
@@ -301,12 +301,13 @@ where F: Fn(&Expression) -> Result<Option<Expression>> {
                 expr: nested_expr,
                 asc,
                 nulls_first,
+                origin_expr,
             } => Ok(Expression::Sort {
                 expr: Box::new(clone_with_replacement(&**nested_expr, replacement_fn)?),
                 asc: *asc,
                 nulls_first: *nulls_first,
+                origin_expr: origin_expr.clone(),
             }),
-
             Expression::Cast {
                 expr: nested_expr,
                 data_type,

--- a/common/planners/src/plan_expression_rewriter.rs
+++ b/common/planners/src/plan_expression_rewriter.rs
@@ -117,12 +117,14 @@ impl Expression {
                 expr,
                 asc,
                 nulls_first,
+                origin_expr,
             } => {
                 let expr = expr.rewrite(rewriter)?;
                 Expression::Sort {
                     expr: Box::new(expr),
                     asc,
                     nulls_first,
+                    origin_expr,
                 }
             }
             _ => self,

--- a/common/planners/src/plan_expression_sort.rs
+++ b/common/planners/src/plan_expression_sort.rs
@@ -20,5 +20,6 @@ pub fn sort(name: &str, asc: bool, nulls_first: bool) -> Expression {
         expr: Box::new(col(name)),
         asc,
         nulls_first,
+        origin_expr: Box::new(col(name)),
     }
 }

--- a/common/planners/src/plan_rewriter.rs
+++ b/common/planners/src/plan_rewriter.rs
@@ -148,10 +148,12 @@ pub trait PlanRewriter {
                 expr,
                 asc,
                 nulls_first,
+                origin_expr,
             } => Ok(Expression::Sort {
                 expr: Box::new(self.rewrite_expr(schema, expr.as_ref())?),
                 asc: *asc,
                 nulls_first: *nulls_first,
+                origin_expr: origin_expr.clone(),
             }),
             Expression::Cast { expr, data_type } => Ok(Expression::Cast {
                 expr: Box::new(self.rewrite_expr(schema, expr.as_ref())?),

--- a/query/src/datasources/index/range_filter.rs
+++ b/query/src/datasources/index/range_filter.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 //
 
-use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 
@@ -221,12 +220,6 @@ impl StatColumn {
 
 pub(crate) type StatColumns = Vec<StatColumn>;
 
-fn collect_columns_from_expr(expr: &Expression) -> Result<HashSet<String>> {
-    let mut visitor = RequireColumnsVisitor::default();
-    visitor = expr.accept(visitor)?;
-    Ok(visitor.required_columns)
-}
-
 struct VerifiableExprBuilder<'a> {
     args: Expressions,
     op: &'a str,
@@ -246,7 +239,7 @@ impl<'a> VerifiableExprBuilder<'a> {
     ) -> Result<Self> {
         let (args, cols, op) = match exprs.len() {
             1 => {
-                let cols = collect_columns_from_expr(&exprs[0])?;
+                let cols = RequireColumnsVisitor::collect_columns_from_expr(&exprs[0])?;
                 match cols.len() {
                     1 => (exprs, cols, op),
                     _ => {
@@ -257,8 +250,8 @@ impl<'a> VerifiableExprBuilder<'a> {
                 }
             }
             2 => {
-                let lhs_cols = collect_columns_from_expr(&exprs[0])?;
-                let rhs_cols = collect_columns_from_expr(&exprs[1])?;
+                let lhs_cols = RequireColumnsVisitor::collect_columns_from_expr(&exprs[0])?;
+                let rhs_cols = RequireColumnsVisitor::collect_columns_from_expr(&exprs[1])?;
                 match (lhs_cols.len(), rhs_cols.len()) {
                     (1, 0) => (vec![exprs[0].clone(), exprs[1].clone()], lhs_cols, op),
                     (0, 1) => {

--- a/query/src/optimizers/mod.rs
+++ b/query/src/optimizers/mod.rs
@@ -46,4 +46,5 @@ pub use optimizer_projection_push_down::ProjectionPushDownOptimizer;
 pub use optimizer_scatters::ScattersOptimizer;
 pub use optimizer_statistics_exact::StatisticsExactOptimizer;
 pub use optimizer_top_n_push_down::TopNPushDownOptimizer;
+pub use utils::MonotonicityCheckVisitor;
 pub use utils::RequireColumnsVisitor;

--- a/query/src/optimizers/optimizer_constant_folding.rs
+++ b/query/src/optimizers/optimizer_constant_folding.rs
@@ -282,9 +282,15 @@ impl PlanRewriter for ConstantFoldingImpl {
                 expr,
                 asc,
                 nulls_first,
+                origin_expr,
             } => {
                 let new_expr = self.rewrite_expr(schema, expr)?;
-                Ok(ConstantFoldingImpl::create_sort(asc, nulls_first, new_expr))
+                Ok(ConstantFoldingImpl::create_sort(
+                    asc,
+                    nulls_first,
+                    new_expr,
+                    origin_expr.clone(),
+                ))
             }
             Expression::AggregateFunction {
                 op,
@@ -372,11 +378,17 @@ impl ConstantFoldingOptimizer {
 }
 
 impl ConstantFoldingImpl {
-    fn create_sort(asc: &bool, nulls_first: &bool, new_expr: Expression) -> Expression {
+    fn create_sort(
+        asc: &bool,
+        nulls_first: &bool,
+        new_expr: Expression,
+        origin_expr: Box<Expression>,
+    ) -> Expression {
         Expression::Sort {
             expr: Box::new(new_expr),
             asc: *asc,
             nulls_first: *nulls_first,
+            origin_expr,
         }
     }
 }

--- a/query/src/optimizers/utils.rs
+++ b/query/src/optimizers/utils.rs
@@ -14,7 +14,11 @@
 
 use std::collections::HashSet;
 
+use common_exception::ErrorCode;
 use common_exception::Result;
+use common_functions::scalars::FunctionFactory;
+use common_functions::scalars::MonotonicityNode;
+use common_planners::col;
 use common_planners::Expression;
 use common_planners::ExpressionVisitor;
 use common_planners::Recursion;
@@ -40,6 +44,141 @@ impl ExpressionVisitor for RequireColumnsVisitor {
                 Ok(Recursion::Continue(v))
             }
             _ => Ok(Recursion::Continue(self)),
+        }
+    }
+}
+
+pub struct MonotonicityCheckVisitor {
+    // represents the monotonicity of an expression
+    pub node: Option<MonotonicityNode>,
+
+    pub columns: HashSet<String>,
+}
+
+impl MonotonicityCheckVisitor {
+    pub fn new(root: MonotonicityNode, mut columns: HashSet<String>) -> Self {
+        if let MonotonicityNode::Variable(name) = root.clone() {
+            columns.insert(name);
+        }
+
+        MonotonicityCheckVisitor {
+            node: Some(root),
+            columns,
+        }
+    }
+
+    pub fn default() -> Self {
+        MonotonicityCheckVisitor {
+            node: None,
+            columns: HashSet::new(),
+        }
+    }
+
+    fn visit_func_args(op: &str, children: &[Expression]) -> Result<MonotonicityCheckVisitor> {
+        let mut columns: HashSet<String> = HashSet::new();
+        let mut nodes = vec![];
+        for child_expr in children.iter() {
+            let visitor = MonotonicityCheckVisitor::default();
+            let visitor = child_expr.accept(visitor)?;
+
+            // one of the children node is None, no need to check any more.
+            if visitor.node.is_none() {
+                return Ok(MonotonicityCheckVisitor::default());
+            }
+            nodes.push(visitor.node.unwrap());
+            columns.extend(visitor.columns);
+        }
+
+        let func = FunctionFactory::instance().get(op)?;
+        let root_node = func.get_monotonicity(nodes.as_ref())?;
+        let visitor = MonotonicityCheckVisitor::new(root_node, columns);
+        Ok(visitor)
+    }
+
+    // Extract sort column from sort expression. It checks the monotonicity information
+    // of the sort expression (like f(x) = x+2 is a monotonic function), and extract the
+    // column information, returns as Expression::Column.
+    pub fn extract_sort_column(sort_expr: &Expression) -> Result<Expression> {
+        if let Expression::Sort {
+            expr: _,
+            asc,
+            nulls_first,
+            origin_expr,
+        } = sort_expr
+        {
+            let visitor = Self::default();
+            let visitor = origin_expr.accept(visitor)?;
+
+            // One of the expression has more than one column, we don't know the monotonicity.
+            // Skip the optimization, just return the input
+            if visitor.columns.len() != 1 {
+                return Ok(sort_expr.clone());
+            }
+
+            let column_name = visitor.columns.iter().next().unwrap();
+
+            match visitor.node {
+                None => return Ok(sort_expr.clone()),
+                Some(MonotonicityNode::Function(mono)) => {
+                    // the current function is not monotonic, we skip the optimization
+                    if !mono.is_monotonic {
+                        return Ok(sort_expr.clone());
+                    }
+
+                    // need to flip the asc when is_positive is false
+                    let new_asc = if mono.is_positive { *asc } else { !*asc };
+                    return Ok(Expression::Sort {
+                        expr: Box::new(col(column_name)),
+                        asc: new_asc,
+                        nulls_first: *nulls_first,
+                        origin_expr: origin_expr.clone(),
+                    });
+                }
+                Some(MonotonicityNode::Variable(column_name)) => {
+                    return Ok(Expression::Sort {
+                        expr: Box::new(col(&column_name)),
+                        asc: *asc,
+                        nulls_first: *nulls_first,
+                        origin_expr: origin_expr.clone(),
+                    });
+                }
+                Some(MonotonicityNode::Constant(_value)) => return Ok(sort_expr.clone()),
+            };
+        }
+        Err(ErrorCode::BadArguments(format!(
+            "expect sort expression, get {:?}",
+            sort_expr
+        )))
+    }
+}
+
+impl ExpressionVisitor for MonotonicityCheckVisitor {
+    fn pre_visit(self, _expr: &Expression) -> Result<Recursion<Self>> {
+        Ok(Recursion::Continue(self))
+    }
+
+    fn visit(self, expr: &Expression) -> Result<Self> {
+        match expr {
+            Expression::ScalarFunction { op, args } => {
+                MonotonicityCheckVisitor::visit_func_args(op, args)
+            }
+            Expression::BinaryExpression { op, left, right } => {
+                MonotonicityCheckVisitor::visit_func_args(op, &[*left.clone(), *right.clone()])
+            }
+            Expression::UnaryExpression { op, expr } => {
+                MonotonicityCheckVisitor::visit_func_args(op, &[*expr.clone()])
+            }
+            Expression::Column(col) => {
+                let columns: HashSet<String> = HashSet::new();
+                let node = MonotonicityNode::Variable(col.clone());
+                Ok(MonotonicityCheckVisitor::new(node, columns))
+            }
+            Expression::Literal { value, .. } => {
+                let columns: HashSet<String> = HashSet::new();
+                let node = MonotonicityNode::Constant(value.clone());
+                Ok(MonotonicityCheckVisitor::new(node, columns))
+            }
+            _ => Ok(MonotonicityCheckVisitor::default()),
         }
     }
 }

--- a/query/src/pipelines/transforms/transform_sort_partial.rs
+++ b/query/src/pipelines/transforms/transform_sort_partial.rs
@@ -91,6 +91,7 @@ pub fn get_sort_descriptions(
                 ref expr,
                 asc,
                 nulls_first,
+                origin_expr: _,
             } => {
                 let column_name = expr.to_data_field(schema)?.name().clone();
                 sort_columns_descriptions.push(SortColumnDescription {

--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -579,13 +579,14 @@ impl PlanParser {
         let order_by_exprs = order_by
             .iter()
             .map(|e| -> Result<Expression> {
+                let new_expr = self
+                    .sql_to_rex(&e.expr, &plan.schema(), Some(select))
+                    .and_then(|expr| resolve_aliases_to_exprs(&expr, &aliases))?;
                 Ok(Expression::Sort {
-                    expr: Box::new(
-                        self.sql_to_rex(&e.expr, &plan.schema(), Some(select))
-                            .and_then(|expr| resolve_aliases_to_exprs(&expr, &aliases))?,
-                    ),
+                    expr: Box::new(new_expr.clone()),
                     asc: e.asc.unwrap_or(true),
                     nulls_first: e.nulls_first.unwrap_or(true),
+                    origin_expr: Box::new(new_expr),
                 })
             })
             .collect::<Result<Vec<Expression>>>()?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add monotonicity visitor for extracting the column from monotonic function. For example 'order by number+3' can be optimized to 'order by number', because 'number+3' -> f(x) = x+3    is a monotonic function.

The new added class is  applied for top-n optimizer in the PR. Thus query like "select number*number from numbers(100000000000) order by number+number+12 limit 10" will be optimized to only fetch top 10 rows -- will be fast.
```

mysql> select number*number from numbers(100000000000) order by number+number+12 limit 10;
+-------------------+
| (number * number) |
+-------------------+
|                 0 |
|                 1 |
|                 4 |
|                 9 |
|                16 |
|                25 |
|                36 |
|                49 |
|                64 |
|                81 |
+-------------------+
10 rows in set (0.02 sec)
Read 80 rows, 640 B in 0.007 sec., 11.78 thousand rows/sec., 94.27 KB/sec.

```


It can also be used for expression rewriting logic --rewrite the expression  at the very beginning of whole pipeline. It is not covered in this PR.

## Changelog

- New Feature

## Related Issues

Fixes #2343

## Test Plan

Unit Tests

Stateless Tests

