### PR TITLE
ISSUE-2472: namespace -> cluster, tenant -> tenant_id

### DIFF
--- a/cli/src/cmds/clusters/add.rs
+++ b/cli/src/cmds/clusters/add.rs
@@ -160,19 +160,19 @@ impl Command for AddCommand {
                     .default_value("2"),
             )
             .arg(
-                Arg::new("query_namespace")
-                    .long("query-namespace")
-                    .env(databend_query::configs::config_query::QUERY_NAMESPACE)
+                Arg::new("query_cluster_id")
+                    .long("query-cluster-id")
+                    .env(databend_query::configs::config_query::QUERY_CLUSTER_ID)
                     .takes_value(true)
-                    .about("Set the namespace for query to work on")
+                    .about("Set the cluster for query to work on")
                     .default_value("test_cluster"),
             )
             .arg(
-                Arg::new("query_tenant")
-                    .long("query-tenant")
-                    .env(databend_query::configs::config_query::QUERY_TENANT)
+                Arg::new("query_tenant_id")
+                    .long("query-tenant-id")
+                    .env(databend_query::configs::config_query::QUERY_TENANT_ID)
                     .takes_value(true)
-                    .about("Set the tenant for query to work on")
+                    .about("Set the tenant id for query to work on")
                     .default_value("test"),
             )
             .arg(

--- a/cli/src/cmds/clusters/create.rs
+++ b/cli/src/cmds/clusters/create.rs
@@ -249,15 +249,16 @@ pub fn generate_local_query_config(
     config.meta.meta_username = "root".to_string();
     config.meta.meta_password = "root".to_string();
     // tenant
-    if args.value_of("query_namespace").is_some()
-        && !args.value_of("query_namespace").unwrap().is_empty()
+    if args.value_of("query_cluster_id").is_some()
+        && !args.value_of("query_cluster_id").unwrap().is_empty()
     {
-        config.query.namespace = args.value_of("query_namespace").unwrap().to_string();
+        config.query.cluster_id = args.value_of("query_cluster_id").unwrap().to_string();
     }
 
-    if args.value_of("query_tenant").is_some() && !args.value_of("query_tenant").unwrap().is_empty()
+    if args.value_of("query_tenant_id").is_some()
+        && !args.value_of("query_tenant_id").unwrap().is_empty()
     {
-        config.query.tenant = args.value_of("query_tenant").unwrap().to_string();
+        config.query.tenant_id = args.value_of("query_tenant_id").unwrap().to_string();
     }
 
     if args.value_of("num_cpus").is_some() && !args.value_of("num_cpus").unwrap().is_empty() {
@@ -763,19 +764,19 @@ impl Command for CreateCommand {
                     .default_value(""),
             )
             .arg(
-                Arg::new("query_namespace")
-                    .long("query-namespace")
-                    .env(databend_query::configs::config_query::QUERY_NAMESPACE)
+                Arg::new("query_cluster_id")
+                    .long("query-cluster-id")
+                    .env(databend_query::configs::config_query::QUERY_CLUSTER_ID)
                     .takes_value(true)
-                    .about("Set the namespace for query to work on")
+                    .about("Set the cluster for query to work on")
                     .default_value("test_cluster"),
             )
             .arg(
-                Arg::new("query_tenant")
-                    .long("query-tenant")
-                    .env(databend_query::configs::config_query::QUERY_TENANT)
+                Arg::new("query_tenant_id")
+                    .long("query-tenant-id")
+                    .env(databend_query::configs::config_query::QUERY_TENANT_ID)
                     .takes_value(true)
-                    .about("Set the tenant for query to work on")
+                    .about("Set the tenant id for query to work on")
                     .default_value("test"),
             )
             .arg(

--- a/cli/src/cmds/status.rs
+++ b/cli/src/cmds/status.rs
@@ -441,12 +441,12 @@ impl LocalRuntime for LocalQueryConfig {
                 conf.log.log_dir,
             )
             .env(
-                databend_query::configs::config_query::QUERY_NAMESPACE,
-                conf.query.namespace,
+                databend_query::configs::config_query::QUERY_CLUSTER_ID,
+                conf.query.cluster_id,
             )
             .env(
-                databend_query::configs::config_query::QUERY_TENANT,
-                conf.query.tenant,
+                databend_query::configs::config_query::QUERY_TENANT_ID,
+                conf.query.tenant_id,
             )
             .env(
                 databend_query::configs::config_query::QUERY_NUM_CPUS,

--- a/cli/tests/it/clusters/create.rs
+++ b/cli/tests/it/clusters/create.rs
@@ -184,9 +184,12 @@ fn test_generate_local_query_config() -> Result<()> {
                 .mysql_handler_port,
             3307
         );
-        assert_eq!(query_config.as_ref().unwrap().config.query.tenant, "test");
         assert_eq!(
-            query_config.as_ref().unwrap().config.query.namespace,
+            query_config.as_ref().unwrap().config.query.tenant_id,
+            "test"
+        );
+        assert_eq!(
+            query_config.as_ref().unwrap().config.query.cluster_id,
             "test_cluster"
         );
         assert_eq!(
@@ -218,9 +221,9 @@ fn test_generate_local_query_config() -> Result<()> {
             "v0.4.111-nightly",
             "--num-cpus",
             "2",
-            "--query-namespace",
+            "--query-cluster-id",
             "customized_test",
-            "--query-tenant",
+            "--query-tenant-id",
             "customized_tenant",
             "--mysql-handler-port",
             "3309",
@@ -286,11 +289,11 @@ fn test_generate_local_query_config() -> Result<()> {
             3309
         );
         assert_eq!(
-            query_config.as_ref().unwrap().config.query.tenant,
+            query_config.as_ref().unwrap().config.query.tenant_id,
             "customized_tenant"
         );
         assert_eq!(
-            query_config.as_ref().unwrap().config.query.namespace,
+            query_config.as_ref().unwrap().config.query.cluster_id,
             "customized_test"
         );
         assert_eq!(

--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -257,10 +257,9 @@ build_exceptions! {
     TruncateTableFailedError(4008),
     CommitTableError(4009),
 
-    // namespace error.
-    NamespaceUnknownNode(4058),
-    NamespaceNodeAlreadyExists(4059),
-    NamespaceIllegalNodeFormat(4050),
+    // cluster error.
+    ClusterUnknownNode(4058),
+    ClusterNodeAlreadyExists(4059),
 
     // storage-api error codes
     ReadFileError(5001),

--- a/common/management/src/cluster/cluster_api.rs
+++ b/common/management/src/cluster/cluster_api.rs
@@ -17,16 +17,16 @@ use common_exception::Result;
 use common_meta_types::NodeInfo;
 
 #[async_trait::async_trait]
-pub trait NamespaceApi: Sync + Send {
-    // Add a new node info to /tenant/namespace/node-name.
+pub trait ClusterApi: Sync + Send {
+    // Add a new node info to /tenant/cluster_id/node-name.
     async fn add_node(&self, node: NodeInfo) -> Result<u64>;
 
-    // Get the tenant's namespace all nodes.
+    // Get the tenant's cluster all nodes.
     async fn get_nodes(&self) -> Result<Vec<NodeInfo>>;
 
-    // Drop the tenant's namespace one node by node.id.
+    // Drop the tenant's cluster one node by node.id.
     async fn drop_node(&self, node_id: String, seq: Option<u64>) -> Result<()>;
 
-    // Keep the tenant's namespace node alive.
+    // Keep the tenant's cluster node alive.
     async fn heartbeat(&self, node_id: String, seq: Option<u64>) -> Result<u64>;
 }

--- a/common/management/src/cluster/mod.rs
+++ b/common/management/src/cluster/mod.rs
@@ -14,10 +14,10 @@
 //
 
 #[cfg(test)]
-mod namespace_mgr_test;
+mod cluster_mgr_test;
 
-mod namespace_api;
-mod namespace_mgr;
+mod cluster_api;
+mod cluster_mgr;
 
-pub use namespace_api::NamespaceApi;
-pub use namespace_mgr::NamespaceMgr;
+pub use cluster_api::ClusterApi;
+pub use cluster_mgr::ClusterMgr;

--- a/common/management/src/lib.rs
+++ b/common/management/src/lib.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 //
 
-mod namespace;
+mod cluster;
 mod user;
 
-pub use namespace::NamespaceApi;
-pub use namespace::NamespaceMgr;
+pub use cluster::ClusterApi;
+pub use cluster::ClusterMgr;
 pub use user::user_api::UserInfo;
 pub use user::user_api::UserMgrApi;
 pub use user::user_mgr::UserMgr;

--- a/common/meta/types/src/cluster.rs
+++ b/common/meta/types/src/cluster.rs
@@ -65,7 +65,7 @@ impl TryFrom<Vec<u8>> for NodeInfo {
         match serde_json::from_slice(&value) {
             Ok(user_info) => Ok(user_info),
             Err(serialize_error) => Err(ErrorCode::IllegalUserInfoFormat(format!(
-                "Cannot deserialize namespace from bytes. cause {}",
+                "Cannot deserialize cluster id from bytes. cause {}",
                 serialize_error
             ))),
         }

--- a/docker/databend-query-docker.toml
+++ b/docker/databend-query-docker.toml
@@ -23,7 +23,7 @@ mysql_handler_port = 3307
 clickhouse_handler_host = "0.0.0.0"
 clickhouse_handler_port = 9001
 
-namespace = "test_cluster"
+cluster_id = "test_cluster"
 
 # Log
 [log]

--- a/query/src/bin/databend-query.rs
+++ b/query/src/bin/databend-query.rs
@@ -140,12 +140,15 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
         info!("RPC API server listening on {}", listening);
     }
 
-    // Namespace
+    // Cluster register.
     {
         let cluster_discovery = session_manager.get_cluster_discovery();
         let register_to_metastore = cluster_discovery.register_to_metastore(&conf);
         register_to_metastore.await?;
-        info!("Databend query has been registered to metastore.");
+        info!(
+            "Databend query has been registered:{:?} to metasrv:[{:?}].",
+            conf.query.cluster_id, conf.meta.meta_address
+        );
     }
 
     log::info!("Ready for connections.");

--- a/query/src/configs/config_query.rs
+++ b/query/src/configs/config_query.rs
@@ -18,8 +18,8 @@ use structopt_toml::StructOptToml;
 use crate::configs::Config;
 
 // Query env.
-pub const QUERY_TENANT: &str = "QUERY_TENANT";
-pub const QUERY_NAMESPACE: &str = "QUERY_NAMESPACE";
+pub const QUERY_TENANT_ID: &str = "QUERY_TENANT_ID";
+pub const QUERY_CLUSTER_ID: &str = "QUERY_CLUSTER_ID";
 pub const QUERY_NUM_CPUS: &str = "QUERY_NUM_CPUS";
 pub const QUERY_MYSQL_HANDLER_HOST: &str = "QUERY_MYSQL_HANDLER_HOST";
 pub const QUERY_MYSQL_HANDLER_PORT: &str = "QUERY_MYSQL_HANDLER_PORT";
@@ -46,13 +46,13 @@ const QUERY_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "QUERY_RPC_TLS_SERVICE_DOMAIN_NA
     Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
 )]
 pub struct QueryConfig {
-    #[structopt(long, env = QUERY_TENANT, default_value = "", help = "Tenant id for get the information from the MetaStore")]
+    #[structopt(long, env = QUERY_TENANT_ID, default_value = "", help = "Tenant id for get the information from the MetaStore")]
     #[serde(default)]
-    pub tenant: String,
+    pub tenant_id: String,
 
-    #[structopt(long, env = QUERY_NAMESPACE, default_value = "", help = "Namespace for construct the cluster")]
+    #[structopt(long, env = QUERY_CLUSTER_ID, default_value = "", help = "ID for construct the cluster")]
     #[serde(default)]
-    pub namespace: String,
+    pub cluster_id: String,
 
     #[structopt(long, env = QUERY_NUM_CPUS, default_value = "0")]
     #[serde(default)]
@@ -184,8 +184,8 @@ pub struct QueryConfig {
 impl QueryConfig {
     pub fn default() -> Self {
         QueryConfig {
-            tenant: "".to_string(),
-            namespace: "".to_string(),
+            tenant_id: "".to_string(),
+            cluster_id: "".to_string(),
             num_cpus: 8,
             mysql_handler_host: "127.0.0.1".to_string(),
             mysql_handler_port: 3307,
@@ -208,8 +208,8 @@ impl QueryConfig {
     }
 
     pub fn load_from_env(mut_config: &mut Config) {
-        env_helper!(mut_config, query, tenant, String, QUERY_TENANT);
-        env_helper!(mut_config, query, namespace, String, QUERY_NAMESPACE);
+        env_helper!(mut_config, query, tenant_id, String, QUERY_TENANT_ID);
+        env_helper!(mut_config, query, cluster_id, String, QUERY_CLUSTER_ID);
         env_helper!(mut_config, query, num_cpus, u64, QUERY_NUM_CPUS);
         env_helper!(
             mut_config,

--- a/query/src/configs/config_test.rs
+++ b/query/src/configs/config_test.rs
@@ -37,8 +37,8 @@ fn test_default_config() -> Result<()> {
     let tom_expect = "config_file = \"\"
 
 [query]
-tenant = \"\"
-namespace = \"\"
+tenant_id = \"\"
+cluster_id = \"\"
 num_cpus = 8
 mysql_handler_host = \"127.0.0.1\"
 mysql_handler_port = 3307
@@ -99,8 +99,8 @@ container = \"\"
 #[test]
 fn test_env_config() -> Result<()> {
     std::env::set_var("LOG_LEVEL", "DEBUG");
-    std::env::set_var("QUERY_TENANT", "tenant-1");
-    std::env::set_var("QUERY_NAMESPACE", "cluster-1");
+    std::env::set_var("QUERY_TENANT_ID", "tenant-1");
+    std::env::set_var("QUERY_CLUSTER_ID", "cluster-1");
     std::env::set_var("QUERY_MYSQL_HANDLER_HOST", "0.0.0.0");
     std::env::set_var("QUERY_MYSQL_HANDLER_PORT", "3306");
     std::env::set_var("QUERY_MAX_ACTIVE_SESSIONS", "255");
@@ -122,8 +122,8 @@ fn test_env_config() -> Result<()> {
     let configured = Config::load_from_env(&default)?;
     assert_eq!("DEBUG", configured.log.log_level);
 
-    assert_eq!("tenant-1", configured.query.tenant);
-    assert_eq!("cluster-1", configured.query.namespace);
+    assert_eq!("tenant-1", configured.query.tenant_id);
+    assert_eq!("cluster-1", configured.query.cluster_id);
     assert_eq!("0.0.0.0", configured.query.mysql_handler_host);
     assert_eq!(3306, configured.query.mysql_handler_port);
     assert_eq!(255, configured.query.max_active_sessions);
@@ -146,8 +146,8 @@ fn test_env_config() -> Result<()> {
 
     // clean up
     std::env::remove_var("LOG_LEVEL");
-    std::env::remove_var("QUERY_TENANT");
-    std::env::remove_var("QUERY_NAMESPACE");
+    std::env::remove_var("QUERY_TENANT_ID");
+    std::env::remove_var("QUERY_CLUSTER_ID");
     std::env::remove_var("QUERY_MYSQL_HANDLER_HOST");
     std::env::remove_var("QUERY_MYSQL_HANDLER_PORT");
     std::env::remove_var("QUERY_MAX_ACTIVE_SESSIONS");

--- a/query/src/datasources/database/system/configs_table_test.rs
+++ b/query/src/datasources/database/system/configs_table_test.rs
@@ -51,6 +51,7 @@ async fn test_configs_table() -> Result<()> {
         "| api_tls_server_root_ca_cert       |                  | query |             |",
         "| clickhouse_handler_host           | 127.0.0.1        | query |             |",
         "| clickhouse_handler_port           | 9000             | query |             |",
+        "| cluster_id                        |                  | query |             |",
         "| flight_api_address                | 127.0.0.1:9090   | query |             |",
         "| http_api_address                  | 127.0.0.1:8080   | query |             |",
         "| http_handler_host                 | 127.0.0.1        | query |             |",
@@ -66,7 +67,6 @@ async fn test_configs_table() -> Result<()> {
         "| metric_api_address                | 127.0.0.1:7070   | query |             |",
         "| mysql_handler_host                | 127.0.0.1        | query |             |",
         "| mysql_handler_port                | 3307             | query |             |",
-        "| namespace                         |                  | query |             |",
         "| num_cpus                          | 8                | query |             |",
         "| rpc_tls_meta_server_root_ca_cert  |                  | meta  |             |",
         "| rpc_tls_meta_service_domain_name  | localhost        | meta  |             |",
@@ -74,7 +74,7 @@ async fn test_configs_table() -> Result<()> {
         "| rpc_tls_query_service_domain_name | localhost        | query |             |",
         "| rpc_tls_server_cert               |                  | query |             |",
         "| rpc_tls_server_key                |                  | query |             |",
-        "| tenant                            |                  | query |             |",
+        "| tenant_id                         |                  | query |             |",
         "+-----------------------------------+------------------+-------+-------------+",
     ];
     common_datablocks::assert_blocks_sorted_eq(expected, result.as_slice());

--- a/query/src/users/user_mgr.rs
+++ b/query/src/users/user_mgr.rs
@@ -41,11 +41,11 @@ impl UserManager {
     }
 
     pub async fn create_global(cfg: Config) -> Result<UserManagerRef> {
-        let tenant = &cfg.query.tenant;
+        let tenant_id = &cfg.query.tenant_id;
         let kv_client = UserManager::create_kv_client(&cfg).await?;
 
         Ok(Arc::new(UserManager {
-            api_provider: Arc::new(UserMgr::new(kv_client, tenant)),
+            api_provider: Arc::new(UserMgr::new(kv_client, tenant_id)),
         }))
     }
 

--- a/query/src/users/user_mgr_test.rs
+++ b/query/src/users/user_mgr_test.rs
@@ -24,7 +24,7 @@ use crate::users::UserManager;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_user_manager() -> Result<()> {
     let mut config = Config::default();
-    config.query.tenant = "tenant1".to_string();
+    config.query.tenant_id = "tenant1".to_string();
 
     let user = "test-user1";
     let hostname = "localhost";

--- a/scripts/deploy/config/databend-query-embedded-meta.toml
+++ b/scripts/deploy/config/databend-query-embedded-meta.toml
@@ -26,7 +26,7 @@ clickhouse_handler_port = 9001
 http_handler_host = "0.0.0.0"
 http_handler_port = 8001
 
-namespace = "test_cluster"
+cluster_id = "test_cluster"
 
 [log]
 log_level = "ERROR"

--- a/scripts/deploy/config/databend-query-node-1.toml
+++ b/scripts/deploy/config/databend-query-node-1.toml
@@ -26,7 +26,7 @@ clickhouse_handler_port = 9001
 http_handler_host = "0.0.0.0"
 http_handler_port = 8001
 
-namespace = "test_cluster"
+cluster_id = "test_cluster"
 
 [log]
 log_level = "ERROR"

--- a/scripts/deploy/config/databend-query-node-2.toml
+++ b/scripts/deploy/config/databend-query-node-2.toml
@@ -26,7 +26,7 @@ clickhouse_handler_port = 9002
 http_handler_host = "0.0.0.0"
 http_handler_port = 8002
 
-namespace = "test_cluster"
+cluster_id = "test_cluster"
 
 [log]
 log_level = "ERROR"

--- a/scripts/deploy/config/databend-query-node-3.toml
+++ b/scripts/deploy/config/databend-query-node-3.toml
@@ -26,7 +26,7 @@ clickhouse_handler_port = 9003
 http_handler_host = "0.0.0.0"
 http_handler_port = 8003
 
-namespace = "test_cluster"
+cluster_id = "test_cluster"
 
 [log]
 log_level = "ERROR"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

This PR mainly change the config/query field:
1. namespace -> cluster_id
2. tenant -> tenant_id

## Changelog

- Improvement


## Related Issues

Fixes #2742 
Fixes #2746 

## Test Plan

Unit Tests

Stateless Tests

