### PR TITLE
[metasrv] refactor: remove unused temp-dir in test-context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,9 @@ perf.*
 *.error
 *.swp
 _local_fs/*
-_meta/*
+_meta*/*
 stateless_test_data/*
-**/_logs/*
+**/_logs*/*
 
 # for tests in mac
 *.stderr-e

--- a/metasrv/src/api/flight_server.rs
+++ b/metasrv/src/api/flight_server.rs
@@ -99,7 +99,7 @@ impl FlightServer {
         let raft_config = &self.conf.raft_config;
 
         let mn = if raft_config.boot {
-            MetaNode::boot(0, raft_config).await?
+            MetaNode::boot(raft_config).await?
         } else if raft_config.single {
             let (mn, _is_open) =
                 MetaNode::open_create_boot(raft_config, Some(()), Some(()), Some(())).await?;

--- a/metasrv/src/meta_service/meta_service_impl_test.rs
+++ b/metasrv/src/meta_service/meta_service_impl_test.rs
@@ -41,7 +41,7 @@ async fn test_meta_server_upsert_kv() -> anyhow::Result<()> {
     let tc = new_test_context();
     let addr = tc.config.raft_config.raft_api_addr();
 
-    let _mn = MetaNode::boot(0, &tc.config.raft_config).await?;
+    let _mn = MetaNode::boot(&tc.config.raft_config).await?;
     assert_meta_connection(&addr).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
@@ -86,7 +86,7 @@ async fn test_meta_server_incr_seq() -> anyhow::Result<()> {
     let tc = new_test_context();
     let addr = tc.config.raft_config.raft_api_addr();
 
-    let _mn = MetaNode::boot(0, &tc.config.raft_config).await?;
+    let _mn = MetaNode::boot(&tc.config.raft_config).await?;
     assert_meta_connection(&addr).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
@@ -129,7 +129,7 @@ async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
     let addr0 = tc0.config.raft_config.raft_api_addr();
     let addr1 = tc1.config.raft_config.raft_api_addr();
 
-    let mn0 = MetaNode::boot(0, &tc0.config.raft_config).await?;
+    let mn0 = MetaNode::boot(&tc0.config.raft_config).await?;
     assert_meta_connection(&addr0).await?;
 
     {

--- a/metasrv/src/meta_service/meta_service_impl_test.rs
+++ b/metasrv/src/meta_service/meta_service_impl_test.rs
@@ -38,7 +38,7 @@ async fn test_meta_server_upsert_kv() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
+    let tc = new_test_context(0);
     let addr = tc.config.raft_config.raft_api_addr();
 
     let _mn = MetaNode::boot(&tc.config.raft_config).await?;
@@ -83,7 +83,7 @@ async fn test_meta_server_incr_seq() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
+    let tc = new_test_context(0);
     let addr = tc.config.raft_config.raft_api_addr();
 
     let _mn = MetaNode::boot(&tc.config.raft_config).await?;
@@ -123,8 +123,8 @@ async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc0 = new_test_context();
-    let tc1 = new_test_context();
+    let tc0 = new_test_context(0);
+    let tc1 = new_test_context(1);
 
     let addr0 = tc0.config.raft_config.raft_api_addr();
     let addr1 = tc1.config.raft_config.raft_api_addr();
@@ -135,8 +135,7 @@ async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
     {
         tracing::info!("--- add node 1 as non-voter");
 
-        let mut config = tc1.config.raft_config.clone();
-        config.id = 1;
+        let config = tc1.config.raft_config.clone();
         let (mn1, _is_open) = MetaNode::open_create_boot(&config, None, Some(()), None).await?;
 
         assert_meta_connection(&addr0).await?;

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -118,7 +118,7 @@ impl MetaNodeBuilder {
         } else {
             sto.get_node_addr(&node_id).await?
         };
-        tracing::info!("about to start grpc on {}", addr);
+        tracing::info!("about to start raft grpc on {}", addr);
 
         MetaNode::start_grpc(mn.clone(), &addr).await?;
 
@@ -345,16 +345,12 @@ impl MetaNode {
     /// For every cluster this func should be called exactly once.
     /// When a node is initialized with boot or boot_non_voter, start it with databend_meta::new().
     #[tracing::instrument(level = "info", skip(config), fields(config_id=config.config_id.as_str()))]
-    pub async fn boot(
-        node_id: NodeId,
-        config: &RaftConfig,
-    ) -> common_exception::Result<Arc<MetaNode>> {
+    pub async fn boot(config: &RaftConfig) -> common_exception::Result<Arc<MetaNode>> {
         // 1. Bring a node up as non voter, start the grpc service for raft communication.
         // 2. Initialize itself as leader, because it is the only one in the new cluster.
         // 3. Add itself to the cluster storage by committing an `add-node` log so that the cluster members(only this node) is persisted.
 
-        let mut config = config.clone();
-        config.id = node_id;
+        let config = config.clone();
 
         let (mn, _is_open) = Self::open_create_boot(&config, None, Some(()), None).await?;
 

--- a/metasrv/src/meta_service/raftmeta_test.rs
+++ b/metasrv/src/meta_service/raftmeta_test.rs
@@ -42,7 +42,7 @@ use crate::meta_service::MetaNode;
 use crate::proto::meta_service_client::MetaServiceClient;
 use crate::tests::assert_meta_connection;
 use crate::tests::service::new_test_context;
-use crate::tests::service::KVSrvTestContext;
+use crate::tests::service::MetaSrvTestContext;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
 async fn test_meta_node_boot() -> anyhow::Result<()> {
@@ -52,7 +52,7 @@ async fn test_meta_node_boot() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context();
+    let tc = new_test_context(0);
     let addr = tc.config.raft_config.raft_api_addr();
 
     let mn = MetaNode::boot(&tc.config.raft_config).await?;
@@ -273,7 +273,7 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
     // Create a snapshot every 10 logs
     let snap_logs = 10;
 
-    let mut tc = new_test_context();
+    let mut tc = new_test_context(0);
     tc.config.raft_config.snapshot_logs_since_last = snap_logs;
     tc.config.raft_config.install_snapshot_timeout = 10_1000; // milli seconds. In a CI multi-threads test delays async task badly.
     let addr = tc.config.raft_config.raft_api_addr();
@@ -399,9 +399,8 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
     tracing::info!("--- bring up non-voter 2");
 
     let node_id = 2;
-    let tc2 = new_test_context();
-    let mut raft_config = tc2.config.raft_config.clone();
-    raft_config.id = node_id;
+    let tc2 = new_test_context(node_id);
+    let raft_config = tc2.config.raft_config.clone();
     let addr2 = raft_config.raft_api_addr();
 
     let (mn2, is_open) = MetaNode::open_create_boot(&raft_config, None, Some(()), None).await?;
@@ -432,9 +431,8 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
     tracing::info!("--- bring up non-voter 3");
 
     let node_id = 3;
-    let tc3 = new_test_context();
-    let mut raft_config = tc3.config.raft_config.clone();
-    raft_config.id = node_id;
+    let tc3 = new_test_context(node_id);
+    let raft_config = tc3.config.raft_config.clone();
     let addr3 = raft_config.raft_api_addr();
 
     let (mn3, is_open) = MetaNode::open_create_boot(&raft_config, None, Some(()), None).await?;
@@ -619,7 +617,7 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
 async fn setup_cluster(
     voters: BTreeSet<NodeId>,
     non_voters: BTreeSet<NodeId>,
-) -> anyhow::Result<(u64, Vec<KVSrvTestContext>)> {
+) -> anyhow::Result<(u64, Vec<MetaSrvTestContext>)> {
     // TODO(xp): use setup_cluster if possible in tests. Get rid of boilerplate snippets.
     // leader is always node-0
     assert!(voters.contains(&0));
@@ -684,12 +682,12 @@ async fn setup_cluster(
     Ok((nlog, rst))
 }
 
-async fn setup_leader() -> anyhow::Result<(NodeId, KVSrvTestContext)> {
+async fn setup_leader() -> anyhow::Result<(NodeId, MetaSrvTestContext)> {
     // Setup a cluster in which there is a leader and a non-voter.
     // asserts states are consistent
 
     let nid = 0;
-    let mut tc = new_test_context();
+    let mut tc = new_test_context(nid);
     let addr = tc.config.raft_config.raft_api_addr();
 
     // boot up a single-node cluster
@@ -714,8 +712,8 @@ async fn setup_leader() -> anyhow::Result<(NodeId, KVSrvTestContext)> {
 async fn setup_non_voter(
     leader: Arc<MetaNode>,
     id: NodeId,
-) -> anyhow::Result<(NodeId, KVSrvTestContext)> {
-    let mut tc = new_test_context();
+) -> anyhow::Result<(NodeId, MetaSrvTestContext)> {
+    let mut tc = new_test_context(0);
     let addr = tc.config.raft_config.raft_api_addr();
 
     let mut raft_config = tc.config.raft_config.clone();
@@ -881,7 +879,7 @@ fn timeout() -> Option<Duration> {
     Some(Duration::from_millis(10000))
 }
 
-fn test_context_nodes(tcs: &[KVSrvTestContext]) -> Vec<Arc<MetaNode>> {
+fn test_context_nodes(tcs: &[MetaSrvTestContext]) -> Vec<Arc<MetaNode>> {
     tcs.iter()
         .map(|tc| tc.meta_nodes[0].clone())
         .collect::<Vec<_>>()

--- a/metasrv/src/meta_service/raftmeta_test.rs
+++ b/metasrv/src/meta_service/raftmeta_test.rs
@@ -55,7 +55,7 @@ async fn test_meta_node_boot() -> anyhow::Result<()> {
     let tc = new_test_context();
     let addr = tc.config.raft_config.raft_api_addr();
 
-    let mn = MetaNode::boot(0, &tc.config.raft_config).await?;
+    let mn = MetaNode::boot(&tc.config.raft_config).await?;
 
     let got = mn.get_node(&0).await?;
     assert_eq!(addr, got.unwrap().address);
@@ -278,7 +278,7 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
     tc.config.raft_config.install_snapshot_timeout = 10_1000; // milli seconds. In a CI multi-threads test delays async task badly.
     let addr = tc.config.raft_config.raft_api_addr();
 
-    let mn = MetaNode::boot(0, &tc.config.raft_config).await?;
+    let mn = MetaNode::boot(&tc.config.raft_config).await?;
 
     assert_meta_connection(&addr).await?;
 
@@ -693,7 +693,7 @@ async fn setup_leader() -> anyhow::Result<(NodeId, KVSrvTestContext)> {
     let addr = tc.config.raft_config.raft_api_addr();
 
     // boot up a single-node cluster
-    let mn = MetaNode::boot(nid, &tc.config.raft_config).await?;
+    let mn = MetaNode::boot(&tc.config.raft_config).await?;
     tc.meta_nodes.push(mn.clone());
 
     {

--- a/metasrv/src/store/meta_raft_store_test.rs
+++ b/metasrv/src/store/meta_raft_store_test.rs
@@ -46,8 +46,7 @@ async fn test_metasrv_restart() -> anyhow::Result<()> {
     let _ent = ut_span.enter();
 
     let id = 3;
-    let mut tc = new_test_context();
-    tc.config.raft_config.id = id;
+    let tc = new_test_context(id);
 
     tracing::info!("--- new metasrv");
     {
@@ -92,8 +91,7 @@ async fn test_metasrv_get_membership_from_log() -> anyhow::Result<()> {
     let _ent = ut_span.enter();
 
     let id = 3;
-    let mut tc = new_test_context();
-    tc.config.raft_config.id = id;
+    let tc = new_test_context(id);
 
     tracing::info!("--- new metasrv");
     let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
@@ -193,8 +191,7 @@ async fn test_metasrv_do_log_compaction_empty() -> anyhow::Result<()> {
     let _ent = ut_span.enter();
 
     let id = 3;
-    let mut tc = new_test_context();
-    tc.config.raft_config.id = id;
+    let tc = new_test_context(id);
 
     let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
@@ -242,8 +239,7 @@ async fn test_metasrv_do_log_compaction_1_snap_ptr_1_log() -> anyhow::Result<()>
     let _ent = ut_span.enter();
 
     let id = 3;
-    let mut tc = new_test_context();
-    tc.config.raft_config.id = id;
+    let tc = new_test_context(id);
 
     let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
@@ -317,8 +313,7 @@ async fn test_metasrv_do_log_compaction_all_logs_with_memberchange() -> anyhow::
     let _ent = ut_span.enter();
 
     let id = 3;
-    let mut tc = new_test_context();
-    tc.config.raft_config.id = id;
+    let tc = new_test_context(id);
 
     let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
@@ -371,8 +366,7 @@ async fn test_metasrv_do_log_compaction_current_snapshot() -> anyhow::Result<()>
     let _ent = ut_span.enter();
 
     let id = 3;
-    let mut tc = new_test_context();
-    tc.config.raft_config.id = id;
+    let tc = new_test_context(id);
 
     let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
@@ -428,8 +422,7 @@ async fn test_metasrv_install_snapshot() -> anyhow::Result<()> {
     let id = 3;
     let snap;
     {
-        let mut tc = new_test_context();
-        tc.config.raft_config.id = id;
+        let tc = new_test_context(id);
 
         let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
@@ -446,8 +439,7 @@ async fn test_metasrv_install_snapshot() -> anyhow::Result<()> {
 
     tracing::info!("--- reopen a new metasrv to install snapshot");
     {
-        let mut tc = new_test_context();
-        tc.config.raft_config.id = id;
+        let tc = new_test_context(id);
 
         let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 

--- a/metasrv/src/tests/service.rs
+++ b/metasrv/src/tests/service.rs
@@ -19,8 +19,6 @@ use common_base::tokio;
 use common_base::tokio::sync::oneshot;
 use common_base::GlobalSequence;
 use common_tracing::tracing;
-use tempfile::tempdir;
-use tempfile::TempDir;
 
 use crate::api::FlightServer;
 use crate::configs;
@@ -57,9 +55,6 @@ pub fn next_port() -> u32 {
 }
 
 pub struct MetaSrvTestContext {
-    #[allow(dead_code)]
-    temp_raft_dir: TempDir,
-
     // /// To hold a per-case logging guard
     // #[allow(dead_code)]
     // logging_guard: (WorkerGuard, DefaultGuard),
@@ -112,15 +107,9 @@ pub fn new_test_context(id: u64) -> MetaSrvTestContext {
         config.metric_api_address = format!("{}:{}", host, metric_port);
     }
 
-    let temp_raft_dir = tempdir().expect("create temp dir to store meta");
-    config.raft_config.raft_dir = temp_raft_dir.path().to_str().unwrap().to_string();
-
     tracing::info!("new test context config: {:?}", config);
 
     MetaSrvTestContext {
-        // The TempDir type creates a directory on the file system that is deleted once it goes out of scope
-        // So hold the tmp_meta_dir and tmp_local_fs_dir until being dropped.
-        temp_raft_dir,
         config,
         meta_nodes: vec![],
 

--- a/metasrv/tests/flight/metasrv_flight_api.rs
+++ b/metasrv/tests/flight/metasrv_flight_api.rs
@@ -138,12 +138,9 @@ async fn test_join() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut tc0 = new_test_context();
-    let mut tc1 = new_test_context();
+    let mut tc0 = new_test_context(0);
+    let mut tc1 = new_test_context(1);
 
-    tc0.config.raft_config.id = 0;
-
-    tc1.config.raft_config.id = 1;
     tc1.config.raft_config.single = false;
     tc1.config.raft_config.join = vec![tc0.config.raft_config.raft_api_addr()];
 

--- a/metasrv/tests/flight/metasrv_flight_tls.rs
+++ b/metasrv/tests/flight/metasrv_flight_tls.rs
@@ -31,7 +31,7 @@ async fn test_tls_server() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut tc = new_test_context();
+    let mut tc = new_test_context(0);
 
     tc.config.flight_tls_server_key = TEST_SERVER_KEY.to_owned();
     tc.config.flight_tls_server_cert = TEST_SERVER_CERT.to_owned();
@@ -60,7 +60,7 @@ async fn test_tls_server_config_failure() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut tc = new_test_context();
+    let mut tc = new_test_context(0);
 
     tc.config.flight_tls_server_key = "../tests/data/certs/not_exist.key".to_owned();
     tc.config.flight_tls_server_cert = "../tests/data/certs/not_exist.pem".to_owned();


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: remove unused temp-dir in test-context

##### [metasrv] refactor: assign raft-id when creating a test-context

##### [metasrv] refactor: boot() does not need to specify a node-id. use `raft_config.id`

## Changelog




- Improvement


## Related Issues