### PR TITLE
[metasrv] refactor: add MetaNode::start() to start meta in boot, open or join mode etc.

### DIFF
--- a/metasrv/src/lib.rs
+++ b/metasrv/src/lib.rs
@@ -30,3 +30,9 @@ pub mod executor;
 pub mod meta_service;
 pub mod metrics;
 mod store;
+
+pub trait Opened {
+    /// Return true if it is opened from a previous persistent state.
+    /// Otherwise it is just created.
+    fn is_opened(&self) -> bool;
+}

--- a/metasrv/src/meta_service/meta_service_impl_test.rs
+++ b/metasrv/src/meta_service/meta_service_impl_test.rs
@@ -136,7 +136,7 @@ async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
         tracing::info!("--- add node 1 as non-voter");
 
         let config = tc1.config.raft_config.clone();
-        let (mn1, _is_open) = MetaNode::open_create_boot(&config, None, Some(()), None).await?;
+        let mn1 = MetaNode::open_create_boot(&config, None, Some(()), None).await?;
 
         assert_meta_connection(&addr0).await?;
 

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -48,11 +48,13 @@ use crate::meta_service::message::AdminRequest;
 use crate::meta_service::message::AdminResponse;
 use crate::meta_service::meta_leader::MetaLeader;
 use crate::meta_service::AdminRequestInner;
+use crate::meta_service::JoinRequest;
 use crate::meta_service::MetaServiceImpl;
 use crate::meta_service::Network;
 use crate::proto::meta_service_client::MetaServiceClient;
 use crate::proto::meta_service_server::MetaServiceServer;
 use crate::store::MetaRaftStore;
+use crate::Opened;
 
 // MetaRaft is a impl of the generic Raft handling meta data R/W.
 pub type MetaRaft = Raft<LogEntry, AppliedState, Network, MetaRaftStore>;
@@ -66,6 +68,12 @@ pub struct MetaNode {
     pub running_tx: watch::Sender<()>,
     pub running_rx: watch::Receiver<()>,
     pub join_handles: Mutex<Vec<JoinHandle<common_exception::Result<()>>>>,
+}
+
+impl Opened for MetaNode {
+    fn is_opened(&self) -> bool {
+        self.sto.is_opened()
+    }
 }
 
 pub struct MetaNodeBuilder {
@@ -211,7 +219,7 @@ impl MetaNode {
     /// Start a metasrv node from initialized store.
     #[tracing::instrument(level = "info", skip(config), fields(config_id=config.config_id.as_str()))]
     pub async fn open(config: &RaftConfig) -> common_exception::Result<Arc<MetaNode>> {
-        let (mn, _is_open) = Self::open_create_boot(config, Some(()), None, None).await?;
+        let mn = Self::open_create_boot(config, Some(()), None, None).await?;
         Ok(mn)
     }
 
@@ -219,36 +227,41 @@ impl MetaNode {
     /// Optionally boot a single node cluster.
     /// 1. If `open` is `Some`, try to open an existent one.
     /// 2. If `create` is `Some`, try to create an one in non-voter mode.
-    /// 3. If `boot` is `Some` and it is just created, try to initialize a single-node cluster.
+    /// 3. If `init_cluster` is `Some` and it is just created, try to initialize a single-node cluster.
+    ///
+    /// TODO(xp): `init_cluster`: pass in a Map<id, address> to initialize the cluster.
     #[tracing::instrument(level = "info", skip(config), fields(config_id=config.config_id.as_str()))]
     pub async fn open_create_boot(
         config: &RaftConfig,
         open: Option<()>,
         create: Option<()>,
-        boot: Option<()>,
-    ) -> common_exception::Result<(Arc<MetaNode>, bool)> {
+        init_cluster: Option<Vec<String>>,
+    ) -> common_exception::Result<Arc<MetaNode>> {
         let sto = MetaRaftStore::open_create(config, open, create).await?;
-        let is_open = sto.is_open();
+        let is_open = sto.is_opened();
         let sto = Arc::new(sto);
-        let mut b = MetaNode::builder(config).sto(sto.clone());
+
+        let mut builder = MetaNode::builder(config).sto(sto.clone());
 
         if is_open {
             // read id from sto, read listening addr from sto
-            b = b.node_id(sto.id);
+            builder = builder.node_id(sto.id);
         } else {
             // read id from config, read listening addr from config.
-            b = b.node_id(config.id).addr(config.raft_api_addr());
+            builder = builder.node_id(config.id).addr(config.raft_api_addr());
         }
 
-        let mn = b.build().await?;
+        let mn = builder.build().await?;
 
         tracing::info!("MetaNode started: {:?}", config);
 
-        if !is_open && boot.is_some() {
-            mn.init_cluster(config.raft_api_addr()).await?;
+        if !is_open {
+            if let Some(_addrs) = init_cluster {
+                mn.init_cluster(config.raft_api_addr()).await?;
+            }
         }
 
-        Ok((mn, is_open))
+        Ok(mn)
     }
 
     #[tracing::instrument(level = "info", skip(self))]
@@ -341,20 +354,66 @@ impl MetaNode {
         jh.push(h);
     }
 
+    /// Start MetaNode in either `boot`, `single`, `join` or `open` mode,
+    /// according to config.
+    #[tracing::instrument(level = "info")]
+    pub async fn start(config: &RaftConfig) -> Result<Arc<MetaNode>, ErrorCode> {
+        let mn = Self::do_start(config).await?;
+        tracing::info!("Done starting MetaNode: {:?}", config);
+        Ok(mn)
+    }
+
+    async fn do_start(conf: &RaftConfig) -> Result<Arc<MetaNode>, ErrorCode> {
+        // TODO(xp): remove boot mode
+        if conf.boot {
+            let mn = Self::open_create_boot(conf, None, Some(()), Some(vec![])).await?;
+            return Ok(mn);
+        }
+
+        if conf.single {
+            let mn = MetaNode::open_create_boot(conf, Some(()), Some(()), Some(vec![])).await?;
+            return Ok(mn);
+        }
+
+        if !conf.join.is_empty() {
+            // Bring up a new node, join an cluster
+            let mn = MetaNode::open_create_boot(conf, Some(()), Some(()), None).await?;
+
+            let addrs = &conf.join;
+            for addr in addrs {
+                // TODO: retry
+                let mut client = MetaServiceClient::connect(format!("http://{}", addr))
+                    .await
+                    .map_err(|e| ErrorCode::CannotConnectNode(e.to_string()))?;
+
+                let admin_req = AdminRequest {
+                    forward_to_leader: true,
+                    req: AdminRequestInner::Join(JoinRequest {
+                        node_id: conf.id,
+                        address: conf.raft_api_addr(),
+                    }),
+                };
+
+                client.forward(admin_req.clone()).await?;
+            }
+
+            return Ok(mn);
+        }
+
+        // open mode
+        let mn = MetaNode::open_create_boot(conf, Some(()), None, None).await?;
+        Ok(mn)
+    }
+
     /// Boot up the first node to create a cluster.
     /// For every cluster this func should be called exactly once.
-    /// When a node is initialized with boot or boot_non_voter, start it with databend_meta::new().
     #[tracing::instrument(level = "info", skip(config), fields(config_id=config.config_id.as_str()))]
     pub async fn boot(config: &RaftConfig) -> common_exception::Result<Arc<MetaNode>> {
         // 1. Bring a node up as non voter, start the grpc service for raft communication.
         // 2. Initialize itself as leader, because it is the only one in the new cluster.
         // 3. Add itself to the cluster storage by committing an `add-node` log so that the cluster members(only this node) is persisted.
 
-        let config = config.clone();
-
-        let (mn, _is_open) = Self::open_create_boot(&config, None, Some(()), None).await?;
-
-        mn.init_cluster(config.raft_api_addr()).await?;
+        let mn = Self::open_create_boot(config, None, Some(()), Some(vec![])).await?;
 
         Ok(mn)
     }

--- a/metasrv/src/meta_service/raftmeta_test.rs
+++ b/metasrv/src/meta_service/raftmeta_test.rs
@@ -43,6 +43,7 @@ use crate::proto::meta_service_client::MetaServiceClient;
 use crate::tests::assert_meta_connection;
 use crate::tests::service::new_test_context;
 use crate::tests::service::MetaSrvTestContext;
+use crate::Opened;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
 async fn test_meta_node_boot() -> anyhow::Result<()> {
@@ -403,8 +404,8 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
     let raft_config = tc2.config.raft_config.clone();
     let addr2 = raft_config.raft_api_addr();
 
-    let (mn2, is_open) = MetaNode::open_create_boot(&raft_config, None, Some(()), None).await?;
-    assert!(!is_open);
+    let mn2 = MetaNode::open_create_boot(&raft_config, None, Some(()), None).await?;
+    assert!(!mn2.is_opened());
 
     tracing::info!("--- join non-voter 2 to cluster by leader");
 
@@ -435,8 +436,8 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
     let raft_config = tc3.config.raft_config.clone();
     let addr3 = raft_config.raft_api_addr();
 
-    let (mn3, is_open) = MetaNode::open_create_boot(&raft_config, None, Some(()), None).await?;
-    assert!(!is_open);
+    let mn3 = MetaNode::open_create_boot(&raft_config, None, Some(()), None).await?;
+    assert!(!mn3.is_opened());
 
     tracing::info!("--- join node-3 by sending rpc `join`");
 
@@ -582,8 +583,7 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
 
     tracing::info!("--- reopen MetaNode");
 
-    let (leader, _is_open) =
-        MetaNode::open_create_boot(&tc.config.raft_config, Some(()), None, None).await?;
+    let leader = MetaNode::open_create_boot(&tc.config.raft_config, Some(()), None, None).await?;
 
     log_cnt += 1;
 
@@ -719,8 +719,8 @@ async fn setup_non_voter(
     let mut raft_config = tc.config.raft_config.clone();
     raft_config.id = id;
 
-    let (mn, is_open) = MetaNode::open_create_boot(&raft_config, None, Some(()), None).await?;
-    assert!(!is_open);
+    let mn = MetaNode::open_create_boot(&raft_config, None, Some(()), None).await?;
+    assert!(!mn.is_opened());
 
     tc.meta_nodes.push(mn.clone());
 

--- a/metasrv/src/store/meta_raft_store.rs
+++ b/metasrv/src/store/meta_raft_store.rs
@@ -43,6 +43,7 @@ use common_meta_types::NodeId;
 use common_tracing::tracing;
 
 use crate::errors::ShutdownError;
+use crate::Opened;
 
 /// An storage implementing the `async_raft::RaftStorage` trait.
 ///
@@ -61,7 +62,7 @@ pub struct MetaRaftStore {
     config: RaftConfig,
 
     /// If the instance is opened from an existent state(e.g. load from disk) or created.
-    is_open: bool,
+    is_opened: bool,
 
     /// The sled db for log and raft_state.
     /// state machine is stored in another sled db since it contains user data and needs to be export/import as a whole.
@@ -90,11 +91,10 @@ pub struct MetaRaftStore {
     pub current_snapshot: RwLock<Option<Snapshot>>,
 }
 
-impl MetaRaftStore {
+impl Opened for MetaRaftStore {
     /// If the instance is opened(true) from an existent state(e.g. load from disk) or created(false).
-    /// TODO(xp): introduce a trait to define this behavior?
-    pub fn is_open(&self) -> bool {
-        self.is_open
+    fn is_opened(&self) -> bool {
+        self.is_opened
     }
 }
 
@@ -132,7 +132,7 @@ impl MetaRaftStore {
         Ok(Self {
             id: raft_state.id,
             config: config.clone(),
-            is_open,
+            is_opened: is_open,
             _db: db,
             raft_state,
             log,

--- a/metasrv/src/store/meta_raft_store_test.rs
+++ b/metasrv/src/store/meta_raft_store_test.rs
@@ -31,6 +31,7 @@ use maplit::btreeset;
 
 use crate::store::MetaRaftStore;
 use crate::tests::service::new_test_context;
+use crate::Opened;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_metasrv_restart() -> anyhow::Result<()> {
@@ -52,7 +53,7 @@ async fn test_metasrv_restart() -> anyhow::Result<()> {
     {
         let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
         assert_eq!(id, ms.id);
-        assert!(!ms.is_open());
+        assert!(!ms.is_opened());
         assert_eq!(None, ms.read_hard_state().await?);
 
         tracing::info!("--- update metasrv");
@@ -68,7 +69,7 @@ async fn test_metasrv_restart() -> anyhow::Result<()> {
     {
         let ms = MetaRaftStore::open_create(&tc.config.raft_config, Some(()), None).await?;
         assert_eq!(id, ms.id);
-        assert!(ms.is_open());
+        assert!(ms.is_opened());
         assert_eq!(
             Some(HardState {
                 current_term: 10,


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: add MetaNode::start() to start meta in boot, open or join mode etc.
- MetaNode::start() choose boot, open or join mode by `raft_config`.

- Add trait `Opened` to return whether an instance is created or opened
  from some existent state.

  `MetaRaftStore` and `MetaNode` impls `is_opened()`.

## Changelog




- Improvement


## Related Issues