### PR TITLE
[metasrv] refactor: build MetaNode outside FlightServer, let many service be able to reference the meta node

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -227,7 +227,7 @@ build_exceptions! {
 
     // KVSrv server error
 
-    KVSrvError(2501),
+    MetaSrvError(2501),
 
     // FS error
 

--- a/metasrv/src/tests/service.rs
+++ b/metasrv/src/tests/service.rs
@@ -39,7 +39,8 @@ pub async fn start_metasrv() -> Result<(MetaSrvTestContext, String)> {
 }
 
 pub async fn start_metasrv_with_context(tc: &mut MetaSrvTestContext) -> Result<()> {
-    let srv = FlightServer::create(tc.config.clone());
+    let mn = MetaNode::start(&tc.config.raft_config).await?;
+    let srv = FlightServer::create(tc.config.clone(), mn);
     let (stop_tx, fin_rx) = srv.start().await?;
 
     tc.channels = Some((stop_tx, fin_rx));
@@ -62,7 +63,7 @@ pub struct MetaSrvTestContext {
 
     pub meta_nodes: Vec<Arc<MetaNode>>,
 
-    /// channel to send to stop kvsrv, and channel for waiting for shutdown to finish.
+    /// channel to send to stop metasrv, and channel for waiting for shutdown to finish.
     pub channels: Option<(oneshot::Sender<()>, oneshot::Receiver<()>)>,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: build MetaNode outside FlightServer, let many service be able to reference the meta node

## Changelog




- Improvement


## Related Issues

- #2702