### PR TITLE
[function] Add ceil, ceiling, floor func

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,6 +1308,7 @@ dependencies = [
  "num",
  "ordered-float 2.8.0",
  "pretty_assertions",
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/common/functions/Cargo.toml
+++ b/common/functions/Cargo.toml
@@ -29,6 +29,7 @@ bytes = "1.1.0"
 num = "^0.4"
 ordered-float = "2.8"
 crc32fast = "1.2.1"
+regex = "^1.3"
 
 [dev-dependencies]
 bumpalo = "3.8.0"

--- a/common/functions/src/scalars/maths/ceil.rs
+++ b/common/functions/src/scalars/maths/ceil.rs
@@ -1,0 +1,97 @@
+// Copyright 2020 Datafuse Lfloor.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use common_datavalues::prelude::ArrayApply;
+use common_datavalues::prelude::DataColumn;
+use common_datavalues::prelude::DataColumnsWithField;
+use common_datavalues::DataSchema;
+use common_datavalues::DataType;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::scalars::function_factory::FunctionDescription;
+use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::Function;
+
+#[derive(Clone)]
+pub struct CeilFunction {
+    display_name: String,
+}
+
+impl CeilFunction {
+    pub fn try_create(display_name: &str) -> Result<Box<dyn Function>> {
+        Ok(Box::new(CeilFunction {
+            display_name: display_name.to_string(),
+        }))
+    }
+
+    pub fn desc() -> FunctionDescription {
+        FunctionDescription::creator(Box::new(Self::try_create))
+            .features(FunctionFeatures::default().deterministic())
+    }
+}
+
+impl Function for CeilFunction {
+    fn name(&self) -> &str {
+        &*self.display_name
+    }
+
+    fn num_arguments(&self) -> usize {
+        1
+    }
+
+    fn return_type(&self, _args: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Float64)
+    }
+
+    fn nullable(&self, _input_schema: &DataSchema) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {
+        match columns[0].data_type() {
+            DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::Float32
+            | DataType::Float64 => {
+                let result = columns[0]
+                    .column()
+                    .to_minimal_array()?
+                    .cast_with_type(&DataType::Float64)?
+                    .f64()?
+                    .apply_cast_numeric(|v| v.ceil());
+                let column: DataColumn = result.into();
+                Ok(column)
+            }
+            _ => Err(ErrorCode::IllegalDataType(format!(
+                "Expected numeric types, but got {}",
+                columns[0].data_type()
+            ))),
+        }
+    }
+}
+
+impl fmt::Display for CeilFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.display_name.to_uppercase())
+    }
+}

--- a/common/functions/src/scalars/maths/ceil.rs
+++ b/common/functions/src/scalars/maths/ceil.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::fmt;
+use std::str;
 
 use common_datavalues::prelude::ArrayApply;
 use common_datavalues::prelude::DataColumn;
@@ -21,6 +22,7 @@ use common_datavalues::DataSchema;
 use common_datavalues::DataType;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use regex::Regex;
 
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
@@ -81,6 +83,22 @@ impl Function for CeilFunction {
                     .apply_cast_numeric(|v| v.ceil());
                 let column: DataColumn = result.into();
                 Ok(column)
+            }
+            DataType::String => {
+                let re = Regex::new(r"^((\-)?|(\+)?)(\d+)(\.\d+)?").unwrap();
+                let result = columns[0]
+                    .column()
+                    .to_minimal_array()?
+                    .cast_with_type(&DataType::String)?
+                    .string()?
+                    .apply_cast_numeric(|f| {
+                        if let Some(caps) = re.captures(str::from_utf8(f).unwrap()) {
+                            caps[0].parse::<f64>().unwrap().ceil()
+                        } else {
+                            0_f64
+                        }
+                    });
+                Ok(result.into())
             }
             _ => Err(ErrorCode::IllegalDataType(format!(
                 "Expected numeric types, but got {}",

--- a/common/functions/src/scalars/maths/floor.rs
+++ b/common/functions/src/scalars/maths/floor.rs
@@ -1,0 +1,97 @@
+// Copyright 2020 Datafuse Lfloor.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use common_datavalues::prelude::ArrayApply;
+use common_datavalues::prelude::DataColumn;
+use common_datavalues::prelude::DataColumnsWithField;
+use common_datavalues::DataSchema;
+use common_datavalues::DataType;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::scalars::function_factory::FunctionDescription;
+use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::Function;
+
+#[derive(Clone)]
+pub struct FloorFunction {
+    display_name: String,
+}
+
+impl FloorFunction {
+    pub fn try_create(display_name: &str) -> Result<Box<dyn Function>> {
+        Ok(Box::new(FloorFunction {
+            display_name: display_name.to_string(),
+        }))
+    }
+
+    pub fn desc() -> FunctionDescription {
+        FunctionDescription::creator(Box::new(Self::try_create))
+            .features(FunctionFeatures::default().deterministic())
+    }
+}
+
+impl Function for FloorFunction {
+    fn name(&self) -> &str {
+        &*self.display_name
+    }
+
+    fn num_arguments(&self) -> usize {
+        1
+    }
+
+    fn return_type(&self, _args: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Float64)
+    }
+
+    fn nullable(&self, _input_schema: &DataSchema) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {
+        match columns[0].data_type() {
+            DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::Float32
+            | DataType::Float64 => {
+                let result = columns[0]
+                    .column()
+                    .to_minimal_array()?
+                    .cast_with_type(&DataType::Float64)?
+                    .f64()?
+                    .apply_cast_numeric(|v| v.floor());
+                let column: DataColumn = result.into();
+                Ok(column)
+            }
+            _ => Err(ErrorCode::IllegalDataType(format!(
+                "Expected numeric types, but got {}",
+                columns[0].data_type()
+            ))),
+        }
+    }
+}
+
+impl fmt::Display for FloorFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.display_name.to_uppercase())
+    }
+}

--- a/common/functions/src/scalars/maths/math.rs
+++ b/common/functions/src/scalars/maths/math.rs
@@ -15,7 +15,9 @@
 use crate::scalars::function_factory::FunctionFactory;
 use crate::scalars::AbsFunction;
 use crate::scalars::CRC32Function;
+use crate::scalars::CeilFunction;
 use crate::scalars::DegressFunction;
+use crate::scalars::FloorFunction;
 use crate::scalars::LnFunction;
 use crate::scalars::Log10Function;
 use crate::scalars::Log2Function;
@@ -44,5 +46,8 @@ impl MathsFunction {
         factory.register("log10", Log10Function::desc());
         factory.register("log2", Log2Function::desc());
         factory.register("ln", LnFunction::desc());
+        factory.register("ceil", CeilFunction::desc());
+        factory.register("ceiling", CeilFunction::desc());
+        factory.register("floor", FloorFunction::desc());
     }
 }

--- a/common/functions/src/scalars/maths/mod.rs
+++ b/common/functions/src/scalars/maths/mod.rs
@@ -14,7 +14,9 @@
 
 mod abs;
 mod angle;
+mod ceil;
 mod crc32;
+mod floor;
 mod log;
 mod math;
 mod pi;
@@ -23,7 +25,9 @@ mod trigonometric;
 pub use abs::AbsFunction;
 pub use angle::DegressFunction;
 pub use angle::RadiansFunction;
+pub use ceil::CeilFunction;
 pub use crc32::CRC32Function;
+pub use floor::FloorFunction;
 pub use log::LnFunction;
 pub use log::Log10Function;
 pub use log::Log2Function;

--- a/common/functions/tests/it/scalars/maths/ceil.rs
+++ b/common/functions/tests/it/scalars/maths/ceil.rs
@@ -1,0 +1,105 @@
+// Copyright 2020 Datafuse Lceil.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_datavalues::prelude::*;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_functions::scalars::*;
+
+#[test]
+fn test_ceil_function() -> Result<()> {
+    #[allow(dead_code)]
+    struct Test {
+        name: &'static str,
+        func: Box<dyn Function>,
+        arg: DataColumnWithField,
+        expect: Result<DataColumn>,
+    }
+    let tests = vec![
+        Test {
+            name: "ceil(123)",
+            func: CeilFunction::try_create("ceil")?,
+            arg: DataColumnWithField::new(
+                Series::new([123]).into(),
+                DataField::new("arg1", DataType::Int32, false),
+            ),
+            expect: Ok(Series::new(vec![123_f64]).into()),
+        },
+        Test {
+            name: "ceil(1.2)",
+            func: CeilFunction::try_create("ceil")?,
+            arg: DataColumnWithField::new(
+                Series::new([1.2]).into(),
+                DataField::new("arg1", DataType::Float64, false),
+            ),
+            expect: Ok(Series::new(vec![2_f64]).into()),
+        },
+        Test {
+            name: "ceil(-1.2)",
+            func: CeilFunction::try_create("ceil")?,
+            arg: DataColumnWithField::new(
+                Series::new([-1.2]).into(),
+                DataField::new("arg1", DataType::Float64, false),
+            ),
+            expect: Ok(Series::new(vec![-1_f64]).into()),
+        },
+        Test {
+            name: "ceil(true)",
+            func: CeilFunction::try_create("ceil")?,
+            arg: DataColumnWithField::new(
+                Series::new([true]).into(),
+                DataField::new("arg1", DataType::Boolean, true),
+            ),
+            expect: Err(ErrorCode::IllegalDataType(
+                "Expected numeric types, but got Boolean",
+            )),
+        },
+        Test {
+            name: "ceil('123')",
+            func: CeilFunction::try_create("ceil")?,
+            arg: DataColumnWithField::new(
+                Series::new(["123"]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Err(ErrorCode::IllegalDataType(
+                "Expected numeric types, but got String",
+            )),
+        },
+        Test {
+            name: "ceil('a')",
+            func: CeilFunction::try_create("ceil")?,
+            arg: DataColumnWithField::new(
+                Series::new(["a"]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Err(ErrorCode::IllegalDataType(
+                "Expected numeric types, but got String",
+            )),
+        },
+    ];
+
+    for t in tests {
+        let func = t.func;
+        let got = func.eval(&[t.arg.clone()], 1);
+        match t.expect {
+            Ok(expected) => {
+                assert_eq!(&got.unwrap(), &expected, "case: {}", t.name);
+            }
+            Err(expected_err) => {
+                assert_eq!(got.unwrap_err().to_string(), expected_err.to_string());
+            }
+        }
+    }
+    Ok(())
+}

--- a/common/functions/tests/it/scalars/maths/ceil.rs
+++ b/common/functions/tests/it/scalars/maths/ceil.rs
@@ -55,26 +55,31 @@ fn test_ceil_function() -> Result<()> {
             expect: Ok(Series::new(vec![-1_f64]).into()),
         },
         Test {
-            name: "ceil(true)",
-            func: CeilFunction::try_create("ceil")?,
-            arg: DataColumnWithField::new(
-                Series::new([true]).into(),
-                DataField::new("arg1", DataType::Boolean, true),
-            ),
-            expect: Err(ErrorCode::IllegalDataType(
-                "Expected numeric types, but got Boolean",
-            )),
-        },
-        Test {
             name: "ceil('123')",
             func: CeilFunction::try_create("ceil")?,
             arg: DataColumnWithField::new(
                 Series::new(["123"]).into(),
                 DataField::new("arg1", DataType::String, true),
             ),
-            expect: Err(ErrorCode::IllegalDataType(
-                "Expected numeric types, but got String",
-            )),
+            expect: Ok(Series::new(vec![123_f64]).into()),
+        },
+        Test {
+            name: "ceil('+123.2a1')",
+            func: CeilFunction::try_create("ceil")?,
+            arg: DataColumnWithField::new(
+                Series::new(["+123.2a1"]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Ok(Series::new(vec![124_f64]).into()),
+        },
+        Test {
+            name: "ceil('-123.2a1')",
+            func: CeilFunction::try_create("ceil")?,
+            arg: DataColumnWithField::new(
+                Series::new(["-123.2a1"]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Ok(Series::new(vec![-123_f64]).into()),
         },
         Test {
             name: "ceil('a')",
@@ -83,8 +88,26 @@ fn test_ceil_function() -> Result<()> {
                 Series::new(["a"]).into(),
                 DataField::new("arg1", DataType::String, true),
             ),
+            expect: Ok(Series::new(vec![0_f64]).into()),
+        },
+        Test {
+            name: "ceil('a123')",
+            func: CeilFunction::try_create("ceil")?,
+            arg: DataColumnWithField::new(
+                Series::new(["a123"]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Ok(Series::new(vec![0_f64]).into()),
+        },
+        Test {
+            name: "ceil(true)",
+            func: CeilFunction::try_create("ceil")?,
+            arg: DataColumnWithField::new(
+                Series::new([true]).into(),
+                DataField::new("arg1", DataType::Boolean, true),
+            ),
             expect: Err(ErrorCode::IllegalDataType(
-                "Expected numeric types, but got String",
+                "Expected numeric types, but got Boolean",
             )),
         },
     ];

--- a/common/functions/tests/it/scalars/maths/floor.rs
+++ b/common/functions/tests/it/scalars/maths/floor.rs
@@ -1,0 +1,105 @@
+// Copyright 2020 Datafuse Lfloor.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_datavalues::prelude::*;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_functions::scalars::*;
+
+#[test]
+fn test_floor_function() -> Result<()> {
+    #[allow(dead_code)]
+    struct Test {
+        name: &'static str,
+        func: Box<dyn Function>,
+        arg: DataColumnWithField,
+        expect: Result<DataColumn>,
+    }
+    let tests = vec![
+        Test {
+            name: "floor(123)",
+            func: FloorFunction::try_create("floor")?,
+            arg: DataColumnWithField::new(
+                Series::new([123]).into(),
+                DataField::new("arg1", DataType::Int32, false),
+            ),
+            expect: Ok(Series::new(vec![123_f64]).into()),
+        },
+        Test {
+            name: "floor(1.7)",
+            func: FloorFunction::try_create("floor")?,
+            arg: DataColumnWithField::new(
+                Series::new([1.7]).into(),
+                DataField::new("arg1", DataType::Float64, false),
+            ),
+            expect: Ok(Series::new(vec![1_f64]).into()),
+        },
+        Test {
+            name: "floor(-2.1)",
+            func: FloorFunction::try_create("floor")?,
+            arg: DataColumnWithField::new(
+                Series::new([-2.1]).into(),
+                DataField::new("arg1", DataType::Float64, false),
+            ),
+            expect: Ok(Series::new(vec![-3_f64]).into()),
+        },
+        Test {
+            name: "floor(true)",
+            func: FloorFunction::try_create("floor")?,
+            arg: DataColumnWithField::new(
+                Series::new([true]).into(),
+                DataField::new("arg1", DataType::Boolean, true),
+            ),
+            expect: Err(ErrorCode::IllegalDataType(
+                "Expected numeric types, but got Boolean",
+            )),
+        },
+        Test {
+            name: "floor('123')",
+            func: FloorFunction::try_create("floor")?,
+            arg: DataColumnWithField::new(
+                Series::new(["123"]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Err(ErrorCode::IllegalDataType(
+                "Expected numeric types, but got String",
+            )),
+        },
+        Test {
+            name: "floor('a')",
+            func: FloorFunction::try_create("floor")?,
+            arg: DataColumnWithField::new(
+                Series::new(["a"]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Err(ErrorCode::IllegalDataType(
+                "Expected numeric types, but got String",
+            )),
+        },
+    ];
+
+    for t in tests {
+        let func = t.func;
+        let got = func.eval(&[t.arg.clone()], 1);
+        match t.expect {
+            Ok(expected) => {
+                assert_eq!(&got.unwrap(), &expected, "case: {}", t.name);
+            }
+            Err(expected_err) => {
+                assert_eq!(got.unwrap_err().to_string(), expected_err.to_string());
+            }
+        }
+    }
+    Ok(())
+}

--- a/common/functions/tests/it/scalars/maths/floor.rs
+++ b/common/functions/tests/it/scalars/maths/floor.rs
@@ -55,26 +55,31 @@ fn test_floor_function() -> Result<()> {
             expect: Ok(Series::new(vec![-3_f64]).into()),
         },
         Test {
-            name: "floor(true)",
-            func: FloorFunction::try_create("floor")?,
-            arg: DataColumnWithField::new(
-                Series::new([true]).into(),
-                DataField::new("arg1", DataType::Boolean, true),
-            ),
-            expect: Err(ErrorCode::IllegalDataType(
-                "Expected numeric types, but got Boolean",
-            )),
-        },
-        Test {
             name: "floor('123')",
             func: FloorFunction::try_create("floor")?,
             arg: DataColumnWithField::new(
                 Series::new(["123"]).into(),
                 DataField::new("arg1", DataType::String, true),
             ),
-            expect: Err(ErrorCode::IllegalDataType(
-                "Expected numeric types, but got String",
-            )),
+            expect: Ok(Series::new(vec![123_f64]).into()),
+        },
+        Test {
+            name: "floor('+123.8a1')",
+            func: FloorFunction::try_create("floor")?,
+            arg: DataColumnWithField::new(
+                Series::new(["+123.8a1"]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Ok(Series::new(vec![123_f64]).into()),
+        },
+        Test {
+            name: "floor('-123.2a1')",
+            func: FloorFunction::try_create("floor")?,
+            arg: DataColumnWithField::new(
+                Series::new(["-123.2a1"]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Ok(Series::new(vec![-124_f64]).into()),
         },
         Test {
             name: "floor('a')",
@@ -83,8 +88,26 @@ fn test_floor_function() -> Result<()> {
                 Series::new(["a"]).into(),
                 DataField::new("arg1", DataType::String, true),
             ),
+            expect: Ok(Series::new(vec![0_f64]).into()),
+        },
+        Test {
+            name: "floor('a123')",
+            func: FloorFunction::try_create("floor")?,
+            arg: DataColumnWithField::new(
+                Series::new(["a123"]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Ok(Series::new(vec![0_f64]).into()),
+        },
+        Test {
+            name: "floor(true)",
+            func: FloorFunction::try_create("floor")?,
+            arg: DataColumnWithField::new(
+                Series::new([true]).into(),
+                DataField::new("arg1", DataType::Boolean, true),
+            ),
             expect: Err(ErrorCode::IllegalDataType(
-                "Expected numeric types, but got String",
+                "Expected numeric types, but got Boolean",
             )),
         },
     ];

--- a/common/functions/tests/it/scalars/maths/mod.rs
+++ b/common/functions/tests/it/scalars/maths/mod.rs
@@ -14,7 +14,9 @@
 
 mod abs;
 mod angle;
+mod ceil;
 mod crc32;
+mod floor;
 mod log;
 mod pi;
 mod trigonometric;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add ceil, ceiling, floor func
```sql
mysql> select ceil(123.6);
+-------------+
| ceil(123.6) |
+-------------+
|         124 |
+-------------+
1 row in set (0.01 sec)
Read 1 rows, 1 B in 0.002 sec., 477.44 rows/sec., 477.44 B/sec.

mysql> select ceil(123);
+-----------+
| ceil(123) |
+-----------+
|       123 |
+-----------+
1 row in set (0.01 sec)
Read 1 rows, 1 B in 0.003 sec., 301.25 rows/sec., 301.25 B/sec.

mysql> select ceiling('-12.3aa1');
+---------------------+
| ceiling('-12.3aa1') |
+---------------------+
|                 -12 |
+---------------------+
1 row in set (0.00 sec)
Read 1 rows, 1 B in 0.000 sec., 2.26 thousand rows/sec., 2.26 KB/sec.

mysql> select ceiling('+12.3aa1');
+---------------------+
| ceiling('+12.3aa1') |
+---------------------+
|                   0 |
+---------------------+
1 row in set (0.01 sec)
Read 1 rows, 1 B in 0.000 sec., 2.29 thousand rows/sec., 2.29 KB/sec.

mysql> select ceiling('a123');
+-----------------+
| ceiling('a123') |
+-----------------+
|               0 |
+-----------------+
1 row in set (0.01 sec)
Read 1 rows, 1 B in 0.000 sec., 2.44 thousand rows/sec., 2.44 KB/sec.

mysql> select ceiling('a');
+--------------+
| ceiling('a') |
+--------------+
|            0 |
+--------------+
1 row in set (0.00 sec)
Read 1 rows, 1 B in 0.000 sec., 3.2 thousand rows/sec., 3.2 KB/sec.

mysql> select floor(true);
ERROR 1105 (HY000): Code: 7, displayText = Expected numeric types, but got Boolean.
```

## Changelog

- New Feature
- Need Documentation (Need to add documentation to https://databend.rs)

## Related Issues

#2563 

## Test Plan

Unit Tests

Stateless Tests

