### PR TITLE
[metasrv] impl Stoppable for meta/FlightServer

### DIFF
--- a/metasrv/src/api/flight_server.rs
+++ b/metasrv/src/api/flight_server.rs
@@ -19,10 +19,12 @@ use common_base::tokio;
 use common_base::tokio::sync::oneshot;
 use common_base::tokio::sync::oneshot::Receiver;
 use common_base::tokio::sync::oneshot::Sender;
+use common_base::tokio::task::JoinHandle;
+use common_base::Stoppable;
 use common_exception::ErrorCode;
-use common_exception::ToErrorCode;
 use common_tracing::tracing;
 use common_tracing::tracing::Instrument;
+use futures::future::Either;
 use tonic::transport;
 use tonic::transport::Identity;
 use tonic::transport::Server;
@@ -35,19 +37,35 @@ use crate::meta_service::MetaNode;
 pub struct FlightServer {
     conf: Config,
     meta_node: Arc<MetaNode>,
+    join_handle: Option<JoinHandle<()>>,
+    stop_tx: Option<Sender<()>>,
+    fin_rx: Option<Receiver<()>>,
 }
 
 impl FlightServer {
     pub fn create(conf: Config, meta_node: Arc<MetaNode>) -> Self {
-        Self { conf, meta_node }
+        Self {
+            conf,
+            meta_node,
+            join_handle: None,
+            stop_tx: None,
+            fin_rx: None,
+        }
     }
 
     /// Start metasrv and returns two channel to send shutdown signal and receive signal when shutdown finished.
-    pub async fn start(self) -> Result<(oneshot::Sender<()>, oneshot::Receiver<()>), ErrorCode> {
-        // TODO(xp): move component startup from serve() to start().
-        //           block as long as possible to reduce unknown startup time cost.
+    pub async fn do_start(&mut self) -> Result<(), ErrorCode> {
+        let conf = self.conf.clone();
+        let meta_node = self.meta_node.clone();
+
+        // For sending signal when server started.
+        let (started_tx, started_rx) = oneshot::channel::<()>();
+        // For receiving stop signal
         let (stop_tx, stop_rx) = oneshot::channel::<()>();
+        // For sending the signal when server finished shutting down.
         let (fin_tx, fin_rx) = oneshot::channel::<()>();
+
+        let builder = Server::builder();
 
         let tls_conf = Self::tls_config(&self.conf).await.map_err(|e| {
             ErrorCode::TLSConfigurationFailure(format!(
@@ -55,40 +73,6 @@ impl FlightServer {
                 e.to_string()
             ))
         })?;
-
-        let fut = self.serve(stop_rx, fin_tx, tls_conf);
-        tokio::spawn(
-            async move {
-                // TODO(xp): handle errors.
-                // TODO(xp): move server building up actions out of serve(). errors should be caught.
-                let res = fut.await;
-                tracing::info!("metasrv serve res: {:?}", res);
-            }
-            .instrument(tracing::debug_span!("spawn-rpc")),
-        );
-
-        Ok((stop_tx, fin_rx))
-    }
-
-    /// Start serving metasrv. It does not return until metasrv is stopped.
-    #[tracing::instrument(level = "debug", skip(self, stop_rx, fin_tx))]
-    pub async fn serve(
-        self,
-        stop_rx: Receiver<()>,
-        fin_tx: Sender<()>,
-        tls_conf: Option<ServerTlsConfig>,
-    ) -> Result<(), ErrorCode> {
-        let addr = self
-            .conf
-            .flight_api_address
-            .parse::<std::net::SocketAddr>()?;
-
-        tracing::info!("flight addr: {}", addr);
-
-        let flight_impl = MetaFlightImpl::create(self.conf.clone(), self.meta_node.clone());
-        let flight_srv = FlightServiceServer::new(flight_impl);
-
-        let builder = Server::builder();
 
         let mut builder = if let Some(conf) = tls_conf {
             tracing::info!("TLS RPC enabled");
@@ -102,26 +86,82 @@ impl FlightServer {
             builder
         };
 
-        let res = builder
-            .add_service(flight_srv)
-            .serve_with_shutdown(addr, async move {
-                tracing::info!("metasrv start to wait for stop signal: {}", addr);
-                let _ = stop_rx.await;
-                tracing::info!("metasrv receives stop signal: {}", addr);
-            })
-            .await;
+        let addr = conf.flight_api_address.parse::<std::net::SocketAddr>()?;
+        tracing::info!("flight addr: {}", addr);
 
-        let _ = self.meta_node.stop().await;
-        let s = fin_tx.send(());
-        tracing::info!(
-            "metasrv sending signal of finishing shutdown {}: res: {:?}",
-            addr,
-            s
+        let flight_impl = MetaFlightImpl::create(conf, meta_node.clone());
+        let flight_srv = FlightServiceServer::new(flight_impl);
+
+        let j = tokio::spawn(
+            async move {
+                let res = builder
+                    .add_service(flight_srv)
+                    .serve_with_shutdown(addr, async move {
+                        let _ = started_tx.send(());
+                        tracing::info!("metasrv start to wait for stop signal: {}", addr);
+                        let _ = stop_rx.await;
+                        tracing::info!("metasrv receives stop signal: {}", addr);
+                    })
+                    .await;
+
+                // Server quit. Start to shutdown meta node.
+
+                let _ = meta_node.stop().await;
+                let send_fin_res = fin_tx.send(());
+                tracing::info!(
+                    "metasrv sending signal of finishing shutdown {}: res: {:?}",
+                    addr,
+                    send_fin_res
+                );
+
+                tracing::info!("metasrv returned res: {:?}", res);
+            }
+            .instrument(tracing::debug_span!("spawn-rpc")),
         );
 
-        tracing::info!("metasrv returning");
+        // Blocks until server started or the tx is dropped.
+        started_rx
+            .await
+            .map_err(|e| ErrorCode::MetaServiceError(e.to_string()))?;
 
-        res.map_err_to_code(ErrorCode::MetaSrvError, || "metasrv error")
+        self.join_handle = Some(j);
+        self.stop_tx = Some(stop_tx);
+        self.fin_rx = Some(fin_rx);
+
+        Ok(())
+    }
+
+    pub async fn do_stop(
+        &mut self,
+        force: Option<tokio::sync::broadcast::Receiver<()>>,
+    ) -> Result<(), ErrorCode> {
+        if let Some(tx) = self.stop_tx.take() {
+            let _ = tx.send(());
+        }
+
+        if let Some(j) = self.join_handle.take() {
+            if let Some(mut frc) = force {
+                let f = Box::pin(frc.recv());
+                let j = Box::pin(j);
+
+                match futures::future::select(f, j).await {
+                    Either::Left((_x, j)) => {
+                        // force shutdown signal received.
+                        j.abort();
+                    }
+                    Either::Right((_, _)) => {
+                        // graceful shutdown finished.
+                    }
+                }
+            } else {
+                let _ = j.await;
+            }
+        }
+
+        if let Some(rx) = self.fin_rx.take() {
+            let _ = rx.await;
+        }
+        Ok(())
     }
 
     async fn tls_config(conf: &Config) -> anyhow::Result<Option<ServerTlsConfig>> {
@@ -135,5 +175,19 @@ impl FlightServer {
         } else {
             Ok(None)
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl Stoppable for FlightServer {
+    async fn start(&mut self) -> Result<(), ErrorCode> {
+        self.do_start().await
+    }
+
+    async fn stop(
+        &mut self,
+        force: Option<tokio::sync::broadcast::Receiver<()>>,
+    ) -> Result<(), ErrorCode> {
+        self.do_stop(force).await
     }
 }

--- a/metasrv/src/tests/service.rs
+++ b/metasrv/src/tests/service.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use common_base::tokio;
-use common_base::tokio::sync::oneshot;
 use common_base::GlobalSequence;
+use common_base::Stoppable;
 use common_tracing::tracing;
 
 use crate::api::FlightServer;
@@ -40,14 +40,14 @@ pub async fn start_metasrv() -> Result<(MetaSrvTestContext, String)> {
 
 pub async fn start_metasrv_with_context(tc: &mut MetaSrvTestContext) -> Result<()> {
     let mn = MetaNode::start(&tc.config.raft_config).await?;
-    let srv = FlightServer::create(tc.config.clone(), mn);
-    let (stop_tx, fin_rx) = srv.start().await?;
-
-    tc.channels = Some((stop_tx, fin_rx));
+    let mut srv = FlightServer::create(tc.config.clone(), mn);
+    srv.start().await?;
 
     // TODO(xp): some times the MetaNode takes more than 200 ms to startup, with disk-backed store.
     //           Find out why and using some kind of waiting routine to ensure service is on.
     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+
+    tc.fligh_srv = Some(Box::new(srv));
     Ok(())
 }
 
@@ -63,8 +63,7 @@ pub struct MetaSrvTestContext {
 
     pub meta_nodes: Vec<Arc<MetaNode>>,
 
-    /// channel to send to stop metasrv, and channel for waiting for shutdown to finish.
-    pub channels: Option<(oneshot::Sender<()>, oneshot::Receiver<()>)>,
+    pub fligh_srv: Option<Box<FlightServer>>,
 }
 
 /// Create a new Config for test, with unique port assigned
@@ -113,8 +112,7 @@ pub fn new_test_context(id: u64) -> MetaSrvTestContext {
     MetaSrvTestContext {
         config,
         meta_nodes: vec![],
-
-        channels: None,
+        fligh_srv: None,
     }
 }
 

--- a/metasrv/tests/flight/metasrv_flight_api.rs
+++ b/metasrv/tests/flight/metasrv_flight_api.rs
@@ -15,6 +15,7 @@
 //! Test arrow-flight API of metasrv
 
 use common_base::tokio;
+use common_base::Stoppable;
 use common_meta_api::KVApi;
 use common_meta_flight::MetaFlightClient;
 use common_meta_types::MatchSeq;
@@ -89,12 +90,8 @@ async fn test_restart() -> anyhow::Result<()> {
 
     tracing::info!("--- stop metasrv");
     {
-        let (stop_tx, fin_rx) = tc.channels.take().unwrap();
-        stop_tx
-            .send(())
-            .map_err(|_| anyhow::anyhow!("fail to send"))?;
-
-        fin_rx.await?;
+        let mut srv = tc.fligh_srv.take().unwrap();
+        srv.stop(None).await?;
 
         drop(client);
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] impl Stoppable for meta/FlightServer
- Feature: FlightServer::start() blocks until listening is estabelisthed.

- Refactor: FlightServer::start() takes a ref to self instead of an
  owned instance, to let user be able to call FlightServer::stop().

- Feature: impl force/graceful shutdown for FlightServer.

- Refactor: simplify FlightServer life cycle mng in tests.

## Changelog







## Related Issues