### PR TITLE
Improve the stateful test from debug to release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ PLATFORM ?= linux/amd64,linux/arm64
 VERSION ?= latest
 ADD_NODES ?= 0
 NUM_CPUS ?= 2
-TENANT ?= "tenant"
-CLUSTER_NAME ?= "test"
+TENANT_ID ?= "tenant"
+CLUSTER_ID ?= "test"
 # Setup dev toolchain
 setup:
 	bash ./scripts/setup/dev_setup.sh
@@ -21,19 +21,6 @@ miri:
 	cargo miri setup
 	MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test
 
-cluster: build-debug cli-build-debug
-	mkdir -p ./.databend/local/bin/test/ && make cluster_stop || echo "stop"
-	cp ./target/debug/databend-query ./.databend/local/bin/test/databend-query
-	cp ./target/debug/databend-meta ./.databend/local/bin/test/databend-meta
-	./target/release/bendctl cluster create --databend_dir ./.databend --group local --version test --num-cpus ${NUM_CPUS} --query-tenant ${TENANT} --query-namespace ${CLUSTER_NAME} --force
-	for i in `seq 1 ${ADD_NODES}`; do make cluster_add; done;
-	make cluster_view
-cluster_add:
-	./target/release/bendctl cluster add --databend_dir ./.databend --group local --num-cpus ${NUM_CPUS}
-cluster_view:
-	./target/release/bendctl cluster view --databend_dir ./.databend --group local
-cluster_stop:
-	@if find ./.databend/local/configs/local/ -maxdepth 0 -empty | read v ; then echo there is no cluster exists; else ./target/release/bendctl cluster stop --databend_dir ./.databend --group local; fi
 run: build
 	bash ./scripts/deploy/databend-query-standalone.sh release
 
@@ -77,6 +64,21 @@ cli-test:
 
 unit-test:
 	ulimit -n 10000; bash ./scripts/ci/ci-run-unit-tests.sh
+
+# Bendctl with cluster for stateful test.
+cluster: build-release cli-build-release
+	mkdir -p ./.databend/local/bin/test/ && make cluster_stop || echo "stop"
+	cp ./target/release/databend-query ./.databend/local/bin/test/databend-query
+	cp ./target/release/databend-meta ./.databend/local/bin/test/databend-meta
+	./target/release/bendctl cluster create --databend_dir ./.databend --group local --version test --num-cpus ${NUM_CPUS} --query-tenant-id ${TENANT_ID} --query-cluster-id ${CLUSTER_ID} --force
+	for i in `seq 1 ${ADD_NODES}`; do make cluster_add; done;
+	make cluster_view
+cluster_add:
+	./target/release/bendctl cluster add --databend_dir ./.databend --group local --num-cpus ${NUM_CPUS}
+cluster_view:
+	./target/release/bendctl cluster view --databend_dir ./.databend --group local
+cluster_stop:
+	@if find ./.databend/local/configs/local/ -maxdepth 0 -empty | read v ; then echo there is no cluster exists; else ./target/release/bendctl cluster stop --databend_dir ./.databend --group local; fi
 
 embedded-meta-test: build-debug
 	rm -rf ./_meta_embedded

--- a/scripts/ci/ci-run-stateful-tests-standalone.sh
+++ b/scripts/ci/ci-run-stateful-tests-standalone.sh
@@ -29,14 +29,14 @@ else
     exit 1
 fi
 
-./target/debug/bendctl --databend_dir ./.databend --group local query ./tests/suites/0_stateful/ddl/create_table.sql
+./target/release/bendctl --databend_dir ./.databend --group local query ./tests/suites/0_stateful/ddl/create_table.sql
 if [ $? -eq 0 ]; then
     echo "dataset table DDL passed"
 else
     echo "cannot create DDL"
     exit 1
 fi
-./target/debug/bendctl --databend_dir ./.databend --group local load $HOME/dataset/ontime.csv --table ontime
+./target/release/bendctl --databend_dir ./.databend --group local load $HOME/dataset/ontime.csv --table ontime
 if [ $? -eq 0 ]; then
     echo "successfull loaded ontime dataset"
 else
@@ -46,7 +46,7 @@ echo "Starting stateful databend-test"
 # Create table
 # shellcheck disable=SC2044
 for i in `find ./tests/suites/0_stateful/sql -name "*.sql" -type f`; do
-  ./target/debug/bendctl --databend_dir ./.databend --group local query $i 2>$i.error > $i.out
+  ./target/release/bendctl --databend_dir ./.databend --group local query $i 2>$i.error > $i.out
   # shellcheck disable=SC2046
   if [ $(cat $i.error | wc -l ) -ne 0 ]; then
       cat $i.error


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR:
1. Fix the query tenant_id and cluster_id parameters
2. Change bendctl from debug to release for stateful test

## Changelog

- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

