### PR TITLE
[metasrv] test: always disable fsync on mac, to let integration test pass on mac VM

### DIFF
--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -216,13 +216,6 @@ impl MetaNode {
         Ok(())
     }
 
-    /// Start a metasrv node from initialized store.
-    #[tracing::instrument(level = "info", skip(config), fields(config_id=config.config_id.as_str()))]
-    pub async fn open(config: &RaftConfig) -> common_exception::Result<Arc<MetaNode>> {
-        let mn = Self::open_create_boot(config, Some(()), None, None).await?;
-        Ok(mn)
-    }
-
     /// Open or create a metasrv node.
     /// Optionally boot a single node cluster.
     /// 1. If `open` is `Some`, try to open an existent one.

--- a/metasrv/src/tests/service.rs
+++ b/metasrv/src/tests/service.rs
@@ -47,7 +47,7 @@ pub async fn start_metasrv_with_context(tc: &mut MetaSrvTestContext) -> Result<(
     //           Find out why and using some kind of waiting routine to ensure service is on.
     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
 
-    tc.fligh_srv = Some(Box::new(srv));
+    tc.flight_srv = Some(Box::new(srv));
     Ok(())
 }
 
@@ -63,7 +63,7 @@ pub struct MetaSrvTestContext {
 
     pub meta_nodes: Vec<Arc<MetaNode>>,
 
-    pub fligh_srv: Option<Box<FlightServer>>,
+    pub flight_srv: Option<Box<FlightServer>>,
 }
 
 /// Create a new Config for test, with unique port assigned
@@ -112,7 +112,7 @@ pub fn new_test_context(id: u64) -> MetaSrvTestContext {
     MetaSrvTestContext {
         config,
         meta_nodes: vec![],
-        fligh_srv: None,
+        flight_srv: None,
     }
 }
 

--- a/metasrv/tests/flight/metasrv_flight_api.rs
+++ b/metasrv/tests/flight/metasrv_flight_api.rs
@@ -90,7 +90,7 @@ async fn test_restart() -> anyhow::Result<()> {
 
     tracing::info!("--- stop metasrv");
     {
-        let mut srv = tc.fligh_srv.take().unwrap();
+        let mut srv = tc.flight_srv.take().unwrap();
         srv.stop(None).await?;
 
         drop(client);


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] test: always disable fsync on mac, to let integration test pass on mac VM
- fix: #2764


##### refactor: fix typo

## Changelog




- Improvement
- Build/Testing/CI

## Related Issues