### PR TITLE
ISSUE-2767: Try to fix http handler get_schema

### DIFF
--- a/query/src/servers/http/v1/query/http_query.rs
+++ b/query/src/servers/http/v1/query/http_query.rs
@@ -65,7 +65,7 @@ impl HttpQuery {
         let (block_tx, block_rx) = mpsc::channel(10);
 
         let state = ExecuteState::try_create(&request, session_manager, block_tx).await?;
-        let schema = state.read().await.get_schema();
+        let schema = state.read().await.get_schema()?;
         let data = Arc::new(TokioMutex::new(ResultDataManager::new(schema, block_rx)));
         let query = HttpQuery {
             id,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR:
1. Return err instead unreachable panic in get_schema.
2. Fix some unwarp to return err

This PR not addressed:
1. The root cause of get_schema when the state is Stopped @youngsofun 

## Changelog

- Bug Fix


## Related Issues

Fixes #2767

## Test Plan

Unit Tests

Stateless Tests

