### PR TITLE
Adjust response of /v1/query.

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -274,12 +274,14 @@ build_exceptions! {
     UnknownStorageSchemeName(7001),
     SecretKeyNotSet(7002),
 
-
     // datasource error
     DuplicatedTableEngineProvider(8000),
     UnknownDatabaseEngine(8001),
     UnknownTableEngine(8002),
     DuplicatedDatabaseEngineProvider(8003),
+
+    // http query error
+    HttpNotFound(9404),
 
 }
 // General errors

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -25,6 +25,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use futures::StreamExt;
 use serde::Deserialize;
+use serde::Serialize;
 
 use crate::interpreters::InterpreterFactory;
 use crate::sessions::DatabendQueryContextRef;
@@ -37,9 +38,28 @@ pub struct HttpQueryRequest {
     pub sql: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq)]
+pub enum ExecuteStateName {
+    Running,
+    Failed,
+    Succeeded,
+}
+
 pub(crate) enum ExecuteState {
     Running(ExecuteRunning),
     Stopped(ExecuteStopped),
+}
+
+impl ExecuteState {
+    pub(crate) fn extract(&self) -> (ExecuteStateName, Option<ErrorCode>) {
+        match self {
+            ExecuteState::Running(_) => (ExecuteStateName::Running, None),
+            ExecuteState::Stopped(v) => match &v.reason {
+                Ok(_) => (ExecuteStateName::Succeeded, None),
+                Err(e) => (ExecuteStateName::Failed, Some(e.clone())),
+            },
+        }
+    }
 }
 
 use ExecuteState::*;
@@ -56,16 +76,7 @@ pub(crate) struct ExecuteStateWrapper {
     pub(crate) state: ExecuteState,
 }
 
-pub const STATE_RUNNING: &str = "running";
-pub const STATE_STOPPED: &str = "stopped";
-
 impl ExecuteStateWrapper {
-    pub(crate) fn get_state(&self) -> &str {
-        match &self.state {
-            Running(_) => STATE_RUNNING,
-            Stopped(_) => STATE_STOPPED,
-        }
-    }
     pub(crate) fn get_progress(&self) -> Option<ProgressValues> {
         match &self.state {
             Running(r) => Some(r.context.get_progress_value()),
@@ -134,17 +145,17 @@ impl ExecuteState {
                             Ok(block) => tokio::select! {
                                 _ = block_tx.send(block) => { },
                                 _ = abort_rx.recv() => {
-                                    ExecuteState::stop(&state, Err(ErrorCode::AbortedQuery("query aborted"))).await;
+                                    ExecuteState::stop(&state, Err(ErrorCode::AbortedQuery("query aborted")), true).await;
                                     break;
                                 },
                             },
                             Err(err) => {
-                                ExecuteState::stop(&state, Err(err)).await;
+                                ExecuteState::stop(&state, Err(err), false).await;
                                 break
                             }
                         };
                     } else {
-                        ExecuteState::stop(&state, Ok(())).await;
+                        ExecuteState::stop(&state, Ok(()), false).await;
                         break;
                     }
                 }
@@ -153,12 +164,14 @@ impl ExecuteState {
         Ok((state_clone, schema))
     }
 
-    pub(crate) async fn stop(this: &ExecuteStateRef, reason: Result<()>) {
+    pub(crate) async fn stop(this: &ExecuteStateRef, reason: Result<()>, kill: bool) {
         let mut guard = this.write().await;
         if let Running(r) = &guard.state {
             // release session
             let progress = Some(r.context.get_progress_value());
-            r.session.force_kill_session();
+            if kill {
+                r.session.force_kill_query();
+            }
             guard.state = Stopped(ExecuteStopped { progress, reason });
         };
     }

--- a/query/src/servers/http/v1/query/http_query_manager.rs
+++ b/query/src/servers/http/v1/query/http_query_manager.rs
@@ -19,10 +19,7 @@ use common_base::tokio::sync::RwLock;
 use common_exception::Result;
 
 use crate::configs::Config;
-use crate::servers::http::v1::query::execute_state::HttpQueryRequest;
-use crate::servers::http::v1::query::http_query::HttpQuery;
 use crate::servers::http::v1::query::http_query::HttpQueryRef;
-use crate::sessions::SessionManagerRef;
 
 pub struct HttpQueryManager {
     pub(crate) queries: Arc<RwLock<HashMap<String, HttpQueryRef>>>,
@@ -37,22 +34,8 @@ impl HttpQueryManager {
         }))
     }
 
-    fn next_query_id(self: &Arc<Self>) -> String {
+    pub(crate) fn next_query_id(self: &Arc<Self>) -> String {
         uuid::Uuid::new_v4().to_string()
-    }
-
-    pub(crate) async fn create_query(
-        self: &Arc<Self>,
-        req: HttpQueryRequest,
-        session_manager: &SessionManagerRef,
-    ) -> Result<HttpQueryRef> {
-        let query_id = self.next_query_id();
-        let query = HttpQuery::try_create(query_id.clone(), req, session_manager).await?;
-        self.queries
-            .write()
-            .await
-            .insert(query_id.clone(), query.clone());
-        Ok(query)
     }
 
     pub(crate) async fn get_query_by_id(self: &Arc<Self>, query_id: &str) -> Option<HttpQueryRef> {

--- a/query/src/servers/http/v1/query/result_data_manager.rs
+++ b/query/src/servers/http/v1/query/result_data_manager.rs
@@ -99,7 +99,8 @@ impl ResultDataManager {
                 .ok_or_else(|| ErrorCode::UnexpectedError("last_page is None"))?
                 .clone())
         } else {
-            Err(ErrorCode::LogicalError("page no too large"))
+            let message = format!("wrong page number {}", page_no,);
+            Err(ErrorCode::HttpNotFound(message))
         }
     }
 

--- a/query/src/servers/http/v1/statement.rs
+++ b/query/src/servers/http/v1/statement.rs
@@ -44,7 +44,6 @@ use crate::sql::PlanParser;
 #[derive(Serialize, Deserialize, Debug)]
 pub struct HttpQueryResult {
     id: String,
-    #[serde(rename = "nextUri")] // to be compatible with presto
     pub next_uri: Option<String>,
     pub data: Option<Vec<Vec<JsonValue>>>,
     pub columns: Option<DataSchemaRef>,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

1. remove request_error  and use HTTP status codes like 404  with text messages for these errors.
2. extend error, include fields of ErrorCode
3. move progress into stats
4. rename delete_uri  to  final_uri to be in concert with next_uri, let the server decide what to do.
     5.  user SHOULD get final_uri if next_uri is null(all fetched) or does not need the remaining data. 
     6. serve as ack for the last page. (other page is acked by next_uri)



## Changelog


## Related Issues

/v1/query was introduced in  https://github.com/datafuselabs/databend/pull/2688


## Test Plan

Unit Tests

Stateless Tests

