### PR TITLE
Fix make test failure on macOS 12.0

### DIFF
--- a/scripts/ci/ci-run-unit-tests.sh
+++ b/scripts/ci/ci-run-unit-tests.sh
@@ -6,4 +6,4 @@ SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 cd "$SCRIPT_PATH/../../" || exit
 
 echo "Starting unit tests"
-cargo test
+env "MACOSX_DEPLOYMENT_TARGET=10.7" cargo test


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Fix make test failure on macOS 12.0 https://github.com/rust-lang/rust/issues/90342

## Changelog

- Build/Testing/CI

## Related Issues

Fixes #issue