### PR TITLE
ISSUE-2806: Add metrics to dal operations (label with tenant_id and cluster_id) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ dependencies = [
  "common-datablocks",
  "common-exception",
  "common-infallible",
+ "common-metrics",
  "futures",
  "metrics",
  "pretty_assertions",
@@ -1212,6 +1213,7 @@ dependencies = [
  "rusoto_s3",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -2128,8 +2130,6 @@ dependencies = [
  "quantiles",
  "rand 0.8.4",
  "reqwest",
- "rusoto_core",
- "rusoto_s3",
  "serde",
  "serde_json",
  "sha1",

--- a/common/dal/Cargo.toml
+++ b/common/dal/Cargo.toml
@@ -15,6 +15,7 @@ common-base = {path = "../base"}
 common-datablocks = {path = "../datablocks"}
 common-exception = {path = "../exception"}
 common-infallible = {path = "../infallible"}
+common-metrics= {path = "../metrics"}
 
 async-compat = "0.2.1"
 async-trait = "0.1"
@@ -32,4 +33,5 @@ reqwest = "0.11"
 [dev-dependencies]
 pretty_assertions = "1.0"
 rand = "0.8.4"
+tempfile = "3.2.0"
 

--- a/common/dal/src/data_accessor.rs
+++ b/common/dal/src/data_accessor.rs
@@ -39,8 +39,6 @@ impl<T> SeekableReader for T where T: Read + Seek {}
 pub trait DataAccessor: Send + Sync {
     fn get_input_stream(&self, path: &str, stream_len: Option<u64>) -> Result<InputStream>;
 
-    async fn get(&self, path: &str) -> Result<Bytes>;
-
     async fn put(&self, path: &str, content: Vec<u8>) -> Result<()>;
 
     async fn put_stream(

--- a/common/dal/src/impls/local.rs
+++ b/common/dal/src/impls/local.rs
@@ -25,10 +25,8 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use futures::Stream;
 use futures::StreamExt;
-use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 
-use crate::Bytes;
 use crate::DataAccessor;
 use crate::InputStream;
 
@@ -70,14 +68,6 @@ impl DataAccessor for Local {
         let std_file = std::fs::File::open(path)?;
         let tokio_file = tokio::fs::File::from_std(std_file);
         Ok(Box::new(tokio_file.compat()))
-    }
-
-    async fn get(&self, path: &str) -> Result<Bytes> {
-        let path = self.prefix_with_root(path)?;
-        let mut file = tokio::fs::File::open(path).await?;
-        let mut contents = vec![];
-        let _ = file.read_to_end(&mut contents).await?;
-        Ok(contents)
     }
 
     // not "atomic", for test purpose only

--- a/common/dal/src/lib.rs
+++ b/common/dal/src/lib.rs
@@ -27,7 +27,13 @@ pub use impls::local::Local;
 pub use in_memory_data::InMemoryData;
 pub use schemes::StorageScheme;
 
+pub use self::metrics::DalWithMetric;
+pub use self::metrics::InputStreamWithMetric;
+pub use self::metrics::METRIC_DAL_READ_BYTES;
+pub use self::metrics::METRIC_DAL_WRITE_BYTES;
+
 mod data_accessor;
 mod impls;
 mod in_memory_data;
+mod metrics;
 mod schemes;

--- a/common/dal/src/metrics/constants.rs
+++ b/common/dal/src/metrics/constants.rs
@@ -1,0 +1,17 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+pub const METRIC_DAL_READ_BYTES: &str = "dal_read_bytes";
+pub const METRIC_DAL_WRITE_BYTES: &str = "dal_write_bytes";

--- a/common/dal/src/metrics/dal_metrics.rs
+++ b/common/dal/src/metrics/dal_metrics.rs
@@ -1,0 +1,89 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_metrics::label_counter_with_val;
+use common_metrics::TenantLabel;
+use futures::Stream;
+
+use crate::metrics::stream_metrics::InputStreamWithMetric;
+use crate::metrics::METRIC_DAL_WRITE_BYTES;
+use crate::AsyncSeekableReader;
+use crate::DataAccessor;
+use crate::InputStream;
+
+pub struct DalWithMetric {
+    tenant_label: TenantLabel,
+    inner: Arc<dyn DataAccessor>,
+}
+
+impl DalWithMetric {
+    pub fn new(tenant_label: TenantLabel, inner: Arc<dyn DataAccessor>) -> Self {
+        Self {
+            tenant_label,
+            inner,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl DataAccessor for DalWithMetric {
+    fn get_input_stream(
+        &self,
+        path: &str,
+        stream_len: Option<u64>,
+    ) -> common_exception::Result<InputStream> {
+        self.inner
+            .get_input_stream(path, stream_len)
+            .map(|input_stream| {
+                let r = InputStreamWithMetric::new(self.tenant_label.clone(), input_stream);
+                Box::new(r) as Box<dyn AsyncSeekableReader + Unpin + Send>
+            })
+    }
+
+    async fn put(&self, path: &str, content: Vec<u8>) -> common_exception::Result<()> {
+        let len = content.len();
+        self.inner.put(path, content).await.map(|_| {
+            label_counter_with_val(
+                METRIC_DAL_WRITE_BYTES,
+                len as u64,
+                self.tenant_label.tenant_id.as_str(),
+                self.tenant_label.cluster_id.as_str(),
+            )
+        })
+    }
+
+    async fn put_stream(
+        &self,
+        path: &str,
+        input_stream: Box<
+            dyn Stream<Item = Result<bytes::Bytes, std::io::Error>> + Send + Unpin + 'static,
+        >,
+        stream_len: usize,
+    ) -> common_exception::Result<()> {
+        self.inner
+            .put_stream(path, input_stream, stream_len)
+            .await
+            .map(|_| {
+                label_counter_with_val(
+                    METRIC_DAL_WRITE_BYTES,
+                    stream_len as u64,
+                    self.tenant_label.tenant_id.as_str(),
+                    self.tenant_label.cluster_id.as_str(),
+                )
+            })
+    }
+}

--- a/common/dal/src/metrics/mod.rs
+++ b/common/dal/src/metrics/mod.rs
@@ -1,0 +1,22 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+mod constants;
+mod dal_metrics;
+mod stream_metrics;
+
+pub use constants::METRIC_DAL_READ_BYTES;
+pub use constants::METRIC_DAL_WRITE_BYTES;
+pub use dal_metrics::DalWithMetric;
+pub use stream_metrics::InputStreamWithMetric;

--- a/common/dal/src/metrics/stream_metrics.rs
+++ b/common/dal/src/metrics/stream_metrics.rs
@@ -1,0 +1,67 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::pin::Pin;
+use std::task::Poll;
+
+use common_base::tokio::io::SeekFrom;
+use common_metrics::label_counter_with_val;
+use common_metrics::TenantLabel;
+
+use crate::metrics::METRIC_DAL_READ_BYTES;
+use crate::InputStream;
+
+pub struct InputStreamWithMetric {
+    tenant_label: TenantLabel,
+    inner: InputStream,
+}
+
+impl InputStreamWithMetric {
+    pub fn new(tenant_label: TenantLabel, input_stream: InputStream) -> Self {
+        Self {
+            tenant_label,
+            inner: input_stream,
+        }
+    }
+}
+
+impl futures::AsyncRead for InputStreamWithMetric {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        ctx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::result::Result<usize, std::io::Error>> {
+        let r = Pin::new(&mut self.inner).poll_read(ctx, buf);
+        if let Poll::Ready(Ok(len)) = r {
+            label_counter_with_val(
+                METRIC_DAL_READ_BYTES,
+                len as u64,
+                self.tenant_label.tenant_id.as_str(),
+                self.tenant_label.cluster_id.as_str(),
+            )
+        };
+        r
+    }
+}
+
+impl futures::AsyncSeek for InputStreamWithMetric {
+    fn poll_seek(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        pos: SeekFrom,
+    ) -> Poll<std::io::Result<u64>> {
+        Pin::new(&mut self.inner).poll_seek(cx, pos)
+    }
+}

--- a/common/dal/tests/it/main.rs
+++ b/common/dal/tests/it/main.rs
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 mod impls;
+mod metrics;
 mod schemes;

--- a/common/dal/tests/it/metrics/dal_metrics.rs
+++ b/common/dal/tests/it/metrics/dal_metrics.rs
@@ -1,0 +1,193 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common_base::tokio;
+use common_base::tokio::io::SeekFrom;
+use common_dal::DalWithMetric;
+use common_dal::DataAccessor;
+use common_dal::Local;
+use common_dal::METRIC_DAL_READ_BYTES;
+use common_dal::METRIC_DAL_WRITE_BYTES;
+use common_metrics::dump_metric_samples;
+use common_metrics::init_default_metrics_recorder;
+use common_metrics::try_handle;
+use common_metrics::MetricSample;
+use common_metrics::MetricValue;
+use common_metrics::TenantLabel;
+use common_metrics::LABEL_KEY_CLUSTER;
+use common_metrics::LABEL_KEY_TENANT;
+use futures::AsyncReadExt;
+use futures::AsyncSeekExt;
+use tempfile::TempDir;
+
+struct TestFixture {
+    _tmp_dir: TempDir,
+    label_map: HashMap<String, String>,
+    da_with_metric: Arc<dyn DataAccessor>,
+    raw_da: Local,
+}
+
+impl TestFixture {
+    fn new(tenant_label: TenantLabel) -> Self {
+        let label_map = [
+            (
+                LABEL_KEY_CLUSTER.to_owned(),
+                tenant_label.cluster_id.to_owned(),
+            ),
+            (
+                LABEL_KEY_TENANT.to_owned(),
+                tenant_label.tenant_id.to_owned(),
+            ),
+        ]
+        .into_iter()
+        .collect::<HashMap<_, _>>();
+
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().to_str().unwrap();
+        let raw_da = Local::new(path);
+
+        // da with metric
+        let local = Local::new(path);
+        let da_with_metric = DalWithMetric::new(tenant_label, Arc::new(local));
+
+        init_default_metrics_recorder();
+
+        Self {
+            _tmp_dir: tmp_dir,
+            label_map,
+            da_with_metric: Arc::new(da_with_metric),
+            raw_da,
+        }
+    }
+
+    fn label_map(&self) -> &HashMap<String, String> {
+        &self.label_map
+    }
+
+    async fn gen_rand_content(&self, path: &str, len: i64) -> common_exception::Result<()> {
+        let random_bytes: Vec<u8> = (0..len).map(|_| rand::random::<u8>()).collect();
+        self.raw_da.put(path, random_bytes).await
+    }
+}
+#[tokio::test]
+async fn test_dal_metrics_write() -> common_exception::Result<()> {
+    // setup
+    let label = TenantLabel::new("test_tenant", "test_cluster");
+    let fixture = TestFixture::new(label);
+    let dal = &fixture.da_with_metric;
+
+    let len = 100;
+    let random_bytes: Vec<u8> = (0..len).map(|_| rand::random::<u8>()).collect();
+
+    // write 100 bytes
+    dal.put("test_path", random_bytes).await?;
+
+    // check
+    let label_map = fixture.label_map();
+    let samples = dump_samples(METRIC_DAL_WRITE_BYTES, label_map);
+    assert_eq!(1, samples.len());
+    let sample = &samples[0];
+    assert_eq!(MetricValue::Counter(len as f64), sample.value);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_dal_metrics_put_stream() -> common_exception::Result<()> {
+    // setup
+    let label = TenantLabel::new("test_tenant_put_stream", "test_cluster_put_stream");
+    let fixture = TestFixture::new(label);
+    let dal = &fixture.da_with_metric;
+
+    let len = 100;
+    let random_bytes: Vec<u8> = (0..len).map(|_| rand::random::<u8>()).collect();
+
+    // write 100 bytes
+
+    let stream = Box::pin(futures::stream::once(async move {
+        Ok(bytes::Bytes::from(random_bytes))
+    }));
+    dal.put_stream("test_path", Box::new(stream), len).await?;
+
+    // check
+    let label_map = fixture.label_map();
+    let samples = dump_samples(METRIC_DAL_WRITE_BYTES, label_map);
+    assert_eq!(1, samples.len());
+    let sample = &samples[0];
+    assert_eq!(MetricValue::Counter(len as f64), sample.value);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_dal_metrics_read() -> common_exception::Result<()> {
+    // setup
+    let label = TenantLabel::new("test_tenant_read", "test_cluster_read");
+    let fixture = TestFixture::new(label);
+    let dal = &fixture.da_with_metric;
+
+    let len = 100;
+    fixture.gen_rand_content("test_path", len).await?;
+
+    // read all
+    let mut input_stream = dal.get_input_stream("test_path", None)?;
+    let mut buf = Vec::new();
+    input_stream.read_to_end(&mut buf).await?;
+
+    let label_map = fixture.label_map();
+    let samples = dump_samples(METRIC_DAL_READ_BYTES, label_map);
+    assert_eq!(1, samples.len());
+    let sample = &samples[0];
+    assert_eq!(MetricValue::Counter(len as f64), sample.value);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_dal_metrics_partial_read() -> common_exception::Result<()> {
+    // setup
+    let label = TenantLabel::new("test_tenant_partial_read", "test_cluster_partial_read");
+    let fixture = TestFixture::new(label);
+    let dal = &fixture.da_with_metric;
+
+    let len = 100;
+    fixture.gen_rand_content("test_path", len).await?;
+
+    // partial read
+    let seek_pos = 10;
+    let mut input_stream = dal.get_input_stream("test_path", None)?;
+    let mut buf = Vec::new();
+    input_stream.seek(SeekFrom::Current(seek_pos)).await?;
+    input_stream.read_to_end(&mut buf).await?;
+
+    let partial_read_len = len - seek_pos;
+    let label_map = fixture.label_map();
+    let samples = dump_samples(METRIC_DAL_READ_BYTES, label_map);
+    assert_eq!(1, samples.len());
+    let sample = &samples[0];
+    assert_eq!(MetricValue::Counter(partial_read_len as f64), sample.value);
+
+    Ok(())
+}
+
+fn dump_samples(name: &str, lbl_map: &HashMap<String, String>) -> Vec<MetricSample> {
+    let handle = try_handle().unwrap();
+    dump_metric_samples(handle)
+        .unwrap()
+        .into_iter()
+        .filter(|s| s.name == name && &s.labels == lbl_map)
+        .collect()
+}

--- a/common/dal/tests/it/metrics/mod.rs
+++ b/common/dal/tests/it/metrics/mod.rs
@@ -1,0 +1,16 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+mod dal_metrics;

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -17,9 +17,14 @@ mod recorder;
 
 pub use dump::dump_metric_samples;
 pub use dump::HistogramCount;
+pub use dump::MetricSample;
 pub use dump::MetricValue;
 pub use dump::SummaryCount;
 pub use metrics_exporter_prometheus::PrometheusHandle;
 pub use recorder::init_default_metrics_recorder;
 pub use recorder::label_counter;
+pub use recorder::label_counter_with_val;
 pub use recorder::try_handle;
+pub use recorder::TenantLabel;
+pub use recorder::LABEL_KEY_CLUSTER;
+pub use recorder::LABEL_KEY_TENANT;

--- a/common/metrics/src/recorder.rs
+++ b/common/metrics/src/recorder.rs
@@ -27,12 +27,36 @@ lazy_static! {
         Arc::new(RwLock::new(None));
 }
 
-pub fn label_counter(name: &'static str, tenant: &str, cluster_name: &str) {
+pub const LABEL_KEY_TENANT: &str = "tenant";
+pub const LABEL_KEY_CLUSTER: &str = "cluster_name";
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TenantLabel {
+    pub tenant_id: String,
+    pub cluster_id: String,
+}
+
+impl TenantLabel {
+    pub fn new(tenant_id: impl Into<String>, cluster_id: impl Into<String>) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            cluster_id: cluster_id.into(),
+        }
+    }
+}
+
+#[inline]
+pub fn label_counter(name: &'static str, tenant_id: &str, cluster_id: &str) {
+    label_counter_with_val(name, 1, tenant_id, cluster_id)
+}
+
+#[inline]
+pub fn label_counter_with_val(name: &'static str, val: u64, tenant_id: &str, cluster_id: &str) {
     let labels = [
-        ("tenant", tenant.to_string()),
-        ("cluster_name", cluster_name.to_string()),
+        (LABEL_KEY_TENANT, tenant_id.to_string()),
+        (LABEL_KEY_CLUSTER, cluster_id.to_string()),
     ];
-    counter!(name, 1, &labels);
+    counter!(name, val, &labels);
 }
 
 pub fn init_default_metrics_recorder() {

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -83,8 +83,6 @@ paste = "^1.0"
 prost = "0.9.0"
 quantiles = "0.7.1"
 rand = "0.8.4"
-rusoto_core = "0.47.0"
-rusoto_s3 = "0.47.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha1 = "0.6.0"

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -257,9 +257,15 @@ impl DatabendQueryContext {
         let settings = self.get_settings();
         let max_threads = settings.get_max_threads()? as usize;
 
+        let tenant_id = self.shared.conf.query.tenant_id.clone();
+        let cluster_id = self.shared.conf.query.cluster_id.clone();
         Ok(TableIOContext::new(
             self.get_shared_runtime()?,
-            Arc::new(ContextDalBuilder::new(self.get_config().storage)),
+            Arc::new(ContextDalBuilder::new(
+                tenant_id,
+                cluster_id,
+                self.get_config().storage,
+            )),
             max_threads,
             nodes,
             Some(self.clone()),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

introduce a delegation of DAL  `DALWithMetric`, which intercepts input/output operations and spills simple statistics (bytes read/write) to metrics components

fixing 
- issue #2806

## Changelog

- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2806

## Test Plan

Unit Tests

Stateless Tests

