### PR TITLE
[function] Add support for inet_ntoa

### DIFF
--- a/common/functions/src/scalars/others/inet_ntoa.rs
+++ b/common/functions/src/scalars/others/inet_ntoa.rs
@@ -1,0 +1,100 @@
+// Copyright 2020 Datafuse Lfloor.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::str;
+
+use common_datavalues::is_numeric;
+use common_datavalues::prelude::DFStringArray;
+use common_datavalues::prelude::DataColumn;
+use common_datavalues::prelude::DataColumnsWithField;
+use common_datavalues::prelude::NewDataArray;
+use common_datavalues::DataSchema;
+use common_datavalues::DataType;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::scalars::function_factory::FunctionDescription;
+use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::Function;
+
+#[derive(Clone)]
+#[doc(alias = "IPv4NumToStringFunction")]
+pub struct InetNtoaFunction {
+    display_name: String,
+}
+
+impl InetNtoaFunction {
+    pub fn try_create(display_name: &str) -> Result<Box<dyn Function>> {
+        Ok(Box::new(InetNtoaFunction {
+            display_name: display_name.to_string(),
+        }))
+    }
+
+    pub fn desc() -> FunctionDescription {
+        FunctionDescription::creator(Box::new(Self::try_create))
+            .features(FunctionFeatures::default().deterministic())
+    }
+}
+
+impl Function for InetNtoaFunction {
+    fn name(&self) -> &str {
+        &*self.display_name
+    }
+
+    fn num_arguments(&self) -> usize {
+        1
+    }
+
+    fn return_type(&self, args: &[DataType]) -> Result<DataType> {
+        if is_numeric(&args[0]) || args[0] == DataType::String || args[0] == DataType::Null {
+            Ok(DataType::String)
+        } else {
+            Err(ErrorCode::IllegalDataType(format!(
+                "Expected numeric or string or null type, but got {}",
+                args[0]
+            )))
+        }
+    }
+
+    fn nullable(&self, _input_schema: &DataSchema) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {
+        let opt_iter = columns[0]
+            .column()
+            .to_minimal_array()?
+            .cast_with_type(&DataType::Float64)?;
+        let opt_iter = opt_iter.f64()?.iter().map(|val_opt| match val_opt {
+            Some(&val) => {
+                if val.is_nan() || val < 0.0 || val > u32::MAX as f64 {
+                    None
+                } else {
+                    Some(std::net::Ipv4Addr::from((val as u32).to_be_bytes()).to_string())
+                }
+            }
+            None => None,
+        });
+        let result = DFStringArray::new_from_opt_iter(opt_iter);
+        let column: DataColumn = result.into();
+        Ok(column.resize_constant(columns[0].column().len()))
+    }
+}
+
+impl fmt::Display for InetNtoaFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.display_name.to_uppercase())
+    }
+}

--- a/common/functions/src/scalars/others/mod.rs
+++ b/common/functions/src/scalars/others/mod.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod inet_ntoa;
 mod other;
 mod running_difference_function;
 
+pub use inet_ntoa::InetNtoaFunction;
 pub use other::OtherFunction;
 pub use running_difference_function::RunningDifferenceFunction;

--- a/common/functions/src/scalars/others/other.rs
+++ b/common/functions/src/scalars/others/other.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::inet_ntoa::InetNtoaFunction;
 use super::running_difference_function::RunningDifferenceFunction;
 use crate::scalars::function_factory::FunctionFactory;
 
@@ -21,5 +22,7 @@ pub struct OtherFunction {}
 impl OtherFunction {
     pub fn register(factory: &mut FunctionFactory) {
         factory.register("runningDifference", RunningDifferenceFunction::desc());
+        factory.register("inet_ntoa", InetNtoaFunction::desc());
+        factory.register("IPv4NumToString", InetNtoaFunction::desc());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add support for inet_ntoa(convert IPv4 bytes to string)

- [clickhouse IPv4NumToString/INET_NTOA](https://clickhouse.com/docs/en/sql-reference/functions/ip-address-functions/#ipv4numtostringnum)
- [MySQL INET_NTOA](https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_inet-ntoa)
- [glibc inet_ntoa() - man7.org](https://man7.org/linux/man-pages/man3/inet_aton.3.html)

## Changelog

- New Feature

## Related Issues

Fixes #2823

## Test Plan

Unit Tests

Stateless Tests

