### PR TITLE
Make Fuse Engine as default table engine

### DIFF
--- a/query/src/sql/sql_parser.rs
+++ b/query/src/sql/sql_parser.rs
@@ -630,7 +630,7 @@ impl<'a> DfParser<'a> {
     fn parse_table_engine(&mut self) -> Result<String, ParserError> {
         // TODO make ENGINE as a keyword
         if !self.consume_token("ENGINE") {
-            return Ok("NULL".to_string());
+            return Ok("FUSE".to_string());
         }
 
         self.parser.expect_token(&Token::Eq)?;


### PR DESCRIPTION
Make Fuse Engine as default table engine

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR

## Changelog


- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

