### PR TITLE
Set storage_type to disk by default

### DIFF
--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -165,7 +165,7 @@ impl fmt::Debug for AzureStorageBlobConfig {
     Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
 )]
 pub struct StorageConfig {
-    #[structopt(long, env = STORAGE_TYPE, default_value = "", help = "Current storage type: disk|s3")]
+    #[structopt(long, env = STORAGE_TYPE, default_value = "disk", help = "Current storage type: disk|s3")]
     #[serde(default)]
     pub storage_type: String,
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Set storage_type to `disk` by default, make databend-query works with fuse engine wihtout yaml file.

## Changelog

- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

