### PR TITLE
ISSUE-2845: Initial the data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,6 @@ cli/e2e/bendctl
 .AppleDouble
 .LSOverride
 
-### Linux(include WSL) ###
-
-### Windows ###
-
 # profile
 flamegraph.*
 perf.*
@@ -35,6 +31,9 @@ _local_fs/*
 _meta*/*
 stateless_test_data/*
 **/_logs*/*
+_data/*
+_tmp/*
+tls/certs/*
 
 # for tests in mac
 *.stderr-e
@@ -43,5 +42,3 @@ tests/perfs/*-result.json
 
 # python
 venv/
-
-tls/certs/*

--- a/query/src/bin/databend-query.rs
+++ b/query/src/bin/databend-query.rs
@@ -46,6 +46,7 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
     // Prefer to use env variable in cloud native deployment
     // Override configs based on env variables
     conf = Config::load_from_env(&conf)?;
+    conf.initial_dir()?;
 
     env_logger::Builder::from_env(
         env_logger::Env::default().default_filter_or(conf.log.log_level.to_lowercase().as_str()),

--- a/query/src/configs/config.rs
+++ b/query/src/configs/config.rs
@@ -143,8 +143,12 @@ impl Config {
         let scheme = StorageScheme::from_str(self.storage.storage_type.as_str())?;
         match scheme {
             StorageScheme::LocalFs => {
-                fs::create_dir_all(self.storage.disk.data_path.as_str())?;
-                fs::create_dir_all(self.storage.disk.temp_data_path.as_str())?;
+                if !self.storage.disk.data_path.is_empty() {
+                    fs::create_dir_all(self.storage.disk.data_path.as_str())?;
+                }
+                if !self.storage.disk.temp_data_path.is_empty() {
+                    fs::create_dir_all(self.storage.disk.temp_data_path.as_str())?;
+                }
             }
             StorageScheme::S3 => {}
             StorageScheme::AzureStorageBlob => {}

--- a/query/src/configs/config.rs
+++ b/query/src/configs/config.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fs;
+use std::str::FromStr;
+
+use common_dal::StorageScheme;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_flight_rpc::FlightClientTlsConfig;
@@ -131,6 +135,21 @@ impl Config {
         QueryConfig::load_from_env(&mut mut_config);
 
         Ok(mut_config)
+    }
+
+    /// Initial the directory of the config.
+    /// Such as the localfs data_path and temp_data_path.
+    pub fn initial_dir(&self) -> Result<()> {
+        let scheme = StorageScheme::from_str(self.storage.storage_type.as_str())?;
+        match scheme {
+            StorageScheme::LocalFs => {
+                fs::create_dir_all(self.storage.disk.data_path.as_str())?;
+                fs::create_dir_all(self.storage.disk.temp_data_path.as_str())?;
+            }
+            StorageScheme::S3 => {}
+            StorageScheme::AzureStorageBlob => {}
+        }
+        Ok(())
     }
 
     pub fn tls_query_client_conf(&self) -> FlightClientTlsConfig {

--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -67,7 +67,7 @@ pub struct DiskStorageConfig {
     #[structopt(long, env = DISK_STORAGE_DATA_PATH, default_value = "_data", help = "Disk storage backend data path")]
     #[serde(default)]
     pub data_path: String,
-    #[structopt(long, env = DISK_STORAGE_TEMP_DATA_PATH, default_value = "_tmp", help = "Disk storage temporary data path for external data")]
+    #[structopt(long, env = DISK_STORAGE_TEMP_DATA_PATH, default_value = "", help = "Disk storage temporary data path for external data")]
     #[serde(default)]
     pub temp_data_path: String,
 }
@@ -76,7 +76,7 @@ impl DiskStorageConfig {
     pub fn default() -> Self {
         DiskStorageConfig {
             data_path: "_data".to_string(),
-            temp_data_path: "_tmp".to_string(),
+            temp_data_path: "".to_string(),
         }
     }
 }

--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -64,10 +64,10 @@ impl FromStr for StorageType {
     Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
 )]
 pub struct DiskStorageConfig {
-    #[structopt(long, env = DISK_STORAGE_DATA_PATH, default_value = "", help = "Disk storage backend data path")]
+    #[structopt(long, env = DISK_STORAGE_DATA_PATH, default_value = "_data", help = "Disk storage backend data path")]
     #[serde(default)]
     pub data_path: String,
-    #[structopt(long, env = DISK_STORAGE_TEMP_DATA_PATH, default_value = "", help = "Disk storage tempory data path for external data")]
+    #[structopt(long, env = DISK_STORAGE_TEMP_DATA_PATH, default_value = "_tmp", help = "Disk storage temporary data path for external data")]
     #[serde(default)]
     pub temp_data_path: String,
 }
@@ -75,8 +75,8 @@ pub struct DiskStorageConfig {
 impl DiskStorageConfig {
     pub fn default() -> Self {
         DiskStorageConfig {
-            data_path: "".to_string(),
-            temp_data_path: "".to_string(),
+            data_path: "_data".to_string(),
+            temp_data_path: "_tmp".to_string(),
         }
     }
 }

--- a/query/src/configs/config_test.rs
+++ b/query/src/configs/config_test.rs
@@ -76,7 +76,7 @@ rpc_tls_meta_service_domain_name = \"localhost\"
 storage_type = \"disk\"
 
 [storage.disk]
-data_path = \"\"
+data_path = \"_data\"
 temp_data_path = \"\"
 
 [storage.s3]
@@ -182,7 +182,11 @@ fn test_initial_dir() -> Result<()> {
     conf.initial_dir()?;
 
     // Remove.
-    std::fs::remove_dir_all(conf.storage.disk.data_path)?;
-    std::fs::remove_dir_all(conf.storage.disk.temp_data_path)?;
+    if !conf.storage.disk.data_path.is_empty() {
+        std::fs::remove_dir_all(conf.storage.disk.data_path)?;
+    }
+    if !conf.storage.disk.temp_data_path.is_empty() {
+        std::fs::remove_dir_all(conf.storage.disk.temp_data_path)?;
+    }
     Ok(())
 }

--- a/query/src/configs/config_test.rs
+++ b/query/src/configs/config_test.rs
@@ -174,3 +174,15 @@ fn test_fuse_commit_version() -> Result<()> {
     assert!(v.len() > 0);
     Ok(())
 }
+
+#[test]
+fn test_initial_dir() -> Result<()> {
+    let mut conf = Config::default();
+    conf.storage.storage_type = "disk".to_string();
+    conf.initial_dir()?;
+
+    // Remove.
+    std::fs::remove_dir_all(conf.storage.disk.data_path)?;
+    std::fs::remove_dir_all(conf.storage.disk.temp_data_path)?;
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR:
1. Change the disk storage data_path to `_data`
2. Add a new function called `initial_dir` for the config data path initial

## Changelog

- Improvement


## Related Issues

Fixes #2845 

## Test Plan

Unit Tests

Stateless Tests

