### PR TITLE
[metasrv] fix: graceful shutdown blocks for ever.

### DIFF
--- a/common/base/src/http_shutdown_handlers.rs
+++ b/common/base/src/http_shutdown_handlers.rs
@@ -17,6 +17,7 @@ use std::net::SocketAddr;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_tracing::tracing;
+use futures::future::Either;
 use futures::FutureExt;
 use poem::listener::Acceptor;
 use poem::listener::AcceptorExt;
@@ -27,6 +28,8 @@ use poem::listener::TcpListener;
 use poem::Endpoint;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
+
+use crate::tokio::sync::broadcast;
 
 pub struct HttpShutdownHandler {
     service_name: String,
@@ -88,22 +91,58 @@ impl HttpShutdownHandler {
         Ok(addr)
     }
 
-    pub async fn shutdown(&mut self, graceful: bool) {
-        if graceful {
-            if let Some(abort_handle) = self.abort_handle.take() {
-                let _ = abort_handle.send(());
-            }
-            if let Some(join_handle) = self.join_handle.take() {
-                if let Err(error) = join_handle.await {
-                    tracing::error!(
-                        "Unexpected error during shutdown Http Server {}. cause {}",
-                        self.service_name,
-                        error
-                    );
+    /// Shutdown in graceful mode and returns a join handle.
+    /// To force shutdown: call the `abort()` method of the returned handle.
+    fn send_stop_signal(&mut self) -> JoinHandle<std::io::Result<()>> {
+        tracing::info!("{}: graceful stop", self.service_name);
+
+        if let Some(abort_handle) = self.abort_handle.take() {
+            tracing::info!("{}: send signal to abort_handle", self.service_name);
+
+            let res = abort_handle.send(());
+
+            tracing::info!(
+                "Done: {}: send signal to abort_handle, res: {:?}",
+                self.service_name,
+                res
+            );
+        }
+
+        let join_handle = self.join_handle.take();
+        join_handle.unwrap()
+    }
+
+    /// Stop service gracefully. If `force` is ready, force shutdown the service.
+    pub async fn stop(&mut self, force: Option<broadcast::Receiver<()>>) -> Result<()> {
+        let join_handle = self.send_stop_signal();
+
+        if let Some(mut force) = force {
+            let h = Box::pin(join_handle);
+            let f = Box::pin(force.recv());
+
+            match futures::future::select(f, h).await {
+                Either::Left((_x, h)) => {
+                    tracing::info!("{}: received force shutdown signal", self.service_name);
+                    h.abort();
+                }
+                Either::Right((_, _)) => {
+                    tracing::info!("Done: {}: graceful shutdown", self.service_name);
                 }
             }
-        } else if let Some(join_handle) = self.join_handle.take() {
-            join_handle.abort();
+        } else {
+            tracing::info!(
+                "{}: force is None, wait for join handle for ever",
+                self.service_name
+            );
+
+            let res = join_handle.await;
+
+            tracing::info!(
+                "Done: {}: waiting for join handle for ever, res: {:?}",
+                self.service_name,
+                res
+            );
         }
+        Ok(())
     }
 }

--- a/metasrv/src/api/flight_server.rs
+++ b/metasrv/src/api/flight_server.rs
@@ -146,20 +146,26 @@ impl FlightServer {
 
                 match futures::future::select(f, j).await {
                     Either::Left((_x, j)) => {
+                        tracing::info!("received force shutdown signal");
                         // force shutdown signal received.
                         j.abort();
                     }
                     Either::Right((_, _)) => {
+                        tracing::info!("Done: graceful force shutdown");
                         // graceful shutdown finished.
                     }
                 }
             } else {
+                tracing::info!("no force signal, block waiting for join handle for ever");
                 let _ = j.await;
+                tracing::info!("Done: waiting for join handle for ever");
             }
         }
 
         if let Some(rx) = self.fin_rx.take() {
+            tracing::info!("block waiting for fin_rx");
             let _ = rx.await;
+            tracing::info!("Done: block waiting for fin_rx");
         }
         Ok(())
     }

--- a/metasrv/src/metrics/metric_service.rs
+++ b/metasrv/src/metrics/metric_service.rs
@@ -84,16 +84,6 @@ impl Stoppable for MetricService {
     }
 
     async fn stop(&mut self, force: Option<broadcast::Receiver<()>>) -> Result<()> {
-        self.shutdown_handler.shutdown(true).await;
-        if let Some(mut force) = force {
-            log::info!("waiting for force");
-            let _ = force
-                .recv()
-                .await
-                .expect("Failed to recv the shutdown signal");
-            log::info!("shutdown the service force");
-            self.shutdown_handler.shutdown(false).await;
-        }
-        Ok(())
+        self.shutdown_handler.stop(force).await
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] fix: graceful shutdown blocks for ever.
- Problem:

The current impl of 2-phase shutdown(graceful then force)
always blocks on `force.recv()`:

```rust
self.shutdown_handler.shutdown(true).await;

if let Some(mut force) = force {
    log::info!("waiting for force");
    let _ = force
        .recv()
        .await
        .expect("Failed to recv the shutdown signal");
    self.shutdown_handler.shutdown(false).await;
```

Thus when a graceful shutdown is actually finished,
it still does not return.

- Solution:

The shutdown handler has to wait for both the graceful shutdown join
handle and the force.recv(),
and receive the first returned one.

- This is one of the causes of that restarting a metasrv cluster does
  not work. Because the running metasrv processes never quit.

## Changelog


- Bug Fix




## Related Issues