### PR TITLE
[metasrv] refactor: use derive_more to simplify StateMachine meta value conversion

### DIFF
--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -617,7 +617,7 @@ impl StateMachine {
         let sm_meta = self.sm_meta();
         let mem = sm_meta
             .get(&StateMachineMetaKey::LastMembership)?
-            .map(MembershipConfig::from);
+            .map(|x| x.try_into().expect("Membership"));
 
         Ok(mem)
     }
@@ -626,7 +626,7 @@ impl StateMachine {
         let sm_meta = self.sm_meta();
         let last_applied = sm_meta
             .get(&LastApplied)?
-            .map(LogId::from)
+            .map(|x| x.try_into().expect("LogId"))
             .unwrap_or_default();
 
         Ok(last_applied)

--- a/common/meta/raft-store/src/state_machine/state_machine_meta.rs
+++ b/common/meta/raft-store/src/state_machine/state_machine_meta.rs
@@ -34,7 +34,7 @@ pub enum StateMachineMetaKey {
     /// The last membership config
     LastMembership,
 }
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, derive_more::TryInto)]
 pub enum StateMachineMetaValue {
     LogId(LogId),
     Bool(bool),
@@ -80,31 +80,5 @@ impl SledOrderedSerde for StateMachineMetaKey {
         }
 
         Err(ErrorCode::MetaStoreDamaged("invalid key IVec"))
-    }
-}
-
-impl From<StateMachineMetaValue> for LogId {
-    fn from(v: StateMachineMetaValue) -> Self {
-        match v {
-            StateMachineMetaValue::LogId(x) => x,
-            _ => panic!("expect LogId"),
-        }
-    }
-}
-
-impl From<StateMachineMetaValue> for bool {
-    fn from(v: StateMachineMetaValue) -> Self {
-        match v {
-            StateMachineMetaValue::Bool(x) => x,
-            _ => panic!("expect LogId"),
-        }
-    }
-}
-impl From<StateMachineMetaValue> for MembershipConfig {
-    fn from(v: StateMachineMetaValue) -> Self {
-        match v {
-            StateMachineMetaValue::Membership(x) => x,
-            _ => panic!("expect Membership"),
-        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: use derive_more to simplify StateMachine meta value conversion

## Changelog




- Improvement


## Related Issues

- #2899