### PR TITLE
Support nullable value in SHA1 and MD5 func

### DIFF
--- a/common/functions/src/scalars/hashes/md5hash.rs
+++ b/common/functions/src/scalars/hashes/md5hash.rs
@@ -53,7 +53,7 @@ impl Function for Md5HashFunction {
     }
 
     fn return_type(&self, args: &[DataType]) -> Result<DataType> {
-        if args[0] == DataType::String {
+        if args[0] == DataType::String || args[0] == DataType::Null {
             Ok(DataType::String)
         } else {
             Err(ErrorCode::IllegalDataType(format!(

--- a/common/functions/src/scalars/hashes/sha1hash.rs
+++ b/common/functions/src/scalars/hashes/sha1hash.rs
@@ -53,7 +53,7 @@ impl Function for Sha1HashFunction {
     }
 
     fn return_type(&self, args: &[DataType]) -> Result<DataType> {
-        if args[0] == DataType::String {
+        if args[0] == DataType::String || args[0] == DataType::Null {
             Ok(DataType::String)
         } else {
             Err(ErrorCode::IllegalDataType(format!(

--- a/common/functions/tests/it/scalars/hashes.rs
+++ b/common/functions/tests/it/scalars/hashes.rs
@@ -178,17 +178,30 @@ fn test_md5hash_function() -> Result<()> {
         arg: DataColumnWithField,
         expect: Result<DataColumn>,
     }
-    let tests = vec![Test {
-        name: "valid input",
-        arg: DataColumnWithField::new(
-            Series::new(["testing"]).into(),
-            DataField::new("arg1", DataType::String, true),
-        ),
-        expect: Ok(DataColumn::Constant(
-            DataValue::String(Some("ae2b1fca515949e5d54fb22b8ed95575".as_bytes().to_vec())),
-            1,
-        )),
-    }];
+    let tests = vec![
+        Test {
+            name: "valid input",
+            arg: DataColumnWithField::new(
+                Series::new([Some("testing")]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Ok(DataColumn::Constant(
+                DataValue::String(Some("ae2b1fca515949e5d54fb22b8ed95575".as_bytes().to_vec())),
+                1,
+            )),
+        },
+        Test {
+            name: "valid input with null",
+            arg: DataColumnWithField::new(
+                Series::new([Some("testing"), None]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Ok(DataColumn::Array(Series::new(vec![
+                Some("ae2b1fca515949e5d54fb22b8ed95575".as_bytes().to_vec()),
+                None,
+            ]))),
+        },
+    ];
 
     let func = Md5HashFunction::try_create("md5")?;
     for t in tests {
@@ -213,21 +226,38 @@ fn test_sha1hash_function() -> Result<()> {
         arg: DataColumnWithField,
         expect: Result<DataColumn>,
     }
-    let tests = vec![Test {
-        name: "valid input",
-        arg: DataColumnWithField::new(
-            Series::new(["abc"]).into(),
-            DataField::new("arg1", DataType::String, true),
-        ),
-        expect: Ok(DataColumn::Constant(
-            DataValue::String(Some(
-                "a9993e364706816aba3e25717850c26c9cd0d89d"
-                    .as_bytes()
-                    .to_vec(),
+    let tests = vec![
+        Test {
+            name: "valid input",
+            arg: DataColumnWithField::new(
+                Series::new(["abc"]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Ok(DataColumn::Constant(
+                DataValue::String(Some(
+                    "a9993e364706816aba3e25717850c26c9cd0d89d"
+                        .as_bytes()
+                        .to_vec(),
+                )),
+                1,
             )),
-            1,
-        )),
-    }];
+        },
+        Test {
+            name: "valid input with null",
+            arg: DataColumnWithField::new(
+                Series::new([Some("abc"), None]).into(),
+                DataField::new("arg1", DataType::String, true),
+            ),
+            expect: Ok(DataColumn::Array(Series::new(vec![
+                Some(
+                    "a9993e364706816aba3e25717850c26c9cd0d89d"
+                        .as_bytes()
+                        .to_vec(),
+                ),
+                None,
+            ]))),
+        },
+    ];
 
     let func = Sha1HashFunction::try_create("sha1")?;
     for t in tests {

--- a/website/databend/docs/sqlstatement/hash-functions/md5hash.md
+++ b/website/databend/docs/sqlstatement/hash-functions/md5hash.md
@@ -3,7 +3,8 @@ id: hash-md5hash
 title: MD5
 ---
 
-Calculates an MD5 128-bit checksum for the string. The value is returned as a string of 32 hexadecimal digits.
+Calculates an MD5 128-bit checksum for the string.
+The value is returned as a string of 32 hexadecimal digits or NULL if the argument was NULL.
 
 ## Syntax
 

--- a/website/databend/docs/sqlstatement/hash-functions/sha1hash.md
+++ b/website/databend/docs/sqlstatement/hash-functions/sha1hash.md
@@ -4,7 +4,7 @@ title: SHA1
 ---
 
 Calculates an SHA-1 160-bit checksum for the string, as described in RFC 3174 (Secure Hash Algorithm).
-The value is returned as a string of 40 hexadecimal digits.
+The value is returned as a string of 40 hexadecimal digits or NULL if the argument was NULL.
 
 ## Syntax
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

In addition to #2889 added support nullable value in SHA1 and MD5 func

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

