### PR TITLE
[common/meta] refactor: rename get_tables to list_tables

### DIFF
--- a/common/meta/api/src/meta_api.rs
+++ b/common/meta/api/src/meta_api.rs
@@ -53,7 +53,7 @@ pub trait MetaApi: Send + Sync {
 
     async fn get_table(&self, db: &str, table: &str) -> Result<Arc<TableInfo>>;
 
-    async fn get_tables(&self, db: &str) -> Result<Vec<Arc<TableInfo>>>;
+    async fn list_tables(&self, db: &str) -> Result<Vec<Arc<TableInfo>>>;
 
     async fn get_table_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)>;
 

--- a/common/meta/api/src/meta_api.rs
+++ b/common/meta/api/src/meta_api.rs
@@ -43,7 +43,7 @@ pub trait MetaApi: Send + Sync {
 
     async fn get_database(&self, req: GetDatabaseReq) -> Result<Arc<DatabaseInfo>>;
 
-    async fn get_databases(&self) -> Result<Vec<Arc<DatabaseInfo>>>;
+    async fn list_databases(&self) -> Result<Vec<Arc<DatabaseInfo>>>;
 
     // table
 

--- a/common/meta/api/src/meta_api.rs
+++ b/common/meta/api/src/meta_api.rs
@@ -25,6 +25,7 @@ use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
+use common_meta_types::GetDatabaseReq;
 use common_meta_types::MetaId;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
@@ -40,7 +41,7 @@ pub trait MetaApi: Send + Sync {
 
     async fn drop_database(&self, req: DropDatabaseReq) -> Result<DropDatabaseReply>;
 
-    async fn get_database(&self, db: &str) -> Result<Arc<DatabaseInfo>>;
+    async fn get_database(&self, req: GetDatabaseReq) -> Result<Arc<DatabaseInfo>>;
 
     async fn get_databases(&self) -> Result<Vec<Arc<DatabaseInfo>>>;
 

--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -413,7 +413,7 @@ impl MetaApiTestSuite {
 
             tracing::info!("--- get_tables");
             {
-                let res = mt.get_tables(db_name).await?;
+                let res = mt.list_tables(db_name).await?;
                 assert_eq!(1, res[0].ident.table_id);
                 assert_eq!(2, res[1].ident.table_id);
             }

--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -23,6 +23,7 @@ use common_meta_types::CreateDatabaseReq;
 use common_meta_types::CreateTableReq;
 use common_meta_types::DropDatabaseReq;
 use common_meta_types::DropTableReq;
+use common_meta_types::GetDatabaseReq;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
@@ -84,7 +85,7 @@ impl MetaApiTestSuite {
 
         tracing::info!("--- get db1");
         {
-            let res = mt.get_database("db1").await;
+            let res = mt.get_database(GetDatabaseReq::new("db1")).await;
             tracing::debug!("get present database res: {:?}", res);
             let res = res?;
             assert_eq!(1, res.database_id, "db1 id is 1");
@@ -110,13 +111,13 @@ impl MetaApiTestSuite {
 
         tracing::info!("--- get db2");
         {
-            let res = mt.get_database("db2").await?;
+            let res = mt.get_database(GetDatabaseReq::new("db2")).await?;
             assert_eq!("db2".to_string(), res.db, "db1.db is db1");
         }
 
         tracing::info!("--- get absent db");
         {
-            let res = mt.get_database("absent").await;
+            let res = mt.get_database(GetDatabaseReq::new("absent")).await;
             tracing::debug!("=== get absent database res: {:?}", res);
             assert!(res.is_err());
             let res = res.unwrap_err();
@@ -135,7 +136,7 @@ impl MetaApiTestSuite {
 
         tracing::info!("--- get db2 should not found");
         {
-            let res = mt.get_database("db2").await;
+            let res = mt.get_database(GetDatabaseReq::new("db2")).await;
             let err = res.unwrap_err();
             assert_eq!(ErrorCode::UnknownDatabase("").code(), err.code());
         }

--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -165,7 +165,7 @@ impl MetaApiTestSuite {
 
         tracing::info!("--- get_databases");
         {
-            let dbs = mt.get_databases().await?;
+            let dbs = mt.list_databases().await?;
             let want: Vec<u64> = vec![1, 2];
             let got = dbs.iter().map(|x| x.database_id).collect::<Vec<_>>();
             assert_eq!(want, got)

--- a/common/meta/embedded/src/meta_api_impl.rs
+++ b/common/meta/embedded/src/meta_api_impl.rs
@@ -103,7 +103,7 @@ impl MetaApi for MetaEmbedded {
         Ok(Arc::new(dbi))
     }
 
-    async fn get_databases(&self) -> Result<Vec<Arc<DatabaseInfo>>> {
+    async fn list_databases(&self) -> Result<Vec<Arc<DatabaseInfo>>> {
         let sm = self.inner.lock().await;
         let res = sm.get_databases()?;
         Ok(res

--- a/common/meta/embedded/src/meta_api_impl.rs
+++ b/common/meta/embedded/src/meta_api_impl.rs
@@ -32,6 +32,7 @@ use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
+use common_meta_types::GetDatabaseReq;
 use common_meta_types::MetaId;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
@@ -89,15 +90,15 @@ impl MetaApi for MetaEmbedded {
         Ok(DropDatabaseReply {})
     }
 
-    async fn get_database(&self, db: &str) -> Result<Arc<DatabaseInfo>> {
+    async fn get_database(&self, req: GetDatabaseReq) -> Result<Arc<DatabaseInfo>> {
         let sm = self.inner.lock().await;
         let res = sm
-            .get_database(db)?
-            .ok_or_else(|| ErrorCode::UnknownDatabase(db.to_string()))?;
+            .get_database(&req.db_name)?
+            .ok_or_else(|| ErrorCode::UnknownDatabase(req.db_name.clone()))?;
 
         let dbi = DatabaseInfo {
             database_id: res.data,
-            db: db.to_string(),
+            db: req.db_name.clone(),
         };
         Ok(Arc::new(dbi))
     }

--- a/common/meta/embedded/src/meta_api_impl.rs
+++ b/common/meta/embedded/src/meta_api_impl.rs
@@ -215,7 +215,7 @@ impl MetaApi for MetaEmbedded {
         Ok(Arc::new(table_info))
     }
 
-    async fn get_tables(&self, db: &str) -> Result<Vec<Arc<TableInfo>>> {
+    async fn list_tables(&self, db: &str) -> Result<Vec<Arc<TableInfo>>> {
         let sm = self.inner.lock().await;
         let tables = sm.get_tables(db)?;
         Ok(tables

--- a/common/meta/flight/src/flight_action.rs
+++ b/common/meta/flight/src/flight_action.rs
@@ -28,6 +28,7 @@ use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
+use common_meta_types::GetDatabaseReq;
 use common_meta_types::GetKVActionReply;
 use common_meta_types::MGetKVActionReply;
 use common_meta_types::MetaId;
@@ -56,7 +57,7 @@ pub struct FlightReq<T> {
 pub enum MetaFlightAction {
     CreateDatabase(FlightReq<CreateDatabaseReq>),
     DropDatabase(FlightReq<DropDatabaseReq>),
-    GetDatabase(GetDatabaseAction),
+    GetDatabase(FlightReq<GetDatabaseReq>),
     GetDatabases(GetDatabasesAction),
 
     CreateTable(FlightReq<CreateTableReq>),
@@ -151,13 +152,8 @@ impl RequestFor for FlightReq<CreateDatabaseReq> {
     type Reply = CreateDatabaseReply;
 }
 
-// - get database
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub struct GetDatabaseAction {
-    pub db: String,
-}
-impl RequestFor for GetDatabaseAction {
-    type Reply = DatabaseInfo;
+impl RequestFor for FlightReq<GetDatabaseReq> {
+    type Reply = Arc<DatabaseInfo>;
 }
 
 impl RequestFor for FlightReq<DropDatabaseReq> {

--- a/common/meta/flight/src/impls/meta_api_impl.rs
+++ b/common/meta/flight/src/impls/meta_api_impl.rs
@@ -26,6 +26,7 @@ use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
+use common_meta_types::GetDatabaseReq;
 use common_meta_types::MetaId;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
@@ -34,7 +35,6 @@ use common_meta_types::UpsertTableOptionReply;
 use common_meta_types::UpsertTableOptionReq;
 
 use crate::FlightReq;
-use crate::GetDatabaseAction;
 use crate::GetDatabasesAction;
 use crate::GetTableAction;
 use crate::GetTableExtReq;
@@ -50,34 +50,26 @@ impl MetaApi for MetaFlightClient {
         self.do_action(FlightReq { req }).await
     }
 
-    /// Drop database call.
     async fn drop_database(&self, req: DropDatabaseReq) -> Result<DropDatabaseReply, ErrorCode> {
         self.do_action(FlightReq { req }).await
     }
 
-    async fn get_database(&self, db: &str) -> common_exception::Result<Arc<DatabaseInfo>> {
-        let x = self
-            .do_action(GetDatabaseAction { db: db.to_string() })
-            .await?;
-
-        Ok(Arc::new(x))
+    async fn get_database(&self, req: GetDatabaseReq) -> Result<Arc<DatabaseInfo>, ErrorCode> {
+        self.do_action(FlightReq { req }).await
     }
 
     async fn get_databases(&self) -> common_exception::Result<Vec<Arc<DatabaseInfo>>> {
         self.do_action(GetDatabasesAction {}).await
     }
 
-    /// Create table call.
     async fn create_table(&self, req: CreateTableReq) -> Result<CreateTableReply, ErrorCode> {
         self.do_action(FlightReq { req }).await
     }
 
-    /// Drop table call.
     async fn drop_table(&self, req: DropTableReq) -> Result<DropTableReply, ErrorCode> {
         self.do_action(FlightReq { req }).await
     }
 
-    /// Get table.
     async fn get_table(&self, db: &str, table: &str) -> common_exception::Result<Arc<TableInfo>> {
         let x = self
             .do_action(GetTableAction {
@@ -88,7 +80,6 @@ impl MetaApi for MetaFlightClient {
         Ok(Arc::new(x))
     }
 
-    /// Get tables.
     async fn get_tables(&self, db: &str) -> common_exception::Result<Vec<Arc<TableInfo>>> {
         self.do_action(GetTablesAction { db: db.to_string() }).await
     }

--- a/common/meta/flight/src/impls/meta_api_impl.rs
+++ b/common/meta/flight/src/impls/meta_api_impl.rs
@@ -58,7 +58,7 @@ impl MetaApi for MetaFlightClient {
         self.do_action(FlightReq { req }).await
     }
 
-    async fn get_databases(&self) -> common_exception::Result<Vec<Arc<DatabaseInfo>>> {
+    async fn list_databases(&self) -> common_exception::Result<Vec<Arc<DatabaseInfo>>> {
         self.do_action(GetDatabasesAction {}).await
     }
 

--- a/common/meta/flight/src/impls/meta_api_impl.rs
+++ b/common/meta/flight/src/impls/meta_api_impl.rs
@@ -80,7 +80,7 @@ impl MetaApi for MetaFlightClient {
         Ok(Arc::new(x))
     }
 
-    async fn get_tables(&self, db: &str) -> common_exception::Result<Vec<Arc<TableInfo>>> {
+    async fn list_tables(&self, db: &str) -> common_exception::Result<Vec<Arc<TableInfo>>> {
         self.do_action(GetTablesAction { db: db.to_string() }).await
     }
 

--- a/common/meta/flight/tests/it/flight_client.rs
+++ b/common/meta/flight/tests/it/flight_client.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use common_base::tokio;
 use common_meta_api::MetaApi;
 use common_meta_flight::MetaFlightClient;
+use common_meta_types::GetDatabaseReq;
 
 use crate::start_flight_server;
 
@@ -29,7 +30,7 @@ async fn test_flight_client_action_timeout() {
         .await
         .unwrap();
 
-    let res = client.get_database("xx").await;
+    let res = client.get_database(GetDatabaseReq::new("xx")).await;
     let actual = res.unwrap_err().message();
     let expect = "status: Cancelled, message: \"Timeout expired\", details: [], metadata: MetadataMap { headers: {} }";
     assert_eq!(actual, expect);

--- a/common/meta/types/src/database.rs
+++ b/common/meta/types/src/database.rs
@@ -14,6 +14,12 @@
 //
 
 use std::collections::HashMap;
+use std::ops::Deref;
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+pub struct DatabaseNameIdent {
+    pub db_name: String,
+}
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct DatabaseInfo {
@@ -41,3 +47,26 @@ pub struct DropDatabaseReq {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct DropDatabaseReply {}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+pub struct GetDatabaseReq {
+    pub inner: DatabaseNameIdent,
+}
+
+impl Deref for GetDatabaseReq {
+    type Target = DatabaseNameIdent;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl GetDatabaseReq {
+    pub fn new(db_name: impl Into<String>) -> GetDatabaseReq {
+        GetDatabaseReq {
+            inner: DatabaseNameIdent {
+                db_name: db_name.into(),
+            },
+        }
+    }
+}

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -25,6 +25,7 @@ pub use database::CreateDatabaseReq;
 pub use database::DatabaseInfo;
 pub use database::DropDatabaseReply;
 pub use database::DropDatabaseReq;
+pub use database::GetDatabaseReq;
 pub use errors::ConflictSeq;
 pub use kv_message::GetKVActionReply;
 pub use kv_message::MGetKVActionReply;

--- a/query/src/catalogs/backends/impls/meta_remote.rs
+++ b/query/src/catalogs/backends/impls/meta_remote.rs
@@ -111,9 +111,9 @@ impl MetaApi for MetaRemote {
             .await
     }
 
-    async fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<TableInfo>>> {
+    async fn list_tables(&self, db_name: &str) -> Result<Vec<Arc<TableInfo>>> {
         let db_name = db_name.to_owned();
-        self.query_backend(move |cli| async move { cli.get_tables(&db_name).await })
+        self.query_backend(move |cli| async move { cli.list_tables(&db_name).await })
             .await
     }
 

--- a/query/src/catalogs/backends/impls/meta_remote.rs
+++ b/query/src/catalogs/backends/impls/meta_remote.rs
@@ -27,6 +27,7 @@ use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
+use common_meta_types::GetDatabaseReq;
 use common_meta_types::MetaId;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
@@ -82,9 +83,8 @@ impl MetaApi for MetaRemote {
             .await
     }
 
-    async fn get_database(&self, db_name: &str) -> Result<Arc<DatabaseInfo>> {
-        let db_name = db_name.to_owned();
-        self.query_backend(move |cli| async move { cli.get_database(&db_name).await })
+    async fn get_database(&self, req: GetDatabaseReq) -> Result<Arc<DatabaseInfo>> {
+        self.query_backend(move |cli| async move { cli.get_database(req).await })
             .await
     }
 

--- a/query/src/catalogs/backends/impls/meta_remote.rs
+++ b/query/src/catalogs/backends/impls/meta_remote.rs
@@ -88,8 +88,8 @@ impl MetaApi for MetaRemote {
             .await
     }
 
-    async fn get_databases(&self) -> Result<Vec<Arc<DatabaseInfo>>> {
-        self.query_backend(move |cli| async move { cli.get_databases().await })
+    async fn list_databases(&self) -> Result<Vec<Arc<DatabaseInfo>>> {
+        self.query_backend(move |cli| async move { cli.list_databases().await })
             .await
     }
 

--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -29,6 +29,7 @@ use common_meta_types::DatabaseInfo;
 use common_meta_types::DropDatabaseReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
+use common_meta_types::GetDatabaseReq;
 use common_meta_types::MetaId;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
@@ -141,7 +142,7 @@ impl Catalog for MetaStoreCatalog {
     }
 
     async fn get_database(&self, db_name: &str) -> Result<Arc<dyn Database>> {
-        let db_info = self.meta.get_database(db_name).await?;
+        let db_info = self.meta.get_database(GetDatabaseReq::new(db_name)).await?;
         self.build_db_instance(&db_info)
     }
 

--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -132,7 +132,7 @@ impl MetaStoreCatalog {
 #[async_trait::async_trait]
 impl Catalog for MetaStoreCatalog {
     async fn get_databases(&self) -> Result<Vec<Arc<dyn Database>>> {
-        let dbs = self.meta.get_databases().await?;
+        let dbs = self.meta.list_databases().await?;
 
         dbs.iter().try_fold(vec![], |mut acc, item| {
             let db = self.build_db_instance(item)?;

--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -152,7 +152,7 @@ impl Catalog for MetaStoreCatalog {
     }
 
     async fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<dyn Table>>> {
-        let table_infos = self.meta.get_tables(db_name).await?;
+        let table_infos = self.meta.list_tables(db_name).await?;
 
         table_infos.iter().try_fold(vec![], |mut acc, item| {
             let tbl = self.build_table(item.as_ref())?;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta] refactor: rename get_tables to list_tables

##### [common/meta] refactor: rename get_databases to list_databases

##### [common/meta/types] refactor: introduce universial type GetDatabaseReq for flight-server, MetaAPI, Catalog etc

## Changelog




- Improvement


## Related Issues