### PR TITLE
Apply monotonic function to range filter

### DIFF
--- a/common/functions/src/scalars/arithmetics/arithmetic.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic.rs
@@ -21,7 +21,7 @@ use common_datavalues::DataValueArithmeticOperator;
 use common_exception::Result;
 
 use crate::scalars::dates::IntervalFunctionFactory;
-use crate::scalars::function::MonotonicityNode;
+use crate::scalars::function::Monotonicity;
 use crate::scalars::function_factory::FunctionFactory;
 use crate::scalars::ArithmeticDivFunction;
 use crate::scalars::ArithmeticMinusFunction;
@@ -55,32 +55,6 @@ impl ArithmeticFunction {
 
     pub fn new(op: DataValueArithmeticOperator) -> Self {
         ArithmeticFunction { op }
-    }
-
-    pub fn eval_range_boundary(
-        &self,
-        args: &[Option<DataColumnWithField>],
-    ) -> Result<Option<DataColumnWithField>> {
-        // if any argument is None, the new boundary will be unknown thus return None.
-        if args.iter().any(|arg| arg.is_none()) {
-            return Ok(None);
-        }
-
-        let input = args
-            .iter()
-            .map(|arg_opt| arg_opt.clone().unwrap())
-            .collect::<Vec<_>>();
-        let new_data_column = self.eval(&input, 1)?;
-
-        let input_types = input
-            .iter()
-            .map(|arg| arg.data_type().clone())
-            .collect::<Vec<_>>();
-        let new_data_column_field = DataColumnWithField::new(
-            new_data_column,
-            DataField::new("", self.return_type(&input_types)?, false),
-        );
-        Ok(Some(new_data_column_field))
     }
 }
 
@@ -144,7 +118,7 @@ impl Function for ArithmeticFunction {
         Some((1, 2))
     }
 
-    fn get_monotonicity(&self, args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
+    fn get_monotonicity(&self, args: &[Monotonicity]) -> Result<Monotonicity> {
         match self.op {
             Plus => ArithmeticPlusFunction::get_monotonicity(args),
             Minus => ArithmeticMinusFunction::get_monotonicity(args),

--- a/common/functions/src/scalars/arithmetics/arithmetic_div.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_div.rs
@@ -21,6 +21,7 @@ use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
 use crate::scalars::MonotonicityNode;
+use crate::scalars::Range;
 
 pub struct ArithmeticDivFunction;
 
@@ -36,6 +37,9 @@ impl ArithmeticDivFunction {
 
     pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
         //TODO: implement
-        Ok(MonotonicityNode::Function(Monotonicity::default(), None))
+        Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+            begin: None,
+            end: None,
+        }))
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_div.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_div.rs
@@ -20,8 +20,6 @@ use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
-use crate::scalars::MonotonicityNode;
-use crate::scalars::Range;
 
 pub struct ArithmeticDivFunction;
 
@@ -35,11 +33,8 @@ impl ArithmeticDivFunction {
             .features(FunctionFeatures::default().deterministic())
     }
 
-    pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
-        //TODO: implement
-        Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-            begin: None,
-            end: None,
-        }))
+    pub fn get_monotonicity(_args: &[Monotonicity]) -> Result<Monotonicity> {
+        // TODO
+        Ok(Monotonicity::default())
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
@@ -16,14 +16,11 @@ use common_datavalues::DataValueArithmeticOperator;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
-use super::ArithmeticPlusFunction;
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
-use crate::scalars::MonotonicityNode;
-use crate::scalars::Range;
 
 pub struct ArithmeticMinusFunction;
 
@@ -37,44 +34,7 @@ impl ArithmeticMinusFunction {
             .features(FunctionFeatures::default().deterministic())
     }
 
-    // get monotonicity from unary negate, like -x should flip the monotonicity and range
-    fn get_unary_operator_monotonicity(node: &MonotonicityNode) -> Result<MonotonicityNode> {
-        let func = ArithmeticFunction::new(DataValueArithmeticOperator::Minus);
-
-        match node {
-            MonotonicityNode::Function(mono, Range { begin, end }) => {
-                if !mono.is_monotonic {
-                    return Ok(node.clone());
-                }
-                let new_begin = func.eval_range_boundary(&[begin.clone()])?;
-                let new_end = func.eval_range_boundary(&[end.clone()])?;
-                Ok(MonotonicityNode::Function(mono.flip_clone(), Range {
-                    begin: new_end,
-                    end: new_begin,
-                }))
-            }
-            MonotonicityNode::Constant(data_column_field) => {
-                let new_val = func.eval_range_boundary(&[Some(data_column_field.clone())])?;
-                Ok(MonotonicityNode::Constant(new_val.unwrap()))
-            }
-            MonotonicityNode::Variable(_column_name, Range { begin, end }) => {
-                let new_begin = func.eval_range_boundary(&[begin.clone()])?;
-                let new_end = func.eval_range_boundary(&[end.clone()])?;
-                Ok(MonotonicityNode::Function(
-                    Monotonicity {
-                        is_monotonic: true,
-                        is_positive: false,
-                    },
-                    Range {
-                        begin: new_end,
-                        end: new_begin,
-                    },
-                ))
-            }
-        }
-    }
-
-    pub fn get_monotonicity(args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
+    pub fn get_monotonicity(args: &[Monotonicity]) -> Result<Monotonicity> {
         if args.is_empty() || args.len() > 2 {
             return Err(ErrorCode::BadArguments(format!(
                 "Invalid argument lengths {} for get_monotonicity",
@@ -82,14 +42,61 @@ impl ArithmeticMinusFunction {
             )));
         }
 
+        // unary operation like '-f(x)', just flip the is_positive.
+        // also pass the is_constant, in case the input is a constant value.
         if args.len() == 1 {
-            return Self::get_unary_operator_monotonicity(&args[0]);
+            return Ok(Monotonicity {
+                is_monotonic: args[0].is_monotonic || args[0].is_constant,
+                is_positive: !args[0].is_positive,
+                is_constant: args[0].is_constant,
+                left: None,
+                right: None,
+            });
         }
 
-        ArithmeticPlusFunction::get_plus_minus_binary_operation_monotonicity(
-            DataValueArithmeticOperator::Minus,
-            args[0].clone(),
-            args[1].clone(),
-        )
+        // For expression f(x) - g(x), only when both f(x) and g(x) are monotonic and have
+        // opposite 'is_positive' can we get a monotonic expression.
+        let f_x = &args[0];
+        let g_x = &args[1];
+
+        // case of 12 - g(x)
+        if f_x.is_constant {
+            return Ok(Monotonicity {
+                is_monotonic: g_x.is_monotonic || g_x.is_constant,
+                is_positive: !g_x.is_positive,
+                is_constant: g_x.is_constant,
+                left: None,
+                right: None,
+            });
+        }
+
+        // case of f(x) - 12
+        if g_x.is_constant {
+            return Ok(Monotonicity {
+                is_monotonic: f_x.is_monotonic,
+                is_positive: f_x.is_positive,
+                is_constant: f_x.is_constant,
+                left: None,
+                right: None,
+            });
+        }
+
+        // if either one is non-monotonic, return non-monotonic
+        if !f_x.is_monotonic || !g_x.is_monotonic {
+            return Ok(Monotonicity::default());
+        }
+
+        // when both are monotonic, and have same 'is_positive', we can't determine the monotonicity
+        if f_x.is_positive == g_x.is_positive {
+            return Ok(Monotonicity::default());
+        }
+
+        Ok(Monotonicity {
+            is_monotonic: true,
+            is_positive: f_x.is_positive,
+            is_constant: false,
+            left: None,
+            right: None,
+        })
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
@@ -13,14 +13,17 @@
 // limitations under the License.
 
 use common_datavalues::DataValueArithmeticOperator;
+use common_exception::ErrorCode;
 use common_exception::Result;
 
+use super::ArithmeticPlusFunction;
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
 use crate::scalars::MonotonicityNode;
+use crate::scalars::Range;
 
 pub struct ArithmeticMinusFunction;
 
@@ -34,8 +37,59 @@ impl ArithmeticMinusFunction {
             .features(FunctionFeatures::default().deterministic())
     }
 
-    pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
-        //TODO: implement
-        Ok(MonotonicityNode::Function(Monotonicity::default(), None))
+    // get monotonicity from unary negate, like -x should flip the monotonicity and range
+    fn get_unary_operator_monotonicity(node: &MonotonicityNode) -> Result<MonotonicityNode> {
+        let func = ArithmeticFunction::new(DataValueArithmeticOperator::Minus);
+
+        match node {
+            MonotonicityNode::Function(mono, Range { begin, end }) => {
+                if !mono.is_monotonic {
+                    return Ok(node.clone());
+                }
+                let new_begin = func.eval_range_boundary(&[begin.clone()])?;
+                let new_end = func.eval_range_boundary(&[end.clone()])?;
+                Ok(MonotonicityNode::Function(mono.flip_clone(), Range {
+                    begin: new_end,
+                    end: new_begin,
+                }))
+            }
+            MonotonicityNode::Constant(data_column_field) => {
+                let new_val = func.eval_range_boundary(&[Some(data_column_field.clone())])?;
+                Ok(MonotonicityNode::Constant(new_val.unwrap()))
+            }
+            MonotonicityNode::Variable(_column_name, Range { begin, end }) => {
+                let new_begin = func.eval_range_boundary(&[begin.clone()])?;
+                let new_end = func.eval_range_boundary(&[end.clone()])?;
+                Ok(MonotonicityNode::Function(
+                    Monotonicity {
+                        is_monotonic: true,
+                        is_positive: false,
+                    },
+                    Range {
+                        begin: new_end,
+                        end: new_begin,
+                    },
+                ))
+            }
+        }
+    }
+
+    pub fn get_monotonicity(args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
+        if args.is_empty() || args.len() > 2 {
+            return Err(ErrorCode::BadArguments(format!(
+                "Invalid argument lengths {} for get_monotonicity",
+                args.len()
+            )));
+        }
+
+        if args.len() == 1 {
+            return Self::get_unary_operator_monotonicity(&args[0]);
+        }
+
+        ArithmeticPlusFunction::get_plus_minus_binary_operation_monotonicity(
+            DataValueArithmeticOperator::Minus,
+            args[0].clone(),
+            args[1].clone(),
+        )
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_modulo.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_modulo.rs
@@ -21,6 +21,7 @@ use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
 use crate::scalars::MonotonicityNode;
+use crate::scalars::Range;
 
 pub struct ArithmeticModuloFunction;
 
@@ -36,6 +37,9 @@ impl ArithmeticModuloFunction {
 
     pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
         //TODO: implement
-        Ok(MonotonicityNode::Function(Monotonicity::default(), None))
+        Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+            begin: None,
+            end: None,
+        }))
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_modulo.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_modulo.rs
@@ -20,8 +20,6 @@ use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
-use crate::scalars::MonotonicityNode;
-use crate::scalars::Range;
 
 pub struct ArithmeticModuloFunction;
 
@@ -35,11 +33,8 @@ impl ArithmeticModuloFunction {
             .features(FunctionFeatures::default().deterministic())
     }
 
-    pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
-        //TODO: implement
-        Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-            begin: None,
-            end: None,
-        }))
+    pub fn get_monotonicity(_args: &[Monotonicity]) -> Result<Monotonicity> {
+        //TODO
+        Ok(Monotonicity::default())
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
@@ -21,6 +21,7 @@ use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
 use crate::scalars::MonotonicityNode;
+use crate::scalars::Range;
 
 pub struct ArithmeticMulFunction;
 
@@ -36,6 +37,9 @@ impl ArithmeticMulFunction {
 
     pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
         //TODO: implement
-        Ok(MonotonicityNode::Function(Monotonicity::default(), None))
+        Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+            begin: None,
+            end: None,
+        }))
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
@@ -20,8 +20,6 @@ use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
-use crate::scalars::MonotonicityNode;
-use crate::scalars::Range;
 
 pub struct ArithmeticMulFunction;
 
@@ -35,11 +33,8 @@ impl ArithmeticMulFunction {
             .features(FunctionFeatures::default().deterministic())
     }
 
-    pub fn get_monotonicity(_args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
-        //TODO: implement
-        Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-            begin: None,
-            end: None,
-        }))
+    pub fn get_monotonicity(_args: &[Monotonicity]) -> Result<Monotonicity> {
+        //TODO
+        Ok(Monotonicity::default())
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
@@ -22,6 +22,7 @@ use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
+use crate::scalars::Range;
 
 pub struct ArithmeticPlusFunction;
 
@@ -33,6 +34,362 @@ impl ArithmeticPlusFunction {
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create_func))
             .features(FunctionFeatures::default().deterministic())
+    }
+
+    pub fn get_plus_minus_binary_operation_monotonicity(
+        op: DataValueArithmeticOperator,
+        left: MonotonicityNode,
+        right: MonotonicityNode,
+    ) -> Result<MonotonicityNode> {
+        let func = ArithmeticFunction::new(op.clone());
+
+        match (left, right) {
+            // 1. f(x) +/- 12, a function plus/minus a constant value. The monotonicity should be the same as f(x)
+            (
+                MonotonicityNode::Function(mono, Range { begin, end }),
+                MonotonicityNode::Constant(val),
+            ) => {
+                if !mono.is_monotonic {
+                    // not a monotonic function, just return
+                    return Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                        begin: None,
+                        end: None,
+                    }));
+                }
+
+                Ok(MonotonicityNode::Function(mono, Range {
+                    begin: func.eval_range_boundary(&[begin, Some(val.clone())])?,
+                    end: func.eval_range_boundary(&[end, Some(val)])?,
+                }))
+            }
+
+            // 2. f(x) +/- x, a function plus/minus the variable.
+            (
+                MonotonicityNode::Function(
+                    mono,
+                    Range {
+                        begin: begin1,
+                        end: end1,
+                    },
+                ),
+                MonotonicityNode::Variable(
+                    _column_name,
+                    Range {
+                        begin: begin2,
+                        end: end2,
+                    },
+                ),
+            ) => {
+                if !mono.is_monotonic {
+                    return Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                        begin: None,
+                        end: None,
+                    }));
+                }
+
+                match op {
+                    // f(x) + x
+                    DataValueArithmeticOperator::Plus => {
+                        if mono.is_positive {
+                            Ok(MonotonicityNode::Function(
+                                Monotonicity {
+                                    is_monotonic: true,
+                                    is_positive: true,
+                                },
+                                Range {
+                                    begin: func.eval_range_boundary(&[begin1, begin2])?,
+                                    end: func.eval_range_boundary(&[end1, end2])?,
+                                },
+                            ))
+                        } else {
+                            // not monotonic any more
+                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                                begin: None,
+                                end: None,
+                            }))
+                        }
+                    }
+                    // f(x) - x
+                    _ => {
+                        if !mono.is_positive {
+                            Ok(MonotonicityNode::Function(
+                                Monotonicity {
+                                    is_monotonic: true,
+                                    is_positive: false,
+                                },
+                                Range {
+                                    // the begin should be the begin/min of f(x) minus the end/max of x
+                                    begin: func.eval_range_boundary(&[begin1, end2])?,
+                                    // the end should be the end/max of f(x) minus the begin/min of x
+                                    end: func.eval_range_boundary(&[end1, begin2])?,
+                                },
+                            ))
+                        } else {
+                            // not monotonic any more
+                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                                begin: None,
+                                end: None,
+                            }))
+                        }
+                    }
+                }
+            }
+
+            // 3. f(x) +/- g(x), a function plus/minus another. If they have same monotonicity, then should return that monotonicity
+            (
+                MonotonicityNode::Function(
+                    mono1,
+                    Range {
+                        begin: begin1,
+                        end: end1,
+                    },
+                ),
+                MonotonicityNode::Function(
+                    mono2,
+                    Range {
+                        begin: begin2,
+                        end: end2,
+                    },
+                ),
+            ) => {
+                if !mono1.is_monotonic || !mono2.is_monotonic {
+                    // not a monotonic function, just return
+                    return Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                        begin: None,
+                        end: None,
+                    }));
+                }
+
+                match op {
+                    // f(x) + g(x)
+                    DataValueArithmeticOperator::Plus => {
+                        if mono1.is_positive == mono2.is_positive {
+                            Ok(MonotonicityNode::Function(
+                                Monotonicity {
+                                    is_monotonic: true,
+                                    is_positive: mono1.is_positive,
+                                },
+                                Range {
+                                    begin: func.eval_range_boundary(&[begin1, begin2])?,
+                                    end: func.eval_range_boundary(&[end1, end2])?,
+                                },
+                            ))
+                        } else {
+                            // unknown monotonicity
+                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                                begin: None,
+                                end: None,
+                            }))
+                        }
+                    }
+                    // f(x) - g(x)
+                    _ => {
+                        if mono1.is_positive != mono2.is_positive {
+                            Ok(MonotonicityNode::Function(mono1, Range {
+                                begin: func.eval_range_boundary(&[begin1, end2])?,
+                                end: func.eval_range_boundary(&[end1, begin2])?,
+                            }))
+                        } else {
+                            // unknown monotonicity
+                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                                begin: None,
+                                end: None,
+                            }))
+                        }
+                    }
+                }
+            }
+
+            // 4. 1234 +/- f(x), a constant value plus/minus a function.
+            // The monotonicity is_positive should be the same as f(x) for '+' or flipping is_positive for '-'.
+            (
+                MonotonicityNode::Constant(val),
+                MonotonicityNode::Function(mono, Range { begin, end }),
+            ) => {
+                if !mono.is_monotonic {
+                    // not a monotonic function, just return
+                    return Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                        begin: None,
+                        end: None,
+                    }));
+                }
+
+                match op {
+                    DataValueArithmeticOperator::Plus => Ok(MonotonicityNode::Function(
+                        Monotonicity {
+                            is_monotonic: true,
+                            is_positive: mono.is_positive,
+                        },
+                        Range {
+                            begin: func.eval_range_boundary(&[Some(val.clone()), begin])?,
+                            end: func.eval_range_boundary(&[Some(val), end])?,
+                        },
+                    )),
+                    _ => Ok(MonotonicityNode::Function(
+                        Monotonicity {
+                            is_monotonic: true,
+                            is_positive: !mono.is_positive,
+                        },
+                        Range {
+                            begin: func.eval_range_boundary(&[Some(val.clone()), end])?,
+                            end: func.eval_range_boundary(&[Some(val), begin])?,
+                        },
+                    )),
+                }
+            }
+
+            // 5. 1234 +/- x, a constant value plus/minus a variable.
+            // The monotonicity is_positive should be the true for '+', false for '-'.
+            (
+                MonotonicityNode::Constant(val),
+                MonotonicityNode::Variable(_column_name, Range { begin, end }),
+            ) => match op {
+                DataValueArithmeticOperator::Plus => Ok(MonotonicityNode::Function(
+                    Monotonicity {
+                        is_monotonic: true,
+                        is_positive: true,
+                    },
+                    Range {
+                        begin: func.eval_range_boundary(&[Some(val.clone()), begin])?,
+                        end: func.eval_range_boundary(&[Some(val), end])?,
+                    },
+                )),
+                _ => Ok(MonotonicityNode::Function(
+                    Monotonicity {
+                        is_monotonic: true,
+                        is_positive: false,
+                    },
+                    Range {
+                        begin: func.eval_range_boundary(&[Some(val.clone()), end])?,
+                        end: func.eval_range_boundary(&[Some(val), begin])?,
+                    },
+                )),
+            },
+
+            // 6. 1234 +/- 5678, a constant value plus/minus a constant.
+            // This should not happen if the constant folding optimizer works well. But no harm to implement it here.
+            (MonotonicityNode::Constant(val1), MonotonicityNode::Constant(val2)) => {
+                let val = func.eval_range_boundary(&[Some(val1), Some(val2)])?;
+                Ok(MonotonicityNode::Constant(val.unwrap()))
+            }
+
+            // 7. x +/- 12, a variable plus/minus a constant
+            (
+                MonotonicityNode::Variable(_column_name, Range { begin, end }),
+                MonotonicityNode::Constant(val),
+            ) => Ok(MonotonicityNode::Function(
+                Monotonicity {
+                    is_monotonic: true,
+                    is_positive: true,
+                },
+                Range {
+                    begin: func.eval_range_boundary(&[begin, Some(val.clone())])?,
+                    end: func.eval_range_boundary(&[end, Some(val)])?,
+                },
+            )),
+
+            // 8. x +/- x, two variable plus/minus (we assume only one variable exists), should be monotonically increasing
+            (
+                MonotonicityNode::Variable(
+                    _var1,
+                    Range {
+                        begin: begin1,
+                        end: end1,
+                    },
+                ),
+                MonotonicityNode::Variable(
+                    _var2,
+                    Range {
+                        begin: begin2,
+                        end: end2,
+                    },
+                ),
+            ) => match op {
+                DataValueArithmeticOperator::Plus => Ok(MonotonicityNode::Function(
+                    Monotonicity {
+                        is_monotonic: true,
+                        is_positive: true,
+                    },
+                    Range {
+                        begin: func.eval_range_boundary(&[begin1, begin2])?,
+                        end: func.eval_range_boundary(&[end1, end2])?,
+                    },
+                )),
+                // TODO: for expression like x-x, should return zero. But need to figure out the DataValue type.
+                _ => Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                    begin: None,
+                    end: None,
+                })),
+            },
+
+            // 9. x +/- f(x), a variable plus/minus a function
+            (
+                MonotonicityNode::Variable(
+                    _column_name,
+                    Range {
+                        begin: begin1,
+                        end: end1,
+                    },
+                ),
+                MonotonicityNode::Function(
+                    mono,
+                    Range {
+                        begin: begin2,
+                        end: end2,
+                    },
+                ),
+            ) => {
+                if !mono.is_monotonic {
+                    return Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                        begin: None,
+                        end: None,
+                    }));
+                }
+
+                match op {
+                    // x + f(x), should be also monotonically increasing if f(x) is so.
+                    DataValueArithmeticOperator::Plus => {
+                        if !mono.is_positive {
+                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                                begin: None,
+                                end: None,
+                            }))
+                        } else {
+                            Ok(MonotonicityNode::Function(
+                                Monotonicity {
+                                    is_monotonic: true,
+                                    is_positive: true,
+                                },
+                                Range {
+                                    begin: func.eval_range_boundary(&[begin1, begin2])?,
+                                    end: func.eval_range_boundary(&[end1, end2])?,
+                                },
+                            ))
+                        }
+                    }
+                    // x - f(x), should be also monotonically increasing if f(x) is monotonically decreasing.
+                    _ => {
+                        if mono.is_positive {
+                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
+                                begin: None,
+                                end: None,
+                            }))
+                        } else {
+                            Ok(MonotonicityNode::Function(
+                                Monotonicity {
+                                    is_monotonic: true,
+                                    is_positive: true,
+                                },
+                                Range {
+                                    begin: func.eval_range_boundary(&[begin1, end2])?,
+                                    end: func.eval_range_boundary(&[end1, begin2])?,
+                                },
+                            ))
+                        }
+                    }
+                }
+            }
+        }
     }
 
     pub fn get_monotonicity(args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
@@ -47,71 +404,10 @@ impl ArithmeticPlusFunction {
             return Ok(args[0].clone());
         }
 
-        // TODO: handle input with data range
-        match (&args[0], &args[1]) {
-            // a constant value plus a function, like 12 + f(x), the monotonicity should be the same as f
-            (MonotonicityNode::Function(mono, None), MonotonicityNode::Constant(_))
-            | (MonotonicityNode::Constant(_), MonotonicityNode::Function(mono, None)) => {
-                Ok(MonotonicityNode::Function(mono.clone(), None))
-            }
-
-            // a constant value plus a variable, like x + 12 should be monotonically increasing
-            (MonotonicityNode::Constant(_), MonotonicityNode::Variable(_, None))
-            | (MonotonicityNode::Variable(_, None), MonotonicityNode::Constant(_)) => {
-                Ok(MonotonicityNode::Function(
-                    Monotonicity {
-                        is_monotonic: true,
-                        is_positive: true,
-                        is_always_monotonic: true,
-                    },
-                    None,
-                ))
-            }
-
-            // two function plus, f(x) + g(x) , if they have same monotonicity, then should return that monotonicity
-            (MonotonicityNode::Function(mono1, None), MonotonicityNode::Function(mono2, None)) => {
-                if mono1.is_monotonic
-                    && mono2.is_monotonic
-                    && mono1.is_positive == mono2.is_positive
-                {
-                    return Ok(MonotonicityNode::Function(
-                        Monotonicity {
-                            is_monotonic: true,
-                            is_positive: mono1.is_positive,
-                            is_always_monotonic: mono1.is_always_monotonic
-                                && mono2.is_always_monotonic,
-                        },
-                        None,
-                    ));
-                }
-                Ok(MonotonicityNode::Function(Monotonicity::default(), None))
-            }
-
-            // two variable plus(we assume only one variable exists), like x+x, should be monotonically increasing
-            (MonotonicityNode::Variable(var1, None), MonotonicityNode::Variable(var2, None)) => {
-                if var1 == var2 {
-                    return Ok(MonotonicityNode::Function(
-                        Monotonicity {
-                            is_monotonic: true,
-                            is_positive: true,
-                            is_always_monotonic: true,
-                        },
-                        None,
-                    ));
-                }
-                Ok(MonotonicityNode::Function(Monotonicity::default(), None))
-            }
-
-            // a function plus the variable, like f(x) + x, if f(x) is monotonically increasing, return it.
-            (MonotonicityNode::Function(mono, None), MonotonicityNode::Variable(_, None))
-            | (MonotonicityNode::Variable(_, None), MonotonicityNode::Function(mono, None)) => {
-                if mono.is_monotonic && mono.is_positive {
-                    return Ok(MonotonicityNode::Function(mono.clone(), None));
-                }
-                Ok(MonotonicityNode::Function(Monotonicity::default(), None))
-            }
-
-            _ => Ok(MonotonicityNode::Function(Monotonicity::default(), None)),
-        }
+        Self::get_plus_minus_binary_operation_monotonicity(
+            DataValueArithmeticOperator::Plus,
+            args[0].clone(),
+            args[1].clone(),
+        )
     }
 }

--- a/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
@@ -16,13 +16,11 @@ use common_datavalues::DataValueArithmeticOperator;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
-use crate::scalars::function::MonotonicityNode;
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::ArithmeticFunction;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
-use crate::scalars::Range;
 
 pub struct ArithmeticPlusFunction;
 
@@ -36,363 +34,7 @@ impl ArithmeticPlusFunction {
             .features(FunctionFeatures::default().deterministic())
     }
 
-    pub fn get_plus_minus_binary_operation_monotonicity(
-        op: DataValueArithmeticOperator,
-        left: MonotonicityNode,
-        right: MonotonicityNode,
-    ) -> Result<MonotonicityNode> {
-        let func = ArithmeticFunction::new(op.clone());
-
-        match (left, right) {
-            // 1. f(x) +/- 12, a function plus/minus a constant value. The monotonicity should be the same as f(x)
-            (
-                MonotonicityNode::Function(mono, Range { begin, end }),
-                MonotonicityNode::Constant(val),
-            ) => {
-                if !mono.is_monotonic {
-                    // not a monotonic function, just return
-                    return Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                        begin: None,
-                        end: None,
-                    }));
-                }
-
-                Ok(MonotonicityNode::Function(mono, Range {
-                    begin: func.eval_range_boundary(&[begin, Some(val.clone())])?,
-                    end: func.eval_range_boundary(&[end, Some(val)])?,
-                }))
-            }
-
-            // 2. f(x) +/- x, a function plus/minus the variable.
-            (
-                MonotonicityNode::Function(
-                    mono,
-                    Range {
-                        begin: begin1,
-                        end: end1,
-                    },
-                ),
-                MonotonicityNode::Variable(
-                    _column_name,
-                    Range {
-                        begin: begin2,
-                        end: end2,
-                    },
-                ),
-            ) => {
-                if !mono.is_monotonic {
-                    return Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                        begin: None,
-                        end: None,
-                    }));
-                }
-
-                match op {
-                    // f(x) + x
-                    DataValueArithmeticOperator::Plus => {
-                        if mono.is_positive {
-                            Ok(MonotonicityNode::Function(
-                                Monotonicity {
-                                    is_monotonic: true,
-                                    is_positive: true,
-                                },
-                                Range {
-                                    begin: func.eval_range_boundary(&[begin1, begin2])?,
-                                    end: func.eval_range_boundary(&[end1, end2])?,
-                                },
-                            ))
-                        } else {
-                            // not monotonic any more
-                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                                begin: None,
-                                end: None,
-                            }))
-                        }
-                    }
-                    // f(x) - x
-                    _ => {
-                        if !mono.is_positive {
-                            Ok(MonotonicityNode::Function(
-                                Monotonicity {
-                                    is_monotonic: true,
-                                    is_positive: false,
-                                },
-                                Range {
-                                    // the begin should be the begin/min of f(x) minus the end/max of x
-                                    begin: func.eval_range_boundary(&[begin1, end2])?,
-                                    // the end should be the end/max of f(x) minus the begin/min of x
-                                    end: func.eval_range_boundary(&[end1, begin2])?,
-                                },
-                            ))
-                        } else {
-                            // not monotonic any more
-                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                                begin: None,
-                                end: None,
-                            }))
-                        }
-                    }
-                }
-            }
-
-            // 3. f(x) +/- g(x), a function plus/minus another. If they have same monotonicity, then should return that monotonicity
-            (
-                MonotonicityNode::Function(
-                    mono1,
-                    Range {
-                        begin: begin1,
-                        end: end1,
-                    },
-                ),
-                MonotonicityNode::Function(
-                    mono2,
-                    Range {
-                        begin: begin2,
-                        end: end2,
-                    },
-                ),
-            ) => {
-                if !mono1.is_monotonic || !mono2.is_monotonic {
-                    // not a monotonic function, just return
-                    return Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                        begin: None,
-                        end: None,
-                    }));
-                }
-
-                match op {
-                    // f(x) + g(x)
-                    DataValueArithmeticOperator::Plus => {
-                        if mono1.is_positive == mono2.is_positive {
-                            Ok(MonotonicityNode::Function(
-                                Monotonicity {
-                                    is_monotonic: true,
-                                    is_positive: mono1.is_positive,
-                                },
-                                Range {
-                                    begin: func.eval_range_boundary(&[begin1, begin2])?,
-                                    end: func.eval_range_boundary(&[end1, end2])?,
-                                },
-                            ))
-                        } else {
-                            // unknown monotonicity
-                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                                begin: None,
-                                end: None,
-                            }))
-                        }
-                    }
-                    // f(x) - g(x)
-                    _ => {
-                        if mono1.is_positive != mono2.is_positive {
-                            Ok(MonotonicityNode::Function(mono1, Range {
-                                begin: func.eval_range_boundary(&[begin1, end2])?,
-                                end: func.eval_range_boundary(&[end1, begin2])?,
-                            }))
-                        } else {
-                            // unknown monotonicity
-                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                                begin: None,
-                                end: None,
-                            }))
-                        }
-                    }
-                }
-            }
-
-            // 4. 1234 +/- f(x), a constant value plus/minus a function.
-            // The monotonicity is_positive should be the same as f(x) for '+' or flipping is_positive for '-'.
-            (
-                MonotonicityNode::Constant(val),
-                MonotonicityNode::Function(mono, Range { begin, end }),
-            ) => {
-                if !mono.is_monotonic {
-                    // not a monotonic function, just return
-                    return Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                        begin: None,
-                        end: None,
-                    }));
-                }
-
-                match op {
-                    DataValueArithmeticOperator::Plus => Ok(MonotonicityNode::Function(
-                        Monotonicity {
-                            is_monotonic: true,
-                            is_positive: mono.is_positive,
-                        },
-                        Range {
-                            begin: func.eval_range_boundary(&[Some(val.clone()), begin])?,
-                            end: func.eval_range_boundary(&[Some(val), end])?,
-                        },
-                    )),
-                    _ => Ok(MonotonicityNode::Function(
-                        Monotonicity {
-                            is_monotonic: true,
-                            is_positive: !mono.is_positive,
-                        },
-                        Range {
-                            begin: func.eval_range_boundary(&[Some(val.clone()), end])?,
-                            end: func.eval_range_boundary(&[Some(val), begin])?,
-                        },
-                    )),
-                }
-            }
-
-            // 5. 1234 +/- x, a constant value plus/minus a variable.
-            // The monotonicity is_positive should be the true for '+', false for '-'.
-            (
-                MonotonicityNode::Constant(val),
-                MonotonicityNode::Variable(_column_name, Range { begin, end }),
-            ) => match op {
-                DataValueArithmeticOperator::Plus => Ok(MonotonicityNode::Function(
-                    Monotonicity {
-                        is_monotonic: true,
-                        is_positive: true,
-                    },
-                    Range {
-                        begin: func.eval_range_boundary(&[Some(val.clone()), begin])?,
-                        end: func.eval_range_boundary(&[Some(val), end])?,
-                    },
-                )),
-                _ => Ok(MonotonicityNode::Function(
-                    Monotonicity {
-                        is_monotonic: true,
-                        is_positive: false,
-                    },
-                    Range {
-                        begin: func.eval_range_boundary(&[Some(val.clone()), end])?,
-                        end: func.eval_range_boundary(&[Some(val), begin])?,
-                    },
-                )),
-            },
-
-            // 6. 1234 +/- 5678, a constant value plus/minus a constant.
-            // This should not happen if the constant folding optimizer works well. But no harm to implement it here.
-            (MonotonicityNode::Constant(val1), MonotonicityNode::Constant(val2)) => {
-                let val = func.eval_range_boundary(&[Some(val1), Some(val2)])?;
-                Ok(MonotonicityNode::Constant(val.unwrap()))
-            }
-
-            // 7. x +/- 12, a variable plus/minus a constant
-            (
-                MonotonicityNode::Variable(_column_name, Range { begin, end }),
-                MonotonicityNode::Constant(val),
-            ) => Ok(MonotonicityNode::Function(
-                Monotonicity {
-                    is_monotonic: true,
-                    is_positive: true,
-                },
-                Range {
-                    begin: func.eval_range_boundary(&[begin, Some(val.clone())])?,
-                    end: func.eval_range_boundary(&[end, Some(val)])?,
-                },
-            )),
-
-            // 8. x +/- x, two variable plus/minus (we assume only one variable exists), should be monotonically increasing
-            (
-                MonotonicityNode::Variable(
-                    _var1,
-                    Range {
-                        begin: begin1,
-                        end: end1,
-                    },
-                ),
-                MonotonicityNode::Variable(
-                    _var2,
-                    Range {
-                        begin: begin2,
-                        end: end2,
-                    },
-                ),
-            ) => match op {
-                DataValueArithmeticOperator::Plus => Ok(MonotonicityNode::Function(
-                    Monotonicity {
-                        is_monotonic: true,
-                        is_positive: true,
-                    },
-                    Range {
-                        begin: func.eval_range_boundary(&[begin1, begin2])?,
-                        end: func.eval_range_boundary(&[end1, end2])?,
-                    },
-                )),
-                // TODO: for expression like x-x, should return zero. But need to figure out the DataValue type.
-                _ => Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                    begin: None,
-                    end: None,
-                })),
-            },
-
-            // 9. x +/- f(x), a variable plus/minus a function
-            (
-                MonotonicityNode::Variable(
-                    _column_name,
-                    Range {
-                        begin: begin1,
-                        end: end1,
-                    },
-                ),
-                MonotonicityNode::Function(
-                    mono,
-                    Range {
-                        begin: begin2,
-                        end: end2,
-                    },
-                ),
-            ) => {
-                if !mono.is_monotonic {
-                    return Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                        begin: None,
-                        end: None,
-                    }));
-                }
-
-                match op {
-                    // x + f(x), should be also monotonically increasing if f(x) is so.
-                    DataValueArithmeticOperator::Plus => {
-                        if !mono.is_positive {
-                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                                begin: None,
-                                end: None,
-                            }))
-                        } else {
-                            Ok(MonotonicityNode::Function(
-                                Monotonicity {
-                                    is_monotonic: true,
-                                    is_positive: true,
-                                },
-                                Range {
-                                    begin: func.eval_range_boundary(&[begin1, begin2])?,
-                                    end: func.eval_range_boundary(&[end1, end2])?,
-                                },
-                            ))
-                        }
-                    }
-                    // x - f(x), should be also monotonically increasing if f(x) is monotonically decreasing.
-                    _ => {
-                        if mono.is_positive {
-                            Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-                                begin: None,
-                                end: None,
-                            }))
-                        } else {
-                            Ok(MonotonicityNode::Function(
-                                Monotonicity {
-                                    is_monotonic: true,
-                                    is_positive: true,
-                                },
-                                Range {
-                                    begin: func.eval_range_boundary(&[begin1, end2])?,
-                                    end: func.eval_range_boundary(&[end1, begin2])?,
-                                },
-                            ))
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    pub fn get_monotonicity(args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
+    pub fn get_monotonicity(args: &[Monotonicity]) -> Result<Monotonicity> {
         if args.is_empty() || args.len() > 2 {
             return Err(ErrorCode::BadArguments(format!(
                 "Invalid argument lengths {} for get_monotonicity",
@@ -404,10 +46,50 @@ impl ArithmeticPlusFunction {
             return Ok(args[0].clone());
         }
 
-        Self::get_plus_minus_binary_operation_monotonicity(
-            DataValueArithmeticOperator::Plus,
-            args[0].clone(),
-            args[1].clone(),
-        )
+        // For expression f(x) + g(x), only when both f(x) and g(x) are monotonic and have
+        // same 'is_positive' can we get a monotonic expression.
+        let f_x = &args[0];
+        let g_x = &args[1];
+
+        // if either one is non-monotonic, return non-monotonic
+        if !f_x.is_monotonic || !g_x.is_monotonic {
+            return Ok(Monotonicity::default());
+        }
+
+        // if f(x) is a constant value, return the monotonicity of g(x)
+        if f_x.is_constant {
+            return Ok(Monotonicity {
+                is_monotonic: g_x.is_monotonic,
+                is_positive: g_x.is_positive,
+                is_constant: g_x.is_constant,
+                left: None,
+                right: None,
+            });
+        }
+
+        // if g(x) is a constant value, return the monotonicity of f(x)
+        if g_x.is_constant {
+            return Ok(Monotonicity {
+                is_monotonic: f_x.is_monotonic,
+                is_positive: f_x.is_positive,
+                is_constant: f_x.is_constant,
+                left: None,
+                right: None,
+            });
+        }
+
+        // Now we have f(x) and g(x) both are non-constant.
+        // When both are monotonic, but have different 'is_positive', we can't determine the monotonicity
+        if f_x.is_positive != g_x.is_positive {
+            return Ok(Monotonicity::default());
+        }
+
+        Ok(Monotonicity {
+            is_monotonic: true,
+            is_positive: f_x.is_positive,
+            is_constant: false,
+            left: None,
+            right: None,
+        })
     }
 }

--- a/common/functions/src/scalars/function.rs
+++ b/common/functions/src/scalars/function.rs
@@ -17,117 +17,38 @@ use std::fmt;
 use common_datavalues::columns::DataColumn;
 use common_datavalues::prelude::DataColumnWithField;
 use common_datavalues::prelude::DataColumnsWithField;
-use common_datavalues::DataField;
 use common_datavalues::DataSchema;
 use common_datavalues::DataType;
-use common_datavalues::DataValue;
 use common_exception::Result;
 use dyn_clone::DynClone;
 
-use super::ComparisonGtEqFunction;
-use super::ComparisonLtEqFunction;
-
-// Represents the range of data column for monotonic function calculation.
-// For example, f(x) = x+2 where x > 10 should have variable range [10, MAX), and f(x) should
-// have range [12, MAX). The range calculation from [10, MAX) to [12, MAX) should rely on the
-// function's eval method.
-#[derive(Clone)]
-pub struct Range {
-    pub begin: Option<DataColumnWithField>, // should have constant DataValue
-    pub end: Option<DataColumnWithField>,   // should have constant DataValue
-}
-
-impl Range {
-    /// Check whether the range is greater-equal than zero.
-    /// The function will compare the 'begin' field in the range with zero, return true if begin >= 0.
-    pub fn gt_eq_zero(&self) -> Result<bool> {
-        if self.begin.is_none() {
-            return Ok(false);
-        }
-
-        let zero = DataColumn::Constant(DataValue::Int8(Some(0)), 1);
-        let zero_column_field =
-            DataColumnWithField::new(zero, DataField::new("", DataType::Int8, false));
-
-        let min_val = self.begin.clone().unwrap();
-        let f = ComparisonGtEqFunction::try_create_func("")?;
-        let res = f.eval(&[min_val, zero_column_field], 1)?;
-        let res_value = res.try_get(0)?;
-        res_value.as_bool()
-    }
-
-    /// Check whether the range is less-equal than zero.
-    /// The function will compare the 'end' field in the range with zero, return true if end <= 0.
-    pub fn lt_eq_zero(&self) -> Result<bool> {
-        if self.end.is_none() {
-            return Ok(false);
-        }
-
-        let zero = DataColumn::Constant(DataValue::Int8(Some(0)), 1);
-        let zero_column_field =
-            DataColumnWithField::new(zero, DataField::new("", DataType::Int8, false));
-
-        let max_val = self.end.clone().unwrap();
-        let f = ComparisonLtEqFunction::try_create_func("")?;
-        let res = f.eval(&[max_val, zero_column_field], 1)?;
-        let res_value = res.try_get(0)?;
-        res_value.as_bool()
-    }
-}
-
-// Represents the node of function tree for calculating monotonicity.
-// For example, a function of Add(Neg(number), 5) for number < -100 will have a tree like this:
-//
-// .                   MonotonicityNode::Function -- 'Add'
-//                      (mono: is_positive=true, Range{105, MAX})
-//                         /                          \
-//                        /                            \
-//      MonotonicityNode::Function -- 'Neg'         Monotonicity::Constant -- 5
-//    (mono: is_positive=true, range{100, MAX})
-//                     /
-//                    /
-//     MonotonicityNode::Variable number -- 'number'
-//         (range{MIN, -100})
-//
-// The structure of the tree is basically the structure of the expression.
-// Simple depth first search visit the expression tree and gete monotonicity from
-// every function. Each function is responsible to implement its own monotonicity
-// function.
-// Notice!! the mechanism doesn't solve multiple variables case.
-#[derive(Clone)]
-pub enum MonotonicityNode {
-    // Describe a function monotonicity information for the range of data.
-    Function(Monotonicity, Range),
-    Constant(DataColumnWithField),
-    Variable(String, Range),
-}
-
 #[derive(Clone)]
 pub struct Monotonicity {
-    // Is the function monotonous (non-decreasing or non-increasing).
+    // Is the function monotonic (non-decreasing or non-increasing).
     pub is_monotonic: bool,
-    // true if the function is non-decreasing, false, if non-increasing. If is_monotonic = false, then it does not matter.
+
+    // Field for indicating monotonic increase or decrease
+    //   1. is_positive=true means non-decreasing
+    //   2. is_positive=false means non-increasing
+    // when is_monotonic is false, just ignore the is_positive information.
     pub is_positive: bool,
+
+    // Is the monotonicity from constant value
+    pub is_constant: bool,
+
+    pub left: Option<DataColumnWithField>,
+
+    pub right: Option<DataColumnWithField>,
 }
 
 impl Monotonicity {
     pub fn default() -> Self {
         Monotonicity {
-            // Field for indicating whether the function is monotonic in the data range
             is_monotonic: false,
-
-            // Field for indicating monotonic increase or decrease
-            //   1. is_positive=true means non-decreasing
-            //   2. is_positive=false means non-increasing
-            // when is_monotonic is false, just ignore ths is_positive information.
             is_positive: true,
-        }
-    }
-
-    pub fn flip_clone(&self) -> Self {
-        Self {
-            is_monotonic: self.is_monotonic,
-            is_positive: !self.is_positive,
+            is_constant: false,
+            left: None,
+            right: None,
         }
     }
 }
@@ -145,12 +66,11 @@ pub trait Function: fmt::Display + Sync + Send + DynClone {
         None
     }
 
-    // return monotonicity node, should always return MonotonicityNode::Function
-    fn get_monotonicity(&self, _args: &[MonotonicityNode]) -> Result<MonotonicityNode> {
-        Ok(MonotonicityNode::Function(Monotonicity::default(), Range {
-            begin: None,
-            end: None,
-        }))
+    /// Calculate the monotonicity from arguments' monotonicity information.
+    /// The input should be argument's monotonicity. For binary function it should be an array of left expression's monotonicity and right expression's monotonicity.
+    /// For unary function, the input should be an array of the only argument's monotonicity.
+    fn get_monotonicity(&self, _args: &[Monotonicity]) -> Result<Monotonicity> {
+        Ok(Monotonicity::default())
     }
 
     fn return_type(&self, args: &[DataType]) -> Result<DataType>;

--- a/common/functions/src/scalars/mod.rs
+++ b/common/functions/src/scalars/mod.rs
@@ -38,8 +38,6 @@ pub use dates::*;
 pub use expressions::*;
 pub use function::Function;
 pub use function::Monotonicity;
-pub use function::MonotonicityNode;
-pub use function::Range;
 pub use function_alias::AliasFunction;
 pub use function_column::ColumnFunction;
 pub use function_factory::FunctionFactory;

--- a/query/src/optimizers/mod.rs
+++ b/query/src/optimizers/mod.rs
@@ -24,6 +24,8 @@ mod optimizer_scatters_test;
 mod optimizer_statistics_exact_test;
 #[cfg(test)]
 mod optimizer_test;
+#[cfg(test)]
+mod utils_test;
 
 #[cfg(test)]
 mod optimizer_top_n_push_down_test;

--- a/query/src/optimizers/optimizer_top_n_push_down.rs
+++ b/query/src/optimizers/optimizer_top_n_push_down.rs
@@ -167,12 +167,9 @@ impl TopNPushDownImpl {
 
                 let column_name = columns.iter().next().unwrap();
 
-                let monotonic_checker = match self.variables_range.get(column_name) {
-                    None => MonotonicityCheckVisitor::new(None),
-                    Some(range) => MonotonicityCheckVisitor::new(Some(range.clone())),
-                };
+                let range: Option<Range> = self.variables_range.get(column_name).cloned();
 
-                match monotonic_checker.extract_sort_column(expr) {
+                match MonotonicityCheckVisitor::extract_sort_column(expr, range) {
                     Ok(new_expr) => Ok(new_expr),
                     Err(error) => {
                         tracing::error!(

--- a/query/src/optimizers/utils.rs
+++ b/query/src/optimizers/utils.rs
@@ -21,8 +21,6 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_functions::scalars::FunctionFactory;
 use common_functions::scalars::Monotonicity;
-use common_functions::scalars::MonotonicityNode;
-use common_functions::scalars::Range;
 use common_planners::col;
 use common_planners::Expression;
 use common_planners::ExpressionVisitor;
@@ -60,37 +58,46 @@ impl ExpressionVisitor for RequireColumnsVisitor {
     }
 }
 
+// MonotonicityCheckVisitor visit the expression tree to calculate monotonicity.
+// For example, a function of Add(Neg(number), 5) for number < -100 will have a tree like this:
+//
+// .                   MonotonicityNode::Function -- 'Add'
+//                      (mono: is_positive=true, Range{105, MAX})
+//                         /                          \
+//                        /                            \
+//      MonotonicityNode::Function -- f(x)=-x         Monotonicity::Constant -- 5
+//    (mono: is_positive=true, range{100, MAX})
+//                     /
+//                    /
+//     MonotonicityNode::Function -- f(x)=x
+//         (range{MIN, -100})
+//
+// The structure of the tree is basically the structure of the expression.
+// Simple depth first search visit the expression tree and gete monotonicity from
+// every function. Each function is responsible to implement its own monotonicity
+// function.
+// Notice!! the mechanism doesn't solve multiple variables case.
 #[derive(Clone)]
 pub struct MonotonicityCheckVisitor {
-    // represents the monotonicity node of an expression
-    pub node: Option<MonotonicityNode>,
+    // represents the monotonicity of an expression
+    pub mono: Option<Monotonicity>,
+
+    // the variable range left, we assume only one variable.
+    pub variable_left: Option<DataColumnWithField>,
+
+    // the variable range right, we assume only one variable.
+    pub variable_right: Option<DataColumnWithField>,
 
     pub columns: HashSet<String>,
-
-    // the variable range, we assume only one variable.
-    pub variable_range: Option<Range>,
 }
 
 impl MonotonicityCheckVisitor {
-    fn create_from_node(
-        root: MonotonicityNode,
-        columns: HashSet<String>,
-        variable_range: Option<Range>,
-    ) -> Self {
-        MonotonicityCheckVisitor {
-            node: Some(root),
-            columns,
-            variable_range,
-        }
-    }
-
-    // Create an instance of MonotonicityCheckVisitor for checking functions with ONLY ONE variable.
-    // Specify the variable range if you know it. Otherwise just pass in None.
-    fn new(variable_range: Option<Range>) -> Self {
-        MonotonicityCheckVisitor {
-            node: None,
+    fn empty() -> Self {
+        Self {
+            mono: None,
+            variable_left: None,
+            variable_right: None,
             columns: HashSet::new(),
-            variable_range,
         }
     }
 
@@ -99,62 +106,110 @@ impl MonotonicityCheckVisitor {
         op: &str,
         children: &[Expression],
     ) -> Result<MonotonicityCheckVisitor> {
-        let mut columns: HashSet<String> = HashSet::new();
-        let mut nodes = vec![];
+        let mut monotonicity_vec = vec![];
+        let mut left_vec = vec![];
+        let mut right_vec = vec![];
+        let mut columns = HashSet::<String>::new();
+
         for child_expr in children.iter() {
-            let visitor = MonotonicityCheckVisitor::new(self.variable_range.clone());
+            let visitor = self.clone();
             let visitor = child_expr.accept(visitor)?;
 
+            columns.extend(visitor.columns);
+
             // one of the children node is None, no need to check any more.
-            if visitor.node.is_none() {
-                return Ok(MonotonicityCheckVisitor::new(self.variable_range));
+            if visitor.mono.is_none() {
+                return Ok(MonotonicityCheckVisitor::empty());
             }
 
-            nodes.push(visitor.node.unwrap());
-            columns.extend(visitor.columns);
+            let monotonicity = visitor.mono.unwrap();
+            if !monotonicity.is_monotonic {
+                return Ok(MonotonicityCheckVisitor::empty());
+            }
+
+            left_vec.push(monotonicity.left.clone());
+            right_vec.push(monotonicity.right.clone());
+            monotonicity_vec.push(monotonicity);
         }
 
         let func = FunctionFactory::instance().get(op)?;
-        let root_node = func.get_monotonicity(nodes.as_ref())?;
-        let visitor =
-            MonotonicityCheckVisitor::create_from_node(root_node, columns, self.variable_range);
-        Ok(visitor)
+
+        let mut root_mono = func.get_monotonicity(monotonicity_vec.as_ref())?;
+
+        // neither a monotonic expression nor constant, no need to calculating boundary
+        if !root_mono.is_monotonic && !root_mono.is_constant {
+            return Ok(MonotonicityCheckVisitor::empty());
+        }
+
+        // lambda to convert data column to data column with field
+        let data_column_to_column_field = |data_column: DataColumn| -> Option<DataColumnWithField> {
+            let data_field = DataField::new("", data_column.data_type(), false);
+            let data_column_field = DataColumnWithField::new(data_column, data_field);
+            Some(data_column_field)
+        };
+
+        // if any one left boundary is None(unknown), we set new_left as None too.
+        let new_left: Option<DataColumnWithField> = if left_vec.iter().any(|col| col.is_none()) {
+            None
+        } else {
+            let args = left_vec
+                .into_iter()
+                .map(|col_opt| col_opt.unwrap())
+                .collect::<Vec<_>>();
+            let new_left_data_column = func.eval(&args, 1)?;
+            data_column_to_column_field(new_left_data_column)
+        };
+
+        let new_right: Option<DataColumnWithField> = if right_vec.iter().any(|col| col.is_none()) {
+            None
+        } else {
+            let args = right_vec
+                .into_iter()
+                .map(|col_opt| col_opt.unwrap())
+                .collect::<Vec<_>>();
+            let new_right_data_column = func.eval(&args, 1)?;
+            data_column_to_column_field(new_right_data_column)
+        };
+
+        root_mono.left = new_left;
+        root_mono.right = new_right;
+
+        Ok(MonotonicityCheckVisitor {
+            mono: Some(root_mono),
+            variable_left: self.variable_left,
+            variable_right: self.variable_right,
+            columns,
+        })
     }
 
-    /// Check whether the expression is monotonic or not.
+    /// Check whether the expression is monotonic or not. The left should be <= right.
     /// Return the monotonicity information, together with column name if any.
     pub fn check_expression(
         expr: &Expression,
-        variable_range: Option<Range>,
+        left: Option<DataColumnWithField>,
+        right: Option<DataColumnWithField>,
     ) -> Result<(Monotonicity, String)> {
-        let visitor = Self::new(variable_range);
+        let visitor = MonotonicityCheckVisitor {
+            mono: None,
+            variable_left: left,
+            variable_right: right,
+            columns: HashSet::new(),
+        };
+
         let visitor = expr.accept(visitor)?;
 
-        // One of the expression has more than one column, we don't know the monotonicity.
+        // The expression has more than one column, we don't know the monotonicity.
         if visitor.columns.len() != 1 {
             return Ok((Monotonicity::default(), String::new()));
         }
 
-        let column_name = visitor.columns.iter().next().unwrap();
-
-        match visitor.node {
-            None => Ok((Monotonicity::default(), String::new())),
-            Some(MonotonicityNode::Function(mono, _)) => Ok((mono, column_name.to_string())),
-            Some(MonotonicityNode::Variable(column_name, _)) => Ok((
-                Monotonicity {
-                    is_monotonic: true,
-                    is_positive: true,
-                },
-                column_name,
-            )),
-            Some(MonotonicityNode::Constant(_value)) => Ok((
-                Monotonicity {
-                    is_monotonic: true,
-                    is_positive: true,
-                },
-                String::new(),
-            )),
+        if visitor.mono.is_none() {
+            return Ok((Monotonicity::default(), String::new()));
         }
+
+        let column_name = visitor.columns.iter().next().unwrap().clone();
+        let monotonicity = visitor.mono.unwrap();
+        Ok((monotonicity, column_name))
     }
 
     /// Extract sort column from sort expression. It checks the monotonicity information
@@ -162,7 +217,8 @@ impl MonotonicityCheckVisitor {
     /// column information, returns as Expression::Column.
     pub fn extract_sort_column(
         sort_expr: &Expression,
-        variable_range: Option<Range>,
+        left: Option<DataColumnWithField>,
+        right: Option<DataColumnWithField>,
     ) -> Result<Expression> {
         if let Expression::Sort {
             expr: _,
@@ -171,44 +227,41 @@ impl MonotonicityCheckVisitor {
             origin_expr,
         } = sort_expr
         {
-            let visitor = Self::new(variable_range);
+            let visitor = MonotonicityCheckVisitor {
+                mono: None,
+                variable_left: left,
+                variable_right: right,
+                columns: HashSet::new(),
+            };
+
             let visitor = origin_expr.accept(visitor)?;
 
-            // One of the expression has more than one column, we don't know the monotonicity.
+            // The expression has more than one column, we don't know the monotonicity.
             // Skip the optimization, just return the input
             if visitor.columns.len() != 1 {
                 return Ok(sort_expr.clone());
             }
 
+            // not a monotonicity expression
+            if visitor.mono.is_none() {
+                return Ok(sort_expr.clone());
+            }
+
+            let mono = visitor.mono.unwrap();
+            if !mono.is_monotonic {
+                return Ok(sort_expr.clone());
+            }
+
             let column_name = visitor.columns.iter().next().unwrap();
 
-            match visitor.node {
-                None => return Ok(sort_expr.clone()),
-                Some(MonotonicityNode::Function(mono, _)) => {
-                    // the current function is not monotonic, we skip the optimization
-                    if !mono.is_monotonic {
-                        return Ok(sort_expr.clone());
-                    }
-
-                    // need to flip the asc when is_positive is false
-                    let new_asc = if mono.is_positive { *asc } else { !*asc };
-                    return Ok(Expression::Sort {
-                        expr: Box::new(col(column_name)),
-                        asc: new_asc,
-                        nulls_first: *nulls_first,
-                        origin_expr: origin_expr.clone(),
-                    });
-                }
-                Some(MonotonicityNode::Variable(column_name, _)) => {
-                    return Ok(Expression::Sort {
-                        expr: Box::new(col(&column_name)),
-                        asc: *asc,
-                        nulls_first: *nulls_first,
-                        origin_expr: origin_expr.clone(),
-                    });
-                }
-                Some(MonotonicityNode::Constant(_value)) => return Ok(sort_expr.clone()),
-            };
+            // need to flip the asc when is_positive is false
+            let new_asc = if mono.is_positive { *asc } else { !*asc };
+            return Ok(Expression::Sort {
+                expr: Box::new(col(column_name)),
+                asc: new_asc,
+                nulls_first: *nulls_first,
+                origin_expr: origin_expr.clone(),
+            });
         }
         Err(ErrorCode::BadArguments(format!(
             "expect sort expression, get {:?}",
@@ -230,47 +283,54 @@ impl ExpressionVisitor for MonotonicityCheckVisitor {
             }
             Expression::UnaryExpression { op, expr } => self.visit_func_args(op, &[*expr.clone()]),
             Expression::Column(col) => {
-                let mut columns = HashSet::new();
-                columns.insert(col.clone());
-
-                let range = match &self.variable_range {
-                    None => Range {
-                        begin: None,
-                        end: None,
-                    },
-                    Some(range) => range.clone(),
+                let mono_node = Monotonicity {
+                    is_monotonic: true,
+                    is_positive: true,
+                    is_constant: false,
+                    left: self.variable_left.clone(),
+                    right: self.variable_right.clone(),
                 };
-                let node = MonotonicityNode::Variable(col.clone(), range);
 
-                Ok(MonotonicityCheckVisitor::create_from_node(
-                    node,
-                    columns,
-                    self.variable_range,
-                ))
+                let mut new_columns: HashSet<String> = HashSet::new();
+                new_columns.insert(col.clone());
+                new_columns.extend(self.columns);
+
+                Ok(MonotonicityCheckVisitor {
+                    mono: Some(mono_node),
+                    variable_left: self.variable_left,
+                    variable_right: self.variable_right,
+                    columns: new_columns,
+                })
             }
             Expression::Literal {
                 value,
                 column_name,
                 data_type,
             } => {
-                let columns = HashSet::new();
-
                 let name = match column_name {
                     Some(n) => n.clone(),
                     None => format!("{}", value),
                 };
                 let data_field = DataField::new(&name, data_type.clone(), false);
-                let data_column =
+                let data_column_field =
                     DataColumnWithField::new(DataColumn::Constant(value.clone(), 1), data_field);
 
-                let node = MonotonicityNode::Constant(data_column);
-                Ok(MonotonicityCheckVisitor::create_from_node(
-                    node,
-                    columns,
-                    self.variable_range,
-                ))
+                let mono_node = Monotonicity {
+                    is_monotonic: true,
+                    is_positive: true,
+                    is_constant: true,
+                    left: Some(data_column_field.clone()),
+                    right: Some(data_column_field),
+                };
+
+                Ok(MonotonicityCheckVisitor {
+                    mono: Some(mono_node),
+                    variable_left: self.variable_left,
+                    variable_right: self.variable_right,
+                    columns: self.columns,
+                })
             }
-            _ => Ok(MonotonicityCheckVisitor::new(self.variable_range)),
+            _ => Ok(MonotonicityCheckVisitor::empty()),
         }
     }
 }

--- a/query/src/optimizers/utils_test.rs
+++ b/query/src/optimizers/utils_test.rs
@@ -19,7 +19,6 @@ use common_datavalues::DataType;
 use common_datavalues::DataValue;
 use common_exception::Result;
 use common_functions::scalars::Monotonicity;
-use common_functions::scalars::Range;
 use common_planners::*;
 
 use crate::optimizers::MonotonicityCheckVisitor;
@@ -30,7 +29,7 @@ fn test_check_expression_monotonicity_without_range() -> Result<()> {
         name: &'static str,
         expr: Expression,
         expect_mono: Monotonicity,
-        column: String,
+        column: &'static str,
     }
 
     let tests: Vec<Test> = vec![
@@ -40,8 +39,11 @@ fn test_check_expression_monotonicity_without_range() -> Result<()> {
             expect_mono: Monotonicity {
                 is_monotonic: true,
                 is_positive: true,
+                is_constant: false,
+                left: None,
+                right: None,
             },
-            column: String::from("x"),
+            column: "x",
         },
         Test {
             name: "f(x) = -x + 12",
@@ -52,8 +54,23 @@ fn test_check_expression_monotonicity_without_range() -> Result<()> {
             expect_mono: Monotonicity {
                 is_monotonic: true,
                 is_positive: false,
+                is_constant: false,
+                left: None,
+                right: None,
             },
-            column: String::from("x"),
+            column: "x",
+        },
+        Test {
+            name: "f(x,y) = x + y", // multi-variable function is not supported,
+            expr: Expression::create_binary_expression("+", vec![col("x"), col("y")]),
+            expect_mono: Monotonicity {
+                is_monotonic: false,
+                is_positive: true,
+                is_constant: false,
+                left: None,
+                right: None,
+            },
+            column: "",
         },
         Test {
             name: "f(x) = (-x + 12) - x + (1 - x)",
@@ -72,8 +89,11 @@ fn test_check_expression_monotonicity_without_range() -> Result<()> {
             expect_mono: Monotonicity {
                 is_monotonic: true,
                 is_positive: false,
+                is_constant: false,
+                left: None,
+                right: None,
             },
-            column: String::from("x"),
+            column: "x",
         },
         Test {
             name: "f(x) = (x + 12) - x + (1 - x)",
@@ -89,8 +109,11 @@ fn test_check_expression_monotonicity_without_range() -> Result<()> {
             expect_mono: Monotonicity {
                 is_monotonic: false,
                 is_positive: false,
+                is_constant: false,
+                left: None,
+                right: None,
             },
-            column: String::from("x"),
+            column: "x",
         },
         Test {
             name: "f(x) = abs(x + 12)",
@@ -100,17 +123,28 @@ fn test_check_expression_monotonicity_without_range() -> Result<()> {
             expect_mono: Monotonicity {
                 is_monotonic: false,
                 is_positive: true,
+                is_constant: false,
+                left: None,
+                right: None,
             },
-            column: String::from("x"),
+            column: "x",
         },
     ];
 
     for t in tests.into_iter() {
-        let (mono, column) = MonotonicityCheckVisitor::check_expression(&t.expr, None)?;
-        assert_eq!(mono.is_monotonic, t.expect_mono.is_monotonic, "{}", t.name);
+        let (mono, column) = MonotonicityCheckVisitor::check_expression(&t.expr, None, None)?;
+        assert_eq!(
+            mono.is_monotonic, t.expect_mono.is_monotonic,
+            "{} is_monotonic",
+            t.name
+        );
         if mono.is_monotonic {
-            assert_eq!(mono.is_positive, t.expect_mono.is_positive, "{}", t.name);
-            assert_eq!(column, t.column, "{}", t.name);
+            assert_eq!(
+                mono.is_positive, t.expect_mono.is_positive,
+                "{} is_positive",
+                t.name
+            );
+            assert_eq!(column, t.column, "{} column", t.name);
         }
     }
 
@@ -119,143 +153,122 @@ fn test_check_expression_monotonicity_without_range() -> Result<()> {
 
 #[test]
 fn test_check_expression_monotonicity_with_range() -> Result<()> {
+    let create_data = |d: i64| -> Option<DataColumnWithField> {
+        let data_field = DataField::new("x", DataType::Int64, false);
+        let data_column = DataColumn::Constant(DataValue::Int64(Some(d)), 1);
+        Some(DataColumnWithField::new(data_column, data_field))
+    };
+
+    let extract_data = |data_column_field: DataColumnWithField| -> Result<i64> {
+        let column = data_column_field.column();
+        column.to_values()?[0].as_i64()
+    };
+
     struct Test {
         name: &'static str,
         expr: Expression,
         expect_mono: Monotonicity,
-        column: String,
-        range: Range,
+        column: &'static str,
+        left: Option<DataColumnWithField>,
+        right: Option<DataColumnWithField>,
     }
 
     let tests: Vec<Test> = vec![
         Test {
-            name: "f(x) = abs(x) where x >= 0",
+            name: "f(x) = abs(x) where  0 <= x <= 10",
             expr: Expression::create_scalar_function("abs", vec![col("x")]),
             expect_mono: Monotonicity {
                 is_monotonic: true,
                 is_positive: true,
+                is_constant: false,
+                left: create_data(0),
+                right: create_data(10),
             },
-            column: String::from("x"),
-            range: Range {
-                begin: Some(DataColumnWithField::new(
-                    DataColumn::Constant(DataValue::Int8(Some(0)), 1),
-                    DataField::new("x", DataType::Int8, false),
-                )),
-                end: None,
-            },
+            column: "x",
+            left: create_data(0),
+            right: create_data(10),
         },
         Test {
-            name: "f(x) = abs(x) where x <= 0",
+            name: "f(x) = abs(x) where  -10 <= x <= -2",
             expr: Expression::create_scalar_function("abs", vec![col("x")]),
             expect_mono: Monotonicity {
                 is_monotonic: true,
                 is_positive: false,
+                is_constant: false,
+                left: create_data(10),
+                right: create_data(2),
             },
-            column: String::from("x"),
-            range: Range {
-                begin: None,
-                end: Some(DataColumnWithField::new(
-                    DataColumn::Constant(DataValue::Int8(Some(0)), 1),
-                    DataField::new("x", DataType::Int8, false),
-                )),
-            },
+            column: "x",
+            left: create_data(-10),
+            right: create_data(-2),
         },
         Test {
-            name: "f(x) = abs(x) where x <= 5", // should NOT be monotonic
+            name: "f(x) = abs(x) where -5 <= x <= 5", // should NOT be monotonic
             expr: Expression::create_scalar_function("abs", vec![col("x")]),
             expect_mono: Monotonicity {
                 is_monotonic: false,
                 is_positive: false,
+                is_constant: false,
+                left: None,
+                right: None,
             },
-            column: String::from("x"),
-            range: Range {
-                begin: None,
-                end: Some(DataColumnWithField::new(
-                    DataColumn::Constant(DataValue::Int8(Some(5)), 1),
-                    DataField::new("x", DataType::Int8, false),
-                )),
-            },
+            column: "x",
+            left: create_data(-5),
+            right: create_data(5),
         },
         Test {
-            name: "f(x) = abs(x + 12) where x >= -12",
+            name: "f(x) = abs(x + 12) where -12 <= x <= 1000",
             expr: Expression::create_scalar_function("abs", vec![
                 Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
             ]),
             expect_mono: Monotonicity {
                 is_monotonic: true,
                 is_positive: true,
+                is_constant: false,
+                left: create_data(0),
+                right: create_data(1012),
             },
-            column: String::from("x"),
-            range: Range {
-                begin: Some(DataColumnWithField::new(
-                    DataColumn::Constant(DataValue::Int8(Some(-12)), 1),
-                    DataField::new("x", DataType::Int8, false),
-                )),
-                end: None,
-            },
+            column: "x",
+            left: create_data(-12),
+            right: create_data(1000),
         },
         Test {
-            name: "f(x) = abs(x + 12) where x >= -14", // should NOT be monotonic
+            name: "f(x) = abs(x + 12) where -14 <=  x <= 20", // should NOT be monotonic
             expr: Expression::create_scalar_function("abs", vec![
                 Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
             ]),
             expect_mono: Monotonicity {
                 is_monotonic: false,
                 is_positive: true,
+                is_constant: false,
+                left: None,
+                right: None,
             },
-            column: String::from("x"),
-            range: Range {
-                begin: Some(DataColumnWithField::new(
-                    DataColumn::Constant(DataValue::Int8(Some(-14)), 1),
-                    DataField::new("x", DataType::Int8, false),
-                )),
-                end: None,
-            },
+            column: "x",
+            left: create_data(-14),
+            right: create_data(20),
         },
         Test {
-            name: "f(x) = abs( (x - 2) + (x - 3) ) where x >= 5",
+            name: "f(x) = abs( (x - 7) + (x - 3) ) where 5 <= x <= 100",
             expr: Expression::create_scalar_function("abs", vec![
                 Expression::create_binary_expression("+", vec![
-                    Expression::create_binary_expression("-", vec![col("x"), lit(2_i32)]),
+                    Expression::create_binary_expression("-", vec![col("x"), lit(7_i32)]),
                     Expression::create_binary_expression("-", vec![col("x"), lit(3_i32)]),
                 ]),
             ]),
             expect_mono: Monotonicity {
                 is_monotonic: true,
                 is_positive: true,
+                is_constant: false,
+                left: create_data(0),
+                right: create_data(190),
             },
-            column: String::from("x"),
-            range: Range {
-                begin: Some(DataColumnWithField::new(
-                    DataColumn::Constant(DataValue::Int8(Some(5)), 1),
-                    DataField::new("x", DataType::Int8, false),
-                )),
-                end: None,
-            },
+            column: "x",
+            left: create_data(5),
+            right: create_data(100),
         },
         Test {
-            name: "f(x) = abs( (x - 2) + (x - 3) ) where x >= 4", // should NOT be monotonic
-            expr: Expression::create_scalar_function("abs", vec![
-                Expression::create_binary_expression("+", vec![
-                    Expression::create_binary_expression("-", vec![col("x"), lit(2_i32)]),
-                    Expression::create_binary_expression("-", vec![col("x"), lit(3_i32)]),
-                ]),
-            ]),
-            expect_mono: Monotonicity {
-                is_monotonic: true,
-                is_positive: true,
-            },
-            column: String::from("x"),
-            range: Range {
-                begin: Some(DataColumnWithField::new(
-                    DataColumn::Constant(DataValue::Int8(Some(4)), 1),
-                    DataField::new("x", DataType::Int8, false),
-                )),
-                end: None,
-            },
-        },
-        Test {
-            name: "f(x) = abs( (-x + 8) - x) where x <= 4",
+            name: "f(x) = abs( (-x + 8) - x) where -100 <= x <= 4",
             expr: Expression::create_scalar_function("abs", vec![
                 Expression::create_binary_expression("-", vec![
                     Expression::create_binary_expression("+", vec![
@@ -268,24 +281,42 @@ fn test_check_expression_monotonicity_with_range() -> Result<()> {
             expect_mono: Monotonicity {
                 is_monotonic: true,
                 is_positive: false,
+                is_constant: false,
+                left: create_data(208),
+                right: create_data(0),
             },
-            column: String::from("x"),
-            range: Range {
-                begin: None,
-                end: Some(DataColumnWithField::new(
-                    DataColumn::Constant(DataValue::Int8(Some(4)), 1),
-                    DataField::new("x", DataType::Int8, false),
-                )),
-            },
+            column: "x",
+            left: create_data(-100),
+            right: create_data(4),
         },
     ];
 
     for t in tests.into_iter() {
-        let (mono, column) = MonotonicityCheckVisitor::check_expression(&t.expr, Some(t.range))?;
-        assert_eq!(mono.is_monotonic, t.expect_mono.is_monotonic, "{}", t.name);
+        let (mono, column) = MonotonicityCheckVisitor::check_expression(&t.expr, t.left, t.right)?;
+        assert_eq!(
+            mono.is_monotonic, t.expect_mono.is_monotonic,
+            "{} is_monotonic",
+            t.name
+        );
         if mono.is_monotonic {
-            assert_eq!(mono.is_positive, t.expect_mono.is_positive, "{}", t.name);
-            assert_eq!(column, t.column, "{}", t.name);
+            assert_eq!(
+                mono.is_positive, t.expect_mono.is_positive,
+                "{} is_positive",
+                t.name
+            );
+            assert_eq!(column, t.column, "{} column", t.name);
+            assert_eq!(
+                extract_data(mono.left.unwrap())?,
+                extract_data(t.expect_mono.left.unwrap())?,
+                "{} left",
+                t.name
+            );
+            assert_eq!(
+                extract_data(mono.right.unwrap())?,
+                extract_data(t.expect_mono.right.unwrap())?,
+                "{} right",
+                t.name
+            );
         }
     }
 

--- a/query/src/optimizers/utils_test.rs
+++ b/query/src/optimizers/utils_test.rs
@@ -1,0 +1,293 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_datavalues::prelude::DataColumn;
+use common_datavalues::prelude::DataColumnWithField;
+use common_datavalues::DataField;
+use common_datavalues::DataType;
+use common_datavalues::DataValue;
+use common_exception::Result;
+use common_functions::scalars::Monotonicity;
+use common_functions::scalars::Range;
+use common_planners::*;
+
+use crate::optimizers::MonotonicityCheckVisitor;
+
+#[test]
+fn test_check_expression_monotonicity_without_range() -> Result<()> {
+    struct Test {
+        name: &'static str,
+        expr: Expression,
+        expect_mono: Monotonicity,
+        column: String,
+    }
+
+    let tests: Vec<Test> = vec![
+        Test {
+            name: "f(x) = x + 12",
+            expr: Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
+            expect_mono: Monotonicity {
+                is_monotonic: true,
+                is_positive: true,
+            },
+            column: String::from("x"),
+        },
+        Test {
+            name: "f(x) = -x + 12",
+            expr: Expression::create_binary_expression("+", vec![
+                Expression::create_unary_expression("-", vec![col("x")]),
+                lit(12i32),
+            ]),
+            expect_mono: Monotonicity {
+                is_monotonic: true,
+                is_positive: false,
+            },
+            column: String::from("x"),
+        },
+        Test {
+            name: "f(x) = (-x + 12) - x + (1 - x)",
+            expr: Expression::create_binary_expression("+", vec![
+                Expression::create_binary_expression("-", vec![
+                    // -x + 12
+                    Expression::create_binary_expression("+", vec![
+                        Expression::create_unary_expression("-", vec![col("x")]),
+                        lit(12i32),
+                    ]),
+                    col("x"),
+                ]),
+                // 1 - x
+                Expression::create_unary_expression("-", vec![lit(1i64), col("x")]),
+            ]),
+            expect_mono: Monotonicity {
+                is_monotonic: true,
+                is_positive: false,
+            },
+            column: String::from("x"),
+        },
+        Test {
+            name: "f(x) = (x + 12) - x + (1 - x)",
+            expr: Expression::create_binary_expression("+", vec![
+                Expression::create_binary_expression("-", vec![
+                    // x + 12
+                    Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
+                    col("x"),
+                ]),
+                // 1 - x
+                Expression::create_unary_expression("-", vec![lit(1i64), col("x")]),
+            ]),
+            expect_mono: Monotonicity {
+                is_monotonic: false,
+                is_positive: false,
+            },
+            column: String::from("x"),
+        },
+        Test {
+            name: "f(x) = abs(x + 12)",
+            expr: Expression::create_scalar_function("abs", vec![
+                Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
+            ]),
+            expect_mono: Monotonicity {
+                is_monotonic: false,
+                is_positive: true,
+            },
+            column: String::from("x"),
+        },
+    ];
+
+    for t in tests.into_iter() {
+        let (mono, column) = MonotonicityCheckVisitor::check_expression(&t.expr, None)?;
+        assert_eq!(mono.is_monotonic, t.expect_mono.is_monotonic, "{}", t.name);
+        if mono.is_monotonic {
+            assert_eq!(mono.is_positive, t.expect_mono.is_positive, "{}", t.name);
+            assert_eq!(column, t.column, "{}", t.name);
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_check_expression_monotonicity_with_range() -> Result<()> {
+    struct Test {
+        name: &'static str,
+        expr: Expression,
+        expect_mono: Monotonicity,
+        column: String,
+        range: Range,
+    }
+
+    let tests: Vec<Test> = vec![
+        Test {
+            name: "f(x) = abs(x) where x >= 0",
+            expr: Expression::create_scalar_function("abs", vec![col("x")]),
+            expect_mono: Monotonicity {
+                is_monotonic: true,
+                is_positive: true,
+            },
+            column: String::from("x"),
+            range: Range {
+                begin: Some(DataColumnWithField::new(
+                    DataColumn::Constant(DataValue::Int8(Some(0)), 1),
+                    DataField::new("x", DataType::Int8, false),
+                )),
+                end: None,
+            },
+        },
+        Test {
+            name: "f(x) = abs(x) where x <= 0",
+            expr: Expression::create_scalar_function("abs", vec![col("x")]),
+            expect_mono: Monotonicity {
+                is_monotonic: true,
+                is_positive: false,
+            },
+            column: String::from("x"),
+            range: Range {
+                begin: None,
+                end: Some(DataColumnWithField::new(
+                    DataColumn::Constant(DataValue::Int8(Some(0)), 1),
+                    DataField::new("x", DataType::Int8, false),
+                )),
+            },
+        },
+        Test {
+            name: "f(x) = abs(x) where x <= 5", // should NOT be monotonic
+            expr: Expression::create_scalar_function("abs", vec![col("x")]),
+            expect_mono: Monotonicity {
+                is_monotonic: false,
+                is_positive: false,
+            },
+            column: String::from("x"),
+            range: Range {
+                begin: None,
+                end: Some(DataColumnWithField::new(
+                    DataColumn::Constant(DataValue::Int8(Some(5)), 1),
+                    DataField::new("x", DataType::Int8, false),
+                )),
+            },
+        },
+        Test {
+            name: "f(x) = abs(x + 12) where x >= -12",
+            expr: Expression::create_scalar_function("abs", vec![
+                Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
+            ]),
+            expect_mono: Monotonicity {
+                is_monotonic: true,
+                is_positive: true,
+            },
+            column: String::from("x"),
+            range: Range {
+                begin: Some(DataColumnWithField::new(
+                    DataColumn::Constant(DataValue::Int8(Some(-12)), 1),
+                    DataField::new("x", DataType::Int8, false),
+                )),
+                end: None,
+            },
+        },
+        Test {
+            name: "f(x) = abs(x + 12) where x >= -14", // should NOT be monotonic
+            expr: Expression::create_scalar_function("abs", vec![
+                Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
+            ]),
+            expect_mono: Monotonicity {
+                is_monotonic: false,
+                is_positive: true,
+            },
+            column: String::from("x"),
+            range: Range {
+                begin: Some(DataColumnWithField::new(
+                    DataColumn::Constant(DataValue::Int8(Some(-14)), 1),
+                    DataField::new("x", DataType::Int8, false),
+                )),
+                end: None,
+            },
+        },
+        Test {
+            name: "f(x) = abs( (x - 2) + (x - 3) ) where x >= 5",
+            expr: Expression::create_scalar_function("abs", vec![
+                Expression::create_binary_expression("+", vec![
+                    Expression::create_binary_expression("-", vec![col("x"), lit(2_i32)]),
+                    Expression::create_binary_expression("-", vec![col("x"), lit(3_i32)]),
+                ]),
+            ]),
+            expect_mono: Monotonicity {
+                is_monotonic: true,
+                is_positive: true,
+            },
+            column: String::from("x"),
+            range: Range {
+                begin: Some(DataColumnWithField::new(
+                    DataColumn::Constant(DataValue::Int8(Some(5)), 1),
+                    DataField::new("x", DataType::Int8, false),
+                )),
+                end: None,
+            },
+        },
+        Test {
+            name: "f(x) = abs( (x - 2) + (x - 3) ) where x >= 4", // should NOT be monotonic
+            expr: Expression::create_scalar_function("abs", vec![
+                Expression::create_binary_expression("+", vec![
+                    Expression::create_binary_expression("-", vec![col("x"), lit(2_i32)]),
+                    Expression::create_binary_expression("-", vec![col("x"), lit(3_i32)]),
+                ]),
+            ]),
+            expect_mono: Monotonicity {
+                is_monotonic: true,
+                is_positive: true,
+            },
+            column: String::from("x"),
+            range: Range {
+                begin: Some(DataColumnWithField::new(
+                    DataColumn::Constant(DataValue::Int8(Some(4)), 1),
+                    DataField::new("x", DataType::Int8, false),
+                )),
+                end: None,
+            },
+        },
+        Test {
+            name: "f(x) = abs( (-x + 8) - x) where x <= 4",
+            expr: Expression::create_scalar_function("abs", vec![
+                Expression::create_binary_expression("-", vec![
+                    Expression::create_binary_expression("+", vec![
+                        Expression::create_unary_expression("-", vec![col("x")]),
+                        lit(8_i64),
+                    ]),
+                    col("x"),
+                ]),
+            ]),
+            expect_mono: Monotonicity {
+                is_monotonic: true,
+                is_positive: false,
+            },
+            column: String::from("x"),
+            range: Range {
+                begin: None,
+                end: Some(DataColumnWithField::new(
+                    DataColumn::Constant(DataValue::Int8(Some(4)), 1),
+                    DataField::new("x", DataType::Int8, false),
+                )),
+            },
+        },
+    ];
+
+    for t in tests.into_iter() {
+        let (mono, column) = MonotonicityCheckVisitor::check_expression(&t.expr, Some(t.range))?;
+        assert_eq!(mono.is_monotonic, t.expect_mono.is_monotonic, "{}", t.name);
+        if mono.is_monotonic {
+            assert_eq!(mono.is_positive, t.expect_mono.is_positive, "{}", t.name);
+            assert_eq!(column, t.column, "{}", t.name);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

1. Add ranged monotonic check for arithmetic Plus/Minus
2. Add ranged monotonic check for function 'abs'
3. Integrate with range_filter 
4. unit test added to verify expression monotonic.

## Changelog

- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

