### PR TITLE
[feature]: return nodes list in metasrv server

### DIFF
--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -934,6 +934,11 @@ impl StateMachine {
         sm_nodes.get(node_id)
     }
 
+    pub fn get_nodes(&self) -> common_exception::Result<Vec<Node>> {
+        let sm_nodes = self.nodes();
+        sm_nodes.range_values(..)
+    }
+
     pub fn get_database_meta_by_id(
         &self,
         db_id: &u64,

--- a/metasrv/src/api/http/v1/cluster_state.rs
+++ b/metasrv/src/api/http/v1/cluster_state.rs
@@ -1,0 +1,57 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_exception::Result;
+use poem::http::StatusCode;
+use poem::web::Data;
+use poem::web::Html;
+use poem::web::IntoResponse;
+use poem::Response;
+
+use crate::meta_service::MetaNode;
+
+pub struct ClusterTemplate {
+    result: Result<String>,
+}
+
+impl IntoResponse for ClusterTemplate {
+    fn into_response(self) -> Response {
+        match self.result {
+            Ok(nodes) => Html(nodes).into_response(),
+            Err(cause) => Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(format!(
+                    "Failed to fetch cluster nodes list. cause: {}",
+                    cause
+                )),
+        }
+    }
+}
+
+// GET /v1/cluster/nodes
+// list all nodes in current databend-query cluster
+// request: None
+// cluster_state: the shared in memory state which store all nodes known to current node
+// return: return a list of cluster node information
+#[poem::handler]
+pub async fn nodes_handler(meta_node: Data<&Arc<MetaNode>>) -> ClusterTemplate {
+    let nodes = meta_node.get_nodes().await.unwrap();
+    // let nodes = meta_node.get_nodes().await.expect("Failed to fetch cluster nodes list");
+    let nodes_list = serde_json::to_string(&nodes).unwrap();
+    ClusterTemplate {
+        result: Ok(nodes_list),
+    }
+}

--- a/metasrv/src/api/http/v1/cluster_state.rs
+++ b/metasrv/src/api/http/v1/cluster_state.rs
@@ -42,14 +42,12 @@ impl IntoResponse for ClusterTemplate {
 }
 
 // GET /v1/cluster/nodes
-// list all nodes in current databend-query cluster
+// list all nodes in current databend-metasrv cluster
 // request: None
-// cluster_state: the shared in memory state which store all nodes known to current node
 // return: return a list of cluster node information
 #[poem::handler]
 pub async fn nodes_handler(meta_node: Data<&Arc<MetaNode>>) -> ClusterTemplate {
     let nodes = meta_node.get_nodes().await.unwrap();
-    // let nodes = meta_node.get_nodes().await.expect("Failed to fetch cluster nodes list");
     let nodes_list = serde_json::to_string(&nodes).unwrap();
     ClusterTemplate {
         result: Ok(nodes_list),

--- a/metasrv/src/api/http/v1/mod.rs
+++ b/metasrv/src/api/http/v1/mod.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod cluster_state;
 pub mod config;
 pub mod health;

--- a/metasrv/src/api/http_service.rs
+++ b/metasrv/src/api/http_service.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_base::tokio::sync::broadcast;
 use common_base::HttpShutdownHandler;
 use common_base::Stoppable;
@@ -24,17 +26,20 @@ use poem::EndpointExt;
 use poem::Route;
 
 use crate::configs::Config;
+use crate::meta_service::MetaNode;
 
 pub struct HttpService {
     cfg: Config,
     shutdown_handler: HttpShutdownHandler,
+    meta_node: Arc<MetaNode>,
 }
 
 impl HttpService {
-    pub fn create(cfg: Config) -> Box<Self> {
+    pub fn create(cfg: Config, meta_node: Arc<MetaNode>) -> Box<Self> {
         Box::new(HttpService {
             cfg,
             shutdown_handler: HttpShutdownHandler::create("http api".to_string()),
+            meta_node,
         })
     }
 
@@ -43,6 +48,10 @@ impl HttpService {
             .at("/v1/health", get(super::http::v1::health::health_handler))
             .at("/v1/config", get(super::http::v1::config::config_handler))
             .at(
+                "/v1/cluster/nodes",
+                get(super::http::v1::cluster_state::nodes_handler),
+            )
+            .at(
                 "/debug/home",
                 get(super::http::debug::home::debug_home_handler),
             )
@@ -50,6 +59,7 @@ impl HttpService {
                 "/debug/pprof/profile",
                 get(super::http::debug::pprof::debug_pprof_handler),
             )
+            .data(self.meta_node.clone())
             .data(self.cfg.clone())
     }
 

--- a/metasrv/src/api/http_service.rs
+++ b/metasrv/src/api/http_service.rs
@@ -52,6 +52,10 @@ impl HttpService {
                 get(super::http::v1::cluster_state::nodes_handler),
             )
             .at(
+                "/v1/cluster/state",
+                get(super::http::v1::cluster_state::state_handler),
+            )
+            .at(
                 "/debug/home",
                 get(super::http::debug::home::debug_home_handler),
             )

--- a/metasrv/src/bin/metasrv.rs
+++ b/metasrv/src/bin/metasrv.rs
@@ -70,7 +70,7 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
 
     // HTTP API service.
     {
-        let mut srv = HttpService::create(conf.clone());
+        let mut srv = HttpService::create(conf.clone(), meta_node.clone());
         tracing::info!("HTTP API server listening on {}", conf.admin_api_address);
         srv.start().await.expect("Failed to start http server");
         stop_handler.push(srv);

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -485,6 +485,18 @@ impl MetaNode {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn get_voters(&self) -> common_exception::Result<Vec<Node>> {
+        // inconsistent get: from local state machine
+        self.sto.get_voters().await
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn get_non_voters(&self) -> common_exception::Result<Vec<Node>> {
+        // inconsistent get: from local state machine
+        self.sto.get_non_voters().await
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn handle_admin_req(&self, req: AdminRequest) -> Result<AdminResponse, MetaError> {
         let forward = req.forward_to_leader;
 

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -478,6 +478,13 @@ impl MetaNode {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn get_nodes(&self) -> common_exception::Result<Vec<Node>> {
+        // inconsistent get: from local state machine
+        let sm = self.sto.state_machine.read().await;
+        sm.get_nodes()
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn handle_admin_req(&self, req: AdminRequest) -> Result<AdminResponse, MetaError> {
         let forward = req.forward_to_leader;
 

--- a/metasrv/tests/it/api/http/clsuter_state_test.rs
+++ b/metasrv/tests/it/api/http/clsuter_state_test.rs
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2021 Datafuse Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+use std::fs::File;
+use std::io::Read;
+use std::string::String;
+
+use common_base::{Stoppable, tokio};
+use common_meta_types::Node;
+use databend_meta::api::HttpService;
+use databend_meta::api::http::v1::cluster_state::nodes_handler;
+use databend_meta::api::http::v1::cluster_state::state_handler;
+use databend_meta::meta_service::MetaNode;
+use poem::get;
+use poem::http::Method;
+use poem::http::StatusCode;
+use poem::http::Uri;
+use poem::Endpoint;
+use poem::EndpointExt;
+use poem::Request;
+use poem::Route;
+use pretty_assertions::assert_eq;
+
+use crate::init_meta_ut;
+use crate::tests::service::new_metasrv_test_context;
+use crate::tests::tls_constants::TEST_CA_CERT;
+use crate::tests::tls_constants::TEST_CN_NAME;
+use crate::tests::tls_constants::TEST_SERVER_CERT;
+use crate::tests::tls_constants::TEST_SERVER_KEY;
+
+#[tokio::test]
+async fn test_cluster_nodes() -> common_exception::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    let tc0 = new_metasrv_test_context(0);
+    let mut tc1 = new_metasrv_test_context(1);
+
+    tc1.config.raft_config.single = false;
+    tc1.config.raft_config.join = vec![tc0.config.raft_config.raft_api_addr()];
+
+    let meta_node = MetaNode::start(&tc0.config.raft_config).await?;
+    let meta_node1 = MetaNode::start(&tc1.config.raft_config).await?;
+
+    let cluster_router = Route::new()
+        .at("/cluster/nodes", get(nodes_handler))
+        .data(meta_node1.clone());
+    let response = cluster_router
+        .call(
+            Request::builder()
+                .uri(Uri::from_static("/cluster/nodes"))
+                .method(Method::GET)
+                .finish(),
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().into_vec().await.unwrap();
+    let nodes: Vec<Node> = serde_json::from_slice(&body).unwrap();
+    assert_eq!(nodes.len(), 2);
+    meta_node.stop().await?;
+    meta_node1.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cluster_state() -> common_exception::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    let tc0 = new_metasrv_test_context(0);
+    let mut tc1 = new_metasrv_test_context(1);
+
+    tc1.config.raft_config.single = false;
+    tc1.config.raft_config.join = vec![tc0.config.raft_config.raft_api_addr()];
+
+    let meta_node = MetaNode::start(&tc0.config.raft_config).await?;
+    let meta_node1 = MetaNode::start(&tc1.config.raft_config).await?;
+
+    let cluster_router = Route::new()
+        .at("/cluster/state", get(state_handler))
+        .data(meta_node1.clone());
+    let response = cluster_router
+        .call(
+            Request::builder()
+                .uri(Uri::from_static("/cluster/state"))
+                .method(Method::GET)
+                .finish(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().into_vec().await.unwrap();
+    let state = serde_json::from_str::<serde_json::Value>((&String::from_utf8_lossy(&body)).as_ref())?;
+    let voters = state["voters"].as_array().unwrap();
+    let non_voters = state["non_voters"].as_array().unwrap();
+    assert_eq!(voters.len(), 2);
+    assert_eq!(non_voters.len(), 0);
+    meta_node.stop().await?;
+    meta_node1.stop().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_http_service_cluster_state() -> common_exception::Result<()> {
+
+    let addr_str = "127.0.0.1:0";
+
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    let tc0 = new_metasrv_test_context(0);
+    let mut tc1 = new_metasrv_test_context(1);
+
+    tc1.config.raft_config.single = false;
+    tc1.config.raft_config.join = vec![tc0.config.raft_config.raft_api_addr()];
+    tc1.config.admin_api_address = addr_str.to_owned();
+    tc1.config.admin_tls_server_key = TEST_SERVER_KEY.to_owned();
+    tc1.config.admin_tls_server_cert = TEST_SERVER_CERT.to_owned();
+
+    let _= MetaNode::start(&tc0.config.raft_config).await?;
+    let meta_node1 = MetaNode::start(&tc1.config.raft_config).await?;
+
+    let mut srv = HttpService::create(tc1.config, meta_node1);
+
+    // test cert is issued for "localhost"
+    let state_url = format!("https://{}:0/v1/cluster/state", TEST_CN_NAME);
+    let node_url = format!("https://{}:0/v1/cluster/nodes", TEST_CN_NAME);
+
+    // load cert
+    let mut buf = Vec::new();
+    File::open(TEST_CA_CERT)?.read_to_end(&mut buf)?;
+    let cert = reqwest::Certificate::from_pem(&buf).unwrap();
+
+    tokio::spawn(async move {
+        srv.start().await.expect("HTTP: admin api error");
+        // kick off
+        let client = reqwest::Client::builder()
+            .add_root_certificate(cert)
+            .build()
+            .unwrap();
+        let resp = client.get(state_url).send().await;
+        assert!(resp.is_ok());
+        let resp = resp.unwrap();
+        assert!(resp.status().is_success());
+        assert_eq!("/v1/cluster/state", resp.url().path());
+
+        let resp_nodes = client.get(node_url).send().await;
+        assert!(resp_nodes.is_ok());
+        let resp_nodes = resp_nodes.unwrap();
+        assert!(resp_nodes.status().is_success());
+        assert_eq!("/v1/cluster/nodes", resp_nodes.url().path());
+    });
+    Ok(())
+}

--- a/metasrv/tests/it/api/http/mod.rs
+++ b/metasrv/tests/it/api/http/mod.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod clsuter_state_test;
 pub mod config;
 pub mod health;

--- a/metasrv/tests/it/api/http/mod.rs
+++ b/metasrv/tests/it/api/http/mod.rs
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod clsuter_state_test;
+pub mod cluster_state_test;
 pub mod config;
 pub mod health;

--- a/metasrv/tests/it/api/http_service.rs
+++ b/metasrv/tests/it/api/http_service.rs
@@ -20,7 +20,9 @@ use common_base::Stoppable;
 use common_exception::Result;
 use databend_meta::api::HttpService;
 use databend_meta::configs::Config;
+use databend_meta::meta_service::MetaNode;
 
+use crate::tests::service::new_test_context;
 use crate::tests::tls_constants::TEST_CA_CERT;
 use crate::tests::tls_constants::TEST_CN_NAME;
 use crate::tests::tls_constants::TEST_SERVER_CERT;
@@ -35,8 +37,10 @@ async fn test_http_service_tls_server() -> Result<()> {
     conf.admin_tls_server_key = TEST_SERVER_KEY.to_owned();
     conf.admin_tls_server_cert = TEST_SERVER_CERT.to_owned();
     conf.admin_api_address = addr_str.to_owned();
+    let tc = new_test_context(0);
+    let meta_node = MetaNode::start(&tc.config.raft_config).await?;
 
-    let mut srv = HttpService::create(conf);
+    let mut srv = HttpService::create(conf, meta_node);
 
     // test cert is issued for "localhost"
     let url = format!("https://{}:0/v1/health", TEST_CN_NAME);

--- a/metasrv/tests/it/api/http_service.rs
+++ b/metasrv/tests/it/api/http_service.rs
@@ -23,7 +23,7 @@ use databend_meta::configs::Config;
 use databend_meta::meta_service::MetaNode;
 
 use crate::init_meta_ut;
-use crate::tests::service::new_test_context;
+use crate::tests::service::new_metasrv_test_context;
 use crate::tests::tls_constants::TEST_CA_CERT;
 use crate::tests::tls_constants::TEST_CN_NAME;
 use crate::tests::tls_constants::TEST_SERVER_CERT;
@@ -41,7 +41,7 @@ async fn test_http_service_tls_server() -> Result<()> {
     conf.admin_tls_server_key = TEST_SERVER_KEY.to_owned();
     conf.admin_tls_server_cert = TEST_SERVER_CERT.to_owned();
     conf.admin_api_address = addr_str.to_owned();
-    let tc = new_test_context(0);
+    let tc = new_metasrv_test_context(0);
     let meta_node = MetaNode::start(&tc.config.raft_config).await?;
 
     let mut srv = HttpService::create(conf, meta_node);

--- a/metasrv/tests/it/api/http_service.rs
+++ b/metasrv/tests/it/api/http_service.rs
@@ -22,6 +22,7 @@ use databend_meta::api::HttpService;
 use databend_meta::configs::Config;
 use databend_meta::meta_service::MetaNode;
 
+use crate::init_meta_ut;
 use crate::tests::service::new_test_context;
 use crate::tests::tls_constants::TEST_CA_CERT;
 use crate::tests::tls_constants::TEST_CN_NAME;
@@ -31,6 +32,9 @@ use crate::tests::tls_constants::TEST_SERVER_KEY;
 // TODO(zhihanz) add tls fail case
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_http_service_tls_server() -> Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
     let mut conf = Config::empty();
     let addr_str = "127.0.0.1:0";
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

add http api, return the nodes list in the metasrc cluster

## Changelog

- New Feature


## Related Issues

related #2702

## Test Plan

Unit Tests

Stateless Tests

