### PR TITLE
CATALOG-2948: Add database engine register for MutableCatalog

### DIFF
--- a/query/src/datasources/context.rs
+++ b/query/src/datasources/context.rs
@@ -18,12 +18,14 @@ use common_dal::InMemoryData;
 use common_infallible::RwLock;
 use common_meta_api::MetaApi;
 
+use crate::datasources::database_engine_registry::DatabaseEngineRegistry;
 use crate::datasources::table_engine_registry::TableEngineRegistry;
 
-/// Datasource Table Context.
+/// Datasource Context.
 #[derive(Clone)]
 pub struct DataSourceContext {
     pub meta: Arc<dyn MetaApi>,
     pub in_memory_data: Arc<RwLock<InMemoryData<u64>>>,
     pub table_engine_registry: Arc<TableEngineRegistry>,
+    pub database_engine_registry: Arc<DatabaseEngineRegistry>,
 }

--- a/query/src/datasources/context.rs
+++ b/query/src/datasources/context.rs
@@ -12,21 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Debug;
 use std::sync::Arc;
 
 use common_dal::InMemoryData;
-use common_exception::Result;
 use common_infallible::RwLock;
+use common_meta_api::MetaApi;
+
+use crate::datasources::table_engine_registry::TableEngineRegistry;
 
 /// Datasource Table Context.
-#[derive(Clone, Debug, Default)]
-pub struct TableContext {
+#[derive(Clone)]
+pub struct DataSourceContext {
+    pub meta: Arc<dyn MetaApi>,
     pub in_memory_data: Arc<RwLock<InMemoryData<u64>>>,
-}
-
-impl TableContext {
-    pub fn get_in_memory_data(&self) -> Result<Arc<RwLock<InMemoryData<u64>>>> {
-        Ok(self.in_memory_data.clone())
-    }
+    pub table_engine_registry: Arc<TableEngineRegistry>,
 }

--- a/query/src/datasources/database/fuse/database.rs
+++ b/query/src/datasources/database/fuse/database.rs
@@ -35,11 +35,11 @@ pub struct FuseDatabase {
 }
 
 impl FuseDatabase {
-    pub fn new(db_name: impl Into<String>, ctx: DataSourceContext) -> Self {
-        Self {
-            db_name: db_name.into(),
+    pub fn try_create(db_name: &str, ctx: DataSourceContext) -> Result<Box<dyn Database>> {
+        Ok(Box::new(Self {
+            db_name: db_name.to_string(),
             ctx,
-        }
+        }))
     }
 
     fn build_table(&self, table_info: &TableInfo) -> Result<Arc<dyn Table>> {
@@ -79,7 +79,7 @@ impl Database for FuseDatabase {
         self.build_table(table_info.as_ref())
     }
 
-    async fn list_tables(&self, db_name: &str) -> common_exception::Result<Vec<Arc<dyn Table>>> {
+    async fn list_tables(&self, db_name: &str) -> Result<Vec<Arc<dyn Table>>> {
         let table_infos = self
             .ctx
             .meta
@@ -93,12 +93,12 @@ impl Database for FuseDatabase {
         })
     }
 
-    async fn create_table(&self, req: CreateTableReq) -> common_exception::Result<()> {
+    async fn create_table(&self, req: CreateTableReq) -> Result<()> {
         self.ctx.meta.create_table(req).await?;
         Ok(())
     }
 
-    async fn drop_table(&self, req: DropTableReq) -> common_exception::Result<DropTableReply> {
+    async fn drop_table(&self, req: DropTableReq) -> Result<DropTableReply> {
         self.ctx.meta.drop_table(req).await
     }
 }

--- a/query/src/datasources/database/mod.rs
+++ b/query/src/datasources/database/mod.rs
@@ -17,4 +17,7 @@
 mod tests;
 
 pub(crate) mod fuse;
+pub(crate) mod prelude;
 pub(crate) mod system;
+
+pub use prelude::register_database_engines;

--- a/query/src/datasources/database/prelude.rs
+++ b/query/src/datasources/database/prelude.rs
@@ -1,0 +1,27 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_exception::Result;
+
+use crate::datasources::database::fuse::database::FuseDatabase;
+use crate::datasources::database_engine_registry::DatabaseEngineRegistry;
+
+pub fn register_database_engines(registry: &DatabaseEngineRegistry) -> Result<()> {
+    // Register a DEFAULT database engine.
+    registry.register("DEFAULT", Arc::new(FuseDatabase::try_create))?;
+    Ok(())
+}

--- a/query/src/datasources/database_engine.rs
+++ b/query/src/datasources/database_engine.rs
@@ -13,34 +13,21 @@
 //  limitations under the License.
 //
 
-use std::sync::Arc;
-
 use common_exception::Result;
-use common_meta_api::MetaApi;
 
 use crate::catalogs::Database;
-use crate::datasources::table_engine_registry::TableEngineRegistry;
+use crate::datasources::context::DataSourceContext;
 
 pub trait DatabaseEngine: Send + Sync {
-    fn try_create(
-        &self,
-        db_name: &str,
-        meta: Arc<dyn MetaApi>,
-        table_engine_register: Arc<TableEngineRegistry>,
-    ) -> Result<Box<dyn Database>>;
+    fn try_create(&self, db_name: &str, ctx: DataSourceContext) -> Result<Box<dyn Database>>;
 }
 
 impl<T> DatabaseEngine for T
 where
-    T: Fn(&str, Arc<dyn MetaApi>, Arc<TableEngineRegistry>) -> Result<Box<dyn Database>>,
+    T: Fn(&str, DataSourceContext) -> Result<Box<dyn Database>>,
     T: Send + Sync,
 {
-    fn try_create(
-        &self,
-        db_name: &str,
-        meta: Arc<dyn MetaApi>,
-        table_engine_register: Arc<TableEngineRegistry>,
-    ) -> Result<Box<dyn Database>> {
-        self(db_name, meta, table_engine_register)
+    fn try_create(&self, db_name: &str, ctx: DataSourceContext) -> Result<Box<dyn Database>> {
+        self(db_name, ctx)
     }
 }

--- a/query/src/datasources/database_engine.rs
+++ b/query/src/datasources/database_engine.rs
@@ -1,0 +1,46 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_exception::Result;
+use common_meta_api::MetaApi;
+
+use crate::catalogs::Database;
+use crate::datasources::table_engine_registry::TableEngineRegistry;
+
+pub trait DatabaseEngine: Send + Sync {
+    fn try_create(
+        &self,
+        db_name: &str,
+        meta: Arc<dyn MetaApi>,
+        table_engine_register: Arc<TableEngineRegistry>,
+    ) -> Result<Box<dyn Database>>;
+}
+
+impl<T> DatabaseEngine for T
+where
+    T: Fn(&str, Arc<dyn MetaApi>, Arc<TableEngineRegistry>) -> Result<Box<dyn Database>>,
+    T: Send + Sync,
+{
+    fn try_create(
+        &self,
+        db_name: &str,
+        meta: Arc<dyn MetaApi>,
+        table_engine_register: Arc<TableEngineRegistry>,
+    ) -> Result<Box<dyn Database>> {
+        self(db_name, meta, table_engine_register)
+    }
+}

--- a/query/src/datasources/database_engine_registry.rs
+++ b/query/src/datasources/database_engine_registry.rs
@@ -1,0 +1,56 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_infallible::RwLock;
+
+use crate::datasources::database_engine::DatabaseEngine;
+
+/// Registry of Database Providers
+#[derive(Default)]
+pub struct DatabaseEngineRegistry {
+    engines: RwLock<HashMap<String, Arc<dyn DatabaseEngine>>>,
+}
+
+impl DatabaseEngineRegistry {
+    pub fn register(
+        &self,
+        engine: impl Into<String>,
+        provider: Arc<dyn DatabaseEngine>,
+    ) -> Result<()> {
+        let engine_name = engine.into().to_uppercase();
+        let mut w = self.engines.write();
+
+        if let Entry::Vacant(e) = w.entry(engine_name.clone()) {
+            e.insert(provider);
+            Ok(())
+        } else {
+            Err(ErrorCode::DuplicatedTableEngineProvider(format!(
+                "Database engine provider {} already exist",
+                engine_name
+            )))
+        }
+    }
+
+    pub fn get_database_factory(&self, engine: impl AsRef<str>) -> Option<Arc<dyn DatabaseEngine>> {
+        let name = engine.as_ref().to_uppercase();
+        self.engines.read().get(&name).cloned()
+    }
+}

--- a/query/src/datasources/database_engine_registry_test.rs
+++ b/query/src/datasources/database_engine_registry_test.rs
@@ -13,10 +13,23 @@
 //  limitations under the License.
 //
 
-use common_base::tokio;
+use std::sync::Arc;
+
 use common_exception::Result;
 
-#[tokio::test]
-async fn test_database_engine_registry() -> Result<()> {
+use crate::datasources::database::fuse::database::FuseDatabase;
+use crate::datasources::database_engine_registry::DatabaseEngineRegistry;
+
+#[test]
+fn test_database_engine_registry() -> Result<()> {
+    let registry = DatabaseEngineRegistry::default();
+    registry.register("DEFAULT", Arc::new(FuseDatabase::try_create))?;
+
+    let engine = registry.get_database_factory("default");
+    assert!(engine.is_some());
+
+    let engine = registry.get_database_factory("xx");
+    assert!(engine.is_none());
+
     Ok(())
 }

--- a/query/src/datasources/database_engine_registry_test.rs
+++ b/query/src/datasources/database_engine_registry_test.rs
@@ -1,0 +1,22 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use common_base::tokio;
+use common_exception::Result;
+
+#[tokio::test]
+async fn test_database_engine_registry() -> Result<()> {
+    Ok(())
+}

--- a/query/src/datasources/mod.rs
+++ b/query/src/datasources/mod.rs
@@ -12,11 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(test)]
+mod database_engine_registry_test;
+
 mod index;
 
 pub(crate) mod common;
 pub(crate) mod context;
 pub(crate) mod database;
+pub(crate) mod database_engine;
+pub(crate) mod database_engine_registry;
 pub(crate) mod table;
 pub(crate) mod table_engine;
 pub(crate) mod table_engine_registry;

--- a/query/src/datasources/table/csv/csv_table.rs
+++ b/query/src/datasources/table/csv/csv_table.rs
@@ -33,7 +33,7 @@ use common_streams::Source;
 
 use crate::catalogs::Table;
 use crate::datasources::common::count_lines;
-use crate::datasources::context::TableContext;
+use crate::datasources::context::DataSourceContext;
 use crate::sessions::DatabendQueryContextRef;
 
 pub struct CsvTable {
@@ -44,7 +44,7 @@ pub struct CsvTable {
 }
 
 impl CsvTable {
-    pub fn try_create(table_info: TableInfo, _table_ctx: TableContext) -> Result<Box<dyn Table>> {
+    pub fn try_create(table_info: TableInfo, _ctx: DataSourceContext) -> Result<Box<dyn Table>> {
         let options = table_info.options();
         let has_header = options.get("has_header").is_some();
         let file = match options.get("location") {

--- a/query/src/datasources/table/csv/csv_table_test.rs
+++ b/query/src/datasources/table/csv/csv_table_test.rs
@@ -25,7 +25,6 @@ use common_planners::*;
 use futures::TryStreamExt;
 
 use crate::catalogs::ToReadDataSourcePlan;
-use crate::datasources::context::TableContext;
 use crate::datasources::table::csv::csv_table::CsvTable;
 
 #[tokio::test]
@@ -57,7 +56,7 @@ async fn test_csv_table() -> Result<()> {
                 options,
             },
         },
-        TableContext::default(),
+        crate::tests::try_create_datasource_context()?,
     )?;
 
     let source_plan = table
@@ -118,7 +117,7 @@ async fn test_csv_table_parse_error() -> Result<()> {
                 options,
             },
         },
-        TableContext::default(),
+        crate::tests::try_create_datasource_context()?,
     )?;
 
     let source_plan = table

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -28,7 +28,7 @@ use common_streams::SendableDataBlockStream;
 
 use super::util;
 use crate::catalogs::Table;
-use crate::datasources::context::TableContext;
+use crate::datasources::context::DataSourceContext;
 use crate::datasources::table::fuse::TableSnapshot;
 use crate::sessions::DatabendQueryContextRef;
 
@@ -37,7 +37,7 @@ pub struct FuseTable {
 }
 
 impl FuseTable {
-    pub fn try_create(table_info: TableInfo, _table_ctx: TableContext) -> Result<Box<dyn Table>> {
+    pub fn try_create(table_info: TableInfo, _ctx: DataSourceContext) -> Result<Box<dyn Table>> {
         Ok(Box::new(FuseTable { table_info }))
     }
 }

--- a/query/src/datasources/table/memory/memory_table.rs
+++ b/query/src/datasources/table/memory/memory_table.rs
@@ -16,7 +16,6 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use common_dal::InMemoryData;
 use common_datablocks::DataBlock;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -33,29 +32,20 @@ use futures::stream::StreamExt;
 
 use crate::catalogs::Table;
 use crate::datasources::common::generate_parts;
-use crate::datasources::context::TableContext;
+use crate::datasources::context::DataSourceContext;
 use crate::datasources::table::memory::memory_table_stream::MemoryTableStream;
 use crate::sessions::DatabendQueryContextRef;
 
 pub struct MemoryTable {
     table_info: TableInfo,
-
-    // TODO(xp): When table is dropped, remove the entry in `in_memory_data`.
-    //           This requires another trait method Table::drop to customize the drop process.
-    #[allow(dead_code)]
-    in_memory_data: Arc<RwLock<InMemoryData<u64>>>,
-
     blocks: Arc<RwLock<Vec<DataBlock>>>,
 }
 
 impl MemoryTable {
-    pub fn try_create(table_info: TableInfo, table_ctx: TableContext) -> Result<Box<dyn Table>> {
+    pub fn try_create(table_info: TableInfo, ctx: DataSourceContext) -> Result<Box<dyn Table>> {
         let table_id = &table_info.ident.table_id;
-        let in_memory_data = table_ctx.get_in_memory_data()?;
-
         let blocks = {
-            let mut in_mem_data = in_memory_data.write();
-
+            let mut in_mem_data = ctx.in_memory_data.write();
             let x = in_mem_data.get(table_id);
             match x {
                 None => {
@@ -67,11 +57,7 @@ impl MemoryTable {
             }
         };
 
-        let table = Self {
-            table_info,
-            in_memory_data,
-            blocks,
-        };
+        let table = Self { table_info, blocks };
         Ok(Box::new(table))
     }
 }

--- a/query/src/datasources/table/memory/memory_table_test.rs
+++ b/query/src/datasources/table/memory/memory_table_test.rs
@@ -24,7 +24,6 @@ use common_planners::*;
 use futures::TryStreamExt;
 
 use crate::catalogs::ToReadDataSourcePlan;
-use crate::datasources::context::TableContext;
 use crate::datasources::table::memory::memory_table::MemoryTable;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -45,7 +44,7 @@ async fn test_memorytable() -> Result<()> {
                 options: TableOptions::default(),
             },
         },
-        TableContext::default(),
+        crate::tests::try_create_datasource_context()?,
     )?;
 
     // append data.

--- a/query/src/datasources/table/null/null_table.rs
+++ b/query/src/datasources/table/null/null_table.rs
@@ -26,7 +26,7 @@ use common_tracing::tracing::info;
 use futures::stream::StreamExt;
 
 use crate::catalogs::Table;
-use crate::datasources::context::TableContext;
+use crate::datasources::context::DataSourceContext;
 use crate::sessions::DatabendQueryContextRef;
 
 pub struct NullTable {
@@ -34,7 +34,7 @@ pub struct NullTable {
 }
 
 impl NullTable {
-    pub fn try_create(table_info: TableInfo, _table_ctx: TableContext) -> Result<Box<dyn Table>> {
+    pub fn try_create(table_info: TableInfo, _ctx: DataSourceContext) -> Result<Box<dyn Table>> {
         Ok(Box::new(Self { table_info }))
     }
 }

--- a/query/src/datasources/table/null/null_table_test.rs
+++ b/query/src/datasources/table/null/null_table_test.rs
@@ -23,7 +23,6 @@ use common_planners::*;
 use futures::TryStreamExt;
 
 use crate::catalogs::ToReadDataSourcePlan;
-use crate::datasources::context::TableContext;
 use crate::datasources::table::null::null_table::NullTable;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -49,7 +48,7 @@ async fn test_null_table() -> Result<()> {
                 options: TableOptions::default(),
             },
         },
-        TableContext::default(),
+        crate::tests::try_create_datasource_context()?,
     )?;
 
     // append data.

--- a/query/src/datasources/table/parquet/parquet_table.rs
+++ b/query/src/datasources/table/parquet/parquet_table.rs
@@ -30,7 +30,7 @@ use common_streams::SendableDataBlockStream;
 use common_streams::Source;
 
 use crate::catalogs::Table;
-use crate::datasources::context::TableContext;
+use crate::datasources::context::DataSourceContext;
 use crate::sessions::DatabendQueryContextRef;
 
 pub struct ParquetTable {
@@ -39,7 +39,7 @@ pub struct ParquetTable {
 }
 
 impl ParquetTable {
-    pub fn try_create(table_info: TableInfo, _table_ctx: TableContext) -> Result<Box<dyn Table>> {
+    pub fn try_create(table_info: TableInfo, _ctx: DataSourceContext) -> Result<Box<dyn Table>> {
         let options = table_info.options();
         let file = options.get("location").cloned();
         return match file {

--- a/query/src/datasources/table/parquet/parquet_table_test.rs
+++ b/query/src/datasources/table/parquet/parquet_table_test.rs
@@ -24,7 +24,6 @@ use common_planners::*;
 use futures::TryStreamExt;
 
 use crate::catalogs::ToReadDataSourcePlan;
-use crate::datasources::context::TableContext;
 use crate::datasources::table::parquet::parquet_table::ParquetTable;
 
 #[tokio::test]
@@ -51,7 +50,8 @@ async fn test_parquet_table() -> Result<()> {
             options,
         },
     };
-    let table = ParquetTable::try_create(table_info, TableContext::default())?;
+    let table =
+        ParquetTable::try_create(table_info, crate::tests::try_create_datasource_context()?)?;
 
     let source_plan = table.read_plan(ctx.clone(), None).await?;
     ctx.try_set_partitions(source_plan.parts.clone())?;

--- a/query/src/datasources/table_engine.rs
+++ b/query/src/datasources/table_engine.rs
@@ -17,22 +17,22 @@ use common_exception::Result;
 use common_meta_types::TableInfo;
 
 use crate::catalogs::Table;
-use crate::datasources::context::TableContext;
+use crate::datasources::context::DataSourceContext;
 
 // TODO maybe we should introduce a
 // `Session::store_provider(...) -> Result<StoreApiProvider>`
 // such that, we no longer need to pass store_provider to Table's constructor
 // instead, table could access apis on demand in method read_plan  and read
 pub trait TableEngine: Send + Sync {
-    fn try_create(&self, table_info: TableInfo, table_ctx: TableContext) -> Result<Box<dyn Table>>;
+    fn try_create(&self, table_info: TableInfo, ctx: DataSourceContext) -> Result<Box<dyn Table>>;
 }
 
 impl<T> TableEngine for T
 where
-    T: Fn(TableInfo, TableContext) -> Result<Box<dyn Table>>,
+    T: Fn(TableInfo, DataSourceContext) -> Result<Box<dyn Table>>,
     T: Send + Sync,
 {
-    fn try_create(&self, table_info: TableInfo, table_ctx: TableContext) -> Result<Box<dyn Table>> {
-        self(table_info, table_ctx)
+    fn try_create(&self, table_info: TableInfo, ctx: DataSourceContext) -> Result<Box<dyn Table>> {
+        self(table_info, ctx)
     }
 }

--- a/query/src/tests/context.rs
+++ b/query/src/tests/context.rs
@@ -21,6 +21,7 @@ use common_meta_types::NodeInfo;
 use crate::clusters::Cluster;
 use crate::configs::Config;
 use crate::datasources::context::DataSourceContext;
+use crate::datasources::database_engine_registry::DatabaseEngineRegistry;
 use crate::datasources::table_engine_registry::TableEngineRegistry;
 use crate::sessions::DatabendQueryContext;
 use crate::sessions::DatabendQueryContextRef;
@@ -112,10 +113,12 @@ pub fn try_create_datasource_context() -> Result<DataSourceContext> {
     let meta_embedded = MetaEmbedded::sync_new_temp().unwrap();
     let meta = Arc::new(meta_embedded);
     let table_engine_registry = Arc::new(TableEngineRegistry::default());
+    let database_engine_registry = Arc::new(DatabaseEngineRegistry::default());
 
     Ok(DataSourceContext {
         meta,
         table_engine_registry,
+        database_engine_registry,
         in_memory_data: Arc::new(Default::default()),
     })
 }

--- a/query/src/tests/context.rs
+++ b/query/src/tests/context.rs
@@ -15,10 +15,13 @@
 use std::sync::Arc;
 
 use common_exception::Result;
+use common_meta_embedded::MetaEmbedded;
 use common_meta_types::NodeInfo;
 
 use crate::clusters::Cluster;
 use crate::configs::Config;
+use crate::datasources::context::DataSourceContext;
+use crate::datasources::table_engine_registry::TableEngineRegistry;
 use crate::sessions::DatabendQueryContext;
 use crate::sessions::DatabendQueryContextRef;
 use crate::sessions::DatabendQueryContextShared;
@@ -103,4 +106,16 @@ pub fn try_create_cluster_context(desc: ClusterDescriptor) -> Result<DatabendQue
 
     context.get_settings().set_max_threads(8)?;
     Ok(context)
+}
+
+pub fn try_create_datasource_context() -> Result<DataSourceContext> {
+    let meta_embedded = MetaEmbedded::sync_new_temp().unwrap();
+    let meta = Arc::new(meta_embedded);
+    let table_engine_registry = Arc::new(TableEngineRegistry::default());
+
+    Ok(DataSourceContext {
+        meta,
+        table_engine_registry,
+        in_memory_data: Arc::new(Default::default()),
+    })
 }

--- a/query/src/tests/mod.rs
+++ b/query/src/tests/mod.rs
@@ -24,6 +24,7 @@ pub use catalog::try_create_catalog;
 pub use context::try_create_cluster_context;
 pub use context::try_create_context;
 pub use context::try_create_context_with_config;
+pub use context::try_create_datasource_context;
 pub use context::ClusterDescriptor;
 pub use number::NumberTestData;
 pub use parquet::ParquetTestData;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR:
1. Introduce `DataSourceContext` as the database creates entry
2. Add database engine register for MutableCatalog

## Changelog

- Improvement


## Related Issues

Fixes #2948 

## Test Plan

Unit Tests

Stateless Tests

