### PR TITLE
[function] Fix log function with constant column

### DIFF
--- a/common/functions/tests/it/scalars/maths/log.rs
+++ b/common/functions/tests/it/scalars/maths/log.rs
@@ -109,6 +109,40 @@ fn test_log_function() -> Result<()> {
             error: "",
         },
         Test {
+            name: "log-with-base-constant",
+            display: "LOG",
+            args: vec![
+                DataColumnWithField::new(
+                    DataColumn::Constant(2.into(), 2),
+                    DataField::new("base", DataType::Float64, true),
+                ),
+                DataColumnWithField::new(
+                    Series::new([1, 2, 4]).into(),
+                    DataField::new("num", DataType::Float64, true),
+                ),
+            ],
+            func: LogFunction::try_create("log")?,
+            expect: Series::new([0_f64, 1_f64, 2.0]).into(),
+            error: "",
+        },
+        Test {
+            name: "log-with-num-constant",
+            display: "LOG",
+            args: vec![
+                DataColumnWithField::new(
+                    Series::new([2, 4]).into(),
+                    DataField::new("base", DataType::Float64, true),
+                ),
+                DataColumnWithField::new(
+                    DataColumn::Constant(2.into(), 2),
+                    DataField::new("num", DataType::Float64, true),
+                ),
+            ],
+            func: LogFunction::try_create("log")?,
+            expect: Series::new([1_f64, 0.5]).into(),
+            error: "",
+        },
+        Test {
             name: "ln on series",
             display: "LN",
             args: vec![DataColumnWithField::new(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Fix log function with constant column. cc @flaneur2020 

before
```
mysql> select number, log(number, 2) from numbers(10);
+--------+---------------------+
| number | log(number, 2)      |
+--------+---------------------+
|      7 |  0.3562071871080222 |
|      8 |  0.3562071871080222 |
|      9 |  0.3562071871080222 |
|      6 |  0.3868528072345416 |
|      4 |                 0.5 |
|      2 |                   1 |
|      3 |  0.6309297535714574 |
|      1 |                 inf |
|      5 | 0.43067655807339306 |
|      0 |                  -0 |
+--------+---------------------+
10 rows in set (0.01 sec)

mysql> select log(8, 2);
+---------------------+
| log(8, 2)           |
+---------------------+
| 0.33333333333333337 |
+---------------------+
1 row in set (0.00 sec)
```

after
```
mysql> select number, log(number, 2) from numbers(10);
+--------+---------------------+
| number | log(number, 2)      |
+--------+---------------------+
|      7 |  0.3562071871080222 |
|      8 | 0.33333333333333337 |
|      9 |  0.3154648767857287 |
|      3 |  0.6309297535714574 |
|      6 |  0.3868528072345416 |
|      5 | 0.43067655807339306 |
|      1 |                 inf |
|      0 |                  -0 |
|      2 |                   1 |
|      4 |                 0.5 |
+--------+---------------------+
10 rows in set (0.00 sec)

mysql> select log(8, 2);
+---------------------+
| log(8, 2)           |
+---------------------+
| 0.33333333333333337 |
+---------------------+
1 row in set (0.00 sec)
```

## Changelog

- Bug Fix

## Related Issues

Fixes [#issue](https://github.com/datafuselabs/databend/issues/2951)

## Test Plan

Unit Tests

Stateless Tests

