### PR TITLE
Rename QueryNormalizeData to QueryASTIR

### DIFF
--- a/query/src/sql/statements/mod.rs
+++ b/query/src/sql/statements/mod.rs
@@ -50,7 +50,7 @@ pub use analyzer_statement::AnalyzableStatement;
 pub use analyzer_statement::AnalyzedResult;
 pub use analyzer_statement::QueryAnalyzeState;
 pub use analyzer_statement::QueryRelation;
-pub use query::QueryNormalizerData;
+pub use query::ASTIR;
 pub use statement_alter_user::DfAlterUser;
 pub use statement_copy::DfCopy;
 pub use statement_create_database::DfCreateDatabase;

--- a/query/src/sql/statements/mod.rs
+++ b/query/src/sql/statements/mod.rs
@@ -50,7 +50,7 @@ pub use analyzer_statement::AnalyzableStatement;
 pub use analyzer_statement::AnalyzedResult;
 pub use analyzer_statement::QueryAnalyzeState;
 pub use analyzer_statement::QueryRelation;
-pub use query::ASTIR;
+pub use query::QueryASTIR;
 pub use statement_alter_user::DfAlterUser;
 pub use statement_copy::DfCopy;
 pub use statement_create_database::DfCreateDatabase;

--- a/query/src/sql/statements/query/mod.rs
+++ b/query/src/sql/statements/query/mod.rs
@@ -26,8 +26,8 @@ mod query_qualified_rewriter;
 mod query_schema_joined;
 mod query_schema_joined_analyzer;
 
+pub use query_normalizer::QueryASTIR;
 pub use query_normalizer::QueryNormalizer;
-pub use query_normalizer::ASTIR;
 pub use query_qualified_rewriter::QualifiedRewriter;
 pub use query_schema_joined::JoinedColumnDesc;
 pub use query_schema_joined::JoinedSchema;

--- a/query/src/sql/statements/query/mod.rs
+++ b/query/src/sql/statements/query/mod.rs
@@ -27,7 +27,7 @@ mod query_schema_joined;
 mod query_schema_joined_analyzer;
 
 pub use query_normalizer::QueryNormalizer;
-pub use query_normalizer::QueryNormalizerData;
+pub use query_normalizer::ASTIR;
 pub use query_qualified_rewriter::QualifiedRewriter;
 pub use query_schema_joined::JoinedColumnDesc;
 pub use query_schema_joined::JoinedSchema;

--- a/query/src/sql/statements/query/query_qualified_rewriter.rs
+++ b/query/src/sql/statements/query/query_qualified_rewriter.rs
@@ -19,7 +19,7 @@ use common_planners::Expression;
 use crate::sessions::DatabendQueryContextRef;
 use crate::sql::statements::query::query_schema_joined::JoinedTableDesc;
 use crate::sql::statements::query::JoinedSchema;
-use crate::sql::statements::QueryNormalizerData;
+use crate::sql::statements::ASTIR;
 
 pub struct QualifiedRewriter {
     tables_schema: JoinedSchema,
@@ -31,16 +31,16 @@ impl QualifiedRewriter {
         QualifiedRewriter { tables_schema, ctx }
     }
 
-    pub async fn rewrite(&self, mut data: QueryNormalizerData) -> Result<QueryNormalizerData> {
-        self.rewrite_group(&mut data)?;
-        self.rewrite_order(&mut data)?;
-        self.rewrite_aggregate(&mut data)?;
-        self.rewrite_projection(&mut data)?;
+    pub async fn rewrite(&self, mut ir: ASTIR) -> Result<ASTIR> {
+        self.rewrite_group(&mut ir)?;
+        self.rewrite_order(&mut ir)?;
+        self.rewrite_aggregate(&mut ir)?;
+        self.rewrite_projection(&mut ir)?;
 
-        if let Some(predicate) = &data.filter_predicate {
+        if let Some(predicate) = &ir.filter_predicate {
             match self.rewrite_expr(predicate) {
                 Ok(predicate) => {
-                    data.filter_predicate = Some(predicate);
+                    ir.filter_predicate = Some(predicate);
                 }
                 Err(cause) => {
                     return Err(cause.add_message_back(format!(
@@ -51,10 +51,10 @@ impl QualifiedRewriter {
             }
         }
 
-        if let Some(predicate) = &data.having_predicate {
+        if let Some(predicate) = &ir.having_predicate {
             match self.rewrite_expr(predicate) {
                 Ok(predicate) => {
-                    data.having_predicate = Some(predicate);
+                    ir.having_predicate = Some(predicate);
                 }
                 Err(cause) => {
                     return Err(cause.add_message_back(format!(
@@ -65,13 +65,13 @@ impl QualifiedRewriter {
             }
         }
 
-        Ok(data)
+        Ok(ir)
     }
 
-    fn rewrite_group(&self, mut data: &mut QueryNormalizerData) -> Result<()> {
-        let mut group_expressions = Vec::with_capacity(data.group_by_expressions.len());
+    fn rewrite_group(&self, mut ir: &mut ASTIR) -> Result<()> {
+        let mut group_expressions = Vec::with_capacity(ir.group_by_expressions.len());
 
-        for group_by_expression in &data.group_by_expressions {
+        for group_by_expression in &ir.group_by_expressions {
             match self.rewrite_expr(group_by_expression) {
                 Ok(expr) => {
                     group_expressions.push(expr);
@@ -85,14 +85,14 @@ impl QualifiedRewriter {
             }
         }
 
-        data.group_by_expressions = group_expressions;
+        ir.group_by_expressions = group_expressions;
         Ok(())
     }
 
-    fn rewrite_aggregate(&self, mut data: &mut QueryNormalizerData) -> Result<()> {
-        let mut aggregate_expressions = Vec::with_capacity(data.aggregate_expressions.len());
+    fn rewrite_aggregate(&self, mut ir: &mut ASTIR) -> Result<()> {
+        let mut aggregate_expressions = Vec::with_capacity(ir.aggregate_expressions.len());
 
-        for aggregate_expression in &data.aggregate_expressions {
+        for aggregate_expression in &ir.aggregate_expressions {
             match self.rewrite_expr(aggregate_expression) {
                 Ok(expr) => {
                     aggregate_expressions.push(expr);
@@ -106,14 +106,14 @@ impl QualifiedRewriter {
             }
         }
 
-        data.aggregate_expressions = aggregate_expressions;
+        ir.aggregate_expressions = aggregate_expressions;
         Ok(())
     }
 
-    fn rewrite_order(&self, mut data: &mut QueryNormalizerData) -> Result<()> {
-        let mut order_expressions = Vec::with_capacity(data.order_by_expressions.len());
+    fn rewrite_order(&self, mut ir: &mut ASTIR) -> Result<()> {
+        let mut order_expressions = Vec::with_capacity(ir.order_by_expressions.len());
 
-        for order_by_expression in &data.order_by_expressions {
+        for order_by_expression in &ir.order_by_expressions {
             match self.rewrite_expr(order_by_expression) {
                 Ok(expr) => {
                     order_expressions.push(expr);
@@ -127,15 +127,15 @@ impl QualifiedRewriter {
             }
         }
 
-        data.order_by_expressions = order_expressions;
+        ir.order_by_expressions = order_expressions;
         Ok(())
     }
 
-    fn rewrite_projection(&self, mut data: &mut QueryNormalizerData) -> Result<()> {
-        let mut projection_expressions = Vec::with_capacity(data.projection_expressions.len());
+    fn rewrite_projection(&self, mut ir: &mut ASTIR) -> Result<()> {
+        let mut projection_expressions = Vec::with_capacity(ir.projection_expressions.len());
 
         // TODO: alias.*
-        for projection_expression in &data.projection_expressions {
+        for projection_expression in &ir.projection_expressions {
             if let Expression::Alias(_, x) = projection_expression {
                 if let Expression::Wildcard = x.as_ref() {
                     return Err(ErrorCode::SyntaxException("* AS alias is wrong syntax"));
@@ -158,7 +158,7 @@ impl QualifiedRewriter {
             }
         }
 
-        data.projection_expressions = projection_expressions;
+        ir.projection_expressions = projection_expressions;
         Ok(())
     }
 

--- a/query/src/sql/statements/query/query_qualified_rewriter.rs
+++ b/query/src/sql/statements/query/query_qualified_rewriter.rs
@@ -19,7 +19,7 @@ use common_planners::Expression;
 use crate::sessions::DatabendQueryContextRef;
 use crate::sql::statements::query::query_schema_joined::JoinedTableDesc;
 use crate::sql::statements::query::JoinedSchema;
-use crate::sql::statements::ASTIR;
+use crate::sql::statements::QueryASTIR;
 
 pub struct QualifiedRewriter {
     tables_schema: JoinedSchema,
@@ -31,7 +31,7 @@ impl QualifiedRewriter {
         QualifiedRewriter { tables_schema, ctx }
     }
 
-    pub async fn rewrite(&self, mut ir: ASTIR) -> Result<ASTIR> {
+    pub async fn rewrite(&self, mut ir: QueryASTIR) -> Result<QueryASTIR> {
         self.rewrite_group(&mut ir)?;
         self.rewrite_order(&mut ir)?;
         self.rewrite_aggregate(&mut ir)?;
@@ -68,7 +68,7 @@ impl QualifiedRewriter {
         Ok(ir)
     }
 
-    fn rewrite_group(&self, mut ir: &mut ASTIR) -> Result<()> {
+    fn rewrite_group(&self, mut ir: &mut QueryASTIR) -> Result<()> {
         let mut group_expressions = Vec::with_capacity(ir.group_by_expressions.len());
 
         for group_by_expression in &ir.group_by_expressions {
@@ -89,7 +89,7 @@ impl QualifiedRewriter {
         Ok(())
     }
 
-    fn rewrite_aggregate(&self, mut ir: &mut ASTIR) -> Result<()> {
+    fn rewrite_aggregate(&self, mut ir: &mut QueryASTIR) -> Result<()> {
         let mut aggregate_expressions = Vec::with_capacity(ir.aggregate_expressions.len());
 
         for aggregate_expression in &ir.aggregate_expressions {
@@ -110,7 +110,7 @@ impl QualifiedRewriter {
         Ok(())
     }
 
-    fn rewrite_order(&self, mut ir: &mut ASTIR) -> Result<()> {
+    fn rewrite_order(&self, mut ir: &mut QueryASTIR) -> Result<()> {
         let mut order_expressions = Vec::with_capacity(ir.order_by_expressions.len());
 
         for order_by_expression in &ir.order_by_expressions {
@@ -131,7 +131,7 @@ impl QualifiedRewriter {
         Ok(())
     }
 
-    fn rewrite_projection(&self, mut ir: &mut ASTIR) -> Result<()> {
+    fn rewrite_projection(&self, mut ir: &mut QueryASTIR) -> Result<()> {
         let mut projection_expressions = Vec::with_capacity(ir.projection_expressions.len());
 
         // TODO: alias.*

--- a/query/src/sql/statements/statement_select.rs
+++ b/query/src/sql/statements/statement_select.rs
@@ -36,8 +36,8 @@ use crate::sql::statements::query::JoinedSchema;
 use crate::sql::statements::query::JoinedSchemaAnalyzer;
 use crate::sql::statements::query::JoinedTableDesc;
 use crate::sql::statements::query::QualifiedRewriter;
+use crate::sql::statements::query::QueryASTIR;
 use crate::sql::statements::query::QueryNormalizer;
-use crate::sql::statements::query::ASTIR;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::statements::QueryRelation;
@@ -75,28 +75,28 @@ impl AnalyzableStatement for DfQueryStatement {
 }
 
 impl DfQueryStatement {
-    async fn analyze_query(&self, ast_ir: ASTIR) -> Result<QueryAnalyzeState> {
-        let limit = ast_ir.limit;
-        let offset = ast_ir.offset;
+    async fn analyze_query(&self, ir: QueryASTIR) -> Result<QueryAnalyzeState> {
+        let limit = ir.limit;
+        let offset = ir.offset;
         let mut analyze_state = QueryAnalyzeState {
             limit,
             offset,
             ..Default::default()
         };
 
-        if let Some(predicate) = &ast_ir.filter_predicate {
+        if let Some(predicate) = &ir.filter_predicate {
             Self::verify_no_aggregate(predicate, "filter")?;
             analyze_state.filter = Some(predicate.clone());
         }
 
-        Self::analyze_projection(&ast_ir.projection_expressions, &mut analyze_state)?;
+        Self::analyze_projection(&ir.projection_expressions, &mut analyze_state)?;
 
         // Allow `SELECT name FROM system.databases HAVING name = 'xxx'`
-        if let Some(predicate) = &ast_ir.having_predicate {
+        if let Some(predicate) = &ir.having_predicate {
             analyze_state.having = Some(rebase_expr(predicate, &analyze_state.expressions)?);
         }
 
-        for item in &ast_ir.order_by_expressions {
+        for item in &ir.order_by_expressions {
             match item {
                 Expression::Sort {
                     expr,
@@ -123,17 +123,17 @@ impl DfQueryStatement {
             }
         }
 
-        if !ast_ir.aggregate_expressions.is_empty() || !ast_ir.group_by_expressions.is_empty() {
+        if !ir.aggregate_expressions.is_empty() || !ir.group_by_expressions.is_empty() {
             // Rebase expressions using aggregate expressions and group by expressions
             let mut expressions = Vec::with_capacity(analyze_state.expressions.len());
             for expression in &analyze_state.expressions {
-                let expression = rebase_expr(expression, &ast_ir.aggregate_expressions)?;
-                expressions.push(rebase_expr(&expression, &ast_ir.group_by_expressions)?);
+                let expression = rebase_expr(expression, &ir.aggregate_expressions)?;
+                expressions.push(rebase_expr(&expression, &ir.group_by_expressions)?);
             }
 
             analyze_state.expressions = expressions;
 
-            for group_expression in &ast_ir.group_by_expressions {
+            for group_expression in &ir.group_by_expressions {
                 analyze_state.add_before_group_expression(group_expression);
                 let base_exprs = &analyze_state.before_group_by_expressions;
                 analyze_state
@@ -141,7 +141,7 @@ impl DfQueryStatement {
                     .push(rebase_expr(group_expression, base_exprs)?);
             }
 
-            Self::analyze_aggregate(&ast_ir.aggregate_expressions, &mut analyze_state)?;
+            Self::analyze_aggregate(&ir.aggregate_expressions, &mut analyze_state)?;
         }
 
         Ok(analyze_state)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Rename QueryNormalizeData to QueryASTIR

## Changelog

- Improvement

## Related Issues

Fixes #issue