### PR TITLE
force kill databend-query/meta when fail to kill it.

### DIFF
--- a/scripts/deploy/databend-query-cluster-3-nodes.sh
+++ b/scripts/deploy/databend-query-cluster-3-nodes.sh
@@ -15,6 +15,14 @@ sleep 3
 killall databend-meta
 sleep 3
 
+for bin in databend-query databend-meta
+do
+  if test -n "$(pgrep $bin)"; then
+      echo "The $bin is not killed. force killing."
+      killall -9 $bin
+  fi
+done
+
 # Temp debugging config:
 # Set `mode` to open to test restarting a metasrv cluster.
 # TODO(xp): remove this and there should be a standard test for this.

--- a/scripts/deploy/databend-query-standalone-embedded-meta.sh
+++ b/scripts/deploy/databend-query-standalone-embedded-meta.sh
@@ -9,6 +9,14 @@ killall databend-query
 killall databend-meta
 sleep 1
 
+for bin in databend-query databend-meta
+do
+  if test -n "$(pgrep $bin)"; then
+      echo "The $bin is not killed. force killing."
+      killall -9 $bin
+  fi
+done
+
 BIN=${1:-debug}
 
 echo 'Start DatabendQuery...'

--- a/scripts/deploy/databend-query-standalone.sh
+++ b/scripts/deploy/databend-query-standalone.sh
@@ -9,6 +9,14 @@ killall databend-query
 killall databend-meta
 sleep 1
 
+for bin in databend-query databend-meta
+do
+  if test -n "$(pgrep $bin)"; then
+      echo "The $bin is not killed. force killing."
+      killall -9 $bin
+  fi
+done
+
 BIN=${1:-debug}
 
 echo 'Start DatabendStore...'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

the servers may fail to shutdown some times (most time it is a bug). developers who use these scripts (maybe through 'make run')  may connect to the old server and encounter strange errors,  or find their changes not working.

and it may not be easily covered by tests, because this may happen after some ops on the servers.

1.  kill -9 to proceed
2. let the user be aware of this. user may report it or it is a bug introduced by the local change.

## Changelog


## Related Issues


## Test Plan

Unit Tests

Stateless Tests

