### PR TITLE
SESSION-2963: Make session lock to be fine-grained

### DIFF
--- a/query/src/sessions/context_shared.rs
+++ b/query/src/sessions/context_shared.rs
@@ -196,7 +196,6 @@ impl DatabendQueryContextShared {
 
 impl Session {
     pub(in crate::sessions) fn destroy_context_shared(&self) {
-        let mut mutable_state = self.mutable_state.lock();
-        mutable_state.context_shared.take();
+        self.mutable_state.take_context_shared();
     }
 }

--- a/query/src/sessions/mod.rs
+++ b/query/src/sessions/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(test)]
+mod session_status_test;
+
 #[macro_use]
 mod macros;
 

--- a/query/src/sessions/mod.rs
+++ b/query/src/sessions/mod.rs
@@ -34,6 +34,7 @@ pub use context_shared::DatabendQueryContextShared;
 pub use session::Session;
 pub use session_info::ProcessInfo;
 pub use session_ref::SessionRef;
+pub use session_status::MutableStatus;
 pub use sessions::SessionManager;
 pub use sessions::SessionManagerRef;
 pub use settings::Settings;

--- a/query/src/sessions/mod.rs
+++ b/query/src/sessions/mod.rs
@@ -21,6 +21,7 @@ mod metrics;
 mod session;
 mod session_info;
 mod session_ref;
+mod session_status;
 mod session_test;
 #[allow(clippy::module_inception)]
 mod sessions;

--- a/query/src/sessions/session.rs
+++ b/query/src/sessions/session.rs
@@ -20,7 +20,6 @@ use common_exception::Result;
 use common_infallible::Mutex;
 use common_macros::MallocSizeOf;
 use common_mem_allocator::malloc_size;
-use futures::channel::oneshot::Sender;
 use futures::channel::*;
 
 use crate::catalogs::impls::DatabaseCatalog;
@@ -28,22 +27,10 @@ use crate::configs::Config;
 use crate::sessions::context_shared::DatabendQueryContextShared;
 use crate::sessions::DatabendQueryContext;
 use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::MutableStatus;
 use crate::sessions::SessionManagerRef;
 use crate::sessions::Settings;
 use crate::users::UserManagerRef;
-
-#[derive(MallocSizeOf)]
-pub(in crate::sessions) struct MutableStatus {
-    pub(in crate::sessions) abort: bool,
-    pub(in crate::sessions) current_database: String,
-    pub(in crate::sessions) session_settings: Arc<Settings>,
-    #[ignore_malloc_size_of = "insignificant"]
-    pub(in crate::sessions) client_host: Option<SocketAddr>,
-    #[ignore_malloc_size_of = "insignificant"]
-    pub(in crate::sessions) io_shutdown_tx: Option<Sender<Sender<()>>>,
-    #[ignore_malloc_size_of = "insignificant"]
-    pub(in crate::sessions) context_shared: Option<Arc<DatabendQueryContextShared>>,
-}
 
 #[derive(Clone, MallocSizeOf)]
 pub struct Session {

--- a/query/src/sessions/session.rs
+++ b/query/src/sessions/session.rs
@@ -56,7 +56,7 @@ impl Session {
             config,
             sessions,
             ref_count: Arc::new(AtomicUsize::new(0)),
-            mutable_state: Arc::new(MutableStatus::default()),
+            mutable_state: Arc::new(MutableStatus::try_create()?),
         }))
     }
 

--- a/query/src/sessions/session_info.rs
+++ b/query/src/sessions/session_info.rs
@@ -15,7 +15,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use crate::sessions::session::MutableStatus;
+use crate::sessions::MutableStatus;
 use crate::sessions::Session;
 use crate::sessions::Settings;
 

--- a/query/src/sessions/session_info.rs
+++ b/query/src/sessions/session_info.rs
@@ -33,14 +33,14 @@ pub struct ProcessInfo {
 
 impl Session {
     pub fn process_info(self: &Arc<Self>) -> ProcessInfo {
-        let session_mutable_state = self.mutable_state.lock();
+        let session_mutable_state = self.mutable_state.clone();
         self.to_process_info(&session_mutable_state)
     }
 
     fn to_process_info(self: &Arc<Self>, status: &MutableStatus) -> ProcessInfo {
         let mut memory_usage = 0;
 
-        if let Some(shared) = &status.context_shared {
+        if let Some(shared) = &status.get_context_shared() {
             if let Ok(runtime) = shared.try_get_runtime() {
                 let runtime_tracker = runtime.get_tracker();
                 let runtime_memory_tracker = runtime_tracker.get_memory_tracker();
@@ -52,17 +52,17 @@ impl Session {
             id: self.id.clone(),
             typ: self.typ.clone(),
             state: self.process_state(status),
-            database: status.current_database.clone(),
-            settings: status.session_settings.clone(),
-            client_address: status.client_host,
+            database: status.get_current_database(),
+            settings: status.get_settings(),
+            client_address: status.get_client_host(),
             session_extra_info: self.process_extra_info(status),
             memory_usage,
         }
     }
 
     fn process_state(self: &Arc<Self>, status: &MutableStatus) -> String {
-        match status.context_shared {
-            _ if status.abort => String::from("Aborting"),
+        match status.get_context_shared() {
+            _ if status.get_abort() => String::from("Aborting"),
             None => String::from("Idle"),
             Some(_) => String::from("Query"),
         }
@@ -76,17 +76,21 @@ impl Session {
     }
 
     fn rpc_extra_info(status: &MutableStatus) -> Option<String> {
-        let context_shared = status.context_shared.as_ref();
-        context_shared.map(|_| String::from("Partial cluster query stage"))
+        status
+            .get_context_shared()
+            .map(|_| String::from("Partial cluster query stage"))
     }
 
     fn query_extra_info(status: &MutableStatus) -> Option<String> {
-        status.context_shared.as_ref().and_then(|context_shared| {
-            context_shared
-                .running_query
-                .read()
-                .as_ref()
-                .map(Clone::clone)
-        })
+        status
+            .get_context_shared()
+            .as_ref()
+            .and_then(|context_shared| {
+                context_shared
+                    .running_query
+                    .read()
+                    .as_ref()
+                    .map(Clone::clone)
+            })
     }
 }

--- a/query/src/sessions/session_status.rs
+++ b/query/src/sessions/session_status.rs
@@ -1,0 +1,35 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use common_macros::MallocSizeOf;
+use futures::channel::oneshot::Sender;
+
+use crate::sessions::context_shared::DatabendQueryContextShared;
+use crate::sessions::Settings;
+
+#[derive(MallocSizeOf)]
+pub(in crate::sessions) struct MutableStatus {
+    pub(in crate::sessions) abort: bool,
+    pub(in crate::sessions) current_database: String,
+    pub(in crate::sessions) session_settings: Arc<Settings>,
+    #[ignore_malloc_size_of = "insignificant"]
+    pub(in crate::sessions) client_host: Option<SocketAddr>,
+    #[ignore_malloc_size_of = "insignificant"]
+    pub(in crate::sessions) io_shutdown_tx: Option<Sender<Sender<()>>>,
+    #[ignore_malloc_size_of = "insignificant"]
+    pub(in crate::sessions) context_shared: Option<Arc<DatabendQueryContextShared>>,
+}

--- a/query/src/sessions/session_status.rs
+++ b/query/src/sessions/session_status.rs
@@ -22,7 +22,7 @@ use crate::sessions::context_shared::DatabendQueryContextShared;
 use crate::sessions::Settings;
 
 #[derive(MallocSizeOf)]
-pub(in crate::sessions) struct MutableStatus {
+pub struct MutableStatus {
     pub(in crate::sessions) abort: bool,
     pub(in crate::sessions) current_database: String,
     pub(in crate::sessions) session_settings: Arc<Settings>,

--- a/query/src/sessions/session_status.rs
+++ b/query/src/sessions/session_status.rs
@@ -13,23 +13,93 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use common_infallible::RwLock;
 use common_macros::MallocSizeOf;
 use futures::channel::oneshot::Sender;
 
 use crate::sessions::context_shared::DatabendQueryContextShared;
 use crate::sessions::Settings;
 
-#[derive(MallocSizeOf)]
+#[derive(MallocSizeOf, Default)]
 pub struct MutableStatus {
-    pub(in crate::sessions) abort: bool,
-    pub(in crate::sessions) current_database: String,
-    pub(in crate::sessions) session_settings: Arc<Settings>,
+    abort: AtomicBool,
+    current_database: RwLock<String>,
+    session_settings: RwLock<Settings>,
     #[ignore_malloc_size_of = "insignificant"]
-    pub(in crate::sessions) client_host: Option<SocketAddr>,
+    client_host: RwLock<Option<SocketAddr>>,
     #[ignore_malloc_size_of = "insignificant"]
-    pub(in crate::sessions) io_shutdown_tx: Option<Sender<Sender<()>>>,
+    io_shutdown_tx: RwLock<Option<Sender<Sender<()>>>>,
     #[ignore_malloc_size_of = "insignificant"]
-    pub(in crate::sessions) context_shared: Option<Arc<DatabendQueryContextShared>>,
+    context_shared: RwLock<Option<Arc<DatabendQueryContextShared>>>,
+}
+
+impl MutableStatus {
+    pub fn get_abort(&self) -> bool {
+        self.abort.load(Ordering::Relaxed) as bool
+    }
+
+    pub fn set_abort(&self, v: bool) {
+        self.abort.fetch_and(v, Ordering::Relaxed);
+    }
+
+    pub fn get_current_database(&self) -> String {
+        let lock = self.current_database.read();
+        lock.clone()
+    }
+
+    pub fn set_current_database(&self, db: String) {
+        let mut lock = self.current_database.write();
+        *lock = db
+    }
+
+    pub fn get_settings(&self) -> Arc<Settings> {
+        let lock = self.session_settings.read();
+        Arc::new(lock.clone())
+    }
+
+    pub fn get_client_host(&self) -> Option<SocketAddr> {
+        let lock = self.client_host.read();
+        *lock
+    }
+
+    pub fn set_client_host(&self, sock: Option<SocketAddr>) {
+        let mut lock = self.client_host.write();
+        *lock = sock
+    }
+
+    pub fn set_io_shutdown_tx(&self, tx: Option<Sender<Sender<()>>>) {
+        let mut lock = self.io_shutdown_tx.write();
+        *lock = tx
+    }
+
+    //  Take the io_shutdown_tx.
+    pub fn take_io_shutdown_tx(&self) -> Option<Sender<Sender<()>>> {
+        let mut lock = self.io_shutdown_tx.write();
+        lock.take()
+    }
+
+    pub fn context_shared_is_none(&self) -> bool {
+        let lock = self.context_shared.read();
+        lock.is_none()
+    }
+
+    pub fn get_context_shared(&self) -> Option<Arc<DatabendQueryContextShared>> {
+        let lock = self.context_shared.read();
+        lock.clone()
+    }
+
+    pub fn set_context_shared(&self, ctx: Option<Arc<DatabendQueryContextShared>>) {
+        let mut lock = self.context_shared.write();
+        *lock = ctx
+    }
+
+    //  Take the context_shared.
+    pub fn take_context_shared(&self) -> Option<Arc<DatabendQueryContextShared>> {
+        let mut lock = self.context_shared.write();
+        lock.take()
+    }
 }

--- a/query/src/sessions/session_status_test.rs
+++ b/query/src/sessions/session_status_test.rs
@@ -44,7 +44,7 @@ fn test_session_status() -> Result<()> {
     // Settings.
     {
         let val = mutable_status.get_settings();
-        assert_eq!(val.get_max_threads()?, 16);
+        assert!(val.get_max_threads()? > 0);
     }
 
     // Client host.

--- a/query/src/sessions/session_status_test.rs
+++ b/query/src/sessions/session_status_test.rs
@@ -1,0 +1,94 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use common_exception::Result;
+
+use crate::clusters::Cluster;
+use crate::sessions::DatabendQueryContextShared;
+use crate::sessions::MutableStatus;
+use crate::tests::SessionManagerBuilder;
+
+#[test]
+fn test_session_status() -> Result<()> {
+    let mutable_status = MutableStatus::try_create()?;
+
+    // Abort status.
+    {
+        mutable_status.set_abort(true);
+        let val = mutable_status.get_abort();
+        assert!(val);
+    }
+
+    // Current database status.
+    {
+        mutable_status.set_current_database("bend".to_string());
+        let val = mutable_status.get_current_database();
+        assert_eq!("bend", val);
+    }
+
+    // Settings.
+    {
+        let val = mutable_status.get_settings();
+        assert_eq!(val.get_max_threads()?, 16);
+    }
+
+    // Client host.
+    {
+        let demo = "127.0.0.1:80";
+        let server: SocketAddr = demo.parse().unwrap();
+        mutable_status.set_client_host(Some(server));
+
+        let val = mutable_status.get_client_host();
+        assert_eq!(Some(server), val);
+    }
+
+    // io shutdown tx.
+    {
+        let (tx, _) = futures::channel::oneshot::channel();
+        mutable_status.set_io_shutdown_tx(Some(tx));
+
+        let val = mutable_status.take_io_shutdown_tx();
+        assert!(val.is_some());
+
+        let val = mutable_status.take_io_shutdown_tx();
+        assert!(val.is_none());
+    }
+
+    // context shared.
+    {
+        let sessions = SessionManagerBuilder::create().build()?;
+        let dummy_session = sessions.create_session("TestSession")?;
+        let shared = DatabendQueryContextShared::try_create(
+            sessions.get_conf().clone(),
+            Arc::new(dummy_session.as_ref().clone()),
+            Cluster::empty(),
+        );
+
+        mutable_status.set_context_shared(Some(shared.clone()));
+        let val = mutable_status.get_context_shared();
+        assert_eq!(shared.conf, val.unwrap().conf);
+
+        let val = mutable_status.take_context_shared();
+        assert_eq!(shared.conf, val.unwrap().conf);
+
+        let val = mutable_status.get_context_shared();
+        assert!(val.is_none());
+    }
+
+    Ok(())
+}

--- a/query/src/sessions/settings.rs
+++ b/query/src/sessions/settings.rs
@@ -20,7 +20,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_infallible::RwLock;
 use common_macros::MallocSizeOf;
-#[derive(Clone, Debug, Default, MallocSizeOf)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub struct Settings {
     inner: SettingsBase,
 }
@@ -53,7 +53,7 @@ impl Settings {
     }
 }
 
-#[derive(Clone, Debug, Default, MallocSizeOf)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub struct SettingsBase {
     // DataValue is of DataValue::Struct([name, value, default_value, description])
     settings: Arc<RwLock<HashMap<&'static str, DataValue>>>,

--- a/query/src/sessions/settings.rs
+++ b/query/src/sessions/settings.rs
@@ -20,7 +20,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_infallible::RwLock;
 use common_macros::MallocSizeOf;
-#[derive(Debug, MallocSizeOf)]
+#[derive(Clone, Debug, Default, MallocSizeOf)]
 pub struct Settings {
     inner: SettingsBase,
 }
@@ -53,7 +53,7 @@ impl Settings {
     }
 }
 
-#[derive(Debug, Clone, MallocSizeOf)]
+#[derive(Clone, Debug, Default, MallocSizeOf)]
 pub struct SettingsBase {
     // DataValue is of DataValue::Struct([name, value, default_value, description])
     settings: Arc<RwLock<HashMap<&'static str, DataValue>>>,

--- a/tests/suites/0_stateless/03_0011_select_from_system_processes.result
+++ b/tests/suites/0_stateless/03_0011_select_from_system_processes.result
@@ -1,0 +1,1 @@
+Query	default

--- a/tests/suites/0_stateless/03_0011_select_from_system_processes.sql
+++ b/tests/suites/0_stateless/03_0011_select_from_system_processes.sql
@@ -1,0 +1,1 @@
+select state, database from system.processes;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

This PR:
* Split session mutable status to single file and make all mutable operations to be fine-grained with RwLock, there is no deadlock happens


## Changelog

- Improvement


## Related Issues

Fixes #2963 

## Test Plan

Unit Tests

Stateless Tests

