### PR TITLE
fix bendcli option names error.

### DIFF
--- a/cli/src/cmds/root.rs
+++ b/cli/src/cmds/root.rs
@@ -105,7 +105,7 @@ impl Command for RootCommand {
                     .takes_value(true),
             )
             .arg(
-                Arg::new("log-level")
+                Arg::new("log_level")
                     .long("log-level")
                     .about("Sets the log-level for current settings")
                     .env("BEND_LOG_LEVEL")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

use both log_level and log-level as option names,  the former seems a typo.

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2696

## Test Plan

Unit Tests

Stateless Tests

