### PR TITLE
MGR-2976: Add stage to management

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -264,6 +264,11 @@ build_exceptions! {
     ClusterUnknownNode(4058),
     ClusterNodeAlreadyExists(4059),
 
+    // stage error.
+    UnknownStage(4060),
+    StageAlreadyExists(4061),
+    IllegalStageInfoFormat(4062),
+
     // storage-api error codes
     ReadFileError(5001),
     BrokenChannel(5002),

--- a/common/management/src/lib.rs
+++ b/common/management/src/lib.rs
@@ -14,11 +14,13 @@
 //
 
 mod cluster;
+mod stage;
 mod user;
 
 pub use cluster::ClusterApi;
 pub use cluster::ClusterMgr;
+pub use stage::StageMgr;
+pub use stage::StageMgrApi;
 pub use user::user_api::UserInfo;
 pub use user::user_api::UserMgrApi;
-pub use user::user_mgr::format_user_key;
 pub use user::user_mgr::UserMgr;

--- a/common/management/src/stage/mod.rs
+++ b/common/management/src/stage/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Datafuse Labs.
+// Copyright 2021 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
-mod cluster;
-mod stage;
-mod user;
+mod stage_api;
+mod stage_mgr;
+
+pub use stage_api::StageMgrApi;
+pub use stage_mgr::StageMgr;

--- a/common/management/src/stage/stage_api.rs
+++ b/common/management/src/stage/stage_api.rs
@@ -1,0 +1,32 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use common_exception::Result;
+use common_meta_types::SeqV;
+use common_meta_types::UserStageInfo;
+
+#[async_trait::async_trait]
+pub trait StageMgrApi: Sync + Send {
+    // Add a stage info to /tenant/stage-name.
+    async fn add_stage(&self, stage: UserStageInfo) -> Result<u64>;
+
+    async fn get_stage(&self, stage_name: &str, seq: Option<u64>) -> Result<SeqV<UserStageInfo>>;
+
+    // Get all the stages for a tenant.
+    async fn get_stages(&self) -> Result<Vec<UserStageInfo>>;
+
+    // Drop the tenant's stage by name.
+    async fn drop_stage(&self, name: &str, seq: Option<u64>) -> Result<()>;
+}

--- a/common/management/src/stage/stage_mgr.rs
+++ b/common/management/src/stage/stage_mgr.rs
@@ -1,0 +1,115 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_meta_api::KVApi;
+use common_meta_types::AddResult;
+use common_meta_types::IntoSeqV;
+use common_meta_types::MatchSeq;
+use common_meta_types::MatchSeqExt;
+use common_meta_types::Operation;
+use common_meta_types::SeqV;
+use common_meta_types::UpsertKVAction;
+use common_meta_types::UserStageInfo;
+
+use crate::stage::StageMgrApi;
+
+static USER_STAGE_API_KEY_PREFIX: &str = "__fd_stages";
+
+pub struct StageMgr {
+    kv_api: Arc<dyn KVApi>,
+    stage_prefix: String,
+}
+
+impl StageMgr {
+    #[allow(dead_code)]
+    pub fn new(kv_api: Arc<dyn KVApi>, tenant: &str) -> Self {
+        StageMgr {
+            kv_api,
+            stage_prefix: format!("{}/{}", USER_STAGE_API_KEY_PREFIX, tenant),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl StageMgrApi for StageMgr {
+    async fn add_stage(&self, info: UserStageInfo) -> Result<u64> {
+        let seq = MatchSeq::Exact(0);
+        let val = Operation::Update(serde_json::to_vec(&info)?);
+        let key = format!("{}/{}", self.stage_prefix, info.stage_name);
+        let upsert_info = self
+            .kv_api
+            .upsert_kv(UpsertKVAction::new(&key, seq, val, None));
+
+        let res = upsert_info.await?.into_add_result()?;
+
+        match res {
+            AddResult::Ok(v) => Ok(v.seq),
+            AddResult::Exists(v) => Err(ErrorCode::StageAlreadyExists(format!(
+                "Stage already exists, seq [{}]",
+                v.seq
+            ))),
+        }
+    }
+
+    async fn get_stage(&self, name: &str, seq: Option<u64>) -> Result<SeqV<UserStageInfo>> {
+        let key = format!("{}/{}", self.stage_prefix, name);
+        let kv_api = self.kv_api.clone();
+        let get_kv = async move { kv_api.get_kv(&key).await };
+        let res = get_kv.await?;
+        let seq_value =
+            res.ok_or_else(|| ErrorCode::UnknownStage(format!("Unknown stage {}", name)))?;
+
+        match MatchSeq::from(seq).match_seq(&seq_value) {
+            Ok(_) => Ok(seq_value.into_seqv()?),
+            Err(_) => Err(ErrorCode::UnknownUser(format!("Unknown stage {}", name))),
+        }
+    }
+
+    async fn get_stages(&self) -> Result<Vec<UserStageInfo>> {
+        let values = self.kv_api.prefix_list_kv(&self.stage_prefix).await?;
+
+        let mut stage_infos = Vec::with_capacity(values.len());
+        for (_, value) in values {
+            let stage_info = serde_json::from_slice::<UserStageInfo>(&value.data)?;
+            stage_infos.push(stage_info);
+        }
+        Ok(stage_infos)
+    }
+
+    async fn drop_stage(&self, name: &str, seq: Option<u64>) -> Result<()> {
+        let key = format!("{}/{}", self.stage_prefix, name);
+        let kv_api = self.kv_api.clone();
+        let upsert_kv = async move {
+            kv_api
+                .upsert_kv(UpsertKVAction::new(
+                    &key,
+                    seq.into(),
+                    Operation::Delete,
+                    None,
+                ))
+                .await
+        };
+        let res = upsert_kv.await?;
+        if res.prev.is_some() && res.result.is_none() {
+            Ok(())
+        } else {
+            Err(ErrorCode::UnknownStage(format!("Unknown stage {}", name)))
+        }
+    }
+}

--- a/common/management/src/user/user_mgr.rs
+++ b/common/management/src/user/user_mgr.rs
@@ -32,7 +32,7 @@ use common_meta_types::UserPrivilege;
 use crate::user::user_api::UserInfo;
 use crate::user::user_api::UserMgrApi;
 
-pub static USER_API_KEY_PREFIX: &str = "__fd_users";
+static USER_API_KEY_PREFIX: &str = "__fd_users";
 
 pub struct UserMgr {
     kv_api: Arc<dyn KVApi>,
@@ -227,6 +227,6 @@ impl UserMgrApi for UserMgr {
     }
 }
 
-pub fn format_user_key(username: &str, hostname: &str) -> String {
+fn format_user_key(username: &str, hostname: &str) -> String {
     format!("'{}'@'{}'", username, hostname)
 }

--- a/common/management/tests/it/stage.rs
+++ b/common/management/tests/it/stage.rs
@@ -1,0 +1,118 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_base::tokio;
+use common_exception::Result;
+use common_management::*;
+use common_meta_api::KVApi;
+use common_meta_embedded::MetaEmbedded;
+use common_meta_types::SeqV;
+use common_meta_types::UserStageInfo;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_add_stage() -> Result<()> {
+    let (kv_api, stage_api) = new_stage_api().await?;
+
+    let stage_info = create_test_stage_info();
+    stage_api.add_stage(stage_info.clone()).await?;
+    let value = kv_api.get_kv("__fd_stages/databend_query/mystage").await?;
+
+    match value {
+        Some(SeqV {
+            seq: 1,
+            meta: _,
+            data: value,
+        }) => {
+            assert_eq!(value, serde_json::to_vec(&stage_info)?);
+        }
+        catch => panic!("GetKVActionReply{:?}", catch),
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_already_exists_add_stage() -> Result<()> {
+    let (_, stage_api) = new_stage_api().await?;
+
+    let stage_info = create_test_stage_info();
+    stage_api.add_stage(stage_info.clone()).await?;
+
+    match stage_api.add_stage(stage_info.clone()).await {
+        Ok(_) => panic!("Already exists add stage must be return Err."),
+        Err(cause) => assert_eq!(cause.code(), 4061),
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_successfully_get_stages() -> Result<()> {
+    let (_, stage_api) = new_stage_api().await?;
+
+    let stages = stage_api.get_stages().await?;
+    assert_eq!(stages, vec![]);
+
+    let stage_info = create_test_stage_info();
+    stage_api.add_stage(stage_info.clone()).await?;
+
+    let stages = stage_api.get_stages().await?;
+    assert_eq!(stages[0], stage_info);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_successfully_drop_stage() -> Result<()> {
+    let (_, stage_api) = new_stage_api().await?;
+
+    let stage_info = create_test_stage_info();
+    stage_api.add_stage(stage_info.clone()).await?;
+
+    let stages = stage_api.get_stages().await?;
+    assert_eq!(stages, vec![stage_info.clone()]);
+
+    stage_api.drop_stage(&stage_info.stage_name, None).await?;
+
+    let stages = stage_api.get_stages().await?;
+    assert_eq!(stages, vec![]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_unknown_stage_drop_stage() -> Result<()> {
+    let (_, stage_api) = new_stage_api().await?;
+
+    match stage_api.drop_stage("UNKNOWN_ID", None).await {
+        Ok(_) => panic!("Unknown stage drop stage must be return Err."),
+        Err(cause) => assert_eq!(cause.code(), 4060),
+    }
+
+    Ok(())
+}
+
+fn create_test_stage_info() -> UserStageInfo {
+    UserStageInfo {
+        stage_name: "mystage".to_string(),
+        comments: "".to_string(),
+    }
+}
+
+async fn new_stage_api() -> Result<(Arc<MetaEmbedded>, StageMgr)> {
+    let test_api = Arc::new(MetaEmbedded::new_temp().await?);
+    let mgr = StageMgr::new(test_api.clone(), "databend_query");
+    Ok((test_api, mgr))
+}

--- a/common/management/tests/it/user.rs
+++ b/common/management/tests/it/user.rs
@@ -52,6 +52,10 @@ mock! {
         }
 }
 
+fn format_user_key(username: &str, hostname: &str) -> String {
+    format!("'{}'@'{}'", username, hostname)
+}
+
 mod add {
     use common_meta_types::AuthType;
     use common_meta_types::Operation;

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -14,6 +14,26 @@
 
 //! This crate defines data types used in meta data storage service.
 
+mod change;
+mod cluster;
+mod cmd;
+mod database;
+mod errors;
+mod grant_object;
+mod kv_message;
+mod log_entry;
+mod match_seq;
+mod operation;
+mod raft_txid;
+mod raft_types;
+mod seq_num;
+mod seq_value;
+mod table;
+mod user_auth;
+mod user_privilege;
+mod user_quota;
+mod user_stage;
+
 pub use change::AddResult;
 pub use change::Change;
 pub use cluster::Node;
@@ -64,22 +84,4 @@ pub use user_auth::AuthType;
 pub use user_privilege::UserPrivilege;
 pub use user_privilege::UserPrivilegeType;
 pub use user_quota::UserQuota;
-
-mod change;
-mod cluster;
-mod cmd;
-mod database;
-mod errors;
-mod grant_object;
-mod kv_message;
-mod log_entry;
-mod match_seq;
-mod operation;
-mod raft_txid;
-mod raft_types;
-mod seq_num;
-mod seq_value;
-mod table;
-mod user_auth;
-mod user_privilege;
-mod user_quota;
+pub use user_stage::UserStageInfo;

--- a/common/meta/types/src/user_stage.rs
+++ b/common/meta/types/src/user_stage.rs
@@ -1,0 +1,49 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+/// Stage for data stage location.
+/// Need to add more fields by need.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct UserStageInfo {
+    #[serde(default)]
+    pub stage_name: String,
+    #[serde(default)]
+    pub comments: String,
+}
+
+impl UserStageInfo {
+    pub fn new(stage_name: &str, comments: &str) -> Self {
+        UserStageInfo {
+            stage_name: stage_name.to_string(),
+            comments: comments.to_string(),
+        }
+    }
+}
+
+impl TryFrom<Vec<u8>> for UserStageInfo {
+    type Error = ErrorCode;
+
+    fn try_from(value: Vec<u8>) -> Result<Self> {
+        match serde_json::from_slice(&value) {
+            Ok(info) => Ok(info),
+            Err(serialize_error) => Err(ErrorCode::IllegalUserInfoFormat(format!(
+                "Cannot deserialize stage from bytes. cause {}",
+                serialize_error
+            ))),
+        }
+    }
+}

--- a/common/meta/types/tests/it/main.rs
+++ b/common/meta/types/tests/it/main.rs
@@ -16,3 +16,4 @@ mod cluster;
 mod match_seq;
 mod user_privilege;
 mod user_quota;
+mod user_stage;

--- a/common/meta/types/tests/it/user_stage.rs
+++ b/common/meta/types/tests/it/user_stage.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Datafuse Labs.
+// Copyright 2021 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod cluster;
-mod stage;
-mod user;
+use common_exception::exception::Result;
+use common_meta_types::UserStageInfo;
+
+#[test]
+fn test_user_stage() -> Result<()> {
+    let stage = UserStageInfo::new("databend", "this is a comment");
+    let ser = serde_json::to_string(&stage)?;
+
+    let de = UserStageInfo::try_from(ser.into_bytes())?;
+    assert_eq!(stage, de);
+
+    Ok(())
+}

--- a/query/src/users/mod.rs
+++ b/query/src/users/mod.rs
@@ -14,9 +14,12 @@
 
 #[cfg(test)]
 mod user_mgr_test;
+#[cfg(test)]
+mod user_stage_test;
 
 mod user;
 mod user_mgr;
+mod user_stage;
 
 pub use user::User;
 pub use user_mgr::CertifiedInfo;

--- a/query/src/users/user_stage.rs
+++ b/query/src/users/user_stage.rs
@@ -1,0 +1,66 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_meta_types::UserStageInfo;
+
+use crate::users::UserManager;
+
+/// user stage operations.
+impl UserManager {
+    // Add a new stage.
+    pub async fn add_stage(&self, info: UserStageInfo) -> Result<u64> {
+        let stage_api_provider = self.get_stage_api_client();
+        let add_stage = stage_api_provider.add_stage(info);
+        match add_stage.await {
+            Ok(res) => Ok(res),
+            Err(failure) => Err(failure.add_message_back("(while add stage).")),
+        }
+    }
+
+    // Get one stage from by tenant.
+    pub async fn get_stage(&self, stage_name: &str) -> Result<UserStageInfo> {
+        let stage_api_provider = self.get_stage_api_client();
+        let get_stage = stage_api_provider.get_stage(stage_name, None);
+        Ok(get_stage.await?.data)
+    }
+
+    // Get the tenant all stage list.
+    pub async fn get_stages(&self) -> Result<Vec<UserStageInfo>> {
+        let stage_api_provider = self.get_stage_api_client();
+        let get_stages = stage_api_provider.get_stages();
+
+        match get_stages.await {
+            Err(failure) => Err(failure.add_message_back("(while get stages).")),
+            Ok(seq_stages_info) => Ok(seq_stages_info),
+        }
+    }
+
+    // Drop a stage by name.
+    pub async fn drop_stage(&self, name: &str, if_exist: bool) -> Result<()> {
+        let stage_api_provider = self.get_stage_api_client();
+        let drop_stage = stage_api_provider.drop_stage(name, None);
+        match drop_stage.await {
+            Ok(res) => Ok(res),
+            Err(failure) => {
+                if if_exist && failure.code() == ErrorCode::UnknownStageCode() {
+                    Ok(())
+                } else {
+                    Err(failure.add_message_back("(while drop stage)"))
+                }
+            }
+        }
+    }
+}

--- a/query/src/users/user_stage_test.rs
+++ b/query/src/users/user_stage_test.rs
@@ -1,0 +1,78 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_base::tokio;
+use common_exception::Result;
+use common_meta_types::UserStageInfo;
+use pretty_assertions::assert_eq;
+
+use crate::configs::Config;
+use crate::users::UserManager;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_user_stage() -> Result<()> {
+    let mut config = Config::default();
+    config.query.tenant_id = "tenant1".to_string();
+
+    let comments = "this is a comment";
+    let stage_name1 = "stage1";
+    let stage_name2 = "stage2";
+    let user_mgr = UserManager::create_global(config).await?;
+
+    // add 1.
+    {
+        let stage_info = UserStageInfo::new(stage_name1, comments);
+        user_mgr.add_stage(stage_info).await?;
+    }
+
+    // add 2.
+    {
+        let stage_info = UserStageInfo::new(stage_name2, comments);
+        user_mgr.add_stage(stage_info).await?;
+    }
+
+    // get all.
+    {
+        let stages = user_mgr.get_stages().await?;
+        assert_eq!(2, stages.len());
+        assert_eq!(stage_name2, stages[1].stage_name);
+    }
+
+    // get.
+    {
+        let stage = user_mgr.get_stage(stage_name1).await?;
+        assert_eq!(stage_name1, stage.stage_name);
+    }
+
+    // drop.
+    {
+        user_mgr.drop_stage(stage_name1, false).await?;
+        let stages = user_mgr.get_stages().await?;
+        assert_eq!(1, stages.len());
+    }
+
+    // repeat drop same one not with if exist.
+    {
+        let res = user_mgr.drop_stage(stage_name1, false).await;
+        assert!(res.is_err());
+    }
+
+    // repeat drop same one with if exist.
+    {
+        let res = user_mgr.drop_stage(stage_name1, true).await;
+        assert!(res.is_ok());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR:
* Add user stage api stored to metasrv,
* Add stage operations to query/users

this is part of #2976

## Changelog

- New Feature


## Related Issues

Fixes #2980

## Test Plan

Unit Tests

Stateless Tests

