### PR TITLE
Add tests for http handler.

### DIFF
--- a/query/src/servers/http/v1/http_query_handlers_test.rs
+++ b/query/src/servers/http/v1/http_query_handlers_test.rs
@@ -137,6 +137,61 @@ async fn test_async() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_multi_page() -> Result<()> {
+    let sessions = SessionManagerBuilder::create().build()?;
+    let route = Route::new().nest("/v1/query", query_route()).data(sessions);
+
+    let max_block_size = 10000;
+    let num_parts = num_cpus::get();
+    let sql = format!("select * from numbers({})", max_block_size * num_parts);
+
+    let json = serde_json::json!({"sql": sql.to_string()});
+    let (status, result) = post_json_to_router(&route, &json, 3).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(result.data.len(), max_block_size);
+    let query_id = result.id;
+    let mut next_uri = get_page_uri(&query_id, 1, 3);
+
+    for p in 1..(num_parts + 1) {
+        let (status, result) = get_uri_checked(&route, &next_uri).await?;
+        assert_eq!(status, StatusCode::OK);
+        assert!(result.error.is_none());
+        assert!(result.stats.progress.is_some());
+        if p == num_parts {
+            assert_eq!(result.data.len(), 0);
+            assert_eq!(result.next_uri, None);
+            assert_eq!(result.state, ExecuteStateName::Succeeded);
+        } else {
+            assert_eq!(result.data.len(), 10000);
+            assert_eq!(result.next_uri, Some(make_page_uri(&query_id, p + 1)));
+            next_uri = get_page_uri(&query_id, p + 1, 3);
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_insert() -> Result<()> {
+    let sessions = SessionManagerBuilder::create().build()?;
+    let route = Route::new().nest("/v1/query", query_route()).data(sessions);
+
+    let sqls = vec![
+        ("create table t(a int) engine=fuse", 0),
+        ("insert into t(a) values (1),(2)", 0),
+        ("select * from t", 2),
+    ];
+
+    for (sql, data_len) in sqls {
+        let json = serde_json::json!({"sql": sql.to_string()});
+        let (status, result) = post_json_to_router(&route, &json, 3).await?;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(result.data.len(), data_len);
+        assert_eq!(result.state, ExecuteStateName::Succeeded);
+    }
+    Ok(())
+}
+
 async fn delete_query(route: &RouteWithData, query_id: String) -> StatusCode {
     let uri = make_final_uri(&query_id);
     let resp = get_uri(route, &uri).await;

--- a/query/src/servers/http/v1/query/result_data_manager.rs
+++ b/query/src/servers/http/v1/query/result_data_manager.rs
@@ -27,6 +27,8 @@ use crate::servers::http::v1::block_to_json::block_to_json;
 use crate::servers::http::v1::block_to_json::JsonBlock;
 use crate::servers::http::v1::block_to_json::JsonBlockRef;
 
+const TARGET_ROWS_PER_PAGE: usize = 10000;
+
 #[derive(Debug)]
 pub enum Wait {
     Async,
@@ -135,7 +137,7 @@ impl ResultDataManager {
                     rows += block.num_rows();
                     results.push(block_to_json(&block).unwrap());
                     // TODO(youngsofun):  set it in post if needed
-                    if rows >= 10000 {
+                    if rows >= TARGET_ROWS_PER_PAGE {
                         break;
                     }
                 }

--- a/query/src/servers/http/v1/query/result_data_manager.rs
+++ b/query/src/servers/http/v1/query/result_data_manager.rs
@@ -125,12 +125,20 @@ impl ResultDataManager {
 
     pub async fn collect_new_page(&mut self, tp: &Wait) -> (JsonBlock, bool) {
         let mut results: Vec<JsonBlock> = Vec::new();
+        let mut rows = 0;
         let block_rx = &mut self.block_rx;
 
         let mut end = false;
         loop {
             match ResultDataManager::receive(block_rx, tp).await {
-                Ok(block) => results.push(block_to_json(&block).unwrap()),
+                Ok(block) => {
+                    rows += block.num_rows();
+                    results.push(block_to_json(&block).unwrap());
+                    // TODO(youngsofun):  set it in post if needed
+                    if rows >= 10000 {
+                        break;
+                    }
+                }
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => {
                     log::debug!("no more data");


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add tests for http handler.  and limit rows per page to 10000 so the client can test on the pagination easily.

1.  pagination
2. insert

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues


## Test Plan

Unit Tests

Stateless Tests

