### PR TITLE
ISSUE-2994: add function current_user()

### DIFF
--- a/common/functions/src/scalars/udfs/current_user.rs
+++ b/common/functions/src/scalars/udfs/current_user.rs
@@ -1,0 +1,67 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use common_datavalues::columns::DataColumn;
+use common_datavalues::prelude::DataColumnsWithField;
+use common_datavalues::DataSchema;
+use common_datavalues::DataType;
+use common_exception::Result;
+
+use crate::scalars::function_factory::FunctionDescription;
+use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::Function;
+
+#[derive(Clone)]
+pub struct CurrentUserFunction {}
+
+impl CurrentUserFunction {
+    pub fn try_create(_display_name: &str) -> Result<Box<dyn Function>> {
+        Ok(Box::new(CurrentUserFunction {}))
+    }
+
+    pub fn desc() -> FunctionDescription {
+        FunctionDescription::creator(Box::new(Self::try_create))
+            .features(FunctionFeatures::default().context_function())
+    }
+}
+
+impl Function for CurrentUserFunction {
+    fn name(&self) -> &str {
+        "CurrentUserFunction"
+    }
+
+    fn return_type(&self, _args: &[DataType]) -> Result<DataType> {
+        Ok(DataType::String)
+    }
+
+    fn nullable(&self, _input_schema: &DataSchema) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {
+        Ok(columns[0].column().clone())
+    }
+
+    fn num_arguments(&self) -> usize {
+        1
+    }
+}
+
+impl fmt::Display for CurrentUserFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "current_user")
+    }
+}

--- a/common/functions/src/scalars/udfs/mod.rs
+++ b/common/functions/src/scalars/udfs/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod crash_me;
+mod current_user;
 mod database;
 mod exists;
 mod sleep;
@@ -22,6 +23,7 @@ mod udf_example;
 mod version;
 
 pub use crash_me::CrashMeFunction;
+pub use current_user::CurrentUserFunction;
 pub use database::DatabaseFunction;
 pub use sleep::SleepFunction;
 pub use to_type_name::ToTypeNameFunction;

--- a/common/functions/src/scalars/udfs/udf.rs
+++ b/common/functions/src/scalars/udfs/udf.rs
@@ -15,6 +15,7 @@
 use crate::scalars::function_factory::FunctionFactory;
 use crate::scalars::udfs::exists::ExistsFunction;
 use crate::scalars::CrashMeFunction;
+use crate::scalars::CurrentUserFunction;
 use crate::scalars::DatabaseFunction;
 use crate::scalars::SleepFunction;
 use crate::scalars::ToTypeNameFunction;
@@ -30,6 +31,7 @@ impl UdfFunction {
         factory.register("totypename", ToTypeNameFunction::desc());
         factory.register("database", DatabaseFunction::desc());
         factory.register("version", VersionFunction::desc());
+        factory.register("current_user", CurrentUserFunction::desc());
         factory.register("sleep", SleepFunction::desc());
         factory.register("crashme", CrashMeFunction::desc());
         factory.register("exists", ExistsFunction::desc());

--- a/common/planners/src/plan_expression.rs
+++ b/common/planners/src/plan_expression.rs
@@ -30,7 +30,10 @@ use lazy_static::lazy_static;
 use crate::PlanNode;
 
 lazy_static! {
-    static ref OP_SET: HashSet<&'static str> = ["database", "version",].iter().copied().collect();
+    static ref OP_SET: HashSet<&'static str> = ["database", "version", "current_user"]
+        .iter()
+        .copied()
+        .collect();
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq)]

--- a/query/src/functions/context_function.rs
+++ b/query/src/functions/context_function.rs
@@ -47,6 +47,11 @@ impl ContextFunction {
             "version" => vec![Expression::create_literal(DataValue::String(Some(
                 ctx.get_fuse_version().into_bytes(),
             )))],
+            "current_user" => vec![Expression::create_literal(DataValue::String(Some(
+                ctx.get_current_user()
+                    .unwrap_or_else(|_| "".to_string())
+                    .into_bytes(),
+            )))],
             _ => vec![],
         })
     }

--- a/query/src/functions/context_function_test.rs
+++ b/query/src/functions/context_function_test.rs
@@ -27,6 +27,12 @@ fn test_context_function_build_arg_from_ctx() -> Result<()> {
         assert_eq!("default", format!("{:?}", args[0]));
     }
 
+    // Ok.
+    {
+        let args = ContextFunction::build_args_from_ctx("current_user", ctx.clone())?;
+        assert_eq!("", format!("{:?}", args[0]));
+    }
+
     // Error.
     {
         let result = ContextFunction::build_args_from_ctx("databasexx", ctx).is_err();

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -204,6 +204,10 @@ impl QueryContext {
         self.shared.get_current_database()
     }
 
+    pub fn get_current_user(&self) -> Result<String> {
+        self.shared.get_current_user()
+    }
+
     pub async fn set_current_database(&self, new_database_name: String) -> Result<()> {
         let catalog = self.get_catalog();
         match catalog.get_database(&new_database_name).await {

--- a/query/src/sessions/context_shared.rs
+++ b/query/src/sessions/context_shared.rs
@@ -112,6 +112,10 @@ impl QueryContextShared {
         self.session.get_current_database()
     }
 
+    pub fn get_current_user(&self) -> Result<String> {
+        self.session.get_current_user()
+    }
+
     pub fn set_current_database(&self, new_database_name: String) {
         self.session.set_current_database(new_database_name);
     }

--- a/tests/suites/0_stateless/02_0016_function_context.result
+++ b/tests/suites/0_stateless/02_0016_function_context.result
@@ -1,0 +1,1 @@
+default

--- a/tests/suites/0_stateless/02_0016_function_context.sql
+++ b/tests/suites/0_stateless/02_0016_function_context.sql
@@ -1,0 +1,1 @@
+SELECT current_user();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

this PR depends on https://github.com/datafuselabs/databend/pull/2986

this PR adds a current_user() function, to test the session's current user

## Changelog

- Improvement

## Related Issues

Fixes #2994

## Test Plan

Unit Tests
Stateless Tests

