### PR TITLE
QUERY-2992: Returning name with *Ref to its original form Arc<T>

### DIFF
--- a/query/src/api/http/v1/cluster.rs
+++ b/query/src/api/http/v1/cluster.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use poem::http::StatusCode;
 use poem::web::Data;
@@ -19,7 +21,7 @@ use poem::web::Html;
 use poem::web::IntoResponse;
 use poem::Response;
 
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 
 pub struct ClusterTemplate {
     result: Result<String>,
@@ -45,14 +47,14 @@ impl IntoResponse for ClusterTemplate {
 // cluster_state: the shared in memory state which store all nodes known to current node
 // return: return a list of cluster node information
 #[poem::handler]
-pub async fn cluster_list_handler(sessions: Data<&SessionManagerRef>) -> ClusterTemplate {
+pub async fn cluster_list_handler(sessions: Data<&Arc<SessionManager>>) -> ClusterTemplate {
     let sessions = sessions.0;
     ClusterTemplate {
         result: list_nodes(sessions.clone()).await,
     }
 }
 
-async fn list_nodes(sessions: SessionManagerRef) -> Result<String> {
+async fn list_nodes(sessions: Arc<SessionManager>) -> Result<String> {
     let watch_cluster_session = sessions.create_session("WatchCluster")?;
     let watch_cluster_context = watch_cluster_session.create_context().await?;
 

--- a/query/src/api/http/v1/logs.rs
+++ b/query/src/api/http/v1/logs.rs
@@ -26,7 +26,7 @@ use tokio_stream::StreamExt;
 
 use crate::catalogs::ToReadDataSourcePlan;
 use crate::sessions::DatabendQueryContext;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 
 pub struct LogTemplate {
     result: Result<String>,
@@ -45,14 +45,14 @@ impl IntoResponse for LogTemplate {
 
 // read log files from cfg.log.log_dir
 #[poem::handler]
-pub async fn logs_handler(sessions_extension: Data<&SessionManagerRef>) -> LogTemplate {
+pub async fn logs_handler(sessions_extension: Data<&Arc<SessionManager>>) -> LogTemplate {
     let sessions = sessions_extension.0;
     LogTemplate {
         result: select_table(sessions.clone()).await,
     }
 }
 
-async fn select_table(sessions: SessionManagerRef) -> Result<String> {
+async fn select_table(sessions: Arc<SessionManager>) -> Result<String> {
     let session = sessions.create_session("WatchLogs")?;
     let query_context = session.create_context().await?;
 

--- a/query/src/api/http/v1/logs.rs
+++ b/query/src/api/http/v1/logs.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_datablocks::DataBlock;
 use common_exception::Result;
 use common_streams::SendableDataBlockStream;
@@ -23,7 +25,7 @@ use poem::Response;
 use tokio_stream::StreamExt;
 
 use crate::catalogs::ToReadDataSourcePlan;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sessions::SessionManagerRef;
 
 pub struct LogTemplate {
@@ -61,7 +63,7 @@ async fn select_table(sessions: SessionManagerRef) -> Result<String> {
     Ok(format!("{:?}", tracing_logs))
 }
 
-async fn execute_query(ctx: DatabendQueryContextRef) -> Result<SendableDataBlockStream> {
+async fn execute_query(ctx: Arc<DatabendQueryContext>) -> Result<SendableDataBlockStream> {
     let tracing_table = ctx.get_table("system", "tracing").await?;
     let tracing_table_read_plan = tracing_table.read_plan(ctx.clone(), None).await?;
 

--- a/query/src/api/http/v1/logs.rs
+++ b/query/src/api/http/v1/logs.rs
@@ -25,7 +25,7 @@ use poem::Response;
 use tokio_stream::StreamExt;
 
 use crate::catalogs::ToReadDataSourcePlan;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sessions::SessionManager;
 
 pub struct LogTemplate {
@@ -63,7 +63,7 @@ async fn select_table(sessions: Arc<SessionManager>) -> Result<String> {
     Ok(format!("{:?}", tracing_logs))
 }
 
-async fn execute_query(ctx: Arc<DatabendQueryContext>) -> Result<SendableDataBlockStream> {
+async fn execute_query(ctx: Arc<QueryContext>) -> Result<SendableDataBlockStream> {
     let tracing_table = ctx.get_table("system", "tracing").await?;
     let tracing_table_read_plan = tracing_table.read_plan(ctx.clone(), None).await?;
 

--- a/query/src/api/http_service.rs
+++ b/query/src/api/http_service.rs
@@ -14,6 +14,7 @@
 
 use std::net::SocketAddr;
 use std::path::Path;
+use std::sync::Arc;
 
 use common_exception::Result;
 use poem::get;
@@ -25,15 +26,15 @@ use poem::Route;
 use crate::common::service::HttpShutdownHandler;
 use crate::configs::Config;
 use crate::servers::Server;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 
 pub struct HttpService {
-    sessions: SessionManagerRef,
+    sessions: Arc<SessionManager>,
     shutdown_handler: HttpShutdownHandler,
 }
 
 impl HttpService {
-    pub fn create(sessions: SessionManagerRef) -> Box<HttpService> {
+    pub fn create(sessions: Arc<SessionManager>) -> Box<HttpService> {
         Box::new(HttpService {
             sessions,
             shutdown_handler: HttpShutdownHandler::create("http api".to_string()),

--- a/query/src/api/rpc/flight_dispatcher.rs
+++ b/query/src/api/rpc/flight_dispatcher.rs
@@ -34,7 +34,7 @@ use crate::api::rpc::flight_scatter_hash::HashFlightScatter;
 use crate::api::rpc::flight_tickets::StreamTicket;
 use crate::api::FlightAction;
 use crate::pipelines::processors::PipelineBuilder;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sessions::SessionRef;
 
 struct StreamInfo {
@@ -119,7 +119,7 @@ impl DatabendQueryFlightDispatcher {
 
     async fn one_sink_action(&self, session: SessionRef, action: &FlightAction) -> Result<()> {
         let query_context = session.create_context().await?;
-        let action_context = DatabendQueryContext::new(query_context.clone());
+        let action_context = QueryContext::new(query_context.clone());
         let pipeline_builder = PipelineBuilder::create(action_context.clone());
 
         let query_plan = action.get_plan();
@@ -171,7 +171,7 @@ impl DatabendQueryFlightDispatcher {
         T: FlightScatter + Send + 'static,
     {
         let query_context = session.create_context().await?;
-        let action_context = DatabendQueryContext::new(query_context.clone());
+        let action_context = QueryContext::new(query_context.clone());
         let pipeline_builder = PipelineBuilder::create(action_context.clone());
 
         let query_plan = action.get_plan();

--- a/query/src/api/rpc/flight_service.rs
+++ b/query/src/api/rpc/flight_service.rs
@@ -41,20 +41,20 @@ use crate::api::rpc::flight_dispatcher::DatabendQueryFlightDispatcher;
 use crate::api::rpc::flight_dispatcher::DatabendQueryFlightDispatcherRef;
 use crate::api::rpc::flight_service_stream::FlightDataStream;
 use crate::api::rpc::flight_tickets::FlightTicket;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 
 pub type FlightStream<T> =
     Pin<Box<dyn Stream<Item = Result<T, tonic::Status>> + Send + Sync + 'static>>;
 
 pub struct DatabendQueryFlightService {
-    sessions: SessionManagerRef,
+    sessions: Arc<SessionManager>,
     dispatcher: Arc<DatabendQueryFlightDispatcher>,
 }
 
 impl DatabendQueryFlightService {
     pub fn create(
         dispatcher: DatabendQueryFlightDispatcherRef,
-        sessions: SessionManagerRef,
+        sessions: Arc<SessionManager>,
     ) -> Self {
         DatabendQueryFlightService {
             sessions,

--- a/query/src/api/rpc_service.rs
+++ b/query/src/api/rpc_service.rs
@@ -31,16 +31,16 @@ use crate::api::rpc::DatabendQueryFlightDispatcher;
 use crate::api::rpc::DatabendQueryFlightService;
 use crate::configs::Config;
 use crate::servers::Server as DatabendQueryServer;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 
 pub struct RpcService {
-    pub(crate) sessions: SessionManagerRef,
+    pub(crate) sessions: Arc<SessionManager>,
     pub(crate) abort_notify: Arc<Notify>,
     pub(crate) dispatcher: Arc<DatabendQueryFlightDispatcher>,
 }
 
 impl RpcService {
-    pub fn create(sessions: SessionManagerRef) -> Box<dyn DatabendQueryServer> {
+    pub fn create(sessions: Arc<SessionManager>) -> Box<dyn DatabendQueryServer> {
         Box::new(Self {
             sessions,
             abort_notify: Arc::new(Notify::new()),

--- a/query/src/catalogs/table.rs
+++ b/query/src/catalogs/table.rs
@@ -31,7 +31,7 @@ use common_planners::Statistics;
 use common_planners::TruncateTablePlan;
 use common_streams::SendableDataBlockStream;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 #[async_trait::async_trait]
 pub trait Table: Sync + Send {
@@ -67,7 +67,7 @@ pub trait Table: Sync + Send {
     // defaults to generate one single part and empty statistics
     async fn read_partitions(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         Ok((Statistics::default(), vec![Part {
@@ -83,14 +83,14 @@ pub trait Table: Sync + Send {
     // Read block data from the underling.
     async fn read(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream>;
 
     // temporary added, pls feel free to rm it
     async fn append_data(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _insert_plan: InsertIntoPlan,
         _stream: SendableDataBlockStream,
     ) -> Result<()> {
@@ -102,7 +102,7 @@ pub trait Table: Sync + Send {
 
     async fn truncate(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
         Err(ErrorCode::UnImplement(format!(
@@ -119,7 +119,7 @@ pub trait ToReadDataSourcePlan {
     /// Real read_plan to access partitions/push_downs
     async fn read_plan(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         push_downs: Option<Extras>,
     ) -> Result<ReadDataSourcePlan>;
 }
@@ -128,7 +128,7 @@ pub trait ToReadDataSourcePlan {
 impl ToReadDataSourcePlan for dyn Table {
     async fn read_plan(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         push_downs: Option<Extras>,
     ) -> Result<ReadDataSourcePlan> {
         let (statistics, parts) = self.read_partitions(ctx, push_downs.clone()).await?;

--- a/query/src/catalogs/table.rs
+++ b/query/src/catalogs/table.rs
@@ -31,7 +31,7 @@ use common_planners::Statistics;
 use common_planners::TruncateTablePlan;
 use common_streams::SendableDataBlockStream;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 #[async_trait::async_trait]
 pub trait Table: Sync + Send {
@@ -67,7 +67,7 @@ pub trait Table: Sync + Send {
     // defaults to generate one single part and empty statistics
     async fn read_partitions(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         Ok((Statistics::default(), vec![Part {
@@ -83,14 +83,14 @@ pub trait Table: Sync + Send {
     // Read block data from the underling.
     async fn read(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream>;
 
     // temporary added, pls feel free to rm it
     async fn append_data(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _insert_plan: InsertIntoPlan,
         _stream: SendableDataBlockStream,
     ) -> Result<()> {
@@ -102,7 +102,7 @@ pub trait Table: Sync + Send {
 
     async fn truncate(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
         Err(ErrorCode::UnImplement(format!(
@@ -119,7 +119,7 @@ pub trait ToReadDataSourcePlan {
     /// Real read_plan to access partitions/push_downs
     async fn read_plan(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         push_downs: Option<Extras>,
     ) -> Result<ReadDataSourcePlan>;
 }
@@ -128,7 +128,7 @@ pub trait ToReadDataSourcePlan {
 impl ToReadDataSourcePlan for dyn Table {
     async fn read_plan(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         push_downs: Option<Extras>,
     ) -> Result<ReadDataSourcePlan> {
         let (statistics, parts) = self.read_partitions(ctx, push_downs.clone()).await?;

--- a/query/src/clusters/mod.rs
+++ b/query/src/clusters/mod.rs
@@ -19,5 +19,3 @@ mod cluster;
 
 pub use cluster::Cluster;
 pub use cluster::ClusterDiscovery;
-pub use cluster::ClusterDiscoveryRef;
-pub use cluster::ClusterRef;

--- a/query/src/datasources/database/system/clusters_table.rs
+++ b/query/src/datasources/database/system/clusters_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -25,7 +26,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct ClustersTable {
     table_info: TableInfo,
@@ -66,7 +67,7 @@ impl Table for ClustersTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let cluster_nodes = ctx.get_cluster().get_nodes();

--- a/query/src/datasources/database/system/clusters_table.rs
+++ b/query/src/datasources/database/system/clusters_table.rs
@@ -26,7 +26,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ClustersTable {
     table_info: TableInfo,
@@ -67,7 +67,7 @@ impl Table for ClustersTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let cluster_nodes = ctx.get_cluster().get_nodes();

--- a/query/src/datasources/database/system/columns_table.rs
+++ b/query/src/datasources/database/system/columns_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::series::Series;
@@ -30,7 +31,7 @@ use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Catalog;
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct ColumnsTable {
     table_info: TableInfo,
@@ -62,7 +63,7 @@ impl ColumnsTable {
 
     pub async fn dump_table_columns(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
     ) -> Result<Vec<(String, String, DataField)>> {
         let catalog = ctx.get_catalog();
         let databases = catalog.list_databases().await?;
@@ -92,7 +93,7 @@ impl Table for ColumnsTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let rows = self.dump_table_columns(ctx).await?;

--- a/query/src/datasources/database/system/columns_table.rs
+++ b/query/src/datasources/database/system/columns_table.rs
@@ -31,7 +31,7 @@ use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Catalog;
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ColumnsTable {
     table_info: TableInfo,
@@ -63,7 +63,7 @@ impl ColumnsTable {
 
     pub async fn dump_table_columns(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
     ) -> Result<Vec<(String, String, DataField)>> {
         let catalog = ctx.get_catalog();
         let databases = catalog.list_databases().await?;
@@ -93,7 +93,7 @@ impl Table for ColumnsTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let rows = self.dump_table_columns(ctx).await?;

--- a/query/src/datasources/database/system/configs_table.rs
+++ b/query/src/datasources/database/system/configs_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -26,7 +27,7 @@ use common_streams::SendableDataBlockStream;
 use serde_json::Value;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct ConfigsTable {
     table_info: TableInfo,
@@ -87,7 +88,7 @@ impl Table for ConfigsTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let config = ctx.get_config();

--- a/query/src/datasources/database/system/configs_table.rs
+++ b/query/src/datasources/database/system/configs_table.rs
@@ -27,7 +27,7 @@ use common_streams::SendableDataBlockStream;
 use serde_json::Value;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ConfigsTable {
     table_info: TableInfo,
@@ -88,7 +88,7 @@ impl Table for ConfigsTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let config = ctx.get_config();

--- a/query/src/datasources/database/system/contributors_table.rs
+++ b/query/src/datasources/database/system/contributors_table.rs
@@ -26,7 +26,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ContributorsTable {
     table_info: TableInfo,
@@ -63,7 +63,7 @@ impl Table for ContributorsTable {
 
     async fn read(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let contributors: Vec<&[u8]> = env!("DATABEND_COMMIT_AUTHORS")

--- a/query/src/datasources/database/system/contributors_table.rs
+++ b/query/src/datasources/database/system/contributors_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -25,7 +26,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct ContributorsTable {
     table_info: TableInfo,
@@ -62,7 +63,7 @@ impl Table for ContributorsTable {
 
     async fn read(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let contributors: Vec<&[u8]> = env!("DATABEND_COMMIT_AUTHORS")

--- a/query/src/datasources/database/system/credits_table.rs
+++ b/query/src/datasources/database/system/credits_table.rs
@@ -26,7 +26,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct CreditsTable {
     table_info: TableInfo,
@@ -66,7 +66,7 @@ impl Table for CreditsTable {
 
     async fn read(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let metadata_command = cargo_metadata::MetadataCommand::new();

--- a/query/src/datasources/database/system/credits_table.rs
+++ b/query/src/datasources/database/system/credits_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -25,7 +26,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct CreditsTable {
     table_info: TableInfo,
@@ -65,7 +66,7 @@ impl Table for CreditsTable {
 
     async fn read(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let metadata_command = cargo_metadata::MetadataCommand::new();

--- a/query/src/datasources/database/system/databases_table.rs
+++ b/query/src/datasources/database/system/databases_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -26,7 +27,7 @@ use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Catalog;
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct DatabasesTable {
     table_info: TableInfo,
@@ -64,7 +65,7 @@ impl Table for DatabasesTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let dbs = ctx.get_catalog().list_databases().await?;

--- a/query/src/datasources/database/system/databases_table.rs
+++ b/query/src/datasources/database/system/databases_table.rs
@@ -27,7 +27,7 @@ use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Catalog;
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct DatabasesTable {
     table_info: TableInfo,
@@ -65,7 +65,7 @@ impl Table for DatabasesTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let dbs = ctx.get_catalog().list_databases().await?;

--- a/query/src/datasources/database/system/functions_table.rs
+++ b/query/src/datasources/database/system/functions_table.rs
@@ -28,7 +28,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct FunctionsTable {
     table_info: TableInfo,
@@ -68,7 +68,7 @@ impl Table for FunctionsTable {
 
     async fn read(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let function_factory = FunctionFactory::instance();

--- a/query/src/datasources/database/system/functions_table.rs
+++ b/query/src/datasources/database/system/functions_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -27,7 +28,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct FunctionsTable {
     table_info: TableInfo,
@@ -67,7 +68,7 @@ impl Table for FunctionsTable {
 
     async fn read(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let function_factory = FunctionFactory::instance();

--- a/query/src/datasources/database/system/metrics_table.rs
+++ b/query/src/datasources/database/system/metrics_table.rs
@@ -34,7 +34,7 @@ use common_streams::SendableDataBlockStream;
 use serde_json;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct MetricsTable {
     table_info: TableInfo,
@@ -101,7 +101,7 @@ impl Table for MetricsTable {
 
     async fn read(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let prometheus_handle = common_metrics::try_handle().ok_or_else(|| {

--- a/query/src/datasources/database/system/metrics_table.rs
+++ b/query/src/datasources/database/system/metrics_table.rs
@@ -14,6 +14,7 @@
 
 use std::any::Any;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::series::Series;
@@ -33,7 +34,7 @@ use common_streams::SendableDataBlockStream;
 use serde_json;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct MetricsTable {
     table_info: TableInfo,
@@ -100,7 +101,7 @@ impl Table for MetricsTable {
 
     async fn read(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let prometheus_handle = common_metrics::try_handle().ok_or_else(|| {

--- a/query/src/datasources/database/system/one_table.rs
+++ b/query/src/datasources/database/system/one_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -29,7 +30,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct OneTable {
     table_info: TableInfo,
@@ -66,7 +67,7 @@ impl Table for OneTable {
 
     async fn read_partitions(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         Ok((Statistics::new_exact(1, 1), vec![Part {
@@ -77,7 +78,7 @@ impl Table for OneTable {
 
     async fn read(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let block =

--- a/query/src/datasources/database/system/one_table.rs
+++ b/query/src/datasources/database/system/one_table.rs
@@ -30,7 +30,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct OneTable {
     table_info: TableInfo,
@@ -67,7 +67,7 @@ impl Table for OneTable {
 
     async fn read_partitions(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         Ok((Statistics::new_exact(1, 1), vec![Part {
@@ -78,7 +78,7 @@ impl Table for OneTable {
 
     async fn read(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let block =

--- a/query/src/datasources/database/system/processes_table.rs
+++ b/query/src/datasources/database/system/processes_table.rs
@@ -30,8 +30,8 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
 use crate::sessions::ProcessInfo;
+use crate::sessions::QueryContext;
 
 pub struct ProcessesTable {
     table_info: TableInfo,
@@ -88,7 +88,7 @@ impl Table for ProcessesTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let sessions_manager = ctx.get_sessions_manager();

--- a/query/src/datasources/database/system/processes_table.rs
+++ b/query/src/datasources/database/system/processes_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::series::Series;
@@ -29,7 +30,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sessions::ProcessInfo;
 
 pub struct ProcessesTable {
@@ -87,7 +88,7 @@ impl Table for ProcessesTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let sessions_manager = ctx.get_sessions_manager();

--- a/query/src/datasources/database/system/settings_table.rs
+++ b/query/src/datasources/database/system/settings_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -25,7 +26,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct SettingsTable {
     table_info: TableInfo,
@@ -68,7 +69,7 @@ impl Table for SettingsTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let settings = ctx.get_settings();

--- a/query/src/datasources/database/system/settings_table.rs
+++ b/query/src/datasources/database/system/settings_table.rs
@@ -26,7 +26,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct SettingsTable {
     table_info: TableInfo,
@@ -69,7 +69,7 @@ impl Table for SettingsTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let settings = ctx.get_settings();

--- a/query/src/datasources/database/system/tables_table.rs
+++ b/query/src/datasources/database/system/tables_table.rs
@@ -27,7 +27,7 @@ use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Catalog;
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct TablesTable {
     table_info: TableInfo,
@@ -69,7 +69,7 @@ impl Table for TablesTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let catalog = ctx.get_catalog();

--- a/query/src/datasources/database/system/tables_table.rs
+++ b/query/src/datasources/database/system/tables_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -26,7 +27,7 @@ use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Catalog;
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct TablesTable {
     table_info: TableInfo,
@@ -68,7 +69,7 @@ impl Table for TablesTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let catalog = ctx.get_catalog();

--- a/query/src/datasources/database/system/tracing_table.rs
+++ b/query/src/datasources/database/system/tracing_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datavalues::DataField;
 use common_datavalues::DataSchemaRefExt;
@@ -29,7 +30,7 @@ use walkdir::WalkDir;
 
 use crate::catalogs::Table;
 use crate::datasources::database::system::TracingTableStream;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct TracingTable {
     table_info: TableInfo,
@@ -76,7 +77,7 @@ impl Table for TracingTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let mut log_files = vec![];

--- a/query/src/datasources/database/system/tracing_table.rs
+++ b/query/src/datasources/database/system/tracing_table.rs
@@ -30,7 +30,7 @@ use walkdir::WalkDir;
 
 use crate::catalogs::Table;
 use crate::datasources::database::system::TracingTableStream;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct TracingTable {
     table_info: TableInfo,
@@ -77,7 +77,7 @@ impl Table for TracingTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let mut log_files = vec![];

--- a/query/src/datasources/database/system/users_table.rs
+++ b/query/src/datasources/database/system/users_table.rs
@@ -26,7 +26,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct UsersTable {
     table_info: TableInfo,
@@ -67,7 +67,7 @@ impl Table for UsersTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let users = ctx

--- a/query/src/datasources/database/system/users_table.rs
+++ b/query/src/datasources/database/system/users_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -25,7 +26,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::catalogs::Table;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct UsersTable {
     table_info: TableInfo,
@@ -66,7 +67,7 @@ impl Table for UsersTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let users = ctx

--- a/query/src/datasources/table/csv/csv_table.rs
+++ b/query/src/datasources/table/csv/csv_table.rs
@@ -34,7 +34,7 @@ use common_streams::Source;
 use crate::catalogs::Table;
 use crate::datasources::common::count_lines;
 use crate::datasources::context::DataSourceContext;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct CsvTable {
     table_info: TableInfo,
@@ -76,7 +76,7 @@ impl Table for CsvTable {
 
     async fn read_partitions(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         let file = &self.file;
@@ -92,7 +92,7 @@ impl Table for CsvTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx_clone = ctx.clone();

--- a/query/src/datasources/table/csv/csv_table.rs
+++ b/query/src/datasources/table/csv/csv_table.rs
@@ -34,7 +34,7 @@ use common_streams::Source;
 use crate::catalogs::Table;
 use crate::datasources::common::count_lines;
 use crate::datasources::context::DataSourceContext;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct CsvTable {
     table_info: TableInfo,
@@ -76,7 +76,7 @@ impl Table for CsvTable {
 
     async fn read_partitions(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         let file = &self.file;
@@ -92,7 +92,7 @@ impl Table for CsvTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx_clone = ctx.clone();

--- a/query/src/datasources/table/fuse/append.rs
+++ b/query/src/datasources/table/fuse/append.rs
@@ -13,6 +13,8 @@
 //  limitations under the License.
 //
 
+use std::sync::Arc;
+
 use common_datavalues::DataSchema;
 use common_exception::Result;
 use common_meta_types::MetaId;
@@ -31,13 +33,13 @@ use crate::datasources::table::fuse::BlockAppender;
 use crate::datasources::table::fuse::FuseTable;
 use crate::datasources::table::fuse::SegmentInfo;
 use crate::datasources::table::fuse::TableSnapshot;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 impl FuseTable {
     #[inline]
     pub async fn do_append(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         insert_plan: InsertIntoPlan,
         stream: SendableDataBlockStream,
     ) -> Result<()> {
@@ -101,7 +103,7 @@ fn merge_snapshot(
 }
 
 async fn commit(
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     table_id: MetaId,
     table_version: MetaVersion,
     new_snapshot_location: String,

--- a/query/src/datasources/table/fuse/append.rs
+++ b/query/src/datasources/table/fuse/append.rs
@@ -33,13 +33,13 @@ use crate::datasources::table::fuse::BlockAppender;
 use crate::datasources::table::fuse::FuseTable;
 use crate::datasources::table::fuse::SegmentInfo;
 use crate::datasources::table::fuse::TableSnapshot;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 impl FuseTable {
     #[inline]
     pub async fn do_append(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         insert_plan: InsertIntoPlan,
         stream: SendableDataBlockStream,
     ) -> Result<()> {
@@ -103,7 +103,7 @@ fn merge_snapshot(
 }
 
 async fn commit(
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     table_id: MetaId,
     table_version: MetaVersion,
     new_snapshot_location: String,

--- a/query/src/datasources/table/fuse/read.rs
+++ b/query/src/datasources/table/fuse/read.rs
@@ -25,13 +25,13 @@ use common_streams::Source;
 use futures::StreamExt;
 
 use crate::datasources::table::fuse::FuseTable;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 impl FuseTable {
     #[inline]
     pub async fn do_read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let default_proj = || {

--- a/query/src/datasources/table/fuse/read.rs
+++ b/query/src/datasources/table/fuse/read.rs
@@ -25,13 +25,13 @@ use common_streams::Source;
 use futures::StreamExt;
 
 use crate::datasources::table::fuse::FuseTable;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 impl FuseTable {
     #[inline]
     pub async fn do_read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let default_proj = || {

--- a/query/src/datasources/table/fuse/read_plan.rs
+++ b/query/src/datasources/table/fuse/read_plan.rs
@@ -14,6 +14,7 @@
 //
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use common_dal::read_obj;
 use common_exception::Result;
@@ -25,13 +26,13 @@ use common_planners::Statistics;
 use crate::datasources::table::fuse::index;
 use crate::datasources::table::fuse::BlockMeta;
 use crate::datasources::table::fuse::FuseTable;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 impl FuseTable {
     #[inline]
     pub async fn do_read_partitions(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         let location = self.snapshot_loc();

--- a/query/src/datasources/table/fuse/read_plan.rs
+++ b/query/src/datasources/table/fuse/read_plan.rs
@@ -26,13 +26,13 @@ use common_planners::Statistics;
 use crate::datasources::table::fuse::index;
 use crate::datasources::table::fuse::BlockMeta;
 use crate::datasources::table::fuse::FuseTable;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 impl FuseTable {
     #[inline]
     pub async fn do_read_partitions(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         let location = self.snapshot_loc();

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -31,7 +31,7 @@ use super::util;
 use crate::catalogs::Table;
 use crate::datasources::context::DataSourceContext;
 use crate::datasources::table::fuse::TableSnapshot;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct FuseTable {
     pub(crate) table_info: TableInfo,
@@ -63,7 +63,7 @@ impl Table for FuseTable {
 
     async fn read_partitions(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         self.do_read_partitions(ctx, push_downs).await
@@ -71,7 +71,7 @@ impl Table for FuseTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         self.do_read(ctx, &plan.push_downs).await
@@ -79,7 +79,7 @@ impl Table for FuseTable {
 
     async fn append_data(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         insert_plan: InsertIntoPlan,
         stream: SendableDataBlockStream,
     ) -> Result<()> {
@@ -88,7 +88,7 @@ impl Table for FuseTable {
 
     async fn truncate(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
         self.do_truncate(ctx, truncate_plan).await
@@ -105,7 +105,7 @@ impl FuseTable {
 
     pub(crate) async fn table_snapshot(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
     ) -> Result<Option<TableSnapshot>> {
         if let Some(loc) = self.snapshot_loc() {
             let da = ctx.get_data_accessor()?;

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -14,6 +14,7 @@
 //
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_dal::read_obj;
 use common_exception::Result;
@@ -30,7 +31,7 @@ use super::util;
 use crate::catalogs::Table;
 use crate::datasources::context::DataSourceContext;
 use crate::datasources::table::fuse::TableSnapshot;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct FuseTable {
     pub(crate) table_info: TableInfo,
@@ -62,7 +63,7 @@ impl Table for FuseTable {
 
     async fn read_partitions(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         self.do_read_partitions(ctx, push_downs).await
@@ -70,7 +71,7 @@ impl Table for FuseTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         self.do_read(ctx, &plan.push_downs).await
@@ -78,7 +79,7 @@ impl Table for FuseTable {
 
     async fn append_data(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         insert_plan: InsertIntoPlan,
         stream: SendableDataBlockStream,
     ) -> Result<()> {
@@ -87,7 +88,7 @@ impl Table for FuseTable {
 
     async fn truncate(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
         self.do_truncate(ctx, truncate_plan).await
@@ -104,7 +105,7 @@ impl FuseTable {
 
     pub(crate) async fn table_snapshot(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
     ) -> Result<Option<TableSnapshot>> {
         if let Some(loc) = self.snapshot_loc() {
             let da = ctx.get_data_accessor()?;

--- a/query/src/datasources/table/fuse/table_test_fixture.rs
+++ b/query/src/datasources/table/fuse/table_test_fixture.rs
@@ -33,11 +33,11 @@ use uuid::Uuid;
 use crate::catalogs::Catalog;
 use crate::catalogs::Table;
 use crate::configs::Config;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct TestFixture {
     _tmp_dir: TempDir,
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     prefix: String,
 }
 
@@ -73,7 +73,7 @@ impl TestFixture {
         }
     }
 
-    pub fn ctx(&self) -> Arc<DatabendQueryContext> {
+    pub fn ctx(&self) -> Arc<QueryContext> {
         self.ctx.clone()
     }
 

--- a/query/src/datasources/table/fuse/table_test_fixture.rs
+++ b/query/src/datasources/table/fuse/table_test_fixture.rs
@@ -13,6 +13,8 @@
 //  limitations under the License.
 //
 
+use std::sync::Arc;
+
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::Series;
 use common_datavalues::prelude::SeriesFrom;
@@ -31,11 +33,11 @@ use uuid::Uuid;
 use crate::catalogs::Catalog;
 use crate::catalogs::Table;
 use crate::configs::Config;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct TestFixture {
     _tmp_dir: TempDir,
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     prefix: String,
 }
 
@@ -71,7 +73,7 @@ impl TestFixture {
         }
     }
 
-    pub fn ctx(&self) -> DatabendQueryContextRef {
+    pub fn ctx(&self) -> Arc<DatabendQueryContext> {
         self.ctx.clone()
     }
 

--- a/query/src/datasources/table/fuse/truncate.rs
+++ b/query/src/datasources/table/fuse/truncate.rs
@@ -24,13 +24,13 @@ use crate::catalogs::Catalog;
 use crate::datasources::table::fuse::util;
 use crate::datasources::table::fuse::util::TBL_OPT_KEY_SNAPSHOT_LOC;
 use crate::datasources::table::fuse::FuseTable;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 impl FuseTable {
     #[inline]
     pub async fn do_truncate(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
         if let Some(prev_snapshot) = self.table_snapshot(ctx.clone()).await? {

--- a/query/src/datasources/table/fuse/truncate.rs
+++ b/query/src/datasources/table/fuse/truncate.rs
@@ -13,6 +13,8 @@
 //  limitations under the License.
 //
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_meta_types::UpsertTableOptionReq;
 use common_planners::TruncateTablePlan;
@@ -22,13 +24,13 @@ use crate::catalogs::Catalog;
 use crate::datasources::table::fuse::util;
 use crate::datasources::table::fuse::util::TBL_OPT_KEY_SNAPSHOT_LOC;
 use crate::datasources::table::fuse::FuseTable;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 impl FuseTable {
     #[inline]
     pub async fn do_truncate(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
         if let Some(prev_snapshot) = self.table_snapshot(ctx.clone()).await? {

--- a/query/src/datasources/table/memory/memory_table.rs
+++ b/query/src/datasources/table/memory/memory_table.rs
@@ -34,7 +34,7 @@ use crate::catalogs::Table;
 use crate::datasources::common::generate_parts;
 use crate::datasources::context::DataSourceContext;
 use crate::datasources::table::memory::memory_table_stream::MemoryTableStream;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct MemoryTable {
     table_info: TableInfo,
@@ -74,7 +74,7 @@ impl Table for MemoryTable {
 
     async fn read_partitions(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         let blocks = self.blocks.read();
@@ -93,7 +93,7 @@ impl Table for MemoryTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let blocks = self.blocks.read();
@@ -105,7 +105,7 @@ impl Table for MemoryTable {
 
     async fn append_data(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         insert_plan: InsertIntoPlan,
         mut stream: SendableDataBlockStream,
     ) -> Result<()> {
@@ -123,7 +123,7 @@ impl Table for MemoryTable {
 
     async fn truncate(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
         let mut blocks = self.blocks.write();

--- a/query/src/datasources/table/memory/memory_table.rs
+++ b/query/src/datasources/table/memory/memory_table.rs
@@ -34,7 +34,7 @@ use crate::catalogs::Table;
 use crate::datasources::common::generate_parts;
 use crate::datasources::context::DataSourceContext;
 use crate::datasources::table::memory::memory_table_stream::MemoryTableStream;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct MemoryTable {
     table_info: TableInfo,
@@ -74,7 +74,7 @@ impl Table for MemoryTable {
 
     async fn read_partitions(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         let blocks = self.blocks.read();
@@ -93,7 +93,7 @@ impl Table for MemoryTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let blocks = self.blocks.read();
@@ -105,7 +105,7 @@ impl Table for MemoryTable {
 
     async fn append_data(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         insert_plan: InsertIntoPlan,
         mut stream: SendableDataBlockStream,
     ) -> Result<()> {
@@ -123,7 +123,7 @@ impl Table for MemoryTable {
 
     async fn truncate(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
         let mut blocks = self.blocks.write();

--- a/query/src/datasources/table/memory/memory_table_stream.rs
+++ b/query/src/datasources/table/memory/memory_table_stream.rs
@@ -21,7 +21,7 @@ use common_datablocks::DataBlock;
 use common_exception::Result;
 use futures::stream::Stream;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 #[derive(Debug, Clone)]
 struct BlockRange {
@@ -30,14 +30,14 @@ struct BlockRange {
 }
 
 pub struct MemoryTableStream {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     block_index: usize,
     block_ranges: Vec<usize>,
     blocks: Vec<DataBlock>,
 }
 
 impl MemoryTableStream {
-    pub fn try_create(ctx: Arc<DatabendQueryContext>, blocks: Vec<DataBlock>) -> Result<Self> {
+    pub fn try_create(ctx: Arc<QueryContext>, blocks: Vec<DataBlock>) -> Result<Self> {
         Ok(Self {
             ctx,
             block_index: 0,

--- a/query/src/datasources/table/memory/memory_table_stream.rs
+++ b/query/src/datasources/table/memory/memory_table_stream.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::usize;
@@ -20,7 +21,7 @@ use common_datablocks::DataBlock;
 use common_exception::Result;
 use futures::stream::Stream;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 #[derive(Debug, Clone)]
 struct BlockRange {
@@ -29,14 +30,14 @@ struct BlockRange {
 }
 
 pub struct MemoryTableStream {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     block_index: usize,
     block_ranges: Vec<usize>,
     blocks: Vec<DataBlock>,
 }
 
 impl MemoryTableStream {
-    pub fn try_create(ctx: DatabendQueryContextRef, blocks: Vec<DataBlock>) -> Result<Self> {
+    pub fn try_create(ctx: Arc<DatabendQueryContext>, blocks: Vec<DataBlock>) -> Result<Self> {
         Ok(Self {
             ctx,
             block_index: 0,

--- a/query/src/datasources/table/null/null_table.rs
+++ b/query/src/datasources/table/null/null_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use common_exception::Result;
@@ -27,7 +28,7 @@ use futures::stream::StreamExt;
 
 use crate::catalogs::Table;
 use crate::datasources::context::DataSourceContext;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct NullTable {
     table_info: TableInfo,
@@ -51,7 +52,7 @@ impl Table for NullTable {
 
     async fn read(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let block = DataBlock::empty_with_schema(self.table_info.schema());
@@ -65,7 +66,7 @@ impl Table for NullTable {
 
     async fn append_data(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _insert_plan: InsertIntoPlan,
         mut stream: SendableDataBlockStream,
     ) -> Result<()> {
@@ -78,7 +79,7 @@ impl Table for NullTable {
 
     async fn truncate(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
         Ok(())

--- a/query/src/datasources/table/null/null_table.rs
+++ b/query/src/datasources/table/null/null_table.rs
@@ -28,7 +28,7 @@ use futures::stream::StreamExt;
 
 use crate::catalogs::Table;
 use crate::datasources::context::DataSourceContext;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct NullTable {
     table_info: TableInfo,
@@ -52,7 +52,7 @@ impl Table for NullTable {
 
     async fn read(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let block = DataBlock::empty_with_schema(self.table_info.schema());
@@ -66,7 +66,7 @@ impl Table for NullTable {
 
     async fn append_data(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _insert_plan: InsertIntoPlan,
         mut stream: SendableDataBlockStream,
     ) -> Result<()> {
@@ -79,7 +79,7 @@ impl Table for NullTable {
 
     async fn truncate(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
         Ok(())

--- a/query/src/datasources/table/parquet/parquet_table.rs
+++ b/query/src/datasources/table/parquet/parquet_table.rs
@@ -31,7 +31,7 @@ use common_streams::Source;
 
 use crate::catalogs::Table;
 use crate::datasources::context::DataSourceContext;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct ParquetTable {
     table_info: TableInfo,
@@ -73,7 +73,7 @@ impl Table for ParquetTable {
 
     async fn read_partitions(
         &self,
-        _ctx: DatabendQueryContextRef,
+        _ctx: Arc<DatabendQueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         let parts = vec![Part {
@@ -85,7 +85,7 @@ impl Table for ParquetTable {
 
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx_clone = ctx.clone();

--- a/query/src/datasources/table/parquet/parquet_table.rs
+++ b/query/src/datasources/table/parquet/parquet_table.rs
@@ -31,7 +31,7 @@ use common_streams::Source;
 
 use crate::catalogs::Table;
 use crate::datasources::context::DataSourceContext;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ParquetTable {
     table_info: TableInfo,
@@ -73,7 +73,7 @@ impl Table for ParquetTable {
 
     async fn read_partitions(
         &self,
-        _ctx: Arc<DatabendQueryContext>,
+        _ctx: Arc<QueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         let parts = vec![Part {
@@ -85,7 +85,7 @@ impl Table for ParquetTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx_clone = ctx.clone();

--- a/query/src/datasources/table_func/numbers_stream.rs
+++ b/query/src/datasources/table_func/numbers_stream.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::usize;
@@ -22,7 +23,7 @@ use common_datavalues::prelude::*;
 use common_exception::Result;
 use futures::stream::Stream;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 #[derive(Debug, Clone)]
 struct BlockRange {
@@ -31,7 +32,7 @@ struct BlockRange {
 }
 
 pub struct NumbersStream {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     schema: DataSchemaRef,
     block_index: usize,
     blocks: Vec<BlockRange>,
@@ -41,7 +42,7 @@ pub struct NumbersStream {
 
 impl NumbersStream {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         schema: DataSchemaRef,
         sort_columns_descriptions: Vec<SortColumnDescription>,
         limit: Option<usize>,

--- a/query/src/datasources/table_func/numbers_stream.rs
+++ b/query/src/datasources/table_func/numbers_stream.rs
@@ -23,7 +23,7 @@ use common_datavalues::prelude::*;
 use common_exception::Result;
 use futures::stream::Stream;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 #[derive(Debug, Clone)]
 struct BlockRange {
@@ -32,7 +32,7 @@ struct BlockRange {
 }
 
 pub struct NumbersStream {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     schema: DataSchemaRef,
     block_index: usize,
     blocks: Vec<BlockRange>,
@@ -42,7 +42,7 @@ pub struct NumbersStream {
 
 impl NumbersStream {
     pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         schema: DataSchemaRef,
         sort_columns_descriptions: Vec<SortColumnDescription>,
         limit: Option<usize>,

--- a/query/src/datasources/table_func/numbers_table.rs
+++ b/query/src/datasources/table_func/numbers_table.rs
@@ -39,7 +39,7 @@ use crate::catalogs::TableFunction;
 use crate::datasources::common::generate_parts;
 use crate::datasources::table_func_engine::TableArgs;
 use crate::pipelines::transforms::get_sort_descriptions;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct NumbersTable {
     table_info: TableInfo,
@@ -112,7 +112,7 @@ impl Table for NumbersTable {
 
     async fn read_partitions(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         let statistics = Statistics::new_exact(
@@ -132,7 +132,7 @@ impl Table for NumbersTable {
 
     async fn read(
         &self,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         // If we have order-by and limit push-downs, try the best to only generate top n rows.

--- a/query/src/datasources/table_func/numbers_table.rs
+++ b/query/src/datasources/table_func/numbers_table.rs
@@ -39,7 +39,7 @@ use crate::catalogs::TableFunction;
 use crate::datasources::common::generate_parts;
 use crate::datasources::table_func_engine::TableArgs;
 use crate::pipelines::transforms::get_sort_descriptions;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct NumbersTable {
     table_info: TableInfo,
@@ -98,27 +98,21 @@ impl NumbersTable {
 
 #[async_trait::async_trait]
 impl Table for NumbersTable {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn is_local(&self) -> bool {
         self.name() == "numbers_local"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     fn get_table_info(&self) -> &TableInfo {
         &self.table_info
     }
 
-    fn table_args(&self) -> Option<Vec<Expression>> {
-        Some(vec![Expression::create_literal(DataValue::UInt64(Some(
-            self.total,
-        )))])
-    }
-
     async fn read_partitions(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         _push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         let statistics = Statistics::new_exact(
@@ -130,9 +124,15 @@ impl Table for NumbersTable {
         Ok((statistics, parts))
     }
 
+    fn table_args(&self) -> Option<Vec<Expression>> {
+        Some(vec![Expression::create_literal(DataValue::UInt64(Some(
+            self.total,
+        )))])
+    }
+
     async fn read(
         &self,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         // If we have order-by and limit push-downs, try the best to only generate top n rows.

--- a/query/src/functions/context_function.rs
+++ b/query/src/functions/context_function.rs
@@ -21,17 +21,14 @@ use common_functions::aggregates::AggregateFunctionFactory;
 use common_functions::scalars::FunctionFactory;
 use common_planners::Expression;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ContextFunction;
 
 impl ContextFunction {
     // Some function args need from context
     // such as `SELECT database()`, the arg is ctx.get_default_db()
-    pub fn build_args_from_ctx(
-        name: &str,
-        ctx: Arc<DatabendQueryContext>,
-    ) -> Result<Vec<Expression>> {
+    pub fn build_args_from_ctx(name: &str, ctx: Arc<QueryContext>) -> Result<Vec<Expression>> {
         // Check the function is supported in common functions.
         let function_factory = FunctionFactory::instance();
         let aggregate_function_factory = AggregateFunctionFactory::instance();

--- a/query/src/functions/context_function.rs
+++ b/query/src/functions/context_function.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_datavalues::DataValue;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -19,7 +21,7 @@ use common_functions::aggregates::AggregateFunctionFactory;
 use common_functions::scalars::FunctionFactory;
 use common_planners::Expression;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct ContextFunction;
 
@@ -28,7 +30,7 @@ impl ContextFunction {
     // such as `SELECT database()`, the arg is ctx.get_default_db()
     pub fn build_args_from_ctx(
         name: &str,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
     ) -> Result<Vec<Expression>> {
         // Check the function is supported in common functions.
         let function_factory = FunctionFactory::instance();

--- a/query/src/interpreters/interpreter_copy.rs
+++ b/query/src/interpreters/interpreter_copy.rs
@@ -31,15 +31,15 @@ use nom::IResult;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct CopyInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: CopyPlan,
 }
 
 impl CopyInterpreter {
-    pub fn try_create(ctx: DatabendQueryContextRef, plan: CopyPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<DatabendQueryContext>, plan: CopyPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(CopyInterpreter { ctx, plan }))
     }
 }
@@ -113,7 +113,7 @@ fn extract_stage_location(path: &str) -> IResult<&str, &str> {
 //  this is mock implementation from env
 //  todo: support get the stage config from metadata
 fn get_dal_by_stage(
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     _stage_name: &str,
 ) -> Result<Arc<dyn DataAccessor>> {
     let conf = ctx.get_config().storage.s3;

--- a/query/src/interpreters/interpreter_copy.rs
+++ b/query/src/interpreters/interpreter_copy.rs
@@ -31,15 +31,15 @@ use nom::IResult;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct CopyInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: CopyPlan,
 }
 
 impl CopyInterpreter {
-    pub fn try_create(ctx: Arc<DatabendQueryContext>, plan: CopyPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: CopyPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(CopyInterpreter { ctx, plan }))
     }
 }
@@ -112,10 +112,7 @@ fn extract_stage_location(path: &str) -> IResult<&str, &str> {
 
 //  this is mock implementation from env
 //  todo: support get the stage config from metadata
-fn get_dal_by_stage(
-    ctx: Arc<DatabendQueryContext>,
-    _stage_name: &str,
-) -> Result<Arc<dyn DataAccessor>> {
+fn get_dal_by_stage(ctx: Arc<QueryContext>, _stage_name: &str) -> Result<Arc<dyn DataAccessor>> {
     let conf = ctx.get_config().storage.s3;
 
     Ok(Arc::new(S3::try_create(

--- a/query/src/interpreters/interpreter_database_create.rs
+++ b/query/src/interpreters/interpreter_database_create.rs
@@ -23,17 +23,17 @@ use common_tracing::tracing;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 #[derive(Debug)]
 pub struct CreateDatabaseInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: CreateDatabasePlan,
 }
 
 impl CreateDatabaseInterpreter {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: CreateDatabasePlan,
     ) -> Result<InterpreterPtr> {
         Ok(Arc::new(CreateDatabaseInterpreter { ctx, plan }))

--- a/query/src/interpreters/interpreter_database_create.rs
+++ b/query/src/interpreters/interpreter_database_create.rs
@@ -23,19 +23,16 @@ use common_tracing::tracing;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 #[derive(Debug)]
 pub struct CreateDatabaseInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: CreateDatabasePlan,
 }
 
 impl CreateDatabaseInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: CreateDatabasePlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: CreateDatabasePlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(CreateDatabaseInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_database_drop.rs
+++ b/query/src/interpreters/interpreter_database_drop.rs
@@ -22,18 +22,15 @@ use common_streams::SendableDataBlockStream;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct DropDatabaseInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: DropDatabasePlan,
 }
 
 impl DropDatabaseInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: DropDatabasePlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: DropDatabasePlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(DropDatabaseInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_database_drop.rs
+++ b/query/src/interpreters/interpreter_database_drop.rs
@@ -22,16 +22,16 @@ use common_streams::SendableDataBlockStream;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct DropDatabaseInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: DropDatabasePlan,
 }
 
 impl DropDatabaseInterpreter {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: DropDatabasePlan,
     ) -> Result<InterpreterPtr> {
         Ok(Arc::new(DropDatabaseInterpreter { ctx, plan }))

--- a/query/src/interpreters/interpreter_describe_table.rs
+++ b/query/src/interpreters/interpreter_describe_table.rs
@@ -24,16 +24,16 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct DescribeTableInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: DescribeTablePlan,
 }
 
 impl DescribeTableInterpreter {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: DescribeTablePlan,
     ) -> Result<InterpreterPtr> {
         Ok(Arc::new(DescribeTableInterpreter { ctx, plan }))

--- a/query/src/interpreters/interpreter_describe_table.rs
+++ b/query/src/interpreters/interpreter_describe_table.rs
@@ -24,18 +24,15 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct DescribeTableInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: DescribeTablePlan,
 }
 
 impl DescribeTableInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: DescribeTablePlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: DescribeTablePlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(DescribeTableInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_explain.rs
+++ b/query/src/interpreters/interpreter_explain.rs
@@ -27,10 +27,10 @@ use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::optimizers::Optimizers;
 use crate::pipelines::processors::PipelineBuilder;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct ExplainInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     explain: ExplainPlan,
 }
 
@@ -62,7 +62,7 @@ impl Interpreter for ExplainInterpreter {
 
 impl ExplainInterpreter {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         explain: ExplainPlan,
     ) -> Result<InterpreterPtr> {
         Ok(Arc::new(ExplainInterpreter { ctx, explain }))

--- a/query/src/interpreters/interpreter_explain.rs
+++ b/query/src/interpreters/interpreter_explain.rs
@@ -27,10 +27,10 @@ use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::optimizers::Optimizers;
 use crate::pipelines::processors::PipelineBuilder;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ExplainInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     explain: ExplainPlan,
 }
 
@@ -61,10 +61,7 @@ impl Interpreter for ExplainInterpreter {
 }
 
 impl ExplainInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        explain: ExplainPlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, explain: ExplainPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(ExplainInterpreter { ctx, explain }))
     }
 

--- a/query/src/interpreters/interpreter_factory.rs
+++ b/query/src/interpreters/interpreter_factory.rs
@@ -38,12 +38,12 @@ use crate::interpreters::SettingInterpreter;
 use crate::interpreters::ShowCreateTableInterpreter;
 use crate::interpreters::TruncateTableInterpreter;
 use crate::interpreters::UseDatabaseInterpreter;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct InterpreterFactory;
 
 impl InterpreterFactory {
-    pub fn get(ctx: DatabendQueryContextRef, plan: PlanNode) -> Result<Arc<dyn Interpreter>> {
+    pub fn get(ctx: Arc<DatabendQueryContext>, plan: PlanNode) -> Result<Arc<dyn Interpreter>> {
         let ctx_clone = ctx.clone();
         let inner = match plan {
             PlanNode::Select(v) => SelectInterpreter::try_create(ctx_clone, v),

--- a/query/src/interpreters/interpreter_factory.rs
+++ b/query/src/interpreters/interpreter_factory.rs
@@ -38,12 +38,12 @@ use crate::interpreters::SettingInterpreter;
 use crate::interpreters::ShowCreateTableInterpreter;
 use crate::interpreters::TruncateTableInterpreter;
 use crate::interpreters::UseDatabaseInterpreter;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct InterpreterFactory;
 
 impl InterpreterFactory {
-    pub fn get(ctx: Arc<DatabendQueryContext>, plan: PlanNode) -> Result<Arc<dyn Interpreter>> {
+    pub fn get(ctx: Arc<QueryContext>, plan: PlanNode) -> Result<Arc<dyn Interpreter>> {
         let ctx_clone = ctx.clone();
         let inner = match plan {
             PlanNode::Select(v) => SelectInterpreter::try_create(ctx_clone, v),

--- a/query/src/interpreters/interpreter_grant_privilege.rs
+++ b/query/src/interpreters/interpreter_grant_privilege.rs
@@ -24,17 +24,17 @@ use common_tracing::tracing;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 #[derive(Debug)]
 pub struct GrantPrivilegeInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: GrantPrivilegePlan,
 }
 
 impl GrantPrivilegeInterpreter {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: GrantPrivilegePlan,
     ) -> Result<InterpreterPtr> {
         Ok(Arc::new(GrantPrivilegeInterpreter { ctx, plan }))

--- a/query/src/interpreters/interpreter_grant_privilege.rs
+++ b/query/src/interpreters/interpreter_grant_privilege.rs
@@ -24,19 +24,16 @@ use common_tracing::tracing;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 #[derive(Debug)]
 pub struct GrantPrivilegeInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: GrantPrivilegePlan,
 }
 
 impl GrantPrivilegeInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: GrantPrivilegePlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: GrantPrivilegePlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(GrantPrivilegeInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_insert_into.rs
+++ b/query/src/interpreters/interpreter_insert_into.rs
@@ -29,19 +29,16 @@ use common_streams::ValueSource;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::interpreters::SelectInterpreter;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct InsertIntoInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: InsertIntoPlan,
     select: Option<Arc<dyn Interpreter>>,
 }
 
 impl InsertIntoInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: InsertIntoPlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: InsertIntoPlan) -> Result<InterpreterPtr> {
         let select = match plan.select_plan.clone().take() {
             Some(select_plan) => {
                 if let PlanNode::Select(select_plan_node) = *select_plan {

--- a/query/src/interpreters/interpreter_insert_into.rs
+++ b/query/src/interpreters/interpreter_insert_into.rs
@@ -29,17 +29,17 @@ use common_streams::ValueSource;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::interpreters::SelectInterpreter;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct InsertIntoInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: InsertIntoPlan,
     select: Option<Arc<dyn Interpreter>>,
 }
 
 impl InsertIntoInterpreter {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: InsertIntoPlan,
     ) -> Result<InterpreterPtr> {
         let select = match plan.select_plan.clone().take() {

--- a/query/src/interpreters/interpreter_interceptor.rs
+++ b/query/src/interpreters/interpreter_interceptor.rs
@@ -23,16 +23,16 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct InterceptorInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     inner: InterpreterPtr,
     result_metric: Arc<Progress>,
 }
 
 impl InterceptorInterpreter {
-    pub fn create(ctx: Arc<DatabendQueryContext>, inner: InterpreterPtr) -> Self {
+    pub fn create(ctx: Arc<QueryContext>, inner: InterpreterPtr) -> Self {
         InterceptorInterpreter {
             ctx,
             inner,

--- a/query/src/interpreters/interpreter_interceptor.rs
+++ b/query/src/interpreters/interpreter_interceptor.rs
@@ -23,16 +23,16 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct InterceptorInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     inner: InterpreterPtr,
     result_metric: Arc<Progress>,
 }
 
 impl InterceptorInterpreter {
-    pub fn create(ctx: DatabendQueryContextRef, inner: InterpreterPtr) -> Self {
+    pub fn create(ctx: Arc<DatabendQueryContext>, inner: InterpreterPtr) -> Self {
         InterceptorInterpreter {
             ctx,
             inner,

--- a/query/src/interpreters/interpreter_kill.rs
+++ b/query/src/interpreters/interpreter_kill.rs
@@ -23,15 +23,15 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct KillInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: KillPlan,
 }
 
 impl KillInterpreter {
-    pub fn try_create(ctx: Arc<DatabendQueryContext>, plan: KillPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: KillPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(KillInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_kill.rs
+++ b/query/src/interpreters/interpreter_kill.rs
@@ -23,15 +23,15 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct KillInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: KillPlan,
 }
 
 impl KillInterpreter {
-    pub fn try_create(ctx: DatabendQueryContextRef, plan: KillPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<DatabendQueryContext>, plan: KillPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(KillInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_select.rs
+++ b/query/src/interpreters/interpreter_select.rs
@@ -38,18 +38,15 @@ use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::optimizers::Optimizers;
 use crate::pipelines::processors::PipelineBuilder;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct SelectInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     select: SelectPlan,
 }
 
 impl SelectInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        select: SelectPlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, select: SelectPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(SelectInterpreter { ctx, select }))
     }
 }
@@ -111,11 +108,7 @@ impl SelectInterpreter {
         in_local_pipeline.execute().await
     }
 
-    async fn error_handler(
-        scheduled: Scheduled,
-        context: &Arc<DatabendQueryContext>,
-        timeout: u64,
-    ) {
+    async fn error_handler(scheduled: Scheduled, context: &Arc<QueryContext>, timeout: u64) {
         let query_id = context.get_id();
         let config = context.get_config();
         let cluster = context.get_cluster();
@@ -152,7 +145,7 @@ impl SelectInterpreter {
 struct ScheduledStream {
     scheduled: Scheduled,
     is_success: AtomicBool,
-    context: Arc<DatabendQueryContext>,
+    context: Arc<QueryContext>,
     inner: SendableDataBlockStream,
 }
 
@@ -160,7 +153,7 @@ impl ScheduledStream {
     pub fn create(
         scheduled: Scheduled,
         inner: SendableDataBlockStream,
-        context: Arc<DatabendQueryContext>,
+        context: Arc<QueryContext>,
     ) -> SendableDataBlockStream {
         Box::pin(ScheduledStream {
             inner,

--- a/query/src/interpreters/interpreter_setting.rs
+++ b/query/src/interpreters/interpreter_setting.rs
@@ -24,15 +24,15 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct SettingInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     set: SettingPlan,
 }
 
 impl SettingInterpreter {
-    pub fn try_create(ctx: Arc<DatabendQueryContext>, set: SettingPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, set: SettingPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(SettingInterpreter { ctx, set }))
     }
 }

--- a/query/src/interpreters/interpreter_setting.rs
+++ b/query/src/interpreters/interpreter_setting.rs
@@ -24,15 +24,15 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct SettingInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     set: SettingPlan,
 }
 
 impl SettingInterpreter {
-    pub fn try_create(ctx: DatabendQueryContextRef, set: SettingPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<DatabendQueryContext>, set: SettingPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(SettingInterpreter { ctx, set }))
     }
 }

--- a/query/src/interpreters/interpreter_show_create_table.rs
+++ b/query/src/interpreters/interpreter_show_create_table.rs
@@ -29,16 +29,16 @@ use log::debug;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct ShowCreateTableInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: ShowCreateTablePlan,
 }
 
 impl ShowCreateTableInterpreter {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: ShowCreateTablePlan,
     ) -> Result<InterpreterPtr> {
         Ok(Arc::new(ShowCreateTableInterpreter { ctx, plan }))

--- a/query/src/interpreters/interpreter_show_create_table.rs
+++ b/query/src/interpreters/interpreter_show_create_table.rs
@@ -29,18 +29,15 @@ use log::debug;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ShowCreateTableInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: ShowCreateTablePlan,
 }
 
 impl ShowCreateTableInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: ShowCreateTablePlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: ShowCreateTablePlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(ShowCreateTableInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_table_create.rs
+++ b/query/src/interpreters/interpreter_table_create.rs
@@ -22,16 +22,16 @@ use common_streams::SendableDataBlockStream;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct CreateTableInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: CreateTablePlan,
 }
 
 impl CreateTableInterpreter {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: CreateTablePlan,
     ) -> Result<InterpreterPtr> {
         Ok(Arc::new(CreateTableInterpreter { ctx, plan }))

--- a/query/src/interpreters/interpreter_table_create.rs
+++ b/query/src/interpreters/interpreter_table_create.rs
@@ -22,18 +22,15 @@ use common_streams::SendableDataBlockStream;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct CreateTableInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: CreateTablePlan,
 }
 
 impl CreateTableInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: CreateTablePlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: CreateTablePlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(CreateTableInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_table_drop.rs
+++ b/query/src/interpreters/interpreter_table_drop.rs
@@ -22,15 +22,18 @@ use common_streams::SendableDataBlockStream;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct DropTableInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: DropTablePlan,
 }
 
 impl DropTableInterpreter {
-    pub fn try_create(ctx: DatabendQueryContextRef, plan: DropTablePlan) -> Result<InterpreterPtr> {
+    pub fn try_create(
+        ctx: Arc<DatabendQueryContext>,
+        plan: DropTablePlan,
+    ) -> Result<InterpreterPtr> {
         Ok(Arc::new(DropTableInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_table_drop.rs
+++ b/query/src/interpreters/interpreter_table_drop.rs
@@ -22,18 +22,15 @@ use common_streams::SendableDataBlockStream;
 use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct DropTableInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: DropTablePlan,
 }
 
 impl DropTableInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: DropTablePlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: DropTablePlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(DropTableInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_truncate_table.rs
+++ b/query/src/interpreters/interpreter_truncate_table.rs
@@ -21,16 +21,16 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct TruncateTableInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: TruncateTablePlan,
 }
 
 impl TruncateTableInterpreter {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: TruncateTablePlan,
     ) -> Result<InterpreterPtr> {
         Ok(Arc::new(TruncateTableInterpreter { ctx, plan }))

--- a/query/src/interpreters/interpreter_truncate_table.rs
+++ b/query/src/interpreters/interpreter_truncate_table.rs
@@ -21,18 +21,15 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct TruncateTableInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: TruncateTablePlan,
 }
 
 impl TruncateTableInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: TruncateTablePlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: TruncateTablePlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(TruncateTableInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_use_database.rs
+++ b/query/src/interpreters/interpreter_use_database.rs
@@ -22,16 +22,16 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct UseDatabaseInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: UseDatabasePlan,
 }
 
 impl UseDatabaseInterpreter {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: UseDatabasePlan,
     ) -> Result<InterpreterPtr> {
         Ok(Arc::new(UseDatabaseInterpreter { ctx, plan }))

--- a/query/src/interpreters/interpreter_use_database.rs
+++ b/query/src/interpreters/interpreter_use_database.rs
@@ -22,18 +22,15 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct UseDatabaseInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: UseDatabasePlan,
 }
 
 impl UseDatabaseInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: UseDatabasePlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: UseDatabasePlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(UseDatabaseInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_user_alter.rs
+++ b/query/src/interpreters/interpreter_user_alter.rs
@@ -22,19 +22,16 @@ use common_tracing::tracing;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 #[derive(Debug)]
 pub struct AlterUserInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: AlterUserPlan,
 }
 
 impl AlterUserInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: AlterUserPlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: AlterUserPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(AlterUserInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_user_alter.rs
+++ b/query/src/interpreters/interpreter_user_alter.rs
@@ -22,16 +22,19 @@ use common_tracing::tracing;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 #[derive(Debug)]
 pub struct AlterUserInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: AlterUserPlan,
 }
 
 impl AlterUserInterpreter {
-    pub fn try_create(ctx: DatabendQueryContextRef, plan: AlterUserPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(
+        ctx: Arc<DatabendQueryContext>,
+        plan: AlterUserPlan,
+    ) -> Result<InterpreterPtr> {
         Ok(Arc::new(AlterUserInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_user_create.rs
+++ b/query/src/interpreters/interpreter_user_create.rs
@@ -25,17 +25,17 @@ use common_tracing::tracing;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 #[derive(Debug)]
 pub struct CreatUserInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: CreateUserPlan,
 }
 
 impl CreatUserInterpreter {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         plan: CreateUserPlan,
     ) -> Result<InterpreterPtr> {
         Ok(Arc::new(CreatUserInterpreter { ctx, plan }))

--- a/query/src/interpreters/interpreter_user_create.rs
+++ b/query/src/interpreters/interpreter_user_create.rs
@@ -25,19 +25,16 @@ use common_tracing::tracing;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 #[derive(Debug)]
 pub struct CreatUserInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: CreateUserPlan,
 }
 
 impl CreatUserInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: CreateUserPlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: CreateUserPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(CreatUserInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_user_drop.rs
+++ b/query/src/interpreters/interpreter_user_drop.rs
@@ -22,16 +22,19 @@ use common_tracing::tracing;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 #[derive(Debug)]
 pub struct DropUserInterpreter {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     plan: DropUserPlan,
 }
 
 impl DropUserInterpreter {
-    pub fn try_create(ctx: DatabendQueryContextRef, plan: DropUserPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(
+        ctx: Arc<DatabendQueryContext>,
+        plan: DropUserPlan,
+    ) -> Result<InterpreterPtr> {
         Ok(Arc::new(DropUserInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_user_drop.rs
+++ b/query/src/interpreters/interpreter_user_drop.rs
@@ -22,19 +22,16 @@ use common_tracing::tracing;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 #[derive(Debug)]
 pub struct DropUserInterpreter {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     plan: DropUserPlan,
 }
 
 impl DropUserInterpreter {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        plan: DropUserPlan,
-    ) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: DropUserPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(DropUserInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/plan_do_readsource.rs
+++ b/query/src/interpreters/plan_do_readsource.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -23,15 +25,15 @@ use common_planners::PlanRewriter;
 use common_planners::ReadDataSourcePlan;
 
 use crate::catalogs::ToReadDataSourcePlan;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct PlanDoReadSource {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     before_group_by_schema: Option<DataSchemaRef>,
 }
 
 impl PlanDoReadSource {
-    pub fn create(ctx: DatabendQueryContextRef) -> PlanDoReadSource {
+    pub fn create(ctx: Arc<DatabendQueryContext>) -> PlanDoReadSource {
         PlanDoReadSource {
             ctx,
             before_group_by_schema: None,

--- a/query/src/interpreters/plan_do_readsource.rs
+++ b/query/src/interpreters/plan_do_readsource.rs
@@ -25,15 +25,15 @@ use common_planners::PlanRewriter;
 use common_planners::ReadDataSourcePlan;
 
 use crate::catalogs::ToReadDataSourcePlan;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct PlanDoReadSource {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     before_group_by_schema: Option<DataSchemaRef>,
 }
 
 impl PlanDoReadSource {
-    pub fn create(ctx: Arc<DatabendQueryContext>) -> PlanDoReadSource {
+    pub fn create(ctx: Arc<QueryContext>) -> PlanDoReadSource {
         PlanDoReadSource {
             ctx,
             before_group_by_schema: None,

--- a/query/src/interpreters/plan_scheduler.rs
+++ b/query/src/interpreters/plan_scheduler.rs
@@ -46,7 +46,7 @@ use common_tracing::tracing;
 use crate::api::BroadcastAction;
 use crate::api::FlightAction;
 use crate::api::ShuffleAction;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 enum RunningMode {
     Cluster,
@@ -55,7 +55,7 @@ enum RunningMode {
 
 pub struct Tasks {
     plan: PlanNode,
-    context: Arc<DatabendQueryContext>,
+    context: Arc<QueryContext>,
     actions: HashMap<String, VecDeque<FlightAction>>,
 }
 
@@ -66,12 +66,12 @@ pub struct PlanScheduler {
     local_pos: usize,
     nodes_plan: Vec<PlanNode>,
     running_mode: RunningMode,
-    query_context: Arc<DatabendQueryContext>,
+    query_context: Arc<QueryContext>,
     subqueries_expressions: Vec<Expressions>,
 }
 
 impl PlanScheduler {
-    pub fn try_create(context: Arc<DatabendQueryContext>) -> Result<PlanScheduler> {
+    pub fn try_create(context: Arc<QueryContext>) -> Result<PlanScheduler> {
         let cluster = context.get_cluster();
         let cluster_nodes = cluster.get_nodes();
 
@@ -116,7 +116,7 @@ impl PlanScheduler {
 }
 
 impl Tasks {
-    pub fn create(context: Arc<DatabendQueryContext>) -> Tasks {
+    pub fn create(context: Arc<QueryContext>) -> Tasks {
         Tasks {
             context,
             actions: HashMap::new(),
@@ -636,7 +636,7 @@ impl PlanScheduler {
     }
 
     fn visit_subquery(&mut self, plan: &PlanNode, tasks: &mut Tasks) -> Result<Vec<PlanNode>> {
-        let subquery_context = DatabendQueryContext::new(self.query_context.clone());
+        let subquery_context = QueryContext::new(self.query_context.clone());
         let mut subquery_scheduler = PlanScheduler::try_create(subquery_context)?;
         subquery_scheduler.visit_plan_node(plan, tasks)?;
         Ok(subquery_scheduler.nodes_plan)

--- a/query/src/interpreters/plan_scheduler.rs
+++ b/query/src/interpreters/plan_scheduler.rs
@@ -47,7 +47,6 @@ use crate::api::BroadcastAction;
 use crate::api::FlightAction;
 use crate::api::ShuffleAction;
 use crate::sessions::DatabendQueryContext;
-use crate::sessions::DatabendQueryContextRef;
 
 enum RunningMode {
     Cluster,
@@ -56,7 +55,7 @@ enum RunningMode {
 
 pub struct Tasks {
     plan: PlanNode,
-    context: DatabendQueryContextRef,
+    context: Arc<DatabendQueryContext>,
     actions: HashMap<String, VecDeque<FlightAction>>,
 }
 
@@ -67,12 +66,12 @@ pub struct PlanScheduler {
     local_pos: usize,
     nodes_plan: Vec<PlanNode>,
     running_mode: RunningMode,
-    query_context: DatabendQueryContextRef,
+    query_context: Arc<DatabendQueryContext>,
     subqueries_expressions: Vec<Expressions>,
 }
 
 impl PlanScheduler {
-    pub fn try_create(context: DatabendQueryContextRef) -> Result<PlanScheduler> {
+    pub fn try_create(context: Arc<DatabendQueryContext>) -> Result<PlanScheduler> {
         let cluster = context.get_cluster();
         let cluster_nodes = cluster.get_nodes();
 
@@ -117,7 +116,7 @@ impl PlanScheduler {
 }
 
 impl Tasks {
-    pub fn create(context: DatabendQueryContextRef) -> Tasks {
+    pub fn create(context: Arc<DatabendQueryContext>) -> Tasks {
         Tasks {
             context,
             actions: HashMap::new(),

--- a/query/src/interpreters/plan_scheduler_test.rs
+++ b/query/src/interpreters/plan_scheduler_test.rs
@@ -21,7 +21,7 @@ use common_planners::*;
 
 use crate::api::FlightAction;
 use crate::interpreters::plan_scheduler::PlanScheduler;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::tests::try_create_cluster_context;
 use crate::tests::ClusterDescriptor;
 
@@ -324,7 +324,7 @@ async fn test_scheduler_plan_with_convergent_and_normal_stage() -> Result<()> {
     Ok(())
 }
 
-async fn create_env() -> Result<DatabendQueryContextRef> {
+async fn create_env() -> Result<Arc<DatabendQueryContext>> {
     try_create_cluster_context(
         ClusterDescriptor::new()
             .with_node("dummy_local", "localhost:9090")

--- a/query/src/interpreters/plan_scheduler_test.rs
+++ b/query/src/interpreters/plan_scheduler_test.rs
@@ -21,7 +21,7 @@ use common_planners::*;
 
 use crate::api::FlightAction;
 use crate::interpreters::plan_scheduler::PlanScheduler;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::tests::try_create_cluster_context;
 use crate::tests::ClusterDescriptor;
 
@@ -324,7 +324,7 @@ async fn test_scheduler_plan_with_convergent_and_normal_stage() -> Result<()> {
     Ok(())
 }
 
-async fn create_env() -> Result<Arc<DatabendQueryContext>> {
+async fn create_env() -> Result<Arc<QueryContext>> {
     try_create_cluster_context(
         ClusterDescriptor::new()
             .with_node("dummy_local", "localhost:9090")

--- a/query/src/interpreters/utils.rs
+++ b/query/src/interpreters/utils.rs
@@ -20,10 +20,10 @@ use common_planners::PlanRewriter;
 
 use super::plan_do_readsource::PlanDoReadSource;
 use crate::optimizers::Optimizers;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub fn apply_plan_rewrite(
-    context: Arc<DatabendQueryContext>,
+    context: Arc<QueryContext>,
     optimizer: Optimizers,
     plan: &PlanNode,
 ) -> Result<PlanNode> {

--- a/query/src/interpreters/utils.rs
+++ b/query/src/interpreters/utils.rs
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_planners::PlanNode;
 use common_planners::PlanRewriter;
 
 use super::plan_do_readsource::PlanDoReadSource;
 use crate::optimizers::Optimizers;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub fn apply_plan_rewrite(
-    context: DatabendQueryContextRef,
+    context: Arc<DatabendQueryContext>,
     optimizer: Optimizers,
     plan: &PlanNode,
 ) -> Result<PlanNode> {

--- a/query/src/metrics/metric_service.rs
+++ b/query/src/metrics/metric_service.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -25,7 +26,7 @@ use poem::Response;
 
 use crate::common::service::HttpShutdownHandler;
 use crate::servers::Server;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 
 pub struct MetricService {
     shutdown_handler: HttpShutdownHandler,
@@ -49,7 +50,7 @@ pub async fn metric_handler(prom_extension: Data<&PrometheusHandle>) -> MetricTe
 
 impl MetricService {
     // TODO add session tls handler
-    pub fn create(_sessions: SessionManagerRef) -> Box<MetricService> {
+    pub fn create(_sessions: Arc<SessionManager>) -> Box<MetricService> {
         Box::new(MetricService {
             shutdown_handler: HttpShutdownHandler::create("metric api".to_string()),
         })

--- a/query/src/optimizers/optimizer.rs
+++ b/query/src/optimizers/optimizer.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 // Copyright 2020 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +25,7 @@ use crate::optimizers::ExprTransformOptimizer;
 use crate::optimizers::ProjectionPushDownOptimizer;
 use crate::optimizers::StatisticsExactOptimizer;
 use crate::optimizers::TopNPushDownOptimizer;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub trait Optimizer {
     fn name(&self) -> &str;
@@ -36,7 +37,7 @@ pub struct Optimizers {
 }
 
 impl Optimizers {
-    pub fn create(ctx: DatabendQueryContextRef) -> Self {
+    pub fn create(ctx: Arc<DatabendQueryContext>) -> Self {
         let mut optimizers = Self::without_scatters(ctx.clone());
         optimizers
             .inner
@@ -44,7 +45,7 @@ impl Optimizers {
         optimizers
     }
 
-    pub fn without_scatters(ctx: DatabendQueryContextRef) -> Self {
+    pub fn without_scatters(ctx: Arc<DatabendQueryContext>) -> Self {
         Optimizers {
             inner: vec![
                 Box::new(ConstantFoldingOptimizer::create(ctx.clone())),

--- a/query/src/optimizers/optimizer.rs
+++ b/query/src/optimizers/optimizer.rs
@@ -25,7 +25,7 @@ use crate::optimizers::ExprTransformOptimizer;
 use crate::optimizers::ProjectionPushDownOptimizer;
 use crate::optimizers::StatisticsExactOptimizer;
 use crate::optimizers::TopNPushDownOptimizer;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub trait Optimizer {
     fn name(&self) -> &str;
@@ -37,7 +37,7 @@ pub struct Optimizers {
 }
 
 impl Optimizers {
-    pub fn create(ctx: Arc<DatabendQueryContext>) -> Self {
+    pub fn create(ctx: Arc<QueryContext>) -> Self {
         let mut optimizers = Self::without_scatters(ctx.clone());
         optimizers
             .inner
@@ -45,7 +45,7 @@ impl Optimizers {
         optimizers
     }
 
-    pub fn without_scatters(ctx: Arc<DatabendQueryContext>) -> Self {
+    pub fn without_scatters(ctx: Arc<QueryContext>) -> Self {
         Optimizers {
             inner: vec![
                 Box::new(ConstantFoldingOptimizer::create(ctx.clone())),

--- a/query/src/optimizers/optimizer_constant_folding.rs
+++ b/query/src/optimizers/optimizer_constant_folding.rs
@@ -29,7 +29,7 @@ use common_planners::PlanRewriter;
 
 use crate::optimizers::Optimizer;
 use crate::pipelines::transforms::ExpressionExecutor;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ConstantFoldingOptimizer {}
 
@@ -372,7 +372,7 @@ impl Optimizer for ConstantFoldingOptimizer {
 }
 
 impl ConstantFoldingOptimizer {
-    pub fn create(_ctx: Arc<DatabendQueryContext>) -> Self {
+    pub fn create(_ctx: Arc<QueryContext>) -> Self {
         ConstantFoldingOptimizer {}
     }
 }

--- a/query/src/optimizers/optimizer_constant_folding.rs
+++ b/query/src/optimizers/optimizer_constant_folding.rs
@@ -29,7 +29,7 @@ use common_planners::PlanRewriter;
 
 use crate::optimizers::Optimizer;
 use crate::pipelines::transforms::ExpressionExecutor;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct ConstantFoldingOptimizer {}
 
@@ -372,7 +372,7 @@ impl Optimizer for ConstantFoldingOptimizer {
 }
 
 impl ConstantFoldingOptimizer {
-    pub fn create(_ctx: DatabendQueryContextRef) -> Self {
+    pub fn create(_ctx: Arc<DatabendQueryContext>) -> Self {
         ConstantFoldingOptimizer {}
     }
 }

--- a/query/src/optimizers/optimizer_expression_transform.rs
+++ b/query/src/optimizers/optimizer_expression_transform.rs
@@ -21,7 +21,7 @@ use common_functions::scalars::FunctionFactory;
 use common_planners::*;
 
 use crate::optimizers::Optimizer;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ExprTransformOptimizer {}
 
@@ -292,7 +292,7 @@ impl Optimizer for ExprTransformOptimizer {
 }
 
 impl ExprTransformOptimizer {
-    pub fn create(_ctx: Arc<DatabendQueryContext>) -> Self {
+    pub fn create(_ctx: Arc<QueryContext>) -> Self {
         ExprTransformOptimizer {}
     }
 }

--- a/query/src/optimizers/optimizer_expression_transform.rs
+++ b/query/src/optimizers/optimizer_expression_transform.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_datavalues::prelude::*;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -19,7 +21,7 @@ use common_functions::scalars::FunctionFactory;
 use common_planners::*;
 
 use crate::optimizers::Optimizer;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct ExprTransformOptimizer {}
 
@@ -188,22 +190,6 @@ impl PlanRewriter for ExprTransformImpl {
         }
     }
 
-    fn rewrite_limit(&mut self, plan: &LimitPlan) -> Result<PlanNode> {
-        let new_input = if let Some(0) = plan.n {
-            // case of limit zero.
-            self.one_time_limit = Some(false);
-            let plan = self.rewrite_plan_node(plan.input.as_ref())?;
-            self.one_time_limit = None;
-            plan
-        } else {
-            self.rewrite_plan_node(plan.input.as_ref())?
-        };
-
-        PlanBuilder::from(&new_input)
-            .limit_offset(plan.n, plan.offset)?
-            .build()
-    }
-
     fn rewrite_filter(&mut self, plan: &FilterPlan) -> Result<PlanNode> {
         if plan.is_literal_false() {
             self.one_time_filter = Some(false);
@@ -234,6 +220,22 @@ impl PlanRewriter for ExprTransformImpl {
         let new_predicate = Self::boolean_transformer(&plan.predicate)?;
         let new_predicate = Self::truth_transformer(&new_predicate, false)?;
         PlanBuilder::from(&new_input).having(new_predicate)?.build()
+    }
+
+    fn rewrite_limit(&mut self, plan: &LimitPlan) -> Result<PlanNode> {
+        let new_input = if let Some(0) = plan.n {
+            // case of limit zero.
+            self.one_time_limit = Some(false);
+            let plan = self.rewrite_plan_node(plan.input.as_ref())?;
+            self.one_time_limit = None;
+            plan
+        } else {
+            self.rewrite_plan_node(plan.input.as_ref())?
+        };
+
+        PlanBuilder::from(&new_input)
+            .limit_offset(plan.n, plan.offset)?
+            .build()
     }
 
     fn rewrite_read_data_source(&mut self, plan: &ReadDataSourcePlan) -> Result<PlanNode> {
@@ -290,7 +292,7 @@ impl Optimizer for ExprTransformOptimizer {
 }
 
 impl ExprTransformOptimizer {
-    pub fn create(_ctx: DatabendQueryContextRef) -> Self {
+    pub fn create(_ctx: Arc<DatabendQueryContext>) -> Self {
         ExprTransformOptimizer {}
     }
 }

--- a/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/query/src/optimizers/optimizer_projection_push_down.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
@@ -34,7 +35,7 @@ use common_planners::SortPlan;
 
 use crate::optimizers::Optimizer;
 use crate::optimizers::RequireColumnsVisitor;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct ProjectionPushDownOptimizer {}
 
@@ -209,7 +210,7 @@ impl Optimizer for ProjectionPushDownOptimizer {
 }
 
 impl ProjectionPushDownOptimizer {
-    pub fn create(_ctx: DatabendQueryContextRef) -> ProjectionPushDownOptimizer {
+    pub fn create(_ctx: Arc<DatabendQueryContext>) -> ProjectionPushDownOptimizer {
         ProjectionPushDownOptimizer {}
     }
 }

--- a/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/query/src/optimizers/optimizer_projection_push_down.rs
@@ -35,7 +35,7 @@ use common_planners::SortPlan;
 
 use crate::optimizers::Optimizer;
 use crate::optimizers::RequireColumnsVisitor;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ProjectionPushDownOptimizer {}
 
@@ -210,7 +210,7 @@ impl Optimizer for ProjectionPushDownOptimizer {
 }
 
 impl ProjectionPushDownOptimizer {
-    pub fn create(_ctx: Arc<DatabendQueryContext>) -> ProjectionPushDownOptimizer {
+    pub fn create(_ctx: Arc<QueryContext>) -> ProjectionPushDownOptimizer {
         ProjectionPushDownOptimizer {}
     }
 }

--- a/query/src/optimizers/optimizer_scatters.rs
+++ b/query/src/optimizers/optimizer_scatters.rs
@@ -33,10 +33,10 @@ use common_planners::StageKind;
 use common_planners::StagePlan;
 
 use crate::optimizers::Optimizer;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct ScattersOptimizer {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
 }
 
 #[derive(Clone, Debug)]
@@ -46,7 +46,7 @@ enum RunningMode {
 }
 
 struct ScattersOptimizerImpl {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     running_mode: RunningMode,
     before_group_by_schema: Option<DataSchemaRef>,
 
@@ -55,7 +55,7 @@ struct ScattersOptimizerImpl {
 }
 
 impl ScattersOptimizerImpl {
-    pub fn create(ctx: Arc<DatabendQueryContext>) -> ScattersOptimizerImpl {
+    pub fn create(ctx: Arc<QueryContext>) -> ScattersOptimizerImpl {
         ScattersOptimizerImpl {
             ctx,
             running_mode: RunningMode::Standalone,
@@ -206,7 +206,7 @@ impl ScattersOptimizerImpl {
 
 impl PlanRewriter for ScattersOptimizerImpl {
     fn rewrite_subquery_plan(&mut self, subquery_plan: &PlanNode) -> Result<PlanNode> {
-        let subquery_ctx = DatabendQueryContext::new(self.ctx.clone());
+        let subquery_ctx = QueryContext::new(self.ctx.clone());
         let mut subquery_optimizer = ScattersOptimizerImpl::create(subquery_ctx);
         let rewritten_subquery = subquery_optimizer.rewrite_plan_node(subquery_plan)?;
 
@@ -291,7 +291,7 @@ impl PlanRewriter for ScattersOptimizerImpl {
 }
 
 impl ScattersOptimizer {
-    pub fn create(ctx: Arc<DatabendQueryContext>) -> ScattersOptimizer {
+    pub fn create(ctx: Arc<QueryContext>) -> ScattersOptimizer {
         ScattersOptimizer { ctx }
     }
 }

--- a/query/src/optimizers/optimizer_scatters.rs
+++ b/query/src/optimizers/optimizer_scatters.rs
@@ -34,10 +34,9 @@ use common_planners::StagePlan;
 
 use crate::optimizers::Optimizer;
 use crate::sessions::DatabendQueryContext;
-use crate::sessions::DatabendQueryContextRef;
 
 pub struct ScattersOptimizer {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
 }
 
 #[derive(Clone, Debug)]
@@ -47,7 +46,7 @@ enum RunningMode {
 }
 
 struct ScattersOptimizerImpl {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     running_mode: RunningMode,
     before_group_by_schema: Option<DataSchemaRef>,
 
@@ -56,7 +55,7 @@ struct ScattersOptimizerImpl {
 }
 
 impl ScattersOptimizerImpl {
-    pub fn create(ctx: DatabendQueryContextRef) -> ScattersOptimizerImpl {
+    pub fn create(ctx: Arc<DatabendQueryContext>) -> ScattersOptimizerImpl {
         ScattersOptimizerImpl {
             ctx,
             running_mode: RunningMode::Standalone,
@@ -292,7 +291,7 @@ impl PlanRewriter for ScattersOptimizerImpl {
 }
 
 impl ScattersOptimizer {
-    pub fn create(ctx: DatabendQueryContextRef) -> ScattersOptimizer {
+    pub fn create(ctx: Arc<DatabendQueryContext>) -> ScattersOptimizer {
         ScattersOptimizer { ctx }
     }
 }

--- a/query/src/optimizers/optimizer_statistics_exact.rs
+++ b/query/src/optimizers/optimizer_statistics_exact.rs
@@ -26,15 +26,15 @@ use common_planners::PlanRewriter;
 
 use crate::catalogs::ToReadDataSourcePlan;
 use crate::optimizers::Optimizer;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 struct StatisticsExactImpl<'a> {
-    ctx: &'a Arc<DatabendQueryContext>,
+    ctx: &'a Arc<QueryContext>,
     rewritten: bool,
 }
 
 pub struct StatisticsExactOptimizer {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
 }
 
 impl PlanRewriter for StatisticsExactImpl<'_> {
@@ -125,7 +125,7 @@ impl Optimizer for StatisticsExactOptimizer {
 }
 
 impl StatisticsExactOptimizer {
-    pub fn create(ctx: Arc<DatabendQueryContext>) -> Self {
+    pub fn create(ctx: Arc<QueryContext>) -> Self {
         StatisticsExactOptimizer { ctx }
     }
 }

--- a/query/src/optimizers/optimizer_statistics_exact.rs
+++ b/query/src/optimizers/optimizer_statistics_exact.rs
@@ -26,15 +26,15 @@ use common_planners::PlanRewriter;
 
 use crate::catalogs::ToReadDataSourcePlan;
 use crate::optimizers::Optimizer;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 struct StatisticsExactImpl<'a> {
-    ctx: &'a DatabendQueryContextRef,
+    ctx: &'a Arc<DatabendQueryContext>,
     rewritten: bool,
 }
 
 pub struct StatisticsExactOptimizer {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
 }
 
 impl PlanRewriter for StatisticsExactImpl<'_> {
@@ -125,7 +125,7 @@ impl Optimizer for StatisticsExactOptimizer {
 }
 
 impl StatisticsExactOptimizer {
-    pub fn create(ctx: DatabendQueryContextRef) -> Self {
+    pub fn create(ctx: Arc<DatabendQueryContext>) -> Self {
         StatisticsExactOptimizer { ctx }
     }
 }

--- a/query/src/optimizers/optimizer_top_n_push_down.rs
+++ b/query/src/optimizers/optimizer_top_n_push_down.rs
@@ -25,7 +25,7 @@ use common_tracing::tracing;
 use super::MonotonicityCheckVisitor;
 use super::RequireColumnsVisitor;
 use crate::optimizers::Optimizer;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct TopNPushDownOptimizer {}
 
@@ -201,7 +201,7 @@ impl Optimizer for TopNPushDownOptimizer {
 }
 
 impl TopNPushDownOptimizer {
-    pub fn create(_ctx: Arc<DatabendQueryContext>) -> TopNPushDownOptimizer {
+    pub fn create(_ctx: Arc<QueryContext>) -> TopNPushDownOptimizer {
         TopNPushDownOptimizer {}
     }
 }

--- a/query/src/optimizers/optimizer_top_n_push_down.rs
+++ b/query/src/optimizers/optimizer_top_n_push_down.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
@@ -24,7 +25,7 @@ use common_tracing::tracing;
 use super::MonotonicityCheckVisitor;
 use super::RequireColumnsVisitor;
 use crate::optimizers::Optimizer;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct TopNPushDownOptimizer {}
 
@@ -200,7 +201,7 @@ impl Optimizer for TopNPushDownOptimizer {
 }
 
 impl TopNPushDownOptimizer {
-    pub fn create(_ctx: DatabendQueryContextRef) -> TopNPushDownOptimizer {
+    pub fn create(_ctx: Arc<DatabendQueryContext>) -> TopNPushDownOptimizer {
         TopNPushDownOptimizer {}
     }
 }

--- a/query/src/pipelines/processors/pipeline.rs
+++ b/query/src/pipelines/processors/pipeline.rs
@@ -22,15 +22,15 @@ use super::MixedProcessor;
 use crate::pipelines::processors::MergeProcessor;
 use crate::pipelines::processors::Pipe;
 use crate::pipelines::processors::Processor;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct Pipeline {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     pipes: Vec<Pipe>,
 }
 
 impl Pipeline {
-    pub fn create(ctx: DatabendQueryContextRef) -> Self {
+    pub fn create(ctx: Arc<DatabendQueryContext>) -> Self {
         Pipeline { ctx, pipes: vec![] }
     }
 

--- a/query/src/pipelines/processors/pipeline.rs
+++ b/query/src/pipelines/processors/pipeline.rs
@@ -22,15 +22,15 @@ use super::MixedProcessor;
 use crate::pipelines::processors::MergeProcessor;
 use crate::pipelines::processors::Pipe;
 use crate::pipelines::processors::Processor;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct Pipeline {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     pipes: Vec<Pipe>,
 }
 
 impl Pipeline {
-    pub fn create(ctx: Arc<DatabendQueryContext>) -> Self {
+    pub fn create(ctx: Arc<QueryContext>) -> Self {
         Pipeline { ctx, pipes: vec![] }
     }
 

--- a/query/src/pipelines/processors/pipeline_builder.rs
+++ b/query/src/pipelines/processors/pipeline_builder.rs
@@ -51,17 +51,17 @@ use crate::pipelines::transforms::SortPartialTransform;
 use crate::pipelines::transforms::SourceTransform;
 use crate::pipelines::transforms::SubQueriesPuller;
 use crate::pipelines::transforms::WhereTransform;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct PipelineBuilder {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
 
     limit: Option<usize>,
     offset: usize,
 }
 
 impl PipelineBuilder {
-    pub fn create(ctx: DatabendQueryContextRef) -> PipelineBuilder {
+    pub fn create(ctx: Arc<DatabendQueryContext>) -> PipelineBuilder {
         PipelineBuilder {
             ctx,
             limit: None,

--- a/query/src/pipelines/processors/pipeline_builder.rs
+++ b/query/src/pipelines/processors/pipeline_builder.rs
@@ -51,17 +51,17 @@ use crate::pipelines::transforms::SortPartialTransform;
 use crate::pipelines::transforms::SourceTransform;
 use crate::pipelines::transforms::SubQueriesPuller;
 use crate::pipelines::transforms::WhereTransform;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct PipelineBuilder {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
 
     limit: Option<usize>,
     offset: usize,
 }
 
 impl PipelineBuilder {
-    pub fn create(ctx: Arc<DatabendQueryContext>) -> PipelineBuilder {
+    pub fn create(ctx: Arc<QueryContext>) -> PipelineBuilder {
         PipelineBuilder {
             ctx,
             limit: None,

--- a/query/src/pipelines/processors/processor_merge.rs
+++ b/query/src/pipelines/processors/processor_merge.rs
@@ -26,15 +26,15 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
 
 use crate::pipelines::processors::Processor;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct MergeProcessor {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     inputs: Vec<Arc<dyn Processor>>,
 }
 
 impl MergeProcessor {
-    pub fn create(ctx: DatabendQueryContextRef) -> Self {
+    pub fn create(ctx: Arc<DatabendQueryContext>) -> Self {
         MergeProcessor {
             ctx,
             inputs: vec![],

--- a/query/src/pipelines/processors/processor_merge.rs
+++ b/query/src/pipelines/processors/processor_merge.rs
@@ -26,15 +26,15 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
 
 use crate::pipelines::processors::Processor;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct MergeProcessor {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     inputs: Vec<Arc<dyn Processor>>,
 }
 
 impl MergeProcessor {
-    pub fn create(ctx: Arc<DatabendQueryContext>) -> Self {
+    pub fn create(ctx: Arc<QueryContext>) -> Self {
         MergeProcessor {
             ctx,
             inputs: vec![],

--- a/query/src/pipelines/processors/processor_mixed.rs
+++ b/query/src/pipelines/processors/processor_mixed.rs
@@ -31,11 +31,11 @@ use tokio_stream::StreamExt;
 
 use crate::pipelines::processors::processor_merge::MergeProcessor;
 use crate::pipelines::processors::Processor;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 // M inputs--> N outputs Mixed processor
 struct MixedWorker {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     n: usize,
     shared_num: AtomicUsize,
     started: AtomicBool,
@@ -82,7 +82,7 @@ pub struct MixedProcessor {
 }
 
 impl MixedProcessor {
-    pub fn create(ctx: DatabendQueryContextRef, n: usize) -> Self {
+    pub fn create(ctx: Arc<DatabendQueryContext>, n: usize) -> Self {
         let worker = MixedWorker {
             ctx: ctx.clone(),
             n,

--- a/query/src/pipelines/processors/processor_mixed.rs
+++ b/query/src/pipelines/processors/processor_mixed.rs
@@ -31,11 +31,11 @@ use tokio_stream::StreamExt;
 
 use crate::pipelines::processors::processor_merge::MergeProcessor;
 use crate::pipelines::processors::Processor;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 // M inputs--> N outputs Mixed processor
 struct MixedWorker {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     n: usize,
     shared_num: AtomicUsize,
     started: AtomicBool,
@@ -82,7 +82,7 @@ pub struct MixedProcessor {
 }
 
 impl MixedProcessor {
-    pub fn create(ctx: Arc<DatabendQueryContext>, n: usize) -> Self {
+    pub fn create(ctx: Arc<QueryContext>, n: usize) -> Self {
         let worker = MixedWorker {
             ctx: ctx.clone(),
             n,

--- a/query/src/pipelines/transforms/transform_create_sets.rs
+++ b/query/src/pipelines/transforms/transform_create_sets.rs
@@ -37,10 +37,10 @@ use crate::pipelines::processors::EmptyProcessor;
 use crate::pipelines::processors::Pipeline;
 use crate::pipelines::processors::PipelineBuilder;
 use crate::pipelines::processors::Processor;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct CreateSetsTransform {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     schema: DataSchemaRef,
     input: Arc<dyn Processor>,
     sub_queries_puller: Arc<Mutex<SubQueriesPuller<'static>>>,
@@ -48,7 +48,7 @@ pub struct CreateSetsTransform {
 
 impl CreateSetsTransform {
     pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         schema: DataSchemaRef,
         sub_queries_puller: Arc<Mutex<SubQueriesPuller<'static>>>,
     ) -> Result<CreateSetsTransform> {
@@ -133,14 +133,14 @@ type SubqueryData = Result<DataValue>;
 type SharedFuture<'a> = Shared<BoxFuture<'a, SubqueryData>>;
 
 pub struct SubQueriesPuller<'a> {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     expressions: Vec<Expression>,
     sub_queries: Vec<SharedFuture<'a>>,
 }
 
 impl<'a> SubQueriesPuller<'a> {
     pub fn create(
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         expressions: Vec<Expression>,
     ) -> Arc<Mutex<SubQueriesPuller<'a>>> {
         let expression_len = expressions.len();
@@ -168,7 +168,7 @@ impl<'a> SubQueriesPuller<'a> {
 
     fn init(&mut self) -> Result<()> {
         for query_expression in &self.expressions {
-            let subquery_ctx = DatabendQueryContext::new(self.ctx.clone());
+            let subquery_ctx = QueryContext::new(self.ctx.clone());
 
             match query_expression {
                 Expression::Subquery { query_plan, .. } => {

--- a/query/src/pipelines/transforms/transform_create_sets.rs
+++ b/query/src/pipelines/transforms/transform_create_sets.rs
@@ -38,10 +38,9 @@ use crate::pipelines::processors::Pipeline;
 use crate::pipelines::processors::PipelineBuilder;
 use crate::pipelines::processors::Processor;
 use crate::sessions::DatabendQueryContext;
-use crate::sessions::DatabendQueryContextRef;
 
 pub struct CreateSetsTransform {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     schema: DataSchemaRef,
     input: Arc<dyn Processor>,
     sub_queries_puller: Arc<Mutex<SubQueriesPuller<'static>>>,
@@ -49,7 +48,7 @@ pub struct CreateSetsTransform {
 
 impl CreateSetsTransform {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         schema: DataSchemaRef,
         sub_queries_puller: Arc<Mutex<SubQueriesPuller<'static>>>,
     ) -> Result<CreateSetsTransform> {
@@ -134,14 +133,14 @@ type SubqueryData = Result<DataValue>;
 type SharedFuture<'a> = Shared<BoxFuture<'a, SubqueryData>>;
 
 pub struct SubQueriesPuller<'a> {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     expressions: Vec<Expression>,
     sub_queries: Vec<SharedFuture<'a>>,
 }
 
 impl<'a> SubQueriesPuller<'a> {
     pub fn create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         expressions: Vec<Expression>,
     ) -> Arc<Mutex<SubQueriesPuller<'a>>> {
         let expression_len = expressions.len();

--- a/query/src/pipelines/transforms/transform_remote.rs
+++ b/query/src/pipelines/transforms/transform_remote.rs
@@ -25,19 +25,19 @@ use crate::api::FlightClient;
 use crate::api::FlightTicket;
 use crate::pipelines::processors::EmptyProcessor;
 use crate::pipelines::processors::Processor;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct RemoteTransform {
     ticket: FlightTicket,
     fetch_node_name: String,
     schema: DataSchemaRef,
-    pub ctx: DatabendQueryContextRef,
+    pub ctx: Arc<DatabendQueryContext>,
 }
 
 impl RemoteTransform {
     pub fn try_create(
         ticket: FlightTicket,
-        context: DatabendQueryContextRef,
+        context: Arc<DatabendQueryContext>,
         fetch_node_name: String,
         schema: DataSchemaRef,
     ) -> Result<RemoteTransform> {

--- a/query/src/pipelines/transforms/transform_remote.rs
+++ b/query/src/pipelines/transforms/transform_remote.rs
@@ -25,19 +25,19 @@ use crate::api::FlightClient;
 use crate::api::FlightTicket;
 use crate::pipelines::processors::EmptyProcessor;
 use crate::pipelines::processors::Processor;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct RemoteTransform {
     ticket: FlightTicket,
     fetch_node_name: String,
     schema: DataSchemaRef,
-    pub ctx: Arc<DatabendQueryContext>,
+    pub ctx: Arc<QueryContext>,
 }
 
 impl RemoteTransform {
     pub fn try_create(
         ticket: FlightTicket,
-        context: Arc<DatabendQueryContext>,
+        context: Arc<QueryContext>,
         fetch_node_name: String,
         schema: DataSchemaRef,
     ) -> Result<RemoteTransform> {

--- a/query/src/pipelines/transforms/transform_source.rs
+++ b/query/src/pipelines/transforms/transform_source.rs
@@ -25,18 +25,15 @@ use common_tracing::tracing;
 
 use crate::pipelines::processors::EmptyProcessor;
 use crate::pipelines::processors::Processor;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 
 pub struct SourceTransform {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     source_plan: ReadDataSourcePlan,
 }
 
 impl SourceTransform {
-    pub fn try_create(
-        ctx: Arc<DatabendQueryContext>,
-        source_plan: ReadDataSourcePlan,
-    ) -> Result<Self> {
+    pub fn try_create(ctx: Arc<QueryContext>, source_plan: ReadDataSourcePlan) -> Result<Self> {
         Ok(SourceTransform { ctx, source_plan })
     }
 

--- a/query/src/pipelines/transforms/transform_source.rs
+++ b/query/src/pipelines/transforms/transform_source.rs
@@ -25,16 +25,16 @@ use common_tracing::tracing;
 
 use crate::pipelines::processors::EmptyProcessor;
 use crate::pipelines::processors::Processor;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 
 pub struct SourceTransform {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     source_plan: ReadDataSourcePlan,
 }
 
 impl SourceTransform {
     pub fn try_create(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         source_plan: ReadDataSourcePlan,
     ) -> Result<Self> {
         Ok(SourceTransform { ctx, source_plan })

--- a/query/src/servers/clickhouse/clickhouse_handler.rs
+++ b/query/src/servers/clickhouse/clickhouse_handler.rs
@@ -34,10 +34,9 @@ use crate::servers::clickhouse::reject_connection::RejectCHConnection;
 use crate::servers::server::ListeningStream;
 use crate::servers::server::Server;
 use crate::sessions::SessionManager;
-use crate::sessions::SessionManagerRef;
 
 pub struct ClickHouseHandler {
-    sessions: SessionManagerRef,
+    sessions: Arc<SessionManager>,
 
     abort_handle: AbortHandle,
     abort_registration: Option<AbortRegistration>,
@@ -45,7 +44,7 @@ pub struct ClickHouseHandler {
 }
 
 impl ClickHouseHandler {
-    pub fn create(sessions: SessionManagerRef) -> Box<dyn Server> {
+    pub fn create(sessions: Arc<SessionManager>) -> Box<dyn Server> {
         let (abort_handle, registration) = AbortHandle::new_pair();
         Box::new(ClickHouseHandler {
             sessions,

--- a/query/src/servers/clickhouse/interactive_worker_base.rs
+++ b/query/src/servers/clickhouse/interactive_worker_base.rs
@@ -40,7 +40,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use super::writers::from_clickhouse_block;
 use crate::interpreters::InterpreterFactory;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sessions::SessionRef;
 use crate::sql::PlanParser;
 
@@ -111,7 +111,7 @@ impl InteractiveWorkerBase {
     pub async fn process_insert_query(
         insert: InsertIntoPlan,
         ch_ctx: &mut CHContext,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
     ) -> Result<Receiver<BlockItem>> {
         let sample_block = DataBlock::empty_with_schema(insert.schema());
         let (sender, rec) = channel(4);

--- a/query/src/servers/clickhouse/interactive_worker_base.rs
+++ b/query/src/servers/clickhouse/interactive_worker_base.rs
@@ -40,7 +40,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use super::writers::from_clickhouse_block;
 use crate::interpreters::InterpreterFactory;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sessions::SessionRef;
 use crate::sql::PlanParser;
 
@@ -111,7 +111,7 @@ impl InteractiveWorkerBase {
     pub async fn process_insert_query(
         insert: InsertIntoPlan,
         ch_ctx: &mut CHContext,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
     ) -> Result<Receiver<BlockItem>> {
         let sample_block = DataBlock::empty_with_schema(insert.schema());
         let (sender, rec) = channel(4);

--- a/query/src/servers/http/http_services.rs
+++ b/query/src/servers/http/http_services.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use common_exception::Result;
 use poem::get;
@@ -24,15 +25,15 @@ use crate::common::service::HttpShutdownHandler;
 use crate::servers::http::v1::query_route;
 use crate::servers::http::v1::statement_router;
 use crate::servers::Server;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 
 pub struct HttpHandler {
-    session_manager: SessionManagerRef,
+    session_manager: Arc<SessionManager>,
     shutdown_handler: HttpShutdownHandler,
 }
 
 impl HttpHandler {
-    pub fn create(session_manager: SessionManagerRef) -> Box<dyn Server> {
+    pub fn create(session_manager: Arc<SessionManager>) -> Box<dyn Server> {
         Box::new(HttpHandler {
             session_manager,
             shutdown_handler: HttpShutdownHandler::create("http handler".to_string()),

--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -44,7 +44,7 @@ use crate::servers::http::v1::query::execute_state::HttpQueryRequest;
 use crate::servers::http::v1::query::http_query::HttpQuery;
 use crate::servers::http::v1::query::http_query::HttpQueryResponseInternal;
 use crate::servers::http::v1::query::result_data_manager::Wait;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 
 pub fn make_page_uri(query_id: &str, page_no: usize) -> String {
     format!("/v1/query/{}/page/{}", query_id, page_no)
@@ -176,7 +176,7 @@ pub(crate) struct CancelParams {
 
 #[poem::handler]
 async fn query_cancel_handler(
-    sessions_extension: Data<&SessionManagerRef>,
+    sessions_extension: Data<&Arc<SessionManager>>,
     Query(params): Query<CancelParams>,
     Path(query_id): Path<String>,
 ) -> impl IntoResponse {
@@ -196,7 +196,7 @@ async fn query_cancel_handler(
 
 #[poem::handler]
 async fn query_state_handler(
-    sessions_extension: Data<&SessionManagerRef>,
+    sessions_extension: Data<&Arc<SessionManager>>,
     Path(query_id): Path<String>,
 ) -> PoemResult<QueryResponse> {
     let session_manager = sessions_extension.0;
@@ -229,7 +229,7 @@ impl PageParams {
 
 #[poem::handler]
 async fn query_page_handler(
-    sessions_extension: Data<&SessionManagerRef>,
+    sessions_extension: Data<&Arc<SessionManager>>,
     Query(params): Query<PageParams>,
     Path((query_id, page_no)): Path<(String, usize)>,
 ) -> PoemResult<QueryResponse> {
@@ -247,7 +247,7 @@ async fn query_page_handler(
 
 #[poem::handler]
 pub(crate) async fn query_handler(
-    sessions_extension: Data<&SessionManagerRef>,
+    sessions_extension: Data<&Arc<SessionManager>>,
     Query(params): Query<PageParams>,
     Json(req): Json<HttpQueryRequest>,
 ) -> PoemResult<QueryResponse> {

--- a/query/src/servers/http/v1/http_query_handlers_test.rs
+++ b/query/src/servers/http/v1/http_query_handlers_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_base::tokio;
 use common_exception::Result;
 use hyper::header;
@@ -32,7 +34,7 @@ use crate::servers::http::v1::http_query_handlers::make_state_uri;
 use crate::servers::http::v1::http_query_handlers::query_route;
 use crate::servers::http::v1::http_query_handlers::QueryResponse;
 use crate::servers::http::v1::query::execute_state::ExecuteStateName;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 use crate::tests::SessionManagerBuilder;
 
 // TODO(youngsofun): add test for
@@ -48,7 +50,7 @@ pub fn get_page_uri(query_id: &str, page_no: usize, wait_time: u32) -> String {
     )
 }
 
-type RouteWithData = AddDataEndpoint<Route, SessionManagerRef>;
+type RouteWithData = AddDataEndpoint<Route, Arc<SessionManager>>;
 
 #[tokio::test]
 async fn test_simple_sql() -> Result<()> {

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -28,7 +28,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::interpreters::InterpreterFactory;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sessions::SessionManager;
 use crate::sessions::SessionRef;
 use crate::sql::PlanParser;
@@ -101,7 +101,7 @@ pub(crate) struct ExecuteRunning {
     // used to kill query
     session: SessionRef,
     // mainly used to get progress for now
-    context: Arc<DatabendQueryContext>,
+    context: Arc<QueryContext>,
 }
 
 impl ExecuteState {

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -28,7 +28,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::interpreters::InterpreterFactory;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sessions::SessionManagerRef;
 use crate::sessions::SessionRef;
 use crate::sql::PlanParser;
@@ -101,7 +101,7 @@ pub(crate) struct ExecuteRunning {
     // used to kill query
     session: SessionRef,
     // mainly used to get progress for now
-    context: DatabendQueryContextRef,
+    context: Arc<DatabendQueryContext>,
 }
 
 impl ExecuteState {

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::interpreters::InterpreterFactory;
 use crate::sessions::DatabendQueryContext;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 use crate::sessions::SessionRef;
 use crate::sql::PlanParser;
 
@@ -107,7 +107,7 @@ pub(crate) struct ExecuteRunning {
 impl ExecuteState {
     pub(crate) async fn try_create(
         request: &HttpQueryRequest,
-        session_manager: &SessionManagerRef,
+        session_manager: &Arc<SessionManager>,
         block_tx: mpsc::Sender<DataBlock>,
     ) -> Result<(ExecuteStateRef, DataSchemaRef)> {
         let sql = &request.sql;

--- a/query/src/servers/http/v1/query/http_query.rs
+++ b/query/src/servers/http/v1/query/http_query.rs
@@ -28,7 +28,7 @@ use crate::servers::http::v1::query::execute_state::HttpQueryRequest;
 use crate::servers::http::v1::query::result_data_manager::ResponseData;
 use crate::servers::http::v1::query::result_data_manager::ResultDataManager;
 use crate::servers::http::v1::query::result_data_manager::Wait;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 
 pub struct ResponseInitialState {
     pub schema: Option<DataSchemaRef>,
@@ -60,7 +60,7 @@ impl HttpQuery {
     pub(crate) async fn try_create(
         id: String,
         request: HttpQueryRequest,
-        session_manager: &SessionManagerRef,
+        session_manager: &Arc<SessionManager>,
     ) -> Result<HttpQueryRef> {
         //TODO(youngsofun): support config/set channel size
         let (block_tx, block_rx) = mpsc::channel(10);

--- a/query/src/servers/http/v1/statement.rs
+++ b/query/src/servers/http/v1/statement.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_base::ProgressValues;
 use common_datavalues::DataSchemaRef;
@@ -36,7 +37,7 @@ use uuid;
 
 use super::block_to_json::block_to_json;
 use crate::interpreters::InterpreterFactory;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sessions::SessionManagerRef;
 use crate::sessions::SessionRef;
 use crate::sql::PlanParser;
@@ -89,7 +90,7 @@ struct HttpQuery {
 struct HttpQueryState {
     #[allow(dead_code)]
     session: SessionRef,
-    context: DatabendQueryContextRef,
+    context: Arc<DatabendQueryContext>,
     data_stream: SendableDataBlockStream,
     schema: DataSchemaRef,
 }

--- a/query/src/servers/http/v1/statement.rs
+++ b/query/src/servers/http/v1/statement.rs
@@ -38,7 +38,7 @@ use uuid;
 use super::block_to_json::block_to_json;
 use crate::interpreters::InterpreterFactory;
 use crate::sessions::DatabendQueryContext;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 use crate::sessions::SessionRef;
 use crate::sql::PlanParser;
 
@@ -106,7 +106,7 @@ impl HttpQuery {
         }
     }
 
-    async fn start(&mut self, session_manager: SessionManagerRef) -> Result<HttpQueryState> {
+    async fn start(&mut self, session_manager: Arc<SessionManager>) -> Result<HttpQueryState> {
         let session = session_manager.create_session("http-statement")?;
         let ctx = session.create_context().await?;
         if self.db.is_some() && !self.db.clone().unwrap().is_empty() {
@@ -126,7 +126,7 @@ impl HttpQuery {
         Ok(state)
     }
 
-    async fn initial_result(&mut self, session_manager: SessionManagerRef) -> HttpQueryResult {
+    async fn initial_result(&mut self, session_manager: Arc<SessionManager>) -> HttpQueryResult {
         let state = self.start(session_manager).await;
         let mut result = HttpQueryResult::create(self.id.clone());
         match state {
@@ -172,7 +172,7 @@ impl HttpQueryState {
 
 #[poem::handler]
 pub(crate) async fn statement_handler(
-    sessions_extension: Data<&SessionManagerRef>,
+    sessions_extension: Data<&Arc<SessionManager>>,
     sql: String,
     Query(params): Query<HashMap<String, String>>,
 ) -> impl IntoResponse {

--- a/query/src/servers/http/v1/statement.rs
+++ b/query/src/servers/http/v1/statement.rs
@@ -37,7 +37,7 @@ use uuid;
 
 use super::block_to_json::block_to_json;
 use crate::interpreters::InterpreterFactory;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sessions::SessionManager;
 use crate::sessions::SessionRef;
 use crate::sql::PlanParser;
@@ -90,7 +90,7 @@ struct HttpQuery {
 struct HttpQueryState {
     #[allow(dead_code)]
     session: SessionRef,
-    context: Arc<DatabendQueryContext>,
+    context: Arc<QueryContext>,
     data_stream: SendableDataBlockStream,
     schema: DataSchemaRef,
 }

--- a/query/src/servers/mysql/mysql_handler.rs
+++ b/query/src/servers/mysql/mysql_handler.rs
@@ -35,17 +35,16 @@ use crate::servers::mysql::reject_connection::RejectConnection;
 use crate::servers::server::ListeningStream;
 use crate::servers::server::Server;
 use crate::sessions::SessionManager;
-use crate::sessions::SessionManagerRef;
 
 pub struct MySQLHandler {
-    sessions: SessionManagerRef,
+    sessions: Arc<SessionManager>,
     abort_handle: AbortHandle,
     abort_registration: Option<AbortRegistration>,
     join_handle: Option<JoinHandle<()>>,
 }
 
 impl MySQLHandler {
-    pub fn create(sessions: SessionManagerRef) -> Box<dyn Server> {
+    pub fn create(sessions: Arc<SessionManager>) -> Box<dyn Server> {
         let (abort_handle, registration) = AbortHandle::new_pair();
         Box::new(MySQLHandler {
             sessions,

--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::marker::PhantomData;
+use std::sync::Arc;
 use std::time::Instant;
 
 use common_base::tokio;
@@ -34,7 +35,7 @@ use tokio_stream::StreamExt;
 use crate::interpreters::InterpreterFactory;
 use crate::servers::mysql::writers::DFInitResultWriter;
 use crate::servers::mysql::writers::DFQueryResultWriter;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sessions::SessionRef;
 use crate::sql::PlanParser;
 use crate::users::CertifiedInfo;
@@ -310,7 +311,7 @@ impl<W: std::io::Write> InteractiveWorkerBase<W> {
 
     async fn exec_query(
         plan: Result<PlanNode>,
-        context: &DatabendQueryContextRef,
+        context: &Arc<DatabendQueryContext>,
     ) -> Result<(Vec<DataBlock>, String)> {
         let instant = Instant::now();
 
@@ -326,7 +327,7 @@ impl<W: std::io::Write> InteractiveWorkerBase<W> {
         query_result.map(|data| (data, Self::extra_info(context, instant)))
     }
 
-    fn extra_info(context: &DatabendQueryContextRef, instant: Instant) -> String {
+    fn extra_info(context: &Arc<DatabendQueryContext>, instant: Instant) -> String {
         let progress = context.get_progress_value();
         let seconds = instant.elapsed().as_nanos() as f64 / 1e9f64;
         format!(

--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -35,7 +35,7 @@ use tokio_stream::StreamExt;
 use crate::interpreters::InterpreterFactory;
 use crate::servers::mysql::writers::DFInitResultWriter;
 use crate::servers::mysql::writers::DFQueryResultWriter;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sessions::SessionRef;
 use crate::sql::PlanParser;
 use crate::users::CertifiedInfo;
@@ -311,7 +311,7 @@ impl<W: std::io::Write> InteractiveWorkerBase<W> {
 
     async fn exec_query(
         plan: Result<PlanNode>,
-        context: &Arc<DatabendQueryContext>,
+        context: &Arc<QueryContext>,
     ) -> Result<(Vec<DataBlock>, String)> {
         let instant = Instant::now();
 
@@ -327,7 +327,7 @@ impl<W: std::io::Write> InteractiveWorkerBase<W> {
         query_result.map(|data| (data, Self::extra_info(context, instant)))
     }
 
-    fn extra_info(context: &Arc<DatabendQueryContext>, instant: Instant) -> String {
+    fn extra_info(context: &Arc<QueryContext>, instant: Instant) -> String {
         let progress = context.get_progress_value();
         let seconds = instant.elapsed().as_nanos() as f64 / 1e9f64;
         format!(

--- a/query/src/servers/server.rs
+++ b/query/src/servers/server.rs
@@ -26,7 +26,7 @@ use futures::stream::Abortable;
 use futures::StreamExt;
 use tokio_stream::wrappers::TcpListenerStream;
 
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 
 pub type ListeningStream = Abortable<TcpListenerStream>;
 
@@ -38,12 +38,12 @@ pub trait Server: Send {
 
 pub struct ShutdownHandle {
     shutdown: Arc<AtomicBool>,
-    sessions: SessionManagerRef,
+    sessions: Arc<SessionManager>,
     services: Vec<Box<dyn Server>>,
 }
 
 impl ShutdownHandle {
-    pub fn create(sessions: SessionManagerRef) -> ShutdownHandle {
+    pub fn create(sessions: Arc<SessionManager>) -> ShutdownHandle {
         ShutdownHandle {
             sessions,
             services: vec![],

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -60,14 +60,12 @@ pub struct DatabendQueryContext {
     shared: Arc<DatabendQueryContextShared>,
 }
 
-pub type DatabendQueryContextRef = Arc<DatabendQueryContext>;
-
 impl DatabendQueryContext {
-    pub fn new(other: DatabendQueryContextRef) -> DatabendQueryContextRef {
+    pub fn new(other: Arc<DatabendQueryContext>) -> Arc<DatabendQueryContext> {
         DatabendQueryContext::from_shared(other.shared.clone())
     }
 
-    pub fn from_shared(shared: Arc<DatabendQueryContextShared>) -> DatabendQueryContextRef {
+    pub fn from_shared(shared: Arc<DatabendQueryContextShared>) -> Arc<DatabendQueryContext> {
         shared.increment_ref_count();
 
         log::info!("Create DatabendQueryContext");

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -45,7 +45,7 @@ use common_streams::SendableDataBlockStream;
 use crate::catalogs::impls::DatabaseCatalog;
 use crate::catalogs::Catalog;
 use crate::catalogs::Table;
-use crate::clusters::ClusterRef;
+use crate::clusters::Cluster;
 use crate::configs::AzureStorageBlobConfig;
 use crate::configs::Config;
 use crate::servers::http::v1::query::HttpQueryHandle;
@@ -171,7 +171,7 @@ impl DatabendQueryContext {
         self.shared.attach_query_plan(query_plan);
     }
 
-    pub fn get_cluster(&self) -> ClusterRef {
+    pub fn get_cluster(&self) -> Arc<Cluster> {
         self.shared.get_cluster()
     }
 

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -50,7 +50,7 @@ use crate::configs::AzureStorageBlobConfig;
 use crate::configs::Config;
 use crate::servers::http::v1::query::HttpQueryHandle;
 use crate::sessions::DatabendQueryContextShared;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 use crate::sessions::Settings;
 
 pub struct DatabendQueryContext {
@@ -236,7 +236,7 @@ impl DatabendQueryContext {
         format!("_subquery_{}", index)
     }
 
-    pub fn get_sessions_manager(self: &Arc<Self>) -> SessionManagerRef {
+    pub fn get_sessions_manager(self: &Arc<Self>) -> Arc<SessionManager> {
         self.shared.session.get_sessions_manager()
     }
 

--- a/query/src/sessions/context_shared.rs
+++ b/query/src/sessions/context_shared.rs
@@ -48,7 +48,7 @@ type DatabaseAndTable = (String, String);
 ///         (SELECT scalar FROM table_name_3) AS scalar_3
 ///     FROM table_name_4;
 /// For each subquery, they will share a runtime, session, progress, init_query_id
-pub struct DatabendQueryContextShared {
+pub struct QueryContextShared {
     pub(in crate::sessions) conf: Config,
     pub(in crate::sessions) progress: Arc<Progress>,
     pub(in crate::sessions) session: Arc<Session>,
@@ -65,13 +65,13 @@ pub struct DatabendQueryContextShared {
     pub(in crate::sessions) dal_ctx: Arc<DalContext>,
 }
 
-impl DatabendQueryContextShared {
+impl QueryContextShared {
     pub fn try_create(
         conf: Config,
         session: Arc<Session>,
         cluster_cache: Arc<Cluster>,
-    ) -> Arc<DatabendQueryContextShared> {
-        Arc::new(DatabendQueryContextShared {
+    ) -> Arc<QueryContextShared> {
+        Arc::new(QueryContextShared {
             conf,
             init_query_id: Arc::new(RwLock::new(Uuid::new_v4().to_string())),
             progress: Arc::new(Progress::create()),

--- a/query/src/sessions/context_shared.rs
+++ b/query/src/sessions/context_shared.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 use crate::catalogs::impls::DatabaseCatalog;
 use crate::catalogs::Catalog;
 use crate::catalogs::Table;
-use crate::clusters::ClusterRef;
+use crate::clusters::Cluster;
 use crate::configs::Config;
 use crate::servers::http::v1::query::HttpQueryHandle;
 use crate::sessions::Session;
@@ -54,7 +54,7 @@ pub struct DatabendQueryContextShared {
     pub(in crate::sessions) session: Arc<Session>,
     pub(in crate::sessions) runtime: Arc<RwLock<Option<Arc<Runtime>>>>,
     pub(in crate::sessions) init_query_id: Arc<RwLock<String>>,
-    pub(in crate::sessions) cluster_cache: ClusterRef,
+    pub(in crate::sessions) cluster_cache: Arc<Cluster>,
     pub(in crate::sessions) sources_abort_handle: Arc<RwLock<Vec<AbortHandle>>>,
     pub(in crate::sessions) ref_count: Arc<AtomicUsize>,
     pub(in crate::sessions) subquery_index: Arc<AtomicUsize>,
@@ -69,7 +69,7 @@ impl DatabendQueryContextShared {
     pub fn try_create(
         conf: Config,
         session: Arc<Session>,
-        cluster_cache: ClusterRef,
+        cluster_cache: Arc<Cluster>,
     ) -> Arc<DatabendQueryContextShared> {
         Arc::new(DatabendQueryContextShared {
             conf,
@@ -104,7 +104,7 @@ impl DatabendQueryContextShared {
         // TODO: Wait for the query to be processed (write out the last error)
     }
 
-    pub fn get_cluster(&self) -> ClusterRef {
+    pub fn get_cluster(&self) -> Arc<Cluster> {
         self.cluster_cache.clone()
     }
 

--- a/query/src/sessions/mod.rs
+++ b/query/src/sessions/mod.rs
@@ -31,8 +31,8 @@ mod sessions;
 mod sessions_info;
 mod settings;
 
-pub use context::DatabendQueryContext;
-pub use context_shared::DatabendQueryContextShared;
+pub use context::QueryContext;
+pub use context_shared::QueryContextShared;
 pub use session::Session;
 pub use session_info::ProcessInfo;
 pub use session_ref::SessionRef;

--- a/query/src/sessions/mod.rs
+++ b/query/src/sessions/mod.rs
@@ -32,7 +32,6 @@ mod sessions_info;
 mod settings;
 
 pub use context::DatabendQueryContext;
-pub use context::DatabendQueryContextRef;
 pub use context_shared::DatabendQueryContextShared;
 pub use session::Session;
 pub use session_info::ProcessInfo;

--- a/query/src/sessions/mod.rs
+++ b/query/src/sessions/mod.rs
@@ -38,5 +38,4 @@ pub use session_info::ProcessInfo;
 pub use session_ref::SessionRef;
 pub use session_status::MutableStatus;
 pub use sessions::SessionManager;
-pub use sessions::SessionManagerRef;
 pub use settings::Settings;

--- a/query/src/sessions/session.rs
+++ b/query/src/sessions/session.rs
@@ -26,7 +26,7 @@ use crate::configs::Config;
 use crate::sessions::context_shared::DatabendQueryContextShared;
 use crate::sessions::DatabendQueryContext;
 use crate::sessions::MutableStatus;
-use crate::sessions::SessionManagerRef;
+use crate::sessions::SessionManager;
 use crate::sessions::Settings;
 use crate::users::UserApiProvider;
 
@@ -37,7 +37,7 @@ pub struct Session {
     #[ignore_malloc_size_of = "insignificant"]
     pub(in crate::sessions) config: Config,
     #[ignore_malloc_size_of = "insignificant"]
-    pub(in crate::sessions) sessions: SessionManagerRef,
+    pub(in crate::sessions) sessions: Arc<SessionManager>,
     pub(in crate::sessions) ref_count: Arc<AtomicUsize>,
     pub(in crate::sessions) mutable_state: Arc<MutableStatus>,
 }
@@ -47,7 +47,7 @@ impl Session {
         config: Config,
         id: String,
         typ: String,
-        sessions: SessionManagerRef,
+        sessions: Arc<SessionManager>,
     ) -> Result<Arc<Session>> {
         Ok(Arc::new(Session {
             id,
@@ -152,7 +152,7 @@ impl Session {
         self.mutable_state.get_settings()
     }
 
-    pub fn get_sessions_manager(self: &Arc<Self>) -> SessionManagerRef {
+    pub fn get_sessions_manager(self: &Arc<Self>) -> Arc<SessionManager> {
         self.sessions.clone()
     }
 

--- a/query/src/sessions/session.rs
+++ b/query/src/sessions/session.rs
@@ -25,7 +25,6 @@ use crate::catalogs::impls::DatabaseCatalog;
 use crate::configs::Config;
 use crate::sessions::context_shared::DatabendQueryContextShared;
 use crate::sessions::DatabendQueryContext;
-use crate::sessions::DatabendQueryContextRef;
 use crate::sessions::MutableStatus;
 use crate::sessions::SessionManagerRef;
 use crate::sessions::Settings;
@@ -102,7 +101,7 @@ impl Session {
     /// Create a query context for query.
     /// For a query, execution environment(e.g cluster) should be immutable.
     /// We can bind the environment to the context in create_context method.
-    pub async fn create_context(self: &Arc<Self>) -> Result<DatabendQueryContextRef> {
+    pub async fn create_context(self: &Arc<Self>) -> Result<Arc<DatabendQueryContext>> {
         let context_shared = self.mutable_state.get_context_shared();
 
         Ok(match context_shared.as_ref() {

--- a/query/src/sessions/session_status.rs
+++ b/query/src/sessions/session_status.rs
@@ -22,7 +22,7 @@ use common_infallible::RwLock;
 use common_macros::MallocSizeOf;
 use futures::channel::oneshot::Sender;
 
-use crate::sessions::context_shared::DatabendQueryContextShared;
+use crate::sessions::context_shared::QueryContextShared;
 use crate::sessions::Settings;
 
 #[derive(MallocSizeOf)]
@@ -35,7 +35,7 @@ pub struct MutableStatus {
     #[ignore_malloc_size_of = "insignificant"]
     io_shutdown_tx: RwLock<Option<Sender<Sender<()>>>>,
     #[ignore_malloc_size_of = "insignificant"]
-    context_shared: RwLock<Option<Arc<DatabendQueryContextShared>>>,
+    context_shared: RwLock<Option<Arc<QueryContextShared>>>,
 }
 
 impl MutableStatus {
@@ -103,18 +103,18 @@ impl MutableStatus {
         lock.is_none()
     }
 
-    pub fn get_context_shared(&self) -> Option<Arc<DatabendQueryContextShared>> {
+    pub fn get_context_shared(&self) -> Option<Arc<QueryContextShared>> {
         let lock = self.context_shared.read();
         lock.clone()
     }
 
-    pub fn set_context_shared(&self, ctx: Option<Arc<DatabendQueryContextShared>>) {
+    pub fn set_context_shared(&self, ctx: Option<Arc<QueryContextShared>>) {
         let mut lock = self.context_shared.write();
         *lock = ctx
     }
 
     //  Take the context_shared.
-    pub fn take_context_shared(&self) -> Option<Arc<DatabendQueryContextShared>> {
+    pub fn take_context_shared(&self) -> Option<Arc<QueryContextShared>> {
         let mut lock = self.context_shared.write();
         lock.take()
     }

--- a/query/src/sessions/session_status_test.rs
+++ b/query/src/sessions/session_status_test.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use common_exception::Result;
 
 use crate::clusters::Cluster;
-use crate::sessions::DatabendQueryContextShared;
 use crate::sessions::MutableStatus;
+use crate::sessions::QueryContextShared;
 use crate::tests::SessionManagerBuilder;
 
 #[test]
@@ -73,7 +73,7 @@ fn test_session_status() -> Result<()> {
     {
         let sessions = SessionManagerBuilder::create().build()?;
         let dummy_session = sessions.create_session("TestSession")?;
-        let shared = DatabendQueryContextShared::try_create(
+        let shared = QueryContextShared::try_create(
             sessions.get_conf().clone(),
             Arc::new(dummy_session.as_ref().clone()),
             Cluster::empty(),

--- a/query/src/sessions/sessions.rs
+++ b/query/src/sessions/sessions.rs
@@ -30,7 +30,6 @@ use futures::StreamExt;
 
 use crate::catalogs::impls::DatabaseCatalog;
 use crate::clusters::ClusterDiscovery;
-use crate::clusters::ClusterDiscoveryRef;
 use crate::configs::Config;
 use crate::servers::http::v1::query::HttpQueryManager;
 use crate::servers::http::v1::query::HttpQueryManagerRef;
@@ -40,7 +39,7 @@ use crate::users::UserApiProvider;
 
 pub struct SessionManager {
     pub(in crate::sessions) conf: Config,
-    pub(in crate::sessions) discovery: ClusterDiscoveryRef,
+    pub(in crate::sessions) discovery: Arc<ClusterDiscovery>,
     pub(in crate::sessions) catalog: Arc<DatabaseCatalog>,
     pub(in crate::sessions) user: Arc<UserApiProvider>,
     pub(in crate::sessions) http_query_manager: HttpQueryManagerRef,
@@ -77,7 +76,7 @@ impl SessionManager {
         &self.conf
     }
 
-    pub fn get_cluster_discovery(self: &Arc<Self>) -> ClusterDiscoveryRef {
+    pub fn get_cluster_discovery(self: &Arc<Self>) -> Arc<ClusterDiscovery> {
         self.discovery.clone()
     }
 

--- a/query/src/sessions/sessions.rs
+++ b/query/src/sessions/sessions.rs
@@ -49,10 +49,8 @@ pub struct SessionManager {
     pub(in crate::sessions) active_sessions: Arc<RwLock<HashMap<String, Arc<Session>>>>,
 }
 
-pub type SessionManagerRef = Arc<SessionManager>;
-
 impl SessionManager {
-    pub async fn from_conf(conf: Config) -> Result<SessionManagerRef> {
+    pub async fn from_conf(conf: Config) -> Result<Arc<SessionManager>> {
         let catalog = Arc::new(DatabaseCatalog::try_create_with_config(conf.clone()).await?);
 
         // Cluster discovery.

--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -22,7 +22,7 @@ use common_planners::PlanBuilder;
 use common_planners::PlanNode;
 use common_planners::SelectPlan;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::statements::QueryAnalyzeState;
@@ -34,14 +34,14 @@ use crate::sql::DfStatement;
 pub struct PlanParser;
 
 impl PlanParser {
-    pub async fn parse(query: &str, ctx: DatabendQueryContextRef) -> Result<PlanNode> {
+    pub async fn parse(query: &str, ctx: Arc<DatabendQueryContext>) -> Result<PlanNode> {
         let (statements, _) = DfParser::parse_sql(query)?;
         PlanParser::build_plan(statements, ctx).await
     }
 
     pub async fn parse_with_hint(
         query: &str,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
     ) -> (Result<PlanNode>, Vec<DfHint>) {
         match DfParser::parse_sql(query) {
             Err(cause) => (Err(cause), vec![]),
@@ -51,7 +51,7 @@ impl PlanParser {
 
     pub async fn build_plan(
         statements: Vec<DfStatement>,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
     ) -> Result<PlanNode> {
         if statements.len() != 1 {
             return Err(ErrorCode::SyntaxException("Only support single query"));

--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -22,7 +22,7 @@ use common_planners::PlanBuilder;
 use common_planners::PlanNode;
 use common_planners::SelectPlan;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::statements::QueryAnalyzeState;
@@ -34,14 +34,14 @@ use crate::sql::DfStatement;
 pub struct PlanParser;
 
 impl PlanParser {
-    pub async fn parse(query: &str, ctx: Arc<DatabendQueryContext>) -> Result<PlanNode> {
+    pub async fn parse(query: &str, ctx: Arc<QueryContext>) -> Result<PlanNode> {
         let (statements, _) = DfParser::parse_sql(query)?;
         PlanParser::build_plan(statements, ctx).await
     }
 
     pub async fn parse_with_hint(
         query: &str,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
     ) -> (Result<PlanNode>, Vec<DfHint>) {
         match DfParser::parse_sql(query) {
             Err(cause) => (Err(cause), vec![]),
@@ -51,7 +51,7 @@ impl PlanParser {
 
     pub async fn build_plan(
         statements: Vec<DfStatement>,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
     ) -> Result<PlanNode> {
         if statements.len() != 1 {
             return Err(ErrorCode::SyntaxException("Only support single query"));

--- a/query/src/sql/statements/analyzer_expr.rs
+++ b/query/src/sql/statements/analyzer_expr.rs
@@ -30,7 +30,7 @@ use sqlparser::ast::UnaryOperator;
 use sqlparser::ast::Value;
 
 use crate::functions::ContextFunction;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::analyzer_value_expr::ValueExprAnalyzer;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
@@ -39,11 +39,11 @@ use crate::sql::PlanParser;
 use crate::sql::SQLCommon;
 
 pub struct ExpressionAnalyzer {
-    context: Arc<DatabendQueryContext>,
+    context: Arc<QueryContext>,
 }
 
 impl ExpressionAnalyzer {
-    pub fn create(context: Arc<DatabendQueryContext>) -> ExpressionAnalyzer {
+    pub fn create(context: Arc<QueryContext>) -> ExpressionAnalyzer {
         ExpressionAnalyzer { context }
     }
 
@@ -220,7 +220,7 @@ impl ExpressionAnalyzer {
         let statement = DfQueryStatement::try_from(subquery.clone())?;
 
         let query_context = self.context.clone();
-        let subquery_context = DatabendQueryContext::new(query_context.clone());
+        let subquery_context = QueryContext::new(query_context.clone());
 
         let analyze_subquery = statement.analyze(subquery_context);
         if let AnalyzedResult::SelectQuery(analyze_data) = analyze_subquery.await? {
@@ -245,7 +245,7 @@ impl ExpressionAnalyzer {
         let statement = DfQueryStatement::try_from(subquery.clone())?;
 
         let query_context = self.context.clone();
-        let subquery_context = DatabendQueryContext::new(query_context.clone());
+        let subquery_context = QueryContext::new(query_context.clone());
 
         let analyze_subquery = statement.analyze(subquery_context);
         if let AnalyzedResult::SelectQuery(analyze_data) = analyze_subquery.await? {

--- a/query/src/sql/statements/analyzer_expr.rs
+++ b/query/src/sql/statements/analyzer_expr.rs
@@ -31,7 +31,6 @@ use sqlparser::ast::Value;
 
 use crate::functions::ContextFunction;
 use crate::sessions::DatabendQueryContext;
-use crate::sessions::DatabendQueryContextRef;
 use crate::sql::statements::analyzer_value_expr::ValueExprAnalyzer;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
@@ -40,11 +39,11 @@ use crate::sql::PlanParser;
 use crate::sql::SQLCommon;
 
 pub struct ExpressionAnalyzer {
-    context: DatabendQueryContextRef,
+    context: Arc<DatabendQueryContext>,
 }
 
 impl ExpressionAnalyzer {
-    pub fn create(context: DatabendQueryContextRef) -> ExpressionAnalyzer {
+    pub fn create(context: Arc<DatabendQueryContext>) -> ExpressionAnalyzer {
         ExpressionAnalyzer { context }
     }
 

--- a/query/src/sql/statements/analyzer_statement.rs
+++ b/query/src/sql/statements/analyzer_statement.rs
@@ -24,7 +24,7 @@ use common_planners::Expression;
 use common_planners::PlanNode;
 use common_planners::ReadDataSourcePlan;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::DfStatement;
 
 #[allow(clippy::enum_variant_names)]
@@ -139,12 +139,12 @@ impl Debug for QueryAnalyzeState {
 
 #[async_trait::async_trait]
 pub trait AnalyzableStatement {
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult>;
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult>;
 }
 
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfStatement {
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         match self {
             DfStatement::Query(v) => v.analyze(ctx).await,
             DfStatement::Explain(v) => v.analyze(ctx).await,

--- a/query/src/sql/statements/analyzer_statement.rs
+++ b/query/src/sql/statements/analyzer_statement.rs
@@ -24,7 +24,7 @@ use common_planners::Expression;
 use common_planners::PlanNode;
 use common_planners::ReadDataSourcePlan;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::DfStatement;
 
 #[allow(clippy::enum_variant_names)]
@@ -139,12 +139,12 @@ impl Debug for QueryAnalyzeState {
 
 #[async_trait::async_trait]
 pub trait AnalyzableStatement {
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult>;
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult>;
 }
 
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfStatement {
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         match self {
             DfStatement::Query(v) => v.analyze(ctx).await,
             DfStatement::Explain(v) => v.analyze(ctx).await,

--- a/query/src/sql/statements/query/query_normalizer.rs
+++ b/query/src/sql/statements/query/query_normalizer.rs
@@ -27,7 +27,7 @@ use sqlparser::ast::Expr;
 use sqlparser::ast::OffsetRows;
 use sqlparser::ast::SelectItem;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::analyzer_expr::ExpressionAnalyzer;
 use crate::sql::statements::DfQueryStatement;
 
@@ -51,7 +51,7 @@ pub struct QueryNormalizer {
 
 /// Replace alias in query and collect aggregate functions
 impl QueryNormalizer {
-    pub fn create(ctx: Arc<DatabendQueryContext>) -> QueryNormalizer {
+    pub fn create(ctx: Arc<QueryContext>) -> QueryNormalizer {
         QueryNormalizer {
             expression_analyzer: ExpressionAnalyzer::create(ctx),
             aliases_map: HashMap::new(),

--- a/query/src/sql/statements/query/query_normalizer.rs
+++ b/query/src/sql/statements/query/query_normalizer.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use common_arrow::arrow_format::ipc::flatbuffers::bitflags::_core::fmt::Formatter;
 use common_exception::ErrorCode;
@@ -26,7 +27,7 @@ use sqlparser::ast::Expr;
 use sqlparser::ast::OffsetRows;
 use sqlparser::ast::SelectItem;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::analyzer_expr::ExpressionAnalyzer;
 use crate::sql::statements::DfQueryStatement;
 
@@ -50,7 +51,7 @@ pub struct QueryNormalizer {
 
 /// Replace alias in query and collect aggregate functions
 impl QueryNormalizer {
-    pub fn create(ctx: DatabendQueryContextRef) -> QueryNormalizer {
+    pub fn create(ctx: Arc<DatabendQueryContext>) -> QueryNormalizer {
         QueryNormalizer {
             expression_analyzer: ExpressionAnalyzer::create(ctx),
             aliases_map: HashMap::new(),

--- a/query/src/sql/statements/query/query_qualified_rewriter.rs
+++ b/query/src/sql/statements/query/query_qualified_rewriter.rs
@@ -12,22 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::Expression;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::query::query_schema_joined::JoinedTableDesc;
 use crate::sql::statements::query::JoinedSchema;
 use crate::sql::statements::QueryASTIR;
 
 pub struct QualifiedRewriter {
     tables_schema: JoinedSchema,
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
 }
 
 impl QualifiedRewriter {
-    pub fn create(tables_schema: JoinedSchema, ctx: DatabendQueryContextRef) -> QualifiedRewriter {
+    pub fn create(
+        tables_schema: JoinedSchema,
+        ctx: Arc<DatabendQueryContext>,
+    ) -> QualifiedRewriter {
         QualifiedRewriter { tables_schema, ctx }
     }
 

--- a/query/src/sql/statements/query/query_qualified_rewriter.rs
+++ b/query/src/sql/statements/query/query_qualified_rewriter.rs
@@ -18,21 +18,18 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::Expression;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::query::query_schema_joined::JoinedTableDesc;
 use crate::sql::statements::query::JoinedSchema;
 use crate::sql::statements::QueryASTIR;
 
 pub struct QualifiedRewriter {
     tables_schema: JoinedSchema,
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
 }
 
 impl QualifiedRewriter {
-    pub fn create(
-        tables_schema: JoinedSchema,
-        ctx: Arc<DatabendQueryContext>,
-    ) -> QualifiedRewriter {
+    pub fn create(tables_schema: JoinedSchema, ctx: Arc<QueryContext>) -> QualifiedRewriter {
         QualifiedRewriter { tables_schema, ctx }
     }
 

--- a/query/src/sql/statements/query/query_schema_joined_analyzer.rs
+++ b/query/src/sql/statements/query/query_schema_joined_analyzer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 use sqlparser::ast::FunctionArg;
@@ -24,7 +26,7 @@ use sqlparser::ast::TableFactor;
 use sqlparser::ast::TableWithJoins;
 
 use crate::catalogs::Catalog;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::analyzer_expr::ExpressionAnalyzer;
 use crate::sql::statements::query::query_schema_joined::JoinedSchema;
 use crate::sql::statements::AnalyzableStatement;
@@ -32,11 +34,11 @@ use crate::sql::statements::AnalyzedResult;
 use crate::sql::statements::DfQueryStatement;
 
 pub struct JoinedSchemaAnalyzer {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
 }
 
 impl JoinedSchemaAnalyzer {
-    pub fn create(ctx: DatabendQueryContextRef) -> JoinedSchemaAnalyzer {
+    pub fn create(ctx: Arc<DatabendQueryContext>) -> JoinedSchemaAnalyzer {
         JoinedSchemaAnalyzer { ctx }
     }
 

--- a/query/src/sql/statements/query/query_schema_joined_analyzer.rs
+++ b/query/src/sql/statements/query/query_schema_joined_analyzer.rs
@@ -26,7 +26,7 @@ use sqlparser::ast::TableFactor;
 use sqlparser::ast::TableWithJoins;
 
 use crate::catalogs::Catalog;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::analyzer_expr::ExpressionAnalyzer;
 use crate::sql::statements::query::query_schema_joined::JoinedSchema;
 use crate::sql::statements::AnalyzableStatement;
@@ -34,11 +34,11 @@ use crate::sql::statements::AnalyzedResult;
 use crate::sql::statements::DfQueryStatement;
 
 pub struct JoinedSchemaAnalyzer {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
 }
 
 impl JoinedSchemaAnalyzer {
-    pub fn create(ctx: Arc<DatabendQueryContext>) -> JoinedSchemaAnalyzer {
+    pub fn create(ctx: Arc<QueryContext>) -> JoinedSchemaAnalyzer {
         JoinedSchemaAnalyzer { ctx }
     }
 

--- a/query/src/sql/statements/statement_alter_user.rs
+++ b/query/src/sql/statements/statement_alter_user.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_meta_types::AuthType;
 use common_planners::AlterUserPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -35,7 +37,7 @@ pub struct DfAlterUser {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfAlterUser {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         Ok(AnalyzedResult::SimpleQuery(PlanNode::AlterUser(
             AlterUserPlan {
                 if_current_user: self.if_current_user,

--- a/query/src/sql/statements/statement_alter_user.rs
+++ b/query/src/sql/statements/statement_alter_user.rs
@@ -20,7 +20,7 @@ use common_planners::AlterUserPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -37,7 +37,7 @@ pub struct DfAlterUser {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfAlterUser {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         Ok(AnalyzedResult::SimpleQuery(PlanNode::AlterUser(
             AlterUserPlan {
                 if_current_user: self.if_current_user,

--- a/query/src/sql/statements/statement_copy.rs
+++ b/query/src/sql/statements/statement_copy.rs
@@ -23,7 +23,7 @@ use sqlparser::ast::Ident;
 use sqlparser::ast::ObjectName;
 use sqlparser::ast::SqlOption;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -38,7 +38,7 @@ pub struct DfCopy {
 
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfCopy {
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let mut db_name = ctx.get_current_database();
         let mut tbl_name = self.name.0[0].value.clone();
 

--- a/query/src/sql/statements/statement_copy.rs
+++ b/query/src/sql/statements/statement_copy.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_datavalues::DataSchemaRefExt;
 use common_exception::Result;
@@ -22,7 +23,7 @@ use sqlparser::ast::Ident;
 use sqlparser::ast::ObjectName;
 use sqlparser::ast::SqlOption;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -37,7 +38,7 @@ pub struct DfCopy {
 
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfCopy {
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let mut db_name = ctx.get_current_database();
         let mut tbl_name = self.name.0[0].value.clone();
 

--- a/query/src/sql/statements/statement_create_database.rs
+++ b/query/src/sql/statements/statement_create_database.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -22,7 +23,7 @@ use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 use sqlparser::ast::SqlOption;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -37,7 +38,7 @@ pub struct DfCreateDatabase {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfCreateDatabase {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let db = self.database_name()?;
         let engine = self.database_engine()?;
         let options = self.database_options();

--- a/query/src/sql/statements/statement_create_database.rs
+++ b/query/src/sql/statements/statement_create_database.rs
@@ -23,7 +23,7 @@ use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 use sqlparser::ast::SqlOption;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -38,7 +38,7 @@ pub struct DfCreateDatabase {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfCreateDatabase {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let db = self.database_name()?;
         let engine = self.database_engine()?;
         let options = self.database_options();

--- a/query/src/sql/statements/statement_create_table.rs
+++ b/query/src/sql/statements/statement_create_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_datavalues::DataField;
 use common_datavalues::DataSchemaRef;
@@ -27,7 +28,7 @@ use sqlparser::ast::ColumnDef;
 use sqlparser::ast::ObjectName;
 use sqlparser::ast::SqlOption;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::SQLCommon;
@@ -45,7 +46,7 @@ pub struct DfCreateTable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfCreateTable {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let table_meta = self.table_meta()?;
         let if_not_exists = self.if_not_exists;
         let (db, table) = self.resolve_table(ctx)?;
@@ -62,7 +63,7 @@ impl AnalyzableStatement for DfCreateTable {
 }
 
 impl DfCreateTable {
-    fn resolve_table(&self, ctx: DatabendQueryContextRef) -> Result<(String, String)> {
+    fn resolve_table(&self, ctx: Arc<DatabendQueryContext>) -> Result<(String, String)> {
         let DfCreateTable {
             name: ObjectName(idents),
             ..

--- a/query/src/sql/statements/statement_create_table.rs
+++ b/query/src/sql/statements/statement_create_table.rs
@@ -28,7 +28,7 @@ use sqlparser::ast::ColumnDef;
 use sqlparser::ast::ObjectName;
 use sqlparser::ast::SqlOption;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::SQLCommon;
@@ -46,7 +46,7 @@ pub struct DfCreateTable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfCreateTable {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let table_meta = self.table_meta()?;
         let if_not_exists = self.if_not_exists;
         let (db, table) = self.resolve_table(ctx)?;
@@ -63,7 +63,7 @@ impl AnalyzableStatement for DfCreateTable {
 }
 
 impl DfCreateTable {
-    fn resolve_table(&self, ctx: Arc<DatabendQueryContext>) -> Result<(String, String)> {
+    fn resolve_table(&self, ctx: Arc<QueryContext>) -> Result<(String, String)> {
         let DfCreateTable {
             name: ObjectName(idents),
             ..

--- a/query/src/sql/statements/statement_create_user.rs
+++ b/query/src/sql/statements/statement_create_user.rs
@@ -20,7 +20,7 @@ use common_planners::CreateUserPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -37,7 +37,7 @@ pub struct DfCreateUser {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfCreateUser {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         Ok(AnalyzedResult::SimpleQuery(PlanNode::CreateUser(
             CreateUserPlan {
                 name: self.name.clone(),

--- a/query/src/sql/statements/statement_create_user.rs
+++ b/query/src/sql/statements/statement_create_user.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_meta_types::AuthType;
 use common_planners::CreateUserPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -35,7 +37,7 @@ pub struct DfCreateUser {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfCreateUser {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         Ok(AnalyzedResult::SimpleQuery(PlanNode::CreateUser(
             CreateUserPlan {
                 name: self.name.clone(),

--- a/query/src/sql/statements/statement_describe_table.rs
+++ b/query/src/sql/statements/statement_describe_table.rs
@@ -25,7 +25,7 @@ use common_planners::PlanNode;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -37,7 +37,7 @@ pub struct DfDescribeTable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfDescribeTable {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let schema = Self::schema();
         let (db, table) = self.resolve_table(ctx)?;
 
@@ -48,7 +48,7 @@ impl AnalyzableStatement for DfDescribeTable {
 }
 
 impl DfDescribeTable {
-    fn resolve_table(&self, ctx: Arc<DatabendQueryContext>) -> Result<(String, String)> {
+    fn resolve_table(&self, ctx: Arc<QueryContext>) -> Result<(String, String)> {
         let DfDescribeTable {
             name: ObjectName(idents),
             ..

--- a/query/src/sql/statements/statement_describe_table.rs
+++ b/query/src/sql/statements/statement_describe_table.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_datavalues::DataField;
 use common_datavalues::DataSchemaRef;
 use common_datavalues::DataSchemaRefExt;
@@ -23,7 +25,7 @@ use common_planners::PlanNode;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -35,7 +37,7 @@ pub struct DfDescribeTable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfDescribeTable {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let schema = Self::schema();
         let (db, table) = self.resolve_table(ctx)?;
 
@@ -46,7 +48,7 @@ impl AnalyzableStatement for DfDescribeTable {
 }
 
 impl DfDescribeTable {
-    fn resolve_table(&self, ctx: DatabendQueryContextRef) -> Result<(String, String)> {
+    fn resolve_table(&self, ctx: Arc<DatabendQueryContext>) -> Result<(String, String)> {
         let DfDescribeTable {
             name: ObjectName(idents),
             ..

--- a/query/src/sql/statements/statement_drop_database.rs
+++ b/query/src/sql/statements/statement_drop_database.rs
@@ -21,7 +21,7 @@ use common_planners::PlanNode;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -34,7 +34,7 @@ pub struct DfDropDatabase {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfDropDatabase {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let db = self.database_name()?;
         let if_exists = self.if_exists;
 

--- a/query/src/sql/statements/statement_drop_database.rs
+++ b/query/src/sql/statements/statement_drop_database.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::DropDatabasePlan;
@@ -19,7 +21,7 @@ use common_planners::PlanNode;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -32,7 +34,7 @@ pub struct DfDropDatabase {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfDropDatabase {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let db = self.database_name()?;
         let if_exists = self.if_exists;
 

--- a/query/src/sql/statements/statement_drop_table.rs
+++ b/query/src/sql/statements/statement_drop_table.rs
@@ -21,7 +21,7 @@ use common_planners::PlanNode;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -34,7 +34,7 @@ pub struct DfDropTable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfDropTable {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let if_exists = self.if_exists;
         let (db, table) = self.resolve_table(ctx)?;
 
@@ -49,7 +49,7 @@ impl AnalyzableStatement for DfDropTable {
 }
 
 impl DfDropTable {
-    fn resolve_table(&self, ctx: Arc<DatabendQueryContext>) -> Result<(String, String)> {
+    fn resolve_table(&self, ctx: Arc<QueryContext>) -> Result<(String, String)> {
         let DfDropTable {
             name: ObjectName(idents),
             ..

--- a/query/src/sql/statements/statement_drop_table.rs
+++ b/query/src/sql/statements/statement_drop_table.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::DropTablePlan;
@@ -19,7 +21,7 @@ use common_planners::PlanNode;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -32,7 +34,7 @@ pub struct DfDropTable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfDropTable {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let if_exists = self.if_exists;
         let (db, table) = self.resolve_table(ctx)?;
 
@@ -47,7 +49,7 @@ impl AnalyzableStatement for DfDropTable {
 }
 
 impl DfDropTable {
-    fn resolve_table(&self, ctx: DatabendQueryContextRef) -> Result<(String, String)> {
+    fn resolve_table(&self, ctx: Arc<DatabendQueryContext>) -> Result<(String, String)> {
         let DfDropTable {
             name: ObjectName(idents),
             ..

--- a/query/src/sql/statements/statement_drop_user.rs
+++ b/query/src/sql/statements/statement_drop_user.rs
@@ -19,7 +19,7 @@ use common_planners::DropUserPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -34,7 +34,7 @@ pub struct DfDropUser {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfDropUser {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         Ok(AnalyzedResult::SimpleQuery(PlanNode::DropUser(
             DropUserPlan {
                 if_exists: self.if_exists,

--- a/query/src/sql/statements/statement_drop_user.rs
+++ b/query/src/sql/statements/statement_drop_user.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_planners::DropUserPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -32,7 +34,7 @@ pub struct DfDropUser {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfDropUser {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         Ok(AnalyzedResult::SimpleQuery(PlanNode::DropUser(
             DropUserPlan {
                 if_exists: self.if_exists,

--- a/query/src/sql/statements/statement_explain.rs
+++ b/query/src/sql/statements/statement_explain.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::ExplainType;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::statements::DfQueryStatement;
@@ -33,7 +35,7 @@ pub struct DfExplain {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfExplain {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         match self.statement.as_ref() {
             DfStatement::Query(v) => {
                 let explain_type = self.typ;
@@ -50,7 +52,7 @@ impl AnalyzableStatement for DfExplain {
 
 impl DfExplain {
     async fn analyze_explain(
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
         v: &DfQueryStatement,
     ) -> Result<Box<QueryAnalyzeState>> {
         match v.analyze(ctx).await? {

--- a/query/src/sql/statements/statement_explain.rs
+++ b/query/src/sql/statements/statement_explain.rs
@@ -19,7 +19,7 @@ use common_exception::Result;
 use common_planners::ExplainType;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::statements::DfQueryStatement;
@@ -35,7 +35,7 @@ pub struct DfExplain {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfExplain {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         match self.statement.as_ref() {
             DfStatement::Query(v) => {
                 let explain_type = self.typ;
@@ -52,7 +52,7 @@ impl AnalyzableStatement for DfExplain {
 
 impl DfExplain {
     async fn analyze_explain(
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
         v: &DfQueryStatement,
     ) -> Result<Box<QueryAnalyzeState>> {
         match v.analyze(ctx).await? {

--- a/query/src/sql/statements/statement_grant.rs
+++ b/query/src/sql/statements/statement_grant.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_meta_types::GrantObject;
 use common_meta_types::UserPrivilege;
@@ -19,7 +21,7 @@ use common_planners::GrantPrivilegePlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -41,7 +43,7 @@ pub enum DfGrantObject {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfGrantStatement {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         Ok(AnalyzedResult::SimpleQuery(PlanNode::GrantPrivilege(
             GrantPrivilegePlan {
                 name: self.name.clone(),

--- a/query/src/sql/statements/statement_grant.rs
+++ b/query/src/sql/statements/statement_grant.rs
@@ -21,7 +21,7 @@ use common_planners::GrantPrivilegePlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -43,7 +43,7 @@ pub enum DfGrantObject {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfGrantStatement {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         Ok(AnalyzedResult::SimpleQuery(PlanNode::GrantPrivilege(
             GrantPrivilegePlan {
                 name: self.name.clone(),

--- a/query/src/sql/statements/statement_insert.rs
+++ b/query/src/sql/statements/statement_insert.rs
@@ -31,7 +31,6 @@ use sqlparser::ast::Values;
 
 use crate::catalogs::Table;
 use crate::sessions::DatabendQueryContext;
-use crate::sessions::DatabendQueryContextRef;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::statements::DfQueryStatement;
@@ -62,7 +61,7 @@ pub struct DfInsertStatement {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfInsertStatement {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         self.is_supported()?;
 
         match &self.source {
@@ -139,7 +138,7 @@ impl DfInsertStatement {
 
     async fn analyze_insert_without_source(
         &self,
-        ctx: &DatabendQueryContextRef,
+        ctx: &Arc<DatabendQueryContext>,
     ) -> Result<AnalyzedResult> {
         let (db, table) = self.resolve_table(ctx)?;
         let write_table = ctx.get_table(&db, &table).await?;
@@ -153,7 +152,7 @@ impl DfInsertStatement {
 
     async fn analyze_insert_select(
         &self,
-        ctx: &DatabendQueryContextRef,
+        ctx: &Arc<DatabendQueryContext>,
         source: &Query,
     ) -> Result<AnalyzedResult> {
         let (db, table) = self.resolve_table(ctx)?;

--- a/query/src/sql/statements/statement_kill.rs
+++ b/query/src/sql/statements/statement_kill.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_planners::KillPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 use sqlparser::ast::Ident;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -31,7 +33,7 @@ pub struct DfKillStatement {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfKillStatement {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let id = self.object_id.value.clone();
         let kill_connection = !self.kill_query;
         Ok(AnalyzedResult::SimpleQuery(PlanNode::Kill(KillPlan {

--- a/query/src/sql/statements/statement_kill.rs
+++ b/query/src/sql/statements/statement_kill.rs
@@ -20,7 +20,7 @@ use common_planners::PlanNode;
 use common_tracing::tracing;
 use sqlparser::ast::Ident;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -33,7 +33,7 @@ pub struct DfKillStatement {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfKillStatement {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let id = self.object_id.value.clone();
         let kill_connection = !self.kill_query;
         Ok(AnalyzedResult::SimpleQuery(PlanNode::Kill(KillPlan {

--- a/query/src/sql/statements/statement_select.rs
+++ b/query/src/sql/statements/statement_select.rs
@@ -32,7 +32,7 @@ use sqlparser::ast::SelectItem;
 use sqlparser::ast::TableWithJoins;
 
 use crate::catalogs::ToReadDataSourcePlan;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::analyzer_statement::QueryAnalyzeState;
 use crate::sql::statements::query::JoinedSchema;
 use crate::sql::statements::query::JoinedSchemaAnalyzer;
@@ -59,7 +59,7 @@ pub struct DfQueryStatement {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfQueryStatement {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let analyzer = JoinedSchemaAnalyzer::create(ctx.clone());
         let joined_schema = analyzer.analyze(self).await?;
 
@@ -197,7 +197,7 @@ impl DfQueryStatement {
         &self,
         schema: JoinedSchema,
         mut state: QueryAnalyzeState,
-        ctx: Arc<DatabendQueryContext>,
+        ctx: Arc<QueryContext>,
     ) -> Result<AnalyzedResult> {
         let dry_run_res = Self::verify_with_dry_run(&schema, &state)?;
         state.finalize_schema = dry_run_res.schema().clone();

--- a/query/src/sql/statements/statement_select.rs
+++ b/query/src/sql/statements/statement_select.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRefExt;
 use common_exception::ErrorCode;
@@ -30,7 +32,7 @@ use sqlparser::ast::SelectItem;
 use sqlparser::ast::TableWithJoins;
 
 use crate::catalogs::ToReadDataSourcePlan;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::analyzer_statement::QueryAnalyzeState;
 use crate::sql::statements::query::JoinedSchema;
 use crate::sql::statements::query::JoinedSchemaAnalyzer;
@@ -57,7 +59,7 @@ pub struct DfQueryStatement {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfQueryStatement {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let analyzer = JoinedSchemaAnalyzer::create(ctx.clone());
         let joined_schema = analyzer.analyze(self).await?;
 
@@ -195,7 +197,7 @@ impl DfQueryStatement {
         &self,
         schema: JoinedSchema,
         mut state: QueryAnalyzeState,
-        ctx: DatabendQueryContextRef,
+        ctx: Arc<DatabendQueryContext>,
     ) -> Result<AnalyzedResult> {
         let dry_run_res = Self::verify_with_dry_run(&schema, &state)?;
         state.finalize_schema = dry_run_res.schema().clone();

--- a/query/src/sql/statements/statement_set_variable.rs
+++ b/query/src/sql/statements/statement_set_variable.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::PlanNode;
@@ -21,7 +23,7 @@ use common_tracing::tracing;
 use sqlparser::ast::Ident;
 use sqlparser::ast::SetVariableValue;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -36,7 +38,7 @@ pub struct DfSetVariable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfSetVariable {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         if self.hivevar {
             return Err(ErrorCode::SyntaxException(
                 "Unsupport hive style set varible",

--- a/query/src/sql/statements/statement_set_variable.rs
+++ b/query/src/sql/statements/statement_set_variable.rs
@@ -23,7 +23,7 @@ use common_tracing::tracing;
 use sqlparser::ast::Ident;
 use sqlparser::ast::SetVariableValue;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -38,7 +38,7 @@ pub struct DfSetVariable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfSetVariable {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         if self.hivevar {
             return Err(ErrorCode::SyntaxException(
                 "Unsupport hive style set varible",

--- a/query/src/sql/statements/statement_show_create_table.rs
+++ b/query/src/sql/statements/statement_show_create_table.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_datavalues::DataField;
 use common_datavalues::DataSchemaRef;
 use common_datavalues::DataSchemaRefExt;
@@ -23,7 +25,7 @@ use common_planners::ShowCreateTablePlan;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -35,7 +37,7 @@ pub struct DfShowCreateTable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowCreateTable {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let schema = Self::schema();
         let (db, table) = self.resolve_table(ctx)?;
         Ok(AnalyzedResult::SimpleQuery(PlanNode::ShowCreateTable(
@@ -52,7 +54,7 @@ impl DfShowCreateTable {
         ])
     }
 
-    fn resolve_table(&self, ctx: DatabendQueryContextRef) -> Result<(String, String)> {
+    fn resolve_table(&self, ctx: Arc<DatabendQueryContext>) -> Result<(String, String)> {
         let DfShowCreateTable {
             name: ObjectName(idents),
         } = &self;

--- a/query/src/sql/statements/statement_show_create_table.rs
+++ b/query/src/sql/statements/statement_show_create_table.rs
@@ -25,7 +25,7 @@ use common_planners::ShowCreateTablePlan;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -37,7 +37,7 @@ pub struct DfShowCreateTable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowCreateTable {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let schema = Self::schema();
         let (db, table) = self.resolve_table(ctx)?;
         Ok(AnalyzedResult::SimpleQuery(PlanNode::ShowCreateTable(
@@ -54,7 +54,7 @@ impl DfShowCreateTable {
         ])
     }
 
-    fn resolve_table(&self, ctx: Arc<DatabendQueryContext>) -> Result<(String, String)> {
+    fn resolve_table(&self, ctx: Arc<QueryContext>) -> Result<(String, String)> {
         let DfShowCreateTable {
             name: ObjectName(idents),
         } = &self;

--- a/query/src/sql/statements/statement_show_databases.rs
+++ b/query/src/sql/statements/statement_show_databases.rs
@@ -18,7 +18,7 @@ use common_exception::Result;
 use common_tracing::tracing;
 use sqlparser::ast::Expr;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -31,7 +31,7 @@ pub struct DfShowDatabases {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowDatabases {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = self.rewritten_query();
         let rewritten_query_plan = PlanParser::parse(rewritten_query.as_str(), ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))

--- a/query/src/sql/statements/statement_show_databases.rs
+++ b/query/src/sql/statements/statement_show_databases.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_tracing::tracing;
 use sqlparser::ast::Expr;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -29,7 +31,7 @@ pub struct DfShowDatabases {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowDatabases {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = self.rewritten_query();
         let rewritten_query_plan = PlanParser::parse(rewritten_query.as_str(), ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))

--- a/query/src/sql/statements/statement_show_metrics.rs
+++ b/query/src/sql/statements/statement_show_metrics.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -28,7 +28,7 @@ pub struct DfShowMetrics;
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowMetrics {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT * FROM system.metrics";
         let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))

--- a/query/src/sql/statements/statement_show_metrics.rs
+++ b/query/src/sql/statements/statement_show_metrics.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -26,7 +28,7 @@ pub struct DfShowMetrics;
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowMetrics {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT * FROM system.metrics";
         let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))

--- a/query/src/sql/statements/statement_show_processlist.rs
+++ b/query/src/sql/statements/statement_show_processlist.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -28,7 +28,7 @@ pub struct DfShowProcessList;
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowProcessList {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT * FROM system.processes";
         let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))

--- a/query/src/sql/statements/statement_show_processlist.rs
+++ b/query/src/sql/statements/statement_show_processlist.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -26,7 +28,7 @@ pub struct DfShowProcessList;
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowProcessList {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT * FROM system.processes";
         let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))

--- a/query/src/sql/statements/statement_show_settings.rs
+++ b/query/src/sql/statements/statement_show_settings.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -26,7 +28,7 @@ pub struct DfShowSettings;
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowSettings {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT name, value FROM system.settings ORDER BY name";
         let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))

--- a/query/src/sql/statements/statement_show_settings.rs
+++ b/query/src/sql/statements/statement_show_settings.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -28,7 +28,7 @@ pub struct DfShowSettings;
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowSettings {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT name, value FROM system.settings ORDER BY name";
         let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))

--- a/query/src/sql/statements/statement_show_tables.rs
+++ b/query/src/sql/statements/statement_show_tables.rs
@@ -20,7 +20,7 @@ use sqlparser::ast::Expr;
 use sqlparser::ast::Ident;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -36,7 +36,7 @@ pub enum DfShowTables {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowTables {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = self.rewritten_query(ctx.clone());
         let rewritten_query_plan = PlanParser::parse(rewritten_query.as_str(), ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))
@@ -44,21 +44,21 @@ impl AnalyzableStatement for DfShowTables {
 }
 
 impl DfShowTables {
-    fn show_all_tables(&self, ctx: Arc<DatabendQueryContext>) -> String {
+    fn show_all_tables(&self, ctx: Arc<QueryContext>) -> String {
         format!(
             "SELECT name FROM system.tables where database = '{}' ORDER BY database, name",
             ctx.get_current_database()
         )
     }
 
-    fn show_tables_with_like(&self, i: &Ident, ctx: Arc<DatabendQueryContext>) -> String {
+    fn show_tables_with_like(&self, i: &Ident, ctx: Arc<QueryContext>) -> String {
         format!(
             "SELECT name FROM system.tables where database = '{}' AND name LIKE {} ORDER BY database, name",
             ctx.get_current_database(), i,
         )
     }
 
-    fn show_tables_with_predicate(&self, e: &Expr, ctx: Arc<DatabendQueryContext>) -> String {
+    fn show_tables_with_predicate(&self, e: &Expr, ctx: Arc<QueryContext>) -> String {
         format!(
             "SELECT name FROM system.tables where database = '{}' AND ({}) ORDER BY database, name",
             ctx.get_current_database(),
@@ -73,7 +73,7 @@ impl DfShowTables {
         )
     }
 
-    fn rewritten_query(&self, ctx: Arc<DatabendQueryContext>) -> String {
+    fn rewritten_query(&self, ctx: Arc<QueryContext>) -> String {
         match self {
             DfShowTables::All => self.show_all_tables(ctx),
             DfShowTables::Like(i) => self.show_tables_with_like(i, ctx),

--- a/query/src/sql/statements/statement_show_tables.rs
+++ b/query/src/sql/statements/statement_show_tables.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_tracing::tracing;
 use sqlparser::ast::Expr;
 use sqlparser::ast::Ident;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -34,7 +36,7 @@ pub enum DfShowTables {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowTables {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = self.rewritten_query(ctx.clone());
         let rewritten_query_plan = PlanParser::parse(rewritten_query.as_str(), ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))
@@ -42,21 +44,21 @@ impl AnalyzableStatement for DfShowTables {
 }
 
 impl DfShowTables {
-    fn show_all_tables(&self, ctx: DatabendQueryContextRef) -> String {
+    fn show_all_tables(&self, ctx: Arc<DatabendQueryContext>) -> String {
         format!(
             "SELECT name FROM system.tables where database = '{}' ORDER BY database, name",
             ctx.get_current_database()
         )
     }
 
-    fn show_tables_with_like(&self, i: &Ident, ctx: DatabendQueryContextRef) -> String {
+    fn show_tables_with_like(&self, i: &Ident, ctx: Arc<DatabendQueryContext>) -> String {
         format!(
             "SELECT name FROM system.tables where database = '{}' AND name LIKE {} ORDER BY database, name",
             ctx.get_current_database(), i,
         )
     }
 
-    fn show_tables_with_predicate(&self, e: &Expr, ctx: DatabendQueryContextRef) -> String {
+    fn show_tables_with_predicate(&self, e: &Expr, ctx: Arc<DatabendQueryContext>) -> String {
         format!(
             "SELECT name FROM system.tables where database = '{}' AND ({}) ORDER BY database, name",
             ctx.get_current_database(),
@@ -71,7 +73,7 @@ impl DfShowTables {
         )
     }
 
-    fn rewritten_query(&self, ctx: DatabendQueryContextRef) -> String {
+    fn rewritten_query(&self, ctx: Arc<DatabendQueryContext>) -> String {
         match self {
             DfShowTables::All => self.show_all_tables(ctx),
             DfShowTables::Like(i) => self.show_tables_with_like(i, ctx),

--- a/query/src/sql/statements/statement_show_users.rs
+++ b/query/src/sql/statements/statement_show_users.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -26,7 +28,7 @@ pub struct DfShowUsers;
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowUsers {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT * FROM system.users ORDER BY name";
         let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))

--- a/query/src/sql/statements/statement_show_users.rs
+++ b/query/src/sql/statements/statement_show_users.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_tracing::tracing;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 use crate::sql::PlanParser;
@@ -28,7 +28,7 @@ pub struct DfShowUsers;
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfShowUsers {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT * FROM system.users ORDER BY name";
         let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
         Ok(AnalyzedResult::SimpleQuery(rewritten_query_plan.await?))

--- a/query/src/sql/statements/statement_truncate_table.rs
+++ b/query/src/sql/statements/statement_truncate_table.rs
@@ -21,7 +21,7 @@ use common_planners::TruncateTablePlan;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -33,7 +33,7 @@ pub struct DfTruncateTable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfTruncateTable {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let (db, table) = self.resolve_table(ctx)?;
         Ok(AnalyzedResult::SimpleQuery(PlanNode::TruncateTable(
             TruncateTablePlan { db, table },
@@ -42,7 +42,7 @@ impl AnalyzableStatement for DfTruncateTable {
 }
 
 impl DfTruncateTable {
-    fn resolve_table(&self, ctx: Arc<DatabendQueryContext>) -> Result<(String, String)> {
+    fn resolve_table(&self, ctx: Arc<QueryContext>) -> Result<(String, String)> {
         let DfTruncateTable {
             name: ObjectName(idents),
             ..

--- a/query/src/sql/statements/statement_truncate_table.rs
+++ b/query/src/sql/statements/statement_truncate_table.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::PlanNode;
@@ -19,7 +21,7 @@ use common_planners::TruncateTablePlan;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -31,7 +33,7 @@ pub struct DfTruncateTable {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfTruncateTable {
     #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn analyze(&self, ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         let (db, table) = self.resolve_table(ctx)?;
         Ok(AnalyzedResult::SimpleQuery(PlanNode::TruncateTable(
             TruncateTablePlan { db, table },
@@ -40,7 +42,7 @@ impl AnalyzableStatement for DfTruncateTable {
 }
 
 impl DfTruncateTable {
-    fn resolve_table(&self, ctx: DatabendQueryContextRef) -> Result<(String, String)> {
+    fn resolve_table(&self, ctx: Arc<DatabendQueryContext>) -> Result<(String, String)> {
         let DfTruncateTable {
             name: ObjectName(idents),
             ..

--- a/query/src/sql/statements/statement_use_database.rs
+++ b/query/src/sql/statements/statement_use_database.rs
@@ -21,7 +21,7 @@ use common_planners::UseDatabasePlan;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -33,7 +33,7 @@ pub struct DfUseDatabase {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfUseDatabase {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         if self.name.0.is_empty() {
             return Result::Err(ErrorCode::SyntaxException("Use database name is empty"));
         }

--- a/query/src/sql/statements/statement_use_database.rs
+++ b/query/src/sql/statements/statement_use_database.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::PlanNode;
@@ -19,7 +21,7 @@ use common_planners::UseDatabasePlan;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::statements::AnalyzableStatement;
 use crate::sql::statements::AnalyzedResult;
 
@@ -31,7 +33,7 @@ pub struct DfUseDatabase {
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfUseDatabase {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
-    async fn analyze(&self, _ctx: DatabendQueryContextRef) -> Result<AnalyzedResult> {
+    async fn analyze(&self, _ctx: Arc<DatabendQueryContext>) -> Result<AnalyzedResult> {
         if self.name.0.is_empty() {
             return Result::Err(ErrorCode::SyntaxException("Use database name is empty"));
         }

--- a/query/src/tests/context.rs
+++ b/query/src/tests/context.rs
@@ -23,15 +23,15 @@ use crate::configs::Config;
 use crate::datasources::context::DataSourceContext;
 use crate::datasources::DatabaseEngineRegistry;
 use crate::datasources::TableEngineRegistry;
-use crate::sessions::DatabendQueryContext;
-use crate::sessions::DatabendQueryContextShared;
+use crate::sessions::QueryContext;
+use crate::sessions::QueryContextShared;
 use crate::tests::SessionManagerBuilder;
 
-pub fn try_create_context() -> Result<Arc<DatabendQueryContext>> {
+pub fn try_create_context() -> Result<Arc<QueryContext>> {
     let sessions = SessionManagerBuilder::create().build()?;
     let dummy_session = sessions.create_session("TestSession")?;
 
-    let context = DatabendQueryContext::from_shared(DatabendQueryContextShared::try_create(
+    let context = QueryContext::from_shared(QueryContextShared::try_create(
         sessions.get_conf().clone(),
         Arc::new(dummy_session.as_ref().clone()),
         Cluster::empty(),
@@ -41,11 +41,11 @@ pub fn try_create_context() -> Result<Arc<DatabendQueryContext>> {
     Ok(context)
 }
 
-pub fn try_create_context_with_config(config: Config) -> Result<Arc<DatabendQueryContext>> {
+pub fn try_create_context_with_config(config: Config) -> Result<Arc<QueryContext>> {
     let sessions = SessionManagerBuilder::create().build()?;
     let dummy_session = sessions.create_session("TestSession")?;
 
-    let context = DatabendQueryContext::from_shared(DatabendQueryContextShared::try_create(
+    let context = QueryContext::from_shared(QueryContextShared::try_create(
         config,
         Arc::new(dummy_session.as_ref().clone()),
         Cluster::empty(),
@@ -91,14 +91,14 @@ impl Default for ClusterDescriptor {
     }
 }
 
-pub fn try_create_cluster_context(desc: ClusterDescriptor) -> Result<Arc<DatabendQueryContext>> {
+pub fn try_create_cluster_context(desc: ClusterDescriptor) -> Result<Arc<QueryContext>> {
     let sessions = SessionManagerBuilder::create().build()?;
     let dummy_session = sessions.create_session("TestSession")?;
 
     let local_id = desc.local_node_id;
     let nodes = desc.cluster_nodes_list;
 
-    let context = DatabendQueryContext::from_shared(DatabendQueryContextShared::try_create(
+    let context = QueryContext::from_shared(QueryContextShared::try_create(
         sessions.get_conf().clone(),
         Arc::new(dummy_session.as_ref().clone()),
         Cluster::create(nodes, local_id),

--- a/query/src/tests/context.rs
+++ b/query/src/tests/context.rs
@@ -24,11 +24,10 @@ use crate::datasources::context::DataSourceContext;
 use crate::datasources::DatabaseEngineRegistry;
 use crate::datasources::TableEngineRegistry;
 use crate::sessions::DatabendQueryContext;
-use crate::sessions::DatabendQueryContextRef;
 use crate::sessions::DatabendQueryContextShared;
 use crate::tests::SessionManagerBuilder;
 
-pub fn try_create_context() -> Result<DatabendQueryContextRef> {
+pub fn try_create_context() -> Result<Arc<DatabendQueryContext>> {
     let sessions = SessionManagerBuilder::create().build()?;
     let dummy_session = sessions.create_session("TestSession")?;
 
@@ -42,7 +41,7 @@ pub fn try_create_context() -> Result<DatabendQueryContextRef> {
     Ok(context)
 }
 
-pub fn try_create_context_with_config(config: Config) -> Result<DatabendQueryContextRef> {
+pub fn try_create_context_with_config(config: Config) -> Result<Arc<DatabendQueryContext>> {
     let sessions = SessionManagerBuilder::create().build()?;
     let dummy_session = sessions.create_session("TestSession")?;
 
@@ -92,7 +91,7 @@ impl Default for ClusterDescriptor {
     }
 }
 
-pub fn try_create_cluster_context(desc: ClusterDescriptor) -> Result<DatabendQueryContextRef> {
+pub fn try_create_cluster_context(desc: ClusterDescriptor) -> Result<Arc<DatabendQueryContext>> {
     let sessions = SessionManagerBuilder::create().build()?;
     let dummy_session = sessions.create_session("TestSession")?;
 

--- a/query/src/tests/number.rs
+++ b/query/src/tests/number.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_datavalues::DataSchemaRef;
 use common_datavalues::DataValue;
 use common_exception::Result;
@@ -21,16 +23,16 @@ use common_planners::ReadDataSourcePlan;
 use crate::catalogs::Catalog;
 use crate::catalogs::ToReadDataSourcePlan;
 use crate::pipelines::transforms::SourceTransform;
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::tests::try_create_catalog;
 
 pub struct NumberTestData {
-    ctx: DatabendQueryContextRef,
+    ctx: Arc<DatabendQueryContext>,
     table: &'static str,
 }
 
 impl NumberTestData {
-    pub fn create(ctx: DatabendQueryContextRef) -> Self {
+    pub fn create(ctx: Arc<DatabendQueryContext>) -> Self {
         NumberTestData {
             ctx,
             table: "numbers_mt",

--- a/query/src/tests/number.rs
+++ b/query/src/tests/number.rs
@@ -23,16 +23,16 @@ use common_planners::ReadDataSourcePlan;
 use crate::catalogs::Catalog;
 use crate::catalogs::ToReadDataSourcePlan;
 use crate::pipelines::transforms::SourceTransform;
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::tests::try_create_catalog;
 
 pub struct NumberTestData {
-    ctx: Arc<DatabendQueryContext>,
+    ctx: Arc<QueryContext>,
     table: &'static str,
 }
 
 impl NumberTestData {
-    pub fn create(ctx: Arc<DatabendQueryContext>) -> Self {
+    pub fn create(ctx: Arc<QueryContext>) -> Self {
         NumberTestData {
             ctx,
             table: "numbers_mt",

--- a/query/src/tests/parse_query.rs
+++ b/query/src/tests/parse_query.rs
@@ -17,10 +17,10 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_planners::PlanNode;
 
-use crate::sessions::DatabendQueryContext;
+use crate::sessions::QueryContext;
 use crate::sql::PlanParser;
 
-pub fn parse_query(query: impl ToString, ctx: &Arc<DatabendQueryContext>) -> Result<PlanNode> {
+pub fn parse_query(query: impl ToString, ctx: &Arc<QueryContext>) -> Result<PlanNode> {
     let query = query.to_string();
     futures::executor::block_on(PlanParser::parse(&query, ctx.clone()))
 }

--- a/query/src/tests/parse_query.rs
+++ b/query/src/tests/parse_query.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_planners::PlanNode;
 
-use crate::sessions::DatabendQueryContextRef;
+use crate::sessions::DatabendQueryContext;
 use crate::sql::PlanParser;
 
-pub fn parse_query(query: impl ToString, ctx: &DatabendQueryContextRef) -> Result<PlanNode> {
+pub fn parse_query(query: impl ToString, ctx: &Arc<DatabendQueryContext>) -> Result<PlanNode> {
     let query = query.to_string();
     futures::executor::block_on(PlanParser::parse(&query, ctx.clone()))
 }

--- a/query/src/tests/sessions.rs
+++ b/query/src/tests/sessions.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::env;
+use std::sync::Arc;
 
 use common_base::tokio::runtime::Runtime;
 use common_base::Thread;
@@ -20,9 +21,8 @@ use common_exception::Result;
 
 use crate::configs::Config;
 use crate::sessions::SessionManager;
-use crate::sessions::SessionManagerRef;
 
-async fn async_try_create_sessions(config: Config) -> Result<SessionManagerRef> {
+async fn async_try_create_sessions(config: Config) -> Result<Arc<SessionManager>> {
     let sessions = SessionManager::from_conf(config.clone()).await?;
 
     let cluster_discovery = sessions.get_cluster_discovery();
@@ -30,7 +30,7 @@ async fn async_try_create_sessions(config: Config) -> Result<SessionManagerRef> 
     Ok(sessions)
 }
 
-fn sync_try_create_sessions(config: Config) -> Result<SessionManagerRef> {
+fn sync_try_create_sessions(config: Config) -> Result<Arc<SessionManager>> {
     let runtime = Runtime::new()?;
     runtime.block_on(async_try_create_sessions(config))
 }
@@ -102,7 +102,7 @@ impl SessionManagerBuilder {
         SessionManagerBuilder::inner_create(new_config)
     }
 
-    pub fn build(self) -> Result<SessionManagerRef> {
+    pub fn build(self) -> Result<Arc<SessionManager>> {
         let config = self.config;
         let handle = Thread::spawn(move || sync_try_create_sessions(config));
         handle.join().unwrap()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

This PR only do re-name, no code logics changed.

* DatabendQueryContextRef -> Arc\<DatabendQueryContext\>
* SessionManagerRef -> Arc\<SessionManager\>
* ClusterRef -> Arc\<Cluster\>
* DatabendQueryContext -> QueryContext
* DatabendQueryContextShared -> QueryContextShared

## Changelog

- Improvement


## Related Issues

Fixes #2992 

## Test Plan

Unit Tests

Stateless Tests

