### PR TITLE
gitignore the query/_data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ _local_fs/*
 _meta*/*
 stateless_test_data/*
 **/_logs*/*
-_data/*
+_data/
 _tmp/*
 tls/certs/*
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

it seems there'll generate a query/_data directory after runnint the stateless test in the localhost.

![Screen Shot 2021-11-24 at 12 01 56 PM](https://user-images.githubusercontent.com/129800/143172981-2457f6db-f882-490c-a250-f6d0dcfa8d1b.png)

gitignore can ignore a directory by a `/` suffix, like `query/_data/`.

after adding this config in .gitignore, the `query/_data/` in untracked files disappears. 

## Changelog

- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

## Test Plan

Unit Tests
Stateless Tests

