### PR TITLE
[metasrv] refactor: remove dup methods

### DIFF
--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -674,24 +674,12 @@ impl StateMachine {
         sm_nodes.get(node_id)
     }
 
-    pub fn get_database_by_id(&self, did: &u64) -> Result<Option<SeqV<DatabaseMeta>>, ErrorCode> {
-        let x = self.databases().get(did)?;
+    pub fn get_database_meta_by_id(&self, db_id: &u64) -> Result<SeqV<DatabaseMeta>, ErrorCode> {
+        let x = self
+            .databases()
+            .get(db_id)?
+            .ok_or_else(|| ErrorCode::UnknownDatabaseId(format!("database_id: {}", db_id)))?;
         Ok(x)
-    }
-
-    pub fn get_databases(&self) -> Result<Vec<(String, u64, DatabaseMeta)>, ErrorCode> {
-        let mut res = vec![];
-
-        let it = self.database_lookup().range(..)?;
-        for r in it {
-            let (a, b) = r?;
-            let meta = self
-                .get_database_by_id(&b.data)?
-                .ok_or_else(|| ErrorCode::UnknownDatabaseId(format!("database_id: {}", b.data)))?;
-            res.push((a, b.data, meta.data));
-        }
-
-        Ok(res)
     }
 
     pub fn get_database_meta_ver(&self) -> common_exception::Result<Option<u64>> {

--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -386,7 +386,7 @@ impl StateMachine {
                 ref table_name,
                 ref table_meta,
             } => {
-                let db_id = self.get_db_id(db_name).await?;
+                let db_id = self.get_database_id(db_name)?;
 
                 let lookup_key = TableLookupKey {
                     database_id: db_id,
@@ -442,7 +442,7 @@ impl StateMachine {
                 ref db_name,
                 ref table_name,
             } => {
-                let db_id = self.get_db_id(db_name).await?;
+                let db_id = self.get_database_id(db_name)?;
 
                 let lookup_key = TableLookupKey {
                     database_id: db_id,
@@ -607,7 +607,7 @@ impl StateMachine {
     }
 
     #[allow(clippy::ptr_arg)]
-    async fn get_db_id(&self, db_name: &String) -> common_exception::Result<u64> {
+    pub fn get_database_id(&self, db_name: &String) -> common_exception::Result<u64> {
         let seq_dbi = self
             .database_lookup()
             .get(db_name)?
@@ -675,13 +675,6 @@ impl StateMachine {
         sm_nodes.get(node_id)
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub fn get_database_id(&self, name: &str) -> Result<Option<SeqV<u64>>, ErrorCode> {
-        let dbs = self.database_lookup();
-        let x = dbs.get(&name.to_string())?;
-        Ok(x)
-    }
-
     pub fn get_database_by_id(&self, did: &u64) -> Result<Option<SeqV<DatabaseMeta>>, ErrorCode> {
         let x = self.databases().get(did)?;
         Ok(x)
@@ -728,19 +721,9 @@ impl StateMachine {
         Ok(result)
     }
 
-    pub fn get_tables(&self, db_name: &str) -> Result<Vec<TableInfo>, ErrorCode> {
-        let db = self.get_database_id(db_name)?;
-        let db = match db {
-            Some(x) => x,
-            None => {
-                return Err(ErrorCode::UnknownDatabase(format!(
-                    "unknown database {}",
-                    db_name
-                )));
-            }
-        };
-
-        let db_id = db.data;
+    #[allow(clippy::ptr_arg)]
+    pub fn get_tables(&self, db_name: &String) -> Result<Vec<TableInfo>, ErrorCode> {
+        let db_id = self.get_database_id(db_name)?;
 
         let mut tbls = vec![];
         let tables = self.tables();

--- a/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
+++ b/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
@@ -94,15 +94,14 @@ impl MetaApi for StateMachine {
     }
 
     async fn get_database(&self, req: GetDatabaseReq) -> Result<Arc<DatabaseInfo>, ErrorCode> {
-        let res = self
-            .get_database_id(&req.db_name)?
-            .ok_or_else(|| ErrorCode::UnknownDatabase(req.db_name.clone()))?;
+        let db_id = self.get_database_id(&req.db_name)?;
+
         let db_meta = self
-            .get_database_by_id(&res.data)?
-            .ok_or_else(|| ErrorCode::UnknownDatabaseId(format!("database_id: {}", res.data)))?;
+            .get_database_by_id(&db_id)?
+            .ok_or_else(|| ErrorCode::UnknownDatabaseId(format!("database_id: {}", db_id)))?;
 
         let dbi = DatabaseInfo {
-            database_id: res.data,
+            database_id: db_id,
             db: req.db_name.clone(),
             meta: db_meta.data,
         };
@@ -191,11 +190,7 @@ impl MetaApi for StateMachine {
         let db = &req.db_name;
         let table_name = &req.table_name;
 
-        let seq_db = self.get_database_id(db)?.ok_or_else(|| {
-            ErrorCode::UnknownDatabase(format!("get table: database not found {:}", db))
-        })?;
-
-        let db_id = seq_db.data;
+        let db_id = self.get_database_id(db)?;
 
         let table_id = self
             .table_lookup()

--- a/common/meta/raft-store/tests/it/state_machine/mod.rs
+++ b/common/meta/raft-store/tests/it/state_machine/mod.rs
@@ -171,10 +171,8 @@ async fn test_state_machine_apply_add_database() -> anyhow::Result<()> {
             }
         };
 
-        let got = m
-            .get_database_id(c.name)?
-            .ok_or_else(|| anyhow::anyhow!("db not found: {}", c.name))?;
-        assert_eq!(*want, got.data);
+        let got = m.get_database_id(&c.name.to_string())?;
+        assert_eq!(*want, got);
     }
 
     Ok(())

--- a/common/meta/types/src/database.rs
+++ b/common/meta/types/src/database.rs
@@ -23,6 +23,7 @@ pub struct DatabaseNameIdent {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct DatabaseInfo {
+    // TODO(xp): store the seq AKA version for CAS update
     pub database_id: u64,
     pub db: String,
     pub meta: DatabaseMeta,

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -104,17 +104,17 @@ impl RequestHandler<FlightReq<GetDatabaseReq>> for ActionHandler {
             .meta_node
             .get_state_machine()
             .await
-            .get_database_id(db_name)?
-            .ok_or_else(|| ErrorCode::UnknownDatabase(db_name.clone()))?;
+            .get_database_id(db_name)?;
+
         let db_meta = self
             .meta_node
             .get_state_machine()
             .await
-            .get_database_by_id(&db_id.data)?
-            .ok_or_else(|| ErrorCode::UnknownDatabaseId(format!("database_id: {}", db_id.data)))?;
+            .get_database_by_id(&db_id)?
+            .ok_or_else(|| ErrorCode::UnknownDatabaseId(format!("database_id: {}", db_id)))?;
 
         Ok(Arc::new(DatabaseInfo {
-            database_id: db_id.data,
+            database_id: db_id,
             db: db_name.to_string(),
             meta: db_meta.data,
         }))
@@ -253,16 +253,11 @@ impl RequestHandler<FlightReq<GetTableReq>> for ActionHandler {
         let db_name = &act.req.db_name;
         let table_name = &act.req.table_name;
 
-        let x = self
+        let db_id = self
             .meta_node
             .get_state_machine()
             .await
             .get_database_id(db_name)?;
-        let db = x.ok_or_else(|| {
-            ErrorCode::UnknownDatabase(format!("get table: database not found {:}", db_name))
-        })?;
-
-        let db_id = db.data;
 
         let seq_table_id = self
             .meta_node

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -328,8 +328,7 @@ impl RequestHandler<FlightReq<ListTableReq>> for ActionHandler {
         &self,
         req: FlightReq<ListTableReq>,
     ) -> common_exception::Result<Vec<Arc<TableInfo>>> {
-        let res = self.meta_node.get_tables(&req.req.db_name).await?;
-        Ok(res.iter().map(|t| Arc::new(t.clone())).collect::<Vec<_>>())
+        self.meta_node.list_tables(req.req).await
     }
 }
 #[async_trait::async_trait]

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -569,8 +569,9 @@ impl MetaNode {
         )
     }
 
+    #[allow(clippy::ptr_arg)]
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn get_tables(&self, db_name: &str) -> Result<Vec<TableInfo>, ErrorCode> {
+    pub async fn get_tables(&self, db_name: &String) -> Result<Vec<TableInfo>, ErrorCode> {
         // inconsistent get: from local state machine
 
         let sm = self.sto.state_machine.read().await;

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -26,12 +26,14 @@ use common_base::tokio::sync::RwLockReadGuard;
 use common_base::tokio::task::JoinHandle;
 use common_exception::prelude::ErrorCode;
 use common_exception::prelude::ToErrorCode;
+use common_meta_api::MetaApi;
 use common_meta_raft_store::config::RaftConfig;
 use common_meta_raft_store::state_machine::AppliedState;
 use common_meta_raft_store::state_machine::StateMachine;
 use common_meta_raft_store::state_machine::TableLookupKey;
 use common_meta_raft_store::state_machine::TableLookupValue;
 use common_meta_types::Cmd;
+use common_meta_types::ListTableReq;
 use common_meta_types::LogEntry;
 use common_meta_types::Node;
 use common_meta_types::NodeId;
@@ -569,13 +571,12 @@ impl MetaNode {
         )
     }
 
-    #[allow(clippy::ptr_arg)]
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn get_tables(&self, db_name: &String) -> Result<Vec<TableInfo>, ErrorCode> {
+    pub async fn list_tables(&self, req: ListTableReq) -> Result<Vec<Arc<TableInfo>>, ErrorCode> {
         // inconsistent get: from local state machine
 
         let sm = self.sto.state_machine.read().await;
-        sm.get_tables(db_name)
+        sm.list_tables(req).await
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/metasrv/tests/it/meta_service/raftmeta.rs
+++ b/metasrv/tests/it/meta_service/raftmeta.rs
@@ -252,9 +252,12 @@ async fn test_meta_node_add_database() -> anyhow::Result<()> {
             assert_applied_index(all.clone(), last_applied + 1).await?;
 
             for (i, mn) in all.iter().enumerate() {
-                let got = mn.get_state_machine().await.get_database_id(name)?;
+                let got = mn
+                    .get_state_machine()
+                    .await
+                    .get_database_id(&name.to_string())?;
 
-                assert_eq!(*want_id, got.unwrap().data, "n{} applied AddDatabase", i);
+                assert_eq!(*want_id, got, "n{} applied AddDatabase", i);
             }
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Methods that are already impl-ed in `MetaApi for StateMachine` are removed.

##### [metasrv] refactor: remove dup method get_databases()

##### [metasrv] refactor: remove dup method get_tables()

##### [metasrv] refactor: remove dup method get_db_id()

## Changelog




- Improvement


## Related Issues