### PR TITLE
ISSUE-3008: Add maybe_monotonic feature for functions

### DIFF
--- a/common/functions/src/scalars/arithmetics/arithmetic_div.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_div.rs
@@ -30,7 +30,7 @@ impl ArithmeticDivFunction {
 
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create_func))
-            .features(FunctionFeatures::default().deterministic())
+            .features(FunctionFeatures::default().deterministic().monotonicity())
     }
 
     pub fn get_monotonicity(_args: &[Monotonicity]) -> Result<Monotonicity> {

--- a/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
@@ -31,7 +31,7 @@ impl ArithmeticMinusFunction {
 
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create_func))
-            .features(FunctionFeatures::default().deterministic())
+            .features(FunctionFeatures::default().deterministic().monotonicity())
     }
 
     pub fn get_monotonicity(args: &[Monotonicity]) -> Result<Monotonicity> {

--- a/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
@@ -30,7 +30,7 @@ impl ArithmeticMulFunction {
 
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create_func))
-            .features(FunctionFeatures::default().deterministic())
+            .features(FunctionFeatures::default().deterministic().monotonicity())
     }
 
     pub fn get_monotonicity(_args: &[Monotonicity]) -> Result<Monotonicity> {

--- a/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
@@ -31,7 +31,7 @@ impl ArithmeticPlusFunction {
 
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create_func))
-            .features(FunctionFeatures::default().deterministic())
+            .features(FunctionFeatures::default().deterministic().monotonicity())
     }
 
     pub fn get_monotonicity(args: &[Monotonicity]) -> Result<Monotonicity> {

--- a/common/functions/src/scalars/dates/date.rs
+++ b/common/functions/src/scalars/dates/date.rs
@@ -53,7 +53,8 @@ impl DateFunction {
             RoundFunction::try_create(display_name, round)
         });
 
-        FunctionDescription::creator(creator).features(FunctionFeatures::default().deterministic())
+        FunctionDescription::creator(creator)
+            .features(FunctionFeatures::default().deterministic().monotonicity())
     }
 
     fn month_arithmetic_function_creator(factor: i64) -> FunctionDescription {

--- a/common/functions/src/scalars/dates/number_function.rs
+++ b/common/functions/src/scalars/dates/number_function.rs
@@ -37,6 +37,7 @@ pub struct NumberFunction<T, R> {
 
 pub trait NumberResultFunction<R> {
     const IS_DETERMINISTIC: bool;
+    const MAYBE_MONOTONIC: bool;
 
     fn return_type() -> Result<DataType>;
     fn to_number(_value: DateTime<Utc>) -> R;
@@ -48,6 +49,7 @@ pub struct ToYYYYMM;
 
 impl NumberResultFunction<u32> for ToYYYYMM {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = true;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::UInt32)
@@ -66,6 +68,7 @@ pub struct ToYYYYMMDD;
 
 impl NumberResultFunction<u32> for ToYYYYMMDD {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = true;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::UInt32)
@@ -84,6 +87,7 @@ pub struct ToYYYYMMDDhhmmss;
 
 impl NumberResultFunction<u64> for ToYYYYMMDDhhmmss {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = true;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::UInt64)
@@ -108,6 +112,7 @@ pub struct ToStartOfYear;
 
 impl NumberResultFunction<u16> for ToStartOfYear {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = true;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::Date16)
@@ -127,6 +132,7 @@ pub struct ToStartOfISOYear;
 
 impl NumberResultFunction<u16> for ToStartOfISOYear {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = true;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::Date16)
@@ -151,6 +157,7 @@ pub struct ToStartOfQuarter;
 
 impl NumberResultFunction<u16> for ToStartOfQuarter {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = true;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::Date16)
@@ -171,6 +178,7 @@ pub struct ToStartOfMonth;
 
 impl NumberResultFunction<u16> for ToStartOfMonth {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = true;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::Date16)
@@ -190,6 +198,7 @@ pub struct ToMonth;
 
 impl NumberResultFunction<u8> for ToMonth {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = false;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::UInt8)
@@ -208,6 +217,7 @@ pub struct ToDayOfYear;
 
 impl NumberResultFunction<u16> for ToDayOfYear {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = false;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::UInt16)
@@ -226,6 +236,7 @@ pub struct ToDayOfMonth;
 
 impl NumberResultFunction<u8> for ToDayOfMonth {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = false;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::UInt8)
@@ -244,6 +255,7 @@ pub struct ToDayOfWeek;
 
 impl NumberResultFunction<u8> for ToDayOfWeek {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = false;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::UInt8)
@@ -262,6 +274,7 @@ pub struct ToHour;
 
 impl NumberResultFunction<u8> for ToHour {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = false;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::UInt8)
@@ -280,6 +293,7 @@ pub struct ToMinute;
 
 impl NumberResultFunction<u8> for ToMinute {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = false;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::UInt8)
@@ -298,6 +312,7 @@ pub struct ToSecond;
 
 impl NumberResultFunction<u8> for ToSecond {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = false;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::UInt8)
@@ -316,6 +331,7 @@ pub struct ToMonday;
 
 impl NumberResultFunction<u16> for ToMonday {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = true;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::Date16)
@@ -349,6 +365,10 @@ where
 
         if T::IS_DETERMINISTIC {
             features = features.deterministic();
+        }
+
+        if T::MAYBE_MONOTONIC {
+            features = features.monotonicity();
         }
 
         FunctionDescription::creator(Box::new(Self::try_create)).features(features)

--- a/common/functions/src/scalars/dates/week_date.rs
+++ b/common/functions/src/scalars/dates/week_date.rs
@@ -38,6 +38,7 @@ pub struct WeekFunction<T, R> {
 
 pub trait WeekResultFunction<R> {
     const IS_DETERMINISTIC: bool;
+    const MAYBE_MONOTONIC: bool;
 
     fn return_type() -> Result<DataType>;
     fn to_number(_value: DateTime<Utc>, mode: Option<u64>) -> R;
@@ -49,6 +50,7 @@ pub struct ToStartOfWeek;
 
 impl WeekResultFunction<u32> for ToStartOfWeek {
     const IS_DETERMINISTIC: bool = true;
+    const MAYBE_MONOTONIC: bool = true;
 
     fn return_type() -> Result<DataType> {
         Ok(DataType::Date16)
@@ -89,6 +91,10 @@ where
 
         if T::IS_DETERMINISTIC {
             features = features.deterministic();
+        }
+
+        if T::MAYBE_MONOTONIC {
+            features = features.monotonicity();
         }
 
         FunctionDescription::creator(Box::new(Self::try_create)).features(features)

--- a/common/functions/src/scalars/expressions/expression.rs
+++ b/common/functions/src/scalars/expressions/expression.rs
@@ -24,7 +24,7 @@ pub struct ToCastFunction;
 
 impl ToCastFunction {
     fn cast_function_creator(to_type: DataType) -> FunctionDescription {
-        let mut features = FunctionFeatures::default().deterministic();
+        let mut features = FunctionFeatures::default().deterministic().monotonicity();
         if to_type == DataType::Boolean {
             features = features.bool_function();
         }

--- a/common/functions/src/scalars/function_factory.rs
+++ b/common/functions/src/scalars/function_factory.rs
@@ -42,6 +42,7 @@ pub struct FunctionFeatures {
     pub negative_function_name: Option<String>,
     pub is_bool_func: bool,
     pub is_context_func: bool,
+    pub maybe_monotonic: bool,
 }
 
 impl FunctionFeatures {
@@ -51,6 +52,7 @@ impl FunctionFeatures {
             negative_function_name: None,
             is_bool_func: false,
             is_context_func: false,
+            maybe_monotonic: false,
         }
     }
 
@@ -71,6 +73,11 @@ impl FunctionFeatures {
 
     pub fn context_function(mut self) -> FunctionFeatures {
         self.is_context_func = true;
+        self
+    }
+
+    pub fn monotonicity(mut self) -> FunctionFeatures {
+        self.maybe_monotonic = true;
         self
     }
 }

--- a/common/functions/src/scalars/maths/abs.rs
+++ b/common/functions/src/scalars/maths/abs.rs
@@ -39,7 +39,7 @@ impl AbsFunction {
 
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create))
-            .features(FunctionFeatures::default().deterministic())
+            .features(FunctionFeatures::default().deterministic().monotonicity())
     }
 }
 

--- a/common/functions/src/scalars/maths/ceil.rs
+++ b/common/functions/src/scalars/maths/ceil.rs
@@ -41,7 +41,7 @@ impl CeilFunction {
 
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create))
-            .features(FunctionFeatures::default().deterministic())
+            .features(FunctionFeatures::default().deterministic().monotonicity())
     }
 }
 

--- a/common/functions/src/scalars/maths/floor.rs
+++ b/common/functions/src/scalars/maths/floor.rs
@@ -41,7 +41,7 @@ impl FloorFunction {
 
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create))
-            .features(FunctionFeatures::default().deterministic())
+            .features(FunctionFeatures::default().deterministic().monotonicity())
     }
 }
 

--- a/common/functions/src/scalars/maths/sign.rs
+++ b/common/functions/src/scalars/maths/sign.rs
@@ -41,7 +41,7 @@ impl SignFunction {
 
     pub fn desc() -> FunctionDescription {
         FunctionDescription::creator(Box::new(Self::try_create))
-            .features(FunctionFeatures::default().deterministic())
+            .features(FunctionFeatures::default().deterministic().monotonicity())
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add maybe_monotonic feature for functions, maybe_monotonic indicate the function maybe monotonicity in a range of values, it can be used in range filter.

## Changelog

- New Feature
- Improvement

## Related Issues

Fixes #3008 

## Test Plan

