### PR TITLE
[common/meta/types] feature: add `ident` to `Change` to indicate what resource is changed

### DIFF
--- a/common/management/src/cluster/cluster_mgr.rs
+++ b/common/management/src/cluster/cluster_mgr.rs
@@ -187,6 +187,7 @@ impl ClusterApi for ClusterMgr {
 
         match upsert_node.await? {
             UpsertKVActionReply {
+                ident: None,
                 prev: Some(_),
                 result: None,
             } => Ok(()),
@@ -215,6 +216,7 @@ impl ClusterApi for ClusterMgr {
 
         match upsert_meta.await? {
             UpsertKVActionReply {
+                ident: None,
                 prev: Some(_),
                 result: Some(SeqV { seq: s, .. }),
             } => Ok(s),

--- a/common/meta/raft-store/src/state_machine/applied_state.rs
+++ b/common/meta/raft-store/src/state_machine/applied_state.rs
@@ -16,7 +16,6 @@ use async_raft::AppDataResponse;
 use common_meta_types::Change;
 use common_meta_types::DatabaseMeta;
 use common_meta_types::Node;
-use common_meta_types::TableIdent;
 use common_meta_types::TableMeta;
 use serde::Deserialize;
 use serde::Serialize;
@@ -42,11 +41,6 @@ pub enum AppliedState {
     DatabaseMeta(Change<DatabaseMeta>),
 
     TableMeta(Change<TableMeta>),
-
-    TableIdent {
-        prev: Option<TableIdent>,
-        result: Option<TableIdent>,
-    },
 
     KV(Change<Vec<u8>>),
 
@@ -93,7 +87,6 @@ impl AppliedState {
             AppliedState::DatabaseId(ref ch) => ch.changed(),
             AppliedState::DatabaseMeta(ref ch) => ch.changed(),
             AppliedState::TableMeta(ref ch) => ch.changed(),
-            AppliedState::TableIdent { prev, result } => prev != result,
             AppliedState::KV(ref ch) => ch.changed(),
             AppliedState::None => false,
         }
@@ -122,7 +115,6 @@ impl AppliedState {
             AppliedState::DatabaseId(Change { ref prev, .. }) => prev.is_none(),
             AppliedState::DatabaseMeta(Change { ref prev, .. }) => prev.is_none(),
             AppliedState::TableMeta(Change { ref prev, .. }) => prev.is_none(),
-            AppliedState::TableIdent { ref prev, .. } => prev.is_none(),
             AppliedState::KV(Change { ref prev, .. }) => prev.is_none(),
             AppliedState::None => true,
         }
@@ -135,7 +127,6 @@ impl AppliedState {
             AppliedState::DatabaseId(Change { ref result, .. }) => result.is_none(),
             AppliedState::DatabaseMeta(Change { ref result, .. }) => result.is_none(),
             AppliedState::TableMeta(Change { ref result, .. }) => result.is_none(),
-            AppliedState::TableIdent { ref result, .. } => result.is_none(),
             AppliedState::KV(Change { ref result, .. }) => result.is_none(),
             AppliedState::None => true,
         }

--- a/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
+++ b/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
@@ -40,7 +40,6 @@ use common_meta_types::UpsertTableOptionReply;
 use common_meta_types::UpsertTableOptionReq;
 use common_tracing::tracing;
 
-use crate::state_machine::AppliedState;
 use crate::state_machine::StateMachine;
 use crate::state_machine::TableLookupKey;
 
@@ -143,12 +142,9 @@ impl MetaApi for StateMachine {
         };
 
         let res = self.apply_cmd(&cr).await?;
-        let (prev, result) = match res {
-            AppliedState::TableIdent { prev, result } => (prev, result),
-            _ => {
-                panic!("not TableIdent result");
-            }
-        };
+        let mut ch: Change<TableMeta, u64> = res.try_into().unwrap();
+        let table_id = ch.ident.take().unwrap();
+        let (prev, result) = ch.unpack_data();
 
         assert!(result.is_some());
 
@@ -158,9 +154,7 @@ impl MetaApi for StateMachine {
                 table_name
             )))
         } else {
-            Ok(CreateTableReply {
-                table_id: result.unwrap().table_id,
-            })
+            Ok(CreateTableReply { table_id })
         }
     }
 

--- a/common/meta/raft-store/tests/it/state_machine/mod.rs
+++ b/common/meta/raft-store/tests/it/state_machine/mod.rs
@@ -201,15 +201,10 @@ async fn test_state_machine_apply_upsert_table_option() -> anyhow::Result<()> {
         })
         .await?;
 
-    let (table_id, mut version) = match resp {
-        AppliedState::TableIdent { result, .. } => {
-            let r = result.unwrap();
-            (r.table_id, r.version)
-        }
-        _ => {
-            panic!("expect AppliedState::TableIdent")
-        }
-    };
+    let mut ch: Change<TableMeta, u64> = resp.try_into().unwrap();
+    let table_id = ch.ident.take().unwrap();
+    let result = ch.result.unwrap();
+    let mut version = result.seq;
 
     tracing::info!("--- upsert options on empty table options");
     {

--- a/common/meta/types/src/change.rs
+++ b/common/meta/types/src/change.rs
@@ -25,22 +25,41 @@ pub enum AddResult<T> {
 
 /// `Change` describes a state change, including the states before and after a change.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, derive_more::From)]
-pub struct Change<T>
-where T: Clone + PartialEq
+pub struct Change<T, ID = u64>
+where
+    ID: Clone + PartialEq,
+    T: Clone + PartialEq,
 {
+    /// identity of the resouce that is changed.
+    pub ident: Option<ID>,
     pub prev: Option<SeqV<T>>,
     pub result: Option<SeqV<T>>,
 }
 
-impl<T> Change<T>
-where T: Clone + PartialEq + std::fmt::Debug
+impl<T, ID> Change<T, ID>
+where
+    ID: Clone + PartialEq + std::fmt::Debug,
+    T: Clone + PartialEq + std::fmt::Debug,
 {
     pub fn new(prev: Option<SeqV<T>>, result: Option<SeqV<T>>) -> Self {
-        Change { prev, result }
+        Change {
+            ident: None,
+            prev,
+            result,
+        }
     }
 
-    pub fn new_nochange(prev: Option<SeqV<T>>) -> Self {
+    pub fn new_with_id(id: ID, prev: Option<SeqV<T>>, result: Option<SeqV<T>>) -> Self {
         Change {
+            ident: Some(id),
+            prev,
+            result,
+        }
+    }
+
+    pub fn nochange_with_id(id: ID, prev: Option<SeqV<T>>) -> Self {
+        Change {
+            ident: Some(id),
             prev: prev.clone(),
             result: prev,
         }

--- a/metasrv/tests/it/meta_service/meta_service_impl.rs
+++ b/metasrv/tests/it/meta_service/meta_service_impl.rs
@@ -61,7 +61,7 @@ async fn test_meta_server_upsert_kv() -> anyhow::Result<()> {
         let rst: Result<AppliedState, RetryableError> = raft_mes.into();
         let resp: AppliedState = rst?;
         match resp {
-            AppliedState::KV(Change { prev, result }) => {
+            AppliedState::KV(Change { prev, result, .. }) => {
                 assert!(prev.is_none());
                 let sv = result.unwrap();
                 assert!(sv.seq > 0);


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/types] feature: add `ident` to `Change` to indicate what resource is changed
- Refactor: internally, CreateTable returns the TableMeta that is saved into
  metasrv.

- Refactor: remove an unused internal response type:
  AppliedState::TableIdent

## Changelog

- New Feature





## Related Issues