### PR TITLE
[common/meta/raft-store] refactor: CreateDatabase returns DatabaseMeta as aninternal result

### DIFF
--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -334,6 +334,14 @@ impl StateMachine {
                 if prev.is_none() && result.is_some() {
                     // TODO(xp): reconsider this impl. it may not be required.
                     self.incr_seq(SEQ_DATABASE_META_ID).await?;
+                } else {
+                    // exist
+                    let db_id = prev.unwrap().data;
+                    let prev = self.get_database_meta_by_id(&db_id)?;
+                    return Ok(AppliedState::DatabaseMeta(Change::nochange_with_id(
+                        db_id,
+                        Some(prev),
+                    )));
                 }
 
                 let dbs = self.databases();
@@ -359,7 +367,12 @@ impl StateMachine {
                     db_id,
                     result
                 );
-                Ok(Change::new(prev, result).into())
+
+                Ok(AppliedState::DatabaseMeta(Change::new_with_id(
+                    db_id,
+                    prev_meta,
+                    result_meta,
+                )))
             }
 
             Cmd::DropDatabase { ref name } => {

--- a/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
+++ b/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
@@ -24,6 +24,7 @@ use common_meta_types::CreateDatabaseReq;
 use common_meta_types::CreateTableReply;
 use common_meta_types::CreateTableReq;
 use common_meta_types::DatabaseInfo;
+use common_meta_types::DatabaseMeta;
 use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
 use common_meta_types::DropTableReply;
@@ -56,7 +57,8 @@ impl MetaApi for StateMachine {
 
         let res = self.apply_cmd(&cmd).await?;
 
-        let ch: Change<u64> = res.try_into().unwrap();
+        let mut ch: Change<DatabaseMeta> = res.try_into().unwrap();
+        let db_id = ch.ident.take().expect("Some(db_id)");
         let (prev, result) = ch.unpack_data();
 
         assert!(result.is_some());
@@ -68,9 +70,7 @@ impl MetaApi for StateMachine {
             )));
         }
 
-        Ok(CreateDatabaseReply {
-            database_id: result.unwrap(),
-        })
+        Ok(CreateDatabaseReply { database_id: db_id })
     }
 
     async fn drop_database(&self, req: DropDatabaseReq) -> Result<DropDatabaseReply, ErrorCode> {

--- a/common/meta/raft-store/tests/it/state_machine/mod.rs
+++ b/common/meta/raft-store/tests/it/state_machine/mod.rs
@@ -33,6 +33,7 @@ use common_meta_raft_store::state_machine::SerializableSnapshot;
 use common_meta_raft_store::state_machine::StateMachine;
 use common_meta_types::Change;
 use common_meta_types::Cmd;
+use common_meta_types::DatabaseMeta;
 use common_meta_types::KVMeta;
 use common_meta_types::LogEntry;
 use common_meta_types::MatchSeq;
@@ -152,27 +153,19 @@ async fn test_state_machine_apply_add_database() -> anyhow::Result<()> {
             })
             .await?;
 
-        let (prev, result) = match resp {
-            AppliedState::DatabaseId(ch) => ch.map(|x| x.data),
-            _ => {
-                panic!("expect AppliedState::Database")
-            }
-        };
-        assert_eq!(c.prev, prev, "{}-th", i);
+        let mut ch: Change<DatabaseMeta> = resp.try_into().expect("DatabaseMeta");
+        let result = ch.ident.take();
+        let prev = ch.prev;
+
+        assert_eq!(c.prev.is_none(), prev.is_none(), "{}-th", i);
         assert_eq!(c.result, result, "{}-th", i);
 
         // get
 
-        let want = match (&prev, &result) {
-            (Some(ref a), _) => a,
-            (_, Some(ref b)) => b,
-            _ => {
-                panic!("both none");
-            }
-        };
+        let want = result.expect("Some(db_id)");
 
         let got = m.get_database_id(&c.name.to_string())?;
-        assert_eq!(*want, got);
+        assert_eq!(want, got);
     }
 
     Ok(())


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/raft-store] refactor: CreateDatabase returns DatabaseMeta as aninternal result
- Fix: when `db_name` exists in `database_lookup` table, it should not
  continue on to create a db-meta record.

## Changelog




- Improvement


## Related Issues