### PR TITLE
[BUILD] add https credential for DAL

### DIFF
--- a/docker/meta/Dockerfile
+++ b/docker/meta/Dockerfile
@@ -1,4 +1,6 @@
 FROM debian:bullseye
 ARG TARGETPLATFORM
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates
 COPY ./distro/$TARGETPLATFORM/databend-meta /databend-meta
 ENTRYPOINT ["bash"]

--- a/docker/query/Dockerfile
+++ b/docker/query/Dockerfile
@@ -1,4 +1,6 @@
 FROM debian:bullseye
 ARG TARGETPLATFORM
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates
 COPY ./distro/$TARGETPLATFORM/databend-query /databend-query
 ENTRYPOINT ["bash"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary
Add basic ca-credential for DAL layer

## Changelog

- Build/Testing/CI
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

