### PR TITLE
remove extra comma in labels and assigness display

### DIFF
--- a/query/src/datasources/database/github/repo_issues_table.rs
+++ b/query/src/datasources/database/github/repo_issues_table.rs
@@ -118,21 +118,23 @@ impl RepoIssuesTable {
             title_array.push(issue.title.clone().into());
             state_array.push(issue.state.clone().into());
             user_array.push(issue.user.login.clone().into());
-            labels_array.push(issue.labels.iter().fold(Vec::new(), |mut content, label| {
+            let mut labels_str = issue.labels.iter().fold(Vec::new(), |mut content, label| {
                 content.extend_from_slice(label.name.clone().as_bytes());
                 content.push(b',');
                 content
-            }));
-            assigness_array.push(
-                issue
-                    .assignees
-                    .iter()
-                    .fold(Vec::new(), |mut content, user| {
-                        content.extend_from_slice(user.login.clone().as_bytes());
-                        content.push(b',');
-                        content
-                    }),
-            );
+            });
+            labels_str.pop();
+            labels_array.push(labels_str);
+            let mut assigness_str = issue
+                .assignees
+                .iter()
+                .fold(Vec::new(), |mut content, user| {
+                    content.extend_from_slice(user.login.clone().as_bytes());
+                    content.push(b',');
+                    content
+                });
+            assigness_str.pop();
+            assigness_array.push(assigness_str);
             comments_number_array.push(issue.comments);
         }
 

--- a/query/src/datasources/database/github/repo_prs_table.rs
+++ b/query/src/datasources/database/github/repo_prs_table.rs
@@ -140,31 +140,32 @@ impl RepoPrsTable {
                     .as_bytes()
                     .to_vec(),
             );
-            labels_array.push(
-                pr.labels
-                    .map(|labels| {
-                        let label_str = labels.iter().fold(Vec::new(), |mut content, label| {
-                            content.extend_from_slice(label.name.clone().as_bytes());
-                            content.push(b',');
-                            content
-                        });
-                        label_str
-                    })
-                    .unwrap_or_else(|| vec![b' ']),
-            );
-            assigness_array.push(
-                pr.assignees
-                    .map(|assignees| {
-                        let assigness_str =
-                            assignees.iter().fold(Vec::new(), |mut content, user| {
-                                content.extend_from_slice(user.login.clone().as_bytes());
-                                content.push(b',');
-                                content
-                            });
-                        assigness_str
-                    })
-                    .unwrap_or_else(|| vec![b' ']),
-            );
+            let mut labels_str = pr
+                .labels
+                .map(|labels| {
+                    let label_str = labels.iter().fold(Vec::new(), |mut content, label| {
+                        content.extend_from_slice(label.name.clone().as_bytes());
+                        content.push(b',');
+                        content
+                    });
+                    label_str
+                })
+                .unwrap_or_else(|| vec![b' ']);
+            labels_str.pop();
+            labels_array.push(labels_str);
+            let mut assignees_str = pr
+                .assignees
+                .map(|assignees| {
+                    let assigness_str = assignees.iter().fold(Vec::new(), |mut content, user| {
+                        content.extend_from_slice(user.login.clone().as_bytes());
+                        content.push(b',');
+                        content
+                    });
+                    assigness_str
+                })
+                .unwrap_or_else(|| vec![b' ']);
+            assignees_str.pop();
+            assigness_array.push(assignees_str);
         }
 
         Ok(vec![


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

remove extra comma in labels and assigness display

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

