### PR TITLE
[metasrv] refactor: rename test function names

### DIFF
--- a/common/building/src/lib.rs
+++ b/common/building/src/lib.rs
@@ -45,7 +45,7 @@ pub fn add_env_vergen() {
 
 pub fn add_env_commit_authors() {
     let r = run_script::run_script!(
-        // use eamil to uniq authors
+        // use email to uniq authors
         r#"git shortlog HEAD -sne | awk '{$1=""; sub(" ", "    \""); print }' | awk -F'<' '!x[$1]++' | \
         awk -F'<' '!x[$2]++' | awk -F'<' '{gsub(/ +$/, "\",", $1); print $1}' | sort | xargs"#
     );

--- a/metasrv/src/lib.rs
+++ b/metasrv/src/lib.rs
@@ -15,9 +15,7 @@
 #![feature(backtrace)]
 
 #[allow(clippy::all)]
-pub mod proto {
-    include!(concat!(env!("OUT_DIR"), concat!("/meta.rs")));
-}
+pub mod proto;
 
 pub mod any_error;
 pub mod api;

--- a/metasrv/src/proto.rs
+++ b/metasrv/src/proto.rs
@@ -12,12 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Supporting mod for tests
-
-pub mod service;
-pub mod tls_constants;
-
-pub use service::assert_metasrv_connection;
-pub use service::next_port;
-pub use service::start_metasrv;
-pub use service::start_metasrv_with_context;
+include!(concat!(env!("OUT_DIR"), "/meta.rs"));

--- a/metasrv/tests/it/configs.rs
+++ b/metasrv/tests/it/configs.rs
@@ -15,7 +15,7 @@
 use databend_meta::configs::Config;
 
 #[test]
-fn test_fuse_commit_version() -> anyhow::Result<()> {
+fn test_bin_commit_version() -> anyhow::Result<()> {
     let v = &databend_meta::configs::DATABEND_COMMIT_VERSION;
     assert!(v.len() > 0);
     Ok(())

--- a/metasrv/tests/it/flight/metasrv_flight_api.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_api.rs
@@ -28,7 +28,7 @@ use pretty_assertions::assert_eq;
 use tokio::time::Duration;
 
 use crate::init_meta_ut;
-use crate::tests::service::new_test_context;
+use crate::tests::service::new_metasrv_test_context;
 use crate::tests::start_metasrv_with_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -136,8 +136,8 @@ async fn test_join() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut tc0 = new_test_context(0);
-    let mut tc1 = new_test_context(1);
+    let mut tc0 = new_metasrv_test_context(0);
+    let mut tc1 = new_metasrv_test_context(1);
 
     tc1.config.raft_config.single = false;
     tc1.config.raft_config.join = vec![tc0.config.raft_config.raft_api_addr()];

--- a/metasrv/tests/it/flight/metasrv_flight_tls.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_tls.rs
@@ -20,7 +20,7 @@ use common_meta_flight::MetaFlightClient;
 use pretty_assertions::assert_eq;
 
 use crate::init_meta_ut;
-use crate::tests::service::new_test_context;
+use crate::tests::service::new_metasrv_test_context;
 use crate::tests::start_metasrv_with_context;
 use crate::tests::tls_constants::TEST_CA_CERT;
 use crate::tests::tls_constants::TEST_CN_NAME;
@@ -32,7 +32,7 @@ async fn test_tls_server() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut tc = new_test_context(0);
+    let mut tc = new_metasrv_test_context(0);
 
     tc.config.flight_tls_server_key = TEST_SERVER_KEY.to_owned();
     tc.config.flight_tls_server_cert = TEST_SERVER_CERT.to_owned();
@@ -63,7 +63,7 @@ async fn test_tls_server_config_failure() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut tc = new_test_context(0);
+    let mut tc = new_metasrv_test_context(0);
 
     tc.config.flight_tls_server_key = "../tests/data/certs/not_exist.key".to_owned();
     tc.config.flight_tls_server_cert = "../tests/data/certs/not_exist.pem".to_owned();

--- a/metasrv/tests/it/meta_service/meta_service_impl.rs
+++ b/metasrv/tests/it/meta_service/meta_service_impl.rs
@@ -29,19 +29,19 @@ use databend_meta::proto::meta_service_client::MetaServiceClient;
 use pretty_assertions::assert_eq;
 
 use crate::init_meta_ut;
-use crate::tests::assert_meta_connection;
-use crate::tests::service::new_test_context;
+use crate::tests::assert_metasrv_connection;
+use crate::tests::service::new_metasrv_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_meta_server_upsert_kv() -> anyhow::Result<()> {
+async fn test_metasrv_upsert_kv() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context(0);
+    let tc = new_metasrv_test_context(0);
     let addr = tc.config.raft_config.raft_api_addr();
 
     let _mn = MetaNode::boot(&tc.config.raft_config).await?;
-    assert_meta_connection(&addr).await?;
+    assert_metasrv_connection(&addr).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
 
@@ -78,15 +78,15 @@ async fn test_meta_server_upsert_kv() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_meta_server_incr_seq() -> anyhow::Result<()> {
+async fn test_metasrv_incr_seq() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc = new_test_context(0);
+    let tc = new_metasrv_test_context(0);
     let addr = tc.config.raft_config.raft_api_addr();
 
     let _mn = MetaNode::boot(&tc.config.raft_config).await?;
-    assert_meta_connection(&addr).await?;
+    assert_metasrv_connection(&addr).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
 
@@ -115,21 +115,21 @@ async fn test_meta_server_incr_seq() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
+async fn test_metasrv_cluster_write_on_non_leader() -> anyhow::Result<()> {
     // - Bring up a cluster of one leader and one non-voter
     // - Assert that writing on the non-voter returns ForwardToLeader error
 
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let tc0 = new_test_context(0);
-    let tc1 = new_test_context(1);
+    let tc0 = new_metasrv_test_context(0);
+    let tc1 = new_metasrv_test_context(1);
 
     let addr0 = tc0.config.raft_config.raft_api_addr();
     let addr1 = tc1.config.raft_config.raft_api_addr();
 
     let mn0 = MetaNode::boot(&tc0.config.raft_config).await?;
-    assert_meta_connection(&addr0).await?;
+    assert_metasrv_connection(&addr0).await?;
 
     {
         tracing::info!("--- add node 1 as non-voter");
@@ -137,7 +137,7 @@ async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
         let config = tc1.config.raft_config.clone();
         let mn1 = MetaNode::open_create_boot(&config, None, Some(()), None).await?;
 
-        assert_meta_connection(&addr0).await?;
+        assert_metasrv_connection(&addr0).await?;
 
         let resp = mn0.add_node(1, addr1.clone()).await?;
         match resp {

--- a/metasrv/tests/it/meta_service/mod.rs
+++ b/metasrv/tests/it/meta_service/mod.rs
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod meta_node;
 mod meta_service_impl;
-mod raftmeta;

--- a/metasrv/tests/it/store.rs
+++ b/metasrv/tests/it/store.rs
@@ -32,7 +32,7 @@ use databend_meta::Opened;
 use maplit::btreeset;
 
 use crate::init_meta_ut;
-use crate::tests::service::new_test_context;
+use crate::tests::service::new_metasrv_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_metasrv_restart() -> anyhow::Result<()> {
@@ -48,7 +48,7 @@ async fn test_metasrv_restart() -> anyhow::Result<()> {
     let _ent = ut_span.enter();
 
     let id = 3;
-    let tc = new_test_context(id);
+    let tc = new_metasrv_test_context(id);
 
     tracing::info!("--- new metasrv");
     {
@@ -93,7 +93,7 @@ async fn test_metasrv_get_membership_from_log() -> anyhow::Result<()> {
     let _ent = ut_span.enter();
 
     let id = 3;
-    let tc = new_test_context(id);
+    let tc = new_metasrv_test_context(id);
 
     tracing::info!("--- new metasrv");
     let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
@@ -193,7 +193,7 @@ async fn test_metasrv_do_log_compaction_empty() -> anyhow::Result<()> {
     let _ent = ut_span.enter();
 
     let id = 3;
-    let tc = new_test_context(id);
+    let tc = new_metasrv_test_context(id);
 
     let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
@@ -241,7 +241,7 @@ async fn test_metasrv_do_log_compaction_1_snap_ptr_1_log() -> anyhow::Result<()>
     let _ent = ut_span.enter();
 
     let id = 3;
-    let tc = new_test_context(id);
+    let tc = new_metasrv_test_context(id);
 
     let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
@@ -315,7 +315,7 @@ async fn test_metasrv_do_log_compaction_all_logs_with_memberchange() -> anyhow::
     let _ent = ut_span.enter();
 
     let id = 3;
-    let tc = new_test_context(id);
+    let tc = new_metasrv_test_context(id);
 
     let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
@@ -368,7 +368,7 @@ async fn test_metasrv_do_log_compaction_current_snapshot() -> anyhow::Result<()>
     let _ent = ut_span.enter();
 
     let id = 3;
-    let tc = new_test_context(id);
+    let tc = new_metasrv_test_context(id);
 
     let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
@@ -424,7 +424,7 @@ async fn test_metasrv_install_snapshot() -> anyhow::Result<()> {
     let id = 3;
     let snap;
     {
-        let tc = new_test_context(id);
+        let tc = new_metasrv_test_context(id);
 
         let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
@@ -441,7 +441,7 @@ async fn test_metasrv_install_snapshot() -> anyhow::Result<()> {
 
     tracing::info!("--- reopen a new metasrv to install snapshot");
     {
-        let tc = new_test_context(id);
+        let tc = new_metasrv_test_context(id);
 
         let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 

--- a/metasrv/tests/it/tests/service.rs
+++ b/metasrv/tests/it/tests/service.rs
@@ -28,7 +28,7 @@ use databend_meta::proto::GetReq;
 // Start one random service and get the session manager.
 #[tracing::instrument(level = "info")]
 pub async fn start_metasrv() -> Result<(MetaSrvTestContext, String)> {
-    let mut tc = new_test_context(0);
+    let mut tc = new_metasrv_test_context(0);
 
     start_metasrv_with_context(&mut tc).await?;
 
@@ -65,7 +65,7 @@ pub struct MetaSrvTestContext {
 }
 
 /// Create a new Config for test, with unique port assigned
-pub fn new_test_context(id: u64) -> MetaSrvTestContext {
+pub fn new_metasrv_test_context(id: u64) -> MetaSrvTestContext {
     let config_id = next_port();
 
     let mut config = configs::Config::empty();
@@ -114,7 +114,7 @@ pub fn new_test_context(id: u64) -> MetaSrvTestContext {
     }
 }
 
-pub async fn assert_meta_connection(addr: &str) -> anyhow::Result<()> {
+pub async fn assert_metasrv_connection(addr: &str) -> anyhow::Result<()> {
     tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: rename test function names

## Changelog




- Improvement


## Related Issues