### PR TITLE
Speed up min/max agg

### DIFF
--- a/common/datavalues/src/arrays/ops/agg.rs
+++ b/common/datavalues/src/arrays/ops/agg.rs
@@ -130,20 +130,6 @@ where
             return Ok(DataValue::from(self.data_type()));
         }
 
-        #[cfg(not(target_arch = "aarch64"))]
-        {
-            let null_count = self.null_count();
-            if null_count == 0 {
-                let c = self
-                    .array
-                    .values()
-                    .as_slice()
-                    .iter()
-                    .reduce(|a, b| if a < b { a } else { b });
-                return Ok(c.map_or(DataValue::from(self.data_type()), |x| (*x).into()));
-            }
-        }
-
         Ok(aggregate::min_primitive(self.inner())
             .map_or(DataValue::from(self.data_type()), |x| x.into()))
     }
@@ -151,20 +137,6 @@ where
     fn max(&self) -> Result<DataValue> {
         if self.is_empty() {
             return Ok(DataValue::from(self.data_type()));
-        }
-
-        #[cfg(not(target_arch = "aarch64"))]
-        {
-            let null_count = self.null_count();
-            if null_count == 0 {
-                let c = self
-                    .inner()
-                    .values()
-                    .as_slice()
-                    .iter()
-                    .reduce(|a, b| if a > b { a } else { b });
-                return Ok(c.map_or(DataValue::from(self.data_type()), |x| (*x).into()));
-            }
         }
 
         Ok(aggregate::max_primitive(self.inner())

--- a/common/datavalues/src/arrays/ops/agg.rs
+++ b/common/datavalues/src/arrays/ops/agg.rs
@@ -130,16 +130,20 @@ where
             return Ok(DataValue::from(self.data_type()));
         }
 
-        let null_count = self.null_count();
-        if null_count == 0 {
-            let c = self
-                .array
-                .values()
-                .as_slice()
-                .iter()
-                .reduce(|a, b| if a < b { a } else { b });
-            return Ok(c.map_or(DataValue::from(self.data_type()), |x| (*x).into()));
+        #[cfg(not(target_arch = "aarch64"))]
+        {
+            let null_count = self.null_count();
+            if null_count == 0 {
+                let c = self
+                    .array
+                    .values()
+                    .as_slice()
+                    .iter()
+                    .reduce(|a, b| if a < b { a } else { b });
+                return Ok(c.map_or(DataValue::from(self.data_type()), |x| (*x).into()));
+            }
         }
+
         Ok(aggregate::min_primitive(self.inner())
             .map_or(DataValue::from(self.data_type()), |x| x.into()))
     }
@@ -149,15 +153,18 @@ where
             return Ok(DataValue::from(self.data_type()));
         }
 
-        let null_count = self.null_count();
-        if null_count == 0 {
-            let c = self
-                .inner()
-                .values()
-                .as_slice()
-                .iter()
-                .reduce(|a, b| if a > b { a } else { b });
-            return Ok(c.map_or(DataValue::from(self.data_type()), |x| (*x).into()));
+        #[cfg(not(target_arch = "aarch64"))]
+        {
+            let null_count = self.null_count();
+            if null_count == 0 {
+                let c = self
+                    .inner()
+                    .values()
+                    .as_slice()
+                    .iter()
+                    .reduce(|a, b| if a > b { a } else { b });
+                return Ok(c.map_or(DataValue::from(self.data_type()), |x| (*x).into()));
+            }
         }
 
         Ok(aggregate::max_primitive(self.inner())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR

```
:) select max(number) from numbers_mt(10000000000);
+-------------+
| max(number) |
+-------------+
|  9999999999 |
+-------------+
1 row in set (2.87 sec)
Read 10000000000 rows, 80 GB in 2.869 sec., 3.49 billion rows/sec., 27.89 GB/sec.

After: 
:) select max(number) from numbers_mt(10000000000);
+-------------+
| max(number) |
+-------------+
|  9999999999 |
+-------------+
1 row in set (0.54 sec)
Read 10000000000 rows, 80 GB in 0.529 sec., 18.92 billion rows/sec., 151.33 GB/sec.
```

## Changelog

 
- Improvement
 

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

