### PR TITLE
[common/meta/embedded] feature: for non-test use, init meta store in configured dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,7 @@ dependencies = [
  "common-tracing",
  "derive_more",
  "futures",
+ "lazy_static",
  "maplit",
  "pretty_assertions",
  "tempfile",

--- a/common/meta/embedded/Cargo.toml
+++ b/common/meta/embedded/Cargo.toml
@@ -29,6 +29,7 @@ common-tracing = {path = "../../tracing" }
 async-trait = "0.1.51"
 derive_more = "0.99.17"
 futures = "0.3.18"
+lazy_static = "1.4.0"
 maplit = "1.0.2"
 tempfile = "3.2.0"
 

--- a/common/meta/embedded/src/meta_embedded.rs
+++ b/common/meta/embedded/src/meta_embedded.rs
@@ -21,6 +21,7 @@ use common_meta_raft_store::config::RaftConfig;
 use common_meta_raft_store::state_machine::StateMachine;
 pub use common_meta_sled_store::init_temp_sled_db;
 use common_tracing::tracing;
+use lazy_static::lazy_static;
 
 /// Local storage that provides the API defined by `KVApi+MetaApi`.
 ///
@@ -34,6 +35,11 @@ use common_tracing::tracing;
 #[derive(Clone)]
 pub struct MetaEmbedded {
     pub(crate) inner: Arc<Mutex<StateMachine>>,
+}
+
+lazy_static! {
+    static ref GLOBAL_META_EMBEDDED: Arc<std::sync::Mutex<Option<Arc<MetaEmbedded>>>> =
+        Arc::new(std::sync::Mutex::new(None));
 }
 
 impl MetaEmbedded {
@@ -76,5 +82,43 @@ impl MetaEmbedded {
         let name = format!("temp-{}", id);
 
         Self::new(&name).await
+    }
+
+    /// Initialize a sled db to store embedded meta data.
+    /// Initialize a global embedded meta store.
+    /// The data in `path` won't be removed after program exit.
+    pub async fn init_global_meta_store(path: String) -> common_exception::Result<()> {
+        common_meta_sled_store::init_sled_db(path);
+
+        {
+            let mut m = GLOBAL_META_EMBEDDED.as_ref().lock().unwrap();
+            let r = m.as_ref();
+
+            if r.is_none() {
+                let meta = MetaEmbedded::new("global").await?;
+                let meta = Arc::new(meta);
+                *m = Some(meta);
+                return Ok(());
+            }
+        }
+
+        panic!("global meta store can not init twice");
+    }
+
+    /// If global meta store is initialized, return it(production use).
+    /// Otherwise, return a meta store backed with temp dir for test.
+    pub async fn get_meta() -> common_exception::Result<Arc<MetaEmbedded>> {
+        {
+            let m = GLOBAL_META_EMBEDDED.as_ref().lock().unwrap();
+            let r = m.as_ref();
+
+            if let Some(x) = r {
+                return Ok(x.clone());
+            }
+        }
+
+        let meta = MetaEmbedded::new_temp().await?;
+        let meta = Arc::new(meta);
+        Ok(meta)
     }
 }

--- a/common/meta/sled-store/src/db.rs
+++ b/common/meta/sled-store/src/db.rs
@@ -26,7 +26,28 @@ pub(crate) struct GlobalSledDb {
     /// When opening a db on a temp dir, the temp dir guard must be held.
     #[allow(dead_code)]
     pub(crate) temp_dir: Option<TempDir>,
+    pub(crate) path: String,
     pub(crate) db: sled::Db,
+}
+
+impl GlobalSledDb {
+    pub(crate) fn new_temp(temp_dir: TempDir) -> Self {
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+
+        GlobalSledDb {
+            temp_dir: Some(temp_dir),
+            path: temp_path.clone(),
+            db: sled::open(temp_path).expect("open global sled::Db"),
+        }
+    }
+
+    pub(crate) fn new(path: String) -> Self {
+        GlobalSledDb {
+            temp_dir: None,
+            path: path.clone(),
+            db: sled::open(path).expect("open global sled::Db"),
+        }
+    }
 }
 
 lazy_static! {
@@ -35,31 +56,40 @@ lazy_static! {
 
 /// Open a db at a temp dir. For test purpose only.
 pub fn init_temp_sled_db(temp_dir: TempDir) {
-    let mut g = GLOBAL_SLED.as_ref().lock().unwrap();
+    let temp_path = temp_dir.path().to_str().unwrap().to_string();
 
-    if g.is_some() {
-        return;
+    let (inited_as_temp, curr_path) = {
+        let mut g = GLOBAL_SLED.as_ref().lock().unwrap();
+        if let Some(gdb) = g.as_ref() {
+            (gdb.temp_dir.is_some(), gdb.path.clone())
+        } else {
+            *g = Some(GlobalSledDb::new_temp(temp_dir));
+            return;
+        }
+    };
+
+    if !inited_as_temp {
+        panic!("sled db is already initialized with specified path: {}, can not re-init with temp path {}", curr_path, temp_path);
     }
-
-    let path = temp_dir.path().to_str().unwrap().to_string();
-
-    *g = Some(GlobalSledDb {
-        temp_dir: Some(temp_dir),
-        db: sled::open(path).expect("open global sled::Db"),
-    });
 }
 
 pub fn init_sled_db(path: String) {
-    let mut g = GLOBAL_SLED.as_ref().lock().unwrap();
+    let (inited_as_temp, curr_path) = {
+        let mut g = GLOBAL_SLED.as_ref().lock().unwrap();
+        if let Some(gdb) = g.as_ref() {
+            (gdb.temp_dir.is_some(), gdb.path.clone())
+        } else {
+            *g = Some(GlobalSledDb::new(path));
+            return;
+        }
+    };
 
-    if g.is_some() {
-        return;
+    if inited_as_temp {
+        panic!(
+            "sled db is already initialized with temp dir: {}, can not re-init with path {}",
+            curr_path, path
+        );
     }
-
-    *g = Some(GlobalSledDb {
-        temp_dir: None,
-        db: sled::open(path).expect("open global sled::Db"),
-    });
 }
 
 pub fn get_sled_db() -> sled::Db {

--- a/query/src/bin/databend-query.rs
+++ b/query/src/bin/databend-query.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_base::RuntimeTracker;
 use common_macros::databend_main;
+use common_meta_embedded::MetaEmbedded;
 use common_metrics::init_default_metrics_recorder;
 use common_tracing::init_tracing_with_file;
 use common_tracing::set_panic_hook;
@@ -48,6 +49,10 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
     // Override configs based on env variables
     conf = Config::load_from_env(&conf)?;
     conf.initial_dir()?;
+
+    if conf.meta.meta_address.is_empty() {
+        MetaEmbedded::init_global_meta_store(conf.meta.meta_embedded_dir.clone()).await?;
+    }
 
     env_logger::Builder::from_env(
         env_logger::Env::default().default_filter_or(conf.log.log_level.to_lowercase().as_str()),

--- a/query/src/catalogs/impls/mutable_catalog.rs
+++ b/query/src/catalogs/impls/mutable_catalog.rs
@@ -80,8 +80,8 @@ impl MutableCatalog {
             tracing::info!("use embedded meta");
             // TODO(xp): This can only be used for test: data will be removed when program quit.
 
-            let meta_embedded = MetaEmbedded::new_temp().await?;
-            Arc::new(meta_embedded)
+            let meta_embedded = MetaEmbedded::get_meta().await?;
+            meta_embedded
         } else {
             tracing::info!("use remote meta");
 

--- a/query/src/common/meta/meta_client.rs
+++ b/query/src/common/meta/meta_client.rs
@@ -45,8 +45,8 @@ impl MetaClientProvider {
     pub async fn try_get_kv_client(&self) -> Result<Arc<dyn KVApi>> {
         let local = self.conf.kv_service_config.address.is_empty();
         if local {
-            let client = common_meta_embedded::MetaEmbedded::new_temp().await?;
-            Ok(Arc::new(client))
+            let meta_store = common_meta_embedded::MetaEmbedded::get_meta().await?;
+            Ok(meta_store)
         } else {
             let client = MetaFlightClient::try_new(&self.conf).await?;
             Ok(Arc::new(client))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/embedded] feature: for non-test use, init meta store in configure dir

For production use of meta-embedded, use a persistent meta-data dir,
to avoid meta-data loss when `query` is restarted.

Let `query` create a process-wise global meta-store if the remote meta-store address is empty.
Then sub routines use this global meta-store.

Unit tests do not initialize such a process-wise global meta-store thus they still build a meta-store backed by a temp-dir.

## Changelog

- New Feature





## Related Issues