### PR TITLE
Set table_engine_memory_enabled default value

### DIFF
--- a/query/src/configs/config_query.rs
+++ b/query/src/configs/config_query.rs
@@ -189,7 +189,13 @@ pub struct QueryConfig {
     #[serde(default)]
     pub table_engine_parquet_enabled: bool,
 
-    #[structopt(long, env, help = "Table engine memory enabled")]
+    #[structopt(
+        long,
+        env,
+        parse(try_from_str),
+        default_value = "true",
+        help = "Table engine memory enabled"
+    )]
     #[serde(default)]
     pub table_engine_memory_enabled: bool,
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Set table_engine_memory_enabled default value: true

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan

