### PR TITLE
add cache for local data accessor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,7 @@ dependencies = [
  "azure_storage_mirror",
  "bytes",
  "common-base",
+ "common-cache",
  "common-datablocks",
  "common-exception",
  "common-infallible",

--- a/common/cache/src/meter/bytes_meter.rs
+++ b/common/cache/src/meter/bytes_meter.rs
@@ -1,0 +1,26 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::borrow::Borrow;
+
+use super::Meter;
+// count bytes for data accessors
+impl<K, T> Meter<K, Vec<T>> for Vec<u8> {
+    type Measure = usize;
+    fn measure<Q: ?Sized>(&self, _: &Q, v: &Vec<T>) -> usize
+        where K: Borrow<Q>
+    {
+        v.len()
+    }
+}

--- a/common/dal/Cargo.toml
+++ b/common/dal/Cargo.toml
@@ -14,6 +14,7 @@ test = false
 common-base = {path = "../base"}
 common-datablocks = {path = "../datablocks"}
 common-exception = {path = "../exception"}
+common-cache = {path = "../cache"}
 common-infallible = {path = "../infallible"}
 
 async-compat = "0.2.1"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

cache object in local disk. s3/azure maybe like this way.
and maybe we can cache them in different types, such as meta data and user data, thay should cached in different caches.
it is a draft pr from #1784 

## Changelog

- New Feature

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

