### PR TITLE
try fix the CI error about protoc

### DIFF
--- a/.github/workflows/databend-base.yml
+++ b/.github/workflows/databend-base.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  PROTOC: protoc
 
 jobs:
   lint_and_build:
@@ -24,6 +25,9 @@ jobs:
         with:
           file_or_dir: ./
           config_file: .yamllint.yml
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
 
       - name: Rust setup
         run: |

--- a/.github/workflows/stateful-tests-standalone.yml
+++ b/.github/workflows/stateful-tests-standalone.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  PROTOC: protoc
 
 jobs:
   build:
@@ -24,6 +25,9 @@ jobs:
           - { os: ubuntu-latest, toolchain: stable, target: x86_64-unknown-linux-gnu, cross: false }
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
 
       - name: Rust setup
         run: |

--- a/.github/workflows/stateless-tests-cluster.yml
+++ b/.github/workflows/stateless-tests-cluster.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  PROTOC: protoc
 
 jobs:
   build:
@@ -27,6 +28,9 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
 
       - name: Rust setup
         run: |

--- a/.github/workflows/stateless-tests-standalone.yml
+++ b/.github/workflows/stateless-tests-standalone.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  PROTOC: protoc
 
 jobs:
   build:
@@ -26,6 +27,9 @@ jobs:
           - { os: macos-latest, toolchain: stable, target: x86_64-apple-darwin, cross: false }
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
 
       - name: Rust setup
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  PROTOC: protoc
 
 jobs:
   test:
@@ -27,6 +28,9 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
 
       - name: Rust setup
         run: |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

the CI seems break in the main branch, error message:

```
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: NotFound, error: "failed to invoke protoc (hint: https://docs.rs/prost-build/#sourcing-protoc): No such file or directory (os error 2)" }', common/meta/flight/build.rs:34:10
```

the cause might be something changed in the CI base image?

this PR is a quick-and-dirty fix on the CI break to avoid blocking the other pull requests, we'd better find out the root cause of this CI break.

## Changelog

- Bug Fix

## Related Issues

Fixes #3208

## Test Plan

Unit Tests

Stateless Tests

