### PR TITLE
show http usage port in config

### DIFF
--- a/query/src/bin/databend-query.rs
+++ b/query/src/bin/databend-query.rs
@@ -117,9 +117,12 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
         let listening = srv.start(listening.parse()?).await?;
         shutdown_handle.add_service(srv);
 
+        let http_handler_usage = HTTP_HANDLER_USAGE
+            .to_string()
+            .replace("8001", conf.query.http_handler_port.to_string().as_str());
         info!(
             "Http handler listening on {} {}",
-            listening, HTTP_HANDLER_USAGE
+            listening, http_handler_usage
         );
     }
 


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Http usage always show 8001 though config changed when app is startting.
This PR change the print information.

## Changelog

## Related Issues

http handler usage, change port along with the config #3239


## Test Plan

