### PR TITLE
Add other table options for create table

### DIFF
--- a/query/src/sql/sql_parser.rs
+++ b/query/src/sql/sql_parser.rs
@@ -690,24 +690,15 @@ impl<'a> DfParser<'a> {
         let (columns, _) = self.parse_columns()?;
         let engine = self.parse_table_engine()?;
 
-        let mut table_properties = vec![];
-
         // parse table options: https://dev.mysql.com/doc/refman/8.0/en/create-table.html
-        if self.consume_token("LOCATION") {
-            self.parser.expect_token(&Token::Eq)?;
-            let value = self.parse_value()?;
-            table_properties.push(SqlOption {
-                name: Ident::new("LOCATION"),
-                value,
-            })
-        }
+        let options = self.parse_options()?;
 
         let create = DfCreateTable {
             if_not_exists,
             name: table_name,
             columns,
             engine,
-            options: table_properties,
+            options,
         };
 
         Ok(DfStatement::CreateTable(create))

--- a/query/src/sql/sql_parser_test.rs
+++ b/query/src/sql/sql_parser_test.rs
@@ -135,14 +135,14 @@ fn create_table() -> Result<()> {
         columns: vec![make_column_def("c1", DataType::Int(None))],
         engine: "CSV".to_string(),
         options: vec![SqlOption {
-            name: Ident::new("LOCATION".to_string()),
+            name: Ident::new("location".to_string()),
             value: Value::SingleQuotedString("/data/33.csv".into()),
         }],
     });
     expect_parse_ok(sql, expected)?;
 
     // positive case: it is ok for parquet files not to have columns specified
-    let sql = "CREATE TABLE t(c1 int, c2 bigint, c3 varchar(255) ) ENGINE = Parquet location = 'foo.parquet' ";
+    let sql = "CREATE TABLE t(c1 int, c2 bigint, c3 varchar(255) ) ENGINE = Parquet location = 'foo.parquet' comment = 'foo'";
     let expected = DfStatement::CreateTable(DfCreateTable {
         if_not_exists: false,
         name: ObjectName(vec![Ident::new("t")]),
@@ -152,10 +152,16 @@ fn create_table() -> Result<()> {
             make_column_def("c3", DataType::Varchar(Some(255))),
         ],
         engine: "Parquet".to_string(),
-        options: vec![SqlOption {
-            name: Ident::new("LOCATION".to_string()),
-            value: Value::SingleQuotedString("foo.parquet".into()),
-        }],
+        options: vec![
+            SqlOption {
+                name: Ident::new("location".to_string()),
+                value: Value::SingleQuotedString("foo.parquet".into()),
+            },
+            SqlOption {
+                name: Ident::new("comment".to_string()),
+                value: Value::SingleQuotedString("foo".into()),
+            },
+        ],
     });
     expect_parse_ok(sql, expected)?;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add other table option for create table with comment.

## Changelog

- New Feature

## Related Issues

related https://github.com/datafuselabs/databend/issues/2979

## Test Plan

Unit Tests

Stateless Tests

