### PR TITLE
show table options

### DIFF
--- a/query/src/interpreters/interpreter_show_create_table.rs
+++ b/query/src/interpreters/interpreter_show_create_table.rs
@@ -67,6 +67,15 @@ impl Interpreter for ShowCreateTableInterpreter {
         }
         let table_engine = format!(") ENGINE={}", engine);
         table_info.push_str(table_engine.as_str());
+        table_info.push_str(
+            table
+                .options()
+                .iter()
+                .map(|(k, v)| format!(" {}='{}'", k.to_uppercase(), v))
+                .collect::<Vec<_>>()
+                .join("")
+                .as_str(),
+        );
 
         let show_fields = vec![
             DataField::new("Table", DataType::String, false),

--- a/query/src/interpreters/interpreter_show_create_table_test.rs
+++ b/query/src/interpreters/interpreter_show_create_table_test.rs
@@ -30,7 +30,7 @@ async fn interpreter_show_create_table_test() -> Result<()> {
         static TEST_CREATE_QUERY: &str = "\
             CREATE TABLE default.a(\
                 a bigint, b int, c varchar(255), d smallint, e Date\
-            ) Engine = Null\
+            ) Engine = Null COMMENT = 'test create'\
         ";
 
         if let PlanNode::CreateTable(plan) = parse_query(TEST_CREATE_QUERY, &ctx)? {
@@ -47,17 +47,17 @@ async fn interpreter_show_create_table_test() -> Result<()> {
             let stream = executor.execute(None).await?;
             let result = stream.try_collect::<Vec<_>>().await?;
             let expected = vec![
-                "+-------+--------------------+",
-                "| Table | Create Table       |",
-                "+-------+--------------------+",
-                "| a     | CREATE TABLE `a` ( |",
-                "|       |   `a` Int64,       |",
-                "|       |   `b` Int32,       |",
-                "|       |   `c` String,      |",
-                "|       |   `d` Int16,       |",
-                "|       |   `e` Date16,      |",
-                "|       | ) ENGINE=Null      |",
-                "+-------+--------------------+",
+                "+-------+-------------------------------------+",
+                "| Table | Create Table                        |",
+                "+-------+-------------------------------------+",
+                "| a     | CREATE TABLE `a` (                  |",
+                "|       |   `a` Int64,                        |",
+                "|       |   `b` Int32,                        |",
+                "|       |   `c` String,                       |",
+                "|       |   `d` Int16,                        |",
+                "|       |   `e` Date16,                       |",
+                "|       | ) ENGINE=Null COMMENT='test create' |",
+                "+-------+-------------------------------------+",
             ];
             common_datablocks::assert_blocks_sorted_eq(expected, result.as_slice());
         } else {

--- a/query/src/storages/storage_table.rs
+++ b/query/src/storages/storage_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use common_datablocks::DataBlock;
@@ -44,6 +45,10 @@ pub trait Table: Sync + Send {
 
     fn schema(&self) -> DataSchemaRef {
         self.get_table_info().schema()
+    }
+
+    fn options(&self) -> &HashMap<String, String> {
+        self.get_table_info().options()
     }
 
     fn get_id(&self) -> MetaId {

--- a/tests/suites/0_stateless/06_0001_show_create_table.result
+++ b/tests/suites/0_stateless/06_0001_show_create_table.result
@@ -1,0 +1,2 @@
+a	CREATE TABLE `a` (\n  `a` Int64,\n  `b` Int32,\n  `c` String,\n  `d` Int16,\n  `e` Date16,\n) ENGINE=Null
+b	CREATE TABLE `b` (\n  `a` Int64,\n  `b` Int32,\n  `c` String,\n  `d` Int16,\n  `e` Date16,\n) ENGINE=Null COMMENT='test b'

--- a/tests/suites/0_stateless/06_0001_show_create_table.sql
+++ b/tests/suites/0_stateless/06_0001_show_create_table.sql
@@ -1,0 +1,13 @@
+DROP DATABASE IF EXISTS `test`;
+CREATE DATABASE `test`;
+CREATE TABLE `test`.`a` (
+    a bigint, b int, c varchar(255), d smallint, e Date
+) Engine = Null;
+SHOW CREATE TABLE `test`.`a`;
+CREATE TABLE `test`.`b` (
+    a bigint, b int, c varchar(255), d smallint, e Date
+) Engine = Null COMMENT = 'test b';
+SHOW CREATE TABLE `test`.`b`;
+DROP TABLE `test`.`a`;
+DROP TABLE `test`.`b`;
+DROP DATABASE `test`;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary
show table options in `show create table`

```
mysql> create table t1(a Int32) comment='this is a comment';
mysql> show create table t1;
+-------+----------------------------------------------------------------------------+
| Table | Create Table                                                               |
+-------+----------------------------------------------------------------------------+
| t1    | CREATE TABLE `t1` (
  `a` Int32,
) ENGINE=FUSE COMMENT='this is a comment' |
+-------+----------------------------------------------------------------------------+
```
## Changelog

- Improvement

## Related Issues

Fixes [#issue](https://github.com/datafuselabs/databend/issues/3251)

## Test Plan

Unit Tests

Stateless Tests

