### PR TITLE
[makefile] use objcopy to reduce binary size

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,0 @@
-[target."x86_64-unknown-linux-gnu"]
-rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi"]
-[target."aarch64-unknown-linux-gnu"]
-rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi"]

--- a/.github/workflows/databend-docker.yml
+++ b/.github/workflows/databend-docker.yml
@@ -51,8 +51,10 @@ jobs:
         run: |
           if [ ${{ matrix.config.cross }} = true ]; then
               cross build --release --target=${{ matrix.config.target }} --bin databend-benchmark
+              objcopy --compress-debug-sections=zlib-gnu ./target/${{ matrix.config.target }}/release/databend-benchmark
           else
               cargo build --release --target=${{ matrix.config.target }} --bin databend-benchmark
+              objcopy --compress-debug-sections=zlib-gnu ./target/${{ matrix.config.target }}/release/databend-benchmark
           fi
           mkdir -p ./distro
           mv ./target/${{ matrix.config.target }}/release/databend-benchmark  ./distro

--- a/.github/workflows/databend-performance-dispatch.yaml
+++ b/.github/workflows/databend-performance-dispatch.yaml
@@ -62,6 +62,8 @@ jobs:
           export SCCACHE_DIR=/home/runner/.cache/sccache
           export RUSTC_WRAPPER=sccache
           cargo build --bin=databend-query --bin=databend-meta --target x86_64-unknown-linux-gnu --release
+          objcopy --compress-debug-sections=zlib-gnu ./target/x86_64-unknown-linux-gnu/release/databend-query
+          objcopy --compress-debug-sections=zlib-gnu ./target/x86_64-unknown-linux-gnu/release/databend-meta
           mkdir -p distro
           sccache --show-stats
           cp target/x86_64-unknown-linux-gnu/release/databend-query ./distro/databend-query
@@ -160,6 +162,8 @@ jobs:
           export SCCACHE_DIR=/home/runner/.cache/sccache
           export RUSTC_WRAPPER=sccache
           cargo build --bin=databend-query --bin=databend-meta --target x86_64-unknown-linux-gnu --release
+          objcopy --compress-debug-sections=zlib-gnu ./target/x86_64-unknown-linux-gnu/release/databend-query
+          objcopy --compress-debug-sections=zlib-gnu ./target/x86_64-unknown-linux-gnu/release/databend-meta
           mkdir -p distro
           sccache --show-stats
           cp target/x86_64-unknown-linux-gnu/release/databend-query ./distro/databend-query

--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -40,8 +40,20 @@ jobs:
           fi
           if [ ${{ matrix.config.cross }} = true ]; then
               cross build --release --target=${{ matrix.config.target }}
+              if [ ${{ matrix.config.os }} = "ubuntu-latest" ]; then
+                  objcopy --compress-debug-sections=zlib-gnu ./target/${{ matrix.config.target }}/release/databend-query
+                  objcopy --compress-debug-sections=zlib-gnu ./target/${{ matrix.config.target }}/release/databend-benchmark
+                  objcopy --compress-debug-sections=zlib-gnu ./target/${{ matrix.config.target }}/release/databend-meta
+                  objcopy --compress-debug-sections=zlib-gnu $./target/${{ matrix.config.target }}/release/bendctl
+              fi
           else
               cargo build --release --target=${{ matrix.config.target }}
+              if [ ${{ matrix.config.os }} = "ubuntu-latest" ]; then
+                  objcopy --compress-debug-sections=zlib-gnu ./target/${{ matrix.config.target }}/release/databend-query
+                  objcopy --compress-debug-sections=zlib-gnu ./target/${{ matrix.config.target }}/release/databend-benchmark
+                  objcopy --compress-debug-sections=zlib-gnu ./target/${{ matrix.config.target }}/release/databend-meta
+                  objcopy --compress-debug-sections=zlib-gnu ./target/${{ matrix.config.target }}/release/bendctl
+              fi
           fi
       - name: Get the version
         id: get_version

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ YAMLLINT_CONFIG ?= .yamllint.yml
 YAMLLINT_IMAGE ?= docker.io/cytopia/yamllint:latest
 YAMLLINT_DOCKER ?= docker $(YAML_DOCKER_ARGS) $(YAMLLINT_IMAGE)
 
+CARGO_TARGET_DIR ?= $(CURDIR)/target
+
 # Setup dev toolchain
 setup:
 	bash ./scripts/setup/dev_setup.sh
@@ -45,6 +47,12 @@ run-debug: build-debug
 
 build:
 	bash ./scripts/build/build-release.sh
+ifeq ($(shell uname),Linux) # Macs don't have objcopy
+	# Reduce binary size by compressing binaries.
+	objcopy --compress-debug-sections=zlib-gnu ${CARGO_TARGET_DIR}/release/databend-query
+	objcopy --compress-debug-sections=zlib-gnu ${CARGO_TARGET_DIR}/release/databend-benchmark
+	objcopy --compress-debug-sections=zlib-gnu ${CARGO_TARGET_DIR}/release/databend-meta
+endif
 
 build-native:
 	bash ./scripts/build/build-native.sh
@@ -57,9 +65,20 @@ cross-compile-debug:
 
 cross-compile-release:
 	cross build --target aarch64-unknown-linux-gnu --release
+ifeq ($(shell uname),Linux) # Macs don't have objcopy
+	# Reduce binary size by compressing binaries.
+	objcopy --compress-debug-sections=zlib-gnu ${CARGO_TARGET_DIR}/aarch64-unknown-linux-gnu/release/databend-query
+	objcopy --compress-debug-sections=zlib-gnu ${CARGO_TARGET_DIR}/aarch64-unknown-linux-gnu/release/databend-benchmark
+	objcopy --compress-debug-sections=zlib-gnu ${CARGO_TARGET_DIR}/aarch64-unknown-linux-gnu/release/databend-meta
+	objcopy --compress-debug-sections=zlib-gnu ${CARGO_TARGET_DIR}/aarch64-unknown-linux-gnu/release/bendctl
+endif
 
 cli-build:
 	bash ./scripts/build/build-cli.sh build-cli
+ifeq ($(shell uname),Linux) # Macs don't have objcopy
+	# Reduce binary size by compressing binaries.
+	objcopy --compress-debug-sections=zlib-gnu ${CARGO_TARGET_DIR}/release/bendctl
+endif
 
 cli-build-debug:
 	bash ./scripts/build/build-cli.sh build-cli-debug


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

use objcopy to reduce binary size

the principle is the same as in the previous programme.

## Changelog

- Build/Testing/CI
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2677 

## Test Plan

Unit Tests

Stateless Tests

