### PR TITLE
Replace AppendOperationLogEntry  vec[] with stream

### DIFF
--- a/query/src/storages/fuse/io/mod.rs
+++ b/query/src/storages/fuse/io/mod.rs
@@ -22,6 +22,7 @@ mod locations;
 mod readers;
 
 pub use block_stream_writer::BlockStreamWriter;
+pub use block_stream_writer::SegmentInfoStream;
 pub use locations::gen_segment_info_location;
 pub use locations::snapshot_location;
 pub use readers::read_obj;

--- a/query/src/storages/fuse/operations/append.rs
+++ b/query/src/storages/fuse/operations/append.rs
@@ -16,8 +16,10 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
+use async_stream::stream;
 use common_exception::Result;
 use common_streams::SendableDataBlockStream;
+use futures::StreamExt;
 
 use crate::sessions::QueryContext;
 use crate::storages::fuse::io;
@@ -29,13 +31,16 @@ use crate::storages::fuse::DEFAULT_CHUNK_BLOCK_NUM;
 use crate::storages::fuse::TBL_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD;
 use crate::storages::fuse::TBL_OPT_KEY_CHUNK_BLOCK_NUM;
 
+pub type AppendOperationLogEntryStream =
+    std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<AppendOperationLogEntry>> + Send>>;
+
 impl FuseTable {
     #[inline]
     pub async fn append_trunks(
         &self,
         ctx: Arc<QueryContext>,
         stream: SendableDataBlockStream,
-    ) -> Result<Vec<AppendOperationLogEntry>> {
+    ) -> Result<AppendOperationLogEntryStream> {
         let chunk_block_num = self.get_option(TBL_OPT_KEY_CHUNK_BLOCK_NUM, DEFAULT_CHUNK_BLOCK_NUM);
         let block_size_threshold = self.get_option(
             TBL_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD,
@@ -43,23 +48,32 @@ impl FuseTable {
         );
 
         let da = ctx.get_data_accessor()?;
-        let segments = BlockStreamWriter::write_block_stream(
+
+        let mut segment_stream = BlockStreamWriter::write_block_stream(
             da.clone(),
             stream,
-            self.table_info.schema().as_ref(),
+            self.table_info.schema().clone(),
             chunk_block_num,
             block_size_threshold,
         )
-        .await?;
+        .await;
 
-        let mut result = Vec::with_capacity(segments.len());
-        for seg in segments {
-            let seg_loc = io::gen_segment_info_location();
-            let bytes = serde_json::to_vec(&seg)?;
-            da.put(&seg_loc, bytes).await?;
-            result.push(AppendOperationLogEntry::new(seg_loc, seg))
-        }
-        Ok(result)
+        let log_entries = stream! {
+            while let Some(segment) = segment_stream.next().await {
+                let log_entry_res = match segment {
+                    Ok(seg) => {
+                        let seg_loc = io::gen_segment_info_location();
+                        let bytes = serde_json::to_vec(&seg)?;
+                        da.put(&seg_loc, bytes).await?;
+                        let log_entry = AppendOperationLogEntry::new(seg_loc, seg);
+                        Ok(log_entry)
+                    },
+                    Err(err) => Err(err),
+                };
+                yield(log_entry_res);
+            }
+        };
+        Ok(Box::pin(log_entries))
     }
 
     fn get_option<T: FromStr>(&self, opt_key: &str, default: T) -> T {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Currently AppendOperationLogEntry is returned as array, the PR is to replace with stream.

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

