### PR TITLE
ci: Add cargo cache to imporve perf tool build speed

### DIFF
--- a/.github/workflows/databend-docker.yml
+++ b/.github/workflows/databend-docker.yml
@@ -47,6 +47,10 @@ jobs:
           bash ./scripts/setup/dev_setup.sh
           cargo install --version 0.1.16 cross
 
+      - uses: ./.github/actions/cache-cargo-registry
+        with:
+          cache_reset_key: ${{ secrets.CACHE_RESET_KEY }}
+
       - name: Build Perf Tool
         run: |
           if [ ${{ matrix.config.cross }} = true ]; then


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

"Build Perf Tool" looks really slow, this PR is a try to improve it.

## Changelog

- Improvement

