### PR TITLE
[common/meta] refactor: add a trait Store to define local store API

### DIFF
--- a/common/meta/sled-store/src/lib.rs
+++ b/common/meta/sled-store/src/lib.rs
@@ -28,8 +28,10 @@ pub use sled_tree::AsTxnKeySpace;
 pub use sled_tree::SledTree;
 pub use sled_tree::SledValueToKey;
 pub use sled_tree::TransactionSledTree;
+pub use store::Store;
 
 mod db;
 mod sled_key_space;
 mod sled_serde;
 mod sled_tree;
+mod store;

--- a/common/meta/sled-store/src/store.rs
+++ b/common/meta/sled-store/src/store.rs
@@ -1,0 +1,29 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::SledKeySpace;
+
+/// Defines low level storage API
+pub trait Store<KV: SledKeySpace> {
+    type Error: std::error::Error;
+
+    fn insert(&self, key: &KV::K, value: &KV::V) -> Result<Option<KV::V>, Self::Error>;
+
+    fn get(&self, key: &KV::K) -> Result<Option<KV::V>, Self::Error>;
+
+    fn remove(&self, key: &KV::K) -> Result<Option<KV::V>, Self::Error>;
+
+    fn update_and_fetch<F>(&self, key: &KV::K, f: F) -> Result<Option<KV::V>, Self::Error>
+    where F: FnMut(Option<KV::V>) -> Option<KV::V>;
+}

--- a/common/meta/sled-store/tests/it/sled_txn_tree.rs
+++ b/common/meta/sled-store/tests/it/sled_txn_tree.rs
@@ -14,47 +14,13 @@
 
 use common_base::tokio;
 use common_meta_sled_store::SledTree;
+use common_meta_sled_store::Store;
 use common_meta_types::Node;
+use common_tracing::tracing;
 
 use crate::init_sled_ut;
 use crate::testing::fake_key_spaces::Nodes;
 use crate::testing::new_sled_test_context;
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_txn_tree_update_and_fetch() -> anyhow::Result<()> {
-    // Test transactional API update_and_fetch on TransactionSledTree
-
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-    tree.txn(false, |txn_tree| {
-        let k = 100;
-
-        for _i in 0..3 {
-            txn_tree.update_and_fetch::<Nodes, _>(&k, |old| match old {
-                Some(v) => Some(Node {
-                    name: v.name + "a",
-                    address: v.address,
-                }),
-                None => Some(Node::default()),
-            })?;
-        }
-
-        Ok(())
-    })?;
-
-    let got = tree.get::<Nodes>(&100)?.unwrap();
-    assert_eq!(
-        "aa".to_string(),
-        got.name,
-        "1st time create a default. then append 2 'a'"
-    );
-
-    Ok(())
-}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sled_txn_tree_key_space_update_and_fetch() -> anyhow::Result<()> {
@@ -66,9 +32,12 @@ async fn test_sled_txn_tree_key_space_update_and_fetch() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledTree::open(db, tc.tree_name, true)?;
-    tree.txn(false, |txn_tree| {
-        let k = 100;
 
+    let k = 100;
+
+    tracing::info!("--- test update default or non-default");
+
+    tree.txn(false, |txn_tree| {
         // sub tree key space
         let nodes_ks = txn_tree.key_space::<Nodes>();
 
@@ -92,5 +61,16 @@ async fn test_sled_txn_tree_key_space_update_and_fetch() -> anyhow::Result<()> {
         "1st time create a default. then append 2 'a'"
     );
 
+    tracing::info!("--- test delete");
+
+    tree.txn(false, |txn_tree| {
+        let nodes_ks = txn_tree.key_space::<Nodes>();
+        nodes_ks.update_and_fetch(&k, |_old| None)?;
+
+        Ok(())
+    })?;
+
+    let got = tree.get::<Nodes>(&100)?;
+    assert!(got.is_none(), "delete by return None");
     Ok(())
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta] refactor: add a trait Store to define local store API
- Use AsTxnKeySpace::update_and_fetch() to impl seq number.

- Impl `Store` for `AsTxnKeySpace`.

- Remove update_and_fetch from TransactionSledTree. It is not acutally
  used.

## Changelog




- Improvement


## Related Issues