### PR TITLE
add string transform unsafe safety comments

### DIFF
--- a/common/datavalues/src/arrays/string/mod.rs
+++ b/common/datavalues/src/arrays/string/mod.rs
@@ -19,6 +19,7 @@ mod transform;
 pub use builder::*;
 use common_arrow::arrow::array::*;
 use common_arrow::arrow::bitmap::Bitmap;
+use common_arrow::arrow::buffer::Buffer;
 use common_arrow::arrow::compute::cast::binary_to_large_binary;
 use common_arrow::arrow::datatypes::DataType as ArrowDataType;
 use common_exception::ErrorCode;
@@ -74,6 +75,28 @@ impl DFStringArray {
                 .unwrap()
                 .clone(),
         )
+    }
+
+    /// construct DFStringArray from unchecked data
+    /// # Safety
+    /// just like BinaryArray::from_data_unchecked, as follows
+    /// * `offsets` MUST be monotonically increasing
+    /// # Panics
+    /// This function panics iff:
+    /// * The last element of `offsets` is different from `values.len()`.
+    /// * The validity is not `None` and its length is different from `offsets.len() - 1`.
+    pub unsafe fn from_data_unchecked(
+        offsets: Buffer<i64>,
+        values: Buffer<u8>,
+        validity: Option<Bitmap>,
+    ) -> Self {
+        let array = BinaryArray::<i64>::from_data_unchecked(
+            BinaryArray::<i64>::default_data_type(),
+            offsets,
+            values,
+            validity,
+        );
+        Self { array }
     }
 
     pub fn inner(&self) -> &LargeBinaryArray {

--- a/common/datavalues/src/arrays/string/transform.rs
+++ b/common/datavalues/src/arrays/string/transform.rs
@@ -18,6 +18,10 @@ use common_arrow::arrow::buffer::MutableBuffer;
 
 use crate::prelude::*;
 
+/// tranform from DFStringArray to DFStringArray
+/// # Safety
+/// The caller must uphold the following invariants:
+/// * ensure the total len of transformed DFStringArray values <= estimate_bytes
 pub fn transform<F>(from: &DFStringArray, estimate_bytes: usize, mut f: F) -> DFStringArray
 where F: FnMut(&[u8], &mut [u8]) -> Option<usize> {
     let mut values: MutableBuffer<u8> = MutableBuffer::with_capacity(estimate_bytes);
@@ -55,6 +59,10 @@ where F: FnMut(&[u8], &mut [u8]) -> Option<usize> {
     }
 }
 
+/// tranform from DFStringArray to DFStringArray
+/// # Safety
+/// The caller must uphold the following invariants:
+/// * ensure the len of transformed DFStringArray values <= estimate_bytes
 pub fn transform_with_no_null<F>(
     from: &DFStringArray,
     estimate_bytes: usize,
@@ -92,6 +100,12 @@ where
     }
 }
 
+/// tranform from DFPrimitiveArray to DFStringArray
+/// # Safety
+/// The caller must uphold the following invariants:
+/// when turn original value1 => transformed value2
+/// * for value1, value2.len() <= f1(value1)
+/// we will need f1 to estimate how much space we need to reserve for a transformed value
 pub fn transform_from_primitive_with_no_null<F1, F2, T>(
     from: &DFPrimitiveArray<T>,
     f1: F1,

--- a/common/datavalues/src/arrays/string/transform.rs
+++ b/common/datavalues/src/arrays/string/transform.rs
@@ -49,13 +49,7 @@ where F: FnMut(&[u8], &mut [u8]) -> Option<usize> {
         values.set_len(offset);
         values.shrink_to_fit();
         let validity = combine_validities(from.array.validity(), Some(&validity.into()));
-        let array = BinaryArray::<i64>::from_data_unchecked(
-            BinaryArray::<i64>::default_data_type(),
-            offsets.into(),
-            values.into(),
-            validity,
-        );
-        DFStringArray::from_arrow_array(&array)
+        DFStringArray::from_data_unchecked(offsets.into(), values.into(), validity)
     }
 }
 
@@ -90,13 +84,11 @@ where
         }
         values.set_len(offset);
         values.shrink_to_fit();
-        let array = BinaryArray::<i64>::from_data_unchecked(
-            BinaryArray::<i64>::default_data_type(),
+        DFStringArray::from_data_unchecked(
             offsets.into(),
             values.into(),
             from.array.validity().cloned(),
-        );
-        DFStringArray::from_arrow_array(&array)
+        )
     }
 }
 
@@ -136,12 +128,10 @@ where
             offsets.push(offset as i64);
         }
         values.shrink_to_fit();
-        let array = BinaryArray::<i64>::from_data_unchecked(
-            BinaryArray::<i64>::default_data_type(),
+        DFStringArray::from_data_unchecked(
             offsets.into(),
             values.into(),
             from.array.validity().cloned(),
-        );
-        DFStringArray::from_arrow_array(&array)
+        )
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

* add string transform unsafe safety comments
* add `DFStringArray::from_data_unchecked` method

## Changelog

- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

