### PR TITLE
[metasrv]: feature: a follower forward GetDatabase request to leader.

### DIFF
--- a/common/exception/src/lib.rs
+++ b/common/exception/src/lib.rs
@@ -16,10 +16,12 @@ pub mod exception;
 
 pub use exception::ErrorCode;
 pub use exception::Result;
+pub use exception::SerializedError;
 pub use exception::ToErrorCode;
 
 pub mod prelude {
     pub use crate::exception::ErrorCode;
     pub use crate::exception::Result;
+    pub use crate::exception::SerializedError;
     pub use crate::exception::ToErrorCode;
 }

--- a/common/meta/sled-store/src/sled_tree.rs
+++ b/common/meta/sled-store/src/sled_tree.rs
@@ -500,43 +500,6 @@ impl TransactionSledTree<'_> {
             phantom: PhantomData,
         }
     }
-
-    fn get<KV>(&self, key: &KV::K) -> Result<Option<KV::V>, UnabortableTransactionError>
-    where KV: SledKeySpace {
-        let k = KV::serialize_key(key).unwrap();
-        let got = self.txn_tree.get(k)?;
-
-        let v = got.map(|v| KV::deserialize_value(v).unwrap());
-
-        Ok(v)
-    }
-
-    fn insert<KV>(
-        &self,
-        key: &KV::K,
-        value: &KV::V,
-    ) -> Result<Option<KV::V>, UnabortableTransactionError>
-    where
-        KV: SledKeySpace,
-    {
-        let k = KV::serialize_key(key).unwrap();
-        let v = KV::serialize_value(value).unwrap();
-
-        let prev = self.txn_tree.insert(k, v)?;
-        let prev = prev.map(|x| KV::deserialize_value(x).unwrap());
-
-        Ok(prev)
-    }
-
-    fn remove<KV>(&self, key: &KV::K) -> Result<Option<KV::V>, UnabortableTransactionError>
-    where KV: SledKeySpace {
-        let k = KV::serialize_key(key).unwrap();
-        let removed = self.txn_tree.remove(k)?;
-
-        let removed = removed.map(|x| KV::deserialize_value(x).unwrap());
-
-        Ok(removed)
-    }
 }
 
 /// It borrows the internal SledTree with access limited to a specified namespace `KV`.
@@ -554,15 +517,31 @@ impl<'a, KV: SledKeySpace> Store<KV> for AsTxnKeySpace<'a, KV> {
     type Error = UnabortableTransactionError;
 
     fn insert(&self, key: &KV::K, value: &KV::V) -> Result<Option<KV::V>, Self::Error> {
-        self.inner.insert::<KV>(key, value)
+        let k = KV::serialize_key(key).unwrap();
+        let v = KV::serialize_value(value).unwrap();
+
+        let prev = self.txn_tree.insert(k, v)?;
+        let prev = prev.map(|x| KV::deserialize_value(x).unwrap());
+
+        Ok(prev)
     }
 
     fn get(&self, key: &KV::K) -> Result<Option<KV::V>, Self::Error> {
-        self.inner.get::<KV>(key)
+        let k = KV::serialize_key(key).unwrap();
+        let got = self.txn_tree.get(k)?;
+
+        let v = got.map(|v| KV::deserialize_value(v).unwrap());
+
+        Ok(v)
     }
 
     fn remove(&self, key: &KV::K) -> Result<Option<KV::V>, Self::Error> {
-        self.inner.remove::<KV>(key)
+        let k = KV::serialize_key(key).unwrap();
+        let removed = self.txn_tree.remove(k)?;
+
+        let removed = removed.map(|x| KV::deserialize_value(x).unwrap());
+
+        Ok(removed)
     }
 
     fn update_and_fetch<F>(&self, key: &KV::K, mut f: F) -> Result<Option<KV::V>, Self::Error>

--- a/metasrv/src/meta_service/message.rs
+++ b/metasrv/src/meta_service/message.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use async_raft::raft::AppendEntriesRequest;
 use async_raft::raft::InstallSnapshotRequest;
 use async_raft::raft::VoteRequest;
 use common_meta_raft_store::state_machine::AppliedState;
+use common_meta_types::DatabaseInfo;
+use common_meta_types::GetDatabaseReq;
 use common_meta_types::LogEntry;
 use common_meta_types::NodeId;
 use serde::de::DeserializeOwned;
@@ -36,6 +40,8 @@ pub struct JoinRequest {
 pub enum AdminRequestInner {
     Join(JoinRequest),
     Write(LogEntry),
+
+    GetDatabase(GetDatabaseReq),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -57,6 +63,8 @@ impl AdminRequest {
 pub enum AdminResponse {
     Join(()),
     AppliedState(AppliedState),
+
+    DatabaseInfo(Arc<DatabaseInfo>),
 }
 
 impl tonic::IntoRequest<RaftRequest> for AdminRequest {

--- a/metasrv/src/meta_service/meta_leader.rs
+++ b/metasrv/src/meta_service/meta_leader.rs
@@ -18,6 +18,7 @@ use async_raft::error::ResponseError;
 use async_raft::raft::ClientWriteRequest;
 use async_raft::ChangeConfigError;
 use async_raft::ClientWriteError;
+use common_meta_api::MetaApi;
 use common_meta_raft_store::state_machine::AppliedState;
 use common_meta_types::Cmd;
 use common_meta_types::LogEntry;
@@ -57,6 +58,11 @@ impl<'a> MetaLeader<'a> {
             AdminRequestInner::Write(entry) => {
                 let res = self.write(entry).await?;
                 Ok(AdminResponse::AppliedState(res))
+            }
+            AdminRequestInner::GetDatabase(req) => {
+                let x = self.meta_node.get_state_machine().await;
+                let res = x.get_database(req).await?;
+                Ok(AdminResponse::DatabaseInfo(res))
             }
         }
     }

--- a/metasrv/tests/it/flight/metasrv_flight_api.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_api.rs
@@ -146,7 +146,7 @@ async fn test_join() -> anyhow::Result<()> {
     start_metasrv_with_context(&mut tc1).await?;
 
     let addr0 = tc0.config.flight_api_address.clone();
-    let addr1 = tc0.config.flight_api_address.clone();
+    let addr1 = tc1.config.flight_api_address.clone();
 
     let client0 = MetaFlightClient::try_create(addr0.as_str(), "root", "xxx").await?;
     let client1 = MetaFlightClient::try_create(addr1.as_str(), "root", "xxx").await?;

--- a/metasrv/tests/it/flight/metasrv_flight_meta_api_leader_follower.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api_leader_follower.rs
@@ -1,0 +1,46 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_base::tokio;
+use common_meta_api::MetaApiTestSuite;
+use common_meta_flight::MetaFlightClient;
+
+use crate::init_meta_ut;
+use crate::tests::service::new_metasrv_test_context;
+use crate::tests::start_metasrv_with_context;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_api_database_create_get_drop() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    let mut tc0 = new_metasrv_test_context(0);
+    let mut tc1 = new_metasrv_test_context(1);
+
+    tc1.config.raft_config.single = false;
+    tc1.config.raft_config.join = vec![tc0.config.raft_config.raft_api_addr()];
+
+    start_metasrv_with_context(&mut tc0).await?;
+    start_metasrv_with_context(&mut tc1).await?;
+
+    let addr0 = tc0.config.flight_api_address.clone();
+    let addr1 = tc1.config.flight_api_address.clone();
+
+    let client0 = MetaFlightClient::try_create(addr0.as_str(), "root", "xxx").await?;
+    let client1 = MetaFlightClient::try_create(addr1.as_str(), "root", "xxx").await?;
+
+    MetaApiTestSuite {}
+        .database_create_get_drop_leader_follower(&client0, &client1)
+        .await
+}

--- a/metasrv/tests/it/flight/mod.rs
+++ b/metasrv/tests/it/flight/mod.rs
@@ -15,4 +15,5 @@
 pub mod metasrv_flight_api;
 pub mod metasrv_flight_kv_api;
 pub mod metasrv_flight_meta_api;
+pub mod metasrv_flight_meta_api_leader_follower;
 pub mod metasrv_flight_tls;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv]: feature: a follower forward GetDatabase request to leader.
- Forward read request to achieve read-after-write consistency.

  - `RequestHandler<GetDatabaseReq>` forward `GetDatabase` request to its internal
    `MetaNode` to deal with it.
    `MetaNode` will forward it to a known leader if it is not a leader.

- Make `SerializedError` a real Error. Use it as a temp workaround to
  wrap an `ErrorCode` with `MetaError`.

  TODO: internally, metasrv should not use ErrorCode to exchange errors.
  `metasrv` has to express more info than an error, e.g.
  `ForwardToLeader`.

- Test: MetaApiTestSuite: add
  `database_create_get_drop_leader_follower()` to test write on leader
  then read on follower.

- Refactor: remove apis from TransactionSledTree.

- fix: #3339

## Changelog

- New Feature





## Related Issues