### PR TITLE
Allow set user for HTTP handler (without auth now).

### DIFF
--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -48,6 +48,7 @@ pub struct HttpQueryRequest {
 #[derive(Deserialize, Debug, Default)]
 pub struct HttpSessionConf {
     pub database: Option<String>,
+    pub user: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq)]

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -16,20 +16,19 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
-use futures::StreamExt;
-use serde::Deserialize;
-use serde::Serialize;
-
-use common_base::ProgressValues;
 use common_base::tokio;
 use common_base::tokio::sync::mpsc;
 use common_base::tokio::sync::RwLock;
+use common_base::ProgressValues;
 use common_base::TrySpawn;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_tracing::tracing;
+use futures::StreamExt;
+use serde::Deserialize;
+use serde::Serialize;
 use ExecuteState::*;
 
 use crate::interpreters::Interpreter;

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -16,19 +16,20 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use futures::StreamExt;
+use serde::Deserialize;
+use serde::Serialize;
+
+use common_base::ProgressValues;
 use common_base::tokio;
 use common_base::tokio::sync::mpsc;
 use common_base::tokio::sync::RwLock;
-use common_base::ProgressValues;
 use common_base::TrySpawn;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_tracing::tracing;
-use futures::StreamExt;
-use serde::Deserialize;
-use serde::Serialize;
 use ExecuteState::*;
 
 use crate::interpreters::Interpreter;
@@ -158,9 +159,8 @@ impl ExecuteState {
             context.set_current_database(db.clone()).await?;
         };
         context.attach_query_str(sql);
-
-        // Auth.
-        let user_name = "root";
+        let default_user = "root".to_string();
+        let user_name = request.session.user.as_ref().unwrap_or(&default_user);
         let user_manager = session.get_user_manager();
         // TODO: list user's grant list and check client address
         let user_info = user_manager.get_user(user_name, "%").await?;

--- a/query/src/servers/http/v1/statement.rs
+++ b/query/src/servers/http/v1/statement.rs
@@ -34,6 +34,7 @@ use crate::sessions::SessionManager;
 #[derive(Deserialize)]
 pub struct StatementHandlerParams {
     db: Option<String>,
+    user: Option<String>,
 }
 
 #[poem::handler]
@@ -47,6 +48,7 @@ pub async fn statement_handler(
     let query_id = http_query_manager.next_query_id();
     let session = HttpSessionConf {
         database: params.db.filter(|x| !x.is_empty()),
+        user: params.user,
     };
     let req = HttpQueryRequest { sql, session };
     let query = HttpQuery::try_create(query_id.clone(), req, session_manager).await;

--- a/query/tests/it/servers/http/statement.rs
+++ b/query/tests/it/servers/http/statement.rs
@@ -32,32 +32,32 @@ async fn test_statement() -> Result<()> {
     {
         let (status, result) = test_sql("select * from system.tables limit 10", None).await?;
         assert_eq!(status, StatusCode::OK);
+        assert!(result.error.is_none(), "%{:?}", result.error);
         assert_eq!(result.data.len(), 10);
-        assert!(!result.error.is_some());
     }
     {
         let (status, result) = test_sql("select * from tables limit 10", Some("system")).await?;
+        assert!(result.error.is_none(), "%{:?}", result.error);
         assert_eq!(status, StatusCode::OK);
         assert_eq!(result.data.len(), 10);
-        assert!(!result.error.is_some());
     }
     {
         let (status, result) = test_sql("show tables", Some("system")).await?;
+        assert!(result.error.is_none(), "%{:?}", result.error);
         assert_eq!(status, StatusCode::OK);
         assert!(!result.data.is_empty());
-        assert!(!result.error.is_some());
     }
     {
         let (status, result) = test_sql("show tables", Some("")).await?;
         assert_eq!(status, StatusCode::OK);
+        assert!(result.error.is_none(), "%{:?}", result.error);
         assert!(result.data.is_empty());
-        assert!(!result.error.is_some());
     }
     {
         let (status, result) = test_sql("bad sql", None).await?;
         assert_eq!(status, StatusCode::OK);
-        assert!(result.data.is_empty());
         assert!(result.error.is_some());
+        assert!(result.data.is_empty());
     }
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary


1. HTTP handler allows set user in  JSON.
2. better Bendcli error handling when calling HTTP streaming load API.
3. better test for HTTP handler so we can see the real reason when CI fails.

postpone to maybe next pr:

1. choose the way to pass the user for the streaming load.
2. check user privilege and client address
3. user auth


## Changelog


## Related Issues


## Test Plan

Unit Tests

Stateless Tests

