### PR TITLE
scripts: Fix build-tool-runner not updated

### DIFF
--- a/scripts/build/build-tool-runner.sh
+++ b/scripts/build/build-tool-runner.sh
@@ -7,9 +7,5 @@ cd "$SCRIPT_PATH/../.." || exit
 
 HUB="datafuselabs"
 
-docker build . -t ${HUB}/build-tool:arm-unknown-linux-gnueabi --file ./docker/build-tool/armv6/Dockerfile
-docker build . -t ${HUB}/build-tool:aarch64-unknown-linux-gnu --file ./docker/build-tool/arm64/Dockerfile
-docker build . -t ${HUB}/build-tool:armv7-unknown-linux-gnueabihf --file ./docker/build-tool/armv7/Dockerfile
-docker push ${HUB}/build-tool:arm-unknown-linux-gnueabi
+docker build . -t ${HUB}/build-tool:aarch64-unknown-linux-gnu --file ./docker/build-tool/aarch64/Dockerfile
 docker push ${HUB}/build-tool:aarch64-unknown-linux-gnu
-docker push ${HUB}/build-tool:armv7-unknown-linux-gnueabihf


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Fix build-tool-runner.sh not updated after #3353 

## Changelog

- Build/Testing/CI


