### PR TITLE
[common/meta/api] refactor: fixup test about returned error from forwarded GetDatabase

### DIFF
--- a/common/exception/tests/it/exception.rs
+++ b/common/exception/tests/it/exception.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_exception::ErrorCode;
+use common_exception::SerializedError;
 use tonic::Code;
 use tonic::Status;
 
@@ -86,6 +88,18 @@ fn test_derive_from_display() {
         "Code: 1000, displayText = 123, cause: 3.",
         format!("{}", rst1.as_ref().unwrap_err())
     );
+}
+
+#[test]
+fn test_from_and_to_serialized_error() {
+    let ec = ErrorCode::UnknownDatabase("foo");
+    let se: SerializedError = ec.clone().into();
+
+    let ec2: ErrorCode = se.into();
+    assert_eq!(ec.code(), ec2.code());
+    assert_eq!(ec.message(), ec2.message());
+    assert_eq!(format!("{}", ec), format!("{}", ec2));
+    assert_eq!(ec.backtrace_str(), ec2.backtrace_str());
 }
 
 #[test]

--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -490,10 +490,9 @@ impl MetaApiTestSuite {
                 .await;
             tracing::debug!("get present database res: {:?}", res);
             let err = res.unwrap_err();
-            println!("{:?}", err);
             assert_eq!(ErrorCode::UnknownDatabase("").code(), err.code());
-            // TODO(xp): this does no pass. serialized error needs to be refined.
-            // assert_eq!("Code: 3, displayText = nonexistent.", err.message());
+            assert_eq!("nonexistent", err.message());
+            assert_eq!("Code: 3, displayText = nonexistent.", format!("{}", err));
         }
 
         // TODO(xp): test drop is replicated to follower


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/api] refactor: fixup test about returned error from forwarded GetDatabase

## Changelog




- Improvement


## Related Issues