### PR TITLE
[common/meta/types] refactor: a AddResult returned by meta op should include an ID to indicate what has been changed

### DIFF
--- a/common/management/src/cluster/cluster_mgr.rs
+++ b/common/management/src/cluster/cluster_mgr.rs
@@ -21,10 +21,10 @@ use std::time::UNIX_EPOCH;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_api::KVApi;
-use common_meta_types::AddResult;
 use common_meta_types::KVMeta;
 use common_meta_types::MatchSeq;
 use common_meta_types::NodeInfo;
+use common_meta_types::OkOrExist;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKVAction;
@@ -148,9 +148,9 @@ impl ClusterApi for ClusterMgr {
 
         let res = upsert_node.await?.into_add_result()?;
 
-        match res {
-            AddResult::Ok(v) => Ok(v.seq),
-            AddResult::Exists(v) => Err(ErrorCode::ClusterNodeAlreadyExists(format!(
+        match res.res {
+            OkOrExist::Ok(v) => Ok(v.seq),
+            OkOrExist::Exists(v) => Err(ErrorCode::ClusterNodeAlreadyExists(format!(
                 "Cluster ID already exists, seq [{}]",
                 v.seq
             ))),

--- a/common/management/src/stage/stage_mgr.rs
+++ b/common/management/src/stage/stage_mgr.rs
@@ -18,10 +18,10 @@ use std::sync::Arc;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_api::KVApi;
-use common_meta_types::AddResult;
 use common_meta_types::IntoSeqV;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
+use common_meta_types::OkOrExist;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKVAction;
@@ -58,9 +58,9 @@ impl StageMgrApi for StageMgr {
 
         let res = upsert_info.await?.into_add_result()?;
 
-        match res {
-            AddResult::Ok(v) => Ok(v.seq),
-            AddResult::Exists(v) => Err(ErrorCode::StageAlreadyExists(format!(
+        match res.res {
+            OkOrExist::Ok(v) => Ok(v.seq),
+            OkOrExist::Exists(v) => Err(ErrorCode::StageAlreadyExists(format!(
                 "Stage already exists, seq [{}]",
                 v.seq
             ))),

--- a/common/management/src/user/user_mgr.rs
+++ b/common/management/src/user/user_mgr.rs
@@ -19,12 +19,12 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_exception::ToErrorCode;
 use common_meta_api::KVApi;
-use common_meta_types::AddResult;
 use common_meta_types::AuthType;
 use common_meta_types::GrantObject;
 use common_meta_types::IntoSeqV;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
+use common_meta_types::OkOrExist;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKVAction;
@@ -100,9 +100,9 @@ impl UserMgrApi for UserMgr {
             None,
         ));
         let res = upsert_kv.await?.into_add_result()?;
-        match res {
-            AddResult::Ok(v) => Ok(v.seq),
-            AddResult::Exists(v) => Err(ErrorCode::UserAlreadyExists(format!(
+        match res.res {
+            OkOrExist::Ok(v) => Ok(v.seq),
+            OkOrExist::Exists(v) => Err(ErrorCode::UserAlreadyExists(format!(
                 "User already exists, seq [{}]",
                 v.seq
             ))),

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -37,6 +37,7 @@ mod user_stage;
 
 pub use change::AddResult;
 pub use change::Change;
+pub use change::OkOrExist;
 pub use cluster::Node;
 pub use cluster::NodeInfo;
 pub use cluster::Slot;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/types] refactor: a AddResult returned by meta op should include an ID to indicate what has been changed

## Changelog




- Improvement


## Related Issues