### PR TITLE
[metasrv] refactor: rename AdminRequest to ForwardRequest

### DIFF
--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -52,8 +52,8 @@ use common_tracing::tracing;
 
 use crate::executor::action_handler::RequestHandler;
 use crate::executor::ActionHandler;
-use crate::meta_service::AdminRequest;
-use crate::meta_service::AdminRequestInner;
+use crate::meta_service::ForwardRequest;
+use crate::meta_service::ForwardRequestBody;
 
 // Db
 #[async_trait::async_trait]
@@ -107,9 +107,9 @@ impl RequestHandler<FlightReq<GetDatabaseReq>> for ActionHandler {
     ) -> common_exception::Result<Arc<DatabaseInfo>> {
         let res = self
             .meta_node
-            .handle_admin_req(AdminRequest {
-                forward_to_leader: true,
-                req: AdminRequestInner::GetDatabase(act.req),
+            .handle_admin_req(ForwardRequest {
+                forward_to_leader: 1,
+                body: ForwardRequestBody::GetDatabase(act.req),
             })
             .await?;
 
@@ -252,9 +252,9 @@ impl RequestHandler<FlightReq<GetTableReq>> for ActionHandler {
     ) -> common_exception::Result<Arc<TableInfo>> {
         let res = self
             .meta_node
-            .handle_admin_req(AdminRequest {
-                forward_to_leader: true,
-                req: AdminRequestInner::GetTable(act.req),
+            .handle_admin_req(ForwardRequest {
+                forward_to_leader: 1,
+                body: ForwardRequestBody::GetTable(act.req),
             })
             .await?;
         let res: Arc<TableInfo> = res
@@ -296,9 +296,9 @@ impl RequestHandler<FlightReq<ListDatabaseReq>> for ActionHandler {
     ) -> common_exception::Result<Vec<Arc<DatabaseInfo>>> {
         let res = self
             .meta_node
-            .handle_admin_req(AdminRequest {
-                forward_to_leader: true,
-                req: AdminRequestInner::ListDatabase(req.req),
+            .handle_admin_req(ForwardRequest {
+                forward_to_leader: 1,
+                body: ForwardRequestBody::ListDatabase(req.req),
             })
             .await?;
 
@@ -320,9 +320,9 @@ impl RequestHandler<FlightReq<ListTableReq>> for ActionHandler {
     ) -> common_exception::Result<Vec<Arc<TableInfo>>> {
         let res = self
             .meta_node
-            .handle_admin_req(AdminRequest {
-                forward_to_leader: true,
-                req: AdminRequestInner::ListTable(req.req),
+            .handle_admin_req(ForwardRequest {
+                forward_to_leader: 1,
+                body: ForwardRequestBody::ListTable(req.req),
             })
             .await?;
 

--- a/metasrv/src/meta_service/meta_leader.rs
+++ b/metasrv/src/meta_service/meta_leader.rs
@@ -29,9 +29,9 @@ use common_tracing::tracing;
 use crate::errors::ForwardToLeader;
 use crate::errors::InvalidMembership;
 use crate::errors::MetaError;
-use crate::meta_service::message::AdminRequest;
 use crate::meta_service::message::AdminResponse;
-use crate::meta_service::AdminRequestInner;
+use crate::meta_service::message::ForwardRequest;
+use crate::meta_service::ForwardRequestBody;
 use crate::meta_service::JoinRequest;
 use crate::meta_service::MetaNode;
 
@@ -49,34 +49,34 @@ impl<'a> MetaLeader<'a> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn handle_admin_req(&self, req: AdminRequest) -> Result<AdminResponse, MetaError> {
-        match req.req {
-            AdminRequestInner::Join(join_req) => {
+    pub async fn handle_admin_req(&self, req: ForwardRequest) -> Result<AdminResponse, MetaError> {
+        match req.body {
+            ForwardRequestBody::Join(join_req) => {
                 self.join(join_req).await?;
                 Ok(AdminResponse::Join(()))
             }
-            AdminRequestInner::Write(entry) => {
+            ForwardRequestBody::Write(entry) => {
                 let res = self.write(entry).await?;
                 Ok(AdminResponse::AppliedState(res))
             }
 
-            AdminRequestInner::ListDatabase(req) => {
+            ForwardRequestBody::ListDatabase(req) => {
                 let sm = self.meta_node.get_state_machine().await;
                 let res = sm.list_databases(req).await?;
                 Ok(AdminResponse::ListDatabase(res))
             }
 
-            AdminRequestInner::GetDatabase(req) => {
+            ForwardRequestBody::GetDatabase(req) => {
                 let sm = self.meta_node.get_state_machine().await;
                 let res = sm.get_database(req).await?;
                 Ok(AdminResponse::DatabaseInfo(res))
             }
-            AdminRequestInner::ListTable(req) => {
+            ForwardRequestBody::ListTable(req) => {
                 let sm = self.meta_node.get_state_machine().await;
                 let res = sm.list_tables(req).await?;
                 Ok(AdminResponse::ListTable(res))
             }
-            AdminRequestInner::GetTable(req) => {
+            ForwardRequestBody::GetTable(req) => {
                 let sm = self.meta_node.get_state_machine().await;
                 let res = sm.get_table(req).await?;
                 Ok(AdminResponse::TableInfo(res))

--- a/metasrv/src/meta_service/mod.rs
+++ b/metasrv/src/meta_service/mod.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use message::AdminRequest;
-pub use message::AdminRequestInner;
+pub use message::ForwardRequest;
+pub use message::ForwardRequestBody;
 pub use message::JoinRequest;
 pub use meta_service_impl::MetaServiceImpl;
 pub use network::Network;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] refactor: rename AdminRequest to ForwardRequest
- make forward_to_leader a u64, to support deep forward.

## Changelog




- Improvement


## Related Issues