### PR TITLE
[metasrv] test: write and read works after restarting the cluster

### DIFF
--- a/metasrv/src/api/flight_server.rs
+++ b/metasrv/src/api/flight_server.rs
@@ -53,6 +53,10 @@ impl FlightServer {
         }
     }
 
+    pub fn get_meta_node(&self) -> Arc<MetaNode> {
+        self.meta_node.clone()
+    }
+
     /// Start metasrv and returns two channel to send shutdown signal and receive signal when shutdown finished.
     pub async fn do_start(&mut self) -> Result<(), ErrorCode> {
         let conf = self.conf.clone();

--- a/metasrv/tests/it/flight/metasrv_flight_meta_api.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Test metasrv MetaApi on a single node.
+
 use common_base::tokio;
 use common_meta_api::MetaApiTestSuite;
 use common_meta_flight::MetaFlightClient;

--- a/metasrv/tests/it/flight/metasrv_flight_meta_api_follower_follower.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api_follower_follower.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Test metasrv MetaApi by writing to one follower and then reading from another follower.
+
 use common_base::tokio;
 use common_meta_api::MetaApiTestSuite;
 

--- a/metasrv/tests/it/flight/metasrv_flight_meta_api_leader_follower.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api_leader_follower.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Test metasrv MetaApi by writing to leader and then reading from a follower.
 use common_base::tokio;
 use common_meta_api::MetaApiTestSuite;
 

--- a/metasrv/tests/it/flight/metasrv_flight_meta_api_restart_cluster.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api_restart_cluster.rs
@@ -35,7 +35,7 @@ async fn test_meta_api_restart_cluster_write_read() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    fn mk_key(tc: &MetaSrvTestContext, k: impl std::fmt::Display) -> String {
+    fn make_ket(tc: &MetaSrvTestContext, k: impl std::fmt::Display) -> String {
         let x = &tc.config.raft_config;
         format!("t-restart-cluster-{}-{}-{}", x.config_id, x.id, k)
     }
@@ -49,7 +49,7 @@ async fn test_meta_api_restart_cluster_write_read() -> anyhow::Result<()> {
         for tc in tcs.iter() {
             let client = tc.flight_client().await?;
 
-            let k = mk_key(tc, key_suffix);
+            let k = make_key(tc, key_suffix);
             let res = client
                 .upsert_kv(UpsertKVAction {
                     key: k.clone(),

--- a/metasrv/tests/it/flight/metasrv_flight_meta_api_restart_cluster.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api_restart_cluster.rs
@@ -35,7 +35,7 @@ async fn test_meta_api_restart_cluster_write_read() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    fn make_ket(tc: &MetaSrvTestContext, k: impl std::fmt::Display) -> String {
+    fn make_key(tc: &MetaSrvTestContext, k: impl std::fmt::Display) -> String {
         let x = &tc.config.raft_config;
         format!("t-restart-cluster-{}-{}-{}", x.config_id, x.id, k)
     }

--- a/metasrv/tests/it/flight/metasrv_flight_meta_api_restart_cluster.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api_restart_cluster.rs
@@ -1,0 +1,127 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test metasrv MetaApi by writing to one node and then reading from another,
+//! on a restarted cluster.
+
+use std::time::Duration;
+
+use common_base::tokio;
+use common_base::Stoppable;
+use common_meta_api::KVApi;
+use common_meta_types::MatchSeq;
+use common_meta_types::Operation;
+use common_meta_types::UpsertKVAction;
+use common_tracing::tracing;
+
+use crate::init_meta_ut;
+use crate::tests::service::start_metasrv_cluster;
+use crate::tests::service::MetaSrvTestContext;
+use crate::tests::start_metasrv_with_context;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_api_restart_cluster_write_read() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    fn mk_key(tc: &MetaSrvTestContext, k: impl std::fmt::Display) -> String {
+        let x = &tc.config.raft_config;
+        format!("t-restart-cluster-{}-{}-{}", x.config_id, x.id, k)
+    }
+
+    async fn test_write_read_on_every_node(
+        tcs: &[MetaSrvTestContext],
+        key_suffix: &str,
+    ) -> anyhow::Result<()> {
+        tracing::info!("--- test write on every node: {}", key_suffix);
+
+        for tc in tcs.iter() {
+            let client = tc.flight_client().await?;
+
+            let k = mk_key(tc, key_suffix);
+            let res = client
+                .upsert_kv(UpsertKVAction {
+                    key: k.clone(),
+                    seq: MatchSeq::Any,
+                    value: Operation::Update(k.clone().into_bytes()),
+                    value_meta: None,
+                })
+                .await?;
+
+            tracing::info!("--- upsert res: {:?}", res);
+
+            let res = client.get_kv(&k).await?;
+            let res = res.unwrap();
+
+            assert_eq!(k.into_bytes(), res.data);
+        }
+
+        Ok(())
+    }
+
+    let tcs = start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    tracing::info!("--- test write on a fresh cluster");
+    test_write_read_on_every_node(&tcs, "1st").await?;
+
+    tracing::info!("--- shutdown the cluster");
+    let stopped_tcs = {
+        let mut stopped_tcs = vec![];
+        for mut tc in tcs {
+            // TODO(xp): remove this field, or split MetaSrvTestContext into two struct:
+            //           one for metasrv and one for meta_node
+            assert!(tc.meta_nodes.is_empty());
+
+            let mut f = tc.flight_srv.take().unwrap();
+            f.stop(None).await?;
+
+            stopped_tcs.push(tc);
+        }
+        stopped_tcs
+    };
+
+    tracing::info!("--- restart the cluster");
+    let tcs = {
+        let mut tcs = vec![];
+        for mut tc in stopped_tcs {
+            start_metasrv_with_context(&mut tc).await?;
+            tcs.push(tc);
+        }
+
+        for tc in tcs.iter() {
+            let flight = tc.flight_srv.as_ref().unwrap();
+            let meta_node = flight.get_meta_node();
+
+            tracing::info!("--- wait until a leader is observed");
+
+            let metrics = meta_node
+                .raft
+                .wait(timeout())
+                .metrics(|m| m.current_leader.is_some(), "a leader is observed")
+                .await?;
+
+            tracing::info!("got leader, metrics: {:?}", metrics);
+        }
+        tcs
+    };
+
+    tracing::info!("--- test write on a restarted cluster");
+    test_write_read_on_every_node(&tcs, "2nd").await?;
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(3000))
+}

--- a/metasrv/tests/it/flight/mod.rs
+++ b/metasrv/tests/it/flight/mod.rs
@@ -18,4 +18,5 @@ pub mod metasrv_flight_kv_api_cross_node;
 pub mod metasrv_flight_meta_api;
 pub mod metasrv_flight_meta_api_follower_follower;
 pub mod metasrv_flight_meta_api_leader_follower;
+pub mod metasrv_flight_meta_api_restart_cluster;
 pub mod metasrv_flight_tls;

--- a/metasrv/tests/it/meta_node/meta_node_all.rs
+++ b/metasrv/tests/it/meta_node/meta_node_all.rs
@@ -1058,7 +1058,7 @@ async fn test_meta_node_cluster_write_on_non_leader() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_metasrv_upsert_kv() -> anyhow::Result<()> {
+async fn test_meta_node_upsert_kv() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
@@ -1103,7 +1103,7 @@ async fn test_metasrv_upsert_kv() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_metasrv_incr_seq() -> anyhow::Result<()> {
+async fn test_meta_node_incr_seq() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] test: write and read works after restarting the cluster

## Changelog




- Improvement
- Build/Testing/CI

## Related Issues