### PR TITLE
[website] fix the github repo link

### DIFF
--- a/website/databend/README.md
+++ b/website/databend/README.md
@@ -5,8 +5,15 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 ## Get Started
 
 Specify node version
+
 ```shell
 nvm use
+```
+
+Install dependencies
+
+```shell
+yarn install
 ```
 
 Local preview

--- a/website/databend/docusaurus.config.js
+++ b/website/databend/docusaurus.config.js
@@ -147,7 +147,7 @@ const config = {
                             },
                             {
                                 label: 'GitHub',
-                                href: 'https://github.com/facebook/docusaurus',
+                                href: 'https://github.com/datafuselabs/databend',
                             },
                         ],
                     },


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

- fix the github repo link
- add a tip for installing dependencies

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

