### PR TITLE
[metasrv] test: extend waiting time from 3sec to 5sec to let restart-cluster test survive timeout failure

### DIFF
--- a/metasrv/tests/it/flight/metasrv_flight_meta_api_restart_cluster.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api_restart_cluster.rs
@@ -123,5 +123,5 @@ async fn test_meta_api_restart_cluster_write_read() -> anyhow::Result<()> {
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(3000))
+    Some(Duration::from_millis(5000))
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] test: extend waiting time from 3sec to 5sec to let restart-cluster test survive timeout failure

## Changelog




- Improvement
- Build/Testing/CI

## Related Issues

- fix: #3411 