### PR TITLE
[metasrv] make `logs_handler` return a bytes stream.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4934,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "poem"
-version = "1.0.38"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5268e20f10bab1b12f2b1bd9aa8263b4418210d4ca1cc49d930f07572c9f49"
+checksum = "a69bd7b9378e4273fc36cdc29b25f4efb5b56c4f96feef92a46cba105a6c1e70"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4947,7 +4947,6 @@ dependencies = [
  "mime",
  "mime_guess",
  "multer",
- "nom 7.1.0",
  "parking_lot",
  "percent-encoding",
  "pin-project-lite",
@@ -4966,9 +4965,9 @@ dependencies = [
 
 [[package]]
 name = "poem-derive"
-version = "1.0.20"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3795975cfc1663ca3932a2fc341b77ace2d81c0f2e1e4ea22348b6767d9d9b75"
+checksum = "3db87c6ece598edaf7830aaddd094dcf1785dd9207348a874e16d8a7d123e99e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/common/base/Cargo.toml
+++ b/common/base/Cargo.toml
@@ -25,7 +25,7 @@ pprof = { version = "0.6.1", features = ["flamegraph", "protobuf"] }
 tokio = { version = "1.14.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "signal"] }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 serde = { version = "1.0.131", features = ["derive"] }
-poem = { version = "1.0.38", features = ["rustls"] }
+poem = { version = "1.1.1", features = ["rustls"] }
 
 
 [dev-dependencies]

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -68,7 +68,7 @@ tonic = { version = "0.6.2", features = ["tls"] }
 
 sha2 = "0.10.0"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
-poem = { version = "1.0.38", features = ["rustls"] }
+poem = { version = "1.1.1", features = ["rustls"] }
 
 [dev-dependencies]
 common-meta-api = {path = "../common/meta/api" }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -59,7 +59,7 @@ ahash = "0.7.6"
 async-compat = "0.2.1"
 async-trait = "0.1.52"
 async-stream = "0.3.2"
-poem = { version = "1.0.38", features = ["rustls", "multipart"] }
+poem = { version = "1.1.1", features = ["rustls", "multipart"] }
 bumpalo = "3.8.0"
 byteorder = "1.4.3"
 bytes = "1.1.0"


### PR DESCRIPTION
 Bump poem from `1.0.38` to `1.1.1`

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

This change will reduce some memory usage, but it will also reduce the performance of `logs_handler` slightly.

It also fixes incorrect results when the stream returns `Err`.

## Changelog

- Bug Fix
- Improvement

## Related Issues

## Test Plan

Unit Tests

Stateless Tests

