### PR TITLE
[metasrv] test: extends restart-cluster wait time to 10 sec

### DIFF
--- a/metasrv/tests/it/flight/metasrv_flight_meta_api_restart_cluster.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api_restart_cluster.rs
@@ -123,5 +123,5 @@ async fn test_meta_api_restart_cluster_write_read() -> anyhow::Result<()> {
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(5000))
+    Some(Duration::from_millis(10_000))
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] test: extends restart-cluster wait time to 10 sec

## Changelog




- Improvement
- Build/Testing/CI

## Related Issues

- fix: #3416