### PR TITLE
[metasrv] refactor: extend timeout to 30 sec for restart test

### DIFF
--- a/metasrv/src/lib.rs
+++ b/metasrv/src/lib.rs
@@ -24,6 +24,7 @@ pub mod errors;
 pub mod executor;
 pub mod meta_service;
 pub mod metrics;
+pub mod network;
 pub mod store;
 
 pub trait Opened {

--- a/metasrv/src/meta_service/mod.rs
+++ b/metasrv/src/meta_service/mod.rs
@@ -16,12 +16,10 @@ pub use message::ForwardRequest;
 pub use message::ForwardRequestBody;
 pub use message::JoinRequest;
 pub use meta_service_impl::MetaServiceImpl;
-pub use network::Network;
 pub use raftmeta::MetaNode;
 
 mod message;
 pub mod meta_leader;
 mod meta_node_kv_api_impl;
 pub mod meta_service_impl;
-pub mod network;
 pub mod raftmeta;

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -53,7 +53,7 @@ use crate::meta_service::meta_leader::MetaLeader;
 use crate::meta_service::ForwardRequestBody;
 use crate::meta_service::JoinRequest;
 use crate::meta_service::MetaServiceImpl;
-use crate::meta_service::Network;
+use crate::network::Network;
 use crate::proto::meta_service_client::MetaServiceClient;
 use crate::proto::meta_service_server::MetaServiceServer;
 use crate::store::MetaRaftStore;

--- a/metasrv/src/network.rs
+++ b/metasrv/src/network.rs
@@ -99,12 +99,12 @@ impl RaftNetwork<LogEntry> for Network {
 
     #[tracing::instrument(level = "debug", skip(self), fields(id=self.sto.id))]
     async fn vote(&self, target: NodeId, rpc: VoteRequest) -> anyhow::Result<VoteResponse> {
-        tracing::debug!("vote req to: id={} {:?}", target, rpc);
+        tracing::debug!("vote: req to: target={} {:?}", target, rpc);
 
         let mut client = self.make_client(&target).await?;
         let req = common_tracing::inject_span_to_tonic_request(rpc);
         let resp = client.vote(req).await;
-        tracing::info!("vote: resp from id={} {:?}", target, resp);
+        tracing::info!("vote: resp from target={} {:?}", target, resp);
 
         let resp = resp?;
         let mes = resp.into_inner();

--- a/metasrv/tests/it/flight/metasrv_flight_kv_api_restart_cluster.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_kv_api_restart_cluster.rs
@@ -30,8 +30,12 @@ use crate::tests::service::start_metasrv_cluster;
 use crate::tests::service::MetaSrvTestContext;
 use crate::tests::start_metasrv_with_context;
 
+/// - Start a cluster of 3.
+/// - Test upsert kv and read on different nodes.
+/// - Stop and restart the cluster.
+/// - Test upsert kv and read on different nodes.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_meta_api_restart_cluster_write_read() -> anyhow::Result<()> {
+async fn test_kv_api_restart_cluster_write_read() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 

--- a/metasrv/tests/it/flight/metasrv_flight_meta_api.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api.rs
@@ -19,13 +19,14 @@ use common_meta_api::MetaApiTestSuite;
 use common_meta_flight::MetaFlightClient;
 
 use crate::init_meta_ut;
+use crate::tests::start_metasrv;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_meta_api_database_create_get_drop() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let (_tc, addr) = crate::tests::start_metasrv().await?;
+    let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -37,7 +38,7 @@ async fn test_meta_api_database_list() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let (_tc, addr) = crate::tests::start_metasrv().await?;
+    let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -49,7 +50,7 @@ async fn test_meta_api_table_create_get_drop() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let (_tc, addr) = crate::tests::start_metasrv().await?;
+    let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -61,7 +62,7 @@ async fn test_meta_api_table_list() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let (_tc, addr) = crate::tests::start_metasrv().await?;
+    let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
 

--- a/metasrv/tests/it/flight/mod.rs
+++ b/metasrv/tests/it/flight/mod.rs
@@ -15,8 +15,8 @@
 pub mod metasrv_flight_api;
 pub mod metasrv_flight_kv_api;
 pub mod metasrv_flight_kv_api_cross_node;
+pub mod metasrv_flight_kv_api_restart_cluster;
 pub mod metasrv_flight_meta_api;
 pub mod metasrv_flight_meta_api_follower_follower;
 pub mod metasrv_flight_meta_api_leader_follower;
-pub mod metasrv_flight_meta_api_restart_cluster;
 pub mod metasrv_flight_tls;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Election timeout is 8~12 sec.
A raft node waits for a interval of election timeout before starting election
TODO: the raft should set the wait time by election_timeout. For now, just use a large timeout.


## Changelog







## Related Issues