### PR TITLE
lower the log level about DatabendQueryContext

### DIFF
--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -72,7 +72,7 @@ impl QueryContext {
     pub fn from_shared(shared: Arc<QueryContextShared>) -> Arc<QueryContext> {
         shared.increment_ref_count();
 
-        tracing::info!("Create DatabendQueryContext");
+        tracing::debug!("Create DatabendQueryContext");
 
         Arc::new(QueryContext {
             statistics: Arc::new(RwLock::new(Statistics::default())),
@@ -325,7 +325,7 @@ impl QueryContextShared {
     pub(in crate::sessions) fn destroy_context_ref(&self) {
         if self.ref_count.fetch_sub(1, Ordering::Release) == 1 {
             std::sync::atomic::fence(Acquire);
-            tracing::info!("Destroy DatabendQueryContext");
+            tracing::debug!("Destroy DatabendQueryContext");
             self.session.destroy_context_shared();
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

![Screen Shot 2021-12-13 at 9 48 54 PM](https://user-images.githubusercontent.com/129800/145824054-0f9efaee-81c5-40c8-9f3c-adc23e6f294a.png)

some says a good log is actionable, when we find a log, we'd better take action on it.

this log seems a bit verbose as the screenshot shows, we can lower the log level to debug?  

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

