### PR TITLE
[metasrv] extend restart-cluster test timeout to 30 sec

### DIFF
--- a/metasrv/tests/it/flight/metasrv_flight_kv_api_restart_cluster.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_kv_api_restart_cluster.rs
@@ -126,6 +126,10 @@ async fn test_kv_api_restart_cluster_write_read() -> anyhow::Result<()> {
     Ok(())
 }
 
+// Election timeout is 8~12 sec.
+// A raft node waits for a interval of election timeout before starting election
+// TODO: the raft should set the wait time by election_timeout.
+//       For now, just use a large timeout.
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(10_000))
+    Some(Duration::from_millis(30_000))
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [metasrv] extend restart-cluster test timeout to 30 sec

## Changelog







## Related Issues