### PR TITLE
[common/containers] feature: add conn pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-containers"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "common-base",
+ "common-tracing",
+]
+
+[[package]]
 name = "common-dal"
 version = "0.1.0"
 dependencies = [
@@ -1980,6 +1990,7 @@ dependencies = [
  "common-arrow",
  "common-base",
  "common-building",
+ "common-containers",
  "common-datavalues",
  "common-exception",
  "common-flight-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "common/building",
     "common/cache",
     "common/clickhouse-srv",
+    "common/containers",
     "common/dal",
     "common/datablocks",
     "common/datavalues",

--- a/common/containers/Cargo.toml
+++ b/common/containers/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "common-containers"
+version = "0.1.0"
+authors = ["Databend Authors <opensource@datafuselabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+common-base = {path = "../base"}
+common-tracing = {path = "../tracing"}
+
+async-trait = "0.1.52"
+
+[dev-dependencies]
+anyhow = "1.0.51"

--- a/common/containers/src/lib.rs
+++ b/common/containers/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod pool;
+
+pub use pool::ItemManager;
+pub use pool::Pool;

--- a/common/containers/src/pool.rs
+++ b/common/containers/src/pool.rs
@@ -148,6 +148,6 @@ where
             interval *= 2;
         }
 
-        panic!("unreachable")
+        unreachable!("the loop should always return!");
     }
 }

--- a/common/containers/src/pool.rs
+++ b/common/containers/src/pool.rs
@@ -1,0 +1,153 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use common_base::tokio;
+use common_base::tokio::time::sleep;
+use common_tracing::tracing;
+
+pub type PoolItem<T> = Arc<tokio::sync::Mutex<Option<T>>>;
+
+/// To build or check an item.
+///
+/// When an item is requested, ItemManager `build()` one for the pool.
+/// When an item is reused, ItemManager `check()` if it is still valid.
+#[async_trait]
+pub trait ItemManager {
+    type Key;
+    type Item;
+    type Error;
+
+    /// Make a new item to put into the pool.
+    ///
+    /// An impl should hold that an item returned by `build()` is passed `check()`.
+    async fn build(&self, key: &Self::Key) -> Result<Self::Item, Self::Error>;
+
+    /// Check if an existent item still valid.
+    ///
+    /// E.g.: check if a tcp connection still alive.
+    /// If the item is valid, `check` should return it in a Ok().
+    /// Otherwise, the item should be dropped and `check` returns an Err().
+    async fn check(&self, item: Self::Item) -> Result<Self::Item, Self::Error>;
+}
+
+/// Pool assumes the items in it is `Clone`, thus it keeps only one item for each key.
+#[allow(clippy::type_complexity)]
+pub struct Pool<Mgr>
+where Mgr: ItemManager
+{
+    /// The first sleep time when `build()` fails.
+    /// The next sleep time is 2 times of the previous one.
+    pub initial_retry_interval: Duration,
+
+    /// Pooled items indexed by key.
+    pub items: Arc<Mutex<HashMap<Mgr::Key, PoolItem<Mgr::Item>>>>,
+
+    manager: Mgr,
+
+    err_type: PhantomData<Mgr::Error>,
+}
+
+impl<Mgr> Pool<Mgr>
+where
+    Mgr: ItemManager,
+    Mgr::Key: Clone + Eq + Hash + Send + Debug,
+    Mgr::Item: Clone + Sync + Send + Debug,
+    Mgr::Error: Sync + Debug,
+{
+    pub fn new(manager: Mgr, initial_retry_interval: Duration) -> Self {
+        Pool {
+            initial_retry_interval,
+            items: Default::default(),
+            manager,
+            err_type: Default::default(),
+        }
+    }
+
+    /// Return an raw pool item.
+    ///
+    /// The returned one may be an uninitialized one, i.e., it contains a None.
+    /// The lock for `items` should not be held for long, e.g. when `build()` a new connection, it takes dozen ms.
+    fn get_pool_item(&self, key: &Mgr::Key) -> PoolItem<Mgr::Item> {
+        let mut items = self.items.lock().unwrap();
+
+        if let Some(item) = items.get(key) {
+            item.clone()
+        } else {
+            let item = PoolItem::default();
+            items.insert(key.clone(), item.clone());
+            item
+        }
+    }
+
+    /// Return a item, by cloning an existent one or making a new one.
+    ///
+    /// When returning an existent one, `check()` will be called on it to ensure it is still valid.
+    /// E.g., when returning a tcp connection.
+    pub async fn get(&self, key: &Mgr::Key) -> Result<Mgr::Item, Mgr::Error> {
+        let pool_item = self.get_pool_item(key);
+
+        let mut guard = pool_item.lock().await;
+        let item_opt = (*guard).clone();
+
+        if let Some(ref item) = item_opt {
+            let check_res = self.manager.check(item.clone()).await;
+            tracing::debug!("check reused item res: {:?}", check_res);
+
+            if let Ok(itm) = check_res {
+                return Ok(itm);
+            } else {
+                // mark broken conn as deleted
+                *guard = None;
+            }
+        }
+
+        let mut interval = self.initial_retry_interval;
+
+        let n_retry = 3;
+
+        for i in 0..n_retry {
+            tracing::info!("build new item of key: {:?}", key);
+
+            let new_item = self.manager.build(key).await;
+
+            tracing::info!("build new item of key res: {:?}", new_item);
+
+            match new_item {
+                Ok(x) => {
+                    *guard = Some(x.clone());
+                    return Ok(x);
+                }
+                Err(err) => {
+                    if i == n_retry - 1 {
+                        return Err(err);
+                    }
+                }
+            }
+
+            sleep(interval).await;
+            interval *= 2;
+        }
+
+        panic!("unreachable")
+    }
+}

--- a/common/containers/tests/main.rs
+++ b/common/containers/tests/main.rs
@@ -1,0 +1,15 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod pool;

--- a/common/containers/tests/pool.rs
+++ b/common/containers/tests/pool.rs
@@ -1,0 +1,86 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use common_base::tokio;
+use common_base::GlobalSequence;
+use common_containers::ItemManager;
+use common_containers::Pool;
+use common_tracing::tracing;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_pool() -> anyhow::Result<()> {
+    let p = Pool::new(FooMgr {}, Duration::from_millis(10));
+
+    let i3_1 = p.get(&3).await?;
+    assert_eq!(3, i3_1.key, "make a new item(3)");
+
+    let i3_2 = p.get(&3).await?;
+    assert_eq!(i3_1.seq, i3_2.seq, "item(3) is reused");
+
+    let _i4 = p.get(&4).await?;
+
+    let i5_1 = p.get(&5).await?;
+    assert_eq!(2, i5_1.seq, "seq=2 valid for make");
+
+    tracing::info!("--- check() is called when reusing it. re-build() an new one");
+    let i5_2 = p.get(&5).await?;
+    assert_eq!(
+        3, i5_2.seq,
+        "seq=2 is dropped by check(), then make() a new item with seq=3"
+    );
+
+    tracing::info!("--- check() is not called for new item");
+    let i6_1 = p.get(&6).await?;
+    assert_eq!(4, i6_1.seq, "seq=4 is valid for make()");
+
+    tracing::info!("--- check() is called when reusing it. re-build() does not succeed");
+    let i6_2 = p.get(&6).await;
+    assert!(i6_2.is_err(), "seq>=4 can not reuse or make()");
+
+    Ok(())
+}
+
+struct FooMgr {}
+
+#[derive(Clone, Debug)]
+struct Item {
+    pub key: u32,
+    pub seq: usize,
+}
+
+#[async_trait]
+impl ItemManager for FooMgr {
+    type Key = u32;
+    type Item = Item;
+    type Error = anyhow::Error;
+
+    async fn build(&self, key: &Self::Key) -> Result<Self::Item, Self::Error> {
+        let seq = GlobalSequence::next();
+        if seq > 4 {
+            return Err(anyhow::anyhow!("invalid seq: {}", seq));
+        }
+        Ok(Item { key: *key, seq })
+    }
+
+    async fn check(&self, item: Self::Item) -> Result<Self::Item, Self::Error> {
+        if item.seq == 2 || item.seq > 3 {
+            Err(anyhow::anyhow!("invalid seq: {}", item.seq))
+        } else {
+            Ok(item)
+        }
+    }
+}

--- a/common/meta/api/src/kv_api_test_suite.rs
+++ b/common/meta/api/src/kv_api_test_suite.rs
@@ -526,6 +526,7 @@ impl KVApiTestSuite {
                 let key = format!("__users/{}", i);
                 let val = format!("val_{}", i);
                 values.push(val.clone());
+                tracing::info!("--- Start upsert-kv: {}", key);
                 kv1.upsert_kv(UpsertKVAction::new(
                     &key,
                     MatchSeq::Any,
@@ -533,6 +534,7 @@ impl KVApiTestSuite {
                     None,
                 ))
                 .await?;
+                tracing::info!("--- Done upsert-kv: {}", key);
             }
 
             kv1.upsert_kv(UpsertKVAction::new(

--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -247,11 +247,13 @@ impl StateMachine {
     /// If a duplicated log entry is detected by checking data.txid, no update
     /// will be made and the previous resp is returned. In this way a client is able to re-send a
     /// command safely in case of network failure etc.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn apply(&self, entry: &Entry<LogEntry>) -> common_exception::Result<AppliedState> {
         // TODO(xp): all update need to be done in a tx.
 
         let log_id = &entry.log_id;
+
+        tracing::debug!("sled tx start: {:?}", entry);
 
         let result = self.sm_tree.txn(true, move |txn_tree| {
             let txn_sm_meta = txn_tree.key_space::<StateMachineMeta>();
@@ -291,6 +293,8 @@ impl StateMachine {
 
             Ok(None)
         })?;
+
+        tracing::debug!("sled tx done: {:?}", entry);
 
         let result = match result {
             Some(r) => r,

--- a/common/meta/sled-store/src/sled_tree.rs
+++ b/common/meta/sled-store/src/sled_tree.rs
@@ -94,6 +94,8 @@ impl SledTree {
         sync: bool,
         f: impl Fn(TransactionSledTree<'_>) -> Result<T, UnabortableTransactionError>,
     ) -> Result<T, ErrorCode> {
+        let sync = sync && self.sync;
+
         // use map_err_to_code
         let result: TransactionResult<T, UnabortableTransactionError> =
             (&self.tree).transaction(move |tree| {

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -22,6 +22,7 @@ simd = ["common-arrow/simd"]
 [dependencies]
 # Workspace dependencies
 common-arrow = {path = "../common/arrow"}
+common-containers = {path = "../common/containers"}
 common-datavalues = {path = "../common/datavalues"}
 common-exception = { path = "../common/exception" }
 common-flight-rpc = { path = "../common/flight-rpc" }

--- a/metasrv/src/api/flight_server.rs
+++ b/metasrv/src/api/flight_server.rs
@@ -185,7 +185,10 @@ impl FlightServer {
 #[async_trait::async_trait]
 impl Stoppable for FlightServer {
     async fn start(&mut self) -> Result<(), ErrorCode> {
-        self.do_start().await
+        tracing::info!("FlightServer::start");
+        let res = self.do_start().await;
+        tracing::info!("Done FlightServer::start");
+        res
     }
 
     async fn stop(

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -395,6 +395,7 @@ impl MetaNode {
             // Joining a node with log has risk messing up the data in this node and in the target cluster.
 
             let addrs = &conf.join;
+            #[allow(clippy::never_loop)]
             for addr in addrs {
                 let mut client = MetaServiceClient::connect(format!("http://{}", addr))
                     .await
@@ -410,7 +411,7 @@ impl MetaNode {
 
                 let _res = client.forward(admin_req.clone()).await?;
                 // TODO: retry
-                // break;
+                break;
             }
 
             return Ok(mn);

--- a/metasrv/src/network.rs
+++ b/metasrv/src/network.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_raft::async_trait::async_trait;
 use async_raft::raft::AppendEntriesRequest;
@@ -22,30 +23,61 @@ use async_raft::raft::InstallSnapshotResponse;
 use async_raft::raft::VoteRequest;
 use async_raft::raft::VoteResponse;
 use async_raft::RaftNetwork;
+use common_containers::ItemManager;
+use common_containers::Pool;
 use common_meta_types::LogEntry;
 use common_meta_types::NodeId;
 use common_tracing::tracing;
+use tonic::client::GrpcService;
 use tonic::transport::channel::Channel;
 
 use crate::proto::meta_service_client::MetaServiceClient;
 use crate::store::MetaRaftStore;
 
+struct ChannelManager {}
+
+#[async_trait]
+impl ItemManager for ChannelManager {
+    type Key = String;
+    type Item = Channel;
+    type Error = tonic::transport::Error;
+
+    async fn build(&self, addr: &Self::Key) -> Result<Channel, tonic::transport::Error> {
+        tonic::transport::Endpoint::new(addr.clone())?
+            .connect()
+            .await
+    }
+
+    async fn check(&self, mut ch: Channel) -> Result<Channel, tonic::transport::Error> {
+        futures::future::poll_fn(|cx| (&mut ch).poll_ready(cx)).await?;
+        Ok(ch)
+    }
+}
+
 pub struct Network {
     sto: Arc<MetaRaftStore>,
+
+    conn_pool: Pool<ChannelManager>,
 }
 
 impl Network {
     pub fn new(sto: Arc<MetaRaftStore>) -> Network {
-        Network { sto }
+        let mgr = ChannelManager {};
+        Network {
+            sto,
+            conn_pool: Pool::new(mgr, Duration::from_millis(50)),
+        }
     }
 
     #[tracing::instrument(level = "info", skip(self), fields(id=self.sto.id))]
     pub async fn make_client(&self, target: &NodeId) -> anyhow::Result<MetaServiceClient<Channel>> {
         let addr = self.sto.get_node_addr(target).await?;
+        let addr = format!("http://{}", addr);
 
-        tracing::info!("connect: target={}: {}", target, addr);
+        tracing::debug!("connect: target={}: {}", target, addr);
 
-        let client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+        let channel = self.conn_pool.get(&addr).await?;
+        let client = MetaServiceClient::new(channel);
 
         tracing::info!("connected: target={}: {}", target, addr);
 

--- a/metasrv/tests/it/api/http/cluster_state_test.rs
+++ b/metasrv/tests/it/api/http/cluster_state_test.rs
@@ -117,7 +117,7 @@ async fn test_cluster_state() -> common_exception::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_http_service_cluster_state() -> common_exception::Result<()> {
     let addr_str = "127.0.0.1:30003";
 

--- a/metasrv/tests/it/api/http_service.rs
+++ b/metasrv/tests/it/api/http_service.rs
@@ -30,7 +30,7 @@ use crate::tests::tls_constants::TEST_SERVER_CERT;
 use crate::tests::tls_constants::TEST_SERVER_KEY;
 
 // TODO(zhihanz) add tls fail case
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_http_service_tls_server() -> Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();

--- a/metasrv/tests/it/flight/metasrv_flight_api.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_api.rs
@@ -31,7 +31,7 @@ use crate::init_meta_ut;
 use crate::tests::service::MetaSrvTestContext;
 use crate::tests::start_metasrv_with_context;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_restart() -> anyhow::Result<()> {
     // Fix: Issue 1134  https://github.com/datafuselabs/databend/issues/1134
     // - Start a metasrv server.
@@ -127,7 +127,7 @@ async fn test_restart() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_join() -> anyhow::Result<()> {
     // - Start 2 metasrv.
     // - Join node-1 to node-0

--- a/metasrv/tests/it/flight/metasrv_flight_kv_api.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_kv_api.rs
@@ -18,7 +18,7 @@ use common_meta_flight::MetaFlightClient;
 
 use crate::init_meta_ut;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_kv_api_mget() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -30,7 +30,7 @@ async fn test_kv_api_mget() -> anyhow::Result<()> {
     KVApiTestSuite {}.kv_mget(&client).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_kv_api_list() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -42,7 +42,7 @@ async fn test_kv_api_list() -> anyhow::Result<()> {
     KVApiTestSuite {}.kv_list(&client).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_kv_api_delete() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -54,7 +54,7 @@ async fn test_kv_api_delete() -> anyhow::Result<()> {
     KVApiTestSuite {}.kv_delete(&client).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_kv_api_update() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -66,7 +66,7 @@ async fn test_kv_api_update() -> anyhow::Result<()> {
     KVApiTestSuite {}.kv_update(&client).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_kv_api_update_meta() -> anyhow::Result<()> {
     // Only update meta, do not touch the value part.
 
@@ -80,7 +80,7 @@ async fn test_kv_api_update_meta() -> anyhow::Result<()> {
     KVApiTestSuite {}.kv_meta(&client).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_kv_api_timeout() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -92,7 +92,7 @@ async fn test_kv_api_timeout() -> anyhow::Result<()> {
     KVApiTestSuite {}.kv_timeout(&client).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_kv_api_write_read() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();

--- a/metasrv/tests/it/flight/metasrv_flight_kv_api_cross_node.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_kv_api_cross_node.rs
@@ -18,7 +18,7 @@ use common_meta_api::KVApiTestSuite;
 use crate::init_meta_ut;
 use crate::tests::service::start_metasrv_cluster;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_kv_api_write_read_cross_nodes() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();

--- a/metasrv/tests/it/flight/metasrv_flight_kv_api_restart_cluster.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_kv_api_restart_cluster.rs
@@ -34,7 +34,7 @@ use crate::tests::start_metasrv_with_context;
 /// - Test upsert kv and read on different nodes.
 /// - Stop and restart the cluster.
 /// - Test upsert kv and read on different nodes.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_kv_api_restart_cluster_write_read() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();

--- a/metasrv/tests/it/flight/metasrv_flight_meta_api.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api.rs
@@ -21,7 +21,7 @@ use common_meta_flight::MetaFlightClient;
 use crate::init_meta_ut;
 use crate::tests::start_metasrv;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_database_create_get_drop() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -33,7 +33,7 @@ async fn test_meta_api_database_create_get_drop() -> anyhow::Result<()> {
     MetaApiTestSuite {}.database_create_get_drop(&client).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_database_list() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -45,7 +45,7 @@ async fn test_meta_api_database_list() -> anyhow::Result<()> {
     MetaApiTestSuite {}.database_list(&client).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_table_create_get_drop() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -57,7 +57,7 @@ async fn test_meta_api_table_create_get_drop() -> anyhow::Result<()> {
     MetaApiTestSuite {}.table_create_get_drop(&client).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_table_list() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -73,7 +73,7 @@ async fn test_meta_api_table_list() -> anyhow::Result<()> {
 // ------------------------------------------------------------
 
 /*
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_flight_get_database_meta_ddl_table() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -151,7 +151,7 @@ async fn test_meta_api_flight_get_database_meta_ddl_table() -> anyhow::Result<()
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_flight_get_database_meta_empty_db() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -165,7 +165,7 @@ async fn test_meta_api_flight_get_database_meta_empty_db() -> anyhow::Result<()>
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_flight_get_database_meta_ddl_db() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();

--- a/metasrv/tests/it/flight/metasrv_flight_meta_api_follower_follower.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api_follower_follower.rs
@@ -20,7 +20,7 @@ use common_meta_api::MetaApiTestSuite;
 use crate::init_meta_ut;
 use crate::tests::service::start_metasrv_cluster;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_database_create_get_drop() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -35,7 +35,7 @@ async fn test_meta_api_database_create_get_drop() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_list_database() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -50,7 +50,7 @@ async fn test_meta_api_list_database() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_table_create_get_drop() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -65,7 +65,7 @@ async fn test_meta_api_table_create_get_drop() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_list_table() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();

--- a/metasrv/tests/it/flight/metasrv_flight_meta_api_leader_follower.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_meta_api_leader_follower.rs
@@ -19,7 +19,7 @@ use common_meta_api::MetaApiTestSuite;
 use crate::init_meta_ut;
 use crate::tests::service::start_metasrv_cluster;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_database_create_get_drop() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -34,7 +34,7 @@ async fn test_meta_api_database_create_get_drop() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_list_database() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -49,7 +49,7 @@ async fn test_meta_api_list_database() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_table_create_get_drop() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -63,7 +63,7 @@ async fn test_meta_api_table_create_get_drop() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_list_table() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();

--- a/metasrv/tests/it/flight/metasrv_flight_tls.rs
+++ b/metasrv/tests/it/flight/metasrv_flight_tls.rs
@@ -27,7 +27,7 @@ use crate::tests::tls_constants::TEST_CN_NAME;
 use crate::tests::tls_constants::TEST_SERVER_CERT;
 use crate::tests::tls_constants::TEST_SERVER_KEY;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_tls_server() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -58,7 +58,7 @@ async fn test_tls_server() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_tls_server_config_failure() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -73,7 +73,7 @@ async fn test_tls_server_config_failure() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_tls_client_config_failure() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();

--- a/metasrv/tests/it/meta_node/meta_node_all.rs
+++ b/metasrv/tests/it/meta_node/meta_node_all.rs
@@ -984,7 +984,7 @@ fn test_context_nodes(tcs: &[MetaSrvTestContext]) -> Vec<Arc<MetaNode>> {
         .collect::<Vec<_>>()
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_node_cluster_write_on_non_leader() -> anyhow::Result<()> {
     // - Bring up a cluster of one leader and one non-voter
     // - Assert that writing on the non-voter returns ForwardToLeader error
@@ -1057,7 +1057,7 @@ async fn test_meta_node_cluster_write_on_non_leader() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_node_upsert_kv() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
@@ -1102,7 +1102,7 @@ async fn test_meta_node_upsert_kv() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_node_incr_seq() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();

--- a/metasrv/tests/it/store.rs
+++ b/metasrv/tests/it/store.rs
@@ -34,7 +34,7 @@ use maplit::btreeset;
 use crate::init_meta_ut;
 use crate::tests::service::MetaSrvTestContext;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_metasrv_restart() -> anyhow::Result<()> {
     // - Create a metasrv
     // - Update metasrv
@@ -83,7 +83,7 @@ async fn test_metasrv_restart() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_metasrv_get_membership_from_log() -> anyhow::Result<()> {
     // - Create a metasrv
     // - Append logs
@@ -184,7 +184,7 @@ async fn test_metasrv_get_membership_from_log() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_metasrv_do_log_compaction_empty() -> anyhow::Result<()> {
     // - Create a metasrv
     // - Create a snapshot check snapshot state
@@ -231,7 +231,7 @@ async fn test_metasrv_do_log_compaction_empty() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_metasrv_do_log_compaction_1_snap_ptr_1_log() -> anyhow::Result<()> {
     // - Create a metasrv
     // - Apply logs
@@ -305,7 +305,7 @@ async fn test_metasrv_do_log_compaction_1_snap_ptr_1_log() -> anyhow::Result<()>
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_metasrv_do_log_compaction_all_logs_with_memberchange() -> anyhow::Result<()> {
     // - Create a metasrv
     // - Apply logs
@@ -358,7 +358,7 @@ async fn test_metasrv_do_log_compaction_all_logs_with_memberchange() -> anyhow::
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_metasrv_do_log_compaction_current_snapshot() -> anyhow::Result<()> {
     // - Create a metasrv
     // - Apply logs
@@ -409,7 +409,7 @@ async fn test_metasrv_do_log_compaction_current_snapshot() -> anyhow::Result<()>
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_metasrv_install_snapshot() -> anyhow::Result<()> {
     // - Create a metasrv
     // - Feed logs

--- a/metasrv/tests/it/tests/service.rs
+++ b/metasrv/tests/it/tests/service.rs
@@ -44,10 +44,6 @@ pub async fn start_metasrv_with_context(tc: &mut MetaSrvTestContext) -> Result<(
     let mut srv = FlightServer::create(tc.config.clone(), mn);
     srv.start().await?;
 
-    // TODO(xp): some times the MetaNode takes more than 200 ms to startup, with disk-backed store.
-    //           Find out why and using some kind of waiting routine to ensure service is on.
-    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
-
     tc.flight_srv = Some(Box::new(srv));
     Ok(())
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/containers] feature: add conn pool
- common_containers::Pool caches Channel and indexes them by addresses.

- Raft Network use Pool to reduce number of connections

- Add tracing logs address the time spent by metasrv tests.

- Increase thread number for metasrv tests.

## Changelog

- New Feature





## Related Issues