### PR TITLE
Rename auth_type to password_type

### DIFF
--- a/common/management/src/user/user_api.rs
+++ b/common/management/src/user/user_api.rs
@@ -14,8 +14,8 @@
 //
 
 use common_exception::Result;
-use common_meta_types::AuthType;
 use common_meta_types::GrantObject;
+use common_meta_types::PasswordType;
 use common_meta_types::SeqV;
 use common_meta_types::UserInfo;
 use common_meta_types::UserPrivilegeSet;
@@ -38,7 +38,7 @@ pub trait UserMgrApi: Sync + Send {
         username: String,
         hostname: String,
         new_password: Option<Vec<u8>>,
-        new_auth: Option<AuthType>,
+        new_password_type: Option<PasswordType>,
         seq: Option<u64>,
     ) -> Result<Option<u64>>;
 

--- a/common/management/src/user/user_mgr.rs
+++ b/common/management/src/user/user_mgr.rs
@@ -19,13 +19,13 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_exception::ToErrorCode;
 use common_meta_api::KVApi;
-use common_meta_types::AuthType;
 use common_meta_types::GrantObject;
 use common_meta_types::IntoSeqV;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::OkOrExist;
 use common_meta_types::Operation;
+use common_meta_types::PasswordType;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKVAction;
 use common_meta_types::UserInfo;
@@ -152,10 +152,10 @@ impl UserMgrApi for UserMgr {
         username: String,
         hostname: String,
         new_password: Option<Vec<u8>>,
-        new_auth: Option<AuthType>,
+        new_password_type: Option<PasswordType>,
         seq: Option<u64>,
     ) -> Result<Option<u64>> {
-        if new_password.is_none() && new_auth.is_none() {
+        if new_password.is_none() && new_password_type.is_none() {
             return Ok(seq);
         }
         let user_val_seq = self.get_user(username.clone(), hostname.clone(), seq);
@@ -165,7 +165,7 @@ impl UserMgrApi for UserMgr {
             username.clone(),
             hostname.clone(),
             new_password.map_or(user_info.password.clone(), |v| v.to_vec()),
-            new_auth.unwrap_or(user_info.auth_type),
+            new_password_type.unwrap_or(user_info.password_type),
         );
         new_user_info.grants = user_info.grants;
 

--- a/common/management/tests/it/user.rs
+++ b/common/management/tests/it/user.rs
@@ -57,8 +57,8 @@ fn format_user_key(username: &str, hostname: &str) -> String {
 }
 
 mod add {
-    use common_meta_types::AuthType;
     use common_meta_types::Operation;
+    use common_meta_types::PasswordType;
     use common_meta_types::UserInfo;
 
     use super::*;
@@ -68,12 +68,12 @@ mod add {
         let test_user_name = "test_user";
         let test_password = "test_password";
         let test_hostname = "localhost";
-        let auth_type = AuthType::Sha256;
+        let password_type = PasswordType::Sha256;
         let user_info = UserInfo::new(
             test_user_name.to_string(),
             test_hostname.to_string(),
             Vec::from(test_password),
-            auth_type.clone(),
+            password_type.clone(),
         );
         let v = serde_json::to_vec(&user_info)?;
         let value = Operation::Update(serde_json::to_vec(&user_info)?);
@@ -130,7 +130,7 @@ mod add {
                 test_user_name.to_string(),
                 test_hostname.to_string(),
                 Vec::from(test_password),
-                auth_type.clone(),
+                password_type.clone(),
             );
 
             let res = user_mgr.add_user(user_info).await;
@@ -161,7 +161,7 @@ mod add {
                 test_user_name.to_string(),
                 test_hostname.to_string(),
                 Vec::from(test_password),
-                auth_type,
+                password_type,
             );
 
             let res = user_mgr.add_user(user_info).await;
@@ -176,7 +176,7 @@ mod add {
 }
 
 mod get {
-    use common_meta_types::AuthType;
+    use common_meta_types::PasswordType;
     use common_meta_types::UserInfo;
 
     use super::*;
@@ -194,7 +194,7 @@ mod get {
             test_user_name.to_string(),
             test_hostname.to_string(),
             Vec::from("pass"),
-            AuthType::Sha256,
+            PasswordType::Sha256,
         );
         let value = serde_json::to_vec(&user_info)?;
 
@@ -229,7 +229,7 @@ mod get {
             test_user_name.to_string(),
             test_hostname.to_string(),
             Vec::from("pass"),
-            AuthType::Sha256,
+            PasswordType::Sha256,
         );
         let value = serde_json::to_vec(&user_info)?;
 
@@ -328,7 +328,7 @@ mod get {
 }
 
 mod get_users {
-    use common_meta_types::AuthType;
+    use common_meta_types::PasswordType;
     use common_meta_types::UserInfo;
 
     use super::*;
@@ -350,7 +350,7 @@ mod get_users {
 
             let key = format!("tenant1/{}", format_user_key(&name, &hostname));
             keys.push(key);
-            let user_info = UserInfo::new(name, hostname, Vec::from("pass"), AuthType::Sha256);
+            let user_info = UserInfo::new(name, hostname, Vec::from("pass"), PasswordType::Sha256);
             res.push((
                 "fake_key".to_string(),
                 SeqV::new(i, serde_json::to_vec(&user_info)?),
@@ -471,7 +471,7 @@ mod drop {
 }
 
 mod update {
-    use common_meta_types::AuthType;
+    use common_meta_types::PasswordType;
     use common_meta_types::UserInfo;
 
     use super::*;
@@ -487,13 +487,13 @@ mod update {
         let test_seq = None;
 
         let old_pass = "old_key";
-        let old_auth_type = AuthType::DoubleSha1;
+        let old_password_type = PasswordType::DoubleSha1;
 
         let user_info = UserInfo::new(
             test_user_name.to_string(),
             test_hostname.to_string(),
             Vec::from(old_pass),
-            old_auth_type,
+            old_password_type,
         );
         let prev_value = serde_json::to_vec(&user_info)?;
 
@@ -514,7 +514,7 @@ mod update {
             test_user_name.to_string(),
             test_hostname.to_string(),
             Vec::from(new_pass),
-            AuthType::DoubleSha1,
+            PasswordType::DoubleSha1,
         );
         let new_value_with_old_salt = serde_json::to_vec(&new_user_info)?;
 
@@ -554,13 +554,13 @@ mod update {
         let test_seq = None;
 
         let old_pass = "old_key";
-        let old_auth_type = AuthType::DoubleSha1;
+        let old_password_type = PasswordType::DoubleSha1;
 
         let user_info = UserInfo::new(
             test_user_name.to_string(),
             test_hostname.to_string(),
             Vec::from(old_pass),
-            old_auth_type,
+            old_password_type,
         );
         let prev_value = serde_json::to_vec(&user_info)?;
 
@@ -576,13 +576,13 @@ mod update {
         // - update_kv should be called
 
         let new_pass = "new_pass";
-        let new_auth_type = AuthType::Sha256;
+        let new_password_type = PasswordType::Sha256;
 
         let new_user_info = UserInfo::new(
             test_user_name.to_string(),
             test_hostname.to_string(),
             Vec::from(new_pass),
-            new_auth_type.clone(),
+            new_password_type.clone(),
         );
         let new_value = serde_json::to_vec(&new_user_info)?;
 
@@ -603,7 +603,7 @@ mod update {
             test_user_name.to_string(),
             test_hostname.to_string(),
             Some(new_user_info.password),
-            Some(new_auth_type),
+            Some(new_password_type),
             test_seq,
         );
         assert!(res.await.is_ok());
@@ -678,13 +678,13 @@ mod update {
         let test_seq = None;
 
         let old_pass = "old_key";
-        let old_auth_type = AuthType::DoubleSha1;
+        let old_password_type = PasswordType::DoubleSha1;
 
         let user_info = UserInfo::new(
             test_user_name.to_string(),
             test_hostname.to_string(),
             Vec::from(old_pass),
-            old_auth_type,
+            old_password_type,
         );
         let prev_value = serde_json::to_vec(&user_info)?;
 
@@ -713,7 +713,7 @@ mod update {
             test_user_name.to_string(),
             test_hostname.to_string(),
             Some(Vec::from("new_pass".as_bytes())),
-            Some(AuthType::Sha256),
+            Some(PasswordType::Sha256),
             test_seq,
         );
         assert_eq!(
@@ -725,8 +725,8 @@ mod update {
 }
 
 mod set_user_privileges {
-    use common_meta_types::AuthType;
     use common_meta_types::GrantObject;
+    use common_meta_types::PasswordType;
     use common_meta_types::UserInfo;
     use common_meta_types::UserPrivilegeSet;
     use common_meta_types::UserPrivilegeType;
@@ -747,7 +747,7 @@ mod set_user_privileges {
             test_user_name.to_string(),
             test_hostname.to_string(),
             Vec::from("pass"),
-            AuthType::DoubleSha1,
+            PasswordType::DoubleSha1,
         );
         let prev_value = serde_json::to_vec(&user_info)?;
 

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -87,7 +87,7 @@ pub use table::TableMeta;
 pub use table::TableNameIndent;
 pub use table::UpsertTableOptionReply;
 pub use table::UpsertTableOptionReq;
-pub use user_auth::AuthType;
+pub use user_auth::PasswordType;
 pub use user_grant::GrantEntry;
 pub use user_grant::GrantObject;
 pub use user_grant::UserGrantSet;

--- a/common/meta/types/src/user_auth.rs
+++ b/common/meta/types/src/user_auth.rs
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub enum AuthType {
+pub enum PasswordType {
     None = 0,
     PlainText = 1,
     DoubleSha1 = 2,
     Sha256 = 3,
 }
 
-impl Default for AuthType {
+impl Default for PasswordType {
     fn default() -> Self {
-        AuthType::None
+        PasswordType::None
     }
 }

--- a/common/meta/types/src/user_info.rs
+++ b/common/meta/types/src/user_info.rs
@@ -19,7 +19,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 
 use crate::user_grant::UserGrantSet;
-use crate::AuthType;
+use crate::PasswordType;
 use crate::UserQuota;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -34,7 +34,7 @@ pub struct UserInfo {
     pub password: Vec<u8>,
 
     #[serde(default)]
-    pub auth_type: AuthType,
+    pub password_type: PasswordType,
 
     #[serde(default)]
     pub grants: UserGrantSet,
@@ -44,7 +44,12 @@ pub struct UserInfo {
 }
 
 impl UserInfo {
-    pub fn new(name: String, hostname: String, password: Vec<u8>, auth_type: AuthType) -> Self {
+    pub fn new(
+        name: String,
+        hostname: String,
+        password: Vec<u8>,
+        password_type: PasswordType,
+    ) -> Self {
         // Default is no privileges.
         let grants = UserGrantSet::default();
         let quota = UserQuota::no_limit();
@@ -53,7 +58,7 @@ impl UserInfo {
             name,
             hostname,
             password,
-            auth_type,
+            password_type,
             grants,
             quota,
         }

--- a/common/meta/types/tests/it/user_info.rs
+++ b/common/meta/types/tests/it/user_info.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_exception::exception::Result;
-use common_meta_types::AuthType;
+use common_meta_types::PasswordType;
 use common_meta_types::UserInfo;
 
 #[test]
@@ -31,14 +31,14 @@ fn test_user_info() -> Result<()> {
         pub password: Vec<u8>,
 
         #[serde(default)]
-        pub auth_type: AuthType,
+        pub password_type: PasswordType,
     }
 
     let old = OldUserInfo {
         name: "old-name".to_string(),
         hostname: "old-host".to_string(),
         password: Vec::from("pwd"),
-        auth_type: AuthType::Sha256,
+        password_type: PasswordType::Sha256,
     };
 
     let ser_old = serde_json::to_string(&old)?;
@@ -48,7 +48,7 @@ fn test_user_info() -> Result<()> {
         "old-name".to_string(),
         "old-host".to_string(),
         Vec::from("pwd"),
-        AuthType::Sha256,
+        PasswordType::Sha256,
     );
     assert_eq!(new, expect);
 

--- a/common/planners/src/plan_user_alter.rs
+++ b/common/planners/src/plan_user_alter.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
-use common_meta_types::AuthType;
+use common_meta_types::PasswordType;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct AlterUserPlan {
@@ -24,7 +24,7 @@ pub struct AlterUserPlan {
     pub name: String,
     pub hostname: String,
     pub new_password: Vec<u8>,
-    pub new_auth_type: AuthType,
+    pub new_password_type: PasswordType,
 }
 
 impl AlterUserPlan {

--- a/common/planners/src/plan_user_create.rs
+++ b/common/planners/src/plan_user_create.rs
@@ -16,14 +16,14 @@ use std::sync::Arc;
 
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
-use common_meta_types::AuthType;
+use common_meta_types::PasswordType;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct CreateUserPlan {
     pub name: String,
     pub password: Vec<u8>,
     pub hostname: String,
-    pub auth_type: AuthType,
+    pub password_type: PasswordType,
 }
 
 impl CreateUserPlan {

--- a/query/src/interpreters/interpreter_user_alter.rs
+++ b/query/src/interpreters/interpreter_user_alter.rs
@@ -54,7 +54,7 @@ impl Interpreter for AlterUserInterpreter {
             .update_user(
                 plan.name.as_str(),
                 plan.hostname.as_str(),
-                Some(plan.new_auth_type),
+                Some(plan.new_password_type),
                 Some(plan.new_password),
             )
             .await?;

--- a/query/src/interpreters/interpreter_user_create.rs
+++ b/query/src/interpreters/interpreter_user_create.rs
@@ -56,7 +56,7 @@ impl Interpreter for CreatUserInterpreter {
             name: plan.name,
             hostname: plan.hostname,
             password: plan.password,
-            auth_type: plan.auth_type,
+            password_type: plan.password_type,
             grants: UserGrantSet::empty(),
             quota: UserQuota::no_limit(),
         };

--- a/query/src/sql/statements/statement_alter_user.rs
+++ b/query/src/sql/statements/statement_alter_user.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use common_exception::Result;
-use common_meta_types::AuthType;
+use common_meta_types::PasswordType;
 use common_planners::AlterUserPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
@@ -30,7 +30,7 @@ pub struct DfAlterUser {
     /// User name
     pub name: String,
     pub hostname: String,
-    pub new_auth_type: AuthType,
+    pub new_password_type: PasswordType,
     pub new_password: String,
 }
 
@@ -44,7 +44,7 @@ impl AnalyzableStatement for DfAlterUser {
                 name: self.name.clone(),
                 new_password: Vec::from(self.new_password.clone()),
                 hostname: self.hostname.clone(),
-                new_auth_type: self.new_auth_type.clone(),
+                new_password_type: self.new_password_type.clone(),
             },
         ))))
     }

--- a/query/src/sql/statements/statement_create_user.rs
+++ b/query/src/sql/statements/statement_create_user.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use common_exception::Result;
-use common_meta_types::AuthType;
+use common_meta_types::PasswordType;
 use common_planners::CreateUserPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
@@ -30,7 +30,7 @@ pub struct DfCreateUser {
     /// User name
     pub name: String,
     pub hostname: String,
-    pub auth_type: AuthType,
+    pub password_type: PasswordType,
     pub password: String,
 }
 
@@ -43,7 +43,7 @@ impl AnalyzableStatement for DfCreateUser {
                 name: self.name.clone(),
                 password: Vec::from(self.password.clone()),
                 hostname: self.hostname.clone(),
-                auth_type: self.auth_type.clone(),
+                password_type: self.password_type.clone(),
             },
         ))))
     }

--- a/query/src/storages/system/users_table.rs
+++ b/query/src/storages/system/users_table.rs
@@ -38,7 +38,7 @@ impl UsersTable {
             DataField::new("name", DataType::String, false),
             DataField::new("hostname", DataType::String, false),
             DataField::new("password", DataType::String, true),
-            DataField::new("auth_type", DataType::UInt8, false),
+            DataField::new("password_type", DataType::UInt8, false),
         ]);
 
         let table_info = TableInfo {
@@ -79,12 +79,15 @@ impl Table for UsersTable {
         let names: Vec<&str> = users.iter().map(|x| x.name.as_str()).collect();
         let hostnames: Vec<&str> = users.iter().map(|x| x.hostname.as_str()).collect();
         let passwords: Vec<&[u8]> = users.iter().map(|x| x.password.as_slice()).collect();
-        let auth_types: Vec<u8> = users.iter().map(|x| x.auth_type.clone() as u8).collect();
+        let password_types: Vec<u8> = users
+            .iter()
+            .map(|x| x.password_type.clone() as u8)
+            .collect();
         let block = DataBlock::create_by_array(self.table_info.schema(), vec![
             Series::new(names),
             Series::new(hostnames),
             Series::new(passwords),
-            Series::new(auth_types),
+            Series::new(password_types),
         ]);
         Ok(Box::pin(DataBlockStream::create(
             self.table_info.schema(),

--- a/query/src/users/user.rs
+++ b/query/src/users/user.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-use common_meta_types::AuthType;
+use common_meta_types::PasswordType;
 use common_meta_types::UserGrantSet;
 use common_meta_types::UserInfo;
 use common_meta_types::UserQuota;
@@ -23,7 +23,7 @@ pub struct User {
     name: String,
     hostname: String,
     password: String,
-    auth_type: AuthType,
+    password_type: PasswordType,
 }
 
 impl User {
@@ -31,13 +31,13 @@ impl User {
         name: impl Into<String>,
         hostname: impl Into<String>,
         password: impl Into<String>,
-        auth_type: AuthType,
+        password_type: PasswordType,
     ) -> Self {
         User {
             name: name.into(),
             hostname: hostname.into(),
             password: password.into(),
-            auth_type,
+            password_type,
         }
     }
 }
@@ -51,7 +51,7 @@ impl From<&User> for UserInfo {
             name: user.name.clone(),
             hostname: user.hostname.clone(),
             password: Vec::from(user.password.clone()),
-            auth_type: user.auth_type.clone(),
+            password_type: user.password_type.clone(),
             grants,
             quota,
         }

--- a/query/src/users/user_mgr.rs
+++ b/query/src/users/user_mgr.rs
@@ -14,8 +14,8 @@
 
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_meta_types::AuthType;
 use common_meta_types::GrantObject;
+use common_meta_types::PasswordType;
 use common_meta_types::UserInfo;
 use common_meta_types::UserPrivilegeSet;
 use sha2::Digest;
@@ -31,7 +31,7 @@ impl UserApiProvider {
             // TODO(BohuTANG): Mock, need removed.
             "default" | "" | "root" => {
                 let mut user_info: UserInfo =
-                    User::new(username, hostname, "", AuthType::None).into();
+                    User::new(username, hostname, "", PasswordType::None).into();
                 if hostname == "127.0.0.1" || &hostname.to_lowercase() == "localhost" {
                     user_info.grants.grant_privileges(
                         username,
@@ -52,12 +52,12 @@ impl UserApiProvider {
 
     // Auth the user and password for different Auth type.
     pub async fn auth_user(&self, user: UserInfo, info: CertifiedInfo) -> Result<bool> {
-        match user.auth_type {
-            AuthType::None => Ok(true),
-            AuthType::PlainText => Ok(user.password == info.user_password),
+        match user.password_type {
+            PasswordType::None => Ok(true),
+            PasswordType::PlainText => Ok(user.password == info.user_password),
             // MySQL already did x = sha1(x)
             // so we just check double sha1(x)
-            AuthType::DoubleSha1 => {
+            PasswordType::DoubleSha1 => {
                 let mut m = sha1::Sha1::new();
                 m.update(&info.user_password);
 
@@ -67,7 +67,7 @@ impl UserApiProvider {
 
                 Ok(user.password == m.digest().bytes().to_vec())
             }
-            AuthType::Sha256 => {
+            PasswordType::Sha256 => {
                 let result = sha2::Sha256::digest(&info.user_password);
                 Ok(user.password == result.to_vec())
             }
@@ -163,7 +163,7 @@ impl UserApiProvider {
         &self,
         username: &str,
         hostname: &str,
-        new_auth_type: Option<AuthType>,
+        new_password_type: Option<PasswordType>,
         new_password: Option<Vec<u8>>,
     ) -> Result<Option<u64>> {
         let client = self.get_user_api_client();
@@ -171,7 +171,7 @@ impl UserApiProvider {
             username.to_string(),
             hostname.to_string(),
             new_password,
-            new_auth_type,
+            new_password_type,
             None,
         );
         match update_user.await {

--- a/query/tests/it/interpreters/interpreter_grant_privilege.rs
+++ b/query/tests/it/interpreters/interpreter_grant_privilege.rs
@@ -14,8 +14,8 @@
 
 use common_base::tokio;
 use common_exception::Result;
-use common_meta_types::AuthType;
 use common_meta_types::GrantObject;
+use common_meta_types::PasswordType;
 use common_meta_types::UserGrantSet;
 use common_meta_types::UserInfo;
 use common_meta_types::UserPrivilegeSet;
@@ -37,7 +37,7 @@ async fn test_grant_privilege_interpreter() -> Result<()> {
         name.to_string(),
         hostname.to_string(),
         Vec::from(password),
-        AuthType::PlainText,
+        PasswordType::PlainText,
     );
     assert_eq!(user_info.grants, UserGrantSet::empty());
     let user_mgr = ctx.get_sessions_manager().get_user_manager();

--- a/query/tests/it/interpreters/interpreter_revoke_previlege.rs
+++ b/query/tests/it/interpreters/interpreter_revoke_previlege.rs
@@ -14,7 +14,7 @@
 
 use common_base::tokio;
 use common_exception::Result;
-use common_meta_types::AuthType;
+use common_meta_types::PasswordType;
 use common_meta_types::UserGrantSet;
 use common_meta_types::UserInfo;
 use common_planners::*;
@@ -35,7 +35,7 @@ async fn test_revoke_privilege_interpreter() -> Result<()> {
         name.to_string(),
         hostname.to_string(),
         Vec::from(password),
-        AuthType::PlainText,
+        PasswordType::PlainText,
     );
     assert_eq!(user_info.grants, UserGrantSet::empty());
     let user_mgr = ctx.get_sessions_manager().get_user_manager();

--- a/query/tests/it/interpreters/interpreter_user_alter.rs
+++ b/query/tests/it/interpreters/interpreter_user_alter.rs
@@ -14,7 +14,7 @@
 
 use common_base::tokio;
 use common_exception::Result;
-use common_meta_types::AuthType;
+use common_meta_types::PasswordType;
 use common_meta_types::UserInfo;
 use common_planners::*;
 use databend_query::interpreters::*;
@@ -35,7 +35,7 @@ async fn test_alter_user_interpreter() -> Result<()> {
         name.to_string(),
         hostname.to_string(),
         Vec::from(password),
-        AuthType::PlainText,
+        PasswordType::PlainText,
     );
     let user_mgr = ctx.get_sessions_manager().get_user_manager();
     user_mgr.add_user(user_info).await?;

--- a/query/tests/it/interpreters/interpreter_user_drop.rs
+++ b/query/tests/it/interpreters/interpreter_user_drop.rs
@@ -14,7 +14,7 @@
 
 use common_base::tokio;
 use common_exception::Result;
-use common_meta_types::AuthType;
+use common_meta_types::PasswordType;
 use common_meta_types::UserInfo;
 use common_planners::*;
 use databend_query::interpreters::*;
@@ -59,7 +59,7 @@ async fn test_drop_user_interpreter() -> Result<()> {
             name.to_string(),
             hostname.to_string(),
             Vec::from(password),
-            AuthType::PlainText,
+            PasswordType::PlainText,
         );
         let user_mgr = ctx.get_sessions_manager().get_user_manager();
         user_mgr.add_user(user_info).await?;

--- a/query/tests/it/sessions/session_status.rs
+++ b/query/tests/it/sessions/session_status.rs
@@ -17,7 +17,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use common_exception::Result;
-use common_meta_types::AuthType;
+use common_meta_types::PasswordType;
 use common_meta_types::UserInfo;
 use databend_query::clusters::Cluster;
 use databend_query::sessions::MutableStatus;
@@ -61,7 +61,12 @@ fn test_session_status() -> Result<()> {
 
     // Current user.
     {
-        let user_info = UserInfo::new("user1".to_string(), "".to_string(), vec![], AuthType::None);
+        let user_info = UserInfo::new(
+            "user1".to_string(),
+            "".to_string(),
+            vec![],
+            PasswordType::None,
+        );
         mutable_status.set_current_user(user_info);
 
         let val = mutable_status.get_current_user().unwrap();

--- a/query/tests/it/sql/sql_parser.rs
+++ b/query/tests/it/sql/sql_parser.rs
@@ -15,11 +15,11 @@
 use std::collections::HashMap;
 
 use common_exception::Result;
-use common_meta_types::AuthType;
 use common_meta_types::Compression;
 use common_meta_types::Credentials;
 use common_meta_types::FileFormat;
 use common_meta_types::Format;
+use common_meta_types::PasswordType;
 use common_meta_types::StageParams;
 use common_meta_types::UserIdentity;
 use common_meta_types::UserPrivilegeSet;
@@ -613,7 +613,7 @@ fn create_user_test() -> Result<()> {
             if_not_exists: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            auth_type: AuthType::Sha256,
+            password_type: PasswordType::Sha256,
             password: String::from("password"),
         }),
     )?;
@@ -624,7 +624,7 @@ fn create_user_test() -> Result<()> {
             if_not_exists: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            auth_type: AuthType::PlainText,
+            password_type: PasswordType::PlainText,
             password: String::from("password"),
         }),
     )?;
@@ -635,7 +635,7 @@ fn create_user_test() -> Result<()> {
             if_not_exists: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            auth_type: AuthType::Sha256,
+            password_type: PasswordType::Sha256,
             password: String::from("password"),
         }),
     )?;
@@ -646,7 +646,7 @@ fn create_user_test() -> Result<()> {
             if_not_exists: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            auth_type: AuthType::DoubleSha1,
+            password_type: PasswordType::DoubleSha1,
             password: String::from("password"),
         }),
     )?;
@@ -657,7 +657,7 @@ fn create_user_test() -> Result<()> {
             if_not_exists: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            auth_type: AuthType::None,
+            password_type: PasswordType::None,
             password: String::from(""),
         }),
     )?;
@@ -668,7 +668,7 @@ fn create_user_test() -> Result<()> {
             if_not_exists: true,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            auth_type: AuthType::Sha256,
+            password_type: PasswordType::Sha256,
             password: String::from("password"),
         }),
     )?;
@@ -679,7 +679,7 @@ fn create_user_test() -> Result<()> {
             if_not_exists: false,
             name: String::from("test@localhost"),
             hostname: String::from("%"),
-            auth_type: AuthType::Sha256,
+            password_type: PasswordType::Sha256,
             password: String::from("password"),
         }),
     )?;
@@ -690,7 +690,7 @@ fn create_user_test() -> Result<()> {
             if_not_exists: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            auth_type: AuthType::None,
+            password_type: PasswordType::None,
             password: String::from(""),
         }),
     )?;
@@ -701,7 +701,7 @@ fn create_user_test() -> Result<()> {
             if_not_exists: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            auth_type: AuthType::None,
+            password_type: PasswordType::None,
             password: String::from(""),
         }),
     )?;
@@ -736,7 +736,7 @@ fn alter_user_test() -> Result<()> {
             if_current_user: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            new_auth_type: AuthType::Sha256,
+            new_password_type: PasswordType::Sha256,
             new_password: String::from("password"),
         }),
     )?;
@@ -747,7 +747,7 @@ fn alter_user_test() -> Result<()> {
             if_current_user: true,
             name: String::from(""),
             hostname: String::from(""),
-            new_auth_type: AuthType::Sha256,
+            new_password_type: PasswordType::Sha256,
             new_password: String::from("password"),
         }),
     )?;
@@ -758,7 +758,7 @@ fn alter_user_test() -> Result<()> {
             if_current_user: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            new_auth_type: AuthType::PlainText,
+            new_password_type: PasswordType::PlainText,
             new_password: String::from("password"),
         }),
     )?;
@@ -769,7 +769,7 @@ fn alter_user_test() -> Result<()> {
             if_current_user: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            new_auth_type: AuthType::Sha256,
+            new_password_type: PasswordType::Sha256,
             new_password: String::from("password"),
         }),
     )?;
@@ -780,7 +780,7 @@ fn alter_user_test() -> Result<()> {
             if_current_user: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            new_auth_type: AuthType::DoubleSha1,
+            new_password_type: PasswordType::DoubleSha1,
             new_password: String::from("password"),
         }),
     )?;
@@ -791,7 +791,7 @@ fn alter_user_test() -> Result<()> {
             if_current_user: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            new_auth_type: AuthType::None,
+            new_password_type: PasswordType::None,
             new_password: String::from(""),
         }),
     )?;
@@ -802,7 +802,7 @@ fn alter_user_test() -> Result<()> {
             if_current_user: false,
             name: String::from("test@localhost"),
             hostname: String::from("%"),
-            new_auth_type: AuthType::Sha256,
+            new_password_type: PasswordType::Sha256,
             new_password: String::from("password"),
         }),
     )?;
@@ -813,7 +813,7 @@ fn alter_user_test() -> Result<()> {
             if_current_user: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            new_auth_type: AuthType::None,
+            new_password_type: PasswordType::None,
             new_password: String::from(""),
         }),
     )?;
@@ -824,7 +824,7 @@ fn alter_user_test() -> Result<()> {
             if_current_user: false,
             name: String::from("test"),
             hostname: String::from("localhost"),
-            new_auth_type: AuthType::None,
+            new_password_type: PasswordType::None,
             new_password: String::from(""),
         }),
     )?;

--- a/query/tests/it/storages/system/users_table.rs
+++ b/query/tests/it/storages/system/users_table.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use common_base::tokio;
 use common_exception::Result;
-use common_meta_types::AuthType;
+use common_meta_types::PasswordType;
 use common_meta_types::UserGrantSet;
 use common_meta_types::UserInfo;
 use common_meta_types::UserQuota;
@@ -36,7 +36,7 @@ async fn test_users_table() -> Result<()> {
             name: "test".to_string(),
             hostname: "localhost".to_string(),
             password: Vec::from(""),
-            auth_type: AuthType::None,
+            password_type: PasswordType::None,
             grants: UserGrantSet::empty(),
             quota: UserQuota::no_limit(),
         })
@@ -47,7 +47,7 @@ async fn test_users_table() -> Result<()> {
             name: "test1".to_string(),
             hostname: "%".to_string(),
             password: Vec::from("123456789"),
-            auth_type: AuthType::PlainText,
+            password_type: PasswordType::PlainText,
             grants: UserGrantSet::empty(),
             quota: UserQuota::no_limit(),
         })
@@ -62,12 +62,12 @@ async fn test_users_table() -> Result<()> {
     assert_eq!(block.num_columns(), 4);
 
     let expected = vec![
-        "+-------+-----------+-----------+-----------+",
-        "| name  | hostname  | password  | auth_type |",
-        "+-------+-----------+-----------+-----------+",
-        "| test  | localhost |           | 0         |",
-        "| test1 | %         | 123456789 | 1         |",
-        "+-------+-----------+-----------+-----------+",
+        "+-------+-----------+-----------+---------------+",
+        "| name  | hostname  | password  | password_type |",
+        "+-------+-----------+-----------+---------------+",
+        "| test  | localhost |           | 0             |",
+        "| test1 | %         | 123456789 | 1             |",
+        "+-------+-----------+-----------+---------------+",
     ];
     common_datablocks::assert_blocks_sorted_eq(expected, result.as_slice());
     Ok(())

--- a/query/tests/it/tests/context.rs
+++ b/query/tests/it/tests/context.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_meta_embedded::MetaEmbedded;
-use common_meta_types::AuthType;
 use common_meta_types::NodeInfo;
+use common_meta_types::PasswordType;
 use common_meta_types::UserInfo;
 use databend_query::catalogs::CatalogContext;
 use databend_query::clusters::Cluster;
@@ -39,7 +39,7 @@ pub fn create_query_context() -> Result<Arc<QueryContext>> {
         "test_user".to_string(),
         "%".to_string(),
         Vec::from("pass"),
-        AuthType::Sha256,
+        PasswordType::Sha256,
     );
     dummy_session.set_current_user(user_info);
 

--- a/query/tests/it/users/user_mgr.rs
+++ b/query/tests/it/users/user_mgr.rs
@@ -14,8 +14,8 @@
 
 use common_base::tokio;
 use common_exception::Result;
-use common_meta_types::AuthType;
 use common_meta_types::GrantObject;
+use common_meta_types::PasswordType;
 use common_meta_types::UserGrantSet;
 use common_meta_types::UserPrivilegeSet;
 use common_meta_types::UserPrivilegeType;
@@ -37,13 +37,13 @@ async fn test_user_manager() -> Result<()> {
 
     // add user hostname.
     {
-        let user_info = User::new(user, hostname, pwd, AuthType::PlainText);
+        let user_info = User::new(user, hostname, pwd, PasswordType::PlainText);
         user_mgr.add_user(user_info.into()).await?;
     }
 
     // add user hostname2.
     {
-        let user_info = User::new(user, hostname2, pwd, AuthType::PlainText);
+        let user_info = User::new(user, hostname2, pwd, PasswordType::PlainText);
         user_mgr.add_user(user_info.into()).await?;
     }
 
@@ -89,7 +89,7 @@ async fn test_user_manager() -> Result<()> {
 
     // grant privileges
     {
-        let user_info = User::new(user, hostname, pwd, AuthType::PlainText);
+        let user_info = User::new(user, hostname, pwd, PasswordType::PlainText);
         user_mgr.add_user(user_info.into()).await?;
         let old_user = user_mgr.get_user(user, hostname).await?;
         assert_eq!(old_user.grants, UserGrantSet::empty());
@@ -113,7 +113,7 @@ async fn test_user_manager() -> Result<()> {
 
     // revoke privileges
     {
-        let user_info = User::new(user, hostname, pwd, AuthType::PlainText);
+        let user_info = User::new(user, hostname, pwd, PasswordType::PlainText);
         user_mgr.add_user(user_info.into()).await?;
         user_mgr
             .grant_user_privileges(
@@ -144,7 +144,7 @@ async fn test_user_manager() -> Result<()> {
         let user = "test";
         let hostname = "localhost";
         let pwd = "test";
-        let user_info = User::new(user, hostname, pwd, AuthType::PlainText);
+        let user_info = User::new(user, hostname, pwd, PasswordType::PlainText);
         user_mgr.add_user(user_info.into()).await?;
 
         let old_user = user_mgr.get_user(user, hostname).await?;
@@ -155,20 +155,20 @@ async fn test_user_manager() -> Result<()> {
             .update_user(
                 user,
                 hostname,
-                Some(AuthType::Sha256),
+                Some(PasswordType::Sha256),
                 Some(Vec::from(new_pwd)),
             )
             .await?;
         let new_user = user_mgr.get_user(user, hostname).await?;
         assert_eq!(new_user.password, Vec::from(new_pwd));
-        assert_eq!(new_user.auth_type, AuthType::Sha256);
+        assert_eq!(new_user.password_type, PasswordType::Sha256);
 
         let new_new_pwd = "test2";
         user_mgr
             .update_user(
                 user,
                 hostname,
-                Some(AuthType::Sha256),
+                Some(PasswordType::Sha256),
                 Some(Vec::from(new_new_pwd)),
             )
             .await?;
@@ -179,7 +179,7 @@ async fn test_user_manager() -> Result<()> {
             .update_user(
                 "user",
                 hostname,
-                Some(AuthType::Sha256),
+                Some(PasswordType::Sha256),
                 Some(Vec::from(new_new_pwd)),
             )
             .await;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Rename auth_type to password_type

## Changelog

- Improvement


## Related Issues

Fixes #3480 

## Test Plan

Unit Tests

Stateless Tests

