### PR TITLE
[metasrv] refine some codes

### DIFF
--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -837,7 +837,7 @@ impl StateMachine {
             },
         };
 
-        seq_kv_value.seq = self.txn_incr_seq(KS::NAME, &*sub_tree)?;
+        seq_kv_value.seq = self.txn_incr_seq(KS::NAME, sub_tree)?;
 
         sub_tree.insert(key, &seq_kv_value)?;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

For #3284  with `Deref` impl, we can use `self.txn_tree` directly in `impl Store for AsTxnKeySpace` [methods](https://github.com/datafuselabs/databend/blob/7705b175e00b728d967a48a29d3fb52d02fbfad3/common/meta/sled-store/src/sled_tree.rs#L518-L566)

For #3285 I investigated some methods that can provide default arg value, but they are all not beautiful enough, so we can leave it for now.

## Changelog

- Improvement


## Related Issues


## Test Plan

Unit Tests

Stateless Tests

