### PR TITLE
use clap 3.0.0-rc.5 to unify the cli arg parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,8 +554,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.0",
- "structopt",
- "structopt-toml",
  "sysinfo 0.21.2",
  "tar",
  "tempfile",
@@ -754,12 +752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecount"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
-
-[[package]]
 name = "bytemuck"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,7 +793,7 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "atty",
- "cargo_metadata 0.14.1",
+ "cargo_metadata",
  "csv",
  "getopts",
  "semver 1.0.4",
@@ -819,19 +811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
-dependencies = [
- "cargo-platform",
- "semver 0.11.0",
- "semver-parser 0.10.2",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -968,11 +947,26 @@ checksum = "9d358d5dcd274692e60df775bd452f66341a49ab90cc6cc1084c4350a3f914d9"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "indexmap",
+ "lazy_static",
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.14.2",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a0823802ec32930a7b22133dc3a8b7cf297297e8af413e59d2fbbf864c7bd63"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1433,6 +1427,7 @@ dependencies = [
  "async-raft",
  "async-trait",
  "bytes",
+ "clap 3.0.0-rc.5",
  "common-arrow",
  "common-base",
  "common-exception",
@@ -1447,8 +1442,6 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde_json",
- "structopt",
- "structopt-toml",
  "tempfile",
 ]
 
@@ -2001,6 +1994,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "byteorder",
+ "clap 3.0.0-rc.5",
  "common-arrow",
  "common-base",
  "common-building",
@@ -2036,8 +2030,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.0",
  "sled",
- "structopt",
- "structopt-toml",
  "tempfile",
  "test-env-log",
  "thiserror",
@@ -2060,9 +2052,10 @@ dependencies = [
  "byteorder",
  "bytes",
  "cargo-license",
- "cargo_metadata 0.14.1",
+ "cargo_metadata",
  "chrono",
  "chrono-tz",
+ "clap 3.0.0-rc.5",
  "clickhouse-rs",
  "common-arrow",
  "common-base",
@@ -2122,8 +2115,6 @@ dependencies = [
  "sha1",
  "sha2 0.10.0",
  "sqlparser",
- "structopt",
- "structopt-toml",
  "tempfile",
  "threadpool",
  "tokio-rustls 0.23.1",
@@ -2439,15 +2430,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -5212,17 +5194,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
-dependencies = [
- "bitflags",
- "memchr",
- "unicase",
-]
-
-[[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5893,17 +5864,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
- "serde",
+ "semver-parser",
 ]
 
 [[package]]
@@ -5920,15 +5881,6 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -6168,21 +6120,6 @@ checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
 dependencies = [
  "bitmaps",
  "typenum",
-]
-
-[[package]]
-name = "skeptic"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "188b810342d98f23f0bb875045299f34187b559370b041eb11520c905370a888"
-dependencies = [
- "bytecount",
- "cargo_metadata 0.12.3",
- "error-chain",
- "glob",
- "pulldown-cmark",
- "tempfile",
- "walkdir",
 ]
 
 [[package]]
@@ -6449,33 +6386,6 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "structopt-toml"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27d68c57e6cc3fb03041c49534e50a6ccef677c511effc1c5bf12a4bc865a62"
-dependencies = [
- "anyhow",
- "clap 2.34.0",
- "serde",
- "serde_derive",
- "skeptic",
- "structopt",
- "structopt-toml-derive",
- "toml",
-]
-
-[[package]]
-name = "structopt-toml-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316302a563af68baf93e5e77b8355a8bfe168c67c4424623365ca5bf521d013e"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,18 +19,18 @@ path = "src/bin/bendctl.rs"
 
 [dependencies]
 # Workspace dependencies
-databend-query = {path = "../query"}
-common-base = {path = "../common/base" }
+databend-query = { path = "../query" }
+common-base = { path = "../common/base" }
 common-datavalues = { path = "../common/datavalues" }
-common-tracing = {path = "../common/tracing" }
+common-tracing = { path = "../common/tracing" }
 
 itertools = "0.10.3"
-databend-meta = {path = "../metasrv" }
-common-meta-raft-store= {path = "../common/meta/raft-store"}
+databend-meta = { path = "../metasrv" }
+common-meta-raft-store = { path = "../common/meta/raft-store" }
 colored = "2.0.0"
 comfy-table = "5.0.0"
 dirs = "4.0.0"
-clap = { version = "3.0.0-rc.0", features = ["env"] }
+clap = { version = "3.0.0-rc.5", features = ["env"] }
 clap_generate = "3.0.0-rc.5"
 dyn-clone = "1.0.4"
 flate2 = "1.0.22"
@@ -51,8 +51,6 @@ thiserror = "1.0.30"
 ureq = { version = "2.3.1", features = ["json"] }
 nix = "0.23.0"
 serde_yaml = "0.8.21"
-structopt = "0.3.25"
-structopt-toml = "0.5.0"
 portpicker = "0.1.1"
 reqwest = { version = "0.11.7", features = ["json", "native-tls", "multipart", "blocking", "tokio-rustls", "stream"] }
 libc = "0.2.109"
@@ -73,4 +71,4 @@ predicates = "2.1.0"
 httpmock = "0.6.4"
 
 [build-dependencies]
-common-building = {path = "../common/building"}
+common-building = { path = "../common/building" }

--- a/common/meta/raft-store/Cargo.toml
+++ b/common/meta/raft-store/Cargo.toml
@@ -12,27 +12,26 @@ doctest = false
 test = false
 
 [dependencies]
-common-arrow = {path = "../../arrow"}
-common-exception = {path = "../../exception"}
-common-io = {path = "../../io"}
-common-meta-api = {path = "../api"}
-common-meta-sled-store = {path = "../sled-store"}
-common-meta-types = {path = "../types"}
-common-tracing = {path = "../../tracing"}
+common-arrow = { path = "../../arrow" }
+common-exception = { path = "../../exception" }
+common-io = { path = "../../io" }
+common-meta-api = { path = "../api" }
+common-meta-sled-store = { path = "../sled-store" }
+common-meta-types = { path = "../types" }
+common-tracing = { path = "../../tracing" }
 
 anyhow = "1.0.51"
 async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.14.1" }
 async-trait = "0.1.52"
+clap = { version = "3.0.0-rc.5", features = ["derive", "env"] }
 bytes = "1.1.0"
 derive_more = "0.99.17"
 maplit = "1.0.2"
 rand = "0.8.4"
 serde = { version = "1.0.131", features = ["derive"] }
 serde_json = "1.0.73"
-structopt = "0.3.25"
-structopt-toml = "0.5.0"
 
 [dev-dependencies]
-common-base = {path = "../../base" }
+common-base = { path = "../../base" }
 pretty_assertions = "1.0.0"
 tempfile = "3.2.0"

--- a/common/meta/raft-store/src/config.rs
+++ b/common/meta/raft-store/src/config.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap::Parser;
 use common_exception::ErrorCode;
 use common_meta_types::NodeId;
 use serde::Deserialize;
 use serde::Serialize;
-use structopt::StructOpt;
-use structopt_toml::StructOptToml;
+
 pub const KVSRV_API_HOST: &str = "KVSRV_API_HOST";
 pub const KVSRV_API_PORT: &str = "KVSRV_API_PORT";
 pub const KVSRV_RAFT_DIR: &str = "KVSRV_RAFT_DIR";
@@ -29,109 +29,68 @@ pub const KVSRV_BOOT: &str = "KVSRV_BOOT";
 pub const KVSRV_SINGLE: &str = "KVSRV_SINGLE";
 pub const KVSRV_ID: &str = "KVSRV_ID";
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, StructOpt, StructOptToml)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Parser)]
 pub struct RaftConfig {
-    /// Identify a config. This is only meant to make debugging easier with more than one Config involved.
-    #[structopt(long, default_value = "")]
+    /// Identify a config.
+    /// This is only meant to make debugging easier with more than one Config involved.
+    #[clap(long, default_value = "")]
     pub config_id: String,
 
-    #[structopt(
-        long,
-        env = KVSRV_API_HOST,
-        default_value = "127.0.0.1",
-        help = "The listening host for metadata communication"
-    )]
+    /// The listening host for metadata communication.
+    #[clap(long, env = KVSRV_API_HOST, default_value = "127.0.0.1")]
     pub raft_api_host: String,
 
-    #[structopt(
-        long,
-        env = KVSRV_API_PORT,
-        default_value = "28004",
-        help = "The listening port for metadata communication"
-    )]
+    /// The listening port for metadata communication.
+    #[clap(long, env = KVSRV_API_PORT, default_value = "28004")]
     pub raft_api_port: u32,
 
-    #[structopt(
-        long,
-        env = KVSRV_RAFT_DIR,
-        default_value = "./_meta",
-        help = "The dir to store persisted meta state, including raft logs, state machine etc."
-    )]
+    /// The dir to store persisted meta state, including raft logs, state machine etc.
+    #[clap(long, env = KVSRV_RAFT_DIR, default_value = "./_meta")]
     pub raft_dir: String,
 
-    #[structopt(
-    long,
-    env = KVSRV_NO_SYNC,
-    help = concat!("Whether to fsync meta to disk for every meta write(raft log, state machine etc).",
-    " No-sync brings risks of data loss during a crash.",
-    " You should only use this in a testing environment, unless YOU KNOW WHAT YOU ARE DOING."
-    ),
-    )]
+    /// Whether to fsync meta to disk for every meta write(raft log, state machine etc).
+    /// No-sync brings risks of data loss during a crash.
+    /// You should only use this in a testing environment, unless YOU KNOW WHAT YOU ARE DOING.
+    #[clap(long, env = KVSRV_NO_SYNC)]
     pub no_sync: bool,
 
-    // raft config
-    #[structopt(
-        long,
-        env = KVSRV_SNAPSHOT_LOGS_SINCE_LAST,
-        default_value = "1024",
-        help = "The number of logs since the last snapshot to trigger next snapshot."
-    )]
+    /// The number of logs since the last snapshot to trigger next snapshot.
+    #[clap(long, env = KVSRV_SNAPSHOT_LOGS_SINCE_LAST, default_value = "1024")]
     pub snapshot_logs_since_last: u64,
 
-    #[structopt(
-    long,
-    env = KVSRV_HEARTBEAT_INTERVAL,
-    default_value = "1000",
-    help = concat!("The interval in milli seconds at which a leader send heartbeat message to followers.",
-    " Different value of this setting on leader and followers may cause unexpected behavior.")
-    )]
+    /// The interval in milli seconds at which a leader send heartbeat message to followers.
+    /// Different value of this setting on leader and followers may cause unexpected behavior.
+    #[clap(long, env = KVSRV_HEARTBEAT_INTERVAL, default_value = "1000")]
     pub heartbeat_interval: u64,
 
-    #[structopt(
-    long,
-    env = KVSRV_INSTALL_SNAPSHOT_TIMEOUT,
-    default_value = "4000",
-    help = concat!("The max time in milli seconds that a leader wait for install-snapshot ack from a follower or non-voter.")
-    )]
+    /// The max time in milli seconds that a leader wait for install-snapshot ack from a follower or non-voter.
+    #[clap(long, env = KVSRV_INSTALL_SNAPSHOT_TIMEOUT, default_value = "4000")]
     pub install_snapshot_timeout: u64,
 
-    #[structopt(
-        long,
-        env = KVSRV_BOOT,
-        help = "Whether to boot up a new cluster. If already booted, it is ignored"
-    )]
+    /// Whether to boot up a new cluster. If already booted, it is ignored
+    #[clap(long, env = KVSRV_BOOT)]
     pub boot: bool,
 
-    #[structopt(
-    long,
-    env = KVSRV_SINGLE,
-    help = concat!("Single node metasrv. It creates a single node cluster if meta data is not initialized.",
-    " Otherwise it opens the previous one.",
-    " This is mainly for testing purpose.")
-    )]
+    /// Single node metasrv. It creates a single node cluster if meta data is not initialized.
+    /// Otherwise it opens the previous one.
+    /// This is mainly for testing purpose.
+    #[clap(long, env = KVSRV_SINGLE)]
     pub single: bool,
 
     /// Bring up a metasrv node and join a cluster.
     ///
     /// The value is one or more addresses of a node in the cluster, to which this node sends a `join` request.
-    #[structopt(long, env = "METASRV_JOIN")]
+    #[clap(long, env = "METASRV_JOIN")]
     pub join: Vec<String>,
 
-    #[structopt(
-    long,
-    env = KVSRV_ID,
-    default_value = "0",
-    help = concat!("The node id. Only used when this server is not initialized,",
-    " e.g. --boot or --single for the first time.",
-    " Otherwise this argument is ignored.")
-    )]
+    /// The node id. Only used when this server is not initialized,
+    ///  e.g. --boot or --single for the first time.
+    ///  Otherwise this argument is ignored.
+    #[clap(long, env = KVSRV_ID, default_value = "0")]
     pub id: NodeId,
 
-    #[structopt(
-        long,
-        default_value = "",
-        help = "For test only: specifies the tree name prefix"
-    )]
+    /// For test only: specifies the tree name prefix
+    #[clap(long, default_value = "")]
     pub sled_tree_prefix: String,
 }
 
@@ -142,7 +101,7 @@ impl RaftConfig {
     ///
     /// Thus we need another method to generate an empty default instance.
     pub fn empty() -> Self {
-        <Self as StructOpt>::from_iter(&Vec::<&'static str>::new())
+        <Self as Parser>::parse_from(&Vec::<&'static str>::new())
     }
 
     pub fn raft_api_addr(&self) -> String {

--- a/common/meta/raft-store/src/config.rs
+++ b/common/meta/raft-store/src/config.rs
@@ -30,6 +30,7 @@ pub const KVSRV_SINGLE: &str = "KVSRV_SINGLE";
 pub const KVSRV_ID: &str = "KVSRV_ID";
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Parser)]
+#[serde(default)]
 pub struct RaftConfig {
     /// Identify a config.
     /// This is only meant to make debugging easier with more than one Config involved.
@@ -92,6 +93,26 @@ pub struct RaftConfig {
     /// For test only: specifies the tree name prefix
     #[clap(long, default_value = "")]
     pub sled_tree_prefix: String,
+}
+
+impl Default for RaftConfig {
+    fn default() -> Self {
+        Self {
+            config_id: "".to_string(),
+            raft_api_host: "127.0.0.1".to_string(),
+            raft_api_port: 28004,
+            raft_dir: "./_meta".to_string(),
+            no_sync: false,
+            snapshot_logs_since_last: 1024,
+            heartbeat_interval: 1000,
+            install_snapshot_timeout: 4000,
+            boot: false,
+            single: false,
+            join: vec![],
+            id: 0,
+            sled_tree_prefix: "".to_string(),
+        }
+    }
 }
 
 impl RaftConfig {

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/databend-meta --single true &> /tmp/databend-meta.log  &
+/databend-meta --single &> /tmp/databend-meta.log  &
 P1=$!
 # add health check to remove the race condition issue during databend-query bootstrap
 sleep 1

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -21,9 +21,9 @@ simd = ["common-arrow/simd"]
 
 [dependencies]
 # Workspace dependencies
-common-arrow = {path = "../common/arrow"}
-common-containers = {path = "../common/containers"}
-common-datavalues = {path = "../common/datavalues"}
+common-arrow = { path = "../common/arrow" }
+common-containers = { path = "../common/containers" }
+common-datavalues = { path = "../common/datavalues" }
 common-exception = { path = "../common/exception" }
 common-flight-rpc = { path = "../common/flight-rpc" }
 common-infallible = { path = "../common/infallible" }
@@ -45,6 +45,7 @@ async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.
 async-trait = "0.1.52"
 backtrace = "0.3.63"
 byteorder = "1.4.3"
+clap = { version = "3.0.0-rc.5", features = ["derive", "env"] }
 derive_more = "0.99.17"
 futures = "0.3.18"
 indexmap = "1.7.0"
@@ -58,9 +59,7 @@ prost = "0.9.0"
 rand = "0.8.4"
 serde = { version = "1.0.131", features = ["derive"] }
 serde_json = "1.0.73"
-sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1",default-features = false }
-structopt = "0.3.25"
-structopt-toml = "0.5.0"
+sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 tempfile = "3.2.0"
 thiserror = "1.0.30"
 threadpool = "1.8.1"
@@ -72,7 +71,7 @@ uuid = { version = "0.8.2", features = ["serde", "v4"] }
 poem = { version = "1.2.2", features = ["rustls"] }
 
 [dev-dependencies]
-common-meta-api = {path = "../common/meta/api" }
+common-meta-api = { path = "../common/meta/api" }
 
 pretty_assertions = "1.0.0"
 test-env-log = "0.2.8"
@@ -80,5 +79,5 @@ flaky_test = "0.1.0"
 reqwest = { version = "0.11.7", features = ["json"] }
 
 [build-dependencies]
-common-building = {path = "../common/building"}
+common-building = { path = "../common/building" }
 tonic-build = "0.6.2"

--- a/metasrv/src/bin/metasrv.rs
+++ b/metasrv/src/bin/metasrv.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use clap::Parser;
 use common_base::RuntimeTracker;
 use common_base::StopHandle;
 use common_base::Stoppable;
@@ -27,11 +28,10 @@ use databend_meta::api::HttpService;
 use databend_meta::configs::Config;
 use databend_meta::meta_service::MetaNode;
 use databend_meta::metrics::MetricService;
-use structopt::StructOpt;
 
 #[databend_main]
 async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<()> {
-    let conf = Config::from_args();
+    let conf = Config::parse();
 
     let _guards = init_global_tracing(
         "databend-meta",

--- a/metasrv/src/configs/config.rs
+++ b/metasrv/src/configs/config.rs
@@ -57,11 +57,7 @@ pub struct Config {
     #[clap(long, env = METASRV_LOG_DIR, default_value = "./_logs")]
     pub log_dir: String,
 
-    #[clap(
-        long,
-        env = METASRV_METRIC_API_ADDRESS,
-        default_value = "127.0.0.1:28001"
-    )]
+    #[clap(long, env = METASRV_METRIC_API_ADDRESS, default_value = "127.0.0.1:28001")]
     pub metric_api_address: String,
 
     #[clap(long, env = ADMIN_API_ADDRESS, default_value = "127.0.0.1:28002")]
@@ -73,19 +69,11 @@ pub struct Config {
     #[clap(long, env = ADMIN_TLS_SERVER_KEY, default_value = "")]
     pub admin_tls_server_key: String,
 
-    #[clap(
-        long,
-        env = METASRV_FLIGHT_API_ADDRESS,
-        default_value = "127.0.0.1:9191"
-    )]
+    #[clap(long, env = METASRV_FLIGHT_API_ADDRESS, default_value = "127.0.0.1:9191")]
     pub flight_api_address: String,
 
-    #[clap(
-        long,
-        env = FLIGHT_TLS_SERVER_CERT,
-        default_value = "",
-        help = "Certificate for server to identify itself"
-    )]
+    /// Certificate for server to identify itself
+    #[clap(long, env = FLIGHT_TLS_SERVER_CERT, default_value = "")]
     pub flight_tls_server_cert: String,
 
     #[clap(long, env = FLIGHT_TLS_SERVER_KEY, default_value = "")]
@@ -93,6 +81,19 @@ pub struct Config {
 
     #[clap(flatten)]
     pub raft_config: RaftConfig,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            log_level: "INFO".to_string(),
+            log_dir: "./_logs".to_string(),
+            metric_api_address: "127.0.0.1:28001".to_string(),
+            admin_api_address: "127.0.0.1:28002".to_string(),
+            flight_api_address: "127.0.0.1:9191".to_string(),
+            ..Default::default()
+        }
+    }
 }
 
 impl Config {

--- a/metasrv/src/configs/config.rs
+++ b/metasrv/src/configs/config.rs
@@ -90,8 +90,12 @@ impl Default for Config {
             log_dir: "./_logs".to_string(),
             metric_api_address: "127.0.0.1:28001".to_string(),
             admin_api_address: "127.0.0.1:28002".to_string(),
+            admin_tls_server_cert: "".to_string(),
+            admin_tls_server_key: "".to_string(),
             flight_api_address: "127.0.0.1:9191".to_string(),
-            ..Default::default()
+            flight_tls_server_cert: "".to_string(),
+            flight_tls_server_key: "".to_string(),
+            raft_config: Default::default(),
         }
     }
 }

--- a/metasrv/src/configs/config.rs
+++ b/metasrv/src/configs/config.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap::Parser;
 use common_meta_raft_store::config::RaftConfig;
 use lazy_static::lazy_static;
 use serde::Deserialize;
 use serde::Serialize;
-use structopt::StructOpt;
-use structopt_toml::StructOptToml;
 
 lazy_static! {
     pub static ref DATABEND_COMMIT_VERSION: String = {
@@ -49,49 +48,50 @@ pub const METASRV_FLIGHT_API_ADDRESS: &str = "METASRV_FLIGHT_API_ADDRESS";
 pub const FLIGHT_TLS_SERVER_CERT: &str = "FLIGHT_TLS_SERVER_CERT";
 pub const FLIGHT_TLS_SERVER_KEY: &str = "FLIGHT_TLS_SERVER_KEY";
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, StructOpt, StructOptToml)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Parser)]
+#[clap(about, version, author)]
 pub struct Config {
-    #[structopt(long, env = METASRV_LOG_LEVEL, default_value = "INFO")]
+    #[clap(long, env = METASRV_LOG_LEVEL, default_value = "INFO")]
     pub log_level: String,
 
-    #[structopt(long, env = METASRV_LOG_DIR, default_value = "./_logs")]
+    #[clap(long, env = METASRV_LOG_DIR, default_value = "./_logs")]
     pub log_dir: String,
 
-    #[structopt(
-    long,
-    env = METASRV_METRIC_API_ADDRESS,
-    default_value = "127.0.0.1:28001"
+    #[clap(
+        long,
+        env = METASRV_METRIC_API_ADDRESS,
+        default_value = "127.0.0.1:28001"
     )]
     pub metric_api_address: String,
 
-    #[structopt(long, env = ADMIN_API_ADDRESS, default_value = "127.0.0.1:28002")]
+    #[clap(long, env = ADMIN_API_ADDRESS, default_value = "127.0.0.1:28002")]
     pub admin_api_address: String,
 
-    #[structopt(long, env = ADMIN_TLS_SERVER_CERT, default_value = "")]
+    #[clap(long, env = ADMIN_TLS_SERVER_CERT, default_value = "")]
     pub admin_tls_server_cert: String,
 
-    #[structopt(long, env = ADMIN_TLS_SERVER_KEY, default_value = "")]
+    #[clap(long, env = ADMIN_TLS_SERVER_KEY, default_value = "")]
     pub admin_tls_server_key: String,
 
-    #[structopt(
-    long,
-    env = METASRV_FLIGHT_API_ADDRESS,
-    default_value = "127.0.0.1:9191"
+    #[clap(
+        long,
+        env = METASRV_FLIGHT_API_ADDRESS,
+        default_value = "127.0.0.1:9191"
     )]
     pub flight_api_address: String,
 
-    #[structopt(
-    long,
-    env = FLIGHT_TLS_SERVER_CERT,
-    default_value = "",
-    help = "Certificate for server to identify itself"
+    #[clap(
+        long,
+        env = FLIGHT_TLS_SERVER_CERT,
+        default_value = "",
+        help = "Certificate for server to identify itself"
     )]
     pub flight_tls_server_cert: String,
 
-    #[structopt(long, env = FLIGHT_TLS_SERVER_KEY, default_value = "")]
+    #[clap(long, env = FLIGHT_TLS_SERVER_KEY, default_value = "")]
     pub flight_tls_server_key: String,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub raft_config: RaftConfig,
 }
 
@@ -102,7 +102,7 @@ impl Config {
     ///
     /// Thus we need another method to generate an empty default instance.
     pub fn empty() -> Self {
-        <Self as StructOpt>::from_iter(&Vec::<&'static str>::new())
+        <Self as Parser>::parse_from(&Vec::<&'static str>::new())
     }
 
     pub fn tls_rpc_server_enabled(&self) -> bool {

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -68,6 +68,7 @@ cargo-license = "0.4.2"
 cargo_metadata = "0.14.1"
 chrono = "0.4.19"
 chrono-tz = "0.6.1"
+clap = { version = "3.0.0-rc.5", features = ["derive", "env"] }
 crossbeam = "0.8.1"
 crossbeam-queue = "0.3.2"
 ctrlc = { version = "3.2.1", features = ["termination"] }
@@ -92,8 +93,6 @@ serde = { version = "1.0.131", features = ["derive"] }
 serde_json = "1.0.73"
 sha1 = "0.6.0"
 sha2 = "0.10.0"
-structopt = "0.3.25"
-structopt-toml = "0.5.0"
 threadpool = "1.8.1"
 tokio-rustls = "0.23.1"
 tokio-stream = { version = "0.1.8", features = ["net"] }
@@ -101,7 +100,7 @@ toml = "0.5.8"
 tonic = "0.6.2"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 walkdir = "2.3.2"
-parquet-format-async-temp= "0.2.0"
+parquet-format-async-temp = "0.2.0"
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/query/src/bin/databend-benchmark.rs
+++ b/query/src/bin/databend-benchmark.rs
@@ -25,6 +25,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Instant;
 
+use clap::Parser;
 use clickhouse_rs::Pool;
 use common_base::tokio;
 use common_base::RuntimeTracker;
@@ -39,32 +40,31 @@ use futures::future::try_join_all;
 use futures::StreamExt;
 use quantiles::ckms::CKMS;
 use rand::Rng;
-use structopt::StructOpt;
-use structopt_toml::StructOptToml;
+use serde::Deserialize;
 
 /// echo "select avg(number) from numbers(1000000)" |  ./target/debug/databend-benchmark -c 1  -i 10
-#[derive(Clone, Debug, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
-#[serde(default)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Parser)]
+#[clap(about, version, author)]
 pub struct Config {
-    #[structopt(long, default_value = "")]
+    #[clap(long, default_value = "")]
     pub query: String,
 
-    #[structopt(long, short = "h", default_value = "127.0.0.1")]
+    #[clap(long, short = 'h', default_value = "127.0.0.1")]
     pub host: String,
-    #[structopt(long, short = "p", default_value = "9000")]
+    #[clap(long, short = 'p', default_value = "9000")]
     pub port: u32,
-    #[structopt(long, short = "i", default_value = "0")]
+    #[clap(long, short = 'i', default_value = "0")]
     pub iterations: usize,
-    #[structopt(long, short = "c", default_value = "1")]
+    #[clap(long, short = 'c', default_value = "1")]
     pub concurrency: usize,
-    #[structopt(long, default_value = "")]
+    #[clap(long, default_value = "")]
     pub json: String,
 }
 
 impl Config {
     /// Load configs from args.
     pub fn load_from_args() -> Self {
-        Config::from_args()
+        Config::parse()
     }
 }
 

--- a/query/src/configs/config.rs
+++ b/query/src/configs/config.rs
@@ -15,13 +15,14 @@
 use std::fs;
 use std::str::FromStr;
 
+use clap::Parser;
 use common_dal::StorageScheme;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_flight_rpc::FlightClientTlsConfig;
 use lazy_static::lazy_static;
-use structopt::StructOpt;
-use structopt_toml::StructOptToml;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::configs::LogConfig;
 use crate::configs::MetaConfig;
@@ -51,34 +52,33 @@ lazy_static! {
 // Config file.
 const CONFIG_FILE: &str = "CONFIG_FILE";
 
-#[derive(
-    Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
-)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Parser)]
+#[clap(about, version, author)]
 #[serde(default)]
 pub struct Config {
-    #[structopt(long, short = "c", env = CONFIG_FILE, default_value = "")]
+    #[clap(long, short = 'c', env = CONFIG_FILE, default_value = "")]
     pub config_file: String,
 
     // Query engine config.
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub query: QueryConfig,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub log: LogConfig,
 
     // Meta Service config.
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub meta: MetaConfig,
 
     // Storage backend config.
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub storage: StorageConfig,
 }
 
-impl Config {
+impl Default for Config {
     /// Default configs.
-    pub fn default() -> Self {
-        Config {
+    fn default() -> Self {
+        Self {
             config_file: "".to_string(),
             query: QueryConfig::default(),
             log: LogConfig::default(),
@@ -86,10 +86,12 @@ impl Config {
             storage: StorageConfig::default(),
         }
     }
+}
 
+impl Config {
     /// Load configs from args.
     pub fn load_from_args() -> Self {
-        let mut cfg = Config::from_args();
+        let mut cfg = Config::parse();
         if cfg.query.num_cpus == 0 {
             cfg.query.num_cpus = num_cpus::get() as u64;
         }
@@ -105,7 +107,7 @@ impl Config {
 
     /// Load configs from toml str.
     pub fn load_from_toml_str(toml_str: &str) -> Result<Self> {
-        let mut cfg = Config::from_args_with_toml(toml_str)
+        let mut cfg = toml::from_str::<Config>(toml_str)
             .map_err(|e| ErrorCode::BadArguments(format!("{:?}", e)))?;
         if cfg.query.num_cpus == 0 {
             cfg.query.num_cpus = num_cpus::get() as u64;

--- a/query/src/configs/config_log.rs
+++ b/query/src/configs/config_log.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use structopt::StructOpt;
-use structopt_toml::StructOptToml;
+use clap::Args;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::configs::Config;
 
@@ -22,28 +23,29 @@ pub const LOG_LEVEL: &str = "LOG_LEVEL";
 pub const LOG_DIR: &str = "LOG_DIR";
 
 /// Log config group.
-/// serde(default) make the toml de to default working.
-#[derive(
-    Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
-)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Args)]
+#[serde(default)]
+
 pub struct LogConfig {
-    #[structopt(long, env = LOG_LEVEL, default_value = "INFO" , help = "Log level <DEBUG|INFO|ERROR>")]
-    #[serde(default)]
+    /// Log level <DEBUG|INFO|ERROR>
+    #[clap(long, env = LOG_LEVEL, default_value = "INFO")]
     pub log_level: String,
 
-    #[structopt(required = false, long, env = LOG_DIR, default_value = "./_logs", help = "Log file dir")]
-    #[serde(default)]
+    /// Log file dir
+    #[clap(required = false, long, env = LOG_DIR, default_value = "./_logs")]
     pub log_dir: String,
 }
 
-impl LogConfig {
-    pub fn default() -> Self {
-        LogConfig {
+impl Default for LogConfig {
+    fn default() -> Self {
+        Self {
             log_level: "INFO".to_string(),
             log_dir: "./_logs".to_string(),
         }
     }
+}
 
+impl LogConfig {
     pub fn load_from_env(mut_config: &mut Config) {
         env_helper!(mut_config, log, log_level, String, LOG_LEVEL);
         env_helper!(mut_config, log, log_dir, String, LOG_DIR);

--- a/query/src/configs/config_meta.rs
+++ b/query/src/configs/config_meta.rs
@@ -14,11 +14,12 @@
 
 use std::fmt;
 
+use clap::Args;
 use common_flight_rpc::FlightClientConf;
 use common_flight_rpc::FlightClientTlsConfig;
 use common_meta_flight::MetaFlightClientConf;
-use structopt::StructOpt;
-use structopt_toml::StructOptToml;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::configs::Config;
 
@@ -31,55 +32,48 @@ pub const META_RPC_TLS_SERVER_ROOT_CA_CERT: &str = "META_RPC_TLS_SERVER_ROOT_CA_
 pub const META_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "META_RPC_TLS_SERVICE_DOMAIN_NAME";
 
 /// Meta config group.
-/// serde(default) make the toml de to default working.
-#[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Args)]
+#[serde(default)]
 pub struct MetaConfig {
     /// The dir to store persisted meta state for a embedded meta store
-    #[structopt(long, env = META_EMBEDDED_DIR, default_value = "./_meta_embedded")]
-    #[serde(default)]
+    #[clap(long, env = META_EMBEDDED_DIR, default_value = "./_meta_embedded")]
     pub meta_embedded_dir: String,
 
-    #[structopt(long, env = META_ADDRESS, default_value = "", help = "MetaStore backend address")]
-    #[serde(default)]
+    #[clap(long, env = META_ADDRESS, default_value = "", help = "MetaStore backend address")]
     pub meta_address: String,
 
-    #[structopt(long, env = META_USERNAME, default_value = "", help = "MetaStore backend user name")]
-    #[serde(default)]
+    #[clap(long, env = META_USERNAME, default_value = "", help = "MetaStore backend user name")]
     pub meta_username: String,
 
-    #[structopt(long, env = META_PASSWORD, default_value = "", help = "MetaStore backend user password")]
-    #[serde(default)]
+    #[clap(long, env = META_PASSWORD, default_value = "", help = "MetaStore backend user password")]
     pub meta_password: String,
 
-    #[structopt(
+    #[clap(
         long,
         default_value = "10",
         help = "Timeout for each client request, in seconds"
     )]
-    #[serde(default)]
     pub meta_client_timeout_in_second: u64,
 
-    #[structopt(
+    #[clap(
         long,
         env = "META_RPC_TLS_SERVER_ROOT_CA_CERT",
         default_value = "",
         help = "Certificate for client to identify meta rpc server"
     )]
-    #[serde(default)]
     pub rpc_tls_meta_server_root_ca_cert: String,
 
-    #[structopt(
+    #[clap(
         long,
         env = "META_RPC_TLS_SERVICE_DOMAIN_NAME",
         default_value = "localhost"
     )]
-    #[serde(default)]
     pub rpc_tls_meta_service_domain_name: String,
 }
 
-impl MetaConfig {
-    pub fn default() -> Self {
-        MetaConfig {
+impl Default for MetaConfig {
+    fn default() -> Self {
+        Self {
             meta_embedded_dir: "./_meta_embedded".to_string(),
             meta_address: "".to_string(),
             meta_username: "root".to_string(),
@@ -89,7 +83,9 @@ impl MetaConfig {
             rpc_tls_meta_service_domain_name: "localhost".to_string(),
         }
     }
+}
 
+impl MetaConfig {
     pub fn load_from_env(mut_config: &mut Config) {
         env_helper!(mut_config, meta, meta_address, String, META_ADDRESS);
         env_helper!(mut_config, meta, meta_username, String, META_USERNAME);

--- a/query/src/configs/config_query.rs
+++ b/query/src/configs/config_query.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use structopt::StructOpt;
-use structopt_toml::StructOptToml;
+use clap::Args;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::configs::Config;
 
@@ -58,199 +59,117 @@ const QUERY_TABLE_ENGINE_MEMORY_ENABLED: &str = "QUERY_TABLE_ENGINE_MEMORY_ENABL
 const QUERY_TABLE_ENGINE_GITHUB_ENABLED: &str = "QUERY_TABLE_ENGINE_GITHUB_ENABLED";
 
 /// Query config group.
-/// serde(default) make the toml de to default working.
-#[derive(
-    Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
-)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Args)]
+#[serde(default)]
 pub struct QueryConfig {
-    #[structopt(long, env = QUERY_TENANT_ID, default_value = "", help = "Tenant id for get the information from the MetaStore")]
-    #[serde(default)]
+    /// Tenant id for get the information from the MetaStore
+    #[clap(long, env = QUERY_TENANT_ID, default_value = "")]
     pub tenant_id: String,
 
-    #[structopt(long, env = QUERY_CLUSTER_ID, default_value = "", help = "ID for construct the cluster")]
-    #[serde(default)]
+    /// ID for construct the cluster
+    #[clap(long, env = QUERY_CLUSTER_ID, default_value = "")]
     pub cluster_id: String,
 
-    #[structopt(long, env = QUERY_NUM_CPUS, default_value = "0")]
-    #[serde(default)]
+    #[clap(long, env = QUERY_NUM_CPUS, default_value = "0")]
     pub num_cpus: u64,
 
-    #[structopt(
-    long,
-    env = QUERY_MYSQL_HANDLER_HOST,
-    default_value = "127.0.0.1"
-    )]
-    #[serde(default)]
+    #[clap(long, env = QUERY_MYSQL_HANDLER_HOST, default_value = "127.0.0.1")]
     pub mysql_handler_host: String,
 
-    #[structopt(long, env = QUERY_MYSQL_HANDLER_PORT, default_value = "3307")]
-    #[serde(default)]
+    #[clap(long, env = QUERY_MYSQL_HANDLER_PORT, default_value = "3307")]
     pub mysql_handler_port: u16,
 
-    #[structopt(
-    long,
-    env = QUERY_MAX_ACTIVE_SESSIONS,
-    default_value = "256"
-    )]
-    #[serde(default)]
+    #[clap(long, env = QUERY_MAX_ACTIVE_SESSIONS, default_value = "256")]
     pub max_active_sessions: u64,
 
-    #[structopt(
-    long,
-    env = QUERY_CLICKHOUSE_HANDLER_HOST,
-    default_value = "127.0.0.1"
-    )]
-    #[serde(default)]
+    #[clap(long, env = QUERY_CLICKHOUSE_HANDLER_HOST, default_value = "127.0.0.1")]
     pub clickhouse_handler_host: String,
 
-    #[structopt(
-    long,
-    env = QUERY_CLICKHOUSE_HANDLER_PORT,
-    default_value = "9000"
-    )]
-    #[serde(default)]
+    #[clap(long, env = QUERY_CLICKHOUSE_HANDLER_PORT, default_value = "9000")]
     pub clickhouse_handler_port: u16,
 
-    #[structopt(
-    long,
-    env = QUERY_HTTP_HANDLER_HOST,
-    default_value = "127.0.0.1"
-    )]
-    #[serde(default)]
+    #[clap(long, env = QUERY_HTTP_HANDLER_HOST, default_value = "127.0.0.1")]
     pub http_handler_host: String,
 
-    #[structopt(
-    long,
-    env = QUERY_HTTP_HANDLER_PORT,
-    default_value = "8000"
-    )]
-    #[serde(default)]
+    #[clap(long, env = QUERY_HTTP_HANDLER_PORT, default_value = "8000")]
     pub http_handler_port: u16,
 
-    #[structopt(
-    long,
-    env = QUERY_FLIGHT_API_ADDRESS,
-    default_value = "127.0.0.1:9090"
-    )]
-    #[serde(default)]
+    #[clap(long, env = QUERY_FLIGHT_API_ADDRESS, default_value = "127.0.0.1:9090")]
     pub flight_api_address: String,
 
-    #[structopt(
-    long,
-    env = QUERY_HTTP_API_ADDRESS,
-    default_value = "127.0.0.1:8080"
-    )]
-    #[serde(default)]
+    #[clap(long, env = QUERY_HTTP_API_ADDRESS, default_value = "127.0.0.1:8080")]
     pub http_api_address: String,
 
-    #[structopt(
-    long,
-    env = QUERY_METRICS_API_ADDRESS,
-    default_value = "127.0.0.1:7070"
-    )]
-    #[serde(default)]
+    #[clap(long,env = QUERY_METRICS_API_ADDRESS, default_value = "127.0.0.1:7070")]
     pub metric_api_address: String,
 
-    #[structopt(long, env = QUERY_HTTP_HANDLER_TLS_SERVER_CERT, default_value = "")]
-    #[serde(default)]
+    #[clap(long, env = QUERY_HTTP_HANDLER_TLS_SERVER_CERT, default_value = "")]
     pub http_handler_tls_server_cert: String,
 
-    #[structopt(long, env = QUERY_HTTP_HANDLER_TLS_SERVER_KEY, default_value = "")]
-    #[serde(default)]
+    #[clap(long, env = QUERY_HTTP_HANDLER_TLS_SERVER_KEY, default_value = "")]
     pub http_handler_tls_server_key: String,
 
-    #[structopt(long, env = QUERY_HTTP_HANDLER_TLS_SERVER_ROOT_CA_CERT, default_value = "")]
-    #[serde(default)]
+    #[clap(long, env = QUERY_HTTP_HANDLER_TLS_SERVER_ROOT_CA_CERT, default_value = "")]
     pub http_handler_tls_server_root_ca_cert: String,
 
-    #[structopt(long, env = QUERY_API_TLS_SERVER_CERT, default_value = "")]
-    #[serde(default)]
+    #[clap(long, env = QUERY_API_TLS_SERVER_CERT, default_value = "")]
     pub api_tls_server_cert: String,
 
-    #[structopt(long, env = QUERY_API_TLS_SERVER_KEY, default_value = "")]
-    #[serde(default)]
+    #[clap(long, env = QUERY_API_TLS_SERVER_KEY, default_value = "")]
     pub api_tls_server_key: String,
 
-    #[structopt(long, env = QUERY_API_TLS_SERVER_ROOT_CA_CERT, default_value = "")]
-    #[serde(default)]
+    #[clap(long, env = QUERY_API_TLS_SERVER_ROOT_CA_CERT, default_value = "")]
     pub api_tls_server_root_ca_cert: String,
 
-    #[structopt(
-        long,
-        env = "QUERY_RPC_TLS_SERVER_CERT",
-        default_value = "",
-        help = "rpc server cert"
-    )]
-    #[serde(default)]
+    /// rpc server cert
+    #[clap(long, env = "QUERY_RPC_TLS_SERVER_CERT", default_value = "")]
     pub rpc_tls_server_cert: String,
 
-    #[structopt(
-        long,
-        env = "QUERY_RPC_TLS_SERVER_KEY",
-        default_value = "key for rpc server cert"
-    )]
-    #[serde(default)]
+    /// key for rpc server cert
+    #[clap(long, env = "QUERY_RPC_TLS_SERVER_KEY", default_value = "")]
     pub rpc_tls_server_key: String,
 
-    #[structopt(
-        long,
-        env = "QUERY_RPC_TLS_SERVER_ROOT_CA_CERT",
-        default_value = "",
-        help = "Certificate for client to identify query rpc server"
-    )]
-    #[serde(default)]
+    /// Certificate for client to identify query rpc server
+    #[clap(long, env = "QUERY_RPC_TLS_SERVER_ROOT_CA_CERT", default_value = "")]
     pub rpc_tls_query_server_root_ca_cert: String,
 
-    #[structopt(
+    #[clap(
         long,
         env = "QUERY_RPC_TLS_SERVICE_DOMAIN_NAME",
         default_value = "localhost"
     )]
-    #[serde(default)]
     pub rpc_tls_query_service_domain_name: String,
 
-    #[structopt(long, env = QUERY_TABLE_ENGINE_CSV_ENABLED, help = "Table engine csv enabled")]
-    #[serde(default)]
+    /// Table engine csv enabled
+    #[clap(long, env = QUERY_TABLE_ENGINE_CSV_ENABLED)]
     pub table_engine_csv_enabled: bool,
 
-    #[structopt(long, env = QUERY_TABLE_ENGINE_PARQUET_ENABLED, help = "Table engine parquet enabled")]
-    #[serde(default)]
+    /// Table engine parquet enabled
+    #[clap(long, env = QUERY_TABLE_ENGINE_PARQUET_ENABLED)]
     pub table_engine_parquet_enabled: bool,
 
-    #[structopt(
+    /// Table engine memory enabled
+    #[clap(
         long,
         env = QUERY_TABLE_ENGINE_MEMORY_ENABLED,
         parse(try_from_str),
         default_value = "true",
-        help = "Table engine memory enabled"
     )]
-    #[serde(default)]
     pub table_engine_memory_enabled: bool,
 
-    #[structopt(
+    /// Table engine github enabled
+    #[clap(
         long,
         env = QUERY_TABLE_ENGINE_GITHUB_ENABLED,
         parse(try_from_str),
         default_value = "true",
-        help = "Table engine github enabled"
     )]
-    #[serde(default)]
     pub table_engine_github_enabled: bool,
 
-    #[structopt(
-    long,
-    env = QUERY_WAIT_TIMEOUT_MILLS,
-    default_value = "5000"
-    )]
-    #[serde(default)]
+    #[clap(long, env = QUERY_WAIT_TIMEOUT_MILLS, default_value = "5000")]
     pub wait_timeout_mills: u64,
 
-    #[structopt(
-    long,
-    env = QUERY_MAX_QUERY_LOG_SIZE,
-    default_value = "10000"
-    )]
-    #[serde(default)]
+    #[clap(long, env = QUERY_MAX_QUERY_LOG_SIZE, default_value = "10000")]
     pub max_query_log_size: usize,
 
     #[structopt(
@@ -291,9 +210,9 @@ pub struct QueryConfig {
     pub table_disk_cache_mb_size: u64,
 }
 
-impl QueryConfig {
-    pub fn default() -> Self {
-        QueryConfig {
+impl Default for QueryConfig {
+    fn default() -> Self {
+        Self {
             tenant_id: "".to_string(),
             cluster_id: "".to_string(),
             num_cpus: 8,
@@ -329,7 +248,9 @@ impl QueryConfig {
             table_disk_cache_mb_size: 1024,
         }
     }
+}
 
+impl QueryConfig {
     pub fn load_from_env(mut_config: &mut Config) {
         env_helper!(mut_config, query, tenant_id, String, QUERY_TENANT_ID);
         env_helper!(mut_config, query, cluster_id, String, QUERY_CLUSTER_ID);

--- a/query/src/configs/config_query.rs
+++ b/query/src/configs/config_query.rs
@@ -172,41 +172,20 @@ pub struct QueryConfig {
     #[clap(long, env = QUERY_MAX_QUERY_LOG_SIZE, default_value = "10000")]
     pub max_query_log_size: usize,
 
-    #[structopt(
-        long,
-        env = QUERY_TABLE_CACHE_ENABLED,
-        parse(try_from_str),
-        default_value = "false",
-        help = "Table Cached enabled"
-    )]
-    #[serde(default)]
+    /// Table Cached enabled
+    #[clap(long, env = QUERY_TABLE_CACHE_ENABLED)]
     pub table_cache_enabled: bool,
 
-    #[structopt(
-        long,
-        env = QUERY_TABLE_MEMORY_CACHE_MB_SIZE,
-        default_value = "256",
-        help = "Table memory cache size (mb)"
-        )]
-    #[serde(default)]
+    /// Table memory cache size (mb)
+    #[clap(long, env = QUERY_TABLE_MEMORY_CACHE_MB_SIZE, default_value = "256")]
     pub table_memory_cache_mb_size: u64,
 
-    #[structopt(
-        long,
-        env = QUERY_TABLE_DISK_CACHE_ROOT,
-        default_value = "_cache",
-        help = "Table disk cache folder root"
-    )]
-    #[serde(default)]
+    /// Table disk cache folder root
+    #[clap(long, env = QUERY_TABLE_DISK_CACHE_ROOT, default_value = "_cache")]
     pub table_disk_cache_root: String,
 
-    #[structopt(
-        long,
-        env = QUERY_TABLE_DISK_CACHE_MB_SIZE,
-        default_value = "1024",
-        help = "Table disk cache size (mb)"
-        )]
-    #[serde(default)]
+    /// Table disk cache size (mb)
+    #[clap(long, env = QUERY_TABLE_DISK_CACHE_MB_SIZE, default_value = "1024")]
     pub table_disk_cache_mb_size: u64,
 }
 

--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -15,8 +15,9 @@
 use std::fmt;
 use std::str::FromStr;
 
-use structopt::StructOpt;
-use structopt_toml::StructOptToml;
+use clap::Args;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::configs::Config;
 
@@ -40,7 +41,7 @@ const AZURE_STORAGE_ACCOUNT: &str = "AZURE_STORAGE_ACCOUNT";
 const AZURE_BLOB_MASTER_KEY: &str = "AZURE_BLOB_MASTER_KEY";
 const AZURE_BLOB_CONTAINER: &str = "AZURE_BLOB_CONTAINER";
 
-#[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub enum StorageType {
     Disk,
     S3,
@@ -61,57 +62,58 @@ impl FromStr for StorageType {
     }
 }
 
-#[derive(
-    Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
-)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Args)]
+#[serde(default)]
 pub struct DiskStorageConfig {
-    #[structopt(long, env = DISK_STORAGE_DATA_PATH, default_value = "_data", help = "Disk storage backend data path")]
-    #[serde(default)]
+    /// Disk storage backend data path
+    #[clap(long, env = DISK_STORAGE_DATA_PATH, default_value = "_data")]
     pub data_path: String,
-    #[structopt(long, env = DISK_STORAGE_TEMP_DATA_PATH, default_value = "", help = "Disk storage temporary data path for external data")]
-    #[serde(default)]
+
+    /// Disk storage temporary data path for external data
+    #[clap(long, env = DISK_STORAGE_TEMP_DATA_PATH, default_value = "")]
     pub temp_data_path: String,
 }
 
-impl DiskStorageConfig {
-    pub fn default() -> Self {
-        DiskStorageConfig {
+impl Default for DiskStorageConfig {
+    fn default() -> Self {
+        Self {
             data_path: "_data".to_string(),
             temp_data_path: "".to_string(),
         }
     }
 }
 
-#[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Args)]
+#[serde(default)]
 pub struct S3StorageConfig {
-    #[structopt(long, env = S3_STORAGE_REGION, default_value = "", help = "Region for S3 storage")]
-    #[serde(default)]
+    /// Region for S3 storage
+    #[clap(long, env = S3_STORAGE_REGION, default_value = "")]
     pub region: String,
 
-    #[structopt(long, env = S3_STORAGE_ENDPOINT_URL, default_value = "", help = "Endpoint URL for S3 storage")]
-    #[serde(default)]
+    /// Endpoint URL for S3 storage
+    #[clap(long, env = S3_STORAGE_ENDPOINT_URL, default_value = "")]
     pub endpoint_url: String,
 
-    #[structopt(long, env = S3_STORAGE_ACCESS_KEY_ID, default_value = "", help = "Access key for S3 storage")]
-    #[serde(default)]
+    // Access key for S3 storage
+    #[clap(long, env = S3_STORAGE_ACCESS_KEY_ID, default_value = "")]
     pub access_key_id: String,
 
-    #[structopt(long, env = S3_STORAGE_SECRET_ACCESS_KEY, default_value = "", help = "Secret key for S3 storage")]
-    #[serde(default)]
+    /// Secret key for S3 storage
+    #[clap(long, env = S3_STORAGE_SECRET_ACCESS_KEY, default_value = "")]
     pub secret_access_key: String,
 
-    #[structopt(long, env = S3_STORAGE_ENABLE_POD_IAM_POLICY, help = "Use iam role service account token to access S3 resource")]
-    #[serde(default)]
+    /// Use iam role service account token to access S3 resource
+    #[clap(long, env = S3_STORAGE_ENABLE_POD_IAM_POLICY)]
     pub enable_pod_iam_policy: bool,
 
-    #[structopt(long, env = S3_STORAGE_BUCKET, default_value = "", help = "S3 Bucket to use for storage")]
-    #[serde(default)]
+    /// S3 Bucket to use for storage
+    #[clap(long, env = S3_STORAGE_BUCKET, default_value = "")]
     pub bucket: String,
 }
 
-impl S3StorageConfig {
-    pub fn default() -> Self {
-        S3StorageConfig {
+impl Default for S3StorageConfig {
+    fn default() -> Self {
+        Self {
             region: "".to_string(),
             endpoint_url: "".to_string(),
             access_key_id: "".to_string(),
@@ -132,24 +134,25 @@ impl fmt::Debug for S3StorageConfig {
     }
 }
 
-#[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Args)]
+#[serde(default)]
 pub struct AzureStorageBlobConfig {
-    #[structopt(long, env = AZURE_STORAGE_ACCOUNT, default_value = "", help = "Account for Azure storage")]
-    #[serde(default)]
+    /// Account for Azure storage
+    #[clap(long, env = AZURE_STORAGE_ACCOUNT, default_value = "")]
     pub account: String,
 
-    #[structopt(long, env = AZURE_BLOB_MASTER_KEY, default_value = "", help = "Master key for Azure storage")]
-    #[serde(default)]
+    /// Master key for Azure storage
+    #[clap(long, env = AZURE_BLOB_MASTER_KEY, default_value = "")]
     pub master_key: String,
 
-    #[structopt(long, env = AZURE_BLOB_CONTAINER, default_value = "", help = "Container for Azure storage")]
-    #[serde(default)]
+    /// Container for Azure storage
+    #[clap(long, env = AZURE_BLOB_CONTAINER, default_value = "")]
     pub container: String,
 }
 
-impl AzureStorageBlobConfig {
-    pub fn default() -> Self {
-        AzureStorageBlobConfig {
+impl Default for AzureStorageBlobConfig {
+    fn default() -> Self {
+        Self {
             account: "".to_string(),
             master_key: "".to_string(),
             container: "".to_string(),
@@ -166,38 +169,39 @@ impl fmt::Debug for AzureStorageBlobConfig {
 }
 
 /// Storage config group.
-/// serde(default) make the toml de to default working.
-#[derive(
-    Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, StructOpt, StructOptToml,
-)]
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Args)]
+#[serde(default)]
 pub struct StorageConfig {
-    #[structopt(long, env = STORAGE_TYPE, default_value = "disk", help = "Current storage type: disk|s3")]
-    #[serde(default)]
+    /// Current storage type: disk|s3
+    #[clap(long, env = STORAGE_TYPE, default_value = "disk")]
     pub storage_type: String,
 
     // Disk storage backend config.
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub disk: DiskStorageConfig,
 
     // S3 storage backend config.
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub s3: S3StorageConfig,
 
     // azure storage blob config.
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub azure_storage_blob: AzureStorageBlobConfig,
 }
 
-impl StorageConfig {
-    pub fn default() -> Self {
-        StorageConfig {
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
             storage_type: "disk".to_string(),
             disk: DiskStorageConfig::default(),
             s3: S3StorageConfig::default(),
             azure_storage_blob: AzureStorageBlobConfig::default(),
         }
     }
+}
 
+impl StorageConfig {
     pub fn load_from_env(mut_config: &mut Config) {
         env_helper!(mut_config, storage, storage_type, String, STORAGE_TYPE);
 

--- a/scripts/deploy/databend-query-cluster-3-nodes.sh
+++ b/scripts/deploy/databend-query-cluster-3-nodes.sh
@@ -34,7 +34,7 @@ if [ "$mode" == "boot" ]; then
 	echo 'Start Meta service HA cluster(3 nodes)...'
 
 	nohup ./target/debug/databend-meta \
-		--single true \
+		--single \
 		--id 1 \
 		--raft-dir "./_meta1" \
 		--metric-api-address 0.0.0.0:28100 \

--- a/scripts/deploy/databend-query-standalone.sh
+++ b/scripts/deploy/databend-query-standalone.sh
@@ -19,7 +19,7 @@ done
 BIN=${1:-debug}
 
 echo 'Start DatabendStore...'
-nohup target/${BIN}/databend-meta --single=true --log-level=ERROR &
+nohup target/${BIN}/databend-meta --single --log-level=ERROR &
 echo "Waiting on databend-meta 10 seconds..."
 python scripts/ci/wait_tcp.py --timeout 5 --port 9191
 


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

use clap 3 to unify the cli arguments parsing

## Changelog

- Improvement

## Related Issues

Close #3504 

## Test Plan

Unit Tests

Stateless Tests