### PR TITLE
Fix: missing field `created_on` in initializer of `common_meta_types::TableMeta`

### DIFF
--- a/query/src/storages/fuse/table_functions/fuse_history_truncate.rs
+++ b/query/src/storages/fuse/table_functions/fuse_history_truncate.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use common_dal::DataAccessor;
 use common_datablocks::DataBlock;
+use common_datavalues::chrono::Utc;
 use common_datavalues::prelude::Series;
 use common_datavalues::prelude::SeriesFrom;
 use common_datavalues::DataField;
@@ -80,6 +81,7 @@ impl FuseTruncateHistory {
                 schema,
                 engine,
                 options: Default::default(),
+                created_on: Utc::now(),
             },
         };
         Arc::new(FuseTruncateHistory {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR

## Changelog


- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

