### PR TITLE
improve `#[serde(default)]` attr usage for some types

### DIFF
--- a/common/meta/types/src/cluster.rs
+++ b/common/meta/types/src/cluster.rs
@@ -44,17 +44,12 @@ impl fmt::Display for Node {
 }
 
 /// Query node
-#[derive(
-    serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Default,
-)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Default)]
+#[serde(default)]
 pub struct NodeInfo {
-    #[serde(default)]
     pub id: String,
-    #[serde(default)]
     pub cpu_nums: u64,
-    #[serde(default)]
     pub version: u32,
-    #[serde(default)]
     pub flight_address: String,
 }
 

--- a/common/meta/types/src/user_info.rs
+++ b/common/meta/types/src/user_info.rs
@@ -17,29 +17,26 @@ use std::convert::TryFrom;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::user_grant::UserGrantSet;
 use crate::PasswordType;
 use crate::UserQuota;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+#[serde(default)]
 pub struct UserInfo {
-    #[serde(default)]
     pub name: String,
 
-    #[serde(default)]
     pub hostname: String,
 
-    #[serde(default)]
     pub password: Vec<u8>,
 
-    #[serde(default)]
     pub password_type: PasswordType,
 
-    #[serde(default)]
     pub grants: UserGrantSet,
 
-    #[serde(default)]
     pub quota: UserQuota,
 }
 

--- a/common/meta/types/src/user_quota.rs
+++ b/common/meta/types/src/user_quota.rs
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[serde(default)]
 pub struct UserQuota {
     // The max cpu can be used (0 is no limited).
-    #[serde(default)]
     pub max_cpu: u64,
 
     // The max memory(bytes) can be used(0 is no limited).
-    #[serde(default)]
     pub max_memory_in_bytes: u64,
 
     // The max storage(bytes) can be used(0 is no limited).
-    #[serde(default)]
     pub max_storage_in_bytes: u64,
 }
 

--- a/common/meta/types/src/user_stage.rs
+++ b/common/meta/types/src/user_stage.rs
@@ -26,25 +26,20 @@ pub struct StageParams {
 #[derive(serde::Serialize, serde::Deserialize, Default, Clone, Debug, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "lowercase")]
+#[serde(default)]
 pub struct Credentials {
-    #[serde(default)]
     pub access_key_id: String,
-    #[serde(default)]
     pub secret_access_key: String,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct FileFormat {
-    #[serde(default)]
     pub format: Format,
-    #[serde(default = "default_record_delimiter")]
     pub record_delimiter: String,
-    #[serde(default = "default_field_delimiter")]
     pub field_delimiter: String,
-    #[serde(default = "default_csv_header")]
     pub csv_header: bool,
-    #[serde(default)]
     pub compression: Compression,
 }
 
@@ -157,8 +152,8 @@ impl StageParams {
 }
 /// Stage for data stage location.
 #[derive(serde::Serialize, serde::Deserialize, Default, Clone, Debug, Eq, PartialEq)]
+#[serde(default)]
 pub struct UserStageInfo {
-    #[serde(default)]
     pub stage_name: String,
 
     pub stage_params: StageParams,

--- a/common/meta/types/tests/it/user_info.rs
+++ b/common/meta/types/tests/it/user_info.rs
@@ -20,17 +20,13 @@ use common_meta_types::UserInfo;
 fn test_user_info() -> Result<()> {
     // This test will introduce a older UserInfo struct and a new UserInfo struct.
     // And check the serialize(old_userinfo) can be deserialized by the new UserInfo.
-    #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
+    #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+    #[serde(default)]
+
     pub struct OldUserInfo {
-        #[serde(default)]
         pub name: String,
-        #[serde(default)]
         pub hostname: String,
-
-        #[serde(default)]
         pub password: Vec<u8>,
-
-        #[serde(default)]
         pub password_type: PasswordType,
     }
 


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

improve `#[serde(default)]` attr usage for some types

## Changelog

- Improvement

## Related Issues

## Test Plan

Unit Tests

Stateless Tests

