### PR TITLE
[pprof] make pprof work again

### DIFF
--- a/metasrv/src/api/http/debug/pprof.rs
+++ b/metasrv/src/api/http/debug/pprof.rs
@@ -48,10 +48,7 @@ pub async fn debug_pprof_handler(
             Profiling::create(duration, i32::from(PProfRequest::default_frequency()))
         }
     };
-    let body = profile
-        .dump_flamegraph()
-        .await
-        .map_err(InternalServerError)?;
+    let body = profile.dump_proto().await.map_err(InternalServerError)?;
 
     tracing::info!("finished pprof request");
     Ok(body)

--- a/query/src/api/http/debug/pprof.rs
+++ b/query/src/api/http/debug/pprof.rs
@@ -48,10 +48,7 @@ pub async fn debug_pprof_handler(
             Profiling::create(duration, i32::from(PProfRequest::default_frequency()))
         }
     };
-    let body = profile
-        .dump_flamegraph()
-        .await
-        .map_err(InternalServerError)?;
+    let body = profile.dump_proto().await.map_err(InternalServerError)?;
 
     tracing::info!("finished pprof request");
     Ok(body)

--- a/website/databend/docs/dev/building/profiling.md
+++ b/website/databend/docs/dev/building/profiling.md
@@ -2,12 +2,6 @@
 title: How to profile Databend
 ---
 
-## flame graph
-
-Open `http://localhost:8080/debug/pprof/profile?seconds=5` in browser, Databend debug api will response the svg of the flame graph to the client.
-
-![](images/profiling-flamegraph.png)
-
 ## go pprof tool
 
 `go tool pprof http://localhost:8080/debug/pprof/profile?seconds=20`


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

- make pprof work again
- remove browser flamegraph in doc

## Changelog

- Bug Fix
- Documentation
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2941 

## Test Plan

Unit Tests

Stateless Tests

