### PR TITLE
Improve constant filter

### DIFF
--- a/common/datablocks/src/kernels/data_block_filter.rs
+++ b/common/datablocks/src/kernels/data_block_filter.rs
@@ -14,10 +14,10 @@
 
 use common_arrow::arrow::array::ArrayRef;
 use common_arrow::arrow::compute::filter::build_filter;
-use common_datavalues::DataValue;
 use common_datavalues::columns::DataColumn;
 use common_datavalues::prelude::IntoSeries;
 use common_datavalues::DataType;
+use common_datavalues::DataValue;
 use common_exception::ErrorCode;
 use common_exception::Result;
 

--- a/common/datablocks/tests/it/kernels/data_block_filter.rs
+++ b/common/datablocks/tests/it/kernels/data_block_filter.rs
@@ -34,8 +34,8 @@ fn test_filter_non_const_data_block() -> Result<()> {
         Series::new(vec!["x1", "x1", "x2", "x1", "x2", "x3"]),
     ]);
 
-    let predicate = Series::new(vec![true, false, true, true, false, false]);
-    let block = DataBlock::filter_block(&block, predicate)?;
+    let predicate = Series::new(vec![true, false, true, true, false, false]).into();
+    let block = DataBlock::filter_block(&block, &predicate)?;
 
     common_datablocks::assert_blocks_eq(
         vec![
@@ -65,8 +65,8 @@ fn test_filter_all_false_data_block() -> Result<()> {
         Series::new(vec!["x1", "x1", "x2", "x1", "x2", "x3"]),
     ]);
 
-    let predicate = Series::new(vec![false, false, false, false, false, false]);
-    let block = DataBlock::filter_block(&block, predicate)?;
+    let predicate = Series::new(vec![false, false, false, false, false, false]).into();
+    let block = DataBlock::filter_block(&block, &predicate)?;
 
     common_datablocks::assert_blocks_eq(
         vec!["+---+---+", "| a | b |", "+---+---+", "+---+---+"],
@@ -88,8 +88,8 @@ fn test_filter_const_data_block() -> Result<()> {
         DataColumn::Constant(DataValue::String(Some(vec![b'x', b'1'])), 6),
     ]);
 
-    let predicate = Series::new(vec![true, false, true, true, false, false]);
-    let block = DataBlock::filter_block(&block, predicate)?;
+    let predicate = Series::new(vec![true, false, true, true, false, false]).into();
+    let block = DataBlock::filter_block(&block, &predicate)?;
 
     common_datablocks::assert_blocks_eq(
         vec![
@@ -119,8 +119,8 @@ fn test_filter_all_const_data_block() -> Result<()> {
         DataColumn::Constant(DataValue::String(Some(vec![b'x', b'1'])), 6),
     ]);
 
-    let predicate = Series::new(vec![true, false, true, true, false, false]);
-    let block = DataBlock::filter_block(&block, predicate)?;
+    let predicate = Series::new(vec![true, false, true, true, false, false]).into();
+    let block = DataBlock::filter_block(&block, &predicate)?;
 
     common_datablocks::assert_blocks_eq(
         vec![

--- a/query/src/pipelines/transforms/transform_filter.rs
+++ b/query/src/pipelines/transforms/transform_filter.rs
@@ -66,8 +66,7 @@ impl<const HAVING: bool> FilterTransform<HAVING> {
 
     fn filter(executor: Arc<ExpressionExecutor>, data: DataBlock) -> Result<DataBlock> {
         let filter_block = executor.execute(&data)?;
-        let filter_array = filter_block.column(0).to_array()?;
-        DataBlock::filter_block(&data, filter_array)
+        DataBlock::filter_block(&data, filter_block.column(0))
     }
 
     fn filter_map(executor: ExpressionExecutorRef, data: DataBlock) -> Option<Result<DataBlock>> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR



Before:
```
:) SELECT sum(  number  )  FROM numbers_mt(1000000000)  where true;
+--------------------+
| sum(number)        |
+--------------------+
| 499999999500000000 |
+--------------------+
1 row in set (0.18 sec)
Read 1000000000 rows, 8 GB in 0.171 sec., 5.84 billion rows/sec., 46.69 GB/sec.
```

After:
```

:) SELECT sum(  number  )  FROM numbers_mt(1000000000) where true  ;
+--------------------+
| sum(number)        |
+--------------------+
| 499999999500000000 |
+--------------------+
1 row in set (0.07 sec)
Read 1000000000 rows, 8 GB in 0.070 sec., 14.2 billion rows/sec., 113.57 GB/sec.


```

## Changelog

- Improvement
- Performance Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

