### PR TITLE
Support engine options and refactor github engine

### DIFF
--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -22,6 +22,7 @@ use common_exception::ErrorCode;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::CreateDatabaseReq;
 use common_meta_types::CreateTableReq;
+use common_meta_types::DatabaseMeta;
 use common_meta_types::DropDatabaseReq;
 use common_meta_types::DropTableReq;
 use common_meta_types::GetDatabaseReq;
@@ -50,8 +51,10 @@ impl MetaApiTestSuite {
             let req = CreateDatabaseReq {
                 if_not_exists: false,
                 db: "db1".to_string(),
-                engine: "github".to_string(),
-                options: Default::default(),
+                meta: DatabaseMeta {
+                    engine: "github".to_string(),
+                    ..Default::default()
+                },
             };
 
             let res = mt.create_database(req).await;
@@ -65,8 +68,10 @@ impl MetaApiTestSuite {
             let req = CreateDatabaseReq {
                 if_not_exists: false,
                 db: "db1".to_string(),
-                engine: "".to_string(),
-                options: Default::default(),
+                meta: DatabaseMeta {
+                    engine: "".to_string(),
+                    ..Default::default()
+                },
             };
 
             let res = mt.create_database(req).await;
@@ -80,8 +85,10 @@ impl MetaApiTestSuite {
             let req = CreateDatabaseReq {
                 if_not_exists: false,
                 db: "db1".to_string(),
-                engine: "".to_string(),
-                options: Default::default(),
+                meta: DatabaseMeta {
+                    engine: "".to_string(),
+                    ..DatabaseMeta::default()
+                },
             };
 
             let res = mt.create_database(req).await;
@@ -104,8 +111,10 @@ impl MetaApiTestSuite {
             let req = CreateDatabaseReq {
                 if_not_exists: false,
                 db: "db2".to_string(),
-                engine: "".to_string(),
-                options: Default::default(),
+                meta: DatabaseMeta {
+                    engine: "".to_string(),
+                    ..DatabaseMeta::default()
+                },
             };
 
             let res = mt.create_database(req).await;
@@ -191,8 +200,10 @@ impl MetaApiTestSuite {
             let plan = CreateDatabaseReq {
                 if_not_exists: false,
                 db: db_name.to_string(),
-                engine: "".to_string(),
-                options: Default::default(),
+                meta: DatabaseMeta {
+                    engine: "".to_string(),
+                    ..DatabaseMeta::default()
+                },
             };
 
             let res = mt.create_database(plan).await?;
@@ -223,6 +234,7 @@ impl MetaApiTestSuite {
                     engine: "JSON".to_string(),
                     options: options.clone(),
                     created_on,
+                    ..TableMeta::default()
                 },
             };
 
@@ -241,6 +253,7 @@ impl MetaApiTestSuite {
                         engine: "JSON".to_owned(),
                         options: options.clone(),
                         created_on,
+                        ..Default::default()
                     },
                 };
                 assert_eq!(want, got.as_ref().clone(), "get created table");
@@ -262,6 +275,7 @@ impl MetaApiTestSuite {
                         engine: "JSON".to_owned(),
                         options: options.clone(),
                         created_on,
+                        ..Default::default()
                     },
                 };
                 assert_eq!(want, got.as_ref().clone(), "get created table");
@@ -292,6 +306,7 @@ impl MetaApiTestSuite {
                         engine: "JSON".to_owned(),
                         options: options.clone(),
                         created_on,
+                        ..Default::default()
                     },
                 };
                 assert_eq!(want, got.as_ref().clone(), "get old table");
@@ -451,8 +466,10 @@ impl MetaApiTestSuite {
         let req = CreateDatabaseReq {
             if_not_exists: false,
             db: db_name.to_string(),
-            engine: "".to_string(),
-            options: Default::default(),
+            meta: DatabaseMeta {
+                engine: "".to_string(),
+                ..Default::default()
+            },
         };
 
         let res = mt.create_database(req).await?;
@@ -475,8 +492,10 @@ impl MetaApiTestSuite {
             let req = CreateDatabaseReq {
                 if_not_exists: false,
                 db: "db1".to_string(),
-                engine: "github".to_string(),
-                options: Default::default(),
+                meta: DatabaseMeta {
+                    engine: "github".to_string(),
+                    ..Default::default()
+                },
             };
 
             let res = node_a.create_database(req).await;
@@ -522,8 +541,10 @@ impl MetaApiTestSuite {
                 let req = CreateDatabaseReq {
                     if_not_exists: false,
                     db: db_name.to_string(),
-                    engine: "github".to_string(),
-                    options: Default::default(),
+                    meta: DatabaseMeta {
+                        engine: "github".to_string(),
+                        ..Default::default()
+                    },
                 };
                 let res = node_a.create_database(req).await;
                 tracing::info!("create database res: {:?}", res);
@@ -558,8 +579,10 @@ impl MetaApiTestSuite {
             let req = CreateDatabaseReq {
                 if_not_exists: false,
                 db: db_name.to_string(),
-                engine: "github".to_string(),
-                options: Default::default(),
+                meta: DatabaseMeta {
+                    engine: "github".to_string(),
+                    ..Default::default()
+                },
             };
             let res = node_a.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
@@ -618,8 +641,10 @@ impl MetaApiTestSuite {
             let req = CreateDatabaseReq {
                 if_not_exists: false,
                 db: db_name.to_string(),
-                engine: "github".to_string(),
-                options: Default::default(),
+                meta: DatabaseMeta {
+                    engine: "github".to_string(),
+                    ..Default::default()
+                },
             };
             let res = node_a.create_database(req).await;
             tracing::info!("create database res: {:?}", res);

--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -348,10 +348,7 @@ impl StateMachine {
                 }
             }
 
-            Cmd::CreateDatabase {
-                ref name,
-                ref engine,
-            } => {
+            Cmd::CreateDatabase { ref name, ref meta } => {
                 let db_id = self.txn_incr_seq(SEQ_DATABASE_ID, txn_tree).map_err(|e| {
                     let e: ConflictableTransactionError<Infallible> = e.into();
                     ErrorCode::from(e)
@@ -403,9 +400,7 @@ impl StateMachine {
                         &dbs,
                         &db_id,
                         &MatchSeq::Exact(0),
-                        Operation::Update(DatabaseMeta {
-                            engine: engine.clone(),
-                        }),
+                        Operation::Update(meta.clone()),
                         None,
                     )
                     .map_err(|e| {

--- a/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
+++ b/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
@@ -52,7 +52,7 @@ impl MetaApi for StateMachine {
     ) -> Result<CreateDatabaseReply, ErrorCode> {
         let cmd = Cmd::CreateDatabase {
             name: req.db.clone(),
-            engine: req.engine.clone(),
+            meta: req.meta.clone(),
         };
 
         let res = self.sm_tree.txn(true, |t| {

--- a/common/meta/raft-store/tests/it/state_machine/mod.rs
+++ b/common/meta/raft-store/tests/it/state_machine/mod.rs
@@ -161,7 +161,10 @@ async fn test_state_machine_apply_add_database() -> anyhow::Result<()> {
             Ok(m.apply_cmd(
                 &Cmd::CreateDatabase {
                     name: c.name.to_string(),
-                    engine: c.engine.to_string(),
+                    meta: DatabaseMeta {
+                        engine: c.engine.to_string(),
+                        ..Default::default()
+                    },
                 },
                 &t,
             )
@@ -200,7 +203,10 @@ async fn test_state_machine_apply_upsert_table_option() -> anyhow::Result<()> {
         Ok(m.apply_cmd(
             &Cmd::CreateDatabase {
                 name: "db1".to_string(),
-                engine: "default".to_string(),
+                meta: DatabaseMeta {
+                    engine: "defeault".to_string(),
+                    ..Default::default()
+                },
             },
             &t,
         )

--- a/common/meta/types/src/cmd.rs
+++ b/common/meta/types/src/cmd.rs
@@ -18,6 +18,7 @@ use async_raft::NodeId;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::DatabaseMeta;
 use crate::KVMeta;
 use crate::MatchSeq;
 use crate::Node;
@@ -37,7 +38,7 @@ pub enum Cmd {
     AddNode { node_id: NodeId, node: Node },
 
     /// Add a database if absent
-    CreateDatabase { name: String, engine: String },
+    CreateDatabase { name: String, meta: DatabaseMeta },
 
     /// Drop a database if absent
     DropDatabase { name: String },
@@ -88,8 +89,8 @@ impl fmt::Display for Cmd {
             Cmd::AddNode { node_id, node } => {
                 write!(f, "add_node:{}={}", node_id, node)
             }
-            Cmd::CreateDatabase { name, engine } => {
-                write!(f, "create_db:{} engine: {}", name, engine)
+            Cmd::CreateDatabase { name, meta } => {
+                write!(f, "create_db:{}={}", name, meta)
             }
             Cmd::DropDatabase { name } => {
                 write!(f, "drop_db:{}", name)

--- a/common/meta/types/src/database.rs
+++ b/common/meta/types/src/database.rs
@@ -14,6 +14,8 @@
 //
 
 use std::collections::HashMap;
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::ops::Deref;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
@@ -32,6 +34,18 @@ pub struct DatabaseInfo {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct DatabaseMeta {
     pub engine: String,
+    pub engine_options: HashMap<String, String>,
+    pub options: HashMap<String, String>,
+}
+
+impl Display for DatabaseMeta {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Engine: {}={:?}, Options: {:?}",
+            self.engine, self.engine_options, self.options
+        )
+    }
 }
 
 impl DatabaseInfo {
@@ -44,8 +58,7 @@ impl DatabaseInfo {
 pub struct CreateDatabaseReq {
     pub if_not_exists: bool,
     pub db: String,
-    pub engine: String,
-    pub options: HashMap<String, String>,
+    pub meta: DatabaseMeta,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]

--- a/common/meta/types/src/table.rs
+++ b/common/meta/types/src/table.rs
@@ -99,6 +99,7 @@ pub struct TableInfo {
 pub struct TableMeta {
     pub schema: Arc<DataSchema>,
     pub engine: String,
+    pub engine_options: HashMap<String, String>,
     pub options: HashMap<String, String>,
     pub created_on: DateTime<Utc>,
 }
@@ -138,6 +139,10 @@ impl TableInfo {
         &self.meta.engine
     }
 
+    pub fn engine_options(&self) -> &HashMap<String, String> {
+        &self.meta.engine_options
+    }
+
     pub fn set_schema(mut self, schema: Arc<DataSchema>) -> TableInfo {
         self.meta.schema = schema;
         self
@@ -149,6 +154,7 @@ impl Default for TableMeta {
         TableMeta {
             schema: Arc::new(DataSchema::empty()),
             engine: "".to_string(),
+            engine_options: HashMap::new(),
             options: HashMap::new(),
             created_on: Utc::now(),
         }
@@ -159,8 +165,8 @@ impl Display for TableMeta {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Engine: {}, Schema: {}, Options: {:?} CreatedOn: {:?}",
-            self.engine, self.schema, self.options, self.created_on
+            "Engine: {}={:?}, Schema: {}, Options: {:?} CreatedOn: {:?}",
+            self.engine, self.engine_options, self.schema, self.options, self.created_on
         )
     }
 }

--- a/common/planners/src/plan_database_create.rs
+++ b/common/planners/src/plan_database_create.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
 use common_meta_types::CreateDatabaseReq;
+use common_meta_types::DatabaseMeta;
 
 pub type DatabaseOptions = HashMap<String, String>;
 
@@ -25,8 +26,7 @@ pub type DatabaseOptions = HashMap<String, String>;
 pub struct CreateDatabasePlan {
     pub if_not_exists: bool,
     pub db: String,
-    pub engine: String,
-    pub options: DatabaseOptions,
+    pub meta: DatabaseMeta,
 }
 
 impl From<CreateDatabasePlan> for CreateDatabaseReq {
@@ -34,8 +34,7 @@ impl From<CreateDatabasePlan> for CreateDatabaseReq {
         CreateDatabaseReq {
             if_not_exists: p.if_not_exists,
             db: p.db.clone(),
-            engine: p.engine.to_string(),
-            options: p.options,
+            meta: p.meta,
         }
     }
 }
@@ -45,8 +44,7 @@ impl From<&CreateDatabasePlan> for CreateDatabaseReq {
         CreateDatabaseReq {
             if_not_exists: p.if_not_exists,
             db: p.db.clone(),
-            engine: p.engine.clone(),
-            options: p.options.clone(),
+            meta: p.meta.clone(),
         }
     }
 }

--- a/common/planners/src/plan_display_indent.rs
+++ b/common/planners/src/plan_display_indent.rs
@@ -248,7 +248,14 @@ impl<'a> PlanNodeIndentFormatDisplay<'a> {
     fn format_create_database(f: &mut Formatter, plan: &CreateDatabasePlan) -> fmt::Result {
         write!(f, "Create database {:},", plan.db)?;
         write!(f, " if_not_exists:{:},", plan.if_not_exists)?;
-        write!(f, " option: {:?}", plan.options)
+        if !plan.meta.engine.is_empty() {
+            write!(
+                f,
+                " engine: {}={:?},",
+                plan.meta.engine, plan.meta.engine_options
+            )?;
+        }
+        write!(f, " option: {:?}", plan.meta.options)
     }
 
     fn format_drop_database(f: &mut Formatter, plan: &DropDatabasePlan) -> fmt::Result {

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -58,14 +58,14 @@ impl RequestHandler<CreateDatabaseReq> for ActionHandler {
         req: CreateDatabaseReq,
     ) -> common_exception::Result<CreateDatabaseReply> {
         let db_name = &req.db;
-        let engine = &req.engine;
+        let db_meta = &req.meta;
         let if_not_exists = req.if_not_exists;
 
         let cr = LogEntry {
             txid: None,
             cmd: CreateDatabase {
                 name: db_name.clone(),
-                engine: engine.clone(),
+                meta: db_meta.clone(),
             },
         };
 

--- a/metasrv/tests/it/meta_node/meta_node_all.rs
+++ b/metasrv/tests/it/meta_node/meta_node_all.rs
@@ -23,6 +23,7 @@ use common_meta_api::KVApi;
 use common_meta_raft_store::state_machine::AppliedState;
 use common_meta_types::Change;
 use common_meta_types::Cmd;
+use common_meta_types::DatabaseMeta;
 use common_meta_types::LogEntry;
 use common_meta_types::MatchSeq;
 use common_meta_types::NodeId;
@@ -242,7 +243,11 @@ async fn test_meta_node_add_database() -> anyhow::Result<()> {
                     txid: None,
                     cmd: Cmd::CreateDatabase {
                         name: name.to_string(),
-                        engine: "default".to_string(),
+                        meta: DatabaseMeta {
+                            engine: "default".to_string(),
+                            engine_options: Default::default(),
+                            options: Default::default(),
+                        },
                     },
                 })
                 .await;

--- a/query/src/configs/config_query.rs
+++ b/query/src/configs/config_query.rs
@@ -56,7 +56,7 @@ const QUERY_RPC_TLS_SERVICE_DOMAIN_NAME: &str = "QUERY_RPC_TLS_SERVICE_DOMAIN_NA
 const QUERY_TABLE_ENGINE_CSV_ENABLED: &str = "QUERY_TABLE_ENGINE_CSV_ENABLED";
 const QUERY_TABLE_ENGINE_PARQUET_ENABLED: &str = "QUERY_TABLE_ENGINE_PARQUET_ENABLED";
 const QUERY_TABLE_ENGINE_MEMORY_ENABLED: &str = "QUERY_TABLE_ENGINE_MEMORY_ENABLED";
-const QUERY_TABLE_ENGINE_GITHUB_ENABLED: &str = "QUERY_TABLE_ENGINE_GITHUB_ENABLED";
+const QUERY_DATABASE_ENGINE_GITHUB_ENABLED: &str = "QUERY_DATABASE_ENGINE_GITHUB_ENABLED";
 
 /// Query config group.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Args)]
@@ -157,14 +157,14 @@ pub struct QueryConfig {
     )]
     pub table_engine_memory_enabled: bool,
 
-    /// Table engine github enabled
+    /// Database engine github enabled
     #[clap(
         long,
-        env = QUERY_TABLE_ENGINE_GITHUB_ENABLED,
+        env = QUERY_DATABASE_ENGINE_GITHUB_ENABLED,
         parse(try_from_str),
         default_value = "true",
     )]
-    pub table_engine_github_enabled: bool,
+    pub database_engine_github_enabled: bool,
 
     #[clap(long, env = QUERY_WAIT_TIMEOUT_MILLS, default_value = "5000")]
     pub wait_timeout_mills: u64,
@@ -218,7 +218,7 @@ impl Default for QueryConfig {
             table_engine_csv_enabled: false,
             table_engine_parquet_enabled: false,
             table_engine_memory_enabled: true,
-            table_engine_github_enabled: true,
+            database_engine_github_enabled: true,
             wait_timeout_mills: 5000,
             max_query_log_size: 10000,
             table_cache_enabled: false,
@@ -403,9 +403,9 @@ impl QueryConfig {
         env_helper!(
             mut_config,
             query,
-            table_engine_github_enabled,
+            database_engine_github_enabled,
             bool,
-            QUERY_TABLE_ENGINE_GITHUB_ENABLED
+            QUERY_DATABASE_ENGINE_GITHUB_ENABLED
         );
         env_helper!(
             mut_config,

--- a/query/src/databases/default/default_database.rs
+++ b/query/src/databases/default/default_database.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_exception::Result;
+use common_meta_types::DatabaseMeta;
 
 use crate::databases::Database;
 use crate::databases::DatabaseContext;
@@ -26,7 +27,7 @@ impl DefaultDatabase {
     pub fn try_create(
         _ctx: DatabaseContext,
         db_name: &str,
-        _db_engine: &str,
+        _db_meta: DatabaseMeta,
     ) -> Result<Box<dyn Database>> {
         Ok(Box::new(Self {
             db_name: db_name.to_string(),

--- a/query/src/sql/sql_parser.rs
+++ b/query/src/sql/sql_parser.rs
@@ -553,13 +553,14 @@ impl<'a> DfParser<'a> {
         let if_not_exists =
             self.parser
                 .parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
-        let db_name = self.parser.parse_object_name()?;
-        let db_engine = self.parse_database_engine()?;
+        let name = self.parser.parse_object_name()?;
+        let (engine, engine_options) = self.parse_database_engine()?;
 
         let create = DfCreateDatabase {
             if_not_exists,
-            name: db_name,
-            engine: db_engine,
+            name,
+            engine,
+            engine_options,
             options: HashMap::new(),
         };
 
@@ -873,14 +874,22 @@ impl<'a> DfParser<'a> {
         Ok(DfStatement::CreateTable(create))
     }
 
-    fn parse_database_engine(&mut self) -> Result<String, ParserError> {
+    fn parse_database_engine(&mut self) -> Result<(String, HashMap<String, String>), ParserError> {
         // TODO make ENGINE as a keyword
         if !self.consume_token("ENGINE") {
-            return Ok("".to_string());
+            return Ok(("".to_string(), HashMap::new()));
         }
 
         self.parser.expect_token(&Token::Eq)?;
-        Ok(self.parser.next_token().to_string())
+        let engine = self.parser.next_token().to_string();
+        let options = if self.parser.consume_token(&Token::LParen) {
+            let options = self.parse_options()?;
+            self.parser.expect_token(&Token::RParen)?;
+            options
+        } else {
+            HashMap::new()
+        };
+        Ok((engine, options))
     }
 
     /// Parses the set of valid formats

--- a/query/src/sql/statements/statement_create_database.rs
+++ b/query/src/sql/statements/statement_create_database.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::DatabaseMeta;
 use common_planners::CreateDatabasePlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
@@ -31,6 +32,7 @@ pub struct DfCreateDatabase {
     pub if_not_exists: bool,
     pub name: ObjectName,
     pub engine: String,
+    pub engine_options: HashMap<String, String>,
     pub options: HashMap<String, String>,
 }
 
@@ -39,16 +41,14 @@ impl AnalyzableStatement for DfCreateDatabase {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
     async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let db = self.database_name()?;
-        let engine = self.database_engine()?;
-        let options = self.options.clone();
         let if_not_exists = self.if_not_exists;
+        let meta = self.database_meta()?;
 
         Ok(AnalyzedResult::SimpleQuery(Box::new(
             PlanNode::CreateDatabase(CreateDatabasePlan {
-                db,
-                engine,
-                options,
                 if_not_exists,
+                db,
+                meta,
             }),
         )))
     }
@@ -63,7 +63,11 @@ impl DfCreateDatabase {
         Ok(self.name.0[0].value.clone())
     }
 
-    fn database_engine(&self) -> Result<String> {
-        Ok(self.engine.clone())
+    fn database_meta(&self) -> Result<DatabaseMeta> {
+        Ok(DatabaseMeta {
+            engine: self.engine.clone(),
+            engine_options: self.engine_options.clone(),
+            options: self.options.clone(),
+        })
     }
 }

--- a/query/src/storages/github/github_table.rs
+++ b/query/src/storages/github/github_table.rs
@@ -1,0 +1,123 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::fmt::Display;
+use std::sync::Arc;
+
+use common_datablocks::DataBlock;
+use common_datavalues::prelude::*;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_meta_types::TableInfo;
+use common_planners::ReadDataSourcePlan;
+use common_streams::DataBlockStream;
+use common_streams::SendableDataBlockStream;
+
+use crate::sessions::QueryContext;
+use crate::storages::github::RepoCommentsTable;
+use crate::storages::github::RepoInfoTable;
+use crate::storages::github::RepoIssuesTable;
+use crate::storages::github::RepoPRsTable;
+use crate::storages::github::RepoTableOptions;
+use crate::storages::StorageContext;
+use crate::storages::Table;
+
+pub enum GithubTableType {
+    Comments,
+    Info,
+    Issues,
+    PullRequests,
+}
+
+impl Display for GithubTableType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GithubTableType::Comments => write!(f, "comments"),
+            GithubTableType::Info => write!(f, "info"),
+            GithubTableType::Issues => write!(f, "issues"),
+            GithubTableType::PullRequests => write!(f, "pull_requests"),
+        }
+    }
+}
+
+pub struct GithubTable {
+    table_info: TableInfo,
+    options: RepoTableOptions,
+}
+
+impl GithubTable {
+    pub fn try_create(_ctx: StorageContext, table_info: TableInfo) -> Result<Box<dyn Table>> {
+        let engine_options = table_info.engine_options();
+        Ok(Box::new(GithubTable {
+            options: engine_options.try_into()?,
+            table_info,
+        }))
+    }
+
+    fn get_table_type(&self) -> Result<GithubTableType> {
+        match self.options.table_type.as_str() {
+            "comments" => Ok(GithubTableType::Comments),
+            "issues" => Ok(GithubTableType::Issues),
+            "pull_requests" => Ok(GithubTableType::PullRequests),
+            "info" => Ok(GithubTableType::Info),
+            table_type => Err(ErrorCode::UnexpectedError(format!(
+                "Unsupported Github table type: {}",
+                table_type
+            ))),
+        }
+    }
+
+    async fn get_data_from_github(&self) -> Result<Vec<Series>> {
+        let table_type = self.get_table_type()?;
+        let table = match table_type {
+            GithubTableType::Comments => RepoCommentsTable::create(self.options.clone()),
+            GithubTableType::Info => RepoInfoTable::create(self.options.clone()),
+            GithubTableType::Issues => RepoIssuesTable::create(self.options.clone()),
+            GithubTableType::PullRequests => RepoPRsTable::create(self.options.clone()),
+        };
+        Ok(table.get_data_from_github().await?)
+    }
+}
+
+#[async_trait::async_trait]
+impl Table for GithubTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn get_table_info(&self) -> &TableInfo {
+        &self.table_info
+    }
+
+    async fn read(
+        &self,
+        _ctx: Arc<QueryContext>,
+        _plan: &ReadDataSourcePlan,
+    ) -> Result<SendableDataBlockStream> {
+        let arrays = self.get_data_from_github().await?;
+        let block = DataBlock::create_by_array(self.table_info.schema(), arrays);
+
+        Ok(Box::pin(DataBlockStream::create(
+            self.table_info.schema(),
+            None,
+            vec![block],
+        )))
+    }
+}
+
+#[async_trait::async_trait]
+pub trait GithubDataGetter: Sync + Send {
+    async fn get_data_from_github(&self) -> Result<Vec<Series>>;
+}

--- a/query/src/storages/github/mod.rs
+++ b/query/src/storages/github/mod.rs
@@ -14,19 +14,19 @@
 //
 
 mod github_client;
+mod github_table;
+mod repo;
 mod repo_comments_table;
 mod repo_info_table;
 mod repo_issues_table;
 mod repo_prs_table;
 
+pub use github_client::create_github_client;
+pub use github_table::GithubDataGetter;
+pub use github_table::GithubTable;
+pub use github_table::GithubTableType;
+pub use repo::RepoTableOptions;
 pub use repo_comments_table::RepoCommentsTable;
 pub use repo_info_table::RepoInfoTable;
 pub use repo_issues_table::RepoIssuesTable;
-pub use repo_prs_table::RepoPrsTable;
-
-pub const GITHUB_REPO_INFO_TABLE_ENGINE: &str = "GITHUB_REPO_INFO_TABLE_ENGINE";
-pub const GITHUB_REPO_ISSUES_TABLE_ENGINE: &str = "GITHUB_REPO_ISSUES_TABLE_ENGINE";
-pub const GITHUB_REPO_PRS_TABLE_ENGINE: &str = "GITHUB_REPO_PRS_TABLE_ENGINE";
-pub const GITHUB_REPO_COMMENTS_TABLE_ENGINE: &str = "GITHUB_REPO_COMMENTS_TABLE_ENGINE";
-pub const OWNER: &str = "owner";
-pub const REPO: &str = "repo";
+pub use repo_prs_table::RepoPRsTable;

--- a/query/src/storages/github/repo.rs
+++ b/query/src/storages/github/repo.rs
@@ -1,0 +1,75 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+pub const OWNER: &str = "owner";
+pub const REPO: &str = "repo";
+pub const TOKEN: &str = "token";
+pub const TABLE_TYPE: &str = "table_type";
+
+#[derive(Clone)]
+pub struct RepoTableOptions {
+    pub repo: String,
+    pub owner: String,
+    pub token: String,
+    pub table_type: String,
+}
+
+impl From<RepoTableOptions> for HashMap<String, String> {
+    fn from(options: RepoTableOptions) -> HashMap<String, String> {
+        let mut map = HashMap::new();
+        map.insert(OWNER.to_string(), options.owner);
+        map.insert(REPO.to_string(), options.repo);
+        map.insert(TOKEN.to_string(), options.token);
+        map.insert(TABLE_TYPE.to_string(), options.table_type);
+        map
+    }
+}
+
+impl TryFrom<&HashMap<String, String>> for RepoTableOptions {
+    type Error = ErrorCode;
+    fn try_from(options: &HashMap<String, String>) -> Result<RepoTableOptions> {
+        let owner = options
+            .get(OWNER)
+            .ok_or_else(|| ErrorCode::UnexpectedError("Github engine table missing owner key"))?
+            .clone();
+        let repo = options
+            .get(REPO)
+            .ok_or_else(|| ErrorCode::UnexpectedError("Github engine table missing repo key"))?
+            .clone();
+        let token = options
+            .get(TOKEN)
+            .ok_or_else(|| ErrorCode::UnexpectedError("Github engine table missing token key"))?
+            .clone();
+        let table_type = options
+            .get(TABLE_TYPE)
+            .ok_or_else(|| {
+                ErrorCode::UnexpectedError("Github engine table missing table_type key")
+            })?
+            .clone();
+        let options = RepoTableOptions {
+            repo,
+            owner,
+            token,
+            table_type,
+        };
+        Ok(options)
+    }
+}

--- a/query/src/storages/github/repo_info_table.rs
+++ b/query/src/storages/github/repo_info_table.rs
@@ -12,28 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::CreateTableReq;
-use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
-use common_planners::ReadDataSourcePlan;
-use common_streams::DataBlockStream;
-use common_streams::SendableDataBlockStream;
 
-use crate::sessions::QueryContext;
 use crate::storages::github::github_client::create_github_client;
-use crate::storages::github::github_client::get_own_repo_from_table_info;
-use crate::storages::github::GITHUB_REPO_INFO_TABLE_ENGINE;
-use crate::storages::github::OWNER;
-use crate::storages::github::REPO;
+use crate::storages::github::GithubDataGetter;
+use crate::storages::github::GithubTableType;
+use crate::storages::github::RepoTableOptions;
 use crate::storages::StorageContext;
-use crate::storages::Table;
 
 const REPOSITORY: &str = "reposiroty";
 const LANGUAGE: &str = "language";
@@ -45,27 +35,25 @@ const OPEN_ISSUES_COUNT: &str = "open_issues_count";
 const SUBSCRIBERS_COUNT: &str = "subscribers_count";
 
 pub struct RepoInfoTable {
-    table_info: TableInfo,
+    options: RepoTableOptions,
 }
 
 impl RepoInfoTable {
-    pub fn try_create(_ctx: StorageContext, table_info: TableInfo) -> Result<Box<dyn Table>> {
-        Ok(Box::new(RepoInfoTable { table_info }))
+    pub fn create(options: RepoTableOptions) -> Box<dyn GithubDataGetter> {
+        Box::new(RepoInfoTable { options })
     }
 
-    pub async fn create(ctx: StorageContext, owner: String, repo: String) -> Result<()> {
-        let mut options = HashMap::new();
-        options.insert(OWNER.to_string(), owner.clone());
-        options.insert(REPO.to_string(), repo.clone());
-
+    pub async fn create_table(ctx: StorageContext, options: RepoTableOptions) -> Result<()> {
+        let mut options = options;
+        options.table_type = GithubTableType::Info.to_string();
         let req = CreateTableReq {
             if_not_exists: false,
-            db: owner.clone(),
-            table: repo.clone(),
+            db: options.owner.clone(),
+            table: options.repo.clone(),
             table_meta: TableMeta {
                 schema: RepoInfoTable::schema(),
-                engine: GITHUB_REPO_INFO_TABLE_ENGINE.into(),
-                options,
+                engine: "GITHUB".into(),
+                engine_options: options.into(),
                 ..Default::default()
             },
         };
@@ -87,10 +75,18 @@ impl RepoInfoTable {
 
         Arc::new(DataSchema::new(fields))
     }
+}
 
+#[async_trait::async_trait]
+impl GithubDataGetter for RepoInfoTable {
     async fn get_data_from_github(&self) -> Result<Vec<Series>> {
-        let (owner, repo) = get_own_repo_from_table_info(&self.table_info)?;
-        let instance = create_github_client()?;
+        let RepoTableOptions {
+            ref repo,
+            ref owner,
+            ref token,
+            ..
+        } = self.options;
+        let instance = create_github_client(token)?;
 
         let repo = instance.repos(owner, repo).get().await?;
 
@@ -125,31 +121,5 @@ impl RepoInfoTable {
             Series::new(open_issues_count_array),
             Series::new(subscribers_count_array),
         ])
-    }
-}
-
-#[async_trait::async_trait]
-impl Table for RepoInfoTable {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn get_table_info(&self) -> &TableInfo {
-        &self.table_info
-    }
-
-    async fn read(
-        &self,
-        _ctx: Arc<QueryContext>,
-        _plan: &ReadDataSourcePlan,
-    ) -> Result<SendableDataBlockStream> {
-        let arrays = self.get_data_from_github().await?;
-        let block = DataBlock::create_by_array(self.table_info.schema(), arrays);
-
-        Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema(),
-            None,
-            vec![block],
-        )))
     }
 }

--- a/query/src/storages/github/repo_issues_table.rs
+++ b/query/src/storages/github/repo_issues_table.rs
@@ -12,30 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::CreateTableReq;
-use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
-use common_planners::ReadDataSourcePlan;
-use common_streams::DataBlockStream;
-use common_streams::SendableDataBlockStream;
 use octocrab::models;
 use octocrab::params;
 
-use crate::sessions::QueryContext;
 use crate::storages::github::github_client::create_github_client;
-use crate::storages::github::github_client::get_own_repo_from_table_info;
-use crate::storages::github::GITHUB_REPO_ISSUES_TABLE_ENGINE;
-use crate::storages::github::OWNER;
-use crate::storages::github::REPO;
+use crate::storages::github::GithubDataGetter;
+use crate::storages::github::GithubTableType;
+use crate::storages::github::RepoTableOptions;
 use crate::storages::StorageContext;
-use crate::storages::Table;
 
 const NUMBER: &str = "number";
 const TITLE: &str = "title";
@@ -49,27 +39,25 @@ const UPDATED_AT: &str = "updated_at";
 const CLOSED_AT: &str = "closed_at";
 
 pub struct RepoIssuesTable {
-    table_info: TableInfo,
+    options: RepoTableOptions,
 }
 
 impl RepoIssuesTable {
-    pub fn try_create(_ctx: StorageContext, table_info: TableInfo) -> Result<Box<dyn Table>> {
-        Ok(Box::new(RepoIssuesTable { table_info }))
+    pub fn create(options: RepoTableOptions) -> Box<dyn GithubDataGetter> {
+        Box::new(RepoIssuesTable { options })
     }
 
-    pub async fn create(ctx: StorageContext, owner: String, repo: String) -> Result<()> {
-        let mut options = HashMap::new();
-        options.insert(OWNER.to_string(), owner.clone());
-        options.insert(REPO.to_string(), repo.clone());
-
+    pub async fn create_table(ctx: StorageContext, options: RepoTableOptions) -> Result<()> {
+        let mut options = options;
+        options.table_type = GithubTableType::Issues.to_string();
         let req = CreateTableReq {
             if_not_exists: false,
-            db: owner.clone(),
-            table: repo.clone() + "_issues",
+            db: options.owner.clone(),
+            table: format!("{}_{}", options.repo.clone(), "issues"),
             table_meta: TableMeta {
                 schema: RepoIssuesTable::schema(),
-                engine: GITHUB_REPO_ISSUES_TABLE_ENGINE.into(),
-                options,
+                engine: "GITHUB".into(),
+                engine_options: options.into(),
                 ..Default::default()
             },
         };
@@ -94,7 +82,10 @@ impl RepoIssuesTable {
 
         Arc::new(DataSchema::new(fields))
     }
+}
 
+#[async_trait::async_trait]
+impl GithubDataGetter for RepoIssuesTable {
     async fn get_data_from_github(&self) -> Result<Vec<Series>> {
         // init array
         let mut issue_numer_array: Vec<i64> = Vec::new();
@@ -108,9 +99,13 @@ impl RepoIssuesTable {
         let mut updated_at_array: Vec<u32> = Vec::new();
         let mut closed_at_array: Vec<Option<u32>> = Vec::new();
 
-        // get owner repo info from table meta
-        let (owner, repo) = get_own_repo_from_table_info(&self.table_info)?;
-        let instance = create_github_client()?;
+        let RepoTableOptions {
+            ref repo,
+            ref owner,
+            ref token,
+            ..
+        } = self.options;
+        let instance = create_github_client(token)?;
 
         #[allow(unused_mut)]
         let mut page = instance
@@ -168,31 +163,5 @@ impl RepoIssuesTable {
             Series::new(updated_at_array),
             Series::new(closed_at_array),
         ])
-    }
-}
-
-#[async_trait::async_trait]
-impl Table for RepoIssuesTable {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn get_table_info(&self) -> &TableInfo {
-        &self.table_info
-    }
-
-    async fn read(
-        &self,
-        _ctx: Arc<QueryContext>,
-        _plan: &ReadDataSourcePlan,
-    ) -> Result<SendableDataBlockStream> {
-        let arrays = self.get_data_from_github().await?;
-        let block = DataBlock::create_by_array(self.table_info.schema(), arrays);
-
-        Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema(),
-            None,
-            vec![block],
-        )))
     }
 }

--- a/query/src/storages/github/repo_prs_table.rs
+++ b/query/src/storages/github/repo_prs_table.rs
@@ -12,30 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::CreateTableReq;
-use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
-use common_planners::ReadDataSourcePlan;
-use common_streams::DataBlockStream;
-use common_streams::SendableDataBlockStream;
 use octocrab::models;
 use octocrab::params;
 
-use crate::sessions::QueryContext;
 use crate::storages::github::github_client::create_github_client;
-use crate::storages::github::github_client::get_own_repo_from_table_info;
-use crate::storages::github::GITHUB_REPO_PRS_TABLE_ENGINE;
-use crate::storages::github::OWNER;
-use crate::storages::github::REPO;
+use crate::storages::github::GithubDataGetter;
+use crate::storages::github::GithubTableType;
+use crate::storages::github::RepoTableOptions;
 use crate::storages::StorageContext;
-use crate::storages::Table;
 
 const NUMBER: &str = "number";
 const TITLE: &str = "title";
@@ -47,28 +37,26 @@ const CREATED_AT: &str = "created_at";
 const UPDATED_AT: &str = "updated_at";
 const CLOSED_AT: &str = "closed_at";
 
-pub struct RepoPrsTable {
-    table_info: TableInfo,
+pub struct RepoPRsTable {
+    options: RepoTableOptions,
 }
 
-impl RepoPrsTable {
-    pub fn try_create(_ctx: StorageContext, table_info: TableInfo) -> Result<Box<dyn Table>> {
-        Ok(Box::new(RepoPrsTable { table_info }))
+impl RepoPRsTable {
+    pub fn create(options: RepoTableOptions) -> Box<dyn GithubDataGetter> {
+        Box::new(RepoPRsTable { options })
     }
 
-    pub async fn create(ctx: StorageContext, owner: String, repo: String) -> Result<()> {
-        let mut options = HashMap::new();
-        options.insert(OWNER.to_string(), owner.clone());
-        options.insert(REPO.to_string(), repo.clone());
-
+    pub async fn create_table(ctx: StorageContext, options: RepoTableOptions) -> Result<()> {
+        let mut options = options;
+        options.table_type = GithubTableType::PullRequests.to_string();
         let req = CreateTableReq {
             if_not_exists: false,
-            db: owner.clone(),
-            table: repo.clone() + "_prs",
+            db: options.owner.clone(),
+            table: format!("{}_{}", options.repo.clone(), "prs"),
             table_meta: TableMeta {
-                schema: RepoPrsTable::schema(),
-                engine: GITHUB_REPO_PRS_TABLE_ENGINE.into(),
-                options,
+                schema: RepoPRsTable::schema(),
+                engine: "GITHUB".into(),
+                engine_options: options.into(),
                 ..Default::default()
             },
         };
@@ -91,7 +79,10 @@ impl RepoPrsTable {
 
         Arc::new(DataSchema::new(fields))
     }
+}
 
+#[async_trait::async_trait]
+impl GithubDataGetter for RepoPRsTable {
     async fn get_data_from_github(&self) -> Result<Vec<Series>> {
         // init array
         let mut issue_numer_array: Vec<u64> = Vec::new();
@@ -105,9 +96,13 @@ impl RepoPrsTable {
         let mut updated_at_array: Vec<Option<u32>> = Vec::new();
         let mut closed_at_array: Vec<Option<u32>> = Vec::new();
 
-        // get owner repo info from table meta
-        let (owner, repo) = get_own_repo_from_table_info(&self.table_info)?;
-        let instance = create_github_client()?;
+        let RepoTableOptions {
+            ref owner,
+            ref repo,
+            ref token,
+            ..
+        } = self.options;
+        let instance = create_github_client(token)?;
 
         #[allow(unused_mut)]
         let mut page = instance
@@ -202,31 +197,5 @@ impl RepoPrsTable {
             Series::new(updated_at_array),
             Series::new(closed_at_array),
         ])
-    }
-}
-
-#[async_trait::async_trait]
-impl Table for RepoPrsTable {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn get_table_info(&self) -> &TableInfo {
-        &self.table_info
-    }
-
-    async fn read(
-        &self,
-        _ctx: Arc<QueryContext>,
-        _plan: &ReadDataSourcePlan,
-    ) -> Result<SendableDataBlockStream> {
-        let arrays = self.get_data_from_github().await?;
-        let block = DataBlock::create_by_array(self.table_info.schema(), arrays);
-
-        Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema(),
-            None,
-            vec![block],
-        )))
     }
 }

--- a/query/src/storages/storage_factory.rs
+++ b/query/src/storages/storage_factory.rs
@@ -23,7 +23,7 @@ use common_meta_types::TableInfo;
 use crate::configs::Config;
 use crate::storages::csv::CsvTable;
 use crate::storages::fuse::FuseTable;
-use crate::storages::github;
+use crate::storages::github::GithubTable;
 use crate::storages::memory::MemoryTable;
 use crate::storages::null::NullTable;
 use crate::storages::parquet::ParquetTable;
@@ -69,23 +69,8 @@ impl StorageFactory {
         }
 
         // Register github table engine;
-        if conf.query.table_engine_github_enabled {
-            creators.insert(
-                github::GITHUB_REPO_COMMENTS_TABLE_ENGINE.to_string(),
-                Arc::new(github::RepoCommentsTable::try_create),
-            );
-            creators.insert(
-                github::GITHUB_REPO_INFO_TABLE_ENGINE.to_string(),
-                Arc::new(github::RepoInfoTable::try_create),
-            );
-            creators.insert(
-                github::GITHUB_REPO_ISSUES_TABLE_ENGINE.to_string(),
-                Arc::new(github::RepoIssuesTable::try_create),
-            );
-            creators.insert(
-                github::GITHUB_REPO_PRS_TABLE_ENGINE.to_string(),
-                Arc::new(github::RepoPrsTable::try_create),
-            );
+        if conf.query.database_engine_github_enabled {
+            creators.insert("GITHUB".to_string(), Arc::new(GithubTable::try_create));
         }
 
         // Register NULL table engine.

--- a/query/src/table_functions/numbers_table.rs
+++ b/query/src/table_functions/numbers_table.rs
@@ -91,10 +91,10 @@ impl NumbersTable {
                     false,
                 )]),
                 engine: engine.to_string(),
-                options: Default::default(),
                 // Assuming that created_on is unnecessary for function table,
                 // we could make created_on fixed to pass test_shuffle_action_try_into.
                 created_on: Utc.from_utc_datetime(&NaiveDateTime::from_timestamp(0, 0)),
+                ..Default::default()
             },
         };
 

--- a/query/tests/it/configs.rs
+++ b/query/tests/it/configs.rs
@@ -62,7 +62,7 @@ rpc_tls_query_service_domain_name = \"localhost\"
 table_engine_csv_enabled = false
 table_engine_parquet_enabled = false
 table_engine_memory_enabled = true
-table_engine_github_enabled = true
+database_engine_github_enabled = true
 wait_timeout_mills = 5000
 max_query_log_size = 10000
 table_cache_enabled = false
@@ -138,7 +138,7 @@ fn test_env_config() -> Result<()> {
     std::env::set_var("QUERY_TABLE_ENGINE_CSV_ENABLED", "true");
     std::env::set_var("QUERY_TABLE_ENGINE_PARQUET_ENABLED", "true");
     std::env::set_var("QUERY_TABLE_ENGINE_MEMORY_ENABLED", "true");
-    std::env::set_var("QUERY_TABLE_ENGINE_GITHUB_ENABLED", "false");
+    std::env::set_var("QUERY_DATABASE_ENGINE_GITHUB_ENABLED", "false");
     std::env::remove_var("CONFIG_FILE");
 
     let default = Config::default();
@@ -171,7 +171,7 @@ fn test_env_config() -> Result<()> {
     assert!(configured.query.table_engine_csv_enabled);
     assert!(configured.query.table_engine_parquet_enabled);
     assert!(configured.query.table_engine_memory_enabled);
-    assert!(!configured.query.table_engine_github_enabled);
+    assert!(!configured.query.database_engine_github_enabled);
 
     assert!(configured.query.table_cache_enabled);
     assert_eq!(512, configured.query.table_memory_cache_mb_size);
@@ -205,7 +205,7 @@ fn test_env_config() -> Result<()> {
     std::env::remove_var("QUERY_TABLE_ENGINE_CSV_ENABLED");
     std::env::remove_var("QUERY_TABLE_ENGINE_PARQUET_ENABLED");
     std::env::remove_var("QUERY_TABLE_ENGINE_MEMORY_ENABLED");
-    std::env::remove_var("QUERY_TABLE_ENGINE_GITHUB_ENABLED");
+    std::env::remove_var("QUERY_DATABASE_ENGINE_GITHUB_ENABLED");
     Ok(())
 }
 

--- a/query/tests/it/sql/plan_parser.rs
+++ b/query/tests/it/sql/plan_parser.rs
@@ -34,6 +34,18 @@ fn test_plan_parser() -> Result<()> {
             error: "",
         },
         Test {
+            name: "create-database-default-engine-passed",
+            sql: "CREATE DATABASE db1 ENGINE=default",
+            expect: "Create database db1, if_not_exists:false, engine: default={}, option: {}",
+            error: "",
+        },
+        Test {
+            name: "create-database-github-engine-passed",
+            sql: "CREATE DATABASE db1 ENGINE=github(token='abc')",
+            expect: "Create database db1, if_not_exists:false, engine: github={\"token\": \"abc\"}, option: {}",
+            error: "",
+        },
+        Test {
             name: "create-database-if-not-exists-passed",
             sql: "CREATE DATABASE IF NOT EXISTS db1",
             expect: "Create database db1, if_not_exists:true, option: {}",

--- a/query/tests/it/sql/sql_parser.rs
+++ b/query/tests/it/sql/sql_parser.rs
@@ -110,6 +110,7 @@ fn create_database() -> Result<()> {
             if_not_exists: false,
             name: ObjectName(vec![Ident::new("db1")]),
             engine: "".to_string(),
+            engine_options: HashMap::new(),
             options: HashMap::new(),
         });
         expect_parse_ok(sql, expected)?;
@@ -121,6 +122,7 @@ fn create_database() -> Result<()> {
             if_not_exists: false,
             name: ObjectName(vec![Ident::new("db1")]),
             engine: "github".to_string(),
+            engine_options: HashMap::new(),
             options: HashMap::new(),
         });
         expect_parse_ok(sql, expected)?;
@@ -132,6 +134,7 @@ fn create_database() -> Result<()> {
             if_not_exists: true,
             name: ObjectName(vec![Ident::new("db1")]),
             engine: "".to_string(),
+            engine_options: HashMap::new(),
             options: HashMap::new(),
         });
         expect_parse_ok(sql, expected)?;

--- a/query/tests/it/storages/fuse/table_test_fixture.rs
+++ b/query/tests/it/storages/fuse/table_test_fixture.rs
@@ -23,6 +23,7 @@ use common_datavalues::DataSchemaRef;
 use common_datavalues::DataSchemaRefExt;
 use common_datavalues::DataType;
 use common_exception::Result;
+use common_meta_types::DatabaseMeta;
 use common_meta_types::TableMeta;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -58,8 +59,10 @@ impl TestFixture {
         let plan = CreateDatabasePlan {
             if_not_exists: false,
             db: db_name,
-            engine: "".to_string(),
-            options: Default::default(),
+            meta: DatabaseMeta {
+                engine: "".to_string(),
+                ..Default::default()
+            },
         };
         ctx.get_catalog()
             .create_database(plan.into())

--- a/query/tests/it/storages/system/configs_table.rs
+++ b/query/tests/it/storages/system/configs_table.rs
@@ -77,7 +77,7 @@ async fn test_configs_table() -> Result<()> {
         "| rpc_tls_server_cert                  |                  | query |             |",
         "| rpc_tls_server_key                   |                  | query |             |",
         "| table_engine_csv_enabled             | false            | query |             |",
-        "| table_engine_github_enabled          | true             | query |             |",
+        "| database_engine_github_enabled       | true             | query |             |",
         "| table_engine_memory_enabled          | true             | query |             |",
         "| table_engine_parquet_enabled         | false            | query |             |",
         "| tenant_id                            |                  | query |             |",

--- a/scripts/deploy/config/databend-query-embedded-meta.toml
+++ b/scripts/deploy/config/databend-query-embedded-meta.toml
@@ -32,7 +32,7 @@ cluster_id = "test_cluster"
 table_engine_memory_enabled = true
 table_engine_csv_enabled = true
 table_engine_parquet_enabled = true
-table_engine_github_enabled = true
+database_engine_github_enabled = true
 
 [log]
 log_level = "INFO"

--- a/scripts/deploy/config/databend-query-node-1.toml
+++ b/scripts/deploy/config/databend-query-node-1.toml
@@ -32,7 +32,7 @@ cluster_id = "test_cluster"
 table_engine_memory_enabled = true
 table_engine_csv_enabled = true
 table_engine_parquet_enabled = true
-table_engine_github_enabled = true
+database_engine_github_enabled = true
 
 [log]
 log_level = "ERROR"

--- a/scripts/deploy/config/databend-query-node-2.toml
+++ b/scripts/deploy/config/databend-query-node-2.toml
@@ -32,7 +32,7 @@ cluster_id = "test_cluster"
 table_engine_memory_enabled = true
 table_engine_csv_enabled = true
 table_engine_parquet_enabled = true
-table_engine_github_enabled = true
+database_engine_github_enabled = true
 
 [log]
 log_level = "ERROR"

--- a/scripts/deploy/config/databend-query-node-3.toml
+++ b/scripts/deploy/config/databend-query-node-3.toml
@@ -32,7 +32,7 @@ cluster_id = "test_cluster"
 table_engine_memory_enabled = true
 table_engine_csv_enabled = true
 table_engine_parquet_enabled = true
-table_engine_github_enabled = true
+database_engine_github_enabled = true
 
 [log]
 log_level = "ERROR"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

- Add `engine_options` field to `DatabaseMeta` and `TableMeta`
- Change `table_engine_github_enabled` config flag to `database_engine_github_enabled`
- Use `GITHUB` engine to replace `GITHUB_REPO_XXX_TABLE_ENGINE` table engine

```
mysql> create database datafuselabs engine=github(token='xxx');
Query OK, 0 rows affected (1.21 sec)
Read 0 rows, 0 B in 1.203 sec., 0 rows/sec., 0 B/sec.

mysql> use datafuselabs;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> show tables;
+-------------------------------+---------------------------------+
| created_on                    | name                            |
+-------------------------------+---------------------------------+
| 2021-12-19 11:20:37.844 +0000 | .github                         |
| 2021-12-19 11:20:37.847 +0000 | .github_comments                |
| 2021-12-19 11:20:37.845 +0000 | .github_issues                  |
| 2021-12-19 11:20:37.846 +0000 | .github_prs                     |
| 2021-12-19 11:20:37.806 +0000 | databend                        |
| 2021-12-19 11:20:37.836 +0000 | databend-playground             |
| 2021-12-19 11:20:37.839 +0000 | databend-playground_comments    |
| 2021-12-19 11:20:37.837 +0000 | databend-playground_issues      |
| 2021-12-19 11:20:37.838 +0000 | databend-playground_prs         |
| 2021-12-19 11:20:37.814 +0000 | databend_comments               |
| 2021-12-19 11:20:37.810 +0000 | databend_issues                 |
| 2021-12-19 11:20:37.813 +0000 | databend_prs                    |
| 2021-12-19 11:20:37.852 +0000 | datafuse-operator               |
| 2021-12-19 11:20:37.855 +0000 | datafuse-operator_comments      |
| 2021-12-19 11:20:37.853 +0000 | datafuse-operator_issues        |
| 2021-12-19 11:20:37.854 +0000 | datafuse-operator_prs           |
| 2021-12-19 11:20:37.826 +0000 | datafuse-presentations          |
| 2021-12-19 11:20:37.834 +0000 | datafuse-presentations_comments |
| 2021-12-19 11:20:37.828 +0000 | datafuse-presentations_issues   |
| 2021-12-19 11:20:37.829 +0000 | datafuse-presentations_prs      |
| 2021-12-19 11:20:37.821 +0000 | datafuse-shop                   |
| 2021-12-19 11:20:37.825 +0000 | datafuse-shop_comments          |
| 2021-12-19 11:20:37.822 +0000 | datafuse-shop_issues            |
| 2021-12-19 11:20:37.823 +0000 | datafuse-shop_prs               |
| 2021-12-19 11:20:37.840 +0000 | fusebots                        |
| 2021-12-19 11:20:37.843 +0000 | fusebots_comments               |
| 2021-12-19 11:20:37.841 +0000 | fusebots_issues                 |
| 2021-12-19 11:20:37.842 +0000 | fusebots_prs                    |
| 2021-12-19 11:20:37.848 +0000 | test-infra                      |
| 2021-12-19 11:20:37.851 +0000 | test-infra_comments             |
| 2021-12-19 11:20:37.849 +0000 | test-infra_issues               |
| 2021-12-19 11:20:37.850 +0000 | test-infra_prs                  |
| 2021-12-19 11:20:37.816 +0000 | weekly                          |
| 2021-12-19 11:20:37.820 +0000 | weekly_comments                 |
| 2021-12-19 11:20:37.817 +0000 | weekly_issues                   |
| 2021-12-19 11:20:37.818 +0000 | weekly_prs                      |
+-------------------------------+---------------------------------+
36 rows in set (0.01 sec)
Read 52 rows, 4.99 KB in 0.007 sec., 7.83 thousand rows/sec., 752.15 KB/sec.

mysql> show create table databend_issues;
+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table           | Create Table                                                                                                                                                                                                                                                          |
+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| databend_issues | CREATE TABLE `databend_issues` (
  `number` Int64,
  `title` String,
  `state` String,
  `user` String,
  `labels` String,
  `assigness` String,
  `comments` UInt32,
  `created_at` DateTime32,
  `updated_at` DateTime32,
  `closed_at` DateTime32,
) ENGINE=GITHUB |
+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)
Read 0 rows, 0 B in 0.004 sec., 0 rows/sec., 0 B/sec.
```

todo:
- [ ] make github database immutable

## Changelog

- New Feature

## Related Issues

Fixes [#issue](https://github.com/datafuselabs/databend/issues/3431)

## Test Plan

Unit Tests

Stateless Tests

