### PR TITLE
[audit] temporarily ignore lru < 0.7.1

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,12 +1,11 @@
 [advisories]
 ignore = [
-    # https://github.com/datafuselabs/databend/issues/3159
-    "RUSTSEC-2021-0119",
     # https://github.com/datafuselabs/databend/issues/2565
     # need to fix upstream rusoto dependencies on credential and sts for this issue as well
     "RUSTSEC-2020-0159",
     "RUSTSEC-2020-0071",
     # https://github.com/datafuselabs/databend/issues/2690
-    "RUSTSEC-2021-0122"
-
+    "RUSTSEC-2021-0122",
+    # https://github.com/datafuselabs/databend/issues/3584
+    "RUSTSEC-2021-0130"
 ]


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

temporarily ignore lru < 0.7.1

to fix it, need

- https://github.com/blackbeam/rust-mysql-simple/pull/298/
- or mysql_async 0.29.0

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Related #3584 

## Test Plan

Unit Tests

Stateless Tests

