### PR TITLE
misc: Ignore folder instead to make editor works correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@
 .dir-locals.el
 
 # Rust
-target/*
-distro/*
+target/
 cli/e2e/bendctl
 .cargo/config.toml
 
@@ -28,14 +27,14 @@ perf.*
 *.err
 *.error
 *.swp
-_local_fs/*
-_meta*/*
-stateless_test_data/*
-**/_logs*/*
+_local_fs/
+**/_meta*/
+stateless_test_data/
+**/_logs*/
 _data/
 _cache/
-_tmp/*
-tls/certs/*
+_tmp/
+tls/certs/
 .databend/
 checksums.txt
 
@@ -47,5 +46,5 @@ tests/perfs/*-result.json
 # python
 venv/
 *.pyc
-__pycache__/*
+__pycache__/
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

This PR changes `.gitignore` pattern from `abc/*` to `abc/`.

After this change, our editor will show ignored folders correctly.

![image](https://user-images.githubusercontent.com/5351546/147059312-7ba5da4a-675a-488c-b3b7-9d8b0b04a285.png)

## Changelog

- Other 

