### PR TITLE
ISSUE-3627: adding distributed tracing instrumentation to query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,6 +1550,7 @@ dependencies = [
  "common-exception",
  "common-functions",
  "common-io",
+ "common-tracing",
  "csv-async",
  "futures",
  "pin-project-lite",
@@ -2075,6 +2076,7 @@ dependencies = [
  "tokio-stream",
  "toml",
  "tonic",
+ "tracing-futures",
  "uuid",
  "walkdir",
 ]
@@ -6911,6 +6913,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
+ "futures",
+ "futures-task",
  "pin-project",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,6 +1569,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-bunyan-formatter",
+ "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -2076,7 +2077,6 @@ dependencies = [
  "tokio-stream",
  "toml",
  "tonic",
- "tracing-futures",
  "uuid",
  "walkdir",
 ]

--- a/common/streams/Cargo.toml
+++ b/common/streams/Cargo.toml
@@ -20,6 +20,7 @@ common-datavalues = { path = "../datavalues" }
 common-exception = { path = "../exception" }
 common-functions = { path = "../functions" }
 common-io = { path = "../io" }
+common-tracing = {path = "../tracing"}
 
 
 # Github dependencies

--- a/common/streams/src/sources/source_parquet.rs
+++ b/common/streams/src/sources/source_parquet.rs
@@ -28,13 +28,10 @@ use common_datavalues::series::IntoSeries;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_tracing::tracing;
 use common_tracing::tracing::debug_span;
 use common_tracing::tracing::Instrument;
 use futures::StreamExt;
 use futures::TryStreamExt;
-//use tracing::debug_span;
-use tracing::info_span;
 
 use crate::Source;
 
@@ -81,7 +78,7 @@ impl Source for ParquetSource {
                     .data_accessor
                     .get_input_stream(self.path.as_str(), None)?;
                 let m = read_metadata_async(&mut reader)
-                    .instrument(info_span!("parquet_source_read_meta"))
+                    .instrument(debug_span!("parquet_source_read_meta"))
                     .await
                     .map_err(|e| ErrorCode::ParquetError(e.to_string()))?;
                 self.metadata = Some(m.clone());
@@ -126,7 +123,7 @@ impl Source for ParquetSource {
                 let array: Arc<dyn common_arrow::arrow::array::Array> = array.into();
                 Ok::<_, ErrorCode>(DataColumn::Array(array.into_series()))
             }
-            .instrument(info_span!("parquet_source_read_column"))
+            .instrument(debug_span!("parquet_source_read_column"))
         });
 
         // TODO configuration of the buffer size

--- a/common/streams/src/sources/source_parquet.rs
+++ b/common/streams/src/sources/source_parquet.rs
@@ -123,7 +123,7 @@ impl Source for ParquetSource {
                 let array: Arc<dyn common_arrow::arrow::array::Array> = array.into();
                 Ok::<_, ErrorCode>(DataColumn::Array(array.into_series()))
             }
-            .instrument(debug_span!("parquet_source_read_column"))
+            .instrument(debug_span!("parquet_source_read_column").or_current())
         });
 
         // TODO configuration of the buffer size

--- a/common/tracing/Cargo.toml
+++ b/common/tracing/Cargo.toml
@@ -18,5 +18,6 @@ tonic = "0.6.2"
 tracing = "0.1.29"
 tracing-appender = "0.2.0"
 tracing-bunyan-formatter = "0.3.1"
+tracing-futures = {version ="0.2.5", features = ["futures-03"]}
 tracing-opentelemetry = "0.16.0"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/common/tracing/src/lib.rs
+++ b/common/tracing/src/lib.rs
@@ -23,6 +23,7 @@ pub use logging::init_tracing;
 pub use logging::init_tracing_with_file;
 pub use panic_hook::set_panic_hook;
 pub use tracing;
+pub use tracing_futures;
 pub use tracing_to_jaeger::extract_remote_span_as_parent;
 pub use tracing_to_jaeger::inject_span_to_tonic_request;
 

--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -35,11 +35,11 @@ use tracing_subscriber::EnvFilter;
 use crate::tracing::subscriber::DefaultGuard;
 
 /// Write logs to stdout.
-pub fn init_default_tracing() {
+pub fn init_default_tracing(app_name: &str) {
     static START: Once = Once::new();
 
     START.call_once(|| {
-        init_tracing_stdout();
+        init_tracing_stdout(app_name);
     });
 }
 
@@ -71,7 +71,7 @@ lazy_static! {
 ///   DATABEND_JAEGER=on RUST_LOG=trace OTEL_BSP_SCHEDULE_DELAY=1 cargo test
 ///
 // TODO(xp): use DATABEND_JAEGER to assign jaeger server address.
-fn init_tracing_stdout() {
+fn init_tracing_stdout(app_name: &str) {
     let fmt_layer = Layer::default()
         .with_thread_ids(true)
         .with_thread_names(false)
@@ -82,7 +82,7 @@ fn init_tracing_stdout() {
     let subscriber = Registry::default()
         .with(EnvFilter::from_default_env())
         .with(fmt_layer)
-        .with(jaeger_layer());
+        .with(jaeger_layer(app_name));
 
     tracing::subscriber::set_global_default(subscriber)
         .expect("error setting global tracing subscriber");
@@ -90,14 +90,15 @@ fn init_tracing_stdout() {
 
 fn jaeger_layer<
     S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
->() -> Option<impl tracing_subscriber::layer::Layer<S>> {
+>(
+    service_name: &str,
+) -> Option<impl tracing_subscriber::layer::Layer<S>> {
     let fuse_jaeger = env::var("DATABEND_JAEGER").unwrap_or_else(|_| "".to_string());
 
     if !fuse_jaeger.is_empty() {
         global::set_text_map_propagator(TraceContextPropagator::new());
-
         let tracer = opentelemetry_jaeger::new_pipeline()
-            .with_service_name("databend-meta")
+            .with_service_name(service_name)
             .install_batch(opentelemetry::runtime::Tokio)
             .expect("install");
 
@@ -127,7 +128,7 @@ pub fn init_tracing_with_file(app_name: &str, dir: &str, level: &str) -> Vec<Wor
         .with(stdout_logging_layer)
         .with(JsonStorageLayer)
         .with(file_logging_layer)
-        .with(jaeger_layer());
+        .with(jaeger_layer(app_name));
 
     tracing::subscriber::set_global_default(subscriber)
         .expect("error setting global tracing subscriber");
@@ -188,7 +189,7 @@ pub fn init_file_subscriber(
     let subscriber = Registry::default()
         .with(env_filter)
         .with(f_layer)
-        .with(jaeger_layer());
+        .with(jaeger_layer(app_name));
 
     (writer_guard, subscriber)
 }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -98,6 +98,7 @@ tokio-rustls = "0.23.1"
 tokio-stream = { version = "0.1.8", features = ["net"] }
 toml = "0.5.8"
 tonic = "0.6.2"
+tracing-futures = {version ="0.2.5", features = ["futures-03"]}
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 walkdir = "2.3.2"
 parquet-format-async-temp = "0.2.0"

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -98,7 +98,6 @@ tokio-rustls = "0.23.1"
 tokio-stream = { version = "0.1.8", features = ["net"] }
 toml = "0.5.8"
 tonic = "0.6.2"
-tracing-futures = {version ="0.2.5", features = ["futures-03"]}
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 walkdir = "2.3.2"
 parquet-format-async-temp = "0.2.0"

--- a/query/src/bin/databend-query.rs
+++ b/query/src/bin/databend-query.rs
@@ -59,7 +59,6 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
     );
     //let _guards = init_tracing_with_file(
     let _guards = init_global_tracing(
-        //"databend-query",
         app_name.as_str(),
         conf.log.log_dir.as_str(),
         conf.log.log_level.as_str(),

--- a/query/src/bin/databend-query.rs
+++ b/query/src/bin/databend-query.rs
@@ -18,7 +18,7 @@ use common_base::RuntimeTracker;
 use common_macros::databend_main;
 use common_meta_embedded::MetaEmbedded;
 use common_metrics::init_default_metrics_recorder;
-use common_tracing::init_tracing_with_file;
+use common_tracing::init_global_tracing;
 use common_tracing::set_panic_hook;
 use common_tracing::tracing;
 use databend_query::api::HttpService;
@@ -53,8 +53,14 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
         MetaEmbedded::init_global_meta_store(conf.meta.meta_embedded_dir.clone()).await?;
     }
 
-    let _guards = init_tracing_with_file(
-        "databend-query",
+    let app_name = format!(
+        "databend-query-{}@{}:{}",
+        conf.query.cluster_id, conf.query.mysql_handler_host, conf.query.mysql_handler_port
+    );
+    //let _guards = init_tracing_with_file(
+    let _guards = init_global_tracing(
+        //"databend-query",
+        app_name.as_str(),
         conf.log.log_dir.as_str(),
         conf.log.log_level.as_str(),
     );

--- a/query/src/interpreters/interpreter_select.rs
+++ b/query/src/interpreters/interpreter_select.rs
@@ -53,7 +53,7 @@ impl Interpreter for SelectInterpreter {
         self.select.schema()
     }
 
-    #[tracing::instrument(level = "info", skip(self, _input_stream), fields(ctx.id = self.ctx.get_id().as_str()))]
+    #[tracing::instrument(level = "info", name="select_interpreter_execute", skip(self, _input_stream), fields(ctx.id = self.ctx.get_id().as_str()))]
     async fn execute(
         &self,
         _input_stream: Option<SendableDataBlockStream>,

--- a/query/src/interpreters/plan_schedulers/plan_scheduler.rs
+++ b/query/src/interpreters/plan_schedulers/plan_scheduler.rs
@@ -101,7 +101,7 @@ impl PlanScheduler {
     }
 
     /// Schedule the plan to Local or Remote mode.
-    #[tracing::instrument(level = "debug", skip(self, plan))]
+    #[tracing::instrument(level = "info", skip(self, plan))]
     pub fn reschedule(mut self, plan: &PlanNode) -> Result<Tasks> {
         let context = self.query_context.clone();
         let cluster = context.get_cluster();

--- a/query/src/interpreters/plan_schedulers/plan_scheduler.rs
+++ b/query/src/interpreters/plan_schedulers/plan_scheduler.rs
@@ -101,7 +101,7 @@ impl PlanScheduler {
     }
 
     /// Schedule the plan to Local or Remote mode.
-    #[tracing::instrument(level = "info", skip(self, plan))]
+    #[tracing::instrument(level = "debug", skip(self, plan))]
     pub fn reschedule(mut self, plan: &PlanNode) -> Result<Tasks> {
         let context = self.query_context.clone();
         let cluster = context.get_cluster();

--- a/query/src/interpreters/plan_schedulers/plan_scheduler_query.rs
+++ b/query/src/interpreters/plan_schedulers/plan_scheduler_query.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_planners::PlanNode;
 use common_streams::SendableDataBlockStream;
+use common_tracing::tracing;
 
 use crate::interpreters::plan_schedulers;
 use crate::interpreters::plan_schedulers::Scheduled;
@@ -26,6 +27,7 @@ use crate::interpreters::PlanScheduler;
 use crate::pipelines::processors::PipelineBuilder;
 use crate::sessions::QueryContext;
 
+#[tracing::instrument(level = "debug", skip(ctx), fields(ctx.id = ctx.get_id().as_str()))]
 pub async fn schedule_query(
     ctx: &Arc<QueryContext>,
     plan: &PlanNode,

--- a/query/src/pipelines/processors/pipeline.rs
+++ b/query/src/pipelines/processors/pipeline.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_streams::SendableDataBlockStream;
+use common_tracing::tracing;
 
 use super::MixedProcessor;
 use crate::pipelines::processors::MergeProcessor;
@@ -150,6 +151,7 @@ impl Pipeline {
         Ok(())
     }
 
+    #[tracing::instrument(level = "info", name="pipeline_execute", skip(self), fields(ctx.id = self.ctx.get_id().as_str()))]
     pub async fn execute(&mut self) -> Result<SendableDataBlockStream> {
         if self.last_pipe()?.nums() > 1 {
             self.merge_processor()?;

--- a/query/src/pipelines/processors/processor_merge.rs
+++ b/query/src/pipelines/processors/processor_merge.rs
@@ -22,6 +22,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_streams::SendableDataBlockStream;
 use common_tracing::tracing;
+use common_tracing::tracing::Instrument;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
 
@@ -41,6 +42,7 @@ impl MergeProcessor {
         }
     }
 
+    #[tracing::instrument(level = "info", skip(self), fields(ctx.id = self.ctx.get_id().as_str()))]
     pub fn merge(&self) -> Result<SendableDataBlockStream> {
         let len = self.inputs.len();
         if len == 0 {
@@ -53,36 +55,39 @@ impl MergeProcessor {
         for i in 0..len {
             let processor = self.inputs[i].clone();
             let sender = sender.clone();
-            self.ctx.try_spawn(async move {
-                let mut stream = match processor.execute().await {
-                    Err(e) => {
-                        if let Err(error) = sender.send(Result::Err(e)).await {
-                            tracing::error!("Merge processor cannot push data: {}", error);
-                        }
-                        return;
-                    }
-                    Ok(stream) => stream,
-                };
-
-                while let Some(item) = stream.next().await {
-                    match item {
-                        Ok(item) => {
-                            if let Err(error) = sender.send(Ok(item)).await {
-                                // Stop pulling data
-                                tracing::error!("Merge processor cannot push data: {}", error);
-                                return;
-                            }
-                        }
-                        Err(error) => {
-                            // Stop pulling data
-                            if let Err(error) = sender.send(Err(error)).await {
+            self.ctx.try_spawn(
+                async move {
+                    let mut stream = match processor.execute().await {
+                        Err(e) => {
+                            if let Err(error) = sender.send(Result::Err(e)).await {
                                 tracing::error!("Merge processor cannot push data: {}", error);
                             }
                             return;
                         }
+                        Ok(stream) => stream,
+                    };
+
+                    while let Some(item) = stream.next().await {
+                        match item {
+                            Ok(item) => {
+                                if let Err(error) = sender.send(Ok(item)).await {
+                                    // Stop pulling data
+                                    tracing::error!("Merge processor cannot push data: {}", error);
+                                    return;
+                                }
+                            }
+                            Err(error) => {
+                                // Stop pulling data
+                                if let Err(error) = sender.send(Err(error)).await {
+                                    tracing::error!("Merge processor cannot push data: {}", error);
+                                }
+                                return;
+                            }
+                        }
                     }
                 }
-            })?;
+                .instrument(tracing::debug_span!("merge_input").or_current()),
+            )?;
         }
         Ok(Box::pin(ReceiverStream::new(receiver)))
     }
@@ -107,6 +112,7 @@ impl Processor for MergeProcessor {
         self
     }
 
+    #[tracing::instrument(level = "info", name="merge_processor_execute", skip(self), fields(ctx.id = self.ctx.get_id().as_str()))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         match self.inputs.len() {
             1 => self.inputs[0].execute().await,

--- a/query/src/pipelines/processors/processor_mixed.rs
+++ b/query/src/pipelines/processors/processor_mixed.rs
@@ -133,6 +133,7 @@ impl Processor for MixedProcessor {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "mixed_processor_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         let receiver = {
             let mut worker = self.worker.write();

--- a/query/src/pipelines/transforms/transform_aggregator_final.rs
+++ b/query/src/pipelines/transforms/transform_aggregator_final.rs
@@ -75,6 +75,7 @@ impl Processor for AggregatorFinalTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "aggregator_final_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         tracing::debug!("execute...");
 

--- a/query/src/pipelines/transforms/transform_aggregator_partial.rs
+++ b/query/src/pipelines/transforms/transform_aggregator_partial.rs
@@ -88,7 +88,6 @@ impl Processor for AggregatorPartialTransform {
 
     #[tracing::instrument(level = "info", name = "aggregator_partial_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
-        tracing::info!("enter");
         tracing::debug!("execute...");
         let start = Instant::now();
 
@@ -145,7 +144,6 @@ impl Processor for AggregatorPartialTransform {
 
         let block = DataBlock::create_by_array(self.schema.clone(), columns);
 
-        tracing::info!("return");
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,

--- a/query/src/pipelines/transforms/transform_aggregator_partial.rs
+++ b/query/src/pipelines/transforms/transform_aggregator_partial.rs
@@ -86,7 +86,9 @@ impl Processor for AggregatorPartialTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "aggregator_partial_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
+        tracing::info!("enter");
         tracing::debug!("execute...");
         let start = Instant::now();
 
@@ -143,6 +145,7 @@ impl Processor for AggregatorPartialTransform {
 
         let block = DataBlock::create_by_array(self.schema.clone(), columns);
 
+        tracing::info!("return");
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,

--- a/query/src/pipelines/transforms/transform_create_sets.rs
+++ b/query/src/pipelines/transforms/transform_create_sets.rs
@@ -25,6 +25,7 @@ use common_infallible::Mutex;
 use common_planners::Expression;
 use common_streams::SendableDataBlockStream;
 use common_streams::SubQueriesStream;
+use common_tracing::tracing;
 use futures::future::join_all;
 use futures::future::BoxFuture;
 use futures::future::JoinAll;
@@ -118,6 +119,7 @@ impl Processor for CreateSetsTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "create_sets_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         let data = self.execute_sub_queries()?.await;
 
@@ -155,6 +157,7 @@ impl<'a> SubQueriesPuller<'a> {
         self.expressions.len()
     }
 
+    #[tracing::instrument(level = "info", skip(self))]
     pub fn take_subquery_data(
         &mut self,
         pos: usize,

--- a/query/src/pipelines/transforms/transform_filter.rs
+++ b/query/src/pipelines/transforms/transform_filter.rs
@@ -100,6 +100,7 @@ impl<const HAVING: bool> Processor for FilterTransform<HAVING> {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "filter_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         let input_stream = self.input.execute().await?;
         let executor = self.executor.clone();

--- a/query/src/pipelines/transforms/transform_group_by_final.rs
+++ b/query/src/pipelines/transforms/transform_group_by_final.rs
@@ -81,6 +81,7 @@ impl Processor for GroupByFinalTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "group_by_final_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         tracing::debug!("execute...");
         let funcs = self

--- a/query/src/pipelines/transforms/transform_group_by_partial.rs
+++ b/query/src/pipelines/transforms/transform_group_by_partial.rs
@@ -125,6 +125,7 @@ impl Processor for GroupByPartialTransform {
     ///  3, 1 -> state1
     ///  4, 2 -> state2
     /// 1.2)  serialize the state to the output block
+    #[tracing::instrument(level = "info", name = "group_by_partial_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         tracing::debug!("execute...");
         let group_cols = self.extract_group_columns();

--- a/query/src/pipelines/transforms/transform_limit.rs
+++ b/query/src/pipelines/transforms/transform_limit.rs
@@ -59,6 +59,7 @@ impl Processor for LimitTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "limit_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         tracing::debug!("execute...");
         let input_stream = self.input.execute().await?;

--- a/query/src/pipelines/transforms/transform_limit_by.rs
+++ b/query/src/pipelines/transforms/transform_limit_by.rs
@@ -59,6 +59,7 @@ impl Processor for LimitByTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name="limit_by_execute" skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         tracing::debug!("execute...");
 

--- a/query/src/pipelines/transforms/transform_projection.rs
+++ b/query/src/pipelines/transforms/transform_projection.rs
@@ -73,6 +73,7 @@ impl Processor for ProjectionTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "projection_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         tracing::debug!("execute...");
 

--- a/query/src/pipelines/transforms/transform_remote.rs
+++ b/query/src/pipelines/transforms/transform_remote.rs
@@ -80,6 +80,7 @@ impl Processor for RemoteTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "remote_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         tracing::debug!(
             "execute, flight_ticket {:?}, node name:{:#}...",
@@ -92,9 +93,9 @@ impl Processor for RemoteTransform {
 
         let fetch_ticket = self.ticket.clone();
         let mut flight_client = self.flight_client().await?;
-        let fetch_stream = flight_client.fetch_stream(fetch_ticket, data_schema, timeout);
-        Ok(Box::pin(
-            self.ctx.try_create_abortable(fetch_stream.await?)?,
-        ))
+        let fetch_stream = flight_client
+            .fetch_stream(fetch_ticket, data_schema, timeout)
+            .await?;
+        Ok(Box::pin(self.ctx.try_create_abortable(fetch_stream)?))
     }
 }

--- a/query/src/pipelines/transforms/transform_sink.rs
+++ b/query/src/pipelines/transforms/transform_sink.rs
@@ -76,6 +76,7 @@ impl Processor for SinkTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "sink_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         tracing::debug!("executing sink transform");
         let tbl = self

--- a/query/src/pipelines/transforms/transform_sort_merge.rs
+++ b/query/src/pipelines/transforms/transform_sort_merge.rs
@@ -71,6 +71,7 @@ impl Processor for SortMergeTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "sort_merge_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         tracing::debug!("execute...");
 

--- a/query/src/pipelines/transforms/transform_sort_partial.rs
+++ b/query/src/pipelines/transforms/transform_sort_partial.rs
@@ -69,6 +69,7 @@ impl Processor for SortPartialTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name = "sort_partial_execute", skip(self))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         tracing::debug!("execute...");
 

--- a/query/src/pipelines/transforms/transform_source.rs
+++ b/query/src/pipelines/transforms/transform_source.rs
@@ -70,6 +70,7 @@ impl Processor for SourceTransform {
         self
     }
 
+    #[tracing::instrument(level = "info", name="source_execute", skip(self), fields(ctx.id = self.ctx.get_id().as_str()))]
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         let desc = self.source_plan.table_info.desc.clone();
         tracing::debug!("execute, table:{:#} ...", desc);

--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -281,6 +281,7 @@ impl<W: std::io::Write> InteractiveWorkerBase<W> {
 
     fn do_close(&mut self, _: u32) {}
 
+    #[tracing::instrument(level = "info", skip(self))]
     async fn do_query(&mut self, query: &str) -> Result<(Vec<DataBlock>, String)> {
         tracing::debug!("{}", query);
 

--- a/query/src/storages/fuse/operations/commit.rs
+++ b/query/src/storages/fuse/operations/commit.rs
@@ -44,7 +44,7 @@ impl FuseTable {
     ) -> Result<()> {
         // TODO OCC retry & resolves conflicts if applicable
 
-        let prev = self.table_snapshot(ctx.as_ref()).await?;
+        let prev = self.read_table_snapshot(ctx.as_ref()).await?;
         let new_snapshot = if overwrite {
             let schema = self.table_info.meta.schema.as_ref().clone();
             let (segments, summary) = Self::merge_append_operations(&schema, operation_log)?;

--- a/query/src/storages/fuse/operations/read.rs
+++ b/query/src/storages/fuse/operations/read.rs
@@ -22,8 +22,8 @@ use common_planners::Extras;
 use common_streams::ParquetSource;
 use common_streams::SendableDataBlockStream;
 use common_streams::Source;
+use common_tracing::tracing_futures::Instrument;
 use futures::StreamExt;
-use tracing_futures::Instrument;
 
 use crate::sessions::QueryContext;
 use crate::storages::fuse::FuseTable;

--- a/query/src/storages/fuse/operations/read.rs
+++ b/query/src/storages/fuse/operations/read.rs
@@ -15,14 +15,15 @@
 
 use std::sync::Arc;
 
-use async_stream::stream;
 use common_datavalues::DataSchema;
+use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::Extras;
 use common_streams::ParquetSource;
 use common_streams::SendableDataBlockStream;
 use common_streams::Source;
 use futures::StreamExt;
+use tracing_futures::Instrument;
 
 use crate::sessions::QueryContext;
 use crate::storages::fuse::FuseTable;
@@ -66,25 +67,27 @@ impl FuseTable {
         let arrow_schema = self.table_info.schema().to_arrow();
         let table_schema = Arc::new(DataSchema::from(arrow_schema));
 
-        let mut iter = futures::stream::iter(iter);
-        let stream = stream! {
-            while let Some(part) = iter.next().await {
-                let mut source = ParquetSource::new(
-                    da.clone(),
-                    part.name.clone(),
-                    table_schema.clone(),
-                    projection.clone(),
-                );
-                loop {
-                    let block = source.read().await;
-                    match block {
-                        Ok(None) => break,
-                        Ok(Some(b)) =>  yield(Ok(b)),
-                        Err(e) => yield(Err(e)),
-                    }
+        let part_stream = futures::stream::iter(iter);
+
+        // fallback to stream combinator from async_stream, since
+        // 1. when using `stream!`, the trace always contains a unclosed call-span (of ParquetSource::read)
+        // 2. later, when `bit_size` is larger than one, the async reads could be buffered
+
+        let stream = part_stream
+            .map(move |part| {
+                let da = da.clone();
+                let table_schema = table_schema.clone();
+                let projection = projection.clone();
+                async move {
+                    let mut source =
+                        ParquetSource::new(da, part.name.clone(), table_schema, projection);
+                    source.read().await?.ok_or_else(|| {
+                        ErrorCode::ParquetError(format!("fail to read block {}", part.name))
+                    })
                 }
-            }
-        };
+            })
+            .buffered(bite_size) // buffer_unordered?
+            .instrument(common_tracing::tracing::Span::current());
         Ok(Box::pin(stream))
     }
 }

--- a/query/src/storages/fuse/operations/read_plan.rs
+++ b/query/src/storages/fuse/operations/read_plan.rs
@@ -34,7 +34,7 @@ impl FuseTable {
         ctx: Arc<QueryContext>,
         push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
-        let snapshot = self.table_snapshot(ctx.as_ref()).await?;
+        let snapshot = self.read_table_snapshot(ctx.as_ref()).await?;
         match snapshot {
             Some(snapshot) => {
                 let da = ctx.get_data_accessor()?;

--- a/query/src/storages/fuse/operations/truncate.rs
+++ b/query/src/storages/fuse/operations/truncate.rs
@@ -29,7 +29,7 @@ use crate::storages::fuse::TBL_OPT_KEY_SNAPSHOT_LOC;
 impl FuseTable {
     #[inline]
     pub async fn do_truncate(&self, ctx: Arc<QueryContext>, plan: TruncateTablePlan) -> Result<()> {
-        if let Some(prev_snapshot) = self.table_snapshot(ctx.as_ref()).await? {
+        if let Some(prev_snapshot) = self.read_table_snapshot(ctx.as_ref()).await? {
             let prev_id = prev_snapshot.snapshot_id;
             let mut new_snapshot = prev_snapshot;
             new_snapshot.segments = vec![];

--- a/query/src/storages/fuse/pruning/block_pruner.rs
+++ b/query/src/storages/fuse/pruning/block_pruner.rs
@@ -19,6 +19,7 @@ use common_dal::DataAccessor;
 use common_datavalues::DataSchemaRef;
 use common_exception::Result;
 use common_planners::Extras;
+use common_tracing::tracing;
 use futures::StreamExt;
 use futures::TryStreamExt;
 
@@ -109,6 +110,7 @@ impl BlockPruner {
     }
 }
 
+#[tracing::instrument(level = "info", skip(table_snapshot, schema, push_down, data_accessor, ctx), fields(ctx.id = ctx.get_id().as_str()))]
 pub async fn apply_block_pruning(
     table_snapshot: &TableSnapshot,
     schema: DataSchemaRef,

--- a/query/src/storages/fuse/table.rs
+++ b/query/src/storages/fuse/table.rs
@@ -27,6 +27,7 @@ use common_planners::ReadDataSourcePlan;
 use common_planners::Statistics;
 use common_planners::TruncateTablePlan;
 use common_streams::SendableDataBlockStream;
+use common_tracing::tracing;
 use futures::StreamExt;
 
 use crate::sessions::QueryContext;
@@ -65,6 +66,7 @@ impl Table for FuseTable {
         true
     }
 
+    #[tracing::instrument(level = "info", name="fuse_table_read_partitions", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn read_partitions(
         &self,
         ctx: Arc<QueryContext>,
@@ -73,6 +75,7 @@ impl Table for FuseTable {
         self.do_read_partitions(ctx, push_downs).await
     }
 
+    #[tracing::instrument(level = "info", name="fuse_table_read", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn read(
         &self,
         ctx: Arc<QueryContext>,
@@ -81,6 +84,7 @@ impl Table for FuseTable {
         self.do_read(ctx, &plan.push_downs).await
     }
 
+    #[tracing::instrument(level = "info", name="fuse_table_append_data", skip(self, ctx, stream), fields(ctx.id = ctx.get_id().as_str()))]
     async fn append_data(
         &self,
         ctx: Arc<QueryContext>,
@@ -130,7 +134,11 @@ impl FuseTable {
             .cloned()
     }
 
-    pub(crate) async fn table_snapshot(&self, ctx: &QueryContext) -> Result<Option<TableSnapshot>> {
+    #[tracing::instrument(level = "info", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
+    pub(crate) async fn read_table_snapshot(
+        &self,
+        ctx: &QueryContext,
+    ) -> Result<Option<TableSnapshot>> {
         if let Some(loc) = self.snapshot_loc() {
             let da = ctx.get_data_accessor()?;
             Ok(Some(

--- a/scripts/deploy/env_trace.sh
+++ b/scripts/deploy/env_trace.sh
@@ -1,0 +1,47 @@
+echo "*-------------------------------------*"
+echo "* setting up env RUST_LOG for tracing *"
+echo "*-------------------------------------*"
+echo ""
+
+export RUST_LOG=info
+export OTEL_BSP_MAX_EXPORT_BATCH_SIZE=1
+export DATABEND_JAEGER=on
+
+function set_env() {
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		case $arg in
+		-d)
+			echo "- flight rpc tracing enabled"
+			export TRACE_RPC=",databend_query::api::rpc=debug"
+			shift
+			;;
+		-p)
+			echo "- parquet reader tracing enabled"
+			export TRACE_PARQUET_READER=",common_streams::sources::source_parquet=debug"
+			shift
+			;;
+		*)
+			echo "! unknown option [$arg], ignored"
+			shift
+			;;
+		esac
+	done
+}
+
+if [ $# -eq 0 ]; then
+	set_env "-d" "-p"
+else
+	set_env $@
+fi
+
+export RUST_LOG=${RUST_LOG}${TRACE_RPC}${TRACE_PARQUET_READER}
+echo ""
+echo "envs:"
+echo "*** RUST_LOG=$RUST_LOG"
+echo "*** OTEL_BSP_MAX_EXPORT_BATCH_SIZE=$OTEL_BSP_MAX_EXPORT_BATCH_SIZE"
+echo "*** DATABEND_JAEGER=$DATABEND_JAEGER"
+echo ""
+
+echo "please be sure that jaeger is started"
+echo "    e.g. docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

- enable opentelemetry_jaeger for databend-query
- add instruments

**how to play:**

- bring up jaeger
   `docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest`
-  set up env vars
   under project root path
   ~~~
   > # set up env vars: RUST_LOG, DATABEND_JAEGER, and OTEL_BSP_MAX_EXPORT_BATCH_SIZE
   > source ./scripts/deploy/env_trace.sh

   > # kick off ur favorite deploy script, e.g.
   > ./scripts/deploy/databend-query-cluster-3-nodes.sh

   > # run some sqls
   > # visit http://127.0.0.1:16686/
    
   ~~~
  


**NOTE**:

  - for transformers that implements `Processor::execute`, the name of span has been tweaked a little bit
   
     like this
     ~~~rust
      impl Processor for ProjectionTransform { 
       ...
      #[tracing::instrument(level = "info", name = "projection_execute", skip(self))]
      async fn execute(&self) -> Result<SendableDataBlockStream> {
       ... 
     ~~~
     hope it will be helpful in browsing the jaeger report
  - service-name is encoded as **databend_query-${cluster_id}@${mysql_host}:${mysql_port}**  
  - by default
    - almost all the transformers's `execute` method are traced at `INFO` level
    - distributed RPC are traced at `DEBUG` level   
  - some spawned task and stream has been instrumented manually, to make the span sensible
  
 **A sample span diagram** :

  - global tracing level INFO
  - query flight rpc's tracing level DEBUG
  - parquet-source tracing level DEBUG
     
![127 0 0 1_16686_trace_382b579d57865d4dca57ac30f765c711 (1)](https://user-images.githubusercontent.com/22081156/147256371-2e282a30-b7aa-4b9a-bb69-a30ac745b18c.png)


## Changelog

- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #3627

## Test Plan

Unit Tests

Stateless Tests

