### PR TITLE
ci: Only ping author after PR has been approved

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,9 +2,8 @@ pull_request_rules:
   # if there is a conflict in a approved PR, ping the author.
   - name: ping author on conflicts
     conditions:
-      - and:
-        - conflict
-        - #approved-reviews-by>=2
+      - conflict
+      - "#approved-reviews-by >= 2"
     actions:
       comment:
         message: This pull request has merge conflicts that must be resolved before it can be merged. @{{author}} please rebase it 🙏

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,9 @@
 pull_request_rules:
-  # if there is a conflict in a backport PR, ping the author.
+  # if there is a conflict in a approved PR, ping the author.
   - name: ping author on conflicts
     conditions:
       - conflict
+      - #approved-reviews-by>=2
     actions:
       comment:
         message: This pull request has merge conflicts that must be resolved before it can be merged. @{{author}} please rebase it 🙏

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,4 +6,7 @@ pull_request_rules:
       - "#approved-reviews-by >= 2"
     actions:
       comment:
-        message: This pull request has merge conflicts that must be resolved before it can be merged. @{{author}} please rebase it 🙏
+        message: |
+          This pull request has merge conflicts that must be resolved before it can be merged. @{{author}} please update it 🙏.
+
+          Try `@mergify update` or update manually.

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,8 +2,9 @@ pull_request_rules:
   # if there is a conflict in a approved PR, ping the author.
   - name: ping author on conflicts
     conditions:
-      - conflict
-      - #approved-reviews-by>=2
+      - and:
+        - conflict
+        - #approved-reviews-by>=2
     actions:
       comment:
         message: This pull request has merge conflicts that must be resolved before it can be merged. @{{author}} please rebase it 🙏


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

It's noisy for a PR author to keep receiving comments like the following.

https://github.com/datafuselabs/databend/pull/3606

![image](https://user-images.githubusercontent.com/5351546/147338753-f246588c-9d86-4957-abda-466a8c783309.png)

The PR is not ready for merge yet, we don't need to trouble them.

This PR adds a new condition that only pings the author while the PR has been approved by two reviewers.

## Changelog

- Build/Testing/CI

