### PR TITLE
fix: migrate from analytics.js to gtag.js

### DIFF
--- a/website/databend/docusaurus.config.js
+++ b/website/databend/docusaurus.config.js
@@ -35,7 +35,7 @@ const config = {
                 theme: {
                     customCss: require.resolve('./src/css/custom.scss'),
                 },
-                googleAnalytics: {
+                gtag: {
                   trackingID: 'G-WBQPTTG4ZG',
                   anonymizeIP: true,
                 },
@@ -79,7 +79,7 @@ const config = {
               },
             ],
           },
-        ],
+        ]
     ],
     themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
@@ -176,10 +176,7 @@ const config = {
                 indexName: 'TBD',
                 contextualSearch: true,
                 searchParameters: {},
-            },
-            gtag: {
-                trackingID: 'TBD',
-            },
+            }
         }),
 };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary
I found that analytics.js had problems collecting data, and I checked the official documents and needed to do a migration.
Refer to these materials for details:
[https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs](url)
[https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-analytics](url)
[https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag](url)

and docusaurus options items are modified, specific reference: [https://github.com/facebook/docusaurus/pull/5832 ](url)

## Changelog

- Bug Fix
- Improvement

