### PR TITLE
[ci] try to add sharedkey and resetkey

### DIFF
--- a/.github/actions/build_debug/action.yml
+++ b/.github/actions/build_debug/action.yml
@@ -23,7 +23,8 @@ runs:
 
     - uses: Swatinem/rust-cache@v1
       with:
-        sharedKey: debug-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        sharedKey: debug
 
     - uses: actions-rs/cargo@v1
       with:

--- a/.github/actions/build_debug/action.yml
+++ b/.github/actions/build_debug/action.yml
@@ -21,9 +21,10 @@ runs:
         target: ${{ matrix.config.target }}
         components: rustfmt, clippy
 
+    # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
         sharedKey: debug
 
     - uses: actions-rs/cargo@v1

--- a/.github/actions/build_debug/action.yml
+++ b/.github/actions/build_debug/action.yml
@@ -22,6 +22,8 @@ runs:
         components: rustfmt, clippy
 
     - uses: Swatinem/rust-cache@v1
+      with:
+        sharedKey: debug-${{ secrets.CACHE_RESET_KEY }}
 
     - uses: actions-rs/cargo@v1
       with:

--- a/.github/actions/build_debug/action.yml
+++ b/.github/actions/build_debug/action.yml
@@ -24,8 +24,7 @@ runs:
     # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
-        sharedKey: debug
+        sharedKey: debug-v1
 
     - uses: actions-rs/cargo@v1
       with:

--- a/.github/actions/build_release/action.yml
+++ b/.github/actions/build_release/action.yml
@@ -22,6 +22,8 @@ runs:
         components: rustfmt, clippy
 
     - uses: Swatinem/rust-cache@v1
+      with:
+        sharedKey: release-${{ secrets.CACHE_RESET_KEY }}
 
     - name: Build Databend
       uses: actions-rs/cargo@v1

--- a/.github/actions/build_release/action.yml
+++ b/.github/actions/build_release/action.yml
@@ -23,7 +23,8 @@ runs:
 
     - uses: Swatinem/rust-cache@v1
       with:
-        sharedKey: release-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        sharedKey: release
 
     - name: Build Databend
       uses: actions-rs/cargo@v1

--- a/.github/actions/build_release/action.yml
+++ b/.github/actions/build_release/action.yml
@@ -21,9 +21,10 @@ runs:
         target: ${{ matrix.config.target }}
         components: rustfmt, clippy
 
+    # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
         sharedKey: release
 
     - name: Build Databend

--- a/.github/actions/build_release/action.yml
+++ b/.github/actions/build_release/action.yml
@@ -24,8 +24,7 @@ runs:
     # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
-        sharedKey: release
+        sharedKey: release-v1
 
     - name: Build Databend
       uses: actions-rs/cargo@v1

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -23,8 +23,7 @@ runs:
     # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
-        sharedKey: base
+        sharedKey: base-v1
 
     - name: Format
       uses: actions-rs/cargo@v1

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -20,9 +20,10 @@ runs:
       with:
         components: rustfmt, clippy
 
+    # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
         sharedKey: base
 
     - name: Format

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -21,6 +21,8 @@ runs:
         components: rustfmt, clippy
 
     - uses: Swatinem/rust-cache@v1
+      with:
+        sharedKey: base-${{ secrets.CACHE_RESET_KEY }}
 
     - name: Format
       uses: actions-rs/cargo@v1

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -22,7 +22,8 @@ runs:
 
     - uses: Swatinem/rust-cache@v1
       with:
-        sharedKey: base-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        sharedKey: base
 
     - name: Format
       uses: actions-rs/cargo@v1

--- a/.github/actions/test_stateful_standalone/action.yml
+++ b/.github/actions/test_stateful_standalone/action.yml
@@ -12,9 +12,10 @@ runs:
       with:
         target: ${{ matrix.config.target }}
 
+    # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
         sharedKey: stateful
 
     - uses: actions/download-artifact@v2

--- a/.github/actions/test_stateful_standalone/action.yml
+++ b/.github/actions/test_stateful_standalone/action.yml
@@ -14,7 +14,8 @@ runs:
 
     - uses: Swatinem/rust-cache@v1
       with:
-        sharedKey: stateful-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        sharedKey: stateful
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/actions/test_stateful_standalone/action.yml
+++ b/.github/actions/test_stateful_standalone/action.yml
@@ -13,6 +13,8 @@ runs:
         target: ${{ matrix.config.target }}
 
     - uses: Swatinem/rust-cache@v1
+      with:
+        sharedKey: stateful-${{ secrets.CACHE_RESET_KEY }}
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/actions/test_stateful_standalone/action.yml
+++ b/.github/actions/test_stateful_standalone/action.yml
@@ -15,8 +15,7 @@ runs:
     # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
-        sharedKey: stateful
+        sharedKey: stateful-v1
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/actions/test_stateless_cluster/action.yml
+++ b/.github/actions/test_stateless_cluster/action.yml
@@ -13,6 +13,8 @@ runs:
         target: ${{ matrix.config.target }}
 
     - uses: Swatinem/rust-cache@v1
+      with:
+        sharedKey: stateless-${{ secrets.CACHE_RESET_KEY }}
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/actions/test_stateless_cluster/action.yml
+++ b/.github/actions/test_stateless_cluster/action.yml
@@ -12,9 +12,10 @@ runs:
       with:
         target: ${{ matrix.config.target }}
 
+    # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
         sharedKey: stateless
 
     - uses: actions/download-artifact@v2

--- a/.github/actions/test_stateless_cluster/action.yml
+++ b/.github/actions/test_stateless_cluster/action.yml
@@ -14,7 +14,8 @@ runs:
 
     - uses: Swatinem/rust-cache@v1
       with:
-        sharedKey: stateless-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        sharedKey: stateless
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/actions/test_stateless_cluster/action.yml
+++ b/.github/actions/test_stateless_cluster/action.yml
@@ -15,8 +15,7 @@ runs:
     # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
-        sharedKey: stateless
+        sharedKey: stateless-v1
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/actions/test_stateless_standalone/action.yml
+++ b/.github/actions/test_stateless_standalone/action.yml
@@ -16,8 +16,7 @@ runs:
     # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
-        sharedKey: stateless
+        sharedKey: stateless-v1
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/actions/test_stateless_standalone/action.yml
+++ b/.github/actions/test_stateless_standalone/action.yml
@@ -15,7 +15,8 @@ runs:
 
     - uses: Swatinem/rust-cache@v1
       with:
-        sharedKey: stateless-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        sharedKey: stateless
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/actions/test_stateless_standalone/action.yml
+++ b/.github/actions/test_stateless_standalone/action.yml
@@ -14,6 +14,8 @@ runs:
         target: ${{ matrix.config.target }}
 
     - uses: Swatinem/rust-cache@v1
+      with:
+        sharedKey: stateless-${{ secrets.CACHE_RESET_KEY }}
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/actions/test_stateless_standalone/action.yml
+++ b/.github/actions/test_stateless_standalone/action.yml
@@ -13,9 +13,10 @@ runs:
         toolchain: ${{ matrix.config.toolchain }}
         target: ${{ matrix.config.target }}
 
+    # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
         sharedKey: stateless
 
     - uses: actions/download-artifact@v2

--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -27,6 +27,8 @@ runs:
         components: rustfmt, clippy
 
     - uses: Swatinem/rust-cache@v1
+      with:
+        sharedKey: unit-${{ secrets.CACHE_RESET_KEY }}
 
     - name: Test
       uses: actions-rs/cargo@v1

--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -29,8 +29,7 @@ runs:
     # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
-        sharedKey: unit
+        sharedKey: unit-v1
 
     - name: Test
       uses: actions-rs/cargo@v1

--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -28,7 +28,8 @@ runs:
 
     - uses: Swatinem/rust-cache@v1
       with:
-        sharedKey: unit-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        sharedKey: unit
 
     - name: Test
       uses: actions-rs/cargo@v1

--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -26,9 +26,10 @@ runs:
         target: ${{ matrix.config.target }}
         components: rustfmt, clippy
 
+    # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-${{ secrets.CACHE_RESET_KEY }}
+        key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.config.toolchain }}-v1
         sharedKey: unit
 
     - name: Test


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

try to add sharedkey and resetkey

- `sharedkey`  an additional key that is stable over multiple jobs.
- `resetkey` use `v*` to control the cache version. If we need to reset the cache version, increment the number after `v`.

## Changelog

- Build/Testing/CI
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

