### PR TITLE
Improve origin array builder & make nullable/no-nullable builder support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ version = "0.1.0"
 dependencies = [
  "async-compat",
  "async-trait",
- "bytes",
+ "bytes 1.1.0",
  "common-exception",
  "futures",
  "reqwest",

--- a/common/datavalues/src/arrays/boolean/mutable.rs
+++ b/common/datavalues/src/arrays/boolean/mutable.rs
@@ -30,8 +30,8 @@ pub struct MutableBooleanArrayBuilder {
 }
 
 impl MutableArrayBuilder for MutableBooleanArrayBuilder {
-    fn data_type(&self) -> DataType {
-        DataType::Boolean
+    fn data_type(&self) -> &DataType {
+        &self.data_type
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -43,9 +43,8 @@ impl MutableArrayBuilder for MutableBooleanArrayBuilder {
     }
 
     fn as_series(&mut self) -> Series {
-        let arrow_data_type = self.data_type.to_arrow();
         let array: Arc<dyn Array> = Arc::new(BooleanArray::from_data(
-            arrow_data_type,
+            self.data_type.to_arrow(),
             std::mem::take(&mut self.values).into(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
         ));
@@ -76,16 +75,9 @@ impl MutableBooleanArrayBuilder {
         }
     }
 
-    pub fn from_data(
-        data_type: DataType,
-        values: MutableBitmap,
-        validity: Option<MutableBitmap>,
-    ) -> Self {
-        if data_type != DataType::Boolean {
-            panic!("MutableBooleanArrayBuilder can only be initialized with DataType::Boolean")
-        }
+    pub fn from_data(values: MutableBitmap, validity: Option<MutableBitmap>) -> Self {
         Self {
-            data_type,
+            data_type: DataType::Boolean,
             values,
             validity,
         }

--- a/common/datavalues/src/arrays/boolean/mutable.rs
+++ b/common/datavalues/src/arrays/boolean/mutable.rs
@@ -12,19 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_arrow::arrow::array::MutableArray;
-use common_arrow::arrow::array::MutableBooleanArray;
+use std::sync::Arc;
+
+use common_arrow::arrow::array::Array;
+use common_arrow::arrow::array::BooleanArray;
 use common_arrow::arrow::bitmap::MutableBitmap;
-use common_arrow::arrow::datatypes::DataType as ArrowDataType;
 
 use crate::arrays::mutable::MutableArrayBuilder;
 use crate::series::IntoSeries;
 use crate::series::Series;
 use crate::DataType;
 
-#[derive(Default)]
 pub struct MutableBooleanArrayBuilder {
-    builder: MutableBooleanArray,
+    data_type: DataType,
+    values: MutableBitmap,
+    validity: Option<MutableBitmap>,
 }
 
 impl MutableArrayBuilder for MutableBooleanArrayBuilder {
@@ -41,33 +43,85 @@ impl MutableArrayBuilder for MutableBooleanArrayBuilder {
     }
 
     fn as_series(&mut self) -> Series {
-        self.builder.as_arc().into_series()
+        let arrow_data_type = self.data_type.to_arrow();
+        let array: Arc<dyn Array> = Arc::new(BooleanArray::from_data(
+            arrow_data_type,
+            std::mem::take(&mut self.values).into(),
+            std::mem::take(&mut self.validity).map(|x| x.into()),
+        ));
+        array.into_series()
     }
 
     fn push_null(&mut self) {
-        self.builder.push_null();
+        self.push_option(None);
+    }
+}
+
+impl Default for MutableBooleanArrayBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 impl MutableBooleanArrayBuilder {
+    pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            data_type: DataType::Boolean,
+            values: MutableBitmap::with_capacity(capacity),
+            validity: None,
+        }
+    }
+
     pub fn from_data(
-        data_type: ArrowDataType,
+        data_type: DataType,
         values: MutableBitmap,
         validity: Option<MutableBitmap>,
     ) -> Self {
-        let builder = MutableBooleanArray::from_data(data_type, values, validity);
-        Self { builder }
+        if data_type != DataType::Boolean {
+            panic!("MutableBooleanArrayBuilder can only be initialized with DataType::Boolean")
+        }
+        Self {
+            data_type,
+            values,
+            validity,
+        }
     }
 
     pub fn push(&mut self, value: bool) {
-        self.builder.push(Some(value));
+        self.values.push(value);
+        match &mut self.validity {
+            Some(validity) => validity.push(true),
+            None => {}
+        }
     }
 
     pub fn push_option(&mut self, value: Option<bool>) {
-        self.builder.push(value);
+        match value {
+            Some(value) => {
+                self.push(value);
+            }
+            None => {
+                self.values.push(false);
+                match &mut self.validity {
+                    Some(validity) => validity.push(false),
+                    None => self.init_validity(),
+                }
+            }
+        }
     }
 
-    pub fn push_null(&mut self) {
-        self.builder.push_null();
+    fn init_validity(&mut self) {
+        let mut validity = MutableBitmap::with_capacity(self.values.capacity());
+        validity.extend_constant(self.len(), true);
+        validity.set(self.len() - 1, false);
+        self.validity = Some(validity)
+    }
+
+    fn len(&self) -> usize {
+        self.values.len()
     }
 }

--- a/common/datavalues/src/arrays/mutable.rs
+++ b/common/datavalues/src/arrays/mutable.rs
@@ -30,7 +30,7 @@ pub trait MutableArrayBuilder {
 
 pub fn create_mutable_array(datatype: DataType) -> Box<dyn MutableArrayBuilder> {
     match datatype {
-        DataType::Boolean => Box::new(MutableBooleanArrayBuilder::default()),
+        DataType::Boolean => Box::new(MutableBooleanArrayBuilder::<true>::default()),
         DataType::UInt8 => Box::new(MutablePrimitiveArrayBuilder::<u8, true>::default()),
         DataType::UInt16 => Box::new(MutablePrimitiveArrayBuilder::<u16, true>::default()),
         DataType::UInt32 => Box::new(MutablePrimitiveArrayBuilder::<u32, true>::default()),

--- a/common/datavalues/src/arrays/mutable.rs
+++ b/common/datavalues/src/arrays/mutable.rs
@@ -31,16 +31,16 @@ pub trait MutableArrayBuilder {
 pub fn create_mutable_array(datatype: DataType) -> Box<dyn MutableArrayBuilder> {
     match datatype {
         DataType::Boolean => Box::new(MutableBooleanArrayBuilder::default()),
-        DataType::UInt8 => Box::new(MutablePrimitiveArrayBuilder::<u8>::default()),
-        DataType::UInt16 => Box::new(MutablePrimitiveArrayBuilder::<u16>::default()),
-        DataType::UInt32 => Box::new(MutablePrimitiveArrayBuilder::<u32>::default()),
-        DataType::UInt64 => Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
-        DataType::Int8 => Box::new(MutablePrimitiveArrayBuilder::<i8>::default()),
-        DataType::Int16 => Box::new(MutablePrimitiveArrayBuilder::<i16>::default()),
-        DataType::Int32 => Box::new(MutablePrimitiveArrayBuilder::<i32>::default()),
-        DataType::Int64 => Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-        DataType::Float32 => Box::new(MutablePrimitiveArrayBuilder::<f32>::default()),
-        DataType::Float64 => Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
+        DataType::UInt8 => Box::new(MutablePrimitiveArrayBuilder::<u8, true>::default()),
+        DataType::UInt16 => Box::new(MutablePrimitiveArrayBuilder::<u16, true>::default()),
+        DataType::UInt32 => Box::new(MutablePrimitiveArrayBuilder::<u32, true>::default()),
+        DataType::UInt64 => Box::new(MutablePrimitiveArrayBuilder::<u64, true>::default()),
+        DataType::Int8 => Box::new(MutablePrimitiveArrayBuilder::<i8, true>::default()),
+        DataType::Int16 => Box::new(MutablePrimitiveArrayBuilder::<i16, true>::default()),
+        DataType::Int32 => Box::new(MutablePrimitiveArrayBuilder::<i32, true>::default()),
+        DataType::Int64 => Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+        DataType::Float32 => Box::new(MutablePrimitiveArrayBuilder::<f32, true>::default()),
+        DataType::Float64 => Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
         DataType::String => Box::new(MutableStringArrayBuilder::default()),
         _ => {
             todo!()

--- a/common/datavalues/src/arrays/mutable.rs
+++ b/common/datavalues/src/arrays/mutable.rs
@@ -21,7 +21,7 @@ use crate::series::Series;
 use crate::DataType;
 
 pub trait MutableArrayBuilder {
-    fn data_type(&self) -> DataType;
+    fn data_type(&self) -> &DataType;
     fn as_any(&self) -> &dyn Any;
     fn as_mut_any(&mut self) -> &mut dyn Any;
     fn as_series(&mut self) -> Series;

--- a/common/datavalues/src/arrays/mutable.rs
+++ b/common/datavalues/src/arrays/mutable.rs
@@ -14,6 +14,8 @@
 
 use std::any::Any;
 
+use common_arrow::arrow::bitmap::MutableBitmap;
+
 use super::MutableBooleanArrayBuilder;
 use super::MutablePrimitiveArrayBuilder;
 use super::MutableStringArrayBuilder;
@@ -26,6 +28,7 @@ pub trait MutableArrayBuilder {
     fn as_mut_any(&mut self) -> &mut dyn Any;
     fn as_series(&mut self) -> Series;
     fn push_null(&mut self);
+    fn validity(&self) -> Option<&MutableBitmap>;
 }
 
 pub fn create_mutable_array(datatype: DataType) -> Box<dyn MutableArrayBuilder> {
@@ -41,7 +44,7 @@ pub fn create_mutable_array(datatype: DataType) -> Box<dyn MutableArrayBuilder> 
         DataType::Int64 => Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
         DataType::Float32 => Box::new(MutablePrimitiveArrayBuilder::<f32, true>::default()),
         DataType::Float64 => Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
-        DataType::String => Box::new(MutableStringArrayBuilder::default()),
+        DataType::String => Box::new(MutableStringArrayBuilder::<true>::default()),
         _ => {
             todo!()
         }

--- a/common/datavalues/src/arrays/primitive/mutable.rs
+++ b/common/datavalues/src/arrays/primitive/mutable.rs
@@ -37,9 +37,8 @@ where T: DFPrimitiveType
 impl<T> MutableArrayBuilder for MutablePrimitiveArrayBuilder<T>
 where T: DFPrimitiveType
 {
-    // TODO(veeupup) change it into reference
-    fn data_type(&self) -> DataType {
-        self.data_type.clone()
+    fn data_type(&self) -> &DataType {
+        &self.data_type
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -51,9 +50,8 @@ where T: DFPrimitiveType
     }
 
     fn as_series(&mut self) -> Series {
-        let arrow_data_type = self.data_type.to_arrow();
         let array: Arc<dyn Array> = Arc::new(PrimitiveArray::<T>::from_data(
-            arrow_data_type,
+            self.data_type.to_arrow(),
             std::mem::take(&mut self.values).into(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
         ));

--- a/common/datavalues/src/arrays/primitive/mutable.rs
+++ b/common/datavalues/src/arrays/primitive/mutable.rs
@@ -61,7 +61,7 @@ where T: DFPrimitiveType
     }
 
     fn push_null(&mut self) {
-        self.push_null()
+        self.push_option(None)
     }
 }
 
@@ -115,11 +115,7 @@ where T: DFPrimitiveType
     pub fn push_option(&mut self, val: Option<T>) {
         match val {
             Some(val) => {
-                self.values.push(val);
-                match &mut self.validity {
-                    Some(validity) => validity.push(true),
-                    None => {}
-                }
+                self.push(val);
             }
             None => {
                 self.values.push(T::default());
@@ -131,10 +127,6 @@ where T: DFPrimitiveType
                 }
             }
         }
-    }
-
-    pub fn push_null(&mut self) {
-        self.push_option(None);
     }
 
     fn init_validity(&mut self) {

--- a/common/functions/src/aggregates/aggregate_arg_min_max.rs
+++ b/common/functions/src/aggregates/aggregate_arg_min_max.rs
@@ -192,7 +192,7 @@ where
                 DataValue::Boolean(val) => {
                     let mut array = array
                     .as_mut_any()
-                    .downcast_mut::<MutableBooleanArrayBuilder>()
+                    .downcast_mut::<MutableBooleanArrayBuilder<true>>()
                     .ok_or_else(|| {
                         ErrorCode::UnexpectedError(
                             "error occured when downcast MutableArray".to_string(),
@@ -342,7 +342,7 @@ impl AggregateArgMinMaxState for StringState {
                 DataValue::Boolean(val) => {
                     let mut array = array
                     .as_mut_any()
-                    .downcast_mut::<MutableBooleanArrayBuilder>()
+                    .downcast_mut::<MutableBooleanArrayBuilder<true>>()
                     .ok_or_else(|| {
                         ErrorCode::UnexpectedError(
                             "error occured when downcast MutableArray".to_string(),

--- a/common/functions/src/aggregates/aggregate_arg_min_max.rs
+++ b/common/functions/src/aggregates/aggregate_arg_min_max.rs
@@ -165,7 +165,7 @@ where
 
     #[allow(unused_mut)]
     fn merge_result(&mut self, array: &mut dyn MutableArrayBuilder) -> Result<()> {
-        let datatype: DataType = array.data_type();
+        let datatype = array.data_type();
         with_match_primitive_type!(datatype, |$T| {
             let mut array = array
                 .as_mut_any()
@@ -315,7 +315,7 @@ impl AggregateArgMinMaxState for StringState {
 
     #[allow(unused_mut)]
     fn merge_result(&mut self, array: &mut dyn MutableArrayBuilder) -> Result<()> {
-        let datatype: DataType = array.data_type();
+        let datatype = array.data_type();
         with_match_primitive_type!(datatype, |$T| {
             let mut array = array
                 .as_mut_any()

--- a/common/functions/src/aggregates/aggregate_arg_min_max.rs
+++ b/common/functions/src/aggregates/aggregate_arg_min_max.rs
@@ -169,7 +169,7 @@ where
         with_match_primitive_type!(datatype, |$T| {
             let mut array = array
                 .as_mut_any()
-                .downcast_mut::<MutablePrimitiveArrayBuilder<$T>>()
+                .downcast_mut::<MutablePrimitiveArrayBuilder<$T, true>>()
                 .ok_or_else(|| {
                     ErrorCode::UnexpectedError(
                         "error occured when downcast MutableArray".to_string(),
@@ -319,7 +319,7 @@ impl AggregateArgMinMaxState for StringState {
         with_match_primitive_type!(datatype, |$T| {
             let mut array = array
                 .as_mut_any()
-                .downcast_mut::<MutablePrimitiveArrayBuilder<$T>>()
+                .downcast_mut::<MutablePrimitiveArrayBuilder<$T, true>>()
                 .ok_or_else(|| {
                     ErrorCode::UnexpectedError(
                         "error occured when downcast MutableArray".to_string(),

--- a/common/functions/src/aggregates/aggregate_arg_min_max.rs
+++ b/common/functions/src/aggregates/aggregate_arg_min_max.rs
@@ -203,7 +203,7 @@ where
                 DataValue::String(val) => {
                     let mut array = array
                     .as_mut_any()
-                    .downcast_mut::<MutableStringArrayBuilder>()
+                    .downcast_mut::<MutableStringArrayBuilder<true>>()
                     .ok_or_else(|| {
                         ErrorCode::UnexpectedError(
                             "error occured when downcast MutableArray".to_string(),
@@ -353,7 +353,7 @@ impl AggregateArgMinMaxState for StringState {
                 DataValue::String(val) => {
                     let mut array = array
                     .as_mut_any()
-                    .downcast_mut::<MutableStringArrayBuilder>()
+                    .downcast_mut::<MutableStringArrayBuilder<true>>()
                     .ok_or_else(|| {
                         ErrorCode::UnexpectedError(
                             "error occured when downcast MutableArray".to_string(),

--- a/common/functions/src/aggregates/aggregate_avg.rs
+++ b/common/functions/src/aggregates/aggregate_avg.rs
@@ -159,7 +159,7 @@ where
 
         let mut array = array
             .as_mut_any()
-            .downcast_mut::<MutablePrimitiveArrayBuilder<f64>>()
+            .downcast_mut::<MutablePrimitiveArrayBuilder<f64, true>>()
             .ok_or_else(|| {
                 ErrorCode::UnexpectedError("error occured when downcast MutableArray".to_string())
             })?;

--- a/common/functions/src/aggregates/aggregate_combinator_distinct.rs
+++ b/common/functions/src/aggregates/aggregate_combinator_distinct.rs
@@ -210,7 +210,7 @@ impl AggregateFunction for AggregateDistinctCombinator {
         if self.nested.name() == "AggregateFunctionCount" {
             let mut array = array
                 .as_mut_any()
-                .downcast_mut::<MutablePrimitiveArrayBuilder<u64>>()
+                .downcast_mut::<MutablePrimitiveArrayBuilder<u64, true>>()
                 .ok_or_else(|| {
                     ErrorCode::UnexpectedError(
                         "error occured when downcast MutableArray".to_string(),

--- a/common/functions/src/aggregates/aggregate_count.rs
+++ b/common/functions/src/aggregates/aggregate_count.rs
@@ -146,7 +146,7 @@ impl AggregateFunction for AggregateCountFunction {
     fn merge_result(&self, place: StateAddr, array: &mut dyn MutableArrayBuilder) -> Result<()> {
         let mut array = array
             .as_mut_any()
-            .downcast_mut::<MutablePrimitiveArrayBuilder<u64>>()
+            .downcast_mut::<MutablePrimitiveArrayBuilder<u64, true>>()
             .ok_or_else(|| {
                 ErrorCode::UnexpectedError("error occured when downcast MutableArray".to_string())
             })?;

--- a/common/functions/src/aggregates/aggregate_covariance.rs
+++ b/common/functions/src/aggregates/aggregate_covariance.rs
@@ -251,7 +251,7 @@ where
     fn merge_result(&self, place: StateAddr, array: &mut dyn MutableArrayBuilder) -> Result<()> {
         let mut array = array
             .as_mut_any()
-            .downcast_mut::<MutablePrimitiveArrayBuilder<f64>>()
+            .downcast_mut::<MutablePrimitiveArrayBuilder<f64, true>>()
             .ok_or_else(|| {
                 ErrorCode::UnexpectedError("error occured when downcast MutableArray".to_string())
             })?;

--- a/common/functions/src/aggregates/aggregate_min_max.rs
+++ b/common/functions/src/aggregates/aggregate_min_max.rs
@@ -222,7 +222,7 @@ impl AggregateMinMaxState for StringState {
         let v = self.value.clone();
         let mut array = array
             .as_mut_any()
-            .downcast_mut::<MutableStringArrayBuilder>()
+            .downcast_mut::<MutableStringArrayBuilder<true>>()
             .ok_or_else(|| {
                 ErrorCode::UnexpectedError("error occured when downcast MutableArray".to_string())
             })?;

--- a/common/functions/src/aggregates/aggregate_min_max.rs
+++ b/common/functions/src/aggregates/aggregate_min_max.rs
@@ -139,7 +139,7 @@ where
         if let Some(val) = self.value {
             let mut array = array
                 .as_mut_any()
-                .downcast_mut::<MutablePrimitiveArrayBuilder<T>>()
+                .downcast_mut::<MutablePrimitiveArrayBuilder<T, true>>()
                 .ok_or_else(|| {
                     ErrorCode::UnexpectedError(
                         "error occured when downcast MutableArray".to_string(),

--- a/common/functions/src/aggregates/aggregate_stddev_pop.rs
+++ b/common/functions/src/aggregates/aggregate_stddev_pop.rs
@@ -187,7 +187,7 @@ where T: DFPrimitiveType + AsPrimitive<f64>
         }
         let mut array = array
             .as_mut_any()
-            .downcast_mut::<MutablePrimitiveArrayBuilder<f64>>()
+            .downcast_mut::<MutablePrimitiveArrayBuilder<f64, true>>()
             .ok_or_else(|| {
                 ErrorCode::UnexpectedError("error occured when downcast MutableArray".to_string())
             })?;

--- a/common/functions/src/aggregates/aggregate_sum.rs
+++ b/common/functions/src/aggregates/aggregate_sum.rs
@@ -169,7 +169,7 @@ where
         if let Some(val) = state.value {
             let mut array = array
                 .as_mut_any()
-                .downcast_mut::<MutablePrimitiveArrayBuilder<SumT>>()
+                .downcast_mut::<MutablePrimitiveArrayBuilder<SumT, true>>()
                 .ok_or_else(|| {
                     ErrorCode::UnexpectedError(
                         "error occured when downcast MutableArray".to_string(),

--- a/common/functions/src/aggregates/aggregate_window_funnel.rs
+++ b/common/functions/src/aggregates/aggregate_window_funnel.rs
@@ -255,7 +255,7 @@ where
         let result = self.get_event_level(place);
         let mut array = array
             .as_mut_any()
-            .downcast_mut::<MutablePrimitiveArrayBuilder<u8>>()
+            .downcast_mut::<MutablePrimitiveArrayBuilder<u8, true>>()
             .ok_or_else(|| {
                 ErrorCode::UnexpectedError("error occured when downcast MutableArray".to_string())
             })?;

--- a/common/functions/tests/it/aggregates/aggregate_combinator.rs
+++ b/common/functions/tests/it/aggregates/aggregate_combinator.rs
@@ -56,8 +56,8 @@ fn test_aggregate_combinator_function() -> Result<()> {
             func_name: "countdistinct",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::from_data(
                 DataType::UInt64,
                 MutableBuffer::from([4u64]),
                 Some(MutableBitmap::from([true])),
@@ -71,8 +71,8 @@ fn test_aggregate_combinator_function() -> Result<()> {
             func_name: "sumdistinct",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([10i64]),
                 Some(MutableBitmap::from([true])),
@@ -86,8 +86,8 @@ fn test_aggregate_combinator_function() -> Result<()> {
             func_name: "countif",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::from_data(
                 DataType::UInt64,
                 MutableBuffer::from([10u64]),
                 Some(MutableBitmap::from([true])),
@@ -101,8 +101,8 @@ fn test_aggregate_combinator_function() -> Result<()> {
             func_name: "minif",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([1i64]),
                 Some(MutableBitmap::from([true])),
@@ -116,8 +116,8 @@ fn test_aggregate_combinator_function() -> Result<()> {
             func_name: "maxif",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([4i64]),
                 Some(MutableBitmap::from([true])),
@@ -131,8 +131,8 @@ fn test_aggregate_combinator_function() -> Result<()> {
             func_name: "sumif",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([30i64]),
                 Some(MutableBitmap::from([true])),
@@ -146,8 +146,8 @@ fn test_aggregate_combinator_function() -> Result<()> {
             func_name: "avgif",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([3f64]),
                 Some(MutableBitmap::from([true])),
@@ -181,12 +181,12 @@ fn test_aggregate_combinator_function() -> Result<()> {
                 let array = t
                         .input_array
                         .as_mut_any()
-                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T>>()
+                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T, true>>()
                         .unwrap();
                 let expect = t
                         .expect_array
                         .as_mut_any()
-                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T>>()
+                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T, true>>()
                         .unwrap();
 
                 assert_eq!(array.data_type(), expect.data_type(), "{}", t.name);
@@ -240,8 +240,8 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             func_name: "countdistinct",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::from_data(
                 DataType::UInt64,
                 MutableBuffer::from([0u64]),
                 Some(MutableBitmap::from([true])),
@@ -255,8 +255,8 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             func_name: "sumdistinct",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
@@ -270,8 +270,8 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             func_name: "countif",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::from_data(
                 DataType::UInt64,
                 MutableBuffer::from([0u64]),
                 Some(MutableBitmap::from([true])),
@@ -285,8 +285,8 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             func_name: "minif",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
@@ -300,8 +300,8 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             func_name: "maxif",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
@@ -315,8 +315,8 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             func_name: "sumif",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
@@ -330,8 +330,8 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             func_name: "avgif",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([0f64]),
                 Some(MutableBitmap::from([false])),
@@ -366,12 +366,12 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
                 let array = t
                         .input_array
                         .as_mut_any()
-                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T>>()
+                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T, true>>()
                         .unwrap();
                 let expect = t
                         .expect_array
                         .as_mut_any()
-                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T>>()
+                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T, true>>()
                         .unwrap();
 
                 assert_eq!(array.data_type(), expect.data_type(), "{}", t.name);

--- a/common/functions/tests/it/aggregates/aggregate_combinator.rs
+++ b/common/functions/tests/it/aggregates/aggregate_combinator.rs
@@ -17,7 +17,6 @@ use std::borrow::BorrowMut;
 use bumpalo::Bump;
 use common_arrow::arrow::bitmap::MutableBitmap;
 use common_arrow::arrow::buffer::MutableBuffer;
-use common_arrow::arrow::datatypes::DataType as ArrowDataType;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_functions::aggregates::AggregateFunctionFactory;
@@ -59,7 +58,7 @@ fn test_aggregate_combinator_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt64,
+                DataType::UInt64,
                 MutableBuffer::from([4u64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -74,7 +73,7 @@ fn test_aggregate_combinator_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([10i64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -89,7 +88,7 @@ fn test_aggregate_combinator_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt64,
+                DataType::UInt64,
                 MutableBuffer::from([10u64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -104,7 +103,7 @@ fn test_aggregate_combinator_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([1i64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -119,7 +118,7 @@ fn test_aggregate_combinator_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([4i64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -134,7 +133,7 @@ fn test_aggregate_combinator_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([30i64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -149,7 +148,7 @@ fn test_aggregate_combinator_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([3f64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -243,7 +242,7 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt64,
+                DataType::UInt64,
                 MutableBuffer::from([0u64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -258,7 +257,7 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -273,7 +272,7 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt64,
+                DataType::UInt64,
                 MutableBuffer::from([0u64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -288,7 +287,7 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -303,7 +302,7 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -318,7 +317,7 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -333,7 +332,7 @@ fn test_aggregate_combinator_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([0f64]),
                 Some(MutableBitmap::from([false])),
             )),

--- a/common/functions/tests/it/aggregates/aggregate_function.rs
+++ b/common/functions/tests/it/aggregates/aggregate_function.rs
@@ -69,8 +69,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "count",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::from_data(
                 DataType::UInt64,
                 MutableBuffer::from([4u64]),
                 Some(MutableBitmap::from([true])),
@@ -85,8 +85,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "max",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([4i64]),
                 Some(MutableBitmap::from([true])),
@@ -101,8 +101,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "min",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([1i64]),
                 Some(MutableBitmap::from([true])),
@@ -117,8 +117,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "avg",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([2.5f64]),
                 Some(MutableBitmap::from([true])),
@@ -133,8 +133,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "sum",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([10i64]),
                 Some(MutableBitmap::from([true])),
@@ -149,8 +149,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "argmax",
             arrays: vec![arrays[0].clone(), arrays[1].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([1i64]),
                 Some(MutableBitmap::from([true])),
@@ -165,8 +165,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "argmin",
             arrays: vec![arrays[0].clone(), arrays[1].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([4i64]),
                 Some(MutableBitmap::from([true])),
@@ -181,8 +181,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "argmin",
             arrays: arrays.clone(),
             error: "Code: 28, displayText = argmin expect to have two arguments, but got 1.",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([4i64]),
                 Some(MutableBitmap::from([true])),
@@ -197,8 +197,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "uniq",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::from_data(
                 DataType::UInt64,
                 MutableBuffer::from([4u64]),
                 Some(MutableBitmap::from([true])),
@@ -213,8 +213,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "std",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([1.118033988749895f64]),
                 Some(MutableBitmap::from([true])),
@@ -229,8 +229,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "stddev",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([1.118033988749895f64]),
                 Some(MutableBitmap::from([true])),
@@ -245,8 +245,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "stddev_pop",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([1.118033988749895f64]),
                 Some(MutableBitmap::from([true])),
@@ -261,8 +261,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "covar_samp",
             arrays: vec![arrays[0].clone(), arrays[1].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([-1.6666666666666667f64]),
                 Some(MutableBitmap::from([true])),
@@ -277,8 +277,8 @@ fn test_aggregate_function() -> Result<()> {
             func_name: "covar_pop",
             arrays: vec![arrays[0].clone(), arrays[1].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([-1.25000f64]),
                 Some(MutableBitmap::from([true])),
@@ -303,8 +303,8 @@ fn test_aggregate_function() -> Result<()> {
                 arrays[5].clone(),
             ],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u8>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u8, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u8, true>::from_data(
                 DataType::UInt8,
                 MutableBuffer::from([3u8]),
                 Some(MutableBitmap::from([true])),
@@ -345,12 +345,12 @@ fn test_aggregate_function() -> Result<()> {
                 let array = t
                         .input_array
                         .as_mut_any()
-                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T>>()
+                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T, true>>()
                         .unwrap();
                 let expect = t
                         .expect_array
                         .as_mut_any()
-                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T>>()
+                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T, true>>()
                         .unwrap();
 
                 assert_eq!(array.data_type(), expect.data_type(), "{}", t.name);
@@ -417,8 +417,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "count",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::from_data(
                 DataType::UInt64,
                 MutableBuffer::from([2u64, 2u64]),
                 Some(MutableBitmap::from([true, true])),
@@ -433,8 +433,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "max",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([4i64, 3i64]),
                 Some(MutableBitmap::from([true, true])),
@@ -449,8 +449,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "min",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([2i64, 1i64]),
                 Some(MutableBitmap::from([true, true])),
@@ -465,8 +465,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "avg",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([3.0f64, 2.0f64]),
                 Some(MutableBitmap::from([true, true])),
@@ -481,8 +481,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "sum",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([6i64, 4i64]),
                 Some(MutableBitmap::from([true, true])),
@@ -497,8 +497,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "argmax",
             arrays: vec![arrays[0].clone(), arrays[1].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([2i64, 1i64]),
                 Some(MutableBitmap::from([true, true])),
@@ -513,8 +513,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "argmax",
             arrays: vec![arrays[0].clone(), arrays[2].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([2i64, 1i64]),
                 Some(MutableBitmap::from([true, true])),
@@ -529,8 +529,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "argmin",
             arrays: vec![arrays[0].clone(), arrays[1].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([4i64, 3i64]),
                 Some(MutableBitmap::from([true, true])),
@@ -545,8 +545,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "argmin",
             arrays: vec![arrays[0].clone(), arrays[1].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([4i64, 3i64]),
                 Some(MutableBitmap::from([true, true])),
@@ -561,8 +561,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "uniq",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::from_data(
                 DataType::UInt64,
                 MutableBuffer::from([2u64, 2u64]),
                 Some(MutableBitmap::from([true, true])),
@@ -577,8 +577,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "std",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([1.0f64, 1.0f64]),
                 Some(MutableBitmap::from([true, true])),
@@ -593,8 +593,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "stddev",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([1.0f64, 1.0f64]),
                 Some(MutableBitmap::from([true, true])),
@@ -609,8 +609,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "stddev_pop",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([1.0f64, 1.0f64]),
                 Some(MutableBitmap::from([true, true])),
@@ -625,8 +625,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "covar_samp",
             arrays: vec![arrays[0].clone(), arrays[1].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([-2.0f64, -2.0f64]),
                 Some(MutableBitmap::from([true, true])),
@@ -641,8 +641,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             func_name: "covar_pop",
             arrays: vec![arrays[0].clone(), arrays[1].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([-1.0f64, -1.0f64]),
                 Some(MutableBitmap::from([true, true])),
@@ -662,8 +662,8 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
                 arrays[6].clone(),
             ],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u8>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u8, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u8, true>::from_data(
                 DataType::UInt8,
                 MutableBuffer::from([2u8, 1u8]),
                 Some(MutableBitmap::from([true, true])),
@@ -699,12 +699,12 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
                 let array = t
                         .input_array
                         .as_mut_any()
-                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T>>()
+                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T, true>>()
                         .unwrap();
                 let expect = t
                         .expect_array
                         .as_mut_any()
-                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T>>()
+                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T, true>>()
                         .unwrap();
 
                 assert_eq!(array.data_type(), expect.data_type(), "{}", t.name);
@@ -760,8 +760,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "count",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::from_data(
                 DataType::UInt64,
                 MutableBuffer::from([0u64]),
                 Some(MutableBitmap::from([true])),
@@ -776,8 +776,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "max",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
@@ -792,8 +792,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "min",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
@@ -808,8 +808,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "avg",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([0f64]),
                 Some(MutableBitmap::from([false])),
@@ -824,8 +824,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "sum",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
@@ -840,8 +840,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "argmax",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
@@ -856,8 +856,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "argmin",
             arrays: arrays.clone(),
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<i64, true>::from_data(
                 DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
@@ -872,8 +872,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "uniq",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<u64, true>::from_data(
                 DataType::UInt64,
                 MutableBuffer::from([0u64]),
                 Some(MutableBitmap::from([true])),
@@ -888,8 +888,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "std",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([0f64]),
                 Some(MutableBitmap::from([false])),
@@ -904,8 +904,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "stddev",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([0f64]),
                 Some(MutableBitmap::from([false])),
@@ -920,8 +920,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "stddev_pop",
             arrays: vec![arrays[0].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([0f64]),
                 Some(MutableBitmap::from([false])),
@@ -936,8 +936,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "covar_samp",
             arrays: vec![arrays[0].clone(), arrays[1].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([f64::INFINITY]),
                 Some(MutableBitmap::from([true])),
@@ -952,8 +952,8 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             func_name: "covar_pop",
             arrays: vec![arrays[0].clone(), arrays[1].clone()],
             error: "",
-            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
-            expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
+            input_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::default()),
+            expect_array: Box::new(MutablePrimitiveArrayBuilder::<f64, true>::from_data(
                 DataType::Float64,
                 MutableBuffer::from([f64::INFINITY]),
                 Some(MutableBitmap::from([true])),
@@ -990,12 +990,12 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
                 let array = t
                         .input_array
                         .as_mut_any()
-                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T>>()
+                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T, true>>()
                         .unwrap();
                 let expect = t
                         .expect_array
                         .as_mut_any()
-                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T>>()
+                        .downcast_ref::<MutablePrimitiveArrayBuilder<$T, true>>()
                         .unwrap();
 
                 assert_eq!(array.data_type(), expect.data_type(), "{}", t.name);
@@ -1048,17 +1048,17 @@ fn test_covariance_with_comparable_data_sets() -> Result<()> {
         let _ = func.merge_result(addr.into(), array)?;
         let array = array
             .as_mut_any()
-            .downcast_ref::<MutablePrimitiveArrayBuilder<f64>>()
+            .downcast_ref::<MutablePrimitiveArrayBuilder<f64, true>>()
             .unwrap();
         let val = array.values()[0];
         Ok(val)
     };
 
-    let mut array = MutablePrimitiveArrayBuilder::<f64>::default();
+    let mut array = MutablePrimitiveArrayBuilder::<f64, true>::default();
     let r = run_test("covar_samp", &mut array)?;
     approx_eq!(f64, 0.0, r, epsilon = 0.000001);
 
-    let mut array = MutablePrimitiveArrayBuilder::<f64>::default();
+    let mut array = MutablePrimitiveArrayBuilder::<f64, true>::default();
     let r = run_test("covar_pop", &mut array)?;
     approx_eq!(f64, 0.0, r, epsilon = 0.000001);
 

--- a/common/functions/tests/it/aggregates/aggregate_function.rs
+++ b/common/functions/tests/it/aggregates/aggregate_function.rs
@@ -17,7 +17,6 @@ use std::borrow::BorrowMut;
 use bumpalo::Bump;
 use common_arrow::arrow::bitmap::MutableBitmap;
 use common_arrow::arrow::buffer::MutableBuffer;
-use common_arrow::arrow::datatypes::DataType as ArrowDataType;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_functions::aggregates::*;
@@ -72,7 +71,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt64,
+                DataType::UInt64,
                 MutableBuffer::from([4u64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -88,7 +87,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([4i64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -104,7 +103,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([1i64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -120,7 +119,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([2.5f64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -136,7 +135,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([10i64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -152,7 +151,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([1i64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -168,7 +167,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([4i64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -184,7 +183,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "Code: 28, displayText = argmin expect to have two arguments, but got 1.",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([4i64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -200,7 +199,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt64,
+                DataType::UInt64,
                 MutableBuffer::from([4u64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -216,7 +215,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([1.118033988749895f64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -232,7 +231,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([1.118033988749895f64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -248,7 +247,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([1.118033988749895f64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -264,7 +263,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([-1.6666666666666667f64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -280,7 +279,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([-1.25000f64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -306,7 +305,7 @@ fn test_aggregate_function() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u8>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt8,
+                DataType::UInt8,
                 MutableBuffer::from([3u8]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -420,7 +419,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt64,
+                DataType::UInt64,
                 MutableBuffer::from([2u64, 2u64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -436,7 +435,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([4i64, 3i64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -452,7 +451,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([2i64, 1i64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -468,7 +467,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([3.0f64, 2.0f64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -484,7 +483,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([6i64, 4i64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -500,7 +499,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([2i64, 1i64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -516,7 +515,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([2i64, 1i64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -532,7 +531,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([4i64, 3i64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -548,7 +547,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([4i64, 3i64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -564,7 +563,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt64,
+                DataType::UInt64,
                 MutableBuffer::from([2u64, 2u64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -580,7 +579,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([1.0f64, 1.0f64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -596,7 +595,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([1.0f64, 1.0f64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -612,7 +611,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([1.0f64, 1.0f64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -628,7 +627,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([-2.0f64, -2.0f64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -644,7 +643,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([-1.0f64, -1.0f64]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -665,7 +664,7 @@ fn test_aggregate_function_with_grpup_by() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u8>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt8,
+                DataType::UInt8,
                 MutableBuffer::from([2u8, 1u8]),
                 Some(MutableBitmap::from([true, true])),
             )),
@@ -763,7 +762,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt64,
+                DataType::UInt64,
                 MutableBuffer::from([0u64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -779,7 +778,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -795,7 +794,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -811,7 +810,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([0f64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -827,7 +826,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -843,7 +842,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -859,7 +858,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<i64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Int64,
+                DataType::Int64,
                 MutableBuffer::from([0i64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -875,7 +874,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<u64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::UInt64,
+                DataType::UInt64,
                 MutableBuffer::from([0u64]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -891,7 +890,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([0f64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -907,7 +906,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([0f64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -923,7 +922,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([0f64]),
                 Some(MutableBitmap::from([false])),
             )),
@@ -939,7 +938,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([f64::INFINITY]),
                 Some(MutableBitmap::from([true])),
             )),
@@ -955,7 +954,7 @@ fn test_aggregate_function_on_empty_data() -> Result<()> {
             error: "",
             input_array: Box::new(MutablePrimitiveArrayBuilder::<f64>::default()),
             expect_array: Box::new(MutablePrimitiveArrayBuilder::from_data(
-                ArrowDataType::Float64,
+                DataType::Float64,
                 MutableBuffer::from([f64::INFINITY]),
                 Some(MutableBitmap::from([true])),
             )),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* improve `MutableBooleanArrayBuilder`, `MutablePrimitiveArrayBuilder` and `MutableStringArrayBuilder`, to push value directly rather then call `try_push` to avoid branch prediction cost
* add nullable generic builder support. For example, if we determine that a certain column is with no nullable value, we can have a more efficient arraybuilder, just like below:

```rust
// with no nullable value
let builder = MutableStringArrayBuilder::<false>::default(); // false means no nullable, true means the value may be null
builder.push(val);
```

## Changelog

- Improvement

## Related Issues

Fixes #3692 

## Test Plan

Unit Tests

Stateless Tests

