### PR TITLE
feat: wait_tcp.py to python3

### DIFF
--- a/scripts/ci/wait_tcp.py
+++ b/scripts/ci/wait_tcp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 
 import socket
@@ -11,10 +11,10 @@ def tcp_ping(port, timeout):
 
     while time.time() - now < timeout:
         try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.connect(('0.0.0.0', port))
-            print("OK :{} is listening".format(port))
-            return
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.connect(('0.0.0.0', port))
+                print("OK :{} is listening".format(port))
+                return
         except:
             print("not connected to :{}".format(port))
             time.sleep(0.5)

--- a/scripts/deploy/databend-query-cluster-3-nodes.sh
+++ b/scripts/deploy/databend-query-cluster-3-nodes.sh
@@ -43,7 +43,7 @@ if [ "$mode" == "boot" ]; then
 		--log-dir ./_logs1 \
 		--raft-api-port 28103 \
 		&
-	python scripts/ci/wait_tcp.py --timeout 5 --port 9191
+	python3 scripts/ci/wait_tcp.py --timeout 5 --port 9191
 
 	nohup ./target/debug/databend-meta \
 		--id 2 \
@@ -55,7 +55,7 @@ if [ "$mode" == "boot" ]; then
 		--raft-api-port 28203 \
 		--join 127.0.0.1:28103 \
 		&
-	python scripts/ci/wait_tcp.py --timeout 5 --port 28202
+	python3 scripts/ci/wait_tcp.py --timeout 5 --port 28202
 
 	nohup ./target/debug/databend-meta \
 		--id 3 \
@@ -67,7 +67,7 @@ if [ "$mode" == "boot" ]; then
 		--raft-api-port 28303 \
 		--join 127.0.0.1:28103 \
 		&
-	python scripts/ci/wait_tcp.py --timeout 5 --port 28302
+	python3 scripts/ci/wait_tcp.py --timeout 5 --port 28302
 
 else
 
@@ -83,7 +83,7 @@ else
 		--flight-api-address 0.0.0.0:9191 \
 		--log-dir ./_logs1 \
 		&
-	python scripts/ci/wait_tcp.py --timeout 5 --port 9191
+	python3 scripts/ci/wait_tcp.py --timeout 5 --port 9191
 
 	nohup ./target/debug/databend-meta \
 		--raft-dir "./_meta2" \
@@ -92,7 +92,7 @@ else
 		--flight-api-address 0.0.0.0:28202 \
 		--log-dir ./_logs2 \
 		&
-	python scripts/ci/wait_tcp.py --timeout 5 --port 28202
+	python3 scripts/ci/wait_tcp.py --timeout 5 --port 28202
 
 	nohup ./target/debug/databend-meta \
 		--raft-dir "./_meta3" \
@@ -101,7 +101,7 @@ else
 		--flight-api-address 0.0.0.0:28302 \
 		--log-dir ./_logs3 \
 		&
-	python scripts/ci/wait_tcp.py --timeout 5 --port 28302
+	python3 scripts/ci/wait_tcp.py --timeout 5 --port 28302
 
 fi
 
@@ -109,18 +109,18 @@ echo 'Start DatabendQuery node-1'
 nohup target/debug/databend-query -c scripts/deploy/config/databend-query-node-1.toml &
 
 echo "Waiting on node-1..."
-python scripts/ci/wait_tcp.py --timeout 5 --port 9091
+python3 scripts/ci/wait_tcp.py --timeout 5 --port 9091
 
 echo 'Start DatabendQuery node-2'
 nohup target/debug/databend-query -c scripts/deploy/config/databend-query-node-2.toml &
 
 echo "Waiting on node-2..."
-python scripts/ci/wait_tcp.py --timeout 5 --port 9092
+python3 scripts/ci/wait_tcp.py --timeout 5 --port 9092
 
 echo 'Start DatabendQuery node-3'
 nohup target/debug/databend-query -c scripts/deploy/config/databend-query-node-3.toml &
 
 echo "Waiting on node-3..."
-python scripts/ci/wait_tcp.py --timeout 5 --port 9093
+python3 scripts/ci/wait_tcp.py --timeout 5 --port 9093
 
 echo "All done..."

--- a/scripts/deploy/databend-query-standalone-embedded-meta.sh
+++ b/scripts/deploy/databend-query-standalone-embedded-meta.sh
@@ -21,4 +21,4 @@ BIN=${1:-debug}
 echo 'Start DatabendQuery...'
 nohup target/${BIN}/databend-query -c scripts/deploy/config/databend-query-embedded-meta.toml &
 echo "Waiting on databend-query 10 seconds..."
-python scripts/ci/wait_tcp.py --timeout 5 --port 3307
+python3 scripts/ci/wait_tcp.py --timeout 5 --port 3307

--- a/scripts/deploy/databend-query-standalone.sh
+++ b/scripts/deploy/databend-query-standalone.sh
@@ -21,9 +21,9 @@ BIN=${1:-debug}
 echo 'Start DatabendStore...'
 nohup target/${BIN}/databend-meta --single --log-level=ERROR &
 echo "Waiting on databend-meta 10 seconds..."
-python scripts/ci/wait_tcp.py --timeout 5 --port 9191
+python3 scripts/ci/wait_tcp.py --timeout 5 --port 9191
 
 echo 'Start DatabendQuery...'
 nohup target/${BIN}/databend-query -c scripts/deploy/config/databend-query-node-1.toml &
 echo "Waiting on databend-query 10 seconds..."
-python scripts/ci/wait_tcp.py --timeout 5 --port 3307
+python3 scripts/ci/wait_tcp.py --timeout 5 --port 3307

--- a/tests/perfs/compare.py
+++ b/tests/perfs/compare.py
@@ -268,7 +268,7 @@ def report(releaser, pull, files, type, current_log_link, ref_log_link):
         f.close()
 
 
-## python compare.py -r xxxx -p xxxx
+## python3 compare.py -r xxxx -p xxxx
 if __name__ == '__main__':
     parser = ArgumentParser(description='databend perf results compare tools')
     parser.add_argument('-r',


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

## Changelog

- Improvement
- Build/Testing/CI
- Not for changelog (changelog entry is not required)

## Related Issues

As discussed in #3689 port the `wait_tcp.py` to Python3. 
And use `context manager` to make sure the sock close.