### PR TITLE
ISSUE-3698: Support `as` case-insensitive when create udf

### DIFF
--- a/query/src/sql/sql_parser.rs
+++ b/query/src/sql/sql_parser.rs
@@ -948,8 +948,7 @@ impl<'a> DfParser<'a> {
                 .parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
 
         let udf_name = self.parser.parse_literal_string()?;
-        let as_token = Token::make_keyword("AS");
-        self.parser.expect_token(&as_token)?;
+        self.parser.expect_keyword(Keyword::AS)?;
 
         let desc_token = "DESC";
         let parameters = self.parse_udf_parameters()?;

--- a/query/tests/it/sql/sql_parser.rs
+++ b/query/tests/it/sql/sql_parser.rs
@@ -1417,6 +1417,17 @@ fn test_create_udf() -> Result<()> {
         }),
     )?;
 
+    expect_parse_ok(
+        "CREATE FUNCTION test_udf as (p, d) -> not(isnotnull(p, d)) DESC = 'this is a description'",
+        DfStatement::CreateUDF(DfCreateUDF {
+            if_not_exists: false,
+            udf_name: "test_udf".to_string(),
+            parameters: vec!["p".to_string(), "d".to_string()],
+            definition: "not(isnotnull(p,d))".to_string(),
+            description: "this is a description".to_string(),
+        }),
+    )?;
+
     Ok(())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support `as` case-insensitive when create udf

## Changelog

- Bug Fix

## Related Issues

Fixes #3698

## Test Plan

Unit Tests

Stateless Tests
