### PR TITLE
Merge nullable and return_type methods

### DIFF
--- a/common/functions/src/scalars/arithmetics/binary_arithmetic.rs
+++ b/common/functions/src/scalars/arithmetics/binary_arithmetic.rs
@@ -58,8 +58,9 @@ where T: ArithmeticTrait + Clone + Sync + Send + 'static
         "BinaryArithmeticFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(self.result_type.clone())
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        Ok(DataTypeAndNullable::create(&self.result_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/arithmetics/unary_arithmetic.rs
+++ b/common/functions/src/scalars/arithmetics/unary_arithmetic.rs
@@ -53,8 +53,9 @@ where T: ArithmeticTrait + Clone + Sync + Send + 'static
         "UnaryArithmeticFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(self.result_type.clone())
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        Ok(DataTypeAndNullable::create(&self.result_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/comparisons/comparison.rs
+++ b/common/functions/src/scalars/comparisons/comparison.rs
@@ -58,8 +58,10 @@ impl Function for ComparisonFunction {
         "ComparisonFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::Boolean)
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::Boolean;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/dates/interval_function.rs
+++ b/common/functions/src/scalars/dates/interval_function.rs
@@ -73,11 +73,11 @@ where T: IntegerTypedArithmetic + Clone + Sync + Send + 'static
         self.display_name.as_str()
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if args[0].is_date_or_date_time() {
-            Ok(args[0].data_type().clone())
+            Ok(args[0].clone())
         } else {
-            Ok(args[1].data_type().clone())
+            Ok(args[1].clone())
         }
     }
 

--- a/common/functions/src/scalars/dates/now.rs
+++ b/common/functions/src/scalars/dates/now.rs
@@ -47,8 +47,9 @@ impl Function for NowFunction {
         self.display_name.as_str()
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::DateTime32(None))
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::DateTime32(None);
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, _columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/dates/number_function.rs
+++ b/common/functions/src/scalars/dates/number_function.rs
@@ -416,8 +416,10 @@ where
         self.display_name.as_str()
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        T::return_type()
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = T::return_type()?;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/dates/round_function.rs
+++ b/common/functions/src/scalars/dates/round_function.rs
@@ -52,14 +52,18 @@ impl Function for RoundFunction {
         self.display_name.as_str()
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        match args[0].data_type() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|field| field.is_nullable());
+
+        let data_type = match args[0].data_type() {
             DataType::DateTime32(_) => Ok(DataType::DateTime32(None)),
             _ => Err(ErrorCode::BadDataValueType(format!(
                 "Function {} must have a DateTime type as argument, but got {}",
                 self.display_name, args[0],
             ))),
-        }
+        }?;
+
+        Ok(DataTypeAndNullable::create(&data_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/dates/simple_date.rs
+++ b/common/functions/src/scalars/dates/simple_date.rs
@@ -112,8 +112,9 @@ where T: NoArgDateFunction + Clone + Sync + Send + 'static
         self.display_name.as_str()
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::Date16)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::Date16;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, _columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/dates/week_date.rs
+++ b/common/functions/src/scalars/dates/week_date.rs
@@ -114,8 +114,10 @@ where
         self.display_name.as_str()
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        T::return_type()
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = T::return_type()?;
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/expressions/cast.rs
+++ b/common/functions/src/scalars/expressions/cast.rs
@@ -60,8 +60,10 @@ impl Function for CastFunction {
         "CastFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(self.cast_type.clone())
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = self.cast_type.clone();
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/function.rs
+++ b/common/functions/src/scalars/function.rs
@@ -16,7 +16,6 @@ use std::fmt;
 
 use common_datavalues::columns::DataColumn;
 use common_datavalues::prelude::DataColumnsWithField;
-use common_datavalues::DataType;
 use common_datavalues::DataTypeAndNullable;
 use common_exception::Result;
 use dyn_clone::DynClone;
@@ -38,14 +37,7 @@ pub trait Function: fmt::Display + Sync + Send + DynClone {
     }
 
     /// The method returns the return_type of this function.
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType>;
-
-    /// Whether the function may return null.
-    /// The default implementation checks if any nullable input exists and returns true if exist; otherwise false.
-    fn nullable(&self, arg_fields: &[DataTypeAndNullable]) -> Result<bool> {
-        let any_input_nullable = arg_fields.iter().any(|field| field.is_nullable());
-        Ok(any_input_nullable)
-    }
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable>;
 
     /// Evaluate the function, e.g. run/execute the function.
     fn eval(&self, _columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn>;

--- a/common/functions/src/scalars/function_alias.rs
+++ b/common/functions/src/scalars/function_alias.rs
@@ -16,7 +16,6 @@ use std::fmt;
 
 use common_datavalues::columns::DataColumn;
 use common_datavalues::prelude::DataColumnsWithField;
-use common_datavalues::DataType;
 use common_datavalues::DataTypeAndNullable;
 use common_exception::Result;
 
@@ -38,8 +37,8 @@ impl Function for AliasFunction {
         "AliasFunction"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(args[0].data_type().clone())
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        Ok(args[0].clone())
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/function_column.rs
+++ b/common/functions/src/scalars/function_column.rs
@@ -16,7 +16,6 @@ use std::fmt;
 
 use common_datavalues::columns::DataColumn;
 use common_datavalues::prelude::DataColumnsWithField;
-use common_datavalues::DataType;
 use common_datavalues::DataTypeAndNullable;
 use common_datavalues::DataValue;
 use common_exception::Result;
@@ -43,8 +42,8 @@ impl Function for ColumnFunction {
         "ColumnFunction"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(args[0].data_type().clone())
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        Ok(args[0].clone())
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/function_literal.rs
+++ b/common/functions/src/scalars/function_literal.rs
@@ -16,7 +16,6 @@ use std::fmt;
 
 use common_datavalues::columns::DataColumn;
 use common_datavalues::prelude::DataColumnsWithField;
-use common_datavalues::DataType;
 use common_datavalues::DataTypeAndNullable;
 use common_datavalues::DataValue;
 use common_exception::Result;
@@ -39,12 +38,12 @@ impl Function for LiteralFunction {
         "LiteralFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(self.value.data_type())
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(self.value.is_null())
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = self.value.is_null();
+        Ok(DataTypeAndNullable::create(
+            &self.value.data_type(),
+            nullable,
+        ))
     }
 
     fn eval(&self, _columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/hashes/sha2hash.rs
+++ b/common/functions/src/scalars/hashes/sha2hash.rs
@@ -47,19 +47,17 @@ impl Function for Sha2HashFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if args[0].is_string() && args[1].is_unsigned_integer() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let data_type = if args[0].is_string() && args[1].is_unsigned_integer() {
             Ok(DataType::String)
         } else {
             Err(ErrorCode::IllegalDataType(format!(
                 "Expected string and numeric type, but got {}",
                 args[0]
             )))
-        }
-    }
+        }?;
 
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(true)
+        Ok(DataTypeAndNullable::create(&data_type, true))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/hashes/siphash.rs
+++ b/common/functions/src/scalars/hashes/siphash.rs
@@ -47,8 +47,10 @@ impl Function for SipHashFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        match args[0].data_type() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+
+        let data_type = match args[0].data_type() {
             DataType::Int8
             | DataType::Int16
             | DataType::Int32
@@ -67,7 +69,9 @@ impl Function for SipHashFunction {
                 "Function Error: {} does not support {} type parameters",
                 self.display_name, args[0]
             ))),
-        }
+        }?;
+
+        Ok(DataTypeAndNullable::create(&data_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/logics/logic.rs
+++ b/common/functions/src/scalars/logics/logic.rs
@@ -49,8 +49,10 @@ impl Function for LogicFunction {
         "LogicFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::Boolean)
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::Boolean;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/abs.rs
+++ b/common/functions/src/scalars/maths/abs.rs
@@ -69,8 +69,9 @@ impl Function for AbsFunction {
         "abs"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let data_type = if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
             Ok(match args[0].data_type() {
                 DataType::Int8 => DataType::UInt8,
                 DataType::Int16 => DataType::UInt16,
@@ -84,7 +85,9 @@ impl Function for AbsFunction {
                 "Expected numeric types, but got {}",
                 args[0]
             )))
-        }
+        }?;
+
+        Ok(DataTypeAndNullable::create(&data_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/angle.rs
+++ b/common/functions/src/scalars/maths/angle.rs
@@ -57,15 +57,19 @@ where T: AngleConvertFunction + Clone + Sync + Send + 'static
         "AngleFunction"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+
+        let data_type = if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
             Ok(DataType::Float64)
         } else {
             Err(ErrorCode::IllegalDataType(format!(
                 "Expected numeric, but got {}",
                 args[0]
             )))
-        }
+        }?;
+
+        Ok(DataTypeAndNullable::create(&data_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/ceil.rs
+++ b/common/functions/src/scalars/maths/ceil.rs
@@ -55,8 +55,10 @@ impl Function for CeilFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if matches!(
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+
+        let data_type = if matches!(
             args[0].data_type(),
             DataType::UInt8
                 | DataType::UInt16
@@ -77,7 +79,9 @@ impl Function for CeilFunction {
                 "Expected numeric types, but got {}",
                 args[0]
             )))
-        }
+        }?;
+
+        Ok(DataTypeAndNullable::create(&data_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/crc32.rs
+++ b/common/functions/src/scalars/maths/crc32.rs
@@ -46,8 +46,10 @@ impl Function for CRC32Function {
         &*self._display_name
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::UInt32)
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::UInt32;
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/exp.rs
+++ b/common/functions/src/scalars/maths/exp.rs
@@ -46,15 +46,19 @@ impl Function for ExpFunction {
         &*self._display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+
+        let data_type = if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
             Ok(DataType::Float64)
         } else {
             Err(ErrorCode::IllegalDataType(format!(
                 "Expected numeric, but got {}",
                 args[0]
             )))
-        }
+        }?;
+
+        Ok(DataTypeAndNullable::create(&data_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/floor.rs
+++ b/common/functions/src/scalars/maths/floor.rs
@@ -55,8 +55,10 @@ impl Function for FloorFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if matches!(
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+
+        let data_type = if matches!(
             args[0].data_type(),
             DataType::UInt8
                 | DataType::UInt16
@@ -77,7 +79,8 @@ impl Function for FloorFunction {
                 "Expected numeric types, but got {}",
                 args[0]
             )))
-        }
+        }?;
+        Ok(DataTypeAndNullable::create(&data_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/log.rs
+++ b/common/functions/src/scalars/maths/log.rs
@@ -43,8 +43,10 @@ impl Function for GenericLogFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::Float64)
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::Float64;
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/pi.rs
+++ b/common/functions/src/scalars/maths/pi.rs
@@ -46,8 +46,9 @@ impl Function for PiFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::Float64)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::Float64;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, _columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/pow.rs
+++ b/common/functions/src/scalars/maths/pow.rs
@@ -47,15 +47,19 @@ impl Function for PowFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+
+        let data_type = if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
             Ok(DataType::Float64)
         } else {
             Err(ErrorCode::IllegalDataType(format!(
                 "Expected numeric, but got {}",
                 args[0]
             )))
-        }
+        }?;
+
+        Ok(DataTypeAndNullable::create(&data_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/random.rs
+++ b/common/functions/src/scalars/maths/random.rs
@@ -47,8 +47,9 @@ impl Function for RandomFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if args.is_empty()
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let data_type = if args.is_empty()
             || matches!(
                 args[0].data_type(),
                 DataType::UInt8
@@ -63,15 +64,15 @@ impl Function for RandomFunction {
                     | DataType::Float64
                     | DataType::String
                     | DataType::Null
-            )
-        {
+            ) {
             Ok(DataType::Float64)
         } else {
             Err(ErrorCode::IllegalDataType(format!(
                 "Expected numeric types, but got {}",
                 args[0]
             )))
-        }
+        }?;
+        Ok(DataTypeAndNullable::create(&data_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/round.rs
+++ b/common/functions/src/scalars/maths/round.rs
@@ -44,8 +44,10 @@ impl Function for RoundingFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::Float64)
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::Float64;
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/sign.rs
+++ b/common/functions/src/scalars/maths/sign.rs
@@ -56,8 +56,9 @@ impl Function for SignFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if matches!(
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let data_type = if matches!(
             args[0].data_type(),
             DataType::UInt8
                 | DataType::UInt16
@@ -78,7 +79,8 @@ impl Function for SignFunction {
                 "Expected numeric types, but got {}",
                 args[0]
             )))
-        }
+        }?;
+        Ok(DataTypeAndNullable::create(&data_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/sqrt.rs
+++ b/common/functions/src/scalars/maths/sqrt.rs
@@ -46,19 +46,18 @@ impl Function for SqrtFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let data_type = if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
             Ok(DataType::Float64)
         } else {
             Err(ErrorCode::IllegalDataType(format!(
                 "Expected numeric types, but got {}",
                 args[0]
             )))
-        }
-    }
+        }?;
 
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(true)
+        // sqrt on negative returns null, so nullable should be true.
+        Ok(DataTypeAndNullable::create(&data_type, true))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/maths/trigonometric.rs
+++ b/common/functions/src/scalars/maths/trigonometric.rs
@@ -67,15 +67,16 @@ impl Function for TrigonometricFunction {
         "TrigonometricFunction"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let data_type = if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
             Ok(DataType::Float64)
         } else {
             Err(ErrorCode::IllegalDataType(format!(
                 "Expected numeric, but got {}",
                 args[0]
             )))
-        }
+        }?;
+        Ok(DataTypeAndNullable::create(&data_type, false))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/nullables/is_not_null.rs
+++ b/common/functions/src/scalars/nullables/is_not_null.rs
@@ -52,12 +52,9 @@ impl Function for IsNotNullFunction {
         "IsNotNullFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::Boolean)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::Boolean;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/nullables/is_null.rs
+++ b/common/functions/src/scalars/nullables/is_null.rs
@@ -52,12 +52,9 @@ impl Function for IsNullFunction {
         "IsNullFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::Boolean)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::Boolean;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/others/ignore.rs
+++ b/common/functions/src/scalars/others/ignore.rs
@@ -55,12 +55,9 @@ impl Function for IgnoreFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::UInt8)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::UInt8;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, _columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/others/inet_aton.rs
+++ b/common/functions/src/scalars/others/inet_aton.rs
@@ -52,19 +52,17 @@ impl Function for InetAtonFunction {
         &*self.display_name
     }
 
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(true)
-    }
-
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if args[0].is_string() || args[0].is_null() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let data_type = if args[0].is_string() || args[0].is_null() {
             Ok(DataType::UInt32)
         } else {
             Err(ErrorCode::IllegalDataType(format!(
                 "Expected string or null type, but got {}",
                 args[0]
             )))
-        }
+        }?;
+        // For invalid input, the function returns null, so the nullable is true.
+        Ok(DataTypeAndNullable::create(&data_type, true))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/others/inet_ntoa.rs
+++ b/common/functions/src/scalars/others/inet_ntoa.rs
@@ -52,19 +52,18 @@ impl Function for InetNtoaFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let data_type = if args[0].is_numeric() || args[0].is_string() || args[0].is_null() {
             Ok(DataType::String)
         } else {
             Err(ErrorCode::IllegalDataType(format!(
                 "Expected numeric or string or null type, but got {}",
                 args[0]
             )))
-        }
-    }
+        }?;
 
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(true)
+        // The function returns null for invalid input, so the nullable is true.
+        Ok(DataTypeAndNullable::create(&data_type, true))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/others/running_difference_function.rs
+++ b/common/functions/src/scalars/others/running_difference_function.rs
@@ -49,8 +49,9 @@ impl Function for RunningDifferenceFunction {
         self.display_name.as_str()
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        match args[0].data_type() {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let data_type = match args[0].data_type() {
             DataType::Int8 | DataType::UInt8 => Ok(DataType::Int16),
             DataType::Int16 | DataType::UInt16 | DataType::Date16 => Ok(DataType::Int32),
             DataType::Int32
@@ -63,7 +64,8 @@ impl Function for RunningDifferenceFunction {
             _ => Result::Err(ErrorCode::IllegalDataType(
                 "Argument for function runningDifference must have numeric type",
             )),
-        }
+        }?;
+        Ok(DataTypeAndNullable::create(&data_type, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/bin.rs
+++ b/common/functions/src/scalars/strings/bin.rs
@@ -46,7 +46,7 @@ impl Function for BinFunction {
         "bin"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_numeric() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected number or null, but got {}",
@@ -54,7 +54,9 @@ impl Function for BinFunction {
             )));
         }
 
-        Ok(DataType::String)
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/char_.rs
+++ b/common/functions/src/scalars/strings/char_.rs
@@ -50,7 +50,8 @@ impl Function for CharFunction {
         "char"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
         for arg in args {
             if !arg.is_numeric() && !arg.is_null() {
                 return Err(ErrorCode::IllegalDataType(format!(
@@ -59,7 +60,8 @@ impl Function for CharFunction {
                 )));
             }
         }
-        Ok(DataType::String)
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/concat.rs
+++ b/common/functions/src/scalars/strings/concat.rs
@@ -123,13 +123,10 @@ impl Function for ConcatFunction {
         "concat"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
-        for arg in args {
-            if arg.is_null() {
-                return Ok(DataType::Null);
-            }
-        }
-        Ok(DataType::String)
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/elt.rs
+++ b/common/functions/src/scalars/strings/elt.rs
@@ -49,13 +49,14 @@ impl Function for EltFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_numeric() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected string or null, but got {}",
                 args[0]
             )));
         }
+
         for arg in &args[1..] {
             if !arg.is_numeric() && !arg.is_string() && !arg.is_null() {
                 return Err(ErrorCode::IllegalDataType(format!(
@@ -64,7 +65,9 @@ impl Function for EltFunction {
                 )));
             }
         }
-        Ok(DataType::String)
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/export_set.rs
+++ b/common/functions/src/scalars/strings/export_set.rs
@@ -52,7 +52,7 @@ impl Function for ExportSetFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_integer() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected integer or string or null, but got {}",
@@ -84,7 +84,9 @@ impl Function for ExportSetFunction {
             )));
         }
 
-        Ok(DataType::String)
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, r: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/field.rs
+++ b/common/functions/src/scalars/strings/field.rs
@@ -48,8 +48,10 @@ impl Function for FieldFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::UInt64)
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::UInt64;
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/find_in_set.rs
+++ b/common/functions/src/scalars/strings/find_in_set.rs
@@ -47,7 +47,7 @@ impl Function for FindInSetFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_integer() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected integer or string or null, but got {}",
@@ -60,7 +60,10 @@ impl Function for FindInSetFunction {
                 args[1]
             )));
         }
-        Ok(DataType::UInt64)
+
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::UInt64;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, r: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/format.rs
+++ b/common/functions/src/scalars/strings/format.rs
@@ -77,23 +77,22 @@ impl Function for FormatFunction {
         "format"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        // Format(value, format, culture), the 'culture' is optional.
+        // if 'value' or 'format' is nullable, the result should be nullable.
+        let nullable = args[0].is_nullable() || args[1].is_nullable();
+
         if (args[0].is_numeric() || args[0].is_string() || args[0].is_null())
             && (args[1].is_numeric() || args[1].is_string() || args[1].is_null())
         {
-            Ok(DataType::String)
+            let dt = DataType::String;
+            Ok(DataTypeAndNullable::create(&dt, nullable))
         } else {
             Err(ErrorCode::IllegalDataType(format!(
                 "Expected string/numeric, but got {}",
                 args[0]
             )))
         }
-    }
-
-    // Format(value, format, culture), the 'culture' is optional.
-    // if 'value' or 'format' is nullable, the result should be nullable.
-    fn nullable(&self, args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(args[0].is_nullable() || args[1].is_nullable())
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/hex.rs
+++ b/common/functions/src/scalars/strings/hex.rs
@@ -47,7 +47,7 @@ impl Function for HexFunction {
         "hex"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_integer() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected integer or string or null, but got {}",
@@ -55,7 +55,9 @@ impl Function for HexFunction {
             )));
         }
 
-        Ok(DataType::String)
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/insert.rs
+++ b/common/functions/src/scalars/strings/insert.rs
@@ -93,7 +93,7 @@ impl<T: InsertOperator> Function for InsFunction<T> {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[1].is_integer() && !args[1].is_string() && !args[1].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected integer or string or null, but got {}",
@@ -106,7 +106,10 @@ impl<T: InsertOperator> Function for InsFunction<T> {
                 args[2]
             )));
         }
-        Ok(DataType::String)
+
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/leftright.rs
+++ b/common/functions/src/scalars/strings/leftright.rs
@@ -91,7 +91,7 @@ impl<T: LeftRightOperator> Function for LeftRightFunction<T> {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_numeric() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected integer or string or null, but got {}",
@@ -104,7 +104,10 @@ impl<T: LeftRightOperator> Function for LeftRightFunction<T> {
                 args[1]
             )));
         }
-        Ok(DataType::String)
+
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/locate.rs
+++ b/common/functions/src/scalars/strings/locate.rs
@@ -60,8 +60,10 @@ impl<const T: u8> Function for LocatingFunction<T> {
         &*self.display_name
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::UInt64)
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::UInt64;
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/oct.rs
+++ b/common/functions/src/scalars/strings/oct.rs
@@ -73,7 +73,7 @@ impl Function for OctFunction {
         "oct"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_integer() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected integer or string or null, but got {}",
@@ -81,7 +81,9 @@ impl Function for OctFunction {
             )));
         }
 
-        Ok(DataType::String)
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/pad.rs
+++ b/common/functions/src/scalars/strings/pad.rs
@@ -114,7 +114,7 @@ impl<T: PadOperator> Function for PadFunction<T> {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_numeric() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected integer or string or null, but got {}",
@@ -133,7 +133,10 @@ impl<T: PadOperator> Function for PadFunction<T> {
                 args[2]
             )));
         }
-        Ok(DataType::String)
+
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/repeat.rs
+++ b/common/functions/src/scalars/strings/repeat.rs
@@ -48,7 +48,7 @@ impl Function for RepeatFunction {
         "repeat"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected parameter 1 is string, but got {}",
@@ -63,7 +63,9 @@ impl Function for RepeatFunction {
             )));
         }
 
-        Ok(DataType::String)
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/replace.rs
+++ b/common/functions/src/scalars/strings/replace.rs
@@ -85,7 +85,7 @@ impl<T: ReplaceOperator> Function for ReplaceImplFunction<T> {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_integer() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected integer or string or null, but got {}",
@@ -104,7 +104,10 @@ impl<T: ReplaceOperator> Function for ReplaceImplFunction<T> {
                 args[2]
             )));
         }
-        Ok(DataType::String)
+
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/space.rs
+++ b/common/functions/src/scalars/strings/space.rs
@@ -74,14 +74,17 @@ impl<T: SpaceGenOperator> Function for SpaceGenFunction<T> {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_unsigned_integer() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected unsigned integer or null, but got {}",
                 args[0]
             )));
         }
-        Ok(DataType::String)
+
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/strcmp.rs
+++ b/common/functions/src/scalars/strings/strcmp.rs
@@ -48,7 +48,7 @@ impl Function for StrcmpFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_integer() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected integer or string or null, but got {}",
@@ -61,7 +61,10 @@ impl Function for StrcmpFunction {
                 args[1]
             )));
         }
-        Ok(DataType::Int8)
+
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::Int8;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/string2number.rs
+++ b/common/functions/src/scalars/strings/string2number.rs
@@ -80,14 +80,16 @@ where
         self.display_name.as_str()
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_numeric() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected string or null, but got {}",
                 args[0]
             )));
         }
-        T::return_type()
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = T::return_type()?;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/string2string.rs
+++ b/common/functions/src/scalars/strings/string2string.rs
@@ -66,7 +66,7 @@ impl<T: StringOperator> Function for String2StringFunction<T> {
         &self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_numeric() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected string or null, but got {}",
@@ -74,14 +74,12 @@ impl<T: StringOperator> Function for String2StringFunction<T> {
             )));
         }
 
-        Ok(DataType::String)
-    }
-
-    fn nullable(&self, args: &[DataTypeAndNullable]) -> Result<bool> {
-        match T::default().may_turn_to_null() {
-            true => Ok(true),
-            false => Ok(args.iter().any(|arg| arg.is_nullable())),
-        }
+        let nullable = match T::default().may_turn_to_null() {
+            true => true,
+            false => args.iter().any(|arg| arg.is_nullable()),
+        };
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/substring.rs
+++ b/common/functions/src/scalars/strings/substring.rs
@@ -50,7 +50,7 @@ impl Function for SubstringFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_numeric() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected string or null, but got {}",
@@ -69,7 +69,9 @@ impl Function for SubstringFunction {
                 args[2]
             )));
         }
-        Ok(DataType::String)
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/substring_index.rs
+++ b/common/functions/src/scalars/strings/substring_index.rs
@@ -47,7 +47,7 @@ impl Function for SubstringIndexFunction {
         &*self.display_name
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_numeric() && !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected string or null, but got {}",
@@ -66,7 +66,10 @@ impl Function for SubstringIndexFunction {
                 args[2]
             )));
         }
-        Ok(DataType::String)
+
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/strings/unhex.rs
+++ b/common/functions/src/scalars/strings/unhex.rs
@@ -46,7 +46,7 @@ impl Function for UnhexFunction {
         "unhex"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_string() && !args[0].is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected string or null, but got {}",
@@ -54,7 +54,9 @@ impl Function for UnhexFunction {
             )));
         }
 
-        Ok(DataType::String)
+        let nullable = args.iter().any(|arg| arg.is_nullable());
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, nullable))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/tuples/tuple.rs
+++ b/common/functions/src/scalars/tuples/tuple.rs
@@ -55,7 +55,7 @@ impl Function for TupleFunction {
         "TupleFunction"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         let fields = args
             .iter()
             .enumerate()
@@ -63,11 +63,8 @@ impl Function for TupleFunction {
                 DataField::new(format!("item_{}", i).as_str(), x.data_type().clone(), false)
             })
             .collect::<Vec<_>>();
-        Ok(DataType::Struct(fields))
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+        let dt = DataType::Struct(fields);
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/udfs/crash_me.rs
+++ b/common/functions/src/scalars/udfs/crash_me.rs
@@ -47,12 +47,9 @@ impl Function for CrashMeFunction {
         "CrashMeFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::Null)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::Null;
+        Ok(DataTypeAndNullable::create(&dt, true))
     }
 
     fn eval(&self, _columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/udfs/current_user.rs
+++ b/common/functions/src/scalars/udfs/current_user.rs
@@ -46,12 +46,9 @@ impl Function for CurrentUserFunction {
         "CurrentUserFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::String)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/udfs/database.rs
+++ b/common/functions/src/scalars/udfs/database.rs
@@ -47,12 +47,9 @@ impl Function for DatabaseFunction {
         "DatabaseFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::String)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/udfs/exists.rs
+++ b/common/functions/src/scalars/udfs/exists.rs
@@ -45,12 +45,9 @@ impl Function for ExistsFunction {
         "ExistsFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::Boolean)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::Boolean;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/udfs/sleep.rs
+++ b/common/functions/src/scalars/udfs/sleep.rs
@@ -50,7 +50,7 @@ impl Function for SleepFunction {
         "SleepFunction"
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].is_numeric() {
             return Err(ErrorCode::BadArguments(format!(
                 "Illegal type {} of argument of function {}, expected numeric",
@@ -58,11 +58,8 @@ impl Function for SleepFunction {
             )));
         }
 
-        Ok(DataType::UInt8)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+        let dt = DataType::UInt8;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/udfs/to_type_name.rs
+++ b/common/functions/src/scalars/udfs/to_type_name.rs
@@ -48,12 +48,9 @@ impl Function for ToTypeNameFunction {
         "ToTypeNameFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::String)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/udfs/udf_example.rs
+++ b/common/functions/src/scalars/udfs/udf_example.rs
@@ -48,12 +48,9 @@ impl Function for UdfExampleFunction {
         "UdfExampleFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::Boolean)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, _columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/udfs/version.rs
+++ b/common/functions/src/scalars/udfs/version.rs
@@ -50,12 +50,9 @@ impl Function for VersionFunction {
         "VersionFunction"
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::String)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/uuids/uuid_creator.rs
+++ b/common/functions/src/scalars/uuids/uuid_creator.rs
@@ -87,8 +87,9 @@ where T: UUIDCreator + Clone + Sync + Send + 'static
         self.display_name.as_str()
     }
 
-    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataType> {
-        Ok(DataType::String)
+    fn return_type(&self, _args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
+        let dt = DataType::String;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, _columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/src/scalars/uuids/uuid_verifier.rs
+++ b/common/functions/src/scalars/uuids/uuid_verifier.rs
@@ -99,7 +99,7 @@ where T: UUIDVerifier + Clone + Sync + Send + 'static
         self.display_name.as_str()
     }
 
-    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataType> {
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable> {
         if !args[0].data_type().is_string() && !args[0].data_type().is_null() {
             return Err(ErrorCode::IllegalDataType(format!(
                 "Expected string or null, but got {}",
@@ -107,11 +107,8 @@ where T: UUIDVerifier + Clone + Sync + Send + 'static
             )));
         }
 
-        Ok(DataType::Boolean)
-    }
-
-    fn nullable(&self, _args: &[DataTypeAndNullable]) -> Result<bool> {
-        Ok(false)
+        let dt = DataType::Boolean;
+        Ok(DataTypeAndNullable::create(&dt, false))
     }
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {

--- a/common/functions/tests/it/scalars/scalar_function_test.rs
+++ b/common/functions/tests/it/scalars/scalar_function_test.rs
@@ -112,12 +112,12 @@ pub fn test_scalar_functions_with_type(
             };
         }
 
-        assert_eq!(
-            test.nullable,
-            test_function.nullable(&arguments_type)?,
-            "{}",
-            test.name
-        );
+        // Check the return type and nullable for non-error.
+        if test.error.is_empty() {
+            let return_type = test_function.return_type(&arguments_type)?;
+            assert_eq!(test.nullable, return_type.is_nullable(), "{}", test.name);
+        }
+
         match eval(&test_function, rows_size, &test.columns, &arguments_type) {
             Ok(v) if !matches!(v.data_type(), DataType::Struct(_)) => {
                 let cmp = v.to_array()?.eq(&test.expect.to_array()?)?;

--- a/common/planners/src/plan_expression_chain.rs
+++ b/common/planners/src/plan_expression_chain.rs
@@ -126,7 +126,6 @@ impl ExpressionChain {
                 let arg_types = vec![nested_expr.to_data_type_and_nullable(&self.schema)?];
                 let func = FunctionFactory::instance().get(op, &arg_types)?;
                 let return_type = func.return_type(&arg_types)?;
-                let is_nullable = func.nullable(&arg_types)?;
 
                 let function = ActionFunction {
                     name: expr.column_name(),
@@ -134,8 +133,8 @@ impl ExpressionChain {
                     func,
                     arg_names: vec![nested_expr.column_name()],
                     arg_types,
-                    is_nullable,
-                    return_type,
+                    is_nullable: return_type.is_nullable(),
+                    return_type: return_type.data_type().clone(),
                 };
 
                 self.actions.push(ExpressionAction::Function(function));
@@ -148,7 +147,6 @@ impl ExpressionChain {
                 ];
 
                 let func = FunctionFactory::instance().get(op, &arg_types)?;
-                let is_nullable = func.nullable(&arg_types)?;
                 let return_type = func.return_type(&arg_types)?;
 
                 let function = ActionFunction {
@@ -157,8 +155,8 @@ impl ExpressionChain {
                     func,
                     arg_names: vec![left.column_name(), right.column_name()],
                     arg_types,
-                    is_nullable,
-                    return_type,
+                    is_nullable: return_type.is_nullable(),
+                    return_type: return_type.data_type().clone(),
                 };
 
                 self.actions.push(ExpressionAction::Function(function));
@@ -171,7 +169,6 @@ impl ExpressionChain {
                     .collect::<Result<Vec<_>>>()?;
 
                 let func = FunctionFactory::instance().get(op, &arg_types)?;
-                let is_nullable = func.nullable(&arg_types)?;
                 let return_type = func.return_type(&arg_types)?;
 
                 let function = ActionFunction {
@@ -180,8 +177,8 @@ impl ExpressionChain {
                     func,
                     arg_names: args.iter().map(|action| action.column_name()).collect(),
                     arg_types,
-                    is_nullable,
-                    return_type,
+                    is_nullable: return_type.is_nullable(),
+                    return_type: return_type.data_type().clone(),
                 };
 
                 self.actions.push(ExpressionAction::Function(function));

--- a/common/planners/src/plan_expression_common.rs
+++ b/common/planners/src/plan_expression_common.rs
@@ -409,10 +409,8 @@ impl ExpressionDataTypeVisitor {
         }
 
         let function = FunctionFactory::instance().get(op, &arguments)?;
-        let nullable = function.nullable(&arguments)?;
         let return_type = function.return_type(&arguments)?;
-        self.stack
-            .push(DataTypeAndNullable::create(&return_type, nullable));
+        self.stack.push(return_type);
         Ok(self)
     }
 }

--- a/website/databend/docs/dev/contributing/how-to-write-scalar-functions.md
+++ b/website/databend/docs/dev/contributing/how-to-write-scalar-functions.md
@@ -62,14 +62,7 @@ pub trait Function: fmt::Display + Sync + Send + DynClone {
     }
 
     /// The method returns the return_type of this function.
-    fn return_type(&self, args: &[DataType]) -> Result<DataType>;
-
-    /// Whether the function may return null.
-    /// The default implementation checks if any nullable input exists and returns true if exist; otherwise false.
-    fn nullable(&self, arg_fields: &[DataField]) -> Result<bool> {
-        let any_input_nullable = arg_fields.iter().any(|field| field.is_nullable());
-        Ok(any_input_nullable)
-    }
+    fn return_type(&self, args: &[DataTypeAndNullable]) -> Result<DataTypeAndNullable>;
 
     /// Evaluate the function, e.g. run/execute the function.
     fn eval(&self, _columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn>;
@@ -183,8 +176,8 @@ binary
 binary(x_series.f64()?, y_series.f64()?, |x, y| x.pow(y))
 ```
 
-### Nullable check
-Nullable is annoying, but we can accept `DataType::Null` argument in most cases. The default implementation is to return true if any of the inputs is nullable, otherwise false. Some function may return null, even when none of the inputs is nullable. Thus we need to override the function to return true.
+### Return type
+The return value of `return_type` is `DataTypeAndNullable`, which is a wrapper of `DataType` and `nullable`. Most functions produces nullable data type only when one of the input data types is nullable. Some exceptions include `sqrt(-1)`,`from_base64("1")`, etc.
 
 ### Implicit cast
 Databend can accept implicit cast, eg: `pow('3', 2)`, `sign('1232')` we can cast the argument to specific column using `cast_with_type`.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Function trait's ```return_type``` and ```nullable``` should be merged into one function. The PR is to remove ```nullable``` and change the return value of ```return_type``` to ```DataTypeAndNullable```. 

This is part of the on-going task adding nullable type -- adding nullable as part of data_type, thus we don't need to the ```nullable``` function to get boolean nullable or not. 


## Changelog

- Improvement

## Related Issues

Related #3664

## Test Plan

Unit Tests

Stateless Tests

