### PR TITLE
ISSUE-3705 Fix "datafuse-extras/clickhouse_driver/ Repository not found."

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "clickhouse-driver"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/datafuse-extras/clickhouse_driver/?rev=6e0ecb2#6e0ecb2718cb5dd84ac76827e08586a48f2e719d"
+source = "git+https://github.com/datafuse-extras/clickhouse_driver?rev=6e0ecb2#6e0ecb2718cb5dd84ac76827e08586a48f2e719d"
 dependencies = [
  "byteorder",
  "bytes 0.5.6",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "clickhouse-driver-cthrs"
 version = "0.1.1"
-source = "git+https://github.com/datafuse-extras/clickhouse_driver/?rev=6e0ecb2#6e0ecb2718cb5dd84ac76827e08586a48f2e719d"
+source = "git+https://github.com/datafuse-extras/clickhouse_driver?rev=6e0ecb2#6e0ecb2718cb5dd84ac76827e08586a48f2e719d"
 
 [[package]]
 name = "clipboard-win"

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -53,7 +53,7 @@ common-tracing = { path = "../common/tracing" }
 common-sql = { path = "../common/sql" }
 
 # Github dependencies
-clickhouse-driver = { git = "https://github.com/datafuse-extras/clickhouse_driver/", rev = "6e0ecb2" }
+clickhouse-driver = { git = "https://github.com/datafuse-extras/clickhouse_driver", rev = "6e0ecb2" }
 msql-srv = { git = "https://github.com/datafuse-extras/msql-srv", rev = "e4c8f3d" }
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "b42ff01" }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

A cargo GitHub dependency URL with trailing slash can't be fetched via ssh protocol. If someone has a git URL replacement configuration(https://github.com -> git@github.com: ), cargo build will fail. 

## Changelog

- Build/Testing/CI

## Related Issues

Fixes #3705
