### PR TITLE
ISSUE-3444: Show Metric API server router in log

### DIFF
--- a/query/src/bin/databend-query.rs
+++ b/query/src/bin/databend-query.rs
@@ -131,7 +131,7 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
         let mut srv = MetricService::create(session_manager.clone());
         let listening = srv.start(address.parse()?).await?;
         shutdown_handle.add_service(srv);
-        tracing::info!("Metric API server listening on {}", listening);
+        tracing::info!("Metric API server listening on {}/metrics", listening);
     }
 
     // HTTP API service.


### PR DESCRIPTION
Signed-off-by: jyz0309 <45495947@qq.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Show Metric API server router in log

## Changelog

- Improvement

## Related Issues

Fixes #3444 

## Test Plan

Unit Tests

Stateless Tests

