### PR TITLE
[ci] feature: enqueue PR if it passes basic check and approved by 2; merge PRs one by one when all checks passed.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,41 @@
+queue_rules:
+  - name: shared_queue
+    conditions:
+      - "#approved-reviews-by>=2"
+
+      - '#check-success>=10'
+      - check-success=check
+      - check-success~=build
+      - check-success~=test_unit
+      - check-success~=test_stateless_standalone
+      - check-success~=test_stateless_cluster
+      - check-success~=test_stateful_standalone
+
 pull_request_rules:
+
+  - name: put bug fix pr to queue with high priority
+    conditions:
+      - "#approved-reviews-by>=2"
+      - check-success=check
+      - label=pr-bugfix
+
+    actions:
+      queue:
+        name: shared_queue
+        priority: high
+
+  - name: put other pr to queue
+    conditions:
+      - "#approved-reviews-by>=2"
+      - check-success=check
+      - label!=pr-bugfix
+
+    actions:
+      queue:
+        name: shared_queue
+        priority: medium
+
+
   # if there is a conflict in a approved PR, ping the author.
   - name: ping author on conflicts
     conditions:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [ci] feature: enqueue PR if it passes basic check and approved by 2; merge PRs one by one when all checks passed.
- PR with label `pr-bugfix` will be put into queue with high priority.

Workflow:

```
PR created
|
`-----> + Pass CI task `check`
        + Approved by 2 reviewers
          |
          | mergify enqueue this PR
          |
          `------> queue:
                   PR-a: pr-bugfix ----> Merge when all checks passed
                   PR-b: pr-bugfix
                   ...
                   PR-x:
                   PR-y:
                   ..
```

## Changelog

- New Feature





## Related Issues