### PR TITLE
Rename common/codegen result_type.rs -> arithmetics_type.rs

### DIFF
--- a/common/codegen/src/bin/codegen.rs
+++ b/common/codegen/src/bin/codegen.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use codegen::writes::write_arithmetic_result_type;
+use codegen::writes::codegen_arithmetic_type;
 
 fn main() {
-    write_arithmetic_result_type();
+    codegen_arithmetic_type();
 }

--- a/common/codegen/src/writes/arithmetics_type.rs
+++ b/common/codegen/src/writes/arithmetics_type.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 
 use common_datavalues::prelude::*;
 
-pub fn write_arithmetic_result_type() {
+pub fn codegen_arithmetic_type() {
     use DataType::*;
     use DataValueBinaryOperator::*;
     use DataValueUnaryOperator::*;

--- a/common/codegen/src/writes/mod.rs
+++ b/common/codegen/src/writes/mod.rs
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod result_type;
+mod arithmetics_type;
 
-pub use result_type::*;
+pub use arithmetics_type::*;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Rename common/codegen result_type.rs -> arithmetics_type.rs

## Changelog


- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

