### PR TITLE
ISSUE-3740: Add tenant to user management functions

### DIFF
--- a/query/src/interpreters/interpreter_describe_stage.rs
+++ b/query/src/interpreters/interpreter_describe_stage.rs
@@ -49,11 +49,10 @@ impl Interpreter for DescribeStageInterpreter {
     ) -> Result<SendableDataBlockStream> {
         let schema = self.plan.schema();
         let default_stage = UserStageInfo::default();
-        let stage = self
-            .ctx
-            .get_user_manager()
-            .get_stage(self.plan.name.as_str())
-            .await?;
+
+        let tenant = self.ctx.get_tenant();
+        let user_mgr = self.ctx.get_user_manager();
+        let stage = user_mgr.get_stage(tenant, self.plan.name.as_str()).await?;
 
         let mut parent_properties: Vec<&str> = vec![];
         let mut properties: Vec<&str> = vec![];

--- a/query/src/interpreters/interpreter_grant_privilege.rs
+++ b/query/src/interpreters/interpreter_grant_privilege.rs
@@ -56,9 +56,10 @@ impl Interpreter for GrantPrivilegeInterpreter {
         // TODO: check user existence
         // TODO: check privilege on granting on the grant object
 
+        let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
         user_mgr
-            .grant_user_privileges(&plan.name, &plan.hostname, plan.on, plan.priv_types)
+            .grant_user_privileges(tenant, &plan.name, &plan.hostname, plan.on, plan.priv_types)
             .await?;
 
         Ok(Box::pin(DataBlockStream::create(

--- a/query/src/interpreters/interpreter_revoke_privilege.rs
+++ b/query/src/interpreters/interpreter_revoke_privilege.rs
@@ -55,9 +55,16 @@ impl Interpreter for RevokePrivilegeInterpreter {
         // TODO: check user existence
         // TODO: check privilege on granting on the grant object
 
+        let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
         user_mgr
-            .revoke_user_privileges(&plan.username, &plan.hostname, plan.on, plan.priv_types)
+            .revoke_user_privileges(
+                tenant,
+                &plan.username,
+                &plan.hostname,
+                plan.on,
+                plan.priv_types,
+            )
             .await?;
 
         Ok(Box::pin(DataBlockStream::create(

--- a/query/src/interpreters/interpreter_show_grants.rs
+++ b/query/src/interpreters/interpreter_show_grants.rs
@@ -53,9 +53,10 @@ impl Interpreter for ShowGrantsInterpreter {
         let user_info = match self.plan.user_identity {
             None => self.ctx.get_current_user()?,
             Some(ref user_identity) => {
-                self.ctx
-                    .get_user_manager()
-                    .get_user(&user_identity.username, &user_identity.hostname)
+                let tenant = self.ctx.get_tenant();
+                let user_mgr = self.ctx.get_user_manager();
+                user_mgr
+                    .get_user(tenant, &user_identity.username, &user_identity.hostname)
                     .await?
             }
         };

--- a/query/src/interpreters/interpreter_stage_create.rs
+++ b/query/src/interpreters/interpreter_stage_create.rs
@@ -48,9 +48,10 @@ impl Interpreter for CreatStageInterpreter {
         _input_stream: Option<SendableDataBlockStream>,
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
+        let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
         let user_stage = plan.user_stage_info;
-        let create_stage = user_mgr.add_stage(user_stage).await;
+        let create_stage = user_mgr.add_stage(tenant, user_stage).await;
         if plan.if_not_exists {
             create_stage.or_else(|e| {
                 // StageAlreadyExists(4061)

--- a/query/src/interpreters/interpreter_stage_drop.rs
+++ b/query/src/interpreters/interpreter_stage_drop.rs
@@ -48,9 +48,10 @@ impl Interpreter for DropStageInterpreter {
         _input_stream: Option<SendableDataBlockStream>,
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
+        let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
         user_mgr
-            .drop_stage(plan.name.as_str(), plan.if_exists)
+            .drop_stage(tenant, plan.name.as_str(), plan.if_exists)
             .await?;
 
         Ok(Box::pin(DataBlockStream::create(

--- a/query/src/interpreters/interpreter_udf_alter.rs
+++ b/query/src/interpreters/interpreter_udf_alter.rs
@@ -48,8 +48,10 @@ impl Interpreter for AlterUDFInterpreter {
         _input_stream: Option<SendableDataBlockStream>,
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
+
+        let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
-        user_mgr.update_udf(plan.udf).await?;
+        user_mgr.update_udf(tenant, plan.udf).await?;
 
         Ok(Box::pin(DataBlockStream::create(
             self.plan.schema(),

--- a/query/src/interpreters/interpreter_udf_create.rs
+++ b/query/src/interpreters/interpreter_udf_create.rs
@@ -48,9 +48,10 @@ impl Interpreter for CreatUDFInterpreter {
         _input_stream: Option<SendableDataBlockStream>,
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
+        let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
         let udf = plan.udf;
-        let create_udf = user_mgr.add_udf(udf).await;
+        let create_udf = user_mgr.add_udf(tenant, udf).await;
         if plan.if_not_exists {
             create_udf.or_else(|e| {
                 // UDFAlreadyExists(4072)

--- a/query/src/interpreters/interpreter_udf_drop.rs
+++ b/query/src/interpreters/interpreter_udf_drop.rs
@@ -48,9 +48,10 @@ impl Interpreter for DropUDFInterpreter {
         _input_stream: Option<SendableDataBlockStream>,
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
+        let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
         user_mgr
-            .drop_udf(plan.name.as_str(), plan.if_exists)
+            .drop_udf(tenant, plan.name.as_str(), plan.if_exists)
             .await?;
 
         Ok(Box::pin(DataBlockStream::create(

--- a/query/src/interpreters/interpreter_udf_show.rs
+++ b/query/src/interpreters/interpreter_udf_show.rs
@@ -48,8 +48,9 @@ impl Interpreter for ShowUDFInterpreter {
         _input_stream: Option<SendableDataBlockStream>,
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
+        let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
-        let udf = user_mgr.get_udf(&plan.name).await?;
+        let udf = user_mgr.get_udf(tenant, &plan.name).await?;
 
         let show_fields = vec![
             DataField::new("name", DataType::String, false),

--- a/query/src/interpreters/interpreter_user_alter.rs
+++ b/query/src/interpreters/interpreter_user_alter.rs
@@ -48,10 +48,12 @@ impl Interpreter for AlterUserInterpreter {
         _input_stream: Option<SendableDataBlockStream>,
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
+        let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
         //TODO:alter current user
         user_mgr
             .update_user(
+                tenant,
                 plan.name.as_str(),
                 plan.hostname.as_str(),
                 Some(plan.new_password_type),

--- a/query/src/interpreters/interpreter_user_create.rs
+++ b/query/src/interpreters/interpreter_user_create.rs
@@ -51,6 +51,7 @@ impl Interpreter for CreateUserInterpreter {
         _input_stream: Option<SendableDataBlockStream>,
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
+        let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
         let user_info = UserInfo {
             name: plan.name,
@@ -60,7 +61,7 @@ impl Interpreter for CreateUserInterpreter {
             grants: UserGrantSet::empty(),
             quota: UserQuota::no_limit(),
         };
-        user_mgr.add_user(user_info).await?;
+        user_mgr.add_user(tenant, user_info).await?;
 
         Ok(Box::pin(DataBlockStream::create(
             self.plan.schema(),

--- a/query/src/interpreters/interpreter_user_drop.rs
+++ b/query/src/interpreters/interpreter_user_drop.rs
@@ -48,9 +48,15 @@ impl Interpreter for DropUserInterpreter {
         _input_stream: Option<SendableDataBlockStream>,
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
+        let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
         user_mgr
-            .drop_user(plan.name.as_str(), plan.hostname.as_str(), plan.if_exists)
+            .drop_user(
+                tenant,
+                plan.name.as_str(),
+                plan.hostname.as_str(),
+                plan.if_exists,
+            )
             .await?;
 
         Ok(Box::pin(DataBlockStream::create(

--- a/query/src/servers/clickhouse/interactive_worker.rs
+++ b/query/src/servers/clickhouse/interactive_worker.rs
@@ -105,7 +105,10 @@ impl ClickHouseSession for InteractiveWorker {
         // TODO: push async up to clickhouse server lib
         futures::executor::block_on(async move {
             // TODO: use get_users and check client address
-            let (authed, user_info) = match user_manager.get_user(user, "%").await {
+            // Here we don't handle the create context error.
+            let ctx = self.session.create_context().await.unwrap();
+            let tenant = ctx.get_tenant();
+            let (authed, user_info) = match user_manager.get_user(tenant, user, "%").await {
                 Ok(user_info) => (
                     user_manager.auth_user(user_info.clone(), info).await,
                     Some(user_info),

--- a/query/src/servers/http/v1/load.rs
+++ b/query/src/servers/http/v1/load.rs
@@ -58,9 +58,15 @@ pub async fn streaming_load(
     // Auth.
     let user_name = "root";
     let user_manager = session.get_user_manager();
+
     // TODO: list user's grant list and check client address
+
+    let ctx = session
+        .create_context()
+        .await
+        .map_err(InternalServerError)?;
     let user_info = user_manager
-        .get_user(user_name, "%")
+        .get_user(ctx.get_tenant(), user_name, "%")
         .await
         .map_err(InternalServerError)?;
     session.set_current_user(user_info);

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -161,8 +161,12 @@ impl ExecuteState {
         let default_user = "root".to_string();
         let user_name = request.session.user.as_ref().unwrap_or(&default_user);
         let user_manager = session.get_user_manager();
+
         // TODO: list user's grant list and check client address
-        let user_info = user_manager.get_user(user_name, "%").await?;
+        let ctx = session.create_context().await?;
+        let user_info = user_manager
+            .get_user(ctx.get_tenant(), user_name, "%")
+            .await?;
         session.set_current_user(user_info);
 
         let plan = PlanParser::parse(sql, context.clone()).await?;

--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -208,10 +208,13 @@ impl<W: std::io::Write> InteractiveWorkerBase<W> {
     ) -> Result<bool> {
         let user_name = &info.user_name;
         let address = &info.user_client_address;
-
         let user_manager = self.session.get_user_manager();
+
         // TODO: list user's grant list and check client address
-        let user_info = user_manager.get_user(user_name, "%").await?;
+        let ctx = self.session.create_context().await?;
+        let user_info = user_manager
+            .get_user(ctx.get_tenant(), user_name, "%")
+            .await?;
 
         let input = &info.user_password;
         let saved = &user_info.password;

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -231,6 +231,10 @@ impl QueryContext {
         self.shared.conf.clone()
     }
 
+    pub fn get_tenant(&self) -> &str {
+        &self.shared.conf.query.tenant_id
+    }
+
     pub fn get_subquery_name(&self, _query: &PlanNode) -> String {
         let index = self.shared.subquery_index.fetch_add(1, Ordering::Relaxed);
         format!("_subquery_{}", index)

--- a/query/src/sessions/sessions.rs
+++ b/query/src/sessions/sessions.rs
@@ -79,7 +79,7 @@ impl SessionManager {
 
         // User manager and init the default users.
         let user = UserApiProvider::create_global(conf.clone()).await?;
-        user.load_udfs(conf.clone()).await?;
+        user.load_udfs(&conf.query.tenant_id).await?;
 
         let http_query_manager = HttpQueryManager::create_global(conf.clone()).await?;
 

--- a/query/src/storages/system/users_table.rs
+++ b/query/src/storages/system/users_table.rs
@@ -70,7 +70,8 @@ impl Table for UsersTable {
         ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
-        let users = ctx.get_user_manager().get_users().await?;
+        let tenant = ctx.get_tenant();
+        let users = ctx.get_user_manager().get_users(tenant).await?;
 
         let names: Vec<&str> = users.iter().map(|x| x.name.as_str()).collect();
         let hostnames: Vec<&str> = users.iter().map(|x| x.hostname.as_str()).collect();

--- a/query/src/users/user_api.rs
+++ b/query/src/users/user_api.rs
@@ -27,9 +27,7 @@ use crate::common::MetaClientProvider;
 use crate::configs::Config;
 
 pub struct UserApiProvider {
-    user_api_provider: Arc<dyn UserMgrApi>,
-    stage_api_provider: Arc<dyn StageMgrApi>,
-    udf_api_provider: Arc<dyn UdfMgrApi>,
+    client: Arc<dyn KVApi>,
 }
 
 impl UserApiProvider {
@@ -43,26 +41,21 @@ impl UserApiProvider {
         }
     }
 
-    pub async fn create_global(cfg: Config) -> Result<Arc<UserApiProvider>> {
-        let tenant_id = &cfg.query.tenant_id;
-        let client = UserApiProvider::create_kv_client(&cfg).await?;
+    pub async fn create_global(conf: Config) -> Result<Arc<UserApiProvider>> {
+        let client = UserApiProvider::create_kv_client(&conf).await?;
 
-        Ok(Arc::new(UserApiProvider {
-            user_api_provider: Arc::new(UserMgr::new(client.clone(), tenant_id)),
-            stage_api_provider: Arc::new(StageMgr::new(client.clone(), tenant_id)),
-            udf_api_provider: Arc::new(UdfMgr::new(client, tenant_id)),
-        }))
+        Ok(Arc::new(UserApiProvider { client }))
     }
 
-    pub fn get_user_api_client(&self) -> Arc<dyn UserMgrApi> {
-        self.user_api_provider.clone()
+    pub fn get_user_api_client(&self, tenant: &str) -> Arc<dyn UserMgrApi> {
+        Arc::new(UserMgr::new(self.client.clone(), tenant))
     }
 
-    pub fn get_stage_api_client(&self) -> Arc<dyn StageMgrApi> {
-        self.stage_api_provider.clone()
+    pub fn get_stage_api_client(&self, tenant: &str) -> Arc<dyn StageMgrApi> {
+        Arc::new(StageMgr::new(self.client.clone(), tenant))
     }
 
-    pub fn get_udf_api_client(&self) -> Arc<dyn UdfMgrApi> {
-        self.udf_api_provider.clone()
+    pub fn get_udf_api_client(&self, tenant: &str) -> Arc<dyn UdfMgrApi> {
+        Arc::new(UdfMgr::new(self.client.clone(), tenant))
     }
 }

--- a/query/src/users/user_stage.rs
+++ b/query/src/users/user_stage.rs
@@ -21,8 +21,8 @@ use crate::users::UserApiProvider;
 /// user stage operations.
 impl UserApiProvider {
     // Add a new stage.
-    pub async fn add_stage(&self, info: UserStageInfo) -> Result<u64> {
-        let stage_api_provider = self.get_stage_api_client();
+    pub async fn add_stage(&self, tenant: &str, info: UserStageInfo) -> Result<u64> {
+        let stage_api_provider = self.get_stage_api_client(tenant);
         let add_stage = stage_api_provider.add_stage(info);
         match add_stage.await {
             Ok(res) => Ok(res),
@@ -31,15 +31,15 @@ impl UserApiProvider {
     }
 
     // Get one stage from by tenant.
-    pub async fn get_stage(&self, stage_name: &str) -> Result<UserStageInfo> {
-        let stage_api_provider = self.get_stage_api_client();
+    pub async fn get_stage(&self, tenant: &str, stage_name: &str) -> Result<UserStageInfo> {
+        let stage_api_provider = self.get_stage_api_client(tenant);
         let get_stage = stage_api_provider.get_stage(stage_name, None);
         Ok(get_stage.await?.data)
     }
 
     // Get the tenant all stage list.
-    pub async fn get_stages(&self) -> Result<Vec<UserStageInfo>> {
-        let stage_api_provider = self.get_stage_api_client();
+    pub async fn get_stages(&self, tenant: &str) -> Result<Vec<UserStageInfo>> {
+        let stage_api_provider = self.get_stage_api_client(tenant);
         let get_stages = stage_api_provider.get_stages();
 
         match get_stages.await {
@@ -49,8 +49,8 @@ impl UserApiProvider {
     }
 
     // Drop a stage by name.
-    pub async fn drop_stage(&self, name: &str, if_exist: bool) -> Result<()> {
-        let stage_api_provider = self.get_stage_api_client();
+    pub async fn drop_stage(&self, tenant: &str, name: &str, if_exist: bool) -> Result<()> {
+        let stage_api_provider = self.get_stage_api_client(tenant);
         let drop_stage = stage_api_provider.drop_stage(name, None);
         match drop_stage.await {
             Ok(res) => Ok(res),

--- a/query/tests/it/interpreters/interpreter_grant_privilege.rs
+++ b/query/tests/it/interpreters/interpreter_grant_privilege.rs
@@ -30,6 +30,8 @@ async fn test_grant_privilege_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
     let ctx = crate::tests::create_query_context()?;
+    let tenant = ctx.get_tenant();
+
     let name = "test";
     let hostname = "localhost";
     let password = "test";
@@ -41,7 +43,7 @@ async fn test_grant_privilege_interpreter() -> Result<()> {
     );
     assert_eq!(user_info.grants, UserGrantSet::empty());
     let user_mgr = ctx.get_user_manager();
-    user_mgr.add_user(user_info).await?;
+    user_mgr.add_user(tenant, user_info).await?;
 
     #[allow(dead_code)]
     struct Test {
@@ -116,7 +118,7 @@ async fn test_grant_privilege_interpreter() -> Result<()> {
                 assert!(r.is_ok(), "got err on query {}: {:?}", tt.query, r);
             }
             if let Some((name, hostname)) = tt.user_identity {
-                let new_user = user_mgr.get_user(name, hostname).await?;
+                let new_user = user_mgr.get_user(tenant, name, hostname).await?;
                 assert_eq!(new_user.grants, tt.expected_grants.unwrap())
             }
         } else {

--- a/query/tests/it/interpreters/interpreter_revoke_previlege.rs
+++ b/query/tests/it/interpreters/interpreter_revoke_previlege.rs
@@ -28,6 +28,8 @@ async fn test_revoke_privilege_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
     let ctx = crate::tests::create_query_context()?;
+    let tenant = ctx.get_tenant().to_string();
+
     let name = "test";
     let hostname = "localhost";
     let password = "test";
@@ -39,7 +41,7 @@ async fn test_revoke_privilege_interpreter() -> Result<()> {
     );
     assert_eq!(user_info.grants, UserGrantSet::empty());
     let user_mgr = ctx.get_user_manager();
-    user_mgr.add_user(user_info).await?;
+    user_mgr.add_user(&tenant, user_info).await?;
 
     let test_query = format!("REVOKE ALL ON *.* FROM '{}'@'{}'", name, hostname);
     if let PlanNode::RevokePrivilege(plan) = PlanParser::parse(&test_query, ctx.clone()).await? {
@@ -47,7 +49,7 @@ async fn test_revoke_privilege_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "RevokePrivilegeInterpreter");
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}
-        let new_user = user_mgr.get_user(name, hostname).await?;
+        let new_user = user_mgr.get_user(&tenant, name, hostname).await?;
         assert_eq!(new_user.grants, UserGrantSet::empty());
     } else {
         panic!()

--- a/query/tests/it/interpreters/interpreter_stage_create.rs
+++ b/query/tests/it/interpreters/interpreter_stage_create.rs
@@ -28,6 +28,7 @@ async fn test_create_stage_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
     let ctx = crate::tests::create_query_context()?;
+    let tenant = ctx.get_tenant();
 
     static TEST_QUERY: &str = "CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(access_key_id='1a2b3c' secret_access_key='4x5y6z') file_format=(FORMAT=CSV compression=GZIP record_delimiter='\n') comments='test'";
     if let PlanNode::CreateUserStage(plan) = PlanParser::parse(TEST_QUERY, ctx.clone()).await? {
@@ -35,7 +36,10 @@ async fn test_create_stage_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatStageInterpreter");
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}
-        let stage = ctx.get_user_manager().get_stage("test_stage").await?;
+        let stage = ctx
+            .get_user_manager()
+            .get_stage(tenant, "test_stage")
+            .await?;
 
         assert_eq!(stage.file_format, FileFormat {
             format: Format::Csv,
@@ -52,7 +56,10 @@ async fn test_create_stage_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatStageInterpreter");
         let is_err = executor.execute(None).await.is_err();
         assert!(!is_err);
-        let stage = ctx.get_user_manager().get_stage("test_stage").await?;
+        let stage = ctx
+            .get_user_manager()
+            .get_stage(tenant, "test_stage")
+            .await?;
 
         assert_eq!(stage.file_format, FileFormat {
             format: Format::Csv,
@@ -70,7 +77,10 @@ async fn test_create_stage_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatStageInterpreter");
         let is_err = executor.execute(None).await.is_err();
         assert!(is_err);
-        let stage = ctx.get_user_manager().get_stage("test_stage").await?;
+        let stage = ctx
+            .get_user_manager()
+            .get_stage(tenant, "test_stage")
+            .await?;
 
         assert_eq!(stage.file_format, FileFormat {
             format: Format::Csv,

--- a/query/tests/it/interpreters/interpreter_stage_drop.rs
+++ b/query/tests/it/interpreters/interpreter_stage_drop.rs
@@ -28,6 +28,7 @@ async fn test_drop_stage_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
     let ctx = crate::tests::create_query_context()?;
+    let tenant = ctx.get_tenant();
 
     static CREATE_STAGE: &str = "CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(access_key_id='1a2b3c' secret_access_key='4x5y6z') file_format=(FORMAT=CSV compression=GZIP record_delimiter='\n') comments='test'";
 
@@ -39,7 +40,10 @@ async fn test_drop_stage_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatStageInterpreter");
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}
-        let stage = ctx.get_user_manager().get_stage("test_stage").await?;
+        let stage = ctx
+            .get_user_manager()
+            .get_stage(tenant, "test_stage")
+            .await?;
 
         assert_eq!(stage.file_format, FileFormat {
             format: Format::Csv,
@@ -85,7 +89,10 @@ async fn test_drop_stage_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatStageInterpreter");
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}
-        let stage = ctx.get_user_manager().get_stage("test_stage").await?;
+        let stage = ctx
+            .get_user_manager()
+            .get_stage(tenant, "test_stage")
+            .await?;
 
         assert_eq!(stage.file_format, FileFormat {
             format: Format::Csv,

--- a/query/tests/it/interpreters/interpreter_udf_alter.rs
+++ b/query/tests/it/interpreters/interpreter_udf_alter.rs
@@ -25,6 +25,7 @@ async fn test_alter_udf_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
     let ctx = crate::tests::create_query_context()?;
+    let tenant = ctx.get_tenant();
 
     static TEST_QUERY: &str =
         "CREATE FUNCTION IF NOT EXISTS isnotempty AS (p) -> not(isnull(p)) DESC = 'This is a description'";
@@ -33,7 +34,7 @@ async fn test_alter_udf_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatUDFInterpreter");
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}
-        let udf = ctx.get_user_manager().get_udf("isnotempty").await?;
+        let udf = ctx.get_user_manager().get_udf(tenant, "isnotempty").await?;
 
         assert_eq!(udf.name, "isnotempty");
         assert_eq!(udf.parameters, vec!["p".to_string()]);
@@ -52,7 +53,7 @@ async fn test_alter_udf_interpreter() -> Result<()> {
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}
 
-        let udf = ctx.get_user_manager().get_udf("isnotempty").await?;
+        let udf = ctx.get_user_manager().get_udf(tenant, "isnotempty").await?;
 
         assert_eq!(udf.name, "isnotempty");
         assert_eq!(udf.parameters, vec!["d".to_string()]);

--- a/query/tests/it/interpreters/interpreter_udf_create.rs
+++ b/query/tests/it/interpreters/interpreter_udf_create.rs
@@ -25,6 +25,7 @@ async fn test_create_udf_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
     let ctx = crate::tests::create_query_context()?;
+    let tenant = ctx.get_tenant();
 
     static TEST_QUERY: &str =
         "CREATE FUNCTION IF NOT EXISTS isnotempty AS (p) -> not(isnull(p)) DESC = 'This is a description'";
@@ -33,7 +34,7 @@ async fn test_create_udf_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatUDFInterpreter");
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}
-        let udf = ctx.get_user_manager().get_udf("isnotempty").await?;
+        let udf = ctx.get_user_manager().get_udf(tenant, "isnotempty").await?;
 
         assert_eq!(udf.name, "isnotempty");
         assert_eq!(udf.parameters, vec!["p".to_string()]);
@@ -48,7 +49,7 @@ async fn test_create_udf_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatUDFInterpreter");
         let is_err = executor.execute(None).await.is_err();
         assert!(!is_err);
-        let udf = ctx.get_user_manager().get_udf("isnotempty").await?;
+        let udf = ctx.get_user_manager().get_udf(tenant, "isnotempty").await?;
 
         assert_eq!(udf.name, "isnotempty");
         assert_eq!(udf.parameters, vec!["p".to_string()]);
@@ -65,7 +66,7 @@ async fn test_create_udf_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatUDFInterpreter");
         let is_err = executor.execute(None).await.is_err();
         assert!(is_err);
-        let udf = ctx.get_user_manager().get_udf("isnotempty").await?;
+        let udf = ctx.get_user_manager().get_udf(tenant, "isnotempty").await?;
 
         assert_eq!(udf.name, "isnotempty");
         assert_eq!(udf.parameters, vec!["p".to_string()]);

--- a/query/tests/it/interpreters/interpreter_udf_drop.rs
+++ b/query/tests/it/interpreters/interpreter_udf_drop.rs
@@ -25,6 +25,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
     let ctx = crate::tests::create_query_context()?;
+    let tenant = ctx.get_tenant();
 
     static CREATE_UDF: &str =
         "CREATE FUNCTION IF NOT EXISTS isnotempty AS (p) -> not(isnull(p)) DESC = 'This is a description'";
@@ -37,7 +38,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatUDFInterpreter");
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}
-        let udf = ctx.get_user_manager().get_udf("isnotempty").await?;
+        let udf = ctx.get_user_manager().get_udf(tenant, "isnotempty").await?;
 
         assert_eq!(udf.name, "isnotempty");
         assert_eq!(udf.parameters, vec!["p".to_string()]);
@@ -79,7 +80,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatUDFInterpreter");
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}
-        let udf = ctx.get_user_manager().get_udf("isnotempty").await?;
+        let udf = ctx.get_user_manager().get_udf(tenant, "isnotempty").await?;
 
         assert_eq!(udf.name, "isnotempty");
         assert_eq!(udf.parameters, vec!["p".to_string()]);

--- a/query/tests/it/interpreters/interpreter_udf_show.rs
+++ b/query/tests/it/interpreters/interpreter_udf_show.rs
@@ -26,6 +26,7 @@ use crate::tests::parse_query;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_show_create_udf_interpreter() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
+    let tenant = ctx.get_tenant();
 
     static CREATE_UDF: &str =
         "CREATE FUNCTION IF NOT EXISTS isnotempty AS (p) -> not(isnull(p)) DESC = 'This is a description'";
@@ -35,7 +36,7 @@ async fn test_show_create_udf_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CreatUDFInterpreter");
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}
-        let udf = ctx.get_user_manager().get_udf("isnotempty").await?;
+        let udf = ctx.get_user_manager().get_udf(tenant, "isnotempty").await?;
 
         assert_eq!(udf.name, "isnotempty");
         assert_eq!(udf.parameters, vec!["p".to_string()]);

--- a/query/tests/it/interpreters/interpreter_user_alter.rs
+++ b/query/tests/it/interpreters/interpreter_user_alter.rs
@@ -27,6 +27,8 @@ async fn test_alter_user_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
     let ctx = crate::tests::create_query_context()?;
+    let tenant = ctx.get_tenant().to_string();
+
     let name = "test";
     let hostname = "localhost";
     let password = "test";
@@ -38,9 +40,9 @@ async fn test_alter_user_interpreter() -> Result<()> {
         PasswordType::PlainText,
     );
     let user_mgr = ctx.get_user_manager();
-    user_mgr.add_user(user_info).await?;
+    user_mgr.add_user("", user_info).await?;
 
-    let old_user = user_mgr.get_user(name, hostname).await?;
+    let old_user = user_mgr.get_user(&tenant, name, hostname).await?;
     assert_eq!(old_user.password, Vec::from(password));
 
     let test_query = format!(
@@ -53,7 +55,7 @@ async fn test_alter_user_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "AlterUserInterpreter");
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}
-        let new_user = user_mgr.get_user(name, hostname).await?;
+        let new_user = user_mgr.get_user(&tenant, name, hostname).await?;
         assert_eq!(new_user.password, Vec::from(new_password))
     } else {
         panic!()

--- a/query/tests/it/interpreters/interpreter_user_drop.rs
+++ b/query/tests/it/interpreters/interpreter_user_drop.rs
@@ -26,6 +26,7 @@ async fn test_drop_user_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
     let ctx = crate::tests::create_query_context()?;
+    let tenant = ctx.get_tenant();
 
     {
         static TEST_QUERY: &str = "DROP USER 'test'@'localhost'";
@@ -62,9 +63,9 @@ async fn test_drop_user_interpreter() -> Result<()> {
             PasswordType::PlainText,
         );
         let user_mgr = ctx.get_user_manager();
-        user_mgr.add_user(user_info).await?;
+        user_mgr.add_user(tenant, user_info).await?;
 
-        let old_user = user_mgr.get_user(name, hostname).await?;
+        let old_user = user_mgr.get_user(tenant, name, hostname).await?;
         assert_eq!(old_user.password, Vec::from(password));
 
         static TEST_QUERY: &str = "DROP USER 'test'@'localhost'";

--- a/query/tests/it/storages/system/users_table.rs
+++ b/query/tests/it/storages/system/users_table.rs
@@ -29,9 +29,10 @@ use pretty_assertions::assert_eq;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_users_table() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
+    let tenant = ctx.get_tenant();
     ctx.get_settings().set_max_threads(2)?;
     ctx.get_user_manager()
-        .add_user(UserInfo {
+        .add_user(tenant, UserInfo {
             name: "test".to_string(),
             hostname: "localhost".to_string(),
             password: Vec::from(""),
@@ -41,7 +42,7 @@ async fn test_users_table() -> Result<()> {
         })
         .await?;
     ctx.get_user_manager()
-        .add_user(UserInfo {
+        .add_user(tenant, UserInfo {
             name: "test1".to_string(),
             hostname: "%".to_string(),
             password: Vec::from("123456789"),

--- a/query/tests/it/users/user_mgr.rs
+++ b/query/tests/it/users/user_mgr.rs
@@ -29,6 +29,7 @@ async fn test_user_manager() -> Result<()> {
     let mut config = Config::default();
     config.query.tenant_id = "tenant1".to_string();
 
+    let tenant = "tenant1";
     let user = "test-user1";
     let hostname = "localhost";
     let hostname2 = "%";
@@ -38,68 +39,68 @@ async fn test_user_manager() -> Result<()> {
     // add user hostname.
     {
         let user_info = User::new(user, hostname, pwd, PasswordType::PlainText);
-        user_mgr.add_user(user_info.into()).await?;
+        user_mgr.add_user(tenant, user_info.into()).await?;
     }
 
     // add user hostname2.
     {
         let user_info = User::new(user, hostname2, pwd, PasswordType::PlainText);
-        user_mgr.add_user(user_info.into()).await?;
+        user_mgr.add_user(tenant, user_info.into()).await?;
     }
 
     // get all users.
     {
-        let users = user_mgr.get_users().await?;
+        let users = user_mgr.get_users(tenant).await?;
         assert_eq!(2, users.len());
         assert_eq!(pwd.as_bytes(), users[0].password);
     }
 
     // get user hostname.
     {
-        let user = user_mgr.get_user(user, hostname).await?;
+        let user = user_mgr.get_user(tenant, user, hostname).await?;
         assert_eq!(hostname, user.hostname);
         assert_eq!(pwd.as_bytes(), user.password);
     }
 
     // get user hostname2.
     {
-        let user = user_mgr.get_user(user, hostname2).await?;
+        let user = user_mgr.get_user(tenant, user, hostname2).await?;
         assert_eq!(hostname2, user.hostname);
         assert_eq!(pwd.as_bytes(), user.password);
     }
 
     // drop.
     {
-        user_mgr.drop_user(user, hostname, false).await?;
-        let users = user_mgr.get_users().await?;
+        user_mgr.drop_user(tenant, user, hostname, false).await?;
+        let users = user_mgr.get_users(tenant).await?;
         assert_eq!(1, users.len());
     }
 
     // repeat drop same user not with if exist.
     {
-        let res = user_mgr.drop_user(user, hostname, false).await;
+        let res = user_mgr.drop_user(tenant, user, hostname, false).await;
         assert!(res.is_err());
     }
 
     // repeat drop same user with if exist.
     {
-        let res = user_mgr.drop_user(user, hostname, true).await;
+        let res = user_mgr.drop_user(tenant, user, hostname, true).await;
         assert!(res.is_ok());
     }
 
     // grant privileges
     {
         let user_info = User::new(user, hostname, pwd, PasswordType::PlainText);
-        user_mgr.add_user(user_info.into()).await?;
-        let old_user = user_mgr.get_user(user, hostname).await?;
+        user_mgr.add_user(tenant, user_info.into()).await?;
+        let old_user = user_mgr.get_user(tenant, user, hostname).await?;
         assert_eq!(old_user.grants, UserGrantSet::empty());
 
         let mut add_priv = UserPrivilegeSet::empty();
         add_priv.set_privilege(UserPrivilegeType::Set);
         user_mgr
-            .grant_user_privileges(user, hostname, GrantObject::Global, add_priv)
+            .grant_user_privileges(tenant, user, hostname, GrantObject::Global, add_priv)
             .await?;
-        let new_user = user_mgr.get_user(user, hostname).await?;
+        let new_user = user_mgr.get_user(tenant, user, hostname).await?;
         assert!(new_user
             .grants
             .verify_global_privilege(user, hostname, UserPrivilegeType::Set));
@@ -108,35 +109,37 @@ async fn test_user_manager() -> Result<()> {
             hostname,
             UserPrivilegeType::Create
         ));
-        user_mgr.drop_user(user, hostname, true).await?;
+        user_mgr.drop_user(tenant, user, hostname, true).await?;
     }
 
     // revoke privileges
     {
         let user_info = User::new(user, hostname, pwd, PasswordType::PlainText);
-        user_mgr.add_user(user_info.into()).await?;
+        user_mgr.add_user(tenant, user_info.into()).await?;
         user_mgr
             .grant_user_privileges(
+                tenant,
                 user,
                 hostname,
                 GrantObject::Global,
                 UserPrivilegeSet::all_privileges(),
             )
             .await?;
-        let user_info = user_mgr.get_user(user, hostname).await?;
+        let user_info = user_mgr.get_user(tenant, user, hostname).await?;
         assert_eq!(user_info.grants.entries().len(), 1);
 
         user_mgr
             .revoke_user_privileges(
+                tenant,
                 user,
                 hostname,
                 GrantObject::Global,
                 UserPrivilegeSet::all_privileges(),
             )
             .await?;
-        let user_info = user_mgr.get_user(user, hostname).await?;
+        let user_info = user_mgr.get_user(tenant, user, hostname).await?;
         assert_eq!(user_info.grants.entries().len(), 0);
-        user_mgr.drop_user(user, hostname, true).await?;
+        user_mgr.drop_user(tenant, user, hostname, true).await?;
     }
 
     // alter.
@@ -145,38 +148,41 @@ async fn test_user_manager() -> Result<()> {
         let hostname = "localhost";
         let pwd = "test";
         let user_info = User::new(user, hostname, pwd, PasswordType::PlainText);
-        user_mgr.add_user(user_info.into()).await?;
+        user_mgr.add_user(tenant, user_info.into()).await?;
 
-        let old_user = user_mgr.get_user(user, hostname).await?;
+        let old_user = user_mgr.get_user(tenant, user, hostname).await?;
         assert_eq!(old_user.password, Vec::from(pwd));
 
         let new_pwd = "test1";
         user_mgr
             .update_user(
+                tenant,
                 user,
                 hostname,
                 Some(PasswordType::Sha256),
                 Some(Vec::from(new_pwd)),
             )
             .await?;
-        let new_user = user_mgr.get_user(user, hostname).await?;
+        let new_user = user_mgr.get_user(tenant, user, hostname).await?;
         assert_eq!(new_user.password, Vec::from(new_pwd));
         assert_eq!(new_user.password_type, PasswordType::Sha256);
 
         let new_new_pwd = "test2";
         user_mgr
             .update_user(
+                tenant,
                 user,
                 hostname,
                 Some(PasswordType::Sha256),
                 Some(Vec::from(new_new_pwd)),
             )
             .await?;
-        let new_new_user = user_mgr.get_user(user, hostname).await?;
+        let new_new_user = user_mgr.get_user(tenant, user, hostname).await?;
         assert_eq!(new_new_user.password, Vec::from(new_new_pwd));
 
         let not_exist = user_mgr
             .update_user(
+                tenant,
                 "user",
                 hostname,
                 Some(PasswordType::Sha256),
@@ -194,6 +200,7 @@ async fn test_user_manager_with_root_user() -> Result<()> {
     let mut config = Config::default();
     config.query.tenant_id = "tenant1".to_string();
 
+    let tenant = "tenant1";
     let username1 = "default";
     let username2 = "root";
 
@@ -205,7 +212,7 @@ async fn test_user_manager_with_root_user() -> Result<()> {
 
     // Get user via username `default` and hostname `127.0.0.1`.
     {
-        let user = user_mgr.get_user(username1, hostname1).await?;
+        let user = user_mgr.get_user(tenant, username1, hostname1).await?;
         assert_eq!(user.name, username1);
         assert_eq!(user.hostname, hostname1);
         assert!(user.grants.verify_global_privilege(
@@ -232,7 +239,7 @@ async fn test_user_manager_with_root_user() -> Result<()> {
 
     // Get user via username `default` and hostname `localhost`.
     {
-        let user = user_mgr.get_user(username1, hostname2).await?;
+        let user = user_mgr.get_user(tenant, username1, hostname2).await?;
         assert_eq!(user.name, username1);
         assert_eq!(user.hostname, hostname2);
         assert!(user.grants.verify_global_privilege(
@@ -259,7 +266,7 @@ async fn test_user_manager_with_root_user() -> Result<()> {
 
     // Get user via username `default` and hostname `otherhost`.
     {
-        let user = user_mgr.get_user(username1, hostname3).await?;
+        let user = user_mgr.get_user(tenant, username1, hostname3).await?;
         assert_eq!(user.name, username1);
         assert_eq!(user.hostname, hostname3);
         assert!(user.grants.entries().is_empty());
@@ -267,7 +274,7 @@ async fn test_user_manager_with_root_user() -> Result<()> {
 
     // Get user via username `root` and hostname `127.0.0.1`.
     {
-        let user = user_mgr.get_user(username2, hostname1).await?;
+        let user = user_mgr.get_user(tenant, username2, hostname1).await?;
         assert_eq!(user.name, username2);
         assert_eq!(user.hostname, hostname1);
         assert!(user.grants.verify_global_privilege(
@@ -294,7 +301,7 @@ async fn test_user_manager_with_root_user() -> Result<()> {
 
     // Get user via username `root` and hostname `localhost`.
     {
-        let user = user_mgr.get_user(username2, hostname2).await?;
+        let user = user_mgr.get_user(tenant, username2, hostname2).await?;
         assert_eq!(user.name, username2);
         assert_eq!(user.hostname, hostname2);
         assert!(user.grants.verify_global_privilege(
@@ -321,7 +328,7 @@ async fn test_user_manager_with_root_user() -> Result<()> {
 
     // Get user via username `root` and hostname `otherhost`.
     {
-        let user = user_mgr.get_user(username2, hostname3).await?;
+        let user = user_mgr.get_user(tenant, username2, hostname3).await?;
         assert_eq!(user.name, username2);
         assert_eq!(user.hostname, hostname3);
         assert!(user.grants.entries().is_empty());

--- a/query/tests/it/users/user_stage.rs
+++ b/query/tests/it/users/user_stage.rs
@@ -27,6 +27,7 @@ async fn test_user_stage() -> Result<()> {
     let mut config = Config::default();
     config.query.tenant_id = "tenant1".to_string();
 
+    let tenant = "tenant1";
     let comments = "this is a comment";
     let stage_name1 = "stage1";
     let stage_name2 = "stage2";
@@ -43,7 +44,7 @@ async fn test_user_stage() -> Result<()> {
             }),
             FileFormat::default(),
         );
-        user_mgr.add_stage(stage_info).await?;
+        user_mgr.add_stage(tenant, stage_info).await?;
     }
 
     // add 2.
@@ -57,38 +58,38 @@ async fn test_user_stage() -> Result<()> {
             }),
             FileFormat::default(),
         );
-        user_mgr.add_stage(stage_info).await?;
+        user_mgr.add_stage(tenant, stage_info).await?;
     }
 
     // get all.
     {
-        let stages = user_mgr.get_stages().await?;
+        let stages = user_mgr.get_stages(tenant).await?;
         assert_eq!(2, stages.len());
         assert_eq!(stage_name2, stages[1].stage_name);
     }
 
     // get.
     {
-        let stage = user_mgr.get_stage(stage_name1).await?;
+        let stage = user_mgr.get_stage(tenant, stage_name1).await?;
         assert_eq!(stage_name1, stage.stage_name);
     }
 
     // drop.
     {
-        user_mgr.drop_stage(stage_name1, false).await?;
-        let stages = user_mgr.get_stages().await?;
+        user_mgr.drop_stage(tenant, stage_name1, false).await?;
+        let stages = user_mgr.get_stages(tenant).await?;
         assert_eq!(1, stages.len());
     }
 
     // repeat drop same one not with if exist.
     {
-        let res = user_mgr.drop_stage(stage_name1, false).await;
+        let res = user_mgr.drop_stage(tenant, stage_name1, false).await;
         assert!(res.is_err());
     }
 
     // repeat drop same one with if exist.
     {
-        let res = user_mgr.drop_stage(stage_name1, true).await;
+        let res = user_mgr.drop_stage(tenant, stage_name1, true).await;
         assert!(res.is_ok());
     }
 

--- a/query/tests/it/users/user_udf.rs
+++ b/query/tests/it/users/user_udf.rs
@@ -24,6 +24,7 @@ async fn test_user_udf() -> Result<()> {
     let mut config = Config::default();
     config.query.tenant_id = "tenant1".to_string();
 
+    let tenant = "tenant1";
     let description = "this is a description";
     let isempty = "isempty";
     let isnotempty = "isnotempty";
@@ -33,7 +34,7 @@ async fn test_user_udf() -> Result<()> {
     {
         let udf =
             UserDefinedFunction::new(isempty, vec!["p".to_string()], "isnull(p)", description);
-        user_mgr.add_udf(udf).await?;
+        user_mgr.add_udf(tenant, udf).await?;
     }
 
     // add isnotempty.
@@ -44,12 +45,12 @@ async fn test_user_udf() -> Result<()> {
             "not(isempty(p))",
             description,
         );
-        user_mgr.add_udf(udf).await?;
+        user_mgr.add_udf(tenant, udf).await?;
     }
 
     // get all.
     {
-        let udfs = user_mgr.get_udfs().await?;
+        let udfs = user_mgr.get_udfs(tenant).await?;
         assert_eq!(2, udfs.len());
         assert_eq!(isempty, udfs[0].name);
         assert_eq!(isnotempty, udfs[1].name);
@@ -57,27 +58,27 @@ async fn test_user_udf() -> Result<()> {
 
     // get.
     {
-        let udf = user_mgr.get_udf(isempty).await?;
+        let udf = user_mgr.get_udf(tenant, isempty).await?;
         assert_eq!(isempty, udf.name);
     }
 
     // drop.
     {
-        user_mgr.drop_udf(isnotempty, false).await?;
-        let udfs = user_mgr.get_udfs().await?;
+        user_mgr.drop_udf(tenant, isnotempty, false).await?;
+        let udfs = user_mgr.get_udfs(tenant).await?;
         assert_eq!(1, udfs.len());
         assert_eq!(isempty, udfs[0].name);
     }
 
     // repeat drop same one not with if exist.
     {
-        let res = user_mgr.drop_udf(isnotempty, false).await;
+        let res = user_mgr.drop_udf(tenant, isnotempty, false).await;
         assert!(res.is_err());
     }
 
     // repeat drop same one with if exist.
     {
-        let res = user_mgr.drop_udf(isnotempty, true).await;
+        let res = user_mgr.drop_udf(tenant, isnotempty, true).await;
         assert!(res.is_ok());
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Part of #3740 
Make `tenant` not binding with the management api, so we can dynamically set the tenant(e.g from the api) to a session and do some meta operations with multi-tenant.


## Changelog

- Improvement


## Related Issues

Part of #3740 

## Test Plan

Unit Tests

Stateless Tests

