### PR TITLE
doc: Add http and clickhouse port forward in Docker

### DIFF
--- a/website/databend/docs/user/index.md
+++ b/website/databend/docs/user/index.md
@@ -23,7 +23,7 @@ $ bendctl cluster create
 
 ```shell
 $ docker pull datafuselabs/databend
-$ docker run --init --rm -p 3307:3307 datafuselabs/databend
+$ docker run --init --rm -p 3307:3307 -p 8001:8001 -p 9001:9001 datafuselabs/databend
 ```
   </TabItem>
   <TabItem value="source" label="From source">


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

# Summary

Add http and clickhouse port forward in Docker

# Changelog
Documentation

# Related Issues
Fixes #3787

# Test Plan
Unit Tests

Stateless Tests