### PR TITLE
fix the schema about system.query_log table

### DIFF
--- a/query/src/interpreters/interpreter_query_log.rs
+++ b/query/src/interpreters/interpreter_query_log.rs
@@ -110,8 +110,8 @@ impl InterpreterQueryLog {
             Series::new(vec![event.tenant_id.as_str()]),
             Series::new(vec![event.cluster_id.as_str()]),
             Series::new(vec![event.sql_user.as_str()]),
-            Series::new(vec![event.sql_user_privileges.as_str()]),
             Series::new(vec![event.sql_user_quota.as_str()]),
+            Series::new(vec![event.sql_user_privileges.as_str()]),
             // Query.
             Series::new(vec![event.query_id.as_str()]),
             Series::new(vec![event.query_kind.as_str()]),

--- a/query/tests/it/interpreters/interpreter_interceptor.rs
+++ b/query/tests/it/interpreters/interpreter_interceptor.rs
@@ -55,7 +55,7 @@ async fn test_interpreter_interceptor() -> Result<()> {
 
     // Check.
     {
-        let query = "select log_type, handler_type, cpu_usage, memory_usage, scan_rows, scan_bytes, scan_partitions, written_rows, written_bytes, result_rows, result_bytes, query_kind, query_text, sql_user, sql_user_privileges from system.query_log";
+        let query = "select log_type, handler_type, cpu_usage, memory_usage, scan_rows, scan_bytes, scan_partitions, written_rows, written_bytes, result_rows, result_bytes, query_kind, query_text, sql_user, sql_user_quota from system.query_log";
         let plan = PlanParser::parse(query, ctx.clone()).await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
 
@@ -64,7 +64,7 @@ async fn test_interpreter_interceptor() -> Result<()> {
 
         let expected = vec![
             "+----------+--------------+-----------+--------------+-----------+------------+-----------------+--------------+---------------+-------------+--------------+------------+------------------------------------------------------+----------+---------------------------------------------------------------------------+",
-            "| log_type | handler_type | cpu_usage | memory_usage | scan_rows | scan_bytes | scan_partitions | written_rows | written_bytes | result_rows | result_bytes | query_kind | query_text                                           | sql_user | sql_user_privileges                                                       |",
+            "| log_type | handler_type | cpu_usage | memory_usage | scan_rows | scan_bytes | scan_partitions | written_rows | written_bytes | result_rows | result_bytes | query_kind | query_text                                           | sql_user | sql_user_quota                                                            |",
             "+----------+--------------+-----------+--------------+-----------+------------+-----------------+--------------+---------------+-------------+--------------+------------+------------------------------------------------------+----------+---------------------------------------------------------------------------+",
             "| 1        | TestSession  | 8         | 4097         | 0         | 0          | 0               | 0            | 0             | 0           | 0            | SelectPlan | select number from numbers_mt(100) where number > 90 | root     | UserQuota { max_cpu: 0, max_memory_in_bytes: 0, max_storage_in_bytes: 0 } |",
             "| 2        | TestSession  | 8         | 4097         | 100       | 800        | 0               | 0            | 0             | 9           | 72           | SelectPlan | select number from numbers_mt(100) where number > 90 | root     | UserQuota { max_cpu: 0, max_memory_in_bytes: 0, max_storage_in_bytes: 0 } |",
@@ -103,7 +103,7 @@ async fn test_interpreter_interceptor_for_insert() -> Result<()> {
 
         let expected = vec![
             "+----------+--------------+-----------+-----------+------------+-----------------+--------------+---------------+-------------+--------------+-----------------+----------------------------------------------------+----------+---------------------------------------------------------------------------+",
-            "| log_type | handler_type | cpu_usage | scan_rows | scan_bytes | scan_partitions | written_rows | written_bytes | result_rows | result_bytes | query_kind      | query_text                                         | sql_user | sql_user_privileges                                                       |",
+            "| log_type | handler_type | cpu_usage | scan_rows | scan_bytes | scan_partitions | written_rows | written_bytes | result_rows | result_bytes | query_kind      | query_text                                         | sql_user | sql_user_quota                                                            |",
             "+----------+--------------+-----------+-----------+------------+-----------------+--------------+---------------+-------------+--------------+-----------------+----------------------------------------------------+----------+---------------------------------------------------------------------------+",
             "| 1        | TestSession  | 8         | 0         | 0          | 0               | 0            | 0             | 0           | 0            | CreateTablePlan | create table t as select number from numbers_mt(1) | root     | UserQuota { max_cpu: 0, max_memory_in_bytes: 0, max_storage_in_bytes: 0 } |",
             "| 2        | TestSession  | 8         | 1         | 8          | 0               | 1            | 1121          | 0           | 0            | CreateTablePlan | create table t as select number from numbers_mt(1) | root     | UserQuota { max_cpu: 0, max_memory_in_bytes: 0, max_storage_in_bytes: 0 } |",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

the order of sql_user_quota & sql_user_privilege fields in system.query_log is accidently swapped, this PR fix the order about these two feilds.

## Changelog

- Bug Fix

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

