### PR TITLE
refactor: simplify the grant verify logic

### DIFF
--- a/common/meta/types/src/user_grant.rs
+++ b/common/meta/types/src/user_grant.rs
@@ -14,7 +14,6 @@
 
 use std::fmt;
 
-use common_exception::Result;
 use enumflags2::BitFlags;
 
 use crate::UserPrivilegeSet;

--- a/common/meta/types/src/user_grant.rs
+++ b/common/meta/types/src/user_grant.rs
@@ -51,20 +51,6 @@ impl GrantObject {
             GrantObject::Table(_, _) => UserPrivilegeSet::available_privileges_on_table(),
         }
     }
-
-    /// Check if there's any privilege which can not be granted to this GrantObject.
-    /// Some global privileges can not be granted to a database or table, for example,
-    /// a KILL statement is meaningless for a table.
-    pub fn validate_available_privileges(&self, privileges: UserPrivilegeSet) -> Result<()> {
-        let available_privileges = self.available_privileges();
-        let ok = BitFlags::from(privileges)
-            .iter()
-            .all(|p| available_privileges.has_privilege(p));
-        if !ok {
-            return Err(common_exception::ErrorCode::IllegalGrant("Illegal GRANT/REVOKE command; please consult the manual to see which privileges can be used"));
-        }
-        Ok(())
-    }
 }
 
 impl fmt::Display for GrantObject {

--- a/common/meta/types/src/user_grant.rs
+++ b/common/meta/types/src/user_grant.rs
@@ -31,16 +31,15 @@ impl GrantObject {
     /// Comparing the grant objects, the Database object contains all the Table objects inside it.
     /// Global object contains all the Database objects.
     pub fn contains(&self, object: &GrantObject) -> bool {
-        use GrantObject::*;
         match (self, object) {
-            (Global, _) => true,
-            (Database(_), Global) => false,
-            (Database(lhs), Database(rhs)) => lhs == rhs,
-            (Database(lhs), Table(rhs, _)) => lhs == rhs,
-            (Table(lhs_db, lhs_table), Table(rhs_db, rhs_table)) => {
+            (GrantObject::Global, _) => true,
+            (GrantObject::Database(_), GrantObject::Global) => false,
+            (GrantObject::Database(lhs), GrantObject::Database(rhs)) => lhs == rhs,
+            (GrantObject::Database(lhs), GrantObject::Table(rhs, _)) => lhs == rhs,
+            (GrantObject::Table(lhs_db, lhs_table), GrantObject::Table(rhs_db, rhs_table)) => {
                 (lhs_db == rhs_db) && (lhs_table == rhs_table)
             }
-            (Table(_, _), _) => false,
+            (GrantObject::Table(_, _), _) => false,
         }
     }
 

--- a/common/meta/types/src/user_grant.rs
+++ b/common/meta/types/src/user_grant.rs
@@ -28,6 +28,22 @@ pub enum GrantObject {
 }
 
 impl GrantObject {
+    /// Comparing the grant objects, the Database object contains all the Table objects inside it.
+    /// Global object contains all the Database objects.
+    pub fn contains(&self, object: &GrantObject) -> bool {
+        use GrantObject::*;
+        match (self, object) {
+            (Global, _) => true,
+            (Database(_), Global) => false,
+            (Database(lhs), Database(rhs)) => lhs == rhs,
+            (Database(lhs), Table(rhs, _)) => lhs == rhs,
+            (Table(lhs_db, lhs_table), Table(rhs_db, rhs_table)) => {
+                (lhs_db == rhs_db) && (lhs_table == rhs_table)
+            }
+            (Table(_, _), _) => false,
+        }
+    }
+
     /// Some global privileges can not be granted to a database or table, for example, a KILL
     /// statement is meaningless for a table.
     pub fn allow_privilege(&self, privilege: UserPrivilegeType) -> bool {

--- a/common/meta/types/src/user_privilege.rs
+++ b/common/meta/types/src/user_privilege.rs
@@ -103,6 +103,10 @@ impl UserPrivilegeSet {
         }
     }
 
+    pub fn iter(self) -> impl Iterator<Item = UserPrivilegeType> {
+        BitFlags::from(self).iter()
+    }
+
     /// The all privileges which available to the global grant object. It contains ALL the privileges
     /// on databases and tables, and has some Global only privileges.
     pub fn available_privileges_on_global() -> Self {

--- a/common/meta/types/tests/it/user_grant.rs
+++ b/common/meta/types/tests/it/user_grant.rs
@@ -27,9 +27,24 @@ fn test_user_grant_entry() -> Result<()> {
         GrantObject::Global,
         make_bitflags!(UserPrivilegeType::{Create}),
     );
-    assert!(grant.verify_database_privilege("u1", "h1", "db1", UserPrivilegeType::Create));
-    assert!(!grant.verify_database_privilege("u1", "h1", "db1", UserPrivilegeType::Insert));
-    assert!(!grant.verify_database_privilege("u1", "h2", "db1", UserPrivilegeType::Create));
+    assert!(grant.verify_privilege(
+        "u1",
+        "h1",
+        &GrantObject::Database("db1".into()),
+        UserPrivilegeType::Create
+    ));
+    assert!(!grant.verify_privilege(
+        "u1",
+        "h1",
+        &GrantObject::Database("db1".into()),
+        UserPrivilegeType::Insert
+    ));
+    assert!(!grant.verify_privilege(
+        "u1",
+        "h2",
+        &GrantObject::Database("db1".into()),
+        UserPrivilegeType::Create
+    ));
 
     let grant = GrantEntry::new(
         "u1".into(),
@@ -37,12 +52,42 @@ fn test_user_grant_entry() -> Result<()> {
         GrantObject::Database("db1".into()),
         make_bitflags!(UserPrivilegeType::{Create}),
     );
-    assert!(grant.verify_table_privilege("u1", "h1", "db1", "table1", UserPrivilegeType::Create));
-    assert!(!grant.verify_table_privilege("u1", "h1", "db2", "table1", UserPrivilegeType::Create));
-    assert!(!grant.verify_table_privilege("u1", "h1", "db1", "table1", UserPrivilegeType::Insert));
-    assert!(grant.verify_table_privilege("u1", "h233", "db1", "table1", UserPrivilegeType::Create));
-    assert!(grant.verify_database_privilege("u1", "h233", "db1", UserPrivilegeType::Create));
-    assert!(!grant.verify_database_privilege("u1", "h233", "db2", UserPrivilegeType::Create));
+    assert!(grant.verify_privilege(
+        "u1",
+        "h1",
+        &GrantObject::Table("db1".into(), "table1".into()),
+        UserPrivilegeType::Create
+    ));
+    assert!(!grant.verify_privilege(
+        "u1",
+        "h1",
+        &GrantObject::Table("db2".into(), "table1".into()),
+        UserPrivilegeType::Create
+    ));
+    assert!(!grant.verify_privilege(
+        "u1",
+        "h1",
+        &GrantObject::Table("db1".into(), "table1".into()),
+        UserPrivilegeType::Insert
+    ));
+    assert!(grant.verify_privilege(
+        "u1",
+        "h233",
+        &GrantObject::Table("db1".into(), "table1".into()),
+        UserPrivilegeType::Create
+    ));
+    assert!(grant.verify_privilege(
+        "u1",
+        "h233",
+        &GrantObject::Database("db1".into()),
+        UserPrivilegeType::Create
+    ));
+    assert!(!grant.verify_privilege(
+        "u1",
+        "h233",
+        &GrantObject::Database("db2".into()),
+        UserPrivilegeType::Create
+    ));
 
     let grant = GrantEntry::new(
         "u1".into(),
@@ -50,10 +95,30 @@ fn test_user_grant_entry() -> Result<()> {
         GrantObject::Database("db1".into()),
         make_bitflags!(UserPrivilegeType::{Create}),
     );
-    assert!(grant.verify_table_privilege("u1", "h1", "db1", "table1", UserPrivilegeType::Create));
-    assert!(!grant.verify_table_privilege("u1", "h1", "db2", "table1", UserPrivilegeType::Create));
-    assert!(!grant.verify_table_privilege("u1", "h1", "db1", "table1", UserPrivilegeType::Insert));
-    assert!(grant.verify_table_privilege("u1", "h233", "db1", "table1", UserPrivilegeType::Create));
+    assert!(grant.verify_privilege(
+        "u1",
+        "h1",
+        &GrantObject::Table("db1".into(), "table1".into()),
+        UserPrivilegeType::Create
+    ));
+    assert!(!grant.verify_privilege(
+        "u1",
+        "h1",
+        &GrantObject::Table("db2".into(), "table1".into()),
+        UserPrivilegeType::Create
+    ));
+    assert!(!grant.verify_privilege(
+        "u1",
+        "h1",
+        &GrantObject::Table("db1".into(), "table1".into()),
+        UserPrivilegeType::Insert
+    ));
+    assert!(grant.verify_privilege(
+        "u1",
+        "h233",
+        &GrantObject::Table("db1".into(), "table1".into()),
+        UserPrivilegeType::Create
+    ));
 
     Ok(())
 }

--- a/common/meta/types/tests/it/user_grant.rs
+++ b/common/meta/types/tests/it/user_grant.rs
@@ -20,6 +20,77 @@ use common_meta_types::UserPrivilegeType;
 use enumflags2::make_bitflags;
 
 #[test]
+fn test_grant_object_contains() -> Result<()> {
+    struct Test {
+        lhs: GrantObject,
+        rhs: GrantObject,
+        expect: bool,
+    }
+    let tests: Vec<Test> = vec![
+        Test {
+            lhs: GrantObject::Global,
+            rhs: GrantObject::Table("a".into(), "b".into()),
+            expect: true,
+        },
+        Test {
+            lhs: GrantObject::Global,
+            rhs: GrantObject::Global,
+            expect: true,
+        },
+        Test {
+            lhs: GrantObject::Global,
+            rhs: GrantObject::Database("a".into()),
+            expect: true,
+        },
+        Test {
+            lhs: GrantObject::Database("a".into()),
+            rhs: GrantObject::Global,
+            expect: false,
+        },
+        Test {
+            lhs: GrantObject::Database("a".into()),
+            rhs: GrantObject::Database("b".into()),
+            expect: false,
+        },
+        Test {
+            lhs: GrantObject::Database("a".into()),
+            rhs: GrantObject::Table("b".into(), "c".into()),
+            expect: false,
+        },
+        Test {
+            lhs: GrantObject::Database("db1".into()),
+            rhs: GrantObject::Table("db1".into(), "c".into()),
+            expect: true,
+        },
+        Test {
+            lhs: GrantObject::Table("db1".into(), "c".into()),
+            rhs: GrantObject::Table("db1".into(), "c".into()),
+            expect: true,
+        },
+        Test {
+            lhs: GrantObject::Table("db1".into(), "c".into()),
+            rhs: GrantObject::Global,
+            expect: false,
+        },
+        Test {
+            lhs: GrantObject::Table("db1".into(), "c".into()),
+            rhs: GrantObject::Database("db1".into()),
+            expect: false,
+        },
+    ];
+    for t in tests {
+        assert!(
+            t.lhs.contains(&t.rhs) == t.expect,
+            "{} contains {} expect {}",
+            &t.lhs,
+            &t.rhs,
+            &t.expect,
+        )
+    }
+    Ok(())
+}
+
+#[test]
 fn test_user_grant_entry() -> Result<()> {
     let grant = GrantEntry::new(
         "u1".into(),

--- a/query/src/interpreters/interpreter_common.rs
+++ b/query/src/interpreters/interpreter_common.rs
@@ -20,7 +20,7 @@ use common_meta_types::GrantObject;
 use crate::catalogs::Catalog;
 use crate::sessions::QueryContext;
 
-pub async fn grant_object_exists_or_err(
+pub async fn validate_grant_object_exists(
     ctx: &Arc<QueryContext>,
     object: &GrantObject,
 ) -> Result<()> {

--- a/query/src/interpreters/interpreter_grant_privilege.rs
+++ b/query/src/interpreters/interpreter_grant_privilege.rs
@@ -15,6 +15,8 @@
 use std::sync::Arc;
 
 use common_exception::Result;
+use common_meta_types::GrantObject;
+use common_meta_types::UserPrivilegeSet;
 use common_planners::GrantPrivilegePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -50,7 +52,7 @@ impl Interpreter for GrantPrivilegeInterpreter {
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
 
-        plan.on.validate_available_privileges(plan.priv_types)?;
+        validate_grant_privileges(&plan.on, plan.priv_types)?;
         grant_object_exists_or_err(&self.ctx, &plan.on).await?;
 
         // TODO: check user existence
@@ -74,4 +76,18 @@ impl Interpreter for GrantPrivilegeInterpreter {
             vec![],
         )))
     }
+}
+
+/// Check if there's any privilege which can not be granted to this GrantObject.
+/// Some global privileges can not be granted to a database or table, for example,
+/// a KILL statement is meaningless for a table.
+pub fn validate_grant_privileges(object: &GrantObject, privileges: UserPrivilegeSet) -> Result<()> {
+    let available_privileges = object.available_privileges();
+    let ok = BitFlags::from(privileges)
+        .iter()
+        .all(|p| available_privileges.has_privilege(p));
+    if !ok {
+        return Err(common_exception::ErrorCode::IllegalGrant("Illegal GRANT/REVOKE command; please consult the manual to see which privileges can be used"));
+    }
+    Ok(())
 }

--- a/query/src/interpreters/interpreter_grant_privilege.rs
+++ b/query/src/interpreters/interpreter_grant_privilege.rs
@@ -50,7 +50,7 @@ impl Interpreter for GrantPrivilegeInterpreter {
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
 
-        plan.on.validate_privileges(plan.priv_types)?;
+        plan.on.validate_available_privileges(plan.priv_types)?;
         grant_object_exists_or_err(&self.ctx, &plan.on).await?;
 
         // TODO: check user existence

--- a/query/src/interpreters/interpreter_grant_privilege.rs
+++ b/query/src/interpreters/interpreter_grant_privilege.rs
@@ -22,7 +22,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 use common_tracing::tracing;
 
-use crate::interpreters::interpreter_common::grant_object_exists_or_err;
+use crate::interpreters::interpreter_common::validate_grant_object_exists;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::sessions::QueryContext;
@@ -53,7 +53,7 @@ impl Interpreter for GrantPrivilegeInterpreter {
         let plan = self.plan.clone();
 
         validate_grant_privileges(&plan.on, plan.priv_types)?;
-        grant_object_exists_or_err(&self.ctx, &plan.on).await?;
+        validate_grant_object_exists(&self.ctx, &plan.on).await?;
 
         // TODO: check user existence
         // TODO: check privilege on granting on the grant object

--- a/query/src/interpreters/interpreter_grant_privilege.rs
+++ b/query/src/interpreters/interpreter_grant_privilege.rs
@@ -83,7 +83,7 @@ impl Interpreter for GrantPrivilegeInterpreter {
 /// a KILL statement is meaningless for a table.
 pub fn validate_grant_privileges(object: &GrantObject, privileges: UserPrivilegeSet) -> Result<()> {
     let available_privileges = object.available_privileges();
-    let ok = BitFlags::from(privileges)
+    let ok = privileges
         .iter()
         .all(|p| available_privileges.has_privilege(p));
     if !ok {

--- a/query/src/interpreters/interpreter_revoke_privilege.rs
+++ b/query/src/interpreters/interpreter_revoke_privilege.rs
@@ -20,7 +20,7 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 use common_tracing::tracing;
 
-use crate::interpreters::interpreter_common::grant_object_exists_or_err;
+use crate::interpreters::interpreter_common::validate_grant_object_exists;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::sessions::QueryContext;
@@ -50,7 +50,7 @@ impl Interpreter for RevokePrivilegeInterpreter {
     ) -> Result<SendableDataBlockStream> {
         let plan = self.plan.clone();
 
-        grant_object_exists_or_err(&self.ctx, &plan.on).await?;
+        validate_grant_object_exists(&self.ctx, &plan.on).await?;
 
         // TODO: check user existence
         // TODO: check privilege on granting on the grant object


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

this PR introduces a `GrantObject::contains` method to compare grant objects, with this helper function, we can replace some adhoc logics like `verify_database_privilege`, `verify_global_privilege`, `verify_table_privilege` into a unified logic: the verified object should be smaller than the object inside grant entry.

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

