### PR TITLE
ISSUE-3828 MySQL Driver Compalibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,6 +2573,7 @@ dependencies = [
  "pretty_assertions",
  "prost",
  "rand 0.8.4",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -95,6 +95,7 @@ tonic = "0.6.2"
 uuid = { version = "1.0.0-alpha.1", features = ["serde", "v4"] }
 walkdir = "2.3.2"
 parquet-format-async-temp = "0.2.0"
+regex = "1.5.4"
 
 [dev-dependencies]
 clickhouse-driver = { git = "https://github.com/datafuse-extras/clickhouse_driver", rev = "6e0ecb2" }

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -36,6 +36,7 @@ def remove_control_characters(s):
     """
     https://github.com/html5lib/html5lib-python/issues/96#issuecomment-43438438
     """
+
     def str_to_int(s, default, base=10):
         if int(s, base) < 0x10000:
             return chr(int(s, base))

--- a/tests/helpers/client.py
+++ b/tests/helpers/client.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.join(CURDIR))
 
 
 class client(object):
+
     def __init__(self, name='', log=None):
         self.name = name
         self.log = log

--- a/tests/suites/0_stateless/00_0000_dummy_select_py.py
+++ b/tests/suites/0_stateless/00_0000_dummy_select_py.py
@@ -31,6 +31,7 @@ client1.run("select 3")
 
 
 class MyModel(object):
+
     def __init__(self, name, value):
         self.name = name
         self.value = value


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

[MySQL Python connector](https://github.com/mysql/mysql-connector-python) will send some queries that databend not supported now,

so the driver will not connect the databend.


* some test not fmt, modify them.
    tests/databend-test
    tests/helpers/client.py
    tests/suites/0_stateless/00_0000_dummy_select_py.py

## Changelog

- Bug Fix

## Related Issues

Fixes #3828 

## Test Plan

Unit Tests

Stateless Tests

