### PR TITLE
Refactor: split the apply_cmd function to sub functions, make code more clearly

### DIFF
--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -305,6 +305,434 @@ impl StateMachine {
         Ok(result)
     }
 
+    #[tracing::instrument(level = "debug", skip(self, txn_tree))]
+    fn apply_incr_seq_cmd(
+        &self,
+        key: &String,
+        cmd: &Cmd,
+        txn_tree: &TransactionSledTree,
+    ) -> common_exception::Result<AppliedState> {
+        let r = self.txn_incr_seq(key, txn_tree).map_err(|e| {
+            let e: ConflictableTransactionError<Infallible> = e.into();
+            ErrorCode::from(e)
+        })?;
+
+        Ok(r.into())
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, txn_tree))]
+    fn apply_add_node_cmd(
+        &self,
+        node_id: &u64,
+        node: &Node,
+        cmd: &Cmd,
+        txn_tree: &TransactionSledTree,
+    ) -> common_exception::Result<AppliedState> {
+        let sm_nodes = txn_tree.key_space::<Nodes>();
+
+        let prev = sm_nodes.get(node_id).map_err(|e| {
+            let e: ConflictableTransactionError<Infallible> = e.into();
+            ErrorCode::from(e)
+        })?;
+
+        if prev.is_some() {
+            Ok((prev, None).into())
+        } else {
+            sm_nodes.insert(node_id, node).map_err(|e| {
+                let e: ConflictableTransactionError<Infallible> = e.into();
+                ErrorCode::from(e)
+            })?;
+            tracing::info!("applied AddNode: {}={:?}", node_id, node);
+            Ok((prev, Some(node.clone())).into())
+        }
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, txn_tree))]
+    fn apply_create_database_cmd(
+        &self,
+        tenant: &String,
+        name: &String,
+        meta: &DatabaseMeta,
+        cmd: &Cmd,
+        txn_tree: &TransactionSledTree,
+    ) -> common_exception::Result<AppliedState> {
+        let db_id = self.txn_incr_seq(SEQ_DATABASE_ID, txn_tree).map_err(|e| {
+            let e: ConflictableTransactionError<Infallible> = e.into();
+            ErrorCode::from(e)
+        })?;
+
+        let db_lookup_tree = txn_tree.key_space::<DatabaseLookup>();
+
+        let (prev, result) = self
+            .sub_txn_tree_upsert(
+                &db_lookup_tree,
+                &DatabaseLookupKey::new(tenant.to_string(), name.to_string()),
+                &MatchSeq::Exact(0),
+                Operation::Update(db_id),
+                None,
+            )
+            .map_err(|e| {
+                let e: ConflictableTransactionError<Infallible> = e.into();
+                ErrorCode::from(e)
+            })?;
+
+        // if it is just created
+        if prev.is_none() && result.is_some() {
+            // TODO(xp): reconsider this impl. it may not be required.
+            self.txn_incr_seq(SEQ_DATABASE_META_ID, txn_tree)
+                .map_err(|e| {
+                    let e: ConflictableTransactionError<Infallible> = e.into();
+                    ErrorCode::from(e)
+                })?;
+        } else {
+            // exist
+            let db_id = prev.unwrap().data;
+            let prev = self
+                .txn_get_database_meta_by_id(&db_id, txn_tree)
+                .map_err(|e| {
+                    let e: ConflictableTransactionError<Infallible> = e.into();
+                    ErrorCode::from(e)
+                })?;
+            if let Some(prev) = prev {
+                return Ok(AppliedState::DatabaseMeta(Change::nochange_with_id(
+                    db_id,
+                    Some(prev),
+                )));
+            }
+        }
+
+        let dbs = txn_tree.key_space::<Databases>();
+        let (prev_meta, result_meta) = self
+            .sub_txn_tree_upsert(
+                &dbs,
+                &db_id,
+                &MatchSeq::Exact(0),
+                Operation::Update(meta.clone()),
+                None,
+            )
+            .map_err(|e| {
+                let e: ConflictableTransactionError<Infallible> = e.into();
+                ErrorCode::from(e)
+            })?;
+
+        if prev_meta.is_none() && result_meta.is_some() {
+            self.txn_incr_seq(SEQ_DATABASE_META_ID, txn_tree)
+                .map_err(|e| {
+                    let e: ConflictableTransactionError<Infallible> = e.into();
+                    ErrorCode::from(e)
+                })?;
+        }
+
+        tracing::debug!(
+            "applied create Database: {}, db_id: {}, meta: {:?}",
+            name,
+            db_id,
+            result
+        );
+
+        Ok(AppliedState::DatabaseMeta(Change::new_with_id(
+            db_id,
+            prev_meta,
+            result_meta,
+        )))
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, txn_tree))]
+    fn apply_drop_database_cmd(
+        &self,
+        tenant: &String,
+        name: &String,
+        cmd: &Cmd,
+        txn_tree: &TransactionSledTree,
+    ) -> common_exception::Result<AppliedState> {
+        let dbs = txn_tree.key_space::<DatabaseLookup>();
+
+        let (prev, result) = self
+            .sub_txn_tree_upsert(
+                &dbs,
+                &DatabaseLookupKey::new(tenant.to_string(), name.to_string()),
+                &MatchSeq::Any,
+                Operation::Delete,
+                None,
+            )
+            .map_err(|e| {
+                let e: ConflictableTransactionError<Infallible> = e.into();
+                ErrorCode::from(e)
+            })?;
+
+        assert!(
+            result.is_none(),
+            "delete with MatchSeq::Any always succeeds"
+        );
+
+        // if it is just deleted
+        if let Some(seq_db_id) = prev {
+            // TODO(xp): reconsider this impl. it may not be required.
+            self.txn_incr_seq(SEQ_DATABASE_META_ID, txn_tree)
+                .map_err(|e| {
+                    let e: ConflictableTransactionError<Infallible> = e.into();
+                    ErrorCode::from(e)
+                })?;
+
+            let db_id = seq_db_id.data;
+
+            let dbs = txn_tree.key_space::<Databases>();
+            let (prev_meta, result_meta) = self
+                .sub_txn_tree_upsert(&dbs, &db_id, &MatchSeq::Any, Operation::Delete, None)
+                .map_err(|e| {
+                    let e: ConflictableTransactionError<Infallible> = e.into();
+                    ErrorCode::from(e)
+                })?;
+
+            tracing::debug!("applied drop Database: {} {:?}", name, result);
+
+            return Ok(AppliedState::DatabaseMeta(Change::new_with_id(
+                db_id,
+                prev_meta,
+                result_meta,
+            )));
+        }
+
+        // not exist
+
+        tracing::debug!("applied drop Database: {} {:?}", name, result);
+        Ok(AppliedState::DatabaseMeta(Change::new(None, None)))
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, txn_tree))]
+    fn apply_create_table_cmd(
+        &self,
+        tenant: &String,
+        db_name: &String,
+        table_name: &String,
+        table_meta: &TableMeta,
+        cmd: &Cmd,
+        txn_tree: &TransactionSledTree,
+    ) -> common_exception::Result<AppliedState> {
+        let db_id = self
+            .txn_get_database_id(tenant, db_name, txn_tree)
+            .map_err(|e| {
+                let e: ConflictableTransactionError<Infallible> = e.into();
+                ErrorCode::from(e)
+            })?;
+
+        let lookup_key = TableLookupKey {
+            database_id: db_id.unwrap(),
+            table_name: table_name.to_string(),
+        };
+
+        let table_lookup_tree = txn_tree.key_space::<TableLookup>();
+        let seq_table_id = table_lookup_tree.get(&lookup_key).map_err(|e| {
+            let e: ConflictableTransactionError<Infallible> = e.into();
+            ErrorCode::from(e)
+        })?;
+
+        if let Some(u) = seq_table_id {
+            let table_id = u.data.0;
+
+            let prev = self
+                .txn_get_table_meta_by_id(&table_id, txn_tree)
+                .map_err(|e| {
+                    let e: ConflictableTransactionError<Infallible> = e.into();
+                    ErrorCode::from(e)
+                })?;
+
+            return Ok(AppliedState::TableMeta(Change::nochange_with_id(
+                table_id, prev,
+            )));
+        }
+
+        let table_meta = table_meta.clone();
+        let table_id = self.txn_incr_seq(SEQ_TABLE_ID, txn_tree).map_err(|e| {
+            let e: ConflictableTransactionError<Infallible> = e.into();
+            ErrorCode::from(e)
+        })?;
+
+        self.sub_txn_tree_upsert(
+            &table_lookup_tree,
+            &lookup_key,
+            &MatchSeq::Exact(0),
+            Operation::Update(TableLookupValue(table_id)),
+            None,
+        )
+        .map_err(|e| {
+            let e: ConflictableTransactionError<Infallible> = e.into();
+            ErrorCode::from(e)
+        })?;
+
+        let table_tree = txn_tree.key_space::<Tables>();
+        let (prev, result) = self
+            .sub_txn_tree_upsert(
+                &table_tree,
+                &table_id,
+                &MatchSeq::Exact(0),
+                Operation::Update(table_meta),
+                None,
+            )
+            .map_err(|e| {
+                let e: ConflictableTransactionError<Infallible> = e.into();
+                ErrorCode::from(e)
+            })?;
+
+        tracing::debug!("applied create Table: {}={:?}", table_name, result);
+
+        if prev.is_none() && result.is_some() {
+            self.txn_incr_seq(SEQ_DATABASE_META_ID, txn_tree)
+                .map_err(|e| {
+                    let e: ConflictableTransactionError<Infallible> = e.into();
+                    ErrorCode::from(e)
+                })?;
+        }
+
+        Ok(AppliedState::TableMeta(Change::new_with_id(
+            table_id, prev, result,
+        )))
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, txn_tree))]
+    fn apply_drop_table_cmd(
+        &self,
+        tenant: &String,
+        db_name: &String,
+        table_name: &String,
+        cmd: &Cmd,
+        txn_tree: &TransactionSledTree,
+    ) -> common_exception::Result<AppliedState> {
+        let db_id = self
+            .txn_get_database_id(tenant, db_name, txn_tree)
+            .map_err(|e| {
+                let e: ConflictableTransactionError<Infallible> = e.into();
+                ErrorCode::from(e)
+            })?;
+
+        let lookup_key = TableLookupKey {
+            database_id: db_id.unwrap(),
+            table_name: table_name.to_string(),
+        };
+
+        let table_lookup_tree = txn_tree.key_space::<TableLookup>();
+        let seq_table_id = table_lookup_tree.get(&lookup_key).map_err(|e| {
+            let e: ConflictableTransactionError<Infallible> = e.into();
+            ErrorCode::from(e)
+        })?;
+
+        if seq_table_id.is_none() {
+            return Ok(Change::<TableMeta>::new(None, None).into());
+        }
+
+        let table_id = seq_table_id.unwrap().data.0;
+
+        self.sub_txn_tree_upsert(
+            &table_lookup_tree,
+            &lookup_key,
+            &MatchSeq::Any,
+            Operation::Delete,
+            None,
+        )
+        .map_err(|e| {
+            let e: ConflictableTransactionError<Infallible> = e.into();
+            ErrorCode::from(e)
+        })?;
+
+        let tables = txn_tree.key_space::<Tables>();
+        let (prev, result) = self
+            .sub_txn_tree_upsert(&tables, &table_id, &MatchSeq::Any, Operation::Delete, None)
+            .map_err(|e| {
+                let e: ConflictableTransactionError<Infallible> = e.into();
+                ErrorCode::from(e)
+            })?;
+        if prev.is_some() && result.is_none() {
+            self.txn_incr_seq(SEQ_DATABASE_META_ID, txn_tree)
+                .map_err(|e| {
+                    let e: ConflictableTransactionError<Infallible> = e.into();
+                    ErrorCode::from(e)
+                })?;
+        }
+        tracing::debug!("applied drop Table: {} {:?}", table_name, result);
+        Ok(Change::new_with_id(table_id, prev, result).into())
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, txn_tree))]
+    fn apply_update_kv_cmd(
+        &self,
+        key: &String,
+        seq: &MatchSeq,
+        value_op: &Operation<Vec<u8>>,
+        value_meta: &Option<KVMeta>,
+        cmd: &Cmd,
+        txn_tree: &TransactionSledTree,
+    ) -> common_exception::Result<AppliedState> {
+        let sub_tree = txn_tree.key_space::<GenericKV>();
+        let (prev, result) = self
+            .sub_txn_tree_upsert(&sub_tree, key, seq, value_op.clone(), value_meta.clone())
+            .map_err(|e| {
+                let e: ConflictableTransactionError<Infallible> = e.into();
+                ErrorCode::from(e)
+            })?;
+
+        tracing::debug!("applied UpsertKV: {} {:?}", key, result);
+        Ok(Change::new(prev, result).into())
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, txn_tree))]
+    fn apply_upsert_table_options_cmd(
+        &self,
+        req: &common_meta_types::UpsertTableOptionReq,
+        cmd: &Cmd,
+        txn_tree: &TransactionSledTree,
+    ) -> common_exception::Result<AppliedState> {
+        let table_tree = txn_tree.key_space::<Tables>();
+        let prev = table_tree.get(&req.table_id).map_err(|e| {
+            let e: ConflictableTransactionError<Infallible> = e.into();
+            ErrorCode::from(e)
+        })?;
+
+        // Unlike other Cmd, prev to be None is not allowed for upsert-options.
+        let prev =
+            prev.ok_or_else(|| ErrorCode::UnknownTableId(format!("table_id:{}", req.table_id)))?;
+
+        if req.seq.match_seq(&prev).is_err() {
+            let res = AppliedState::TableMeta(Change::new(Some(prev.clone()), Some(prev)));
+            return Ok(res);
+        }
+
+        let meta = prev.meta.clone();
+        let mut table_meta = prev.data.clone();
+        let opts = &mut table_meta.options;
+
+        for (k, opt_v) in &req.options {
+            match opt_v {
+                None => {
+                    opts.remove(k);
+                }
+                Some(v) => {
+                    opts.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
+
+        let new_seq = self.txn_incr_seq(Tables::NAME, txn_tree).map_err(|e| {
+            let e: ConflictableTransactionError<Infallible> = e.into();
+            ErrorCode::from(e)
+        })?;
+        let sv = SeqV {
+            seq: new_seq,
+            meta,
+            data: table_meta,
+        };
+
+        table_tree.insert(&req.table_id, &sv).map_err(|e| {
+            let e: ConflictableTransactionError<Infallible> = e.into();
+            ErrorCode::from(e)
+        })?;
+
+        Ok(AppliedState::TableMeta(Change::new_with_id(
+            req.table_id,
+            Some(prev),
+            Some(sv),
+        )))
+    }
+
     /// Apply a `Cmd` to state machine.
     ///
     /// Already applied log should be filtered out before passing into this function.
@@ -318,35 +746,14 @@ impl StateMachine {
     ) -> common_exception::Result<AppliedState> {
         match cmd {
             Cmd::IncrSeq { ref key } => {
-                let r = self.txn_incr_seq(key, txn_tree).map_err(|e| {
-                    let e: ConflictableTransactionError<Infallible> = e.into();
-                    ErrorCode::from(e)
-                })?;
-
-                Ok(r.into())
+                return self.apply_incr_seq_cmd(key, cmd, txn_tree);
             }
 
             Cmd::AddNode {
                 ref node_id,
                 ref node,
             } => {
-                let sm_nodes = txn_tree.key_space::<Nodes>();
-
-                let prev = sm_nodes.get(node_id).map_err(|e| {
-                    let e: ConflictableTransactionError<Infallible> = e.into();
-                    ErrorCode::from(e)
-                })?;
-
-                if prev.is_some() {
-                    Ok((prev, None).into())
-                } else {
-                    sm_nodes.insert(node_id, node).map_err(|e| {
-                        let e: ConflictableTransactionError<Infallible> = e.into();
-                        ErrorCode::from(e)
-                    })?;
-                    tracing::info!("applied AddNode: {}={:?}", node_id, node);
-                    Ok((prev, Some(node.clone())).into())
-                }
+                return self.apply_add_node_cmd(node_id, node, cmd, txn_tree);
             }
 
             Cmd::CreateDatabase {
@@ -354,143 +761,14 @@ impl StateMachine {
                 ref name,
                 ref meta,
             } => {
-                let db_id = self.txn_incr_seq(SEQ_DATABASE_ID, txn_tree).map_err(|e| {
-                    let e: ConflictableTransactionError<Infallible> = e.into();
-                    ErrorCode::from(e)
-                })?;
-
-                let db_lookup_tree = txn_tree.key_space::<DatabaseLookup>();
-
-                let (prev, result) = self
-                    .sub_txn_tree_upsert(
-                        &db_lookup_tree,
-                        &DatabaseLookupKey::new(tenant.to_string(), name.to_string()),
-                        &MatchSeq::Exact(0),
-                        Operation::Update(db_id),
-                        None,
-                    )
-                    .map_err(|e| {
-                        let e: ConflictableTransactionError<Infallible> = e.into();
-                        ErrorCode::from(e)
-                    })?;
-
-                // if it is just created
-                if prev.is_none() && result.is_some() {
-                    // TODO(xp): reconsider this impl. it may not be required.
-                    self.txn_incr_seq(SEQ_DATABASE_META_ID, txn_tree)
-                        .map_err(|e| {
-                            let e: ConflictableTransactionError<Infallible> = e.into();
-                            ErrorCode::from(e)
-                        })?;
-                } else {
-                    // exist
-                    let db_id = prev.unwrap().data;
-                    let prev = self
-                        .txn_get_database_meta_by_id(&db_id, txn_tree)
-                        .map_err(|e| {
-                            let e: ConflictableTransactionError<Infallible> = e.into();
-                            ErrorCode::from(e)
-                        })?;
-                    if let Some(prev) = prev {
-                        return Ok(AppliedState::DatabaseMeta(Change::nochange_with_id(
-                            db_id,
-                            Some(prev),
-                        )));
-                    }
-                }
-
-                let dbs = txn_tree.key_space::<Databases>();
-                let (prev_meta, result_meta) = self
-                    .sub_txn_tree_upsert(
-                        &dbs,
-                        &db_id,
-                        &MatchSeq::Exact(0),
-                        Operation::Update(meta.clone()),
-                        None,
-                    )
-                    .map_err(|e| {
-                        let e: ConflictableTransactionError<Infallible> = e.into();
-                        ErrorCode::from(e)
-                    })?;
-
-                if prev_meta.is_none() && result_meta.is_some() {
-                    self.txn_incr_seq(SEQ_DATABASE_META_ID, txn_tree)
-                        .map_err(|e| {
-                            let e: ConflictableTransactionError<Infallible> = e.into();
-                            ErrorCode::from(e)
-                        })?;
-                }
-
-                tracing::debug!(
-                    "applied create Database: {}, db_id: {}, meta: {:?}",
-                    name,
-                    db_id,
-                    result
-                );
-
-                Ok(AppliedState::DatabaseMeta(Change::new_with_id(
-                    db_id,
-                    prev_meta,
-                    result_meta,
-                )))
+                return self.apply_create_database_cmd(tenant, name, meta, cmd, txn_tree);
             }
 
             Cmd::DropDatabase {
                 ref tenant,
                 ref name,
             } => {
-                let dbs = txn_tree.key_space::<DatabaseLookup>();
-
-                let (prev, result) = self
-                    .sub_txn_tree_upsert(
-                        &dbs,
-                        &DatabaseLookupKey::new(tenant.to_string(), name.to_string()),
-                        &MatchSeq::Any,
-                        Operation::Delete,
-                        None,
-                    )
-                    .map_err(|e| {
-                        let e: ConflictableTransactionError<Infallible> = e.into();
-                        ErrorCode::from(e)
-                    })?;
-
-                assert!(
-                    result.is_none(),
-                    "delete with MatchSeq::Any always succeeds"
-                );
-
-                // if it is just deleted
-                if let Some(seq_db_id) = prev {
-                    // TODO(xp): reconsider this impl. it may not be required.
-                    self.txn_incr_seq(SEQ_DATABASE_META_ID, txn_tree)
-                        .map_err(|e| {
-                            let e: ConflictableTransactionError<Infallible> = e.into();
-                            ErrorCode::from(e)
-                        })?;
-
-                    let db_id = seq_db_id.data;
-
-                    let dbs = txn_tree.key_space::<Databases>();
-                    let (prev_meta, result_meta) = self
-                        .sub_txn_tree_upsert(&dbs, &db_id, &MatchSeq::Any, Operation::Delete, None)
-                        .map_err(|e| {
-                            let e: ConflictableTransactionError<Infallible> = e.into();
-                            ErrorCode::from(e)
-                        })?;
-
-                    tracing::debug!("applied drop Database: {} {:?}", name, result);
-
-                    return Ok(AppliedState::DatabaseMeta(Change::new_with_id(
-                        db_id,
-                        prev_meta,
-                        result_meta,
-                    )));
-                }
-
-                // not exist
-
-                tracing::debug!("applied drop Database: {} {:?}", name, result);
-                Ok(AppliedState::DatabaseMeta(Change::new(None, None)))
+                return self.apply_drop_database_cmd(tenant, name, cmd, txn_tree);
             }
 
             Cmd::CreateTable {
@@ -499,84 +777,9 @@ impl StateMachine {
                 ref table_name,
                 ref table_meta,
             } => {
-                let db_id = self
-                    .txn_get_database_id(tenant, db_name, txn_tree)
-                    .map_err(|e| {
-                        let e: ConflictableTransactionError<Infallible> = e.into();
-                        ErrorCode::from(e)
-                    })?;
-
-                let lookup_key = TableLookupKey {
-                    database_id: db_id.unwrap(),
-                    table_name: table_name.to_string(),
-                };
-
-                let table_lookup_tree = txn_tree.key_space::<TableLookup>();
-                let seq_table_id = table_lookup_tree.get(&lookup_key).map_err(|e| {
-                    let e: ConflictableTransactionError<Infallible> = e.into();
-                    ErrorCode::from(e)
-                })?;
-
-                if let Some(u) = seq_table_id {
-                    let table_id = u.data.0;
-
-                    let prev = self
-                        .txn_get_table_meta_by_id(&table_id, txn_tree)
-                        .map_err(|e| {
-                            let e: ConflictableTransactionError<Infallible> = e.into();
-                            ErrorCode::from(e)
-                        })?;
-
-                    return Ok(AppliedState::TableMeta(Change::nochange_with_id(
-                        table_id, prev,
-                    )));
-                }
-
-                let table_meta = table_meta.clone();
-                let table_id = self.txn_incr_seq(SEQ_TABLE_ID, txn_tree).map_err(|e| {
-                    let e: ConflictableTransactionError<Infallible> = e.into();
-                    ErrorCode::from(e)
-                })?;
-
-                self.sub_txn_tree_upsert(
-                    &table_lookup_tree,
-                    &lookup_key,
-                    &MatchSeq::Exact(0),
-                    Operation::Update(TableLookupValue(table_id)),
-                    None,
-                )
-                .map_err(|e| {
-                    let e: ConflictableTransactionError<Infallible> = e.into();
-                    ErrorCode::from(e)
-                })?;
-
-                let table_tree = txn_tree.key_space::<Tables>();
-                let (prev, result) = self
-                    .sub_txn_tree_upsert(
-                        &table_tree,
-                        &table_id,
-                        &MatchSeq::Exact(0),
-                        Operation::Update(table_meta),
-                        None,
-                    )
-                    .map_err(|e| {
-                        let e: ConflictableTransactionError<Infallible> = e.into();
-                        ErrorCode::from(e)
-                    })?;
-
-                tracing::debug!("applied create Table: {}={:?}", table_name, result);
-
-                if prev.is_none() && result.is_some() {
-                    self.txn_incr_seq(SEQ_DATABASE_META_ID, txn_tree)
-                        .map_err(|e| {
-                            let e: ConflictableTransactionError<Infallible> = e.into();
-                            ErrorCode::from(e)
-                        })?;
-                }
-
-                Ok(AppliedState::TableMeta(Change::new_with_id(
-                    table_id, prev, result,
-                )))
+                return self.apply_create_table_cmd(
+                    tenant, db_name, table_name, table_meta, cmd, txn_tree,
+                );
             }
 
             Cmd::DropTable {
@@ -584,64 +787,7 @@ impl StateMachine {
                 ref db_name,
                 ref table_name,
             } => {
-                let db_id = self
-                    .txn_get_database_id(tenant, db_name, txn_tree)
-                    .map_err(|e| {
-                        let e: ConflictableTransactionError<Infallible> = e.into();
-                        ErrorCode::from(e)
-                    })?;
-
-                let lookup_key = TableLookupKey {
-                    database_id: db_id.unwrap(),
-                    table_name: table_name.to_string(),
-                };
-
-                let table_lookup_tree = txn_tree.key_space::<TableLookup>();
-                let seq_table_id = table_lookup_tree.get(&lookup_key).map_err(|e| {
-                    let e: ConflictableTransactionError<Infallible> = e.into();
-                    ErrorCode::from(e)
-                })?;
-
-                if seq_table_id.is_none() {
-                    return Ok(Change::<TableMeta>::new(None, None).into());
-                }
-
-                let table_id = seq_table_id.unwrap().data.0;
-
-                self.sub_txn_tree_upsert(
-                    &table_lookup_tree,
-                    &lookup_key,
-                    &MatchSeq::Any,
-                    Operation::Delete,
-                    None,
-                )
-                .map_err(|e| {
-                    let e: ConflictableTransactionError<Infallible> = e.into();
-                    ErrorCode::from(e)
-                })?;
-
-                let tables = txn_tree.key_space::<Tables>();
-                let (prev, result) = self
-                    .sub_txn_tree_upsert(
-                        &tables,
-                        &table_id,
-                        &MatchSeq::Any,
-                        Operation::Delete,
-                        None,
-                    )
-                    .map_err(|e| {
-                        let e: ConflictableTransactionError<Infallible> = e.into();
-                        ErrorCode::from(e)
-                    })?;
-                if prev.is_some() && result.is_none() {
-                    self.txn_incr_seq(SEQ_DATABASE_META_ID, txn_tree)
-                        .map_err(|e| {
-                            let e: ConflictableTransactionError<Infallible> = e.into();
-                            ErrorCode::from(e)
-                        })?;
-                }
-                tracing::debug!("applied drop Table: {} {:?}", table_name, result);
-                Ok(Change::new_with_id(table_id, prev, result).into())
+                return self.apply_drop_table_cmd(tenant, db_name, table_name, cmd, txn_tree);
             }
 
             Cmd::UpsertKV {
@@ -650,70 +796,11 @@ impl StateMachine {
                 value: value_op,
                 value_meta,
             } => {
-                let sub_tree = txn_tree.key_space::<GenericKV>();
-                let (prev, result) = self
-                    .sub_txn_tree_upsert(&sub_tree, key, seq, value_op.clone(), value_meta.clone())
-                    .map_err(|e| {
-                        let e: ConflictableTransactionError<Infallible> = e.into();
-                        ErrorCode::from(e)
-                    })?;
-
-                tracing::debug!("applied UpsertKV: {} {:?}", key, result);
-                Ok(Change::new(prev, result).into())
+                return self.apply_update_kv_cmd(key, seq, value_op, value_meta, cmd, txn_tree);
             }
 
             Cmd::UpsertTableOptions(ref req) => {
-                let table_tree = txn_tree.key_space::<Tables>();
-                let prev = table_tree.get(&req.table_id).map_err(|e| {
-                    let e: ConflictableTransactionError<Infallible> = e.into();
-                    ErrorCode::from(e)
-                })?;
-
-                // Unlike other Cmd, prev to be None is not allowed for upsert-options.
-                let prev = prev.ok_or_else(|| {
-                    ErrorCode::UnknownTableId(format!("table_id:{}", req.table_id))
-                })?;
-
-                if req.seq.match_seq(&prev).is_err() {
-                    let res = AppliedState::TableMeta(Change::new(Some(prev.clone()), Some(prev)));
-                    return Ok(res);
-                }
-
-                let meta = prev.meta.clone();
-                let mut table_meta = prev.data.clone();
-                let opts = &mut table_meta.options;
-
-                for (k, opt_v) in &req.options {
-                    match opt_v {
-                        None => {
-                            opts.remove(k);
-                        }
-                        Some(v) => {
-                            opts.insert(k.to_string(), v.to_string());
-                        }
-                    }
-                }
-
-                let new_seq = self.txn_incr_seq(Tables::NAME, txn_tree).map_err(|e| {
-                    let e: ConflictableTransactionError<Infallible> = e.into();
-                    ErrorCode::from(e)
-                })?;
-                let sv = SeqV {
-                    seq: new_seq,
-                    meta,
-                    data: table_meta,
-                };
-
-                table_tree.insert(&req.table_id, &sv).map_err(|e| {
-                    let e: ConflictableTransactionError<Infallible> = e.into();
-                    ErrorCode::from(e)
-                })?;
-
-                Ok(AppliedState::TableMeta(Change::new_with_id(
-                    req.table_id,
-                    Some(prev),
-                    Some(sv),
-                )))
+                return self.apply_upsert_table_options_cmd(req, cmd, txn_tree);
             }
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

In `StateMachine` struct `apply_cmd` function, all the commands are handled in this function, make this function too long to read. This pr split the function into sub cmd handler functions, make code more clearly.

## Changelog

- Improvement


## Related Issues


