### PR TITLE
ISSUE-3850: Range filter support more multi-column expression scenarios

### DIFF
--- a/common/planners/src/lib.rs
+++ b/common/planners/src/lib.rs
@@ -116,6 +116,7 @@ pub use plan_expression_function::avg;
 pub use plan_expression_function::modular;
 pub use plan_expression_function::neg;
 pub use plan_expression_function::not;
+pub use plan_expression_function::sub;
 pub use plan_expression_function::sum;
 pub use plan_expression_literal::lit;
 pub use plan_expression_monotonicity::ExpressionMonotonicityVisitor;

--- a/common/planners/src/plan_expression_function.rs
+++ b/common/planners/src/plan_expression_function.rs
@@ -28,6 +28,11 @@ pub fn add(left: Expression, right: Expression) -> Expression {
     binary_expr(left, "+", right)
 }
 
+/// Sub binary function.
+pub fn sub(left: Expression, right: Expression) -> Expression {
+    binary_expr(left, "-", right)
+}
+
 /// Not.
 pub fn not(other: Expression) -> Expression {
     Expression::UnaryExpression {

--- a/common/planners/tests/it/plan_expression_monotonicity.rs
+++ b/common/planners/tests/it/plan_expression_monotonicity.rs
@@ -570,7 +570,7 @@ fn test_dates_function() -> Result<()> {
 fn test_single_point() -> Result<()> {
     let test_suite = vec![
         Test {
-            name: "f(x) = rand() + x",
+            name: "f(x) = x + rand()",
             expr: add(col("x"), Expression::create_scalar_function("rand", vec![])),
             column: "x",
             left: create_f64(1.0),
@@ -580,7 +580,7 @@ fn test_single_point() -> Result<()> {
                 "Code: 1000, displayText = Function 'rand' is not monotonic in the variables range.",
         },
         Test {
-            name: "f(x) = x * (12-x)",
+            name: "f(x) = x * (12 - x)",
             expr: Expression::create_binary_expression("*", vec![
                 col("x"),
                 sub(lit(12_i64), col("x")),

--- a/common/planners/tests/it/plan_expression_monotonicity.rs
+++ b/common/planners/tests/it/plan_expression_monotonicity.rs
@@ -131,10 +131,11 @@ fn verify_test(t: Test) -> Result<()> {
 
 #[test]
 fn test_arithmetic_plus_minus() -> Result<()> {
-    let test_suite = vec![
+    let test_suite =
+        vec![
         Test {
             name: "f(x) = x + 12",
-            expr: Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
+            expr: add(col("x"), lit(12i32)),
             column: "x",
             left: None,
             right: None,
@@ -149,10 +150,7 @@ fn test_arithmetic_plus_minus() -> Result<()> {
         },
         Test {
             name: "f(x) = -x + 12",
-            expr: Expression::create_binary_expression("+", vec![
-                Expression::create_unary_expression("negate", vec![col("x")]),
-                lit(12i32),
-            ]),
+            expr: add(neg(col("x")), lit(12)),
             column: "x",
             left: None,
             right: None,
@@ -167,7 +165,7 @@ fn test_arithmetic_plus_minus() -> Result<()> {
         },
         Test {
             name: "f(x,y) = x + y",
-            expr: Expression::create_binary_expression("+", vec![col("x"), col("y")]),
+            expr: add(col("x"), col("y")),
             column: "x",
             left: None,
             right: None,
@@ -182,18 +180,7 @@ fn test_arithmetic_plus_minus() -> Result<()> {
         },
         Test {
             name: "f(x) = (-x + 12) - x + (1 - x)",
-            expr: Expression::create_binary_expression("+", vec![
-                Expression::create_binary_expression("-", vec![
-                    // -x + 12
-                    Expression::create_binary_expression("+", vec![
-                        Expression::create_unary_expression("negate", vec![col("x")]),
-                        lit(12i32),
-                    ]),
-                    col("x"),
-                ]),
-                // 1 - x
-                Expression::create_unary_expression("negate", vec![lit(1i64), col("x")]),
-            ]),
+            expr: add(sub(add(neg(col("x")), lit(12)), col("x")), sub(lit(1), col("x"))),
             column: "x",
             left: None,
             right: None,
@@ -208,15 +195,7 @@ fn test_arithmetic_plus_minus() -> Result<()> {
         },
         Test {
             name: "f(x) = (x + 12) - x + (1 - x)",
-            expr: Expression::create_binary_expression("+", vec![
-                Expression::create_binary_expression("-", vec![
-                    // x + 12
-                    Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
-                    col("x"),
-                ]),
-                // 1 - x
-                Expression::create_unary_expression("negate", vec![lit(1i64), col("x")]),
-            ]),
+            expr: add(sub(add(col("x"), lit(12)), col("x")), sub(lit(1), col("x"))),
             column: "x",
             left: None,
             right: None,
@@ -284,7 +263,7 @@ fn test_arithmetic_mul_div() -> Result<()> {
             name: "f(x) = x * (x-12) where x in [10-1000]",
             expr: Expression::create_binary_expression("*", vec![
                 col("x"),
-                Expression::create_binary_expression("-", vec![col("x"), lit(12_i64)]),
+                sub(col("x"), lit(12_i64)),
             ]),
             column: "x",
             left: create_f64(10.0),
@@ -297,7 +276,7 @@ fn test_arithmetic_mul_div() -> Result<()> {
             name: "f(x) = x * (x-12) where x in [12, 100]",
             expr: Expression::create_binary_expression("*", vec![
                 col("x"),
-                Expression::create_binary_expression("-", vec![col("x"), lit(12_i64)]),
+                sub(col("x"), lit(12_i64)),
             ]),
             column: "x",
             left: create_f64(12.0),
@@ -332,10 +311,10 @@ fn test_arithmetic_mul_div() -> Result<()> {
         Test {
             name: "f(x) = -x/(2/(x-2)) where  x in [0-10]",
             expr: Expression::create_binary_expression("/", vec![
-                Expression::create_unary_expression("negate", vec![col("x")]),
+                neg(col("x")),
                 Expression::create_binary_expression("/", vec![
                     lit(2_i8),
-                    Expression::create_binary_expression("-", vec![col("x"), lit(2_i8)]),
+                    sub(col("x"), lit(2_i8)),
                 ]),
             ]),
             column: "x",
@@ -348,10 +327,10 @@ fn test_arithmetic_mul_div() -> Result<()> {
         Test {
             name: "f(x) = -x/(2/(x-2)) where  x in [4-10]",
             expr: Expression::create_binary_expression("/", vec![
-                Expression::create_unary_expression("negate", vec![col("x")]),
+                neg(col("x")),
                 Expression::create_binary_expression("/", vec![
                     lit(2_i8),
-                    Expression::create_binary_expression("-", vec![col("x"), lit(2_i8)]),
+                    sub(col("x"), lit(2_i8)),
                 ]),
             ]),
             column: "x",
@@ -379,9 +358,7 @@ fn test_abs_function() -> Result<()> {
     let test_suite = vec![
         Test {
             name: "f(x) = abs(x + 12)",
-            expr: Expression::create_scalar_function("abs", vec![
-                Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
-            ]),
+            expr: Expression::create_scalar_function("abs", vec![add(col("x"), lit(12i32))]),
             column: "x",
             left: None,
             right: None,
@@ -431,9 +408,7 @@ fn test_abs_function() -> Result<()> {
         },
         Test {
             name: "f(x) = abs(x + 12) where -12 <= x <= 1000",
-            expr: Expression::create_scalar_function("abs", vec![
-                Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
-            ]),
+            expr: Expression::create_scalar_function("abs", vec![add(col("x"), lit(12i32))]),
             column: "x",
             left: create_f64(-12.0),
             right: create_f64(1000.0),
@@ -448,9 +423,7 @@ fn test_abs_function() -> Result<()> {
         },
         Test {
             name: "f(x) = abs(x + 12) where -14 <=  x <= 20", // should NOT be monotonic
-            expr: Expression::create_scalar_function("abs", vec![
-                Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
-            ]),
+            expr: Expression::create_scalar_function("abs", vec![add(col("x"), lit(12i32))]),
             column: "x",
             left: create_f64(-14.0),
             right: create_f64(20.0),
@@ -460,12 +433,10 @@ fn test_abs_function() -> Result<()> {
         },
         Test {
             name: "f(x) = abs( (x - 7) + (x - 3) ) where 5 <= x <= 100",
-            expr: Expression::create_scalar_function("abs", vec![
-                Expression::create_binary_expression("+", vec![
-                    Expression::create_binary_expression("-", vec![col("x"), lit(7_i32)]),
-                    Expression::create_binary_expression("-", vec![col("x"), lit(3_i32)]),
-                ]),
-            ]),
+            expr: Expression::create_scalar_function("abs", vec![add(
+                sub(col("x"), lit(7_i32)),
+                sub(col("x"), lit(3_i32)),
+            )]),
             column: "x",
             left: create_f64(5.0),
             right: create_f64(100.0),
@@ -480,15 +451,10 @@ fn test_abs_function() -> Result<()> {
         },
         Test {
             name: "f(x) = abs( (-x + 8) - x) where -100 <= x <= 4",
-            expr: Expression::create_scalar_function("abs", vec![
-                Expression::create_binary_expression("-", vec![
-                    Expression::create_binary_expression("+", vec![
-                        Expression::create_unary_expression("negate", vec![col("x")]),
-                        lit(8_i64),
-                    ]),
-                    col("x"),
-                ]),
-            ]),
+            expr: Expression::create_scalar_function("abs", vec![sub(
+                add(neg(col("x")), lit(8)),
+                col("x"),
+            )]),
             column: "x",
             left: create_f64(-100.0),
             right: create_f64(4.0),
@@ -515,7 +481,7 @@ fn test_dates_function() -> Result<()> {
         Test {
             name: "f(x) = toStartOfWeek(x+12)",
             expr: Expression::create_scalar_function("toStartOfWeek", vec![
-                Expression::create_binary_expression("+", vec![col("x"), lit(12i32)]),
+                add(col("x"), lit(12i32)),
             ]),
             column: "x",
             left: None,
@@ -605,10 +571,7 @@ fn test_single_point() -> Result<()> {
     let test_suite = vec![
         Test {
             name: "f(x) = rand() + x",
-            expr: Expression::create_binary_expression("+", vec![
-                col("x"),
-                Expression::create_scalar_function("rand", vec![]),
-            ]),
+            expr: add(col("x"), Expression::create_scalar_function("rand", vec![])),
             column: "x",
             left: create_f64(1.0),
             right: create_f64(1.0),
@@ -620,7 +583,7 @@ fn test_single_point() -> Result<()> {
             name: "f(x) = x * (12-x)",
             expr: Expression::create_binary_expression("*", vec![
                 col("x"),
-                Expression::create_binary_expression("-", vec![lit(12_i64), col("x")]),
+                sub(lit(12_i64), col("x")),
             ]),
             column: "x",
             left: create_f64(1.0),

--- a/query/src/storages/index/range_filter.rs
+++ b/query/src/storages/index/range_filter.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 
@@ -154,9 +155,12 @@ impl fmt::Display for StatType {
     }
 }
 
+pub type StatColumns = Vec<StatColumn>;
+pub type ColumnFields = HashMap<u32, DataField>;
+
 #[derive(Debug, Clone)]
 pub struct StatColumn {
-    column_fields: HashMap<u32, DataField>,
+    column_fields: ColumnFields,
     stat_type: StatType,
     stat_field: DataField,
     expr: Expression,
@@ -164,7 +168,7 @@ pub struct StatColumn {
 
 impl StatColumn {
     fn create(
-        column_fields: HashMap<u32, DataField>,
+        column_fields: ColumnFields,
         stat_type: StatType,
         field: &DataField,
         expr: Expression,
@@ -268,13 +272,10 @@ impl StatColumn {
     }
 }
 
-pub type StatColumns = Vec<StatColumn>;
-
 struct VerifiableExprBuilder<'a> {
     op: &'a str,
     args: Expressions,
-    column_fields: HashMap<u32, DataField>,
-    field: DataField,
+    fields: Vec<(DataField, ColumnFields)>,
     stat_columns: &'a mut StatColumns,
 }
 
@@ -289,7 +290,7 @@ impl<'a> VerifiableExprBuilder<'a> {
             1 => {
                 let cols = RequireColumnsVisitor::collect_columns_from_expr(&exprs[0])?;
                 match cols.len() {
-                    1 => (exprs, cols, op),
+                    1 => (exprs, vec![cols], op),
                     _ => {
                         return Err(ErrorCode::UnknownException(
                             "Multi-column expressions are not currently supported",
@@ -301,15 +302,41 @@ impl<'a> VerifiableExprBuilder<'a> {
                 let lhs_cols = RequireColumnsVisitor::collect_columns_from_expr(&exprs[0])?;
                 let rhs_cols = RequireColumnsVisitor::collect_columns_from_expr(&exprs[1])?;
                 match (lhs_cols.len(), rhs_cols.len()) {
-                    (a, 0) if a > 0 => (vec![exprs[0].clone(), exprs[1].clone()], lhs_cols, op),
-                    (0, a) if a > 0 => {
+                    (0, 0) => {
+                        return Err(ErrorCode::UnknownException(
+                            "Constant expression donot need to be handled",
+                        ))
+                    }
+                    (_, 0) => (vec![exprs[0].clone(), exprs[1].clone()], vec![lhs_cols], op),
+                    (0, _) => {
                         let op = inverse_operator(op)?;
-                        (vec![exprs[1].clone(), exprs[0].clone()], rhs_cols, op)
+                        (vec![exprs[1].clone(), exprs[0].clone()], vec![rhs_cols], op)
                     }
                     _ => {
-                        return Err(ErrorCode::UnknownException(
-                            "Multi-column expressions are not currently supported",
-                        ));
+                        if !lhs_cols.is_disjoint(&rhs_cols) {
+                            return Err(ErrorCode::UnknownException(
+                                "Unsupported condition for left and right have same columns",
+                            ));
+                        }
+
+                        if !matches!(op, "=" | "<" | "<=" | ">" | ">=") {
+                            return Err(ErrorCode::UnknownException(format!(
+                                "Unsupported operator '{:?}' for multi-column expression",
+                                op
+                            )));
+                        }
+
+                        if !check_maybe_monotonic(&exprs[1])? {
+                            return Err(ErrorCode::UnknownException(
+                                "Only support the monotonic expression",
+                            ));
+                        }
+
+                        (
+                            vec![exprs[0].clone(), exprs[1].clone()],
+                            vec![lhs_cols, rhs_cols],
+                            op,
+                        )
                     }
                 }
             }
@@ -326,21 +353,22 @@ impl<'a> VerifiableExprBuilder<'a> {
             ));
         }
 
-        let mut column_fields = HashMap::with_capacity(cols.len());
-        for col in cols {
-            let (index, column_field) = schema
-                .column_with_name(col.as_str())
-                .ok_or_else(|| ErrorCode::UnknownException("Unable to find the column name"))?;
-            column_fields.insert(index as u32, column_field.clone());
-        }
+        let mut fields = Vec::with_capacity(cols.len());
 
-        let field = args[0].to_data_field(schema)?;
+        let left_cols = get_column_fields(schema, cols[0].clone())?;
+        let left_field = args[0].to_data_field(schema)?;
+        fields.push((left_field, left_cols));
+
+        if cols.len() > 1 {
+            let right_cols = get_column_fields(schema, cols[1].clone())?;
+            let right_field = args[1].to_data_field(schema)?;
+            fields.push((right_field, right_cols));
+        }
 
         Ok(Self {
             op,
             args,
-            column_fields,
-            field,
+            fields,
             stat_columns,
         })
     }
@@ -349,45 +377,88 @@ impl<'a> VerifiableExprBuilder<'a> {
         // TODO: support in/not in.
         match self.op {
             "isnull" => {
-                let nulls_expr = self.nulls_column_expr()?;
+                let nulls_expr = self.nulls_column_expr(0)?;
                 let scalar_expr = lit(0u64);
                 Ok(nulls_expr.gt(scalar_expr))
             }
             "isnotnull" => {
-                let min_expr = self.min_column_expr()?;
+                let left_min = self.min_column_expr(0)?;
                 Ok(Expression::create_scalar_function("isNotNull", vec![
-                    min_expr,
+                    left_min,
                 ]))
             }
             "=" => {
-                let min_expr = self.min_column_expr()?;
-                let max_expr = self.max_column_expr()?;
-                Ok(min_expr
-                    .lt_eq(self.args[1].clone())
-                    .and(max_expr.gt_eq(self.args[1].clone())))
+                // left = right => min_left <= max_right and max_left >= min_right
+                let left_min = self.min_column_expr(0)?;
+                let left_max = self.max_column_expr(0)?;
+
+                let right_min = if self.fields.len() == 1 {
+                    self.args[1].clone()
+                } else {
+                    self.min_column_expr(1)?
+                };
+                let right_max = if self.fields.len() == 1 {
+                    self.args[1].clone()
+                } else {
+                    self.max_column_expr(1)?
+                };
+
+                Ok(left_min.lt_eq(right_max).and(left_max.gt_eq(right_min)))
             }
             "!=" => {
-                let min_expr = self.min_column_expr()?;
-                let max_expr = self.max_column_expr()?;
-                Ok(min_expr
+                let left_min = self.min_column_expr(0)?;
+                let left_max = self.max_column_expr(0)?;
+                Ok(left_min
                     .not_eq(self.args[1].clone())
-                    .or(max_expr.not_eq(self.args[1].clone())))
+                    .or(left_max.not_eq(self.args[1].clone())))
             }
             ">" => {
-                let max_expr = self.max_column_expr()?;
-                Ok(max_expr.gt(self.args[1].clone()))
+                // left > right => max_left > min_right
+                let left_max = self.max_column_expr(0)?;
+
+                let right_min = if self.fields.len() == 1 {
+                    self.args[1].clone()
+                } else {
+                    self.min_column_expr(1)?
+                };
+
+                Ok(left_max.gt(right_min))
             }
             ">=" => {
-                let max_expr = self.max_column_expr()?;
-                Ok(max_expr.gt_eq(self.args[1].clone()))
+                // left >= right => max_left >= min_right
+                let left_max = self.max_column_expr(0)?;
+
+                let right_min = if self.fields.len() == 1 {
+                    self.args[1].clone()
+                } else {
+                    self.min_column_expr(1)?
+                };
+
+                Ok(left_max.gt_eq(right_min))
             }
             "<" => {
-                let min_expr = self.min_column_expr()?;
-                Ok(min_expr.lt(self.args[1].clone()))
+                // left < right => min_left < max_right
+                let left_min = self.min_column_expr(0)?;
+
+                let right_max = if self.fields.len() == 1 {
+                    self.args[1].clone()
+                } else {
+                    self.max_column_expr(1)?
+                };
+
+                Ok(left_min.lt(right_max))
             }
             "<=" => {
-                let min_expr = self.min_column_expr()?;
-                Ok(min_expr.lt_eq(self.args[1].clone()))
+                // left <= right => min_left <= max_right
+                let left_min = self.min_column_expr(0)?;
+
+                let right_max = if self.fields.len() == 1 {
+                    self.args[1].clone()
+                } else {
+                    self.max_column_expr(1)?
+                };
+
+                Ok(left_min.lt_eq(right_max))
             }
             "like" => {
                 if let Expression::Literal {
@@ -399,11 +470,11 @@ impl<'a> VerifiableExprBuilder<'a> {
                     let left = left_bound_for_like_pattern(v);
                     if !left.is_empty() {
                         let right = right_bound_for_like_pattern(left.clone());
-                        let max_expr = self.max_column_expr()?;
+                        let max_expr = self.max_column_expr(0)?;
                         if right.is_empty() {
                             return Ok(max_expr.gt_eq(lit(left)));
                         } else {
-                            let min_expr = self.min_column_expr()?;
+                            let min_expr = self.min_column_expr(0)?;
                             return Ok(max_expr.gt_eq(lit(left)).and(min_expr.lt(lit(right))));
                         }
                     }
@@ -423,8 +494,8 @@ impl<'a> VerifiableExprBuilder<'a> {
                         // e.g. col not like 'abc' => min_col != 'abc' or max_col != 'abc'
                         PatternType::OrdinalStr => {
                             let const_arg = left_bound_for_like_pattern(v);
-                            let max_expr = self.max_column_expr()?;
-                            let min_expr = self.min_column_expr()?;
+                            let max_expr = self.max_column_expr(0)?;
+                            let min_expr = self.min_column_expr(0)?;
                             return Ok(min_expr
                                 .not_eq(lit(const_arg.clone()))
                                 .or(max_expr.not_eq(lit(const_arg))));
@@ -434,11 +505,11 @@ impl<'a> VerifiableExprBuilder<'a> {
                             let left = left_bound_for_like_pattern(v);
                             if !left.is_empty() {
                                 let right = right_bound_for_like_pattern(left.clone());
-                                let min_expr = self.min_column_expr()?;
+                                let min_expr = self.min_column_expr(0)?;
                                 if right.is_empty() {
                                     return Ok(min_expr.lt(lit(left)));
                                 } else {
-                                    let max_expr = self.max_column_expr()?;
+                                    let max_expr = self.max_column_expr(0)?;
                                     return Ok(min_expr
                                         .lt(lit(left))
                                         .or(max_expr.gt_eq(lit(right))));
@@ -459,33 +530,34 @@ impl<'a> VerifiableExprBuilder<'a> {
         }
     }
 
-    fn stat_column_expr(&mut self, stat_type: StatType) -> Result<Expression> {
+    fn stat_column_expr(&mut self, stat_type: StatType, index: usize) -> Result<Expression> {
+        let (data_field, column_fields) = self.fields[index].clone();
         let stat_col = StatColumn::create(
-            self.column_fields.clone(),
+            column_fields,
             stat_type,
-            &self.field,
-            self.args[0].clone(),
+            &data_field,
+            self.args[index].clone(),
         );
         if !self
             .stat_columns
             .iter()
-            .any(|c| c.stat_type == stat_type && c.stat_field.name() == self.field.name())
+            .any(|c| c.stat_type == stat_type && c.stat_field.name() == data_field.name())
         {
             self.stat_columns.push(stat_col.clone());
         }
         Ok(Expression::Column(stat_col.stat_field.name().to_owned()))
     }
 
-    fn min_column_expr(&mut self) -> Result<Expression> {
-        self.stat_column_expr(StatType::Min)
+    fn min_column_expr(&mut self, index: usize) -> Result<Expression> {
+        self.stat_column_expr(StatType::Min, index)
     }
 
-    fn max_column_expr(&mut self) -> Result<Expression> {
-        self.stat_column_expr(StatType::Max)
+    fn max_column_expr(&mut self, index: usize) -> Result<Expression> {
+        self.stat_column_expr(StatType::Max, index)
     }
 
-    fn nulls_column_expr(&mut self) -> Result<Expression> {
-        self.stat_column_expr(StatType::Nulls)
+    fn nulls_column_expr(&mut self, index: usize) -> Result<Expression> {
+        self.stat_column_expr(StatType::Nulls, index)
     }
 }
 
@@ -560,4 +632,15 @@ fn check_maybe_monotonic(expr: &Expression) -> Result<bool> {
         Expression::Cast { expr, .. } => check_maybe_monotonic(expr),
         _ => Ok(false),
     }
+}
+
+fn get_column_fields(schema: &DataSchemaRef, cols: HashSet<String>) -> Result<ColumnFields> {
+    let mut column_fields = HashMap::with_capacity(cols.len());
+    for col in &cols {
+        let (index, field) = schema
+            .column_with_name(col.as_str())
+            .ok_or_else(|| ErrorCode::UnknownException("Unable to find the column name"))?;
+        column_fields.insert(index as u32, field.clone());
+    }
+    Ok(column_fields)
 }

--- a/query/tests/it/storages/index/range_filter.rs
+++ b/query/tests/it/storages/index/range_filter.rs
@@ -312,7 +312,10 @@ fn test_build_verifiable_function() -> Result<()> {
         },
         Test {
             name: "a <= b + rand()",
-            expr: add(col("a"), add(col("b"), Expression::create_scalar_function("rand", vec![]))),
+            expr: add(
+                col("a"),
+                add(col("b"), Expression::create_scalar_function("rand", vec![])),
+            ),
             expect: "true",
         },
     ];

--- a/query/tests/it/storages/index/range_filter.rs
+++ b/query/tests/it/storages/index/range_filter.rs
@@ -161,6 +161,12 @@ fn test_range_filter() -> Result<()> {
             expect: true,
             error: "",
         },
+        Test {
+            name: "a + 9 < b",
+            expr: add(col("a"), lit(9)).lt(col("b")),
+            expect: false,
+            error: "",
+        },
     ];
 
     for test in tests {

--- a/query/tests/it/storages/index/range_filter.rs
+++ b/query/tests/it/storages/index/range_filter.rs
@@ -310,6 +310,11 @@ fn test_build_verifiable_function() -> Result<()> {
             expr: add(col("a"), col("b")).lt_eq(sub(lit(10), col("a"))),
             expect: "true",
         },
+        Test {
+            name: "a <= b + rand()",
+            expr: add(col("a"), add(col("b"), Expression::create_scalar_function("rand", vec![]))),
+            expect: "true",
+        },
     ];
 
     for test in tests {

--- a/query/tests/it/storages/index/range_filter.rs
+++ b/query/tests/it/storages/index/range_filter.rs
@@ -149,8 +149,7 @@ fn test_range_filter() -> Result<()> {
         },
         Test {
             name: "a - b <= -10",
-            expr: Expression::create_binary_expression("-", vec![col("a"), col("b")])
-                .lt_eq(lit(-10)),
+            expr: sub(col("a"), col("b")).lt_eq(lit(-10)),
             expect: true,
             error:
                 "Code: 1000, displayText = Function '-' is not monotonic in the variables range.",
@@ -294,6 +293,22 @@ fn test_build_verifiable_function() -> Result<()> {
                 lit(vec![255u8, 255, 255, 37]),
             ]),
             expect: "(min_c < ffffff)",
+        },
+        Test {
+            name: "abs(a) = b - 3",
+            expr: Expression::create_scalar_function("abs", vec![col("a")])
+                .eq(add(col("b"), lit(3))),
+            expect: "((min_abs(a) <= max_(b + 3)) and (max_abs(a) >= min_(b + 3)))",
+        },
+        Test {
+            name: "a + b <= 3",
+            expr: add(col("a"), col("b")).lt_eq(lit(3)),
+            expect: "(min_(a + b) <= 3)",
+        },
+        Test {
+            name: "a + b <= 10 - a",
+            expr: add(col("a"), col("b")).lt_eq(sub(lit(10), col("a"))),
+            expect: "true",
         },
     ];
 

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -36,7 +36,6 @@ def remove_control_characters(s):
     """
     https://github.com/html5lib/html5lib-python/issues/96#issuecomment-43438438
     """
-
     def str_to_int(s, default, base=10):
         if int(s, base) < 0x10000:
             return chr(int(s, base))

--- a/tests/helpers/client.py
+++ b/tests/helpers/client.py
@@ -14,7 +14,6 @@ sys.path.insert(0, os.path.join(CURDIR))
 
 
 class client(object):
-
     def __init__(self, name='', log=None):
         self.name = name
         self.log = log

--- a/tests/suites/0_stateless/00_0000_dummy_select_py.py
+++ b/tests/suites/0_stateless/00_0000_dummy_select_py.py
@@ -31,7 +31,6 @@ client1.run("select 3")
 
 
 class MyModel(object):
-
     def __init__(self, name, value):
         self.name = name
         self.value = value


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Both `left` and `right` contain different columns.
```
left = right => min_left <= max_right and max_left >= min_right
left > right => max_left > min_right
left >= right => max_left >= min_right
left < right => min_left < max_right
left <= right => min_left <= max_right
```

## Changelog

- Improvement

## Related Issues

Fixes #3850 

## Test Plan

Unit Tests


