### PR TITLE
[Build/CI] introduce databend Dev container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # visual studio code files
 .vscode
 .dir-locals.el
+.bash_history
+.mysql_history
 
 # Rust
 target/

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ hfuzz_workspace/
 *.stderr-e
 *.stdout-e
 tests/perfs/*-result.json
+docker/build-tool/dev_setup.sh
+docker/build-tool/rust-toolchain.toml
 
 # python
 venv/

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,9 @@ run-codegen:
 
 perf-tool: build-perf-tool
 	docker buildx build . -f ./docker/perf-tool/Dockerfile  --platform linux/amd64 --allow network.host --builder host -t ${HUB}/perf-tool:${TAG} --push
-
+# used for the build of dev container
+dev-docker:
+	docker build ./docker/build-tool -t ${HUB}/build-tool:${TAG} -f ./docker/build-tool/Dockerfile
 profile:
 	bash ./scripts/ci/ci-run-profile.sh
 

--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,9 @@ run-codegen:
 perf-tool: build-perf-tool
 	docker buildx build . -f ./docker/perf-tool/Dockerfile  --platform linux/amd64 --allow network.host --builder host -t ${HUB}/perf-tool:${TAG} --push
 # used for the build of dev container
-dev-docker:
-	docker build ./docker/build-tool -t ${HUB}/build-tool:${TAG} -f ./docker/build-tool/Dockerfile
+dev-container:
+	cp ./rust-toolchain.toml ./docker/build-tool
+	docker build ./docker/build-tool -t ${HUB}/dev-container:${TAG} -f ./docker/build-tool/Dockerfile
 profile:
 	bash ./scripts/ci/ci-run-profile.sh
 

--- a/docker/build-tool/Dockerfile
+++ b/docker/build-tool/Dockerfile
@@ -46,5 +46,5 @@ RUN curl https://sh.rustup.rs -sSf -sSf |\
 RUN mkdir -p /home/rust/libs /home/rust/src /home/rust/.cargo && \
     ln -s /opt/rust/cargo/config /home/rust/.cargo/config
 
-
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update -y && apt-get install  -yq apt-utils &&  export DEBIAN_FRONTEND=noninteractive && apt-get install -yq psmisc  && python3 -m pip install boto3 "moto[all]" yapf shfmt-py
 

--- a/docker/build-tool/Dockerfile
+++ b/docker/build-tool/Dockerfile
@@ -46,5 +46,9 @@ RUN curl https://sh.rustup.rs -sSf -sSf |\
 RUN mkdir -p /home/rust/libs /home/rust/src /home/rust/.cargo && \
     ln -s /opt/rust/cargo/config /home/rust/.cargo/config
 
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get update -y && apt-get install  -yq apt-utils &&  export DEBIAN_FRONTEND=noninteractive && apt-get install -yq psmisc  && python3 -m pip install boto3 "moto[all]" yapf shfmt-py
-
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update -y && apt-get install  -yq apt-utils && apt-get install -yq psmisc procps locales && python3 -m pip install boto3 "moto[all]" yapf shfmt-py coscmd PyYAML
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8

--- a/docker/build-tool/Dockerfile
+++ b/docker/build-tool/Dockerfile
@@ -1,0 +1,50 @@
+FROM debian:buster
+COPY ./dev_setup.sh /build_setup.sh
+COPY ./rust-toolchain.toml /rust-toolchain.toml
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update -y && \
+    apt-get install -yq \
+        build-essential \
+        curl \
+        file \
+        git \
+        libssl-dev \
+        pkgconf \
+        sudo \
+        unzip \
+        xutils-dev \
+        protobuf-compiler \
+        lcov \
+        python3 \
+        coreutils \
+        default-mysql-client \
+        clang \
+        llvm \
+        python3-all-dev \
+        python3-setuptools \
+        python3-pip \
+        && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    useradd rust --user-group --create-home --shell /bin/bash --groups sudo
+# We use the instructions at https://github.com/rust-lang/rustup/issues/2383
+# to install the rustup toolchain as root.
+ENV RUSTUP_HOME=/opt/rust/rustup \
+    PATH=/home/rust/.cargo/bin:/opt/rust/cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN curl https://sh.rustup.rs -sSf -sSf |\
+    env CARGO_HOME=/opt/rust/cargo \
+        sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path && \
+    export RUST_VERSION="$(awk -F'[ ="]+' '$1 == "channel" { print $2 }' /rust-toolchain.toml)" && \
+    env CARGO_HOME=/opt/rust/cargo rustup install $RUST_VERSION && \
+    env CARGO_HOME=/opt/rust/cargo rustup set profile minimal && \
+    env CARGO_HOME=/opt/rust/cargo rustup component add rustfmt --toolchain $RUST_VERSION && \
+    env CARGO_HOME=/opt/rust/cargo  rustup component add rust-src --toolchain $RUST_VERSION && \
+    env CARGO_HOME=/opt/rust/cargo  rustup component add clippy --toolchain $RUST_VERSION && \
+    env CARGO_HOME=/opt/rust/cargo  rustup component add miri --toolchain $RUST_VERSION && \
+    env CARGO_HOME=/opt/rust/cargo rustup default "$RUST_VERSION"
+
+
+RUN mkdir -p /home/rust/libs /home/rust/src /home/rust/.cargo && \
+    ln -s /opt/rust/cargo/config /home/rust/.cargo/config
+
+
+

--- a/docker/build-tool/Dockerfile
+++ b/docker/build-tool/Dockerfile
@@ -1,7 +1,8 @@
 FROM debian:buster
 COPY ./dev_setup.sh /build_setup.sh
 COPY ./rust-toolchain.toml /rust-toolchain.toml
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get update -y && \
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && \
     apt-get install -yq \
         build-essential \
         curl \
@@ -22,6 +23,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update -y && \
         python3-all-dev \
         python3-setuptools \
         python3-pip \
+        psmisc \
+        procps \
+        locales \
         && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     useradd rust --user-group --create-home --shell /bin/bash --groups sudo
@@ -30,25 +34,20 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update -y && \
 ENV RUSTUP_HOME=/opt/rust/rustup \
     PATH=/home/rust/.cargo/bin:/opt/rust/cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-RUN curl https://sh.rustup.rs -sSf -sSf |\
+RUN curl https://sh.rustup.rs -sSf |\
     env CARGO_HOME=/opt/rust/cargo \
         sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path && \
     export RUST_VERSION="$(awk -F'[ ="]+' '$1 == "channel" { print $2 }' /rust-toolchain.toml)" && \
     env CARGO_HOME=/opt/rust/cargo rustup install $RUST_VERSION && \
     env CARGO_HOME=/opt/rust/cargo rustup set profile minimal && \
-    env CARGO_HOME=/opt/rust/cargo rustup component add rustfmt --toolchain $RUST_VERSION && \
-    env CARGO_HOME=/opt/rust/cargo  rustup component add rust-src --toolchain $RUST_VERSION && \
-    env CARGO_HOME=/opt/rust/cargo  rustup component add clippy --toolchain $RUST_VERSION && \
-    env CARGO_HOME=/opt/rust/cargo  rustup component add miri --toolchain $RUST_VERSION && \
+    env CARGO_HOME=/opt/rust/cargo rustup component add rustfmt rust-src clippy miri --toolchain $RUST_VERSION && \
     env CARGO_HOME=/opt/rust/cargo rustup default "$RUST_VERSION"
 
 
 RUN mkdir -p /home/rust/libs /home/rust/src /home/rust/.cargo && \
-    ln -s /opt/rust/cargo/config /home/rust/.cargo/config
-
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get update -y && apt-get install  -yq apt-utils && apt-get install -yq psmisc procps locales && python3 -m pip install boto3 "moto[all]" yapf shfmt-py coscmd PyYAML
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
-    locale-gen
+    ln -s /opt/rust/cargo/config /home/rust/.cargo/config && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen && \
+    python3 -m pip install boto3 "moto[all]" yapf shfmt-py coscmd PyYAML
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8

--- a/scripts/setup/run_docker.sh
+++ b/scripts/setup/run_docker.sh
@@ -18,7 +18,7 @@ START_COMMAND=("/bin/bash" "-lc" "groupadd --gid $(id -g) -f databendgroup \
   && chown -R databendbuild:databendgroup /source \
   && chown -R databendbuild:databendgroup /opt/rust/cargo \
   && chown -R databendbuild:databendgroup /tmp \
-  && sudo -EHs -u databendbuild bash -c 'cd /source && export LC_NUMERIC='de_DE.UTF-8' && export LC_ALL=C && DATABEND_DEV_CONTAINER=TRUE RUST_BACKTRACE=full env CARGO_HOME=/opt/rust/cargo PATH=/home/rust/.cargo/bin:/opt/rust/cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin $*'")
+  && sudo -EHs -u databendbuild bash -c 'cd /source && export LC_NUMERIC='en_US.UTF-8' && export LC_ALL=en_US.UTF-8 && DATABEND_DEV_CONTAINER=TRUE RUST_BACKTRACE=full env CARGO_HOME=/opt/rust/cargo PATH=/home/rust/.cargo/bin:/opt/rust/cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin $*'")
 
 [[ -f .git ]] && [[ ! -d .git ]] && DOCKER_OPTIONS+=(-v "$(git rev-parse --git-common-dir):$(git rev-parse --git-common-dir)")
 [[ -n "${SSH_AUTH_SOCK}" ]] && DOCKER_OPTIONS+=(-v "${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}" -e SSH_AUTH_SOCK)

--- a/scripts/setup/run_docker.sh
+++ b/scripts/setup/run_docker.sh
@@ -16,7 +16,8 @@ START_COMMAND=("/bin/bash" "-lc" "groupadd --gid $(id -g) -f databendgroup \
   && chown -R databendbuild:databendgroup /source \
   && chown -R databendbuild:databendgroup /opt/rust/cargo \
   && chown -R databendbuild:databendgroup /tmp \
-  && sudo -EHs -u databendbuild bash -c 'cd /source && RUST_BACKTRACE=full env CARGO_HOME=/opt/rust/cargo PATH=/home/rust/.cargo/bin:/opt/rust/cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin $*'")
+  && sudo -EHs -u databendbuild bash -c 'cd /source && export LC_NUMERIC='de_DE.UTF-8' && \
+     export LC_ALL=C && RUST_BACKTRACE=full env CARGO_HOME=/opt/rust/cargo PATH=/home/rust/.cargo/bin:/opt/rust/cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin $*'")
 
 [[ -f .git ]] && [[ ! -d .git ]] && DOCKER_OPTIONS+=(-v "$(git rev-parse --git-common-dir):$(git rev-parse --git-common-dir)")
 [[ -n "${SSH_AUTH_SOCK}" ]] && DOCKER_OPTIONS+=(-v "${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}" -e SSH_AUTH_SOCK)
@@ -32,5 +33,5 @@ docker run --rm \
        -v "${SOURCE_DIR}":"${SOURCE_DIR_MOUNT_DEST}" \
        -v "${CARGO_GIT_DIR}":"/opt/rust/cargo/git" \
        -v "${CARGO_REGISTRY_DIR}":"/opt/rust/cargo/registry" \
-       zhihanz/build-tool:v4 \
+       zhihanz/build-tool:rc1 \
        "${START_COMMAND[@]}"

--- a/scripts/setup/run_docker.sh
+++ b/scripts/setup/run_docker.sh
@@ -7,6 +7,8 @@ DOCKER_OPTIONS+=(-v /var/run/docker.sock:/var/run/docker.sock)
 DOCKER_OPTIONS+=(--cap-add SYS_PTRACE --cap-add NET_RAW --cap-add NET_ADMIN)
 DOCKER_OPTIONS+=("-it")
 SOURCE_DIR="${PWD}"
+HUB="${HUB:-datafuselabs}"
+TAG="${TAG:-latest}"
 SOURCE_DIR_MOUNT_DEST=/source
 # how does it work?
 # 1. docker build under root user with cargo installed on /opt/rust/cargo/bin
@@ -33,5 +35,5 @@ docker run --rm \
        -v "${SOURCE_DIR}":"${SOURCE_DIR_MOUNT_DEST}" \
        -v "${CARGO_GIT_DIR}":"/opt/rust/cargo/git" \
        -v "${CARGO_REGISTRY_DIR}":"/opt/rust/cargo/registry" \
-       zhihanz/build-tool:rc1 \
+       "${HUB}"/dev-container:"${TAG}" \
        "${START_COMMAND[@]}"

--- a/scripts/setup/run_docker.sh
+++ b/scripts/setup/run_docker.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+DOCKER_OPTIONS+=(-u root:root)
+DOCKER_OPTIONS+=(-v /var/run/docker.sock:/var/run/docker.sock)
+DOCKER_OPTIONS+=(--cap-add SYS_PTRACE --cap-add NET_RAW --cap-add NET_ADMIN)
+DOCKER_OPTIONS+=("-it")
+SOURCE_DIR="${PWD}"
+SOURCE_DIR_MOUNT_DEST=/source
+# how does it work?
+# 1. docker build under root user with cargo installed on /opt/rust/cargo/bin
+# 2. to handle with permission issue on target release, we grant a user with same uid/gid to the host user for target dir access
+START_COMMAND=("/bin/bash" "-lc" "groupadd --gid $(id -g) -f databendgroup \
+  && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home --home-dir /source databendbuild \
+  && chown -R databendbuild:databendgroup /source \
+  && chown -R databendbuild:databendgroup /opt/rust/cargo \
+  && chown -R databendbuild:databendgroup /tmp \
+  && sudo -EHs -u databendbuild bash -c 'cd /source && RUST_BACKTRACE=full env CARGO_HOME=/opt/rust/cargo PATH=/home/rust/.cargo/bin:/opt/rust/cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin $*'")
+
+[[ -f .git ]] && [[ ! -d .git ]] && DOCKER_OPTIONS+=(-v "$(git rev-parse --git-common-dir):$(git rev-parse --git-common-dir)")
+[[ -n "${SSH_AUTH_SOCK}" ]] && DOCKER_OPTIONS+=(-v "${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}" -e SSH_AUTH_SOCK)
+
+# to get rid of confliction between host cargo directory and docker registry, we should use tmp directory instead of $HOME/.cargo directory
+mkdir -p /tmp/dev/.cargo/git
+mkdir -p /tmp/dev/.cargo/registry
+CARGO_GIT_DIR=/tmp/dev/.cargo/git
+CARGO_REGISTRY_DIR=/tmp/dev/.cargo/registry
+
+docker run --rm \
+       "${DOCKER_OPTIONS[@]}" \
+       -v "${SOURCE_DIR}":"${SOURCE_DIR_MOUNT_DEST}" \
+       -v "${CARGO_GIT_DIR}":"/opt/rust/cargo/git" \
+       -v "${CARGO_REGISTRY_DIR}":"/opt/rust/cargo/registry" \
+       zhihanz/build-tool:v4 \
+       "${START_COMMAND[@]}"

--- a/scripts/setup/run_docker.sh
+++ b/scripts/setup/run_docker.sh
@@ -18,8 +18,7 @@ START_COMMAND=("/bin/bash" "-lc" "groupadd --gid $(id -g) -f databendgroup \
   && chown -R databendbuild:databendgroup /source \
   && chown -R databendbuild:databendgroup /opt/rust/cargo \
   && chown -R databendbuild:databendgroup /tmp \
-  && sudo -EHs -u databendbuild bash -c 'cd /source && export LC_NUMERIC='de_DE.UTF-8' && \
-     export LC_ALL=C && RUST_BACKTRACE=full env CARGO_HOME=/opt/rust/cargo PATH=/home/rust/.cargo/bin:/opt/rust/cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin $*'")
+  && sudo -EHs -u databendbuild bash -c 'cd /source && export LC_NUMERIC='de_DE.UTF-8' && export LC_ALL=C && DATABEND_DEV_CONTAINER=TRUE RUST_BACKTRACE=full env CARGO_HOME=/opt/rust/cargo PATH=/home/rust/.cargo/bin:/opt/rust/cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin $*'")
 
 [[ -f .git ]] && [[ ! -d .git ]] && DOCKER_OPTIONS+=(-v "$(git rev-parse --git-common-dir):$(git rev-parse --git-common-dir)")
 [[ -n "${SSH_AUTH_SOCK}" ]] && DOCKER_OPTIONS+=(-v "${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}" -e SSH_AUTH_SOCK)

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -545,7 +545,7 @@ if __name__ == '__main__':
         help='Path to databend-query binary or name of binary in PATH')
     parser.add_argument('-c',
                         '--client',
-                        default='stdbuf -i0 -o0 -e0 mysql',
+                        default='mysql',
                         help='Client program')
     parser.add_argument('-opt',
                         '--options',
@@ -618,7 +618,8 @@ if __name__ == '__main__':
     )
 
     args = parser.parse_args()
-
+    if os.getenv("DATABEND_DEV_CONTAINER") is not None:
+        args.client = 'stdbuf -i0 -o0 -e0 {}'.format(args.client)
     if args.suites is None and os.path.isdir('suites'):
         args.suites = 'suites'
     if args.suites is None:

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -65,7 +65,6 @@ def run_single_test(args, ext, client_options, case_file, stdout_file,
         pattern = "sed '/^\s*--/d' {test} | {client} {options} > {stdout} 2>&1"
 
     command = pattern.format(**params)
-
     proc = Popen(command, shell=True, env=os.environ)
     start_time = datetime.now()
     while (datetime.now() -
@@ -546,7 +545,7 @@ if __name__ == '__main__':
         help='Path to databend-query binary or name of binary in PATH')
     parser.add_argument('-c',
                         '--client',
-                        default='mysql',
+                        default='stdbuf -i0 -o0 -e0 mysql',
                         help='Client program')
     parser.add_argument('-opt',
                         '--options',


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
1. support to run databend build && test with zero dependencies(only need to setup docker with proper permission write permission on /tmp and source code directory)
2. disable std io buffer during stateless tests(would introduce flaky issues on docker based environment, and should be compatible with currently setups)
3. support to cache intermediate results built from cargo, and use /tmp directory to get avoid of conflictions between native and docker based cargo environment

How to use

build binary artifacts
```bash
./scripts/setup/run_docker.sh  make build
```
run test
```bash
./scripts/setup/run_docker.sh  make test
```
debug or get into dev container
```bash
./scripts/setup/run_docker.sh /bin/bash
```
## Changelog

- New Feature
- Build/Testing/CI

## Related Issues

Fixes #3845 

## Test Plan

Unit Tests

Stateless Tests

