### PR TITLE
ISSUE-3858: Move if_not_exists to user mgr api

### DIFF
--- a/query/src/users/user_mgr.rs
+++ b/query/src/users/user_mgr.rs
@@ -62,11 +62,11 @@ impl UserApiProvider {
             .get_user(tenant, username, client_ip)
             .await
             .map(Some)
-            .or_else(|err| {
-                if err.code() == ErrorCode::unknown_user_code() {
+            .or_else(|e| {
+                if e.code() == ErrorCode::unknown_user_code() {
                     Ok(None)
                 } else {
-                    Err(err)
+                    Err(e)
                 }
             })?;
         match user {
@@ -106,7 +106,7 @@ impl UserApiProvider {
 
         let mut res = vec![];
         match get_users.await {
-            Err(failure) => Err(failure.add_message_back("(while get users).")),
+            Err(e) => Err(e.add_message_back("(while get users).")),
             Ok(seq_users_info) => {
                 for seq_user_info in seq_users_info {
                     res.push(seq_user_info.data);
@@ -123,7 +123,7 @@ impl UserApiProvider {
         let add_user = client.add_user(user_info);
         match add_user.await {
             Ok(res) => Ok(res),
-            Err(failure) => Err(failure.add_message_back("(while add user).")),
+            Err(e) => Err(e.add_message_back("(while add user).")),
         }
     }
     pub async fn grant_user_privileges(
@@ -144,7 +144,7 @@ impl UserApiProvider {
                 None,
             )
             .await
-            .map_err(|failure| failure.add_message_back("(while set user privileges)"))
+            .map_err(|e| e.add_message_back("(while set user privileges)"))
     }
 
     pub async fn revoke_user_privileges(
@@ -165,7 +165,7 @@ impl UserApiProvider {
                 None,
             )
             .await
-            .map_err(|failure| failure.add_message_back("(while revoke user privileges)"))
+            .map_err(|e| e.add_message_back("(while revoke user privileges)"))
     }
 
     // Drop a user by name and hostname.
@@ -174,17 +174,17 @@ impl UserApiProvider {
         tenant: &str,
         username: &str,
         hostname: &str,
-        if_exist: bool,
+        if_exists: bool,
     ) -> Result<()> {
         let client = self.get_user_api_client(tenant);
         let drop_user = client.drop_user(username.to_string(), hostname.to_string(), None);
         match drop_user.await {
             Ok(res) => Ok(res),
-            Err(failure) => {
-                if if_exist && failure.code() == ErrorCode::UnknownUserCode() {
+            Err(e) => {
+                if if_exists && e.code() == ErrorCode::unknown_user_code() {
                     Ok(())
                 } else {
-                    Err(failure.add_message_back("(while set drop user)"))
+                    Err(e.add_message_back("(while set drop user)"))
                 }
             }
         }
@@ -209,7 +209,7 @@ impl UserApiProvider {
         );
         match update_user.await {
             Ok(res) => Ok(res),
-            Err(failure) => Err(failure.add_message_back("(while alter user).")),
+            Err(e) => Err(e.add_message_back("(while alter user).")),
         }
     }
 }

--- a/query/tests/it/interpreters/interpreter_stage_create.rs
+++ b/query/tests/it/interpreters/interpreter_stage_create.rs
@@ -50,7 +50,6 @@ async fn test_create_stage_interpreter() -> Result<()> {
 
     // IF NOT EXISTS.
     {
-        // TODO(bohu): this is a bug, IF NOT EXISTS should not return error.
         let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "CreatStageInterpreter");

--- a/query/tests/it/users/user_stage.rs
+++ b/query/tests/it/users/user_stage.rs
@@ -31,6 +31,7 @@ async fn test_user_stage() -> Result<()> {
     let comments = "this is a comment";
     let stage_name1 = "stage1";
     let stage_name2 = "stage2";
+    let if_not_exists = false;
     let user_mgr = UserApiProvider::create_global(config).await?;
 
     // add 1.
@@ -44,7 +45,9 @@ async fn test_user_stage() -> Result<()> {
             }),
             FileFormat::default(),
         );
-        user_mgr.add_stage(tenant, stage_info).await?;
+        user_mgr
+            .add_stage(tenant, stage_info, if_not_exists)
+            .await?;
     }
 
     // add 2.
@@ -58,7 +61,9 @@ async fn test_user_stage() -> Result<()> {
             }),
             FileFormat::default(),
         );
-        user_mgr.add_stage(tenant, stage_info).await?;
+        user_mgr
+            .add_stage(tenant, stage_info, if_not_exists)
+            .await?;
     }
 
     // get all.

--- a/query/tests/it/users/user_udf.rs
+++ b/query/tests/it/users/user_udf.rs
@@ -28,13 +28,14 @@ async fn test_user_udf() -> Result<()> {
     let description = "this is a description";
     let isempty = "isempty";
     let isnotempty = "isnotempty";
+    let if_not_exists = false;
     let user_mgr = UserApiProvider::create_global(config).await?;
 
     // add isempty.
     {
         let udf =
             UserDefinedFunction::new(isempty, vec!["p".to_string()], "isnull(p)", description);
-        user_mgr.add_udf(tenant, udf).await?;
+        user_mgr.add_udf(tenant, udf, if_not_exists).await?;
     }
 
     // add isnotempty.
@@ -45,7 +46,7 @@ async fn test_user_udf() -> Result<()> {
             "not(isempty(p))",
             description,
         );
-        user_mgr.add_udf(tenant, udf).await?;
+        user_mgr.add_udf(tenant, udf, if_not_exists).await?;
     }
 
     // get all.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Move if_not_exists to user mgr api
* Rename `failure` to `e`

## Changelog


- Improvement


## Related Issues

Fixes #3858

## Test Plan

Unit Tests

Stateless Tests

