### PR TITLE
ISSUE-3829: optimize table cause of meta data damage

### DIFF
--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -34,7 +34,7 @@ runs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --all-features --no-fail-fast
+        args: --no-fail-fast
       env:
         RUST_TEST_THREADS: 2
         RUST_LOG: ERROR

--- a/common/dal/Cargo.toml
+++ b/common/dal/Cargo.toml
@@ -34,3 +34,7 @@ rusoto_credential = "0.47.0"
 common-metrics = { path = "../metrics" }
 rand = "0.8.4"
 tempfile = "3.2.0"
+
+[features]
+# for unit test only
+ut_mock_s3 = []

--- a/common/dal/src/accessors/aws_s3/s3_input_stream.rs
+++ b/common/dal/src/accessors/aws_s3/s3_input_stream.rs
@@ -83,7 +83,6 @@ impl futures::AsyncRead for S3InputStream {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<std::io::Result<usize>> {
-        dbg!("async read");
         loop {
             let empty = { self.buffer.is_empty() };
             match &mut self.state {
@@ -102,9 +101,14 @@ impl futures::AsyncRead for S3InputStream {
                             counter!(super::metrics::METRIC_S3_GETOBJECT_ERRORS, 1);
                             match e {
                                 RusotoError::Service(GetObjectError::NoSuchKey(msg)) => {
+                                    dbg!("not found");
                                     Error::new(ErrorKind::NotFound, msg)
                                 }
-                                _ => Error::new(ErrorKind::Other, e),
+                                _ => {
+                                    dbg!("other");
+                                    let e = dbg!(e);
+                                    Error::new(ErrorKind::Other, e)
+                                }
                             }
                         })?;
                         histogram!(

--- a/common/dal/src/accessors/aws_s3/s3_input_stream.rs
+++ b/common/dal/src/accessors/aws_s3/s3_input_stream.rs
@@ -101,14 +101,9 @@ impl futures::AsyncRead for S3InputStream {
                             counter!(super::metrics::METRIC_S3_GETOBJECT_ERRORS, 1);
                             match e {
                                 RusotoError::Service(GetObjectError::NoSuchKey(msg)) => {
-                                    dbg!("not found");
                                     Error::new(ErrorKind::NotFound, msg)
                                 }
-                                _ => {
-                                    dbg!("other");
-                                    let e = dbg!(e);
-                                    Error::new(ErrorKind::Other, e)
-                                }
+                                _ => Error::new(ErrorKind::Other, e),
                             }
                         })?;
                         histogram!(

--- a/common/dal/src/accessors/aws_s3/s3_input_stream.rs
+++ b/common/dal/src/accessors/aws_s3/s3_input_stream.rs
@@ -83,6 +83,7 @@ impl futures::AsyncRead for S3InputStream {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<std::io::Result<usize>> {
+        dbg!("async read");
         loop {
             let empty = { self.buffer.is_empty() };
             match &mut self.state {
@@ -110,6 +111,7 @@ impl futures::AsyncRead for S3InputStream {
                             super::metrics::METRIC_S3_GETOBJECT_USEDTIME,
                             start.elapsed()
                         );
+
                         reply
                             .body
                             .map(|s| s.fuse())
@@ -123,7 +125,7 @@ impl futures::AsyncRead for S3InputStream {
                         Ok(v) => {
                             self.state = State::GotBody(v);
                         }
-                        Err(e) => return Poll::Ready(Err(Error::new(ErrorKind::Other, e))),
+                        Err(e) => return Poll::Ready(Err(e)),
                     }
                 }
                 State::GotBody(stream) => {

--- a/common/dal/tests/it/accessors/aws_s3.rs
+++ b/common/dal/tests/it/accessors/aws_s3.rs
@@ -30,19 +30,34 @@ struct TestFixture {
     region_name: String,
     endpoint_url: String,
     bucket_name: String,
-    test_key: String,
-    content: Vec<u8>,
+    key_id: String,
+    access_key: String,
+    test_obj_key: String,
+    test_obj_content: Vec<u8>,
 }
 
 impl TestFixture {
-    fn new(size: usize, key: String) -> Self {
-        let random_bytes: Vec<u8> = (0..size).map(|_| rand::random::<u8>()).collect();
+    fn new() -> Self {
+        Self::with_test_obj(0, "")
+    }
+
+    fn with_test_obj(test_obj_size: usize, test_obj_key: impl Into<String>) -> Self {
+        let random_bytes: Vec<u8> = (0..test_obj_size).map(|_| rand::random::<u8>()).collect();
+
+        let endpoint_url = std::env::var("S3_STORAGE_ENDPOINT_URL").unwrap();
+        let bucket_name = std::env::var("S3_STORAGE_BUCKET").unwrap();
+        let region_name = std::env::var("S3_STORAGE_REGION").unwrap();
+        let key_id = std::env::var("S3_STORAGE_ACCESS_KEY_ID").unwrap();
+        let access_key = std::env::var("S3_STORAGE_SECRET_ACCESS_KEY").unwrap();
+
         Self {
-            region_name: "us-east-1".to_string(),
-            endpoint_url: "http://localhost:9000".to_string(),
-            bucket_name: "test-bucket".to_string(),
-            test_key: key,
-            content: random_bytes,
+            region_name,
+            endpoint_url,
+            bucket_name,
+            key_id,
+            access_key,
+            test_obj_key: test_obj_key.into(),
+            test_obj_content: random_bytes,
         }
     }
 
@@ -58,8 +73,8 @@ impl TestFixture {
             self.region_name.as_str(),
             self.endpoint_url.as_str(),
             self.bucket_name.as_str(),
-            "",
-            "",
+            &self.key_id,
+            &self.access_key,
             false,
         )
     }
@@ -70,8 +85,8 @@ impl TestFixture {
         let rusoto_client = S3Client::new(self.region());
         let put_req = PutObjectRequest {
             bucket: self.bucket_name.clone(),
-            key: self.test_key.clone(),
-            body: Some(ByteStream::from(self.content.clone())),
+            key: self.test_obj_key.clone(),
+            body: Some(ByteStream::from(self.test_obj_content.clone())),
             ..Default::default()
         };
         rusoto_client
@@ -86,14 +101,14 @@ impl TestFixture {
 #[ignore]
 async fn test_s3_input_stream_api() -> common_exception::Result<()> {
     let test_key = "test_s3_input_stream".to_string();
-    let fixture = TestFixture::new(1024 * 10, test_key.clone());
+    let fixture = TestFixture::with_test_obj(1024 * 10, test_key.clone());
     fixture.gen_test_obj().await?;
 
     let s3 = fixture.data_accessor()?;
     let mut input = s3.get_input_stream(&test_key, None)?;
     let mut buffer = vec![];
     input.read_to_end(&mut buffer).await?;
-    assert_eq!(fixture.content, buffer);
+    assert_eq!(fixture.test_obj_content, buffer);
     Ok(())
 }
 
@@ -101,7 +116,7 @@ async fn test_s3_input_stream_api() -> common_exception::Result<()> {
 #[ignore]
 async fn test_s3_input_stream_seek_api() -> common_exception::Result<()> {
     let test_key = "test_s3_seek_stream_seek".to_string();
-    let fixture = TestFixture::new(1024 * 10, test_key.clone());
+    let fixture = TestFixture::with_test_obj(1024 * 10, test_key.clone());
     fixture.gen_test_obj().await?;
 
     let s3 = fixture.data_accessor()?;
@@ -109,10 +124,27 @@ async fn test_s3_input_stream_seek_api() -> common_exception::Result<()> {
     let mut buffer = vec![];
     input.seek(SeekFrom::Current(1)).await?;
     input.read_to_end(&mut buffer).await?;
-    assert_eq!(fixture.content.len() - 1, buffer.len());
+    assert_eq!(fixture.test_obj_content.len() - 1, buffer.len());
     let r = input.seek(SeekFrom::End(0)).await?;
-    assert_eq!(fixture.content.len() as u64, r);
+    assert_eq!(fixture.test_obj_content.len() as u64, r);
     let r = input.seek(SeekFrom::End(1)).await;
     assert!(r.is_err());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore]
+async fn test_s3_input_stream_read_exception() -> common_exception::Result<()> {
+    let test_key = "not_exist".to_string();
+    // we do need a random test obj in this case
+    let fixture = TestFixture::new();
+    let s3 = fixture.data_accessor()?;
+    let mut input = s3.get_input_stream(&test_key, None)?;
+    let mut buffer = vec![];
+    let r = input.read_to_end(&mut buffer).await;
+    match r {
+        Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::NotFound),
+        Ok(_) => panic!("expecting error"),
+    }
     Ok(())
 }

--- a/common/dal/tests/it/accessors/aws_s3.rs
+++ b/common/dal/tests/it/accessors/aws_s3.rs
@@ -143,7 +143,6 @@ async fn test_s3_input_stream_seek_api() -> common_exception::Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_s3_input_stream_read_exception() -> common_exception::Result<()> {
     let test_key = "not_exist".to_string();
-    // we do need a random test obj in this case
     let fixture = TestFixture::new();
     let s3 = fixture.data_accessor()?;
     let mut input = s3.get_input_stream(&test_key, None)?;

--- a/common/dal/tests/it/accessors/aws_s3.rs
+++ b/common/dal/tests/it/accessors/aws_s3.rs
@@ -26,6 +26,16 @@ use rusoto_s3::PutObjectRequest;
 use rusoto_s3::S3Client;
 use rusoto_s3::S3 as RusotoS3;
 
+/// This test suite is not CI ready, and intended to be
+/// used in local dev box, with
+///
+/// - properly configured S3 env vars
+///    pls take a look at `scripts/ci/ci-run-stateful-tests-standalone-s3.sh`
+/// - or mocked s3 service, like minio
+///
+/// To enable this suite, features `ut_mock_s3` should be enabled:
+///
+/// e.g. cargo test --features ut_mock_s3 -p common-dal --test it
 struct TestFixture {
     region_name: String,
     endpoint_url: String,
@@ -98,7 +108,6 @@ impl TestFixture {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-#[ignore]
 async fn test_s3_input_stream_api() -> common_exception::Result<()> {
     let test_key = "test_s3_input_stream".to_string();
     let fixture = TestFixture::with_test_obj(1024 * 10, test_key.clone());
@@ -113,7 +122,6 @@ async fn test_s3_input_stream_api() -> common_exception::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-#[ignore]
 async fn test_s3_input_stream_seek_api() -> common_exception::Result<()> {
     let test_key = "test_s3_seek_stream_seek".to_string();
     let fixture = TestFixture::with_test_obj(1024 * 10, test_key.clone());
@@ -133,7 +141,6 @@ async fn test_s3_input_stream_seek_api() -> common_exception::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-#[ignore]
 async fn test_s3_input_stream_read_exception() -> common_exception::Result<()> {
     let test_key = "not_exist".to_string();
     // we do need a random test obj in this case

--- a/common/dal/tests/it/accessors/mod.rs
+++ b/common/dal/tests/it/accessors/mod.rs
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+#[cfg(feature = "ut_mock_s3")]
 mod aws_s3;
 mod azure_blob;
 mod local;

--- a/tests/suites/0_stateless/09_0008_fuse_optimize_table.sql
+++ b/tests/suites/0_stateless/09_0008_fuse_optimize_table.sql
@@ -50,13 +50,15 @@ optimize table m compact;
 drop table m;
 
 
--- optimize memory table should not panic/throws exception (fuse engine)
+-- optimize fuse table multiple times should not panic/throws exception
 
 create table m(a uint64) engine=Fuse;
 insert into m values(1);
 insert into m values(2);
+
 optimize table m;
 optimize table m;
+
 optimize table m all;
 optimize table m purge;
 optimize table m compact;

--- a/tests/suites/0_stateless/09_0008_fuse_optimize_table.sql
+++ b/tests/suites/0_stateless/09_0008_fuse_optimize_table.sql
@@ -47,9 +47,22 @@ optimize table m;
 optimize table m all;
 optimize table m purge;
 optimize table m compact;
+drop table m;
+
+
+-- optimize memory table should not panic/throws exception (fuse engine)
+
+create table m(a uint64) engine=Fuse;
+insert into m values(1);
+insert into m values(2);
+optimize table m;
+optimize table m;
+optimize table m all;
+optimize table m purge;
+optimize table m compact;
 
 ---------------------
 
-DROP TABLE t;
 DROP TABLE m;
+DROP TABLE t;
 DROP DATABASE db_09_0008;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fixes issue #3829:

previously, io errors inside s3_inputstream are not propagated properly. the underlying errors should not be wrapped into another error of kind `ErrorKind::Other` blindly.

## Changelog


- Bug Fix
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #3829

## Test Plan

Unit Tests

Stateless Tests

