### PR TITLE
[metasrv]fix: list_databases return all tenants' databases

### DIFF
--- a/common/meta/embedded/tests/it/meta_api_impl.rs
+++ b/common/meta/embedded/tests/it/meta_api_impl.rs
@@ -37,6 +37,12 @@ async fn test_meta_embedded_database_list() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_embedded_database_list_in_diff_tenant() -> anyhow::Result<()> {
+    let mt = MetaEmbedded::new_temp().await?;
+    MetaApiTestSuite {}.database_list_in_diff_tenant(&mt).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_meta_embedded_table_create_get_drop() -> anyhow::Result<()> {
     let mt = MetaEmbedded::new_temp().await?;
     MetaApiTestSuite {}.table_create_get_drop(&mt).await

--- a/common/meta/raft-store/src/state_machine/database_lookup.rs
+++ b/common/meta/raft-store/src/state_machine/database_lookup.rs
@@ -13,12 +13,8 @@
 // limitations under the License.
 
 use std::fmt;
-use std::io::Cursor;
 
-use bytes::BytesMut;
 use common_exception::ErrorCode;
-use common_io::prelude::BinaryRead;
-use common_io::prelude::BinaryWriteBuf;
 use common_meta_sled_store::sled::IVec;
 use common_meta_sled_store::SledOrderedSerde;
 use serde::Deserialize;
@@ -49,19 +45,13 @@ impl DatabaseLookupKey {
 
 impl SledOrderedSerde for DatabaseLookupKey {
     fn ser(&self) -> Result<IVec, ErrorCode> {
-        let mut buf = BytesMut::new();
-
-        buf.write_string(format!(
-            "{}{}{}",
-            self.tenant, self.delimiter, self.database_name
-        ))?;
-        Ok(IVec::from(buf.to_vec()))
+        let k = format!("{}{}{}", self.tenant, self.delimiter, self.database_name);
+        Ok(IVec::from(k.as_str()))
     }
 
     fn de<V: AsRef<[u8]>>(v: V) -> Result<Self, ErrorCode>
     where Self: Sized {
-        let mut buf_read = Cursor::new(v);
-        let db_lookup_key = buf_read.read_string()?;
+        let db_lookup_key = String::from_utf8(v.as_ref().to_vec())?;
 
         let db_lookup_key: Vec<&str> = db_lookup_key
             .split(DB_LOOKUP_KEY_DELIMITER as char)
@@ -102,9 +92,18 @@ mod tests {
 
     #[test]
     fn test_db_lookup_key_serde() {
-        let k = DatabaseLookupKey::new("tenant1".to_string(), "db1".to_string());
-        let ser_k = k.ser().unwrap();
-        let de_k = DatabaseLookupKey::de(ser_k).unwrap();
-        assert_eq!(k, de_k);
+        {
+            let k = DatabaseLookupKey::new("tenant1".to_string(), "db1".to_string());
+            let ser_k = k.ser().unwrap();
+            let de_k = DatabaseLookupKey::de(ser_k).unwrap();
+            assert_eq!(k, de_k);
+        }
+
+        {
+            let k = DatabaseLookupKey::new("tenant1".to_string(), "".to_string());
+            let ser_k = k.ser().unwrap();
+            let de_k = DatabaseLookupKey::de(ser_k).unwrap();
+            assert_eq!(k, de_k);
+        }
     }
 }

--- a/common/meta/raft-store/src/state_machine/database_lookup.rs
+++ b/common/meta/raft-store/src/state_machine/database_lookup.rs
@@ -83,27 +83,3 @@ impl fmt::Display for DatabaseLookupValue {
         write!(f, "{}", self.0)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use common_meta_sled_store::SledOrderedSerde;
-
-    use crate::state_machine::DatabaseLookupKey;
-
-    #[test]
-    fn test_db_lookup_key_serde() {
-        {
-            let k = DatabaseLookupKey::new("tenant1".to_string(), "db1".to_string());
-            let ser_k = k.ser().unwrap();
-            let de_k = DatabaseLookupKey::de(ser_k).unwrap();
-            assert_eq!(k, de_k);
-        }
-
-        {
-            let k = DatabaseLookupKey::new("tenant1".to_string(), "".to_string());
-            let ser_k = k.ser().unwrap();
-            let de_k = DatabaseLookupKey::de(ser_k).unwrap();
-            assert_eq!(k, de_k);
-        }
-    }
-}

--- a/common/meta/raft-store/tests/it/state_machine/database_lookup.rs
+++ b/common/meta/raft-store/tests/it/state_machine/database_lookup.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use common_meta_raft_store::state_machine::DatabaseLookupKey;
 use common_meta_sled_store::SledOrderedSerde;
 

--- a/common/meta/raft-store/tests/it/state_machine/database_lookup.rs
+++ b/common/meta/raft-store/tests/it/state_machine/database_lookup.rs
@@ -1,0 +1,19 @@
+use common_meta_raft_store::state_machine::DatabaseLookupKey;
+use common_meta_sled_store::SledOrderedSerde;
+
+#[test]
+fn test_db_lookup_key_serde() {
+    {
+        let k = DatabaseLookupKey::new("tenant1".to_string(), "db1".to_string());
+        let ser_k = k.ser().unwrap();
+        let de_k = DatabaseLookupKey::de(ser_k).unwrap();
+        assert_eq!(k, de_k);
+    }
+
+    {
+        let k = DatabaseLookupKey::new("tenant1".to_string(), "".to_string());
+        let ser_k = k.ser().unwrap();
+        let de_k = DatabaseLookupKey::de(ser_k).unwrap();
+        assert_eq!(k, de_k);
+    }
+}

--- a/common/meta/raft-store/tests/it/state_machine/meta_api_impl.rs
+++ b/common/meta/raft-store/tests/it/state_machine/meta_api_impl.rs
@@ -51,6 +51,16 @@ async fn test_meta_embedded_database_list() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_embedded_database_list_in_diff_tenant() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_raft_store_ut!();
+    let _ent = ut_span.enter();
+    let tc = new_raft_test_context();
+    let sm = StateMachine::open(&tc.raft_config, 1).await?;
+
+    MetaApiTestSuite {}.database_list_in_diff_tenant(&sm).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_meta_embedded_table_create_get_drop() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_raft_store_ut!();
     let _ent = ut_span.enter();

--- a/common/meta/raft-store/tests/it/state_machine/mod.rs
+++ b/common/meta/raft-store/tests/it/state_machine/mod.rs
@@ -49,6 +49,7 @@ use pretty_assertions::assert_eq;
 use crate::init_raft_store_ut;
 use crate::testing::new_raft_test_context;
 
+mod database_lookup;
 mod meta_api_impl;
 mod placement;
 

--- a/common/meta/sled-store/src/sled_tree.rs
+++ b/common/meta/sled-store/src/sled_tree.rs
@@ -342,7 +342,7 @@ impl SledTree {
         Ok(it)
     }
 
-    /// Get key-valuess in with the same prefix
+    /// Get key-values in with the same prefix
     pub fn scan_prefix<KV>(&self, prefix: &KV::K) -> common_exception::Result<Vec<(KV::K, KV::V)>>
     where KV: SledKeySpace {
         let mut res = vec![];

--- a/metasrv/tests/it/grpc/metasrv_grpc_meta_api.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_meta_api.rs
@@ -60,6 +60,20 @@ async fn test_meta_api_database_list() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_meta_api_database_list_in_diff_tenant() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    let (_tc, addr) = start_metasrv().await?;
+
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+
+    MetaApiTestSuite {}
+        .database_list_in_diff_tenant(&client)
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_meta_api_table_create_get_drop() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix bug that `list_databases` return all tenants' databases.

## Changelog

- Bug Fix

## Related Issues

Fixes #3875 

## Test Plan

Unit Tests

Stateless Tests

