### PR TITLE
Factor out unnecessary async move

### DIFF
--- a/common/management/src/user/user_mgr.rs
+++ b/common/management/src/user/user_mgr.rs
@@ -62,17 +62,14 @@ impl UserMgr {
         };
 
         let kv_api = self.kv_api.clone();
-        let upsert_kv = async move {
-            kv_api
-                .upsert_kv(UpsertKVAction::new(
-                    &key,
-                    match_seq,
-                    Operation::Update(value),
-                    None,
-                ))
-                .await
-        };
-        let res = upsert_kv.await?;
+        let res = kv_api
+            .upsert_kv(UpsertKVAction::new(
+                &key,
+                match_seq,
+                Operation::Update(value),
+                None,
+            ))
+            .await?;
         match res.result {
             Some(SeqV { seq: s, .. }) => Ok(s),
             None => Err(ErrorCode::UnknownUser(format!(
@@ -117,8 +114,7 @@ impl UserMgrApi for UserMgr {
         let user_key = format_user_key(&username, &hostname);
         let key = format!("{}/{}", self.user_prefix, user_key);
         let kv_api = self.kv_api.clone();
-        let get_kv = async move { kv_api.get_kv(&key).await };
-        let res = get_kv.await?;
+        let res = kv_api.get_kv(&key).await?;
         let seq_value =
             res.ok_or_else(|| ErrorCode::UnknownUser(format!("unknown user {}", user_key)))?;
 
@@ -132,8 +128,7 @@ impl UserMgrApi for UserMgr {
     async fn get_users(&self) -> Result<Vec<SeqV<UserInfo>>> {
         let user_prefix = self.user_prefix.clone();
         let kv_api = self.kv_api.clone();
-        let prefix_list_kv = async move { kv_api.prefix_list_kv(user_prefix.as_str()).await };
-        let values = prefix_list_kv.await?;
+        let values = kv_api.prefix_list_kv(user_prefix.as_str()).await?;
 
         let mut r = vec![];
         for (_key, val) in values {
@@ -178,17 +173,14 @@ impl UserMgrApi for UserMgr {
         };
 
         let kv_api = self.kv_api.clone();
-        let upsert_kv = async move {
-            kv_api
-                .upsert_kv(UpsertKVAction::new(
-                    &key,
-                    match_seq,
-                    Operation::Update(value),
-                    None,
-                ))
-                .await
-        };
-        let res = upsert_kv.await?;
+        let res = kv_api
+            .upsert_kv(UpsertKVAction::new(
+                &key,
+                match_seq,
+                Operation::Update(value),
+                None,
+            ))
+            .await?;
         match res.result {
             Some(SeqV { seq: s, .. }) => Ok(Some(s)),
             None => Err(ErrorCode::UnknownUser(format!(
@@ -236,17 +228,14 @@ impl UserMgrApi for UserMgr {
         let user_key = format_user_key(&username, &hostname);
         let key = format!("{}/{}", self.user_prefix, user_key);
         let kv_api = self.kv_api.clone();
-        let upsert_kv = async move {
-            kv_api
-                .upsert_kv(UpsertKVAction::new(
-                    &key,
-                    seq.into(),
-                    Operation::Delete,
-                    None,
-                ))
-                .await
-        };
-        let res = upsert_kv.await?;
+        let res = kv_api
+            .upsert_kv(UpsertKVAction::new(
+                &key,
+                seq.into(),
+                Operation::Delete,
+                None,
+            ))
+            .await?;
         if res.prev.is_some() && res.result.is_none() {
             Ok(())
         } else {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- removes async move block in user_mgr.rs
- removes unnecessary kv_api.clone()

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

