### PR TITLE
[metasrv] fix connection failed when metasrv restart that caused by token expired

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,6 +1803,7 @@ version = "0.1.0"
 dependencies = [
  "common-arrow",
  "common-base",
+ "common-containers",
  "common-exception",
  "common-grpc",
  "common-meta-api",

--- a/common/meta/grpc/Cargo.toml
+++ b/common/meta/grpc/Cargo.toml
@@ -15,6 +15,7 @@ test = false
 
 [dependencies]
 common-arrow = { path = "../../arrow" }
+common-base = { path = "../../base" }
 common-containers = { path = "../../containers" }
 common-exception = { path = "../../exception" }
 common-grpc = {path = "../../grpc" }

--- a/common/meta/grpc/Cargo.toml
+++ b/common/meta/grpc/Cargo.toml
@@ -15,6 +15,7 @@ test = false
 
 [dependencies]
 common-arrow = { path = "../../arrow" }
+common-containers = { path = "../../containers" }
 common-exception = { path = "../../exception" }
 common-grpc = {path = "../../grpc" }
 common-meta-api = { path = "../api" }

--- a/common/meta/grpc/src/grpc_action.rs
+++ b/common/meta/grpc/src/grpc_action.rs
@@ -86,6 +86,15 @@ impl TryInto<MetaGrpcWriteReq> for Request<RaftRequest> {
     }
 }
 
+impl tonic::IntoRequest<RaftRequest> for MetaGrpcWriteReq {
+    fn into_request(self) -> Request<RaftRequest> {
+        let raft_request = RaftRequest {
+            data: serde_json::to_string(&self).expect("fail to serialize"),
+        };
+        tonic::Request::new(raft_request)
+    }
+}
+
 /// Try convert DoActionAction to tonic::Request<RaftRequest>.
 impl TryInto<Request<RaftRequest>> for &MetaGrpcWriteReq {
     type Error = ErrorCode;
@@ -110,6 +119,16 @@ impl TryInto<MetaGrpcReadReq> for Request<GetRequest> {
         let action = serde_json::from_str::<MetaGrpcReadReq>(json_str)
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
         Ok(action)
+    }
+}
+
+impl tonic::IntoRequest<GetRequest> for MetaGrpcReadReq {
+    fn into_request(self) -> Request<GetRequest> {
+        let get_req = GetRequest {
+            key: serde_json::to_string(&self).expect("fail to serialize"),
+        };
+
+        tonic::Request::new(get_req)
     }
 }
 

--- a/common/meta/grpc/src/grpc_client.rs
+++ b/common/meta/grpc/src/grpc_client.rs
@@ -133,9 +133,9 @@ impl MetaGrpcClient {
             Some(t) => t,
             None => MetaGrpcClient::handshake(&mut client, &self.username, &self.password).await?,
         };
-        {
-            *t = Some(token.clone());
-        }
+
+        *t = Some(token.clone());
+
         let client = { MetaClient::with_interceptor(channel, AuthInterceptor { token }) };
 
         Ok(client)

--- a/common/meta/grpc/tests/it/grpc_client.rs
+++ b/common/meta/grpc/tests/it/grpc_client.rs
@@ -29,7 +29,8 @@ async fn test_grpc_client_action_timeout() {
     // use `timeout=3secs` here cause our mock grpc
     // server's handshake impl will sleep 2secs.
     let timeout = Duration::from_secs(3);
-    let client = MetaGrpcClient::with_tls_conf(&srv_addr, "", "", Some(timeout), None)
+
+    let client = MetaGrpcClient::try_create(&srv_addr, "", "", Some(timeout), None)
         .await
         .unwrap();
 
@@ -46,8 +47,11 @@ async fn test_grpc_client_handshake_timeout() {
     let srv_addr = start_grpc_server();
 
     let timeout = Duration::from_secs(1);
-    let res = MetaGrpcClient::with_tls_conf(&srv_addr, "", "", Some(timeout), None).await;
-    let actual = res.unwrap_err().message();
+    let res = MetaGrpcClient::try_create(&srv_addr, "", "", Some(timeout), None)
+        .await
+        .unwrap();
+    let client = res.make_client_with_tls().await;
+    let actual = client.unwrap_err().message();
     let expect = "status: Cancelled, message: \"Timeout expired\", details: [], metadata: MetadataMap { headers: {} }";
     assert_eq!(actual, expect);
 }

--- a/common/meta/grpc/tests/it/grpc_client.rs
+++ b/common/meta/grpc/tests/it/grpc_client.rs
@@ -50,7 +50,7 @@ async fn test_grpc_client_handshake_timeout() {
     let res = MetaGrpcClient::try_create(&srv_addr, "", "", Some(timeout), None)
         .await
         .unwrap();
-    let client = res.make_client_with_tls().await;
+    let client = res.make_client().await;
     let actual = client.unwrap_err().message();
     let expect = "status: Cancelled, message: \"Timeout expired\", details: [], metadata: MetadataMap { headers: {} }";
     assert_eq!(actual, expect);

--- a/metasrv/src/api/grpc/grpc_service.rs
+++ b/metasrv/src/api/grpc/grpc_service.rs
@@ -57,12 +57,12 @@ impl MetaGrpcImpl {
             .get_bin("auth-token-bin")
             .and_then(|v| v.to_bytes().ok())
             .and_then(|b| String::from_utf8(b.to_vec()).ok())
-            .ok_or_else(|| Status::internal("Error auth-token-bin is empty"))?;
+            .ok_or_else(|| Status::unauthenticated("Error auth-token-bin is empty"))?;
 
         let claim = self
             .token
             .try_verify_token(token)
-            .map_err(|e| Status::internal(e.to_string()))?;
+            .map_err(|e| Status::unauthenticated(e.to_string()))?;
         Ok(claim)
     }
 }

--- a/metasrv/tests/it/grpc/metasrv_grpc_api.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_api.rs
@@ -44,7 +44,7 @@ async fn test_restart() -> anyhow::Result<()> {
 
     let (mut tc, addr) = crate::tests::start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     tracing::info!("--- upsert kv");
     {
@@ -106,7 +106,7 @@ async fn test_restart() -> anyhow::Result<()> {
     tokio::time::sleep(Duration::from_millis(10_000)).await;
 
     // try to reconnect the restarted server.
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     tracing::info!("--- get kv");
     {
@@ -148,8 +148,8 @@ async fn test_join() -> anyhow::Result<()> {
     let addr0 = tc0.config.grpc_api_address.clone();
     let addr1 = tc1.config.grpc_api_address.clone();
 
-    let client0 = MetaGrpcClient::try_create(addr0.as_str(), "root", "xxx").await?;
-    let client1 = MetaGrpcClient::try_create(addr1.as_str(), "root", "xxx").await?;
+    let client0 = MetaGrpcClient::try_create(addr0.as_str(), "root", "xxx", None, None).await?;
+    let client1 = MetaGrpcClient::try_create(addr1.as_str(), "root", "xxx", None, None).await?;
 
     let clients = vec![client0, client1];
 

--- a/metasrv/tests/it/grpc/metasrv_grpc_kv_api.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_kv_api.rs
@@ -25,7 +25,7 @@ async fn test_kv_api_mget() -> anyhow::Result<()> {
 
     let (_tc, addr) = crate::tests::start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     KVApiTestSuite {}.kv_mget(&client).await
 }
@@ -37,7 +37,7 @@ async fn test_kv_api_list() -> anyhow::Result<()> {
 
     let (_tc, addr) = crate::tests::start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     KVApiTestSuite {}.kv_list(&client).await
 }
@@ -49,7 +49,7 @@ async fn test_kv_api_delete() -> anyhow::Result<()> {
 
     let (_tc, addr) = crate::tests::start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     KVApiTestSuite {}.kv_delete(&client).await
 }
@@ -61,7 +61,7 @@ async fn test_kv_api_update() -> anyhow::Result<()> {
 
     let (_tc, addr) = crate::tests::start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     KVApiTestSuite {}.kv_update(&client).await
 }
@@ -75,7 +75,7 @@ async fn test_kv_api_update_meta() -> anyhow::Result<()> {
 
     let (_tc, addr) = crate::tests::start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     KVApiTestSuite {}.kv_meta(&client).await
 }
@@ -87,7 +87,7 @@ async fn test_kv_api_timeout() -> anyhow::Result<()> {
 
     let (_tc, addr) = crate::tests::start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     KVApiTestSuite {}.kv_timeout(&client).await
 }
@@ -99,7 +99,7 @@ async fn test_kv_api_write_read() -> anyhow::Result<()> {
 
     let (_tc, addr) = crate::tests::start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     KVApiTestSuite {}.kv_write_read(&client).await
 }

--- a/metasrv/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use common_base::tokio;
 use common_base::Stoppable;
 use common_meta_api::KVApi;
+use common_meta_grpc::MetaGrpcClient;
 use common_meta_types::MatchSeq;
 use common_meta_types::Operation;
 use common_meta_types::UpsertKVAction;
@@ -125,6 +126,123 @@ async fn test_kv_api_restart_cluster_write_read() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// - Start a cluster of 3.
+/// - Test upsert kv and read on different nodes.
+/// - Stop and restart the cluster.
+/// - Test upsert kv and read on different nodes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_kv_api_restart_cluster_token_expired() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    fn make_key(tc: &MetaSrvTestContext, k: impl std::fmt::Display) -> String {
+        let x = &tc.config.raft_config;
+        format!("t-restart-cluster-{}-{}-{}", x.config_id, x.id, k)
+    }
+
+    async fn test_write_read_on_every_node(
+        tcs: &[MetaSrvTestContext],
+        client: &MetaGrpcClient,
+        key_suffix: &str,
+    ) -> anyhow::Result<()> {
+        tracing::info!("--- test write on every node: {}", key_suffix);
+
+        for (i, tc) in tcs.iter().enumerate() {
+            let k = make_key(tc, key_suffix);
+            if i == 0 {
+                let res = client
+                    .upsert_kv(UpsertKVAction {
+                        key: k.clone(),
+                        seq: MatchSeq::Any,
+                        value: Operation::Update(k.clone().into_bytes()),
+                        value_meta: None,
+                    })
+                    .await?;
+                tracing::info!("--- upsert res: {:?}", res);
+            } else {
+                let client = tc.grpc_client().await.unwrap();
+                let res = client
+                    .upsert_kv(UpsertKVAction {
+                        key: k.clone(),
+                        seq: MatchSeq::Any,
+                        value: Operation::Update(k.clone().into_bytes()),
+                        value_meta: None,
+                    })
+                    .await?;
+                tracing::info!("--- upsert res: {:?}", res);
+            }
+
+            let res = client.get_kv(&k).await?;
+            let res = res.unwrap();
+
+            assert_eq!(k.into_bytes(), res.data);
+        }
+
+        Ok(())
+    }
+
+    let tcs = start_metasrv_cluster(&[0, 1, 2]).await?;
+    let client = MetaGrpcClient::try_create(
+        tcs[0].config.grpc_api_address.clone().as_str(),
+        "root",
+        "xxx",
+        None,
+        None,
+    )
+    .await?;
+
+    tracing::info!("--- test write on a fresh cluster");
+    let key_suffix = "1st";
+    test_write_read_on_every_node(&tcs, &client, key_suffix).await?;
+
+    tracing::info!("--- shutdown the cluster");
+    let stopped_tcs = {
+        let mut stopped_tcs = vec![];
+        for mut tc in tcs {
+            assert!(tc.meta_nodes.is_empty());
+
+            let mut srv = tc.grpc_srv.take().unwrap();
+            srv.stop(None).await?;
+
+            stopped_tcs.push(tc);
+        }
+        stopped_tcs
+    };
+
+    tracing::info!("--- restart the cluster");
+    let tcs = {
+        let mut tcs = vec![];
+        for mut tc in stopped_tcs {
+            start_metasrv_with_context(&mut tc).await?;
+            tcs.push(tc);
+        }
+
+        for tc in &tcs {
+            tracing::info!("--- wait until a leader is observed");
+            // Every tcs[i] contains one meta node in this context.
+            let g = tc.grpc_srv.as_ref().unwrap();
+            let meta_node = g.get_meta_node();
+            let metrics = meta_node
+                .raft
+                .wait(timeout())
+                .metrics(|m| m.current_leader.is_some(), "a leader is observed")
+                .await?;
+
+            tracing::info!("got leader, metrics: {:?}", metrics);
+        }
+        tcs
+    };
+
+    tracing::info!("--- read use old client");
+    let tc = &tcs[0];
+    let k = make_key(tc, key_suffix);
+    let res = client.get_kv(&k).await?;
+    let res = res.unwrap();
+
+    assert_eq!(k.into_bytes(), res.data);
+
+    Ok(())
+}
 // Election timeout is 8~12 sec.
 // A raft node waits for a interval of election timeout before starting election
 // TODO: the raft should set the wait time by election_timeout.

--- a/metasrv/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -129,7 +129,7 @@ async fn test_kv_api_restart_cluster_write_read() -> anyhow::Result<()> {
 /// - Start a cluster of 3.
 /// - Test upsert kv and read on different nodes.
 /// - Stop and restart the cluster.
-/// - Test upsert kv and read on different nodes.
+/// - Test read kv using same grpc client.
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_kv_api_restart_cluster_token_expired() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();

--- a/metasrv/tests/it/grpc/metasrv_grpc_meta_api.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_meta_api.rs
@@ -28,7 +28,7 @@ async fn test_meta_api_database_create_get_drop() -> anyhow::Result<()> {
 
     let (_tc, addr) = start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     MetaApiTestSuite {}.database_create_get_drop(&client).await
 }
@@ -40,7 +40,7 @@ async fn test_meta_api_database_create_get_drop_in_diff_tenant() -> anyhow::Resu
 
     let (_tc, addr) = start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     MetaApiTestSuite {}
         .database_create_get_drop_in_diff_tenant(&client)
@@ -54,7 +54,7 @@ async fn test_meta_api_database_list() -> anyhow::Result<()> {
 
     let (_tc, addr) = start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     MetaApiTestSuite {}.database_list(&client).await
 }
@@ -66,7 +66,7 @@ async fn test_meta_api_database_list_in_diff_tenant() -> anyhow::Result<()> {
 
     let (_tc, addr) = start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     MetaApiTestSuite {}
         .database_list_in_diff_tenant(&client)
@@ -80,7 +80,7 @@ async fn test_meta_api_table_create_get_drop() -> anyhow::Result<()> {
 
     let (_tc, addr) = start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     MetaApiTestSuite {}.table_create_get_drop(&client).await
 }
@@ -92,7 +92,7 @@ async fn test_meta_api_table_list() -> anyhow::Result<()> {
 
     let (_tc, addr) = start_metasrv().await?;
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     MetaApiTestSuite {}.table_list(&client).await
 }
@@ -106,7 +106,7 @@ async fn test_meta_api_flight_get_database_meta_ddl_table() -> anyhow::Result<()
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
     let (_tc, addr) = crate::tests::start_metasrv().await?;
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     let test_db = "db1";
     let plan = CreateDatabasePlan {
@@ -184,7 +184,7 @@ async fn test_meta_api_flight_get_database_meta_empty_db() -> anyhow::Result<()>
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
     let (_tc, addr) = crate::tests::start_metasrv().await?;
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     // Empty Database
     let res = client.get_database_meta(None).await?;
@@ -198,7 +198,7 @@ async fn test_meta_api_flight_get_database_meta_ddl_db() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
     let (_tc, addr) = crate::tests::start_metasrv().await?;
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
 
     // create-db operation will increases meta_version
     let plan = CreateDatabasePlan {

--- a/metasrv/tests/it/grpc/metasrv_grpc_tls.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_tls.rs
@@ -87,7 +87,7 @@ async fn test_tls_client_config_failure() -> anyhow::Result<()> {
         .await
         .unwrap();
 
-    let c = r.make_client_with_tls().await;
+    let c = r.make_client().await;
     assert!(c.is_err());
     if let Err(e) = c {
         assert_eq!(e.code(), ErrorCode::TLSConfigurationFailure("").code());

--- a/metasrv/tests/it/grpc/metasrv_grpc_tls.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_tls.rs
@@ -48,7 +48,7 @@ async fn test_tls_server() -> anyhow::Result<()> {
     };
 
     let client =
-        MetaGrpcClient::with_tls_conf(addr.as_str(), "root", "xxx", None, Some(tls_conf)).await?;
+        MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, Some(tls_conf)).await?;
 
     let r = client
         .get_table(("do not care", "do not care", "do not care").into())
@@ -83,10 +83,13 @@ async fn test_tls_client_config_failure() -> anyhow::Result<()> {
         domain_name: TEST_CN_NAME.to_string(),
     };
 
-    let r = MetaGrpcClient::with_tls_conf("addr", "root", "xxx", None, Some(tls_conf)).await;
+    let r = MetaGrpcClient::try_create("addr", "root", "xxx", None, Some(tls_conf))
+        .await
+        .unwrap();
 
-    assert!(r.is_err());
-    if let Err(e) = r {
+    let c = r.make_client_with_tls().await;
+    assert!(c.is_err());
+    if let Err(e) = c {
         assert_eq!(e.code(), ErrorCode::TLSConfigurationFailure("").code());
     }
     Ok(())

--- a/metasrv/tests/it/tests/service.rs
+++ b/metasrv/tests/it/tests/service.rs
@@ -142,7 +142,7 @@ impl MetaSrvTestContext {
     pub async fn grpc_client(&self) -> anyhow::Result<MetaGrpcClient> {
         let addr = self.config.grpc_api_address.clone();
 
-        let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx").await?;
+        let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
         Ok(client)
     }
 

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -36,6 +36,7 @@ def remove_control_characters(s):
     """
     https://github.com/html5lib/html5lib-python/issues/96#issuecomment-43438438
     """
+
     def str_to_int(s, default, base=10):
         if int(s, base) < 0x10000:
             return chr(int(s, base))

--- a/tests/helpers/client.py
+++ b/tests/helpers/client.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.join(CURDIR))
 
 
 class client(object):
+
     def __init__(self, name='', log=None):
         self.name = name
         self.log = log

--- a/tests/suites/0_stateless/00_0000_dummy_select_py.py
+++ b/tests/suites/0_stateless/00_0000_dummy_select_py.py
@@ -31,6 +31,7 @@ client1.run("select 3")
 
 
 class MyModel(object):
+
     def __init__(self, name, value):
         self.name = name
         self.value = value


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Bugfix: fix connection failed when metasrv restart that caused by token expired.
This fix reuse raft nodes connect pool that @drmingdrmer made.

## Changelog

- Bug Fix

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

