### PR TITLE
Use mysql-connector-python instead of deprecated mysql-connector

### DIFF
--- a/scripts/setup/dev_setup.sh
+++ b/scripts/setup/dev_setup.sh
@@ -295,7 +295,7 @@ if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
 	install_pkg llvm "$PACKAGE_MANAGER"
 	install_pkg python3 "$PACKAGE_MANAGER"
 	install_pkg_config "$PACKAGE_MANAGER"
-	python3 -m pip install boto3 "moto[all]" yapf shfmt-py mysql-connector
+	python3 -m pip install boto3 "moto[all]" yapf shfmt-py mysql-connector-python
 
 	case "$PACKAGE_MANAGER" in
 	apt-get)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Use mysql-connector-python instead of deprecated mysql-connector
ref: https://pypi.org/project/mysql-connector/

## Changelog

- Build/Testing/CI

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

