### PR TITLE
ci: Unittest don't need to wait for build

### DIFF
--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -47,7 +47,7 @@ jobs:
 
   test_unit:
     runs-on: ${{ matrix.config.os }}
-    needs: build
+    needs: check
     strategy:
       matrix:
         config:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -43,7 +43,7 @@ jobs:
 
   test_unit:
     runs-on: ${{ matrix.config.os }}
-    needs: build
+    needs: check
     strategy:
       matrix:
         config:


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Our unittest used to wait for build, but it doesn't need to in fact.

## Changelog

- Build/Testing/CI

## Test Plan

Unit Tests

Stateless Tests

