### PR TITLE
Upgrade openraft to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df0eff878df53fcffe838345abfa5b3d7eeb87e856f53b7461e0e5d51fb9d045"
 dependencies = [
+ "anyhow",
  "backtrace",
  "serde",
  "serde_json",
@@ -169,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e996dc7940838b7ef1096b882e29ec30a3149a3a443cdc8dba19ed382eca1fe2"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -299,25 +300,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-raft"
-version = "0.6.1"
-source = "git+https://github.com/datafuselabs/openraft?tag=v0.6.2-alpha.14.1#5086c8b38d2c3307b460fd958eb56d0b767e2467"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "derive_more",
- "futures",
- "log",
- "rand",
- "serde",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,9 +416,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "aws-config"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb6c465279db702be3388e9ee0d8cbc8cfb4b470ad1916981d1a0e2ff26f12d"
+checksum = "0a5421955d4744207053bef13a65cc60af6cd1e9ad0ff447bd5e630d1edddd72"
 dependencies = [
  "aws-http",
  "aws-sdk-sts",
@@ -457,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72549a509836fa0dcdc2a4e291f5b3c732ebae1acf6564701e9cb779be43ed01"
+checksum = "c45bafccabcc4953bd71015ae187c3fe85dec2960aef1c2cf5515c867c0fbd54"
 dependencies = [
  "aws-smithy-http",
  "aws-types",
@@ -470,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ad8b6cda2e119df93b02a44fc86a1c56294aabd4f4469a299311436b8e9971"
+checksum = "4ad5cd76c37a16219dc6f73474f1cd1603872b6f5e6a765df7ef5a2000c6dcd8"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -485,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c9432a07d9522115a0bc4c338a93585e99bbea2fde17b87c1cdf6e7ce58a06"
+checksum = "8c4c9685f0e30ffb9043cd4aa1302a77289a30f1837f3d3f265decf089fccfb2"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -510,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f6ee7e1862da6c1f82222423a5dd19897af8a313b1fdad3016711d3f76d3fd"
+checksum = "b4e4397ce5e2b21bda02db9b4ed4642f0717b5fe6dd2c276d364a019734108e3"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -532,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92d50e5ec810ecba45cde8b8287cbe670541c65a6d0def0fcda4b6bdf3b6d15"
+checksum = "446fbc7a132042271fc363a442b0f97e6036e71a6f55c535ca5cf2062b73aece"
 dependencies = [
  "aws-sigv4",
  "aws-smithy-eventstream",
@@ -547,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675a411b2afff9272c370a61322ceaae74c3102d70524c145e1d43f389ee5bbb"
+checksum = "9c60fde70ec639a20e30b2ea425619a72242e5fff0b3a8ac7f729d07b847deb3"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http",
@@ -567,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f1fd575567cb5822e32c2d61aefe2d7afd14d4e49d4879b3efaf5372800de3"
+checksum = "9ce0f12c49772b774e2d65b579d09c205948ea8679b2b39d08d1ae9476bb535d"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -579,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06f2664795a1bb545d651089146f6033d3581ef198d96033a59ca1b2fd0cb6dd"
+checksum = "42212ca483db4774b1cbadf648be4a06dc45dec0ecfd552506a63c98ea4e2838"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -603,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790716b9e6a8aef428592921efd6d15dfdf556091015e15af6e6e62f9ae42d5f"
+checksum = "2340a513c3956459d5b0238976847aa94ab8c9efc9a26f1d91fe5178c6fbc2f9"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -614,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713ad03f7d51a02e8542d92c8674fb4a3b777acec967eb46018d1776bceca86c"
+checksum = "009e7ddec00dfe28a5eb1d6749342d274aa05c2fddb3b8abf82429fd060544c9"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",
@@ -635,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2abf5583dbd165d39c1c31f7495c1a5d5cab93e8090689769ff12cc65dd23a71"
+checksum = "0317649bd8f4b0fc0e1721b3bbe878af6352926a89b5d2cfb4211d5fe8342c75"
 dependencies = [
  "aws-smithy-http",
  "bytes",
@@ -650,18 +632,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d3931e5d170f66a8d84594ebceff66497f2227a4355ac5e25818b547ff9a9b"
+checksum = "06c858f5049c12eb77ea1b9624c8463d41bbefa9e8e8c3159ce4565e8e3b27ce"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90645f9a051e9d33a8740493c691449bf45acc212797c1316c55ae076e1a0327"
+checksum = "77b94596aef43e18fed1e5370aa9dac9c402b28441fc56577b00b757b3fb001b"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -669,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f35e1fc3f0bbd986d45d59d4e41d4f90cbb3762986f580ff0d08e069a8e1a5"
+checksum = "8d9ea9658f2576b4e91c6b00c4963a68614daf74b5160a66daa02c9f897da3ae"
 dependencies = [
  "itoa 1.0.1",
  "num-integer",
@@ -681,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc9be9d70d5884e334cd6a0ceac607953a70be4ec33e75a65fe939cf3b621ad"
+checksum = "db1bbd22e96540cf8809a9137bf627e28e5bc6b365ab1ac58d9d81649b31def1"
 dependencies = [
  "thiserror",
  "xmlparser",
@@ -691,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cb693d2383f85e22d5b131c9848059dbc552b0ed19121b249a920c71afe752"
+checksum = "490a491f7592e110762a305970a3c88b6a5bd662bde27f3b2f2ab7be6b8f1589"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -834,7 +816,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "byte-unit",
- "clap 3.0.5",
+ "clap 3.0.7",
  "clap_complete",
  "colored",
  "comfy-table",
@@ -868,8 +850,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2 0.10.0",
- "sysinfo 0.22.4",
+ "sha2 0.10.1",
+ "sysinfo 0.22.5",
  "tar",
  "tempfile",
  "thiserror",
@@ -986,16 +968,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526c210b4520e416420759af363083471656e819a75e831b8d2c9d5a584f2413"
+checksum = "882e99e4a0cb2ae6cb6e442102e8e6b7131718d94110e64c3e6a34ea9b106f37"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
  "cc",
  "cfg-if 1.0.0",
  "constant_time_eq",
- "digest 0.9.0",
+ "digest 0.10.1",
 ]
 
 [[package]]
@@ -1016,7 +998,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -1025,7 +1007,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -1065,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c9d2f2b0fb88a112154ed81e30b0a491c29322afe1db3b6eec5811f5ba0"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byte-tools"
@@ -1120,9 +1102,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "camino"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
 dependencies = [
  "serde",
 ]
@@ -1284,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.5"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f34b09b9ee8c7c7b400fe2f8df39cafc9538b03d6ba7f4ae13e4cb90bfbb7d"
+checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
 dependencies = [
  "atty",
  "bitflags",
@@ -1301,18 +1283,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.0.2"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a394f7ec0715b42a4e52b294984c27c9a61f77c8d82f7774c5198350be143f19"
+checksum = "d044e9db8cd0f68191becdeb5246b7462e4cf0c069b19ae00d1bf3fa9889498d"
 dependencies = [
- "clap 3.0.5",
+ "clap 3.0.7",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.5"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a0645a430ec9136d2d701e54a95d557de12649a9dd7109ced3187e648ac824"
+checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1349,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8340083d28acb43451166543b98c838299b7e0863621be53a338adceea0ed"
+checksum = "1951fb8aa063a2ee18b4b4d217e4aa2ec9cc4f2430482983f607fa10cd36d7aa"
 dependencies = [
  "error-code",
  "str-buf",
@@ -1360,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.46"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
 dependencies = [
  "cc",
 ]
@@ -1399,9 +1381,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b2f5d0ee456f3928812dfc8c6d9a1d592b98678f6d56db9b0cd2b7bc6c8db5"
+checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
 dependencies = [
  "bytes",
  "memchr",
@@ -1675,7 +1657,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2 0.10.0",
+ "sha2 0.10.1",
  "sqlparser",
  "strength_reduce",
  "twox-hash",
@@ -1825,10 +1807,9 @@ name = "common-meta-raft-store"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-raft",
  "async-trait",
  "bytes",
- "clap 3.0.5",
+ "clap 3.0.7",
  "common-arrow",
  "common-base",
  "common-exception",
@@ -1856,13 +1837,13 @@ name = "common-meta-sled-store"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-raft",
  "byteorder",
  "common-base",
  "common-exception",
  "common-meta-types",
  "common-tracing",
  "once_cell",
+ "openraft",
  "serde",
  "serde_json",
  "sled",
@@ -1874,7 +1855,6 @@ name = "common-meta-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-raft",
  "common-building",
  "common-datavalues",
  "common-exception",
@@ -1884,11 +1864,12 @@ dependencies = [
  "lazy_static",
  "maplit",
  "once_cell",
+ "openraft",
  "prost",
  "serde",
  "serde_json",
  "sha1",
- "sha2 0.10.0",
+ "sha2 0.10.1",
  "thiserror",
  "tonic",
  "tonic-build",
@@ -2028,9 +2009,9 @@ checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
 name = "const_fn"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "constant_time_eq"
@@ -2139,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -2160,9 +2141,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -2173,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+checksum = "b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -2183,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -2228,7 +2209,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
@@ -2240,7 +2221,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -2249,7 +2230,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -2327,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc6d233563261f8db6ffb83bbaad5a73837a6e6b28868e926337ebbdece0be3"
+checksum = "7de97b894edd5b5bcceef8b78d7da9b75b1d2f2f9a910569d0bde3dd31d84939"
 dependencies = [
  "curl-sys",
  "libc",
@@ -2342,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.51+curl-7.80.0"
+version = "0.4.52+curl-7.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d130987e6a6a34fe0889e1083022fa48cd90e6709a84be3fb8dd95801de5af20"
+checksum = "14b8c2d1023ea5fded5b7b892e4b8e95f70038a421126a056761a84246a28971"
 dependencies = [
  "cc",
  "libc",
@@ -2376,7 +2357,7 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 name = "databend-benchmark"
 version = "0.1.0"
 dependencies = [
- "clap 3.0.5",
+ "clap 3.0.7",
  "clickhouse-driver",
  "common-base",
  "common-exception",
@@ -2405,11 +2386,10 @@ version = "0.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
- "async-raft",
  "async-trait",
  "backtrace",
  "byteorder",
- "clap 3.0.5",
+ "clap 3.0.7",
  "common-arrow",
  "common-base",
  "common-building",
@@ -2441,7 +2421,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.0",
+ "sha2 0.10.1",
  "sled",
  "tempfile",
  "thiserror",
@@ -2469,7 +2449,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "chrono-tz",
- "clap 3.0.5",
+ "clap 3.0.7",
  "clickhouse-driver",
  "common-arrow",
  "common-ast",
@@ -2525,7 +2505,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2 0.10.0",
+ "sha2 0.10.1",
  "sqlparser",
  "tempfile",
  "threadpool",
@@ -2596,7 +2576,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -2607,7 +2587,8 @@ checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
  "block-buffer 0.10.0",
  "crypto-common",
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
+ "subtle",
 ]
 
 [[package]]
@@ -2717,7 +2698,7 @@ checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
  "crypto-bigint",
  "ff",
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "group",
  "pkcs8",
  "rand_core 0.6.3",
@@ -2920,9 +2901,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "flatbuffers"
@@ -2990,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
+checksum = "8da1b8f89c5b5a5b7e59405cfcf0bb9588e5ed19f0b57a4cd542bbba3f164a6d"
 
 [[package]]
 name = "frunk"
@@ -3206,9 +3187,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -3216,9 +3197,9 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
+checksum = "4addc164932852d066774c405dbbdb7914742d2b39e39e1a7ca949c856d054d1"
 dependencies = [
  "libc",
  "winapi",
@@ -3235,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3330,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f072413d126e57991455e0a922b31e4c8ba7c2ffbebf6b78b4f8521397d65cd"
+checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
 dependencies = [
  "bytes",
  "fnv",
@@ -3551,9 +3532,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "httpmock"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24a520a3193799852cc4baf0d8356d7578a8847dfc5603d087529f099661e42"
+checksum = "c159c4fc205e6c1a9b325cb7ec135d13b5f47188ce175dabb76ec847f331d9bd"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
@@ -3568,13 +3549,13 @@ dependencies = [
  "lazy_static",
  "levenshtein",
  "log",
- "qstring",
  "regex",
  "serde",
  "serde_json",
  "serde_regex",
  "similar",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -3692,9 +3673,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
@@ -3714,14 +3695,14 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe3ba15e9cce341de198353aebd07d8009d211fb5556920bd4bdd3bb79fafd7"
+checksum = "5b4445abb2e1f32b02fb78f957f17efa7a43c8258cd3e848157949c59157657d"
 dependencies = [
  "ahash",
  "atty",
  "indexmap",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "lazy_static",
  "log",
  "num-format",
@@ -3895,7 +3876,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.9.8",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -4082,9 +4063,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
@@ -4152,9 +4133,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469898e909a1774d844793b347135a0cd344ca2f69d082013ecb8061a2229a3a"
+checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
 dependencies = [
  "hashbrown",
 ]
@@ -4496,7 +4477,7 @@ dependencies = [
  "mysql_common 0.28.0",
  "native-tls",
  "once_cell",
- "pem 1.0.1",
+ "pem 1.0.2",
  "percent-encoding",
  "pin-project",
  "serde",
@@ -4541,7 +4522,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "smallvec",
  "subprocess",
  "thiserror",
@@ -4578,7 +4559,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "smallvec",
  "subprocess",
  "thiserror",
@@ -4838,7 +4819,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "thiserror",
  "url",
 ]
@@ -4899,6 +4880,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openraft"
+version = "0.6.4"
+source = "git+https://github.com/datafuselabs/openraft?rev=f633756d60152d171909aea56f80d18905cd4002#f633756d60152d171909aea56f80d18905cd4002"
+dependencies = [
+ "anyerror",
+ "anyhow",
+ "async-trait",
+ "byte-unit",
+ "bytes",
+ "clap 3.0.7",
+ "derive_more",
+ "futures",
+ "maplit",
+ "rand",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4914,9 +4917,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
@@ -5018,7 +5021,7 @@ checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.9.8",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -5123,13 +5126,11 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06673860db84d02a63942fa69cd9543f2624a5df3aea7f33173048fa7ad5cf1a"
+checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
  "base64 0.13.0",
- "once_cell",
- "regex",
 ]
 
 [[package]]
@@ -5206,7 +5207,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
- "fixedbitset 0.4.0",
+ "fixedbitset 0.4.1",
  "indexmap",
 ]
 
@@ -5356,9 +5357,9 @@ dependencies = [
 
 [[package]]
 name = "poem"
-version = "1.2.27"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0521e54164887bd0390ebdb8c8d953fd2228c08a7b12097fc2832b3676bad01"
+checksum = "b0d58e10ab7f28066b2f48a6d938896efe299b6d20728f29308be4ac0885f66f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5367,7 +5368,6 @@ dependencies = [
  "http",
  "hyper",
  "mime",
- "mime_guess",
  "multer",
  "parking_lot",
  "percent-encoding",
@@ -5388,9 +5388,9 @@ dependencies = [
 
 [[package]]
 name = "poem-derive"
-version = "1.2.27"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51d923308fc12809b71013799e4644ea0d3d1c56085576986a319b817b25b6e"
+checksum = "bff2b4d01de39ca6d30a2fde7b2d30d2c019fd0d3a7302ffaf71823f889fa3dc"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5446,9 +5446,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "precomputed-hash"
@@ -5458,9 +5458,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e5a7689e456ab905c22c2b48225bb921aba7c8dfa58440d68ba13f6222a715"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -5472,15 +5472,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -5609,15 +5609,6 @@ checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
  "prost",
-]
-
-[[package]]
-name = "qstring"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
-dependencies = [
- "percent-encoding",
 ]
 
 [[package]]
@@ -5833,15 +5824,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4e0a76dc12a116108933f6301b95e83634e0c47b0afbed6abbaa0601e99258"
+checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
  "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
@@ -6021,7 +6013,7 @@ dependencies = [
  "rusoto_credential",
  "rustc_version 0.4.0",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "tokio",
 ]
 
@@ -6042,9 +6034,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2d4912d369fb95a351c221475657970678d344d70c1a788223f6e74d1e3732"
+checksum = "e0593ce4677e3800ddafb3de917e8397b1348e06e688128ade722d88fbe11ebf"
 dependencies = [
  "arrayvec 0.7.2",
  "num-traits",
@@ -6207,9 +6199,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -6220,9 +6212,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6296,9 +6288,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
 dependencies = [
  "indexmap",
  "itoa 1.0.1",
@@ -6308,9 +6300,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0421d4f173fab82d72d6babf36d57fae38b994ca5c2d78e704260ba6d12118b"
+checksum = "9bd186dd4e1748b2798a2e86789dd77f5834ecda0bf15db76962e8e104bfc9bd"
 dependencies = [
  "serde",
 ]
@@ -6327,12 +6319,12 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -6376,15 +6368,24 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -6395,9 +6396,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d964dd36bb15bcf2f2b35694c072feab74969a54f2bbeec7a2d725d2bdcb6"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -6484,9 +6485,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+checksum = "ba1eead9e94aa5a2e02de9e7839f96a007f686ae7a1d57c7797774810d24908a"
 
 [[package]]
 name = "sized-chunks"
@@ -6536,9 +6537,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "snafu"
@@ -6823,9 +6824,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6861,9 +6862,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb37aa4af23791c584202d286ed9420e023e9d27e49d5a76215623f4bcc2502"
+checksum = "7f1bfab07306a27332451a662ca9c8156e3a9986f82660ba9c8e744fe8455d43"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -6893,13 +6894,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -6937,9 +6938,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
@@ -7133,9 +7134,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-io-timeout"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
  "pin-project-lite",
  "tokio",
@@ -7335,9 +7336,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-bunyan-formatter"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb2ad6aa9b1c637d84c54db002275bbf72a7f3c6fed80f8b33f5af0c39027e9"
+checksum = "bd99ff040622c69c0fc4bd3ea5fe16630ce46400a79bd41339391b2d416ea24c"
 dependencies = [
  "gethostname",
  "log",
@@ -7397,9 +7398,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
+checksum = "77be66445c4eeebb934a7340f227bfe7b338173d3f8c00a60a5a58005c9faecf"
 dependencies = [
  "ansi_term",
  "lazy_static",
@@ -7701,9 +7702,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"
@@ -7856,9 +7857,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
+checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
 dependencies = [
  "webpki 0.22.0",
 ]
@@ -8040,9 +8041,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
+checksum = "81e8f13fef10b63c06356d65d416b070798ddabcadc10d3ece0c5be9b3c7eddb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/common/meta/raft-store/Cargo.toml
+++ b/common/meta/raft-store/Cargo.toml
@@ -20,22 +20,20 @@ common-meta-sled-store = { path = "../sled-store" }
 common-meta-types = { path = "../types" }
 common-tracing = { path = "../../tracing" }
 
-# github deps
-async-raft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.6.2-alpha.14.1" }
 
 # crates.io deps
 anyhow = "1.0.52"
 async-trait = "0.1.52"
-clap = { version = "3.0.5", features = ["derive", "env"] }
 bytes = "1.1.0"
-once_cell = "1.9.0"
+clap = { version = "3.0.5", features = ["derive", "env"] }
 derive_more = "0.99.17"
-maplit = "1.0.2"
-rand = "0.8.4"
 futures = "0.3.19"
+maplit = "1.0.2"
+once_cell = "1.9.0"
+prost = "0.9.0"
+rand = "0.8.4"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
-prost = "0.9.0"
 thiserror = "1.0.30"
 tonic = { version = "0.6.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
 

--- a/common/meta/raft-store/src/config.rs
+++ b/common/meta/raft-store/src/config.rs
@@ -87,6 +87,10 @@ pub struct RaftConfig {
     #[clap(long, env = KVSRV_INSTALL_SNAPSHOT_TIMEOUT, default_value = "4000")]
     pub install_snapshot_timeout: u64,
 
+    /// The maximum number of applied logs to keep before purging
+    #[clap(long, env = "RAFT_MAX_APPLIED_LOG_TO_KEEP", default_value = "1000")]
+    pub max_applied_log_to_keep: u64,
+
     /// Whether to boot up a new cluster. If already booted, it is ignored
     #[clap(long, env = KVSRV_BOOT)]
     pub boot: bool,
@@ -125,6 +129,7 @@ impl Default for RaftConfig {
             snapshot_logs_since_last: 1024,
             heartbeat_interval: 1000,
             install_snapshot_timeout: 4000,
+            max_applied_log_to_keep: 1000,
             boot: false,
             single: false,
             join: vec![],

--- a/common/meta/raft-store/src/sled_key_spaces.rs
+++ b/common/meta/raft-store/src/sled_key_spaces.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_raft::raft::Entry;
+use common_meta_sled_store::openraft;
 use common_meta_sled_store::SledKeySpace;
 use common_meta_types::DatabaseMeta;
 use common_meta_types::LogEntry;
@@ -22,12 +22,15 @@ use common_meta_types::NodeId;
 use common_meta_types::SeqNum;
 use common_meta_types::SeqV;
 use common_meta_types::TableMeta;
+use openraft::raft::Entry;
 
 use crate::state::RaftStateKey;
 use crate::state::RaftStateValue;
 use crate::state_machine::table_lookup::TableLookupValue;
 use crate::state_machine::ClientLastRespValue;
 use crate::state_machine::DatabaseLookupKey;
+use crate::state_machine::LogMetaKey;
+use crate::state_machine::LogMetaValue;
 use crate::state_machine::StateMachineMetaKey;
 use crate::state_machine::StateMachineMetaValue;
 use crate::state_machine::TableLookupKey;
@@ -39,6 +42,15 @@ impl SledKeySpace for Logs {
     const NAME: &'static str = "log";
     type K = LogIndex;
     type V = Entry<LogEntry>;
+}
+
+/// Types for raft log meta data in SledTree
+pub struct LogMeta {}
+impl SledKeySpace for LogMeta {
+    const PREFIX: u8 = 13;
+    const NAME: &'static str = "log-meta";
+    type K = LogMetaKey;
+    type V = LogMetaValue;
 }
 
 /// Types for Node in SledTree

--- a/common/meta/raft-store/src/state/raft_state.rs
+++ b/common/meta/raft-store/src/state/raft_state.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_raft::storage::HardState;
 use common_exception::ErrorCode;
+use common_meta_sled_store::openraft;
 use common_meta_sled_store::sled;
 use common_meta_sled_store::AsKeySpace;
 use common_meta_sled_store::SledTree;
 use common_meta_types::NodeId;
 use common_tracing::tracing;
+use openraft::storage::HardState;
 
 use crate::config::RaftConfig;
 use crate::sled_key_spaces::RaftStateKV;

--- a/common/meta/raft-store/src/state/raft_state_kv.rs
+++ b/common/meta/raft-store/src/state/raft_state_kv.rs
@@ -14,11 +14,12 @@
 
 use std::fmt;
 
-use async_raft::storage::HardState;
 use common_exception::ErrorCode;
+use common_meta_sled_store::openraft;
 use common_meta_sled_store::sled;
 use common_meta_sled_store::SledOrderedSerde;
 use common_meta_types::NodeId;
+use openraft::storage::HardState;
 use serde::Deserialize;
 use serde::Serialize;
 use sled::IVec;

--- a/common/meta/raft-store/src/state_machine/mod.rs
+++ b/common/meta/raft-store/src/state_machine/mod.rs
@@ -15,6 +15,8 @@
 pub use client_last_resp::ClientLastRespValue;
 pub use database_lookup::DatabaseLookupKey;
 pub use database_lookup::DatabaseLookupValue;
+pub use log_meta::LogMetaKey;
+pub use log_meta::LogMetaValue;
 pub use sm::SerializableSnapshot;
 pub use sm::SnapshotKeyValue;
 pub use sm::StateMachine;
@@ -26,6 +28,7 @@ pub use table_lookup::TableLookupValue;
 
 pub mod client_last_resp;
 pub mod database_lookup;
+pub mod log_meta;
 pub mod placement;
 pub mod sm;
 mod sm_kv_api_impl;

--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -17,12 +17,12 @@ use std::fmt::Debug;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
-use async_raft::raft::Entry;
-use async_raft::raft::EntryPayload;
-use async_raft::raft::MembershipConfig;
 use common_exception::ErrorCode;
 use common_exception::ToErrorCode;
 use common_meta_sled_store::get_sled_db;
+use common_meta_sled_store::openraft;
+use common_meta_sled_store::openraft::EffectiveMembership;
+use common_meta_sled_store::openraft::MessageSummary;
 use common_meta_sled_store::sled;
 use common_meta_sled_store::AsKeySpace;
 use common_meta_sled_store::AsTxnKeySpace;
@@ -45,6 +45,8 @@ use common_meta_types::Operation;
 use common_meta_types::SeqV;
 use common_meta_types::TableMeta;
 use common_tracing::tracing;
+use openraft::raft::Entry;
+use openraft::raft::EntryPayload;
 use serde::Deserialize;
 use serde::Serialize;
 use sled::IVec;
@@ -169,14 +171,14 @@ impl StateMachine {
     ) -> common_exception::Result<(
         impl Iterator<Item = sled::Result<(IVec, IVec)>>,
         LogId,
-        MembershipConfig,
         String,
     )> {
         let last_applied = self.get_last_applied()?;
-        let mem = self.get_membership()?;
 
         // NOTE: An initialize node/cluster always has the first log contains membership config.
-        let mem = mem.unwrap_or_default();
+
+        let last_applied =
+            last_applied.expect("not allowed to build snapshot with empty state machine");
 
         let snapshot_idx = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -188,7 +190,7 @@ impl StateMachine {
             last_applied.term, last_applied.index, snapshot_idx
         );
 
-        Ok((self.sm_tree.tree.iter(), last_applied, mem, snapshot_id))
+        Ok((self.sm_tree.tree.iter(), last_applied, snapshot_id))
     }
 
     /// Serialize a snapshot for transport.
@@ -231,9 +233,12 @@ impl StateMachine {
     /// If a duplicated log entry is detected by checking data.txid, no update
     /// will be made and the previous resp is returned. In this way a client is able to re-send a
     /// command safely in case of network failure etc.
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self, entry), fields(log_id=%entry.log_id))]
     pub async fn apply(&self, entry: &Entry<LogEntry>) -> common_exception::Result<AppliedState> {
         // TODO(xp): all update need to be done in a tx.
+
+        tracing::debug!("apply: summary: {}", entry.summary());
+        tracing::debug!("apply: payload: {:?}", entry.payload);
 
         let log_id = &entry.log_id;
 
@@ -245,8 +250,7 @@ impl StateMachine {
 
             match entry.payload {
                 EntryPayload::Blank => {}
-                EntryPayload::Normal(ref norm) => {
-                    let data = &norm.data;
+                EntryPayload::Normal(ref data) => {
                     if let Some(ref txid) = data.txid {
                         let (serial, resp) =
                             self.txn_get_client_last_resp(&txid.client, &txn_tree)?;
@@ -266,14 +270,16 @@ impl StateMachine {
                     }
                     return Ok(Some(resp));
                 }
-                EntryPayload::ConfigChange(ref mem) => {
+                EntryPayload::Membership(ref mem) => {
                     txn_sm_meta.insert(
                         &LastMembership,
-                        &StateMachineMetaValue::Membership(mem.membership.clone()),
+                        &StateMachineMetaValue::Membership(EffectiveMembership {
+                            log_id: *log_id,
+                            membership: mem.clone(),
+                        }),
                     )?;
                     return Ok(Some(AppliedState::None));
                 }
-                EntryPayload::SnapshotPointer(_) => {}
             };
 
             Ok(None)
@@ -616,12 +622,14 @@ impl StateMachine {
     /// Already applied log should be filtered out before passing into this function.
     /// This is the only entry to modify state machine.
     /// The `cmd` is always committed by raft before applying.
-    #[tracing::instrument(level = "debug", skip(self, txn_tree))]
+    #[tracing::instrument(level = "debug", skip(self, cmd, txn_tree))]
     pub fn apply_cmd(
         &self,
         cmd: &Cmd,
         txn_tree: &TransactionSledTree,
     ) -> common_exception::Result<AppliedState> {
+        tracing::debug!("apply_cmd: {:?}", cmd);
+
         match cmd {
             Cmd::IncrSeq { ref key } => self.apply_incr_seq_cmd(key, txn_tree),
 
@@ -850,7 +858,7 @@ impl StateMachine {
         Ok(value.1)
     }
 
-    pub fn get_membership(&self) -> common_exception::Result<Option<MembershipConfig>> {
+    pub fn get_membership(&self) -> common_exception::Result<Option<EffectiveMembership>> {
         let sm_meta = self.sm_meta();
         let mem = sm_meta
             .get(&StateMachineMetaKey::LastMembership)?
@@ -859,12 +867,11 @@ impl StateMachine {
         Ok(mem)
     }
 
-    pub fn get_last_applied(&self) -> common_exception::Result<LogId> {
+    pub fn get_last_applied(&self) -> common_exception::Result<Option<LogId>> {
         let sm_meta = self.sm_meta();
         let last_applied = sm_meta
             .get(&LastApplied)?
-            .map(|x| x.try_into().expect("LogId"))
-            .unwrap_or_default();
+            .map(|x| x.try_into().expect("LogId"));
 
         Ok(last_applied)
     }

--- a/common/meta/raft-store/src/state_machine/snapshot.rs
+++ b/common/meta/raft-store/src/state_machine/snapshot.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_raft::SnapshotMeta;
+use common_meta_sled_store::openraft;
+use openraft::SnapshotMeta;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/common/meta/raft-store/tests/it/log.rs
+++ b/common/meta/raft-store/tests/it/log.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_raft::raft::Entry;
-use async_raft::raft::EntryNormal;
-use async_raft::raft::EntryPayload;
-use async_raft::LogId;
 use common_base::tokio;
 use common_meta_raft_store::log::RaftLog;
+use common_meta_sled_store::openraft;
 use common_meta_types::Cmd;
 use common_meta_types::LogEntry;
+use openraft::raft::Entry;
+use openraft::raft::EntryPayload;
+use openraft::LogId;
 
 use crate::init_raft_store_ut;
 use crate::testing::new_raft_test_context;
@@ -50,12 +50,10 @@ async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -127,12 +125,10 @@ async fn test_raft_log_insert() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -164,12 +160,10 @@ async fn test_raft_log_get() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -203,12 +197,10 @@ async fn test_raft_log_last() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -235,12 +227,10 @@ async fn test_raft_log_range_remove() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },

--- a/common/meta/raft-store/tests/it/state.rs
+++ b/common/meta/raft-store/tests/it/state.rs
@@ -11,9 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use async_raft::storage::HardState;
 use common_base::tokio;
 use common_meta_raft_store::state::RaftState;
+use common_meta_sled_store::openraft;
+use openraft::storage::HardState;
 
 use crate::init_raft_store_ut;
 use crate::testing::new_raft_test_context;

--- a/common/meta/raft-store/tests/it/state_machine/mod.rs
+++ b/common/meta/raft-store/tests/it/state_machine/mod.rs
@@ -17,11 +17,6 @@ use std::convert::TryInto;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
-use async_raft::raft::Entry;
-use async_raft::raft::EntryNormal;
-use async_raft::raft::EntryPayload;
-use async_raft::raft::MembershipConfig;
-use async_raft::LogId;
 use common_base::tokio;
 use common_exception::ErrorCode;
 use common_meta_api::KVApi;
@@ -30,6 +25,7 @@ use common_meta_raft_store::state_machine::testing::pretty_snapshot_iter;
 use common_meta_raft_store::state_machine::testing::snapshot_logs;
 use common_meta_raft_store::state_machine::SerializableSnapshot;
 use common_meta_raft_store::state_machine::StateMachine;
+use common_meta_sled_store::openraft;
 use common_meta_types::AppliedState;
 use common_meta_types::Change;
 use common_meta_types::Cmd;
@@ -42,8 +38,10 @@ use common_meta_types::SeqV;
 use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReq;
 use common_tracing::tracing;
-use maplit::btreeset;
 use maplit::hashmap;
+use openraft::raft::Entry;
+use openraft::raft::EntryPayload;
+use openraft::LogId;
 use pretty_assertions::assert_eq;
 
 use crate::init_raft_store_ut;
@@ -109,11 +107,9 @@ async fn test_state_machine_apply_incr_seq() -> anyhow::Result<()> {
         let resp = sm
             .apply(&Entry {
                 log_id: LogId { term: 0, index: 5 },
-                payload: EntryPayload::Normal(EntryNormal {
-                    data: LogEntry {
-                        txid: txid.clone(),
-                        cmd: Cmd::IncrSeq { key: k.to_string() },
-                    },
+                payload: EntryPayload::Normal(LogEntry {
+                    txid: txid.clone(),
+                    cmd: Cmd::IncrSeq { key: k.to_string() },
                 }),
             })
             .await?;
@@ -737,17 +733,10 @@ async fn test_state_machine_snapshot() -> anyhow::Result<()> {
         sm.apply(l).await?;
     }
 
-    let (it, last, mem, id) = sm.snapshot()?;
+    let (it, last, id) = sm.snapshot()?;
 
     assert_eq!(LogId { term: 1, index: 9 }, last);
     assert!(id.starts_with(&format!("{}-{}-", 1, 9)));
-    assert_eq!(
-        MembershipConfig {
-            members: btreeset![4, 5, 6],
-            members_after_consensus: None,
-        },
-        mem
-    );
 
     let res = pretty_snapshot_iter(it);
     assert_eq!(want, res);
@@ -755,7 +744,7 @@ async fn test_state_machine_snapshot() -> anyhow::Result<()> {
     // test serialized snapshot
 
     {
-        let (it, _last, _mem, _id) = sm.snapshot()?;
+        let (it, _last, _id) = sm.snapshot()?;
 
         let data = StateMachine::serialize_snapshot(it)?;
 

--- a/common/meta/sled-store/Cargo.toml
+++ b/common/meta/sled-store/Cargo.toml
@@ -16,10 +16,10 @@ common-exception = { path = "../../exception" }
 common-tracing = { path = "../../tracing" }
 
 anyhow = "1.0.52"
-async-raft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.6.2-alpha.14.1" }
 byteorder = "1.4.3"
 once_cell = "1.9.0"
 serde = { version = "1.0.133", features = ["derive"] }
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "f633756d60152d171909aea56f80d18905cd4002"}
 serde_json = "1.0.74"
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 tempfile = "3.2.0"

--- a/common/meta/sled-store/src/lib.rs
+++ b/common/meta/sled-store/src/lib.rs
@@ -18,6 +18,7 @@
 pub use db::get_sled_db;
 pub use db::init_sled_db;
 pub use db::init_temp_sled_db;
+pub use openraft;
 pub use sled;
 pub use sled_key_space::SledKeySpace;
 pub use sled_serde::SledOrderedSerde;

--- a/common/meta/sled-store/src/sled_serde.rs
+++ b/common/meta/sled-store/src/sled_serde.rs
@@ -16,11 +16,11 @@ use std::mem::size_of_val;
 use std::ops::Bound;
 use std::ops::RangeBounds;
 
-use async_raft::raft::Entry;
-use async_raft::AppData;
 use byteorder::BigEndian;
 use byteorder::ByteOrder;
 use common_exception::ErrorCode;
+use openraft::raft::Entry;
+use openraft::AppData;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sled::IVec;

--- a/common/meta/sled-store/tests/it/sled_tree.rs
+++ b/common/meta/sled-store/tests/it/sled_tree.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_raft::raft::Entry;
-use async_raft::raft::EntryNormal;
-use async_raft::raft::EntryPayload;
 use common_base::tokio;
 use common_meta_sled_store::SledTree;
 use common_meta_types::Cmd;
@@ -22,6 +19,8 @@ use common_meta_types::LogEntry;
 use common_meta_types::LogId;
 use common_meta_types::LogIndex;
 use common_meta_types::SeqV;
+use openraft::raft::Entry;
+use openraft::raft::EntryPayload;
 use testing::new_sled_test_context;
 
 use crate::init_sled_ut;
@@ -63,12 +62,10 @@ async fn test_sled_tree_append() -> anyhow::Result<()> {
         }),
         (5, Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         }),
@@ -79,12 +76,10 @@ async fn test_sled_tree_append() -> anyhow::Result<()> {
     let want: Vec<Entry<LogEntry>> = vec![
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -122,12 +117,10 @@ async fn test_sled_tree_append_values_and_range_get() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -287,12 +280,10 @@ async fn test_sled_tree_range() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -406,12 +397,10 @@ async fn test_sled_tree_insert() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -467,12 +456,10 @@ async fn test_sled_tree_contains_key() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -529,12 +516,10 @@ async fn test_sled_tree_get() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -573,12 +558,10 @@ async fn test_sled_tree_last() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -660,12 +643,10 @@ async fn test_sled_tree_range_remove() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -722,12 +703,10 @@ async fn test_sled_tree_multi_types() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -792,12 +771,10 @@ async fn test_as_append() -> anyhow::Result<()> {
         }),
         (5, Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         }),
@@ -808,12 +785,10 @@ async fn test_as_append() -> anyhow::Result<()> {
     let want: Vec<Entry<LogEntry>> = vec![
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -852,12 +827,10 @@ async fn test_as_append_values_and_range_get() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -1062,12 +1035,10 @@ async fn test_as_insert() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -1124,12 +1095,10 @@ async fn test_as_contains_key() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -1188,12 +1157,10 @@ async fn test_as_get() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -1229,12 +1196,10 @@ async fn test_as_last() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -1297,12 +1262,10 @@ async fn test_as_range_remove() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },
@@ -1361,12 +1324,10 @@ async fn test_as_multi_types() -> anyhow::Result<()> {
         },
         Entry {
             log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(EntryNormal {
-                data: LogEntry {
-                    txid: None,
-                    cmd: Cmd::IncrSeq {
-                        key: "foo".to_string(),
-                    },
+            payload: EntryPayload::Normal(LogEntry {
+                txid: None,
+                cmd: Cmd::IncrSeq {
+                    key: "foo".to_string(),
                 },
             }),
         },

--- a/common/meta/sled-store/tests/it/testing/fake_key_spaces.rs
+++ b/common/meta/sled-store/tests/it/testing/fake_key_spaces.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_raft::raft::Entry;
 use common_meta_sled_store::SledKeySpace;
 use common_meta_types::LogEntry;
 use common_meta_types::LogIndex;
 use common_meta_types::Node;
 use common_meta_types::NodeId;
 use common_meta_types::SeqV;
+use openraft::raft::Entry;
 
 use crate::testing::fake_state_machine_meta::StateMachineMetaKey;
 use crate::testing::fake_state_machine_meta::StateMachineMetaValue;

--- a/common/meta/sled-store/tests/it/testing/fake_state_machine_meta.rs
+++ b/common/meta/sled-store/tests/it/testing/fake_state_machine_meta.rs
@@ -14,10 +14,10 @@
 
 use std::fmt;
 
-use async_raft::raft::MembershipConfig;
-use async_raft::LogId;
 use common_exception::ErrorCode;
 use common_meta_sled_store::SledOrderedSerde;
+use openraft::LogId;
+use openraft::Membership;
 use serde::Deserialize;
 use serde::Serialize;
 use sled::IVec;
@@ -37,7 +37,7 @@ pub enum StateMachineMetaKey {
 pub enum StateMachineMetaValue {
     LogId(LogId),
     Bool(bool),
-    Membership(MembershipConfig),
+    Membership(Membership),
 }
 
 impl fmt::Display for StateMachineMetaKey {
@@ -99,7 +99,7 @@ impl From<StateMachineMetaValue> for bool {
         }
     }
 }
-impl From<StateMachineMetaValue> for MembershipConfig {
+impl From<StateMachineMetaValue> for Membership {
     fn from(v: StateMachineMetaValue) -> Self {
         match v {
             StateMachineMetaValue::Membership(x) => x,

--- a/common/meta/types/Cargo.toml
+++ b/common/meta/types/Cargo.toml
@@ -14,11 +14,11 @@ test = false
 common-datavalues = { path = "../../datavalues" }
 common-exception = { path = "../../exception" }
 
-async-raft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.6.2-alpha.14.1" }
 derive_more = "0.99.17"
 enumflags2 = { version = "0.7.3", features = ["serde"] }
 lazy_static = "1.4.0"
 maplit = "1.0.2"
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "f633756d60152d171909aea56f80d18905cd4002"}
 once_cell = "1.9.0"
 prost = "0.9.0"
 serde = { version = "1.0.133", features = ["derive"] }

--- a/common/meta/types/src/applied_state.rs
+++ b/common/meta/types/src/applied_state.rs
@@ -14,8 +14,8 @@
 
 use std::fmt::Debug;
 
-use async_raft::AppDataResponse;
 use common_exception::ErrorCode;
+use openraft::AppDataResponse;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/common/meta/types/src/cluster.rs
+++ b/common/meta/types/src/cluster.rs
@@ -17,9 +17,9 @@ use std::fmt;
 use std::net::SocketAddr;
 use std::str::FromStr;
 
-use async_raft::NodeId;
 use common_exception::exception::ErrorCode;
 use common_exception::exception::Result;
+use openraft::NodeId;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/common/meta/types/src/cmd.rs
+++ b/common/meta/types/src/cmd.rs
@@ -14,7 +14,7 @@
 
 use std::fmt;
 
-use async_raft::NodeId;
+use openraft::NodeId;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/common/meta/types/src/log_entry.rs
+++ b/common/meta/types/src/log_entry.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_raft::AppData;
+use openraft::AppData;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/common/meta/types/src/message.rs
+++ b/common/meta/types/src/message.rs
@@ -14,9 +14,9 @@
 
 use std::sync::Arc;
 
-use async_raft::raft::AppendEntriesRequest;
-use async_raft::raft::InstallSnapshotRequest;
-use async_raft::raft::VoteRequest;
+use openraft::raft::AppendEntriesRequest;
+use openraft::raft::InstallSnapshotRequest;
+use openraft::raft::VoteRequest;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;

--- a/common/meta/types/src/raft_types.rs
+++ b/common/meta/types/src/raft_types.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use async_raft::LogId;
-pub use async_raft::NodeId;
+pub use openraft::LogId;
+pub use openraft::NodeId;
 
 pub type LogIndex = u64;
 pub type Term = u64;

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -43,7 +43,6 @@ common-metrics = { path = "../common/metrics" }
 # Crates.io dependencies
 anyerror = "0.1.1"
 anyhow = "1.0.52"
-async-raft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.6.2-alpha.14.1" }
 async-trait = "0.1.52"
 backtrace = "0.3.63"
 byteorder = "1.4.3"

--- a/metasrv/src/errors.rs
+++ b/metasrv/src/errors.rs
@@ -15,6 +15,7 @@
 use anyerror::AnyError;
 use common_exception::ErrorCode;
 use common_exception::SerializedError;
+use common_meta_sled_store::openraft::error::ChangeMembershipError;
 use common_meta_types::NodeId;
 use serde::Deserialize;
 use serde::Serialize;
@@ -26,11 +27,8 @@ pub enum MetaError {
     #[error(transparent)]
     ForwardToLeader(#[from] ForwardToLeader),
 
-    #[error("MembershipChangeInProgress")]
-    MembershipChangeInProgress,
-
     #[error(transparent)]
-    InvalidMembership(#[from] InvalidMembership),
+    ChangeMembershipError(#[from] ChangeMembershipError),
 
     #[error(transparent)]
     ConnectionError(#[from] ConnectionError),
@@ -40,9 +38,6 @@ pub enum MetaError {
 
     #[error("{0}")]
     UnknownError(String),
-    // TODO(xp): RaftError needs impl Serialize etc.
-    // #[error(transparent)]
-    // RaftError(RaftError)
 }
 
 impl From<ErrorCode> for MetaError {

--- a/metasrv/src/meta_service/meta_leader.rs
+++ b/metasrv/src/meta_service/meta_leader.rs
@@ -14,12 +14,11 @@
 
 use std::collections::BTreeSet;
 
-use async_raft::error::ResponseError;
-use async_raft::raft::ClientWriteRequest;
-use async_raft::ChangeConfigError;
-use async_raft::ClientWriteError;
 use common_meta_api::KVApi;
 use common_meta_api::MetaApi;
+use common_meta_sled_store::openraft;
+use common_meta_sled_store::openraft::error::ClientWriteError;
+use common_meta_sled_store::openraft::raft::EntryPayload;
 use common_meta_types::AppliedState;
 use common_meta_types::Cmd;
 use common_meta_types::ForwardRequest;
@@ -28,9 +27,9 @@ use common_meta_types::LogEntry;
 use common_meta_types::Node;
 use common_meta_types::NodeId;
 use common_tracing::tracing;
+use openraft::raft::ClientWriteRequest;
 
 use crate::errors::ForwardToLeader;
-use crate::errors::InvalidMembership;
 use crate::errors::MetaError;
 use crate::meta_service::ForwardRequestBody;
 use crate::meta_service::JoinRequest;
@@ -49,11 +48,13 @@ impl<'a> MetaLeader<'a> {
         MetaLeader { meta_node }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self, req), fields(target=%req.forward_to_leader))]
     pub async fn handle_forwardable_req(
         &self,
         req: ForwardRequest,
     ) -> Result<ForwardResponse, MetaError> {
+        tracing::debug!("handle_forwardable_req: {:?}", req);
+
         match req.body {
             ForwardRequestBody::Join(join_req) => {
                 self.join(join_req).await?;
@@ -114,11 +115,16 @@ impl<'a> MetaLeader<'a> {
         let node_id = req.node_id;
         let addr = req.address;
         let metrics = self.meta_node.metrics_rx.borrow().clone();
-        let mut membership = metrics.membership_config.members.clone();
+        let membership = metrics.membership_config.membership.clone();
 
         if membership.contains(&node_id) {
             return Ok(());
         }
+
+        // TODO(xp): deal with joint config
+        assert!(membership.get_ith_config(1).is_none());
+
+        let mut membership = membership.get_ith_config(0).unwrap().clone();
 
         membership.insert(node_id);
 
@@ -140,7 +146,11 @@ impl<'a> MetaLeader<'a> {
 
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn change_membership(&self, membership: BTreeSet<NodeId>) -> Result<(), MetaError> {
-        let res = self.meta_node.raft.change_membership(membership).await;
+        let res = self
+            .meta_node
+            .raft
+            .change_membership(membership, true)
+            .await;
 
         let err = match res {
             Ok(_) => return Ok(()),
@@ -148,26 +158,14 @@ impl<'a> MetaLeader<'a> {
         };
 
         match err {
-            ResponseError::ChangeConfig(e) => match e {
-                // TODO(xp): enable MetaNode::RaftError when RaftError impl Serialized
-                ChangeConfigError::RaftError(raft_error) => {
-                    Err(MetaError::UnknownError(raft_error.to_string()))
-                }
-                ChangeConfigError::ConfigChangeInProgress => {
-                    Err(MetaError::MembershipChangeInProgress)
-                }
-                ChangeConfigError::InoperableConfig => {
-                    Err(MetaError::InvalidMembership(InvalidMembership {}))
-                }
-                ChangeConfigError::NodeNotLeader(leader) => {
-                    Err(MetaError::ForwardToLeader(ForwardToLeader { leader }))
-                }
-                ChangeConfigError::Noop => Ok(()),
-                _ => Err(MetaError::UnknownError("uncovered error".to_string())),
-            },
+            ClientWriteError::ChangeMembershipError(e) => Err(MetaError::ChangeMembershipError(e)),
             // TODO(xp): enable MetaNode::RaftError when RaftError impl Serialized
-            ResponseError::Raft(raft_error) => Err(MetaError::UnknownError(raft_error.to_string())),
-            _ => Err(MetaError::UnknownError("uncovered error".to_string())),
+            ClientWriteError::Fatal(fatal) => Err(MetaError::UnknownError(fatal.to_string())),
+            ClientWriteError::ForwardToLeader(to_leader) => {
+                Err(MetaError::ForwardToLeader(ForwardToLeader {
+                    leader: to_leader.leader_id,
+                }))
+            }
         }
     }
 
@@ -181,7 +179,7 @@ impl<'a> MetaLeader<'a> {
         let write_rst = self
             .meta_node
             .raft
-            .client_write(ClientWriteRequest::new(entry))
+            .client_write(ClientWriteRequest::new(EntryPayload::Normal(entry)))
             .await;
 
         tracing::debug!("raft.client_write rst: {:?}", write_rst);
@@ -190,12 +188,15 @@ impl<'a> MetaLeader<'a> {
             Ok(resp) => Ok(resp.data),
             Err(cli_write_err) => match cli_write_err {
                 // fatal error
-                ClientWriteError::RaftError(raft_err) => {
-                    Err(MetaError::UnknownError(raft_err.to_string()))
-                }
+                ClientWriteError::Fatal(fatal) => Err(MetaError::UnknownError(fatal.to_string())),
                 // retryable error
-                ClientWriteError::ForwardToLeader(_, leader) => {
-                    Err(MetaError::ForwardToLeader(ForwardToLeader { leader }))
+                ClientWriteError::ForwardToLeader(to_leader) => {
+                    Err(MetaError::ForwardToLeader(ForwardToLeader {
+                        leader: to_leader.leader_id,
+                    }))
+                }
+                ClientWriteError::ChangeMembershipError(_) => {
+                    unreachable!("there should not be a ChangeMembershipError for client_write")
                 }
             },
         }

--- a/metasrv/src/store/mod.rs
+++ b/metasrv/src/store/mod.rs
@@ -13,5 +13,7 @@
 // limitations under the License.
 
 mod meta_raft_store;
+mod to_storage_error;
 
 pub use meta_raft_store::MetaRaftStore;
+pub use to_storage_error::ToStorageError;

--- a/metasrv/src/store/to_storage_error.rs
+++ b/metasrv/src/store/to_storage_error.rs
@@ -1,0 +1,39 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyerror::AnyError;
+use common_exception::ErrorCode;
+use common_meta_sled_store::openraft;
+use openraft::ErrorSubject;
+use openraft::ErrorVerb;
+use openraft::StorageError;
+use openraft::StorageIOError;
+
+/// Convert error to openraft::StorageError;  
+pub trait ToStorageError<T> {
+    fn map_to_sto_err(self, subject: ErrorSubject, verb: ErrorVerb) -> Result<T, StorageError>;
+}
+
+impl<T> ToStorageError<T> for Result<T, ErrorCode> {
+    fn map_to_sto_err(self, subject: ErrorSubject, verb: ErrorVerb) -> Result<T, StorageError> {
+        match self {
+            Ok(x) => Ok(x),
+            Err(e) => {
+                let ae = AnyError::new(&e);
+                let io_err = StorageIOError::new(subject, verb, ae);
+                Err(io_err.into())
+            }
+        }
+    }
+}

--- a/metasrv/tests/it/meta_node/meta_node_all.rs
+++ b/metasrv/tests/it/meta_node/meta_node_all.rs
@@ -15,11 +15,13 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use async_raft::RaftMetrics;
-use async_raft::State;
 use common_base::tokio;
 use common_base::tokio::time::Duration;
 use common_meta_api::KVApi;
+use common_meta_sled_store::openraft;
+use common_meta_sled_store::openraft::LogIdOptionExt;
+use common_meta_sled_store::openraft::RaftMetrics;
+use common_meta_sled_store::openraft::State;
 use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use common_meta_types::AppliedState;
 use common_meta_types::Change;
@@ -257,7 +259,7 @@ async fn test_meta_node_add_database() -> anyhow::Result<()> {
             assert!(rst.is_ok());
 
             // No matter if a db is created, the log that tries to create db always applies.
-            assert_applied_index(all.clone(), last_applied + 1).await?;
+            assert_applied_index(all.clone(), last_applied.next_index()).await?;
 
             for (i, mn) in all.iter().enumerate() {
                 let got = mn
@@ -290,6 +292,7 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
     let mut tc = MetaSrvTestContext::new(0);
     tc.config.raft_config.snapshot_logs_since_last = snap_logs;
     tc.config.raft_config.install_snapshot_timeout = 10_1000; // milli seconds. In a CI multi-threads test delays async task badly.
+    tc.config.raft_config.max_applied_log_to_keep = 0;
     let addr = tc.config.raft_config.raft_api_addr();
 
     let mn = MetaNode::boot(&tc.config.raft_config).await?;
@@ -299,11 +302,12 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
     wait_for_state(&mn, State::Leader).await?;
     wait_for_current_leader(&mn, 0).await?;
 
-    let mut n_logs = 2;
+    // initial membership, leader blank log, add node.
+    let mut log_index = 2;
 
     mn.raft
         .wait(timeout())
-        .log(n_logs, "leader init logs")
+        .log(Some(log_index), "leader init logs")
         .await?;
 
     let n_req = 12;
@@ -321,13 +325,13 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
         })
         .await?;
     }
-    n_logs += n_req;
+    log_index += n_req;
 
     tracing::info!("--- check the log is locally applied");
 
     mn.raft
         .wait(timeout())
-        .log(n_logs, "applied on leader")
+        .log(Some(log_index), "applied on leader")
         .await?;
 
     tracing::info!("--- check the snapshot is created");
@@ -335,7 +339,7 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
     mn.raft
         .wait(timeout())
         .metrics(
-            |x| x.snapshot.term == 1 && x.snapshot.index >= 10,
+            |x| x.snapshot.map(|x| x.term) == Some(1) && x.snapshot.next_index() >= snap_logs,
             "snapshot is created by leader",
         )
         .await?;
@@ -343,19 +347,19 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
     tracing::info!("--- start a non_voter to receive snapshot replication");
 
     let (_, tc1) = start_meta_node_non_voter(mn.clone(), 1).await?;
-    n_logs += 1;
+    log_index += 1;
 
     let mn1 = tc1.meta_nodes[0].clone();
 
     mn1.raft
         .wait(timeout())
-        .log(n_logs, "non-voter replicated all logs")
+        .log(Some(log_index), "non-voter replicated all logs")
         .await?;
 
     mn1.raft
         .wait(timeout())
         .metrics(
-            |x| x.snapshot.term == 1 && x.snapshot.index >= 10,
+            |x| x.snapshot.map(|x| x.term) == Some(1) && x.snapshot.next_index() >= snap_logs,
             "snapshot is received by non-voter",
         )
         .await?;
@@ -619,7 +623,7 @@ async fn test_meta_node_restart() -> anyhow::Result<()> {
     let meta_nodes = vec![mn0.clone(), mn1.clone()];
 
     wait_for_state(&mn0, State::Leader).await?;
-    wait_for_state(&mn1, State::NonVoter).await?;
+    wait_for_state(&mn1, State::Learner).await?;
     wait_for_current_leader(&mn1, 0).await?;
 
     assert_upsert_kv_synced(meta_nodes.clone(), "key2").await?;
@@ -653,9 +657,10 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    let mut log_cnt: u64 = 0;
+    let mut log_index: u64 = 0;
     let (_id, mut tc) = start_meta_node_leader().await?;
-    log_cnt += 2;
+    // initial membeship, leader blank, add node
+    log_index += 2;
 
     let want_hs;
     {
@@ -674,7 +679,7 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
                 },
             })
             .await?;
-        log_cnt += 1;
+        log_index += 1;
 
         want_hs = leader.sto.raft_state.read_hard_state()?;
 
@@ -685,10 +690,10 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
 
     let leader = MetaNode::open_create_boot(&tc.config.raft_config, Some(()), None, None).await?;
 
-    log_cnt += 1;
+    log_index += 1;
 
     wait_for_state(&leader, State::Leader).await?;
-    wait_for_log(&leader, log_cnt as u64).await?;
+    wait_for_log(&leader, log_index as u64).await?;
 
     tracing::info!("--- check hard state");
     {
@@ -700,7 +705,7 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
     {
         let logs = leader.sto.log.range_values(..)?;
         tracing::info!("logs: {:?}", logs);
-        assert_eq!(log_cnt as usize, logs.len());
+        assert_eq!(log_index as usize + 1, logs.len());
     }
 
     tracing::info!("--- check state machine: nodes");
@@ -729,9 +734,9 @@ async fn start_meta_node_cluster(
     let leader = tc0.meta_nodes[0].clone();
     res.push(tc0);
 
-    // blank log and add node
-    let mut nlog = 2;
-    wait_for_log(&leader, nlog).await?;
+    // membership log, blank log and add node
+    let mut log_index = 2;
+    wait_for_log(&leader, log_index).await?;
 
     for id in voters.iter() {
         // leader is already created.
@@ -741,8 +746,13 @@ async fn start_meta_node_cluster(
         let (_id, tc) = start_meta_node_non_voter(leader.clone(), *id).await?;
 
         // Adding a node
-        nlog += 1;
-        wait_for_log(&tc.meta_nodes[0], nlog).await?;
+        log_index += 1;
+        // wait_for_log(&tc.meta_nodes[0], log_index).await?;
+        tc.meta_nodes[0]
+            .raft
+            .wait(timeout())
+            .log(Some(log_index), format!("add :{}", id))
+            .await?;
 
         res.push(tc);
     }
@@ -751,14 +761,22 @@ async fn start_meta_node_cluster(
         let (_id, tc) = start_meta_node_non_voter(leader.clone(), *id).await?;
 
         // Adding a node
-        nlog += 1;
-        wait_for_log(&tc.meta_nodes[0], nlog).await?;
+        log_index += 1;
+
+        tc.meta_nodes[0]
+            .raft
+            .wait(timeout())
+            .log(Some(log_index), format!("add :{}", id))
+            .await?;
+        // wait_for_log(&tc.meta_nodes[0], log_index).await?;
 
         res.push(tc);
     }
 
-    leader.raft.change_membership(voters.clone()).await?;
-    nlog += 2;
+    if voters != btreeset! {0} {
+        leader.raft.change_membership(voters.clone(), true).await?;
+        log_index += 2;
+    }
 
     tracing::info!("--- check node roles");
     {
@@ -768,18 +786,18 @@ async fn start_meta_node_cluster(
             wait_for_state(&item.meta_nodes[0], State::Follower).await?;
         }
         for item in res.iter().skip(voters.len()).take(non_voters.len()) {
-            wait_for_state(&item.meta_nodes[0], State::NonVoter).await?;
+            wait_for_state(&item.meta_nodes[0], State::Learner).await?;
         }
     }
 
     tracing::info!("--- check node logs");
     {
         for tc in &res {
-            wait_for_log(&tc.meta_nodes[0], nlog).await?;
+            wait_for_log(&tc.meta_nodes[0], log_index).await?;
         }
     }
 
-    Ok((nlog, res))
+    Ok((log_index, res))
 }
 
 async fn start_meta_node_leader() -> anyhow::Result<(NodeId, MetaSrvTestContext)> {
@@ -838,7 +856,7 @@ async fn start_meta_node_non_voter(
 
     {
         assert_metasrv_connection(&addr).await?;
-        wait_for_state(&mn, State::NonVoter).await?;
+        wait_for_state(&mn, State::Learner).await?;
         wait_for_current_leader(&mn, 0).await?;
     }
 
@@ -859,7 +877,7 @@ async fn assert_upsert_kv_synced(meta_nodes: Vec<Arc<MetaNode>>, key: &str) -> a
     let leader = meta_nodes[leader_id as usize].clone();
 
     let last_applied = leader.raft.metrics().borrow().last_applied;
-    tracing::info!("leader: last_applied={}", last_applied);
+    tracing::info!("leader: last_applied={:?}", last_applied);
     {
         leader
             .as_leader()
@@ -876,7 +894,7 @@ async fn assert_upsert_kv_synced(meta_nodes: Vec<Arc<MetaNode>>, key: &str) -> a
             .await?;
     }
 
-    assert_applied_index(meta_nodes.clone(), last_applied + 1).await?;
+    assert_applied_index(meta_nodes.clone(), last_applied.next_index()).await?;
     assert_get_kv(meta_nodes.clone(), key, key).await?;
 
     Ok(1)
@@ -893,7 +911,7 @@ async fn assert_upsert_kv_on_specified_node_synced(
     let leader = meta_nodes[leader_id as usize].clone();
 
     let last_applied = leader.raft.metrics().borrow().last_applied;
-    tracing::info!("leader: last_applied={}", last_applied);
+    tracing::info!("leader: last_applied={:?}", last_applied);
 
     {
         write_to
@@ -909,7 +927,7 @@ async fn assert_upsert_kv_on_specified_node_synced(
             .await?;
     }
 
-    assert_applied_index(meta_nodes.clone(), last_applied + 1).await?;
+    assert_applied_index(meta_nodes.clone(), last_applied.next_index()).await?;
     assert_get_kv(meta_nodes.clone(), key, key).await?;
 
     Ok(1)
@@ -958,16 +976,13 @@ pub async fn wait_for_current_leader(
 /// Wait for raft log to become the expected `index` until a default 2000 ms time out.
 #[tracing::instrument(level = "info", skip(mn))]
 async fn wait_for_log(mn: &MetaNode, index: u64) -> anyhow::Result<RaftMetrics> {
-    let metrics = mn.raft.wait(timeout()).log(index, "").await?;
+    let metrics = mn.raft.wait(timeout()).log(Some(index), "").await?;
     Ok(metrics)
 }
 
 /// Wait for raft state to become the expected `state` until a default 2000 ms time out.
 #[tracing::instrument(level = "debug", skip(mn))]
-pub async fn wait_for_state(
-    mn: &MetaNode,
-    state: async_raft::State,
-) -> anyhow::Result<RaftMetrics> {
+pub async fn wait_for_state(mn: &MetaNode, state: openraft::State) -> anyhow::Result<RaftMetrics> {
     let metrics = mn.raft.wait(timeout()).state(state, "").await?;
     Ok(metrics)
 }
@@ -1022,10 +1037,13 @@ async fn test_meta_node_cluster_write_on_non_leader() -> anyhow::Result<()> {
                 panic!("expect node")
             }
         }
-        mn1.raft.wait(timeout()).state(State::NonVoter, "").await?;
+        mn1.raft.wait(timeout()).state(State::Learner, "").await?;
         mn1.raft.wait(timeout()).current_leader(0, "").await?;
         // 3 log: init blank log, add-node-0 log, add-node-1 log
-        mn1.raft.wait(timeout()).log(3, "replicated log").await?;
+        mn1.raft
+            .wait(timeout())
+            .log(Some(3), "replicated log")
+            .await?;
     }
 
     let mut client1 = tc1.raft_client().await?;

--- a/metasrv/tests/it/tests/service.rs
+++ b/metasrv/tests/it/tests/service.rs
@@ -15,11 +15,11 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use async_raft::NodeId;
 use common_base::tokio;
 use common_base::GlobalSequence;
 use common_base::Stoppable;
 use common_meta_grpc::MetaGrpcClient;
+use common_meta_sled_store::openraft::NodeId;
 use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use common_meta_types::protobuf::GetRequest;
 use common_tracing::tracing;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Update openraft to https://github.com/datafuselabs/openraft/commit/f633756d60152d171909aea56f80d18905cd4002

## Changelog

[meta] feature: upgrade openraft

- Feature: add raft config: `max_applied_log_to_keep`.

- Feature: upgrade meta store to latest `RaftStorage`:

Benefit:

- Explicit, strict and simpler API definition makes impl much easier.
- New `RaftStorage` provides default impl if possible.
- Provided test suite guarantees an impl is correct.

Changes:

- Stores `last_purged_log_id`, to support append-entries without
  needs of StateMachine.
- A snapshot does not need to store last-membership in its meta.

- Removed log entry type `SnapshotPointer`, which requires
  transactional update to log store and state machine and introduce
  unnecessary complex.

- Storage APIs always returns `StorageError`. It describes errors
  precisely.

- Simplified struct `Entry`.

- Use errors provided by openraft if possible. Avoid re-define
  errors, such as `ForwardToLeader` etc.

- Remove methods that have default impl in `RaftStorage`.

- Test `MetaRaftStore` with test suite provided by openraft.

Openraft changes:

-   Fix: a single Candidate should be able to vote itself.

    A Candidate should check if it is the only member in a cluster before
    sending vote request.
    Otherwise a single node cluster does work.

-   Fix: when lack entry, the snapshot to build has to include at least all purged logs

-   Fix: save leader_id if a higher term is seen when handling append-entries RPC

    Problem:

    A follower saves hard state `(term=msg.term, voted_for=None)`
    when a `msg.term > local.term` when handling append-entries RPC.

    This is quite enough to be correct but not perfect. Correct because:

    - In one term, only an established leader will send append-entries;

    - Thus, there is a quorum voted for this leader;

    - Thus, no matter what `voted_for` is saved, it is still correct. E.g.
      when handling append-entries, a follower node could save hard state
      `(term=msg.term, voted_for=Some(ANY_VALUE))`.

    The problem is that a follower already knows the legal leader for a term
    but still does not save it. This leads to an unstable cluster state: The
    test sometimes fails.

    Solution:

    A follower always save hard state with the id of a known legal leader.

-   Fix: consider joint config when starting up and committing.

-   Fix: commit without replication only when membership contains only one node.

    Previously it just checks the first config, which results in
    data loss if the cluster is in a joint config.

-   Fix: when starting up, count all nodes but not only the nodes in the first config to decide if it is a single node cluster.

-   Fix: a restarted follower should not wait too long to elect. Otherwise the entire cluster hangs

-   Fix: the timeout for `Wait()` should be a total timeout. Otherwise a `Wait()` never quits.

-   Fix: when send append-entries request, if a log is not found, it should retry loading, but not enter snapshot state.

    Because a log may be deleted by RaftCore just after Replication read
    `prev_log_id` from the store.

-   Fix: handle-vote should compare last_log_id in dictionary order, not in vector order

    A log `{term:2, index:1}` is definitely greater than log `{term:1, index:2}` in raft spec.
    Comparing log id in the way of `term1 >= term2 && index1 >= index2` blocks election:
    no one can become a leader.

-   Fix: at first always init `matched` to `term:0, index:0`.

    This field can only be updated monotonically.
    It should reflect the actual replication progress.

-   Fix: race condition of concurrent snapshot-install and apply.

    Problem:

    Concurrent snapshot-install and apply mess up `last_applied`.

    `finalize_snapshot_installation` runs in the `RaftCore` thread.
    `apply_to_state_machine` runs in a separate tokio task(thread).

    Thus there is chance the `last_applied` being reset to a previous value:

    - `apply_to_state_machine` is called and finished in a thread.

    - `finalize_snapshot_installation` is called in `RaftCore` thread and
      finished with `last_applied` updated.

    - `RaftCore` thread finished waiting for `apply_to_state_machine`, and
      updated `last_applied` to a previous value.

    ```
    RaftCore: -.    install-snapshot,         .-> replicate_to_sm_handle.next(),
               |    update last_applied=5     |   update last_applied=2
               |                              |
               v                              |
    task:      apply 2------------------------'
    --------------------------------------------------------------------> time
    ```

    Solution:

    Rule: All changes to state machine must be serialized.

    A temporary simple solution for now is to call all methods that modify state
    machine in `RaftCore` thread.
    But this way it blocks `RaftCore` thread.

    A better way is to move all tasks that modifies state machine to a
    standalone thread, and send update request back to `RaftCore` to update
    its fields such as `last_applied`

-   Fix: a non-voter not in joint config should not block replication

-   Fix: when append-entries, deleting entries after prev-log-id causes committed entry to be lost

    Problem:

    When append-entries, raft core removes old entries after
    `prev_log_id.index`, then append new logs sent from leader.

    Since deleting then appending entries are not atomic(two calls to `RaftStore`),
    deleting consistent entries may cause loss of committed entries, if
    server crashes after the delete.

    E.g., an example cluster state with logs as following and R1 now is the leader:

    ```
    R1 1,1  1,2  1,3
    R2 1,1  1,2
    R3
    ```

    Committed entry `{1,2}` gets lost after the following steps:

    - R1 to R2: `append_entries(entries=[{1,2}, {1,3}], prev_log_id={1,1})`
    - R2 deletes 1,2
    - R2 crash
    - R2 is elected as leader with R3, and only see 1,1; the committed entry 1,2 is lost.

    Solution:

    The safe way is to skip every entry that are consistent to the leader.
    And delete only the inconsistent entries.

    Another issue with this solution is that:

    Because we can not just delete `log[prev_log_id.index..]`, the commit index:
    - must be update only after append-entries,
    - and must point to a log entry that is consistent to leader.

    Or there could be chance applying an uncommitted entry:

    ```
    R0 1,1  1,2  3,3
    R1 1,1  1,2  2,3
    R2 1,1  1,2  3,3
    ```

    - R0 to R1 `append_entries: entries=[{1,2}], prev_log_id = {1,1}, commit_index = 3`
    - R1 accepted this `append_entries` request but was not aware of that entry {2,3} is inconsistent to leader.
      Updating commit index to 3 allows it to apply an uncommitted entrie `{2,3}`.

-   Fix: too many(50) inconsistent log should not live lock append-entries

    - Reproduce the bug that when append-entries, if there are more than 50
      inconsistent logs,  the responded `conflict` is always set to
      `self.last_log`, which blocks replication for ever.
      Because the next time append-entries use the same `prev_log_id`, it
      actually does not search backward for the first consistent log entry.

      https://github.com/drmingdrmer/async-raft/blob/79a39970855d80e1d3b761fadbce140ecf1da59e/async-raft/src/core/append_entries.rs#L131-L154

    The test to reproduce it fakes a cluster of node 0,1,2:
    R0 has 100 uncommitted log at term 2.
    R2 has 100 uncommitted log at term 3.

    ```
    R0 ... 2,99 2,100
    R1
    R2 ... 3,99, 3,00
    ```

    Before this fix, brings up the cluster, R2 becomes leader and will never sync any log to R0.

    The fix is also quite simple:

    - Search backward instead of searching forward, to find the last log
      entry that matches `prev_log_id.term`, and responds this log id to the
      leader to let it send next `append_entries` RPC since this log id.

    - If no such matching term is found, use the first log id it sees, e.g.,
      the entry at index `prev_log_id.index - 50` for next `append_entries`.


## Related Issues

- Fix: #3741
- Fix: #3474 

## Test Plan



