### PR TITLE
[common/tracing] test: add span logging for metasrv

### DIFF
--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -57,8 +57,8 @@ runs:
       with:
         path: |
           _local_fs/
-          _logs/
-          _meta/
-          metasrv/_logs/
-          query/_logs/
-          store/_logs/
+          _logs*/
+          _meta*/
+          metasrv/_logs*/
+          query/_logs*/
+          store/_logs*/

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ profile:
 clean:
 	cargo clean
 	rm -f ./nohup.out ./tests/suites/0_stateless/*.stdout-e
-	rm -rf ./_meta*/ ./_logs/ ./query/_logs/ ./metasrv/_logs/
-	rm -rf ./common/base/_logs/ ./common/meta/raft-store/_logs/ ./common/meta/sled-store/_logs/
+	rm -rf ./_meta*/ ./_logs*/ ./query/_logs*/ ./metasrv/_logs*/
+	rm -rf ./common/base/_logs*/ ./common/meta/raft-store/_logs*/ ./common/meta/sled-store/_logs*/
 
 .PHONY: setup test run build fmt lint docker clean

--- a/common/meta/raft-store/tests/it/testing.rs
+++ b/common/meta/raft-store/tests/it/testing.rs
@@ -45,7 +45,7 @@ macro_rules! init_raft_store_ut {
         common_meta_sled_store::init_temp_sled_db(t);
 
         // common_tracing::init_tracing(&format!("ut-{}", name), "./_logs")
-        common_tracing::init_default_ut_tracing();
+        common_tracing::init_meta_ut_tracing();
 
         let name = common_tracing::func_name!();
         let span =

--- a/common/meta/sled-store/tests/it/testing/mod.rs
+++ b/common/meta/sled-store/tests/it/testing/mod.rs
@@ -27,7 +27,7 @@ macro_rules! init_sled_ut {
         let t = tempfile::tempdir().expect("create temp dir to sled db");
 
         common_meta_sled_store::init_temp_sled_db(t);
-        common_tracing::init_default_ut_tracing();
+        common_tracing::init_meta_ut_tracing();
 
         let name = common_tracing::func_name!();
         let span =

--- a/common/tracing/src/lib.rs
+++ b/common/tracing/src/lib.rs
@@ -18,6 +18,7 @@ mod tracing_to_jaeger;
 
 pub use logging::init_default_ut_tracing;
 pub use logging::init_global_tracing;
+pub use logging::init_meta_ut_tracing;
 pub use panic_hook::set_panic_hook;
 pub use tracing;
 pub use tracing_futures;

--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -20,15 +20,26 @@ use std::sync::Once;
 use once_cell::sync::Lazy;
 use opentelemetry::global;
 use opentelemetry::sdk::propagation::TraceContextPropagator;
+use tracing::Event;
+use tracing::Subscriber;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::RollingFileAppender;
 use tracing_appender::rolling::Rotation;
 use tracing_bunyan_formatter::BunyanFormattingLayer;
 use tracing_bunyan_formatter::JsonStorageLayer;
+use tracing_subscriber::fmt;
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::time::FormatTime;
+use tracing_subscriber::fmt::time::SystemTime;
+use tracing_subscriber::fmt::FmtContext;
+use tracing_subscriber::fmt::FormatEvent;
+use tracing_subscriber::fmt::FormatFields;
+use tracing_subscriber::fmt::FormattedFields;
 use tracing_subscriber::fmt::Layer;
-use tracing_subscriber::prelude::*;
-use tracing_subscriber::registry::Registry;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Registry;
 
 /// Init tracing for unittest.
 /// Write logs to file `unittest`.
@@ -91,6 +102,100 @@ pub fn init_global_tracing(app_name: &str, dir: &str, level: &str) -> Vec<Worker
 
     #[cfg(feature = "console")]
     let subscriber = subscriber.with(console_subscriber::spawn());
+
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("error setting global tracing subscriber");
+
+    guards
+}
+
+/// Initialize unit test tracing for metasrv
+pub fn init_meta_ut_tracing() {
+    static START: Once = Once::new();
+
+    START.call_once(|| {
+        let mut g = META_UT_LOG_GUARD.as_ref().lock().unwrap();
+        *g = Some(do_init_meta_ut_tracing(
+            "unittest-meta",
+            "_logs_unittest",
+            "DEBUG",
+        ));
+    });
+}
+
+static META_UT_LOG_GUARD: Lazy<Arc<Mutex<Option<Vec<WorkerGuard>>>>> =
+    Lazy::new(|| Arc::new(Mutex::new(None)));
+
+pub struct EventFormatter {}
+
+impl<S, N> FormatEvent<S, N> for EventFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        let meta = event.metadata();
+
+        SystemTime {}.format_time(&mut writer)?;
+        writer.write_char(' ')?;
+
+        let fmt_level = meta.level().as_str();
+        write!(writer, "{:>5} ", fmt_level)?;
+
+        write!(writer, "{:0>2?} ", std::thread::current().id())?;
+
+        if let Some(scope) = ctx.event_scope() {
+            let mut seen = false;
+
+            for span in scope.from_root() {
+                write!(writer, "{}", span.metadata().name())?;
+                write!(writer, "#{:x}", span.id().into_u64())?;
+
+                seen = true;
+
+                let ext = span.extensions();
+                if let Some(fields) = &ext.get::<FormattedFields<N>>() {
+                    if !fields.is_empty() {
+                        write!(writer, "{{{}}}", fields)?;
+                    }
+                }
+                write!(writer, ":")?;
+            }
+
+            if seen {
+                writer.write_char(' ')?;
+            }
+        };
+
+        ctx.format_fields(writer.by_ref(), event)?;
+        writeln!(writer)
+    }
+}
+
+pub fn do_init_meta_ut_tracing(app_name: &str, dir: &str, level: &str) -> Vec<WorkerGuard> {
+    let mut guards = vec![];
+
+    let span_rolling_appender = RollingFileAppender::new(Rotation::HOURLY, dir, app_name);
+    let (writer, writer_guard) = tracing_appender::non_blocking(span_rolling_appender);
+
+    let f_layer = fmt::Layer::new()
+        .with_span_events(fmt::format::FmtSpan::FULL)
+        .with_writer(writer)
+        .with_ansi(false)
+        .event_format(EventFormatter {});
+
+    guards.push(writer_guard);
+
+    // Use env RUST_LOG to initialize log if present.
+    // Otherwise use the specified level.
+    let directives = env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_x| level.to_string());
+    let env_filter = EnvFilter::new(directives);
+    let subscriber = Registry::default().with(env_filter).with(f_layer);
 
     tracing::subscriber::set_global_default(subscriber)
         .expect("error setting global tracing subscriber");

--- a/metasrv/tests/it/tests/service.rs
+++ b/metasrv/tests/it/tests/service.rs
@@ -200,7 +200,7 @@ macro_rules! init_meta_ut {
         common_meta_sled_store::init_temp_sled_db(t);
 
         // common_tracing::init_tracing(&format!("ut-{}", name), "./_logs")
-        common_tracing::init_default_ut_tracing();
+        common_tracing::init_meta_ut_tracing();
 
         let name = common_tracing::func_name!();
         let span =

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -36,7 +36,6 @@ def remove_control_characters(s):
     """
     https://github.com/html5lib/html5lib-python/issues/96#issuecomment-43438438
     """
-
     def str_to_int(s, default, base=10):
         if int(s, base) < 0x10000:
             return chr(int(s, base))

--- a/tests/helpers/client.py
+++ b/tests/helpers/client.py
@@ -14,7 +14,6 @@ sys.path.insert(0, os.path.join(CURDIR))
 
 
 class client(object):
-
     def __init__(self, name='', log=None):
         self.name = name
         self.log = log

--- a/tests/suites/0_stateless/00_0000_dummy_select_py.py
+++ b/tests/suites/0_stateless/00_0000_dummy_select_py.py
@@ -31,7 +31,6 @@ client1.run("select 3")
 
 
 class MyModel(object):
-
     def __init__(self, name, value):
         self.name = name
         self.value = value


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [common/tracing] test: add span logging for metasrv

- Also log span id for easy grep.

- Clean `_logs*` in Makefile and Upload `_logs*/ artifact.

## Changelog




- Improvement
- Build/Testing/CI

## Related Issues