### PR TITLE
[metasrv] refactor: remove unnecessary MetaNode.metrics_rx

### DIFF
--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -235,8 +235,6 @@ impl StateMachine {
     /// command safely in case of network failure etc.
     #[tracing::instrument(level = "debug", skip(self, entry), fields(log_id=%entry.log_id))]
     pub async fn apply(&self, entry: &Entry<LogEntry>) -> common_exception::Result<AppliedState> {
-        // TODO(xp): all update need to be done in a tx.
-
         tracing::debug!("apply: summary: {}", entry.summary());
         tracing::debug!("apply: payload: {:?}", entry.payload);
 

--- a/metasrv/src/meta_service/meta_leader.rs
+++ b/metasrv/src/meta_service/meta_leader.rs
@@ -114,7 +114,7 @@ impl<'a> MetaLeader<'a> {
     pub async fn join(&self, req: JoinRequest) -> Result<(), MetaError> {
         let node_id = req.node_id;
         let addr = req.address;
-        let metrics = self.meta_node.metrics_rx.borrow().clone();
+        let metrics = self.meta_node.raft.metrics().borrow().clone();
         let membership = metrics.membership_config.membership.clone();
 
         if membership.contains(&node_id) {

--- a/metasrv/tests/it/store.rs
+++ b/metasrv/tests/it/store.rs
@@ -20,6 +20,8 @@ use common_meta_raft_store::state_machine::testing::pretty_snapshot;
 use common_meta_raft_store::state_machine::testing::snapshot_logs;
 use common_meta_raft_store::state_machine::SerializableSnapshot;
 use common_meta_sled_store::openraft::async_trait::async_trait;
+use common_meta_sled_store::openraft::raft::Entry;
+use common_meta_sled_store::openraft::raft::EntryPayload;
 use common_meta_sled_store::openraft::storage::HardState;
 use common_meta_sled_store::openraft::testing::StoreBuilder;
 use common_meta_sled_store::openraft::EffectiveMembership;
@@ -29,6 +31,7 @@ use common_meta_sled_store::openraft::RaftStorage;
 use common_meta_types::AppliedState;
 use common_meta_types::LogEntry;
 use common_tracing::tracing;
+use common_tracing::tracing_futures::Instrument;
 use databend_meta::store::MetaRaftStore;
 use databend_meta::Opened;
 use maplit::btreeset;
@@ -36,12 +39,12 @@ use maplit::btreeset;
 use crate::init_meta_ut;
 use crate::tests::service::MetaSrvTestContext;
 
-struct BB {
+struct MetaStoreBuilder {
     pub test_contexts: Arc<Mutex<Vec<MetaSrvTestContext>>>,
 }
 
 #[async_trait]
-impl StoreBuilder<LogEntry, AppliedState, MetaRaftStore> for BB {
+impl StoreBuilder<LogEntry, AppliedState, MetaRaftStore> for MetaStoreBuilder {
     async fn build(&self) -> MetaRaftStore {
         let tc = MetaSrvTestContext::new(555);
         let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(()))
@@ -61,7 +64,7 @@ fn test_impl_raft_storage() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    common_meta_sled_store::openraft::testing::Suite::test_all(BB {
+    common_meta_sled_store::openraft::testing::Suite::test_all(MetaStoreBuilder {
         test_contexts: Arc::new(Mutex::new(vec![])),
     })?;
 
@@ -69,271 +72,96 @@ fn test_impl_raft_storage() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_metasrv_restart() -> anyhow::Result<()> {
-    // - Create a metasrv
-    // - Update metasrv
+async fn test_meta_store_restart() -> anyhow::Result<()> {
+    // - Create a meta store
+    // - Update meta store
     // - Close and reopen it
-    // - Test state is restored
-
-    // TODO check log
-    // TODO check state machine
+    // - Test state is restored: hard state, log, state machine
 
     let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
 
-    let id = 3;
-    let tc = MetaSrvTestContext::new(id);
-
-    tracing::info!("--- new metasrv");
-    {
-        let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
-        assert_eq!(id, ms.id);
-        assert!(!ms.is_opened());
-        assert_eq!(None, ms.read_hard_state().await?);
-
-        tracing::info!("--- update metasrv");
-
-        ms.save_hard_state(&HardState {
-            current_term: 10,
-            voted_for: Some(5),
-        })
-        .await?;
-    }
-
-    tracing::info!("--- reopen metasrv");
-    {
-        let ms = MetaRaftStore::open_create(&tc.config.raft_config, Some(()), None).await?;
-        assert_eq!(id, ms.id);
-        assert!(ms.is_opened());
-        assert_eq!(
-            Some(HardState {
-                current_term: 10,
-                voted_for: Some(5),
-            }),
-            ms.read_hard_state().await?
-        );
-    }
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_metasrv_do_log_compaction_1_snap_ptr_1_log() -> anyhow::Result<()> {
-    // - Create a metasrv
-    // - Apply logs
-    // - Create a snapshot check snapshot state
-
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
-    let id = 3;
-    let tc = MetaSrvTestContext::new(id);
-
-    let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
-
-    tracing::info!("--- feed logs and state machine");
-
-    let (logs, _want) = snapshot_logs();
-
-    for (i, l) in logs.iter().enumerate() {
-        ms.log.insert(l).await?;
-
-        if i < 2 {
-            ms.state_machine.write().await.apply(l).await?;
-        }
-    }
-
-    let curr_snap = ms.build_snapshot().await?;
-    assert_eq!(LogId { term: 1, index: 4 }, curr_snap.meta.last_log_id);
-
-    tracing::info!("--- check snapshot");
-    {
-        let data = curr_snap.snapshot.into_inner();
-
-        let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
-        let res = pretty_snapshot(&ser_snap.kvs);
-        tracing::debug!("res: {:?}", res);
-
-        let want = vec![
-            "[3, 1]:{\"LogId\":{\"term\":1,\"index\":4}}", // sm meta: LastApplied
-            "[3, 2]:{\"Bool\":true}",                      // sm meta: init
-            "[3, 3]:{\"Membership\":{\"log_id\":{\"term\":1,\"index\":1},\"membership\":{\"configs\":[[1,2,3]],\"all_nodes\":[1,2,3]}}}", // membership
-            "[6, 97]:{\"seq\":1,\"meta\":null,\"data\":[65]}", // generic kv
-            "[7, 103, 101, 110, 101, 114, 105, 99, 45, 107, 118]:1", // sequence: by upsertkv
-        ]
-        .iter()
-        .map(|x| x.to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(want, res);
-    }
-
-    tracing::info!("--- check logs");
-    {
-        let log_indexes = ms.log.range_keys(..)?;
-        // build_snapshot does not purge logs
-        assert_eq!(vec![1u64, 4u64, 5u64, 6, 8, 9], log_indexes);
-    }
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_metasrv_do_log_compaction_all_logs_with_memberchange() -> anyhow::Result<()> {
-    // - Create a metasrv
-    // - Apply logs
-    // - Create a snapshot check snapshot state
-
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
-    let id = 3;
-    let tc = MetaSrvTestContext::new(id);
-
-    let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
-
-    tracing::info!("--- feed logs and state machine");
-
-    let (logs, want) = snapshot_logs();
-
-    for l in logs.iter() {
-        ms.log.insert(l).await?;
-        ms.state_machine.write().await.apply(l).await?;
-    }
-
-    let curr_snap = ms.build_snapshot().await?;
-    assert_eq!(LogId { term: 1, index: 9 }, curr_snap.meta.last_log_id);
-
-    tracing::info!("--- check snapshot");
-    {
-        let data = curr_snap.snapshot.into_inner();
-
-        let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
-        let res = pretty_snapshot(&ser_snap.kvs);
-        tracing::debug!("res: {:?}", res);
-
-        assert_eq!(want, res);
-    }
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_metasrv_do_log_compaction_current_snapshot() -> anyhow::Result<()> {
-    // - Create a metasrv
-    // - Apply logs
-    // - Create a snapshot check snapshot state
-
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
-    let id = 3;
-    let tc = MetaSrvTestContext::new(id);
-
-    let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
-
-    tracing::info!("--- feed logs and state machine");
-
-    let (logs, want) = snapshot_logs();
-
-    for l in logs.iter() {
-        ms.log.insert(l).await?;
-        ms.state_machine.write().await.apply(l).await?;
-    }
-
-    ms.build_snapshot().await?;
-
-    tracing::info!("--- check get_current_snapshot");
-
-    let curr_snap = ms.get_current_snapshot().await?.unwrap();
-    assert_eq!(LogId { term: 1, index: 9 }, curr_snap.meta.last_log_id);
-
-    tracing::info!("--- check snapshot");
-    {
-        let data = curr_snap.snapshot.into_inner();
-
-        let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
-        let res = pretty_snapshot(&ser_snap.kvs);
-        tracing::debug!("res: {:?}", res);
-
-        assert_eq!(want, res);
-    }
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_metasrv_install_snapshot() -> anyhow::Result<()> {
-    // - Create a metasrv
-    // - Feed logs
-    // - Create a snapshot
-    // - Create a new metasrv and restore it by install the snapshot
-
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
-    let (logs, want) = snapshot_logs();
-
-    let id = 3;
-    let snap;
-    {
+    async {
+        let id = 3;
         let tc = MetaSrvTestContext::new(id);
 
-        let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
+        tracing::info!("--- new meta store");
+        {
+            let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
+            assert_eq!(id, sto.id);
+            assert!(!sto.is_opened());
+            assert_eq!(None, sto.read_hard_state().await?);
+
+            tracing::info!("--- update metasrv");
+
+            sto.save_hard_state(&HardState {
+                current_term: 10,
+                voted_for: Some(5),
+            })
+            .await?;
+
+            sto.append_to_log(&[&Entry {
+                log_id: LogId::new(1, 1),
+                payload: EntryPayload::Blank,
+            }])
+            .await?;
+
+            sto.apply_to_state_machine(&[&Entry {
+                log_id: LogId::new(1, 2),
+                payload: EntryPayload::Blank,
+            }])
+            .await?;
+        }
+
+        tracing::info!("--- reopen meta store");
+        {
+            let sto = MetaRaftStore::open_create(&tc.config.raft_config, Some(()), None).await?;
+            assert_eq!(id, sto.id);
+            assert!(sto.is_opened());
+            assert_eq!(
+                Some(HardState {
+                    current_term: 10,
+                    voted_for: Some(5),
+                }),
+                sto.read_hard_state().await?
+            );
+
+            assert_eq!(LogId::new(1, 1), sto.get_log_id(1).await?);
+            assert_eq!(Some(LogId::new(1, 2)), sto.last_applied_state().await?.0);
+        }
+        Ok(())
+    }
+    .instrument(ut_span)
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_meta_store_build_snapshot() -> anyhow::Result<()> {
+    // - Create a metasrv
+    // - Apply logs
+    // - Create a snapshot check snapshot state
+
+    let (_log_guards, ut_span) = init_meta_ut!();
+
+    async {
+        let id = 3;
+        let tc = MetaSrvTestContext::new(id);
+
+        let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
         tracing::info!("--- feed logs and state machine");
 
+        let (logs, want) = snapshot_logs();
+
         for l in logs.iter() {
-            ms.log.insert(l).await?;
-            ms.state_machine.write().await.apply(l).await?;
-        }
-        snap = ms.build_snapshot().await?;
-    }
-
-    let data = snap.snapshot.into_inner();
-
-    tracing::info!("--- reopen a new metasrv to install snapshot");
-    {
-        let tc = MetaSrvTestContext::new(id);
-
-        let ms = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
-
-        tracing::info!("--- rejected because old sm is not cleaned");
-        {
-            ms.raft_state.write_state_machine_id(&(1, 2)).await?;
-            let res = ms.install_snapshot(&data).await;
-            assert!(res.is_err(), "different ids disallow installing snapshot");
-            assert!(res.unwrap_err().to_string().starts_with(
-                "Code: 2007, displayText = another snapshot install is not finished yet: 1 2"
-            ));
+            sto.log.insert(l).await?;
+            sto.state_machine.write().await.apply(l).await?;
         }
 
-        tracing::info!("--- install snapshot");
-        {
-            ms.raft_state.write_state_machine_id(&(0, 0)).await?;
-            ms.install_snapshot(&data).await?;
-        }
-
-        tracing::info!("--- check installed meta");
-        {
-            assert_eq!((1, 1), ms.raft_state.read_state_machine_id()?);
-
-            let mem = ms.state_machine.write().await.get_membership()?;
-            assert_eq!(
-                Some(EffectiveMembership {
-                    log_id: LogId::new(1, 5),
-                    membership: Membership::new_single(btreeset! {4,5,6})
-                }),
-                mem
-            );
-
-            let last_applied = ms.state_machine.write().await.get_last_applied()?;
-            assert_eq!(Some(LogId::new(1, 9)), last_applied);
-        }
+        let curr_snap = sto.build_snapshot().await?;
+        assert_eq!(LogId { term: 1, index: 9 }, curr_snap.meta.last_log_id);
 
         tracing::info!("--- check snapshot");
         {
-            let curr_snap = ms.build_snapshot().await?;
             let data = curr_snap.snapshot.into_inner();
 
             let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
@@ -342,7 +170,143 @@ async fn test_metasrv_install_snapshot() -> anyhow::Result<()> {
 
             assert_eq!(want, res);
         }
-    }
 
-    Ok(())
+        Ok(())
+    }
+    .instrument(ut_span)
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_meta_store_current_snapshot() -> anyhow::Result<()> {
+    // - Create a metasrv
+    // - Apply logs
+    // - Create a snapshot check snapshot state
+
+    let (_log_guards, ut_span) = init_meta_ut!();
+    async {
+        let id = 3;
+        let tc = MetaSrvTestContext::new(id);
+
+        let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
+
+        tracing::info!("--- feed logs and state machine");
+
+        let (logs, want) = snapshot_logs();
+
+        for l in logs.iter() {
+            sto.log.insert(l).await?;
+            sto.state_machine.write().await.apply(l).await?;
+        }
+
+        sto.build_snapshot().await?;
+
+        tracing::info!("--- check get_current_snapshot");
+
+        let curr_snap = sto.get_current_snapshot().await?.unwrap();
+        assert_eq!(LogId { term: 1, index: 9 }, curr_snap.meta.last_log_id);
+
+        tracing::info!("--- check snapshot");
+        {
+            let data = curr_snap.snapshot.into_inner();
+
+            let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
+            let res = pretty_snapshot(&ser_snap.kvs);
+            tracing::debug!("res: {:?}", res);
+
+            assert_eq!(want, res);
+        }
+
+        Ok(())
+    }
+    .instrument(ut_span)
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
+    // - Create a metasrv
+    // - Feed logs
+    // - Create a snapshot
+    // - Create a new metasrv and restore it by install the snapshot
+
+    let (_log_guards, ut_span) = init_meta_ut!();
+
+    async {
+        let (logs, want) = snapshot_logs();
+
+        let id = 3;
+        let snap;
+        {
+            let tc = MetaSrvTestContext::new(id);
+
+            let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
+
+            tracing::info!("--- feed logs and state machine");
+
+            for l in logs.iter() {
+                sto.log.insert(l).await?;
+                sto.state_machine.write().await.apply(l).await?;
+            }
+            snap = sto.build_snapshot().await?;
+        }
+
+        let data = snap.snapshot.into_inner();
+
+        tracing::info!("--- reopen a new metasrv to install snapshot");
+        {
+            let tc = MetaSrvTestContext::new(id);
+
+            let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
+
+            tracing::info!("--- rejected because old sm is not cleaned");
+            {
+                sto.raft_state.write_state_machine_id(&(1, 2)).await?;
+                let res = sto.install_snapshot(&data).await;
+                assert!(res.is_err(), "different ids disallow installing snapshot");
+                assert!(res.unwrap_err().to_string().starts_with(
+                    "Code: 2007, displayText = another snapshot install is not finished yet: 1 2"
+                ));
+            }
+
+            tracing::info!("--- install snapshot");
+            {
+                sto.raft_state.write_state_machine_id(&(0, 0)).await?;
+                sto.install_snapshot(&data).await?;
+            }
+
+            tracing::info!("--- check installed meta");
+            {
+                assert_eq!((1, 1), sto.raft_state.read_state_machine_id()?);
+
+                let mem = sto.state_machine.write().await.get_membership()?;
+                assert_eq!(
+                    Some(EffectiveMembership {
+                        log_id: LogId::new(1, 5),
+                        membership: Membership::new_single(btreeset! {4,5,6})
+                    }),
+                    mem
+                );
+
+                let last_applied = sto.state_machine.write().await.get_last_applied()?;
+                assert_eq!(Some(LogId::new(1, 9)), last_applied);
+            }
+
+            tracing::info!("--- check snapshot");
+            {
+                let curr_snap = sto.build_snapshot().await?;
+                let data = curr_snap.snapshot.into_inner();
+
+                let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
+                let res = pretty_snapshot(&ser_snap.kvs);
+                tracing::debug!("res: {:?}", res);
+
+                assert_eq!(want, res);
+            }
+        }
+
+        Ok(())
+    }
+    .instrument(ut_span)
+    .await
 }

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -250,11 +250,12 @@ def run_tests_array(all_tests_with_params):
                     if args.mode == 'cluster' and os.path.isfile(
                             cluster_result_file):
                         result_file = cluster_result_file
-                        stdout_file = os.path.join(suite_tmp_dir,
-                                                   name) + file_suffix + '_cluster.stdout'
-                        stderr_file = os.path.join(suite_tmp_dir,
-                                               name) + file_suffix + '_cluster.stderr'
-
+                        stdout_file = os.path.join(
+                            suite_tmp_dir,
+                            name) + file_suffix + '_cluster.stdout'
+                        stderr_file = os.path.join(
+                            suite_tmp_dir,
+                            name) + file_suffix + '_cluster.stderr'
 
                     proc, stdout, stderr, total_time = run_single_test(
                         args, ext, client_options, case_file, stdout_file,


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] refactor: remove unnecessary MetaNode.metrics_rx

##### [metasrv] refactor: clean up meta-store test

## Changelog




- Improvement


## Related Issues