### PR TITLE
ci: Try to reduce unittest memory usage

### DIFF
--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -32,7 +32,7 @@ runs:
         RUST_TEST_THREADS: 2
         RUST_LOG: ERROR
         RUST_BACKTRACE: full
-        # symbol-manging-version=v0 is a trick to reduce memory usage
+        # symbol-mangling-version=v0 is a trick to reduce memory usage
         # ref: https://github.com/rust-lang/rust/issues/82406#issuecomment-787541615
         RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests --cfg tokio_unstable -Z symbol-mangling-version=v0'
         RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Z symbol-mangling-version=v0'

--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -34,8 +34,8 @@ runs:
         RUST_BACKTRACE: full
         # symbol-manging-version=v0 is a trick to reduce memory usage
         # ref: https://github.com/rust-lang/rust/issues/82406#issuecomment-787541615
-        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests --cfg tokio_unstable -Z symbol-manging-version=v0'
-        RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Z symbol-manging-version=v0'
+        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests --cfg tokio_unstable -Z symbol-mangling-version=v0'
+        RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Z symbol-mangling-version=v0'
 
     - name: Install grcov
       uses: actions-rs/cargo@v1

--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -32,8 +32,10 @@ runs:
         RUST_TEST_THREADS: 2
         RUST_LOG: ERROR
         RUST_BACKTRACE: full
-        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests --cfg tokio_unstable'
-        RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
+        # symbol-manging-version=v0 is a trick to reduce memory usage
+        # ref: https://github.com/rust-lang/rust/issues/82406#issuecomment-787541615
+        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests --cfg tokio_unstable -Z symbol-manging-version=v0'
+        RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Z symbol-manging-version=v0'
 
     - name: Install grcov
       uses: actions-rs/cargo@v1

--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -21,7 +21,7 @@ runs:
     # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1
       with:
-        sharedKey: unit-v1
+        sharedKey: unit-v2
 
     - name: Test
       uses: actions-rs/cargo@v1


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR intends to reduce memory usage during compiling.

It's a workaround inspired by https://github.com/rust-lang/rust/issues/82406#issuecomment-787541615.

Hoping this can resolve the failed tests for databend.

## Changelog

- Build/Testing/CI


## Test Plan

Unit Tests

Stateless Tests

