### PR TITLE
[metasrv] refactor: add KVApiTestSuite::test_single_node() to run all single-node tests

### DIFF
--- a/common/meta/api/src/kv_api.rs
+++ b/common/meta/api/src/kv_api.rs
@@ -23,6 +23,13 @@ use common_meta_types::UpsertKVAction;
 use common_meta_types::UpsertKVActionReply;
 
 #[async_trait]
+pub trait KVApiBuilder<T>
+where T: KVApi
+{
+    async fn build(&self) -> T;
+}
+
+#[async_trait]
 pub trait KVApi: Send + Sync {
     async fn upsert_kv(&self, act: UpsertKVAction)
         -> common_exception::Result<UpsertKVActionReply>;

--- a/common/meta/api/src/kv_api_test_suite.rs
+++ b/common/meta/api/src/kv_api_test_suite.rs
@@ -24,10 +24,30 @@ use common_meta_types::UpsertKVAction;
 use common_tracing::tracing;
 
 use crate::KVApi;
+use crate::KVApiBuilder;
 
 pub struct KVApiTestSuite {}
 
 impl KVApiTestSuite {
+    #[tracing::instrument(level = "info", skip(self, builder))]
+    pub async fn test_single_node<KV, B>(&self, builder: B) -> anyhow::Result<()>
+    where
+        KV: KVApi,
+        B: KVApiBuilder<KV>,
+    {
+        self.kv_write_read(&builder.build().await).await?;
+        self.kv_delete(&builder.build().await).await?;
+        self.kv_update(&builder.build().await).await?;
+        self.kv_timeout(&builder.build().await).await?;
+        self.kv_meta(&builder.build().await).await?;
+        self.kv_list(&builder.build().await).await?;
+        self.kv_mget(&builder.build().await).await?;
+        Ok(())
+    }
+}
+
+impl KVApiTestSuite {
+    #[tracing::instrument(level = "info", skip(self, kv))]
     pub async fn kv_write_read<KV: KVApi>(&self, kv: &KV) -> anyhow::Result<()> {
         {
             // write
@@ -88,22 +108,22 @@ impl KVApiTestSuite {
         Ok(())
     }
 
-    pub async fn kv_delete<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
+    #[tracing::instrument(level = "info", skip(self, kv))]
+    pub async fn kv_delete<KV: KVApi>(&self, kv: &KV) -> anyhow::Result<()> {
         let test_key = "test_key";
-        client
-            .upsert_kv(UpsertKVAction::new(
-                test_key,
-                MatchSeq::Any,
-                Operation::Update(b"v1".to_vec()),
-                None,
-            ))
-            .await?;
+        kv.upsert_kv(UpsertKVAction::new(
+            test_key,
+            MatchSeq::Any,
+            Operation::Update(b"v1".to_vec()),
+            None,
+        ))
+        .await?;
 
-        let current = client.get_kv(test_key).await?;
+        let current = kv.get_kv(test_key).await?;
         if let Some(SeqV { seq, .. }) = current {
             // seq mismatch
             let wrong_seq = Some(seq + 1);
-            let res = client
+            let res = kv
                 .upsert_kv(UpsertKVAction::new(
                     test_key,
                     wrong_seq.into(),
@@ -115,7 +135,7 @@ impl KVApiTestSuite {
             assert_eq!(res.prev, res.result);
 
             // seq match
-            let res = client
+            let res = kv
                 .upsert_kv(UpsertKVAction::new(
                     test_key,
                     MatchSeq::Exact(seq),
@@ -126,14 +146,14 @@ impl KVApiTestSuite {
             assert!(res.result.is_none());
 
             // read nothing
-            let r = client.get_kv(test_key).await?;
+            let r = kv.get_kv(test_key).await?;
             assert!(r.is_none());
         } else {
             panic!("expecting a value, but got nothing");
         }
 
         // key not exist
-        let res = client
+        let res = kv
             .upsert_kv(UpsertKVAction::new(
                 "not exists",
                 MatchSeq::Any,
@@ -145,16 +165,15 @@ impl KVApiTestSuite {
         assert_eq!(None, res.result);
 
         // do not care seq
-        client
-            .upsert_kv(UpsertKVAction::new(
-                test_key,
-                MatchSeq::Any,
-                Operation::Update(b"v2".to_vec()),
-                None,
-            ))
-            .await?;
+        kv.upsert_kv(UpsertKVAction::new(
+            test_key,
+            MatchSeq::Any,
+            Operation::Update(b"v2".to_vec()),
+            None,
+        ))
+        .await?;
 
-        let res = client
+        let res = kv
             .upsert_kv(UpsertKVAction::new(
                 test_key,
                 MatchSeq::Any,
@@ -170,10 +189,11 @@ impl KVApiTestSuite {
         Ok(())
     }
 
-    pub async fn kv_update<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
+    #[tracing::instrument(level = "info", skip(self, kv))]
+    pub async fn kv_update<KV: KVApi>(&self, kv: &KV) -> anyhow::Result<()> {
         let test_key = "test_key_for_update";
 
-        let r = client
+        let r = kv
             .upsert_kv(UpsertKVAction::new(
                 test_key,
                 MatchSeq::GE(1),
@@ -183,7 +203,7 @@ impl KVApiTestSuite {
             .await?;
         assert_eq!((None, None), (r.prev, r.result), "not changed");
 
-        let r = client
+        let r = kv
             .upsert_kv(UpsertKVAction::new(
                 test_key,
                 MatchSeq::Any,
@@ -195,7 +215,7 @@ impl KVApiTestSuite {
         let seq = r.result.unwrap().seq;
 
         // unmatched seq
-        let r = client
+        let r = kv
             .upsert_kv(UpsertKVAction::new(
                 test_key,
                 MatchSeq::Exact(seq + 1),
@@ -207,7 +227,7 @@ impl KVApiTestSuite {
         assert_eq!(Some(SeqV::with_meta(1, None, b"v1".to_vec())), r.result);
 
         // matched seq
-        let r = client
+        let r = kv
             .upsert_kv(UpsertKVAction::new(
                 test_key,
                 MatchSeq::Exact(seq),
@@ -219,7 +239,7 @@ impl KVApiTestSuite {
         assert_eq!(Some(SeqV::with_meta(2, None, b"v2".to_vec())), r.result);
 
         // blind update
-        let r = client
+        let r = kv
             .upsert_kv(UpsertKVAction::new(
                 test_key,
                 MatchSeq::GE(1),
@@ -231,14 +251,18 @@ impl KVApiTestSuite {
         assert_eq!(Some(SeqV::with_meta(3, None, b"v3".to_vec())), r.result);
 
         // value updated
-        let kv = client.get_kv(test_key).await?;
-        assert!(kv.is_some());
-        let kv = kv.unwrap();
-        assert_eq!(kv, SeqV::with_meta(kv.seq, None, b"v3".to_vec()));
+        let key_value = kv.get_kv(test_key).await?;
+        assert!(key_value.is_some());
+        let key_value = key_value.unwrap();
+        assert_eq!(
+            key_value,
+            SeqV::with_meta(key_value.seq, None, b"v3".to_vec())
+        );
         Ok(())
     }
 
-    pub async fn kv_timeout<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
+    #[tracing::instrument(level = "info", skip(self, kv))]
+    pub async fn kv_timeout<KV: KVApi>(&self, kv: &KV) -> anyhow::Result<()> {
         // - Test get  expired and non-expired.
         // - Test mget expired and non-expired.
         // - Test list expired and non-expired.
@@ -249,27 +273,26 @@ impl KVApiTestSuite {
             .unwrap()
             .as_secs();
 
-        client
-            .upsert_kv(UpsertKVAction::new(
-                "k1",
-                MatchSeq::Any,
-                Operation::Update(b"v1".to_vec()),
-                Some(KVMeta {
-                    expire_at: Some(now + 1),
-                }),
-            ))
-            .await?;
+        kv.upsert_kv(UpsertKVAction::new(
+            "k1",
+            MatchSeq::Any,
+            Operation::Update(b"v1".to_vec()),
+            Some(KVMeta {
+                expire_at: Some(now + 1),
+            }),
+        ))
+        .await?;
 
         tracing::info!("---get unexpired");
         {
-            let res = client.get_kv("k1").await?;
+            let res = kv.get_kv("k1").await?;
             assert!(res.is_some(), "got unexpired");
         }
 
         tracing::info!("---get expired");
         {
             tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
-            let res = client.get_kv("k1").await?;
+            let res = kv.get_kv("k1").await?;
             tracing::debug!("got k1:{:?}", res);
             assert!(res.is_none(), "got expired");
         }
@@ -281,31 +304,27 @@ impl KVApiTestSuite {
 
         tracing::info!("--- expired entry act as if it does not exist, an ADD op should apply");
         {
-            client
-                .upsert_kv(UpsertKVAction::new(
-                    "k1",
-                    MatchSeq::Exact(0),
-                    Operation::Update(b"v1".to_vec()),
-                    Some(KVMeta {
-                        expire_at: Some(now - 1),
-                    }),
-                ))
-                .await?;
-            client
-                .upsert_kv(UpsertKVAction::new(
-                    "k2",
-                    MatchSeq::Exact(0),
-                    Operation::Update(b"v2".to_vec()),
-                    Some(KVMeta {
-                        expire_at: Some(now + 2),
-                    }),
-                ))
-                .await?;
+            kv.upsert_kv(UpsertKVAction::new(
+                "k1",
+                MatchSeq::Exact(0),
+                Operation::Update(b"v1".to_vec()),
+                Some(KVMeta {
+                    expire_at: Some(now - 1),
+                }),
+            ))
+            .await?;
+            kv.upsert_kv(UpsertKVAction::new(
+                "k2",
+                MatchSeq::Exact(0),
+                Operation::Update(b"v2".to_vec()),
+                Some(KVMeta {
+                    expire_at: Some(now + 2),
+                }),
+            ))
+            .await?;
 
             tracing::info!("--- mget should not return expired");
-            let res = client
-                .mget_kv(&["k1".to_string(), "k2".to_string()])
-                .await?;
+            let res = kv.mget_kv(&["k1".to_string(), "k2".to_string()]).await?;
             assert_eq!(res, vec![
                 None,
                 Some(SeqV::with_meta(
@@ -320,7 +339,7 @@ impl KVApiTestSuite {
 
         tracing::info!("--- list should not return expired");
         {
-            let res = client.prefix_list_kv("k").await?;
+            let res = kv.prefix_list_kv("k").await?;
             let res_vec = res.iter().map(|(key, _)| key.clone()).collect::<Vec<_>>();
 
             assert_eq!(res_vec, vec!["k2".to_string(),]);
@@ -328,25 +347,25 @@ impl KVApiTestSuite {
 
         tracing::info!("--- update expire");
         {
-            client
-                .upsert_kv(UpsertKVAction::new(
-                    "k2",
-                    MatchSeq::Exact(3),
-                    Operation::Update(b"v2".to_vec()),
-                    Some(KVMeta {
-                        expire_at: Some(now - 1),
-                    }),
-                ))
-                .await?;
+            kv.upsert_kv(UpsertKVAction::new(
+                "k2",
+                MatchSeq::Exact(3),
+                Operation::Update(b"v2".to_vec()),
+                Some(KVMeta {
+                    expire_at: Some(now - 1),
+                }),
+            ))
+            .await?;
 
-            let res = client.get_kv("k2").await?;
+            let res = kv.get_kv("k2").await?;
             assert!(res.is_none(), "k2 expired");
         }
 
         Ok(())
     }
 
-    pub async fn kv_meta<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
+    #[tracing::instrument(level = "info", skip(self, kv))]
+    pub async fn kv_meta<KV: KVApi>(&self, kv: &KV) -> anyhow::Result<()> {
         let test_key = "test_key_for_update_meta";
 
         let now = SystemTime::now()
@@ -354,7 +373,7 @@ impl KVApiTestSuite {
             .unwrap()
             .as_secs();
 
-        let r = client
+        let r = kv
             .upsert_kv(UpsertKVAction::new(
                 test_key,
                 MatchSeq::Any,
@@ -367,7 +386,7 @@ impl KVApiTestSuite {
 
         tracing::info!("--- mismatching seq does nothing");
 
-        let r = client
+        let r = kv
             .upsert_kv(UpsertKVAction::new(
                 test_key,
                 MatchSeq::Exact(seq + 1),
@@ -382,7 +401,7 @@ impl KVApiTestSuite {
 
         tracing::info!("--- matching seq only update meta");
 
-        let r = client
+        let r = kv
             .upsert_kv(UpsertKVAction::new(
                 test_key,
                 MatchSeq::Exact(seq),
@@ -405,8 +424,8 @@ impl KVApiTestSuite {
         );
 
         tracing::info!("--- get returns the value with meta and seq updated");
-        let kv = client.get_kv(test_key).await?;
-        assert!(kv.is_some());
+        let key_value = kv.get_kv(test_key).await?;
+        assert!(key_value.is_some());
         assert_eq!(
             SeqV::with_meta(
                 seq + 1,
@@ -415,48 +434,46 @@ impl KVApiTestSuite {
                 }),
                 b"v1".to_vec()
             ),
-            kv.unwrap(),
+            key_value.unwrap(),
         );
 
         Ok(())
     }
 
-    pub async fn kv_list<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
+    #[tracing::instrument(level = "info", skip(self, kv))]
+    pub async fn kv_list<KV: KVApi>(&self, kv: &KV) -> anyhow::Result<()> {
         let mut values = vec![];
         {
-            client
-                .upsert_kv(UpsertKVAction::new(
-                    "t",
-                    MatchSeq::Any,
-                    Operation::Update("".as_bytes().to_vec()),
-                    None,
-                ))
-                .await?;
+            kv.upsert_kv(UpsertKVAction::new(
+                "t",
+                MatchSeq::Any,
+                Operation::Update("".as_bytes().to_vec()),
+                None,
+            ))
+            .await?;
 
             for i in 0..9 {
                 let key = format!("__users/{}", i);
                 let val = format!("val_{}", i);
                 values.push(val.clone());
-                client
-                    .upsert_kv(UpsertKVAction::new(
-                        &key,
-                        MatchSeq::Any,
-                        Operation::Update(val.as_bytes().to_vec()),
-                        None,
-                    ))
-                    .await?;
-            }
-            client
-                .upsert_kv(UpsertKVAction::new(
-                    "v",
+                kv.upsert_kv(UpsertKVAction::new(
+                    &key,
                     MatchSeq::Any,
-                    Operation::Update(b"".to_vec()),
+                    Operation::Update(val.as_bytes().to_vec()),
                     None,
                 ))
                 .await?;
+            }
+            kv.upsert_kv(UpsertKVAction::new(
+                "v",
+                MatchSeq::Any,
+                Operation::Update(b"".to_vec()),
+                None,
+            ))
+            .await?;
         }
 
-        let res = client.prefix_list_kv("__users/").await?;
+        let res = kv.prefix_list_kv("__users/").await?;
         assert_eq!(
             res.iter()
                 .map(|(_key, val)| val.data.clone())
@@ -469,34 +486,31 @@ impl KVApiTestSuite {
         Ok(())
     }
 
-    pub async fn kv_mget<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
-        client
-            .upsert_kv(UpsertKVAction::new(
-                "k1",
-                MatchSeq::Any,
-                Operation::Update(b"v1".to_vec()),
-                None,
-            ))
-            .await?;
-        client
-            .upsert_kv(UpsertKVAction::new(
-                "k2",
-                MatchSeq::Any,
-                Operation::Update(b"v2".to_vec()),
-                None,
-            ))
-            .await?;
+    #[tracing::instrument(level = "info", skip(self, kv))]
+    pub async fn kv_mget<KV: KVApi>(&self, kv: &KV) -> anyhow::Result<()> {
+        kv.upsert_kv(UpsertKVAction::new(
+            "k1",
+            MatchSeq::Any,
+            Operation::Update(b"v1".to_vec()),
+            None,
+        ))
+        .await?;
+        kv.upsert_kv(UpsertKVAction::new(
+            "k2",
+            MatchSeq::Any,
+            Operation::Update(b"v2".to_vec()),
+            None,
+        ))
+        .await?;
 
-        let res = client
-            .mget_kv(&["k1".to_string(), "k2".to_string()])
-            .await?;
+        let res = kv.mget_kv(&["k1".to_string(), "k2".to_string()]).await?;
         assert_eq!(res, vec![
             Some(SeqV::with_meta(1, None, b"v1".to_vec(),)),
             // NOTE, the sequence number is increased globally (inside the namespace of generic kv)
             Some(SeqV::with_meta(2, None, b"v2".to_vec(),)),
         ]);
 
-        let res = client
+        let res = kv
             .mget_kv(&["k1".to_string(), "key_no exist".to_string()])
             .await?;
         assert_eq!(res, vec![Some(SeqV::new(1, b"v1".to_vec())), None]);
@@ -507,6 +521,7 @@ impl KVApiTestSuite {
 
 /// Test that write and read should be forwarded to leader
 impl KVApiTestSuite {
+    #[tracing::instrument(level = "info", skip(self, kv1, kv2))]
     pub async fn kv_write_read_cross_nodes<KV: KVApi>(
         &self,
         kv1: &KV,

--- a/common/meta/api/src/lib.rs
+++ b/common/meta/api/src/lib.rs
@@ -21,6 +21,7 @@ mod meta_api;
 mod meta_api_test_suite;
 
 pub use kv_api::KVApi;
+pub use kv_api::KVApiBuilder;
 pub use kv_api_test_suite::KVApiTestSuite;
 pub use meta_api::MetaApi;
 pub use meta_api_test_suite::MetaApiTestSuite;

--- a/metasrv/tests/it/grpc/metasrv_grpc_kv_api.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_kv_api.rs
@@ -12,94 +12,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
 use common_base::tokio;
+use common_meta_api::KVApiBuilder;
 use common_meta_api::KVApiTestSuite;
 use common_meta_grpc::MetaGrpcClient;
+use common_tracing::tracing_futures::Instrument;
 
 use crate::init_meta_ut;
+use crate::tests::service::MetaSrvTestContext;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_kv_api_mget() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
+struct Builder {
+    pub test_contexts: Arc<Mutex<Vec<MetaSrvTestContext>>>,
+}
 
-    let (_tc, addr) = crate::tests::start_metasrv().await?;
+#[async_trait]
+impl KVApiBuilder<MetaGrpcClient> for Builder {
+    async fn build(&self) -> MetaGrpcClient {
+        let (tc, addr) = crate::tests::start_metasrv().await.unwrap();
 
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
+        let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None)
+            .await
+            .unwrap();
 
-    KVApiTestSuite {}.kv_mget(&client).await
+        {
+            let mut tcs = self.test_contexts.lock().unwrap();
+            tcs.push(tc);
+        }
+
+        client
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_kv_api_list() -> anyhow::Result<()> {
+async fn test_kv_api_single_node() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
 
-    let (_tc, addr) = crate::tests::start_metasrv().await?;
-
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
-
-    KVApiTestSuite {}.kv_list(&client).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_kv_api_delete() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
-    let (_tc, addr) = crate::tests::start_metasrv().await?;
-
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
-
-    KVApiTestSuite {}.kv_delete(&client).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_kv_api_update() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
-    let (_tc, addr) = crate::tests::start_metasrv().await?;
-
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
-
-    KVApiTestSuite {}.kv_update(&client).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_kv_api_update_meta() -> anyhow::Result<()> {
-    // Only update meta, do not touch the value part.
-
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
-    let (_tc, addr) = crate::tests::start_metasrv().await?;
-
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
-
-    KVApiTestSuite {}.kv_meta(&client).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_kv_api_timeout() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
-    let (_tc, addr) = crate::tests::start_metasrv().await?;
-
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
-
-    KVApiTestSuite {}.kv_timeout(&client).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_kv_api_write_read() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
-    let (_tc, addr) = crate::tests::start_metasrv().await?;
-
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
-
-    KVApiTestSuite {}.kv_write_read(&client).await
+    let builder = Builder {
+        test_contexts: Arc::new(Mutex::new(vec![])),
+    };
+    async { KVApiTestSuite {}.test_single_node(builder).await }
+        .instrument(ut_span)
+        .await
 }

--- a/metasrv/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -86,7 +86,7 @@ async fn test_kv_api_restart_cluster_write_read() -> anyhow::Result<()> {
         for mut tc in tcs {
             // TODO(xp): remove this field, or split MetaSrvTestContext into two struct:
             //           one for metasrv and one for meta_node
-            assert!(tc.meta_nodes.is_empty());
+            assert!(tc.meta_node.is_none());
 
             let mut srv = tc.grpc_srv.take().unwrap();
             srv.stop(None).await?;
@@ -199,7 +199,7 @@ async fn test_kv_api_restart_cluster_token_expired() -> anyhow::Result<()> {
     let stopped_tcs = {
         let mut stopped_tcs = vec![];
         for mut tc in tcs {
-            assert!(tc.meta_nodes.is_empty());
+            assert!(tc.meta_node.is_none());
 
             let mut srv = tc.grpc_srv.take().unwrap();
             srv.stop(None).await?;

--- a/metasrv/tests/it/main.rs
+++ b/metasrv/tests/it/main.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Because the compiler complains about recursion limit for a trait requirement check...
+// error[[E0275](https://doc.rust-lang.org/error-index.html#E0275)]: overflow evaluating the requirement `(...)`
+// When compiling `impl KVApiBuilder<MetaGrpcClient> for Builder`.
+#![recursion_limit = "1024"]
+
 mod api;
 mod configs;
 mod grpc;

--- a/metasrv/tests/it/tests/service.rs
+++ b/metasrv/tests/it/tests/service.rs
@@ -83,7 +83,7 @@ pub struct MetaSrvTestContext {
     // logging_guard: (WorkerGuard, DefaultGuard),
     pub config: configs::Config,
 
-    pub meta_nodes: Vec<Arc<MetaNode>>,
+    pub meta_node: Option<Arc<MetaNode>>,
 
     pub grpc_srv: Option<Box<GrpcServer>>,
 }
@@ -134,9 +134,13 @@ impl MetaSrvTestContext {
 
         MetaSrvTestContext {
             config,
-            meta_nodes: vec![],
+            meta_node: None,
             grpc_srv: None,
         }
+    }
+
+    pub fn meta_node(&self) -> Arc<MetaNode> {
+        self.meta_node.clone().unwrap()
     }
 
     pub async fn grpc_client(&self) -> anyhow::Result<MetaGrpcClient> {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] refactor: add KVApiTestSuite::test_single_node() to run all single-node tests

##### [metasrv] refactor: make meta_node an Option in test context

## Changelog




- Improvement


## Related Issues