### PR TITLE
[metasrv] refactor: test KVApi for MetaNode

### DIFF
--- a/common/meta/api/src/kv_api.rs
+++ b/common/meta/api/src/kv_api.rs
@@ -13,7 +13,7 @@
 //  limitations under the License.
 //
 
-use std::sync::Arc;
+use std::ops::Deref;
 
 use async_trait::async_trait;
 use common_meta_types::GetKVActionReply;
@@ -47,23 +47,23 @@ pub trait KVApi: Send + Sync {
 }
 
 #[async_trait]
-impl KVApi for Arc<dyn KVApi> {
+impl<U: KVApi, T: Deref<Target = U> + Send + Sync> KVApi for T {
     async fn upsert_kv(
         &self,
         act: UpsertKVAction,
     ) -> common_exception::Result<UpsertKVActionReply> {
-        self.as_ref().upsert_kv(act).await
+        self.deref().upsert_kv(act).await
     }
 
     async fn get_kv(&self, key: &str) -> common_exception::Result<GetKVActionReply> {
-        self.as_ref().get_kv(key).await
+        self.deref().get_kv(key).await
     }
 
     async fn mget_kv(&self, key: &[String]) -> common_exception::Result<MGetKVActionReply> {
-        self.as_ref().mget_kv(key).await
+        self.deref().mget_kv(key).await
     }
 
     async fn prefix_list_kv(&self, prefix: &str) -> common_exception::Result<PrefixListReply> {
-        self.as_ref().prefix_list_kv(prefix).await
+        self.deref().prefix_list_kv(prefix).await
     }
 }

--- a/common/meta/api/src/kv_api_test_suite.rs
+++ b/common/meta/api/src/kv_api_test_suite.rs
@@ -43,16 +43,18 @@ impl KVApiTestSuite {
         self.kv_list(&builder.build().await).await?;
         self.kv_mget(&builder.build().await).await?;
 
-        {
-            let cluster = builder.build_cluster().await;
-            self.kv_write_read_across_nodes(&cluster[0], &cluster[1])
-                .await?;
-        }
+        // Run cross node test on every 2 adjacent nodes
 
-        {
+        let mut i = 0;
+        loop {
             let cluster = builder.build_cluster().await;
-            self.kv_write_read_across_nodes(&cluster[1], &cluster[2])
+            self.kv_write_read_across_nodes(&cluster[i], &cluster[i + 1])
                 .await?;
+
+            if i + 1 == cluster.len() - 1 {
+                break;
+            }
+            i += 1;
         }
 
         Ok(())

--- a/metasrv/tests/it/meta_node/meta_node_kv_api.rs
+++ b/metasrv/tests/it/meta_node/meta_node_kv_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2022 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metasrv/tests/it/meta_node/meta_node_kv_api.rs
+++ b/metasrv/tests/it/meta_node/meta_node_kv_api.rs
@@ -1,0 +1,83 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use common_base::tokio;
+use common_meta_api::KVApiBuilder;
+use common_meta_api::KVApiTestSuite;
+use common_tracing::tracing::Instrument;
+use databend_meta::meta_service::MetaNode;
+use maplit::btreeset;
+
+use crate::init_meta_ut;
+use crate::meta_node::meta_node_all::start_meta_node_cluster;
+use crate::meta_node::meta_node_all::start_meta_node_leader;
+use crate::tests::service::MetaSrvTestContext;
+
+struct MetaNodeUnitTestBuilder {
+    pub test_contexts: Arc<Mutex<Vec<MetaSrvTestContext>>>,
+}
+
+#[async_trait]
+impl KVApiBuilder<Arc<MetaNode>> for MetaNodeUnitTestBuilder {
+    async fn build(&self) -> Arc<MetaNode> {
+        let (_id, tc) = start_meta_node_leader().await.unwrap();
+
+        let meta_node = tc.meta_node();
+
+        {
+            let mut tcs = self.test_contexts.lock().unwrap();
+            tcs.push(tc);
+        }
+
+        meta_node
+    }
+
+    async fn build_cluster(&self) -> Vec<Arc<MetaNode>> {
+        let (_log_index, tcs) = start_meta_node_cluster(btreeset! {0,1,2}, btreeset! {3,4})
+            .await
+            .unwrap();
+
+        let cluster = vec![
+            tcs[0].meta_node(),
+            tcs[1].meta_node(),
+            tcs[2].meta_node(),
+            tcs[3].meta_node(),
+            tcs[4].meta_node(),
+        ];
+
+        {
+            let mut test_contexts = self.test_contexts.lock().unwrap();
+            test_contexts.extend(tcs);
+        }
+
+        cluster
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_meta_node_kv_api() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+
+    let builder = MetaNodeUnitTestBuilder {
+        test_contexts: Arc::new(Mutex::new(vec![])),
+    };
+
+    async { KVApiTestSuite {}.test_all(builder).await }
+        .instrument(ut_span)
+        .await
+}

--- a/metasrv/tests/it/meta_node/mod.rs
+++ b/metasrv/tests/it/meta_node/mod.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod meta_node_all;
+pub(crate) mod meta_node_all;
+pub(crate) mod meta_node_kv_api;

--- a/metasrv/tests/it/tests/mod.rs
+++ b/metasrv/tests/it/tests/mod.rs
@@ -17,7 +17,6 @@
 pub mod service;
 pub mod tls_constants;
 
-pub use service::assert_metasrv_connection;
 pub use service::next_port;
 pub use service::start_metasrv;
 pub use service::start_metasrv_with_context;

--- a/metasrv/tests/it/tests/service.rs
+++ b/metasrv/tests/it/tests/service.rs
@@ -170,7 +170,7 @@ impl MetaSrvTestContext {
         panic!("can not connect to raft server: {:?}", self.config);
     }
 
-    pub async fn assert_meta_connection(&self) -> anyhow::Result<()> {
+    pub async fn assert_raft_server_connection(&self) -> anyhow::Result<()> {
         let mut client = self.raft_client().await?;
 
         let req = tonic::Request::new(GetRequest {
@@ -180,18 +180,6 @@ impl MetaSrvTestContext {
         assert_eq!("", rst.value, "connected");
         Ok(())
     }
-}
-
-pub async fn assert_metasrv_connection(addr: &str) -> anyhow::Result<()> {
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-
-    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
-    let req = tonic::Request::new(GetRequest {
-        key: "ensure-connection".into(),
-    });
-    let rst = client.get(req).await?.into_inner();
-    assert_eq!("", rst.value, "connected");
-    Ok(())
 }
 
 /// 1. Open a temp sled::Db for all tests.


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] refactor: test KVApi for MetaNode
- Feature: generalize KVApi implementation for `Arc<dyn KVApi>` with `Deref`.

- Test: run cross node KVApi test on every 2 adjacent nodes in a
  cluster.
  This covers all test patterns such as write-leader-read-follower or
  write-learner-read-learner.

- Test: remove old case by case KVApi tests that are already covered by `KVApiTestSuite`.

## Changelog




- Improvement


## Related Issues