### PR TITLE
[metasrv] refactor: termninology

### DIFF
--- a/common/meta/grpc/src/grpc_action.rs
+++ b/common/meta/grpc/src/grpc_action.rs
@@ -17,7 +17,6 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use common_exception::ErrorCode;
-use common_meta_types::protobuf::GetRequest;
 use common_meta_types::protobuf::RaftRequest;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::CreateDatabaseReq;
@@ -56,6 +55,7 @@ pub enum MetaGrpcWriteReq {
     CreateTable(CreateTableReq),
     DropTable(DropTableReq),
     CommitTable(UpsertTableOptionReq),
+
     UpsertKV(UpsertKVAction),
 }
 
@@ -63,9 +63,11 @@ pub enum MetaGrpcWriteReq {
 pub enum MetaGrpcReadReq {
     GetDatabase(GetDatabaseReq),
     ListDatabases(ListDatabaseReq),
+
     GetTable(GetTableReq),
     GetTableExt(GetTableExtReq),
     ListTables(ListTableReq),
+
     GetKV(GetKVAction),
     MGetKV(MGetKVAction),
     PrefixListKV(PrefixListReq),
@@ -109,35 +111,35 @@ impl TryInto<Request<RaftRequest>> for &MetaGrpcWriteReq {
     }
 }
 
-impl TryInto<MetaGrpcReadReq> for Request<GetRequest> {
+impl TryInto<MetaGrpcReadReq> for Request<RaftRequest> {
     type Error = tonic::Status;
 
     fn try_into(self) -> Result<MetaGrpcReadReq, Self::Error> {
-        let get_req = self.into_inner();
+        let raft_req = self.into_inner();
 
-        let json_str = get_req.key.as_str();
+        let json_str = raft_req.data.as_str();
         let action = serde_json::from_str::<MetaGrpcReadReq>(json_str)
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
         Ok(action)
     }
 }
 
-impl tonic::IntoRequest<GetRequest> for MetaGrpcReadReq {
-    fn into_request(self) -> Request<GetRequest> {
-        let get_req = GetRequest {
-            key: serde_json::to_string(&self).expect("fail to serialize"),
+impl tonic::IntoRequest<RaftRequest> for MetaGrpcReadReq {
+    fn into_request(self) -> Request<RaftRequest> {
+        let raft_req = RaftRequest {
+            data: serde_json::to_string(&self).expect("fail to serialize"),
         };
 
-        tonic::Request::new(get_req)
+        tonic::Request::new(raft_req)
     }
 }
 
-impl TryInto<Request<GetRequest>> for &MetaGrpcReadReq {
+impl TryInto<Request<RaftRequest>> for &MetaGrpcReadReq {
     type Error = ErrorCode;
 
-    fn try_into(self) -> Result<Request<GetRequest>, Self::Error> {
-        let get_req = GetRequest {
-            key: serde_json::to_string(&self)?,
+    fn try_into(self) -> Result<Request<RaftRequest>, Self::Error> {
+        let get_req = RaftRequest {
+            data: serde_json::to_string(&self)?,
         };
 
         let request = tonic::Request::new(get_req);

--- a/common/meta/grpc/src/kv_api_impl.rs
+++ b/common/meta/grpc/src/kv_api_impl.rs
@@ -34,7 +34,7 @@ impl KVApi for MetaGrpcClient {
     }
 
     async fn get_kv(&self, key: &str) -> common_exception::Result<GetKVActionReply> {
-        self.do_get(GetKVAction {
+        self.do_read(GetKVAction {
             key: key.to_string(),
         })
         .await
@@ -42,10 +42,10 @@ impl KVApi for MetaGrpcClient {
 
     async fn mget_kv(&self, keys: &[String]) -> common_exception::Result<MGetKVActionReply> {
         let keys = keys.to_vec();
-        self.do_get(MGetKVAction { keys }).await
+        self.do_read(MGetKVAction { keys }).await
     }
 
     async fn prefix_list_kv(&self, prefix: &str) -> common_exception::Result<PrefixListReply> {
-        self.do_get(PrefixListReq(prefix.to_string())).await
+        self.do_read(PrefixListReq(prefix.to_string())).await
     }
 }

--- a/common/meta/grpc/src/meta_api_impl.rs
+++ b/common/meta/grpc/src/meta_api_impl.rs
@@ -58,14 +58,14 @@ impl MetaApi for MetaGrpcClient {
         &self,
         req: GetDatabaseReq,
     ) -> common_exception::Result<Arc<DatabaseInfo>> {
-        self.do_get(req).await
+        self.do_read(req).await
     }
 
     async fn list_databases(
         &self,
         req: ListDatabaseReq,
     ) -> common_exception::Result<Vec<Arc<DatabaseInfo>>> {
-        self.do_get(req).await
+        self.do_read(req).await
     }
 
     async fn create_table(
@@ -80,21 +80,21 @@ impl MetaApi for MetaGrpcClient {
     }
 
     async fn get_table(&self, req: GetTableReq) -> common_exception::Result<Arc<TableInfo>> {
-        self.do_get(req).await
+        self.do_read(req).await
     }
 
     async fn list_tables(
         &self,
         req: ListTableReq,
     ) -> common_exception::Result<Vec<Arc<TableInfo>>> {
-        self.do_get(req).await
+        self.do_read(req).await
     }
 
     async fn get_table_by_id(
         &self,
         table_id: MetaId,
     ) -> common_exception::Result<(TableIdent, Arc<TableMeta>)> {
-        let x: TableInfo = self.do_get(GetTableExtReq { tbl_id: table_id }).await?;
+        let x: TableInfo = self.do_read(GetTableExtReq { tbl_id: table_id }).await?;
         Ok((x.ident, Arc::new(x.meta)))
     }
 

--- a/common/meta/grpc/tests/it/grpc_server.rs
+++ b/common/meta/grpc/tests/it/grpc_server.rs
@@ -19,8 +19,6 @@ use std::time::Duration;
 use common_base::tokio;
 use common_meta_types::protobuf::meta_server::Meta;
 use common_meta_types::protobuf::meta_server::MetaServer;
-use common_meta_types::protobuf::GetReply;
-use common_meta_types::protobuf::GetRequest;
 use common_meta_types::protobuf::HandshakeResponse;
 use common_meta_types::protobuf::RaftReply;
 use common_meta_types::protobuf::RaftRequest;
@@ -55,7 +53,10 @@ impl Meta for GrpcServiceForTestImpl {
         Err(Status::unimplemented("Not yet implemented"))
     }
 
-    async fn read_msg(&self, _request: Request<GetRequest>) -> Result<Response<GetReply>, Status> {
+    async fn read_msg(
+        &self,
+        _request: Request<RaftRequest>,
+    ) -> Result<Response<RaftReply>, Status> {
         // for timeout test
         tokio::time::sleep(Duration::from_secs(60)).await;
         Err(Status::unimplemented("Not yet implemented"))

--- a/common/meta/types/proto/meta.proto
+++ b/common/meta/types/proto/meta.proto
@@ -42,7 +42,7 @@ message HandshakeResponse {
   bytes payload = 2;
 }
 
-service MetaService {
+service RaftService {
 
   rpc Write(RaftRequest) returns (RaftReply) {}
   rpc Get(GetRequest) returns (GetReply) {}
@@ -63,5 +63,5 @@ service Meta {
 
   // message
   rpc WriteMsg(RaftRequest) returns (RaftReply);
-  rpc ReadMsg(GetRequest) returns (GetReply);
+  rpc ReadMsg(RaftRequest) returns (RaftReply);
 }

--- a/metasrv/src/api/grpc/grpc_service.rs
+++ b/metasrv/src/api/grpc/grpc_service.rs
@@ -20,8 +20,6 @@ use common_grpc::GrpcToken;
 use common_meta_grpc::MetaGrpcReadReq;
 use common_meta_grpc::MetaGrpcWriteReq;
 use common_meta_types::protobuf::meta_server::Meta;
-use common_meta_types::protobuf::GetReply;
-use common_meta_types::protobuf::GetRequest;
 use common_meta_types::protobuf::HandshakeRequest;
 use common_meta_types::protobuf::HandshakeResponse;
 use common_meta_types::protobuf::RaftReply;
@@ -125,7 +123,7 @@ impl Meta for MetaGrpcImpl {
         Ok(Response::new(body))
     }
 
-    async fn read_msg(&self, request: Request<GetRequest>) -> Result<Response<GetReply>, Status> {
+    async fn read_msg(&self, request: Request<RaftRequest>) -> Result<Response<RaftReply>, Status> {
         self.check_token(request.metadata())?;
         common_tracing::extract_remote_span_as_parent(&request);
 
@@ -133,9 +131,9 @@ impl Meta for MetaGrpcImpl {
         tracing::info!("Receive read_action: {:?}", action);
 
         let body = self.action_handler.execute_read(action).await?;
-        let r = GetReply {
-            ok: true,
-            value: body,
+        let r = RaftReply {
+            data: body,
+            error: "".to_string(),
         };
         Ok(Response::new(r))
     }

--- a/metasrv/src/meta_service/meta_service_impl.rs
+++ b/metasrv/src/meta_service/meta_service_impl.rs
@@ -19,7 +19,7 @@ use std::convert::TryInto;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use common_meta_types::protobuf::meta_service_server::MetaService;
+use common_meta_types::protobuf::raft_service_server::RaftService;
 use common_meta_types::protobuf::GetReply;
 use common_meta_types::protobuf::GetRequest;
 use common_meta_types::protobuf::RaftReply;
@@ -36,18 +36,18 @@ use crate::meta_service::MetaNode;
 pub type GrpcStream<T> =
     Pin<Box<dyn Stream<Item = Result<T, tonic::Status>> + Send + Sync + 'static>>;
 
-pub struct MetaServiceImpl {
+pub struct RaftServiceImpl {
     pub meta_node: Arc<MetaNode>,
 }
 
-impl MetaServiceImpl {
+impl RaftServiceImpl {
     pub fn create(meta_node: Arc<MetaNode>) -> Self {
         Self { meta_node }
     }
 }
 
 #[async_trait::async_trait]
-impl MetaService for MetaServiceImpl {
+impl RaftService for RaftServiceImpl {
     /// Handles a write request.
     /// This node must be leader or an error returned.
     #[tracing::instrument(level = "info", skip(self))]

--- a/metasrv/src/meta_service/mod.rs
+++ b/metasrv/src/meta_service/mod.rs
@@ -15,7 +15,7 @@
 pub use common_meta_types::ForwardRequest;
 pub use common_meta_types::ForwardRequestBody;
 pub use common_meta_types::JoinRequest;
-pub use meta_service_impl::MetaServiceImpl;
+pub use meta_service_impl::RaftServiceImpl;
 pub use raftmeta::MetaNode;
 
 pub mod meta_leader;

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -29,8 +29,8 @@ use common_meta_raft_store::state_machine::StateMachine;
 use common_meta_raft_store::state_machine::TableLookupKey;
 use common_meta_raft_store::state_machine::TableLookupValue;
 use common_meta_sled_store::openraft;
-use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
-use common_meta_types::protobuf::meta_service_server::MetaServiceServer;
+use common_meta_types::protobuf::raft_service_client::RaftServiceClient;
+use common_meta_types::protobuf::raft_service_server::RaftServiceServer;
 use common_meta_types::AppliedState;
 use common_meta_types::Cmd;
 use common_meta_types::ForwardRequest;
@@ -55,7 +55,7 @@ use crate::errors::MetaError;
 use crate::meta_service::meta_leader::MetaLeader;
 use crate::meta_service::ForwardRequestBody;
 use crate::meta_service::JoinRequest;
-use crate::meta_service::MetaServiceImpl;
+use crate::meta_service::RaftServiceImpl;
 use crate::network::Network;
 use crate::store::MetaRaftStore;
 use crate::Opened;
@@ -196,8 +196,8 @@ impl MetaNode {
     pub async fn start_grpc(mn: Arc<MetaNode>, addr: &str) -> common_exception::Result<()> {
         let mut rx = mn.running_rx.clone();
 
-        let meta_srv_impl = MetaServiceImpl::create(mn.clone());
-        let meta_srv = MetaServiceServer::new(meta_srv_impl);
+        let meta_srv_impl = RaftServiceImpl::create(mn.clone());
+        let meta_srv = RaftServiceServer::new(meta_srv_impl);
 
         let addr_str = addr.to_string();
         let addr = addr.parse::<std::net::SocketAddr>()?;
@@ -403,7 +403,7 @@ impl MetaNode {
             let addrs = &conf.join;
             #[allow(clippy::never_loop)]
             for addr in addrs {
-                let mut client = MetaServiceClient::connect(format!("http://{}", addr))
+                let mut client = RaftServiceClient::connect(format!("http://{}", addr))
                     .await
                     .map_err(|e| ErrorCode::CannotConnectNode(e.to_string()))?;
 
@@ -704,7 +704,7 @@ impl MetaNode {
             .await
             .map_err(|e| MetaError::UnknownError(e.to_string()))?;
 
-        let mut client = MetaServiceClient::connect(format!("http://{}", addr))
+        let mut client = RaftServiceClient::connect(format!("http://{}", addr))
             .await
             .map_err(|e| ConnectionError::new(e, format!("address: {}", addr)))?;
 

--- a/metasrv/src/network.rs
+++ b/metasrv/src/network.rs
@@ -19,7 +19,7 @@ use common_containers::ItemManager;
 use common_containers::Pool;
 use common_meta_sled_store::openraft;
 use common_meta_sled_store::openraft::MessageSummary;
-use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
+use common_meta_types::protobuf::raft_service_client::RaftServiceClient;
 use common_meta_types::LogEntry;
 use common_meta_types::NodeId;
 use common_tracing::tracing;
@@ -72,14 +72,14 @@ impl Network {
     }
 
     #[tracing::instrument(level = "info", skip(self), fields(id=self.sto.id))]
-    pub async fn make_client(&self, target: &NodeId) -> anyhow::Result<MetaServiceClient<Channel>> {
+    pub async fn make_client(&self, target: &NodeId) -> anyhow::Result<RaftServiceClient<Channel>> {
         let addr = self.sto.get_node_addr(target).await?;
         let addr = format!("http://{}", addr);
 
         tracing::debug!("connect: target={}: {}", target, addr);
 
         let channel = self.conn_pool.get(&addr).await?;
-        let client = MetaServiceClient::new(channel);
+        let client = RaftServiceClient::new(channel);
 
         tracing::info!("connected: target={}: {}", target, addr);
 

--- a/metasrv/tests/it/tests/service.rs
+++ b/metasrv/tests/it/tests/service.rs
@@ -20,7 +20,7 @@ use common_base::GlobalSequence;
 use common_base::Stoppable;
 use common_meta_grpc::MetaGrpcClient;
 use common_meta_sled_store::openraft::NodeId;
-use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
+use common_meta_types::protobuf::raft_service_client::RaftServiceClient;
 use common_meta_types::protobuf::GetRequest;
 use common_tracing::tracing;
 use databend_meta::api::GrpcServer;
@@ -152,12 +152,12 @@ impl MetaSrvTestContext {
 
     pub async fn raft_client(
         &self,
-    ) -> anyhow::Result<MetaServiceClient<tonic::transport::Channel>> {
+    ) -> anyhow::Result<RaftServiceClient<tonic::transport::Channel>> {
         let addr = self.config.raft_config.raft_api_addr();
 
         // retry 3 times until server starts listening.
         for _ in 0..4 {
-            let client = MetaServiceClient::connect(format!("http://{}", addr)).await;
+            let client = RaftServiceClient::connect(format!("http://{}", addr)).await;
             match client {
                 Ok(x) => return Ok(x),
                 Err(err) => {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] refactor: termninology
- Refactor: rename MetaService to RaftService. It serves for internal
  raft communications.

- Refactor: use RaftRequest/RaftReply for `read_msg()`.

- Refactor: rename `MetaServiceServer::do_get()` to `do_read()`.

## Changelog




- Improvement


## Related Issues