### PR TITLE
impl Debug trait for Column

### DIFF
--- a/common/datavalues2/src/columns/array/mod.rs
+++ b/common/datavalues2/src/columns/array/mod.rs
@@ -145,3 +145,16 @@ impl Column for ArrayColumn {
         DataValue::Array(values)
     }
 }
+
+impl std::fmt::Debug for ArrayColumn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut data = Vec::new();
+        for idx in 0..self.len() {
+            let x = self.get(idx);
+            data.push(format!("{:?}", x));
+        }
+        let head = "ArrayColumn";
+        let iter = data.iter();
+        display_fmt(iter, head, self.len(), self.data_type_id(), f)
+    }
+}

--- a/common/datavalues2/src/columns/boolean/mod.rs
+++ b/common/datavalues2/src/columns/boolean/mod.rs
@@ -27,7 +27,7 @@ mod mutable;
 pub use iterator::*;
 pub use mutable::*;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct BooleanColumn {
     values: Bitmap,
 }
@@ -165,5 +165,13 @@ impl ScalarColumn for BooleanColumn {
         BooleanColumn {
             values: bitmap.into(),
         }
+    }
+}
+
+impl std::fmt::Debug for BooleanColumn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let iter = self.iter().map(|x| if x { "true" } else { "false" });
+        let head = "BooleanColumn";
+        display_fmt(iter, head, self.len(), self.data_type_id(), f)
     }
 }

--- a/common/datavalues2/src/columns/null/mod.rs
+++ b/common/datavalues2/src/columns/null/mod.rs
@@ -23,7 +23,7 @@ use crate::prelude::*;
 mod mutable;
 
 pub use mutable::*;
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct NullColumn {
     length: usize,
 }
@@ -104,5 +104,18 @@ impl Column for NullColumn {
 
     fn get(&self, _index: usize) -> DataValue {
         DataValue::Null
+    }
+}
+
+impl std::fmt::Debug for NullColumn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let data = if self.len() > 0 {
+            vec!["NULL...".to_string()]
+        } else {
+            vec![]
+        };
+        let iter = data.iter();
+        let head = "NullColumn";
+        display_fmt(iter, head, self.len(), self.data_type_id(), f)
     }
 }

--- a/common/datavalues2/src/columns/nullable/mod.rs
+++ b/common/datavalues2/src/columns/nullable/mod.rs
@@ -140,3 +140,25 @@ impl Column for NullableColumn {
         }
     }
 }
+
+impl std::fmt::Debug for NullableColumn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut data = Vec::new();
+        for idx in 0..self.len() {
+            if self.validity.get_bit(idx) {
+                let val = self.column.get(idx);
+                data.push(format!("{:?}", val));
+            } else {
+                data.push("NULL".to_string());
+            }
+        }
+        let head = "NullableColumn";
+        display_fmt(
+            data.iter(),
+            head,
+            self.len(),
+            self.inner().data_type_id(),
+            f,
+        )
+    }
+}

--- a/common/datavalues2/src/columns/primitive/mod.rs
+++ b/common/datavalues2/src/columns/primitive/mod.rs
@@ -32,7 +32,7 @@ pub use mutable::*;
 use crate::prelude::*;
 
 /// PrimitiveColumn is generic struct which wrapped arrow's PrimitiveArray
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PrimitiveColumn<T: PrimitiveType> {
     values: Buffer<T>,
 }
@@ -268,3 +268,11 @@ pub type Int64Column = PrimitiveColumn<i64>;
 
 pub type Float32Column = PrimitiveColumn<f32>;
 pub type Float64Column = PrimitiveColumn<f64>;
+
+impl<T: PrimitiveType> std::fmt::Debug for PrimitiveColumn<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let iter = self.iter();
+        let head = "PrimitiveColumn";
+        display_fmt(iter, head, self.len(), self.data_type_id(), f)
+    }
+}

--- a/common/datavalues2/src/columns/string/mod.rs
+++ b/common/datavalues2/src/columns/string/mod.rs
@@ -28,7 +28,7 @@ pub use mutable::*;
 use crate::prelude::*;
 
 // TODO adaptive offset
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct StringColumn {
     offsets: Buffer<i64>,
     values: Buffer<u8>,
@@ -221,5 +221,13 @@ impl ScalarColumn for StringColumn {
 
     fn iter(&self) -> ScalarColumnIterator<Self> {
         ScalarColumnIterator::new(self)
+    }
+}
+
+impl std::fmt::Debug for StringColumn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let iter = self.iter().map(String::from_utf8_lossy);
+        let head = "StringColumn";
+        display_fmt(iter, head, self.len(), self.data_type_id(), f)
     }
 }

--- a/common/datavalues2/src/columns/struct_/mod.rs
+++ b/common/datavalues2/src/columns/struct_/mod.rs
@@ -116,3 +116,16 @@ impl Column for StructColumn {
         Arc::new(self.clone())
     }
 }
+
+impl std::fmt::Debug for StructColumn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut data = Vec::new();
+        for idx in 0..self.len() {
+            let x = self.get(idx);
+            data.push(format!("{:?}", x));
+        }
+        let head = "StructColumn";
+        let iter = data.iter();
+        display_fmt(iter, head, self.len(), self.data_type_id(), f)
+    }
+}

--- a/common/datavalues2/src/data_value.rs
+++ b/common/datavalues2/src/data_value.rs
@@ -312,7 +312,7 @@ impl fmt::Debug for DataValue {
             DataValue::UInt64(v) => write!(f, "{}", v),
             DataValue::Float64(v) => write!(f, "{}", v),
             DataValue::String(_) => write!(f, "{}", self),
-            DataValue::Array(_) => write!(f, "[{}]", self),
+            DataValue::Array(_) => write!(f, "{}", self),
             DataValue::Struct(v) => write!(f, "{:?}", v),
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add `Debug` impl for `Column` for better debugging, just like below:
```
PrimitiveColumn          typeid: UInt8   len: 2  data: [1, 2]
PrimitiveColumn          typeid: Float32         len: 2  data: [1, 2]
NullColumn       typeid: Null    len: 3  data: [NULL...]
BooleanColumn    typeid: Boolean         len: 3  data: [true, false, true]
StringColumn     typeid: String  len: 2  data: [aaa, bbb]
NullableColumn   typeid: Int32   len: 3  data: [NULL, NULL, 12]
ArrayColumn      typeid: Array   len: 3  data: [[test], [data, bend], [hello, world, NULL]]
StructColumn     typeid: Struct  len: 3  data: [[18869, 1], [18948, 2], [1, 3]]
```

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

