### PR TITLE
chore(datavalue2): fix too-strong bound on ScalarBinaryExpression

### DIFF
--- a/common/functions/src/scalars/expressions/binary.rs
+++ b/common/functions/src/scalars/expressions/binary.rs
@@ -27,7 +27,7 @@ pub struct ScalarBinaryExpression<L: Scalar, R: Scalar, O: Scalar, F> {
     _phantom: PhantomData<(L, R, O)>,
 }
 
-impl<'a, L: Scalar, R: Scalar, O: Scalar, F> ScalarBinaryExpression<L, R, O, F>
+impl<L: Scalar, R: Scalar, O: Scalar, F> ScalarBinaryExpression<L, R, O, F>
 where F: ScalarBinaryFunction<L, R, O>
 {
     /// Create a binary expression from generic columns  and a lambda function.
@@ -39,7 +39,7 @@ where F: ScalarBinaryFunction<L, R, O>
     }
 
     /// Evaluate the expression with the given array.
-    pub fn eval(&self, l: &'a ColumnRef, r: &'a ColumnRef) -> Result<<O as Scalar>::ColumnType> {
+    pub fn eval(&self, l: &ColumnRef, r: &ColumnRef) -> Result<<O as Scalar>::ColumnType> {
         let left = ColumnViewerIter::<L>::try_create(l)?;
         let right = ColumnViewerIter::<R>::try_create(r)?;
 

--- a/common/functions/tests/it/scalars/expressions.rs
+++ b/common/functions/tests/it/scalars/expressions.rs
@@ -161,10 +161,6 @@ fn test_datetime_cast_function() -> Result<()> {
 #[test]
 fn test_binary_contains() {
     //create two string columns
-    let l = Series::from_data(vec!["11", "22", "33"]);
-    let r = Series::from_data(vec!["1", "2", "43"]);
-    let expected = Series::from_data(vec![true, true, false]);
-
     struct Contains {}
 
     impl ScalarBinaryFunction<Vu8, Vu8, bool> for Contains {
@@ -174,10 +170,15 @@ fn test_binary_contains() {
     }
 
     let binary_expression = ScalarBinaryExpression::<Vec<u8>, Vec<u8>, bool, _>::new(Contains {});
-    let result = binary_expression.eval(&l, &r).unwrap();
 
-    let r = Arc::new(result) as ColumnRef;
-    assert!(r == expected);
+    for _ in 0..10 {
+        let l = Series::from_data(vec!["11", "22", "33"]);
+        let r = Series::from_data(vec!["1", "2", "43"]);
+        let expected = Series::from_data(vec![true, true, false]);
+        let result = binary_expression.eval(&l, &r).unwrap();
+        let result = Arc::new(result) as ColumnRef;
+        assert!(result == expected);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

I made the same mistake when building my own Array type system. <del>To brief, if we constraint the `ColumnRef` to have `'a` lifetime, we have to create an expression every time we want to do evaluation:</del>

```rust
for (a, b) in columns_left.iter().zip(columns_right.iter()) {
  let func = ScalarBinaryFunction::new(some_sql_func);
  func.eval(a, b);
}
```

... instead of

```rust
let func = ScalarBinaryFunction::new(some_sql_func);
// if we keep the 'a bound, the following a, b must have the same lifetime of
// `'a` at this point, but this is impossible -- they will be dropped in each
// loop. This snippet will CE with the `'a` bound applied to `ColumnRef`.
for (a, b) in columns_left.iter().zip(columns_right.iter()) {
  func.eval(a, b);
}
```

The above example may compile even when we retain the `'a` bound... Anyway, removing unnecessary lifetime could prevent future issues, especially when implementing generics types.

## Changelog

- Improvement

## Related Issues

## Test Plan

Compile pass
