### PR TITLE
[HTTP API] also allow POST method on kill query

### DIFF
--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -255,7 +255,10 @@ pub fn query_route() -> Route {
         .at("/", post(query_handler))
         .at("/:id", get(query_state_handler))
         .at("/:id/page/:page_no", get(query_page_handler))
-        .at("/:id/kill", get(query_cancel_handler))
+        .at(
+            "/:id/kill",
+            get(query_cancel_handler).post(query_cancel_handler),
+        )
 }
 
 fn query_id_not_found(query_id: String) -> PoemError {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

kill query is a write operation, maybe we can send the kill request by the POST verb?

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

