### PR TITLE
fix if with null & fix convert to nullable column bug

### DIFF
--- a/common/datavalues2/src/convert/column_convert.rs
+++ b/common/datavalues2/src/convert/column_convert.rs
@@ -27,7 +27,7 @@ use crate::NullableColumn;
 
 pub fn convert2_new_column(column: &OldDataColumnWithField) -> ColumnWithField {
     let result = convert2_new_column_nonull(column);
-    if column.field().is_nullable() && result.data_type().can_inside_nullable() {
+    if column.field().is_nullable() && result.column().data_type().can_inside_nullable() {
         let arrow_c = column.column().get_array_ref().unwrap();
         let bitmap = arrow_c.validity().cloned();
 

--- a/common/functions/src/scalars/conditionals/if.rs
+++ b/common/functions/src/scalars/conditionals/if.rs
@@ -109,13 +109,10 @@ impl Function2 for IfFunction {
 
                     for row in 0..size {
                         let predicate = predicate_wrapper.value(row);
-                        let valid = predicate_wrapper.valid_at(row);
                         if predicate {
-                            builder
-                                .append(lhs_wrapper.value(row), valid & lhs_wrapper.valid_at(row));
+                            builder.append(lhs_wrapper.value(row), lhs_wrapper.valid_at(row));
                         } else {
-                            builder
-                                .append(rhs_wrapper.value(row), valid & rhs_wrapper.valid_at(row));
+                            builder.append(rhs_wrapper.value(row), rhs_wrapper.valid_at(row));
                         };
                     }
 

--- a/common/functions/src/scalars/expressions/cast_with_type.rs
+++ b/common/functions/src/scalars/expressions/cast_with_type.rs
@@ -94,6 +94,8 @@ pub fn cast_with_type(
         //all is null
         if data_type.is_nullable() {
             return data_type.create_constant_column(&DataValue::Null, column.len());
+        } else if data_type.data_type_id() == TypeID::Boolean {
+            return data_type.create_constant_column(&DataValue::Boolean(false), column.len());
         }
         return Err(ErrorCode::BadDataValueType(
             "Can't cast column from null into non-nullable type".to_string(),

--- a/common/functions/tests/it/scalars/conditionals.rs
+++ b/common/functions/tests/it/scalars/conditionals.rs
@@ -57,20 +57,20 @@ fn test_if_function() -> Result<()> {
             name: "if-null-in-predicate",
             columns: vec![
                 Series::from_data([Some(true), None, Some(false), Some(true)]),
-                Series::from_data([1u8, 2, 3, 4]),
+                Series::from_data([Some(1u8), Some(2u8), Some(3u8), None]),
                 Series::from_data([2i32, 3, 2, 2]),
             ],
-            expect: Series::from_data(vec![Some(1i32), None, Some(2i32), Some(4i32)]), // nullable becase predicate is nullable
+            expect: Series::from_data(vec![Some(1i32), Some(3i32), Some(2i32), None]), // nullable becase predicate is nullable
             error: "",
         },
         ScalarFunction2Test {
             name: "if-nullable-and-nonnullable",
             columns: vec![
-                Series::from_data([Some(true), None, Some(false), Some(false)]),
-                Series::from_data([1u8, 2, 3, 4]),
-                Series::from_data([Some(2i32), Some(3), None, Some(2)]),
+                Series::from_data([Some(1u8), None, None, Some(2)]),
+                Series::from_data([Some(2u8), Some(2), Some(2), Some(2)]),
+                Series::from_data([Some(3i32), Some(3i32), None, None]),
             ],
-            expect: Series::from_data(vec![Some(1i32), None, None, Some(2i32)]), // nullable becase predicate and rhs are nullable
+            expect: Series::from_data(vec![Some(2i32), Some(3i32), None, Some(2i32)]), // nullable becase predicate and rhs are nullable
             error: "",
         },
         ScalarFunction2Test {
@@ -80,7 +80,7 @@ fn test_if_function() -> Result<()> {
                 Series::from_data([Some(1u8), Some(2), Some(3), Some(4)]),
                 Series::from_data([Some(2i32), Some(3), None, Some(2)]),
             ],
-            expect: Series::from_data(vec![Some(1i32), None, None, Some(2i32)]), // nullable becase all column are nullable
+            expect: Series::from_data(vec![Some(1i32), Some(3i32), None, Some(2i32)]), // nullable becase all column are nullable
             error: "",
         },
         ScalarFunction2Test {
@@ -91,6 +91,16 @@ fn test_if_function() -> Result<()> {
                 Arc::new(NullColumn::new(4)),
             ],
             expect: Series::from_data(vec![Some(1u8), None, None, Some(4)]),
+            error: "",
+        },
+        ScalarFunction2Test {
+            name: "if-null",
+            columns: vec![
+                Arc::new(NullColumn::new(4)),
+                Series::from_data([0u8, 0, 0, 0]),
+                Series::from_data([1u8, 2, 3, 4]),
+            ],
+            expect: Series::from_data(vec![1u8, 2, 3, 4]),
             error: "",
         },
     ];

--- a/tests/suites/0_stateless/02_0002_function_cast.result
+++ b/tests/suites/0_stateless/02_0002_function_cast.result
@@ -8,6 +8,7 @@ Int64
 UInt32
 2
 3
+0
 1
 1
 ===DATE/DATETIME===

--- a/tests/suites/0_stateless/02_0002_function_cast.sql
+++ b/tests/suites/0_stateless/02_0002_function_cast.sql
@@ -11,9 +11,10 @@ SELECT CAST(1 + 1, Float64);
 SELECT CAST(CAST(1 + 1 + 1, String) AS Int8);
 
 SELECT CAST(Null as Int64); -- {ErrorCode 1010}
-SELECT CAST(Null as Boolean); -- {ErrorCode 1010}
 SELECT CAST(Null as Varchar); -- {ErrorCode 1010}
 
+-- Null can only be cast successfully to type boolean(false)
+SELECT CAST(Null as Boolean);
 SELECT CAST('33' as signed) = 33;
 SELECT CAST('33' as unsigned) = 33;
 SELECT CAST('-33aa' as signed) = 33; -- {ErrorCode 1010}


### PR DESCRIPTION
Signed-off-by: Veeupup <code@tanweime.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* modify `if` behavoior, in detail:
before:
`select if(null, 1, 2)` -> `null`
now:
`select if(null, 1, 2)` -> `2`
when considering with if, null will be used as `false`.

* fix `old-datavalues` column convert into nullable `new-datavalues` column bug

* A Special case:when casting `NullColumn` into `BooleanColumn`, it will return a `BooleanColumn` with full `false`. It will not affect other behaviors.

## Changelog

- Bug Fix
- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

