### PR TITLE
Fix Unable to get field name bug

### DIFF
--- a/common/planners/src/plan_expression.rs
+++ b/common/planners/src/plan_expression.rs
@@ -176,13 +176,14 @@ impl Expression {
             Expression::UnaryExpression { op, expr } => {
                 format!("({} {})", op.to_lowercase(), expr.column_name())
             }
-            Expression::BinaryExpression { op, left, right } => {format!(
-                "({} {} {})",
-                left.column_name(),
-                op.to_lowercase(),
-                right.column_name()
-            )
-        }
+            Expression::BinaryExpression { op, left, right } => {
+                format!(
+                    "({} {} {})",
+                    left.column_name(),
+                    op.to_lowercase(),
+                    right.column_name()
+                )
+            }
             Expression::ScalarFunction { op, args } => {
                 match OP_SET.get(&op.to_lowercase().as_ref()) {
                     Some(_) => format!("{}()", op),

--- a/common/planners/src/plan_expression.rs
+++ b/common/planners/src/plan_expression.rs
@@ -174,11 +174,15 @@ impl Expression {
                 }
             },
             Expression::UnaryExpression { op, expr } => {
-                format!("({} {})", op, expr.column_name())
+                format!("({} {})", op.to_lowercase(), expr.column_name())
             }
-            Expression::BinaryExpression { op, left, right } => {
-                format!("({} {} {})", left.column_name(), op, right.column_name())
-            }
+            Expression::BinaryExpression { op, left, right } => {format!(
+                "({} {} {})",
+                left.column_name(),
+                op.to_lowercase(),
+                right.column_name()
+            )
+        }
             Expression::ScalarFunction { op, args } => {
                 match OP_SET.get(&op.to_lowercase().as_ref()) {
                     Some(_) => format!("{}()", op),

--- a/query/src/optimizers/optimizer_expression_transform.rs
+++ b/query/src/optimizers/optimizer_expression_transform.rs
@@ -149,6 +149,108 @@ impl ExprTransformImpl {
             _ => Ok(origin.not_eq(lit(0))),
         }
     }
+
+    fn constant_transformer(origin: &Expression) -> Result<Expression> {
+        let (column_name, left, right, is_and) = match origin {
+            Expression::BinaryExpression { op, left, right } => match op.to_lowercase().as_str() {
+                "and" => (origin.column_name(), left, right, true),
+                "or" => (origin.column_name(), left, right, false),
+                _ => return Ok(origin.clone()),
+            },
+            _ => return Ok(origin.clone()),
+        };
+
+        let left = Self::constant_transformer(left)?;
+        let right = Self::constant_transformer(right)?;
+
+        let mut is_remove = false;
+
+        let mut left_const = false;
+        let new_left = Self::eval_const_cond(
+            column_name.clone(),
+            &left,
+            is_and,
+            &mut left_const,
+            &mut is_remove,
+        )?;
+        if is_remove {
+            return Ok(new_left);
+        }
+
+        let mut right_const = false;
+        let new_right = Self::eval_const_cond(
+            column_name.clone(),
+            &right,
+            is_and,
+            &mut right_const,
+            &mut is_remove,
+        )?;
+        if is_remove {
+            return Ok(new_right);
+        }
+
+        match (left_const, right_const) {
+            (true, true) => {
+                if is_and {
+                    Ok(Expression::Literal {
+                        value: DataValue::Boolean(Some(true)),
+                        column_name: Some(column_name),
+                        data_type: DataType::Boolean,
+                    })
+                } else {
+                    Ok(Expression::Literal {
+                        value: DataValue::Boolean(Some(false)),
+                        column_name: Some(column_name),
+                        data_type: DataType::Boolean,
+                    })
+                }
+            }
+            (true, false) => Ok(new_right),
+            (false, true) => Ok(new_left),
+            (false, false) => {
+                if is_and {
+                    Ok(new_left.and(new_right))
+                } else {
+                    Ok(new_left.or(new_right))
+                }
+            }
+        }
+    }
+
+    fn eval_const_cond(
+        column_name: String,
+        expr: &Expression,
+        is_and: bool,
+        is_const: &mut bool,
+        is_remove: &mut bool,
+    ) -> Result<Expression> {
+        match expr {
+            Expression::Literal { ref value, .. } => {
+                *is_const = true;
+                let val = value.as_bool()?;
+                if val {
+                    if !is_and {
+                        *is_remove = true;
+                        return Ok(Expression::Literal {
+                            value: DataValue::Boolean(Some(true)),
+                            column_name: Some(column_name),
+                            data_type: DataType::Boolean,
+                        });
+                    }
+                } else if is_and {
+                    *is_remove = true;
+                    return Ok(Expression::Literal {
+                        value: DataValue::Boolean(Some(false)),
+                        column_name: Some(column_name),
+                        data_type: DataType::Boolean,
+                    });
+                }
+            }
+            _ => *is_const = false,
+        }
+        *is_remove = false;
+        Ok(expr.clone())
+    }
 }
 
 impl PlanRewriter for ExprTransformImpl {
@@ -201,7 +303,8 @@ impl PlanRewriter for ExprTransformImpl {
         }
 
         let new_input = self.rewrite_plan_node(plan.input.as_ref())?;
-        let new_predicate = Self::boolean_transformer(&plan.predicate)?;
+        let new_predicate = Self::constant_transformer(&plan.predicate)?;
+        let new_predicate = Self::boolean_transformer(&new_predicate)?;
         let new_predicate = Self::truth_transformer(&new_predicate, false)?;
         PlanBuilder::from(&new_input).filter(new_predicate)?.build()
     }

--- a/query/src/optimizers/optimizer_expression_transform.rs
+++ b/query/src/optimizers/optimizer_expression_transform.rs
@@ -320,7 +320,8 @@ impl PlanRewriter for ExprTransformImpl {
         }
 
         let new_input = self.rewrite_plan_node(plan.input.as_ref())?;
-        let new_predicate = Self::boolean_transformer(&plan.predicate)?;
+        let new_predicate = Self::constant_transformer(&plan.predicate)?;
+        let new_predicate = Self::boolean_transformer(&new_predicate)?;
         let new_predicate = Self::truth_transformer(&new_predicate, false)?;
         PlanBuilder::from(&new_input).having(new_predicate)?.build()
     }

--- a/query/tests/it/optimizers/optimizer_constant_folding.rs
+++ b/query/tests/it/optimizers/optimizer_constant_folding.rs
@@ -83,14 +83,6 @@ async fn test_constant_folding_optimizer() -> Result<()> {
                 \n    ReadDataSource: scan schema: [dummy:UInt8], statistics: [read_rows: 1, read_bytes: 1, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]",
             },
             Test {
-                name: "Projection logics const recursion",
-                query: "SELECT 1 = 1 AND 2 > 1",
-                expect: "\
-                Projection: ((1 = 1) AND (2 > 1)):Boolean\
-                \n  Expression: true:Boolean (Before Projection)\
-                \n    ReadDataSource: scan schema: [dummy:UInt8], statistics: [read_rows: 1, read_bytes: 1, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]",
-            },
-            Test {
                 name: "Projection strings const recursion",
                 query: "SELECT SUBSTRING('1234567890' FROM 3 FOR 3)",
                 expect: "\
@@ -105,70 +97,6 @@ async fn test_constant_folding_optimizer() -> Result<()> {
                 Projection: toTypeName('1234567890'):String\
                 \n  Expression: String:String (Before Projection)\
                 \n    ReadDataSource: scan schema: [dummy:UInt8], statistics: [read_rows: 1, read_bytes: 1, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]",
-            },
-            Test {
-                name: "Filter true and cond",
-                query: "SELECT number from numbers(10) where true AND number > 1",
-                expect: "\
-                Projection: number:UInt64\
-                \n  Filter: (number > 1)\
-                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [(true AND (number > 1))]]",
-            },
-            Test {
-                name: "Filter cond and true",
-                query: "SELECT number from numbers(10) where number > 1 AND true",
-                expect: "\
-                Projection: number:UInt64\
-                \n  Filter: (number > 1)\
-                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [((number > 1) AND true)]]",
-            },
-            Test {
-                name: "Filter false and cond",
-                query: "SELECT number from numbers(10) where false AND number > 1",
-                expect: "\
-                Projection: number:UInt64\
-                \n  Filter: false\
-                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [(false AND (number > 1))]]",
-            },
-            Test {
-                name: "Filter cond and false",
-                query: "SELECT number from numbers(10) where number > 1 AND false",
-                expect: "\
-                Projection: number:UInt64\
-                \n  Filter: false\
-                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [((number > 1) AND false)]]",
-            },
-            Test {
-                name: "Filter false or cond",
-                query: "SELECT number from numbers(10) where false OR number > 1",
-                expect: "\
-                Projection: number:UInt64\
-                \n  Filter: (number > 1)\
-                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [(false OR (number > 1))]]",
-            },
-            Test {
-                name: "Filter cond or false",
-                query: "SELECT number from numbers(10) where number > 1 OR false",
-                expect: "\
-                Projection: number:UInt64\
-                \n  Filter: (number > 1)\
-                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [((number > 1) OR false)]]",
-            },
-            Test {
-                name: "Filter true or cond",
-                query: "SELECT number from numbers(10) where true OR number > 1",
-                expect: "\
-                Projection: number:UInt64\
-                \n  Filter: true\
-                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [(true OR (number > 1))]]",
-            },
-            Test {
-                name: "Filter cond or true",
-                query: "SELECT number from numbers(10) where number > 1 OR true",
-                expect: "\
-                Projection: number:UInt64\
-                \n  Filter: true\
-                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [((number > 1) OR true)]]",
             },
         ];
 

--- a/query/tests/it/optimizers/optimizer_expression_transform.rs
+++ b/query/tests/it/optimizers/optimizer_expression_transform.rs
@@ -179,6 +179,22 @@ async fn test_expression_transform_optimizer() -> Result<()> {
                 \n  Filter: true\
                 \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [((number > 1) OR true)]]",
             },
+            Test {
+                name: "Projection logics const",
+                query: "SELECT 1 = 1 and 2 > 1",
+                expect: "\
+                Projection: ((1 = 1) and (2 > 1)):Boolean\
+                \n  Expression: ((1 = 1) and (2 > 1)):Boolean (Before Projection)\
+                \n    ReadDataSource: scan schema: [dummy:UInt8], statistics: [read_rows: 1, read_bytes: 1, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]",
+            },
+            Test {
+                name: "Projection cond",
+                query: "select number<3 or number>5 from numbers(10);",
+                expect: "\
+                Projection: ((number < 3) or (number > 5)):Boolean\
+                \n  Expression: ((number < 3) or (number > 5)):Boolean (Before Projection)\
+                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]",
+            },
         ];
 
     for test in tests {

--- a/query/tests/it/optimizers/optimizer_expression_transform.rs
+++ b/query/tests/it/optimizers/optimizer_expression_transform.rs
@@ -115,6 +115,70 @@ async fn test_expression_transform_optimizer() -> Result<()> {
                 \n    Filter: true\
                 \n      ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 0, read_bytes: 0, partitions_scanned: 0, partitions_total: 0], push_downs: [projections: [0], filters: [true]]",
             },
+            Test {
+                name: "Filter true and cond",
+                query: "SELECT number from numbers(10) where true AND number > 1",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: (number > 1)\
+                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [(true AND (number > 1))]]",
+            },
+            Test {
+                name: "Filter cond and true",
+                query: "SELECT number from numbers(10) where number > 1 AND true",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: (number > 1)\
+                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [((number > 1) AND true)]]",
+            },
+            Test {
+                name: "Filter false and cond",
+                query: "SELECT number from numbers(10) where false AND number > 1",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: false\
+                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [(false AND (number > 1))]]",
+            },
+            Test {
+                name: "Filter cond and false",
+                query: "SELECT number from numbers(10) where number > 1 AND false",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: false\
+                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [((number > 1) AND false)]]",
+            },
+            Test {
+                name: "Filter false or cond",
+                query: "SELECT number from numbers(10) where false OR number > 1",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: (number > 1)\
+                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [(false OR (number > 1))]]",
+            },
+            Test {
+                name: "Filter cond or false",
+                query: "SELECT number from numbers(10) where number > 1 OR false",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: (number > 1)\
+                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [((number > 1) OR false)]]",
+            },
+            Test {
+                name: "Filter true or cond",
+                query: "SELECT number from numbers(10) where true OR number > 1",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: true\
+                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [(true OR (number > 1))]]",
+            },
+            Test {
+                name: "Filter cond or true",
+                query: "SELECT number from numbers(10) where number > 1 OR true",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: true\
+                \n    ReadDataSource: scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0], filters: [((number > 1) OR true)]]",
+            },
         ];
 
     for test in tests {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

CC @Veeupup , it's another bug, I just move `constant_cond_remove` from `constant_folding` to `expression_transform`. The problem `null value will be optimized as false` described in the issue #4004  is still exists.
I think doing this in the filter maybe has no effect.

This is the same problem as issue #2165


## Changelog

- Bug Fix

## Related Issues

Fixes #4012 

## Test Plan

Unit Tests
