### PR TITLE
Implement the parser for expression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,6 +1437,7 @@ dependencies = [
  "nom-rule",
  "nom-supreme",
  "once_cell",
+ "pratt",
  "pretty_assertions",
  "sqlparser",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,15 +1039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brownstone"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ea61398f34f1395ccbeb046fb68c87b631d1f34567fed0f0f11fa35d18d8d"
-dependencies = [
- "arrayvec 0.7.2",
-]
-
-[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,7 +1426,6 @@ dependencies = [
  "logos",
  "nom 7.1.0",
  "nom-rule",
- "nom-supreme",
  "once_cell",
  "pratt",
  "pretty_assertions",
@@ -3692,12 +3682,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indent_write"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
-
-[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3846,12 +3830,6 @@ checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "joinery"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-sys"
@@ -4656,19 +4634,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "nom-supreme"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadc66631948f6b65da03be4c4cd8bd104d481697ecbb9bbd65719b1ec60bc9f"
-dependencies = [
- "brownstone",
- "indent_write",
- "joinery",
- "memchr",
- "nom 7.1.0",
 ]
 
 [[package]]

--- a/common/ast/Cargo.toml
+++ b/common/ast/Cargo.toml
@@ -23,11 +23,11 @@ async-trait = "0.1.52"
 logos = "0.12"
 nom = "7"
 nom-rule = "0.1"
-nom-supreme = "0.6"
 once_cell = "1.9.0"
 thiserror = "1.0.30"
 pratt = "0.3"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
+nom-supreme = "0.6"
 common-base = { path = "../base" }

--- a/common/ast/Cargo.toml
+++ b/common/ast/Cargo.toml
@@ -29,5 +29,4 @@ pratt = "0.3"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
-nom-supreme = "0.6"
 common-base = { path = "../base" }

--- a/common/ast/Cargo.toml
+++ b/common/ast/Cargo.toml
@@ -23,10 +23,11 @@ async-trait = "0.1.52"
 logos = "0.12"
 nom = "7"
 nom-rule = "0.1"
+nom-supreme = "0.6"
 once_cell = "1.9.0"
 thiserror = "1.0.30"
+pratt = "0.3"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
-nom-supreme = "0.6"
 common-base = { path = "../base" }

--- a/common/ast/src/lib.rs
+++ b/common/ast/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(trait_alias)]
+
 pub mod error;
 pub mod parser;
 pub mod udfs;

--- a/common/ast/src/parser/ast/expression.rs
+++ b/common/ast/src/parser/ast/expression.rs
@@ -22,73 +22,68 @@ use crate::parser::ast::display_identifier_vec;
 #[derive(Debug, Clone, PartialEq)]
 #[allow(dead_code)]
 pub enum Expr {
-    // Wildcard star
-    Wildcard,
-    // Column reference, with indirection like `table.column`
+    /// Column reference, with indirection like `table.column`
     ColumnRef {
         database: Option<Identifier>,
         table: Option<Identifier>,
         column: Identifier,
     },
-    // `IS NULL` expression
-    IsNull(Box<Expr>),
-    // `IS NOT NULL` expression
-    IsNotNull(Box<Expr>),
-    // `[ NOT ] IN (expr, ...)`
+    /// `IS [ NOT ] NULL` expression
+    IsNull { expr: Box<Expr>, not: bool },
+    /// `[ NOT ] IN (expr, ...)`
     InList {
         expr: Box<Expr>,
         list: Vec<Expr>,
         not: bool,
     },
-    // `[ NOT ] IN (SELECT ...)`
+    /// `[ NOT ] IN (SELECT ...)`
     InSubquery {
         expr: Box<Expr>,
         subquery: Box<Query>,
         not: bool,
     },
-    // `BETWEEN ... AND ...`
+    /// `BETWEEN ... AND ...`
     Between {
         expr: Box<Expr>,
-        negated: bool,
         low: Box<Expr>,
         high: Box<Expr>,
+        not: bool,
     },
-    // Binary operation
+    /// Binary operation
     BinaryOp {
         op: BinaryOperator,
         left: Box<Expr>,
         right: Box<Expr>,
     },
-    // Unary operation
-    UnaryOp {
-        op: UnaryOperator,
-        expr: Box<Expr>,
-    },
-    // `CAST` expression, like `CAST(expr AS target_type)`
+    /// Unary operation
+    UnaryOp { op: UnaryOperator, expr: Box<Expr> },
+    /// `CAST` expression, like `CAST(expr AS target_type)`
     Cast {
         expr: Box<Expr>,
         target_type: TypeName,
     },
-    // A literal value, such as string, number, date or NULL
+    /// A literal value, such as string, number, date or NULL
     Literal(Literal),
-    // Scalar function call
+    /// `COUNT(*)` expression
+    CountAll,
+    /// Scalar function call
     FunctionCall {
-        // Set to true if the function is aggregate function with `DISTINCT`, like `COUNT(DISTINCT a)`
+        /// Set to true if the function is aggregate function with `DISTINCT`, like `COUNT(DISTINCT a)`
         distinct: bool,
         name: String,
         args: Vec<Expr>,
         params: Vec<Literal>,
     },
-    // `CASE ... WHEN ... ELSE ...` expression
+    /// `CASE ... WHEN ... ELSE ...` expression
     Case {
         operand: Option<Box<Expr>>,
         conditions: Vec<Expr>,
         results: Vec<Expr>,
         else_result: Option<Box<Expr>>,
     },
-    // `EXISTS` expression
+    /// `EXISTS` expression
     Exists(Box<Query>),
-    // Scalar subquery, which will only return a single row with a single column.
+    /// Scalar subquery, which will only return a single row with a single column.
     Subquery(Box<Query>),
 }
 
@@ -164,7 +159,7 @@ impl Display for UnaryOperator {
                 write!(f, "+")
             }
             UnaryOperator::Minus => {
-                write!(f, "NEGATE")
+                write!(f, "-")
             }
             UnaryOperator::Not => {
                 write!(f, "NOT")
@@ -346,9 +341,6 @@ impl Display for Literal {
 impl Display for Expr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Expr::Wildcard => {
-                write!(f, "*")?;
-            }
             Expr::ColumnRef {
                 database,
                 table,
@@ -367,19 +359,16 @@ impl Display for Expr {
                     .as_slice(),
                 )?;
             }
-            Expr::IsNull(expr) => {
-                write!(f, "{} IS NULL", expr)?;
+            Expr::IsNull { expr, not } => {
+                write!(f, "{} IS ", expr)?;
+                if *not {
+                    write!(f, "NOT ")?;
+                }
+                write!(f, "NULL")?;
             }
-            Expr::IsNotNull(expr) => {
-                write!(f, "{} IS NOT NULL", expr)?;
-            }
-            Expr::InList {
-                expr,
-                list,
-                not: negated,
-            } => {
+            Expr::InList { expr, list, not } => {
                 write!(f, "{} ", expr)?;
-                if *negated {
+                if *not {
                     write!(f, "NOT ")?;
                 }
                 write!(f, "IN(")?;
@@ -394,22 +383,22 @@ impl Display for Expr {
             Expr::InSubquery {
                 expr,
                 subquery,
-                not: negated,
+                not,
             } => {
                 write!(f, "{} ", expr)?;
-                if *negated {
+                if *not {
                     write!(f, "NOT ")?;
                 }
                 write!(f, "IN({})", subquery)?;
             }
             Expr::Between {
                 expr,
-                negated,
                 low,
                 high,
+                not,
             } => {
                 write!(f, "{} ", expr)?;
-                if *negated {
+                if *not {
                     write!(f, "NOT ")?;
                 }
                 write!(f, "BETWEEN {} AND {}", low, high)?;
@@ -425,6 +414,9 @@ impl Display for Expr {
             }
             Expr::Literal(lit) => {
                 write!(f, "{}", lit)?;
+            }
+            Expr::CountAll => {
+                write!(f, "COUNT(*)")?;
             }
             Expr::FunctionCall {
                 distinct,

--- a/common/ast/src/parser/rule/expr.rs
+++ b/common/ast/src/parser/rule/expr.rs
@@ -75,8 +75,6 @@ where Error: ParseError<Input<'a>> {
 
         let (i, expr_elements) = rule! { #expr_element_limited+ }(i)?;
 
-        dbg!(&expr_elements);
-
         let mut iter = expr_elements.into_iter();
         let expr = ExprParser
             .parse(&mut iter)

--- a/common/ast/src/parser/rule/expr.rs
+++ b/common/ast/src/parser/rule/expr.rs
@@ -334,9 +334,9 @@ where Error: ParseError<Input<'a>> {
         rule! {
             NOT? ~ IN ~ "(" ~ #expr ~ ("," ~ #expr)*  ~ ")"
         },
-        |(not, _, _, head, tails, _)| {
+        |(not, _, _, head, tail, _)| {
             let mut list = vec![head];
-            list.extend(tails.into_iter().map(|(_, expr)| expr));
+            list.extend(tail.into_iter().map(|(_, expr)| expr));
             ExprElement::InList {
                 list,
                 not: not.is_some(),
@@ -593,7 +593,7 @@ where Error: ParseError<Input<'a>> {
     )(i)
 }
 
-// TODO(andylokandy): complete the keyword-function list, or remove the function name from keywords
+// TODO(andylokandy): complete the keyword-function list, or remove the functions' name from keywords
 pub fn function_name<'a, Error>(i: Input<'a>) -> IResult<Input<'a>, String, Error>
 where Error: ParseError<Input<'a>> {
     map(

--- a/common/ast/src/parser/rule/expr.rs
+++ b/common/ast/src/parser/rule/expr.rs
@@ -1,0 +1,555 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use nom::branch::alt;
+use nom::combinator::map;
+use nom::combinator::value;
+use nom::error::make_error;
+use nom::error::ContextError;
+use nom::error::ErrorKind;
+use nom::IResult;
+use pratt::Affix;
+use pratt::Associativity;
+use pratt::PrattError;
+use pratt::PrattParser;
+use pratt::Precedence;
+
+use crate::parser::ast::BinaryOperator;
+use crate::parser::ast::Expr;
+use crate::parser::ast::Identifier;
+use crate::parser::ast::Literal;
+use crate::parser::ast::Query;
+use crate::parser::ast::TypeName;
+use crate::parser::ast::UnaryOperator;
+use crate::parser::rule::util::ident;
+use crate::parser::rule::util::literal_u64;
+use crate::parser::rule::util::Input;
+use crate::parser::rule::util::ParseError;
+use crate::parser::token::*;
+use crate::rule;
+
+pub fn query<'a, Error>(i: Input<'a>) -> IResult<Input<'a>, Query, Error>
+where Error: ParseError<Input<'a>> {
+    todo!()
+}
+
+pub fn expr<'a, Error>(i: Input<'a>) -> IResult<Input<'a>, Expr, Error>
+where Error: ParseError<Input<'a>> {
+    let (i, expr_elements) = rule! { #expr_element+ }(i)?;
+    let mut iter = expr_elements.into_iter();
+    let expr = ExprParser
+        .parse(&mut iter)
+        .map_err(|err| match err {
+            PrattError::EmptyInput => {
+                ContextError::add_context(i, "empty expresssion", make_error(i, ErrorKind::Eof))
+            }
+            // TODO (andylokandy): report the proper span
+            PrattError::UnexpectedNilfix(_) => ContextError::add_context(
+                i,
+                "unable to parse the value",
+                make_error(i, ErrorKind::Complete),
+            ),
+            PrattError::UnexpectedPrefix(_) => ContextError::add_context(
+                i,
+                "unable to parse the prefix operator",
+                make_error(i, ErrorKind::Complete),
+            ),
+            PrattError::UnexpectedInfix(_) => ContextError::add_context(
+                i,
+                "unable to parse the binary operator",
+                make_error(i, ErrorKind::Complete),
+            ),
+            PrattError::UnexpectedPostfix(_) => ContextError::add_context(
+                i,
+                "unable to parse the postfix operator",
+                make_error(i, ErrorKind::Complete),
+            ),
+            PrattError::UserError(_) => unreachable!(),
+        })
+        .map_err(nom::Err::Error)?;
+
+    let rest: Vec<_> = iter.collect();
+    if !rest.is_empty() {
+        return Err(nom::Err::Error(ContextError::add_context(
+            i,
+            "unable to parse the rest of expression",
+            make_error(i, ErrorKind::Complete),
+        )));
+    }
+
+    Ok((i, expr))
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
+pub enum ExprElement {
+    /// Column reference, with indirection like `table.column`
+    ColumnRef {
+        database: Option<Identifier>,
+        table: Option<Identifier>,
+        column: Identifier,
+    },
+    /// `IS NULL` expression
+    IsNull { not: bool },
+    /// `IS NOT NULL` expression
+    /// `[ NOT ] IN (list, ...)`
+    InList { list: Vec<Expr>, not: bool },
+    /// `[ NOT ] IN (SELECT ...)`
+    InSubquery { subquery: Query, not: bool },
+    /// `BETWEEN ... AND ...`
+    Between { low: Expr, high: Expr, not: bool },
+    /// Binary operation
+    BinaryOp { op: BinaryOperator },
+    /// Unary operation
+    UnaryOp { op: UnaryOperator },
+    /// `CAST` expression, like `CAST(expr AS target_type)`
+    Cast { expr: Expr, target_type: TypeName },
+    /// A literal value, such as string, number, date or NULL
+    Literal(Literal),
+    /// `Count(*)` expression
+    CountAll,
+    /// Scalar function call
+    FunctionCall {
+        /// Set to true if the function is aggregate function with `DISTINCT`, like `COUNT(DISTINCT a)`
+        distinct: bool,
+        name: String,
+        args: Vec<Expr>,
+        params: Vec<Literal>,
+    },
+    /// `CASE ... WHEN ... ELSE ...` expression
+    Case {
+        operand: Option<Expr>,
+        conditions: Vec<Expr>,
+        results: Vec<Expr>,
+        else_result: Option<Expr>,
+    },
+    /// `EXISTS` expression
+    Exists(Query),
+    /// Scalar subquery, which will only return a single row with a single column.
+    Subquery(Query),
+    /// An expression between parentheses
+    Group(Expr),
+}
+
+struct ExprParser;
+
+impl<I: Iterator<Item = ExprElement>> PrattParser<I> for ExprParser {
+    type Error = pratt::NoError;
+    type Input = ExprElement;
+    type Output = Expr;
+
+    fn query(&mut self, elem: &ExprElement) -> pratt::Result<Affix> {
+        let affix = match elem {
+            ExprElement::IsNull { .. } => Affix::Postfix(Precedence(17)),
+            ExprElement::Between { .. } => Affix::Postfix(Precedence(20)),
+            ExprElement::InList { .. } => Affix::Postfix(Precedence(20)),
+            ExprElement::InSubquery { .. } => Affix::Postfix(Precedence(20)),
+            ExprElement::UnaryOp { op } => match op {
+                UnaryOperator::Not => Affix::Prefix(Precedence(15)),
+
+                UnaryOperator::Plus => Affix::Prefix(Precedence(30)),
+                UnaryOperator::Minus => Affix::Prefix(Precedence(30)),
+            },
+            ExprElement::BinaryOp { op } => match op {
+                BinaryOperator::Or => Affix::Infix(Precedence(5), Associativity::Left),
+
+                BinaryOperator::And => Affix::Infix(Precedence(10), Associativity::Left),
+
+                BinaryOperator::Eq => Affix::Infix(Precedence(20), Associativity::Right),
+                BinaryOperator::NotEq => Affix::Infix(Precedence(20), Associativity::Left),
+                BinaryOperator::Gt => Affix::Infix(Precedence(20), Associativity::Left),
+                BinaryOperator::Lt => Affix::Infix(Precedence(20), Associativity::Left),
+                BinaryOperator::Gte => Affix::Infix(Precedence(20), Associativity::Left),
+                BinaryOperator::Lte => Affix::Infix(Precedence(20), Associativity::Left),
+                BinaryOperator::Like => Affix::Infix(Precedence(20), Associativity::Left),
+                BinaryOperator::NotLike => Affix::Infix(Precedence(20), Associativity::Left),
+
+                BinaryOperator::BitwiseOr => Affix::Infix(Precedence(22), Associativity::Left),
+                BinaryOperator::BitwiseAnd => Affix::Infix(Precedence(22), Associativity::Left),
+                BinaryOperator::BitwiseXor => Affix::Infix(Precedence(22), Associativity::Left),
+
+                BinaryOperator::Plus => Affix::Infix(Precedence(30), Associativity::Left),
+                BinaryOperator::Minus => Affix::Infix(Precedence(30), Associativity::Left),
+
+                BinaryOperator::Multiply => Affix::Infix(Precedence(40), Associativity::Left),
+                BinaryOperator::Div => Affix::Infix(Precedence(40), Associativity::Left),
+                BinaryOperator::Divide => Affix::Infix(Precedence(40), Associativity::Left),
+                BinaryOperator::Modulo => Affix::Infix(Precedence(40), Associativity::Left),
+                BinaryOperator::StringConcat => Affix::Infix(Precedence(40), Associativity::Left),
+            },
+            _ => Affix::Nilfix,
+        };
+        Ok(affix)
+    }
+
+    fn primary(&mut self, elem: ExprElement) -> pratt::Result<Expr> {
+        let expr = match elem {
+            ExprElement::ColumnRef {
+                database,
+                table,
+                column,
+            } => Expr::ColumnRef {
+                database,
+                table,
+                column,
+            },
+            ExprElement::Cast { expr, target_type } => Expr::Cast {
+                expr: Box::new(expr),
+                target_type,
+            },
+            ExprElement::Literal(lit) => Expr::Literal(lit),
+            ExprElement::CountAll => Expr::CountAll,
+            ExprElement::FunctionCall {
+                distinct,
+                name,
+                args,
+                params,
+            } => Expr::FunctionCall {
+                distinct,
+                name,
+                args,
+                params,
+            },
+            ExprElement::Case {
+                operand,
+                conditions,
+                results,
+                else_result,
+            } => Expr::Case {
+                operand: operand.map(Box::new),
+                conditions,
+                results,
+                else_result: else_result.map(Box::new),
+            },
+            ExprElement::Exists(subquery) => Expr::Exists(Box::new(subquery)),
+            ExprElement::Subquery(subquery) => Expr::Subquery(Box::new(subquery)),
+            ExprElement::Group(expr) => expr,
+            _ => unreachable!(),
+        };
+        Ok(expr)
+    }
+
+    fn infix(&mut self, lhs: Expr, elem: ExprElement, rhs: Expr) -> pratt::Result<Expr> {
+        match elem {
+            ExprElement::BinaryOp { op } => Ok(Expr::BinaryOp {
+                left: Box::new(lhs),
+                right: Box::new(rhs),
+                op,
+            }),
+            _ => unreachable!(),
+        }
+    }
+
+    fn prefix(&mut self, elem: ExprElement, rhs: Expr) -> pratt::Result<Expr> {
+        match elem {
+            ExprElement::UnaryOp { op } => Ok(Expr::UnaryOp {
+                op,
+                expr: Box::new(rhs),
+            }),
+            _ => unreachable!(),
+        }
+    }
+
+    fn postfix(&mut self, lhs: Expr, elem: ExprElement) -> pratt::Result<Expr> {
+        let expr = match elem {
+            ExprElement::IsNull { not } => Expr::IsNull {
+                expr: Box::new(lhs),
+                not,
+            },
+            ExprElement::InList { list, not } => Expr::InList {
+                expr: Box::new(lhs),
+                list,
+                not,
+            },
+            ExprElement::InSubquery { subquery, not } => Expr::InSubquery {
+                expr: Box::new(lhs),
+                subquery: Box::new(subquery),
+                not,
+            },
+            ExprElement::Between { low, high, not } => Expr::Between {
+                expr: Box::new(lhs),
+                low: Box::new(low),
+                high: Box::new(high),
+                not,
+            },
+            _ => unreachable!(),
+        };
+        Ok(expr)
+    }
+}
+
+pub fn expr_element<'a, Error>(i: Input<'a>) -> IResult<Input<'a>, ExprElement, Error>
+where Error: ParseError<Input<'a>> {
+    let column_ref = map(
+        rule! {
+            ((#ident ~ ".")? ~ #ident ~ ".")? ~ #ident
+        },
+        |res| match res {
+            (None, column) => ExprElement::ColumnRef {
+                database: None,
+                table: None,
+                column,
+            },
+            (Some((None, table, _)), column) => ExprElement::ColumnRef {
+                database: None,
+                table: Some(table),
+                column,
+            },
+            (Some((Some((database, _)), table, _)), column) => ExprElement::ColumnRef {
+                database: Some(database),
+                table: Some(table),
+                column,
+            },
+        },
+    );
+    let is_null = map(
+        rule! {
+            IS ~ NOT? ~ NULL
+        },
+        |(_, not, _)| ExprElement::IsNull { not: not.is_some() },
+    );
+    let in_list = map(
+        rule! {
+            NOT? ~ IN ~ "(" ~ #expr ~ ("," ~ #expr)*  ~ ")"
+        },
+        |(not, _, _, head, tails, _)| {
+            let mut list = vec![head];
+            list.extend(tails.into_iter().map(|(_, expr)| expr));
+            ExprElement::InList {
+                list,
+                not: not.is_some(),
+            }
+        },
+    );
+    let in_subquery = map(
+        rule! {
+            NOT? ~ IN ~ "(" ~ #query  ~ ")"
+        },
+        |(not, _, _, subquery, _)| ExprElement::InSubquery {
+            subquery,
+            not: not.is_some(),
+        },
+    );
+    let between = map(
+        rule! {
+            NOT? ~ BETWEEN ~ #expr ~ AND ~  #expr
+        },
+        |(not, _, low, _, high)| ExprElement::Between {
+            low,
+            high,
+            not: not.is_some(),
+        },
+    );
+    let cast = map(
+        rule! {
+            CAST ~ "(" ~ #expr ~ AS ~ #type_name ~ ")"
+        },
+        |(_, _, expr, _, target_type, _)| ExprElement::Cast { expr, target_type },
+    );
+    let count_all = value(ExprElement::CountAll, rule! {
+        COUNT ~ "(" ~ "*" ~ ")"
+    });
+    let function_call = map(
+        rule! {
+            Ident ~ ("(" ~ #literal ~ ("," ~ #literal)*  ~ ")")? ~ "(" ~ DISTINCT? ~ #expr ~ ("," ~ #expr)*  ~ ")"
+        },
+        |(name, params, _, distinct, args_head, args_tail, _)| {
+            let params = params
+                .map(|(_, head, tail, _)| {
+                    let mut params = vec![head];
+                    params.extend(tail.into_iter().map(|(_, param)| param));
+                    params
+                })
+                .unwrap_or_else(Vec::new);
+
+            let mut args = vec![args_head];
+            args.extend(args_tail.into_iter().map(|(_, arg)| arg));
+
+            ExprElement::FunctionCall {
+                distinct: distinct.is_some(),
+                name: name.text.to_string(),
+                args,
+                params,
+            }
+        },
+    );
+    let case = map(
+        rule! {
+            CASE ~ #expr? ~ (WHEN ~ #expr ~ THEN ~ #expr)+ ~ (ELSE ~ #expr)? ~ END
+        },
+        |(_, operand, branches, else_result, _)| {
+            let (conditions, results) = branches
+                .into_iter()
+                .map(|(_, cond, _, result)| (cond, result))
+                .unzip();
+            let else_result = else_result.map(|(_, result)| result);
+            ExprElement::Case {
+                operand,
+                conditions,
+                results,
+                else_result,
+            }
+        },
+    );
+    let exists = map(
+        rule! { EXISTS ~ "(" ~ #query ~ ")" },
+        |(_, _, subquery, _)| ExprElement::Exists(subquery),
+    );
+    let subquery = map(rule! { "(" ~ #query ~ ")" }, |(_, subquery, _)| {
+        ExprElement::Subquery(subquery)
+    });
+    let group = map(rule! { "(" ~ #expr ~ ")" }, |(_, expr, _)| {
+        ExprElement::Group(expr)
+    });
+    let binary_op = map(binary_op, |op| ExprElement::BinaryOp { op });
+    let unary_op = map(unary_op, |op| ExprElement::UnaryOp { op });
+    let literal = map(literal, ExprElement::Literal);
+
+    rule! (
+        #column_ref
+        | #is_null
+        | #in_list
+        | #in_subquery
+        | #between
+        | #binary_op
+        | #unary_op
+        | #cast
+        | #count_all
+        | #literal
+        | #function_call
+        | #case
+        | #exists
+        | #subquery
+        | #group
+    )(i)
+}
+
+pub fn unary_op<'a, Error>(i: Input<'a>) -> IResult<Input<'a>, UnaryOperator, Error>
+where Error: ParseError<Input<'a>> {
+    alt((
+        value(UnaryOperator::Plus, rule! { Plus }),
+        value(UnaryOperator::Minus, rule! { Minus }),
+        value(UnaryOperator::Not, rule! { NOT }),
+    ))(i)
+}
+
+pub fn binary_op<'a, Error>(i: Input<'a>) -> IResult<Input<'a>, BinaryOperator, Error>
+where Error: ParseError<Input<'a>> {
+    alt((
+        value(BinaryOperator::Plus, rule! { Plus }),
+        value(BinaryOperator::Minus, rule! { Minus }),
+        value(BinaryOperator::Multiply, rule! { Multiply }),
+        value(BinaryOperator::Divide, rule! { Divide }),
+        value(BinaryOperator::Div, rule! { DIV }),
+        value(BinaryOperator::StringConcat, rule! { StringConcat }),
+        value(BinaryOperator::Gt, rule! { Gt }),
+        value(BinaryOperator::Lt, rule! { Lt }),
+        value(BinaryOperator::Gte, rule! { Gte }),
+        value(BinaryOperator::Lte, rule! { Lte }),
+        value(BinaryOperator::Eq, rule! { Eq }),
+        value(BinaryOperator::NotEq, rule! { NotEq }),
+        value(BinaryOperator::And, rule! { AND }),
+        value(BinaryOperator::Or, rule! { OR }),
+        value(BinaryOperator::NotLike, rule! { NOT ~ LIKE }),
+        value(BinaryOperator::Like, rule! { LIKE }),
+        value(BinaryOperator::BitwiseOr, rule! { "|" }),
+        value(BinaryOperator::BitwiseAnd, rule! { "&" }),
+        value(BinaryOperator::BitwiseXor, rule! { "^" }),
+    ))(i)
+}
+
+pub fn literal<'a, Error>(i: Input<'a>) -> IResult<Input<'a>, Literal, Error>
+where Error: ParseError<Input<'a>> {
+    let string = map(
+        rule! {
+            LiteralString
+        },
+        |quoted| Literal::String(quoted.text[1..quoted.text.len() - 1].to_string()),
+    );
+    // TODO (andylokandy): handle hex numbers in parser
+    let number = map(
+        rule! {
+            LiteralHex | LiteralNumber
+        },
+        |number| Literal::Number(number.text.to_string()),
+    );
+    let boolean = alt((
+        value(Literal::Boolean(true), rule! { TRUE }),
+        value(Literal::Boolean(false), rule! { FALSE }),
+    ));
+    let null = value(Literal::Null, rule! { NULL });
+
+    rule!(
+        #string
+        | #number
+        | #boolean
+        | #null
+    )(i)
+}
+
+pub fn type_name<'a, Error>(i: Input<'a>) -> IResult<Input<'a>, TypeName, Error>
+where Error: ParseError<Input<'a>> {
+    let ty_char = map(
+        rule! { CHAR ~ ("(" ~ #literal_u64 ~ ")")? },
+        |(_, opt_args)| TypeName::Char(opt_args.map(|(_, length, _)| length)),
+    );
+    let ty_varchar = map(
+        rule! { VARCHAR ~ ("(" ~ #literal_u64 ~ ")")? },
+        |(_, opt_args)| TypeName::Varchar(opt_args.map(|(_, length, _)| length)),
+    );
+    let ty_float = map(
+        rule! { FLOAT ~ ("(" ~ #literal_u64 ~ ")")? },
+        |(_, opt_args)| TypeName::Float(opt_args.map(|(_, prec, _)| prec)),
+    );
+    let ty_int = map(
+        rule! { INTEGER ~ ("(" ~ #literal_u64 ~ ")")? },
+        |(_, opt_args)| TypeName::Int(opt_args.map(|(_, display, _)| display)),
+    );
+    let ty_tiny_int = map(
+        rule! { TINYINT ~ ("(" ~ #literal_u64 ~ ")")? },
+        |(_, opt_args)| TypeName::TinyInt(opt_args.map(|(_, display, _)| display)),
+    );
+    let ty_small_int = map(
+        rule! { SMALLINT ~ ("(" ~ #literal_u64 ~ ")")? },
+        |(_, opt_args)| TypeName::SmallInt(opt_args.map(|(_, display, _)| display)),
+    );
+    let ty_big_int = map(
+        rule! { BIGINT ~ ("(" ~ #literal_u64 ~ ")")? },
+        |(_, opt_args)| TypeName::BigInt(opt_args.map(|(_, display, _)| display)),
+    );
+    let ty_real = value(TypeName::Real, rule! { REAL });
+    let ty_double = value(TypeName::Double, rule! { DOUBLE });
+    let ty_boolean = value(TypeName::Boolean, rule! { BOOLEAN });
+    let ty_date = value(TypeName::Date, rule! { DATE });
+    let ty_time = value(TypeName::Time, rule! { TIME });
+    let ty_timestamp = value(TypeName::Timestamp, rule! { TIMESTAMP });
+    let ty_text = value(TypeName::Text, rule! { TEXT });
+
+    rule!(
+        #ty_char
+        | #ty_varchar
+        | #ty_float
+        | #ty_int
+        | #ty_tiny_int
+        | #ty_small_int
+        | #ty_big_int
+        | #ty_real
+        | #ty_double
+        | #ty_boolean
+        | #ty_date
+        | #ty_time
+        | #ty_timestamp
+        | #ty_text
+    )(i)
+}

--- a/common/ast/src/parser/rule/mod.rs
+++ b/common/ast/src/parser/rule/mod.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod expr;
 pub mod statement;
 pub mod util;

--- a/common/ast/src/parser/rule/statement.rs
+++ b/common/ast/src/parser/rule/statement.rs
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use nom::error::ParseError;
 use nom::IResult;
 
 use crate::parser::ast::Statement;
 use crate::parser::rule::util::ident;
 use crate::parser::rule::util::Input;
+use crate::parser::rule::util::ParseError;
 use crate::parser::token::*;
 use crate::rule;
 
 pub fn truncate_table<'a, Error>(i: Input<'a>) -> IResult<Input<'a>, Statement, Error>
 where Error: ParseError<Input<'a>> {
-    let (i, (_, _, database, table, _)) = rule!(
+    let (i, (_, _, database, table, _)) = rule! {
         TRUNCATE ~ TABLE ~ ( #ident ~ "." )? ~ #ident ~ ";"
-    )(i)?;
+    }(i)?;
 
     Ok((i, Statement::TruncateTable {
         database: database.map(|(name, _)| name),
@@ -35,9 +35,9 @@ where Error: ParseError<Input<'a>> {
 
 pub fn drop_table<'a, Error>(i: Input<'a>) -> IResult<Input<'a>, Statement, Error>
 where Error: ParseError<Input<'a>> {
-    let (i, (_, _, if_exists, database, table, _)) = rule!(
+    let (i, (_, _, if_exists, database, table, _)) = rule! {
         DROP ~ TABLE ~ ( IF ~ EXISTS )? ~ ( #ident ~ "." )? ~ #ident ~ ";"
-    )(i)?;
+    }(i)?;
 
     Ok((i, Statement::DropTable {
         if_exists: if_exists.is_some(),

--- a/common/ast/src/parser/rule/util.rs
+++ b/common/ast/src/parser/rule/util.rs
@@ -24,7 +24,9 @@ use crate::parser::token::*;
 pub type Input<'a> = &'a [Token<'a>];
 pub trait ParseError<I> = nom::error::ParseError<I> + nom::error::ContextError<I>;
 
-pub fn satisfy<'a, F, Error>(cond: F) -> impl Fn(Input<'a>) -> IResult<Input<'a>, &'a Token, Error>
+pub fn satisfy<'a, F, Error>(
+    cond: F,
+) -> impl FnMut(Input<'a>) -> IResult<Input<'a>, &'a Token, Error>
 where
     F: Fn(&Token) -> bool,
     Error: ParseError<Input<'a>>,

--- a/common/ast/src/parser/rule/util.rs
+++ b/common/ast/src/parser/rule/util.rs
@@ -14,15 +14,15 @@
 
 use nom::branch::alt;
 use nom::combinator::map;
+use nom::error::make_error;
 use nom::error::ErrorKind;
-use nom::error::ParseError;
 use nom::IResult;
 
 use crate::parser::ast::Identifier;
-use crate::parser::token::Token;
-use crate::parser::token::TokenKind;
+use crate::parser::token::*;
 
 pub type Input<'a> = &'a [Token<'a>];
+pub trait ParseError<I> = nom::error::ParseError<I> + nom::error::ContextError<I>;
 
 pub fn satisfy<'a, F, Error>(cond: F) -> impl Fn(Input<'a>) -> IResult<Input<'a>, &'a Token, Error>
 where
@@ -72,6 +72,17 @@ where Error: ParseError<Input<'a>> {
             },
         ),
     ))(i)
+}
+
+pub fn literal_u64<'a, Error>(i: Input<'a>) -> IResult<Input<'a>, u64, Error>
+where Error: ParseError<Input<'a>> {
+    match_token(LiteralNumber)(i).and_then(|(i, token)| {
+        token
+            .text
+            .parse()
+            .map(|num| (i, num))
+            .map_err(|_| nom::Err::Error(make_error(i, ErrorKind::Digit)))
+    })
 }
 
 #[macro_export]

--- a/common/ast/src/parser/token.rs
+++ b/common/ast/src/parser/token.rs
@@ -25,6 +25,8 @@ pub enum TokenKind {
     #[error]
     Error,
 
+    EOI,
+
     #[regex(r"[ \t\n\f]+", logos::skip)]
     Whitespace,
 
@@ -1067,6 +1069,12 @@ pub fn tokenise(input: &str) -> Result<Vec<Token>> {
             })
         }
     }
+
+    tokens.push(Token {
+        kind: TokenKind::EOI,
+        text: "",
+        span: (lex.span().end)..(lex.span().end),
+    });
 
     Ok(tokens)
 }

--- a/common/ast/src/parser/token.rs
+++ b/common/ast/src/parser/token.rs
@@ -49,7 +49,7 @@ pub enum TokenKind {
     #[regex(r"[0-9]+")]
     #[regex(r"[0-9]+e[+-]?[0-9]+")]
     #[regex(r"([0-9]*\.[0-9]+(e[+-]?[0-9]+)?)|([0-9]+\.[0-9]*(e[+-]?[0-9]+)?)")]
-    LiteralNumeber,
+    LiteralNumber,
 
     // Symbols
     #[token("==")]
@@ -58,15 +58,15 @@ pub enum TokenKind {
     Eq,
     #[token("<>")]
     #[token("!=")]
-    Neq,
+    NotEq,
     #[token("<")]
     Lt,
     #[token(">")]
     Gt,
     #[token("<=")]
-    LtEq,
+    Lte,
     #[token(">=")]
-    GtEq,
+    Gte,
     #[token("<=>")]
     Spaceship,
     #[token("+")]
@@ -383,6 +383,8 @@ pub enum TokenKind {
     DISTINCT,
     #[token("DISTRIBUTE", ignore(ascii_case))]
     DISTRIBUTE,
+    #[token("DIV", ignore(ascii_case))]
+    DIV,
     #[token("DOUBLE", ignore(ascii_case))]
     DOUBLE,
     #[token("DROP", ignore(ascii_case))]

--- a/common/ast/tests/it/ast.rs
+++ b/common/ast/tests/it/ast.rs
@@ -183,33 +183,36 @@ fn test_display_expr() {
             name: "FUNC".to_owned(),
             args: vec![
                 Expr::Cast {
-                    expr: Box::new(Expr::Wildcard),
+                    expr: Box::new(Expr::Literal(Literal::Number("1".to_string()))),
                     target_type: TypeName::Int(None),
                 },
                 Expr::Between {
-                    expr: Box::new(Expr::Wildcard),
-                    negated: true,
-                    low: Box::new(Expr::Wildcard),
-                    high: Box::new(Expr::Wildcard),
+                    expr: Box::new(Expr::Literal(Literal::Number("1".to_string()))),
+                    low: Box::new(Expr::Literal(Literal::Number("1".to_string()))),
+                    high: Box::new(Expr::Literal(Literal::Number("1".to_string()))),
+                    not: true,
                 },
                 Expr::InList {
-                    expr: Box::new(Expr::Wildcard),
-                    list: vec![Expr::Wildcard, Expr::Wildcard],
+                    expr: Box::new(Expr::Literal(Literal::Number("1".to_string()))),
+                    list: vec![
+                        Expr::Literal(Literal::Number("1".to_string())),
+                        Expr::Literal(Literal::Number("1".to_string())),
+                    ],
                     not: true,
                 },
             ],
             params: vec![Literal::Number("123".to_owned())],
         }),
         right: Box::new(Expr::Case {
-            operand: Some(Box::new(Expr::Wildcard)),
-            conditions: vec![Expr::Wildcard],
-            results: vec![Expr::Wildcard],
-            else_result: Some(Box::new(Expr::Wildcard)),
+            operand: Some(Box::new(Expr::Literal(Literal::Number("1".to_string())))),
+            conditions: vec![Expr::Literal(Literal::Number("1".to_string()))],
+            results: vec![Expr::Literal(Literal::Number("1".to_string()))],
+            else_result: Some(Box::new(Expr::Literal(Literal::Number("1".to_string())))),
         }),
     };
 
     assert_eq!(
         format!("{}", expr),
-        r#"FUNC(123)(DISTINCT CAST(* AS INTEGER), * NOT BETWEEN * AND *, * NOT IN(*, *)) AND CASE * WHEN * THEN * ELSE * END"#
+        r#"FUNC(123)(DISTINCT CAST(1 AS INTEGER), 1 NOT BETWEEN 1 AND 1, 1 NOT IN(1, 1)) AND CASE 1 WHEN 1 THEN 1 ELSE 1 END"#
     );
 }

--- a/common/ast/tests/it/rule.rs
+++ b/common/ast/tests/it/rule.rs
@@ -50,6 +50,7 @@ fn test_statement() {
 // TODO (andylokandy): test tree structure, maybe add parentheses?
 #[test]
 fn test_expr() {
+    assert_parse!(expr, "a", "a");
     assert_parse!(expr, "1 + a * c.d", "1 + a * c.d");
     assert_parse!(expr, "col1 not between 1 and 2", "col1 NOT BETWEEN 1 AND 2");
     assert_parse!(expr, "sum(col1)", "sum(col1)");

--- a/common/ast/tests/it/rule.rs
+++ b/common/ast/tests/it/rule.rs
@@ -16,18 +16,29 @@ use common_ast::parser::rule::expr::*;
 use common_ast::parser::rule::statement::*;
 use common_ast::parser::rule::util::Input;
 use common_ast::parser::token::*;
+use nom::error::VerboseError;
 use nom::Parser;
 use pretty_assertions::assert_eq;
 
 macro_rules! assert_parse {
     ($parser:expr, $source:literal, $expected:literal $(,)*) => {
         let tokens = tokenise($source).unwrap();
-        let res: nom::IResult<_, _, nom_supreme::error::ErrorTree<Input>> =
-            $parser.parse(&(tokens));
+        let res: nom::IResult<_, _, VerboseError<Input>> = $parser.parse(&(tokens));
         let (i, output) = res.unwrap();
 
         assert_eq!(&format!("{}", output), $expected);
-        assert_eq!(i, &[]);
+        assert_eq!(i[0].kind, TokenKind::EOI);
+    };
+}
+
+// TODO (andylokandy): render the parsing error more human-friendly
+macro_rules! assert_parse_error {
+    ($parser:expr, $source:literal, $expected:literal $(,)*) => {
+        let tokens = tokenise($source).unwrap();
+        let res: nom::IResult<_, _, VerboseError<Input>> = $parser.parse(&(tokens));
+        let err = res.unwrap_err();
+
+        assert_eq!(&format!("{}", err), $expected);
     };
 }
 
@@ -59,4 +70,10 @@ fn test_expr() {
         "G.E.B IS NOT NULL AND col1 not between col2 and (1 + col3) DIV sum(col4)",
         "G.E.B IS NOT NULL AND col1 NOT BETWEEN col2 AND 1 + col3 DIV sum(col4)"
     );
+}
+
+#[test]
+fn test_expr_error() {
+    assert_parse_error!(expr, "(a and ) 1", "Parsing Error: VerboseError { errors: [([Token { kind: RParen, text: \")\", span: 7..8 }], Nom(Complete)), ([Token { kind: RParen, text: \")\", span: 7..8 }], Context(\"unexpected end of an expression\")), ([Token { kind: LParen, text: \"(\", span: 0..1 }, Token { kind: Ident, text: \"a\", span: 1..2 }, Token { kind: AND, text: \"and\", span: 3..6 }, Token { kind: RParen, text: \")\", span: 7..8 }, Token { kind: LiteralNumber, text: \"1\", span: 9..10 }, Token { kind: EOI, text: \"\", span: 10..10 }], Nom(Alt)), ([Token { kind: LParen, text: \"(\", span: 0..1 }, Token { kind: Ident, text: \"a\", span: 1..2 }, Token { kind: AND, text: \"and\", span: 3..6 }, Token { kind: RParen, text: \")\", span: 7..8 }, Token { kind: LiteralNumber, text: \"1\", span: 9..10 }, Token { kind: EOI, text: \"\", span: 10..10 }], Nom(Many1))] }");
+    assert_parse_error!(expr, "a + +", "Parsing Error: VerboseError { errors: [([Token { kind: Plus, text: \"+\", span: 4..5 }], Nom(Complete)), ([Token { kind: Plus, text: \"+\", span: 4..5 }], Context(\"unable to parse the binary operator\"))] }");
 }

--- a/common/ast/tests/it/rule.rs
+++ b/common/ast/tests/it/rule.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_ast::parser::rule::expr::*;
 use common_ast::parser::rule::statement::*;
 use common_ast::parser::rule::util::Input;
 use common_ast::parser::token::*;
@@ -21,7 +22,8 @@ use pretty_assertions::assert_eq;
 macro_rules! assert_parse {
     ($parser:expr, $source:literal, $expected:literal $(,)*) => {
         let tokens = tokenise($source).unwrap();
-        let res: nom::IResult<_, _, nom_supreme::error::ErrorTree<Input>> = $parser.parse(&tokens);
+        let res: nom::IResult<_, _, nom_supreme::error::ErrorTree<Input>> =
+            $parser.parse(&(tokens));
         let (i, output) = res.unwrap();
 
         assert_eq!(&format!("{}", output), $expected);
@@ -42,5 +44,18 @@ fn test_statement() {
         drop_table,
         r#"drop table if exists a."b";"#,
         r#"DROP TABLE IF EXISTS a."b""#,
+    );
+}
+
+// TODO (andylokandy): test tree structure, maybe add parentheses?
+#[test]
+fn test_expr() {
+    assert_parse!(expr, "1 + a * c.d", "1 + a * c.d");
+    assert_parse!(expr, "col1 not between 1 and 2", "col1 NOT BETWEEN 1 AND 2");
+    assert_parse!(expr, "sum(col1)", "sum(col1)");
+    assert_parse!(
+        expr,
+        "G.E.B IS NOT NULL AND col1 not between col2 and (1 + col3) DIV sum(col4)",
+        "G.E.B IS NOT NULL AND col1 NOT BETWEEN col2 AND 1 + col3 DIV sum(col4)"
     );
 }

--- a/common/ast/tests/it/token.rs
+++ b/common/ast/tests/it/token.rs
@@ -19,6 +19,7 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn test_lexer() {
+    assert_lex("", &[(EOI, "", 0..0)]);
     assert_lex(
         "x'deadbeef' -- a hex string\n 'a string literal\n escape quote by '' or \\\'. '",
         &[
@@ -28,11 +29,13 @@ fn test_lexer() {
                 "'a string literal\n escape quote by '' or \\'. '",
                 29..75,
             ),
+            (EOI, "", 75..75),
         ],
     );
     assert_lex("'中文' '日本語'", &[
         (LiteralString, "'中文'", 0..8),
         (LiteralString, "'日本語'", 9..20),
+        (EOI, "", 20..20),
     ]);
     assert_lex("42 3.5 4. .001 5e2 1.925e-3 .38e+7 1.e-01", &[
         (LiteralNumber, "42", 0..2),
@@ -43,6 +46,7 @@ fn test_lexer() {
         (LiteralNumber, "1.925e-3", 19..27),
         (LiteralNumber, ".38e+7", 28..34),
         (LiteralNumber, "1.e-01", 35..41),
+        (EOI, "", 41..41),
     ]);
     assert_lex(
         r#"create table "user" (id int, name varchar /* the user name */);"#,
@@ -58,6 +62,7 @@ fn test_lexer() {
             (VARCHAR, "varchar", 34..41),
             (RParen, ")", 61..62),
             (SemiColon, ";", 62..63),
+            (EOI, "", 63..63),
         ],
     )
 }

--- a/common/ast/tests/it/token.rs
+++ b/common/ast/tests/it/token.rs
@@ -35,14 +35,14 @@ fn test_lexer() {
         (LiteralString, "'日本語'", 9..20),
     ]);
     assert_lex("42 3.5 4. .001 5e2 1.925e-3 .38e+7 1.e-01", &[
-        (LiteralNumeber, "42", 0..2),
-        (LiteralNumeber, "3.5", 3..6),
-        (LiteralNumeber, "4.", 7..9),
-        (LiteralNumeber, ".001", 10..14),
-        (LiteralNumeber, "5e2", 15..18),
-        (LiteralNumeber, "1.925e-3", 19..27),
-        (LiteralNumeber, ".38e+7", 28..34),
-        (LiteralNumeber, "1.e-01", 35..41),
+        (LiteralNumber, "42", 0..2),
+        (LiteralNumber, "3.5", 3..6),
+        (LiteralNumber, "4.", 7..9),
+        (LiteralNumber, ".001", 10..14),
+        (LiteralNumber, "5e2", 15..18),
+        (LiteralNumber, "1.925e-3", 19..27),
+        (LiteralNumber, ".38e+7", 28..34),
+        (LiteralNumber, "1.e-01", 35..41),
     ]);
     assert_lex(
         r#"create table "user" (id int, name varchar /* the user name */);"#,

--- a/common/ast/tests/it/transformer.rs
+++ b/common/ast/tests/it/transformer.rs
@@ -42,7 +42,7 @@ fn test_parse_with_sqlparser() {
         })
         .collect();
     let expected = vec![
-        r#"SELECT DISTINCT a, count(*) FROM t WHERE a = 1 AND b - 1 < a GROUP BY a HAVING a = 1"#,
+        r#"SELECT DISTINCT a, COUNT(*) FROM t WHERE a = 1 AND b - 1 < a GROUP BY a HAVING a = 1"#,
         r#"SELECT * FROM a CROSS JOIN b CROSS JOIN c"#,
         r#"SELECT * FROM a INNER JOIN b ON a.a = b.a"#,
         r#"SELECT * FROM a LEFT OUTER JOIN b ON a.a = b.a"#,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Implement the parser for expressions. 

The core technique used here to help arrange the operator precedence and associativity is called Pratt parser, which is also known as the Top-Down Operator-Precedence (TDOP) parser. I recommend this [tdop-tutorial](https://eli.thegreenplace.net/2010/01/02/top-down-operator-precedence-parsing) if you're interested in how it works.

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Ref #866

## Test Plan

Unit Tests
