### PR TITLE
SESSIONS-3933: Add default value and type to settings

### DIFF
--- a/query/src/sessions/settings.rs
+++ b/query/src/sessions/settings.rs
@@ -27,6 +27,7 @@ use crate::configs::Config;
 
 #[derive(Clone, Debug, MallocSizeOf)]
 pub struct SettingValue {
+    default_value: DataValue,
     #[ignore_malloc_size_of = "insignificant"]
     user_setting: UserSetting,
     desc: &'static str,
@@ -42,48 +43,56 @@ impl Settings {
         let values = vec![
             // max_block_size
             SettingValue {
+                default_value:DataValue::UInt64(Some(10000)),
                 user_setting: UserSetting::create("max_block_size", DataValue::UInt64(Some(10000))),
                 desc: "Maximum block size for reading",
             },
 
             // max_threads
             SettingValue {
+                default_value:DataValue::UInt64(Some(16)),
                 user_setting: UserSetting::create("max_threads", DataValue::UInt64(Some(16))),
                 desc: "The maximum number of threads to execute the request. By default, it is determined automatically.",
             },
 
             // flight_client_timeout
             SettingValue {
+                default_value:DataValue::UInt64(Some(60)),
                 user_setting: UserSetting::create("flight_client_timeout", DataValue::UInt64(Some(60))),
                 desc:"Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds",
             },
 
             // parallel_read_threads
             SettingValue {
+                default_value: DataValue::UInt64(Some(1)),
                 user_setting: UserSetting::create("parallel_read_threads", DataValue::UInt64(Some(1))),
                 desc:"The maximum number of parallelism for reading data. By default, it is 1.",
             },
 
             // storage_read_buffer_size
             SettingValue {
+                default_value: DataValue::UInt64(Some(1024*1024)),
                 user_setting: UserSetting::create("storage_read_buffer_size", DataValue::UInt64(Some(1024*1024))),
                 desc:"The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.",
             },
 
             // storage_backoff_init_delay_ms
             SettingValue {
+                default_value: DataValue::UInt64(Some(5)),
                 user_setting: UserSetting::create("storage_occ_backoff_init_delay_ms", DataValue::UInt64(Some(5))),
                 desc:"The initial retry delay in millisecond. By default,  it is 5 ms.",
             },
 
             // storage_occ_backoff_max_delay_ms
             SettingValue {
+                default_value:DataValue::UInt64(Some(20*1000)),
                 user_setting: UserSetting::create("storage_occ_backoff_max_delay_ms", DataValue::UInt64(Some(20*1000))),
                 desc:"The maximum  back off delay in millisecond, once the retry interval reaches this value, it stops increasing. By default, it is 20 seconds.",
             },
 
             // storage_occ_backoff_max_elapsed_ms
             SettingValue {
+                default_value:DataValue::UInt64(Some(120*1000)),
                 user_setting: UserSetting::create("storage_occ_backoff_max_elapsed_ms", DataValue::UInt64(Some(120*1000))),
                 desc:"The maximum elapsed time after the occ starts, beyond which there will be no more retries. By default, it is 2 minutes.",
             },
@@ -244,6 +253,8 @@ impl Settings {
                 DataValue::String(Some(k.as_bytes().to_vec())),
                 // Value.
                 v.user_setting.value.clone(),
+                // Default Value.
+                v.default_value.clone(),
                 // Desc.
                 DataValue::String(Some(v.desc.as_bytes().to_vec())),
             ]);

--- a/query/src/sql/statements/statement_show_settings.rs
+++ b/query/src/sql/statements/statement_show_settings.rs
@@ -29,7 +29,8 @@ pub struct DfShowSettings;
 impl AnalyzableStatement for DfShowSettings {
     #[tracing::instrument(level = "debug", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
-        let rewritten_query = "SELECT name, value FROM system.settings ORDER BY name";
+        let rewritten_query =
+            "SELECT name, value, default, description, type FROM system.settings ORDER BY name";
         let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
         Ok(AnalyzedResult::SimpleQuery(Box::new(
             rewritten_query_plan.await?,

--- a/query/src/storages/system/settings_table.rs
+++ b/query/src/storages/system/settings_table.rs
@@ -37,7 +37,9 @@ impl SettingsTable {
         let schema = DataSchemaRefExt::create(vec![
             DataField::new("name", DataType::String, false),
             DataField::new("value", DataType::String, false),
+            DataField::new("default", DataType::String, false),
             DataField::new("description", DataType::String, false),
+            DataField::new("type", DataType::String, false),
         ]);
 
         let table_info = TableInfo {
@@ -75,22 +77,35 @@ impl Table for SettingsTable {
 
         let mut names: Vec<String> = vec![];
         let mut values: Vec<String> = vec![];
+        let mut defaults: Vec<String> = vec![];
         let mut descs: Vec<String> = vec![];
+        let mut types: Vec<String> = vec![];
         for setting in settings {
             if let DataValue::Struct(vals) = setting {
+                // Name.
                 names.push(format!("{:?}", vals[0]));
+                // Value.
                 values.push(format!("{:?}", vals[1]));
-                descs.push(format!("{:?}", vals[2]));
+                // Default Value.
+                defaults.push(format!("{:?}", vals[2]));
+                // Desc.
+                descs.push(format!("{:?}", vals[3]));
+                // Types.
+                types.push(format!("{:?}", vals[2].data_type()));
             }
         }
 
         let names: Vec<&[u8]> = names.iter().map(|x| x.as_bytes()).collect();
         let values: Vec<&[u8]> = values.iter().map(|x| x.as_bytes()).collect();
+        let defaults: Vec<&[u8]> = defaults.iter().map(|x| x.as_bytes()).collect();
         let descs: Vec<&[u8]> = descs.iter().map(|x| x.as_bytes()).collect();
+        let types: Vec<&[u8]> = types.iter().map(|x| x.as_bytes()).collect();
         let block = DataBlock::create_by_array(self.table_info.schema(), vec![
             Series::new(names),
             Series::new(values),
+            Series::new(defaults),
             Series::new(descs),
+            Series::new(types),
         ]);
         Ok(Box::pin(DataBlockStream::create(
             self.table_info.schema(),

--- a/query/tests/it/storages/system/settings_table.rs
+++ b/query/tests/it/storages/system/settings_table.rs
@@ -20,7 +20,6 @@ use databend_query::storages::system::SettingsTable;
 use databend_query::storages::Table;
 use databend_query::storages::ToReadDataSourcePlan;
 use futures::TryStreamExt;
-use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_settings_table() -> Result<()> {
@@ -32,24 +31,20 @@ async fn test_settings_table() -> Result<()> {
 
     let stream = table.read(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
-    let block = &result[0];
-    assert_eq!(block.num_columns(), 3);
 
     let expected = vec![
-        "+------------------------------------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+",
-        "| name                               | value   | description                                                                                                                                |",
-        "+------------------------------------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+",
-        "| flight_client_timeout              | 60      | Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds                                         |",
-        "| max_block_size                     | 10000   | Maximum block size for reading                                                                                                             |",
-        "| storage_occ_backoff_init_delay_ms  | 5       | The initial retry delay in millisecond. By default,  it is 5 ms.                                                                           |",
-        "| max_threads                        | 2       | The maximum number of threads to execute the request. By default, it is determined automatically.                                          |",
-        "| storage_read_buffer_size           | 1048576 | The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.                                                             |",
-        "| storage_occ_backoff_max_delay_ms   | 20000   | The maximum  back off delay in millisecond, once the retry interval reaches this value, it stops increasing. By default, it is 20 seconds. |",
-        "| storage_occ_backoff_max_elapsed_ms | 120000  | The maximum elapsed time after the occ starts, beyond which there will be no more retries. By default, it is 2 minutes.                    |",
-        "| parallel_read_threads              | 1       | The maximum number of parallelism for reading data. By default, it is 1.                                                                   |",
-        "+------------------------------------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+",
-
-
+        "+------------------------------------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+",
+        "| name                               | value   | default | description                                                                                                                                | type   |",
+        "+------------------------------------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+",
+        "| flight_client_timeout              | 60      | 60      | Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds                                         | UInt64 |",
+        "| max_block_size                     | 10000   | 10000   | Maximum block size for reading                                                                                                             | UInt64 |",
+        "| max_threads                        | 2       | 16      | The maximum number of threads to execute the request. By default, it is determined automatically.                                          | UInt64 |",
+        "| parallel_read_threads              | 1       | 1       | The maximum number of parallelism for reading data. By default, it is 1.                                                                   | UInt64 |",
+        "| storage_occ_backoff_init_delay_ms  | 5       | 5       | The initial retry delay in millisecond. By default,  it is 5 ms.                                                                           | UInt64 |",
+        "| storage_occ_backoff_max_delay_ms   | 20000   | 20000   | The maximum  back off delay in millisecond, once the retry interval reaches this value, it stops increasing. By default, it is 20 seconds. | UInt64 |",
+        "| storage_occ_backoff_max_elapsed_ms | 120000  | 120000  | The maximum elapsed time after the occ starts, beyond which there will be no more retries. By default, it is 2 minutes.                    | UInt64 |",
+        "| storage_read_buffer_size           | 1048576 | 1048576 | The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.                                                             | UInt64 |",
+        "+------------------------------------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+",
     ];
     common_datablocks::assert_blocks_sorted_eq(expected, result.as_slice());
 

--- a/tests/suites/0_stateless/06_show/06_0003_show_settings.result
+++ b/tests/suites/0_stateless/06_show/06_0003_show_settings.result
@@ -1,8 +1,8 @@
-flight_client_timeout	60
-max_block_size	10000
-max_threads	11
-parallel_read_threads	1
-storage_occ_backoff_init_delay_ms	5
-storage_occ_backoff_max_delay_ms	20000
-storage_occ_backoff_max_elapsed_ms	120000
-storage_read_buffer_size	1048576
+flight_client_timeout	60	60	Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds	UInt64
+max_block_size	10000	10000	Maximum block size for reading	UInt64
+max_threads	11	16	The maximum number of threads to execute the request. By default, it is determined automatically.	UInt64
+parallel_read_threads	1	1	The maximum number of parallelism for reading data. By default, it is 1.	UInt64
+storage_occ_backoff_init_delay_ms	5	5	The initial retry delay in millisecond. By default,  it is 5 ms.	UInt64
+storage_occ_backoff_max_delay_ms	20000	20000	The maximum  back off delay in millisecond, once the retry interval reaches this value, it stops increasing. By default, it is 20 seconds.	UInt64
+storage_occ_backoff_max_elapsed_ms	120000	120000	The maximum elapsed time after the occ starts, beyond which there will be no more retries. By default, it is 2 minutes.	UInt64
+storage_read_buffer_size	1048576	1048576	The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.	UInt64


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add default value and type to settings:
```
mysql> set max_threads=1;
Query OK, 0 rows affected (0.02 sec)
Read 0 rows, 0 B in 0.001 sec., 0 rows/sec., 0 B/sec.

mysql> show settings;
+------------------------------------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+
| name                               | value   | default | description                                                                                                                                | type   |
+------------------------------------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+
| flight_client_timeout              | 60      | 60      | Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds                                         | UInt64 |
| max_block_size                     | 10000   | 10000   | Maximum block size for reading                                                                                                             | UInt64 |
| max_threads                        | 1       | 16      | The maximum number of threads to execute the request. By default, it is determined automatically.                                          | UInt64 |
| parallel_read_threads              | 1       | 1       | The maximum number of parallelism for reading data. By default, it is 1.                                                                   | UInt64 |
| storage_occ_backoff_init_delay_ms  | 5       | 5       | The initial retry delay in millisecond. By default,  it is 5 ms.                                                                           | UInt64 |
| storage_occ_backoff_max_delay_ms   | 20000   | 20000   | The maximum  back off delay in millisecond, once the retry interval reaches this value, it stops increasing. By default, it is 20 seconds. | UInt64 |
| storage_occ_backoff_max_elapsed_ms | 120000  | 120000  | The maximum elapsed time after the occ starts, beyond which there will be no more retries. By default, it is 2 minutes.                    | UInt64 |
| storage_read_buffer_size           | 1048576 | 1048576 | The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.                                                             | UInt64 |
+------------------------------------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+

```

## Changelog


- Improvement


## Related Issues

Part of #3933

## Test Plan

Unit Tests

Stateless Tests

