### PR TITLE
SESSION-3933: Global setting to metasrv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,6 +1741,7 @@ dependencies = [
  "async-trait",
  "common-ast",
  "common-base",
+ "common-datavalues",
  "common-exception",
  "common-functions",
  "common-meta-api",

--- a/common/exception/src/exception_code.rs
+++ b/common/exception/src/exception_code.rs
@@ -56,7 +56,6 @@ build_exceptions! {
     UnknownTypeOfQuery(1001),
     UnImplement(1002),
     UnknownDatabase(1003),
-    UnknownSetting(1004),
     SyntaxException(1005),
     BadArguments(1006),
     IllegalDataType(1007),
@@ -186,7 +185,6 @@ build_exceptions! {
     IllegalUDFFormat(2601),
     UnknownUDF(2602),
     UdfAlreadyExists(2603),
-
 
     // database error.
     UnknownDatabaseEngine(2701),

--- a/common/exception/src/exception_code.rs
+++ b/common/exception/src/exception_code.rs
@@ -71,7 +71,6 @@ build_exceptions! {
     DataStructMissMatch(1017),
     BadDataArrayLength(1018),
     UnknownContextID(1019),
-    UnknownVariable(1020),
     UnknownTableFunction(1021),
     BadOption(1022),
     CannotReadFile(1023),
@@ -118,31 +117,31 @@ build_exceptions! {
     UnmarshalError(1064),
     SemanticError(1065),
 
-    // uncategorized
+    // Uncategorized error codes.
     UnexpectedResponseType(1066),
     UnknownException(1067),
     TokioError(1068),
 
-    // pipeline executor
+    // Pipeline executor error codes.
     PipelineAreadlyStarted(1069),
     PipelineNotStarted(1070),
     PipelineUnInitialized(1071),
 
-    // http query error
+    // Http query error codes.
     HttpNotFound(1072),
 
-    // network error
+    // Network error codes.
     NetworkRequestError(1073),
 }
 
 // Metasvr errors [2001, 3000].
 build_exceptions! {
-    // meta service does not work.
+    // Meta service does not work.
     MetaServiceError(2001),
     InvalidConfig(2002),
     UnknownNode(2003),
 
-    // meta store errors
+    // Meta store error codes.
     MetaStoreDamaged(2004),
     MetaStoreAlreadyExists(2005),
     MetaStoreNotFound(2006),
@@ -153,42 +152,44 @@ build_exceptions! {
     UnknownDatabaseId(2010),
     OCCRetryFailure(2011),
 
-
-    // KVSrv server error
+    // KVSrv server error codes.
     MetaSrvError(2101),
     TransactionAbort(2102),
     TransactionError(2103),
 
-    // user-api error codes
+    // User api error codes.
     UnknownUser(2201),
     UserAlreadyExists(2202),
     IllegalUserInfoFormat(2203),
     UnknownRole(2204),
     IllegalRoleInfoFormat(2205),
 
-    // meta-api error codes
+    // Meta api error codes.
     DatabaseAlreadyExists(2301),
     TableAlreadyExists(2302),
     IllegalMetaOperationArgument(2303),
     IllegalMetaState(2304),
     MetaNodeInternalError(2305),
 
-    // cluster error.
+    // Cluster error codes.
     ClusterUnknownNode(2401),
     ClusterNodeAlreadyExists(2402),
 
-    // stage error.
+    // Stage error codes.
     UnknownStage(2501),
     StageAlreadyExists(2502),
 
-    // user defined function error.
+    // User defined function error codes.
     IllegalUDFFormat(2601),
     UnknownUDF(2602),
     UdfAlreadyExists(2603),
 
-    // database error.
+    // Database error codes.
     UnknownDatabaseEngine(2701),
     UnknownTableEngine(2702),
+
+    // Variable error codes.
+    UnknownVariable(2801),
 }
 
 // Storage errors [3001, 4000].

--- a/common/management/Cargo.toml
+++ b/common/management/Cargo.toml
@@ -14,6 +14,7 @@ test = false
 
 [dependencies]
 common-base= {path = "../base" }
+common-datavalues = {path = "../datavalues" }
 common-exception= {path = "../exception"}
 common-meta-api= {path = "../meta/api" }
 common-meta-types= {path = "../meta/types"}

--- a/common/management/src/lib.rs
+++ b/common/management/src/lib.rs
@@ -14,6 +14,7 @@
 
 mod cluster;
 mod role;
+mod setting;
 mod stage;
 mod udf;
 mod user;
@@ -22,9 +23,11 @@ pub use cluster::ClusterApi;
 pub use cluster::ClusterMgr;
 pub use role::RoleApi;
 pub use role::RoleMgr;
+pub use setting::SettingApi;
+pub use setting::SettingMgr;
 pub use stage::StageApi;
 pub use stage::StageMgr;
 pub use udf::UdfApi;
 pub use udf::UdfMgr;
-pub use user::user_api::UserApi;
-pub use user::user_mgr::UserMgr;
+pub use user::UserApi;
+pub use user::UserMgr;

--- a/common/management/src/setting/mod.rs
+++ b/common/management/src/setting/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2022 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod cluster;
-mod setting;
-mod stage;
-mod udf;
-mod user;
+mod setting_api;
+mod setting_mgr;
+
+pub use setting_api::SettingApi;
+pub use setting_mgr::SettingMgr;

--- a/common/management/src/setting/setting_api.rs
+++ b/common/management/src/setting/setting_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2022 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod cluster;
-mod setting;
-mod stage;
-mod udf;
-mod user;
+use common_exception::Result;
+use common_meta_types::UserSetting;
+
+#[async_trait::async_trait]
+pub trait SettingApi: Sync + Send {
+    // Add a setting to /tenant/cluster/setting-name.
+    async fn set_setting(&self, setting: UserSetting) -> Result<u64>;
+
+    // Get all the settings for tenant/cluster.
+    async fn get_settings(&self) -> Result<Vec<UserSetting>>;
+
+    // Drop the setting by name.
+    async fn drop_setting(&self, name: &str, seq: Option<u64>) -> Result<()>;
+}

--- a/common/management/src/setting/setting_api.rs
+++ b/common/management/src/setting/setting_api.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_exception::Result;
+use common_meta_types::SeqV;
 use common_meta_types::UserSetting;
 
 #[async_trait::async_trait]
@@ -22,6 +23,8 @@ pub trait SettingApi: Sync + Send {
 
     // Get all the settings for tenant/cluster.
     async fn get_settings(&self) -> Result<Vec<UserSetting>>;
+
+    async fn get_setting(&self, name: &str, seq: Option<u64>) -> Result<SeqV<UserSetting>>;
 
     // Drop the setting by name.
     async fn drop_setting(&self, name: &str, seq: Option<u64>) -> Result<()>;

--- a/common/management/src/setting/setting_mgr.rs
+++ b/common/management/src/setting/setting_mgr.rs
@@ -1,0 +1,98 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_meta_api::KVApi;
+use common_meta_types::MatchSeq;
+use common_meta_types::OkOrExist;
+use common_meta_types::Operation;
+use common_meta_types::UpsertKVAction;
+use common_meta_types::UserSetting;
+
+use crate::setting::SettingApi;
+
+static USER_SETTING_API_KEY_PREFIX: &str = "__fd_settings";
+
+pub struct SettingMgr {
+    kv_api: Arc<dyn KVApi>,
+    setting_prefix: String,
+}
+
+impl SettingMgr {
+    #[allow(dead_code)]
+    pub fn new(kv_api: Arc<dyn KVApi>, tenant: &str) -> Self {
+        SettingMgr {
+            kv_api,
+            setting_prefix: format!("{}/{}", USER_SETTING_API_KEY_PREFIX, tenant),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SettingApi for SettingMgr {
+    async fn set_setting(&self, setting: UserSetting) -> Result<u64> {
+        // Upsert.
+        let seq = MatchSeq::Any;
+        let val = Operation::Update(serde_json::to_vec(&setting)?);
+        let key = format!("{}/{}", self.setting_prefix, setting.name);
+        let upsert = self
+            .kv_api
+            .upsert_kv(UpsertKVAction::new(&key, seq, val, None));
+
+        let res = upsert.await?.into_add_result()?;
+
+        match res.res {
+            OkOrExist::Ok(v) => Ok(v.seq),
+            OkOrExist::Exists(v) => Ok(v.seq),
+        }
+    }
+
+    async fn get_settings(&self) -> Result<Vec<UserSetting>> {
+        let values = self.kv_api.prefix_list_kv(&self.setting_prefix).await?;
+
+        let mut settings = Vec::with_capacity(values.len());
+        for (_, value) in values {
+            let setting = serde_json::from_slice::<UserSetting>(&value.data)?;
+            settings.push(setting);
+        }
+        Ok(settings)
+    }
+
+    async fn drop_setting(&self, name: &str, seq: Option<u64>) -> Result<()> {
+        let key = format!("{}/{}", self.setting_prefix, name);
+        let kv_api = self.kv_api.clone();
+        let upsert_kv = async move {
+            kv_api
+                .upsert_kv(UpsertKVAction::new(
+                    &key,
+                    seq.into(),
+                    Operation::Delete,
+                    None,
+                ))
+                .await
+        };
+        let res = upsert_kv.await?;
+        if res.prev.is_some() && res.result.is_none() {
+            Ok(())
+        } else {
+            Err(ErrorCode::UnknownVariable(format!(
+                "Unknown setting {}",
+                name
+            )))
+        }
+    }
+}

--- a/common/management/src/stage/stage_mgr.rs
+++ b/common/management/src/stage/stage_mgr.rs
@@ -76,7 +76,7 @@ impl StageApi for StageMgr {
 
         match MatchSeq::from(seq).match_seq(&seq_value) {
             Ok(_) => Ok(seq_value.into_seqv()?),
-            Err(_) => Err(ErrorCode::UnknownUser(format!("Unknown stage {}", name))),
+            Err(_) => Err(ErrorCode::UnknownStage(format!("Unknown stage {}", name))),
         }
     }
 

--- a/common/management/src/udf/udf_mgr.rs
+++ b/common/management/src/udf/udf_mgr.rs
@@ -117,7 +117,7 @@ impl UdfApi for UdfMgr {
 
         match MatchSeq::from(seq).match_seq(&seq_value) {
             Ok(_) => Ok(seq_value.into_seqv()?),
-            Err(_) => Err(ErrorCode::UnknownUser(format!("Unknown UDF {}", udf_name))),
+            Err(_) => Err(ErrorCode::UnknownUDF(format!("Unknown UDF {}", udf_name))),
         }
     }
 

--- a/common/management/src/user/mod.rs
+++ b/common/management/src/user/mod.rs
@@ -12,5 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod user_api;
-pub(crate) mod user_mgr;
+mod user_api;
+mod user_mgr;
+
+pub use user_api::UserApi;
+pub use user_mgr::UserMgr;

--- a/common/management/tests/it/setting.rs
+++ b/common/management/tests/it/setting.rs
@@ -68,12 +68,19 @@ async fn test_set_setting() -> Result<()> {
 
     // Get settings.
     {
-        let actual = vec![UserSetting::create(
+        let expect = vec![UserSetting::create(
             "max_threads",
             DataValue::UInt64(Some(1)),
         )];
-        let expect = mgr.get_settings().await?;
+        let actual = mgr.get_settings().await?;
         assert_eq!(actual, expect);
+    }
+
+    // Get setting.
+    {
+        let expect = UserSetting::create("max_threads", DataValue::UInt64(Some(1)));
+        let actual = mgr.get_setting("max_threads", None).await?;
+        assert_eq!(actual.data, expect);
     }
 
     // Drop setting.
@@ -83,8 +90,14 @@ async fn test_set_setting() -> Result<()> {
 
     // Get settings.
     {
-        let expect = mgr.get_settings().await?;
-        assert_eq!(0, expect.len());
+        let actual = mgr.get_settings().await?;
+        assert_eq!(0, actual.len());
+    }
+
+    // Get setting.
+    {
+        let res = mgr.get_setting("max_threads", None).await;
+        assert!(res.is_err());
     }
 
     // Drop setting not exists.

--- a/common/management/tests/it/setting.rs
+++ b/common/management/tests/it/setting.rs
@@ -1,0 +1,103 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_base::tokio;
+use common_datavalues::DataValue;
+use common_exception::Result;
+use common_management::*;
+use common_meta_api::KVApi;
+use common_meta_embedded::MetaEmbedded;
+use common_meta_types::SeqV;
+use common_meta_types::UserSetting;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_set_setting() -> Result<()> {
+    let (kv_api, mgr) = new_setting_api().await?;
+
+    {
+        let setting = UserSetting::create("max_threads", DataValue::UInt64(Some(3)));
+        mgr.set_setting(setting.clone()).await?;
+        let value = kv_api
+            .get_kv("__fd_settings/databend_query/max_threads")
+            .await?;
+
+        match value {
+            Some(SeqV {
+                seq: 1,
+                meta: _,
+                data: value,
+            }) => {
+                assert_eq!(value, serde_json::to_vec(&setting)?);
+            }
+            catch => panic!("GetKVActionReply{:?}", catch),
+        }
+    }
+
+    // Set again.
+    {
+        let setting = UserSetting::create("max_threads", DataValue::UInt64(Some(1)));
+        mgr.set_setting(setting.clone()).await?;
+        let value = kv_api
+            .get_kv("__fd_settings/databend_query/max_threads")
+            .await?;
+
+        match value {
+            Some(SeqV {
+                seq: 2,
+                meta: _,
+                data: value,
+            }) => {
+                assert_eq!(value, serde_json::to_vec(&setting)?);
+            }
+            catch => panic!("GetKVActionReply{:?}", catch),
+        }
+    }
+
+    // Get settings.
+    {
+        let actual = vec![UserSetting::create(
+            "max_threads",
+            DataValue::UInt64(Some(1)),
+        )];
+        let expect = mgr.get_settings().await?;
+        assert_eq!(actual, expect);
+    }
+
+    // Drop setting.
+    {
+        mgr.drop_setting("max_threads", None).await?;
+    }
+
+    // Get settings.
+    {
+        let expect = mgr.get_settings().await?;
+        assert_eq!(0, expect.len());
+    }
+
+    // Drop setting not exists.
+    {
+        let res = mgr.drop_setting("max_threads_not", None).await;
+        assert!(res.is_err());
+    }
+
+    Ok(())
+}
+
+async fn new_setting_api() -> Result<(Arc<MetaEmbedded>, SettingMgr)> {
+    let test_api = Arc::new(MetaEmbedded::new_temp().await?);
+    let mgr = SettingMgr::new(test_api.clone(), "databend_query");
+    Ok((test_api, mgr))
+}

--- a/common/meta/types/src/user_setting.rs
+++ b/common/meta/types/src/user_setting.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use common_datavalues::DataValue;
+use common_exception::ErrorCode;
+use common_exception::Result;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -40,6 +42,20 @@ impl Default for UserSetting {
         UserSetting {
             name: "".to_string(),
             value: DataValue::Null,
+        }
+    }
+}
+
+impl TryFrom<Vec<u8>> for UserSetting {
+    type Error = ErrorCode;
+
+    fn try_from(value: Vec<u8>) -> Result<Self> {
+        match serde_json::from_slice(&value) {
+            Ok(info) => Ok(info),
+            Err(serialize_error) => Err(ErrorCode::IllegalUserInfoFormat(format!(
+                "Cannot deserialize setting from bytes. cause {}",
+                serialize_error
+            ))),
         }
     }
 }

--- a/query/src/interpreters/interpreter_setting.rs
+++ b/query/src/interpreters/interpreter_setting.rs
@@ -52,14 +52,10 @@ impl Interpreter for SettingInterpreter {
             match var.variable.to_lowercase().as_str() {
                 // To be compatible with some drivers
                 "sql_mode" | "autocommit" => {}
-                "max_threads" => {
-                    let threads: u64 = var.value.parse()?;
-                    self.ctx.get_settings().set_max_threads(threads)?;
-                }
                 _ => {
                     self.ctx
                         .get_settings()
-                        .set_settings(var.variable, var.value)?;
+                        .set_settings(var.variable, var.value, false)?;
                 }
             }
         }

--- a/query/src/sessions/mod.rs
+++ b/query/src/sessions/mod.rs
@@ -21,7 +21,7 @@ mod session_info;
 #[allow(clippy::module_inception)]
 mod session_mgr;
 mod session_ref;
-mod settings;
+mod session_settings;
 
 pub use query_ctx::QueryContext;
 pub use query_ctx_shared::QueryContextShared;
@@ -30,4 +30,4 @@ pub use session_ctx::SessionContext;
 pub use session_info::ProcessInfo;
 pub use session_mgr::SessionManager;
 pub use session_ref::SessionRef;
-pub use settings::Settings;
+pub use session_settings::Settings;

--- a/query/src/sessions/query_ctx.rs
+++ b/query/src/sessions/query_ctx.rs
@@ -347,7 +347,7 @@ impl TrySpawn for QueryContext {
 
 impl std::fmt::Debug for QueryContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.get_settings())
+        write!(f, "{:?}", self.get_current_user())
     }
 }
 

--- a/query/src/sessions/query_ctx_shared.rs
+++ b/query/src/sessions/query_ctx_shared.rs
@@ -128,11 +128,7 @@ impl QueryContextShared {
     }
 
     pub fn get_tenant(&self) -> String {
-        if self.conf.query.management_mode {
-            self.session.get_current_tenant()
-        } else {
-            self.conf.query.tenant_id.clone()
-        }
+        self.session.get_current_tenant()
     }
 
     pub fn get_settings(&self) -> Arc<Settings> {

--- a/query/src/sessions/session_info.rs
+++ b/query/src/sessions/session_info.rs
@@ -60,7 +60,7 @@ impl Session {
             state: self.process_state(status),
             database: status.get_current_database(),
             user: status.get_current_user(),
-            settings: status.get_settings(),
+            settings: self.get_settings(),
             client_address: status.get_client_host(),
             session_extra_info: self.process_extra_info(status),
             memory_usage,

--- a/query/src/sessions/session_settings.rs
+++ b/query/src/sessions/session_settings.rs
@@ -72,7 +72,7 @@ impl Settings {
         session_ctx: Arc<SessionContext>,
         user_api: Arc<UserApiProvider>,
     ) -> Result<Settings> {
-        let mut values = vec![
+        let values = vec![
             // max_block_size
             SettingValue {
                 default_value:DataValue::UInt64(Some(10000)),
@@ -141,23 +141,7 @@ impl Settings {
         let settings = Arc::new(RwLock::new(HashMap::default()));
 
         // Initial settings.
-        // Note: Use code block here to drop the write lock at the end.
         {
-            // Get settings from metasrv.
-            let global_settings = futures::executor::block_on(
-                user_api.get_settings(&session_ctx.get_current_tenant()),
-            )?;
-
-            for global in &global_settings {
-                for vx in values.iter_mut() {
-                    // Overwrite setting from metasrv.
-                    if global.name == vx.user_setting.name {
-                        vx.level = ScopeLevel::Global;
-                        vx.default_value = global.value.clone();
-                    }
-                }
-            }
-
             let mut settings_mut = settings.write();
             for value in values {
                 let name = value.user_setting.name.clone();
@@ -171,7 +155,7 @@ impl Settings {
             session_ctx,
         };
 
-        // Overwrite settings.
+        // Overwrite settings from conf.
         {
             // Set max threads.
             let cpus = if conf.query.num_cpus == 0 {

--- a/query/src/sessions/session_settings.rs
+++ b/query/src/sessions/session_settings.rs
@@ -77,7 +77,7 @@ impl Settings {
             SettingValue {
                 default_value:DataValue::UInt64(Some(10000)),
                 user_setting: UserSetting::create("max_block_size", DataValue::UInt64(Some(10000))),
-                level:ScopeLevel::Session,
+                level: ScopeLevel::Session,
                 desc: "Maximum block size for reading",
             },
 
@@ -85,7 +85,7 @@ impl Settings {
             SettingValue {
                 default_value:DataValue::UInt64(Some(16)),
                 user_setting: UserSetting::create("max_threads", DataValue::UInt64(Some(16))),
-                level:ScopeLevel::Session,
+                level: ScopeLevel::Session,
                 desc: "The maximum number of threads to execute the request. By default, it is determined automatically.",
             },
 
@@ -93,7 +93,7 @@ impl Settings {
             SettingValue {
                 default_value:DataValue::UInt64(Some(60)),
                 user_setting: UserSetting::create("flight_client_timeout", DataValue::UInt64(Some(60))),
-                level:ScopeLevel::Session,
+                level: ScopeLevel::Session,
                 desc:"Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds",
             },
 
@@ -101,7 +101,7 @@ impl Settings {
             SettingValue {
                 default_value: DataValue::UInt64(Some(1)),
                 user_setting: UserSetting::create("parallel_read_threads", DataValue::UInt64(Some(1))),
-                level:ScopeLevel::Session,
+                level: ScopeLevel::Session,
                 desc:"The maximum number of parallelism for reading data. By default, it is 1.",
             },
 
@@ -109,7 +109,7 @@ impl Settings {
             SettingValue {
                 default_value: DataValue::UInt64(Some(1024*1024)),
                 user_setting: UserSetting::create("storage_read_buffer_size", DataValue::UInt64(Some(1024*1024))),
-                level:ScopeLevel::Session,
+                level: ScopeLevel::Session,
                 desc:"The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.",
             },
 
@@ -117,7 +117,7 @@ impl Settings {
             SettingValue {
                 default_value: DataValue::UInt64(Some(5)),
                 user_setting: UserSetting::create("storage_occ_backoff_init_delay_ms", DataValue::UInt64(Some(5))),
-                level:ScopeLevel::Session,
+                level: ScopeLevel::Session,
                 desc:"The initial retry delay in millisecond. By default, it is 5 ms.",
             },
 
@@ -125,7 +125,7 @@ impl Settings {
             SettingValue {
                 default_value:DataValue::UInt64(Some(20*1000)),
                 user_setting: UserSetting::create("storage_occ_backoff_max_delay_ms", DataValue::UInt64(Some(20*1000))),
-                level:ScopeLevel::Session,
+                level: ScopeLevel::Session,
                 desc:"The maximum  back off delay in millisecond, once the retry interval reaches this value, it stops increasing. By default, it is 20 seconds.",
             },
 
@@ -133,7 +133,7 @@ impl Settings {
             SettingValue {
                 default_value:DataValue::UInt64(Some(120*1000)),
                 user_setting: UserSetting::create("storage_occ_backoff_max_elapsed_ms", DataValue::UInt64(Some(120*1000))),
-                level:ScopeLevel::Session,
+                level: ScopeLevel::Session,
                 desc:"The maximum elapsed time after the occ starts, beyond which there will be no more retries. By default, it is 2 minutes.",
             },
         ];

--- a/query/src/sql/statements/statement_show_settings.rs
+++ b/query/src/sql/statements/statement_show_settings.rs
@@ -30,7 +30,7 @@ impl AnalyzableStatement for DfShowSettings {
     #[tracing::instrument(level = "debug", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query =
-            "SELECT name, value, default, description, type FROM system.settings ORDER BY name";
+            "SELECT name, value, default, level, description, type FROM system.settings ORDER BY name";
         let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
         Ok(AnalyzedResult::SimpleQuery(Box::new(
             rewritten_query_plan.await?,

--- a/query/src/storages/system/settings_table.rs
+++ b/query/src/storages/system/settings_table.rs
@@ -38,6 +38,7 @@ impl SettingsTable {
             DataField::new("name", DataType::String, false),
             DataField::new("value", DataType::String, false),
             DataField::new("default", DataType::String, false),
+            DataField::new("level", DataType::String, false),
             DataField::new("description", DataType::String, false),
             DataField::new("type", DataType::String, false),
         ]);
@@ -78,6 +79,7 @@ impl Table for SettingsTable {
         let mut names: Vec<String> = vec![];
         let mut values: Vec<String> = vec![];
         let mut defaults: Vec<String> = vec![];
+        let mut levels: Vec<String> = vec![];
         let mut descs: Vec<String> = vec![];
         let mut types: Vec<String> = vec![];
         for setting in settings {
@@ -88,8 +90,10 @@ impl Table for SettingsTable {
                 values.push(format!("{:?}", vals[1]));
                 // Default Value.
                 defaults.push(format!("{:?}", vals[2]));
+                // Scope level.
+                levels.push(format!("{:?}", vals[3]));
                 // Desc.
-                descs.push(format!("{:?}", vals[3]));
+                descs.push(format!("{:?}", vals[4]));
                 // Types.
                 types.push(format!("{:?}", vals[2].data_type()));
             }
@@ -98,15 +102,18 @@ impl Table for SettingsTable {
         let names: Vec<&[u8]> = names.iter().map(|x| x.as_bytes()).collect();
         let values: Vec<&[u8]> = values.iter().map(|x| x.as_bytes()).collect();
         let defaults: Vec<&[u8]> = defaults.iter().map(|x| x.as_bytes()).collect();
+        let levels: Vec<&[u8]> = levels.iter().map(|x| x.as_bytes()).collect();
         let descs: Vec<&[u8]> = descs.iter().map(|x| x.as_bytes()).collect();
         let types: Vec<&[u8]> = types.iter().map(|x| x.as_bytes()).collect();
         let block = DataBlock::create_by_array(self.table_info.schema(), vec![
             Series::new(names),
             Series::new(values),
             Series::new(defaults),
+            Series::new(levels),
             Series::new(descs),
             Series::new(types),
         ]);
+
         Ok(Box::pin(DataBlockStream::create(
             self.table_info.schema(),
             None,

--- a/query/src/users/mod.rs
+++ b/query/src/users/mod.rs
@@ -20,6 +20,8 @@ mod user_stage;
 mod user_udf;
 
 pub mod auth;
+mod user_setting;
+
 pub use user::CertifiedInfo;
 pub use user::User;
 pub use user_api::UserApiProvider;

--- a/query/src/users/user_api.rs
+++ b/query/src/users/user_api.rs
@@ -17,6 +17,8 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_management::RoleApi;
 use common_management::RoleMgr;
+use common_management::SettingApi;
+use common_management::SettingMgr;
 use common_management::StageApi;
 use common_management::StageMgr;
 use common_management::UdfApi;
@@ -55,5 +57,9 @@ impl UserApiProvider {
 
     pub fn get_udf_api_client(&self, tenant: &str) -> Arc<dyn UdfApi> {
         Arc::new(UdfMgr::new(self.client.clone(), tenant))
+    }
+
+    pub fn get_setting_api_client(&self, tenant: &str) -> Arc<dyn SettingApi> {
+        Arc::new(SettingMgr::new(self.client.clone(), tenant))
     }
 }

--- a/query/src/users/user_setting.rs
+++ b/query/src/users/user_setting.rs
@@ -1,0 +1,38 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::Result;
+use common_meta_types::UserSetting;
+
+use crate::users::UserApiProvider;
+
+impl UserApiProvider {
+    // Set a setting.
+    pub async fn set_setting(&self, tenant: &str, setting: UserSetting) -> Result<u64> {
+        let setting_api_provider = self.get_setting_api_client(tenant);
+        setting_api_provider.set_setting(setting).await
+    }
+
+    // Get all settings list.
+    pub async fn get_settings(&self, tenant: &str) -> Result<Vec<UserSetting>> {
+        let setting_api_provider = self.get_setting_api_client(tenant);
+        setting_api_provider.get_settings().await
+    }
+
+    // Drop a setting by name.
+    pub async fn drop_setting(&self, tenant: &str, name: &str) -> Result<()> {
+        let setting_api_provider = self.get_setting_api_client(tenant);
+        setting_api_provider.drop_setting(name, None).await
+    }
+}

--- a/query/tests/it/sessions/mod.rs
+++ b/query/tests/it/sessions/mod.rs
@@ -14,3 +14,4 @@
 
 mod session;
 mod session_context;
+mod session_setting;

--- a/query/tests/it/sessions/session.rs
+++ b/query/tests/it/sessions/session.rs
@@ -13,14 +13,16 @@
 // limitations under the License.
 
 use common_base::tokio;
+use common_exception::Result;
 use common_mem_allocator::malloc_size;
 use databend_query::configs::Config;
 use databend_query::sessions::Session;
 use databend_query::sessions::SessionManager;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_session_mem_usage() {
-    let conf = Config::load_from_args();
+async fn test_session() -> Result<()> {
+    let mut conf = Config::default();
+    conf.query.tenant_id = "tenant1".to_string();
 
     let session_manager = SessionManager::from_conf(conf.clone()).await.unwrap();
 
@@ -32,8 +34,31 @@ async fn test_session_mem_usage() {
     )
     .unwrap();
 
-    let session_size = malloc_size(&session);
+    // Tenant.
+    {
+        let actual = session.get_current_tenant();
+        assert_eq!(&actual, "tenant1");
 
-    assert!(session_size > 3000);
-    assert_eq!(session_size, session.get_memory_usage());
+        // We are not in management mode, so always get the config tenant.
+        session.set_current_tenant("tenant2".to_string());
+        let actual = session.get_current_tenant();
+        assert_eq!(&actual, "tenant1");
+    }
+
+    // Settings.
+    {
+        let settings = session.get_settings();
+        settings.set_max_threads(3)?;
+        let actual = settings.get_max_threads()?;
+        assert_eq!(actual, 3);
+    }
+
+    // Malloc size.
+    {
+        let session_size = malloc_size(&session);
+        assert!(session_size > 2500);
+        assert_eq!(session_size, session.get_memory_usage());
+    }
+
+    Ok(())
 }

--- a/query/tests/it/sessions/session_context.rs
+++ b/query/tests/it/sessions/session_context.rs
@@ -28,7 +28,7 @@ use crate::tests::SessionManagerBuilder;
 #[test]
 fn test_session_context() -> Result<()> {
     let conf = Config::load_from_args();
-    let session_ctx = SessionContext::try_create(&conf)?;
+    let session_ctx = SessionContext::try_create(conf)?;
 
     // Abort status.
     {
@@ -42,12 +42,6 @@ fn test_session_context() -> Result<()> {
         session_ctx.set_current_database("bend".to_string());
         let val = session_ctx.get_current_database();
         assert_eq!("bend", val);
-    }
-
-    // Settings.
-    {
-        let val = session_ctx.get_settings();
-        assert!(val.get_max_threads()? > 0);
     }
 
     // Client host.

--- a/query/tests/it/sessions/session_setting.rs
+++ b/query/tests/it/sessions/session_setting.rs
@@ -1,0 +1,45 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_base::tokio;
+use common_exception::Result;
+use databend_query::configs::Config;
+use databend_query::sessions::Session;
+use databend_query::sessions::SessionManager;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_session_setting() -> Result<()> {
+    let mut conf = Config::default();
+    conf.query.tenant_id = "tenant1".to_string();
+
+    let session_manager = SessionManager::from_conf(conf.clone()).await.unwrap();
+
+    let session = Session::try_create(
+        conf.clone(),
+        String::from("test-001"),
+        String::from("test-type"),
+        session_manager,
+    )?;
+
+    // Settings.
+    {
+        let settings = session.get_settings();
+        settings.set_settings("max_threads".to_string(), "3".to_string(), true)?;
+        let actual = settings.get_max_threads()?;
+        let expect = 3;
+        assert_eq!(actual, expect);
+    }
+
+    Ok(())
+}

--- a/query/tests/it/storages/system/settings_table.rs
+++ b/query/tests/it/storages/system/settings_table.rs
@@ -33,18 +33,18 @@ async fn test_settings_table() -> Result<()> {
     let result = stream.try_collect::<Vec<_>>().await?;
 
     let expected = vec![
-        "+------------------------------------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+",
-        "| name                               | value   | default | description                                                                                                                                | type   |",
-        "+------------------------------------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+",
-        "| flight_client_timeout              | 60      | 60      | Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds                                         | UInt64 |",
-        "| max_block_size                     | 10000   | 10000   | Maximum block size for reading                                                                                                             | UInt64 |",
-        "| max_threads                        | 2       | 16      | The maximum number of threads to execute the request. By default, it is determined automatically.                                          | UInt64 |",
-        "| parallel_read_threads              | 1       | 1       | The maximum number of parallelism for reading data. By default, it is 1.                                                                   | UInt64 |",
-        "| storage_occ_backoff_init_delay_ms  | 5       | 5       | The initial retry delay in millisecond. By default,  it is 5 ms.                                                                           | UInt64 |",
-        "| storage_occ_backoff_max_delay_ms   | 20000   | 20000   | The maximum  back off delay in millisecond, once the retry interval reaches this value, it stops increasing. By default, it is 20 seconds. | UInt64 |",
-        "| storage_occ_backoff_max_elapsed_ms | 120000  | 120000  | The maximum elapsed time after the occ starts, beyond which there will be no more retries. By default, it is 2 minutes.                    | UInt64 |",
-        "| storage_read_buffer_size           | 1048576 | 1048576 | The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.                                                             | UInt64 |",
-        "+------------------------------------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+",
+        "+------------------------------------+---------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+",
+        "| name                               | value   | default | level   | description                                                                                                                                | type   |",
+        "+------------------------------------+---------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+",
+        "| flight_client_timeout              | 60      | 60      | SESSION | Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds                                         | UInt64 |",
+        "| max_block_size                     | 10000   | 10000   | SESSION | Maximum block size for reading                                                                                                             | UInt64 |",
+        "| max_threads                        | 2       | 16      | SESSION | The maximum number of threads to execute the request. By default, it is determined automatically.                                          | UInt64 |",
+        "| parallel_read_threads              | 1       | 1       | SESSION | The maximum number of parallelism for reading data. By default, it is 1.                                                                   | UInt64 |",
+        "| storage_occ_backoff_init_delay_ms  | 5       | 5       | SESSION | The initial retry delay in millisecond. By default, it is 5 ms.                                                                            | UInt64 |",
+        "| storage_occ_backoff_max_delay_ms   | 20000   | 20000   | SESSION | The maximum  back off delay in millisecond, once the retry interval reaches this value, it stops increasing. By default, it is 20 seconds. | UInt64 |",
+        "| storage_occ_backoff_max_elapsed_ms | 120000  | 120000  | SESSION | The maximum elapsed time after the occ starts, beyond which there will be no more retries. By default, it is 2 minutes.                    | UInt64 |",
+        "| storage_read_buffer_size           | 1048576 | 1048576 | SESSION | The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.                                                             | UInt64 |",
+        "+------------------------------------+---------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------+",
     ];
     common_datablocks::assert_blocks_sorted_eq(expected, result.as_slice());
 

--- a/query/tests/it/tests/context.rs
+++ b/query/tests/it/tests/context.rs
@@ -66,7 +66,7 @@ pub fn create_query_context() -> Result<Arc<QueryContext>> {
 }
 
 pub fn create_query_context_with_config(config: Config) -> Result<Arc<QueryContext>> {
-    let sessions = SessionManagerBuilder::create().build()?;
+    let sessions = SessionManagerBuilder::create_with_conf(config.clone()).build()?;
     let dummy_session = sessions.create_session("TestSession")?;
 
     let mut user_info = UserInfo::new(

--- a/query/tests/it/tests/sessions.rs
+++ b/query/tests/it/tests/sessions.rs
@@ -40,48 +40,48 @@ pub struct SessionManagerBuilder {
 
 impl SessionManagerBuilder {
     pub fn create() -> SessionManagerBuilder {
-        SessionManagerBuilder::inner_create(Config::default())
+        SessionManagerBuilder::create_with_conf(Config::default())
             .log_dir_with_relative("../tests/data/logs")
     }
 
-    fn inner_create(config: Config) -> SessionManagerBuilder {
+    pub fn create_with_conf(config: Config) -> SessionManagerBuilder {
         SessionManagerBuilder { config }
     }
 
     pub fn max_sessions(self, max_sessions: u64) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.query.max_active_sessions = max_sessions;
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn rpc_tls_server_key(self, value: impl Into<String>) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.query.rpc_tls_server_key = value.into();
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn rpc_tls_server_cert(self, value: impl Into<String>) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.query.rpc_tls_server_cert = value.into();
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn jwt_key_file(self, value: impl Into<String>) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.query.jwt_key_file = value.into();
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn http_handler_tls_server_key(self, value: impl Into<String>) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.query.http_handler_tls_server_key = value.into();
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn http_handler_tls_server_cert(self, value: impl Into<String>) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.query.http_handler_tls_server_cert = value.into();
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn http_handler_tls_server_root_ca_cert(
@@ -90,31 +90,31 @@ impl SessionManagerBuilder {
     ) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.query.http_handler_tls_server_root_ca_cert = value.into();
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn api_tls_server_key(self, value: impl Into<String>) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.query.api_tls_server_key = value.into();
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn api_tls_server_cert(self, value: impl Into<String>) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.query.api_tls_server_cert = value.into();
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn api_tls_server_root_ca_cert(self, value: impl Into<String>) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.query.api_tls_server_root_ca_cert = value.into();
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn disk_storage_path(self, path: String) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.storage.disk.data_path = path;
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn log_dir_with_relative(self, path: impl Into<String>) -> SessionManagerBuilder {
@@ -125,7 +125,7 @@ impl SessionManagerBuilder {
             .display()
             .to_string();
 
-        SessionManagerBuilder::inner_create(new_config)
+        SessionManagerBuilder::create_with_conf(new_config)
     }
 
     pub fn build(self) -> Result<Arc<SessionManager>> {

--- a/tests/suites/0_stateless/06_show/06_0003_show_settings.result
+++ b/tests/suites/0_stateless/06_show/06_0003_show_settings.result
@@ -1,8 +1,8 @@
-flight_client_timeout	60	60	Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds	UInt64
-max_block_size	10000	10000	Maximum block size for reading	UInt64
-max_threads	11	16	The maximum number of threads to execute the request. By default, it is determined automatically.	UInt64
-parallel_read_threads	1	1	The maximum number of parallelism for reading data. By default, it is 1.	UInt64
-storage_occ_backoff_init_delay_ms	5	5	The initial retry delay in millisecond. By default,  it is 5 ms.	UInt64
-storage_occ_backoff_max_delay_ms	20000	20000	The maximum  back off delay in millisecond, once the retry interval reaches this value, it stops increasing. By default, it is 20 seconds.	UInt64
-storage_occ_backoff_max_elapsed_ms	120000	120000	The maximum elapsed time after the occ starts, beyond which there will be no more retries. By default, it is 2 minutes.	UInt64
-storage_read_buffer_size	1048576	1048576	The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.	UInt64
+flight_client_timeout	60	60	SESSION	Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds	UInt64
+max_block_size	10000	10000	SESSION	Maximum block size for reading	UInt64
+max_threads	11	16	SESSION	The maximum number of threads to execute the request. By default, it is determined automatically.	UInt64
+parallel_read_threads	1	1	SESSION	The maximum number of parallelism for reading data. By default, it is 1.	UInt64
+storage_occ_backoff_init_delay_ms	5	5	SESSION	The initial retry delay in millisecond. By default, it is 5 ms.	UInt64
+storage_occ_backoff_max_delay_ms	20000	20000	SESSION	The maximum  back off delay in millisecond, once the retry interval reaches this value, it stops increasing. By default, it is 20 seconds.	UInt64
+storage_occ_backoff_max_elapsed_ms	120000	120000	SESSION	The maximum elapsed time after the occ starts, beyond which there will be no more retries. By default, it is 2 minutes.	UInt64
+storage_read_buffer_size	1048576	1048576	SESSION	The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.	UInt64

--- a/tests/suites/0_stateless/06_show/06_0003_show_settings.sql
+++ b/tests/suites/0_stateless/06_show/06_0003_show_settings.sql
@@ -1,3 +1,3 @@
 SET max_threads=11;
-SET unknown_settings=11; -- {ErrorCode 1020}
+SET unknown_settings=11; -- {ErrorCode 2801}
 SHOW SETTINGS;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR:
* Add setting to metasrv api

This patch not do(TODO in another patch):
* Read global settings and over-write the local settings

## Changelog

- Improvement


## Related Issues

Part of #3933 

## Test Plan

Unit Tests

Stateless Tests

