### PR TITLE
Migrate uuid functions to datavalues2

### DIFF
--- a/common/functions/src/scalars/function2_factory.rs
+++ b/common/functions/src/scalars/function2_factory.rs
@@ -33,6 +33,7 @@ use super::ToCastFunction;
 use super::TupleClassFunction;
 use super::UdfFunction;
 use crate::scalars::DateFunction;
+use crate::scalars::UUIDFunction;
 
 pub type Factory2Creator = Box<dyn Fn(&str) -> Result<Box<dyn Function2>> + Send + Sync>;
 
@@ -99,6 +100,7 @@ static FUNCTION2_FACTORY: Lazy<Arc<Function2Factory>> = Lazy::new(|| {
     LogicFunction::register(&mut function_factory);
     DateFunction::register2(&mut function_factory);
     OtherFunction::register(&mut function_factory);
+    UUIDFunction::register2(&mut function_factory);
 
     Arc::new(function_factory)
 });

--- a/common/functions/src/scalars/function_factory.rs
+++ b/common/functions/src/scalars/function_factory.rs
@@ -29,7 +29,6 @@ use crate::scalars::Function;
 use crate::scalars::MathsFunction;
 use crate::scalars::NullableFunction;
 use crate::scalars::StringFunction;
-use crate::scalars::UUIDFunction;
 use crate::scalars::UdfFunction;
 
 pub type FactoryCreator = Box<dyn Fn(&str) -> Result<Box<dyn Function>> + Send + Sync>;
@@ -130,7 +129,6 @@ static FUNCTION_FACTORY: Lazy<Arc<FunctionFactory>> = Lazy::new(|| {
     UdfFunction::register(&mut function_factory);
     DateFunction::register(&mut function_factory);
     MathsFunction::register(&mut function_factory);
-    UUIDFunction::register(&mut function_factory);
 
     Arc::new(function_factory)
 });

--- a/common/functions/src/scalars/uuids/uuid.rs
+++ b/common/functions/src/scalars/uuids/uuid.rs
@@ -16,12 +16,12 @@ use super::uuid_creator::UUIDZeroFunction;
 use super::uuid_creator::UUIDv4Function;
 use super::uuid_verifier::UUIDIsEmptyFunction;
 use super::uuid_verifier::UUIDIsNotEmptyFunction;
-use crate::scalars::function_factory::FunctionFactory;
+use crate::scalars::Function2Factory;
 
 pub struct UUIDFunction;
 
 impl UUIDFunction {
-    pub fn register(factory: &mut FunctionFactory) {
+    pub fn register2(factory: &mut Function2Factory) {
         factory.register("generateUUIDv4", UUIDv4Function::desc());
         factory.register("zeroUUID", UUIDZeroFunction::desc());
         factory.register("isemptyUUID", UUIDIsEmptyFunction::desc());

--- a/common/functions/src/scalars/uuids/uuid_creator.rs
+++ b/common/functions/src/scalars/uuids/uuid_creator.rs
@@ -14,8 +14,9 @@
 
 use std::fmt;
 use std::marker::PhantomData;
-use std::sync::Arc;
 
+use common_datavalues2::Column;
+use common_datavalues2::ConstColumn;
 use common_datavalues2::NewColumn;
 use common_datavalues2::StringColumn;
 use common_datavalues2::StringType;
@@ -96,11 +97,11 @@ where T: UUIDCreator + Clone + Sync + Send + 'static
     fn eval(
         &self,
         _columns: &common_datavalues2::ColumnsWithField,
-        _input_rows: usize,
+        input_rows: usize,
     ) -> Result<common_datavalues2::ColumnRef> {
         let uuid = T::create();
         let col = StringColumn::new_from_slice(vec![uuid.to_string()]);
 
-        Ok(Arc::new(col))
+        Ok(ConstColumn::new(col.arc(), input_rows).arc())
     }
 }

--- a/common/functions/tests/it/scalars/uuids/uuid_creator.rs
+++ b/common/functions/tests/it/scalars/uuids/uuid_creator.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_datavalues::prelude::*;
+use common_datavalues2::prelude::*;
 use common_exception::Result;
 use common_functions::scalars::*;
 
-use crate::scalars::scalar_function_test::test_scalar_functions;
-use crate::scalars::scalar_function_test::ScalarFunctionTest;
+use crate::scalars::scalar_function2_test::test_scalar_functions2;
+use crate::scalars::scalar_function2_test::ScalarFunction2Test;
 
 #[test]
 fn test_uuid_creator_functions() -> Result<()> {
@@ -33,13 +33,12 @@ fn test_uuid_creator_functions() -> Result<()> {
     //     error: "",
     // },
 
-    let tests = vec![ScalarFunctionTest {
+    let tests = vec![ScalarFunction2Test {
         name: "zeroUUID-passed",
-        nullable: false,
         columns: vec![],
-        expect: Series::new(vec!["00000000-0000-0000-0000-000000000000"]).into(),
+        expect: Series::from_data(vec!["00000000-0000-0000-0000-000000000000"]),
         error: "",
     }];
 
-    test_scalar_functions(UUIDZeroFunction::try_create("")?, &tests)
+    test_scalar_functions2(UUIDZeroFunction::try_create("")?, &tests)
 }

--- a/common/functions/tests/it/scalars/uuids/uuid_creator.rs
+++ b/common/functions/tests/it/scalars/uuids/uuid_creator.rs
@@ -35,7 +35,7 @@ fn test_uuid_creator_functions() -> Result<()> {
 
     let tests = vec![ScalarFunction2Test {
         name: "zeroUUID-passed",
-        columns: vec![],
+        columns: vec![Series::from_data(vec![""])],
         expect: Series::from_data(vec!["00000000-0000-0000-0000-000000000000"]),
         error: "",
     }];

--- a/common/functions/tests/it/scalars/uuids/uuid_verifier.rs
+++ b/common/functions/tests/it/scalars/uuids/uuid_verifier.rs
@@ -12,35 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_datavalues::prelude::*;
+use common_datavalues2::prelude::*;
 use common_exception::Result;
 use common_functions::scalars::*;
 
-use crate::scalars::scalar_function_test::test_scalar_functions;
-use crate::scalars::scalar_function_test::ScalarFunctionTest;
+use crate::scalars::scalar_function2_test::test_scalar_functions2;
+use crate::scalars::scalar_function2_test::ScalarFunction2Test;
 
 #[test]
 fn test_uuid_is_empty_functions() -> Result<()> {
-    let tests = vec![ScalarFunctionTest {
+    let tests = vec![ScalarFunction2Test {
         name: "is-empty-uuid-passed",
-        nullable: false,
-        columns: vec![Series::new(vec![Some("00000000-0000-0000-0000-000000000000"), None]).into()],
-        expect: Series::new(vec![true, true]).into(),
+        columns: vec![Series::from_data(vec![
+            "00000000-0000-0000-0000-000000000000",
+            "5",
+        ])],
+        expect: Series::from_data(vec![true, true]),
         error: "",
     }];
 
-    test_scalar_functions(UUIDIsEmptyFunction::try_create("")?, &tests)
+    test_scalar_functions2(UUIDIsEmptyFunction::try_create("")?, &tests)
 }
 
 #[test]
 fn test_uuid_is_not_empty_functions() -> Result<()> {
-    let tests = vec![ScalarFunctionTest {
+    let tests = vec![ScalarFunction2Test {
         name: "is-not-empty-uuid-passed",
-        nullable: false,
-        columns: vec![Series::new(vec![Some("59b69da3-81d0-4db2-96e8-3e20b505a7b2")]).into()],
-        expect: Series::new(vec![true]).into(),
+        columns: vec![Series::from_data(vec![
+            "59b69da3-81d0-4db2-96e8-3e20b505a7b2",
+            "5",
+        ])],
+        expect: Series::from_data(vec![true, false]),
         error: "",
     }];
 
-    test_scalar_functions(UUIDIsNotEmptyFunction::try_create("")?, &tests)
+    test_scalar_functions2(UUIDIsNotEmptyFunction::try_create("")?, &tests)
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Migrate uuid functions to datavalues2

## Changelog

- Improvement

## Related Issues

Fixes #3977

## Test Plan

Unit Tests

Stateless Tests

