### PR TITLE
CONTEXT: Always put ctx:Arc<QueryContext> as the first argument of the function

### DIFF
--- a/query/benches/suites/mod.rs
+++ b/query/benches/suites/mod.rs
@@ -32,7 +32,7 @@ pub async fn select_executor(sql: &str) -> Result<()> {
     let executor_session = sessions.create_session("Benches")?;
     let ctx = executor_session.create_query_context().await?;
 
-    if let PlanNode::Select(plan) = PlanParser::parse(sql, ctx.clone()).await? {
+    if let PlanNode::Select(plan) = PlanParser::parse(ctx.clone(), sql).await? {
         let executor = SelectInterpreter::try_create(ctx, plan)?;
         let mut stream = executor.execute(None).await?;
         while let Some(_block) = stream.next().await {}

--- a/query/src/functions/context_function.rs
+++ b/query/src/functions/context_function.rs
@@ -28,7 +28,7 @@ pub struct ContextFunction;
 impl ContextFunction {
     // Some function args need from context
     // such as `SELECT database()`, the arg is ctx.get_default_db()
-    pub fn build_args_from_ctx(name: &str, ctx: Arc<QueryContext>) -> Result<Vec<Expression>> {
+    pub fn build_args_from_ctx(ctx: Arc<QueryContext>, name: &str) -> Result<Vec<Expression>> {
         // Check the function is supported in common functions.
         let function_factory = FunctionFactory::instance();
         let aggregate_function_factory = AggregateFunctionFactory::instance();

--- a/query/src/interpreters/interpreter_table_optimize.rs
+++ b/query/src/interpreters/interpreter_table_optimize.rs
@@ -62,7 +62,7 @@ impl Interpreter for OptimizeTableInterpreter {
             let rewritten_query =
                 format!("INSERT OVERWRITE {} SELECT * FROM {}", obj_name, obj_name);
             let rewritten_plan =
-                PlanParser::parse(rewritten_query.as_str(), self.ctx.clone()).await?;
+                PlanParser::parse(self.ctx.clone(), rewritten_query.as_str()).await?;
             let interpreter = InterpreterFactory::get(self.ctx.clone(), rewritten_plan)?;
             let mut stream = interpreter.execute(None).await?;
             while let Some(Ok(_)) = stream.next().await {}

--- a/query/src/servers/clickhouse/interactive_worker_base.rs
+++ b/query/src/servers/clickhouse/interactive_worker_base.rs
@@ -66,7 +66,7 @@ impl InteractiveWorkerBase {
         let ctx = session.create_query_context().await?;
         ctx.attach_query_str(query);
 
-        let plan = PlanParser::parse(query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         match plan {
             PlanNode::Insert(ref insert) => {
                 // It has select plan, so we do not need to consume data from client

--- a/query/src/servers/http/v1/load.rs
+++ b/query/src/servers/http/v1/load.rs
@@ -111,7 +111,7 @@ pub async fn streaming_load(
         })
         .unwrap_or(b'\n');
 
-    let plan = PlanParser::parse(insert_sql, context.clone())
+    let plan = PlanParser::parse(context.clone(), insert_sql)
         .await
         .map_err(InternalServerError)?;
     context.attach_query_str(insert_sql);

--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -34,7 +34,7 @@ use crate::sql::DfStatement;
 pub struct PlanParser;
 
 impl PlanParser {
-    pub async fn parse(query: &str, ctx: Arc<QueryContext>) -> Result<PlanNode> {
+    pub async fn parse(ctx: Arc<QueryContext>, query: &str) -> Result<PlanNode> {
         let (statements, _) = DfParser::parse_sql(query)?;
         PlanParser::build_plan(statements, ctx).await
     }

--- a/query/src/sql/statements/analyzer_expr.rs
+++ b/query/src/sql/statements/analyzer_expr.rs
@@ -176,7 +176,7 @@ impl ExpressionAnalyzer {
     /// Function to process when args's size is more than 2.
     fn other_function(&self, info: &FunctionExprInfo, args: &[Expression]) -> Result<Expression> {
         let query_context = self.context.clone();
-        let context_args = ContextFunction::build_args_from_ctx(&info.name, query_context)?;
+        let context_args = ContextFunction::build_args_from_ctx(query_context, &info.name)?;
 
         match context_args.is_empty() {
             true => {

--- a/query/src/sql/statements/statement_show_databases.rs
+++ b/query/src/sql/statements/statement_show_databases.rs
@@ -33,7 +33,7 @@ impl AnalyzableStatement for DfShowDatabases {
     #[tracing::instrument(level = "debug", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = self.rewritten_query();
-        let rewritten_query_plan = PlanParser::parse(rewritten_query.as_str(), ctx);
+        let rewritten_query_plan = PlanParser::parse(ctx, rewritten_query.as_str());
         Ok(AnalyzedResult::SimpleQuery(Box::new(
             rewritten_query_plan.await?,
         )))

--- a/query/src/sql/statements/statement_show_engines.rs
+++ b/query/src/sql/statements/statement_show_engines.rs
@@ -30,7 +30,7 @@ impl AnalyzableStatement for DfShowEngines {
     #[tracing::instrument(level = "debug", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT Engine, Comment FROM system.engines ORDER BY Engine ASC";
-        let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
+        let rewritten_query_plan = PlanParser::parse(ctx, rewritten_query);
         Ok(AnalyzedResult::SimpleQuery(Box::new(
             rewritten_query_plan.await?,
         )))

--- a/query/src/sql/statements/statement_show_functions.rs
+++ b/query/src/sql/statements/statement_show_functions.rs
@@ -36,7 +36,7 @@ impl AnalyzableStatement for DfShowFunctions {
     #[tracing::instrument(level = "debug", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = self.rewritten_query(ctx.clone());
-        let rewritten_query_plan = PlanParser::parse(rewritten_query.as_str(), ctx);
+        let rewritten_query_plan = PlanParser::parse(ctx, rewritten_query.as_str());
         Ok(AnalyzedResult::SimpleQuery(Box::new(
             rewritten_query_plan.await?,
         )))

--- a/query/src/sql/statements/statement_show_metrics.rs
+++ b/query/src/sql/statements/statement_show_metrics.rs
@@ -30,7 +30,7 @@ impl AnalyzableStatement for DfShowMetrics {
     #[tracing::instrument(level = "debug", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT * FROM system.metrics";
-        let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
+        let rewritten_query_plan = PlanParser::parse(ctx, rewritten_query);
         Ok(AnalyzedResult::SimpleQuery(Box::new(
             rewritten_query_plan.await?,
         )))

--- a/query/src/sql/statements/statement_show_processlist.rs
+++ b/query/src/sql/statements/statement_show_processlist.rs
@@ -30,7 +30,7 @@ impl AnalyzableStatement for DfShowProcessList {
     #[tracing::instrument(level = "debug", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT * FROM system.processes";
-        let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
+        let rewritten_query_plan = PlanParser::parse(ctx, rewritten_query);
         Ok(AnalyzedResult::SimpleQuery(Box::new(
             rewritten_query_plan.await?,
         )))

--- a/query/src/sql/statements/statement_show_settings.rs
+++ b/query/src/sql/statements/statement_show_settings.rs
@@ -31,7 +31,7 @@ impl AnalyzableStatement for DfShowSettings {
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query =
             "SELECT name, value, default, level, description, type FROM system.settings ORDER BY name";
-        let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
+        let rewritten_query_plan = PlanParser::parse(ctx, rewritten_query);
         Ok(AnalyzedResult::SimpleQuery(Box::new(
             rewritten_query_plan.await?,
         )))

--- a/query/src/sql/statements/statement_show_tables.rs
+++ b/query/src/sql/statements/statement_show_tables.rs
@@ -38,7 +38,7 @@ impl AnalyzableStatement for DfShowTables {
     #[tracing::instrument(level = "debug", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = self.rewritten_query(ctx.clone());
-        let rewritten_query_plan = PlanParser::parse(rewritten_query.as_str(), ctx);
+        let rewritten_query_plan = PlanParser::parse(ctx, rewritten_query.as_str());
         Ok(AnalyzedResult::SimpleQuery(Box::new(
             rewritten_query_plan.await?,
         )))

--- a/query/src/sql/statements/statement_show_users.rs
+++ b/query/src/sql/statements/statement_show_users.rs
@@ -30,7 +30,7 @@ impl AnalyzableStatement for DfShowUsers {
     #[tracing::instrument(level = "debug", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let rewritten_query = "SELECT * FROM system.users ORDER BY name";
-        let rewritten_query_plan = PlanParser::parse(rewritten_query, ctx);
+        let rewritten_query_plan = PlanParser::parse(ctx, rewritten_query);
         Ok(AnalyzedResult::SimpleQuery(Box::new(
             rewritten_query_plan.await?,
         )))

--- a/query/tests/it/api/rpc/flight_actions.rs
+++ b/query/tests/it/api/rpc/flight_actions.rs
@@ -32,7 +32,7 @@ async fn test_shuffle_action_try_into() -> Result<()> {
     let shuffle_action = ShuffleAction {
         query_id: String::from("query_id"),
         stage_id: String::from("stage_id"),
-        plan: PlanParser::parse("SELECT number FROM numbers(5)", ctx.clone()).await?,
+        plan: PlanParser::parse(ctx.clone(), "SELECT number FROM numbers(5)").await?,
         sinks: vec![String::from("stream_id")],
         scatters_expression: Expression::create_literal(DataValue::UInt64(Some(1))),
     };
@@ -48,7 +48,7 @@ async fn test_shuffle_action_try_into() -> Result<()> {
             assert_eq!(action.stage_id, "stage_id");
             assert_eq!(
                 action.plan,
-                PlanParser::parse("SELECT number FROM numbers(5)", ctx.clone()).await?
+                PlanParser::parse(ctx.clone(), "SELECT number FROM numbers(5)").await?
             );
             assert_eq!(action.sinks, vec![String::from("stream_id")]);
             assert_eq!(

--- a/query/tests/it/api/rpc/flight_dispatcher.rs
+++ b/query/tests/it/api/rpc/flight_dispatcher.rs
@@ -61,7 +61,7 @@ async fn test_run_shuffle_action_with_no_scatters() -> Result<()> {
                 FlightAction::PrepareShuffleAction(ShuffleAction {
                     query_id: query_id.clone(),
                     stage_id: stage_id.clone(),
-                    plan: PlanParser::parse("SELECT number FROM numbers(5)", ctx.clone()).await?,
+                    plan: PlanParser::parse(ctx.clone(), "SELECT number FROM numbers(5)").await?,
                     sinks: vec![stream_id.clone()],
                     scatters_expression: Expression::create_literal(DataValue::UInt64(Some(1))),
                 }),
@@ -106,7 +106,7 @@ async fn test_run_shuffle_action_with_scatter() -> Result<()> {
                 FlightAction::PrepareShuffleAction(ShuffleAction {
                     query_id: query_id.clone(),
                     stage_id: stage_id.clone(),
-                    plan: PlanParser::parse("SELECT number FROM numbers(5)", ctx.clone()).await?,
+                    plan: PlanParser::parse(ctx.clone(), "SELECT number FROM numbers(5)").await?,
                     sinks: vec!["stream_1".to_string(), "stream_2".to_string()],
                     scatters_expression: Expression::Column("number".to_string()),
                 }),

--- a/query/tests/it/api/rpc/flight_service.rs
+++ b/query/tests/it/api/rpc/flight_service.rs
@@ -166,7 +166,7 @@ async fn do_action_request(query_id: &str, stage_id: &str) -> Result<Request<Act
     let flight_action = FlightAction::PrepareShuffleAction(ShuffleAction {
         query_id: String::from(query_id),
         stage_id: String::from(stage_id),
-        plan: PlanParser::parse("SELECT number FROM numbers(5)", ctx.clone()).await?,
+        plan: PlanParser::parse(ctx.clone(), "SELECT number FROM numbers(5)").await?,
         sinks: vec![String::from("stream_id")],
         scatters_expression: Expression::create_literal(DataValue::UInt64(Some(1))),
     });

--- a/query/tests/it/functions/context_function.rs
+++ b/query/tests/it/functions/context_function.rs
@@ -22,19 +22,19 @@ fn test_context_function_build_arg_from_ctx() -> Result<()> {
 
     // Ok.
     {
-        let args = ContextFunction::build_args_from_ctx("database", ctx.clone())?;
+        let args = ContextFunction::build_args_from_ctx(ctx.clone(), "database")?;
         assert_eq!("default", format!("{:?}", args[0]));
     }
 
     // Ok.
     {
-        let args = ContextFunction::build_args_from_ctx("current_user", ctx.clone())?;
+        let args = ContextFunction::build_args_from_ctx(ctx.clone(), "current_user")?;
         assert_eq!("'root'@'127.0.0.1'", format!("{:?}", args[0]));
     }
 
     // Error.
     {
-        let result = ContextFunction::build_args_from_ctx("databasexx", ctx).is_err();
+        let result = ContextFunction::build_args_from_ctx(ctx, "databasexx").is_err();
         assert!(result);
     }
 

--- a/query/tests/it/interpreters/access/management_mode_access.rs
+++ b/query/tests/it/interpreters/access/management_mode_access.rs
@@ -114,14 +114,14 @@ async fn test_management_mode_access() -> Result<()> {
     let ctx = crate::tests::create_query_context_with_config(conf.clone())?;
     // First to set tenant.
     {
-        let plan = PlanParser::parse("SUDO USE TENANT 'test'", ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), "SUDO USE TENANT 'test'").await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
         let _ = interpreter.execute(None).await?;
     }
 
     for group in groups {
         for test in group.tests {
-            let plan = PlanParser::parse(test.query, ctx.clone()).await?;
+            let plan = PlanParser::parse(ctx.clone(), test.query).await?;
             let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
             let res = interpreter.execute(None).await;
             assert_eq!(

--- a/query/tests/it/interpreters/interpreter_database_create.rs
+++ b/query/tests/it/interpreters/interpreter_database_create.rs
@@ -25,7 +25,7 @@ async fn test_create_database_interpreter() -> Result<()> {
 
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse("create database db1", ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), "create database db1").await?;
     let executor = InterpreterFactory::get(ctx, plan.clone())?;
     assert_eq!(executor.name(), "CreateDatabaseInterpreter");
     let mut stream = executor.execute(None).await?;

--- a/query/tests/it/interpreters/interpreter_database_drop.rs
+++ b/query/tests/it/interpreters/interpreter_database_drop.rs
@@ -23,7 +23,7 @@ use pretty_assertions::assert_eq;
 async fn test_drop_database_interpreter() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse("drop database default", ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), "drop database default").await?;
     let executor = InterpreterFactory::get(ctx, plan.clone())?;
     assert_eq!(executor.name(), "DropDatabaseInterpreter");
     let stream = executor.execute(None).await?;

--- a/query/tests/it/interpreters/interpreter_describe_stage.rs
+++ b/query/tests/it/interpreters/interpreter_describe_stage.rs
@@ -27,8 +27,8 @@ async fn test_desc_stageinterpreter() -> Result<()> {
 
     // create stage
     {
-        static TEST_QUERY: &str = "CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(access_key_id='1a2b3c' secret_access_key='4x5y6z') file_format=(FORMAT=CSV compression=GZIP  record_delimiter='|') comments='test'";
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let query = "CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(access_key_id='1a2b3c' secret_access_key='4x5y6z') file_format=(FORMAT=CSV compression=GZIP  record_delimiter='|') comments='test'";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "CreatStageInterpreter");
         let _ = executor.execute(None).await?;
@@ -36,7 +36,7 @@ async fn test_desc_stageinterpreter() -> Result<()> {
 
     // desc stage
     {
-        let plan = PlanParser::parse("desc stage test_stage", ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), "desc stage test_stage").await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let stream = executor.execute(None).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/query/tests/it/interpreters/interpreter_describe_table.rs
+++ b/query/tests/it/interpreters/interpreter_describe_table.rs
@@ -25,20 +25,20 @@ async fn interpreter_describe_table_test() -> Result<()> {
 
     // Create table.
     {
-        static TEST_CREATE_QUERY: &str = "\
+        let query = "\
             CREATE TABLE default.a(\
                 a bigint, b int, c varchar(255), d smallint, e Date \
             ) Engine = Null\
         ";
 
-        let plan = PlanParser::parse(TEST_CREATE_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let _ = interpreter.execute(None).await?;
     }
 
     // describe table.
     {
-        let plan = PlanParser::parse("DESCRIBE a", ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), "DESCRIBE a").await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DescribeTableInterpreter");
 

--- a/query/tests/it/interpreters/interpreter_explain.rs
+++ b/query/tests/it/interpreters/interpreter_explain.rs
@@ -23,12 +23,12 @@ use pretty_assertions::assert_eq;
 async fn test_explain_interpreter() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
 
-    static TEST_QUERY: &str = "\
+    let query = "\
         EXPLAIN SELECT number FROM numbers_mt(10) \
         WHERE (number + 1) = 4 HAVING (number + 1) = 4\
     ";
 
-    let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), query).await?;
     let executor = InterpreterFactory::get(ctx, plan)?;
     assert_eq!(executor.name(), "ExplainInterpreter");
 

--- a/query/tests/it/interpreters/interpreter_grant_privilege.rs
+++ b/query/tests/it/interpreters/interpreter_grant_privilege.rs
@@ -96,7 +96,7 @@ async fn test_grant_privilege_interpreter() -> Result<()> {
     ];
 
     for tt in tests {
-        let plan = PlanParser::parse(&tt.query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), &tt.query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "GrantPrivilegeInterpreter");
         let r = match executor.execute(None).await {

--- a/query/tests/it/interpreters/interpreter_insert.rs
+++ b/query/tests/it/interpreters/interpreter_insert.rs
@@ -24,24 +24,24 @@ async fn test_insert_into_interpreter() -> Result<()> {
 
     // Create default value table.
     {
-        static TEST_QUERY: &str = "create table default.default_value_table(a String, b String DEFAULT 'b') Engine = Memory";
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let query = "create table default.default_value_table(a String, b String DEFAULT 'b') Engine = Memory";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let _ = executor.execute(None).await?;
     }
 
     // Create input table.
     {
-        static TEST_QUERY: &str = "create table default.input_table(a String, b String, c String, d String, e String) Engine = Memory";
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let query = "create table default.input_table(a String, b String, c String, d String, e String) Engine = Memory";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let _ = executor.execute(None).await?;
     }
 
     // Create output table.
     {
-        static TEST_QUERY: &str = "create table default.output_table(a UInt8, b Int8, c UInt16, d Int16, e String) Engine = Memory";
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let query = "create table default.output_table(a UInt8, b Int8, c UInt16, d Int16, e String) Engine = Memory";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let _ = executor.execute(None).await?;
     }
@@ -50,24 +50,24 @@ async fn test_insert_into_interpreter() -> Result<()> {
     {
         // insert into.
         {
-            static TEST_QUERY: &str = "insert into default.default_value_table(a) values('a')";
-            let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+            let query = "insert into default.default_value_table(a) values('a')";
+            let plan = PlanParser::parse(ctx.clone(), query).await?;
             let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
             let _ = executor.execute(None).await?;
         }
 
         // insert into select.
         {
-            static TEST_QUERY: &str = "insert into default.default_value_table(a) select a from default.default_value_table";
-            let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+            let query = "insert into default.default_value_table(a) select a from default.default_value_table";
+            let plan = PlanParser::parse(ctx.clone(), query).await?;
             let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
             let _ = executor.execute(None).await?;
         }
 
         // select.
         {
-            static TEST_QUERY: &str = "select * from default.default_value_table";
-            let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+            let query = "select * from default.default_value_table";
+            let plan = PlanParser::parse(ctx.clone(), query).await?;
             let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
             let stream = executor.execute(None).await?;
             let result = stream.try_collect::<Vec<_>>().await?;
@@ -85,26 +85,25 @@ async fn test_insert_into_interpreter() -> Result<()> {
 
     // Insert into input table.
     {
-        static TEST_QUERY: &str = "insert into default.input_table values(1,1,1,1,1), (2,2,2,2,2)";
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let query = "insert into default.input_table values(1,1,1,1,1), (2,2,2,2,2)";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let _ = executor.execute(None).await?;
     }
 
     // Insert into output table.
     {
-        static TEST_QUERY: &str =
-            "insert into default.output_table select * from default.input_table";
+        let query = "insert into default.output_table select * from default.input_table";
 
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let _ = executor.execute(None).await?;
     }
 
     // select.
     {
-        static TEST_QUERY: &str = "select * from default.output_table";
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let query = "select * from default.output_table";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let stream = executor.execute(None).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/query/tests/it/interpreters/interpreter_interceptor.rs
+++ b/query/tests/it/interpreters/interpreter_interceptor.rs
@@ -26,7 +26,7 @@ async fn test_interpreter_interceptor() -> Result<()> {
     {
         let query = "select number from numbers_mt(100) where number > 90";
         ctx.attach_query_str(query);
-        let plan = PlanParser::parse(query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
         interpreter.start().await?;
         let stream = interpreter.execute(None).await?;
@@ -56,7 +56,7 @@ async fn test_interpreter_interceptor() -> Result<()> {
     // Check.
     {
         let query = "select log_type, handler_type, cpu_usage, scan_rows, scan_bytes, scan_partitions, written_rows, written_bytes, result_rows, result_bytes, query_kind, query_text, sql_user, sql_user_quota from system.query_log";
-        let plan = PlanParser::parse(query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
 
         let stream = interpreter.execute(None).await?;
@@ -84,7 +84,7 @@ async fn test_interpreter_interceptor_for_insert() -> Result<()> {
     {
         let query = "create table t as select number from numbers_mt(1)";
         ctx.attach_query_str(query);
-        let plan = PlanParser::parse(query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
         interpreter.start().await?;
         let stream = interpreter.execute(None).await?;
@@ -95,7 +95,7 @@ async fn test_interpreter_interceptor_for_insert() -> Result<()> {
     // Check.
     {
         let query = "select log_type, handler_type, cpu_usage, scan_rows, scan_bytes, scan_partitions, written_rows, written_bytes, result_rows, result_bytes, query_kind, query_text, sql_user, sql_user_quota from system.query_log";
-        let plan = PlanParser::parse(query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
 
         let stream = interpreter.execute(None).await?;

--- a/query/tests/it/interpreters/interpreter_revoke_previlege.rs
+++ b/query/tests/it/interpreters/interpreter_revoke_previlege.rs
@@ -42,8 +42,8 @@ async fn test_revoke_privilege_interpreter() -> Result<()> {
     let user_mgr = ctx.get_user_manager();
     user_mgr.add_user(&tenant, user_info).await?;
 
-    let test_query = format!("REVOKE ALL ON *.* FROM '{}'@'{}'", name, hostname);
-    let plan = PlanParser::parse(&test_query, ctx.clone()).await?;
+    let query = format!("REVOKE ALL ON *.* FROM '{}'@'{}'", name, hostname);
+    let plan = PlanParser::parse(ctx.clone(), &query).await?;
     let executor = InterpreterFactory::get(ctx, plan.clone())?;
     assert_eq!(executor.name(), "RevokePrivilegeInterpreter");
     let mut stream = executor.execute(None).await?;

--- a/query/tests/it/interpreters/interpreter_select.rs
+++ b/query/tests/it/interpreters/interpreter_select.rs
@@ -25,8 +25,8 @@ async fn test_select_interpreter() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
 
     {
-        static TEST_QUERY_1: &str = "select number from numbers_mt(10)";
-        let plan = PlanParser::parse(TEST_QUERY_1, ctx.clone()).await?;
+        let query = "select number from numbers_mt(10)";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan)?;
         assert_eq!(executor.name(), "SelectInterpreter");
 
@@ -55,8 +55,8 @@ async fn test_select_interpreter() -> Result<()> {
     }
 
     {
-        static TEST_QUERY_2: &str = "select 1 + 1, 2 + 2, 3 * 3, 4 * 4";
-        let plan = PlanParser::parse(TEST_QUERY_2, ctx.clone()).await?;
+        let query = "select 1 + 1, 2 + 2, 3 * 3, 4 * 4";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan)?;
         assert_eq!(executor.name(), "SelectInterpreter");
 

--- a/query/tests/it/interpreters/interpreter_setting.rs
+++ b/query/tests/it/interpreters/interpreter_setting.rs
@@ -23,7 +23,7 @@ use pretty_assertions::assert_eq;
 async fn test_setting_interpreter() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse("SET max_block_size=1", ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), "SET max_block_size=1").await?;
     let executor = InterpreterFactory::get(ctx.clone(), plan)?;
     assert_eq!(executor.name(), "SettingInterpreter");
 
@@ -37,7 +37,7 @@ async fn test_setting_interpreter() -> Result<()> {
 async fn test_setting_interpreter_error() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse("SET max_block_size=1", ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), "SET max_block_size=1").await?;
     let executor = InterpreterFactory::get(ctx.clone(), plan)?;
     if let Err(e) = executor.execute(None).await {
         let expect = "Code: 1020, displayText = Unknown variable: \"xx\".";

--- a/query/tests/it/interpreters/interpreter_show_create_database.rs
+++ b/query/tests/it/interpreters/interpreter_show_create_database.rs
@@ -25,7 +25,7 @@ async fn test_show_create_database_interpreter() -> Result<()> {
 
     // show create database default
     {
-        let plan = PlanParser::parse("show create database default", ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), "show create database default").await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "ShowCreateDatabaseInterpreter");
         let stream = executor.execute(None).await?;
@@ -42,7 +42,7 @@ async fn test_show_create_database_interpreter() -> Result<()> {
 
     // show create database system
     {
-        let plan = PlanParser::parse("show create database system", ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), "show create database system").await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "ShowCreateDatabaseInterpreter");
         let stream = executor.execute(None).await?;

--- a/query/tests/it/interpreters/interpreter_show_create_table.rs
+++ b/query/tests/it/interpreters/interpreter_show_create_table.rs
@@ -25,20 +25,20 @@ async fn interpreter_show_create_table_test() -> Result<()> {
 
     // Create table.
     {
-        static TEST_CREATE_QUERY: &str = "\
+        let query = "\
             CREATE TABLE default.a(\
                 a bigint, b int, c varchar(255), d smallint, e Date\
             ) Engine = Null COMMENT = 'test create'\
         ";
 
-        let plan = PlanParser::parse(TEST_CREATE_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let _ = executor.execute(None).await?;
     }
 
     // Show create table.
     {
-        let plan = PlanParser::parse("SHOW CREATE TABLE a", ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), "SHOW CREATE TABLE a").await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "ShowCreateTableInterpreter");
         let stream = executor.execute(None).await?;

--- a/query/tests/it/interpreters/interpreter_stage_create.rs
+++ b/query/tests/it/interpreters/interpreter_stage_create.rs
@@ -29,9 +29,9 @@ async fn test_create_stage_interpreter() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
     let tenant = ctx.get_tenant();
 
-    static TEST_QUERY: &str = "CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(access_key_id='1a2b3c' secret_access_key='4x5y6z') file_format=(FORMAT=CSV compression=GZIP record_delimiter='\n') comments='test'";
+    let query = "CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(access_key_id='1a2b3c' secret_access_key='4x5y6z') file_format=(FORMAT=CSV compression=GZIP record_delimiter='\n') comments='test'";
     {
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "CreatStageInterpreter");
         executor.execute(None).await?;
@@ -50,7 +50,7 @@ async fn test_create_stage_interpreter() -> Result<()> {
 
     // IF NOT EXISTS.
     {
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "CreatStageInterpreter");
         executor.execute(None).await?;
@@ -68,9 +68,9 @@ async fn test_create_stage_interpreter() -> Result<()> {
         assert_eq!(stage.comments, String::from("test"));
     }
 
-    static TEST_QUERY1: &str = "CREATE STAGE test_stage url='s3://load/files/' credentials=(access_key_id='1a2b3c' secret_access_key='4x5y6z') file_format=(FORMAT=CSV compression=GZIP record_delimiter='\n') comments='test'";
     {
-        let plan = PlanParser::parse(TEST_QUERY1, ctx.clone()).await?;
+        let query = "CREATE STAGE test_stage url='s3://load/files/' credentials=(access_key_id='1a2b3c' secret_access_key='4x5y6z') file_format=(FORMAT=CSV compression=GZIP record_delimiter='\n') comments='test'";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "CreatStageInterpreter");
         let r = executor.execute(None).await;

--- a/query/tests/it/interpreters/interpreter_stage_drop.rs
+++ b/query/tests/it/interpreters/interpreter_stage_drop.rs
@@ -35,7 +35,7 @@ async fn test_drop_stage_interpreter() -> Result<()> {
     static DROP_STAGE: &str = "DROP STAGE test_stage";
 
     {
-        let plan = PlanParser::parse(CREATE_STAGE, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), CREATE_STAGE).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "CreatStageInterpreter");
         let mut stream = executor.execute(None).await?;
@@ -54,7 +54,7 @@ async fn test_drop_stage_interpreter() -> Result<()> {
     }
 
     {
-        let plan = PlanParser::parse(DROP_STAGE, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), DROP_STAGE).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DropStageInterpreter");
         let res = executor.execute(None).await;
@@ -62,7 +62,7 @@ async fn test_drop_stage_interpreter() -> Result<()> {
     }
 
     {
-        let plan = PlanParser::parse(DROP_STAGE_IF_EXISTS, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), DROP_STAGE_IF_EXISTS).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DropStageInterpreter");
         let res = executor.execute(None).await;
@@ -70,7 +70,7 @@ async fn test_drop_stage_interpreter() -> Result<()> {
     }
 
     {
-        let plan = PlanParser::parse(DROP_STAGE, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), DROP_STAGE).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DropStageInterpreter");
         let res = executor.execute(None).await;
@@ -78,7 +78,7 @@ async fn test_drop_stage_interpreter() -> Result<()> {
     }
 
     {
-        let plan = PlanParser::parse(CREATE_STAGE, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), CREATE_STAGE).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "CreatStageInterpreter");
         let mut stream = executor.execute(None).await?;
@@ -97,7 +97,7 @@ async fn test_drop_stage_interpreter() -> Result<()> {
     }
 
     {
-        let plan = PlanParser::parse(DROP_STAGE_IF_EXISTS, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), DROP_STAGE_IF_EXISTS).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DropStageInterpreter");
         let res = executor.execute(None).await;

--- a/query/tests/it/interpreters/interpreter_table_create.rs
+++ b/query/tests/it/interpreters/interpreter_table_create.rs
@@ -23,13 +23,13 @@ async fn test_create_table_interpreter() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
 
     {
-        static TEST_CREATE_QUERY: &str = "\
+        let query = "\
         CREATE TABLE default.a(\
             a bigint not null default 3, b int default a + 3, c varchar(255), d smallint, e Date\
         ) Engine = Null\
     ";
 
-        let plan = PlanParser::parse(TEST_CREATE_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let mut stream = interpreter.execute(None).await?;
         while let Some(_block) = stream.next().await {}
@@ -56,7 +56,7 @@ async fn test_create_table_interpreter() -> Result<()> {
             ) Engine = Null\
         ";
 
-        let plan = PlanParser::parse(TEST_CREATE_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), TEST_CREATE_QUERY).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let _ = executor.execute(None).await?;
     }
@@ -65,7 +65,7 @@ async fn test_create_table_interpreter() -> Result<()> {
         static TEST_CREATE_QUERY_SELECT: &str =
             "CREATE TABLE default.test_b(a varchar, x int) select b, a from default.test_a";
 
-        let plan = PlanParser::parse(TEST_CREATE_QUERY_SELECT, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), TEST_CREATE_QUERY_SELECT).await?;
         let interpreter = InterpreterFactory::get(ctx, plan.clone())?;
         let mut stream = interpreter.execute(None).await?;
         while let Some(_block) = stream.next().await {}

--- a/query/tests/it/interpreters/interpreter_table_drop.rs
+++ b/query/tests/it/interpreters/interpreter_table_drop.rs
@@ -25,20 +25,20 @@ async fn test_drop_table_interpreter() -> Result<()> {
 
     // Create table.
     {
-        static TEST_CREATE_QUERY: &str = "\
+        let query = "\
             CREATE TABLE default.a(\
                 a bigint, b int, c varchar(255), d smallint, e Date\
             ) Engine = Null\
         ";
 
-        let plan = PlanParser::parse(TEST_CREATE_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let _ = executor.execute(None).await?;
     }
 
     // Drop table.
     {
-        let plan = PlanParser::parse("DROP TABLE a", ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), "DROP TABLE a").await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DropTableInterpreter");
         let stream = executor.execute(None).await?;

--- a/query/tests/it/interpreters/interpreter_table_truncate.rs
+++ b/query/tests/it/interpreters/interpreter_table_truncate.rs
@@ -25,29 +25,29 @@ async fn test_truncate_table_interpreter() -> Result<()> {
 
     // Create table.
     {
-        static TEST_CREATE_QUERY: &str = "\
+        let query = "\
             CREATE TABLE default.a(\
                 a String, b String\
             ) Engine = Memory\
         ";
 
-        let plan = PlanParser::parse(TEST_CREATE_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let _ = interpreter.execute(None).await?;
     }
 
     // Insert into.
     {
-        static TEST_INSERT_QUERY: &str = "INSERT INTO default.a VALUES('1,1', '2,2')";
-        let plan = PlanParser::parse(TEST_INSERT_QUERY, ctx.clone()).await?;
+        let query = "INSERT INTO default.a VALUES('1,1', '2,2')";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let _ = executor.execute(None).await?;
     }
 
     // select.
     {
-        static TEST_SELECT_QUERY: &str = "SELECT * FROM default.a";
-        let plan = PlanParser::parse(TEST_SELECT_QUERY, ctx.clone()).await?;
+        let query = "SELECT * FROM default.a";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let stream = interpreter.execute(None).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -63,8 +63,8 @@ async fn test_truncate_table_interpreter() -> Result<()> {
 
     // truncate table.
     {
-        static TEST_TRUNCATE_QUERY: &str = "TRUNCATE TABLE default.a";
-        let plan = PlanParser::parse(TEST_TRUNCATE_QUERY, ctx.clone()).await?;
+        let query = "TRUNCATE TABLE default.a";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(interpreter.name(), "TruncateTableInterpreter");
 
@@ -76,8 +76,8 @@ async fn test_truncate_table_interpreter() -> Result<()> {
 
     // select.
     {
-        static TEST_SELECT_QUERY: &str = "SELECT * FROM default.a";
-        let plan = PlanParser::parse(TEST_SELECT_QUERY, ctx.clone()).await?;
+        let query = "SELECT * FROM default.a";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let interpreter = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let stream = interpreter.execute(None).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/query/tests/it/interpreters/interpreter_udf_alter.rs
+++ b/query/tests/it/interpreters/interpreter_udf_alter.rs
@@ -27,9 +27,9 @@ async fn test_alter_udf_interpreter() -> Result<()> {
     let tenant = ctx.get_tenant();
 
     {
-        static TEST_QUERY: &str =
+        let query =
             "CREATE FUNCTION IF NOT EXISTS isnotempty AS (p) -> not(isnull(p)) DESC = 'This is a description'";
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "CreatUDFInterpreter");
         let mut stream = executor.execute(None).await?;
@@ -46,9 +46,9 @@ async fn test_alter_udf_interpreter() -> Result<()> {
     }
 
     {
-        static TEST_QUERY1: &str =
+        let query =
         "ALTER FUNCTION isnotempty AS (d) -> not(isnotnull(d)) DESC = 'This is a new description'";
-        let plan = PlanParser::parse(TEST_QUERY1, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "AlterUDFInterpreter");
 

--- a/query/tests/it/interpreters/interpreter_udf_create.rs
+++ b/query/tests/it/interpreters/interpreter_udf_create.rs
@@ -27,11 +27,11 @@ async fn test_create_udf_interpreter() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
     let tenant = ctx.get_tenant();
 
-    static TEST_QUERY: &str =
+    let query =
         "CREATE FUNCTION IF NOT EXISTS isnotempty AS (p) -> not(isnull(p)) DESC = 'This is a description'";
 
     {
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "CreatUDFInterpreter");
         let mut stream = executor.execute(None).await?;
@@ -49,7 +49,7 @@ async fn test_create_udf_interpreter() -> Result<()> {
 
     {
         // IF NOT EXISTS.
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         executor.execute(None).await?;
 
@@ -64,11 +64,10 @@ async fn test_create_udf_interpreter() -> Result<()> {
         assert_eq!(udf.description, "This is a description")
     }
 
-    static TEST_QUERY1: &str =
-        "CREATE FUNCTION isnotempty AS (p) -> not(isnull(p)) DESC = 'This is a description'";
-
     {
-        let plan = PlanParser::parse(TEST_QUERY1, ctx.clone()).await?;
+        let query1 =
+            "CREATE FUNCTION isnotempty AS (p) -> not(isnull(p)) DESC = 'This is a description'";
+        let plan = PlanParser::parse(ctx.clone(), query1).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         let r = executor.execute(None).await;
         assert!(r.is_err());

--- a/query/tests/it/interpreters/interpreter_udf_drop.rs
+++ b/query/tests/it/interpreters/interpreter_udf_drop.rs
@@ -33,7 +33,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
     static DROP_UDF: &str = "DROP FUNCTION isnotempty";
 
     {
-        let plan = PlanParser::parse(CREATE_UDF, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), CREATE_UDF).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "CreatUDFInterpreter");
         let mut stream = executor.execute(None).await?;
@@ -50,7 +50,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
     }
 
     {
-        let plan = PlanParser::parse(DROP_UDF, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), DROP_UDF).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DropUDFInterpreter");
         let res = executor.execute(None).await;
@@ -58,7 +58,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
     }
 
     {
-        let plan = PlanParser::parse(DROP_UDF_IF_EXISTS, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), DROP_UDF_IF_EXISTS).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DropUDFInterpreter");
         let res = executor.execute(None).await;
@@ -66,7 +66,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
     }
 
     {
-        let plan = PlanParser::parse(DROP_UDF, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), DROP_UDF).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DropUDFInterpreter");
         let res = executor.execute(None).await;
@@ -74,7 +74,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
     }
 
     {
-        let plan = PlanParser::parse(CREATE_UDF, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), CREATE_UDF).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "CreatUDFInterpreter");
         let mut stream = executor.execute(None).await?;
@@ -90,7 +90,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
         assert_eq!(udf.description, "This is a description")
     }
     {
-        let plan = PlanParser::parse(DROP_UDF_IF_EXISTS, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), DROP_UDF_IF_EXISTS).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DropUDFInterpreter");
         let res = executor.execute(None).await;

--- a/query/tests/it/interpreters/interpreter_use_database.rs
+++ b/query/tests/it/interpreters/interpreter_use_database.rs
@@ -23,7 +23,7 @@ use pretty_assertions::assert_eq;
 async fn test_use_interpreter() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse("USE default", ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), "USE default").await?;
     let interpreter = InterpreterFactory::get(ctx, plan)?;
     assert_eq!(interpreter.name(), "UseDatabaseInterpreter");
 
@@ -37,7 +37,7 @@ async fn test_use_interpreter() -> Result<()> {
 async fn test_use_database_interpreter_error() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse("USE xx", ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), "USE xx").await?;
     let interpreter = InterpreterFactory::get(ctx, plan)?;
 
     if let Err(e) = interpreter.execute(None).await {

--- a/query/tests/it/interpreters/interpreter_use_tenant.rs
+++ b/query/tests/it/interpreters/interpreter_use_tenant.rs
@@ -26,7 +26,7 @@ async fn test_use_tenant_interpreter() -> Result<()> {
         .config();
     let ctx = crate::tests::create_query_context_with_config(conf.clone())?;
 
-    let plan = PlanParser::parse("SUDO USE TENANT 't1'", ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), "SUDO USE TENANT 't1'").await?;
     let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
 
     assert_eq!(interpreter.name(), "UseTenantInterpreter");
@@ -43,7 +43,7 @@ async fn test_use_tenant_interpreter() -> Result<()> {
 async fn test_use_tenant_interpreter_error() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse("SUDO USE TENANT 't1'", ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), "SUDO USE TENANT 't1'").await?;
     let interpreter = InterpreterFactory::get(ctx, plan)?;
 
     if let Err(e) = interpreter.execute(None).await {

--- a/query/tests/it/interpreters/interpreter_user_alter.rs
+++ b/query/tests/it/interpreters/interpreter_user_alter.rs
@@ -52,7 +52,7 @@ async fn test_alter_user_interpreter() -> Result<()> {
         name, hostname, new_password
     );
 
-    let plan = PlanParser::parse(&test_query, ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), &test_query).await?;
     let executor = InterpreterFactory::get(ctx, plan.clone())?;
     assert_eq!(executor.name(), "AlterUserInterpreter");
     let mut stream = executor.execute(None).await?;

--- a/query/tests/it/interpreters/interpreter_user_create.rs
+++ b/query/tests/it/interpreters/interpreter_user_create.rs
@@ -25,8 +25,8 @@ async fn test_create_user_interpreter() -> Result<()> {
 
     let ctx = crate::tests::create_query_context()?;
 
-    static TEST_QUERY: &str = "CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'";
-    let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+    let query = "CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'";
+    let plan = PlanParser::parse(ctx.clone(), query).await?;
     let executor = InterpreterFactory::get(ctx, plan.clone())?;
     assert_eq!(executor.name(), "CreateUserInterpreter");
     let mut stream = executor.execute(None).await?;

--- a/query/tests/it/interpreters/interpreter_user_drop.rs
+++ b/query/tests/it/interpreters/interpreter_user_drop.rs
@@ -29,8 +29,8 @@ async fn test_drop_user_interpreter() -> Result<()> {
     let tenant = ctx.get_tenant();
 
     {
-        static TEST_QUERY: &str = "DROP USER 'test'@'localhost'";
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let query = "DROP USER 'test'@'localhost'";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DropUserInterpreter");
         let ret = executor.execute(None).await;
@@ -38,8 +38,8 @@ async fn test_drop_user_interpreter() -> Result<()> {
     }
 
     {
-        static TEST_QUERY: &str = "DROP USER IF EXISTS 'test'@'localhost'";
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let query = "DROP USER IF EXISTS 'test'@'localhost'";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
         assert_eq!(executor.name(), "DropUserInterpreter");
         let ret = executor.execute(None).await;
@@ -65,8 +65,8 @@ async fn test_drop_user_interpreter() -> Result<()> {
             Vec::from(password)
         );
 
-        static TEST_QUERY: &str = "DROP USER 'test'@'localhost'";
-        let plan = PlanParser::parse(TEST_QUERY, ctx.clone()).await?;
+        let query = "DROP USER 'test'@'localhost'";
+        let plan = PlanParser::parse(ctx.clone(), query).await?;
         let executor = InterpreterFactory::get(ctx, plan.clone())?;
         assert_eq!(executor.name(), "DropUserInterpreter");
         executor.execute(None).await?;

--- a/query/tests/it/optimizers/optimizer.rs
+++ b/query/tests/it/optimizers/optimizer.rs
@@ -50,7 +50,7 @@ async fn test_literal_false_filter() -> Result<()> {
     let query = "select * from numbers_mt(10) where 1 + 2 = 2";
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse(query, ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), query).await?;
     let mut optimizer = Optimizers::without_scatters(ctx);
     let optimized = optimizer.optimize(&plan)?;
     let actual = format!("{:?}", optimized);
@@ -105,7 +105,7 @@ async fn test_skip_read_data_source() -> Result<()> {
 
     for test in tests {
         let ctx = crate::tests::create_query_context()?;
-        let plan = PlanParser::parse(test.query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let mut optimizer = Optimizers::without_scatters(ctx);
 
         let optimized_plan = optimizer.optimize(&plan)?;

--- a/query/tests/it/optimizers/optimizer_constant_folding.rs
+++ b/query/tests/it/optimizers/optimizer_constant_folding.rs
@@ -103,7 +103,7 @@ async fn test_constant_folding_optimizer() -> Result<()> {
     for test in tests {
         let ctx = crate::tests::create_query_context()?;
 
-        let plan = PlanParser::parse(test.query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let mut optimizer = ConstantFoldingOptimizer::create(ctx);
         let optimized = optimizer.optimize(&plan)?;
         let actual = format!("{:?}", optimized);

--- a/query/tests/it/optimizers/optimizer_expression_transform.rs
+++ b/query/tests/it/optimizers/optimizer_expression_transform.rs
@@ -200,7 +200,7 @@ async fn test_expression_transform_optimizer() -> Result<()> {
     for test in tests {
         let ctx = crate::tests::create_query_context()?;
 
-        let plan = PlanParser::parse(test.query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let mut optimizer = ExprTransformOptimizer::create(ctx);
         let optimized = optimizer.optimize(&plan)?;
         let actual = format!("{:?}", optimized);

--- a/query/tests/it/optimizers/optimizer_scatters.rs
+++ b/query/tests/it/optimizers/optimizer_scatters.rs
@@ -210,7 +210,7 @@ async fn test_scatter_optimizer() -> Result<()> {
                 .with_local_id("dummy_local"),
         )?;
 
-        let plan = PlanParser::parse(test.query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let mut optimizer = ScattersOptimizer::create(ctx);
         let optimized = optimizer.optimize(&plan)?;
         let actual = format!("{:?}", optimized);

--- a/query/tests/it/optimizers/optimizer_top_n_push_down.rs
+++ b/query/tests/it/optimizers/optimizer_top_n_push_down.rs
@@ -22,7 +22,7 @@ async fn test_simple() -> Result<()> {
     let query = "select number from numbers(1000) order by number limit 10;";
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse(query, ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), query).await?;
 
     let mut optimizer = TopNPushDownOptimizer::create(ctx);
     let plan_node = optimizer.optimize(&plan)?;
@@ -43,7 +43,7 @@ async fn test_simple_with_offset() -> Result<()> {
     let query = "select number from numbers(1000) order by number limit 10 offset 5;";
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse(query, ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), query).await?;
 
     let mut optimizer = TopNPushDownOptimizer::create(ctx);
     let plan_node = optimizer.optimize(&plan)?;
@@ -65,7 +65,7 @@ async fn test_nested_projection() -> Result<()> {
         "select number from (select * from numbers(1000) order by number limit 11) limit 10;";
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse(query, ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), query).await?;
 
     let mut optimizer = TopNPushDownOptimizer::create(ctx);
     let plan_node = optimizer.optimize(&plan)?;
@@ -89,7 +89,7 @@ async fn test_aggregate() -> Result<()> {
         "select sum(number) FROM numbers(1000) group by number % 10 order by sum(number) limit 5;";
     let ctx = crate::tests::create_query_context()?;
 
-    let plan = PlanParser::parse(query, ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), query).await?;
 
     let mut optimizer = TopNPushDownOptimizer::create(ctx);
     let plan_node = optimizer.optimize(&plan)?;
@@ -142,7 +142,7 @@ async fn test_monotonic_function() -> Result<()> {
 
     for test in tests {
         let ctx = crate::tests::create_query_context()?;
-        let plan = PlanParser::parse(test.query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let mut optimizer = Optimizers::without_scatters(ctx);
 
         let optimized_plan = optimizer.optimize(&plan)?;

--- a/query/tests/it/pipelines/processors/pipeline_builder.rs
+++ b/query/tests/it/pipelines/processors/pipeline_builder.rs
@@ -174,7 +174,7 @@ async fn test_local_pipeline_builds() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
     for test in tests {
         // Plan build check.
-        let plan = PlanParser::parse(test.query, ctx.clone()).await?;
+        let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let actual_plan = format!("{:?}", plan);
         assert_eq!(test.plan, actual_plan, "{:#?}", test.name);
 

--- a/query/tests/it/pipelines/processors/pipeline_display.rs
+++ b/query/tests/it/pipelines/processors/pipeline_display.rs
@@ -22,14 +22,14 @@ use pretty_assertions::assert_eq;
 async fn test_pipeline_display() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
 
-    static TEST_EXPLAIN_QUERY: &str = "\
+    let query = "\
         EXPLAIN PIPELINE SELECT \
             sum(number + 1) + 2 AS sumx \
         FROM numbers_mt(80000) \
         WHERE (number + 1) = 4 limit 1\
     ";
 
-    let plan = PlanParser::parse(TEST_EXPLAIN_QUERY, ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), query).await?;
     let pipeline_builder = PipelineBuilder::create(ctx);
     let pipeline = pipeline_builder.build(plan.input(0).as_ref())?;
     let expect = "LimitTransform × 1 processor\

--- a/query/tests/it/pipelines/processors/pipeline_walker.rs
+++ b/query/tests/it/pipelines/processors/pipeline_walker.rs
@@ -22,14 +22,14 @@ use pretty_assertions::assert_eq;
 async fn test_pipeline_walker() -> Result<()> {
     let ctx = crate::tests::create_query_context()?;
 
-    static TEST_SELECT_QUERY: &str = "\
+    let query = "\
         SELECT sum(number + 1) + 2 AS sumx \
         FROM numbers_mt(80000) \
         WHERE (number + 1) = 4 \
         LIMIT 1\
     ";
 
-    let plan = PlanParser::parse(TEST_SELECT_QUERY, ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), query).await?;
     let pipeline_builder = PipelineBuilder::create(ctx);
     let pipeline = pipeline_builder.build(&plan)?;
 

--- a/query/tests/it/sql/plan_parser.rs
+++ b/query/tests/it/sql/plan_parser.rs
@@ -239,7 +239,7 @@ async fn test_plan_parser() -> Result<()> {
 
     let ctx = crate::tests::create_query_context()?;
     for t in tests {
-        match PlanParser::parse(t.sql, ctx.clone()).await {
+        match PlanParser::parse(ctx.clone(), t.sql).await {
             Ok(v) => {
                 assert_eq!(t.expect, format!("{:?}", v), "{}", t.name);
             }

--- a/query/tests/it/storages/fuse/operations/commit.rs
+++ b/query/tests/it/storages/fuse/operations/commit.rs
@@ -60,7 +60,7 @@ async fn test_fuse_occ_retry() -> Result<()> {
 
     // let's check it out
     let qry = format!("select * from '{}'.'{}' order by id ", db, tbl);
-    let blocks = execute_query(qry.as_str(), ctx.clone())
+    let blocks = execute_query(ctx.clone(), qry.as_str())
         .await?
         .try_collect::<Vec<DataBlock>>()
         .await?;

--- a/query/tests/it/storages/fuse/operations/optimize.rs
+++ b/query/tests/it/storages/fuse/operations/optimize.rs
@@ -60,7 +60,7 @@ async fn insert_test_data(qry: &str, fixture: &TestFixture) -> Result<()> {
     append_sample_data(1, fixture).await?;
     // then, overwrite the table, new data set: 1 block, 1 segment, 1 snapshot
     append_sample_data_overwrite(1, true, fixture).await?;
-    execute_command(qry, ctx.clone()).await?;
+    execute_command(ctx.clone(), qry).await?;
     Ok(())
 }
 
@@ -86,7 +86,7 @@ async fn test_fuse_history_optimize_compact() -> Result<()> {
 
     // optimize compact
     let qry = format!("optimize table '{}'.'{}' compact", db, tbl);
-    execute_command(qry.as_str(), ctx.clone()).await?;
+    execute_command(fixture.ctx(), qry.as_str()).await?;
 
     // optimize compact should keep the histories
     // there should be 6 history items there, 5 for the above insertions, 1 for that compaction
@@ -101,7 +101,7 @@ async fn test_fuse_history_optimize_compact() -> Result<()> {
 
     expects_ok(
         "count_should_be_1",
-        execute_query(qry.as_str(), fixture.ctx()).await,
+        execute_query(fixture.ctx(), qry.as_str()).await,
         expected,
     )
     .await

--- a/query/tests/it/storages/fuse/operations/purge_drop.rs
+++ b/query/tests/it/storages/fuse/operations/purge_drop.rs
@@ -33,7 +33,7 @@ async fn test_fuse_history_truncate_in_drop_stmt() -> Result<()> {
     append_sample_data(10, &fixture).await?;
     // let's Drop
     let qry = format!("drop table '{}'.'{}'", db, tbl);
-    execute_command(qry.as_str(), ctx.clone()).await?;
+    execute_command(ctx.clone(), qry.as_str()).await?;
     // there should be no files left inside test root (dirs are kept, though)
     check_data_dir(
         &fixture,

--- a/query/tests/it/storages/fuse/operations/purge_truncate.rs
+++ b/query/tests/it/storages/fuse/operations/purge_truncate.rs
@@ -38,7 +38,7 @@ async fn test_fuse_truncate_purge_stmt() -> Result<()> {
 
     // let's truncate
     let qry = format!("truncate table '{}'.'{}' purge", db, tbl);
-    execute_command(qry.as_str(), ctx.clone()).await?;
+    execute_command(ctx.clone(), qry.as_str()).await?;
 
     // one history item left there
     history_should_have_only_one_item(

--- a/query/tests/it/storages/fuse/table.rs
+++ b/query/tests/it/storages/fuse/table.rs
@@ -256,7 +256,7 @@ async fn test_fuse_table_optimize() -> Result<()> {
     // do compact
     let query = format!("optimize table {}.{} compact", db_name, tbl_name);
 
-    let plan = PlanParser::parse(&query, ctx.clone()).await?;
+    let plan = PlanParser::parse(ctx.clone(), &query).await?;
     let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
 
     // `PipelineBuilder` will parallelize the table reading according to value of setting `max_threads`,

--- a/query/tests/it/storages/fuse/table_functions/fuse_history_table.rs
+++ b/query/tests/it/storages/fuse/table_functions/fuse_history_table.rs
@@ -118,7 +118,7 @@ async fn test_fuse_history_table_read() -> Result<()> {
 
         expects_ok(
             "count_should_be_1",
-            execute_query(qry.as_str(), ctx.clone()).await,
+            execute_query(ctx.clone(), qry.as_str()).await,
             expected,
         )
         .await?;
@@ -138,7 +138,7 @@ async fn test_fuse_history_table_read() -> Result<()> {
         );
         expects_ok(
             "check_row_and_block_count",
-            execute_query(qry.as_str(), ctx.clone()).await,
+            execute_query(ctx.clone(), qry.as_str()).await,
             expected,
         )
         .await?;
@@ -161,7 +161,7 @@ async fn test_fuse_history_table_read() -> Result<()> {
         );
         expects_ok(
             "check_row_and_block_count_after_append",
-            execute_query(qry.as_str(), ctx.clone()).await,
+            execute_query(ctx.clone(), qry.as_str()).await,
             expected,
         )
         .await?;
@@ -170,13 +170,13 @@ async fn test_fuse_history_table_read() -> Result<()> {
     {
         // incompatible table engine
         let qry = format!("create table {}.in_mem (a int) engine =Memory", db);
-        execute_query(qry.as_str(), ctx.clone()).await?;
+        execute_query(ctx.clone(), qry.as_str()).await?;
 
         let qry = format!("select * from fuse_history('{}', '{}')", db, "in_mem");
         expects_err(
             "check_row_and_block_count_after_append",
             ErrorCode::bad_arguments_code(),
-            execute_query(qry.as_str(), ctx.clone()).await,
+            execute_query(ctx.clone(), qry.as_str()).await,
         );
     }
 

--- a/query/tests/it/storages/fuse/table_test_fixture.rs
+++ b/query/tests/it/storages/fuse/table_test_fixture.rs
@@ -257,15 +257,15 @@ pub async fn expects_ok(
     Ok(())
 }
 
-pub async fn execute_query(query: &str, ctx: Arc<QueryContext>) -> Result<SendableDataBlockStream> {
-    let plan = PlanParser::parse(query, ctx.clone()).await?;
+pub async fn execute_query(ctx: Arc<QueryContext>, query: &str) -> Result<SendableDataBlockStream> {
+    let plan = PlanParser::parse(ctx.clone(), query).await?;
     InterpreterFactory::get(ctx.clone(), plan)?
         .execute(None)
         .await
 }
 
-pub async fn execute_command(query: &str, ctx: Arc<QueryContext>) -> Result<()> {
-    let res = execute_query(query, ctx).await?;
+pub async fn execute_command(ctx: Arc<QueryContext>, query: &str) -> Result<()> {
+    let res = execute_query(ctx, query).await?;
     res.try_collect::<Vec<DataBlock>>().await?;
     Ok(())
 }
@@ -357,7 +357,7 @@ pub async fn history_should_have_only_one_item(
 
     expects_ok(
         format!("{}: count_of_history_item_should_be_1", case_name),
-        execute_query(qry.as_str(), fixture.ctx()).await,
+        execute_query(fixture.ctx(), qry.as_str()).await,
         expected,
     )
     .await


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR:
1. **Put ctx:Arc\<QueryContext\> as the first argument of the function**

## Changelog


- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

