### PR TITLE
[metasrv] refactor: remove CLI arg "--boot". Use "--single" instead.

### DIFF
--- a/common/meta/raft-store/src/config.rs
+++ b/common/meta/raft-store/src/config.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use clap::Parser;
-use common_meta_types::MetaError;
 use common_meta_types::MetaResult;
 use common_meta_types::NodeId;
 use once_cell::sync::Lazy;
@@ -92,10 +91,6 @@ pub struct RaftConfig {
     #[clap(long, env = "RAFT_MAX_APPLIED_LOG_TO_KEEP", default_value = "1000")]
     pub max_applied_log_to_keep: u64,
 
-    /// Whether to boot up a new cluster. If already booted, it is ignored
-    #[clap(long, env = KVSRV_BOOT)]
-    pub boot: bool,
-
     /// Single node metasrv. It creates a single node cluster if meta data is not initialized.
     /// Otherwise it opens the previous one.
     /// This is mainly for testing purpose.
@@ -131,7 +126,6 @@ impl Default for RaftConfig {
             heartbeat_interval: 1000,
             install_snapshot_timeout: 4000,
             max_applied_log_to_keep: 1000,
-            boot: false,
             single: false,
             join: vec![],
             id: 0,
@@ -160,12 +154,6 @@ impl RaftConfig {
     }
 
     pub fn check(&self) -> MetaResult<()> {
-        if self.boot && self.single {
-            return Err(MetaError::InvalidConfig(String::from(
-                "--boot and --single can not be both set",
-            )));
-        }
-
         Ok(())
     }
 

--- a/metasrv/src/bin/metasrv.rs
+++ b/metasrv/src/bin/metasrv.rs
@@ -44,8 +44,7 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
     init_default_metrics_recorder();
 
     tracing::info!(
-        "Starting MetaNode boot:{} single: {} with config: {:?}",
-        conf.raft_config.boot,
+        "Starting MetaNode single: {} with config: {:?}",
         conf.raft_config.single,
         conf
     );

--- a/metasrv/src/configs/config.rs
+++ b/metasrv/src/configs/config.rs
@@ -182,7 +182,6 @@ impl Config {
             u64,
             raft_config::KVSRV_INSTALL_SNAPSHOT_TIMEOUT
         );
-        load_field_from_env!(cfg.raft_config.boot, bool, raft_config::KVSRV_BOOT);
         load_field_from_env!(cfg.raft_config.single, bool, raft_config::KVSRV_SINGLE);
         load_field_from_env!(cfg.raft_config.id, u64, raft_config::KVSRV_ID);
     }

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -379,12 +379,6 @@ impl MetaNode {
     }
 
     async fn do_start(conf: &RaftConfig) -> Result<Arc<MetaNode>, MetaError> {
-        // TODO(xp): remove boot mode
-        if conf.boot {
-            let mn = Self::open_create_boot(conf, None, Some(()), Some(vec![])).await?;
-            return Ok(mn);
-        }
-
         if conf.single {
             let mn = MetaNode::open_create_boot(conf, Some(()), Some(()), Some(vec![])).await?;
             return Ok(mn);

--- a/metasrv/tests/it/configs.rs
+++ b/metasrv/tests/it/configs.rs
@@ -64,7 +64,6 @@ no_sync = true
 snapshot_logs_since_last = 1000
 heartbeat_interval = 2000
 install_snapshot_timeout = 3000
-boot = false
 single = true
 join = ["j1", "j2"]
 id = 20
@@ -90,7 +89,6 @@ sled_tree_prefix = "sled_foo"
     assert_eq!(cfg.raft_config.snapshot_logs_since_last, 1000);
     assert_eq!(cfg.raft_config.heartbeat_interval, 2000);
     assert_eq!(cfg.raft_config.install_snapshot_timeout, 3000);
-    assert!(!cfg.raft_config.boot);
     assert!(cfg.raft_config.single);
     assert_eq!(cfg.raft_config.join, vec!["j1", "j2"]);
     assert_eq!(cfg.raft_config.id, 20);

--- a/metasrv/tests/it/grpc/metasrv_grpc_api.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_api.rs
@@ -98,8 +98,6 @@ async fn test_restart() -> anyhow::Result<()> {
 
         tokio::time::sleep(Duration::from_millis(1000)).await;
 
-        // restart by opening existent meta db
-        tc.config.raft_config.boot = false;
         crate::tests::start_metasrv_with_context(&mut tc).await?;
     }
 

--- a/scripts/ci/deploy/databend-query-cluster-3-nodes.sh
+++ b/scripts/ci/deploy/databend-query-cluster-3-nodes.sh
@@ -22,61 +22,17 @@ for bin in databend-query databend-meta; do
 	fi
 done
 
-# Temp debugging config:
-# Set `mode` to open to test restarting a metasrv cluster.
-# TODO(xp): remove this and there should be a standard test for this.
-mode=boot
-# mode=open
+echo 'Start Meta service HA cluster(3 nodes)...'
 
-if [ "$mode" == "boot" ]; then
-	echo "=== boot new metasrv cluster of 3"
+nohup ./target/debug/databend-meta -c scripts/ci/deploy/config/databend-meta-node-1.toml &
+python3 scripts/ci/wait_tcp.py --timeout 5 --port 9191
 
-	echo 'Start Meta service HA cluster(3 nodes)...'
+nohup ./target/debug/databend-meta -c scripts/ci/deploy/config/databend-meta-node-2.toml &
+python3 scripts/ci/wait_tcp.py --timeout 5 --port 28202
 
-	nohup ./target/debug/databend-meta -c scripts/ci/deploy/config/databend-meta-node-1.toml &
-	python3 scripts/ci/wait_tcp.py --timeout 5 --port 9191
+nohup ./target/debug/databend-meta -c scripts/ci/deploy/config/databend-meta-node-3.toml &
+python3 scripts/ci/wait_tcp.py --timeout 5 --port 28302
 
-	nohup ./target/debug/databend-meta -c scripts/ci/deploy/config/databend-meta-node-2.toml &
-	python3 scripts/ci/wait_tcp.py --timeout 5 --port 28202
-
-	nohup ./target/debug/databend-meta -c scripts/ci/deploy/config/databend-meta-node-3.toml &
-	python3 scripts/ci/wait_tcp.py --timeout 5 --port 28302
-
-else
-
-	echo "=== start initialized metasrv cluster of 3"
-
-	# In the `open` mode, id and raft-api-port are not needed.
-	# They are already stored in raft store.
-
-	nohup ./target/debug/databend-meta \
-		--raft-dir "./_meta1" \
-		--metric-api-address 0.0.0.0:28100 \
-		--admin-api-address 0.0.0.0:28101 \
-		--grpc-api-address 0.0.0.0:9191 \
-		--log-dir ./_logs1 \
-		&
-	python3 scripts/ci/wait_tcp.py --timeout 5 --port 9191
-
-	nohup ./target/debug/databend-meta \
-		--raft-dir "./_meta2" \
-		--metric-api-address 0.0.0.0:28200 \
-		--admin-api-address 0.0.0.0:28201 \
-		--grpc-api-address 0.0.0.0:28202 \
-		--log-dir ./_logs2 \
-		&
-	python3 scripts/ci/wait_tcp.py --timeout 5 --port 28202
-
-	nohup ./target/debug/databend-meta \
-		--raft-dir "./_meta3" \
-		--metric-api-address 0.0.0.0:28300 \
-		--admin-api-address 0.0.0.0:28301 \
-		--grpc-api-address 0.0.0.0:28302 \
-		--log-dir ./_logs3 \
-		&
-	python3 scripts/ci/wait_tcp.py --timeout 5 --port 28302
-
-fi
 
 echo 'Start databend-query node-1'
 nohup target/debug/databend-query -c scripts/ci/deploy/config/databend-query-node-1.toml &


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] refactor: remove CLI arg "--boot". Use "--single" instead.
`metasrv` automatically ignores initializing arguments such as
`--single` and `--join`, if metasrv is already initialized.

Thus when restarting, metasrv can just use the same CLI args as
initializing it.

## Changelog




- Improvement


## Related Issues