### PR TITLE
Refactor: move some storage related errors to MetaStorageError

### DIFF
--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -48,7 +48,6 @@ use common_meta_types::NodeId;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 use common_meta_types::TableMeta;
-use common_meta_types::ToMetaError;
 use common_meta_types::ToMetaStorageError;
 use common_meta_types::UnknownDatabase;
 use common_meta_types::UnknownDatabaseId;
@@ -138,7 +137,9 @@ impl StateMachine {
 
         // it blocks and slow
         db.drop_tree(tree_name)
-            .map_error_to_meta_error(MetaError::MetaStoreDamaged, || "drop prev state machine")?;
+            .map_error_to_meta_storage_error(MetaStorageError::SledError, || {
+                "drop prev state machine"
+            })?;
 
         Ok(())
     }

--- a/common/meta/types/src/meta_errors.rs
+++ b/common/meta/types/src/meta_errors.rs
@@ -52,15 +52,6 @@ pub enum MetaError {
     #[error("raft state absent, can not open")]
     MetaStoreNotFound,
 
-    #[error("serde_json error: {0}")]
-    SerdeJsonError(String),
-
-    #[error("{0}")]
-    MetaStoreDamaged(String),
-
-    #[error("{0}")]
-    BadBytes(String),
-
     #[error("{0}")]
     LoadConfigError(String),
 

--- a/common/meta/types/src/meta_errors_into.rs
+++ b/common/meta/types/src/meta_errors_into.rs
@@ -51,15 +51,6 @@ impl From<serde_json::Error> for MetaError {
     }
 }
 
-impl From<std::string::FromUtf8Error> for MetaError {
-    fn from(error: std::string::FromUtf8Error) -> Self {
-        MetaError::BadBytes(format!(
-            "Bad bytes, cannot parse bytes with UTF8, cause: {}",
-            error
-        ))
-    }
-}
-
 impl From<std::net::AddrParseError> for MetaError {
     fn from(error: std::net::AddrParseError) -> Self {
         MetaError::BadAddressFormat(format!("Bad address format, cause: {}", error))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

move some storage related errors to MetaStorageError

## Changelog

- Improvement

## Related Issues

[Fixes #issue 4000](https://github.com/datafuselabs/databend/issues/4000)

## Test Plan

Unit Tests

Stateless Tests

