### PR TITLE
[metasrv] fix: app-error should not fail state machine txn

### DIFF
--- a/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
+++ b/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
@@ -58,7 +58,7 @@ impl MetaApi for StateMachine {
         };
 
         let res = self.sm_tree.txn(true, |t| {
-            let r = self.apply_cmd(&cmd, &t).unwrap();
+            let r = self.apply_cmd(&cmd, &t)?;
             Ok(r)
         })?;
 
@@ -85,7 +85,7 @@ impl MetaApi for StateMachine {
         };
 
         let res = self.sm_tree.txn(true, |t| {
-            let r = self.apply_cmd(&cmd, &t).unwrap();
+            let r = self.apply_cmd(&cmd, &t)?;
             Ok(r)
         })?;
 
@@ -156,7 +156,7 @@ impl MetaApi for StateMachine {
         };
 
         let res = self.sm_tree.txn(true, |t| {
-            let r = self.apply_cmd(&cr, &t).unwrap();
+            let r = self.apply_cmd(&cr, &t)?;
             Ok(r)
         })?;
 
@@ -189,7 +189,7 @@ impl MetaApi for StateMachine {
         };
 
         let res = self.sm_tree.txn(true, |t| {
-            let r = self.apply_cmd(&cr, &t).unwrap();
+            let r = self.apply_cmd(&cr, &t)?;
             Ok(r)
         })?;
 
@@ -299,7 +299,7 @@ impl MetaApi for StateMachine {
         let cmd = Cmd::UpsertTableOptions(req.clone());
 
         let res = self.sm_tree.txn(true, |t| {
-            let r = self.apply_cmd(&cmd, &t).unwrap();
+            let r = self.apply_cmd(&cmd, &t)?;
             Ok(r)
         })?;
         if !res.changed() {

--- a/common/meta/sled-store/src/sled_tree.rs
+++ b/common/meta/sled-store/src/sled_tree.rs
@@ -22,11 +22,11 @@ use common_meta_types::MetaStorageError;
 use common_meta_types::MetaStorageResult;
 use common_meta_types::ToMetaStorageError;
 use common_tracing::tracing;
-use sled::transaction::abort;
 use sled::transaction::ConflictableTransactionError;
 use sled::transaction::TransactionResult;
 use sled::transaction::TransactionalTree;
 
+use crate::sled::transaction::TransactionError;
 use crate::store::Store;
 use crate::SledKeySpace;
 
@@ -109,8 +109,8 @@ impl SledTree {
     pub fn txn<T>(
         &self,
         sync: bool,
-        f: impl Fn(TransactionSledTree<'_>) -> MetaStorageResult<T>,
-    ) -> MetaStorageResult<T> {
+        f: impl Fn(TransactionSledTree<'_>) -> Result<T, MetaStorageError>,
+    ) -> Result<T, MetaStorageError> {
         let sync = sync && self.sync;
 
         let result: TransactionResult<T, MetaStorageError> = self.tree.transaction(move |tree| {
@@ -123,13 +123,42 @@ impl SledTree {
                     }
                     Ok(r)
                 }
-                Err(e) => {
-                    tracing::warn!("txn abort: {}", e);
-                    abort(e)?
+                Err(meta_sto_err) => {
+                    tracing::warn!("txn error: {:?}", meta_sto_err);
+
+                    match &meta_sto_err {
+                        MetaStorageError::BytesError(_e) => {
+                            Err(ConflictableTransactionError::Abort(meta_sto_err))
+                        }
+                        MetaStorageError::SerdeError(_e) => {
+                            Err(ConflictableTransactionError::Abort(meta_sto_err))
+                        }
+                        MetaStorageError::SledError(_e) => {
+                            Err(ConflictableTransactionError::Abort(meta_sto_err))
+                        }
+                        MetaStorageError::TransactionAbort(_e) => {
+                            Err(ConflictableTransactionError::Abort(meta_sto_err))
+                        }
+                        MetaStorageError::TransactionConflict => {
+                            Err(ConflictableTransactionError::Conflict)
+                        }
+                        MetaStorageError::AppError(_app_err) => {
+                            Err(ConflictableTransactionError::Abort(meta_sto_err))
+                        }
+                    }
                 }
             }
         });
-        result.map_err(MetaStorageError::from)
+
+        match result {
+            Ok(x) => Ok(x),
+            Err(txn_err) => match txn_err {
+                TransactionError::Abort(meta_sto_err) => Err(meta_sto_err),
+                TransactionError::Storage(sto_err) => {
+                    Err(MetaStorageError::SerdeError(sto_err.to_string()))
+                }
+            },
+        }
     }
 
     /// Return true if the tree contains the key.
@@ -548,10 +577,7 @@ impl<'a, KV: SledKeySpace> Store<KV> for AsTxnKeySpace<'a, KV> {
         let k = KV::serialize_key(key)?;
         let v = KV::serialize_value(value)?;
 
-        let prev = self.txn_tree.insert(k, v).map_err(|e| {
-            let e: ConflictableTransactionError = e.into();
-            MetaStorageError::from(e)
-        })?;
+        let prev = self.txn_tree.insert(k, v)?;
         match prev {
             Some(v) => Ok(Some(KV::deserialize_value(v)?)),
             None => Ok(None),
@@ -560,10 +586,7 @@ impl<'a, KV: SledKeySpace> Store<KV> for AsTxnKeySpace<'a, KV> {
 
     fn get(&self, key: &KV::K) -> Result<Option<KV::V>, Self::Error> {
         let k = KV::serialize_key(key)?;
-        let got = self.txn_tree.get(k).map_err(|e| {
-            let e: ConflictableTransactionError = e.into();
-            MetaStorageError::from(e)
-        })?;
+        let got = self.txn_tree.get(k)?;
 
         match got {
             Some(v) => Ok(Some(KV::deserialize_value(v)?)),
@@ -573,10 +596,7 @@ impl<'a, KV: SledKeySpace> Store<KV> for AsTxnKeySpace<'a, KV> {
 
     fn remove(&self, key: &KV::K) -> Result<Option<KV::V>, Self::Error> {
         let k = KV::serialize_key(key)?;
-        let removed = self.txn_tree.remove(k).map_err(|e| {
-            let e: ConflictableTransactionError = e.into();
-            MetaStorageError::from(e)
-        })?;
+        let removed = self.txn_tree.remove(k)?;
 
         match removed {
             Some(v) => Ok(Some(KV::deserialize_value(v)?)),
@@ -588,10 +608,7 @@ impl<'a, KV: SledKeySpace> Store<KV> for AsTxnKeySpace<'a, KV> {
     where F: FnMut(Option<KV::V>) -> Option<KV::V> {
         let key_ivec = KV::serialize_key(key)?;
 
-        let old_val_ivec = self.txn_tree.get(&key_ivec).map_err(|e| {
-            let e: ConflictableTransactionError = e.into();
-            MetaStorageError::from(e)
-        })?;
+        let old_val_ivec = self.txn_tree.get(&key_ivec)?;
         let old_val: Result<Option<KV::V>, MetaStorageError> = match old_val_ivec {
             Some(v) => Ok(Some(KV::deserialize_value(v)?)),
             None => Ok(None),
@@ -601,17 +618,8 @@ impl<'a, KV: SledKeySpace> Store<KV> for AsTxnKeySpace<'a, KV> {
 
         let new_val = f(old_val);
         let _ = match new_val {
-            Some(ref v) => self
-                .txn_tree
-                .insert(key_ivec, KV::serialize_value(v)?)
-                .map_err(|e| {
-                    let e: ConflictableTransactionError = e.into();
-                    MetaStorageError::from(e)
-                })?,
-            None => self.txn_tree.remove(key_ivec).map_err(|e| {
-                let e: ConflictableTransactionError = e.into();
-                MetaStorageError::from(e)
-            })?,
+            Some(ref v) => self.txn_tree.insert(key_ivec, KV::serialize_value(v)?)?,
+            None => self.txn_tree.remove(key_ivec)?,
         };
 
         Ok(new_val)

--- a/scripts/ci/deploy/databend-query-cluster-3-nodes.sh
+++ b/scripts/ci/deploy/databend-query-cluster-3-nodes.sh
@@ -33,7 +33,6 @@ python3 scripts/ci/wait_tcp.py --timeout 5 --port 28202
 nohup ./target/debug/databend-meta -c scripts/ci/deploy/config/databend-meta-node-3.toml &
 python3 scripts/ci/wait_tcp.py --timeout 5 --port 28302
 
-
 echo 'Start databend-query node-1'
 nohup target/debug/databend-query -c scripts/ci/deploy/config/databend-query-node-1.toml &
 

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -32,7 +32,6 @@ def remove_control_characters(s):
     """
     https://github.com/html5lib/html5lib-python/issues/96#issuecomment-43438438
     """
-
     def str_to_int(s, default, base=10):
         if int(s, base) < 0x10000:
             return chr(int(s, base))

--- a/tests/helpers/client.py
+++ b/tests/helpers/client.py
@@ -14,7 +14,6 @@ sys.path.insert(0, os.path.join(CURDIR))
 
 
 class client(object):
-
     def __init__(self, name='', log=None):
         self.name = name
         self.log = log

--- a/tests/suites/0_stateless/00_dummy/00_0002_dummy_select_py.py
+++ b/tests/suites/0_stateless/00_dummy/00_0002_dummy_select_py.py
@@ -31,7 +31,6 @@ client1.run("select 3")
 
 
 class MyModel(object):
-
     def __init__(self, name, value):
         self.name = name
         self.value = value


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] fix: app-error should not fail state machine txn
When a application-error occurs, such as `UnknownDatabase`, the error
should pop up and finally return to the caller, instead of aborting the
transcation applying this meta log.

- Change: remove MetaStorageError::TransactionError, it is not actually
  used. Add TransactionConflict to indicate a retry-able txn error.

- SledTree: txn() should distinguishes txn-abort error and txn-conflict
  error.

- StateMachine: when applying an log, if the error is `AppError`, fill
  it into `AppliedState` and it is finally returned to the caller.

- Test: add test creating table on a absent db, to ensure an error code
  is returned instead of a txn failure.

Thanks to @wubx :DDD

## Changelog


- Bug Fix




## Related Issues