### PR TITLE
PLANNER-4091: Refine the plan order and udf/stage planner name [PATCH-1]

### DIFF
--- a/common/planners/src/lib.rs
+++ b/common/planners/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod plan_admin_use_tenant;
 mod plan_aggregator_final;
 mod plan_aggregator_partial;
 mod plan_broadcast;
@@ -67,7 +68,6 @@ mod plan_table_drop;
 mod plan_table_optimize;
 mod plan_truncate_table;
 mod plan_use_database;
-mod plan_use_tenant;
 mod plan_user_alter;
 mod plan_user_create;
 mod plan_user_drop;
@@ -78,6 +78,7 @@ mod plan_user_udf_create;
 mod plan_user_udf_drop;
 mod plan_visitor;
 
+pub use plan_admin_use_tenant::AdminUseTenantPlan;
 pub use plan_aggregator_final::AggregatorFinalPlan;
 pub use plan_aggregator_partial::AggregatorPartialPlan;
 pub use plan_broadcast::BroadcastPlan;
@@ -86,7 +87,7 @@ pub use plan_copy::CopyPlan;
 pub use plan_database_create::CreateDatabasePlan;
 pub use plan_database_create::DatabaseOptions;
 pub use plan_database_drop::DropDatabasePlan;
-pub use plan_describe_stage::DescribeStagePlan;
+pub use plan_describe_stage::DescribeUserStagePlan;
 pub use plan_describe_table::DescribeTablePlan;
 pub use plan_empty::EmptyPlan;
 pub use plan_explain::ExplainPlan;
@@ -163,13 +164,12 @@ pub use plan_table_optimize::Optimization;
 pub use plan_table_optimize::OptimizeTablePlan;
 pub use plan_truncate_table::TruncateTablePlan;
 pub use plan_use_database::UseDatabasePlan;
-pub use plan_use_tenant::UseTenantPlan;
 pub use plan_user_alter::AlterUserPlan;
 pub use plan_user_create::CreateUserPlan;
 pub use plan_user_drop::DropUserPlan;
 pub use plan_user_stage_create::CreateUserStagePlan;
 pub use plan_user_stage_drop::DropUserStagePlan;
-pub use plan_user_udf_alter::AlterUDFPlan;
-pub use plan_user_udf_create::CreateUDFPlan;
-pub use plan_user_udf_drop::DropUDFPlan;
+pub use plan_user_udf_alter::AlterUserUDFPlan;
+pub use plan_user_udf_create::CreateUserUDFPlan;
+pub use plan_user_udf_drop::DropUserUDFPlan;
 pub use plan_visitor::PlanVisitor;

--- a/common/planners/src/plan_admin_use_tenant.rs
+++ b/common/planners/src/plan_admin_use_tenant.rs
@@ -18,11 +18,11 @@ use common_datavalues2::DataSchema;
 use common_datavalues2::DataSchemaRef;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
-pub struct UseTenantPlan {
+pub struct AdminUseTenantPlan {
     pub tenant: String,
 }
 
-impl UseTenantPlan {
+impl AdminUseTenantPlan {
     pub fn schema(&self) -> DataSchemaRef {
         Arc::new(DataSchema::empty())
     }

--- a/common/planners/src/plan_describe_stage.rs
+++ b/common/planners/src/plan_describe_stage.rs
@@ -14,11 +14,11 @@
 
 use common_datavalues2::prelude::*;
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
-pub struct DescribeStagePlan {
+pub struct DescribeUserStagePlan {
     pub name: String,
 }
 
-impl DescribeStagePlan {
+impl DescribeUserStagePlan {
     pub fn schema(&self) -> DataSchemaRef {
         DataSchemaRefExt::create(vec![
             DataField::new("parent_properties", Vu8::to_data_type()),

--- a/common/planners/src/plan_user_udf_alter.rs
+++ b/common/planners/src/plan_user_udf_alter.rs
@@ -19,11 +19,11 @@ use common_datavalues2::DataSchemaRef;
 use common_meta_types::UserDefinedFunction;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
-pub struct AlterUDFPlan {
+pub struct AlterUserUDFPlan {
     pub udf: UserDefinedFunction,
 }
 
-impl AlterUDFPlan {
+impl AlterUserUDFPlan {
     pub fn schema(&self) -> DataSchemaRef {
         Arc::new(DataSchema::empty())
     }

--- a/common/planners/src/plan_user_udf_create.rs
+++ b/common/planners/src/plan_user_udf_create.rs
@@ -19,12 +19,12 @@ use common_datavalues2::DataSchemaRef;
 use common_meta_types::UserDefinedFunction;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
-pub struct CreateUDFPlan {
+pub struct CreateUserUDFPlan {
     pub if_not_exists: bool,
     pub udf: UserDefinedFunction,
 }
 
-impl CreateUDFPlan {
+impl CreateUserUDFPlan {
     pub fn schema(&self) -> DataSchemaRef {
         Arc::new(DataSchema::empty())
     }

--- a/common/planners/src/plan_user_udf_drop.rs
+++ b/common/planners/src/plan_user_udf_drop.rs
@@ -18,12 +18,12 @@ use common_datavalues2::DataSchema;
 use common_datavalues2::DataSchemaRef;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
-pub struct DropUDFPlan {
+pub struct DropUserUDFPlan {
     pub if_exists: bool,
     pub name: String,
 }
 
-impl DropUDFPlan {
+impl DropUserUDFPlan {
     pub fn schema(&self) -> DataSchemaRef {
         Arc::new(DataSchema::empty())
     }

--- a/query/src/interpreters/access/management_mode_access.rs
+++ b/query/src/interpreters/access/management_mode_access.rs
@@ -40,7 +40,7 @@ impl ManagementModeAccess {
                 | PlanNode::DropDatabase(_)
                 | PlanNode::CreateTable(_)
                 | PlanNode::DescribeTable(_)
-                | PlanNode::DescribeStage(_)
+                | PlanNode::DescribeUserStage(_)
                 | PlanNode::DropTable(_)
                 | PlanNode::ShowCreateTable(_)
                 | PlanNode::CreateUser(_)
@@ -51,12 +51,12 @@ impl ManagementModeAccess {
                 | PlanNode::CreateUserStage(_)
                 | PlanNode::DropUserStage(_)
                 | PlanNode::ShowGrants(_)
-                | PlanNode::UseTenant(_)
-                | PlanNode::CreateUDF(_)
-                | PlanNode::DropUDF(_)
+                | PlanNode::AdminUseTenant(_)
+                | PlanNode::CreateUserUDF(_)
+                | PlanNode::DropUserUDF(_)
                 | PlanNode::UseDatabase(_)
                 | PlanNode::Select(_) // Allow select from system.* tables, like show tables;
-                | PlanNode::AlterUDF(_) => Ok(()),
+                | PlanNode::AlterUserUDF(_) => Ok(()),
                 _ => Err(ErrorCode::ManagementModePermissionDenied(format!(
                     "Access denied for operation:{:?} in management-mode",
                     plan.name()
@@ -64,7 +64,7 @@ impl ManagementModeAccess {
             };
         } else {
             match plan {
-                PlanNode::UseTenant(_) => Err(ErrorCode::ManagementModePermissionDenied(
+                PlanNode::AdminUseTenant(_) => Err(ErrorCode::ManagementModePermissionDenied(
                     "Access denied:'USE TENANT' only used in management-mode",
                 )),
                 _ => Ok(()),

--- a/query/src/interpreters/interpreter_factory.rs
+++ b/query/src/interpreters/interpreter_factory.rs
@@ -67,7 +67,7 @@ impl InterpreterFactory {
             PlanNode::TruncateTable(v) => TruncateTableInterpreter::try_create(ctx_clone, v),
             PlanNode::OptimizeTable(v) => OptimizeTableInterpreter::try_create(ctx_clone, v),
             PlanNode::UseDatabase(v) => UseDatabaseInterpreter::try_create(ctx_clone, v),
-            PlanNode::UseTenant(v) => UseTenantInterpreter::try_create(ctx_clone, v),
+            PlanNode::AdminUseTenant(v) => UseTenantInterpreter::try_create(ctx_clone, v),
             PlanNode::SetVariable(v) => SettingInterpreter::try_create(ctx_clone, v),
             PlanNode::Insert(v) => InsertInterpreter::try_create(ctx_clone, v),
             PlanNode::ShowCreateTable(v) => ShowCreateTableInterpreter::try_create(ctx_clone, v),
@@ -81,13 +81,13 @@ impl InterpreterFactory {
             PlanNode::CreateUserStage(v) => CreatStageInterpreter::try_create(ctx_clone, v),
             PlanNode::DropUserStage(v) => DropStageInterpreter::try_create(ctx_clone, v),
             PlanNode::ShowGrants(v) => ShowGrantsInterpreter::try_create(ctx_clone, v),
-            PlanNode::DescribeStage(v) => DescribeStageInterpreter::try_create(ctx_clone, v),
+            PlanNode::DescribeUserStage(v) => DescribeStageInterpreter::try_create(ctx_clone, v),
             PlanNode::ShowCreateDatabase(v) => {
                 ShowCreateDatabaseInterpreter::try_create(ctx_clone, v)
             }
-            PlanNode::CreateUDF(v) => CreatUDFInterpreter::try_create(ctx_clone, v),
-            PlanNode::DropUDF(v) => DropUDFInterpreter::try_create(ctx_clone, v),
-            PlanNode::AlterUDF(v) => AlterUDFInterpreter::try_create(ctx_clone, v),
+            PlanNode::CreateUserUDF(v) => CreatUDFInterpreter::try_create(ctx_clone, v),
+            PlanNode::DropUserUDF(v) => DropUDFInterpreter::try_create(ctx_clone, v),
+            PlanNode::AlterUserUDF(v) => AlterUDFInterpreter::try_create(ctx_clone, v),
             _ => Result::Err(ErrorCode::UnknownTypeOfQuery(format!(
                 "Can't get the interpreter by plan:{}",
                 plan.name()

--- a/query/src/interpreters/interpreter_stage_describe.rs
+++ b/query/src/interpreters/interpreter_stage_describe.rs
@@ -18,7 +18,7 @@ use common_datablocks::DataBlock;
 use common_datavalues2::prelude::*;
 use common_exception::Result;
 use common_meta_types::UserStageInfo;
-use common_planners::DescribeStagePlan;
+use common_planners::DescribeUserStagePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
@@ -28,11 +28,14 @@ use crate::sessions::QueryContext;
 
 pub struct DescribeStageInterpreter {
     ctx: Arc<QueryContext>,
-    plan: DescribeStagePlan,
+    plan: DescribeUserStagePlan,
 }
 
 impl DescribeStageInterpreter {
-    pub fn try_create(ctx: Arc<QueryContext>, plan: DescribeStagePlan) -> Result<InterpreterPtr> {
+    pub fn try_create(
+        ctx: Arc<QueryContext>,
+        plan: DescribeUserStagePlan,
+    ) -> Result<InterpreterPtr> {
         Ok(Arc::new(DescribeStageInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_udf_alter.rs
+++ b/query/src/interpreters/interpreter_udf_alter.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use common_exception::Result;
-use common_planners::AlterUDFPlan;
+use common_planners::AlterUserUDFPlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 use common_tracing::tracing;
@@ -27,11 +27,11 @@ use crate::sessions::QueryContext;
 #[derive(Debug)]
 pub struct AlterUDFInterpreter {
     ctx: Arc<QueryContext>,
-    plan: AlterUDFPlan,
+    plan: AlterUserUDFPlan,
 }
 
 impl AlterUDFInterpreter {
-    pub fn try_create(ctx: Arc<QueryContext>, plan: AlterUDFPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: AlterUserUDFPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(AlterUDFInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_udf_create.rs
+++ b/query/src/interpreters/interpreter_udf_create.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use common_exception::Result;
-use common_planners::CreateUDFPlan;
+use common_planners::CreateUserUDFPlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 use common_tracing::tracing;
@@ -27,11 +27,11 @@ use crate::sessions::QueryContext;
 #[derive(Debug)]
 pub struct CreatUDFInterpreter {
     ctx: Arc<QueryContext>,
-    plan: CreateUDFPlan,
+    plan: CreateUserUDFPlan,
 }
 
 impl CreatUDFInterpreter {
-    pub fn try_create(ctx: Arc<QueryContext>, plan: CreateUDFPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: CreateUserUDFPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(CreatUDFInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_udf_drop.rs
+++ b/query/src/interpreters/interpreter_udf_drop.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use common_exception::Result;
-use common_planners::DropUDFPlan;
+use common_planners::DropUserUDFPlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 use common_tracing::tracing;
@@ -27,11 +27,11 @@ use crate::sessions::QueryContext;
 #[derive(Debug)]
 pub struct DropUDFInterpreter {
     ctx: Arc<QueryContext>,
-    plan: DropUDFPlan,
+    plan: DropUserUDFPlan,
 }
 
 impl DropUDFInterpreter {
-    pub fn try_create(ctx: Arc<QueryContext>, plan: DropUDFPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: DropUserUDFPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(DropUDFInterpreter { ctx, plan }))
     }
 }

--- a/query/src/interpreters/interpreter_use_tenant.rs
+++ b/query/src/interpreters/interpreter_use_tenant.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use common_datavalues2::DataSchema;
 use common_exception::Result;
-use common_planners::UseTenantPlan;
+use common_planners::AdminUseTenantPlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 use common_tracing::tracing;
@@ -27,11 +27,11 @@ use crate::sessions::QueryContext;
 
 pub struct UseTenantInterpreter {
     ctx: Arc<QueryContext>,
-    plan: UseTenantPlan,
+    plan: AdminUseTenantPlan,
 }
 
 impl UseTenantInterpreter {
-    pub fn try_create(ctx: Arc<QueryContext>, plan: UseTenantPlan) -> Result<InterpreterPtr> {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: AdminUseTenantPlan) -> Result<InterpreterPtr> {
         Ok(Arc::new(UseTenantInterpreter { ctx, plan }))
     }
 }

--- a/query/src/sql/statements/statement_alter_udf.rs
+++ b/query/src/sql/statements/statement_alter_udf.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_meta_types::UserDefinedFunction;
-use common_planners::AlterUDFPlan;
+use common_planners::AlterUserUDFPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 
@@ -36,15 +36,15 @@ pub struct DfAlterUDF {
 impl AnalyzableStatement for DfAlterUDF {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
     async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
-        Ok(AnalyzedResult::SimpleQuery(Box::new(PlanNode::AlterUDF(
-            AlterUDFPlan {
+        Ok(AnalyzedResult::SimpleQuery(Box::new(
+            PlanNode::AlterUserUDF(AlterUserUDFPlan {
                 udf: UserDefinedFunction::new(
                     self.udf_name.as_str(),
                     self.parameters.clone(),
                     self.definition.as_str(),
                     self.description.as_str(),
                 ),
-            },
-        ))))
+            }),
+        )))
     }
 }

--- a/query/src/sql/statements/statement_create_udf.rs
+++ b/query/src/sql/statements/statement_create_udf.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_meta_types::UserDefinedFunction;
-use common_planners::CreateUDFPlan;
+use common_planners::CreateUserUDFPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 
@@ -37,8 +37,8 @@ pub struct DfCreateUDF {
 impl AnalyzableStatement for DfCreateUDF {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
     async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
-        Ok(AnalyzedResult::SimpleQuery(Box::new(PlanNode::CreateUDF(
-            CreateUDFPlan {
+        Ok(AnalyzedResult::SimpleQuery(Box::new(
+            PlanNode::CreateUserUDF(CreateUserUDFPlan {
                 if_not_exists: self.if_not_exists,
                 udf: UserDefinedFunction::new(
                     self.udf_name.as_str(),
@@ -46,7 +46,7 @@ impl AnalyzableStatement for DfCreateUDF {
                     self.definition.as_str(),
                     self.description.as_str(),
                 ),
-            },
-        ))))
+            }),
+        )))
     }
 }

--- a/query/src/sql/statements/statement_describe_stage.rs
+++ b/query/src/sql/statements/statement_describe_stage.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_planners::DescribeStagePlan;
+use common_planners::DescribeUserStagePlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
@@ -36,7 +36,7 @@ impl AnalyzableStatement for DfDescribeStage {
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let (_, name) = self.resolve_table(ctx)?;
         Ok(AnalyzedResult::SimpleQuery(Box::new(
-            PlanNode::DescribeStage(DescribeStagePlan { name }),
+            PlanNode::DescribeUserStage(DescribeUserStagePlan { name }),
         )))
     }
 }

--- a/query/src/sql/statements/statement_drop_udf.rs
+++ b/query/src/sql/statements/statement_drop_udf.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use common_exception::Result;
-use common_planners::DropUDFPlan;
+use common_planners::DropUserUDFPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
 
@@ -33,11 +33,11 @@ pub struct DfDropUDF {
 impl AnalyzableStatement for DfDropUDF {
     #[tracing::instrument(level = "info", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
     async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
-        Ok(AnalyzedResult::SimpleQuery(Box::new(PlanNode::DropUDF(
-            DropUDFPlan {
+        Ok(AnalyzedResult::SimpleQuery(Box::new(
+            PlanNode::DropUserUDF(DropUserUDFPlan {
                 if_exists: self.if_exists,
                 name: self.udf_name.clone(),
-            },
-        ))))
+            }),
+        )))
     }
 }

--- a/query/src/sql/statements/statement_use_tenant.rs
+++ b/query/src/sql/statements/statement_use_tenant.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_planners::AdminUseTenantPlan;
 use common_planners::PlanNode;
-use common_planners::UseTenantPlan;
 use common_tracing::tracing;
 use sqlparser::ast::ObjectName;
 
@@ -39,8 +39,8 @@ impl AnalyzableStatement for DfUseTenant {
         }
 
         let tenant = self.name.0[0].value.clone();
-        Ok(AnalyzedResult::SimpleQuery(Box::new(PlanNode::UseTenant(
-            UseTenantPlan { tenant },
-        ))))
+        Ok(AnalyzedResult::SimpleQuery(Box::new(
+            PlanNode::AdminUseTenant(AdminUseTenantPlan { tenant }),
+        )))
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR:
1. **Group the planner, let add new planner more clearly**
2. **Rename stage and udf, add `_user_` to function name**
3. **plan_use_tenant.rs => plan_admin_use_tenant.rs**

## Changelog

- Improvement


## Related Issues

PATCH-1 of #4091 

## Test Plan

Unit Tests

Stateless Tests

