### PR TITLE
dal2: Fix SeekableRead not read correctly

### DIFF
--- a/common/dal2/src/readers/seekable.rs
+++ b/common/dal2/src/readers/seekable.rs
@@ -100,6 +100,7 @@ impl AsyncRead for SeekableReader {
 
                     let n = ready!(r.poll_read(cx, buf))?;
                     self.pos += n as u64;
+                    self.state = SeekableReaderState::Idle;
                     return Poll::Ready(Ok(n));
                 }
             }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Part of https://github.com/datafuselabs/databend/issues/3677

The following SQL doesn't works:

```sql
create table test as select * from numbers(1234567890);
select * from test;
```

Meeting EOF errors like:

```
2022-02-11T12:22:55.395256Z ERROR databend_query::servers::mysql::writers::query_result_writer: OnQuery Error: Code: 1024, displayText = fail to read block _b/4e5ffe0fad65439990109f9a0d9bf5ff.parquet, Code: 1002, displayText = External format error: underlying IO error: unexpected end of file..

   0: common_exception::exception_code::<impl common_exception::exception::ErrorCode>::ParquetError
             at common/exception/src/exception_code.rs:36:66
   1: databend_query::storages::fuse::operations::read::<impl databend_query::storages::fuse::table::FuseTable>::do_read::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at query/src/storages/fuse/operations/read.rs:88:25
   2: core::result::Result<T,E>::map_err
```

This is caused by the incorrect `SeekableReader` implementation.


## Changelog

- New Feature

## Test Plan

Unit Tests

Stateless Tests

