### PR TITLE
[meta] refactor: cleanup MetaStorageError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,14 +54,13 @@ dependencies = [
 
 [[package]]
 name = "anyerror"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad463f35c2858e54959324c3bc6c076a1f159f53b4ac402658a65ee863180a5"
+checksum = "59e74c994272090d6d62049799a5edc1d81b9fcdc36dc5ce11a08986b98175a8"
 dependencies = [
  "anyhow",
  "backtrace",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/common/meta/raft-store/src/state/raft_state_kv.rs
+++ b/common/meta/raft-store/src/state/raft_state_kv.rs
@@ -17,6 +17,7 @@ use std::fmt;
 use common_meta_sled_store::openraft;
 use common_meta_sled_store::sled;
 use common_meta_sled_store::SledOrderedSerde;
+use common_meta_types::anyerror::AnyError;
 use common_meta_types::MetaStorageError;
 use common_meta_types::NodeId;
 use openraft::storage::HardState;
@@ -86,7 +87,7 @@ impl SledOrderedSerde for RaftStateKey {
             return Ok(RaftStateKey::StateMachineId);
         }
 
-        Err(MetaStorageError::SledError(String::from(
+        Err(MetaStorageError::SledError(AnyError::error(
             "invalid key IVec",
         )))
     }

--- a/common/meta/raft-store/src/state_machine/log_meta.rs
+++ b/common/meta/raft-store/src/state_machine/log_meta.rs
@@ -17,6 +17,7 @@ use std::fmt;
 use common_meta_sled_store::openraft;
 use common_meta_sled_store::sled;
 use common_meta_sled_store::SledOrderedSerde;
+use common_meta_types::anyerror::AnyError;
 use common_meta_types::MetaStorageError;
 use openraft::LogId;
 use serde::Deserialize;
@@ -63,7 +64,7 @@ impl SledOrderedSerde for LogMetaKey {
             return Ok(LogMetaKey::LastPurged);
         }
 
-        Err(MetaStorageError::SledError(String::from(
+        Err(MetaStorageError::SledError(AnyError::error(
             "invalid key IVec",
         )))
     }

--- a/common/meta/raft-store/src/state_machine/state_machine_meta.rs
+++ b/common/meta/raft-store/src/state_machine/state_machine_meta.rs
@@ -18,6 +18,7 @@ use common_meta_sled_store::openraft;
 use common_meta_sled_store::openraft::EffectiveMembership;
 use common_meta_sled_store::sled;
 use common_meta_sled_store::SledOrderedSerde;
+use common_meta_types::anyerror::AnyError;
 use common_meta_types::MetaStorageError;
 use openraft::LogId;
 use serde::Deserialize;
@@ -80,7 +81,7 @@ impl SledOrderedSerde for StateMachineMetaKey {
             return Ok(StateMachineMetaKey::LastMembership);
         }
 
-        Err(MetaStorageError::SledError(String::from(
+        Err(MetaStorageError::SledError(AnyError::error(
             "invalid key IVec",
         )))
     }

--- a/common/meta/sled-store/src/sled_key_space.rs
+++ b/common/meta/sled-store/src/sled_key_space.rs
@@ -19,6 +19,7 @@ use std::fmt::Display;
 use std::ops::Bound;
 use std::ops::RangeBounds;
 
+use common_meta_types::anyerror::AnyError;
 use common_meta_types::MetaStorageError;
 use sled::IVec;
 
@@ -54,7 +55,9 @@ pub trait SledKeySpace {
     fn deserialize_key<T: AsRef<[u8]>>(iv: T) -> Result<Self::K, MetaStorageError> {
         let b = iv.as_ref();
         if b[0] != Self::PREFIX {
-            return Err(MetaStorageError::SledError(String::from("invalid prefix")));
+            return Err(MetaStorageError::SledError(AnyError::error(
+                "invalid prefix",
+            )));
         }
         <Self::K as SledOrderedSerde>::de(&b[1..])
     }

--- a/common/meta/sled-store/tests/it/testing/fake_state_machine_meta.rs
+++ b/common/meta/sled-store/tests/it/testing/fake_state_machine_meta.rs
@@ -15,6 +15,7 @@
 use std::fmt;
 
 use common_meta_sled_store::SledOrderedSerde;
+use common_meta_types::anyerror::AnyError;
 use common_meta_types::MetaStorageError;
 use openraft::LogId;
 use openraft::Membership;
@@ -78,7 +79,7 @@ impl SledOrderedSerde for StateMachineMetaKey {
             return Ok(StateMachineMetaKey::LastMembership);
         }
 
-        Err(MetaStorageError::SledError(String::from(
+        Err(MetaStorageError::SledError(AnyError::error(
             "invalid key IVec",
         )))
     }

--- a/common/meta/types/Cargo.toml
+++ b/common/meta/types/Cargo.toml
@@ -14,7 +14,7 @@ test = false
 common-datavalues2 = { path = "../../datavalues2" }
 common-exception = { path = "../../exception" }
 
-anyerror = "0.1.1"
+anyerror = "0.1.3"
 derive_more = "0.99.17"
 enumflags2 = { version = "0.7.3", features = ["serde"] }
 lazy_static = "1.4.0"

--- a/common/meta/types/src/error_context.rs
+++ b/common/meta/types/src/error_context.rs
@@ -1,0 +1,67 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, thiserror::Error)]
+#[error("{err} while {context}")]
+pub struct ErrorWithContext<E> {
+    #[source]
+    pub err: E,
+    pub context: String,
+}
+
+impl<E> ErrorWithContext<E> {
+    pub fn new(err: E) -> Self {
+        Self {
+            err,
+            context: "".to_string(),
+        }
+    }
+
+    pub fn with_context<S, F>(err: E, context: F) -> Self
+    where
+        S: ToString,
+        F: FnOnce() -> S,
+    {
+        Self {
+            err,
+            context: context().to_string(),
+        }
+    }
+}
+
+pub trait WithContext<T, E>
+where E: Error
+{
+    fn context<S, F>(self, f: F) -> Result<T, ErrorWithContext<E>>
+    where
+        S: ToString,
+        F: FnOnce() -> S;
+}
+
+impl<T, E> WithContext<T, E> for Result<T, E>
+where E: Error
+{
+    fn context<S, F>(self, f: F) -> Result<T, ErrorWithContext<E>>
+    where
+        S: ToString,
+        F: FnOnce() -> S,
+    {
+        self.map_err(|e| ErrorWithContext::with_context(e, f))
+    }
+}

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -45,6 +45,12 @@ mod user_quota;
 mod user_setting;
 mod user_stage;
 
+pub mod error_context;
+
+// reexport
+
+pub use anyerror;
+
 // ProtoBuf generated files.
 #[allow(clippy::all)]
 pub mod protobuf {

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -42,7 +42,7 @@ common-metrics = { path = "../common/metrics" }
 # Github dependencies
 
 # Crates.io dependencies
-anyerror = "0.1.2"
+anyerror = "0.1.3"
 anyhow = "1.0.53"
 async-trait = "0.1.52"
 backtrace = "0.3.64"

--- a/metasrv/src/store/meta_raft_store.rs
+++ b/metasrv/src/store/meta_raft_store.rs
@@ -17,6 +17,7 @@ use std::fmt::Debug;
 use std::io::Cursor;
 use std::ops::RangeBounds;
 
+use anyerror::AnyError;
 use common_base::tokio::sync::RwLock;
 use common_base::tokio::sync::RwLockWriteGuard;
 use common_meta_raft_store::config::RaftConfig;
@@ -32,6 +33,7 @@ use common_meta_sled_store::openraft::EffectiveMembership;
 use common_meta_sled_store::openraft::ErrorSubject;
 use common_meta_sled_store::openraft::ErrorVerb;
 use common_meta_sled_store::openraft::StateMachineChanges;
+use common_meta_types::error_context::WithContext;
 use common_meta_types::AppliedState;
 use common_meta_types::LogEntry;
 use common_meta_types::MetaError;
@@ -39,7 +41,6 @@ use common_meta_types::MetaResult;
 use common_meta_types::MetaStorageError;
 use common_meta_types::Node;
 use common_meta_types::NodeId;
-use common_meta_types::ToMetaStorageError;
 use common_tracing::tracing;
 use openraft::async_trait::async_trait;
 use openraft::raft::Entry;
@@ -157,15 +158,15 @@ impl MetaRaftStore {
 
     /// Install a snapshot to build a state machine from it and replace the old state machine with the new one.
     #[tracing::instrument(level = "debug", skip(self, data))]
-    pub async fn install_snapshot(&self, data: &[u8]) -> MetaResult<()> {
+    pub async fn install_snapshot(&self, data: &[u8]) -> Result<(), MetaStorageError> {
         let mut sm = self.state_machine.write().await;
 
         let (sm_id, prev_sm_id) = self.raft_state.read_state_machine_id()?;
         if sm_id != prev_sm_id {
-            return Err(MetaError::ConcurrentSnapshotInstall(format!(
+            return Err(MetaStorageError::SnapshotError(AnyError::error(format!(
                 "another snapshot install is not finished yet: {} {}",
                 sm_id, prev_sm_id
-            )));
+            ))));
         }
 
         let new_sm_id = sm_id + 1;
@@ -190,10 +191,7 @@ impl MetaRaftStore {
         for x in snap.kvs.into_iter() {
             let k = &x[0];
             let v = &x[1];
-            tree.insert(k, v.clone())
-                .map_error_to_meta_storage_error(MetaStorageError::SledError, || {
-                    "fail to insert snapshot"
-                })?;
+            tree.insert(k, v.clone()).context(|| "insert snapshot")?;
         }
 
         tracing::info!(
@@ -202,11 +200,7 @@ impl MetaRaftStore {
             new_sm.get_last_applied()?,
         );
 
-        tree.flush_async()
-            .await
-            .map_error_to_meta_storage_error(MetaStorageError::SledError, || {
-                "fail to flush snapshot"
-            })?;
+        tree.flush_async().await.context(|| "flush snapshot")?;
 
         tracing::info!("flushed tree, no_kvs: {}", nkvs);
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [meta] refactor: cleanup MetaStorageError
- MetaStorageError::SledError() use AnyError to express the causing error.
  This way the error message includes more context information and it
  get rid of some manually error convertion job, by utilizing `From`.

- Feature: add trait `WithContext` to create a wrapper error that
  includes additional context info. See: `WithContext::context()`

- Add MetaStorageError::SnapshotError, as a wrapper all snapshot errors.
  Snapshot error is a **storage** level error and it does not have to be
  a sub error of the top-level error `MetaError`.

- Remove MetaStorageError::TransactionAbort, because all abortion is
  caused by MetaStorageError::AppError.

## Changelog




- Improvement


## Related Issues