### PR TITLE
[grpc] ConnectionFactory: returns structured error so that a depending mod does not need to deal with every error defined in ErrorCode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,7 @@ dependencies = [
 name = "common-grpc"
 version = "0.1.0"
 dependencies = [
+ "anyerror",
  "async-trait",
  "common-arrow",
  "common-base",
@@ -1611,6 +1612,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio-stream",
  "tonic",
  "trust-dns-resolver",

--- a/common/grpc/Cargo.toml
+++ b/common/grpc/Cargo.toml
@@ -20,17 +20,19 @@ common-tracing = { path = "../tracing" }
 # Github dependencies
 
 # Crates.io dependencies
+async-trait = "0.1.52"
+anyerror = "0.1.3"
 futures = "0.3.21"
+hyper = "0.14.16"
 jwt-simple = "0.10.8"
+once_cell = "1.9.0"
 prost = "0.9.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
+thiserror = "1.0.30"
 tokio-stream = "0.1.8"
 tonic = { version = "0.6.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
-hyper = "0.14.16"
-once_cell = "1.9.0"
 trust-dns-resolver = { version = "0.20.4", features = ["system-config"] }
-async-trait = "0.1.52"
 
 [build-dependencies]
 

--- a/common/grpc/src/lib.rs
+++ b/common/grpc/src/lib.rs
@@ -16,6 +16,7 @@ pub use client_conf::RpcClientConf;
 pub use client_conf::RpcClientTlsConfig;
 pub use dns_resolver::ConnectionFactory;
 pub use dns_resolver::DNSResolver;
+pub use dns_resolver::GrpcConnectionError;
 pub use grpc_token::GrpcClaim;
 pub use grpc_token::GrpcToken;
 

--- a/common/meta/types/src/meta_errors.rs
+++ b/common/meta/types/src/meta_errors.rs
@@ -51,9 +51,6 @@ pub enum MetaError {
     LoadConfigError(String),
 
     #[error("{0}")]
-    TLSConfigurationFailure(String),
-
-    #[error("{0}")]
     StartMetaServiceError(String),
 
     #[error("{0}")]

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -420,7 +420,12 @@ impl MetaNode {
             for addr in addrs {
                 let mut client = RaftServiceClient::connect(format!("http://{}", addr))
                     .await
-                    .map_err(|e| MetaNetworkError::CannotConnectNode(e.to_string()))?;
+                    .map_err(|e| {
+                        MetaNetworkError::ConnectionError(ConnectionError::new(
+                            e,
+                            format!("while connect to {}", addr),
+                        ))
+                    })?;
 
                 let admin_req = ForwardRequest {
                     forward_to_leader: 1,

--- a/query/src/catalogs/backends/meta_backend.rs
+++ b/query/src/catalogs/backends/meta_backend.rs
@@ -70,7 +70,10 @@ impl MetaBackend {
         F: Send + Sync + 'static,
         T: Send + Sync + 'static,
     {
-        let cli = self.meta_api_provider.try_get_meta_client().await?;
+        let res: Result<_, std::convert::Infallible> =
+            self.meta_api_provider.try_get_meta_client().await;
+        let cli = res.unwrap();
+
         f(cli).await
     }
 }

--- a/query/src/common/meta/meta_client.rs
+++ b/query/src/common/meta/meta_client.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 //
 
+use std::convert::Infallible;
 use std::sync::Arc;
 
 use common_exception::Result;
@@ -36,7 +37,9 @@ impl MetaClientProvider {
     }
 
     /// Get meta async client, trait is defined in MetaApi.
-    pub async fn try_get_meta_client(&self) -> Result<Arc<MetaGrpcClient>> {
+    pub async fn try_get_meta_client(
+        &self,
+    ) -> std::result::Result<Arc<MetaGrpcClient>, Infallible> {
         let client = MetaGrpcClient::try_new(&self.grpc_conf).await?;
         Ok(Arc::new(client))
     }

--- a/query/tests/it/api/rpc_service.rs
+++ b/query/tests/it/api/rpc_service.rs
@@ -24,6 +24,7 @@ use common_base::tokio::sync::Notify;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_grpc::ConnectionFactory;
+use common_grpc::GrpcConnectionError;
 use common_grpc::RpcClientTlsConfig;
 use databend_query::api::DatabendQueryFlightDispatcher;
 use databend_query::api::RpcService;
@@ -102,6 +103,11 @@ async fn test_tls_rpc_server_invalid_client_config() -> Result<()> {
     let r = ConnectionFactory::create_rpc_channel("fake:1234", None, Some(client_conf));
     assert!(r.is_err());
     let e = r.unwrap_err();
-    assert_eq!(e.code(), ErrorCode::TLSConfigurationFailure("").code());
+    match e {
+        GrpcConnectionError::TLSConfigError { action, .. } => {
+            assert_eq!("loading", action);
+        }
+        _ => unimplemented!("expect TLSConfigError"),
+    }
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [grpc] ConnectionFactory: returns structured error so that a depending mod does not need to deal with every error defined in ErrorCode
- Remove conversion from ErrorCode to MetaError, which is a potential bug maker:
  It can not find out missing matching branch at compile time.

- Remove MetaNetworkError::CannotConnectNode, it should be a sub error of ConnectionError

- Remove MetaError:TLSConfigurationFailure, it should be a sub error of MetaNetworkError

- Return Infallible if a method does not return any error

- fix: #4151

## Changelog







## Related Issues