### PR TITLE
Enhancement: Add sha256sum check for ontime.csv

### DIFF
--- a/tests/suites/1_stateful/01_load/01_0000_streaming_load.sh
+++ b/tests/suites/1_stateful/01_load/01_0000_streaming_load.sh
@@ -14,7 +14,7 @@ fi
 
 
 # do the Data integrity check
-sha256sum -c $CURDIR/ontime.sha1sum.txt
+echo "429c47cdd49b7d75eec9b9244c8b1288edd132506203e37d2d1e70e1ac1eccc7 /tmp/ontime.csv" | sha256sum --check
 if [ $? -eq 0 ]; then
 	echo "dataset checksum passed"
 else

--- a/tests/suites/1_stateful/01_load/01_0000_streaming_load.sh
+++ b/tests/suites/1_stateful/01_load/01_0000_streaming_load.sh
@@ -13,6 +13,16 @@ if [ ! -f /tmp/ontime.csv ]; then
 fi
 
 
+# do the Data integrity check
+sha256sum -c $CURDIR/ontime.sha1sum.txt
+if [ $? -eq 0 ]; then
+	echo "dataset checksum passed"
+else
+	echo "current dataset is not our stateful test dataset"
+	exit 1
+fi
+
+
 curl -H "insert_sql:insert into ontime_streaming_load format CSV" -H "csv_header:1" -F  "upload=@/tmp/ontime.csv"  -XPUT http://localhost:8001/v1/streaming_load > /dev/null 2>&1
 
 

--- a/tests/suites/1_stateful/01_load/01_0000_streaming_load.sh
+++ b/tests/suites/1_stateful/01_load/01_0000_streaming_load.sh
@@ -14,10 +14,8 @@ fi
 
 
 # do the Data integrity check
-echo "429c47cdd49b7d75eec9b9244c8b1288edd132506203e37d2d1e70e1ac1eccc7 /tmp/ontime.csv" | sha256sum --check
-if [ $? -eq 0 ]; then
-	echo "dataset checksum passed"
-else
+echo "429c47cdd49b7d75eec9b9244c8b1288edd132506203e37d2d1e70e1ac1eccc7 /tmp/ontime.csv" | sha256sum --check > /dev/null 2>&1
+if [ $? -ne 0 ]; then
 	echo "current dataset is not our stateful test dataset"
 	exit 1
 fi

--- a/tests/suites/1_stateful/01_load/01_0000_streaming_load.sh
+++ b/tests/suites/1_stateful/01_load/01_0000_streaming_load.sh
@@ -16,7 +16,7 @@ fi
 # do the Data integrity check
 echo "429c47cdd49b7d75eec9b9244c8b1288edd132506203e37d2d1e70e1ac1eccc7 /tmp/ontime.csv" | sha256sum --check > /dev/null 2>&1
 if [ $? -ne 0 ]; then
-	echo "current dataset is not our stateful test dataset"
+	echo "The downloaded dataset </tmp/ontime.csv> has been corrupted, please remove and fetch it again."
 	exit 1
 fi
 

--- a/tests/suites/1_stateful/01_load/ontime.sha1sum.txt
+++ b/tests/suites/1_stateful/01_load/ontime.sha1sum.txt
@@ -1,0 +1,1 @@
+429c47cdd49b7d75eec9b9244c8b1288edd132506203e37d2d1e70e1ac1eccc7 /tmp/ontime.csv

--- a/tests/suites/1_stateful/01_load/ontime.sha1sum.txt
+++ b/tests/suites/1_stateful/01_load/ontime.sha1sum.txt
@@ -1,1 +1,0 @@
-429c47cdd49b7d75eec9b9244c8b1288edd132506203e37d2d1e70e1ac1eccc7 /tmp/ontime.csv


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add sha256 check for the data file download from the webserver to make sure the 01_0000_streaming_load.sh
not failed for file broken!

## Changelog
- Improvement
01_0000_streaming_load.sh
## Related Issues

Fixes #4105

## Test Plan
Unit Tests
Stateless Tests

