### PR TITLE
Add precision in EvalContext

### DIFF
--- a/common/functions/src/scalars/dates/date.rs
+++ b/common/functions/src/scalars/dates/date.rs
@@ -62,7 +62,7 @@ impl DateFunction {
         )
     }
 
-    pub fn register2(factory: &mut FunctionFactory) {
+    pub fn register(factory: &mut FunctionFactory) {
         factory.register("today", TodayFunction::desc());
         factory.register("yesterday", YesterdayFunction::desc());
         factory.register("tomorrow", TomorrowFunction::desc());

--- a/common/functions/src/scalars/dates/macros.rs
+++ b/common/functions/src/scalars/dates/macros.rs
@@ -122,9 +122,7 @@ macro_rules! define_datetime32_add_year_months {
 macro_rules! define_datetime64_add_year_months {
     ($l: ident, $r: ident, $ctx: ident, $op: expr) => {{
         let factor = $ctx.factor;
-        let precision = $ctx
-            .get_meta_value("precision".to_string())
-            .map_or(0, |v| v.parse::<u32>().unwrap());
+        let precision = $ctx.precision as u32;
         let base = 10_i64.pow(9 - precision);
         let nano = $l * base;
         let naive =

--- a/common/functions/src/scalars/expressions/ctx.rs
+++ b/common/functions/src/scalars/expressions/ctx.rs
@@ -32,11 +32,7 @@ impl Default for EvalContext {
 }
 
 impl EvalContext {
-    pub fn new(
-        factor: i64,
-        precision: usize,
-        error: Option<ErrorCode>,
-    ) -> Self {
+    pub fn new(factor: i64, precision: usize, error: Option<ErrorCode>) -> Self {
         Self {
             factor,
             precision,

--- a/common/functions/src/scalars/expressions/ctx.rs
+++ b/common/functions/src/scalars/expressions/ctx.rs
@@ -12,25 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
-
 use common_exception::ErrorCode;
-use common_exception::Result;
 
 #[derive(Debug, Clone)]
 pub struct EvalContext {
     pub factor: i64,
+    pub precision: usize,
     pub error: Option<ErrorCode>,
-    /// A map of key-value pairs containing additional custom meta data.
-    pub metadata: Option<BTreeMap<String, String>>,
 }
 
 impl Default for EvalContext {
     fn default() -> Self {
         Self {
             factor: 1,
+            precision: 0,
             error: None,
-            metadata: None,
         }
     }
 }
@@ -38,23 +34,14 @@ impl Default for EvalContext {
 impl EvalContext {
     pub fn new(
         factor: i64,
+        precision: usize,
         error: Option<ErrorCode>,
-        metadata: Option<BTreeMap<String, String>>,
     ) -> Self {
         Self {
             factor,
+            precision,
             error,
-            metadata,
         }
-    }
-
-    pub fn get_meta_value(&self, key: String) -> Result<String> {
-        self.metadata
-            .clone()
-            .ok_or_else(|| ErrorCode::UnknownException("metadata is not set".to_string()))?
-            .get(&key)
-            .cloned()
-            .ok_or_else(|| ErrorCode::UnknownException(format!("metadata key {} is not set", key)))
     }
 
     pub fn set_error(&mut self, e: ErrorCode) {

--- a/common/functions/src/scalars/function_factory.rs
+++ b/common/functions/src/scalars/function_factory.rs
@@ -158,16 +158,16 @@ static FUNCTION_FACTORY: Lazy<Arc<FunctionFactory>> = Lazy::new(|| {
     ToCastFunction::register(&mut function_factory);
     TupleClassFunction::register(&mut function_factory);
     ComparisonFunction::register(&mut function_factory);
-    UdfFunction::register2(&mut function_factory);
-    StringFunction::register2(&mut function_factory);
-    HashesFunction::register2(&mut function_factory);
+    UdfFunction::register(&mut function_factory);
+    StringFunction::register(&mut function_factory);
+    HashesFunction::register(&mut function_factory);
     ConditionalFunction::register(&mut function_factory);
     LogicFunction::register(&mut function_factory);
     NullableFunction::register(&mut function_factory);
-    DateFunction::register2(&mut function_factory);
+    DateFunction::register(&mut function_factory);
     OtherFunction::register(&mut function_factory);
-    UUIDFunction::register2(&mut function_factory);
-    MathsFunction::register2(&mut function_factory);
+    UUIDFunction::register(&mut function_factory);
+    MathsFunction::register(&mut function_factory);
 
     Arc::new(function_factory)
 });

--- a/common/functions/src/scalars/hashes/hash.rs
+++ b/common/functions/src/scalars/hashes/hash.rs
@@ -33,7 +33,7 @@ pub type XxHash64Function = BaseHashFunction<XxHash64, u64>;
 pub type SipHash64Function = BaseHashFunction<DefaultHasher, u64>;
 
 impl HashesFunction {
-    pub fn register2(factory: &mut FunctionFactory) {
+    pub fn register(factory: &mut FunctionFactory) {
         factory.register("md5", Md5HashFunction::desc());
         factory.register("sha", Sha1HashFunction::desc());
         factory.register("sha1", Sha1HashFunction::desc());

--- a/common/functions/src/scalars/maths/math.rs
+++ b/common/functions/src/scalars/maths/math.rs
@@ -47,7 +47,7 @@ pub type CRC32Function = BaseHashFunction<CRC32, u32>;
 pub struct MathsFunction;
 
 impl MathsFunction {
-    pub fn register2(factory: &mut FunctionFactory) {
+    pub fn register(factory: &mut FunctionFactory) {
         factory.register("abs", AbsFunction::desc());
         factory.register("sign", SignFunction::desc());
         factory.register("pi", PiFunction::desc());

--- a/common/functions/src/scalars/strings/string.rs
+++ b/common/functions/src/scalars/strings/string.rs
@@ -60,7 +60,7 @@ use crate::scalars::UpperFunction;
 pub struct StringFunction;
 
 impl StringFunction {
-    pub fn register2(factory: &mut FunctionFactory) {
+    pub fn register(factory: &mut FunctionFactory) {
         factory.register("to_base64", Base64EncodeFunction::desc());
         factory.register("from_base64", Base64DecodeFunction::desc());
         factory.register("rtrim", RTrimFunction::desc());

--- a/common/functions/src/scalars/udfs/udf.rs
+++ b/common/functions/src/scalars/udfs/udf.rs
@@ -26,7 +26,7 @@ use crate::scalars::VersionFunction;
 pub struct UdfFunction;
 
 impl UdfFunction {
-    pub fn register2(factory: &mut FunctionFactory) {
+    pub fn register(factory: &mut FunctionFactory) {
         factory.register("in", InFunction::<false>::desc());
         factory.register("not_in", InFunction::<true>::desc());
         factory.register("example", UdfExampleFunction::desc());

--- a/common/functions/src/scalars/uuids/uuid.rs
+++ b/common/functions/src/scalars/uuids/uuid.rs
@@ -21,7 +21,7 @@ use crate::scalars::FunctionFactory;
 pub struct UUIDFunction;
 
 impl UUIDFunction {
-    pub fn register2(factory: &mut FunctionFactory) {
+    pub fn register(factory: &mut FunctionFactory) {
         factory.register("generateUUIDv4", UUIDv4Function::desc());
         factory.register("zeroUUID", UUIDZeroFunction::desc());
         factory.register("isemptyUUID", UUIDIsEmptyFunction::desc());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Remove the `BTreeMap`, use `precision` directly.

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan


