### PR TITLE
remove buffer in block_reader of fuse store

### DIFF
--- a/common/streams/src/stream_limit_by.rs
+++ b/common/streams/src/stream_limit_by.rs
@@ -74,7 +74,6 @@ impl LimitByStream {
         let array = BooleanArray::from_data(ArrowType::Boolean, filter.into(), None);
         let chunk = block.clone().try_into()?;
         let chunk = arrow::compute::filter::filter_chunk(&chunk, &array)?;
-        //let chunk = chunk.into();
         Some(DataBlock::from_chunk(block.schema(), &chunk)).transpose()
     }
 }

--- a/query/src/storages/fuse/operations/read.rs
+++ b/query/src/storages/fuse/operations/read.rs
@@ -63,7 +63,6 @@ impl FuseTable {
 
         let part_stream = futures::stream::iter(iter);
 
-        let read_buffer_size = ctx.get_settings().get_storage_read_buffer_size()?;
         let stream = part_stream
             .map(move |part| {
                 let da = operator.clone();
@@ -81,7 +80,6 @@ impl FuseTable {
                         table_schema,
                         projection,
                         part_len,
-                        read_buffer_size,
                         reader,
                     );
                     block_reader.read().await.map_err(|e| {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

do not need buffer since  "we execute exactly 1 seek and 1 read on them."
https://github.com/jorgecarleitao/arrow2/blob/3d528c99589e96f0539de4c07b11843fa22f23ac/examples/parquet_read_async.rs#L31

a buffer with column chunk length is allocated each time.
https://github.com/jorgecarleitao/arrow2/blob/3d528c99589e96f0539de4c07b11843fa22f23ac/src/io/parquet/read/row_group.rs#L126


thanks to @dantengsky 
https://github.com/datafuselabs/databend/pull/4212#discussion_r812863275

## Changelog

## Related Issues


## Test Plan

Unit Tests

Stateless Tests

