### PR TITLE
[metasrv] refactor: lower down log level to debug for tracing::instrument to prevent potential "message too long" error when sending to jaeger

### DIFF
--- a/common/meta/raft-store/src/log/raft_log.rs
+++ b/common/meta/raft-store/src/log/raft_log.rs
@@ -41,7 +41,7 @@ pub struct RaftLog {
 
 impl RaftLog {
     /// Open RaftLog
-    #[tracing::instrument(level = "info", skip(db,config), fields(config_id=%config.config_id))]
+    #[tracing::instrument(level = "debug", skip(db,config), fields(config_id=%config.config_id))]
     pub async fn open(db: &sled::Db, config: &RaftConfig) -> MetaStorageResult<RaftLog> {
         tracing::info!(?config);
 

--- a/common/meta/raft-store/src/state/raft_state.rs
+++ b/common/meta/raft-store/src/state/raft_state.rs
@@ -58,7 +58,7 @@ impl RaftState {
     /// 1. If `open` is `Some`,  it tries to open an existent RaftState if there is one.
     /// 2. If `create` is `Some`, it tries to initialize a new RaftState if there is not one.
     /// If none of them is `Some`, it is a programming error and will panic.
-    #[tracing::instrument(level = "info", skip(db,config,open,create), fields(config_id=%config.config_id))]
+    #[tracing::instrument(level = "debug", skip(db,config,open,create), fields(config_id=%config.config_id))]
     pub async fn open_create(
         db: &sled::Db,
         config: &RaftConfig,
@@ -106,7 +106,7 @@ impl RaftState {
 
     /// Initialize a raft state. The only thing to do is to persist the node id
     /// so that next time opening it the caller knows it is initialized.
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn init(&self) -> MetaResult<()> {
         let state = self.state();
         state

--- a/metasrv/src/api/grpc/grpc_service.rs
+++ b/metasrv/src/api/grpc/grpc_service.rs
@@ -76,7 +76,7 @@ impl MetaService for MetaServiceImpl {
     type HandshakeStream = GrpcStream<HandshakeResponse>;
 
     // rpc handshake first
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn handshake(
         &self,
         request: Request<Streaming<HandshakeRequest>>,

--- a/metasrv/src/meta_service/meta_service_impl.rs
+++ b/metasrv/src/meta_service/meta_service_impl.rs
@@ -52,7 +52,7 @@ impl RaftServiceImpl {
 impl RaftService for RaftServiceImpl {
     /// Handles a write request.
     /// This node must be leader or an error returned.
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn write(
         &self,
         request: tonic::Request<RaftRequest>,
@@ -88,7 +88,7 @@ impl RaftService for RaftServiceImpl {
         return Ok(tonic::Response::new(raft_reply));
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get(
         &self,
         request: tonic::Request<GetRequest>,
@@ -105,7 +105,7 @@ impl RaftService for RaftServiceImpl {
         Ok(tonic::Response::new(rst))
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn forward(
         &self,
         request: tonic::Request<RaftRequest>,
@@ -124,7 +124,7 @@ impl RaftService for RaftServiceImpl {
         Ok(tonic::Response::new(raft_mes))
     }
 
-    #[tracing::instrument(level = "info", skip(self, request))]
+    #[tracing::instrument(level = "debug", skip(self, request))]
     async fn append_entries(
         &self,
         request: tonic::Request<RaftRequest>,
@@ -151,7 +151,7 @@ impl RaftService for RaftServiceImpl {
         Ok(tonic::Response::new(mes))
     }
 
-    #[tracing::instrument(level = "info", skip(self, request))]
+    #[tracing::instrument(level = "debug", skip(self, request))]
     async fn install_snapshot(
         &self,
         request: tonic::Request<RaftRequest>,
@@ -178,7 +178,7 @@ impl RaftService for RaftServiceImpl {
         Ok(tonic::Response::new(mes))
     }
 
-    #[tracing::instrument(level = "info", skip(self, request))]
+    #[tracing::instrument(level = "debug", skip(self, request))]
     async fn vote(
         &self,
         request: tonic::Request<RaftRequest>,

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -201,7 +201,7 @@ impl MetaNode {
     }
 
     /// Start the grpc service for raft communication and meta operation API.
-    #[tracing::instrument(level = "info", skip(mn))]
+    #[tracing::instrument(level = "debug", skip(mn))]
     pub async fn start_grpc(mn: Arc<MetaNode>, host: &str, port: u32) -> MetaNetworkResult<()> {
         let mut rx = mn.running_rx.clone();
 
@@ -269,7 +269,7 @@ impl MetaNode {
     /// 3. If `init_cluster` is `Some` and it is just created, try to initialize a single-node cluster.
     ///
     /// TODO(xp): `init_cluster`: pass in a Map<id, address> to initialize the cluster.
-    #[tracing::instrument(level = "info", skip(config), fields(config_id=config.config_id.as_str()))]
+    #[tracing::instrument(level = "debug", skip(config), fields(config_id=config.config_id.as_str()))]
     pub async fn open_create_boot(
         config: &RaftConfig,
         open: Option<()>,
@@ -313,7 +313,7 @@ impl MetaNode {
         Ok(mn)
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn stop(&self) -> MetaResult<i32> {
         // TODO(xp): need to be reentrant.
 
@@ -406,7 +406,7 @@ impl MetaNode {
 
     /// Start MetaNode in either `boot`, `single`, `join` or `open` mode,
     /// according to config.
-    #[tracing::instrument(level = "info", skip(config))]
+    #[tracing::instrument(level = "debug", skip(config))]
     pub async fn start(config: &RaftConfig) -> Result<Arc<MetaNode>, MetaError> {
         tracing::info!(?config, "start()");
         let mn = Self::do_start(config).await?;
@@ -502,7 +502,7 @@ impl MetaNode {
 
     /// Boot up the first node to create a cluster.
     /// For every cluster this func should be called exactly once.
-    #[tracing::instrument(level = "info", skip(config), fields(config_id=config.config_id.as_str()))]
+    #[tracing::instrument(level = "debug", skip(config), fields(config_id=config.config_id.as_str()))]
     pub async fn boot(config: &RaftConfig) -> MetaResult<Arc<MetaNode>> {
         // 1. Bring a node up as non voter, start the grpc service for raft communication.
         // 2. Initialize itself as leader, because it is the only one in the new cluster.
@@ -516,7 +516,7 @@ impl MetaNode {
     // Initialized a single node cluster by:
     // - Initializing raft membership.
     // - Adding current node into the meta data.
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn init_cluster(&self, endpoint: Endpoint) -> MetaResult<()> {
         let node_id = self.sto.id;
 
@@ -539,7 +539,7 @@ impl MetaNode {
     /// When a leader is established, it is the leader's responsibility to setup replication from itself to non-voters, AKA learners.
     /// openraft does not persist the node set of non-voters, thus we need to do it manually.
     /// This fn should be called once a node found it becomes leader.
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn add_configured_non_voters(&self) -> MetaResult<()> {
         // TODO after leader established, add non-voter through apis
         let node_ids = self.sto.list_non_voters().await;
@@ -731,7 +731,7 @@ impl MetaNode {
     }
 
     /// Submit a write request to the known leader. Returns the response after applying the request.
-    #[tracing::instrument(level = "info", skip(self, req))]
+    #[tracing::instrument(level = "debug", skip(self, req))]
     pub async fn write(&self, req: LogEntry) -> Result<AppliedState, MetaError> {
         tracing::debug!("req: {:?}", req);
 
@@ -749,7 +749,7 @@ impl MetaNode {
 
     /// Try to get the leader from the latest metrics of the local raft node.
     /// If leader is absent, wait for an metrics update in which a leader is set.
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn get_leader(&self) -> NodeId {
         // fast path: there is a known leader
 
@@ -779,7 +779,7 @@ impl MetaNode {
         }
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn forward(
         &self,
         node_id: &NodeId,

--- a/metasrv/src/network.rs
+++ b/metasrv/src/network.rs
@@ -71,7 +71,7 @@ impl Network {
         }
     }
 
-    #[tracing::instrument(level = "info", skip(self), fields(id=self.sto.id))]
+    #[tracing::instrument(level = "debug", skip(self), fields(id=self.sto.id))]
     pub async fn make_client(&self, target: &NodeId) -> anyhow::Result<RaftServiceClient<Channel>> {
         let endpoint = self.sto.get_node_endpoint(target).await?;
         let addr = format!("http://{}", endpoint);

--- a/metasrv/src/store/meta_raft_store.rs
+++ b/metasrv/src/store/meta_raft_store.rs
@@ -114,7 +114,7 @@ impl MetaRaftStore {
     /// 1. If `open` is `Some`, try to open an existent one.
     /// 2. If `create` is `Some`, try to create one.
     /// Otherwise it panic
-    #[tracing::instrument(level = "info", skip(config,open,create), fields(config_id=%config.config_id))]
+    #[tracing::instrument(level = "debug", skip(config,open,create), fields(config_id=%config.config_id))]
     pub async fn open_create(
         config: &RaftConfig,
         open: Option<()>,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] refactor: lower down log level to debug for tracing::instrument to prevent potential "message too long" error when sending to jaeger

## Changelog




- Improvement


## Related Issues

- #4254