### PR TITLE
Add execute2 for Interpreter

### DIFF
--- a/query/src/interpreters/interpreter.rs
+++ b/query/src/interpreters/interpreter.rs
@@ -18,6 +18,8 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_streams::SendableDataBlockStream;
 
+use crate::pipelines::new::NewPipeline;
+
 #[async_trait::async_trait]
 pub trait Interpreter: Sync + Send {
     fn name(&self) -> &str;
@@ -30,6 +32,14 @@ pub trait Interpreter: Sync + Send {
         &self,
         input_stream: Option<SendableDataBlockStream>,
     ) -> Result<SendableDataBlockStream>;
+
+    // TODO: maybe remove async
+    async fn execute2(&self) -> Result<NewPipeline> {
+        Err(ErrorCode::UnImplement(format!(
+            "UnImplement execute2 method for {:?}",
+            self.name()
+        )))
+    }
 
     /// Do some start work for the interpreter.
     async fn start(&self) -> Result<()> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add execute2 for Interpreter(useful for insert into select)

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

