### PR TITLE
fix httphandler async query.

### DIFF
--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -158,9 +158,6 @@ impl ExecuteState {
             .await
             .map_err(|e| tracing::error!("interpreter.start.error: {:?}", e));
 
-        let data_stream = interpreter.execute(None).await?;
-        let mut data_stream = ctx.try_create_abortable(data_stream)?;
-
         let (abort_tx, mut abort_rx) = mpsc::channel(2);
         ctx.attach_http_query(HttpQueryHandle {
             abort_sender: abort_tx,
@@ -177,31 +174,39 @@ impl ExecuteState {
         }));
 
         let executor_clone = executor.clone();
-        ctx
-            .try_spawn(async move {
-                loop {
-                    if let Some(block_r) = data_stream.next().await {
-                        match block_r {
-                            Ok(block) => tokio::select! {
-                                _ = block_tx.send(block) => { },
-                                _ = abort_rx.recv() => {
-                                    Executor::stop(&executor, Err(ErrorCode::AbortedQuery("query aborted")), true).await;
-                                    break;
-                                },
-                            },
-                            Err(err) => {
-                                Executor::stop(&executor, Err(err), false).await;
-                                break;
-                            }
-                        };
-                    } else {
-                        Executor::stop(&executor, Ok(()), false).await;
-                        break;
-                    }
+        let ctx_clone = ctx.clone();
+        ctx.try_spawn(async move {
+            match execute(interpreter, ctx_clone, block_tx, &mut abort_rx).await {
+                Ok(_) => Executor::stop(&executor_clone, Ok(()), false).await,
+                Err(err) => {
+                    let kill = err.message().starts_with("aborted");
+                    Executor::stop(&executor_clone, Err(err), kill).await
                 }
-                tracing::debug!("drop block sender!");
-            })?;
+            };
+        })?;
 
-        Ok((executor_clone, schema))
+        Ok((executor, schema))
     }
+}
+
+async fn execute(
+    interpreter: Arc<dyn Interpreter>,
+    ctx: Arc<QueryContext>,
+    block_tx: mpsc::Sender<DataBlock>,
+    abort_rx: &mut mpsc::Receiver<()>,
+) -> Result<()> {
+    let data_stream = interpreter.execute(None).await?;
+    let mut data_stream = ctx.try_create_abortable(data_stream)?;
+    while let Some(block_r) = data_stream.next().await {
+        match block_r {
+            Ok(block) => tokio::select! {
+                _ = block_tx.send(block) => { },
+                _ = abort_rx.recv() => {
+                    return Err(ErrorCode::AbortedQuery("aborted"))
+                },
+            },
+            Err(err) => return Err(err),
+        };
+    }
+    Ok(())
 }

--- a/query/src/servers/http/v1/query/http_query.rs
+++ b/query/src/servers/http/v1/query/http_query.rs
@@ -37,6 +37,7 @@ use crate::servers::http::v1::query::Wait;
 use crate::sessions::SessionManager;
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct HttpQueryRequest {
     #[serde(default)]
     pub session: HttpSessionConf,

--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -77,7 +77,7 @@ async fn test_simple_sql() -> Result<()> {
     assert_eq!(status, StatusCode::OK, "{:?}", result);
     assert!(result.error.is_none(), "{:?}", result.error);
     assert_eq!(result.data.len(), 10);
-    assert_eq!(result.state, ExecuteStateName::Succeeded);
+    assert_eq!(result.state, ExecuteStateName::Succeeded, "{:?}", result);
     assert!(result.next_uri.is_none(), "{:?}", result);
     assert!(result.stats.progress.is_some());
     assert!(result.schema.is_some());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

request blocked because the interpreter is called in handler task. move it to the spawned task.
it works for select which get a stream immediately and the caller wait on it. 
but errors show up for queries like COPY,  which return a useless stream after real work is done.  cc @ZhiHanZ 


## Changelog

## Related Issues

Fix https://github.com/datafuselabs/databend/issues/4297

## Test Plan

Unit Tests

Stateless Tests

long copy tested on my mac