### PR TITLE
ISSUE-4331 fix cannot find node id after heartbeat failure

### DIFF
--- a/common/management/src/cluster/cluster_api.rs
+++ b/common/management/src/cluster/cluster_api.rs
@@ -27,5 +27,5 @@ pub trait ClusterApi: Sync + Send {
     async fn drop_node(&self, node_id: String, seq: Option<u64>) -> Result<()>;
 
     // Keep the tenant's cluster node alive.
-    async fn heartbeat(&self, node_id: String, seq: Option<u64>) -> Result<u64>;
+    async fn heartbeat(&self, node: &NodeInfo, seq: Option<u64>) -> Result<u64>;
 }

--- a/common/management/tests/it/cluster.rs
+++ b/common/management/tests/it/cluster.rs
@@ -127,7 +127,7 @@ async fn test_successfully_heartbeat_node() -> Result<()> {
     assert!(value.unwrap().meta.unwrap().expire_at.unwrap() - current_time >= 60);
 
     let current_time = current_seconds_time();
-    cluster_api.heartbeat(node_info.id.clone(), None).await?;
+    cluster_api.heartbeat(&node_info, None).await?;
 
     let value = kv_api
         .get_kv("__fd_clusters/admin//databend_query/test_node")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix cannot find node id after heartbeat failure

## Changelog

- Bug Fix

## Related Issues

Fixes #4331

## Test Plan

Unit Tests

Stateless Tests

