### PR TITLE
polish wall_time_ms in http handler

### DIFF
--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -72,7 +72,7 @@ impl QueryError {
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct QueryStats {
     pub progress: Option<ProgressValues>,
-    pub wall_time_ms: u128,
+    pub wall_time_ms: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -82,10 +82,10 @@ impl Executor {
             Stopped(f) => f.progress.clone(),
         }
     }
-    pub(crate) fn elapsed(&self) -> Duration {
+    pub(crate) fn elapsed(&self) -> Option<Duration> {
         match &self.state {
-            Running(_) => Instant::now() - self.start_time,
-            Stopped(f) => f.stop_time - self.start_time,
+            Running(_) => None,
+            Stopped(f) => Some(f.stop_time - self.start_time),
         }
     }
     pub(crate) async fn stop(this: &Arc<RwLock<Executor>>, reason: Result<()>, kill: bool) {

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -140,6 +140,7 @@ impl ExecuteState {
         block_tx: mpsc::Sender<DataBlock>,
     ) -> Result<(Arc<RwLock<Executor>>, DataSchemaRef)> {
         let sql = &request.sql;
+        let start_time = Instant::now();
         let session = session_manager.create_session("http-statement")?;
         let ctx = session.create_query_context().await?;
         if let Some(db) = &request.session.database {
@@ -169,7 +170,7 @@ impl ExecuteState {
             interpreter: interpreter.clone(),
         };
         let executor = Arc::new(RwLock::new(Executor {
-            start_time: Instant::now(),
+            start_time,
             state: Running(running_state),
         }));
 

--- a/query/src/servers/http/v1/query/http_query.rs
+++ b/query/src/servers/http/v1/query/http_query.rs
@@ -78,7 +78,7 @@ pub struct ResponseInitialState {
 }
 
 pub struct ResponseState {
-    pub wall_time_ms: u128,
+    pub wall_time_ms: Option<f64>,
     pub progress: Option<ProgressValues>,
     pub state: ExecuteStateName,
     pub error: Option<ErrorCode>,
@@ -164,7 +164,7 @@ impl HttpQuery {
     async fn get_state(&self) -> ResponseState {
         let state = self.state.read().await;
         let (exe_state, err) = state.state.extract();
-        let wall_time_ms = state.elapsed().as_millis();
+        let wall_time_ms = state.elapsed().map(|d| d.as_secs_f64() * 1000.0);
         ResponseState {
             wall_time_ms,
             progress: state.get_progress(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. return wall_time_ms only after execute finished, before that it is None/nil
2. use float instead of int
3. include parse and analyze time

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

