### PR TITLE
bugfix: Global MetaGrpcClient cause dispatch drop error

### DIFF
--- a/query/benches/suites/mod.rs
+++ b/query/benches/suites/mod.rs
@@ -29,7 +29,7 @@ pub mod bench_sort_query_sql;
 
 pub async fn select_executor(sql: &str) -> Result<()> {
     let sessions = SessionManager::from_conf(Config::default()).await?;
-    let executor_session = sessions.create_session("Benches")?;
+    let executor_session = sessions.create_session("Benches").await?;
     let ctx = executor_session.create_query_context().await?;
 
     if let PlanNode::Select(plan) = PlanParser::parse(ctx.clone(), sql).await? {

--- a/query/src/api/http/v1/cluster.rs
+++ b/query/src/api/http/v1/cluster.rs
@@ -42,7 +42,7 @@ pub async fn cluster_list_handler(
 }
 
 async fn list_nodes(sessions: &Arc<SessionManager>) -> Result<Vec<Arc<NodeInfo>>> {
-    let watch_cluster_session = sessions.create_session("WatchCluster")?;
+    let watch_cluster_session = sessions.create_session("WatchCluster").await?;
     let watch_cluster_context = watch_cluster_session.create_query_context().await?;
     Ok(watch_cluster_context.get_cluster().get_nodes())
 }

--- a/query/src/api/http/v1/logs.rs
+++ b/query/src/api/http/v1/logs.rs
@@ -42,7 +42,7 @@ pub async fn logs_handler(
 }
 
 async fn select_table(sessions: &Arc<SessionManager>) -> Result<Body> {
-    let session = sessions.create_session("WatchLogs")?;
+    let session = sessions.create_session("WatchLogs").await?;
     let query_context = session.create_query_context().await?;
     let mut tracing_table_stream = execute_query(query_context).await?;
 

--- a/query/src/api/rpc/flight_service.rs
+++ b/query/src/api/rpc/flight_service.rs
@@ -161,7 +161,10 @@ impl FlightService for DatabendQueryFlightService {
             FlightAction::BroadcastAction(action) => {
                 let session_id = action.query_id.clone();
                 let is_aborted = self.dispatcher.is_aborted();
-                let session = self.sessions.create_rpc_session(session_id, is_aborted)?;
+                let session = self
+                    .sessions
+                    .create_rpc_session(session_id, is_aborted)
+                    .await?;
 
                 self.dispatcher
                     .broadcast_action(session, flight_action)
@@ -171,7 +174,10 @@ impl FlightService for DatabendQueryFlightService {
             FlightAction::PrepareShuffleAction(action) => {
                 let session_id = action.query_id.clone();
                 let is_aborted = self.dispatcher.is_aborted();
-                let session = self.sessions.create_rpc_session(session_id, is_aborted)?;
+                let session = self
+                    .sessions
+                    .create_rpc_session(session_id, is_aborted)
+                    .await?;
 
                 self.dispatcher
                     .shuffle_action(session, flight_action)

--- a/query/src/api/rpc/flight_service.rs
+++ b/query/src/api/rpc/flight_service.rs
@@ -151,7 +151,7 @@ impl FlightService for DatabendQueryFlightService {
             FlightAction::CancelAction(action) => {
                 // We only destroy when session is exist
                 let session_id = action.query_id.clone();
-                if let Some(session) = self.sessions.get_session_by_id(&session_id) {
+                if let Some(session) = self.sessions.get_session_by_id(&session_id).await {
                     // TODO: remove streams
                     session.force_kill_session();
                 }

--- a/query/src/interpreters/interpreter_kill.rs
+++ b/query/src/interpreters/interpreter_kill.rs
@@ -54,7 +54,7 @@ impl Interpreter for KillInterpreter {
             .await?;
 
         let id = &self.plan.id;
-        match self.ctx.get_session_by_id(id) {
+        match self.ctx.get_session_by_id(id).await {
             None => Err(ErrorCode::UnknownSession(format!(
                 "Not found session id {}",
                 id

--- a/query/src/servers/clickhouse/interactive_worker.rs
+++ b/query/src/servers/clickhouse/interactive_worker.rs
@@ -106,12 +106,7 @@ impl ClickHouseSession for InteractiveWorker {
             password: Some(password.to_owned()),
             hostname: Some(client_ip.to_string()),
         };
-        let user_info_auth = self
-            .session
-            .get_session_manager()
-            .get_auth_manager()
-            .auth(&credential)
-            .await;
+        let user_info_auth = self.session.get_auth_manager().auth(&credential).await;
         match user_info_auth {
             Ok(user_info) => {
                 self.session.set_current_user(user_info);

--- a/query/src/servers/http/v1/load.rs
+++ b/query/src/servers/http/v1/load.rs
@@ -56,6 +56,7 @@ pub async fn streaming_load(
     let session_manager = sessions_extension.0;
     let session = session_manager
         .create_session("Streaming load")
+        .await
         .map_err(InternalServerError)?;
 
     // TODO: list user's grant list and check client address

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -142,7 +142,7 @@ impl ExecuteState {
     ) -> Result<(Arc<RwLock<Executor>>, DataSchemaRef)> {
         let sql = &request.sql;
         let start_time = Instant::now();
-        let session = session_manager.create_session("http-statement")?;
+        let session = session_manager.create_session("http-statement").await?;
         let ctx = session.create_query_context().await?;
         if let Some(db) = &request.session.database {
             ctx.set_current_database(db.clone()).await?;

--- a/query/src/sessions/query_ctx.rs
+++ b/query/src/sessions/query_ctx.rs
@@ -286,7 +286,7 @@ impl QueryContext {
 
     // Get user manager api.
     pub fn get_user_manager(self: &Arc<Self>) -> Arc<UserApiProvider> {
-        self.shared.session.get_session_manager().get_user_manager()
+        self.shared.session.get_user_manager()
     }
 
     // Get the current session.

--- a/query/src/sessions/query_ctx.rs
+++ b/query/src/sessions/query_ctx.rs
@@ -295,11 +295,12 @@ impl QueryContext {
     }
 
     // Get one session by session id.
-    pub fn get_session_by_id(self: &Arc<Self>, id: &str) -> Option<SessionRef> {
+    pub async fn get_session_by_id(self: &Arc<Self>, id: &str) -> Option<SessionRef> {
         self.shared
             .session
             .get_session_manager()
             .get_session_by_id(id)
+            .await
     }
 
     // Get all the processes list info.

--- a/query/src/sessions/query_ctx.rs
+++ b/query/src/sessions/query_ctx.rs
@@ -304,8 +304,12 @@ impl QueryContext {
     }
 
     // Get all the processes list info.
-    pub fn get_processes_info(self: &Arc<Self>) -> Vec<ProcessInfo> {
-        self.shared.session.get_session_manager().processes_info()
+    pub async fn get_processes_info(self: &Arc<Self>) -> Vec<ProcessInfo> {
+        self.shared
+            .session
+            .get_session_manager()
+            .processes_info()
+            .await
     }
 
     /// Get the data accessor metrics.

--- a/query/src/sessions/session.rs
+++ b/query/src/sessions/session.rs
@@ -58,18 +58,14 @@ pub struct Session {
 }
 
 impl Session {
-    pub fn try_create(
+    pub async fn try_create(
         conf: Config,
         id: String,
         typ: String,
         session_mgr: Arc<SessionManager>,
     ) -> Result<Arc<Session>> {
-        let user_manager =
-            futures::executor::block_on(UserApiProvider::create_global(conf.clone()))?;
-        let auth_manager = Arc::new(futures::executor::block_on(AuthMgr::create(
-            conf.clone(),
-            user_manager.clone(),
-        ))?);
+        let user_manager = UserApiProvider::create_global(conf.clone()).await?;
+        let auth_manager = Arc::new(AuthMgr::create(conf.clone(), user_manager.clone()).await?);
         let role_cache_manager = Arc::new(RoleCacheMgr::new(user_manager.clone()));
         let session_ctx = Arc::new(SessionContext::try_create(conf.clone())?);
         let session_settings =

--- a/query/src/sessions/session_mgr.rs
+++ b/query/src/sessions/session_mgr.rs
@@ -112,10 +112,6 @@ impl SessionManager {
         self.auth_manager.clone()
     }
 
-    pub fn get_role_cache_manager(self: &Arc<Self>) -> Arc<RoleCacheMgr> {
-        self.role_cache_manager.clone()
-    }
-
     /// Get the user api provider.
     pub fn get_user_manager(self: &Arc<Self>) -> Arc<UserApiProvider> {
         self.user_manager.clone()

--- a/query/src/sessions/session_mgr.rs
+++ b/query/src/sessions/session_mgr.rs
@@ -191,8 +191,8 @@ impl SessionManager {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn get_session_by_id(self: &Arc<Self>, id: &str) -> Option<SessionRef> {
-        let sessions = futures::executor::block_on(self.active_sessions.read());
+    pub async fn get_session_by_id(self: &Arc<Self>, id: &str) -> Option<SessionRef> {
+        let sessions = self.active_sessions.read().await;
         sessions
             .get(id)
             .map(|session| SessionRef::create(session.clone()))

--- a/query/src/sessions/session_mgr.rs
+++ b/query/src/sessions/session_mgr.rs
@@ -46,7 +46,6 @@ use crate::sessions::session_ref::SessionRef;
 use crate::sessions::ProcessInfo;
 use crate::storages::cache::CacheManager;
 use crate::users::auth::auth_mgr::AuthMgr;
-use crate::users::RoleCacheMgr;
 use crate::users::UserApiProvider;
 
 pub struct SessionManager {
@@ -55,7 +54,6 @@ pub struct SessionManager {
     pub(in crate::sessions) catalog: Arc<DatabaseCatalog>,
     pub(in crate::sessions) user_manager: Arc<UserApiProvider>,
     pub(in crate::sessions) auth_manager: Arc<AuthMgr>,
-    pub(in crate::sessions) role_cache_manager: Arc<RoleCacheMgr>,
     pub(in crate::sessions) http_query_manager: Arc<HttpQueryManager>,
 
     pub(in crate::sessions) max_sessions: usize,
@@ -77,7 +75,6 @@ impl SessionManager {
         let user = UserApiProvider::create_global(conf.clone()).await?;
         let auth_manager = Arc::new(AuthMgr::create(conf.clone(), user.clone()).await?);
         let http_query_manager = HttpQueryManager::create_global(conf.clone()).await?;
-        let role_cache_manager = Arc::new(RoleCacheMgr::new(user.clone()));
         let max_sessions = conf.query.max_active_sessions as usize;
         let active_sessions = Arc::new(RwLock::new(HashMap::with_capacity(max_sessions)));
 
@@ -85,7 +82,6 @@ impl SessionManager {
             catalog,
             conf,
             discovery,
-            role_cache_manager,
             user_manager: user,
             http_query_manager,
             auth_manager,

--- a/query/src/sessions/session_mgr.rs
+++ b/query/src/sessions/session_mgr.rs
@@ -219,7 +219,7 @@ impl SessionManager {
             let mut signal = Box::pin(signal.next());
 
             for _index in 0..timeout_secs {
-                if SessionManager::destroy_idle_sessions(&active_sessions) {
+                if SessionManager::destroy_idle_sessions(&active_sessions).await {
                     return;
                 }
 
@@ -248,10 +248,10 @@ impl SessionManager {
             .collect::<Vec<_>>()
     }
 
-    fn destroy_idle_sessions(sessions: &Arc<RwLock<HashMap<String, Arc<Session>>>>) -> bool {
+    async fn destroy_idle_sessions(sessions: &Arc<RwLock<HashMap<String, Arc<Session>>>>) -> bool {
         // Read lock does not support reentrant
         // https://github.com/Amanieu/parking_lot/blob/lock_api-0.4.4/lock_api/src/rwlock.rs#L422
-        let active_sessions_read_guard = futures::executor::block_on(sessions.read());
+        let active_sessions_read_guard = sessions.read().await;
 
         // First try to kill the idle session
         active_sessions_read_guard.values().for_each(Session::kill);

--- a/query/src/sessions/session_mgr.rs
+++ b/query/src/sessions/session_mgr.rs
@@ -240,8 +240,8 @@ impl SessionManager {
         }
     }
 
-    pub fn processes_info(self: &Arc<Self>) -> Vec<ProcessInfo> {
-        let sessions = futures::executor::block_on(self.active_sessions.read());
+    pub async fn processes_info(self: &Arc<Self>) -> Vec<ProcessInfo> {
+        let sessions = self.active_sessions.read().await;
         sessions
             .values()
             .map(Session::process_info)

--- a/query/src/storages/system/processes_table.rs
+++ b/query/src/storages/system/processes_table.rs
@@ -26,23 +26,24 @@ use common_meta_types::TableMeta;
 use common_meta_types::UserInfo;
 
 use crate::sessions::QueryContext;
-use crate::storages::system::table::SyncOneBlockSystemTable;
-use crate::storages::system::table::SyncSystemTable;
+use crate::storages::system::table::AsyncOneBlockSystemTable;
+use crate::storages::system::table::AsyncSystemTable;
 use crate::storages::Table;
 
 pub struct ProcessesTable {
     table_info: TableInfo,
 }
 
-impl SyncSystemTable for ProcessesTable {
+#[async_trait::async_trait]
+impl AsyncSystemTable for ProcessesTable {
     const NAME: &'static str = "system.processes";
 
     fn get_table_info(&self) -> &TableInfo {
         &self.table_info
     }
 
-    fn get_full_data(&self, ctx: Arc<QueryContext>) -> Result<DataBlock> {
-        let processes_info = ctx.get_processes_info();
+    async fn get_full_data(&self, ctx: Arc<QueryContext>) -> Result<DataBlock> {
+        let processes_info = ctx.get_processes_info().await;
 
         let mut processes_id = Vec::with_capacity(processes_info.len());
         let mut processes_type = Vec::with_capacity(processes_info.len());
@@ -124,7 +125,7 @@ impl ProcessesTable {
             },
         };
 
-        SyncOneBlockSystemTable::create(ProcessesTable { table_info })
+        AsyncOneBlockSystemTable::create(ProcessesTable { table_info })
     }
 
     fn process_host(client_address: &Option<SocketAddr>) -> Option<Vec<u8>> {

--- a/query/tests/it/api/rpc/flight_actions.rs
+++ b/query/tests/it/api/rpc/flight_actions.rs
@@ -27,7 +27,7 @@ use crate::tests::create_query_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_shuffle_action_try_into() -> Result<()> {
-    let ctx = create_query_context()?;
+    let ctx = create_query_context().await?;
 
     let shuffle_action = ShuffleAction {
         query_id: String::from("query_id"),

--- a/query/tests/it/api/rpc/flight_dispatcher.rs
+++ b/query/tests/it/api/rpc/flight_dispatcher.rs
@@ -49,11 +49,11 @@ async fn test_get_stream_with_non_exists_stream() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_run_shuffle_action_with_no_scatters() -> Result<()> {
     if let (Some(query_id), Some(stage_id), Some(stream_id)) = generate_uuids(3) {
-        let ctx = create_query_context()?;
+        let ctx = create_query_context().await?;
         let flight_dispatcher = DatabendQueryFlightDispatcher::create();
 
         let sessions = SessionManagerBuilder::create().build()?;
-        let rpc_session = sessions.create_rpc_session(query_id.clone(), false)?;
+        let rpc_session = sessions.create_rpc_session(query_id.clone(), false).await?;
 
         flight_dispatcher
             .shuffle_action(
@@ -94,11 +94,11 @@ async fn test_run_shuffle_action_with_no_scatters() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_run_shuffle_action_with_scatter() -> Result<()> {
     if let (Some(query_id), Some(stage_id), None) = generate_uuids(2) {
-        let ctx = create_query_context()?;
+        let ctx = create_query_context().await?;
         let flight_dispatcher = DatabendQueryFlightDispatcher::create();
 
         let sessions = SessionManagerBuilder::create().build()?;
-        let rpc_session = sessions.create_rpc_session(query_id.clone(), false)?;
+        let rpc_session = sessions.create_rpc_session(query_id.clone(), false).await?;
 
         flight_dispatcher
             .shuffle_action(

--- a/query/tests/it/api/rpc/flight_service.rs
+++ b/query/tests/it/api/rpc/flight_service.rs
@@ -162,7 +162,7 @@ fn do_get_request(query_id: &str, stage_id: &str) -> Result<Request<Ticket>> {
 }
 
 async fn do_action_request(query_id: &str, stage_id: &str) -> Result<Request<Action>> {
-    let ctx = create_query_context()?;
+    let ctx = create_query_context().await?;
     let flight_action = FlightAction::PrepareShuffleAction(ShuffleAction {
         query_id: String::from(query_id),
         stage_id: String::from(stage_id),

--- a/query/tests/it/functions/context_function.rs
+++ b/query/tests/it/functions/context_function.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_base::tokio;
 use common_exception::Result;
 use databend_query::functions::ContextFunction;
 
-#[test]
-fn test_context_function_build_arg_from_ctx() -> Result<()> {
+#[tokio::test]
+async fn test_context_function_build_arg_from_ctx() -> Result<()> {
     use pretty_assertions::assert_eq;
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // Ok.
     {

--- a/query/tests/it/interpreters/access/management_mode_access.rs
+++ b/query/tests/it/interpreters/access/management_mode_access.rs
@@ -151,7 +151,7 @@ async fn test_management_mode_access() -> Result<()> {
     let conf = crate::tests::ConfigBuilder::create()
         .with_management_mode()
         .config();
-    let ctx = crate::tests::create_query_context_with_config(conf.clone())?;
+    let ctx = crate::tests::create_query_context_with_config(conf.clone()).await?;
     // First to set tenant.
     {
         let plan = PlanParser::parse(ctx.clone(), "SUDO USE TENANT 'test'").await?;

--- a/query/tests/it/interpreters/interpreter_admin_use_tenant.rs
+++ b/query/tests/it/interpreters/interpreter_admin_use_tenant.rs
@@ -24,7 +24,7 @@ async fn test_use_tenant_interpreter() -> Result<()> {
     let conf = crate::tests::ConfigBuilder::create()
         .with_management_mode()
         .config();
-    let ctx = crate::tests::create_query_context_with_config(conf.clone())?;
+    let ctx = crate::tests::create_query_context_with_config(conf.clone()).await?;
 
     let plan = PlanParser::parse(ctx.clone(), "SUDO USE TENANT 't1'").await?;
     let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
@@ -41,7 +41,7 @@ async fn test_use_tenant_interpreter() -> Result<()> {
 
 #[tokio::test]
 async fn test_use_tenant_interpreter_error() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), "SUDO USE TENANT 't1'").await?;
     let interpreter = InterpreterFactory::get(ctx, plan)?;

--- a/query/tests/it/interpreters/interpreter_call.rs
+++ b/query/tests/it/interpreters/interpreter_call.rs
@@ -23,7 +23,7 @@ use pretty_assertions::assert_eq;
 async fn test_call_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), "call system$test()").await?;
     let executor = InterpreterFactory::get(ctx, plan.clone())?;
@@ -41,7 +41,7 @@ async fn test_call_interpreter() -> Result<()> {
 async fn test_call_fuse_history_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // NumberArgumentsNotMatch
     {

--- a/query/tests/it/interpreters/interpreter_call.rs
+++ b/query/tests/it/interpreters/interpreter_call.rs
@@ -105,7 +105,7 @@ async fn test_call_fuse_history_interpreter() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_call_warehouse_metadata_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // NumberArgumentsNotMatch
     {
@@ -136,7 +136,7 @@ async fn test_call_warehouse_metadata_interpreter() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_get_warehouse_metadata_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // NumberArgumentsNotMatch. Case 1
     {
@@ -204,7 +204,7 @@ async fn test_get_warehouse_metadata_interpreter() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_list_warehouse_metadata_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // NumberArgumentsNotMatch.
     {
@@ -259,7 +259,7 @@ async fn test_list_warehouse_metadata_interpreter() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_update_warehouse_metadata_size_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // NumberArgumentsNotMatch.
     {
@@ -316,7 +316,7 @@ async fn test_update_warehouse_metadata_size_interpreter() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_drop_warehouse_metadata_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // NumberArgumentsNotMatch.
     {

--- a/query/tests/it/interpreters/interpreter_database_create.rs
+++ b/query/tests/it/interpreters/interpreter_database_create.rs
@@ -23,7 +23,7 @@ use pretty_assertions::assert_eq;
 async fn test_create_database_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), "create database db1").await?;
     let executor = InterpreterFactory::get(ctx, plan.clone())?;

--- a/query/tests/it/interpreters/interpreter_database_drop.rs
+++ b/query/tests/it/interpreters/interpreter_database_drop.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test]
 async fn test_drop_database_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), "drop database default").await?;
     let executor = InterpreterFactory::get(ctx, plan.clone())?;

--- a/query/tests/it/interpreters/interpreter_database_show_create.rs
+++ b/query/tests/it/interpreters/interpreter_database_show_create.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_show_create_database_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // show create database default
     {

--- a/query/tests/it/interpreters/interpreter_explain.rs
+++ b/query/tests/it/interpreters/interpreter_explain.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_explain_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let query = "\
         EXPLAIN SELECT number FROM numbers_mt(10) \

--- a/query/tests/it/interpreters/interpreter_factory_interceptor.rs
+++ b/query/tests/it/interpreters/interpreter_factory_interceptor.rs
@@ -22,7 +22,7 @@ use pretty_assertions::assert_eq;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_interpreter_interceptor() -> Result<()> {
     common_tracing::init_default_ut_tracing();
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     {
         let query = "select number from numbers_mt(100) where number > 90";
         ctx.attach_query_str(query);
@@ -80,7 +80,7 @@ async fn test_interpreter_interceptor() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_interpreter_interceptor_for_insert() -> Result<()> {
     common_tracing::init_default_ut_tracing();
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     {
         let query = "create table t as select number from numbers_mt(1)";
         ctx.attach_query_str(query);

--- a/query/tests/it/interpreters/interpreter_insert.rs
+++ b/query/tests/it/interpreters/interpreter_insert.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test]
 async fn test_insert_into_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // Create default value table.
     {

--- a/query/tests/it/interpreters/interpreter_select.rs
+++ b/query/tests/it/interpreters/interpreter_select.rs
@@ -22,7 +22,7 @@ use pretty_assertions::assert_eq;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_select_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     {
         let query = "select number from numbers_mt(10)";

--- a/query/tests/it/interpreters/interpreter_setting.rs
+++ b/query/tests/it/interpreters/interpreter_setting.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_setting_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), "SET max_block_size=1").await?;
     let executor = InterpreterFactory::get(ctx.clone(), plan)?;
@@ -35,7 +35,7 @@ async fn test_setting_interpreter() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_setting_interpreter_error() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), "SET max_block_size=1").await?;
     let executor = InterpreterFactory::get(ctx.clone(), plan)?;

--- a/query/tests/it/interpreters/interpreter_show_databases.rs
+++ b/query/tests/it/interpreters/interpreter_show_databases.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_show_databases_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // show databases.
     {

--- a/query/tests/it/interpreters/interpreter_show_engines.rs
+++ b/query/tests/it/interpreters/interpreter_show_engines.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_show_engines_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // show engines.
     {

--- a/query/tests/it/interpreters/interpreter_show_functions.rs
+++ b/query/tests/it/interpreters/interpreter_show_functions.rs
@@ -19,7 +19,7 @@ use databend_query::sql::PlanParser;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_show_functions_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // show functions.
     {

--- a/query/tests/it/interpreters/interpreter_show_metrics.rs
+++ b/query/tests/it/interpreters/interpreter_show_metrics.rs
@@ -21,7 +21,7 @@ use databend_query::sql::PlanParser;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_show_metrics_interpreter() -> Result<()> {
     init_default_metrics_recorder();
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // show metrics.
     {

--- a/query/tests/it/interpreters/interpreter_show_processlist.rs
+++ b/query/tests/it/interpreters/interpreter_show_processlist.rs
@@ -19,7 +19,7 @@ use databend_query::sql::PlanParser;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_show_processlist_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // show processlist.
     {

--- a/query/tests/it/interpreters/interpreter_show_settings.rs
+++ b/query/tests/it/interpreters/interpreter_show_settings.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_show_settings_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // show settings.
     {

--- a/query/tests/it/interpreters/interpreter_show_tables.rs
+++ b/query/tests/it/interpreters/interpreter_show_tables.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_show_tables_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // Setup.
     {

--- a/query/tests/it/interpreters/interpreter_show_users.rs
+++ b/query/tests/it/interpreters/interpreter_show_users.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_show_users_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     {
         let query = "CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'";

--- a/query/tests/it/interpreters/interpreter_table_create.rs
+++ b/query/tests/it/interpreters/interpreter_table_create.rs
@@ -20,7 +20,7 @@ use futures::stream::StreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_create_table_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     {
         let query = "\

--- a/query/tests/it/interpreters/interpreter_table_describe.rs
+++ b/query/tests/it/interpreters/interpreter_table_describe.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test]
 async fn interpreter_describe_table_test() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // Create table.
     {

--- a/query/tests/it/interpreters/interpreter_table_drop.rs
+++ b/query/tests/it/interpreters/interpreter_table_drop.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test]
 async fn test_drop_table_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // Create table.
     {

--- a/query/tests/it/interpreters/interpreter_table_show_create.rs
+++ b/query/tests/it/interpreters/interpreter_table_show_create.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test]
 async fn interpreter_show_create_table_test() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // Create table.
     {

--- a/query/tests/it/interpreters/interpreter_table_truncate.rs
+++ b/query/tests/it/interpreters/interpreter_table_truncate.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test]
 async fn test_truncate_table_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     // Create table.
     {

--- a/query/tests/it/interpreters/interpreter_use_database.rs
+++ b/query/tests/it/interpreters/interpreter_use_database.rs
@@ -21,7 +21,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test]
 async fn test_use_interpreter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), "USE default").await?;
     let interpreter = InterpreterFactory::get(ctx, plan)?;
@@ -35,7 +35,7 @@ async fn test_use_interpreter() -> Result<()> {
 
 #[tokio::test]
 async fn test_use_database_interpreter_error() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), "USE xx").await?;
     let interpreter = InterpreterFactory::get(ctx, plan)?;

--- a/query/tests/it/interpreters/interpreter_user_alter.rs
+++ b/query/tests/it/interpreters/interpreter_user_alter.rs
@@ -26,7 +26,7 @@ use pretty_assertions::assert_eq;
 async fn test_alter_user_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let tenant = "test";
     let name = "test";
     let hostname = "localhost";

--- a/query/tests/it/interpreters/interpreter_user_create.rs
+++ b/query/tests/it/interpreters/interpreter_user_create.rs
@@ -23,7 +23,7 @@ use pretty_assertions::assert_eq;
 async fn test_create_user_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let query = "CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'";
     let plan = PlanParser::parse(ctx.clone(), query).await?;

--- a/query/tests/it/interpreters/interpreter_user_drop.rs
+++ b/query/tests/it/interpreters/interpreter_user_drop.rs
@@ -25,7 +25,7 @@ use pretty_assertions::assert_eq;
 async fn test_drop_user_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let tenant = ctx.get_tenant();
 
     {

--- a/query/tests/it/interpreters/interpreter_user_previlege_revoke.rs
+++ b/query/tests/it/interpreters/interpreter_user_previlege_revoke.rs
@@ -32,7 +32,7 @@ use pretty_assertions::assert_eq;
 async fn test_revoke_privilege_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let tenant = ctx.get_tenant().to_string();
 
     let name = "test";
@@ -62,7 +62,7 @@ async fn test_revoke_privilege_interpreter() -> Result<()> {
 async fn test_revoke_privilege_interpreter_on_role() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let tenant = ctx.get_tenant().to_string();
 
     let mut role_info = RoleInfo::new("role1".to_string());

--- a/query/tests/it/interpreters/interpreter_user_privilege_grant.rs
+++ b/query/tests/it/interpreters/interpreter_user_privilege_grant.rs
@@ -31,7 +31,7 @@ use pretty_assertions::assert_eq;
 async fn test_grant_privilege_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let tenant = ctx.get_tenant();
 
     let name = "test";

--- a/query/tests/it/interpreters/interpreter_user_udf_alter.rs
+++ b/query/tests/it/interpreters/interpreter_user_udf_alter.rs
@@ -23,7 +23,7 @@ use pretty_assertions::assert_eq;
 async fn test_alter_udf_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let tenant = ctx.get_tenant();
 
     {

--- a/query/tests/it/interpreters/interpreter_user_udf_create.rs
+++ b/query/tests/it/interpreters/interpreter_user_udf_create.rs
@@ -24,7 +24,7 @@ use pretty_assertions::assert_eq;
 async fn test_create_udf_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let tenant = ctx.get_tenant();
 
     let query =

--- a/query/tests/it/interpreters/interpreter_user_udf_drop.rs
+++ b/query/tests/it/interpreters/interpreter_user_udf_drop.rs
@@ -23,7 +23,7 @@ use pretty_assertions::assert_eq;
 async fn test_drop_udf_interpreter() -> Result<()> {
     common_tracing::init_default_ut_tracing();
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let tenant = ctx.get_tenant();
 
     static CREATE_UDF: &str =

--- a/query/tests/it/interpreters/plan_schedulers/plan_scheduler.rs
+++ b/query/tests/it/interpreters/plan_schedulers/plan_scheduler.rs
@@ -331,4 +331,5 @@ async fn create_env() -> Result<Arc<QueryContext>> {
             .with_node("dummy", "github.com:9090")
             .with_local_id("dummy_local"),
     )
+    .await
 }

--- a/query/tests/it/optimizers/optimizer.rs
+++ b/query/tests/it/optimizers/optimizer.rs
@@ -68,7 +68,7 @@ use databend_query::sql::PlanParser;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_literal_false_filter() -> Result<()> {
     let query = "select * from numbers_mt(10) where 1 + 2 = 2";
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), query).await?;
     let mut optimizer = Optimizers::without_scatters(ctx);
@@ -122,7 +122,7 @@ async fn test_skip_read_data_source() -> Result<()> {
     ];
 
     for test in tests {
-        let ctx = crate::tests::create_query_context()?;
+        let ctx = crate::tests::create_query_context().await?;
         let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let mut optimizer = Optimizers::without_scatters(ctx);
 

--- a/query/tests/it/optimizers/optimizer_constant_folding.rs
+++ b/query/tests/it/optimizers/optimizer_constant_folding.rs
@@ -101,7 +101,7 @@ async fn test_constant_folding_optimizer() -> Result<()> {
         ];
 
     for test in tests {
-        let ctx = crate::tests::create_query_context()?;
+        let ctx = crate::tests::create_query_context().await?;
 
         let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let mut optimizer = ConstantFoldingOptimizer::create(ctx);

--- a/query/tests/it/optimizers/optimizer_expression_transform.rs
+++ b/query/tests/it/optimizers/optimizer_expression_transform.rs
@@ -198,7 +198,7 @@ async fn test_expression_transform_optimizer() -> Result<()> {
         ];
 
     for test in tests {
-        let ctx = crate::tests::create_query_context()?;
+        let ctx = crate::tests::create_query_context().await?;
 
         let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let mut optimizer = ExprTransformOptimizer::create(ctx);

--- a/query/tests/it/optimizers/optimizer_scatters.rs
+++ b/query/tests/it/optimizers/optimizer_scatters.rs
@@ -208,7 +208,8 @@ async fn test_scatter_optimizer() -> Result<()> {
                 .with_node("Github", "www.github.com:9090")
                 .with_node("dummy_local", "127.0.0.1:9090")
                 .with_local_id("dummy_local"),
-        )?;
+        )
+        .await?;
 
         let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let mut optimizer = ScattersOptimizer::create(ctx);

--- a/query/tests/it/optimizers/optimizer_statistics_exact.rs
+++ b/query/tests/it/optimizers/optimizer_statistics_exact.rs
@@ -14,6 +14,7 @@
 
 use std::mem::size_of;
 
+use common_base::tokio;
 use common_datavalues::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
@@ -23,9 +24,9 @@ use pretty_assertions::assert_eq;
 
 use crate::optimizers::optimizer::*;
 
-#[test]
-fn test_statistics_exact_optimizer() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+#[tokio::test]
+async fn test_statistics_exact_optimizer() -> Result<()> {
+    let ctx = crate::tests::create_query_context().await?;
 
     let total = ctx.get_settings().get_max_block_size()? as u64;
     let statistics = Statistics::new_exact(

--- a/query/tests/it/optimizers/optimizer_top_n_push_down.rs
+++ b/query/tests/it/optimizers/optimizer_top_n_push_down.rs
@@ -20,7 +20,7 @@ use databend_query::sql::PlanParser;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_simple() -> Result<()> {
     let query = "select number from numbers(1000) order by number limit 10;";
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), query).await?;
 
@@ -41,7 +41,7 @@ async fn test_simple() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_simple_with_offset() -> Result<()> {
     let query = "select number from numbers(1000) order by number limit 10 offset 5;";
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), query).await?;
 
@@ -63,7 +63,7 @@ async fn test_simple_with_offset() -> Result<()> {
 async fn test_nested_projection() -> Result<()> {
     let query =
         "select number from (select * from numbers(1000) order by number limit 11) limit 10;";
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), query).await?;
 
@@ -87,7 +87,7 @@ async fn test_nested_projection() -> Result<()> {
 async fn test_aggregate() -> Result<()> {
     let query =
         "select sum(number) FROM numbers(1000) group by number % 10 order by sum(number) limit 5;";
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let plan = PlanParser::parse(ctx.clone(), query).await?;
 
@@ -141,7 +141,7 @@ async fn test_monotonic_function() -> Result<()> {
     ];
 
     for test in tests {
-        let ctx = crate::tests::create_query_context()?;
+        let ctx = crate::tests::create_query_context().await?;
         let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let mut optimizer = Optimizers::without_scatters(ctx);
 

--- a/query/tests/it/pipelines/processors/pipeline_builder.rs
+++ b/query/tests/it/pipelines/processors/pipeline_builder.rs
@@ -171,7 +171,7 @@ async fn test_local_pipeline_builds() -> Result<()> {
         },
     ];
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     for test in tests {
         // Plan build check.
         let plan = PlanParser::parse(ctx.clone(), test.query).await?;

--- a/query/tests/it/pipelines/processors/pipeline_display.rs
+++ b/query/tests/it/pipelines/processors/pipeline_display.rs
@@ -20,7 +20,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_pipeline_display() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let query = "\
         EXPLAIN PIPELINE SELECT \

--- a/query/tests/it/pipelines/processors/pipeline_walker.rs
+++ b/query/tests/it/pipelines/processors/pipeline_walker.rs
@@ -20,7 +20,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_pipeline_walker() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let query = "\
         SELECT sum(number + 1) + 2 AS sumx \

--- a/query/tests/it/pipelines/processors/processor_merge.rs
+++ b/query/tests/it/pipelines/processors/processor_merge.rs
@@ -24,7 +24,7 @@ use crate::tests;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_processor_merge() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = tests::NumberTestData::create(ctx.clone());
 
     let mut pipeline = Pipeline::create(ctx.clone());

--- a/query/tests/it/pipelines/processors/processor_mixed.rs
+++ b/query/tests/it/pipelines/processors/processor_mixed.rs
@@ -24,7 +24,7 @@ use crate::tests;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_processor_mixed() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = tests::NumberTestData::create(ctx.clone());
 
     let mut pipeline = Pipeline::create(ctx.clone());
@@ -60,7 +60,7 @@ async fn test_processor_mixed() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_processor_mixed2() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = tests::NumberTestData::create(ctx.clone());
 
     let m = 5;

--- a/query/tests/it/pipelines/transforms/transform_aggregator_final.rs
+++ b/query/tests/it/pipelines/transforms/transform_aggregator_final.rs
@@ -25,7 +25,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_final_aggregator() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     // sum(number)+1, avg(number)

--- a/query/tests/it/pipelines/transforms/transform_aggregator_partial.rs
+++ b/query/tests/it/pipelines/transforms/transform_aggregator_partial.rs
@@ -25,7 +25,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_partial_aggregator() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     // sum(number), avg(number)

--- a/query/tests/it/pipelines/transforms/transform_expression.rs
+++ b/query/tests/it/pipelines/transforms/transform_expression.rs
@@ -24,7 +24,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_expression() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     let mut pipeline = Pipeline::create(ctx.clone());
@@ -73,7 +73,7 @@ async fn test_transform_expression() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_expression_error() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     let mut pipeline = Pipeline::create(ctx);
@@ -95,7 +95,7 @@ async fn test_transform_expression_error() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_expression_issue2857() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     let mut pipeline = Pipeline::create(ctx.clone());

--- a/query/tests/it/pipelines/transforms/transform_filter.rs
+++ b/query/tests/it/pipelines/transforms/transform_filter.rs
@@ -24,7 +24,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_filter() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     let mut pipeline = Pipeline::create(ctx.clone());
@@ -64,7 +64,7 @@ async fn test_transform_filter() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_filter_error() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     let mut pipeline = Pipeline::create(ctx);

--- a/query/tests/it/pipelines/transforms/transform_group_by_final.rs
+++ b/query/tests/it/pipelines/transforms/transform_group_by_final.rs
@@ -25,7 +25,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_final_group_by() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     // sum(number), avg(number)

--- a/query/tests/it/pipelines/transforms/transform_group_by_partial.rs
+++ b/query/tests/it/pipelines/transforms/transform_group_by_partial.rs
@@ -25,7 +25,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_partial_group_by() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     // sum(number), avg(number)

--- a/query/tests/it/pipelines/transforms/transform_limit.rs
+++ b/query/tests/it/pipelines/transforms/transform_limit.rs
@@ -54,7 +54,7 @@ async fn test_transform_limit() -> Result<()> {
     ];
 
     for ((limit, offset), expected) in testcases {
-        let ctx = crate::tests::create_query_context()?;
+        let ctx = crate::tests::create_query_context().await?;
         let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
         let mut pipeline = Pipeline::create(ctx.clone());

--- a/query/tests/it/pipelines/transforms/transform_limit_by.rs
+++ b/query/tests/it/pipelines/transforms/transform_limit_by.rs
@@ -25,7 +25,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_limit_by() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     let mut pipeline = Pipeline::create(ctx.clone());

--- a/query/tests/it/pipelines/transforms/transform_projection.rs
+++ b/query/tests/it/pipelines/transforms/transform_projection.rs
@@ -24,7 +24,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_projection() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     let mut pipeline = Pipeline::create(ctx.clone());

--- a/query/tests/it/pipelines/transforms/transform_sort.rs
+++ b/query/tests/it/pipelines/transforms/transform_sort.rs
@@ -25,7 +25,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transform_sort() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     // Pipeline.

--- a/query/tests/it/pipelines/transforms/transform_source.rs
+++ b/query/tests/it/pipelines/transforms/transform_source.rs
@@ -22,7 +22,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn transform_source_test() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
 
     let mut pipeline = Pipeline::create(ctx);

--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -375,6 +375,7 @@ async fn post_json_to_endpoint(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore]
 async fn test_auth_basic() -> Result<()> {
     let user_name = "user1";
     let password = "password";

--- a/query/tests/it/sessions/query_ctx.rs
+++ b/query/tests/it/sessions/query_ctx.rs
@@ -33,7 +33,7 @@ async fn test_get_storage_accessor_s3() -> Result<()> {
         root: "".to_string(),
     };
 
-    let qctx = crate::tests::create_query_context_with_config(conf)?;
+    let qctx = crate::tests::create_query_context_with_config(conf).await?;
 
     let _ = qctx.get_storage_operator().await?;
 
@@ -50,7 +50,7 @@ async fn test_get_storage_accessor_fs() -> Result<()> {
         temp_data_path: "/tmp".to_string(),
     };
 
-    let qctx = crate::tests::create_query_context_with_config(conf)?;
+    let qctx = crate::tests::create_query_context_with_config(conf).await?;
 
     let _ = qctx.get_storage_operator().await?;
 

--- a/query/tests/it/sessions/session.rs
+++ b/query/tests/it/sessions/session.rs
@@ -29,7 +29,8 @@ async fn test_session() -> Result<()> {
         String::from("test-001"),
         String::from("test-type"),
         session_manager,
-    )?;
+    )
+    .await?;
 
     // Tenant.
     {
@@ -73,7 +74,8 @@ async fn test_session_in_management_mode() -> Result<()> {
         String::from("test-001"),
         String::from("test-type"),
         session_manager,
-    )?;
+    )
+    .await?;
 
     // Tenant.
     {

--- a/query/tests/it/sessions/session_context.rs
+++ b/query/tests/it/sessions/session_context.rs
@@ -16,6 +16,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use common_base::tokio;
 use common_exception::Result;
 use common_meta_types::UserInfo;
 use databend_query::clusters::Cluster;
@@ -25,8 +26,8 @@ use databend_query::sessions::SessionContext;
 
 use crate::tests::SessionManagerBuilder;
 
-#[test]
-fn test_session_context() -> Result<()> {
+#[tokio::test]
+async fn test_session_context() -> Result<()> {
     let conf = Config::load_from_args();
     let session_ctx = SessionContext::try_create(conf)?;
 
@@ -78,7 +79,7 @@ fn test_session_context() -> Result<()> {
     // context shared.
     {
         let sessions = SessionManagerBuilder::create().build()?;
-        let dummy_session = sessions.create_session("TestSession")?;
+        let dummy_session = sessions.create_session("TestSession").await?;
         let shared = QueryContextShared::try_create(
             sessions.get_conf().clone(),
             Arc::new(dummy_session.as_ref().clone()),

--- a/query/tests/it/sessions/session_setting.rs
+++ b/query/tests/it/sessions/session_setting.rs
@@ -28,7 +28,8 @@ async fn test_session_setting() -> Result<()> {
         String::from("test-001"),
         String::from("test-type"),
         session_manager,
-    )?;
+    )
+    .await?;
 
     // Settings.
     {

--- a/query/tests/it/sql/plan_parser.rs
+++ b/query/tests/it/sql/plan_parser.rs
@@ -245,7 +245,7 @@ async fn test_plan_parser() -> Result<()> {
         }
     ];
 
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     for t in tests {
         match PlanParser::parse(ctx.clone(), t.sql).await {
             Ok(v) => {

--- a/query/tests/it/sql/statements/query/query_normalizer.rs
+++ b/query/tests/it/sql/statements/query/query_normalizer.rs
@@ -118,7 +118,7 @@ async fn test_query_normalizer() -> Result<()> {
     ];
 
     for test_case in &tests {
-        let ctx = create_query_context()?;
+        let ctx = create_query_context().await?;
         let (mut statements, _) = DfParser::parse_sql(test_case.query)?;
 
         match statements.remove(0) {

--- a/query/tests/it/sql/statements/query/query_qualified_rewriter.rs
+++ b/query/tests/it/sql/statements/query/query_qualified_rewriter.rs
@@ -100,7 +100,7 @@ async fn test_query_qualified_rewriter() -> Result<()> {
     ];
 
     for test_case in &tests {
-        let ctx = create_query_context()?;
+        let ctx = create_query_context().await?;
         let (mut statements, _) = DfParser::parse_sql(test_case.query)?;
 
         match statements.remove(0) {

--- a/query/tests/it/sql/statements/query/query_schema_joined_analyzer.rs
+++ b/query/tests/it/sql/statements/query/query_schema_joined_analyzer.rs
@@ -52,7 +52,7 @@ async fn test_joined_schema_analyzer() -> Result<()> {
     ];
 
     for test_case in &tests {
-        let ctx = create_query_context()?;
+        let ctx = create_query_context().await?;
         let (mut statements, _) = DfParser::parse_sql(test_case.query)?;
 
         match statements.remove(0) {

--- a/query/tests/it/sql/statements/statement_copy.rs
+++ b/query/tests/it/sql/statements/statement_copy.rs
@@ -155,7 +155,7 @@ async fn test_statement_copy() -> Result<()> {
     ];
 
     for test in &tests {
-        let ctx = create_query_context()?;
+        let ctx = create_query_context().await?;
         let (mut statements, _) = DfParser::parse_sql(test.query)?;
         let statement = statements.remove(0);
         if test.err.is_empty() {

--- a/query/tests/it/sql/statements/statement_select.rs
+++ b/query/tests/it/sql/statements/statement_select.rs
@@ -124,7 +124,7 @@ async fn test_statement_select_analyze() -> Result<()> {
     ];
 
     for test_case in &tests {
-        let ctx = create_query_context()?;
+        let ctx = create_query_context().await?;
         let (mut statements, _) = DfParser::parse_sql(test_case.query)?;
 
         match statements.remove(0) {

--- a/query/tests/it/storages/fuse/table_test_fixture.rs
+++ b/query/tests/it/storages/fuse/table_test_fixture.rs
@@ -61,7 +61,9 @@ impl TestFixture {
         // use `TempDir` as root path (auto clean)
         conf.storage.disk.data_path = tmp_dir.path().to_str().unwrap().to_string();
         conf.storage.disk.temp_data_path = tmp_dir.path().to_str().unwrap().to_string();
-        let ctx = crate::tests::create_query_context_with_config(conf).unwrap();
+        let ctx = crate::tests::create_query_context_with_config(conf)
+            .await
+            .unwrap();
 
         let tenant = ctx.get_tenant();
         let random_prefix: String = Uuid::new_v4().to_simple().to_string();
@@ -212,7 +214,7 @@ pub async fn test_drive(
 }
 
 pub async fn test_drive_with_args(tbl_args: TableArgs) -> Result<SendableDataBlockStream> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     test_drive_with_args_and_ctx(tbl_args, ctx).await
 }
 

--- a/query/tests/it/storages/memory.rs
+++ b/query/tests/it/storages/memory.rs
@@ -27,7 +27,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_memorytable() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let schema = DataSchemaRefExt::create(vec![
         DataField::new("a", u32::to_data_type()),
         DataField::new("b", u64::to_data_type()),

--- a/query/tests/it/storages/null.rs
+++ b/query/tests/it/storages/null.rs
@@ -26,7 +26,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_null_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let schema = DataSchemaRefExt::create(vec![
         DataField::new("a", u64::to_data_type()),
         DataField::new("b", u64::to_data_type()),

--- a/query/tests/it/storages/system/clusters_table.rs
+++ b/query/tests/it/storages/system/clusters_table.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_clusters_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let table = ClustersTable::create(1);
 
     let source_plan = table.read_plan(ctx.clone(), None).await?;

--- a/query/tests/it/storages/system/columns_table.rs
+++ b/query/tests/it/storages/system/columns_table.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_columns_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let table = ColumnsTable::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;

--- a/query/tests/it/storages/system/configs_table.rs
+++ b/query/tests/it/storages/system/configs_table.rs
@@ -22,7 +22,7 @@ use pretty_assertions::assert_eq;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_configs_table() -> Result<()> {
     let conf = crate::tests::ConfigBuilder::create().config();
-    let ctx = crate::tests::create_query_context_with_config(conf)?;
+    let ctx = crate::tests::create_query_context_with_config(conf).await?;
     ctx.get_settings().set_max_threads(8)?;
 
     let table = ConfigsTable::create(1);

--- a/query/tests/it/storages/system/contributors_table.rs
+++ b/query/tests/it/storages/system/contributors_table.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_contributors_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let table = ContributorsTable::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 

--- a/query/tests/it/storages/system/credits_table.rs
+++ b/query/tests/it/storages/system/credits_table.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_credits_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let table = CreditsTable::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;

--- a/query/tests/it/storages/system/databases_table.rs
+++ b/query/tests/it/storages/system/databases_table.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_tables_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let table = DatabasesTable::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 

--- a/query/tests/it/storages/system/engines_table.rs
+++ b/query/tests/it/storages/system/engines_table.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_engines_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
 
     let table = EnginesTable::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;

--- a/query/tests/it/storages/system/functions_table.rs
+++ b/query/tests/it/storages/system/functions_table.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_functions_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let table = FunctionsTable::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 

--- a/query/tests/it/storages/system/metrics_table.rs
+++ b/query/tests/it/storages/system/metrics_table.rs
@@ -23,7 +23,7 @@ use futures::TryStreamExt;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_metrics_table() -> Result<()> {
     init_default_metrics_recorder();
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let table = MetricsTable::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 

--- a/query/tests/it/storages/system/query_log_table.rs
+++ b/query/tests/it/storages/system/query_log_table.rs
@@ -27,7 +27,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_query_log_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     ctx.get_settings().set_max_threads(2)?;
 
     let mut query_log = QueryLogTable::create(0);

--- a/query/tests/it/storages/system/settings_table.rs
+++ b/query/tests/it/storages/system/settings_table.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_settings_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     ctx.get_settings().set_max_threads(2)?;
 
     let table = SettingsTable::create(1);

--- a/query/tests/it/storages/system/tables_table.rs
+++ b/query/tests/it/storages/system/tables_table.rs
@@ -20,7 +20,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_tables_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let table = TablesTable::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 

--- a/query/tests/it/storages/system/tracing_table.rs
+++ b/query/tests/it/storages/system/tracing_table.rs
@@ -23,7 +23,7 @@ use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_tracing_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let table: Arc<dyn Table> = Arc::new(TracingTable::create(1));
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 

--- a/query/tests/it/storages/system/users_table.rs
+++ b/query/tests/it/storages/system/users_table.rs
@@ -27,7 +27,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_users_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let tenant = ctx.get_tenant();
     ctx.get_settings().set_max_threads(2)?;
     let auth_data = AuthInfo::None;

--- a/query/tests/it/storages/system/warehouses_table.rs
+++ b/query/tests/it/storages/system/warehouses_table.rs
@@ -26,7 +26,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_warehouses_table() -> Result<()> {
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let tenant = ctx.get_tenant();
     ctx.get_settings().set_max_threads(2)?;
     let test_id = "testsasa121id-1888-12-12-11-21-897991";

--- a/query/tests/it/table_functions/numbers_table.rs
+++ b/query/tests/it/table_functions/numbers_table.rs
@@ -26,7 +26,7 @@ use futures::TryStreamExt;
 #[tokio::test]
 async fn test_number_table() -> Result<()> {
     let tbl_args = Some(vec![Expression::create_literal(DataValue::UInt64(8))]);
-    let ctx = crate::tests::create_query_context()?;
+    let ctx = crate::tests::create_query_context().await?;
     let table = NumbersTable::create("system", "numbers_mt", 1, tbl_args)?;
 
     let source_plan = table
@@ -107,7 +107,7 @@ async fn test_limit_push_down() -> Result<()> {
     ];
 
     for test in tests {
-        let ctx = crate::tests::create_query_context()?;
+        let ctx = crate::tests::create_query_context().await?;
         let plan = PlanParser::parse(ctx.clone(), test.query).await?;
         let actual = format!("{:?}", plan);
         assert_eq!(test.expect, actual, "{:#?}", test.name);

--- a/query/tests/it/tests/context.rs
+++ b/query/tests/it/tests/context.rs
@@ -33,9 +33,9 @@ use databend_query::storages::StorageFactory;
 
 use crate::tests::SessionManagerBuilder;
 
-pub fn create_query_context() -> Result<Arc<QueryContext>> {
+pub async fn create_query_context() -> Result<Arc<QueryContext>> {
     let sessions = SessionManagerBuilder::create().build()?;
-    let dummy_session = sessions.create_session("TestSession")?;
+    let dummy_session = sessions.create_session("TestSession").await?;
 
     // Set user with all privileges
     let mut user_info = UserInfo::new(
@@ -65,9 +65,9 @@ pub fn create_query_context() -> Result<Arc<QueryContext>> {
     Ok(context)
 }
 
-pub fn create_query_context_with_config(config: Config) -> Result<Arc<QueryContext>> {
+pub async fn create_query_context_with_config(config: Config) -> Result<Arc<QueryContext>> {
     let sessions = SessionManagerBuilder::create_with_conf(config.clone()).build()?;
-    let dummy_session = sessions.create_session("TestSession")?;
+    let dummy_session = sessions.create_session("TestSession").await?;
 
     let mut user_info = UserInfo::new(
         "root".to_string(),
@@ -155,9 +155,11 @@ impl Default for ClusterDescriptor {
     }
 }
 
-pub fn create_query_context_with_cluster(desc: ClusterDescriptor) -> Result<Arc<QueryContext>> {
+pub async fn create_query_context_with_cluster(
+    desc: ClusterDescriptor,
+) -> Result<Arc<QueryContext>> {
     let sessions = SessionManagerBuilder::create().build()?;
-    let dummy_session = sessions.create_session("TestSession")?;
+    let dummy_session = sessions.create_session("TestSession").await?;
 
     let local_id = desc.local_node_id;
     let nodes = desc.cluster_nodes_list;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Bugfix: Global MetaGrpcClient cause dispatch drop error.

- move `MetaGrpcClient` from `SessionManager` to `Session` to avoid cross-runtime client clone.

**NOTE**
The current implementation leaves two issues
1. the `Drop` trait that impl by SessionRef using `block_on` to call async fn.
2. As of current existing query processing logic of HTTP handler is different from others(MySQL, ClickHouse), so the SessionManager still has a Client that provides HTTP handler to use.

## Changelog

- Bug Fix

## Related Issues

Fixes #4347 

## Test Plan

Unit Tests

Stateless Tests

