### PR TITLE
ISSUE-4341: Fix show init default recorder error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,16 +3958,12 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2da0a53ecf563b398350e3c1834ad27dd050eb47977472f2e654ccb39ff75f"
 dependencies = [
- "hyper",
  "indexmap",
- "ipnet",
  "metrics",
  "metrics-util",
  "parking_lot 0.11.2",
  "quanta",
  "thiserror",
- "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -18,7 +18,7 @@ common-tracing = { path = "../tracing" }
 
 # Crates.io dependencies
 metrics = "0.18.0"
-metrics-exporter-prometheus = "0.8.0"
+metrics-exporter-prometheus = { version = "0.8.0", default-features = false }
 once_cell = "1.9.0"
 prometheus-parse = "0.2.2"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/common/metrics/src/recorder.rs
+++ b/common/metrics/src/recorder.rs
@@ -49,13 +49,11 @@ pub fn init_default_metrics_recorder() {
 
 /// Init prometheus recorder.
 fn init_prometheus_recorder() {
-    let recorder = PrometheusBuilder::new()
-        .build()
-        .expect("failed to build Prometheus recorder");
+    let recorder = PrometheusBuilder::new().build_recorder();
     let mut h = PROMETHEUS_HANDLE.as_ref().write();
-    *h = Some(recorder.0.handle());
+    *h = Some(recorder.handle());
     metrics::clear_recorder();
-    match metrics::set_boxed_recorder(Box::new(recorder.0)) {
+    match metrics::set_boxed_recorder(Box::new(recorder)) {
         Ok(_) => (),
         Err(err) => tracing::warn!("Install prometheus recorder failed, cause: {}", err),
     };

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -52,7 +52,7 @@ clap = { version = "3.1.3", features = ["derive", "env"] }
 derive_more = "0.99.17"
 futures = "0.3.21"
 metrics = "0.18.0"
-metrics-exporter-prometheus = "0.8.0"
+metrics-exporter-prometheus = { version = "0.8.0", default-features = false }
 num = "0.4.0"
 num_cpus = "1.13.1"
 poem = { version = "1.3.6", features = ["rustls"] }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR
- show default metrics recorder bind addr
- call `init_default_metrics_recorder` after set_panic_hook

## Changelog

- Improvement
- Other 
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #4341 

## Test Plan

Unit Tests

Stateless Tests

Some thoughts:
- Should we change `init_default_metrics_recorder` to return an error?
- Make `PrometheusBuilder` use listen addr from config?