### PR TITLE
[http handler] rename response fields and return elapsed time when running.

### DIFF
--- a/cli/src/cmds/queries/query.rs
+++ b/cli/src/cmds/queries/query.rs
@@ -300,12 +300,12 @@ async fn execute_query(
         );
     }
     if data.is_empty() {
-        Ok(("".to_string(), stats.progress))
+        Ok(("".to_string(), stats.scan_progress))
     } else {
         for row in data.as_ref() {
             table.add_row(row.iter().map(|elem| Cell::new(elem.to_string())));
         }
-        Ok((table.trim_fmt(), stats.progress))
+        Ok((table.trim_fmt(), stats.scan_progress))
     }
 }
 

--- a/docs/user/03-api/http-handler.md
+++ b/docs/user/03-api/http-handler.md
@@ -23,7 +23,7 @@ example:
 
 ```
 {
-   "sql": "select * from numbers(10)"
+   "sql": "select * from numbers(10)"[
 }
 ```
 
@@ -52,7 +52,7 @@ example:
             "read_bytes":80,
             "total_rows_to_read":0
             },
-        "wall_time_ms": 10
+        "running_time_ms": 10.1
     },
     error: nil
 }
@@ -85,10 +85,10 @@ Field
 
 QueryStats
 
-| field        | type          | description          |
-|--------------|---------------|----------------------|
-| wall_time_ms | int           | query execution time |
-| progress     | QueryProgress | query progress       |
+| field           | type          | description                                                                                                      |
+|-----------------|---------------|------------------------------------------------------------------------------------------------------------------|
+| running_time_ms | float         | million secs elapsed since query begin to execute internally, stop timing when query Finished (state != Running) |
+| scan_progress   | QueryProgress | query scan progress                                                                                              |
 
 QueryProgress
 
@@ -96,7 +96,7 @@ QueryProgress
 |--------------------|------|
 | read_rows          | int  |
 | read_bytes         | int  |
-| total_rows_to_read | int  |
+
 
 QueryError
 

--- a/docs/user/03-api/http-handler.md
+++ b/docs/user/03-api/http-handler.md
@@ -23,7 +23,7 @@ example:
 
 ```
 {
-   "sql": "select * from numbers(10)"[
+   "sql": "select * from numbers(10)"
 }
 ```
 

--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -72,7 +72,7 @@ impl QueryError {
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct QueryStats {
     pub scan_progress: Option<ProgressValues>,
-    pub wall_time_ms: Option<f64>,
+    pub wall_time_ms: f64,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -72,7 +72,7 @@ impl QueryError {
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct QueryStats {
     pub scan_progress: Option<ProgressValues>,
-    pub wall_time_ms: f64,
+    pub running_time_ms: f64,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -102,7 +102,7 @@ impl QueryResponse {
         let columns = r.initial_state.as_ref().and_then(|v| v.schema.clone());
         let stats = QueryStats {
             scan_progress: r.state.scan_progress.clone(),
-            wall_time_ms: r.state.wall_time_ms,
+            running_time_ms: r.state.running_time_ms,
         };
         QueryResponse {
             data,

--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -71,7 +71,7 @@ impl QueryError {
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct QueryStats {
-    pub progress: Option<ProgressValues>,
+    pub scan_progress: Option<ProgressValues>,
     pub wall_time_ms: Option<f64>,
 }
 
@@ -101,7 +101,7 @@ impl QueryResponse {
         };
         let columns = r.initial_state.as_ref().and_then(|v| v.schema.clone());
         let stats = QueryStats {
-            progress: r.state.progress.clone(),
+            scan_progress: r.state.scan_progress.clone(),
             wall_time_ms: r.state.wall_time_ms,
         };
         QueryResponse {

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -82,12 +82,13 @@ impl Executor {
             Stopped(f) => f.progress.clone(),
         }
     }
-    pub(crate) fn elapsed(&self) -> Option<Duration> {
+    pub(crate) fn elapsed(&self) -> Duration {
         match &self.state {
-            Running(_) => None,
-            Stopped(f) => Some(f.stop_time - self.start_time),
+            Running(_) => Instant::now() - self.start_time,
+            Stopped(f) => f.stop_time - self.start_time,
         }
     }
+
     pub(crate) async fn stop(this: &Arc<RwLock<Executor>>, reason: Result<()>, kill: bool) {
         let mut guard = this.write().await;
         if let Running(r) = &guard.state {

--- a/query/src/servers/http/v1/query/http_query.rs
+++ b/query/src/servers/http/v1/query/http_query.rs
@@ -79,7 +79,7 @@ pub struct ResponseInitialState {
 
 pub struct ResponseState {
     pub wall_time_ms: Option<f64>,
-    pub progress: Option<ProgressValues>,
+    pub scan_progress: Option<ProgressValues>,
     pub state: ExecuteStateName,
     pub error: Option<ErrorCode>,
 }
@@ -167,7 +167,7 @@ impl HttpQuery {
         let wall_time_ms = state.elapsed().map(|d| d.as_secs_f64() * 1000.0);
         ResponseState {
             wall_time_ms,
-            progress: state.get_progress(),
+            scan_progress: state.get_progress(),
             state: exe_state,
             error: err,
         }

--- a/query/src/servers/http/v1/query/http_query.rs
+++ b/query/src/servers/http/v1/query/http_query.rs
@@ -78,7 +78,7 @@ pub struct ResponseInitialState {
 }
 
 pub struct ResponseState {
-    pub wall_time_ms: f64,
+    pub running_time_ms: f64,
     pub scan_progress: Option<ProgressValues>,
     pub state: ExecuteStateName,
     pub error: Option<ErrorCode>,
@@ -164,9 +164,8 @@ impl HttpQuery {
     async fn get_state(&self) -> ResponseState {
         let state = self.state.read().await;
         let (exe_state, err) = state.state.extract();
-        let wall_time_ms = state.elapsed().as_secs_f64() * 1000.0;
         ResponseState {
-            wall_time_ms,
+            running_time_ms: state.elapsed().as_secs_f64() * 1000.0,
             scan_progress: state.get_progress(),
             state: exe_state,
             error: err,

--- a/query/src/servers/http/v1/query/http_query.rs
+++ b/query/src/servers/http/v1/query/http_query.rs
@@ -78,7 +78,7 @@ pub struct ResponseInitialState {
 }
 
 pub struct ResponseState {
-    pub wall_time_ms: Option<f64>,
+    pub wall_time_ms: f64,
     pub scan_progress: Option<ProgressValues>,
     pub state: ExecuteStateName,
     pub error: Option<ErrorCode>,
@@ -164,7 +164,7 @@ impl HttpQuery {
     async fn get_state(&self) -> ResponseState {
         let state = self.state.read().await;
         let (exe_state, err) = state.state.extract();
-        let wall_time_ms = state.elapsed().map(|d| d.as_secs_f64() * 1000.0);
+        let wall_time_ms = state.elapsed().as_secs_f64() * 1000.0;
         ResponseState {
             wall_time_ms,
             scan_progress: state.get_progress(),

--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -80,7 +80,7 @@ async fn test_simple_sql() -> Result<()> {
     assert_eq!(result.data.len(), 10);
     assert_eq!(result.state, ExecuteStateName::Succeeded, "{:?}", result);
     assert!(result.next_uri.is_none(), "{:?}", result);
-    assert!(result.stats.progress.is_some());
+    assert!(result.stats.scan_progress.is_some());
     assert!(result.schema.is_some());
     Ok(())
 }
@@ -93,7 +93,7 @@ async fn test_bad_sql() -> Result<()> {
     assert_eq!(result.data.len(), 0);
     assert!(result.next_uri.is_none());
     assert_eq!(result.state, ExecuteStateName::Failed);
-    assert!(result.stats.progress.is_none());
+    assert!(result.stats.scan_progress.is_none());
     assert!(result.schema.is_none());
     Ok(())
 }
@@ -111,7 +111,7 @@ async fn test_async() -> Result<()> {
     assert!(result.error.is_none(), "{:?}", result);
     assert_eq!(result.data.len(), 0);
     assert_eq!(result.next_uri, Some(next_uri));
-    assert!(result.stats.progress.is_some());
+    assert!(result.stats.scan_progress.is_some());
     assert!(result.schema.is_some());
     assert_eq!(result.state, ExecuteStateName::Running,);
     sleep(Duration::from_millis(100)).await;
@@ -126,7 +126,7 @@ async fn test_async() -> Result<()> {
         assert_eq!(result.data.len(), 1, "{:?}", result);
         assert!(result.next_uri.is_none());
         assert!(result.schema.is_none());
-        assert!(result.stats.progress.is_some());
+        assert!(result.stats.scan_progress.is_some());
         assert_eq!(result.state, ExecuteStateName::Succeeded);
     }
 
@@ -138,7 +138,7 @@ async fn test_async() -> Result<()> {
     assert_eq!(result.data.len(), 0);
     assert!(result.next_uri.is_none());
     assert!(result.schema.is_none());
-    assert!(result.stats.progress.is_some());
+    assert!(result.stats.scan_progress.is_some());
     assert_eq!(result.state, ExecuteStateName::Succeeded);
 
     // get page not expected
@@ -227,7 +227,7 @@ async fn test_system_tables() -> Result<()> {
             "{}",
             error_message
         );
-        assert!(result.stats.progress.is_some());
+        assert!(result.stats.scan_progress.is_some());
         assert!(result.next_uri.is_none(), "{:?}", result);
         assert!(result.schema.is_some());
     }
@@ -256,7 +256,7 @@ async fn test_multi_page() -> Result<()> {
         let (status, result) = get_uri_checked(&ep, &next_uri).await?;
         assert_eq!(status, StatusCode::OK);
         assert!(result.error.is_none(), "{:?}", result.error);
-        assert!(result.stats.progress.is_some());
+        assert!(result.stats.scan_progress.is_some());
         if p == num_parts {
             assert_eq!(result.data.len(), 0);
             assert_eq!(result.next_uri, None);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1.  rename progress to scan_progress.  context also provide result_progress, but I guess client does not need it now.
3.  return elapsed time when running,  useful for client to calculate speed from progress
4.  rename wall_time_ms to running_time_ms. 
5.  polish description about running_time_ms in doc

@Chasen-Zhang @flaneur2020 


## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

no issue

## Test Plan

Unit Tests

Stateless Tests

