### PR TITLE
bump regex to 1.5.5.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5530,9 +5530,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/common/datablocks/Cargo.toml
+++ b/common/datablocks/Cargo.toml
@@ -23,7 +23,7 @@ common-io = { path = "../io" }
 # Crates.io dependencies
 ahash = "0.7.6"
 comfy-table = "5.0.1"
-regex = "1.5.4"
+regex = "1.5.5"
 smallvec = "1.8.0"
 
 [dev-dependencies]

--- a/common/functions/Cargo.toml
+++ b/common/functions/Cargo.toml
@@ -40,7 +40,7 @@ once_cell = "1.9.0"
 ordered-float = "2.10.0"
 paste = "1.0.6"
 rand = { version = "0.8.5", features = ["small_rng"] }
-regex = "1.5.4"
+regex = "1.5.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 sha1 = "0.10.1"

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -77,6 +77,6 @@ tonic-build = "0.6.2"
 [dev-dependencies]
 common-meta-api = { path = "../common/meta/api" }
 maplit = "1.0.2"
-regex = "1.5.4"
+regex = "1.5.5"
 pretty_assertions = "1.1.0"
 reqwest = { version = "0.11.9", features = ["json"] }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -91,7 +91,7 @@ petgraph = "0.6.0"
 poem = { version = "1.3.6", features = ["rustls", "multipart"] }
 prost = "0.9.0"
 rand = "0.8.5"
-regex = "1.5.4"
+regex = "1.5.5"
 reqwest = "0.11.9"
 rsa = "0.5.0"
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

bump regex to 1.5.5.

see https://github.com/datafuselabs/databend/issues/4368

## Changelog


- Not for changelog (changelog entry is not required)

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/4368

## Test Plan

Unit Tests

Stateless Tests

