### PR TITLE
Refactor ScalarExpression and add simd operator

### DIFF
--- a/common/functions/src/lib.rs
+++ b/common/functions/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![feature(core_intrinsics)]
 #![feature(duration_checked_float)]
+#![feature(portable_simd)]
 
 pub mod aggregates;
 pub mod scalars;

--- a/common/functions/src/scalars/arithmetics/arithmetic_div.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_div.rs
@@ -27,12 +27,8 @@ use crate::scalars::Function;
 use crate::scalars::Monotonicity;
 
 #[inline]
-fn div_scalar<L, R>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> f64
-where
-    L: PrimitiveType + AsPrimitive<f64>,
-    R: PrimitiveType + AsPrimitive<f64>,
-{
-    l.to_owned_scalar().as_() / r.to_owned_scalar().as_()
+fn div_scalar(l: impl AsPrimitive<f64>, r: impl AsPrimitive<f64>, _ctx: &mut EvalContext) -> f64 {
+    l.as_() / r.as_()
 }
 
 pub struct ArithmeticDivFunction;
@@ -47,7 +43,7 @@ impl ArithmeticDivFunction {
                 BinaryArithmeticFunction::<$T, $D, f64, _>::try_create_func(
                     DataValueBinaryOperator::Div,
                     Float64Type::arc(),
-                    div_scalar::<$T, $D>
+                    div_scalar
                 )
             })
         })

--- a/common/functions/src/scalars/arithmetics/arithmetic_div.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_div.rs
@@ -26,6 +26,7 @@ use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
 
+#[inline]
 fn div_scalar<L, R>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> f64
 where
     L: PrimitiveType + AsPrimitive<f64>,

--- a/common/functions/src/scalars/arithmetics/arithmetic_intdiv.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_intdiv.rs
@@ -25,6 +25,7 @@ use crate::scalars::BinaryArithmeticFunction;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 
+#[inline]
 fn intdiv_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, ctx: &mut EvalContext) -> O
 where
     f64: AsPrimitive<O>,

--- a/common/functions/src/scalars/arithmetics/arithmetic_intdiv.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_intdiv.rs
@@ -26,15 +26,13 @@ use crate::scalars::EvalContext;
 use crate::scalars::Function;
 
 #[inline]
-fn intdiv_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, ctx: &mut EvalContext) -> O
+fn intdiv_scalar<O>(l: impl AsPrimitive<f64>, r: impl AsPrimitive<f64>, ctx: &mut EvalContext) -> O
 where
     f64: AsPrimitive<O>,
-    L: PrimitiveType + AsPrimitive<f64>,
-    R: PrimitiveType + AsPrimitive<f64>,
     O: IntegerType + Zero,
 {
-    let l = l.to_owned_scalar().as_();
-    let r = r.to_owned_scalar().as_();
+    let l = l.as_();
+    let r = r.as_();
     if std::intrinsics::unlikely(r == 0.0) {
         ctx.set_error(ErrorCode::BadArguments("Division by zero"));
         return O::zero();
@@ -54,7 +52,7 @@ impl ArithmeticIntDivFunction {
                 BinaryArithmeticFunction::<$T, $D, <($T, $D) as ResultTypeOfBinary>::IntDiv, _>::try_create_func(
                     DataValueBinaryOperator::IntDiv,
                     <($T, $D) as ResultTypeOfBinary>::IntDiv::to_data_type(),
-                    intdiv_scalar::<$T, $D, _>
+                    intdiv_scalar
                 )
             })
         })

--- a/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
@@ -31,6 +31,7 @@ use crate::scalars::Function;
 use crate::scalars::FunctionFactory;
 use crate::scalars::Monotonicity;
 
+#[inline]
 fn sub_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
 where
     L: PrimitiveType + AsPrimitive<O>,
@@ -40,6 +41,7 @@ where
     l.to_owned_scalar().as_() - r.to_owned_scalar().as_()
 }
 
+#[inline]
 fn wrapping_sub_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
 where
     L: PrimitiveType + AsPrimitive<O>,

--- a/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_minus.rs
@@ -32,25 +32,21 @@ use crate::scalars::FunctionFactory;
 use crate::scalars::Monotonicity;
 
 #[inline]
-fn sub_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
-where
-    L: PrimitiveType + AsPrimitive<O>,
-    R: PrimitiveType + AsPrimitive<O>,
-    O: PrimitiveType + Sub<Output = O>,
-{
-    l.to_owned_scalar().as_() - r.to_owned_scalar().as_()
+fn sub_scalar<O>(l: impl AsPrimitive<O>, r: impl AsPrimitive<O>, _ctx: &mut EvalContext) -> O
+where O: PrimitiveType + Sub<Output = O> {
+    l.as_() - r.as_()
 }
 
 #[inline]
-fn wrapping_sub_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
+fn wrapping_sub_scalar<O>(
+    l: impl AsPrimitive<O>,
+    r: impl AsPrimitive<O>,
+    _ctx: &mut EvalContext,
+) -> O
 where
-    L: PrimitiveType + AsPrimitive<O>,
-    R: PrimitiveType + AsPrimitive<O>,
     O: IntegerType + WrappingSub<Output = O>,
 {
-    l.to_owned_scalar()
-        .as_()
-        .wrapping_sub(&r.to_owned_scalar().as_())
+    l.as_().wrapping_sub(&r.as_())
 }
 
 pub struct ArithmeticMinusFunction;
@@ -70,7 +66,7 @@ impl ArithmeticMinusFunction {
                     BinaryArithmeticFunction::<$T, $D, $T, _>::try_create_func(
                         op,
                         args[0].clone(),
-                        sub_scalar::<$T,$D, _>
+                        sub_scalar
                     )
                 },{
                     // Argument of type Interval cannot be first.
@@ -84,7 +80,7 @@ impl ArithmeticMinusFunction {
                         BinaryArithmeticFunction::<$T, $D, i32, _>::try_create_func(
                             op,
                             Int32Type::arc(),
-                            sub_scalar::<$T, $D, _>
+                            sub_scalar
                         )
                     })
                 })
@@ -97,7 +93,7 @@ impl ArithmeticMinusFunction {
                     BinaryArithmeticFunction::<$T, $D, $D, _>::try_create_func(
                         op,
                         args[1].clone(),
-                        sub_scalar::<$T, $D, _>
+                        sub_scalar
                     )
                 })
             });
@@ -110,12 +106,12 @@ impl ArithmeticMinusFunction {
                     TypeID::Int64 => BinaryArithmeticFunction::<$T, $D, i64, _>::try_create_func(
                         op,
                         result_type,
-                        wrapping_sub_scalar::<$T, $D, _>
+                        wrapping_sub_scalar
                     ),
                     _ => BinaryArithmeticFunction::<$T, $D, <($T, $D) as ResultTypeOfBinary>::Minus, _>::try_create_func(
                         op,
                         result_type,
-                        sub_scalar::<$T, $D, _>
+                        sub_scalar
                     ),
                 }
             })

--- a/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
@@ -29,25 +29,21 @@ use crate::scalars::Function;
 use crate::scalars::Monotonicity;
 
 #[inline]
-fn mul_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
-where
-    L: PrimitiveType + AsPrimitive<O>,
-    R: PrimitiveType + AsPrimitive<O>,
-    O: PrimitiveType + Mul<Output = O>,
-{
-    l.to_owned_scalar().as_() * r.to_owned_scalar().as_()
+fn mul_scalar<O>(l: impl AsPrimitive<O>, r: impl AsPrimitive<O>, _ctx: &mut EvalContext) -> O
+where O: PrimitiveType + Mul<Output = O> {
+    l.as_() * r.as_()
 }
 
 #[inline]
-fn wrapping_mul_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
+fn wrapping_mul_scalar<O>(
+    l: impl AsPrimitive<O>,
+    r: impl AsPrimitive<O>,
+    _ctx: &mut EvalContext,
+) -> O
 where
-    L: PrimitiveType + AsPrimitive<O>,
-    R: PrimitiveType + AsPrimitive<O>,
     O: IntegerType + WrappingMul<Output = O>,
 {
-    l.to_owned_scalar()
-        .as_()
-        .wrapping_mul(&r.to_owned_scalar().as_())
+    l.as_().wrapping_mul(&r.as_())
 }
 
 pub struct ArithmeticMulFunction;
@@ -66,17 +62,17 @@ impl ArithmeticMulFunction {
                     TypeID::UInt64 => BinaryArithmeticFunction::<$T, $D, u64, _>::try_create_func(
                         op,
                         result_type,
-                        wrapping_mul_scalar::<$T, $D, _>,
+                        wrapping_mul_scalar,
                     ),
                     TypeID::Int64 => BinaryArithmeticFunction::<$T, $D, i64, _>::try_create_func(
                         op,
                         result_type,
-                        wrapping_mul_scalar::<$T, $D, _>,
+                        wrapping_mul_scalar,
                     ),
                     _ => BinaryArithmeticFunction::<$T, $D, <($T, $D) as ResultTypeOfBinary>::AddMul, _>::try_create_func(
                         op,
                         result_type,
-                        mul_scalar::<$T, $D, _>,
+                        mul_scalar,
                     ),
                 }
             })

--- a/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_mul.rs
@@ -28,6 +28,7 @@ use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
 
+#[inline]
 fn mul_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
 where
     L: PrimitiveType + AsPrimitive<O>,
@@ -37,6 +38,7 @@ where
     l.to_owned_scalar().as_() * r.to_owned_scalar().as_()
 }
 
+#[inline]
 fn wrapping_mul_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
 where
     L: PrimitiveType + AsPrimitive<O>,

--- a/common/functions/src/scalars/arithmetics/arithmetic_negate.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_negate.rs
@@ -26,33 +26,16 @@ use crate::scalars::ArithmeticDescription;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
-use crate::scalars::ScalarUnaryFunction;
 use crate::scalars::UnaryArithmeticFunction;
 
-#[derive(Clone, Debug, Default)]
-struct NegFunction {}
-
-impl<L, O> ScalarUnaryFunction<L, O> for NegFunction
-where
-    L: PrimitiveType + AsPrimitive<O>,
-    O: PrimitiveType + Neg<Output = O>,
-{
-    fn eval(&self, l: L::RefType<'_>, _ctx: &mut EvalContext) -> O {
-        -l.to_owned_scalar().as_()
-    }
+fn neg<O>(l: impl AsPrimitive<O>, _ctx: &mut EvalContext) -> O
+where O: PrimitiveType + Neg<Output = O> {
+    -l.as_()
 }
 
-#[derive(Clone, Debug, Default)]
-struct WrappingNegFunction {}
-
-impl<L, O> ScalarUnaryFunction<L, O> for WrappingNegFunction
-where
-    L: PrimitiveType + AsPrimitive<O>,
-    O: IntegerType + WrappingNeg,
-{
-    fn eval(&self, l: L::RefType<'_>, _ctx: &mut EvalContext) -> O {
-        l.to_owned_scalar().as_().wrapping_neg()
-    }
+fn wrapping_neg<O>(l: impl AsPrimitive<O>, _ctx: &mut EvalContext) -> O
+where O: IntegerType + WrappingNeg {
+    l.as_().wrapping_neg()
 }
 
 pub struct ArithmeticNegateFunction;
@@ -70,27 +53,27 @@ impl ArithmeticNegateFunction {
                 TypeID::Int64 => UnaryArithmeticFunction::<$T, i64, _>::try_create_func(
                     op,
                     result_type,
-                    WrappingNegFunction::default(),
+                    wrapping_neg,
                 ),
                 TypeID::Int32 => UnaryArithmeticFunction::<$T, i32, _>::try_create_func(
                     op,
                     result_type,
-                    WrappingNegFunction::default(),
+                    wrapping_neg,
                 ),
                 TypeID::Int16 => UnaryArithmeticFunction::<$T, i16, _>::try_create_func(
                     op,
                     result_type,
-                    WrappingNegFunction::default(),
+                    wrapping_neg,
                 ),
                 TypeID::Int8 => UnaryArithmeticFunction::<$T, i8, _>::try_create_func(
                     op,
                     result_type,
-                    WrappingNegFunction::default(),
+                    wrapping_neg,
                 ),
                 _ => UnaryArithmeticFunction::<$T, <$T as ResultTypeOfUnary>::Negate, _>::try_create_func(
                     op,
                     result_type,
-                    NegFunction::default(),
+                    neg,
                 ),
             }
         })

--- a/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
@@ -31,6 +31,7 @@ use crate::scalars::Function;
 use crate::scalars::FunctionFactory;
 use crate::scalars::Monotonicity;
 
+#[inline]
 fn add_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
 where
     L: PrimitiveType + AsPrimitive<O>,
@@ -40,6 +41,7 @@ where
     l.to_owned_scalar().as_() + r.to_owned_scalar().as_()
 }
 
+#[inline]
 fn wrapping_add_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
 where
     L: PrimitiveType + AsPrimitive<O>,

--- a/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic_plus.rs
@@ -32,25 +32,21 @@ use crate::scalars::FunctionFactory;
 use crate::scalars::Monotonicity;
 
 #[inline]
-fn add_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
-where
-    L: PrimitiveType + AsPrimitive<O>,
-    R: PrimitiveType + AsPrimitive<O>,
-    O: PrimitiveType + Add<Output = O>,
-{
-    l.to_owned_scalar().as_() + r.to_owned_scalar().as_()
+fn add_scalar<O>(l: impl AsPrimitive<O>, r: impl AsPrimitive<O>, _ctx: &mut EvalContext) -> O
+where O: PrimitiveType + Add<Output = O> {
+    l.as_() + r.as_()
 }
 
 #[inline]
-fn wrapping_add_scalar<L, R, O>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> O
+fn wrapping_add_scalar<O>(
+    l: impl AsPrimitive<O>,
+    r: impl AsPrimitive<O>,
+    _ctx: &mut EvalContext,
+) -> O
 where
-    L: PrimitiveType + AsPrimitive<O>,
-    R: PrimitiveType + AsPrimitive<O>,
     O: IntegerType + WrappingAdd<Output = O>,
 {
-    l.to_owned_scalar()
-        .as_()
-        .wrapping_add(&r.to_owned_scalar().as_())
+    l.as_().wrapping_add(&r.as_())
 }
 
 pub struct ArithmeticPlusFunction;
@@ -78,7 +74,7 @@ impl ArithmeticPlusFunction {
                     BinaryArithmeticFunction::<$T, $D, $T, _>::try_create_func(
                         op,
                         args[0].clone(),
-                        add_scalar::<$T, $D, _>,
+                        add_scalar,
                     )
                 },{
                     if right_type.is_interval() {
@@ -99,7 +95,7 @@ impl ArithmeticPlusFunction {
                     BinaryArithmeticFunction::<$T, $D, $D, _>::try_create_func(
                         op,
                         args[1].clone(),
-                        add_scalar::<$T, $D, _>,
+                        add_scalar,
                     )
                 })
             });
@@ -112,17 +108,17 @@ impl ArithmeticPlusFunction {
                     TypeID::UInt64 => BinaryArithmeticFunction::<$T, $D, u64, _>::try_create_func(
                         op,
                         result_type,
-                        wrapping_add_scalar::<$T, $D, _>,
+                        wrapping_add_scalar,
                     ),
                     TypeID::Int64 => BinaryArithmeticFunction::<$T, $D, i64, _>::try_create_func(
                         op,
                         result_type,
-                        wrapping_add_scalar::<$T, $D, _>,
+                        wrapping_add_scalar,
                     ),
                     _ => BinaryArithmeticFunction::<$T, $D, <($T, $D) as ResultTypeOfBinary>::AddMul, _>::try_create_func(
                         op,
                         result_type,
-                        add_scalar::<$T, $D, _>,
+                        add_scalar,
                     ),
                 }
             })

--- a/common/functions/src/scalars/arithmetics/binary_arithmetic.rs
+++ b/common/functions/src/scalars/arithmetics/binary_arithmetic.rs
@@ -75,7 +75,7 @@ where
     }
 
     fn eval(&self, columns: &ColumnsWithField, _input_rows: usize) -> Result<ColumnRef> {
-        let col = scalar_binary_op::<L, R, O, F>(
+        let col = scalar_binary_op(
             columns[0].column(),
             columns[1].column(),
             self.func.clone(),

--- a/common/functions/src/scalars/arithmetics/binary_arithmetic.rs
+++ b/common/functions/src/scalars/arithmetics/binary_arithmetic.rs
@@ -28,7 +28,6 @@ use crate::scalars::ArithmeticPlusFunction;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
-use crate::scalars::ScalarBinaryFunction;
 
 #[derive(Clone)]
 pub struct BinaryArithmeticFunction<L: Scalar, R: Scalar, O: Scalar, F> {
@@ -43,7 +42,7 @@ where
     L: Scalar + Send + Sync + Clone,
     R: Scalar + Send + Sync + Clone,
     O: Scalar + Send + Sync + Clone,
-    F: ScalarBinaryFunction<L, R, O> + Send + Sync + Clone + 'static,
+    F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> O + Send + Sync + Clone + 'static,
 {
     pub fn try_create_func(
         op: DataValueBinaryOperator,
@@ -64,7 +63,7 @@ where
     L: Scalar + Send + Sync + Clone,
     R: Scalar + Send + Sync + Clone,
     O: Scalar + Send + Sync + Clone,
-    F: ScalarBinaryFunction<L, R, O> + Send + Sync + Clone,
+    F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> O + Send + Sync + Clone,
 {
     fn name(&self) -> &str {
         "BinaryArithmeticFunction"
@@ -107,7 +106,7 @@ where
     L: Scalar + Send + Sync + Clone,
     R: Scalar + Send + Sync + Clone,
     O: Scalar + Send + Sync + Clone,
-    F: ScalarBinaryFunction<L, R, O> + Send + Sync + Clone,
+    F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> O + Send + Sync + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.op)

--- a/common/functions/src/scalars/arithmetics/unary_arithmetic.rs
+++ b/common/functions/src/scalars/arithmetics/unary_arithmetic.rs
@@ -25,7 +25,6 @@ use crate::scalars::ArithmeticNegateFunction;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
-use crate::scalars::ScalarUnaryFunction;
 
 #[derive(Clone)]
 pub struct UnaryArithmeticFunction<L: Scalar, O: Scalar, F> {
@@ -39,7 +38,7 @@ impl<L, O, F> UnaryArithmeticFunction<L, O, F>
 where
     L: Scalar + Send + Sync + Clone,
     O: Scalar + Send + Sync + Clone,
-    F: ScalarUnaryFunction<L, O> + Send + Sync + Clone + 'static,
+    F: Fn(L::RefType<'_>, &mut EvalContext) -> O + Send + Sync + Clone + 'static,
 {
     pub fn try_create_func(
         op: DataValueUnaryOperator,
@@ -59,7 +58,7 @@ impl<L, O, F> Function for UnaryArithmeticFunction<L, O, F>
 where
     L: Scalar + Send + Sync + Clone,
     O: Scalar + Send + Sync + Clone,
-    F: ScalarUnaryFunction<L, O> + Send + Sync + Clone,
+    F: Fn(L::RefType<'_>, &mut EvalContext) -> O + Send + Sync + Clone,
 {
     fn name(&self) -> &str {
         "UnaryArithmeticFunction"
@@ -96,7 +95,7 @@ impl<L, O, F> fmt::Display for UnaryArithmeticFunction<L, O, F>
 where
     L: Scalar + Send + Sync + Clone,
     O: Scalar + Send + Sync + Clone,
-    F: ScalarUnaryFunction<L, O> + Send + Sync + Clone,
+    F: Fn(L::RefType<'_>, &mut EvalContext) -> O + Send + Sync + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.op)

--- a/common/functions/src/scalars/comparisons/comparison.rs
+++ b/common/functions/src/scalars/comparisons/comparison.rs
@@ -229,7 +229,7 @@ pub trait ComparisonExpression: Sync + Send {
 
 pub struct ComparisonScalarImpl<L: Scalar, R: Scalar, F> {
     func: F,
-    _phantom: PhantomData<(L, R, F)>,
+    _phantom: PhantomData<(L, R)>,
 }
 
 impl<L: Scalar, R: Scalar, F> ComparisonScalarImpl<L, R, F>
@@ -263,7 +263,7 @@ pub struct ComparisonPrimitiveImpl<T: PrimitiveType, F> {
     least_supertype: DataTypePtr,
     need_cast: bool,
     func: F,
-    _phantom: PhantomData<(T, F)>,
+    _phantom: PhantomData<T>,
 }
 
 impl<T, F> ComparisonPrimitiveImpl<T, F>
@@ -340,7 +340,7 @@ impl<F: BooleanSimdImpl> ComparisonExpression for ComparisonBooleanImpl<F> {
     }
 }
 
-pub type StringSearchFn = fn(bool) -> bool;
+type StringSearchFn = fn(bool) -> bool;
 
 pub struct ComparisonStringImpl<T> {
     op: StringSearchFn,

--- a/common/functions/src/scalars/comparisons/comparison.rs
+++ b/common/functions/src/scalars/comparisons/comparison.rs
@@ -46,6 +46,7 @@ use crate::scalars::ComparisonRegexpFunction;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionFactory;
+use crate::scalars::ScalarBinaryFunction;
 
 #[derive(Clone)]
 pub struct ComparisonFunction {
@@ -233,7 +234,7 @@ pub struct ComparisonScalarImpl<L: Scalar, R: Scalar, F> {
 }
 
 impl<L: Scalar, R: Scalar, F> ComparisonScalarImpl<L, R, F>
-where F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> bool
+where F: ScalarBinaryFunction<L, R, bool>
 {
     pub fn new(func: F) -> Self {
         Self {
@@ -247,10 +248,10 @@ impl<L, R, F> ComparisonExpression for ComparisonScalarImpl<L, R, F>
 where
     L: Scalar + Send + Sync + Clone,
     R: Scalar + Send + Sync + Clone,
-    F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> bool + Send + Sync + Clone,
+    F: ScalarBinaryFunction<L, R, bool> + Send + Sync + Clone,
 {
     fn eval(&self, l: &ColumnWithField, r: &ColumnWithField) -> Result<BooleanColumn> {
-        scalar_binary_op::<L, R, bool, F>(
+        scalar_binary_op(
             l.column(),
             r.column(),
             self.func.clone(),

--- a/common/functions/src/scalars/comparisons/comparison.rs
+++ b/common/functions/src/scalars/comparisons/comparison.rs
@@ -46,7 +46,6 @@ use crate::scalars::ComparisonRegexpFunction;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionFactory;
-use crate::scalars::ScalarBinaryFunction;
 
 #[derive(Clone)]
 pub struct ComparisonFunction {
@@ -234,7 +233,7 @@ pub struct ComparisonScalarImpl<L: Scalar, R: Scalar, F> {
 }
 
 impl<L: Scalar, R: Scalar, F> ComparisonScalarImpl<L, R, F>
-where F: ScalarBinaryFunction<L, R, bool>
+where F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> bool
 {
     pub fn new(func: F) -> Self {
         Self {
@@ -248,7 +247,7 @@ impl<L, R, F> ComparisonExpression for ComparisonScalarImpl<L, R, F>
 where
     L: Scalar + Send + Sync + Clone,
     R: Scalar + Send + Sync + Clone,
-    F: ScalarBinaryFunction<L, R, bool> + Send + Sync + Clone,
+    F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> bool + Send + Sync + Clone,
 {
     fn eval(&self, l: &ColumnWithField, r: &ColumnWithField) -> Result<BooleanColumn> {
         scalar_binary_op(

--- a/common/functions/src/scalars/comparisons/comparison_gt.rs
+++ b/common/functions/src/scalars/comparisons/comparison_gt.rs
@@ -30,8 +30,15 @@ pub type ComparisonGtFunction = ComparisonFunctionCreator<ComparisonGtImpl>;
 pub struct ComparisonGtImpl;
 
 impl ComparisonImpl for ComparisonGtImpl {
-    type PrimitiveSimd = PrimitiveSimdGt;
     type BooleanSimd = BooleanSimdGt;
+
+    fn eval_simd<T>(l: T::Simd, r: T::Simd) -> u8
+    where
+        T: PrimitiveType + Simd8,
+        T::Simd: Simd8PartialOrd,
+    {
+        l.gt(r)
+    }
 
     fn eval_primitive<L, R, M>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> bool
     where
@@ -48,40 +55,11 @@ impl ComparisonImpl for ComparisonGtImpl {
 }
 
 #[derive(Clone)]
-pub struct PrimitiveSimdGt;
-
-impl PrimitiveSimdImpl for PrimitiveSimdGt {
-    fn vector_vector<T>(lhs: &PrimitiveColumn<T>, rhs: &PrimitiveColumn<T>) -> BooleanColumn
-    where
-        T: PrimitiveType + Simd8,
-        T::Simd: Simd8PartialOrd,
-    {
-        CommonPrimitiveImpl::compare_op(lhs, rhs, |a, b| a.gt(b))
-    }
-
-    fn vector_const<T>(lhs: &PrimitiveColumn<T>, rhs: T) -> BooleanColumn
-    where
-        T: PrimitiveType + Simd8,
-        T::Simd: Simd8PartialOrd,
-    {
-        CommonPrimitiveImpl::compare_op_scalar(lhs, rhs, |a, b| a.gt(b))
-    }
-
-    fn const_vector<T>(lhs: T, rhs: &PrimitiveColumn<T>) -> BooleanColumn
-    where
-        T: PrimitiveType + Simd8,
-        T::Simd: Simd8PartialOrd,
-    {
-        CommonPrimitiveImpl::compare_op_scalar(rhs, lhs, |a, b| a.lt(b))
-    }
-}
-
-#[derive(Clone)]
 pub struct BooleanSimdGt;
 
 impl BooleanSimdImpl for BooleanSimdGt {
     fn vector_vector(lhs: &BooleanColumn, rhs: &BooleanColumn) -> BooleanColumn {
-        CommonBooleanImpl::compare_op(lhs, rhs, |a, b| a & !b)
+        CommonBooleanOp::compare_op(lhs, rhs, |a, b| a & !b)
     }
 
     fn vector_const(lhs: &BooleanColumn, rhs: bool) -> BooleanColumn {

--- a/common/functions/src/scalars/comparisons/comparison_not_eq.rs
+++ b/common/functions/src/scalars/comparisons/comparison_not_eq.rs
@@ -28,8 +28,15 @@ pub type ComparisonNotEqFunction = ComparisonFunctionCreator<ComparisonNotEqImpl
 pub struct ComparisonNotEqImpl;
 
 impl ComparisonImpl for ComparisonNotEqImpl {
-    type PrimitiveSimd = PrimitiveSimdNotEq;
     type BooleanSimd = BooleanSimdNotEq;
+
+    fn eval_simd<T>(l: T::Simd, r: T::Simd) -> u8
+    where
+        T: PrimitiveType + Simd8,
+        T::Simd: Simd8PartialEq,
+    {
+        l.neq(r)
+    }
 
     fn eval_primitive<L, R, M>(l: L::RefType<'_>, r: R::RefType<'_>, _ctx: &mut EvalContext) -> bool
     where
@@ -46,45 +53,16 @@ impl ComparisonImpl for ComparisonNotEqImpl {
 }
 
 #[derive(Clone)]
-pub struct PrimitiveSimdNotEq;
-
-impl PrimitiveSimdImpl for PrimitiveSimdNotEq {
-    fn vector_vector<T>(lhs: &PrimitiveColumn<T>, rhs: &PrimitiveColumn<T>) -> BooleanColumn
-    where
-        T: PrimitiveType + Simd8,
-        T::Simd: Simd8PartialEq,
-    {
-        CommonPrimitiveImpl::compare_op(lhs, rhs, |a, b| a.neq(b))
-    }
-
-    fn vector_const<T>(lhs: &PrimitiveColumn<T>, rhs: T) -> BooleanColumn
-    where
-        T: PrimitiveType + Simd8,
-        T::Simd: Simd8PartialEq,
-    {
-        CommonPrimitiveImpl::compare_op_scalar(lhs, rhs, |a, b| a.neq(b))
-    }
-
-    fn const_vector<T>(lhs: T, rhs: &PrimitiveColumn<T>) -> BooleanColumn
-    where
-        T: PrimitiveType + Simd8,
-        T::Simd: Simd8PartialEq,
-    {
-        CommonPrimitiveImpl::compare_op_scalar(rhs, lhs, |a, b| a.neq(b))
-    }
-}
-
-#[derive(Clone)]
 pub struct BooleanSimdNotEq;
 
 impl BooleanSimdImpl for BooleanSimdNotEq {
     fn vector_vector(lhs: &BooleanColumn, rhs: &BooleanColumn) -> BooleanColumn {
-        CommonBooleanImpl::compare_op(lhs, rhs, |a, b| a ^ b)
+        CommonBooleanOp::compare_op(lhs, rhs, |a, b| a ^ b)
     }
 
     fn vector_const(lhs: &BooleanColumn, rhs: bool) -> BooleanColumn {
         if rhs {
-            CommonBooleanImpl::compare_op_scalar(lhs, rhs, |a, _| !a)
+            CommonBooleanOp::compare_op_scalar(lhs, rhs, |a, _| !a)
         } else {
             lhs.clone()
         }

--- a/common/functions/src/scalars/comparisons/utils.rs
+++ b/common/functions/src/scalars/comparisons/utils.rs
@@ -14,33 +14,9 @@
 
 use common_arrow::arrow::bitmap::binary;
 use common_arrow::arrow::bitmap::unary;
-use common_arrow::arrow::bitmap::MutableBitmap;
-use common_arrow::arrow::compute::comparison::Simd8;
-use common_arrow::arrow::compute::comparison::Simd8Lanes;
-use common_arrow::arrow::compute::comparison::Simd8PartialEq;
-use common_arrow::arrow::compute::comparison::Simd8PartialOrd;
 use common_datavalues::prelude::*;
-use common_exception::Result;
 
-use crate::scalars::EvalContext;
-pub trait PrimitiveSimdImpl {
-    fn vector_vector<T>(lhs: &PrimitiveColumn<T>, rhs: &PrimitiveColumn<T>) -> BooleanColumn
-    where
-        T: PrimitiveType + Simd8,
-        T::Simd: Simd8PartialEq + Simd8PartialOrd;
-
-    fn vector_const<T>(lhs: &PrimitiveColumn<T>, rhs: T) -> BooleanColumn
-    where
-        T: PrimitiveType + Simd8,
-        T::Simd: Simd8PartialEq + Simd8PartialOrd;
-
-    fn const_vector<T>(lhs: T, rhs: &PrimitiveColumn<T>) -> BooleanColumn
-    where
-        T: PrimitiveType + Simd8,
-        T::Simd: Simd8PartialEq + Simd8PartialOrd;
-}
-
-pub trait BooleanSimdImpl {
+pub trait BooleanSimdImpl: Sync + Send + Clone + 'static {
     fn vector_vector(lhs: &BooleanColumn, rhs: &BooleanColumn) -> BooleanColumn;
 
     fn vector_const(lhs: &BooleanColumn, rhs: bool) -> BooleanColumn;
@@ -48,7 +24,7 @@ pub trait BooleanSimdImpl {
     fn const_vector(lhs: bool, rhs: &BooleanColumn) -> BooleanColumn;
 }
 
-pub trait StringSearchImpl {
+pub trait StringSearchImpl: Sync + Send + Clone + 'static {
     fn vector_vector(
         lhs: &StringColumn,
         rhs: &StringColumn,
@@ -58,91 +34,9 @@ pub trait StringSearchImpl {
     fn vector_const(lhs: &StringColumn, rhs: &[u8], op: impl Fn(bool) -> bool) -> BooleanColumn;
 }
 
-pub(crate) struct CommonPrimitiveImpl;
+pub(crate) struct CommonBooleanOp;
 
-impl CommonPrimitiveImpl {
-    /// QUOTE: (From common_arrow::arrow::compute::comparison::primitive)
-    pub(crate) fn compare_op<T, F>(
-        lhs: &PrimitiveColumn<T>,
-        rhs: &PrimitiveColumn<T>,
-        op: F,
-    ) -> BooleanColumn
-    where
-        T: PrimitiveType + Simd8,
-        F: Fn(T::Simd, T::Simd) -> u8,
-    {
-        let values = Self::compare_values_op(lhs.values(), rhs.values(), op);
-
-        BooleanColumn::from_arrow_data(values.into())
-    }
-
-    pub(crate) fn compare_op_scalar<T, F>(lhs: &PrimitiveColumn<T>, rhs: T, op: F) -> BooleanColumn
-    where
-        T: PrimitiveType + Simd8,
-        F: Fn(T::Simd, T::Simd) -> u8,
-    {
-        let values = Self::compare_values_op_scalar(lhs.values(), rhs, op);
-
-        BooleanColumn::from_arrow_data(values.into())
-    }
-
-    fn compare_values_op<T, F>(lhs: &[T], rhs: &[T], op: F) -> MutableBitmap
-    where
-        T: PrimitiveType + Simd8,
-        F: Fn(T::Simd, T::Simd) -> u8,
-    {
-        assert_eq!(lhs.len(), rhs.len());
-
-        let lhs_chunks_iter = lhs.chunks_exact(8);
-        let lhs_remainder = lhs_chunks_iter.remainder();
-        let rhs_chunks_iter = rhs.chunks_exact(8);
-        let rhs_remainder = rhs_chunks_iter.remainder();
-
-        let mut values = Vec::with_capacity((lhs.len() + 7) / 8);
-        let iterator = lhs_chunks_iter.zip(rhs_chunks_iter).map(|(lhs, rhs)| {
-            let lhs = T::Simd::from_chunk(lhs);
-            let rhs = T::Simd::from_chunk(rhs);
-            op(lhs, rhs)
-        });
-        values.extend(iterator);
-
-        if !lhs_remainder.is_empty() {
-            let lhs = T::Simd::from_incomplete_chunk(lhs_remainder, T::default());
-            let rhs = T::Simd::from_incomplete_chunk(rhs_remainder, T::default());
-            values.push(op(lhs, rhs))
-        };
-        MutableBitmap::from_vec(values, lhs.len())
-    }
-
-    fn compare_values_op_scalar<T, F>(lhs: &[T], rhs: T, op: F) -> MutableBitmap
-    where
-        T: PrimitiveType + Simd8,
-        F: Fn(T::Simd, T::Simd) -> u8,
-    {
-        let rhs = T::Simd::from_chunk(&[rhs; 8]);
-
-        let lhs_chunks_iter = lhs.chunks_exact(8);
-        let lhs_remainder = lhs_chunks_iter.remainder();
-
-        let mut values = Vec::with_capacity((lhs.len() + 7) / 8);
-        let iterator = lhs_chunks_iter.map(|lhs| {
-            let lhs = T::Simd::from_chunk(lhs);
-            op(lhs, rhs)
-        });
-        values.extend(iterator);
-
-        if !lhs_remainder.is_empty() {
-            let lhs = T::Simd::from_incomplete_chunk(lhs_remainder, T::default());
-            values.push(op(lhs, rhs))
-        };
-
-        MutableBitmap::from_vec(values, lhs.len())
-    }
-}
-
-pub(crate) struct CommonBooleanImpl;
-
-impl CommonBooleanImpl {
+impl CommonBooleanOp {
     /// QUOTE: (From common_arrow::arrow::compute::comparison::boolean)
     pub(crate) fn compare_op<F>(lhs: &BooleanColumn, rhs: &BooleanColumn, op: F) -> BooleanColumn
     where F: Fn(u64, u64) -> u64 {
@@ -157,149 +51,4 @@ impl CommonBooleanImpl {
         let values = unary(lhs.values(), |x| op(x, rhs));
         BooleanColumn::from_arrow_data(values)
     }
-}
-
-pub fn scalar_binary_op<L: Scalar, R: Scalar, O: Scalar, F>(
-    l: &ColumnRef,
-    r: &ColumnRef,
-    f: F,
-    ctx: &mut EvalContext,
-) -> Result<<O as Scalar>::ColumnType>
-where
-    F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> O,
-{
-    debug_assert!(
-        l.len() == r.len(),
-        "Size of columns must match to apply binary expression"
-    );
-
-    let result = match (l.is_const(), r.is_const()) {
-        (false, true) => {
-            let left: &<L as Scalar>::ColumnType = unsafe { Series::static_cast(l) };
-            let right = R::try_create_viewer(r)?;
-
-            let b = right.value_at(0);
-            let it = left.scalar_iter().map(|a| f(a, b, ctx));
-            <O as Scalar>::ColumnType::from_owned_iterator(it)
-        }
-
-        (false, false) => {
-            let left: &<L as Scalar>::ColumnType = unsafe { Series::static_cast(l) };
-            let right: &<R as Scalar>::ColumnType = unsafe { Series::static_cast(r) };
-
-            let it = left
-                .scalar_iter()
-                .zip(right.scalar_iter())
-                .map(|(a, b)| f(a, b, ctx));
-            <O as Scalar>::ColumnType::from_owned_iterator(it)
-        }
-
-        (true, false) => {
-            let left = L::try_create_viewer(l)?;
-            let a = left.value_at(0);
-
-            let right: &<R as Scalar>::ColumnType = unsafe { Series::static_cast(r) };
-            let it = right.scalar_iter().map(|b| f(a, b, ctx));
-            <O as Scalar>::ColumnType::from_owned_iterator(it)
-        }
-
-        // True True ?
-        (true, true) => {
-            let left = L::try_create_viewer(l)?;
-            let right = R::try_create_viewer(r)?;
-
-            let it = left.iter().zip(right.iter()).map(|(a, b)| f(a, b, ctx));
-            <O as Scalar>::ColumnType::from_owned_iterator(it)
-        }
-    };
-
-    if let Some(error) = ctx.error.take() {
-        return Err(error);
-    }
-    Ok(result)
-}
-
-fn primitive_simd_op<T, F>(l: &ColumnRef, r: &ColumnRef) -> Result<BooleanColumn>
-where
-    T: PrimitiveType + Simd8,
-    T::Simd: Simd8PartialEq + Simd8PartialOrd,
-    F: PrimitiveSimdImpl,
-{
-    debug_assert!(
-        l.len() == r.len(),
-        "Size of columns must match to apply binary expression"
-    );
-
-    let res = match (l.is_const(), r.is_const()) {
-        (false, false) => {
-            let lhs: &PrimitiveColumn<T> = Series::check_get(&l)?;
-            let rhs: &PrimitiveColumn<T> = Series::check_get(&r)?;
-            F::vector_vector::<T>(lhs, rhs)
-        }
-        (false, true) => {
-            let lhs: &PrimitiveColumn<T> = Series::check_get(&l)?;
-            let rhs = T::try_create_viewer(&r)?;
-            let r = rhs.value_at(0).to_owned_scalar();
-            F::vector_const::<T>(lhs, r)
-        }
-        (true, false) => {
-            let lhs = T::try_create_viewer(&l)?;
-            let l = lhs.value_at(0).to_owned_scalar();
-
-            let rhs: &PrimitiveColumn<T> = Series::check_get(&r)?;
-            F::const_vector::<T>(l, rhs)
-        }
-        (true, true) => unreachable!(),
-    };
-    Ok(res)
-}
-
-fn boolean_simd_op<F: BooleanSimdImpl>(l: &ColumnRef, r: &ColumnRef) -> Result<BooleanColumn> {
-    debug_assert!(
-        l.len() == r.len(),
-        "Size of columns must match to apply binary expression"
-    );
-
-    let res = match (l.is_const(), r.is_const()) {
-        (false, false) => {
-            let lhs: &BooleanColumn = Series::check_get(l)?;
-            let rhs: &BooleanColumn = Series::check_get(r)?;
-            F::vector_vector(lhs, rhs)
-        }
-        (false, true) => {
-            let lhs: &BooleanColumn = Series::check_get(l)?;
-            let r = r.get_bool(0)?;
-            F::vector_const(lhs, r)
-        }
-        (true, false) => {
-            let l = l.get_bool(0)?;
-            let rhs: &BooleanColumn = Series::check_get(r)?;
-            F::const_vector(l, rhs)
-        }
-        (true, true) => unreachable!(),
-    };
-    Ok(res)
-}
-
-fn string_search_op<T: StringSearchImpl, F>(
-    l: &ColumnRef,
-    r: &ColumnRef,
-    f: F,
-) -> Result<BooleanColumn>
-where
-    F: Fn(bool) -> bool,
-{
-    let res = match r.is_const() {
-        true => {
-            let lhs: &StringColumn = Series::check_get(l)?;
-            let r = r.get_string(0)?;
-            T::vector_const(lhs, &r, f)
-        }
-        false => {
-            let lhs: &StringColumn = Series::check_get(l)?;
-            let rhs: &StringColumn = Series::check_get(r)?;
-            T::vector_vector(lhs, rhs, f)
-        }
-    };
-    Ok(res)
 }

--- a/common/functions/src/scalars/dates/date.rs
+++ b/common/functions/src/scalars/dates/date.rs
@@ -40,7 +40,7 @@ use super::ToYYYYMMFunction;
 use super::TodayFunction;
 use super::TomorrowFunction;
 use super::YesterdayFunction;
-use crate::scalars::function_factory::Factory2Creator;
+use crate::scalars::function_factory::FactoryCreator;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
@@ -51,7 +51,7 @@ pub struct DateFunction {}
 
 impl DateFunction {
     fn round_function_creator(round: u32) -> FunctionDescription {
-        let creator: Factory2Creator = Box::new(move |display_name| -> Result<Box<dyn Function>> {
+        let creator: FactoryCreator = Box::new(move |display_name| -> Result<Box<dyn Function>> {
             RoundFunction::try_create(display_name, round)
         });
 

--- a/common/functions/src/scalars/dates/interval_function.rs
+++ b/common/functions/src/scalars/dates/interval_function.rs
@@ -36,7 +36,6 @@ use crate::scalars::ArithmeticCreator;
 use crate::scalars::ArithmeticDescription;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
-use crate::scalars::ScalarBinaryFunction;
 
 pub struct IntervalFunctionCreator<T> {
     t: PhantomData<T>,
@@ -119,7 +118,7 @@ where
     L: DateType + Send + Sync + Clone,
     R: PrimitiveType + Send + Sync + Clone,
     O: DateType + Send + Sync + Clone,
-    F: ScalarBinaryFunction<L, R, O> + Send + Sync + Clone + 'static,
+    F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> O + Send + Sync + Clone + 'static,
 {
     pub fn try_create_func(
         display_name: &str,
@@ -144,7 +143,7 @@ where
     L: DateType + Send + Sync + Clone,
     R: PrimitiveType + Send + Sync + Clone,
     O: DateType + Send + Sync + Clone,
-    F: ScalarBinaryFunction<L, R, O> + Send + Sync + Clone + 'static,
+    F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> O + Send + Sync + Clone + 'static,
 {
     fn name(&self) -> &str {
         self.display_name.as_str()
@@ -172,7 +171,7 @@ where
     L: DateType + Send + Sync + Clone,
     R: PrimitiveType + Send + Sync + Clone,
     O: DateType + Send + Sync + Clone,
-    F: ScalarBinaryFunction<L, R, O> + Send + Sync + Clone + 'static,
+    F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> O + Send + Sync + Clone + 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}()", self.display_name)

--- a/common/functions/src/scalars/dates/macros.rs
+++ b/common/functions/src/scalars/dates/macros.rs
@@ -22,35 +22,27 @@ macro_rules! impl_interval_year_month {
             type Date16Result = u16;
             type Date32Result = i32;
 
-            fn eval_date16<R: PrimitiveType + AsPrimitive<i64>>(
+            fn eval_date16(
                 l: u16,
-                r: R::RefType<'_>,
+                r: impl AsPrimitive<i64>,
                 ctx: &mut EvalContext,
             ) -> Self::Date16Result {
                 define_date_add_year_months!(l, r, ctx, u16, $op)
             }
 
-            fn eval_date32<R: PrimitiveType + AsPrimitive<i64>>(
+            fn eval_date32(
                 l: i32,
-                r: R::RefType<'_>,
+                r: impl AsPrimitive<i64>,
                 ctx: &mut EvalContext,
             ) -> Self::Date32Result {
                 define_date_add_year_months!(l, r, ctx, i32, $op)
             }
 
-            fn eval_datetime32<R: PrimitiveType + AsPrimitive<i64>>(
-                l: u32,
-                r: R::RefType<'_>,
-                ctx: &mut EvalContext,
-            ) -> u32 {
+            fn eval_datetime32(l: u32, r: impl AsPrimitive<i64>, ctx: &mut EvalContext) -> u32 {
                 define_datetime32_add_year_months!(l, r, ctx, $op)
             }
 
-            fn eval_datetime64<R: PrimitiveType + AsPrimitive<i64>>(
-                l: i64,
-                r: R::RefType<'_>,
-                ctx: &mut EvalContext,
-            ) -> i64 {
+            fn eval_datetime64(l: i64, r: impl AsPrimitive<i64>, ctx: &mut EvalContext) -> i64 {
                 define_datetime64_add_year_months!(l, r, ctx, $op)
             }
         }
@@ -72,12 +64,7 @@ macro_rules! define_date_add_year_months {
         }
 
         let date = naive.unwrap();
-        let new_date = $op(
-            date.year(),
-            date.month(),
-            date.day(),
-            $r.to_owned_scalar().as_() * factor,
-        );
+        let new_date = $op(date.year(), date.month(), date.day(), $r.as_() * factor);
         new_date.map_or_else(
             |e| {
                 $ctx.set_error(e);
@@ -102,12 +89,7 @@ macro_rules! define_datetime32_add_year_months {
         }
 
         let date = naive.unwrap();
-        let new_date = $op(
-            date.year(),
-            date.month(),
-            date.day(),
-            $r.to_owned_scalar().as_() * factor,
-        );
+        let new_date = $op(date.year(), date.month(), date.day(), $r.as_() * factor);
         new_date.map_or_else(
             |e| {
                 $ctx.set_error(e);
@@ -136,12 +118,7 @@ macro_rules! define_datetime64_add_year_months {
         };
 
         let date = naive.unwrap();
-        let new_date = $op(
-            date.year(),
-            date.month(),
-            date.day(),
-            $r.to_owned_scalar().as_() * factor,
-        );
+        let new_date = $op(date.year(), date.month(), date.day(), $r.as_() * factor);
         new_date.map_or_else(
             |e| {
                 $ctx.set_error(e);

--- a/common/functions/src/scalars/dates/number_function.rs
+++ b/common/functions/src/scalars/dates/number_function.rs
@@ -27,13 +27,13 @@ use common_exception::Result;
 
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::CastFunction;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionAdapter;
 use crate::scalars::Monotonicity;
 use crate::scalars::RoundFunction;
-use crate::scalars::ScalarUnaryExpression;
 
 #[derive(Clone, Debug)]
 pub struct NumberFunction<T, R> {
@@ -359,31 +359,30 @@ where
 
         let number_array= match type_id {
             TypeID::Date16 => {
-                let unary = ScalarUnaryExpression::<u16, R, _>::new(|v: u16, _ctx: &mut EvalContext| {
+                let func = |v: u16, _ctx: &mut EvalContext| {
                     let date_time = Utc.timestamp(v as i64 * 24 * 3600, 0_u32);
                     T::to_number(date_time)
-                });
-                let col = unary.eval(columns[0].column(), &mut EvalContext::default())?;
+                };
+                let col = scalar_unary_op::<u16, R, _>(columns[0].column(), func, &mut EvalContext::default())?;
                 Ok(col.arc())
 
             },
             TypeID::Date32 => {
-                let unary = ScalarUnaryExpression::<i32, R, _>::new(|v:i32, _ctx: &mut EvalContext| {
+                let func = |v:i32, _ctx: &mut EvalContext| {
                     let date_time = Utc.timestamp(v as i64 * 24 * 3600, 0_u32);
                     T::to_number(date_time)
-                });
-                let col = unary.eval(columns[0].column(), &mut EvalContext::default())?;
+                };
+                let col = scalar_unary_op::<i32, R, _>(columns[0].column(), func, &mut EvalContext::default())?;
                 Ok(col.arc())
             },
             TypeID::DateTime32 => {
-                let unary = ScalarUnaryExpression::<u32, R, _>::new(|v:u32, _ctx: &mut EvalContext| {
+                let func = |v:u32, _ctx: &mut EvalContext| {
                     let date_time = Utc.timestamp(v as i64 , 0_u32);
                     T::to_number(date_time)
-                });
-                let col = unary.eval(columns[0].column(), &mut EvalContext::default())?;
+                };
+                let col = scalar_unary_op::<u32, R, _>(columns[0].column(), func, &mut EvalContext::default())?;
                 Ok(col.arc())
-
-                },
+            },
             other => Result::Err(ErrorCode::IllegalDataType(format!(
                 "Illegal type {:?} of argument of function {}.Should be a date16/data32 or a dateTime32",
                 other,

--- a/common/functions/src/scalars/dates/round_function.rs
+++ b/common/functions/src/scalars/dates/round_function.rs
@@ -18,10 +18,10 @@ use common_datavalues::prelude::*;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
-use crate::scalars::ScalarUnaryExpression;
 
 #[derive(Clone)]
 pub struct RoundFunction {
@@ -73,10 +73,9 @@ impl Function for RoundFunction {
         columns: &common_datavalues::ColumnsWithField,
         _input_rows: usize,
     ) -> Result<common_datavalues::ColumnRef> {
-        let unary = ScalarUnaryExpression::<u32, _, _>::new(|val: u32, _ctx: &mut EvalContext| {
-            self.execute(val)
-        });
-        let col = unary.eval(columns[0].column(), &mut EvalContext::default())?;
+        let func = |val: u32, _ctx: &mut EvalContext| self.execute(val);
+        let col =
+            scalar_unary_op::<u32, _, _>(columns[0].column(), func, &mut EvalContext::default())?;
         Ok(col.arc())
     }
 

--- a/common/functions/src/scalars/expressions/binary.rs
+++ b/common/functions/src/scalars/expressions/binary.rs
@@ -35,86 +35,6 @@ where F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> O
     }
 }
 
-/// A common struct to caculate binary expression scalar op.
-#[derive(Clone)]
-pub struct ScalarBinaryExpression<L: Scalar, R: Scalar, O: Scalar, F> {
-    func: F,
-    _phantom: PhantomData<(L, R, O)>,
-}
-
-impl<L: Scalar, R: Scalar, O: Scalar, F> ScalarBinaryExpression<L, R, O, F>
-where F: ScalarBinaryFunction<L, R, O>
-{
-    /// Create a binary expression from generic columns  and a lambda function.
-    pub fn new(func: F) -> Self {
-        Self {
-            func,
-            _phantom: PhantomData,
-        }
-    }
-
-    /// Evaluate the expression with the given array.
-    pub fn eval(
-        &self,
-        l: &ColumnRef,
-        r: &ColumnRef,
-        ctx: &mut EvalContext,
-    ) -> Result<<O as Scalar>::ColumnType> {
-        debug_assert!(
-            l.len() == r.len(),
-            "Size of columns must match to apply binary expression"
-        );
-
-        let result = match (l.is_const(), r.is_const()) {
-            (false, true) => {
-                let left: &<L as Scalar>::ColumnType = unsafe { Series::static_cast(l) };
-                let right = R::try_create_viewer(r)?;
-
-                let b = right.value_at(0);
-                let it = left.scalar_iter().map(|a| self.func.eval(a, b, ctx));
-                <O as Scalar>::ColumnType::from_owned_iterator(it)
-            }
-
-            (false, false) => {
-                let left: &<L as Scalar>::ColumnType = unsafe { Series::static_cast(l) };
-                let right: &<R as Scalar>::ColumnType = unsafe { Series::static_cast(r) };
-
-                let it = left
-                    .scalar_iter()
-                    .zip(right.scalar_iter())
-                    .map(|(a, b)| self.func.eval(a, b, ctx));
-                <O as Scalar>::ColumnType::from_owned_iterator(it)
-            }
-
-            (true, false) => {
-                let left = L::try_create_viewer(l)?;
-                let a = left.value_at(0);
-
-                let right: &<R as Scalar>::ColumnType = unsafe { Series::static_cast(r) };
-                let it = right.scalar_iter().map(|b| self.func.eval(a, b, ctx));
-                <O as Scalar>::ColumnType::from_owned_iterator(it)
-            }
-
-            // True True ?
-            (true, true) => {
-                let left = L::try_create_viewer(l)?;
-                let right = R::try_create_viewer(r)?;
-
-                let it = left
-                    .iter()
-                    .zip(right.iter())
-                    .map(|(a, b)| self.func.eval(a, b, ctx));
-                <O as Scalar>::ColumnType::from_owned_iterator(it)
-            }
-        };
-
-        if let Some(error) = ctx.error.take() {
-            return Err(error);
-        }
-        Ok(result)
-    }
-}
-
 pub trait ScalarBinaryRefFunction<'a, L: Scalar, R: Scalar, O: Scalar> {
     fn eval(&self, l: L::RefType<'a>, r: R::RefType<'a>, ctx: &mut EvalContext) -> O::RefType<'a>;
 }
@@ -133,87 +53,14 @@ where F: Fn(L::RefType<'a>, R::RefType<'a>, &mut EvalContext) -> O::RefType<'a>
     }
 }
 
-impl<'a, L: Scalar, R: Scalar, O: Scalar, F> ScalarBinaryExpression<L, R, O, F>
-where F: ScalarBinaryRefFunction<'a, L, R, O>
-{
-    /// Create a binary expression from generic columns  and a lambda function.
-    pub fn new_ref(func: F) -> Self {
-        Self {
-            func,
-            _phantom: PhantomData,
-        }
-    }
-
-    /// Evaluate the expression with the given array.
-    pub fn eval_ref(
-        &self,
-        l: &'a ColumnRef,
-        r: &'a ColumnRef,
-        ctx: &mut EvalContext,
-    ) -> Result<<O as Scalar>::ColumnType> {
-        debug_assert!(
-            l.len() == r.len(),
-            "Size of columns must match to apply binary expression"
-        );
-
-        let result = match (l.is_const(), r.is_const()) {
-            (false, true) => {
-                let left: &<L as Scalar>::ColumnType = unsafe { Series::static_cast(l) };
-                let right = R::try_create_viewer(r)?;
-
-                let b = right.value_at(0);
-                let it = left.scalar_iter().map(|a| self.func.eval(a, b, ctx));
-                <O as Scalar>::ColumnType::from_iterator(it)
-            }
-
-            (false, false) => {
-                let left: &<L as Scalar>::ColumnType = unsafe { Series::static_cast(l) };
-                let right: &<R as Scalar>::ColumnType = unsafe { Series::static_cast(r) };
-
-                let it = left
-                    .scalar_iter()
-                    .zip(right.scalar_iter())
-                    .map(|(a, b)| self.func.eval(a, b, ctx));
-                <O as Scalar>::ColumnType::from_iterator(it)
-            }
-
-            (true, false) => {
-                let left = L::try_create_viewer(l)?;
-                let a = left.value_at(0);
-
-                let right: &<R as Scalar>::ColumnType = unsafe { Series::static_cast(r) };
-                let it = right.scalar_iter().map(|b| self.func.eval(a, b, ctx));
-                <O as Scalar>::ColumnType::from_iterator(it)
-            }
-
-            // True True ?
-            (true, true) => {
-                let left = L::try_create_viewer(l)?;
-                let right = R::try_create_viewer(r)?;
-
-                let it = left
-                    .iter()
-                    .zip(right.iter())
-                    .map(|(a, b)| self.func.eval(a, b, ctx));
-                <O as Scalar>::ColumnType::from_iterator(it)
-            }
-        };
-
-        if let Some(error) = ctx.error.take() {
-            return Err(error);
-        }
-        Ok(result)
-    }
-}
-
-pub fn scalar_binary_op<L: Scalar, R: Scalar, O: Scalar, F>(
-    l: &ColumnRef,
-    r: &ColumnRef,
+pub fn scalar_binary_op_ref<'a, L: Scalar, R: Scalar, O: Scalar, F>(
+    l: &'a ColumnRef,
+    r: &'a ColumnRef,
     f: F,
     ctx: &mut EvalContext,
 ) -> Result<<O as Scalar>::ColumnType>
 where
-    F: Fn(L::RefType<'_>, R::RefType<'_>, &mut EvalContext) -> O,
+    F: ScalarBinaryRefFunction<'a, L, R, O>,
 {
     debug_assert!(
         l.len() == r.len(),
@@ -226,7 +73,70 @@ where
             let right = R::try_create_viewer(r)?;
 
             let b = right.value_at(0);
-            let it = left.scalar_iter().map(|a| f(a, b, ctx));
+            let it = left.scalar_iter().map(|a| f.eval(a, b, ctx));
+            <O as Scalar>::ColumnType::from_iterator(it)
+        }
+
+        (false, false) => {
+            let left: &<L as Scalar>::ColumnType = unsafe { Series::static_cast(l) };
+            let right: &<R as Scalar>::ColumnType = unsafe { Series::static_cast(r) };
+
+            let it = left
+                .scalar_iter()
+                .zip(right.scalar_iter())
+                .map(|(a, b)| f.eval(a, b, ctx));
+            <O as Scalar>::ColumnType::from_iterator(it)
+        }
+
+        (true, false) => {
+            let left = L::try_create_viewer(l)?;
+            let a = left.value_at(0);
+
+            let right: &<R as Scalar>::ColumnType = unsafe { Series::static_cast(r) };
+            let it = right.scalar_iter().map(|b| f.eval(a, b, ctx));
+            <O as Scalar>::ColumnType::from_iterator(it)
+        }
+
+        // True True ?
+        (true, true) => {
+            let left = L::try_create_viewer(l)?;
+            let right = R::try_create_viewer(r)?;
+
+            let it = left
+                .iter()
+                .zip(right.iter())
+                .map(|(a, b)| f.eval(a, b, ctx));
+            <O as Scalar>::ColumnType::from_iterator(it)
+        }
+    };
+
+    if let Some(error) = ctx.error.take() {
+        return Err(error);
+    }
+    Ok(result)
+}
+
+pub fn scalar_binary_op<L: Scalar, R: Scalar, O: Scalar, F>(
+    l: &ColumnRef,
+    r: &ColumnRef,
+    f: F,
+    ctx: &mut EvalContext,
+) -> Result<<O as Scalar>::ColumnType>
+where
+    F: ScalarBinaryFunction<L, R, O>,
+{
+    debug_assert!(
+        l.len() == r.len(),
+        "Size of columns must match to apply binary expression"
+    );
+
+    let result = match (l.is_const(), r.is_const()) {
+        (false, true) => {
+            let left: &<L as Scalar>::ColumnType = unsafe { Series::static_cast(l) };
+            let right = R::try_create_viewer(r)?;
+
+            let b = right.value_at(0);
+            let it = left.scalar_iter().map(|a| f.eval(a, b, ctx));
             <O as Scalar>::ColumnType::from_owned_iterator(it)
         }
 
@@ -237,7 +147,7 @@ where
             let it = left
                 .scalar_iter()
                 .zip(right.scalar_iter())
-                .map(|(a, b)| f(a, b, ctx));
+                .map(|(a, b)| f.eval(a, b, ctx));
             <O as Scalar>::ColumnType::from_owned_iterator(it)
         }
 
@@ -246,7 +156,7 @@ where
             let a = left.value_at(0);
 
             let right: &<R as Scalar>::ColumnType = unsafe { Series::static_cast(r) };
-            let it = right.scalar_iter().map(|b| f(a, b, ctx));
+            let it = right.scalar_iter().map(|b| f.eval(a, b, ctx));
             <O as Scalar>::ColumnType::from_owned_iterator(it)
         }
 
@@ -255,7 +165,10 @@ where
             let left = L::try_create_viewer(l)?;
             let right = R::try_create_viewer(r)?;
 
-            let it = left.iter().zip(right.iter()).map(|(a, b)| f(a, b, ctx));
+            let it = left
+                .iter()
+                .zip(right.iter())
+                .map(|(a, b)| f.eval(a, b, ctx));
             <O as Scalar>::ColumnType::from_owned_iterator(it)
         }
     };

--- a/common/functions/src/scalars/expressions/binary.rs
+++ b/common/functions/src/scalars/expressions/binary.rs
@@ -279,11 +279,11 @@ where
 
     let res = match (l.is_const(), r.is_const()) {
         (false, false) => {
-            let lhs: &PrimitiveColumn<T> = Series::check_get(&l)?;
+            let lhs: &PrimitiveColumn<T> = Series::check_get(l)?;
             let lhs_chunks_iter = lhs.values().chunks_exact(8);
             let lhs_remainder = lhs_chunks_iter.remainder();
 
-            let rhs: &PrimitiveColumn<T> = Series::check_get(&r)?;
+            let rhs: &PrimitiveColumn<T> = Series::check_get(r)?;
             let rhs_chunks_iter = rhs.values().chunks_exact(8);
             let rhs_remainder = rhs_chunks_iter.remainder();
 
@@ -303,11 +303,11 @@ where
             MutableBitmap::from_vec(values, lhs.len())
         }
         (false, true) => {
-            let lhs: &PrimitiveColumn<T> = Series::check_get(&l)?;
+            let lhs: &PrimitiveColumn<T> = Series::check_get(l)?;
             let lhs_chunks_iter = lhs.values().chunks_exact(8);
             let lhs_remainder = lhs_chunks_iter.remainder();
 
-            let rhs = T::try_create_viewer(&r)?;
+            let rhs = T::try_create_viewer(r)?;
             let r = rhs.value_at(0).to_owned_scalar();
             let rhs = T::Simd::from_chunk(&[r; 8]);
 
@@ -326,11 +326,11 @@ where
             MutableBitmap::from_vec(values, lhs.len())
         }
         (true, false) => {
-            let lhs = T::try_create_viewer(&l)?;
+            let lhs = T::try_create_viewer(l)?;
             let l = lhs.value_at(0).to_owned_scalar();
             let lhs = T::Simd::from_chunk(&[l; 8]);
 
-            let rhs: &PrimitiveColumn<T> = Series::check_get(&r)?;
+            let rhs: &PrimitiveColumn<T> = Series::check_get(r)?;
             let rhs_chunks_iter = rhs.values().chunks_exact(8);
             let rhs_remainder = rhs_chunks_iter.remainder();
 

--- a/common/functions/src/scalars/expressions/expression.rs
+++ b/common/functions/src/scalars/expressions/expression.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 use common_exception::Result;
 
-use crate::scalars::function_factory::Factory2Creator;
+use crate::scalars::function_factory::FactoryCreator;
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFactory;
 use crate::scalars::function_factory::FunctionFeatures;
@@ -37,7 +37,7 @@ impl ToCastFunction {
             _ => features.num_arguments(1),
         };
 
-        let function_creator: Factory2Creator =
+        let function_creator: FactoryCreator =
             Box::new(move |display_name| CastFunction::create(display_name, type_name));
 
         Ok(FunctionDescription::creator(function_creator).features(features))

--- a/common/functions/src/scalars/expressions/unary.rs
+++ b/common/functions/src/scalars/expressions/unary.rs
@@ -23,29 +23,16 @@ use common_exception::Result;
 use super::from_incomplete_chunk;
 use super::EvalContext;
 
-pub trait ScalarUnaryFunction<L: Scalar, O: Scalar> {
-    fn eval(&self, l: L::RefType<'_>, _ctx: &mut EvalContext) -> O;
-}
-
-/// Blanket implementation for all binary expression functions
-impl<L: Scalar, O: Scalar, F> ScalarUnaryFunction<L, O> for F
-where F: Fn(L::RefType<'_>, &mut EvalContext) -> O
-{
-    fn eval(&self, i1: L::RefType<'_>, ctx: &mut EvalContext) -> O {
-        self(i1, ctx)
-    }
-}
-
 pub fn scalar_unary_op<L: Scalar, O: Scalar, F>(
     l: &ColumnRef,
     f: F,
     ctx: &mut EvalContext,
 ) -> Result<<O as Scalar>::ColumnType>
 where
-    F: ScalarUnaryFunction<L, O>,
+    F: Fn(L::RefType<'_>, &mut EvalContext) -> O,
 {
     let left = Series::check_get_scalar::<L>(l)?;
-    let it = left.scalar_iter().map(|a| f.eval(a, ctx));
+    let it = left.scalar_iter().map(|a| f(a, ctx));
     let result = <O as Scalar>::ColumnType::from_owned_iterator(it);
 
     if let Some(error) = ctx.error.take() {

--- a/common/functions/src/scalars/expressions/unary.rs
+++ b/common/functions/src/scalars/expressions/unary.rs
@@ -20,6 +20,7 @@ use std::simd::SupportedLaneCount;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 
+use super::from_incomplete_chunk;
 use super::EvalContext;
 
 pub trait ScalarUnaryFunction<L: Scalar, O: Scalar> {
@@ -71,12 +72,8 @@ where
     });
 
     if !lhs_remainder.is_empty() {
-        let mut lhs = [L::default(); N];
-        lhs.iter_mut()
-            .zip(lhs_remainder.iter())
-            .for_each(|(a, b)| *a = *b);
-
-        let res = op(Simd::from_array(lhs));
+        let lhs = from_incomplete_chunk(lhs_remainder, L::default());
+        let res = op(lhs);
         values.extend_from_slice(&res.as_array()[0..lhs_remainder.len()])
     };
 

--- a/common/functions/src/scalars/function_factory.rs
+++ b/common/functions/src/scalars/function_factory.rs
@@ -38,7 +38,7 @@ use super::UdfFunction;
 use crate::scalars::DateFunction;
 use crate::scalars::UUIDFunction;
 
-pub type Factory2Creator = Box<dyn Fn(&str) -> Result<Box<dyn Function>> + Send + Sync>;
+pub type FactoryCreator = Box<dyn Fn(&str) -> Result<Box<dyn Function>> + Send + Sync>;
 
 // Temporary adaptation for arithmetic.
 pub type ArithmeticCreator =
@@ -126,11 +126,11 @@ impl FunctionFeatures {
 
 pub struct FunctionDescription {
     features: FunctionFeatures,
-    function_creator: Factory2Creator,
+    function_creator: FactoryCreator,
 }
 
 impl FunctionDescription {
-    pub fn creator(creator: Factory2Creator) -> FunctionDescription {
+    pub fn creator(creator: FactoryCreator) -> FunctionDescription {
         FunctionDescription {
             function_creator: creator,
             features: FunctionFeatures::default(),

--- a/common/functions/src/scalars/hashes/hash_base.rs
+++ b/common/functions/src/scalars/hashes/hash_base.rs
@@ -25,10 +25,10 @@ use common_exception::Result;
 use num::FromPrimitive;
 
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarUnaryExpression;
 
 /// H ---> Hasher
 /// R ---> Result Type
@@ -92,8 +92,7 @@ where
         _input_rows: usize,
     ) -> Result<common_datavalues::ColumnRef> {
         with_match_scalar_types_error!(columns[0].data_type().data_type_id().to_physical_type(), |$S| {
-            let unary = ScalarUnaryExpression::<$S, R, _>::new(hash_func::<H, $S, R>);
-            let col = unary.eval(columns[0].column(), &mut EvalContext::default())?;
+            let col = scalar_unary_op::<$S, R, _>(columns[0].column(), hash_func::<H, $S, R>, &mut EvalContext::default())?;
             Ok(Arc::new(col))
         })
     }

--- a/common/functions/src/scalars/maths/angle.rs
+++ b/common/functions/src/scalars/maths/angle.rs
@@ -23,9 +23,9 @@ use num::cast::AsPrimitive;
 use crate::scalars::function_common::assert_numeric;
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
-use crate::scalars::ScalarUnaryExpression;
 
 #[derive(Clone)]
 pub struct AngleFunction<T> {
@@ -68,8 +68,7 @@ where T: AngleConvertFunction + Clone + Sync + Send + 'static
     fn eval(&self, columns: &ColumnsWithField, _input_rows: usize) -> Result<ColumnRef> {
         let mut ctx = EvalContext::default();
         with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
-             let unary = ScalarUnaryExpression::<$S, f64, _>::new(T::convert);
-             let col = unary.eval(columns[0].column(), &mut ctx)?;
+             let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), T::convert, &mut ctx)?;
              Ok(col.arc())
         },{
             unreachable!()

--- a/common/functions/src/scalars/maths/ceil.rs
+++ b/common/functions/src/scalars/maths/ceil.rs
@@ -23,10 +23,10 @@ use num::cast::AsPrimitive;
 use crate::scalars::function_common::assert_numeric;
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
-use crate::scalars::ScalarUnaryExpression;
 
 #[derive(Clone)]
 pub struct CeilFunction {
@@ -68,8 +68,7 @@ impl Function for CeilFunction {
     fn eval(&self, columns: &ColumnsWithField, _input_rows: usize) -> Result<ColumnRef> {
         let mut ctx = EvalContext::default();
         with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
-             let unary = ScalarUnaryExpression::<$S, f64, _>::new(ceil::<$S>);
-             let col = unary.eval(columns[0].column(), &mut ctx)?;
+             let col = scalar_unary_op::<$S, f64, _>(columns[0].column(),ceil::<$S>, &mut ctx)?;
              Ok(col.arc())
         },{
             unreachable!()

--- a/common/functions/src/scalars/maths/exp.rs
+++ b/common/functions/src/scalars/maths/exp.rs
@@ -22,9 +22,9 @@ use num::cast::AsPrimitive;
 use crate::scalars::function_common::assert_numeric;
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
-use crate::scalars::ScalarUnaryExpression;
 
 #[derive(Clone)]
 pub struct ExpFunction {
@@ -62,8 +62,7 @@ impl Function for ExpFunction {
     fn eval(&self, columns: &ColumnsWithField, _input_rows: usize) -> Result<ColumnRef> {
         let mut ctx = EvalContext::default();
         with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
-             let unary = ScalarUnaryExpression::<$S, f64, _>::new(exp::<$S>);
-             let col = unary.eval(columns[0].column(), &mut ctx)?;
+             let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), exp::<$S>, &mut ctx)?;
              Ok(col.arc())
         },{
             unreachable!()

--- a/common/functions/src/scalars/maths/floor.rs
+++ b/common/functions/src/scalars/maths/floor.rs
@@ -23,10 +23,10 @@ use num::cast::AsPrimitive;
 use crate::scalars::function_common::assert_numeric;
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::Monotonicity;
-use crate::scalars::ScalarUnaryExpression;
 
 #[derive(Clone)]
 pub struct FloorFunction {
@@ -68,8 +68,7 @@ impl Function for FloorFunction {
     fn eval(&self, columns: &ColumnsWithField, _input_rows: usize) -> Result<ColumnRef> {
         let mut ctx = EvalContext::default();
         with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
-             let unary = ScalarUnaryExpression::<$S, f64, _>::new(floor::<$S>);
-             let col = unary.eval(columns[0].column(), &mut ctx)?;
+             let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), floor::<$S>, &mut ctx)?;
              Ok(col.arc())
         },{
             unreachable!()

--- a/common/functions/src/scalars/maths/log.rs
+++ b/common/functions/src/scalars/maths/log.rs
@@ -24,10 +24,10 @@ use num_traits::AsPrimitive;
 
 use crate::scalars::assert_numeric;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_binary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarBinaryExpression;
 use crate::scalars::ScalarUnaryExpression;
 
 /// Const f64 is now allowed.
@@ -123,8 +123,7 @@ impl<T: Base> Function for GenericLogFunction<T> {
         } else {
             with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
                 with_match_primitive_type_id!(columns[1].data_type().data_type_id(), |$T| {
-                    let binary = ScalarBinaryExpression::<$S, $T, f64, _>::new(Self::log_with_base);
-                    let col = binary.eval(columns[0].column(), columns[1].column(), &mut ctx)?;
+                    let col = scalar_binary_op::<$S, $T, f64, _>(columns[0].column(), columns[1].column(), Self::log_with_base, &mut ctx)?;
                     Ok(Arc::new(col))
                 },{
                     unreachable!()

--- a/common/functions/src/scalars/maths/log.rs
+++ b/common/functions/src/scalars/maths/log.rs
@@ -25,10 +25,10 @@ use num_traits::AsPrimitive;
 use crate::scalars::assert_numeric;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::scalar_binary_op;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarUnaryExpression;
 
 /// Const f64 is now allowed.
 /// feature(adt_const_params) is not stable & complete
@@ -114,8 +114,7 @@ impl<T: Base> Function for GenericLogFunction<T> {
         let mut ctx = EvalContext::default();
         if columns.len() == 1 {
             with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
-                let unary = ScalarUnaryExpression::<$S, f64, _>::new(Self::log);
-                let col = unary.eval(columns[0].column(), &mut ctx)?;
+                let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), Self::log, &mut ctx)?;
                 Ok(Arc::new(col))
             },{
                 unreachable!()

--- a/common/functions/src/scalars/maths/random.rs
+++ b/common/functions/src/scalars/maths/random.rs
@@ -23,10 +23,10 @@ use rand::prelude::*;
 
 use crate::scalars::assert_numeric;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarUnaryExpression;
 
 #[derive(Clone)]
 pub struct RandomFunction {
@@ -70,8 +70,7 @@ impl Function for RandomFunction {
             _ => {
                 let mut ctx = EvalContext::default();
                 with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$T| {
-                      let unary = ScalarUnaryExpression::<$T, f64, _>::new(rand_seed);
-                    let col = unary.eval(columns[0].column(), &mut ctx)?;
+                    let col = scalar_unary_op::<$T, f64, _>(columns[0].column(), rand_seed, &mut ctx)?;
                     Ok(Arc::new(col))
                 },{
                     unreachable!()

--- a/common/functions/src/scalars/maths/round.rs
+++ b/common/functions/src/scalars/maths/round.rs
@@ -24,10 +24,10 @@ use num_traits::AsPrimitive;
 use crate::scalars::assert_numeric;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::scalar_binary_op;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarUnaryExpression;
 
 fn round<S>(value: S, _ctx: &mut EvalContext) -> f64
 where S: AsPrimitive<f64> {
@@ -104,8 +104,7 @@ fn eval_round(columns: &ColumnsWithField) -> Result<ColumnRef> {
     match columns.len() {
         1 => {
             with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
-                let unary = ScalarUnaryExpression::<$S, f64, _>::new(round);
-                let col = unary.eval(columns[0].column(), &mut ctx)?;
+                let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), round, &mut ctx)?;
                 Ok(Arc::new(col))
             },{
                 unreachable!()
@@ -137,8 +136,7 @@ fn eval_trunc(columns: &ColumnsWithField) -> Result<ColumnRef> {
     match columns.len() {
         1 => {
             with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
-                let unary = ScalarUnaryExpression::<$S, f64, _>::new(trunc);
-                let col = unary.eval(columns[0].column(), &mut ctx)?;
+                let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), trunc, &mut ctx)?;
                 Ok(Arc::new(col))
             },{
                 unreachable!()

--- a/common/functions/src/scalars/maths/round.rs
+++ b/common/functions/src/scalars/maths/round.rs
@@ -23,10 +23,10 @@ use num_traits::AsPrimitive;
 
 use crate::scalars::assert_numeric;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_binary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarBinaryExpression;
 use crate::scalars::ScalarUnaryExpression;
 
 fn round<S>(value: S, _ctx: &mut EvalContext) -> f64
@@ -115,10 +115,10 @@ fn eval_round(columns: &ColumnsWithField) -> Result<ColumnRef> {
         _ => {
             with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
                 with_match_primitive_type_id!(columns[1].data_type().data_type_id(), |$T| {
-                    let binary = ScalarBinaryExpression::<$S, $T, f64, _>::new(round_to);
-                    let col = binary.eval(
+                    let col = scalar_binary_op::<$S, $T, f64, _>(
                         columns[0].column(),
                         columns[1].column(),
+                        round_to,
                         &mut ctx
                     )?;
                     Ok(Arc::new(col))
@@ -148,10 +148,10 @@ fn eval_trunc(columns: &ColumnsWithField) -> Result<ColumnRef> {
         _ => {
             with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
                 with_match_primitive_type_id!(columns[1].data_type().data_type_id(), |$T| {
-                    let binary = ScalarBinaryExpression::<$S, $T, f64, _>::new(trunc_to);
-                    let col = binary.eval(
+                    let col = scalar_binary_op::<$S, $T, f64, _>(
                         columns[0].column(),
                         columns[1].column(),
+                        trunc_to,
                         &mut ctx,
                     )?;
                     Ok(Arc::new(col))

--- a/common/functions/src/scalars/maths/sign.rs
+++ b/common/functions/src/scalars/maths/sign.rs
@@ -23,11 +23,11 @@ use common_exception::Result;
 
 use crate::scalars::function_common::assert_numeric;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
 use crate::scalars::Monotonicity;
-use crate::scalars::ScalarUnaryExpression;
 
 #[derive(Clone)]
 pub struct SignFunction {
@@ -73,8 +73,7 @@ impl Function for SignFunction {
     fn eval(&self, columns: &ColumnsWithField, _input_rows: usize) -> Result<ColumnRef> {
         let mut ctx = EvalContext::default();
         with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
-            let unary = ScalarUnaryExpression::<$S, i8, _>::new(sign::<$S>);
-            let col = unary.eval(columns[0].column(), &mut ctx)?;
+            let col = scalar_unary_op::<$S, i8, _>(columns[0].column(), sign::<$S>, &mut ctx)?;
             Ok(Arc::new(col))
         },{
             unreachable!()

--- a/common/functions/src/scalars/maths/sqrt.rs
+++ b/common/functions/src/scalars/maths/sqrt.rs
@@ -22,9 +22,9 @@ use num::cast::AsPrimitive;
 use crate::scalars::function_common::assert_numeric;
 use crate::scalars::function_factory::FunctionDescription;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
-use crate::scalars::ScalarUnaryExpression;
 
 #[derive(Clone)]
 pub struct SqrtFunction {
@@ -62,8 +62,7 @@ impl Function for SqrtFunction {
     fn eval(&self, columns: &ColumnsWithField, _input_rows: usize) -> Result<ColumnRef> {
         let mut ctx = EvalContext::default();
         with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
-             let unary = ScalarUnaryExpression::<$S, f64, _>::new(sqrt::<$S>);
-             let col = unary.eval(columns[0].column(), &mut ctx)?;
+             let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), sqrt::<$S>, &mut ctx)?;
              Ok(col.arc())
         },{
             unreachable!()

--- a/common/functions/src/scalars/maths/trigonometric.rs
+++ b/common/functions/src/scalars/maths/trigonometric.rs
@@ -23,10 +23,10 @@ use num_traits::AsPrimitive;
 use crate::scalars::assert_numeric;
 use crate::scalars::function_factory::FunctionFeatures;
 use crate::scalars::scalar_binary_op;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarUnaryExpression;
 
 #[derive(Clone)]
 pub struct TrigonometricFunction {
@@ -86,40 +86,40 @@ impl Function for TrigonometricFunction {
                 with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
                    match self.t {
                         Trigonometric::COS => {
-                           let unary =  ScalarUnaryExpression::<$S, f64, _>::new(|v: $S, _ctx: &mut EvalContext|  AsPrimitive::<f64>::as_(v).cos());
-                           let col = unary.eval(columns[0].column(), &mut ctx)?;
-                           Ok(Arc::new(col))
+                            let func = |v: $S, _ctx: &mut EvalContext|  AsPrimitive::<f64>::as_(v).cos();
+                            let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), func, &mut ctx)?;
+                            Ok(Arc::new(col))
                         },
                         Trigonometric::SIN => {
-                           let unary =  ScalarUnaryExpression::<$S, f64, _>::new(|v: $S, _ctx: &mut EvalContext|  AsPrimitive::<f64>::as_(v).sin());
-                           let col = unary.eval(columns[0].column(), &mut ctx)?;
-                           Ok(Arc::new(col))
+                            let func = |v: $S, _ctx: &mut EvalContext|  AsPrimitive::<f64>::as_(v).sin();
+                            let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), func, &mut ctx)?;
+                            Ok(Arc::new(col))
                         },
                         Trigonometric::COT => {
-                           let unary =  ScalarUnaryExpression::<$S, f64, _>::new(|v: $S, _ctx: &mut EvalContext| 1.0 /  AsPrimitive::<f64>::as_(v).tan());
-                           let col = unary.eval(columns[0].column(), &mut ctx)?;
-                           Ok(Arc::new(col))
+                            let func = |v: $S, _ctx: &mut EvalContext| 1.0 /  AsPrimitive::<f64>::as_(v).tan();
+                            let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), func, &mut ctx)?;
+                            Ok(Arc::new(col))
                         },
                         Trigonometric::TAN => {
-                           let unary =  ScalarUnaryExpression::<$S, f64, _>::new(|v: $S, _ctx: &mut EvalContext| AsPrimitive::<f64>::as_(v).tan());
-                           let col = unary.eval(columns[0].column(), &mut ctx)?;
-                           Ok(Arc::new(col))
+                            let func = |v: $S, _ctx: &mut EvalContext| AsPrimitive::<f64>::as_(v).tan();
+                            let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), func, &mut ctx)?;
+                            Ok(Arc::new(col))
                         },
                         // the range [0, pi] or NaN if the number is outside the range
                         Trigonometric::ACOS => {
-                           let unary =  ScalarUnaryExpression::<$S, f64, _>::new(|v: $S, _ctx: &mut EvalContext| AsPrimitive::<f64>::as_(v).acos());
-                           let col = unary.eval(columns[0].column(), &mut ctx)?;
-                           Ok(Arc::new(col))
+                            let func = |v: $S, _ctx: &mut EvalContext| AsPrimitive::<f64>::as_(v).acos();
+                            let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), func, &mut ctx)?;
+                            Ok(Arc::new(col))
                         },
                         Trigonometric::ASIN => {
-                           let unary =  ScalarUnaryExpression::<$S, f64, _>::new(|v: $S, _ctx: &mut EvalContext| AsPrimitive::<f64>::as_(v).asin());
-                           let col = unary.eval(columns[0].column(), &mut ctx)?;
+                            let func = |v: $S, _ctx: &mut EvalContext| AsPrimitive::<f64>::as_(v).asin();
+                           let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), func, &mut ctx)?;
                            Ok(Arc::new(col))
                         },
                         Trigonometric::ATAN => {
-                           let unary =  ScalarUnaryExpression::<$S, f64, _>::new(|v: $S, _ctx: &mut EvalContext| AsPrimitive::<f64>::as_(v).atan());
-                           let col = unary.eval(columns[0].column(), &mut ctx)?;
-                           Ok(Arc::new(col))
+                            let func = |v: $S, _ctx: &mut EvalContext| AsPrimitive::<f64>::as_(v).atan();
+                            let col = scalar_unary_op::<$S, f64, _>(columns[0].column(), func, &mut ctx)?;
+                            Ok(Arc::new(col))
                         },
                         _ => unreachable!(),
                     }

--- a/common/functions/src/scalars/maths/trigonometric.rs
+++ b/common/functions/src/scalars/maths/trigonometric.rs
@@ -22,10 +22,10 @@ use num_traits::AsPrimitive;
 
 use crate::scalars::assert_numeric;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_binary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarBinaryExpression;
 use crate::scalars::ScalarUnaryExpression;
 
 #[derive(Clone)]
@@ -132,8 +132,7 @@ impl Function for TrigonometricFunction {
             _ => {
                 with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
                     with_match_primitive_type_id!(columns[1].data_type().data_type_id(), |$T| {
-                        let binary = ScalarBinaryExpression::<$S, $T, f64, _>::new(scalar_atan2);
-                        let col = binary.eval(columns[0].column(), columns[1].column(), &mut EvalContext::default())?;
+                        let col = scalar_binary_op::<$S, $T, f64, _>(columns[0].column(), columns[1].column(), scalar_atan2,&mut EvalContext::default())?;
                         Ok(Arc::new(col))
                     }, {
                         unreachable!()

--- a/common/functions/src/scalars/strings/find_in_set.rs
+++ b/common/functions/src/scalars/strings/find_in_set.rs
@@ -19,10 +19,10 @@ use common_exception::Result;
 
 use crate::scalars::assert_string;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_binary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarBinaryExpression;
 
 #[derive(Clone)]
 pub struct FindInSetFunction {
@@ -54,10 +54,10 @@ impl Function for FindInSetFunction {
     }
 
     fn eval(&self, columns: &ColumnsWithField, _input_rows: usize) -> Result<ColumnRef> {
-        let binary = ScalarBinaryExpression::<Vu8, Vu8, u64, _>::new(find_in_set);
-        let col = binary.eval(
+        let col = scalar_binary_op::<Vu8, Vu8, u64, _>(
             columns[0].column(),
             columns[1].column(),
+            find_in_set,
             &mut EvalContext::default(),
         )?;
         Ok(col.arc())

--- a/common/functions/src/scalars/strings/format.rs
+++ b/common/functions/src/scalars/strings/format.rs
@@ -25,10 +25,10 @@ use num_traits::AsPrimitive;
 use crate::scalars::assert_numeric;
 use crate::scalars::assert_string;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_binary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarBinaryExpression;
 
 const FORMAT_MAX_DECIMALS: i64 = 30;
 
@@ -73,8 +73,7 @@ impl Function for FormatFunction {
     fn eval(&self, columns: &ColumnsWithField, _input_rows: usize) -> Result<ColumnRef> {
         with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$F| {
                 with_match_primitive_type_id!(columns[1].data_type().data_type_id(), |$N| {
-                    let binary = ScalarBinaryExpression::<$F, $N, Vu8, _>::new(format_en_us);
-                    let col = binary.eval(columns[0].column(), columns[1].column(), &mut EvalContext::default())?;
+                    let col = scalar_binary_op::<$F, $N, Vu8, _>(columns[0].column(), columns[1].column(), format_en_us,&mut EvalContext::default())?;
                     Ok(col.arc())
                 },{
                     unreachable!()

--- a/common/functions/src/scalars/strings/leftright.rs
+++ b/common/functions/src/scalars/strings/leftright.rs
@@ -23,10 +23,10 @@ use num_traits::AsPrimitive;
 use crate::scalars::assert_numeric;
 use crate::scalars::assert_string;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_binary_op_ref;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarBinaryExpression;
 
 pub type LeftFunction = LeftRightFunction<true>;
 pub type RightFunction = LeftRightFunction<false>;
@@ -84,8 +84,7 @@ impl<const IS_LEFT: bool> Function for LeftRightFunction<IS_LEFT> {
         match IS_LEFT {
             true => {
                 with_match_primitive_type_id!(columns[1].data_type().data_type_id(), |$S| {
-                    let binary = ScalarBinaryExpression::<Vu8, $S, Vu8, _>::new_ref(left);
-                    let col = binary.eval_ref(columns[0].column(), columns[1].column(), &mut EvalContext::default())?;
+                    let col = scalar_binary_op_ref::<Vu8, $S, Vu8, _>(columns[0].column(), columns[1].column(), left, &mut EvalContext::default())?;
                     Ok(Arc::new(col))
                 },{
                     unreachable!()
@@ -93,8 +92,7 @@ impl<const IS_LEFT: bool> Function for LeftRightFunction<IS_LEFT> {
             }
             false => {
                 with_match_primitive_type_id!(columns[1].data_type().data_type_id(), |$S| {
-                    let binary = ScalarBinaryExpression::<Vu8, $S, Vu8, _>::new_ref(right);
-                    let col = binary.eval_ref(columns[0].column(), columns[1].column(), &mut EvalContext::default())?;
+                    let col = scalar_binary_op_ref::<Vu8, $S, Vu8, _>(columns[0].column(), columns[1].column(), right, &mut EvalContext::default())?;
                     Ok(Arc::new(col))
                 },{
                     unreachable!()

--- a/common/functions/src/scalars/strings/space.rs
+++ b/common/functions/src/scalars/strings/space.rs
@@ -22,10 +22,10 @@ use num_traits::AsPrimitive;
 
 use crate::scalars::assert_numeric;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_unary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarUnaryExpression;
 
 // Returns a string consisting of N space characters.
 #[derive(Clone)]
@@ -59,8 +59,8 @@ impl Function for SpaceFunction {
     fn eval(&self, columns: &ColumnsWithField, _input_rows: usize) -> Result<ColumnRef> {
         let mut ctx = EvalContext::default();
         with_match_primitive_type_id!(columns[0].data_type().data_type_id(), |$S| {
-            let unary = ScalarUnaryExpression::<$S, Vu8, _>::new(|n: $S, _ctx: &mut EvalContext| -> Vu8 { vec![32u8; n.as_()] });
-            let col = unary.eval(columns[0].column(), &mut ctx)?;
+            let func = |n: $S, _ctx: &mut EvalContext| -> Vu8 { vec![32u8; n.as_()] };
+            let col = scalar_unary_op::<$S, Vu8, _>(columns[0].column(), func, &mut ctx)?;
             Ok(Arc::new(col))
         },{
             unreachable!()

--- a/common/functions/src/scalars/strings/strcmp.rs
+++ b/common/functions/src/scalars/strings/strcmp.rs
@@ -21,10 +21,10 @@ use itertools::izip;
 
 use crate::scalars::assert_string;
 use crate::scalars::function_factory::FunctionFeatures;
+use crate::scalars::scalar_binary_op;
 use crate::scalars::EvalContext;
 use crate::scalars::Function;
 use crate::scalars::FunctionDescription;
-use crate::scalars::ScalarBinaryExpression;
 
 #[derive(Clone)]
 pub struct StrcmpFunction {
@@ -57,10 +57,10 @@ impl Function for StrcmpFunction {
     }
 
     fn eval(&self, columns: &ColumnsWithField, _input_rows: usize) -> Result<ColumnRef> {
-        let binary = ScalarBinaryExpression::<Vu8, Vu8, i8, _>::new(strcmp);
-        let col = binary.eval(
+        let col = scalar_binary_op::<Vu8, Vu8, i8, _>(
             columns[0].column(),
             columns[1].column(),
+            strcmp,
             &mut EvalContext::default(),
         )?;
         Ok(col.arc())

--- a/common/functions/tests/it/scalars/expressions.rs
+++ b/common/functions/tests/it/scalars/expressions.rs
@@ -171,6 +171,27 @@ fn test_binary_contains() {
 }
 
 #[test]
+fn test_binary_simd_op() {
+    {
+        let l = Series::from_data(vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let r = Series::from_data(vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let expected = Series::from_data(vec![2u8, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
+        let result = binary_simd_op::<u8, u8, _, 8>(&l, &r, |a, b| a + b).unwrap();
+        let result = Arc::new(result) as ColumnRef;
+        assert!(result == expected);
+    }
+
+    {
+        let l = Series::from_data(vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let r = Arc::new(ConstColumn::new(Series::from_data(vec![1u8]), 10)) as ColumnRef;
+        let expected = Series::from_data(vec![2u8, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+        let result = binary_simd_op::<u8, u8, _, 8>(&l, &r, |a, b| a + b).unwrap();
+        let result = Arc::new(result) as ColumnRef;
+        assert!(result == expected);
+    }
+}
+
+#[test]
 fn test_unary_size() {
     struct LenFunc {}
 

--- a/common/functions/tests/it/scalars/expressions.rs
+++ b/common/functions/tests/it/scalars/expressions.rs
@@ -145,13 +145,8 @@ fn test_datetime_cast_function() -> Result<()> {
 
 #[test]
 fn test_binary_contains() {
-    //create two string columns
-    struct Contains {}
-
-    impl ScalarBinaryFunction<Vu8, Vu8, bool> for Contains {
-        fn eval(&self, a: &'_ [u8], b: &'_ [u8], _ctx: &mut EvalContext) -> bool {
-            a.windows(b.len()).any(|window| window == b)
-        }
+    fn contains(a: &'_ [u8], b: &'_ [u8], _ctx: &mut EvalContext) -> bool {
+        a.windows(b.len()).any(|window| window == b)
     }
 
     for _ in 0..10 {
@@ -161,7 +156,7 @@ fn test_binary_contains() {
         let result = scalar_binary_op::<Vec<u8>, Vec<u8>, bool, _>(
             &l,
             &r,
-            Contains {},
+            contains,
             &mut EvalContext::default(),
         )
         .unwrap();
@@ -193,19 +188,15 @@ fn test_binary_simd_op() {
 
 #[test]
 fn test_unary_size() {
-    struct LenFunc {}
-
-    impl ScalarUnaryFunction<Vu8, i32> for LenFunc {
-        fn eval(&self, l: &[u8], _ctx: &mut EvalContext) -> i32 {
-            l.len() as i32
-        }
+    fn len_func(l: &[u8], _ctx: &mut EvalContext) -> i32 {
+        l.len() as i32
     }
 
     let mut ctx = EvalContext::default();
 
     let l = Series::from_data(vec!["11", "22", "333"]);
     let expected = Series::from_data(vec![2i32, 2, 3]);
-    let result = scalar_unary_op::<Vec<u8>, i32, _>(&l, LenFunc {}, &mut ctx).unwrap();
+    let result = scalar_unary_op::<Vec<u8>, i32, _>(&l, len_func, &mut ctx).unwrap();
     let result = Arc::new(result) as ColumnRef;
     assert!(result == expected);
 }

--- a/common/functions/tests/it/scalars/expressions.rs
+++ b/common/functions/tests/it/scalars/expressions.rs
@@ -154,15 +154,17 @@ fn test_binary_contains() {
         }
     }
 
-    let binary_expression = ScalarBinaryExpression::<Vec<u8>, Vec<u8>, bool, _>::new(Contains {});
-
     for _ in 0..10 {
         let l = Series::from_data(vec!["11", "22", "33"]);
         let r = Series::from_data(vec!["1", "2", "43"]);
         let expected = Series::from_data(vec![true, true, false]);
-        let result = binary_expression
-            .eval(&l, &r, &mut EvalContext::default())
-            .unwrap();
+        let result = scalar_binary_op::<Vec<u8>, Vec<u8>, bool, _>(
+            &l,
+            &r,
+            Contains {},
+            &mut EvalContext::default(),
+        )
+        .unwrap();
         let result = Arc::new(result) as ColumnRef;
         assert!(result == expected);
     }

--- a/common/functions/tests/it/scalars/expressions.rs
+++ b/common/functions/tests/it/scalars/expressions.rs
@@ -184,8 +184,7 @@ fn test_unary_size() {
 
     let l = Series::from_data(vec!["11", "22", "333"]);
     let expected = Series::from_data(vec![2i32, 2, 3]);
-    let unary_expression = ScalarUnaryExpression::<Vec<u8>, i32, _>::new(LenFunc {});
-    let result = unary_expression.eval(&l, &mut ctx).unwrap();
+    let result = scalar_unary_op::<Vec<u8>, i32, _>(&l, LenFunc {}, &mut ctx).unwrap();
     let result = Arc::new(result) as ColumnRef;
     assert!(result == expected);
 }

--- a/query/src/functions/function_factory.rs
+++ b/query/src/functions/function_factory.rs
@@ -23,7 +23,7 @@ use crate::functions::admins::AdminFunction;
 use crate::functions::systems::SystemFunction;
 use crate::functions::Function;
 
-pub type Factory2Creator = Box<dyn Fn() -> Result<Box<dyn Function>> + Send + Sync>;
+pub type FactoryCreator = Box<dyn Fn() -> Result<Box<dyn Function>> + Send + Sync>;
 
 #[derive(Clone)]
 pub struct FunctionFeatures {
@@ -55,11 +55,11 @@ impl FunctionFeatures {
 
 pub struct FunctionDescription {
     features: FunctionFeatures,
-    function_creator: Factory2Creator,
+    function_creator: FactoryCreator,
 }
 
 impl FunctionDescription {
-    pub fn creator(creator: Factory2Creator) -> FunctionDescription {
+    pub fn creator(creator: FactoryCreator) -> FunctionDescription {
         FunctionDescription {
             function_creator: creator,
             features: FunctionFeatures::default(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
Remove ScalarBinaryExpression/ ScalarUnaryExpression, add scalar_binary_op/ scalar_unary_op.
Add binary_simd_op/ unary_simd_op/ primitive_binary_simd_op


## Changelog

- Improvement
## Related Issues

Fixes #issue

## Test Plan


