### PR TITLE
Rename query.http_api_address-> admin_api_address

### DIFF
--- a/cli/src/cmds/clusters/create.rs
+++ b/cli/src/cmds/clusters/create.rs
@@ -103,17 +103,21 @@ async fn reconcile_local(status: &mut Status) -> Result<()> {
 
 pub fn generate_query_config() -> QueryConfig {
     let mut config = QueryConfig::default();
-    if config.query.http_api_address.parse::<SocketAddr>().is_err()
+    if config
+        .query
+        .admin_api_address
+        .parse::<SocketAddr>()
+        .is_err()
         || !portpicker::is_free(
             config
                 .query
-                .http_api_address
+                .admin_api_address
                 .parse::<SocketAddr>()
                 .unwrap()
                 .port(),
         )
     {
-        config.query.http_api_address = Status::find_unused_local_port()
+        config.query.admin_api_address = Status::find_unused_local_port()
     }
 
     if config

--- a/cli/src/cmds/status.rs
+++ b/cli/src/cmds/status.rs
@@ -478,8 +478,8 @@ impl LocalRuntime for LocalQueryConfig {
                 conf.query.flight_api_address,
             )
             .env(
-                databend_query::configs::config_query::QUERY_HTTP_API_ADDRESS,
-                conf.query.http_api_address,
+                databend_query::configs::config_query::QUERY_ADMIN_API_ADDRESS,
+                conf.query.admin_api_address,
             )
             .env(
                 databend_query::configs::config_query::QUERY_METRICS_API_ADDRESS,
@@ -548,7 +548,7 @@ impl LocalRuntime for LocalQueryConfig {
 
         let url = {
             if !self.config.tls_rpc_server_enabled() {
-                format!("http://{}/v1/health", self.config.query.http_api_address)
+                format!("http://{}/v1/health", self.config.query.admin_api_address)
             } else {
                 todo!()
             }

--- a/cli/tests/it/clusters/view.rs
+++ b/cli/tests/it/clusters/view.rs
@@ -82,7 +82,7 @@ async fn test_build_table() -> Result<()> {
             path: Some("./".to_string()),
             log_dir: Some("./".to_string()),
         };
-        query_config.config.query.http_api_address = server.address().to_string();
+        query_config.config.query.admin_api_address = server.address().to_string();
 
         Status::save_local_config(
             &mut status,
@@ -179,7 +179,7 @@ async fn test_build_table_fail() -> Result<()> {
             path: Some("./".to_string()),
             log_dir: Some("./".to_string()),
         };
-        query_config.config.query.http_api_address = server2.address().to_string();
+        query_config.config.query.admin_api_address = server2.address().to_string();
 
         Status::save_local_config(
             &mut status,
@@ -194,7 +194,7 @@ async fn test_build_table_fail() -> Result<()> {
             path: Some("./".to_string()),
             log_dir: Some("./".to_string()),
         };
-        query_config2.config.query.http_api_address = server2.address().to_string();
+        query_config2.config.query.admin_api_address = server2.address().to_string();
 
         Status::save_local_config(
             &mut status,

--- a/cli/tests/it/query.rs
+++ b/cli/tests/it/query.rs
@@ -50,7 +50,7 @@ macro_rules! build_status {
         };
         query_config.config.query.http_handler_host = "127.0.0.1".to_string();
         query_config.config.query.http_handler_port = $http_port;
-        query_config.config.query.http_api_address = format!("127.0.0.1:456");
+        query_config.config.query.admin_api_address = format!("127.0.0.1:456");
 
         Status::save_local_config(
             &mut status,

--- a/cli/tests/it/status.rs
+++ b/cli/tests/it/status.rs
@@ -213,7 +213,7 @@ async fn test_verify() -> Result<()> {
         path: Some("./".to_string()),
         log_dir: Some("./".to_string()),
     };
-    query_config.config.query.http_api_address = server2.address().to_string();
+    query_config.config.query.admin_api_address = server2.address().to_string();
 
     let mut query_config2 = LocalQueryConfig {
         config: QueryConfig::default(),
@@ -221,7 +221,7 @@ async fn test_verify() -> Result<()> {
         path: Some("./".to_string()),
         log_dir: Some("./".to_string()),
     };
-    query_config2.config.query.http_api_address = server2.address().to_string();
+    query_config2.config.query.admin_api_address = server2.address().to_string();
     // successful case should return immediately
     let t1 = meta_config.verify(Some(10), Some(Duration::from_millis(100)));
     // failed case should return after 2 times retry

--- a/docker/databend-query-docker.toml
+++ b/docker/databend-query-docker.toml
@@ -10,7 +10,7 @@ flight_api_address = "0.0.0.0:9091"
 
 # Databend Query http address.
 # For admin RESET API.
-http_api_address = "0.0.0.0:8081"
+admin_api_address = "0.0.0.0:8081"
 
 # Databend Query metrics RESET API.
 metric_api_address = "0.0.0.0:7071"

--- a/docs/user/01-sql-statement/08-system-tables/system-configs.md
+++ b/docs/user/01-sql-statement/08-system-tables/system-configs.md
@@ -20,7 +20,7 @@ mysql> select * from  configs;
 | http_handler_host                    | 127.0.0.1        | query |             |
 | http_handler_port                    | 8000             | query |             |
 | flight_api_address                   | 127.0.0.1:9090   | query |             |
-| http_api_address                     | 127.0.0.1:8080   | query |             |
+| admin_api_address                    | 127.0.0.1:8080   | query |             |
 | metric_api_address                   | 127.0.0.1:7070   | query |             |
 | http_handler_tls_server_cert         |                  | query |             |
 | http_handler_tls_server_key          |                  | query |             |

--- a/query/src/bin/databend-query.rs
+++ b/query/src/bin/databend-query.rs
@@ -135,7 +135,7 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
 
     // HTTP API service.
     {
-        let address = conf.query.http_api_address.clone();
+        let address = conf.query.admin_api_address.clone();
         let mut srv = HttpService::create(session_manager.clone());
         let listening = srv.start(address.parse()?).await?;
         shutdown_handle.add_service(srv);

--- a/query/src/configs/config_query.rs
+++ b/query/src/configs/config_query.rs
@@ -32,7 +32,7 @@ pub const QUERY_HTTP_HANDLER_PORT: &str = "QUERY_HTTP_HANDLER_PORT";
 pub const QUERY_HTTP_HANDLER_RESULT_TIMEOUT_MILLIS: &str =
     "QUERY_HTTP_HANDLER_RESULT_TIMEOUT_MILLIS";
 pub const QUERY_FLIGHT_API_ADDRESS: &str = "QUERY_FLIGHT_API_ADDRESS";
-pub const QUERY_HTTP_API_ADDRESS: &str = "QUERY_HTTP_API_ADDRESS";
+pub const QUERY_ADMIN_API_ADDRESS: &str = "QUERY_ADMIN_API_ADDRESS";
 pub const QUERY_METRICS_API_ADDRESS: &str = "QUERY_METRIC_API_ADDRESS";
 pub const QUERY_WAIT_TIMEOUT_MILLS: &str = "QUERY_WAIT_TIMEOUT_MILLS";
 pub const QUERY_MAX_QUERY_LOG_SIZE: &str = "QUERY_MAX_QUERY_LOG_SIZE";
@@ -108,8 +108,8 @@ pub struct QueryConfig {
     #[clap(long, env = QUERY_FLIGHT_API_ADDRESS, default_value = "127.0.0.1:9090")]
     pub flight_api_address: String,
 
-    #[clap(long, env = QUERY_HTTP_API_ADDRESS, default_value = "127.0.0.1:8080")]
-    pub http_api_address: String,
+    #[clap(long, env = QUERY_ADMIN_API_ADDRESS, default_value = "127.0.0.1:8080")]
+    pub admin_api_address: String,
 
     #[clap(long,env = QUERY_METRICS_API_ADDRESS, default_value = "127.0.0.1:7070")]
     pub metric_api_address: String,
@@ -234,7 +234,7 @@ impl Default for QueryConfig {
             http_handler_port: 8000,
             http_handler_result_timeout_millis: 10000,
             flight_api_address: "127.0.0.1:9090".to_string(),
-            http_api_address: "127.0.0.1:8080".to_string(),
+            admin_api_address: "127.0.0.1:8080".to_string(),
             metric_api_address: "127.0.0.1:7070".to_string(),
             api_tls_server_cert: "".to_string(),
             api_tls_server_key: "".to_string(),
@@ -315,9 +315,9 @@ impl QueryConfig {
         env_helper!(
             mut_config,
             query,
-            http_api_address,
+            admin_api_address,
             String,
-            QUERY_HTTP_API_ADDRESS
+            QUERY_ADMIN_API_ADDRESS
         );
         env_helper!(
             mut_config,

--- a/query/tests/it/configs.rs
+++ b/query/tests/it/configs.rs
@@ -128,7 +128,7 @@ fn test_env_config() -> Result<()> {
     std::env::set_var("QUERY_CLICKHOUSE_HANDLER_HOST", "1.2.3.4");
     std::env::set_var("QUERY_CLICKHOUSE_HANDLER_PORT", "9000");
     std::env::set_var("QUERY_FLIGHT_API_ADDRESS", "1.2.3.4:9091");
-    std::env::set_var("QUERY_HTTP_API_ADDRESS", "1.2.3.4:8081");
+    std::env::set_var("QUERY_ADMIN_API_ADDRESS", "1.2.3.4:8081");
     std::env::set_var("QUERY_METRIC_API_ADDRESS", "1.2.3.4:7071");
     std::env::set_var("QUERY_TABLE_CACHE_ENABLED", "true");
     std::env::set_var("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", "512");
@@ -196,7 +196,7 @@ fn test_env_config() -> Result<()> {
     std::env::remove_var("QUERY_CLICKHOUSE_HANDLER_PORT");
     std::env::remove_var("QUERY_CLICKHOUSE_HANDLER_THREAD_NUM");
     std::env::remove_var("QUERY_FLIGHT_API_ADDRESS");
-    std::env::remove_var("QUERY_HTTP_API_ADDRESS");
+    std::env::remove_var("QUERY_ADMIN_API_ADDRESS");
     std::env::remove_var("QUERY_METRIC_API_ADDRESS");
     std::env::remove_var("QUERY_TABLE_CACHE_ENABLED");
     std::env::remove_var("QUERY_TABLE_MEMORY_CACHE_MB_SIZE");

--- a/query/tests/it/configs.rs
+++ b/query/tests/it/configs.rs
@@ -48,7 +48,7 @@ http_handler_host = \"127.0.0.1\"
 http_handler_port = 8000
 http_handler_result_timeout_millis = 10000
 flight_api_address = \"127.0.0.1:9090\"
-http_api_address = \"127.0.0.1:8080\"
+admin_api_address = \"127.0.0.1:8080\"
 metric_api_address = \"127.0.0.1:7070\"
 http_handler_tls_server_cert = \"\"
 http_handler_tls_server_key = \"\"
@@ -161,7 +161,7 @@ fn test_env_config() -> Result<()> {
     assert_eq!(9000, configured.query.clickhouse_handler_port);
 
     assert_eq!("1.2.3.4:9091", configured.query.flight_api_address);
-    assert_eq!("1.2.3.4:8081", configured.query.http_api_address);
+    assert_eq!("1.2.3.4:8081", configured.query.admin_api_address);
     assert_eq!("1.2.3.4:7071", configured.query.metric_api_address);
 
     assert_eq!("s3", configured.storage.storage_type);

--- a/query/tests/it/storages/system/configs_table.rs
+++ b/query/tests/it/storages/system/configs_table.rs
@@ -50,7 +50,7 @@ async fn test_configs_table() -> Result<()> {
         "| disk.data_path                       | _data                    | storage |             |",
         "| disk.temp_data_path                  |                          | storage |             |",
         "| flight_api_address                   | 127.0.0.1:9090           | query   |             |",
-        "| http_api_address                     | 127.0.0.1:8080           | query   |             |",
+        "| admin_api_address                    | 127.0.0.1:8080           | query   |             |",
         "| http_handler_host                    | 127.0.0.1                | query   |             |",
         "| http_handler_port                    | 8000                     | query   |             |",
         "| http_handler_result_timeout_millis   | 10000                    | query   |             |",

--- a/scripts/ci/deploy/config/databend-query-embedded-meta.toml
+++ b/scripts/ci/deploy/config/databend-query-embedded-meta.toml
@@ -10,7 +10,7 @@ flight_api_address = "0.0.0.0:9091"
 
 # Databend Query http address.
 # For admin RESET API.
-http_api_address = "0.0.0.0:8081"
+admin_api_address = "0.0.0.0:8081"
 
 # Databend Query metrics RESET API.
 metric_api_address = "0.0.0.0:7071"

--- a/scripts/ci/deploy/config/databend-query-management-mode.toml
+++ b/scripts/ci/deploy/config/databend-query-management-mode.toml
@@ -7,7 +7,7 @@ wait_timeout_mills = 5000
 
 # Databend Query http address.
 # For admin RESET API.
-http_api_address = "0.0.0.0:8081"
+admin_api_address = "0.0.0.0:8081"
 
 # Databend Query metrics RESET API.
 metric_api_address = "0.0.0.0:7071"

--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -10,7 +10,7 @@ flight_api_address = "0.0.0.0:9091"
 
 # Databend Query http address.
 # For admin RESET API.
-http_api_address = "0.0.0.0:8081"
+admin_api_address = "0.0.0.0:8081"
 
 # Databend Query metrics RESET API.
 metric_api_address = "0.0.0.0:7071"

--- a/scripts/ci/deploy/config/databend-query-node-2.toml
+++ b/scripts/ci/deploy/config/databend-query-node-2.toml
@@ -10,7 +10,7 @@ flight_api_address = "0.0.0.0:9092"
 
 # Databend Query http address.
 # For admin RESET API.
-http_api_address = "0.0.0.0:8082"
+admin_api_address = "0.0.0.0:8082"
 
 # Databend Query metrics RESET API.
 metric_api_address = "0.0.0.0:7072"

--- a/scripts/ci/deploy/config/databend-query-node-3.toml
+++ b/scripts/ci/deploy/config/databend-query-node-3.toml
@@ -10,7 +10,7 @@ flight_api_address = "0.0.0.0:9093"
 
 # Databend Query http address.
 # For admin RESET API.
-http_api_address = "0.0.0.0:8083"
+admin_api_address = "0.0.0.0:8083"
 
 # Databend Query metrics RESET API.
 metric_api_address = "0.0.0.0:7073"

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -32,6 +32,7 @@ def remove_control_characters(s):
     """
     https://github.com/html5lib/html5lib-python/issues/96#issuecomment-43438438
     """
+
     def str_to_int(s, default, base=10):
         if int(s, base) < 0x10000:
             return chr(int(s, base))

--- a/tests/helpers/client.py
+++ b/tests/helpers/client.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.join(CURDIR))
 
 
 class client(object):
+
     def __init__(self, name='', log=None):
         self.name = name
         self.log = log

--- a/tests/suites/0_stateless/00_dummy/00_0002_dummy_select_py.py
+++ b/tests/suites/0_stateless/00_dummy/00_0002_dummy_select_py.py
@@ -31,6 +31,7 @@ client1.run("select 3")
 
 
 class MyModel(object):
+
     def __init__(self, name, value):
         self.name = name
         self.value = value


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR:
**Rename query.http_api_address-> admin_api_address**

Note:
keep the `flight_api_address` name

## Changelog

- Improvement


## Related Issues

Fixes #4384
Fixes #4388

## Test Plan

Unit Tests

Stateless Tests

