### PR TITLE
 support for super user

### DIFF
--- a/common/meta/types/src/user_info.rs
+++ b/common/meta/types/src/user_info.rs
@@ -36,6 +36,8 @@ pub struct UserInfo {
     pub grants: UserGrantSet,
 
     pub quota: UserQuota,
+
+    pub is_superuser: bool,
 }
 
 impl UserInfo {
@@ -50,6 +52,18 @@ impl UserInfo {
             auth_info,
             grants,
             quota,
+            is_superuser: false,
+        }
+    }
+
+    pub fn new_super(name: String) -> Self {
+        UserInfo {
+            name,
+            hostname: "".to_string(),
+            auth_info: AuthInfo::JWT,
+            grants: UserGrantSet::empty(),
+            quota: UserQuota::no_limit(),
+            is_superuser: true,
         }
     }
 

--- a/query/src/interpreters/interpreter_user_create.rs
+++ b/query/src/interpreters/interpreter_user_create.rs
@@ -59,6 +59,7 @@ impl Interpreter for CreateUserInterpreter {
             hostname: plan.hostname,
             grants: UserGrantSet::empty(),
             quota: UserQuota::no_limit(),
+            is_superuser: false,
         };
         user_mgr.add_user(&tenant, user_info).await?;
 

--- a/query/src/users/auth/auth_mgr.rs
+++ b/query/src/users/auth/auth_mgr.rs
@@ -56,11 +56,15 @@ impl AuthMgr {
     pub async fn auth(&self, credential: &Credential) -> Result<UserInfo> {
         match credential {
             Credential::Jwt { token: t } => {
-                let user_name = match &self.jwt {
+                let (user_name, is_supper) = match &self.jwt {
                     Some(j) => j.get_user(t.as_str())?,
                     None => return Err(ErrorCode::AuthenticateFailure("jwt auth not configured.")),
                 };
-                self.users.get_user(&self.tenant, &user_name, "%").await
+                if is_supper {
+                    Ok(UserInfo::new_super(user_name))
+                } else {
+                    self.users.get_user(&self.tenant, &user_name, "%").await
+                }
             }
             Credential::Password {
                 name: n,

--- a/query/src/users/user.rs
+++ b/query/src/users/user.rs
@@ -45,6 +45,7 @@ impl From<&User> for UserInfo {
             auth_info: user.auth_data.clone(),
             grants,
             quota,
+            is_superuser: false,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

temporary support for super user 

1.  only  auth  by JWT 
2.  temporary bypass current Privilege system (fixed Privileges, no need to store/get in meta)

@flaneur2020 @ZhiHanZ 

by adding is_superuser field,  we have a sep user namespace for  superusers.
this is the way with minimal code change. 

btw, we already has an UserPrivilegeType called `Super`

```
    // Privilege to Kill query, Set global configs, etc.
    Super = 1 << 9,
```

- [ ] add unit test

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues


## Test Plan

Unit Tests

Stateless Tests

