### PR TITLE
Improve Unknown database error message

### DIFF
--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -612,7 +612,7 @@ impl MetaApiTestSuite {
                     let err_code = ErrorCode::from(status);
 
                     assert_eq!(
-                        format!("Code: 1025, displayText = Unknown table: '{:}'.", tbl_name),
+                        format!("Code: 1025, displayText = Unknown table '{:}'.", tbl_name),
                         err_code.to_string(),
                         "get dropped table {}",
                         tbl_name
@@ -1024,8 +1024,11 @@ impl MetaApiTestSuite {
             let err = res.unwrap_err();
             let err = ErrorCode::from(err);
             assert_eq!(ErrorCode::UnknownDatabase("").code(), err.code());
-            assert_eq!("nonexistent", err.message());
-            assert_eq!("Code: 1003, displayText = nonexistent.", format!("{}", err));
+            assert_eq!("Unknown database 'nonexistent'", err.message());
+            assert_eq!(
+                "Code: 1003, displayText = Unknown database 'nonexistent'.",
+                format!("{}", err)
+            );
         }
 
         Ok(())

--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -279,7 +279,7 @@ impl MetaApiTestSuite {
             let err = ErrorCode::from(res);
 
             assert_eq!(ErrorCode::UnknownDatabase("").code(), err.code());
-            assert_eq!("db2".to_string(), err.message());
+            assert_eq!("Unknown database 'db2'".to_string(), err.message());
         }
 
         tracing::info!("--- drop db2");
@@ -535,7 +535,10 @@ impl MetaApiTestSuite {
                 let err_code = ErrorCode::from(status);
 
                 assert_eq!(
-                    format!("Code: 2302, displayText = table exists: {}.", tbl_name),
+                    format!(
+                        "Code: 2302, displayText = Table '{}' already exists.",
+                        tbl_name
+                    ),
                     err_code.to_string()
                 );
 

--- a/common/meta/types/src/meta_storage_errors.rs
+++ b/common/meta/types/src/meta_storage_errors.rs
@@ -200,23 +200,29 @@ pub enum AppError {
 
 impl AppErrorMessage for UnknownDatabase {
     fn message(&self) -> String {
-        self.db_name.to_string()
+        format!("Unknown database '{}'", self.db_name)
     }
 }
+
+impl AppErrorMessage for DatabaseAlreadyExists {
+    fn message(&self) -> String {
+        format!("Database '{}' already exists", self.db_name)
+    }
+}
+
 impl AppErrorMessage for UnknownTable {
     fn message(&self) -> String {
-        format!("Unknown table: '{}'", self.table_name)
+        format!("Unknown table '{}'", self.table_name)
     }
 }
 
 impl AppErrorMessage for UnknownTableId {}
 impl AppErrorMessage for UnknownDatabaseId {}
-impl AppErrorMessage for DatabaseAlreadyExists {}
 impl AppErrorMessage for TableVersionMismatched {}
 
 impl AppErrorMessage for TableAlreadyExists {
     fn message(&self) -> String {
-        format!("table exists: {}", self.table_name)
+        format!("Table '{}' already exists", self.table_name)
     }
 }
 

--- a/query/tests/it/sql/plan_parser.rs
+++ b/query/tests/it/sql/plan_parser.rs
@@ -165,19 +165,19 @@ async fn test_plan_parser() -> Result<()> {
             name: "insert-simple",
             sql: "insert into t(col1, col2) values(1,2), (3,4)",
             expect: "",
-            error: "Code: 1025, displayText = Unknown table: 't'.",
+            error: "Code: 1025, displayText = Unknown table 't'.",
         },
         Test {
             name: "insert-value-other-than-simple-expression",
             sql: "insert into t(col1, col2) values(1 + 0, 1 + 1), (3,4)",
             expect: "",
-            error: "Code: 1025, displayText = Unknown table: 't'.",
+            error: "Code: 1025, displayText = Unknown table 't'.",
         },
         Test {
             name: "insert-subquery-not-supported",
             sql: "insert into t select * from t",
             expect: "",
-            error: "Code: 1025, displayText = Unknown table: 't'.",
+            error: "Code: 1025, displayText = Unknown table 't'.",
         },
         Test {
             name: "select-full",

--- a/query/tests/it/sql/statements/statement_copy.rs
+++ b/query/tests/it/sql/statements/statement_copy.rs
@@ -122,7 +122,7 @@ async fn test_statement_copy() -> Result<()> {
         encryption=(master_key = 'my_master_key')
         file_format = (type = csv field_delimiter = '|' skip_header = 1)",
             expect: "",
-            err: "Code: 1025, displayText = Unknown table: 'mytable'.",
+            err: "Code: 1025, displayText = Unknown table 'mytable'.",
         },
         TestCase {
             name: "copy-external-uri-not-found-error",


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
Improve Unknown database error message

Before this pr:
mysql> create table test.test;
ERROR 1105 (HY000): Code: 1003, displayText = test.

After this pr:
mysql> create table test.test(id int);
ERROR 1105 (HY000): Code: 1003, displayText = Unknown database 'test'.
## Changelog


- Improvement


## Related Issues

Fixes #4249 

## Test Plan
start up services by running up.sh

<details>
  <summary>Click to expand up.sh!</summary>

```sh
cat - > "/tmp/db-meta.toml" <<EOF
log_dir = "metadata/_logs"
admin_api_address = "127.0.0.1:8101"
grpc_api_address = "127.0.0.1:9101"

[raft_config]
id = 1
single = true
raft_dir = "metadata/datas"
EOF



cat - > "/tmp/db-query.toml" <<EOF
[log]
log_level = "INFO"
log_dir = "benddata/_logs"

[query]
# For admin RESET API.
admin_api_address = "127.0.0.1:8001"

# Metrics.
metric_api_address = "127.0.0.1:7071"

# Cluster flight RPC.
flight_api_address = "127.0.0.1:9091"

#

# Query MySQL Handler.
mysql_handler_host = "127.0.0.1"
mysql_handler_port = 3307

# Query ClickHouse Handler.
clickhouse_handler_host = "127.0.0.1"
clickhouse_handler_port = 9001

# Query HTTP Handler.
http_handler_host = "127.0.0.1"
http_handler_port = 8081

tenant_id = "tenant1"
cluster_id = "cluster1"

[meta]
# databend-meta grpc api address.
meta_address = "127.0.0.1:9101"
meta_username = "root"
meta_password = "root"

[storage]
# disk|s3
storage_type = "disk"

[storage.disk]
data_path = "bendata/datas"

[storage.s3]

[storage.azure_storage_blob]
EOF

stop_services() {
    killall -9 databend-meta || true
    killall -9 databend-query || true
}

trap stop_services EXIT

./target/debug/databend-meta -c /tmp/db-meta.toml > meta.log 2>&1 &

sleep 4
./target/debug/databend-query -c /tmp/db-query.toml > query.log 2>&1 &


while true;
do
    sleep 1
done
```

</details>


try create table:
```
mysql -h127.0.0.1 -uroot -P3307
mysql> create table test.test(id int);
ERROR 1105 (HY000): Code: 1003, displayText = Unknown database 'test'.
```

