### PR TITLE
Redirect stderr to file too

### DIFF
--- a/docs/doc/01-deploy/00_local.md
+++ b/docs/doc/01-deploy/00_local.md
@@ -98,7 +98,7 @@ raft_dir = "metadata/datas"
 ### 2.2 Start the databend-meta
 
 ```shell
-./databend-meta -c ./databend-meta.toml 2>&1 > meta.log&
+./databend-meta -c ./databend-meta.toml > meta.log 2>&1 &
 ```
 
 ### 2.3 Check databend-meta
@@ -167,7 +167,7 @@ data_path = "bendata/datas"
 ### 3.2 Start databend-query
 
 ```shell
-./databend-query -c ./databend-query.toml 2>&1 > query.log&
+./databend-query -c ./databend-query.toml > query.log 2>&1 &
 ```
 
 ### 3.3 Check databend-query 

--- a/docs/doc/01-deploy/01_s3.md
+++ b/docs/doc/01-deploy/01_s3.md
@@ -67,7 +67,7 @@ raft_dir = "metadata/datas"
 ### 2.2 Start the databend-meta
 
 ```shell
-./databend-meta -c ./databend-meta.toml 2>&1 > meta.log&
+./databend-meta -c ./databend-meta.toml > meta.log 2>&1 &
 ```
 
 ### 2.3 Check databend-meta
@@ -138,7 +138,7 @@ secret_access_key = "<your-access-key>"
 ### 3.2 Start databend-query
 
 ```shell
-./databend-query -c ./databend-query.toml 2>&1 > query.log&
+./databend-query -c ./databend-query.toml > query.log 2>&1 &
 ```
 
 ### 3.3 Check databend-query

--- a/docs/doc/01-deploy/02_minio.md
+++ b/docs/doc/01-deploy/02_minio.md
@@ -120,7 +120,7 @@ raft_dir = "metadata/datas"
 ### 3.2 Start the databend-meta
 
 ```shell
-./databend-meta -c ./databend-meta.toml 2>&1 > meta.log&
+./databend-meta -c ./databend-meta.toml > meta.log 2>&1 &
 ```
 
 ### 3.3 Check databend-meta
@@ -190,7 +190,7 @@ secret_access_key = "minioadmin"
 ### 4.2 Start databend-query
 
 ```shell
-./databend-query -c ./databend-query.toml 2>&1 > query.log&
+./databend-query -c ./databend-query.toml > query.log 2>&1 &
 ```
 
 ### 4.3 Check databend-query 

--- a/docs/doc/01-deploy/03_cos.md
+++ b/docs/doc/01-deploy/03_cos.md
@@ -74,7 +74,7 @@ raft_dir = "metadata/datas"
 ### 2.2 Start the databend-meta 
 
 ```shell
-./databend-meta -c ./databend-meta.toml 2>&1 > meta.log&
+./databend-meta -c ./databend-meta.toml > meta.log 2>&1 &
 ```
 
 ### 2.3 Check databend-meta 
@@ -158,7 +158,7 @@ In this example COS region is beijing.
 ### 3.2 Start databend-query
 
 ```shell
-./databend-query -c ./databend-query.toml 2>&1 > query.log&
+./databend-query -c ./databend-query.toml > query.log 2>&1 &
 ```
 
 ### 3.3 Check databend-query


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
I think logging both stdout and stderr to file is the intention.

from lint:
SC2069: To redirect stdout+stderr, 2>&1 must be last (or use '{ cmd > file; } 2>&1' to clarify).

## Changelog


- Documentation


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

