### PR TITLE
Doc: Upgrade from -v0.6.95 to -v0.6.96

### DIFF
--- a/docs/doc/01-deploy/00_local.md
+++ b/docs/doc/01-deploy/00_local.md
@@ -32,14 +32,14 @@ import TabItem from '@theme/TabItem';
 <TabItem value="linux" label="Ubuntu">
 
 ```shell
-curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nightly/databend-v0.6.95-nightly-x86_64-unknown-linux-gnu.tar.gz
+curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.96-nightly/databend-v0.6.96-nightly-x86_64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>
 <TabItem value="mac" label="MacOS">
 
 ```shell
-curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nightly/databend-v0.6.95-nightly-aarch64-apple-darwin.tar.gz
+curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.96-nightly/databend-v0.6.96-nightly-aarch64-apple-darwin.tar.gz
 ```
 
 </TabItem>
@@ -47,7 +47,7 @@ curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nig
 <TabItem value="arm" label="Arm">
 
 ```shell
-curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nightly/databend-v0.6.95-nightly-aarch64-unknown-linux-gnu.tar.gz
+curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.96-nightly/databend-v0.6.96-nightly-aarch64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>
@@ -57,14 +57,14 @@ curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nig
 <TabItem value="linux" label="Ubuntu">
 
 ```shell
-tar xzvf databend-v0.6.95-nightly-x86_64-unknown-linux-gnu.tar.gz
+tar xzvf databend-v0.6.96-nightly-x86_64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>
 <TabItem value="mac" label="MacOS">
 
 ```shell
-tar xzvf databend-v0.6.95-nightly-aarch64-apple-darwin.tar.gz
+tar xzvf databend-v0.6.96-nightly-aarch64-apple-darwin.tar.gz
 ```
 
 </TabItem>
@@ -72,7 +72,7 @@ tar xzvf databend-v0.6.95-nightly-aarch64-apple-darwin.tar.gz
 <TabItem value="arm" label="Arm">
 
 ```shell
-tar xzvf databend-v0.6.95-nightly-aarch64-unknown-linux-gnu.tar.gz
+tar xzvf databend-v0.6.96-nightly-aarch64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>

--- a/docs/doc/01-deploy/01_s3.md
+++ b/docs/doc/01-deploy/01_s3.md
@@ -31,7 +31,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="linux" label="Ubuntu">
 
 ```shell
-curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nightly/databend-v0.6.95-nightly-x86_64-unknown-linux-gnu.tar.gz
+curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.96-nightly/databend-v0.6.96-nightly-x86_64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>
@@ -41,7 +41,7 @@ curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nig
 <TabItem value="linux" label="Ubuntu">
 
 ```shell
-tar xzvf databend-v0.6.95-nightly-x86_64-unknown-linux-gnu.tar.gz
+tar xzvf databend-v0.6.96-nightly-x86_64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>

--- a/docs/doc/01-deploy/02_minio.md
+++ b/docs/doc/01-deploy/02_minio.md
@@ -54,14 +54,14 @@ import TabItem from '@theme/TabItem';
 <TabItem value="linux" label="Ubuntu">
 
 ```shell
-curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nightly/databend-v0.6.95-nightly-x86_64-unknown-linux-gnu.tar.gz
+curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.96-nightly/databend-v0.6.96-nightly-x86_64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>
 <TabItem value="mac" label="MacOS">
 
 ```shell
-curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nightly/databend-v0.6.95-nightly-aarch64-apple-darwin.tar.gz
+curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.96-nightly/databend-v0.6.96-nightly-aarch64-apple-darwin.tar.gz
 ```
 
 </TabItem>
@@ -69,7 +69,7 @@ curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nig
 <TabItem value="arm" label="Arm">
 
 ```shell
-curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nightly/databend-v0.6.95-nightly-aarch64-unknown-linux-gnu.tar.gz
+curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.96-nightly/databend-v0.6.96-nightly-aarch64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>
@@ -79,14 +79,14 @@ curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nig
 <TabItem value="linux" label="Ubuntu">
 
 ```shell
-tar xzvf databend-v0.6.95-nightly-x86_64-unknown-linux-gnu.tar.gz
+tar xzvf databend-v0.6.96-nightly-x86_64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>
 <TabItem value="mac" label="MacOS">
 
 ```shell
-tar xzvf databend-v0.6.95-nightly-aarch64-apple-darwin.tar.gz
+tar xzvf databend-v0.6.96-nightly-aarch64-apple-darwin.tar.gz
 ```
 
 </TabItem>
@@ -94,7 +94,7 @@ tar xzvf databend-v0.6.95-nightly-aarch64-apple-darwin.tar.gz
 <TabItem value="arm" label="Arm">
 
 ```shell
-tar xzvf databend-v0.6.95-nightly-aarch64-unknown-linux-gnu.tar.gz
+tar xzvf databend-v0.6.96-nightly-aarch64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>

--- a/docs/doc/01-deploy/03_cos.md
+++ b/docs/doc/01-deploy/03_cos.md
@@ -38,7 +38,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="linux" label="Ubuntu">
 
 ```shell
-curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nightly/databend-v0.6.95-nightly-x86_64-unknown-linux-gnu.tar.gz
+curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.96-nightly/databend-v0.6.96-nightly-x86_64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>
@@ -48,7 +48,7 @@ curl -LJO https://github.com/datafuselabs/databend/releases/download/v0.6.95-nig
 <TabItem value="linux" label="Ubuntu">
 
 ```shell
-tar xzvf databend-v0.6.95-nightly-x86_64-unknown-linux-gnu.tar.gz
+tar xzvf databend-v0.6.96-nightly-x86_64-unknown-linux-gnu.tar.gz
 ```
 
 </TabItem>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Deploy: Upgrade from -v0.6.95 to -v0.6.96

## Changelog

- Documentation


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

