### PR TITLE
fix(clickhouse): to_clickhouse_block always convert to full column if constant

### DIFF
--- a/common/datablocks/src/data_block.rs
+++ b/common/datablocks/src/data_block.rs
@@ -176,6 +176,18 @@ impl DataBlock {
         Ok(Self { columns, schema })
     }
 
+    #[inline]
+    pub fn convert_full_block(self) -> Result<Self> {
+        let mut columns = Vec::with_capacity(self.num_columns());
+        let schema = self.schema().clone();
+        for f in schema.fields() {
+            let column = self.try_column_by_name(f.name())?;
+            columns.push(column.convert_full_column());
+        }
+
+        Ok(Self { columns, schema })
+    }
+
     pub fn from_chunk<A: AsRef<dyn Array>>(
         schema: &DataSchemaRef,
         chuck: &Chunk<A>,

--- a/query/src/servers/clickhouse/writers/query_writer.rs
+++ b/query/src/servers/clickhouse/writers/query_writer.rs
@@ -145,7 +145,7 @@ pub fn to_clickhouse_block(block: DataBlock) -> Result<Block> {
         let serializer = field.data_type().create_serializer();
         result.append_column(column::new_column(
             name,
-            serializer.serialize_clickhouse_format(column)?,
+            serializer.serialize_clickhouse_format(&column.convert_full_column())?,
         ));
     }
     Ok(result)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

to_clickhouse_block always convert to full column if constant

## Changelog
 
- Bug Fix
 
## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

