### PR TITLE
build: Fix musl support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4355,7 +4355,7 @@ dependencies = [
 [[package]]
 name = "pprof"
 version = "0.7.0"
-source = "git+https://github.com/Xuanwo/pprof-rs?rev=c8a0a67#c8a0a677b19de504f28e3d5e5485b44560bdb516"
+source = "git+https://github.com/tikv/pprof-rs?rev=666d9e2#666d9e218e336e6840002f4e502b44440a55a3be"
 dependencies = [
  "backtrace",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,9 +2823,9 @@ checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "inferno"
-version = "0.10.10"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4445abb2e1f32b02fb78f957f17efa7a43c8258cd3e848157949c59157657d"
+checksum = "f202af59e95fce985d0b87df19319528638b6f7654abc283d2815028922cc320"
 dependencies = [
  "ahash",
  "atty",
@@ -4354,22 +4354,20 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f35f865aa964be21fcde114cbd1cfbd9bf8a471460ed965b0f84f96c711401"
+version = "0.7.0"
+source = "git+https://github.com/Xuanwo/pprof-rs?rev=c8a0a67#c8a0a677b19de504f28e3d5e5485b44560bdb516"
 dependencies = [
  "backtrace",
  "cfg-if",
  "findshlibs",
  "inferno",
- "lazy_static",
  "libc",
  "log",
  "nix",
- "parking_lot 0.11.2",
- "prost",
- "prost-build",
- "prost-derive",
+ "once_cell",
+ "parking_lot 0.12.0",
+ "protobuf",
+ "protobuf-codegen-pure",
  "smallvec",
  "symbolic-demangle",
  "tempfile",
@@ -4541,6 +4539,31 @@ checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
  "prost",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aec1632b7c8f2e620343439a7dfd1f3c47b18906c4be58982079911482b5d707"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protobuf-codegen-pure"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8122fdb18e55190c796b088a16bdb70cd7acdcd48f7a8b796b58c62e532cc6"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
 ]
 
 [[package]]
@@ -4836,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a374af9a0e5fdcdd98c1c7b64f05004f9ea2555b6c75f211daa81268a3c50f1"
+checksum = "e74fdc210d8f24a7dbfedc13b04ba5764f5232754ccebfdf5fff1bad791ccbc6"
 dependencies = [
  "bytemuck",
 ]

--- a/common/base/Cargo.toml
+++ b/common/base/Cargo.toml
@@ -26,10 +26,15 @@ ctrlc = { version = "3.2.1", features = ["termination"] }
 futures = "0.3.21"
 hyper = "0.14.17"
 poem = { version = "1.3.6", features = ["rustls"] }
-pprof = { version = "0.6.2", features = ["flamegraph", "protobuf"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.79", default-features = false, features = ["raw_value"] }
 serde_yaml = { version = "0.8.23", default-features = false }
+# Rollback to upstream after https://github.com/tikv/pprof-rs/pull/110 merged.
+pprof = { git = "https://github.com/Xuanwo/pprof-rs", rev = "c8a0a67", features = [
+    "flamegraph",
+    "protobuf-codec",
+    "protobuf",
+] }
 tokio = { version = "1.17.0", features = ["full"] }
 toml = { version = "0.5.8", default-features = false }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/common/base/Cargo.toml
+++ b/common/base/Cargo.toml
@@ -29,8 +29,8 @@ poem = { version = "1.3.6", features = ["rustls"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.79", default-features = false, features = ["raw_value"] }
 serde_yaml = { version = "0.8.23", default-features = false }
-# Rollback to upstream after https://github.com/tikv/pprof-rs/pull/110 merged.
-pprof = { git = "https://github.com/Xuanwo/pprof-rs", rev = "c8a0a67", features = [
+# Rollback to tagged release after 666d9e2 included in new release.
+pprof = { git = "https://github.com/tikv/pprof-rs", rev = "666d9e2", features = [
     "flamegraph",
     "protobuf-codec",
     "protobuf",

--- a/common/base/src/profiling.rs
+++ b/common/base/src/profiling.rs
@@ -60,7 +60,7 @@ impl Profiling {
             .pprof()
             .map_err(|e| ErrorCode::UnknownException(e.to_string()))?;
         profile
-            .encode(&mut body)
+            .write_to_vec(&mut body)
             .map_err(|e| ErrorCode::UnknownException(e.to_string()))?;
 
         Ok(body)


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix https://github.com/datafuselabs/databend/issues/830

pprof-rs doesn't support building on musl for a long time, I have a workaround for it https://github.com/tikv/pprof-rs/pull/110

Now, databend works on `musl`:

```rust
PKG_CONFIG_ALLOW_CROSS=1 cargo build --target x86_64-unknown-linux-musl
```

Please give this PR a test to make sure it also work on `macOS` too :heart: 

## Changelog

- Build/Testing/CI

## Test Plan

Unit Tests

Stateless Tests

