### PR TITLE
support server-side-session for HTTP handler

### DIFF
--- a/query/src/interpreters/interpreter_factory_interceptor.rs
+++ b/query/src/interpreters/interpreter_factory_interceptor.rs
@@ -81,6 +81,7 @@ impl Interpreter for InterceptorInterpreter {
     async fn finish(&self) -> Result<()> {
         let session = self.ctx.get_current_session();
         let now = SystemTime::now();
+        session.get_status().write().query_finish();
         if session.get_type().is_user_session() {
             session
                 .get_session_manager()

--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -78,6 +78,7 @@ pub struct QueryStats {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct QueryResponse {
     pub id: String,
+    pub session_id: Option<String>,
     pub schema: Option<DataSchemaRef>,
     pub data: JsonBlockRef,
     pub state: ExecuteStateName,
@@ -99,7 +100,8 @@ impl QueryResponse {
             ),
             None => (Arc::new(vec![]), None),
         };
-        let columns = r.initial_state.as_ref().and_then(|v| v.schema.clone());
+        let schema = r.initial_state.as_ref().and_then(|v| v.schema.clone());
+        let session_id = r.initial_state.as_ref().map(|v| v.session_id.clone());
         let stats = QueryStats {
             scan_progress: r.state.scan_progress.clone(),
             running_time_ms: r.state.running_time_ms,
@@ -107,7 +109,8 @@ impl QueryResponse {
         QueryResponse {
             data,
             state: r.state.state,
-            schema: columns,
+            schema,
+            session_id,
             stats,
             id: id.clone(),
             next_uri: next_url,
@@ -124,6 +127,7 @@ impl QueryResponse {
             state: ExecuteStateName::Failed,
             data: Arc::new(vec![]),
             schema: None,
+            session_id: None,
             next_uri: None,
             stats_uri: None,
             final_uri: None,

--- a/query/src/servers/http/v1/mod.rs
+++ b/query/src/servers/http/v1/mod.rs
@@ -34,6 +34,8 @@ pub use load::LoadResponse;
 pub use query::ExecuteStateName;
 pub use query::HttpQueryHandle;
 pub use query::HttpQueryManager;
+pub use query::HttpSession;
+pub use query::HttpSessionConf;
 pub use stage::upload_to_stage;
 pub use stage::UploadToStageResponse;
 pub use statement::statement_handler;

--- a/query/src/servers/http/v1/query/expirable.rs
+++ b/query/src/servers/http/v1/query/expirable.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::time::Duration;
 use std::time::Instant;
 

--- a/query/src/servers/http/v1/query/expirable.rs
+++ b/query/src/servers/http/v1/query/expirable.rs
@@ -1,0 +1,35 @@
+use std::time::Instant;
+
+use crate::sessions::SessionRef;
+
+#[derive(PartialEq)]
+pub enum ExpiringState {
+    InUse,
+    Idle { since: Instant },
+    Aborted { need_cleanup: bool },
+}
+
+pub trait Expirable {
+    fn expire_state(&self) -> ExpiringState;
+    fn on_expire(&self);
+}
+
+impl Expirable for SessionRef {
+    fn expire_state(&self) -> ExpiringState {
+        if self.is_aborting() {
+            ExpiringState::Aborted {
+                need_cleanup: false,
+            }
+        } else if !self.query_context_shared_is_none() {
+            ExpiringState::InUse
+        } else {
+            let status = self.get_status();
+            let status = status.read();
+            ExpiringState::Idle {
+                since: status.last_access(),
+            }
+        }
+    }
+
+    fn on_expire(&self) {}
+}

--- a/query/src/servers/http/v1/query/expirable.rs
+++ b/query/src/servers/http/v1/query/expirable.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use std::time::Instant;
 
 use crate::sessions::SessionRef;
@@ -5,7 +6,8 @@ use crate::sessions::SessionRef;
 #[derive(PartialEq)]
 pub enum ExpiringState {
     InUse,
-    Idle { since: Instant },
+    // return Duration, so user can choose to use Systime or Instance
+    Idle { idle_time: Duration },
     Aborted { need_cleanup: bool },
 }
 
@@ -26,7 +28,7 @@ impl Expirable for SessionRef {
             let status = self.get_status();
             let status = status.read();
             ExpiringState::Idle {
-                since: status.last_access(),
+                idle_time: Instant::now() - status.last_access(),
             }
         }
     }

--- a/query/src/servers/http/v1/query/expiring_map.rs
+++ b/query/src/servers/http/v1/query/expiring_map.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2022 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/query/src/servers/http/v1/query/expiring_map.rs
+++ b/query/src/servers/http/v1/query/expiring_map.rs
@@ -1,0 +1,172 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use common_base::tokio::task;
+use common_base::tokio::time::sleep;
+use common_infallible::RwLock;
+
+use crate::servers::http::v1::query::expirable::Expirable;
+use crate::servers::http::v1::query::expirable::ExpiringState;
+
+// todo(youngsofun): use ExpiringMap for HttpQuery
+
+struct MaybeExpiring<V>
+where V: Expirable
+{
+    task: Option<task::JoinHandle<()>>,
+    pub value: V,
+}
+
+// on insert：start task
+//   1. check V for expire
+//   2. call remove if expire
+// on remove:
+//   1. call on_expire
+//   2. Cancel task
+
+pub struct ExpiringMap<K, V>
+where V: Expirable
+{
+    inner: Arc<RwLock<Inner<K, V>>>,
+}
+
+async fn run_check<T: Expirable>(e: &T, max_idle: Duration) -> bool {
+    loop {
+        match e.expire_state() {
+            ExpiringState::InUse => sleep(max_idle).await,
+            ExpiringState::Idle { since } => {
+                let now = Instant::now();
+                if now - since > max_idle {
+                    return true;
+                } else {
+                    sleep(max_idle - (now - since)).await;
+                    continue;
+                }
+            }
+            ExpiringState::Aborted { need_cleanup } => return need_cleanup,
+        }
+    }
+}
+
+impl<K, V> Default for ExpiringMap<K, V>
+where V: Expirable
+{
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(Inner::default())),
+        }
+    }
+}
+
+struct Inner<K, V>
+where V: Expirable
+{
+    map: HashMap<K, MaybeExpiring<V>>,
+}
+
+impl<K, V> Default for Inner<K, V>
+where V: Expirable
+{
+    fn default() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+}
+
+impl<K, V> Inner<K, V>
+where
+    K: Hash + Eq,
+    V: Expirable,
+{
+    pub fn remove<Q: ?Sized>(&mut self, k: &Q)
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        if let Some(mut checker) = self.map.remove(k) {
+            if let Some(t) = checker.task.take() {
+                t.abort()
+            }
+            checker.value.on_expire();
+        }
+    }
+    pub fn insert(&mut self, k: K, v: MaybeExpiring<V>) {
+        self.map.insert(k, v);
+    }
+
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.map.get(k).map(|i| &i.value)
+    }
+}
+
+impl<K, V> ExpiringMap<K, V>
+where
+    K: Hash + Eq,
+    V: Expirable + Clone,
+{
+    pub fn insert(&mut self, k: K, v: V, max_idle_time: Option<Duration>)
+    where
+        K: Clone + Send + Sync + 'static,
+        V: Send + Sync + 'static,
+    {
+        let mut inner = self.inner.write();
+        let task = match max_idle_time {
+            Some(d) => {
+                let inner = self.inner.clone();
+                let v_clone = v.clone();
+                let k_clone = k.clone();
+                let task = task::spawn(async move {
+                    if run_check(&v_clone, d).await {
+                        let mut inner = inner.write();
+                        inner.remove(&k_clone);
+                    }
+                });
+                Some(task)
+            }
+            None => None,
+        };
+        let i = MaybeExpiring { task, value: v };
+        inner.insert(k, i);
+    }
+
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let inner = self.inner.read();
+        inner.get(k).cloned()
+    }
+
+    pub fn remove<Q: ?Sized>(&mut self, k: &Q)
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let mut map = self.inner.write();
+        map.remove(k)
+    }
+}

--- a/query/src/servers/http/v1/query/expiring_map.rs
+++ b/query/src/servers/http/v1/query/expiring_map.rs
@@ -17,7 +17,6 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
 
 use common_base::tokio::task;
 use common_base::tokio::time::sleep;
@@ -52,12 +51,11 @@ async fn run_check<T: Expirable>(e: &T, max_idle: Duration) -> bool {
     loop {
         match e.expire_state() {
             ExpiringState::InUse => sleep(max_idle).await,
-            ExpiringState::Idle { since } => {
-                let now = Instant::now();
-                if now - since > max_idle {
+            ExpiringState::Idle { idle_time } => {
+                if idle_time > max_idle {
                     return true;
                 } else {
-                    sleep(max_idle - (now - since)).await;
+                    sleep(max_idle - idle_time).await;
                     continue;
                 }
             }

--- a/query/src/servers/http/v1/query/mod.rs
+++ b/query/src/servers/http/v1/query/mod.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 mod execute_state;
+mod expirable;
+mod expiring_map;
 mod http_query;
 mod http_query_manager;
 mod result_data_manager;
@@ -24,6 +26,7 @@ pub use execute_state::HttpQueryHandle;
 pub use http_query::HttpQuery;
 pub use http_query::HttpQueryRequest;
 pub use http_query::HttpQueryResponseInternal;
+pub use http_query::HttpSession;
 pub use http_query::HttpSessionConf;
 pub use http_query::PaginationConf;
 pub use http_query::ResponseInitialState;

--- a/query/src/servers/http/v1/statement.rs
+++ b/query/src/servers/http/v1/statement.rs
@@ -26,6 +26,7 @@ use poem::Route;
 use serde::Deserialize;
 
 use super::query::HttpQueryRequest;
+use super::query::HttpSession;
 use super::query::HttpSessionConf;
 use super::query::PaginationConf;
 use super::QueryResponse;
@@ -48,10 +49,11 @@ pub async fn statement_handler(
     let query_id = http_query_manager.next_query_id();
     let session = HttpSessionConf {
         database: params.db.filter(|x| !x.is_empty()),
+        max_idle_time: None,
     };
     let req = HttpQueryRequest {
         sql,
-        session,
+        session: HttpSession::New(session),
         pagination: PaginationConf { wait_time_secs: -1 },
     };
     let query = http_query_manager

--- a/query/src/sessions/mod.rs
+++ b/query/src/sessions/mod.rs
@@ -20,10 +20,11 @@ mod session_ctx;
 mod session_info;
 #[allow(clippy::module_inception)]
 mod session_mgr;
+mod session_mgr_status;
 mod session_ref;
 mod session_settings;
+mod session_status;
 mod session_type;
-mod status;
 
 pub use query_ctx::QueryContext;
 pub use query_ctx_shared::QueryContextShared;
@@ -31,7 +32,8 @@ pub use session::Session;
 pub use session_ctx::SessionContext;
 pub use session_info::ProcessInfo;
 pub use session_mgr::SessionManager;
+pub use session_mgr_status::SessionManagerStatus;
 pub use session_ref::SessionRef;
 pub use session_settings::Settings;
+pub use session_status::SessionStatus;
 pub use session_type::SessionType;
-pub use status::Status;

--- a/query/src/sessions/session_mgr.rs
+++ b/query/src/sessions/session_mgr.rs
@@ -46,8 +46,8 @@ use crate::servers::http::v1::HttpQueryManager;
 use crate::sessions::session::Session;
 use crate::sessions::session_ref::SessionRef;
 use crate::sessions::ProcessInfo;
+use crate::sessions::SessionManagerStatus;
 use crate::sessions::SessionType;
-use crate::sessions::Status;
 use crate::storages::cache::CacheManager;
 use crate::users::auth::auth_mgr::AuthMgr;
 use crate::users::UserApiProvider;
@@ -65,7 +65,7 @@ pub struct SessionManager {
     pub(in crate::sessions) storage_cache_manager: RwLock<Arc<CacheManager>>,
     pub(in crate::sessions) query_logger:
         RwLock<Option<Arc<dyn tracing::Subscriber + Send + Sync>>>,
-    pub status: Arc<RwLock<Status>>,
+    pub status: Arc<RwLock<SessionManagerStatus>>,
     storage_operator: RwLock<Operator>,
     storage_runtime: Runtime,
     _guards: Vec<WorkerGuard>,

--- a/query/src/sessions/session_mgr_status.rs
+++ b/query/src/sessions/session_mgr_status.rs
@@ -15,14 +15,14 @@
 use std::time::SystemTime;
 
 #[derive(Clone)]
-pub struct Status {
+pub struct SessionManagerStatus {
     pub running_queries_count: u64,
     pub last_query_started_at: Option<SystemTime>,
     pub last_query_finished_at: Option<SystemTime>,
     pub instance_started_at: SystemTime,
 }
 
-impl Status {
+impl SessionManagerStatus {
     pub(crate) fn query_start(&mut self, now: SystemTime) {
         self.running_queries_count += 1;
         self.last_query_started_at = Some(now)
@@ -36,9 +36,9 @@ impl Status {
     }
 }
 
-impl Default for Status {
+impl Default for SessionManagerStatus {
     fn default() -> Self {
-        Status {
+        SessionManagerStatus {
             running_queries_count: 0,
             last_query_started_at: None,
             last_query_finished_at: None,

--- a/query/src/sessions/session_status.rs
+++ b/query/src/sessions/session_status.rs
@@ -1,0 +1,40 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Instant;
+
+pub struct SessionStatus {
+    pub session_started_at: Instant,
+    pub last_query_finished_at: Option<Instant>,
+}
+
+impl SessionStatus {
+    pub(crate) fn query_finish(&mut self) {
+        self.last_query_finished_at = Some(Instant::now())
+    }
+
+    pub(crate) fn last_access(&self) -> Instant {
+        self.last_query_finished_at
+            .unwrap_or(self.session_started_at)
+    }
+}
+
+impl Default for SessionStatus {
+    fn default() -> Self {
+        SessionStatus {
+            session_started_at: Instant::now(),
+            last_query_finished_at: None,
+        }
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

support server-side-session for HTTP handler

it is useful for `use` or `set` commands.

to use it
1. for the first query, specify `session.max_idle_time` in secs
2. for the following query, use `session_id` from response to specify `session.id` .  Some Notes:
    1. when `id` field is used, other fields in `session` is invaid.
    2. currently not support queueing in server side, make sure last query response status is Succeeded or Failed before post, otherwise thHTTPtp request will fail with error message `last query on the session not finished`
    
    
Notes:

1.  exist code not affected
1.  timeout for sessions is also needed for clickhouse/MySQL, 
  but they can be implemented more directly(maybe part of `mysql-srv`), 
  so I try to minimize intrusiveness with `Expirable` trait and limit most code to the http mod,



Summary about this PR

## Changelog

- New Feature

No issue

## Test Plan

Unit Tests

Stateless Tests

