### PR TITLE
ISSUE-4436: Mask storage.s3 `access_key_id` and `secret_access_key`

### DIFF
--- a/query/src/configs/config_storage.rs
+++ b/query/src/configs/config_storage.rs
@@ -19,6 +19,7 @@ use clap::Args;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::configs::config_utils::mask_string;
 use crate::configs::Config;
 
 pub const STORAGE_TYPE: &str = "STORAGE_TYPE";
@@ -137,6 +138,16 @@ impl fmt::Debug for S3StorageConfig {
         write!(f, "s3.storage.region: \"{}\", ", self.region)?;
         write!(f, "s3.storage.endpoint_url: \"{}\", ", self.endpoint_url)?;
         write!(f, "s3.storage.bucket: \"{}\", ", self.bucket)?;
+        write!(
+            f,
+            "s3.storage.access_key_id: \"{}\", ",
+            mask_string(&self.access_key_id[..])
+        )?;
+        write!(
+            f,
+            "s3.storage.secret_access_key: \"{}\", ",
+            mask_string(&self.secret_access_key[..])
+        )?;
         write!(f, "}}")
     }
 }

--- a/query/src/configs/config_utils.rs
+++ b/query/src/configs/config_utils.rs
@@ -1,0 +1,12 @@
+/// Mask a string by "******". If the lenght of the string is equal or greater than 9, keep the 3-byte suffix.
+#[inline]
+pub fn mask_string(s: &str) -> String {
+    if s.is_empty() {
+        return "".to_string();
+    }
+    let mut ret = "******".to_string();
+    if s.len() >= 9 {
+        ret.push_str(&s[s.len() - 3..]);
+    }
+    ret
+}

--- a/query/src/configs/mod.rs
+++ b/query/src/configs/mod.rs
@@ -20,6 +20,7 @@ pub mod config_log;
 pub mod config_meta;
 pub mod config_query;
 pub mod config_storage;
+pub mod config_utils;
 
 pub use config::Config;
 pub use config::DATABEND_COMMIT_VERSION;

--- a/query/src/storages/system/configs_table.rs
+++ b/query/src/storages/system/configs_table.rs
@@ -22,6 +22,7 @@ use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use serde_json::Value;
 
+use crate::configs::config_utils::mask_string;
 use crate::sessions::QueryContext;
 use crate::storages::system::table::SyncOneBlockSystemTable;
 use crate::storages::system::table::SyncSystemTable;
@@ -79,7 +80,13 @@ impl SyncSystemTable for ConfigsTable {
             meta_config_value,
         );
 
-        let storage_config = config.storage;
+        let masked_access_key_id = mask_string(&config.storage.s3.access_key_id[..]);
+        let masked_secret_access_key = mask_string(&config.storage.s3.secret_access_key[..]);
+        let mut storage_config = config.storage;
+        // mask sensitive data in storage.s3
+        storage_config.s3.access_key_id = masked_access_key_id;
+        storage_config.s3.secret_access_key = masked_secret_access_key;
+
         let storage_config_value = serde_json::to_value(storage_config)?;
         ConfigsTable::extract_config(
             &mut names,

--- a/query/tests/it/configs.rs
+++ b/query/tests/it/configs.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_exception::Result;
+use databend_query::configs::config_utils::mask_string;
 use databend_query::configs::Config;
 use databend_query::configs::LogConfig;
 use databend_query::configs::MetaConfig;
@@ -223,4 +224,11 @@ fn test_fuse_commit_version() -> Result<()> {
     let v = &databend_query::configs::DATABEND_COMMIT_VERSION;
     assert!(v.len() > 0);
     Ok(())
+}
+
+#[test]
+fn mask_string_test() {
+    assert_eq!(mask_string(""), "".to_string());
+    assert_eq!(mask_string("string"), "******".to_string());
+    assert_eq!(mask_string("long_string"), "******ing".to_string());
 }

--- a/query/tests/it/storages/system/configs_table.rs
+++ b/query/tests/it/storages/system/configs_table.rs
@@ -37,6 +37,7 @@ async fn test_configs_table() -> Result<()> {
         "+--------------------------------------+--------------------------+---------+-------------+",
         "| name                                 | value                    | group   | description |",
         "+--------------------------------------+--------------------------+---------+-------------+",
+        "| admin_api_address                    | 127.0.0.1:8080           | query   |             |",
         "| api_tls_server_cert                  |                          | query   |             |",
         "| api_tls_server_key                   |                          | query   |             |",
         "| api_tls_server_root_ca_cert          |                          | query   |             |",
@@ -50,7 +51,6 @@ async fn test_configs_table() -> Result<()> {
         "| disk.data_path                       | _data                    | storage |             |",
         "| disk.temp_data_path                  |                          | storage |             |",
         "| flight_api_address                   | 127.0.0.1:9090           | query   |             |",
-        "| admin_api_address                    | 127.0.0.1:8080           | query   |             |",
         "| http_handler_host                    | 127.0.0.1                | query   |             |",
         "| http_handler_port                    | 8000                     | query   |             |",
         "| http_handler_result_timeout_millis   | 10000                    | query   |             |",
@@ -81,11 +81,100 @@ async fn test_configs_table() -> Result<()> {
         "| rpc_tls_server_key                   |                          | query   |             |",
         "| s3.access_key_id                     |                          | storage |             |",
         "| s3.bucket                            |                          | storage |             |",
-        "| s3.root                              |                          | storage |             |",
         "| s3.enable_pod_iam_policy             | false                    | storage |             |",
         "| s3.endpoint_url                      | https://s3.amazonaws.com | storage |             |",
         "| s3.region                            |                          | storage |             |",
+        "| s3.root                              |                          | storage |             |",
         "| s3.secret_access_key                 |                          | storage |             |",
+        "| storage_num_cpus                     | 0                        | storage |             |",
+        "| storage_type                         | disk                     | storage |             |",
+        "| table_cache_block_meta_count         | 102400                   | query   |             |",
+        "| table_cache_enabled                  | false                    | query   |             |",
+        "| table_cache_segment_count            | 10240                    | query   |             |",
+        "| table_cache_snapshot_count           | 256                      | query   |             |",
+        "| table_disk_cache_mb_size             | 1024                     | query   |             |",
+        "| table_disk_cache_root                | _cache                   | query   |             |",
+        "| table_engine_csv_enabled             | false                    | query   |             |",
+        "| table_engine_memory_enabled          | true                     | query   |             |",
+        "| table_engine_parquet_enabled         | false                    | query   |             |",
+        "| table_memory_cache_mb_size           | 256                      | query   |             |",
+        "| tenant_id                            | test                     | query   |             |",
+        "| wait_timeout_mills                   | 5000                     | query   |             |",
+        "+--------------------------------------+--------------------------+---------+-------------+",
+    ];
+    common_datablocks::assert_blocks_sorted_eq(expected, result.as_slice());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_configs_table_redact() -> Result<()> {
+    let mut conf = crate::tests::ConfigBuilder::create().config();
+    conf.storage.s3.access_key_id = "access_key_id".to_string();
+    conf.storage.s3.secret_access_key = "secret_access_key".to_string();
+    let ctx = crate::tests::create_query_context_with_config(conf).await?;
+    ctx.get_settings().set_max_threads(8)?;
+
+    let table = ConfigsTable::create(1);
+    let source_plan = table.read_plan(ctx.clone(), None).await?;
+
+    let stream = table.read(ctx, &source_plan).await?;
+    let result = stream.try_collect::<Vec<_>>().await?;
+    let block = &result[0];
+    assert_eq!(block.num_columns(), 4);
+
+    let expected = vec![
+        "+--------------------------------------+--------------------------+---------+-------------+",
+        "| name                                 | value                    | group   | description |",
+        "+--------------------------------------+--------------------------+---------+-------------+",
+        "| admin_api_address                    | 127.0.0.1:8080           | query   |             |",
+        "| api_tls_server_cert                  |                          | query   |             |",
+        "| api_tls_server_key                   |                          | query   |             |",
+        "| api_tls_server_root_ca_cert          |                          | query   |             |",
+        "| azure_storage_blob.account           |                          | storage |             |",
+        "| azure_storage_blob.container         |                          | storage |             |",
+        "| azure_storage_blob.master_key        |                          | storage |             |",
+        "| clickhouse_handler_host              | 127.0.0.1                | query   |             |",
+        "| clickhouse_handler_port              | 9000                     | query   |             |",
+        "| cluster_id                           |                          | query   |             |",
+        "| database_engine_github_enabled       | true                     | query   |             |",
+        "| disk.data_path                       | _data                    | storage |             |",
+        "| disk.temp_data_path                  |                          | storage |             |",
+        "| flight_api_address                   | 127.0.0.1:9090           | query   |             |",
+        "| http_handler_host                    | 127.0.0.1                | query   |             |",
+        "| http_handler_port                    | 8000                     | query   |             |",
+        "| http_handler_result_timeout_millis   | 10000                    | query   |             |",
+        "| http_handler_tls_server_cert         |                          | query   |             |",
+        "| http_handler_tls_server_key          |                          | query   |             |",
+        "| http_handler_tls_server_root_ca_cert |                          | query   |             |",
+        "| jwt_key_file                         |                          | query   |             |",
+        "| log_dir                              | ./_logs                  | log     |             |",
+        "| log_level                            | INFO                     | log     |             |",
+        "| log_query_enabled                    | false                    | log     |             |",
+        "| management_mode                      | false                    | query   |             |",
+        "| max_active_sessions                  | 256                      | query   |             |",
+        "| max_query_log_size                   | 10000                    | query   |             |",
+        "| meta_address                         |                          | meta    |             |",
+        "| meta_client_timeout_in_second        | 10                       | meta    |             |",
+        "| meta_embedded_dir                    | ./_meta_embedded         | meta    |             |",
+        "| meta_password                        |                          | meta    |             |",
+        "| meta_username                        | root                     | meta    |             |",
+        "| metric_api_address                   | 127.0.0.1:7070           | query   |             |",
+        "| mysql_handler_host                   | 127.0.0.1                | query   |             |",
+        "| mysql_handler_port                   | 3307                     | query   |             |",
+        "| num_cpus                             | 0                        | query   |             |",
+        "| rpc_tls_meta_server_root_ca_cert     |                          | meta    |             |",
+        "| rpc_tls_meta_service_domain_name     | localhost                | meta    |             |",
+        "| rpc_tls_query_server_root_ca_cert    |                          | query   |             |",
+        "| rpc_tls_query_service_domain_name    | localhost                | query   |             |",
+        "| rpc_tls_server_cert                  |                          | query   |             |",
+        "| rpc_tls_server_key                   |                          | query   |             |",
+        "| s3.access_key_id                     | ******_id                | storage |             |",
+        "| s3.bucket                            |                          | storage |             |",
+        "| s3.enable_pod_iam_policy             | false                    | storage |             |",
+        "| s3.endpoint_url                      | https://s3.amazonaws.com | storage |             |",
+        "| s3.region                            |                          | storage |             |",
+        "| s3.root                              |                          | storage |             |",
+        "| s3.secret_access_key                 | ******key                | storage |             |",
         "| storage_num_cpus                     | 0                        | storage |             |",
         "| storage_type                         | disk                     | storage |             |",
         "| table_cache_block_meta_count         | 102400                   | query   |             |",


### PR DESCRIPTION
Signed-off-by: RinChanNOWWW <hzy427@gmail.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Mask storage.s3  `access_key_id ` and  `secret_access_key `. If the string's lenght is less than 9(picked arbitrarily), mask the whole string by "******", else keep the 3-bytes suffix.

If  `access_key_id` and `secret_access_key` not set:

![image](https://user-images.githubusercontent.com/33975039/159445934-f7530f3e-3cd1-4cda-adb0-a5827f1348ef.png)

else:

(with `access_key_id` = "\<your-key-id\>", `secret_access_key` = "\<your-access-key\>")

![image](https://user-images.githubusercontent.com/33975039/159446122-890f4cb1-e1ed-4d7f-b942-b9dfc4ceba92.png)



## Changelog

- Improvement

## Related Issues

Fixes [#issue](https://github.com/datafuselabs/databend/issues/4436)

## Test Plan

Unit Tests

Stateless Tests

