### PR TITLE
chore(build): Add git latest tag to the build version

### DIFF
--- a/common/building/src/lib.rs
+++ b/common/building/src/lib.rs
@@ -30,17 +30,30 @@ pub fn setup() {
 }
 
 pub fn add_building_env_vars() {
-    add_env_vergen();
+    set_env_config();
+    add_env_git_tag();
     add_env_commit_authors();
 }
 
-pub fn add_env_vergen() {
+pub fn set_env_config() {
     let mut config = Config::default();
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
 
     if let Err(e) = vergen(config) {
         eprintln!("{}", e);
     }
+}
+
+// Get the latest tag:
+// git describe --tags --abbrev=0
+// v0.6.99-nightly
+pub fn add_env_git_tag() {
+    let r = run_script::run_script!(r#"git describe --tags --abbrev=0"#);
+    let tag = match r {
+        Ok((_, output, _)) => output,
+        Err(e) => e.to_string(),
+    };
+    println!("cargo:rustc-env=VERGEN_GIT_SEMVER={}", tag);
 }
 
 pub fn add_env_commit_authors() {

--- a/query/src/bin/databend-query.rs
+++ b/query/src/bin/databend-query.rs
@@ -70,7 +70,7 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
     set_panic_hook();
     tracing::info!("{:?}", conf);
     tracing::info!(
-        "DatabendQuery v-{}",
+        "DatabendQuery {}",
         *databend_query::configs::DATABEND_COMMIT_VERSION,
     );
 

--- a/query/src/configs/config.rs
+++ b/query/src/configs/config.rs
@@ -27,17 +27,17 @@ use crate::configs::QueryConfig;
 use crate::configs::StorageConfig;
 
 pub static DATABEND_COMMIT_VERSION: Lazy<String> = Lazy::new(|| {
-    let build_semver = option_env!("VERGEN_BUILD_SEMVER");
+    let git_tag = option_env!("VERGEN_GIT_SEMVER");
     let git_sha = option_env!("VERGEN_GIT_SHA_SHORT");
     let rustc_semver = option_env!("VERGEN_RUSTC_SEMVER");
     let timestamp = option_env!("VERGEN_BUILD_TIMESTAMP");
 
-    let ver = match (build_semver, git_sha, rustc_semver, timestamp) {
+    let ver = match (git_tag, git_sha, rustc_semver, timestamp) {
         #[cfg(not(feature = "simd"))]
-        (Some(v1), Some(v2), Some(v3), Some(v4)) => format!("{}-{}({}-{})", v1, v2, v3, v4),
+        (Some(v1), Some(v2), Some(v3), Some(v4)) => format!("{}-{}(rust-{}-{})", v1, v2, v3, v4),
         #[cfg(feature = "simd")]
         (Some(v1), Some(v2), Some(v3), Some(v4)) => {
-            format!("{}-{}-simd({}-{})", v1, v2, v3, v4)
+            format!("{}-{}-simd(rust-{}-{})", v1, v2, v3, v4)
         }
         _ => String::new(),
     };

--- a/query/src/sessions/query_ctx.rs
+++ b/query/src/sessions/query_ctx.rs
@@ -81,10 +81,7 @@ impl QueryContext {
         Arc::new(QueryContext {
             statistics: Arc::new(RwLock::new(Statistics::default())),
             partition_queue: Arc::new(RwLock::new(VecDeque::new())),
-            version: format!(
-                "DatabendQuery v-{}",
-                *crate::configs::DATABEND_COMMIT_VERSION
-            ),
+            version: format!("DatabendQuery {}", *crate::configs::DATABEND_COMMIT_VERSION),
             shared,
         })
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add git latest tag to the build version.

Old:
```
mysql> select version();
+----------------------------------------------------------------------------------------+
| version()                                                                              |
+----------------------------------------------------------------------------------------+
| DatabendQuery v-0.1.0-213b1f7-simd(1.61.0-nightly-2022-03-19T01:39:28.774417429+00:00) |
+----------------------------------------------------------------------------------------+
```

Now:
```
+-------------------------------------------------------------------------------------------------------+
| version()                                                                                             |
+-------------------------------------------------------------------------------------------------------+
| DatabendQuery v0.6.99-nightly-c8fda7f-simd(rust-1.61.0-nightly-2022-03-23T08:28:10.740108668+00:00) |
+-------------------------------------------------------------------------------------------------------+
```

## Changelog

- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests
