### PR TITLE
Add user option for user info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5405,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.13.1-alpha.0"
-source = "git+https://github.com/datafuse-extras/sqlparser-rs?rev=0b1b0d7#0b1b0d7bccbdc15116df4cb1e4ed8b4a2e854a7b"
+source = "git+https://github.com/datafuse-extras/sqlparser-rs?rev=da3b180#da3b1801de9e502c8b8d2ec624cc00e1a5d0e108"
 dependencies = [
  "log",
 ]

--- a/common/ast/Cargo.toml
+++ b/common/ast/Cargo.toml
@@ -19,7 +19,7 @@ common-functions = { path = "../functions" }
 # TODO (andylokandy): Use the version from crates.io once
 # https://github.com/brendanzab/codespan/pull/331 is released.
 codespan-reporting = { git = "https://github.com/brendanzab/codespan", rev = "c84116f5" }
-sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "0b1b0d7" }
+sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "da3b180" }
 
 # Crates.io dependencies
 async-trait = "0.1.52"

--- a/common/exception/Cargo.toml
+++ b/common/exception/Cargo.toml
@@ -27,4 +27,4 @@ tonic = "0.6.2"
 
 # Github dependencies
 bincode = { git = "https://github.com/datafuse-extras/bincode", rev = "fd3f9ff" }
-sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "0b1b0d7" }
+sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "da3b180" }

--- a/common/management/src/user/user_api.rs
+++ b/common/management/src/user/user_api.rs
@@ -18,6 +18,7 @@ use common_meta_types::GrantObject;
 use common_meta_types::RoleIdentity;
 use common_meta_types::SeqV;
 use common_meta_types::UserInfo;
+use common_meta_types::UserOption;
 use common_meta_types::UserPrivilegeSet;
 
 #[async_trait::async_trait]
@@ -37,7 +38,8 @@ pub trait UserApi: Sync + Send {
         &self,
         username: String,
         hostname: String,
-        auth_info_args: AuthInfo,
+        auth_info: Option<AuthInfo>,
+        user_option: Option<UserOption>,
         seq: Option<u64>,
     ) -> Result<Option<u64>>;
 

--- a/common/management/tests/it/user.rs
+++ b/common/management/tests/it/user.rs
@@ -550,7 +550,8 @@ mod update {
         let res = user_mgr.update_user(
             test_user_name.to_string(),
             test_hostname.to_string(),
-            new_test_auth_info(full),
+            Some(new_test_auth_info(full)),
+            None,
             test_seq,
         );
 
@@ -582,7 +583,8 @@ mod update {
         let res = user_mgr.update_user(
             test_user_name.to_string(),
             test_hostname.to_string(),
-            new_test_auth_info(false),
+            Some(new_test_auth_info(false)),
+            None,
             test_seq,
         );
         assert_eq!(
@@ -633,7 +635,8 @@ mod update {
         let res = user_mgr.update_user(
             test_user_name.to_string(),
             test_hostname.to_string(),
-            new_test_auth_info(true),
+            Some(new_test_auth_info(true)),
+            None,
             test_seq,
         );
         assert_eq!(

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -158,6 +158,8 @@ pub use user_grant::GrantObject;
 pub use user_grant::UserGrantSet;
 pub use user_identity::UserIdentity;
 pub use user_info::UserInfo;
+pub use user_info::UserOption;
+pub use user_info::UserOptionFlag;
 pub use user_privilege::UserPrivilegeSet;
 pub use user_privilege::UserPrivilegeType;
 pub use user_quota::UserQuota;

--- a/common/meta/types/src/user_info.rs
+++ b/common/meta/types/src/user_info.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt;
 use std::convert::TryFrom;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use enumflags2::bitflags;
+use enumflags2::BitFlags;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -36,6 +39,8 @@ pub struct UserInfo {
     pub grants: UserGrantSet,
 
     pub quota: UserQuota,
+
+    pub option: UserOption,
 }
 
 impl UserInfo {
@@ -43,6 +48,7 @@ impl UserInfo {
         // Default is no privileges.
         let grants = UserGrantSet::default();
         let quota = UserQuota::no_limit();
+        let option = UserOption::default();
 
         UserInfo {
             name,
@@ -50,6 +56,7 @@ impl UserInfo {
             auth_info,
             grants,
             quota,
+            option,
         }
     }
 
@@ -63,6 +70,10 @@ impl UserInfo {
             hostname: self.hostname.clone(),
         }
     }
+
+    pub fn has_option_flag(&self, flag: UserOptionFlag) -> bool {
+        self.option.has_option_flag(flag)
+    }
 }
 
 impl TryFrom<Vec<u8>> for UserInfo {
@@ -75,6 +86,43 @@ impl TryFrom<Vec<u8>> for UserInfo {
                 "Cannot deserialize user info from bytes. cause {}",
                 serialize_error
             ))),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, PartialEq, Default)]
+#[serde(default)]
+pub struct UserOption {
+    flags: BitFlags<UserOptionFlag>,
+}
+
+impl UserOption {
+    pub fn set_option_flag(&mut self, flag: UserOptionFlag) {
+        self.flags.insert(flag);
+    }
+
+    pub fn unset_option_flag(&mut self, flag: UserOptionFlag) {
+        self.flags.remove(flag);
+    }
+
+    pub fn has_option_flag(&self, flag: UserOptionFlag) -> bool {
+        self.flags.contains(flag)
+    }
+}
+
+#[bitflags]
+#[repr(u64)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UserOptionFlag {
+    TenantSetting = 1 << 0,
+    ConfigReload = 1 << 1,
+}
+
+impl std::fmt::Display for UserOptionFlag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UserOptionFlag::TenantSetting => write!(f, "TENANTSETTING"),
+            UserOptionFlag::ConfigReload => write!(f, "CONFIGRELOAD"),
         }
     }
 }

--- a/common/meta/types/src/user_info.rs
+++ b/common/meta/types/src/user_info.rs
@@ -90,13 +90,17 @@ impl TryFrom<Vec<u8>> for UserInfo {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 #[serde(default)]
 pub struct UserOption {
     flags: BitFlags<UserOptionFlag>,
 }
 
 impl UserOption {
+    pub fn set_all_flag(&mut self) {
+        self.flags = BitFlags::all();
+    }
+
     pub fn set_option_flag(&mut self, flag: UserOptionFlag) {
         self.flags.insert(flag);
     }

--- a/common/planners/src/plan_user_alter.rs
+++ b/common/planners/src/plan_user_alter.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
 use common_meta_types::AuthInfo;
+use common_meta_types::UserOption;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct AlterUserPlan {
@@ -24,6 +25,7 @@ pub struct AlterUserPlan {
     pub hostname: String,
     // None means no change to make
     pub auth_info: Option<AuthInfo>,
+    pub user_option: Option<UserOption>,
 }
 
 impl AlterUserPlan {

--- a/common/planners/src/plan_user_create.rs
+++ b/common/planners/src/plan_user_create.rs
@@ -17,12 +17,14 @@ use std::sync::Arc;
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
 use common_meta_types::AuthInfo;
+use common_meta_types::UserOption;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct CreateUserPlan {
     pub name: String,
     pub hostname: String,
     pub auth_info: AuthInfo,
+    pub user_option: UserOption,
 }
 
 impl CreateUserPlan {

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -55,7 +55,7 @@ bincode = { git = "https://github.com/datafuse-extras/bincode", rev = "fd3f9ff" 
 cargo-license = { git = "https://github.com/datafuse-extras/cargo-license", rev = "f1ce4a2" }
 opensrv-clickhouse = { git = "https://github.com/datafuselabs/opensrv", rev = "9690be9", package = "opensrv-clickhouse" }
 opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "9690be9", package = "opensrv-mysql" }
-sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "0b1b0d7" }
+sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "da3b180" }
 
 # Crates.io dependencies
 ahash = "0.7.6"

--- a/query/src/interpreters/interpreter_user_alter.rs
+++ b/query/src/interpreters/interpreter_user_alter.rs
@@ -50,14 +50,14 @@ impl Interpreter for AlterUserInterpreter {
         let plan = self.plan.clone();
         let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
-        if let Some(new_auth_info) = plan.auth_info {
+        if plan.auth_info.is_some() || plan.user_option.is_some() {
             user_mgr
                 .update_user(
                     &tenant,
                     plan.name.as_str(),
                     plan.hostname.as_str(),
-                    Some(new_auth_info),
-                    None,
+                    plan.auth_info,
+                    plan.user_option,
                 )
                 .await?;
         }

--- a/query/src/interpreters/interpreter_user_alter.rs
+++ b/query/src/interpreters/interpreter_user_alter.rs
@@ -56,7 +56,8 @@ impl Interpreter for AlterUserInterpreter {
                     &tenant,
                     plan.name.as_str(),
                     plan.hostname.as_str(),
-                    new_auth_info,
+                    Some(new_auth_info),
+                    None,
                 )
                 .await?;
         }

--- a/query/src/interpreters/interpreter_user_create.rs
+++ b/query/src/interpreters/interpreter_user_create.rs
@@ -59,6 +59,7 @@ impl Interpreter for CreateUserInterpreter {
             hostname: plan.hostname,
             grants: UserGrantSet::empty(),
             quota: UserQuota::no_limit(),
+            option: plan.user_option,
         };
         user_mgr.add_user(&tenant, user_info, false).await?;
 

--- a/query/src/procedures/admins/bootstrap_tenant.rs
+++ b/query/src/procedures/admins/bootstrap_tenant.rs
@@ -21,6 +21,7 @@ use common_meta_types::AuthInfo;
 use common_meta_types::GrantObject;
 use common_meta_types::RoleInfo;
 use common_meta_types::UserInfo;
+use common_meta_types::UserOptionFlag;
 use common_meta_types::UserPrivilegeSet;
 use common_tracing::tracing;
 
@@ -52,6 +53,7 @@ impl Procedure for BootstrapTenantProcedure {
         ProcedureFeatures::default()
             .num_arguments(5)
             .management_mode_required(true)
+            .user_option_flag(UserOptionFlag::TenantSetting)
     }
 
     async fn inner_eval(&self, ctx: Arc<QueryContext>, args: Vec<String>) -> Result<DataBlock> {

--- a/query/src/procedures/admins/reload_config.rs
+++ b/query/src/procedures/admins/reload_config.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchema;
 use common_exception::Result;
+use common_meta_types::UserOptionFlag;
 
 use crate::procedures::Procedure;
 use crate::procedures::ProcedureFeatures;
@@ -37,7 +38,7 @@ impl Procedure for ReloadConfigProcedure {
     }
 
     fn features(&self) -> ProcedureFeatures {
-        ProcedureFeatures::default()
+        ProcedureFeatures::default().user_option_flag(UserOptionFlag::ConfigReload)
     }
 
     async fn inner_eval(&self, ctx: Arc<QueryContext>, _: Vec<String>) -> Result<DataBlock> {

--- a/query/src/procedures/procedure.rs
+++ b/query/src/procedures/procedure.rs
@@ -43,6 +43,16 @@ pub trait Procedure: Sync + Send {
                 self.name()
             )));
         }
+        if let Some(user_option_flag) = features.user_option_flag {
+            let user_info = ctx.get_current_user()?;
+            if !user_info.has_option_flag(user_option_flag) {
+                return Err(ErrorCode::PermissionDenied(format!(
+                    "Access denied: '{}' requires user {} option flag",
+                    self.name(),
+                    user_option_flag
+                )));
+            }
+        }
         Ok(())
     }
 

--- a/query/src/procedures/procedure_factory.rs
+++ b/query/src/procedures/procedure_factory.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::UserOptionFlag;
 use once_cell::sync::Lazy;
 
 use crate::procedures::admins::AdminProcedure;
@@ -35,6 +36,9 @@ pub struct ProcedureFeatures {
 
     // Management mode only.
     pub management_mode_required: bool,
+
+    // User option flag required.
+    pub user_option_flag: Option<UserOptionFlag>,
 }
 
 impl ProcedureFeatures {
@@ -43,6 +47,7 @@ impl ProcedureFeatures {
             num_arguments: 0,
             variadic_arguments: None,
             management_mode_required: false,
+            user_option_flag: None,
         }
     }
 
@@ -58,6 +63,11 @@ impl ProcedureFeatures {
 
     pub fn management_mode_required(mut self, required: bool) -> ProcedureFeatures {
         self.management_mode_required = required;
+        self
+    }
+
+    pub fn user_option_flag(mut self, flag: UserOptionFlag) -> ProcedureFeatures {
+        self.user_option_flag = Some(flag);
         self
     }
 }

--- a/query/src/sql/statements/mod.rs
+++ b/query/src/sql/statements/mod.rs
@@ -83,6 +83,7 @@ pub use statement_create_table::DfCreateTable;
 pub use statement_create_udf::DfCreateUDF;
 pub use statement_create_user::DfAuthOption;
 pub use statement_create_user::DfCreateUser;
+pub use statement_create_user::DfUserWithOption;
 pub use statement_create_user_stage::DfCreateUserStage;
 pub use statement_describe_table::DfDescribeTable;
 pub use statement_describe_user_stage::DfDescribeUserStage;

--- a/query/src/sql/statements/statement_create_user.rs
+++ b/query/src/sql/statements/statement_create_user.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_meta_types::AuthInfo;
+use common_meta_types::UserOption;
 use common_planners::CreateUserPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
@@ -45,7 +46,8 @@ pub struct DfCreateUser {
     /// User name
     pub name: String,
     pub hostname: String,
-    pub auth_options: DfAuthOption,
+    pub auth_option: DfAuthOption,
+    pub user_option: UserOption,
 }
 
 #[async_trait::async_trait]
@@ -57,9 +59,10 @@ impl AnalyzableStatement for DfCreateUser {
                 name: self.name.clone(),
                 hostname: self.hostname.clone(),
                 auth_info: AuthInfo::create(
-                    &self.auth_options.auth_type,
-                    &self.auth_options.by_value,
+                    &self.auth_option.auth_type,
+                    &self.auth_option.by_value,
                 )?,
+                user_option: self.user_option,
             },
         ))))
     }

--- a/query/src/sql/statements/statement_create_user.rs
+++ b/query/src/sql/statements/statement_create_user.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 use common_exception::Result;
 use common_meta_types::AuthInfo;
 use common_meta_types::UserOption;
+use common_meta_types::UserOptionFlag;
 use common_planners::CreateUserPlan;
 use common_planners::PlanNode;
 use common_tracing::tracing;
@@ -41,19 +43,64 @@ impl DfAuthOption {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum DfUserWithOption {
+    TenantSetting,
+    NoTenantSetting,
+    ConfigReload,
+    NoConfigReload,
+}
+
+impl TryFrom<&str> for DfUserWithOption {
+    type Error = String;
+
+    fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
+        match value {
+            "TENANTSETTING" => Ok(DfUserWithOption::TenantSetting),
+            "NOTENANTSETTING" => Ok(DfUserWithOption::NoTenantSetting),
+            "CONFIGRELOAD" => Ok(DfUserWithOption::ConfigReload),
+            "NOCONFIGRELOAD" => Ok(DfUserWithOption::NoConfigReload),
+            _ => Err(format!("Unknown user option: {}", value)),
+        }
+    }
+}
+
+impl DfUserWithOption {
+    pub fn apply(&self, option: &mut UserOption) {
+        match self {
+            Self::TenantSetting => {
+                option.set_option_flag(UserOptionFlag::TenantSetting);
+            }
+            Self::NoTenantSetting => {
+                option.unset_option_flag(UserOptionFlag::TenantSetting);
+            }
+            Self::ConfigReload => {
+                option.set_option_flag(UserOptionFlag::ConfigReload);
+            }
+            Self::NoConfigReload => {
+                option.unset_option_flag(UserOptionFlag::ConfigReload);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct DfCreateUser {
     pub if_not_exists: bool,
     /// User name
     pub name: String,
     pub hostname: String,
     pub auth_option: DfAuthOption,
-    pub user_option: UserOption,
+    pub with_options: Vec<DfUserWithOption>,
 }
 
 #[async_trait::async_trait]
 impl AnalyzableStatement for DfCreateUser {
     #[tracing::instrument(level = "debug", skip(self, _ctx), fields(ctx.id = _ctx.get_id().as_str()))]
     async fn analyze(&self, _ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
+        let mut user_option = UserOption::default();
+        for option in &self.with_options {
+            option.apply(&mut user_option);
+        }
         Ok(AnalyzedResult::SimpleQuery(Box::new(PlanNode::CreateUser(
             CreateUserPlan {
                 name: self.name.clone(),
@@ -62,7 +109,7 @@ impl AnalyzableStatement for DfCreateUser {
                     &self.auth_option.auth_type,
                     &self.auth_option.by_value,
                 )?,
-                user_option: self.user_option,
+                user_option,
             },
         ))))
     }

--- a/query/src/users/user.rs
+++ b/query/src/users/user.rs
@@ -15,6 +15,7 @@
 use common_meta_types::AuthInfo;
 use common_meta_types::UserGrantSet;
 use common_meta_types::UserInfo;
+use common_meta_types::UserOption;
 use common_meta_types::UserQuota;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -38,6 +39,7 @@ impl From<&User> for UserInfo {
     fn from(user: &User) -> Self {
         let grants = UserGrantSet::empty();
         let quota = UserQuota::no_limit();
+        let option = UserOption::default();
 
         UserInfo {
             name: user.name.clone(),
@@ -45,6 +47,7 @@ impl From<&User> for UserInfo {
             auth_info: user.auth_data.clone(),
             grants,
             quota,
+            option,
         }
     }
 }

--- a/query/src/users/user_mgr.rs
+++ b/query/src/users/user_mgr.rs
@@ -18,6 +18,7 @@ use common_meta_types::AuthInfo;
 use common_meta_types::GrantObject;
 use common_meta_types::RoleIdentity;
 use common_meta_types::UserInfo;
+use common_meta_types::UserOption;
 use common_meta_types::UserPrivilegeSet;
 
 use crate::users::User;
@@ -220,11 +221,17 @@ impl UserApiProvider {
         tenant: &str,
         username: &str,
         hostname: &str,
-        auth_info: AuthInfo,
+        auth_info: Option<AuthInfo>,
+        user_option: Option<UserOption>,
     ) -> Result<Option<u64>> {
         let client = self.get_user_api_client(tenant)?;
-        let update_user =
-            client.update_user(username.to_string(), hostname.to_string(), auth_info, None);
+        let update_user = client.update_user(
+            username.to_string(),
+            hostname.to_string(),
+            auth_info,
+            user_option,
+            None,
+        );
         match update_user.await {
             Ok(res) => Ok(res),
             Err(e) => Err(e.add_message_back("(while alter user).")),

--- a/query/src/users/user_mgr.rs
+++ b/query/src/users/user_mgr.rs
@@ -38,6 +38,7 @@ impl UserApiProvider {
                         &GrantObject::Global,
                         UserPrivilegeSet::available_privileges_on_global(),
                     );
+                    user_info.option.set_all_flag();
                 }
                 Ok(user_info)
             }

--- a/query/tests/it/interpreters/access/management_mode_access.rs
+++ b/query/tests/it/interpreters/access/management_mode_access.rs
@@ -151,7 +151,7 @@ async fn test_management_mode_access() -> Result<()> {
     let conf = crate::tests::ConfigBuilder::create()
         .with_management_mode()
         .config();
-    let ctx = crate::tests::create_query_context_with_config(conf.clone()).await?;
+    let ctx = crate::tests::create_query_context_with_config(conf.clone(), None).await?;
     // First to set tenant.
     {
         let plan = PlanParser::parse(ctx.clone(), "SUDO USE TENANT 'test'").await?;

--- a/query/tests/it/interpreters/interpreter_admin_use_tenant.rs
+++ b/query/tests/it/interpreters/interpreter_admin_use_tenant.rs
@@ -24,7 +24,7 @@ async fn test_use_tenant_interpreter() -> Result<()> {
     let conf = crate::tests::ConfigBuilder::create()
         .with_management_mode()
         .config();
-    let ctx = crate::tests::create_query_context_with_config(conf.clone()).await?;
+    let ctx = crate::tests::create_query_context_with_config(conf.clone(), None).await?;
 
     let plan = PlanParser::parse(ctx.clone(), "SUDO USE TENANT 't1'").await?;
     let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;

--- a/query/tests/it/interpreters/interpreter_user_alter.rs
+++ b/query/tests/it/interpreters/interpreter_user_alter.rs
@@ -17,6 +17,7 @@ use common_exception::Result;
 use common_meta_types::AuthInfo;
 use common_meta_types::PasswordHashMethod;
 use common_meta_types::UserInfo;
+use common_meta_types::UserOptionFlag;
 use databend_query::interpreters::*;
 use databend_query::sql::*;
 use futures::stream::StreamExt;
@@ -31,7 +32,6 @@ async fn test_alter_user_interpreter() -> Result<()> {
     let name = "test";
     let hostname = "localhost";
     let password = "test";
-    let new_password = "password";
     let auth_info = AuthInfo::Password {
         hash_value: Vec::from(password),
         hash_method: PasswordHashMethod::PlainText,
@@ -47,21 +47,49 @@ async fn test_alter_user_interpreter() -> Result<()> {
         Vec::from(password)
     );
 
-    let test_query = format!(
-        "ALTER USER '{}'@'{}' IDENTIFIED BY '{}'",
-        name, hostname, new_password
-    );
+    {
+        let new_password = "password";
+        let test_query = format!(
+            "ALTER USER '{}'@'{}' IDENTIFIED BY '{}'",
+            name, hostname, new_password
+        );
 
-    let plan = PlanParser::parse(ctx.clone(), &test_query).await?;
-    let executor = InterpreterFactory::get(ctx, plan.clone())?;
-    assert_eq!(executor.name(), "AlterUserInterpreter");
-    let mut stream = executor.execute(None).await?;
-    while let Some(_block) = stream.next().await {}
-    let new_user = user_mgr.get_user(tenant, name, hostname).await?;
-    assert_eq!(
-        new_user.auth_info.get_password(),
-        Some(Vec::from(new_password))
-    );
+        let plan = PlanParser::parse(ctx.clone(), &test_query).await?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+        assert_eq!(executor.name(), "AlterUserInterpreter");
+        let mut stream = executor.execute(None).await?;
+        while let Some(_block) = stream.next().await {}
+        let new_user = user_mgr.get_user(tenant, name, hostname).await?;
+        assert_eq!(
+            new_user.auth_info.get_password(),
+            Some(Vec::from(new_password))
+        );
+    }
+
+    {
+        let new_password = "new_password";
+        let test_query = format!(
+            "ALTER USER '{}'@'{}' WITH TENANTSETTING IDENTIFIED BY '{}'",
+            name, hostname, new_password
+        );
+        let plan = PlanParser::parse(ctx.clone(), &test_query).await?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+        assert_eq!(executor.name(), "AlterUserInterpreter");
+        executor.execute(None).await?;
+        let user = user_mgr.get_user(tenant, name, hostname).await?;
+        assert!(user.has_option_flag(UserOptionFlag::TenantSetting));
+        assert_eq!(user.auth_info.get_password(), Some(Vec::from(new_password)));
+    }
+
+    {
+        let test_query = format!("ALTER USER '{}'@'{}' WITH NOTENANTSETTING", name, hostname);
+        let plan = PlanParser::parse(ctx.clone(), &test_query).await?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+        assert_eq!(executor.name(), "AlterUserInterpreter");
+        executor.execute(None).await?;
+        let user = user_mgr.get_user(tenant, name, hostname).await?;
+        assert!(!user.has_option_flag(UserOptionFlag::TenantSetting));
+    }
 
     Ok(())
 }

--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -476,6 +476,7 @@ async fn test_auth_jwt() -> Result<()> {
         auth_info: AuthInfo::JWT,
         grants: Default::default(),
         quota: Default::default(),
+        option: Default::default(),
     };
 
     let tenant = "test";

--- a/query/tests/it/sessions/query_ctx.rs
+++ b/query/tests/it/sessions/query_ctx.rs
@@ -33,7 +33,7 @@ async fn test_get_storage_accessor_s3() -> Result<()> {
         root: "".to_string(),
     };
 
-    let qctx = crate::tests::create_query_context_with_config(conf).await?;
+    let qctx = crate::tests::create_query_context_with_config(conf, None).await?;
 
     let _ = qctx.get_storage_operator()?;
 
@@ -50,7 +50,7 @@ async fn test_get_storage_accessor_fs() -> Result<()> {
         temp_data_path: "/tmp".to_string(),
     };
 
-    let qctx = crate::tests::create_query_context_with_config(conf).await?;
+    let qctx = crate::tests::create_query_context_with_config(conf, None).await?;
 
     let _ = qctx.get_storage_operator()?;
 

--- a/query/tests/it/storages/fuse/table_test_fixture.rs
+++ b/query/tests/it/storages/fuse/table_test_fixture.rs
@@ -61,7 +61,7 @@ impl TestFixture {
         // use `TempDir` as root path (auto clean)
         conf.storage.disk.data_path = tmp_dir.path().to_str().unwrap().to_string();
         conf.storage.disk.temp_data_path = tmp_dir.path().to_str().unwrap().to_string();
-        let ctx = crate::tests::create_query_context_with_config(conf)
+        let ctx = crate::tests::create_query_context_with_config(conf, None)
             .await
             .unwrap();
 

--- a/query/tests/it/storages/system/configs_table.rs
+++ b/query/tests/it/storages/system/configs_table.rs
@@ -22,7 +22,7 @@ use pretty_assertions::assert_eq;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_configs_table() -> Result<()> {
     let conf = crate::tests::ConfigBuilder::create().config();
-    let ctx = crate::tests::create_query_context_with_config(conf).await?;
+    let ctx = crate::tests::create_query_context_with_config(conf, None).await?;
     ctx.get_settings().set_max_threads(8)?;
 
     let table = ConfigsTable::create(1);
@@ -111,7 +111,7 @@ async fn test_configs_table_redact() -> Result<()> {
     let mut conf = crate::tests::ConfigBuilder::create().config();
     conf.storage.s3.access_key_id = "access_key_id".to_string();
     conf.storage.s3.secret_access_key = "secret_access_key".to_string();
-    let ctx = crate::tests::create_query_context_with_config(conf).await?;
+    let ctx = crate::tests::create_query_context_with_config(conf, None).await?;
     ctx.get_settings().set_max_threads(8)?;
 
     let table = ConfigsTable::create(1);

--- a/query/tests/it/storages/system/users_table.rs
+++ b/query/tests/it/storages/system/users_table.rs
@@ -19,6 +19,7 @@ use common_meta_types::AuthType;
 use common_meta_types::PasswordHashMethod;
 use common_meta_types::UserGrantSet;
 use common_meta_types::UserInfo;
+use common_meta_types::UserOption;
 use common_meta_types::UserQuota;
 use databend_query::storages::system::UsersTable;
 use databend_query::storages::ToReadDataSourcePlan;
@@ -40,6 +41,7 @@ async fn test_users_table() -> Result<()> {
                 hostname: "localhost".to_string(),
                 grants: UserGrantSet::empty(),
                 quota: UserQuota::no_limit(),
+                option: UserOption::default(),
             },
             false,
         )
@@ -57,6 +59,7 @@ async fn test_users_table() -> Result<()> {
                 hostname: "%".to_string(),
                 grants: UserGrantSet::empty(),
                 quota: UserQuota::no_limit(),
+                option: UserOption::default(),
             },
             false,
         )
@@ -72,6 +75,7 @@ async fn test_users_table() -> Result<()> {
                 hostname: "%".to_string(),
                 grants: UserGrantSet::empty(),
                 quota: UserQuota::no_limit(),
+                option: UserOption::default(),
             },
             false,
         )

--- a/query/tests/it/tests/context.rs
+++ b/query/tests/it/tests/context.rs
@@ -65,7 +65,10 @@ pub async fn create_query_context() -> Result<Arc<QueryContext>> {
     Ok(context)
 }
 
-pub async fn create_query_context_with_config(config: Config) -> Result<Arc<QueryContext>> {
+pub async fn create_query_context_with_config(
+    config: Config,
+    current_user: Option<UserInfo>,
+) -> Result<Arc<QueryContext>> {
     let sessions = SessionManagerBuilder::create_with_conf(config.clone()).build()?;
     let dummy_session = sessions.create_session(SessionType::Test).await?;
 
@@ -83,6 +86,9 @@ pub async fn create_query_context_with_config(config: Config) -> Result<Arc<Quer
         &GrantObject::Global,
         UserPrivilegeSet::available_privileges_on_global(),
     );
+    if let Some(user) = current_user {
+        user_info = user;
+    }
     dummy_session.set_current_user(user_info);
 
     let context = QueryContext::create_from_shared(

--- a/query/tests/it/users/user_mgr.rs
+++ b/query/tests/it/users/user_mgr.rs
@@ -184,7 +184,7 @@ async fn test_user_manager() -> Result<()> {
             hash_method: PasswordHashMethod::Sha256,
         };
         user_mgr
-            .update_user(tenant, user, hostname, auth_info)
+            .update_user(tenant, user, hostname, Some(auth_info), None)
             .await?;
         let new_user = user_mgr.get_user(tenant, user, hostname).await?;
         assert_eq!(
@@ -203,7 +203,7 @@ async fn test_user_manager() -> Result<()> {
             hash_method: PasswordHashMethod::Sha256,
         };
         user_mgr
-            .update_user(tenant, user, hostname, auth_info.clone())
+            .update_user(tenant, user, hostname, Some(auth_info.clone()), None)
             .await?;
         let new_new_user = user_mgr.get_user(tenant, user, hostname).await?;
         assert_eq!(
@@ -212,7 +212,7 @@ async fn test_user_manager() -> Result<()> {
         );
 
         let not_exist = user_mgr
-            .update_user(tenant, "user", hostname, auth_info.clone())
+            .update_user(tenant, "user", hostname, Some(auth_info.clone()), None)
             .await;
         // ErrorCode::UnknownUser
         assert_eq!(not_exist.err().unwrap().code(), 2201)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

In order to separate system management privileges and security object privileges, we can introduce user options.

## Changelog

- New Feature

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/4494

## Test Plan

Unit Tests

Stateless Tests
