### PR TITLE
docs: use default ports for kubernetes deploy example

### DIFF
--- a/scripts/kubernetes/meta-standalone.yaml
+++ b/scripts/kubernetes/meta-standalone.yaml
@@ -52,7 +52,7 @@ spec:
             - name: METASRV_GRPC_API_ADDRESS
               value: "$(POD_IP):9191"
             - name: KVSRV_API_PORT
-              value: "28003"
+              value: "28004"
             - name: KVSRV_LISTEN_HOST
               value: "$(POD_IP)"
             - name: KVSRV_ADVERTISE_HOST
@@ -67,14 +67,14 @@ spec:
             periodSeconds: 15
             failureThreshold: 3
           ports:
-            - containerPort: 28001
-              name: metrics
-            - containerPort: 28002
-              name: admin
-            - containerPort: 9191
-              name: flight
-            - containerPort: 28003
-              name: raft
+            - name: metrics
+              containerPort: 28001
+            - name: admin
+              containerPort: 28002
+            - name: flight
+              containerPort: 9191
+            - name: raft
+              containerPort: 28004
           volumeMounts:
             - name: data
               mountPath: /mnt/data
@@ -96,17 +96,17 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - port: 28001
+    - name: metrics
+      port: 28001
       targetPort: 28001
-      name: metrics
-    - port: 28002
+    - name: admin
+      port: 28002
       targetPort: 28002
-      name: admin
-    - port: 9191
+    - name: flight
+      port: 9191
       targetPort: 9191
-      name: flight
-    - port: 28003
-      targetPort: 28003
-      name: raft
+    - name: raft
+      port: 28004
+      targetPort: 28004
   selector:
     app: meta-service

--- a/scripts/kubernetes/query-cluster.yaml
+++ b/scripts/kubernetes/query-cluster.yaml
@@ -27,7 +27,7 @@ metadata:
   annotations:
     meta_address: meta-service.databend-system.svc.cluster.local:9191
     prometheus.io/path: /metrics
-    prometheus.io/port: "10010"
+    prometheus.io/port: "7070"
     prometheus.io/scrape: "true"
   labels:
     QUERY_CLUSTER_ID: hello-world
@@ -39,24 +39,24 @@ metadata:
   namespace: tenant1
 spec:
   ports:
-    - name: health
+    - name: http
+      port: 8000
+      targetPort: 8000
+    - name: admin
       port: 8080
       targetPort: 8080
-    - name: query
-      port: 9000
-      targetPort: 9000
-    - name: rpc
-      port: 9091
-      targetPort: 9091
     - name: metrics
-      port: 10010
-      targetPort: 10010
+      port: 7070
+      targetPort: 7070
     - name: mysql
       port: 3307
       targetPort: 3307
     - name: clickhouse
-      port: 10000
-      targetPort: 10000
+      port: 9000
+      targetPort: 9000
+    - name: flight
+      port: 9090
+      targetPort: 9090
   selector:
     QUERY_CLUSTER_ID: hello-world
     QUERY_TENANT_ID: tenant1
@@ -131,10 +131,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['cluster']
-            - name: QUERY_HTTP_HANDLER_HOST
-              value: 0.0.0.0
-            - name: QUERY_HTTP_HANDLER_PORT
-              value: "9000"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -147,38 +143,42 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: QUERY_HTTP_HANDLER_HOST
+              value: "0.0.0.0"
+            - name: QUERY_HTTP_HANDLER_PORT
+              value: "8000"
             - name: QUERY_ADMIN_API_ADDRESS
-              value: 0.0.0.0:8080
+              value: "0.0.0.0:8080"
             - name: QUERY_METRIC_API_ADDRESS
-              value: 0.0.0.0:10010
+              value: "0.0.0.0:7070"
             - name: QUERY_MYSQL_HANDLER_HOST
-              value: 0.0.0.0
+              value: "0.0.0.0"
             - name: QUERY_MYSQL_HANDLER_PORT
               value: "3307"
             - name: QUERY_CLICKHOUSE_HANDLER_HOST
-              value: 0.0.0.0
+              value: "0.0.0.0"
             - name: QUERY_CLICKHOUSE_HANDLER_PORT
-              value: "10000"
+              value: "9000"
             - name: QUERY_FLIGHT_API_ADDRESS
-              value: "$(POD_IP):9191"
+              value: "$(POD_IP):9090"
           envFrom:
             - secretRef:
                 name: query-secrets
           image: datafuselabs/databend-query:v0.6.100-nightly
           name: query
           ports:
-            - containerPort: 9000
-              name: query
-            - containerPort: 8080
-              name: http
-            - containerPort: 10010
-              name: metrics
-            - containerPort: 9091
-              name: flight
-            - containerPort: 3307
-              name: mysql
-            - containerPort: 10000
-              name: clickhouse
+            - name: http
+              containerPort: 8000
+            - name: admin
+              containerPort: 8080
+            - name: metrics
+              containerPort: 7070
+            - name: mysql
+              containerPort: 3307
+            - name: clickhouse
+              containerPort: 9000
+            - name: flight
+              containerPort: 9090
           readinessProbe:
             httpGet:
               path: /v1/health


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary about this PR

use default ports for Kubernetes deploy example

## Changelog

- Documentation

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests
