### PR TITLE
update opensrv for fix issue 4430

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "opensrv-mysql"
 version = "0.1.0"
-source = "git+https://github.com/datafuselabs/opensrv?rev=9690be9#9690be9ff965c0e86e1ff599897c2019b0a379bd"
+source = "git+https://github.com/datafuselabs/opensrv?rev=e744427#e744427ebce9271289e47d655f1223790aae7482"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -54,7 +54,7 @@ common-tracing = { path = "../common/tracing" }
 bincode = { git = "https://github.com/datafuse-extras/bincode", rev = "fd3f9ff" }
 cargo-license = { git = "https://github.com/datafuse-extras/cargo-license", rev = "f1ce4a2" }
 opensrv-clickhouse = { git = "https://github.com/datafuselabs/opensrv", rev = "9690be9", package = "opensrv-clickhouse" }
-opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "9690be9", package = "opensrv-mysql" }
+opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "e744427", package = "opensrv-mysql" }
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "da3b180" }
 
 # Crates.io dependencies

--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -361,6 +361,9 @@ impl<W: std::io::Write> InteractiveWorkerBase<W> {
     }
 
     async fn do_init(&mut self, database_name: &str) -> Result<()> {
+        if database_name.is_empty() {
+            return Ok(());
+        }
         let init_query = format!("USE `{}`;", database_name);
 
         let do_query = self.do_query(&init_query).await;

--- a/query/src/sessions/session_ctx.rs
+++ b/query/src/sessions/session_ctx.rs
@@ -91,10 +91,11 @@ impl SessionContext {
     pub fn get_current_tenant(&self) -> String {
         if self.conf.query.management_mode {
             let lock = self.current_tenant.read();
-            lock.clone()
-        } else {
-            self.conf.query.tenant_id.clone()
+            if !lock.is_empty() {
+                return lock.clone();
+            }
         }
+        self.conf.query.tenant_id.clone()
     }
 
     // Get current user

--- a/query/tests/it/sessions/session.rs
+++ b/query/tests/it/sessions/session.rs
@@ -81,7 +81,7 @@ async fn test_session_in_management_mode() -> Result<()> {
     // Tenant.
     {
         let actual = session.get_current_tenant();
-        assert_eq!(&actual, "");
+        assert_eq!(&actual, "test");
 
         session.set_current_tenant("tenant2".to_string());
         let actual = session.get_current_tenant();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

https://github.com/datafuselabs/opensrv/pull/11

```
[N] ❯ mysql -h 127.0.0.1 -P3306 -u root test
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 8
Server version: 8.0.26-v0.6.91-nightly-93522be-simd(rust-1.61.0-nightly-2022-03-26T12:14:56.337604171+00:00) 0

Copyright (c) 2000, 2022, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> show tables;
+------+
| name |
+------+
| a    |
+------+
1 row in set (0.07 sec)
Read 19 rows, 1.69 KB in 0.051 sec., 372.76 rows/sec., 33.06 KB/sec.
```

```
[N] ❯ mysql -h 127.0.0.1 -P3306 -u root system
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 8
Server version: 8.0.26-v0.6.91-nightly-93522be-simd(rust-1.61.0-nightly-2022-03-26T12:14:56.337604171+00:00) 0

Copyright (c) 2000, 2022, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> show tables;
+--------------+
| name         |
+--------------+
| clusters     |
| columns      |
| configs      |
| contributors |
| credits      |
| databases    |
| engines      |
| functions    |
| metrics      |
| one          |
| processes    |
| query_log    |
| roles        |
| settings     |
| tables       |
| tracing      |
| users        |
| warehouses   |
+--------------+
18 rows in set (0.07 sec)
Read 19 rows, 1.69 KB in 0.047 sec., 404.9 rows/sec., 35.91 KB/sec.
```

## Changelog

- Bug Fix

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/4430

## Test Plan

Unit Tests

Stateless Tests
