### PR TITLE
fix(function): fix parse_json data type match

### DIFF
--- a/common/datavalues/src/types/serializations/mod.rs
+++ b/common/datavalues/src/types/serializations/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_arrow::arrow::bitmap::Bitmap;
+use common_exception::ErrorCode;
 use common_exception::Result;
 use opensrv_clickhouse::types::column::ArcColumnData;
 use serde_json::Value;
@@ -44,4 +46,23 @@ pub trait TypeSerializer: Send + Sync {
     fn serialize_json(&self, column: &ColumnRef) -> Result<Vec<Value>>;
     fn serialize_column(&self, column: &ColumnRef) -> Result<Vec<String>>;
     fn serialize_clickhouse_format(&self, column: &ColumnRef) -> Result<ArcColumnData>;
+
+    fn serialize_json_object(
+        &self,
+        _column: &ColumnRef,
+        _valids: Option<&Bitmap>,
+    ) -> Result<Vec<Value>> {
+        Err(ErrorCode::BadDataValueType(
+            "Error parsing JSON: unsupported data type",
+        ))
+    }
+
+    fn serialize_json_object_suppress_error(
+        &self,
+        _column: &ColumnRef,
+    ) -> Result<Vec<Option<Value>>> {
+        Err(ErrorCode::BadDataValueType(
+            "Error parsing JSON: unsupported data type",
+        ))
+    }
 }

--- a/common/functions/tests/it/scalars/expressions.rs
+++ b/common/functions/tests/it/scalars/expressions.rs
@@ -210,6 +210,18 @@ fn test_cast_function() -> Result<()> {
                 error: "",
             },
         ),
+        (
+            CastFunction::create("cast", "variant")?,
+            ScalarFunctionTest {
+                name: "cast-string-to-variant-error",
+                columns: vec![Series::from_data(vec![
+                    "abc",
+                    "123",
+                ])],
+                expect: Arc::new(NullColumn::new(2)),
+                error: "Expression type does not match column data type, expecting VARIANT but got String",
+            },
+        ),
     ];
 
     for (test_func, test) in tests {
@@ -244,6 +256,18 @@ fn test_datetime_cast_function() -> Result<()> {
                 )],
                 expect: Series::from_data(vec!["2021-03-05 01:01:01", "2021-10-24 10:10:10"]),
                 error: "",
+            },
+        ),
+        (
+            CastFunction::create("cast", "variant")?,
+            ScalarFunctionWithFieldTest {
+                name: "cast-date32-to-variant-error",
+                columns: vec![ColumnWithField::new(
+                    Series::from_data(vec![18691i32, 18924]),
+                    DataField::new("dummy_1", Date32Type::arc()),
+                )],
+                expect: Arc::new(NullColumn::new(2)),
+                error: "Expression type does not match column data type, expecting VARIANT but got Date32",
             },
         ),
     ];

--- a/common/functions/tests/it/scalars/semi_structureds.rs
+++ b/common/functions/tests/it/scalars/semi_structureds.rs
@@ -86,7 +86,7 @@ fn test_parse_json_function() -> Result<()> {
             name: "parse_json_invalid_string",
             columns: vec![Series::from_data(vec!["\"abcd\"", "[1,2", "{\"k"])],
             expect: Series::from_data(vec![JsonValue::Null, JsonValue::Null, JsonValue::Null]),
-            error: "Error parsing JSON: Error(\"EOF while parsing a list\", line: 1, column: 4)",
+            error: "Error parsing JSON: EOF while parsing a list at line 1 column 4",
         },
         ScalarFunctionTest {
             name: "parse_json_nullable_bool",
@@ -164,7 +164,7 @@ fn test_parse_json_function() -> Result<()> {
                 Some("{\"k"),
             ])],
             expect: Series::from_data(vec![Some(json!("abcd")), None, None]),
-            error: "Error parsing JSON: Error(\"EOF while parsing a list\", line: 1, column: 4)",
+            error: "Error parsing JSON: EOF while parsing a list at line 1 column 4",
         },
     ];
 

--- a/tests/suites/0_stateless/02_function/02_0048_function_semi_structureds_parse_json.result
+++ b/tests/suites/0_stateless/02_function/02_0048_function_semi_structureds_parse_json.result
@@ -11,6 +11,8 @@ true
 "Om ara pa ca na dhih"
 [-1,12,289,2188,false]
 {"x":"abc","y":false,"z":10}
+123
+"abc"
 ==try_parse_json==
 NULL
 true
@@ -24,6 +26,10 @@ true
 "Om ara pa ca na dhih"
 [-1,12,289,2188,false]
 {"x":"abc","y":false,"z":10}
+NULL
+NULL
+123
+"abc"
 NULL
 NULL
 ==parse_json from table==

--- a/tests/suites/0_stateless/02_function/02_0048_function_semi_structureds_parse_json.sql
+++ b/tests/suites/0_stateless/02_function/02_0048_function_semi_structureds_parse_json.sql
@@ -13,6 +13,10 @@ select parse_json('[-1, 12, 289, 2188, false]');
 select parse_json('{ "x" : "abc", "y" : false, "z": 10} ');
 select parse_json('[1,'); -- {ErrorCode 1010}
 select parse_json('"ab'); -- {ErrorCode 1010}
+select parse_json(parse_json('123'));
+select parse_json(parse_json('"\\\"abc\\\""'));
+select parse_json(parse_json('"abc"')); -- {ErrorCode 1010}
+select parse_json(todate32('2022-01-01')); -- {ErrorCode 1010}
 
 select '==try_parse_json==';
 select try_parse_json(null);
@@ -29,6 +33,10 @@ select try_parse_json('[-1, 12, 289, 2188, false]');
 select try_parse_json('{ "x" : "abc", "y" : false, "z": 10} ');
 select try_parse_json('[1,');
 select try_parse_json('"ab');
+select try_parse_json(parse_json('123'));
+select try_parse_json(parse_json('"\\\"abc\\\""'));
+select try_parse_json(parse_json('"abc"'));
+select try_parse_json(todate32('2022-01-01'));
 
 DROP DATABASE IF EXISTS db1;
 CREATE DATABASE db1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix `parse_json` data type match error

```sql
mysql> select parse_json(todate32('2022-01-01'));
+------------------------------------+
| parse_json(todate32('2022-01-01')) |
+------------------------------------+
| 18993                              |
+------------------------------------+
1 row in set (0.01 sec)
```

## Changelog

- Bug Fix

## Related Issues

[#4476](https://github.com/datafuselabs/databend/issues/4476)

## Test Plan

Unit Tests

Stateless Tests
