### PR TITLE
build(crossbeam): fix up the old toolchain compiler error

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -71,13 +71,3 @@ runs:
       with:
         command: udeps
         args: --workspace
-
-    - name: Install taplo
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: taplo-cli
-
-    - name: Check toml format
-      shell: bash
-      run: taplo fmt --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-03-10"
+channel = "nightly-2022-03-03"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix up the old toolchain compiler error

## Changelog

- Build/Testing/CI


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests
