### PR TITLE
fix(processor): finish processor executor when no new task

### DIFF
--- a/query/src/pipelines/new/executor/executor_notify.rs
+++ b/query/src/pipelines/new/executor/executor_notify.rs
@@ -37,6 +37,7 @@ struct WorkersNotifyMutable {
 }
 
 pub struct WorkersNotify {
+    workers: usize,
     mutable_state: Mutex<WorkersNotifyMutable>,
     workers_notify: Vec<WorkerNotify>,
 }
@@ -52,12 +53,18 @@ impl WorkersNotify {
         }
 
         Arc::new(WorkersNotify {
+            workers,
             workers_notify,
             mutable_state: Mutex::new(WorkersNotifyMutable {
                 waiting_size: 0,
                 workers_waiting,
             }),
         })
+    }
+
+    pub fn active_workers(&self) -> usize {
+        let mutable_state = self.mutable_state.lock();
+        self.workers - mutable_state.waiting_size
     }
 
     pub fn is_empty(&self) -> bool {

--- a/query/src/pipelines/new/executor/executor_tasks.rs
+++ b/query/src/pipelines/new/executor/executor_tasks.rs
@@ -54,6 +54,7 @@ impl ExecutorTasksQueue {
     pub unsafe fn steal_task_to_context(&self, context: &mut ExecutorWorkerContext) {
         {
             let mut workers_tasks = self.workers_tasks.lock();
+
             if !workers_tasks.is_empty() {
                 let task = workers_tasks.pop_task(context.get_worker_num());
                 context.set_task(task);
@@ -68,6 +69,14 @@ impl ExecutorTasksQueue {
 
                 return;
             }
+        }
+
+        // When tasks queue is empty and all workers are waiting, no new tasks will be generated.
+        let workers_notify = context.get_workers_notify();
+        if workers_notify.active_workers() <= 1 {
+            self.finish();
+            workers_notify.wakeup_all();
+            return;
         }
 
         context.get_workers_notify().wait(context.get_worker_num());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Finished processor executor when no new task

## Changelog

- Improvement

## Related Issues

part #3379

## Test Plan

Unit Tests

Stateless Tests
