### PR TITLE
NullSource should return one data block?

### DIFF
--- a/query/src/storages/null/null_table.rs
+++ b/query/src/storages/null/null_table.rs
@@ -154,7 +154,7 @@ impl SyncSource for NullSource {
     const NAME: &'static str = "NullSource";
 
     fn generate(&mut self) -> Result<Option<DataBlock>> {
-        if !self.finish {
+        if self.finish {
             return Ok(None);
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
I am not sure what `NullSource` means exactly yet, but:

line 160~162 is unreachable code, compare read2 with read, this seems need to return one datablock
https://github.com/datafuselabs/databend/blob/f39cd40cec5ca15f624e9b0e364fe3aa8aa6a176/query/src/storages/null/null_table.rs#L156-L162
## Changelog


- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests
