### PR TITLE
[Cloud] keep environment variable immutable during reload

### DIFF
--- a/query/src/sessions/session_mgr.rs
+++ b/query/src/sessions/session_mgr.rs
@@ -395,6 +395,8 @@ impl SessionManager {
             let mut config = self.conf.write();
             let config_file = config.config_file.clone();
             *config = Config::load_from_file(&config_file)?;
+            // ensure the environment variables are immutable
+            *config = Config::load_from_env(&config)?;
             config.config_file = config_file;
             config.clone()
         };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
During reload command, cluster would reload all configurations from config file and overlap settings from environment variable which is not desired, since environment variable are expected to be immutable

## Changelog

- Bug Fix

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests
