### PR TITLE
fix(ci): use specific toolchain tagged image

### DIFF
--- a/.github/actions/build_debug/action.yml
+++ b/.github/actions/build_debug/action.yml
@@ -27,7 +27,7 @@ runs:
       if: "contains(inputs.target, 'linux')"
       uses: ./.github/actions/setup_build_tool
       with:
-        image: datafuselabs/build-tool:multiarch
+        image: multiarch
 
     # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1

--- a/.github/actions/build_release/action.yml
+++ b/.github/actions/build_release/action.yml
@@ -27,7 +27,7 @@ runs:
       if: "contains(inputs.target, 'linux')"
       uses: ./.github/actions/setup_build_tool
       with:
-        image: datafuselabs/build-tool:multiarch
+        image: multiarch
 
     # If you need to reset the cache version, increment the number after `v`
     - uses: Swatinem/rust-cache@v1

--- a/.github/actions/setup_build_tool/action.yml
+++ b/.github/actions/setup_build_tool/action.yml
@@ -4,7 +4,7 @@ inputs:
   image:
     description: "Build Tool Docker Image to use"
     required: true
-    default: datafuselabs/build-tool:dev-debian-amd64
+    default: dev-debian-amd64
   bypass_env_vars:
     description: "Environment variables bypass to docker container"
     required: false
@@ -28,7 +28,7 @@ runs:
         cat <<EOF >$BIN_LOCAL/build-tool
         #!/bin/bash
         script_name=\$(basename "\$0")
-        export IMAGE=${{ inputs.image }}
+        export IMAGE=datafuselabs/build-tool:${{ inputs.image }}
         export BYPASS_ENV_VARS=${{ inputs.bypass_env_vars }}
         if [[ \${script_name} == "build-tool" ]]; then
           scripts/setup/run_build_tool.sh \$@

--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Setup Build Tool
       uses: ./.github/actions/setup_build_tool
       with:
-        image: datafuselabs/build-tool:dev-debian-amd64
+        image: dev-debian-amd64
         bypass_env_vars: RUST_TEST_THREADS,RUST_LOG,RUST_BACKTRACE
 
     # If you need to reset the cache version, increment the number after `v`

--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Setup Build Tool
         uses: ./.github/actions/setup_build_tool
         with:
-          image: datafuselabs/build-tool:multiarch
+          image: multiarch
       - name: get objcopy path
         id: get_objcopy
         shell: bash

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
     paths:
-      - "rust-toolchain.toml"
       - "scripts/setup/**"
 
 jobs:
@@ -33,7 +32,7 @@ jobs:
       - name: Get rust toolchain version
         id: toolchain_version
         run: |
-          version=$(awk -F'[ ="]+' '$1 == "channel" { print $2 }' rust-toolchain.toml)
+          version=$(awk -F'[ ="]+' '$1 == "channel" { print $2 }' scripts/setup/rust-toolchain.toml)
           echo "::set-output name=RUST_TOOLCHAIN::${version}"
 
       - name: Build and publish databend build base image

--- a/docker/build-tool/alpine/Dockerfile
+++ b/docker/build-tool/alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache sudo bash && delgroup dialout && \
     adduser -u 501 -G staff macos -D -H && \
     printf "builder,runner,macos ALL=(ALL:ALL) NOPASSWD:ALL\n" > /etc/sudoers.d/databend
 
-COPY rust-toolchain.toml /build/rust-toolchain.toml
+COPY scripts/setup/rust-toolchain.toml /build/rust-toolchain.toml
 COPY scripts/setup/dev_setup.sh /build/scripts/setup/dev_setup.sh
 RUN chmod +x /build/scripts/setup/dev_setup.sh && \
     /build/scripts/setup/dev_setup.sh -yb && \

--- a/docker/build-tool/debian/Dockerfile
+++ b/docker/build-tool/debian/Dockerfile
@@ -20,7 +20,7 @@ RUN groupdel dialout && groupdel staff && \
     useradd -u 501 -g 20 macos && \
     printf "builder,runner,macos ALL=(ALL:ALL) NOPASSWD:ALL\n" > /etc/sudoers.d/databend
 
-COPY rust-toolchain.toml /build/rust-toolchain.toml
+COPY scripts/setup/rust-toolchain.toml /build/rust-toolchain.toml
 COPY scripts/setup/dev_setup.sh /build/scripts/setup/dev_setup.sh
 RUN chmod +x /build/scripts/setup/dev_setup.sh && \
     /build/scripts/setup/dev_setup.sh -yb && \

--- a/docs/doc/10-faq/02-routine-maintenance.md
+++ b/docs/doc/10-faq/02-routine-maintenance.md
@@ -14,12 +14,14 @@ Databend will choose a relatively new nightly version for the build/test/bench.
 
 The steps to update toolchain are as follows:
 
-- Step 1: edit `rust-toolchain.toml` to update the `channel` field.
+- Setp 1: edit `scripts/setup/rust-toolchain.toml` to update the `channel` field for builder image.
   - Usually updated to the current date.
-- Step 2: Run `make lint` to make sure clippy is happy.
+  - Merge this change to main and wait for ci to build the new toolchain image
+- Step 2: edit `rust-toolchain.toml` to the same channel as build tool.
+- Step 3: Run `scripts/setup/run_build_tool.sh make lint` to make sure clippy is happy.
   - clippy is not entirely correct. If necessary, you can use `#[allow(clippy::xxx)]` to skip some of the rules.
   - If possible, please add a comment to clarify.
-- Step 3: Run `make test` to check the correctness.
+- Step 4: Run `scripts/setup/run_build_tool.sh make test` to check the correctness.
 
 ## Upgrade the dependencies
 
@@ -40,4 +42,3 @@ Currently, the dependency upgrade process is divided into the following steps:
 :::tip
 If you hacked `Cargo.lock` during the process, make sure everything is working smoothly.
 :::
-

--- a/scripts/setup/run_build_tool.sh
+++ b/scripts/setup/run_build_tool.sh
@@ -30,11 +30,13 @@ done
 mkdir -p "${CARGO_HOME}/registry"
 mkdir -p "${CARGO_HOME}/git"
 
+TOOLCHAIN_VERSION=$(awk -F'[ ="]+' '$1 == "channel" { print $2 }' rust-toolchain.toml)
+
 exec docker run --rm --tty --net=host ${EXTRA_ARGS} \
 	--user $(id -u):$(id -g) \
 	--volume "${CARGO_HOME}/registry:/opt/rust/cargo/registry" \
 	--volume "${CARGO_HOME}/git:/opt/rust/cargo/git" \
 	--volume "${PWD}:/workspace" \
 	--workdir "/workspace" \
-	"${IMAGE}" \
+	"${IMAGE}-${TOOLCHAIN_VERSION}" \
 	${COMMAND}

--- a/scripts/setup/rust-toolchain.toml
+++ b/scripts/setup/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2022-04-03"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Building the base build image with pull request is not safe, we need an extra step for toolchain upgrade.

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

for #4689

## Test Plan

Unit Tests

Stateless Tests
