### PR TITLE
Fix: remove Copy trait for RangeSet, since String dose not impl Copy

### DIFF
--- a/common/range-set/src/range_key.rs
+++ b/common/range-set/src/range_key.rs
@@ -47,21 +47,28 @@ where
 
 impl<T, K> Ord for RangeKey<T, K>
 where
-    T: Ord + std::fmt::Debug + Copy,
-    K: Ord + std::fmt::Debug + Copy,
+    T: Ord + Debug + Clone,
+    K: Ord + Debug + Clone,
 {
     /// the compare weight is: range.end > range.start > key
-    /// example: ((2,3),5) < ((5,1),3) cause 2 < 5
+    /// example: ((2,3),5) < ((5,1),3) since 2 < 5
     fn cmp(&self, other: &RangeKey<T, K>) -> Ordering {
-        ((self.range.end, self.range.start), self.key)
-            .cmp(&((other.range.end, other.range.start), other.key))
+        let ret = self.range.end.cmp(&other.range.end);
+        if !ret.is_eq() {
+            return ret;
+        }
+        let ret = self.range.start.cmp(&other.range.start);
+        if !ret.is_eq() {
+            return ret;
+        }
+        self.key.cmp(&other.key)
     }
 }
 
 impl<T, K> PartialOrd for RangeKey<T, K>
 where
-    T: Ord + std::fmt::Debug + Copy,
-    K: Ord + std::fmt::Debug + Copy,
+    T: Ord + Debug + Clone,
+    K: Ord + Debug + Clone,
 {
     fn partial_cmp(&self, other: &RangeKey<T, K>) -> Option<Ordering> {
         Some(self.cmp(other))

--- a/common/range-set/src/range_set.rs
+++ b/common/range-set/src/range_set.rs
@@ -38,7 +38,7 @@ where
     pub fn insert(&mut self, range: Range<T>, key: K) {
         assert!(range.start <= range.end);
 
-        let range_key: RangeKey<T, K> = RangeKey::new(range.clone(), key);
+        let range_key: RangeKey<T, K> = RangeKey::new(range, key);
 
         self.set.insert(range_key);
     }

--- a/common/range-set/src/range_set.rs
+++ b/common/range-set/src/range_set.rs
@@ -26,8 +26,8 @@ pub struct RangeSet<T, K> {
 
 impl<T, K> RangeSet<T, K>
 where
-    T: Ord + Clone + std::fmt::Debug + Copy,
-    K: Ord + Clone + std::fmt::Debug + Copy + Default,
+    T: Ord + Clone + Debug,
+    K: Ord + Clone + Debug + Default,
 {
     pub fn new() -> Self {
         RangeSet {
@@ -38,7 +38,7 @@ where
     pub fn insert(&mut self, range: Range<T>, key: K) {
         assert!(range.start <= range.end);
 
-        let range_key: RangeKey<T, K> = RangeKey::new(range, key);
+        let range_key: RangeKey<T, K> = RangeKey::new(range.clone(), key);
 
         self.set.insert(range_key);
     }
@@ -50,8 +50,8 @@ where
     // 3. `get_by_point(5)` return [2,4],[2,6]
     // Use the default key when construct `RangeKey::key` for search.
     pub fn get_by_point(&self, point: &T) -> Vec<&RangeKey<T, K>> {
-        let key = *point;
-        let range_key = RangeKey::new(key..key, K::default());
+        let key = point.clone();
+        let range_key = RangeKey::new(key.clone()..key.clone(), K::default());
 
         self.set
             .range((Bound::Included(range_key), Bound::Unbounded))

--- a/common/range-set/tests/it/range_set_test.rs
+++ b/common/range-set/tests/it/range_set_test.rs
@@ -56,14 +56,14 @@ fn test_range_set() {
 
         a.insert(a1.clone()..a1.clone(), 11);
         a.insert(a1.clone()..a5.clone(), 15);
-        a.insert(a2.clone()..a4.clone(), 24);
-        a.insert(a2.clone()..a6.clone(), 26);
+        a.insert(a2.clone()..a4, 24);
+        a.insert(a2.clone()..a6, 26);
 
         assert_eq!(a.get_by_point(&a1), vec![r11, r15]);
         assert_eq!(a.get_by_point(&a2), vec![r24, r15, r26]);
         assert_eq!(a.get_by_point(&a5), vec![r26]);
 
-        a.remove(a1.clone()..a5.clone(), 15);
+        a.remove(a1.clone()..a5, 15);
         assert_eq!(a.get_by_point(&a1), vec![r11]);
         assert_eq!(a.get_by_point(&a2), vec![r24, r26]);
     }

--- a/common/range-set/tests/it/range_set_test.rs
+++ b/common/range-set/tests/it/range_set_test.rs
@@ -17,7 +17,7 @@ use common_range_set::RangeSet;
 
 #[test]
 fn test_range_set() {
-    // test get_by_point
+    // test get_by_point for i32
     {
         let mut a = RangeSet::new();
 
@@ -38,5 +38,33 @@ fn test_range_set() {
         a.remove(1..5, 15);
         assert_eq!(a.get_by_point(&1), vec![r11]);
         assert_eq!(a.get_by_point(&2), vec![r24, r26]);
+    }
+    // test get_by_point for String
+    {
+        let mut a = RangeSet::new();
+
+        let a1 = "1".to_string();
+        let a2 = "2".to_string();
+        let a4 = "4".to_string();
+        let a5 = "5".to_string();
+        let a6 = "6".to_string();
+
+        let r11 = &RangeKey::new(a1.clone()..a1.clone(), 11);
+        let r15 = &RangeKey::new(a1.clone()..a5.clone(), 15);
+        let r24 = &RangeKey::new(a2.clone()..a4.clone(), 24);
+        let r26 = &RangeKey::new(a2.clone()..a6.clone(), 26);
+
+        a.insert(a1.clone()..a1.clone(), 11);
+        a.insert(a1.clone()..a5.clone(), 15);
+        a.insert(a2.clone()..a4.clone(), 24);
+        a.insert(a2.clone()..a6.clone(), 26);
+
+        assert_eq!(a.get_by_point(&a1), vec![r11, r15]);
+        assert_eq!(a.get_by_point(&a2), vec![r24, r15, r26]);
+        assert_eq!(a.get_by_point(&a5), vec![r26]);
+
+        a.remove(a1.clone()..a5.clone(), 15);
+        assert_eq!(a.get_by_point(&a1), vec![r11]);
+        assert_eq!(a.get_by_point(&a2), vec![r24, r26]);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

remove Copy trait for RangeSet, since String dose not impl Copy

## Changelog

- Improvement

## Related Issues

Fixes #issue

