### PR TITLE
ci(mergify): Remove not needed check for build

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,8 +6,6 @@ queue_rules:
       # Must write expected checks explicitly
       # Reference: https://docs.mergify.com/conditions/#validating-all-status-checks
       - check-success=check
-      - check-success=build_macos
-      - check-success=build_linux
       - check-success=test_unit
       - check-success=test_metactl
       - check-success=test_stateless_standalone_linux


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

We don't need to check the response of build: as our tests depends them.

Fix the following states:

![image](https://user-images.githubusercontent.com/5351546/162346837-7b32c516-aed4-49f7-b6cb-5f328d5e7f86.png)


## Changelog

- Build/Testing/CI

## Related Issues

Fixes #issue

