### PR TITLE
docs(benchmarking): fix sql

### DIFF
--- a/docs/doc/60-contributing/02-benchmarking.md
+++ b/docs/doc/60-contributing/02-benchmarking.md
@@ -13,18 +13,18 @@ The benchmark runner and results which run daily are defined in the repository [
 
 This benchmarking mainly for Databend vectorized execution, it will tell us how fast the vectorized execution in the memory is, we run these queries to measure it:
 
-|Number | Query                                                                                                            | 
+|Number | Query                                                                                                            |
 |-------|------------------------------------------------------------------------------------------------------------------|
-| Q1 | SELECT avg(number) FROM numbers_mt(100000000000)                                                                  |
-| Q2 | SELECT sum(number) FROM numbers_mt(100000000000)                                                                  |
-| Q3 | SELECT min(number) FROM numbers_mt(100000000000)                                                                  |
-| Q4 | SELECT max(number) FROM numbers_mt(100000000000)                                                                  |
-| Q5 | SELECT count(number) FROM numbers_mt(100000000000)                                                                |
-| Q6 | SELECT sum(number+number+number) FROM numbers_mt(100000000000)                                                    |
-| Q7 | SELECT sum(number) / count(number) FROM numbers_mt(100000000000)                                                  |
-| Q8 | SELECT sum(number) / count(number), max(number), min(number) FROM numbers_mt(100000000000)                        |
-| Q9 | SELECT number FROM numbers_mt(10000000000) ORDER BY number DESC LIMIT 10                                          |
-| Q10 | SELECT max(number), sum(number) FROM numbers_mt(10000000000) GROUP BY number % 3, number % 4, number % 5 LIMIT 10 |
+| Q1 | SELECT avg(number) FROM numbers_mt(10000000000);                                                                  |
+| Q2 | SELECT sum(number) FROM numbers_mt(10000000000);                                                                  |
+| Q3 | SELECT min(number) FROM numbers_mt(10000000000);                                                                  |
+| Q4 | SELECT max(number) FROM numbers_mt(10000000000);                                                                  |
+| Q5 | SELECT count(number) FROM numbers_mt(10000000000);                                                                |
+| Q6 | SELECT sum(number+number+number) FROM numbers_mt(10000000000);                                                    |
+| Q7 | SELECT sum(number) / count(number) FROM numbers_mt(10000000000);                                                  |
+| Q8 | SELECT sum(number) / count(number), max(number), min(number) FROM numbers_mt(10000000000);                        |
+| Q9 | SELECT number FROM numbers_mt(10000000000) ORDER BY number DESC LIMIT 10;                                         |
+| Q10 | SELECT max(number), sum(number) FROM numbers_mt(10000000000) GROUP BY number % 3, number % 4, number % 5 LIMIT 10;|
 
 
 <p align="center">
@@ -38,20 +38,20 @@ This benchmarking will tell us what the performance is when Databend works with 
 
 | Number      | Query |
 | ----------- | ----------- |
-| Q1   |SELECT DayOfWeek, count(*) AS c FROM ontime WHERE Year >= 2000 AND Year <= 2008 GROUP BY DayOfWeek ORDER BY c DESC;       |
-| Q2   |SELECT DayOfWeek, count(*) AS c FROM ontime WHERE DepDelay>10 AND Year >= 2000 AND Year <= 2008 GROUP BY DayOfWeek ORDER BY c DESC;    |
-| Q3   |SELECT Origin, count(*) AS c FROM ontime WHERE DepDelay>10 AND Year >= 2000 AND Year <= 2008 GROUP BY Origin ORDER BY c DESC LIMIT 10;   |
-| Q4   |SELECT IATA_CODE_Reporting_Airline AS Carrier, count(*) FROM ontime WHERE DepDelay>10 AND Year = 2007 GROUP BY Carrier ORDER BY count(*) DESC;      |
-| Q5   |SELECT IATA_CODE_Reporting_Airline AS Carrier, avg(cast(DepDelay>10 as Int8))*1000 AS c3 FROM ontime WHERE Year=2007 GROUP BY Carrier ORDER BY c3 DESC;|
-| Q6   |SELECT IATA_CODE_Reporting_Airline AS Carrier, avg(cast(DepDelay>10 as Int8))*1000 AS c3 FROM ontime WHERE Year>=2000 AND Year <=2008 GROUP BY Carrier ORDER BY c3 DESC;|
-| Q7   |SELECT IATA_CODE_Reporting_Airline AS Carrier, avg(DepDelay) * 1000 AS c3 FROM ontime WHERE Year >= 2000 AND Year <= 2008 GROUP BY Carrier; |
-| Q8   |SELECT Year, avg(DepDelay) FROM ontime GROUP BY Year;      |
-| Q9   |SELECT Year, count(*) as c1 FROM ontime GROUP BY Year;      |
-| Q10  |SELECT avg(cnt) FROM (SELECT Year,Month,count(*) AS cnt FROM ontime WHERE DepDel15=1 GROUP BY Year,Month) a;      |
-| Q11  |SELECT avg(c1) FROM (SELECT Year,Month,count(*) AS c1 FROM ontime GROUP BY Year,Month) a;      |
-| Q12  |SELECT OriginCityName, DestCityName, count(*) AS c FROM ontime GROUP BY OriginCityName, DestCityName ORDER BY c DESC LIMIT 10;     |
-| Q13  |SELECT OriginCityName, count(*) AS c FROM ontime GROUP BY OriginCityName ORDER BY c DESC LIMIT 10;      |
-| Q14  |SELECT count(*) FROM ontime;     |
+| Q1   |SELECT DayOfWeek, count(*) AS c FROM default.ontime WHERE Year >= 2000 AND Year <= 2008 GROUP BY DayOfWeek ORDER BY c DESC;       |
+| Q2   |SELECT DayOfWeek, count(*) AS c FROM default.ontime WHERE DepDelay>10 AND Year >= 2000 AND Year <= 2008 GROUP BY DayOfWeek ORDER BY c DESC;    |
+| Q3   |SELECT Origin, count(*) AS c FROM default.ontime WHERE DepDelay>10 AND Year >= 2000 AND Year <= 2008 GROUP BY Origin ORDER BY c DESC LIMIT 10;   |
+| Q4   |SELECT IATA_CODE_Reporting_Airline AS Carrier, count() FROM default.ontime WHERE DepDelay>10 AND Year = 2007 GROUP BY Carrier ORDER BY count() DESC;      |
+| Q5   |SELECT IATA_CODE_Reporting_Airline AS Carrier, avg(cast(DepDelay>10 as Int8))*1000 AS c3 FROM default.ontime WHERE Year=2007 GROUP BY Carrier ORDER BY c3 DESC;|
+| Q6   |SELECT IATA_CODE_Reporting_Airline AS Carrier, avg(cast(DepDelay>10 as Int8))*1000 AS c3 FROM default.ontime WHERE Year>=2000 AND Year <=2008 GROUP BY Carrier ORDER BY c3 DESC;|
+| Q7   |SELECT IATA_CODE_Reporting_Airline AS Carrier, avg(DepDelay) * 1000 AS c3 FROM default.ontime WHERE Year >= 2000 AND Year <= 2008 GROUP BY Carrier; |
+| Q8   |SELECT Year, avg(DepDelay) FROM default.ontime GROUP BY Year;      |
+| Q9   |SELECT Year, count(*) as c1 FROM default.ontime GROUP BY Year;      |
+| Q10  |SELECT avg(cnt) FROM (SELECT Year,Month,count(*) AS cnt FROM default.ontime WHERE DepDel15=1 GROUP BY Year,Month) a;      |
+| Q11  |SELECT avg(c1) FROM (SELECT Year,Month,count(*) AS c1 FROM default.ontime GROUP BY Year,Month) a;      |
+| Q12  |SELECT OriginCityName, DestCityName, count(*) AS c FROM default.ontime GROUP BY OriginCityName, DestCityName ORDER BY c DESC LIMIT 10;     |
+| Q13  |SELECT OriginCityName, count(*) AS c FROM default.ontime GROUP BY OriginCityName ORDER BY c DESC LIMIT 10;      |
+| Q14  |SELECT count(*) FROM default.ontime;     |
 
 <p align="center">
 <img src="https://datafuse-1253727613.cos.ap-hongkong.myqcloud.com/contributing/ontime-perf.png" width="800"/>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- 100,000,000,000 -> 10,000,000,000: Considering the time spent by perf, we use ten billion for testing
- ontime -> default.ontime: the default database prefix has been added to perf sql

ref https://github.com/datafuselabs/databend-perf/tree/main/benchmarks

## Changelog

- Documentation

## Related Issues

Fixes #issue

