### PR TITLE
docs: unify query http handler port

### DIFF
--- a/docs/doc/30-reference/30-sql/10-dml/dml-copy.md
+++ b/docs/doc/30-reference/30-sql/10-dml/dml-copy.md
@@ -95,7 +95,7 @@ create stage my_internal_s1;
 
 Then, PUT a local file to `my_internal_s1` stage with [PUT to Stage](../../00-api/10-put-to-stage.md) API:
 ```shell
-curl  -H "stage_name:my_internal_s1" -F "upload=@books.parquet" -XPUT "http://localhost:8000/v1/upload_to_stage"
+curl  -H "stage_name:my_internal_s1" -F "upload=@books.parquet" -XPUT "http://localhost:8081/v1/upload_to_stage"
 ```
 
 Final, copy the file into `mytable` from the `my_internal_s1` named internal stage:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

In the previous doc(deploy), the Query HTTP Handler listen on port `8081` (in the databend-query.toml). 
So, it's necessary to keep unified here.

## Changelog

- Documentation

## Related Issues

