### PR TITLE
http: factor out ResponseInitialState

### DIFF
--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -100,7 +100,7 @@ impl QueryResponse {
             None => (JsonBlock::empty(), None),
         };
         let schema = data.schema().clone();
-        let session_id = r.initial_state.as_ref().map(|v| v.session_id.clone());
+        let session_id = r.session_id.clone();
         let stats = QueryStats {
             scan_progress: state.scan_progress.clone(),
             running_time_ms: state.running_time_ms,
@@ -109,7 +109,7 @@ impl QueryResponse {
             data: data.into(),
             state: state.state,
             schema: Some(schema),
-            session_id,
+            session_id: Some(session_id),
             stats,
             id: id.clone(),
             next_uri: next_url,
@@ -187,7 +187,7 @@ async fn query_page_handler(
         Some(query) => {
             query.clear_expire_time().await;
             let resp = query
-                .get_response_page(page_no, false)
+                .get_response_page(page_no)
                 .await
                 .map_err(|err| poem::Error::from_string(err.message(), StatusCode::NOT_FOUND))?;
             query.update_expire_time().await;
@@ -214,7 +214,7 @@ pub(crate) async fn query_handler(
     match query {
         Ok(query) => {
             let resp = query
-                .get_response_page(0, true)
+                .get_response_page(0)
                 .await
                 .map_err(|err| poem::Error::from_string(err.message(), StatusCode::NOT_FOUND))?;
             query.update_expire_time().await;

--- a/query/src/servers/http/v1/query/http_query.rs
+++ b/query/src/servers/http/v1/query/http_query.rs
@@ -91,10 +91,6 @@ impl Default for HttpSession {
     }
 }
 
-pub struct ResponseInitialState {
-    pub session_id: String,
-}
-
 #[derive(Debug, Clone)]
 pub struct ResponseState {
     pub running_time_ms: f64,
@@ -105,7 +101,7 @@ pub struct ResponseState {
 
 pub struct HttpQueryResponseInternal {
     pub data: Option<ResponseData>,
-    pub initial_state: Option<ResponseInitialState>,
+    pub session_id: String,
     pub state: ResponseState,
 }
 
@@ -184,18 +180,10 @@ impl HttpQuery {
         self.request.pagination.wait_time_secs == 0
     }
 
-    pub async fn get_response_page(
-        &self,
-        page_no: usize,
-        init: bool,
-    ) -> Result<HttpQueryResponseInternal> {
+    pub async fn get_response_page(&self, page_no: usize) -> Result<HttpQueryResponseInternal> {
         Ok(HttpQueryResponseInternal {
             data: Some(self.get_page(page_no).await?),
-            initial_state: if init {
-                Some(self.get_initial_state().await)
-            } else {
-                None
-            },
+            session_id: self.session_id.clone(),
             state: self.get_state().await,
         })
     }
@@ -203,14 +191,8 @@ impl HttpQuery {
     pub async fn get_response_state_only(&self) -> HttpQueryResponseInternal {
         HttpQueryResponseInternal {
             data: None,
-            initial_state: None,
-            state: self.get_state().await,
-        }
-    }
-
-    pub async fn get_initial_state(&self) -> ResponseInitialState {
-        ResponseInitialState {
             session_id: self.session_id.clone(),
+            state: self.get_state().await,
         }
     }
 

--- a/query/src/servers/http/v1/query/mod.rs
+++ b/query/src/servers/http/v1/query/mod.rs
@@ -29,7 +29,6 @@ pub use http_query::HttpQueryResponseInternal;
 pub use http_query::HttpSession;
 pub use http_query::HttpSessionConf;
 pub use http_query::PaginationConf;
-pub use http_query::ResponseInitialState;
 pub use http_query::ResponseState;
 pub use http_query_manager::HttpQueryManager;
 pub use result_data_manager::Page;

--- a/query/src/servers/http/v1/statement.rs
+++ b/query/src/servers/http/v1/statement.rs
@@ -62,7 +62,7 @@ pub async fn statement_handler(
     match query {
         Ok(query) => {
             let resp = query
-                .get_response_page(0, true)
+                .get_response_page(0)
                 .await
                 .map_err(|err| poem::Error::from_string(err.message(), StatusCode::NOT_FOUND))?;
             http_query_manager.remove_query(&query_id).await;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

if I understands correctly, ResponseInitialState is mainly used to store the schema on the first http response, after #4751, this struct can be ommitted?

I dunno if this PR is correct on the display logic about `session_id`, thank you for comments in advance.

## Changelog

- Improvement

## Related Issues

Fixes #issue

