### PR TITLE
fix(function): try_cast from varaint return Null instead of Err

### DIFF
--- a/common/functions/src/scalars/expressions/cast_from_variant.rs
+++ b/common/functions/src/scalars/expressions/cast_from_variant.rs
@@ -68,18 +68,10 @@ pub fn cast_from_variant(
                 JsonValue::String(v) => {
                     match v.parse::<$T>() {
                         Ok(num) => builder.append(num as $T),
-                        Err(_) => {
-                            return Err(ErrorCode::BadDataValueType(format!(
-                                "Failed to cast variant value {} to {}",
-                                v, data_type.data_type_id()
-                            )));
-                        }
+                        Err(_) => bitmap.set(row, false),
                     }
                 }
-                _ => return Err(ErrorCode::BadDataValueType(format!(
-                    "Failed to cast variant value {} to {}",
-                    value.to_string(), data_type.data_type_id()
-                ))),
+                _ => bitmap.set(row, false),
             }
         }
         return Ok((builder.build(size), Some(bitmap.into())));
@@ -98,16 +90,10 @@ pub fn cast_from_variant(
                             } else if v.to_lowercase() == *"false".to_string() {
                                 builder.append(false)
                             } else {
-                                return Err(ErrorCode::BadDataValueType(format!(
-                                    "Failed to cast variant value {} to {}",
-                                    v, data_type.data_type_id()
-                                )));
+                                bitmap.set(row, false)
                             }
                         }
-                        _ => return Err(ErrorCode::BadDataValueType(format!(
-                            "Failed to cast variant value {} to {}",
-                            value, data_type.data_type_id()
-                        ))),
+                        _ => bitmap.set(row, false),
                     }
                 }
                 return Ok((builder.build(size), Some(bitmap.into())));
@@ -138,16 +124,10 @@ pub fn cast_from_variant(
                             if let Some(d) = string_to_date(v) {
                                 builder.append((d.num_days_from_ce() - EPOCH_DAYS_FROM_CE) as u16);
                             } else {
-                                return Err(ErrorCode::BadDataValueType(format!(
-                                    "Failed to cast variant value {} to {}",
-                                    value, data_type.data_type_id()
-                                )));
+                                bitmap.set(row, false);
                             }
                         },
-                        _ => return Err(ErrorCode::BadDataValueType(format!(
-                            "Failed to cast variant value {} to {}",
-                            value, data_type.data_type_id()
-                        ))),
+                        _ => bitmap.set(row, false),
                     }
                 }
                 return Ok((builder.build(size), Some(bitmap.into())));
@@ -162,16 +142,10 @@ pub fn cast_from_variant(
                             if let Some(d) = string_to_date(v) {
                                 builder.append((d.num_days_from_ce() - EPOCH_DAYS_FROM_CE) as i32);
                             } else {
-                                return Err(ErrorCode::BadDataValueType(format!(
-                                    "Failed to cast variant value {} to {}",
-                                    value, data_type.data_type_id()
-                                )));
+                                bitmap.set(row, false);
                             }
                         },
-                        _ => return Err(ErrorCode::BadDataValueType(format!(
-                            "Failed to cast variant value {} to {}",
-                            value, data_type.data_type_id()
-                        ))),
+                        _ => bitmap.set(row, false),
                     }
                 }
                 return Ok((builder.build(size), Some(bitmap.into())));
@@ -186,16 +160,10 @@ pub fn cast_from_variant(
                             if let Some(t) = string_to_datetime(v) {
                                 builder.append(t.timestamp() as u32);
                             } else {
-                                return Err(ErrorCode::BadDataValueType(format!(
-                                    "Failed to cast variant value {} to {}",
-                                    value, data_type.data_type_id()
-                                )));
+                                bitmap.set(row, false);
                             }
                         },
-                        _ => return Err(ErrorCode::BadDataValueType(format!(
-                            "Failed to cast variant value {} to {}",
-                            value, data_type.data_type_id()
-                        ))),
+                        _ => bitmap.set(row, false),
                     }
                 }
                 return Ok((builder.build(size), Some(bitmap.into())));
@@ -211,16 +179,10 @@ pub fn cast_from_variant(
                             if let Some(d) = string_to_datetime64(v) {
                                 builder.append(datetime.from_nano_seconds(d.timestamp_nanos()));
                             } else {
-                                return Err(ErrorCode::BadDataValueType(format!(
-                                    "Failed to cast variant value {} to {}",
-                                    value, data_type.data_type_id()
-                                )));
+                                bitmap.set(row, false);
                             }
                         },
-                        _ => return Err(ErrorCode::BadDataValueType(format!(
-                            "Failed to cast variant value {} to {}",
-                            value, data_type.data_type_id()
-                        ))),
+                        _ => bitmap.set(row, false),
                     }
                 }
                 return Ok((builder.build(size), Some(bitmap.into())));

--- a/common/functions/tests/it/scalars/expressions.rs
+++ b/common/functions/tests/it/scalars/expressions.rs
@@ -358,7 +358,7 @@ fn test_variant_cast_function() -> Result<()> {
                     json!("4"),
                 ])],
                 expect: Series::from_data(vec![4u64, 3, 2, 4]),
-                error: "Failed to cast variant value X4 to UInt64",
+                error: "Cast error happens in casting from Variant to UInt64",
             },
         ),
         (CastFunction::create("cast", "int8")?, ScalarFunctionTest {
@@ -414,7 +414,7 @@ fn test_variant_cast_function() -> Result<()> {
                 json!("-4"),
             ])],
             expect: Series::from_data(vec![4i64, -3, 2, -4]),
-            error: "Failed to cast variant value X4 to Int64",
+            error: "Cast error happens in casting from Variant to Int64",
         }),
         (
             CastFunction::create("cast", "float32")?,
@@ -441,7 +441,7 @@ fn test_variant_cast_function() -> Result<()> {
                     json!("-4.2"),
                 ])],
                 expect: Series::from_data(vec![1.2f32, -1.3, 2.1, -4.2]),
-                error: "Failed to cast variant value X4 to Float32",
+                error: "Cast error happens in casting from Variant to Float32",
             },
         ),
         (
@@ -469,7 +469,7 @@ fn test_variant_cast_function() -> Result<()> {
                     json!("-4.2"),
                 ])],
                 expect: Series::from_data(vec![1.2f64, -1.3, 2.1, -4.2]),
-                error: "Failed to cast variant value X4 to Float64",
+                error: "Cast error happens in casting from Variant to Float64",
             },
         ),
         (
@@ -497,7 +497,7 @@ fn test_variant_cast_function() -> Result<()> {
                     json!(false),
                 ])],
                 expect: Series::from_data(vec![true, false, true, false]),
-                error: "Failed to cast variant value 1 to Boolean",
+                error: "Cast error happens in casting from Variant to Boolean",
             },
         ),
         (
@@ -521,7 +521,7 @@ fn test_variant_cast_function() -> Result<()> {
                     json!("2021-10-24"),
                 ])],
                 expect: Series::from_data(vec![18691u16, 18924]),
-                error: "Failed to cast variant value \"a2021-03-05\" to Date16",
+                error: "Cast error happens in casting from Variant to Date16",
             },
         ),
         (
@@ -545,7 +545,7 @@ fn test_variant_cast_function() -> Result<()> {
                     json!("2021-10-24"),
                 ])],
                 expect: Series::from_data(vec![18691i32, 18924]),
-                error: "Failed to cast variant value \"a2021-03-05\" to Date32",
+                error: "Cast error happens in casting from Variant to Date32",
             },
         ),
         (
@@ -569,7 +569,7 @@ fn test_variant_cast_function() -> Result<()> {
                     json!("2021-10-24 10:10:10"),
                 ])],
                 expect: Series::from_data(vec![1614906061u32, 1635070210]),
-                error: "Failed to cast variant value \"a2021-03-05 01:01:01\" to DateTime32",
+                error: "Cast error happens in casting from Variant to DateTime32",
             },
         ),
         (
@@ -593,7 +593,7 @@ fn test_variant_cast_function() -> Result<()> {
                     json!("2021-10-24 10:10:10.123456789"),
                 ])],
                 expect: Series::from_data(vec![1614906061123i64, 1635070210123]),
-                error: "Failed to cast variant value \"a2021-03-05 01:01:01.123\" to DateTime64",
+                error: "Cast error happens in casting from Variant to DateTime64(3)",
             },
         ),
     ];


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

try_cast from variant return Null instead of Err

## Changelog

- Bug Fix

## Related Issues

Fixes #4777

