### PR TITLE
fix(mysql_handler): salt characters should be ascii.

### DIFF
--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -377,7 +377,7 @@ impl<W: std::io::Write> InteractiveWorker<W> {
 
         let mut scramble: [u8; 20] = [0; 20];
         for i in 0..20 {
-            scramble[i] = bs[i];
+            scramble[i] = bs[i] & 0x7fu8;
             if scramble[i] == b'\0' || scramble[i] == b'$' {
                 scramble[i] += 1;
             }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary




passwordCharacterEncoding is  utf8mb4  by default https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-connp-props-connection.html#cj-conn-prop_passwordCharacterEncoding


code refer to

https://github.com/mysql/mysql-server/blob/3290a66c89eb1625a7058e0ef732432b6952b435/mysys/crypt_genhash_impl.cc#L421

current opensrv impl make sure salt followed by "\0"


## Changelog

- Bug Fix


## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/4802

