### PR TITLE
fix `v1/config` not updated after reload config

### DIFF
--- a/query/src/api/http/v1/config.rs
+++ b/query/src/api/http/v1/config.rs
@@ -12,11 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use poem::web::Data;
+use std::sync::Arc;
 
-use crate::configs::Config;
+use poem::web::Data;
+use poem::web::Json;
+use poem::IntoResponse;
+
+use crate::sessions::SessionManager;
 
 #[poem::handler]
-pub async fn config_handler(cfg: Data<&Config>) -> String {
-    format!("{:?}", cfg.0)
+pub async fn config_handler(
+    session: Data<&Arc<SessionManager>>,
+) -> poem::Result<impl IntoResponse> {
+    Ok(Json(session.0.get_conf()))
 }

--- a/query/src/api/http_service.rs
+++ b/query/src/api/http_service.rs
@@ -61,7 +61,6 @@ impl HttpService {
                 get(super::http::debug::pprof::debug_pprof_handler),
             )
             .data(self.sessions.clone())
-            .data(self.sessions.get_conf())
     }
 
     fn build_tls(config: &Config) -> Result<RustlsConfig> {

--- a/query/src/sessions/session.rs
+++ b/query/src/sessions/session.rs
@@ -239,7 +239,7 @@ impl Session {
     }
 
     pub fn get_config(&self) -> Config {
-        self.session_mgr.get_config()
+        self.session_mgr.get_conf()
     }
 
     pub fn get_status(self: &Arc<Self>) -> Arc<RwLock<SessionStatus>> {

--- a/query/src/sessions/session_mgr.rs
+++ b/query/src/sessions/session_mgr.rs
@@ -166,7 +166,7 @@ impl SessionManager {
 
     pub async fn create_session(self: &Arc<Self>, typ: SessionType) -> Result<SessionRef> {
         // TODO: maybe deadlock
-        let config = self.get_config();
+        let config = self.get_conf();
         {
             let sessions = self.active_sessions.read();
             if sessions.len() == self.max_sessions {
@@ -207,7 +207,7 @@ impl SessionManager {
         aborted: bool,
     ) -> Result<SessionRef> {
         // TODO: maybe deadlock?
-        let config = self.get_config();
+        let config = self.get_conf();
         {
             let sessions = self.active_sessions.read();
             let v = sessions.get(&id);
@@ -254,7 +254,7 @@ impl SessionManager {
 
     #[allow(clippy::ptr_arg)]
     pub fn destroy_session(self: &Arc<Self>, session_id: &String) {
-        let config = self.get_config();
+        let config = self.get_conf();
         label_counter(
             super::metrics::METRIC_SESSION_CLOSE_NUMBERS,
             &config.query.tenant_id,
@@ -382,10 +382,6 @@ impl SessionManager {
         };
 
         Ok(Operator::new(accessor))
-    }
-
-    pub fn get_config(&self) -> Config {
-        self.conf.read().clone()
     }
 
     pub async fn reload_config(&self) -> Result<()> {

--- a/query/tests/it/api/http/config.rs
+++ b/query/tests/it/api/http/config.rs
@@ -26,12 +26,14 @@ use poem::Request;
 use poem::Route;
 use pretty_assertions::assert_eq; // for `app.oneshot()`
 
+use crate::tests::SessionManagerBuilder;
+
 #[tokio::test]
 async fn test_config() -> common_exception::Result<()> {
-    let conf = crate::tests::ConfigBuilder::create().config();
+    let sessions = SessionManagerBuilder::create().build()?;
     let cluster_router = Route::new()
         .at("/v1/config", get(config_handler))
-        .data(conf.clone());
+        .data(sessions);
 
     let response = cluster_router
         .call(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix `v1/config` not updated after reload config

## Changelog

- Bug Fix

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/4819
