### PR TITLE
add a column TABLE_COMMENT for information_schema.TABLES

### DIFF
--- a/query/src/storages/information_schema/tables_table.rs
+++ b/query/src/storages/information_schema/tables_table.rs
@@ -36,6 +36,7 @@ impl TablesTable {
             created_on AS create_time,
             0 AS data_length,
             0 AS index_length,
+            '' AS table_comment,
             database AS TABLE_CATALOG,
             database AS TABLE_SCHEMA,
             name AS TABLE_NAME,
@@ -43,7 +44,8 @@ impl TablesTable {
             engine AS ENGINE,
             created_on AS CREATE_TIME,
             0 AS DATA_LENGTH,
-            0 AS INDEX_LENGTH
+            0 AS INDEX_LENGTH,
+            '' AS TABLE_COMMENT
         FROM system.tables;";
 
         let mut options = HashMap::new();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add a column TABLE_COMMENT for information_schema.TABLES

## Changelog

- Improvement


## Related Issues

Fixes #4829

