### PR TITLE
chore(ci): add clickhouse_driver to dev_setup

### DIFF
--- a/scripts/setup/dev_setup.sh
+++ b/scripts/setup/dev_setup.sh
@@ -448,7 +448,7 @@ if [[ "$INSTALL_DEV_TOOLS" == "true" ]]; then
 	fi
 	python3 -m pip install --quiet boto3 "moto[all]" yapf shfmt-py toml
 	# drivers
-	python3 -m pip install --quiet mysql-connector-python pymysql sqlalchemy
+	python3 -m pip install --quiet mysql-connector-python pymysql sqlalchemy clickhouse_driver
 
 	if [[ -f scripts/setup/rust-tools.txt ]]; then
 		export RUSTFLAGS="-C target-feature=-crt-static"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add a new python dep `clickhouse_driver`


## Changelog

- Build/Testing/CI


## Related Issues

Fixes #4886

