### PR TITLE
fix(function): validate function args before get type

### DIFF
--- a/common/planners/src/plan_expression_common.rs
+++ b/common/planners/src/plan_expression_common.rs
@@ -20,6 +20,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_functions::scalars::FunctionFactory;
 
+use crate::validate_function_arg;
 use crate::Expression;
 use crate::ExpressionVisitor;
 use crate::Recursion;
@@ -395,6 +396,14 @@ impl ExpressionDataTypeVisitor {
     }
 
     fn visit_function(mut self, op: &str, args_size: usize) -> Result<ExpressionDataTypeVisitor> {
+        let features = FunctionFactory::instance().get_features(op)?;
+        validate_function_arg(
+            op,
+            args_size,
+            features.variadic_arguments,
+            features.num_arguments,
+        )?;
+
         let mut arguments = Vec::with_capacity(args_size);
         for index in 0..args_size {
             arguments.push(match self.stack.pop() {

--- a/tests/suites/0_stateless/02_function/02_0048_function_semi_structureds_parse_json.sql
+++ b/tests/suites/0_stateless/02_function/02_0048_function_semi_structureds_parse_json.sql
@@ -17,6 +17,9 @@ select parse_json(parse_json('123'));
 select parse_json(parse_json('"\\\"abc\\\""'));
 select parse_json(parse_json('"abc"')); -- {ErrorCode 1010}
 select parse_json(todate32('2022-01-01')); -- {ErrorCode 1010}
+select parse_json(); -- {ErrorCode 1028}
+select parse_json('a', 'aa'); -- {ErrorCode 1028}
+select get(parse_json('a', 'aa')); -- {ErrorCode 1028}
 
 select '==try_parse_json==';
 select try_parse_json(null);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix panic caused by wrong arg numbers.

## Changelog

- Bug Fix

## Related Issues

Fixes #4776
Fixes #4885 
