### PR TITLE
Set interpolateParams in golang dev doc

### DIFF
--- a/docs/doc/20-develop/00-golang.md
+++ b/docs/doc/20-develop/00-golang.md
@@ -60,7 +60,10 @@ type Book struct {
 }
 
 func dsn() string {
-	return fmt.Sprintf("%s:%s@tcp(%s)/", username, password, hostname)
+	// Note Databend do not support prepared statements.
+	// set interpolateParams to make placeholders (?) in calls to db.Query() and db.Exec() interpolated into a single query string with given parameters.
+	// ref https://github.com/go-sql-driver/mysql#interpolateparams
+	return fmt.Sprintf("%s:%s@tcp(%s)/?interpolateParams=true", username, password, hostname)
 }
 
 func main() {
@@ -100,8 +103,7 @@ func main() {
 	log.Println("Create table: books")
 
 	// Insert 1 row.
-	sql = "insert into books values('mybook', 'author', '2022')"
-	_, err = db.Exec(sql)
+	_, err = db.Exec("insert into books values(?, ?, ?)", "mybook", "author", "2022")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -151,6 +153,5 @@ go run main.go
 2022/04/13 12:20:07 Create database book_db success
 2022/04/13 12:20:07 Create table: books
 2022/04/13 12:20:07 Insert 1 row
-2022/04/13 12:20:08 Select:{mybook author 2022}
 2022/04/13 12:20:08 Select:{mybook author 2022}
 ```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
since do not support prepared statements
set interpolateParams in golang development doc.

or user needs to avoid using placeholders and may take care to escape the value itself.

## Changelog


- Documentation


## Related Issues

Fixes #issue

