### PR TITLE
feat: create user if not exists on JWT authenticate

### DIFF
--- a/common/management/tests/it/user.rs
+++ b/common/management/tests/it/user.rs
@@ -77,11 +77,7 @@ mod add {
     async fn test_add_user() -> common_exception::Result<()> {
         let test_user_name = "test_user";
         let test_hostname = "localhost";
-        let user_info = UserInfo::new(
-            test_user_name.to_string(),
-            test_hostname.to_string(),
-            default_test_auth_info(),
-        );
+        let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
         let v = serde_json::to_vec(&user_info)?;
         let value = Operation::Update(serde_json::to_vec(&user_info)?);
 
@@ -133,11 +129,7 @@ mod add {
             let api = Arc::new(api);
             let user_mgr = UserMgr::create(api, "tenant1")?;
 
-            let user_info = UserInfo::new(
-                test_user_name.to_string(),
-                test_hostname.to_string(),
-                default_test_auth_info(),
-            );
+            let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
 
             let res = user_mgr.add_user(user_info).await;
 
@@ -163,11 +155,7 @@ mod add {
             let kv = Arc::new(api);
 
             let user_mgr = UserMgr::create(kv, "tenant1")?;
-            let user_info = UserInfo::new(
-                test_user_name.to_string(),
-                test_hostname.to_string(),
-                default_test_auth_info(),
-            );
+            let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
 
             let res = user_mgr.add_user(user_info).await;
 
@@ -194,11 +182,7 @@ mod get {
             escape_for_key(&format_user_key(test_user_name, test_hostname))?
         );
 
-        let user_info = UserInfo::new(
-            test_user_name.to_string(),
-            test_hostname.to_string(),
-            default_test_auth_info(),
-        );
+        let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
         let value = serde_json::to_vec(&user_info)?;
 
         let mut kv = MockKV::new();
@@ -224,11 +208,7 @@ mod get {
             escape_for_key(&format_user_key(test_user_name, test_hostname))?
         );
 
-        let user_info = UserInfo::new(
-            test_user_name.to_string(),
-            test_hostname.to_string(),
-            default_test_auth_info(),
-        );
+        let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
         let value = serde_json::to_vec(&user_info)?;
 
         let mut kv = MockKV::new();
@@ -345,7 +325,7 @@ mod get_users {
             let key = format!("tenant1/{}", format_user_key(&name, &hostname));
             keys.push(key);
 
-            let user_info = UserInfo::new(name, hostname, default_test_auth_info());
+            let user_info = UserInfo::new(&name, &hostname, default_test_auth_info());
             res.push((
                 "fake_key".to_string(),
                 SeqV::new(i, serde_json::to_vec(&user_info)?),
@@ -503,11 +483,7 @@ mod update {
         );
         let test_seq = None;
 
-        let user_info = UserInfo::new(
-            test_user_name.to_string(),
-            test_hostname.to_string(),
-            default_test_auth_info(),
-        );
+        let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
         let prev_value = serde_json::to_vec(&user_info)?;
 
         // get_kv should be called
@@ -521,11 +497,7 @@ mod update {
         }
 
         // and then, update_kv should be called
-        let new_user_info = UserInfo::new(
-            test_user_name.to_string(),
-            test_hostname.to_string(),
-            new_test_auth_info(full),
-        );
+        let new_user_info = UserInfo::new(test_user_name, test_hostname, new_test_auth_info(full));
         let new_value_with_old_salt = serde_json::to_vec(&new_user_info)?;
 
         kv.expect_upsert_kv()
@@ -596,11 +568,7 @@ mod update {
         );
         let test_seq = None;
 
-        let user_info = UserInfo::new(
-            test_user_name.to_string(),
-            test_hostname.to_string(),
-            default_test_auth_info(),
-        );
+        let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
         let prev_value = serde_json::to_vec(&user_info)?;
 
         // - get_kv should be called
@@ -656,11 +624,7 @@ mod set_user_privileges {
         );
         let test_seq = None;
 
-        let mut user_info = UserInfo::new(
-            test_user_name.to_string(),
-            test_hostname.to_string(),
-            default_test_auth_info(),
-        );
+        let mut user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
         let prev_value = serde_json::to_vec(&user_info)?;
 
         // - get_kv should be called

--- a/common/meta/types/src/role_info.rs
+++ b/common/meta/types/src/role_info.rs
@@ -28,9 +28,9 @@ pub struct RoleInfo {
 }
 
 impl RoleInfo {
-    pub fn new(name: String) -> Self {
+    pub fn new(name: &str) -> Self {
         Self {
-            name,
+            name: name.to_string(),
             grants: UserGrantSet::empty(),
         }
     }

--- a/common/meta/types/src/user_info.rs
+++ b/common/meta/types/src/user_info.rs
@@ -44,15 +44,15 @@ pub struct UserInfo {
 }
 
 impl UserInfo {
-    pub fn new(name: String, hostname: String, auth_info: AuthInfo) -> Self {
+    pub fn new(name: &str, hostname: &str, auth_info: AuthInfo) -> Self {
         // Default is no privileges.
         let grants = UserGrantSet::default();
         let quota = UserQuota::no_limit();
         let option = UserOption::default();
 
         UserInfo {
-            name,
-            hostname,
+            name: name.to_string(),
+            hostname: hostname.to_string(),
             auth_info,
             grants,
             quota,
@@ -60,7 +60,7 @@ impl UserInfo {
         }
     }
 
-    pub fn new_no_auth(name: String, hostname: String) -> Self {
+    pub fn new_no_auth(name: &str, hostname: &str) -> Self {
         UserInfo::new(name, hostname, AuthInfo::None)
     }
 

--- a/common/meta/types/tests/it/user_info.rs
+++ b/common/meta/types/tests/it/user_info.rs
@@ -41,14 +41,10 @@ fn test_user_info() -> Result<()> {
     let ser_old = serde_json::to_string(&old)?;
     let new = UserInfo::try_from(ser_old.into_bytes())?;
 
-    let expect = UserInfo::new(
-        "old-name".to_string(),
-        "old-host".to_string(),
-        AuthInfo::Password {
-            hash_value: Vec::from("pwd"),
-            hash_method: PasswordHashMethod::Sha256,
-        },
-    );
+    let expect = UserInfo::new("old-name", "old-host", AuthInfo::Password {
+        hash_value: Vec::from("pwd"),
+        hash_method: PasswordHashMethod::Sha256,
+    });
     assert_eq!(new, expect);
 
     Ok(())

--- a/query/src/interpreters/interpreter_role_create.rs
+++ b/query/src/interpreters/interpreter_role_create.rs
@@ -52,7 +52,7 @@ impl Interpreter for CreateRoleInterpreter {
         let plan = self.plan.clone();
         let tenant = self.ctx.get_tenant();
         let user_mgr = self.ctx.get_user_manager();
-        let role_info = RoleInfo::new(plan.role_name);
+        let role_info = RoleInfo::new(&plan.role_name);
         user_mgr.add_role(&tenant, role_info, false).await?;
 
         Ok(Box::pin(DataBlockStream::create(

--- a/query/src/procedures/admins/bootstrap_tenant.rs
+++ b/query/src/procedures/admins/bootstrap_tenant.rs
@@ -73,7 +73,7 @@ impl Procedure for BootstrapTenantProcedure {
         );
 
         // Create account admin role.
-        let mut account_admin_role = RoleInfo::new("account_admin".to_string());
+        let mut account_admin_role = RoleInfo::new("account_admin");
         account_admin_role.grants.grant_privileges(
             &GrantObject::Global,
             UserPrivilegeSet::available_privileges_on_global(),
@@ -84,7 +84,7 @@ impl Procedure for BootstrapTenantProcedure {
 
         // Create user.
         let auth_info = AuthInfo::create(&Some(auth_type), &Some(password))?;
-        let mut user_info = UserInfo::new(user_name.clone(), host_name.clone(), auth_info);
+        let mut user_info = UserInfo::new(&user_name, &host_name, auth_info);
         user_info.grants.grant_role(account_admin_role.identity());
         user_mgr.add_user(&tenant, user_info, true).await?;
 

--- a/query/src/users/auth/auth_mgr.rs
+++ b/query/src/users/auth/auth_mgr.rs
@@ -66,8 +66,12 @@ impl AuthMgr {
                     None => return Err(ErrorCode::AuthenticateFailure("jwt auth not configured.")),
                 };
                 let user_name = jwt.subject.unwrap();
-                let tenant = jwt.custom.get("tenant").unwrap_or(&json!(self.tenant)).to_string();
-                let mut user_info = UserInfo::new(user_name.to_string(), "%".to_string(), AuthInfo::JWT);
+                let tenant = jwt
+                    .custom
+                    .get("tenant")
+                    .unwrap_or(&json!(self.tenant))
+                    .to_string();
+                let mut user_info = UserInfo::new(&user_name, "%", AuthInfo::JWT);
                 if let Some(Value::Array(roles)) = jwt.custom.get("roles") {
                     for role in roles {
                         user_info.grants.grant_role(role.to_string());

--- a/query/src/users/auth/jwt/authenticator.rs
+++ b/query/src/users/auth/jwt/authenticator.rs
@@ -18,6 +18,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use jwt_simple::algorithms::RS256PublicKey;
 use jwt_simple::algorithms::RSAPublicKeyLike;
+use jwt_simple::prelude::JWTClaims;
 
 use crate::configs::Config;
 use crate::users::auth::jwt::jwk;
@@ -44,7 +45,7 @@ impl JwtAuthenticator {
         Ok(Some(JwtAuthenticator { key_store }))
     }
 
-    pub fn get_user(&self, token: &str) -> Result<String> {
+    pub fn get_jwt(&self, token: &str) -> Result<JWTClaims<CustomClaims>> {
         let pub_key = self.key_store.get_key(None)?;
         match &pub_key {
             PubKey::RSA256(pk) => match pk.verify_token::<CustomClaims>(token, None) {
@@ -52,7 +53,7 @@ impl JwtAuthenticator {
                     None => Err(ErrorCode::AuthenticateFailure(
                         "missing  field `subject` in jwt",
                     )),
-                    Some(subject) => Ok(subject),
+                    Some(_) => Ok(c),
                 },
                 Err(err) => Err(ErrorCode::AuthenticateFailure(err.to_string())),
             },

--- a/query/src/users/auth/jwt/jwk.rs
+++ b/query/src/users/auth/jwt/jwk.rs
@@ -61,7 +61,7 @@ impl JwkKey {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct JwkKeys {
     pub keys: Vec<JwkKey>,
 }

--- a/query/src/users/auth/mod.rs
+++ b/query/src/users/auth/mod.rs
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 pub(crate) mod auth_mgr;
-mod jwt;
+pub mod jwt;

--- a/query/src/users/mod.rs
+++ b/query/src/users/mod.rs
@@ -24,6 +24,8 @@ pub mod role_cache_mgr;
 mod user_setting;
 mod user_warehouse;
 
+pub use auth::auth_mgr::AuthMgr;
+pub use auth::auth_mgr::Credential;
 pub use role_cache_mgr::RoleCacheMgr;
 pub use user::CertifiedInfo;
 pub use user::User;

--- a/query/src/users/user_mgr.rs
+++ b/query/src/users/user_mgr.rs
@@ -29,8 +29,7 @@ impl UserApiProvider {
         match user.username.as_str() {
             // TODO(BohuTANG): Mock, need removed.
             "default" | "" | "root" => {
-                let mut user_info =
-                    UserInfo::new_no_auth(user.username.clone(), user.hostname.clone());
+                let mut user_info = UserInfo::new_no_auth(&user.username, &user.hostname);
                 if user.is_localhost() {
                     user_info.grants.grant_privileges(
                         &GrantObject::Global,

--- a/query/tests/it/interpreters/interpreter_privilege_grant.rs
+++ b/query/tests/it/interpreters/interpreter_privilege_grant.rs
@@ -44,14 +44,10 @@ async fn test_grant_privilege_interpreter() -> Result<()> {
 
     let user_mgr = ctx.get_user_manager();
     user_mgr
-        .add_user(
-            &tenant,
-            UserInfo::new(name.to_string(), hostname.to_string(), auth_info),
-            false,
-        )
+        .add_user(&tenant, UserInfo::new(name, hostname, auth_info), false)
         .await?;
     user_mgr
-        .add_role(&tenant, RoleInfo::new("role1".to_string()), false)
+        .add_role(&tenant, RoleInfo::new("role1"), false)
         .await?;
 
     #[allow(dead_code)]

--- a/query/tests/it/interpreters/interpreter_privilege_revoke.rs
+++ b/query/tests/it/interpreters/interpreter_privilege_revoke.rs
@@ -41,7 +41,7 @@ async fn test_revoke_privilege_interpreter() -> Result<()> {
         hash_value: Vec::from(password),
         hash_method: PasswordHashMethod::PlainText,
     };
-    let user_info = UserInfo::new(name.to_string(), hostname.to_string(), auth_info);
+    let user_info = UserInfo::new(name, hostname, auth_info);
     assert_eq!(user_info.grants, UserGrantSet::empty());
     let user_mgr = ctx.get_user_manager();
     user_mgr.add_user(&tenant, user_info.clone(), false).await?;
@@ -64,7 +64,7 @@ async fn test_revoke_privilege_interpreter_on_role() -> Result<()> {
     let ctx = crate::tests::create_query_context().await?;
     let tenant = ctx.get_tenant().to_string();
 
-    let mut role_info = RoleInfo::new("role1".to_string());
+    let mut role_info = RoleInfo::new("role1");
     role_info
         .grants
         .grant_privileges(&GrantObject::Global, UserPrivilegeSet::all_privileges());

--- a/query/tests/it/interpreters/interpreter_role_grant.rs
+++ b/query/tests/it/interpreters/interpreter_role_grant.rs
@@ -39,7 +39,7 @@ async fn test_grant_role_interpreter() -> Result<()> {
     }
 
     user_mgr
-        .add_role(&tenant, RoleInfo::new("test".to_string()), false)
+        .add_role(&tenant, RoleInfo::new("test"), false)
         .await?;
 
     // Grant role to unknown user.
@@ -55,7 +55,7 @@ async fn test_grant_role_interpreter() -> Result<()> {
 
     // Grant role to normal user.
     {
-        let user_info = UserInfo::new_no_auth("test_user".to_string(), "%".to_string());
+        let user_info = UserInfo::new_no_auth("test_user", "%");
         user_mgr.add_user(&tenant, user_info.clone(), false).await?;
         let user_info = user_mgr.get_user(&tenant, user_info.identity()).await?;
         assert_eq!(user_info.grants.roles().len(), 0);
@@ -82,7 +82,7 @@ async fn test_grant_role_interpreter() -> Result<()> {
         assert_eq!(res.err().unwrap().code(), ErrorCode::UnknownRole("").code())
     }
 
-    let test_role = RoleInfo::new("test_role".to_string());
+    let test_role = RoleInfo::new("test_role");
 
     // Grant role to normal role.
     {

--- a/query/tests/it/interpreters/interpreter_role_revoke.rs
+++ b/query/tests/it/interpreters/interpreter_role_revoke.rs
@@ -41,7 +41,7 @@ async fn test_revoke_role_interpreter() -> Result<()> {
 
     // Revoke role from normal user.
     {
-        let mut test_user = UserInfo::new_no_auth("test_user".to_string(), "%".to_string());
+        let mut test_user = UserInfo::new_no_auth("test_user", "%");
         test_user.grants.grant_role("test".to_string());
         user_mgr.add_user(&tenant, test_user.clone(), false).await?;
         let user_info = user_mgr.get_user(&tenant, test_user.identity()).await?;
@@ -82,7 +82,7 @@ async fn test_revoke_role_interpreter() -> Result<()> {
         assert_eq!(res.err().unwrap().code(), ErrorCode::UnknownRole("").code())
     }
 
-    let mut test_role = RoleInfo::new("test_role".to_string());
+    let mut test_role = RoleInfo::new("test_role");
     test_role.grants.grant_role("test".to_string());
     user_mgr.add_role(&tenant, test_role.clone(), false).await?;
     let role_info = user_mgr.get_role(&tenant, test_role.identity()).await?;

--- a/query/tests/it/interpreters/interpreter_show_grant.rs
+++ b/query/tests/it/interpreters/interpreter_show_grant.rs
@@ -31,15 +31,11 @@ async fn test_show_grant_interpreter() -> Result<()> {
     let user_mgr = ctx.get_user_manager();
     let role_cache_mgr = ctx.get_role_cache_manager();
     user_mgr
-        .add_user(
-            &tenant,
-            UserInfo::new_no_auth("test".to_string(), "localhost".to_string()),
-            false,
-        )
+        .add_user(&tenant, UserInfo::new_no_auth("test", "localhost"), false)
         .await?;
 
     user_mgr
-        .add_role(&tenant, RoleInfo::new("role1".to_string()), false)
+        .add_role(&tenant, RoleInfo::new("role1"), false)
         .await?;
 
     {
@@ -64,7 +60,7 @@ async fn test_show_grant_interpreter() -> Result<()> {
         common_datablocks::assert_blocks_sorted_eq(expected, result.as_slice());
     }
 
-    let mut role_info = RoleInfo::new("role2".to_string());
+    let mut role_info = RoleInfo::new("role2");
     let mut privileges = UserPrivilegeSet::empty();
     privileges.set_privilege(UserPrivilegeType::Select);
     role_info

--- a/query/tests/it/interpreters/interpreter_user_alter.rs
+++ b/query/tests/it/interpreters/interpreter_user_alter.rs
@@ -37,7 +37,7 @@ async fn test_alter_user_interpreter() -> Result<()> {
         hash_method: PasswordHashMethod::PlainText,
     };
 
-    let user_info = UserInfo::new(name.to_string(), hostname.to_string(), auth_info);
+    let user_info = UserInfo::new(name, hostname, auth_info);
     let user_mgr = ctx.get_user_manager();
     user_mgr.add_user(tenant, user_info.clone(), false).await?;
 

--- a/query/tests/it/interpreters/interpreter_user_drop.rs
+++ b/query/tests/it/interpreters/interpreter_user_drop.rs
@@ -55,7 +55,7 @@ async fn test_drop_user_interpreter() -> Result<()> {
             hash_method: PasswordHashMethod::PlainText,
         };
 
-        let user_info = UserInfo::new(name.to_string(), hostname.to_string(), auth_info);
+        let user_info = UserInfo::new(name, hostname, auth_info);
         let user_mgr = ctx.get_user_manager();
         user_mgr.add_user(&tenant, user_info.clone(), false).await?;
 

--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -34,6 +34,8 @@ use databend_query::servers::http::v1::ExecuteStateKind;
 use databend_query::servers::http::v1::HttpSession;
 use databend_query::servers::http::v1::QueryResponse;
 use databend_query::servers::HttpHandler;
+use databend_query::users::auth::jwt::CreateUser;
+use databend_query::users::auth::jwt::CustomClaims;
 use headers::Header;
 use hyper::header;
 use jwt_simple::algorithms::RS256KeyPair;
@@ -546,6 +548,63 @@ async fn test_auth_post(ep: &EndpointType, user_name: &str, header: impl Header)
         v[0][0],
         serde_json::Value::String(format!("'{}'@'%'", user_name))
     );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_auth_jwt_with_create_user() -> Result<()> {
+    let user_name = "user1";
+
+    let kid = "test_kid";
+    let key_pair = RS256KeyPair::generate(2048)?.with_key_id(kid);
+    let rsa_components = key_pair.public_key().to_components();
+    let e = encode_config(rsa_components.e, URL_SAFE_NO_PAD);
+    let n = encode_config(rsa_components.n, URL_SAFE_NO_PAD);
+    let j =
+        serde_json::json!({"keys": [ {"kty": "RSA", "kid": kid, "e": e, "n": n, } ] }).to_string();
+
+    let server = MockServer::start().await;
+    let json_path = "/jwks.json";
+    // Create a mock on the server.
+    let template = ResponseTemplate::new(200).set_body_raw(j, "application/json");
+    Mock::given(method("GET"))
+        .and(path(json_path))
+        .respond_with(template)
+        .expect(1..)
+        // Mounting the mock on the mock server - it's now effective!
+        .mount(&server)
+        .await;
+    let jwks_url = format!("http://{}{}", server.address(), json_path);
+
+    let session_manager = SessionManagerBuilder::create()
+        .jwt_key_file(jwks_url)
+        .build()
+        .unwrap();
+
+    let ep = Route::new()
+        .nest("/v1/query", query_route())
+        .with(HTTPSessionMiddleware { session_manager });
+
+    let now = Some(Clock::now_since_epoch());
+    let claims = JWTClaims {
+        issued_at: now,
+        expires_at: Some(now.unwrap() + jwt_simple::prelude::Duration::from_secs(10)),
+        invalid_before: now,
+        audiences: None,
+        issuer: None,
+        jwt_id: None,
+        subject: Some(user_name.to_string()),
+        nonce: None,
+        custom: CustomClaims {
+            create_user: Some(CreateUser {
+                ..Default::default()
+            }),
+        },
+    };
+
+    let token = key_pair.sign(claims)?;
+    let bear = headers::Authorization::bearer(&token).unwrap();
+    test_auth_post(&ep, user_name, bear).await?;
     Ok(())
 }
 

--- a/query/tests/it/sessions/session_context.rs
+++ b/query/tests/it/sessions/session_context.rs
@@ -58,7 +58,7 @@ async fn test_session_context() -> Result<()> {
 
     // Current user.
     {
-        let user_info = UserInfo::new_no_auth("user1".to_string(), "".to_string());
+        let user_info = UserInfo::new_no_auth("user1", "");
         session_ctx.set_current_user(user_info);
 
         let val = session_ctx.get_current_user().unwrap();

--- a/query/tests/it/storages/system/roles_table.rs
+++ b/query/tests/it/storages/system/roles_table.rs
@@ -26,14 +26,14 @@ async fn test_roles_table() -> Result<()> {
     ctx.get_settings().set_max_threads(2)?;
 
     {
-        let role_info = RoleInfo::new("test".to_string());
+        let role_info = RoleInfo::new("test");
         ctx.get_user_manager()
             .add_role(&tenant, role_info, false)
             .await?;
     }
 
     {
-        let mut role_info = RoleInfo::new("test1".to_string());
+        let mut role_info = RoleInfo::new("test1");
         role_info.grants.grant_role("test".to_string());
         ctx.get_user_manager()
             .add_role(&tenant, role_info, false)

--- a/query/tests/it/tests/context.rs
+++ b/query/tests/it/tests/context.rs
@@ -39,14 +39,10 @@ pub async fn create_query_context() -> Result<Arc<QueryContext>> {
     let dummy_session = sessions.create_session(SessionType::Test).await?;
 
     // Set user with all privileges
-    let mut user_info = UserInfo::new(
-        "root".to_string(),
-        "127.0.0.1".to_string(),
-        AuthInfo::Password {
-            hash_method: PasswordHashMethod::Sha256,
-            hash_value: Vec::from("pass"),
-        },
-    );
+    let mut user_info = UserInfo::new("root", "127.0.0.1", AuthInfo::Password {
+        hash_method: PasswordHashMethod::Sha256,
+        hash_value: Vec::from("pass"),
+    });
     user_info.grants.grant_privileges(
         &GrantObject::Global,
         UserPrivilegeSet::available_privileges_on_global(),
@@ -70,14 +66,10 @@ pub async fn create_query_context_with_config(
     let sessions = SessionManagerBuilder::create_with_conf(config.clone()).build()?;
     let dummy_session = sessions.create_session(SessionType::Test).await?;
 
-    let mut user_info = UserInfo::new(
-        "root".to_string(),
-        "127.0.0.1".to_string(),
-        AuthInfo::Password {
-            hash_method: PasswordHashMethod::Sha256,
-            hash_value: Vec::from("pass"),
-        },
-    );
+    let mut user_info = UserInfo::new("root", "127.0.0.1", AuthInfo::Password {
+        hash_method: PasswordHashMethod::Sha256,
+        hash_value: Vec::from("pass"),
+    });
     user_info.grants.grant_privileges(
         &GrantObject::Global,
         UserPrivilegeSet::available_privileges_on_global(),

--- a/query/tests/it/users/auth/auth_mgr.rs
+++ b/query/tests/it/users/auth/auth_mgr.rs
@@ -1,0 +1,177 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use base64::encode_config;
+use base64::URL_SAFE_NO_PAD;
+use common_base::tokio;
+use common_exception::Result;
+use common_meta_types::UserIdentity;
+use databend_query::users::auth::jwt::CreateUser;
+use databend_query::users::auth::jwt::CustomClaims;
+use databend_query::users::AuthMgr;
+use databend_query::users::Credential;
+use databend_query::users::UserApiProvider;
+use jwt_simple::prelude::*;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_auth_mgr_with_jwt() -> Result<()> {
+    let kid = "test_kid";
+    let key_pair = RS256KeyPair::generate(2048)?.with_key_id(kid);
+    let rsa_components = key_pair.public_key().to_components();
+    let e = encode_config(rsa_components.e, URL_SAFE_NO_PAD);
+    let n = encode_config(rsa_components.n, URL_SAFE_NO_PAD);
+    let j =
+        serde_json::json!({"keys": [ {"kty": "RSA", "kid": kid, "e": e, "n": n, } ] }).to_string();
+
+    let server = MockServer::start().await;
+    let json_path = "/jwks.json";
+    // Create a mock on the server.
+    let template = ResponseTemplate::new(200).set_body_raw(j, "application/json");
+    Mock::given(method("GET"))
+        .and(path(json_path))
+        .respond_with(template)
+        .expect(1..)
+        // Mounting the mock on the mock server - it's now effective!
+        .mount(&server)
+        .await;
+    let jwks_url = format!("http://{}{}", server.address(), json_path);
+
+    let mut conf = crate::tests::ConfigBuilder::create().config();
+    conf.query.jwt_key_file = jwks_url;
+    let user_mgr = UserApiProvider::create_global(conf.clone()).await?;
+    let auth_mgr = AuthMgr::create(conf, user_mgr.clone()).await?;
+    let tenant = "test";
+    let user_name = "test";
+
+    // without subject
+    {
+        let claims = Claims::create(Duration::from_hours(2));
+        let token = key_pair.sign(claims)?;
+
+        let res = auth_mgr.auth(&Credential::Jwt { token }).await;
+        assert!(res.is_err());
+        assert_eq!(
+            "Code: 1051, displayText = missing field `subject` in jwt.",
+            res.err().unwrap().to_string()
+        );
+    }
+
+    // without custom claims
+    {
+        let claims = Claims::create(Duration::from_hours(2)).with_subject(user_name.to_string());
+        let token = key_pair.sign(claims)?;
+
+        let res = auth_mgr.auth(&Credential::Jwt { token }).await;
+        assert!(res.is_err());
+        assert_eq!(
+            "Code: 2201, displayText = unknown user 'test'@'%'.",
+            res.err().unwrap().to_string()
+        );
+    }
+
+    // with custom claims
+    {
+        let custom_claims = CustomClaims::new();
+        let claims = Claims::with_custom_claims(custom_claims, Duration::from_hours(2))
+            .with_subject(user_name.to_string());
+        let token = key_pair.sign(claims)?;
+
+        let res = auth_mgr.auth(&Credential::Jwt { token }).await;
+        assert!(res.is_err());
+        assert_eq!(
+            "Code: 2201, displayText = unknown user 'test'@'%'.",
+            res.err().unwrap().to_string()
+        );
+    }
+
+    // with create user in other tenant
+    {
+        let tenant = "other";
+        let custom_claims = CustomClaims::new().with_create_user(CreateUser {
+            tenant_id: Some(tenant.to_string()),
+            ..Default::default()
+        });
+        let claims = Claims::with_custom_claims(custom_claims, Duration::from_hours(2))
+            .with_subject(user_name.to_string());
+        let token = key_pair.sign(claims)?;
+
+        let res = auth_mgr.auth(&Credential::Jwt { token }).await;
+        assert!(res.is_err());
+        assert_eq!(
+            "Code: 2201, displayText = unknown user 'test'@'%'.",
+            res.err().unwrap().to_string()
+        );
+
+        let user_info = user_mgr
+            .get_user(tenant, UserIdentity::new(user_name, "%"))
+            .await?;
+        assert_eq!(user_info.grants.roles().len(), 0);
+    }
+
+    // with create user
+    {
+        let custom_claims = CustomClaims::new().with_create_user(CreateUser {
+            ..Default::default()
+        });
+        let claims = Claims::with_custom_claims(custom_claims, Duration::from_hours(2))
+            .with_subject(user_name.to_string());
+        let token = key_pair.sign(claims)?;
+
+        let user_info = auth_mgr.auth(&Credential::Jwt { token }).await?;
+        assert_eq!(user_info.grants.roles().len(), 0);
+    }
+
+    // with create user again
+    {
+        let custom_claims = CustomClaims::new().with_create_user(CreateUser {
+            roles: vec!["role1".to_string()],
+            ..Default::default()
+        });
+        let claims = Claims::with_custom_claims(custom_claims, Duration::from_hours(2))
+            .with_subject(user_name.to_string());
+        let token = key_pair.sign(claims)?;
+
+        let user_info = auth_mgr.auth(&Credential::Jwt { token }).await?;
+        assert_eq!(user_info.grants.roles().len(), 0);
+    }
+
+    // with create user and grant roles
+    {
+        let user_name = "test-user2";
+        let role_name = "test-role";
+        let custom_claims = CustomClaims::new().with_create_user(CreateUser {
+            roles: vec![role_name.to_string()],
+            ..Default::default()
+        });
+        let claims = Claims::with_custom_claims(custom_claims, Duration::from_hours(2))
+            .with_subject(user_name.to_string());
+        let token = key_pair.sign(claims)?;
+
+        let res = auth_mgr.auth(&Credential::Jwt { token }).await;
+        assert!(res.is_ok());
+
+        let user_info = user_mgr
+            .get_user(tenant, UserIdentity::new(user_name, "%"))
+            .await?;
+        assert_eq!(user_info.grants.roles().len(), 1);
+        assert_eq!(user_info.grants.roles()[0], role_name.to_string());
+    }
+
+    Ok(())
+}

--- a/query/tests/it/users/auth/mod.rs
+++ b/query/tests/it/users/auth/mod.rs
@@ -12,10 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod authenticator;
-mod jwk;
-
-pub use authenticator::CreateUser;
-pub use authenticator::CustomClaims;
-pub use authenticator::JwtAuthenticator;
-pub use authenticator::PubKey;
+mod auth_mgr;

--- a/query/tests/it/users/mod.rs
+++ b/query/tests/it/users/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod auth;
 mod role_cache_mgr;
 mod role_mgr;
 mod user_mgr;

--- a/query/tests/it/users/role_cache_mgr.rs
+++ b/query/tests/it/users/role_cache_mgr.rs
@@ -29,7 +29,7 @@ async fn test_role_cache_mgr() -> Result<()> {
     let conf = crate::tests::ConfigBuilder::create().config();
     let user_api = UserApiProvider::create_global(conf).await?;
 
-    let mut role1 = RoleInfo::new("role1".to_string());
+    let mut role1 = RoleInfo::new("role1");
     role1.grants.grant_privileges(
         &GrantObject::Database("db1".to_string()),
         UserPrivilegeSet::available_privileges_on_database(),
@@ -47,11 +47,11 @@ async fn test_role_cache_mgr() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_find_all_related_roles() -> Result<()> {
     let roles = vec![
-        RoleInfo::new("role1".to_string()),
-        RoleInfo::new("role2".to_string()),
-        RoleInfo::new("role3".to_string()),
-        RoleInfo::new("role4".to_string()),
-        RoleInfo::new("role5".to_string()),
+        RoleInfo::new("role1"),
+        RoleInfo::new("role2"),
+        RoleInfo::new("role3"),
+        RoleInfo::new("role4"),
+        RoleInfo::new("role5"),
     ];
     // role1 -> role2 -> role4 -> role5
     //    <- -> role3

--- a/query/tests/it/users/role_mgr.rs
+++ b/query/tests/it/users/role_mgr.rs
@@ -32,13 +32,13 @@ async fn test_role_manager() -> Result<()> {
 
     // add role
     {
-        let role_info = RoleInfo::new(role_name.clone());
+        let role_info = RoleInfo::new(&role_name);
         role_mgr.add_role(tenant, role_info, false).await?;
     }
 
     // add role again, error
     {
-        let role_info = RoleInfo::new(role_name.clone());
+        let role_info = RoleInfo::new(&role_name);
         let res = role_mgr.add_role(tenant, role_info, false).await;
         assert!(res.is_err());
         assert_eq!(
@@ -49,7 +49,7 @@ async fn test_role_manager() -> Result<()> {
 
     // add role
     {
-        let role_info = RoleInfo::new(role_name.clone());
+        let role_info = RoleInfo::new(&role_name);
         role_mgr.add_role(tenant, role_info, true).await?;
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Create user if not exists on JWT authenticate.

Specify the `create_user` struct in custom claims to create a user.
```rs
#[derive(Default, Deserialize, Serialize)]
pub struct CreateUser {
    pub tenant_id: Option<String>,
    pub roles: Vec<String>,
}

#[derive(Default, Deserialize, Serialize)]
pub struct CustomClaims {
    pub create_user: Option<CreateUser>,
}
```

## Changelog

- New Feature

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/4875

