### PR TITLE
rename CreateUser to EnsureUser

### DIFF
--- a/query/src/users/auth/auth_mgr.rs
+++ b/query/src/users/auth/auth_mgr.rs
@@ -64,10 +64,10 @@ impl AuthMgr {
                     None => return Err(ErrorCode::AuthenticateFailure("jwt auth not configured.")),
                 };
                 let user_name = jwt.subject.unwrap();
-                if let Some(create_user) = jwt.custom.create_user {
-                    let tenant = create_user.tenant_id.unwrap_or_else(|| self.tenant.clone());
+                if let Some(ensure_user) = jwt.custom.ensure_user {
+                    let tenant = ensure_user.tenant_id.unwrap_or_else(|| self.tenant.clone());
                     let mut user_info = UserInfo::new(&user_name, "%", AuthInfo::JWT);
-                    for role in create_user.roles {
+                    for role in ensure_user.roles {
                         user_info.grants.grant_role(role);
                     }
                     self.user_mgr.add_user(&tenant, user_info, true).await?;

--- a/query/src/users/auth/jwt/authenticator.rs
+++ b/query/src/users/auth/jwt/authenticator.rs
@@ -34,23 +34,23 @@ pub struct JwtAuthenticator {
 }
 
 #[derive(Default, Deserialize, Serialize)]
-pub struct CreateUser {
+pub struct EnsureUser {
     pub tenant_id: Option<String>,
     pub roles: Vec<String>,
 }
 
 #[derive(Default, Deserialize, Serialize)]
 pub struct CustomClaims {
-    pub create_user: Option<CreateUser>,
+    pub ensure_user: Option<EnsureUser>,
 }
 
 impl CustomClaims {
     pub fn new() -> Self {
-        CustomClaims { create_user: None }
+        CustomClaims { ensure_user: None }
     }
 
-    pub fn with_create_user(mut self, create_user: CreateUser) -> Self {
-        self.create_user = Some(create_user);
+    pub fn with_ensure_user(mut self, ensure_user: EnsureUser) -> Self {
+        self.ensure_user = Some(ensure_user);
         self
     }
 }

--- a/query/src/users/auth/jwt/mod.rs
+++ b/query/src/users/auth/jwt/mod.rs
@@ -15,7 +15,7 @@
 mod authenticator;
 mod jwk;
 
-pub use authenticator::CreateUser;
 pub use authenticator::CustomClaims;
+pub use authenticator::EnsureUser;
 pub use authenticator::JwtAuthenticator;
 pub use authenticator::PubKey;

--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -34,8 +34,8 @@ use databend_query::servers::http::v1::ExecuteStateKind;
 use databend_query::servers::http::v1::HttpSession;
 use databend_query::servers::http::v1::QueryResponse;
 use databend_query::servers::HttpHandler;
-use databend_query::users::auth::jwt::CreateUser;
 use databend_query::users::auth::jwt::CustomClaims;
+use databend_query::users::auth::jwt::EnsureUser;
 use headers::Header;
 use hyper::header;
 use jwt_simple::algorithms::RS256KeyPair;
@@ -596,7 +596,7 @@ async fn test_auth_jwt_with_create_user() -> Result<()> {
         subject: Some(user_name.to_string()),
         nonce: None,
         custom: CustomClaims {
-            create_user: Some(CreateUser {
+            ensure_user: Some(EnsureUser {
                 ..Default::default()
             }),
         },

--- a/query/tests/it/users/auth/auth_mgr.rs
+++ b/query/tests/it/users/auth/auth_mgr.rs
@@ -17,8 +17,8 @@ use base64::URL_SAFE_NO_PAD;
 use common_base::tokio;
 use common_exception::Result;
 use common_meta_types::UserIdentity;
-use databend_query::users::auth::jwt::CreateUser;
 use databend_query::users::auth::jwt::CustomClaims;
+use databend_query::users::auth::jwt::EnsureUser;
 use databend_query::users::AuthMgr;
 use databend_query::users::Credential;
 use databend_query::users::UserApiProvider;
@@ -103,7 +103,7 @@ async fn test_auth_mgr_with_jwt() -> Result<()> {
     // with create user in other tenant
     {
         let tenant = "other";
-        let custom_claims = CustomClaims::new().with_create_user(CreateUser {
+        let custom_claims = CustomClaims::new().with_ensure_user(EnsureUser {
             tenant_id: Some(tenant.to_string()),
             ..Default::default()
         });
@@ -126,7 +126,7 @@ async fn test_auth_mgr_with_jwt() -> Result<()> {
 
     // with create user
     {
-        let custom_claims = CustomClaims::new().with_create_user(CreateUser {
+        let custom_claims = CustomClaims::new().with_ensure_user(EnsureUser {
             ..Default::default()
         });
         let claims = Claims::with_custom_claims(custom_claims, Duration::from_hours(2))
@@ -139,7 +139,7 @@ async fn test_auth_mgr_with_jwt() -> Result<()> {
 
     // with create user again
     {
-        let custom_claims = CustomClaims::new().with_create_user(CreateUser {
+        let custom_claims = CustomClaims::new().with_ensure_user(EnsureUser {
             roles: vec!["role1".to_string()],
             ..Default::default()
         });
@@ -155,7 +155,7 @@ async fn test_auth_mgr_with_jwt() -> Result<()> {
     {
         let user_name = "test-user2";
         let role_name = "test-role";
-        let custom_claims = CustomClaims::new().with_create_user(CreateUser {
+        let custom_claims = CustomClaims::new().with_ensure_user(EnsureUser {
             roles: vec![role_name.to_string()],
             ..Default::default()
         });


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
https://github.com/datafuselabs/databend/issues/4935

Rename CreateUser to EnsureUser. 

## Changelog

- Improvement

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/4935

