### PR TITLE
ci: fix default image tag for debian

### DIFF
--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -248,7 +248,7 @@ jobs:
         run: |
           _base=${{ secrets.DOCKERHUB_NAMESPACE }}/databend-${{ matrix.service }}:${{ steps.get_version.outputs.VERSION }}
           _tags=${_base}-${{ matrix.distro }}
-          if [[ "${{ matrix.service }}" == "debian" ]]; then
+          if [[ "${{ matrix.distro }}" == "debian" ]]; then
             _tags="${_tags}, ${_base}"
           fi
           echo ::set-output name=IMAGE_TAGS::${_tags}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix default image tag for debian

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

