### PR TITLE
feat(datatype): introduce precision in DateTime type

### DIFF
--- a/common/ast/src/parser/ast/expression.rs
+++ b/common/ast/src/parser/ast/expression.rs
@@ -108,7 +108,7 @@ pub enum TypeName {
     Float,
     Double,
     Date,
-    DateTime(Option<u64>),
+    DateTime { precision: Option<u64> },
     Timestamp,
     Varchar,
     Array { item_type: Box<TypeName> },
@@ -283,8 +283,8 @@ impl Display for TypeName {
             TypeName::Date => {
                 write!(f, "DATE")?;
             }
-            TypeName::DateTime(n) => match n {
-                Some(n) => write!(f, "DATETIME({})", *n)?,
+            TypeName::DateTime { precision } => match precision {
+                Some(precision) => write!(f, "DATETIME({})", *precision)?,
                 None => write!(f, "DATETIME")?,
             },
             TypeName::Timestamp => {

--- a/common/ast/src/parser/ast/expression.rs
+++ b/common/ast/src/parser/ast/expression.rs
@@ -108,7 +108,7 @@ pub enum TypeName {
     Float,
     Double,
     Date,
-    DateTime,
+    DateTime(Option<u64>),
     Timestamp,
     Varchar,
     Array { item_type: Box<TypeName> },
@@ -283,9 +283,10 @@ impl Display for TypeName {
             TypeName::Date => {
                 write!(f, "DATE")?;
             }
-            TypeName::DateTime => {
-                write!(f, "DATETIME")?;
-            }
+            TypeName::DateTime(n) => match n {
+                Some(n) => write!(f, "DATETIME({})", *n)?,
+                None => write!(f, "DATETIME")?,
+            },
             TypeName::Timestamp => {
                 write!(f, "TIMESTAMP")?;
             }

--- a/common/ast/src/parser/ast/statement.rs
+++ b/common/ast/src/parser/ast/statement.rs
@@ -126,7 +126,7 @@ impl Display for Statement {
                 if *analyze {
                     write!(f, "ANALYZE ")?;
                 }
-                write!(f, "{} ", &query)?;
+                write!(f, "{}", &query)?;
             }
             Statement::Select(query) => {
                 write!(f, "{}", &query)?;

--- a/common/ast/src/parser/rule/expr.rs
+++ b/common/ast/src/parser/rule/expr.rs
@@ -582,10 +582,10 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
     let ty_double = value(TypeName::Double, rule! { DOUBLE });
     let ty_date = value(TypeName::Date, rule! { DATE });
     let ty_datetime = map(
-        rule! { DATETIME ~ ("(" ~ #literal_u64 ~ ")")? },
+        rule! { DATETIME ~ ( "(" ~ #literal_u64 ~ ")" )? },
         |(_, opt_precision)| {
             let precision = opt_precision.map(|(_, p, _)| p);
-            TypeName::DateTime(precision)
+            TypeName::DateTime { precision }
         },
     );
     let ty_timestamp = value(TypeName::Timestamp, rule! { TIMESTAMP });

--- a/common/ast/src/parser/rule/expr.rs
+++ b/common/ast/src/parser/rule/expr.rs
@@ -581,7 +581,13 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
     let ty_float = value(TypeName::Float, rule! { FLOAT });
     let ty_double = value(TypeName::Double, rule! { DOUBLE });
     let ty_date = value(TypeName::Date, rule! { DATE });
-    let ty_datetime = value(TypeName::DateTime, rule! { DATETIME });
+    let ty_datetime = map(
+        rule! { DATETIME ~ ("(" ~ #literal_u64 ~ ")")? },
+        |(_, opt_precision)| {
+            let precision = opt_precision.map(|(_, p, _)| p);
+            TypeName::DateTime(precision)
+        },
+    );
     let ty_timestamp = value(TypeName::Timestamp, rule! { TIMESTAMP });
     let ty_varchar = value(TypeName::Varchar, rule! { VARCHAR });
     let ty_object = value(TypeName::Object, rule! { OBJECT });

--- a/common/ast/tests/it/rule.rs
+++ b/common/ast/tests/it/rule.rs
@@ -77,6 +77,7 @@ fn test_statement() {
         r#"drop table if exists a."b";"#,
         r#"use "a";"#,
         "create database if not exists a;",
+        "create table c(a DateTime null, b DateTime(3));",
     ];
 
     for case in cases {
@@ -112,7 +113,7 @@ fn test_query() {
     let mut file = mint.new_goldenfile("query.txt").unwrap();
     let cases = &[
         "select c_count, count(*) as custdist, sum(c_acctbal) as totacctbal
-            from customer, orders ODS, 
+            from customer, orders ODS,
                 (
                     select
                         c_custkey,

--- a/common/ast/tests/it/testdata/query.txt
+++ b/common/ast/tests/it/testdata/query.txt
@@ -1,6 +1,6 @@
 ---------- Input ----------
 select c_count, count(*) as custdist, sum(c_acctbal) as totacctbal
-            from customer, orders ODS, 
+            from customer, orders ODS,
                 (
                     select
                         c_custkey,

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -348,9 +348,9 @@ CreateTable {
                 name: "a",
                 quote: None,
             },
-            data_type: DateTime(
-                None,
-            ),
+            data_type: DateTime {
+                precision: None,
+            },
             nullable: true,
             default_value: None,
         },
@@ -359,11 +359,11 @@ CreateTable {
                 name: "b",
                 quote: None,
             },
-            data_type: DateTime(
-                Some(
+            data_type: DateTime {
+                precision: Some(
                     3,
                 ),
-            ),
+            },
             nullable: true,
             default_value: None,
         },

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -36,7 +36,7 @@ ShowCreateTable {
 ---------- Input ----------
 explain analyze select a from b;
 ---------- Output ---------
-EXPLAIN ANALYZE SELECT a FROM b 
+EXPLAIN ANALYZE SELECT a FROM b
 ---------- AST ------------
 Explain {
     analyze: true,
@@ -327,6 +327,51 @@ CreateDatabase {
     },
     engine: "",
     options: [],
+}
+
+
+---------- Input ----------
+create table c(a DateTime null, b DateTime(3));
+---------- Output ---------
+CREATE TABLE c (a DATETIME NULL, b DATETIME(3) NULL)
+---------- AST ------------
+CreateTable {
+    if_not_exists: false,
+    database: None,
+    table: Identifier {
+        name: "c",
+        quote: None,
+    },
+    columns: [
+        ColumnDefinition {
+            name: Identifier {
+                name: "a",
+                quote: None,
+            },
+            data_type: DateTime(
+                None,
+            ),
+            nullable: true,
+            default_value: None,
+        },
+        ColumnDefinition {
+            name: Identifier {
+                name: "b",
+                quote: None,
+            },
+            data_type: DateTime(
+                Some(
+                    3,
+                ),
+            ),
+            nullable: true,
+            default_value: None,
+        },
+    ],
+    engine: "",
+    options: [],
+    like_db: None,
+    like_table: None,
 }
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. Trim spaces in `Explain` query
2. Add option precision in DataTime DataType

Summary about this PR

## Changelog

 
- Improvement
 
## Related Issues

Fixes #4968
