### PR TITLE
chore(show): add snapshot_location back to show create table

### DIFF
--- a/query/src/interpreters/interpreter_table_show_create.rs
+++ b/query/src/interpreters/interpreter_table_show_create.rs
@@ -62,22 +62,35 @@ impl Interpreter for ShowCreateTableInterpreter {
         let schema = table.schema();
 
         let mut table_info = format!("CREATE TABLE `{}` (\n", name);
-        for field in schema.fields().iter() {
-            let default_expr = match field.default_expr() {
-                Some(expr) => {
-                    let expression: Expression = serde_json::from_slice::<Expression>(expr)?;
-                    format!(" DEFAULT {}", expression.column_name())
-                }
-                None => "".to_string(),
-            };
-            let column = format!(
-                "  `{}` {}{},\n",
-                field.name(),
-                format_data_type_sql(field.data_type()),
-                default_expr
-            );
-            table_info.push_str(column.as_str());
+
+        // Append columns.
+        {
+            let mut columns = vec![];
+            for field in schema.fields().iter() {
+                let default_expr = match field.default_expr() {
+                    Some(expr) => {
+                        let expression: Expression = serde_json::from_slice::<Expression>(expr)?;
+                        format!(" DEFAULT {}", expression.column_name())
+                    }
+                    None => "".to_string(),
+                };
+                let column = format!(
+                    "  `{}` {}{}",
+                    field.name(),
+                    format_data_type_sql(field.data_type()),
+                    default_expr
+                );
+                columns.push(column);
+            }
+            // Format is:
+            //  (
+            //      x,
+            //      y
+            //  )
+            let columns_str = format!("{}\n", columns.join(",\n"));
+            table_info.push_str(&columns_str);
         }
+
         let table_engine = format!(") ENGINE={}", engine);
         table_info.push_str(table_engine.as_str());
         table_info.push_str({

--- a/query/src/sql/table_option_keys.rs
+++ b/query/src/sql/table_option_keys.rs
@@ -33,7 +33,7 @@ pub const OPT_KEY_SNAPSHOT_LOC: &str = "snapshot_loc";
 lazy_static! {
     /// Table option keys that reserved for internal usage only
     /// - Users are not allowed to specified this option keys in DDL
-    /// - Should not be shown in `show create table` statment
+    /// - Should not be shown in `show create table` statement
     pub static ref RESERVED_TABLE_OPTION_KEYS: HashSet<&'static str> = {
         let mut r = HashSet::new();
         r.insert(OPT_KEY_DATABASE_ID);
@@ -41,11 +41,10 @@ lazy_static! {
         r
     };
 
-    /// Table option keys that Should not be shown in `show create table` statment
+    /// Table option keys that Should not be shown in `show create table` statement
     pub static ref INTERNAL_TABLE_OPTION_KEYS: HashSet<&'static str> = {
         let mut r = HashSet::new();
         r.insert(OPT_KEY_SNAPSHOT_LOC);
-        r.insert(OPT_KEY_SNAPSHOT_LOCATION);
         r.insert(OPT_KEY_DATABASE_ID);
         r
     };

--- a/query/tests/it/interpreters/interpreter_table_show_create.rs
+++ b/query/tests/it/interpreters/interpreter_table_show_create.rs
@@ -48,7 +48,7 @@ async fn interpreter_show_create_table_test() -> Result<()> {
             "|       |   `b` INT,                          |",
             "|       |   `c` VARCHAR,                      |",
             "|       |   `d` SMALLINT,                     |",
-            "|       |   `e` DATE,                         |",
+            "|       |   `e` DATE                          |",
             "|       | ) ENGINE=Null COMMENT='test create' |",
             "+-------+-------------------------------------+",
         ],
@@ -63,34 +63,14 @@ async fn interpreter_show_create_table_test() -> Result<()> {
             "| Table | Create Table                        |",
             "+-------+-------------------------------------+",
             "| t     | CREATE TABLE `t` (                  |",
-            "|       |   `a` INT,                          |",
+            "|       |   `a` INT                           |",
             "|       | ) ENGINE=fuse COMMENT='test create' |",
             "+-------+-------------------------------------+",
         ],
         name: "internal options should not be shown in fuse engine",
     };
 
-    //  after insertion, the table snapshot will be created
-    //  with the corresponding table options which should not be shown
-    let internal_opts_after_insert = Case {
-        create_stmt: vec![
-            "CREATE TABLE s( a int) Engine = fuse COMMENT = 'test create'",
-            "insert into s values(1)",
-        ],
-        show_stmt: "SHOW CREATE TABLE s",
-        expects: vec![
-            "+-------+-------------------------------------+",
-            "| Table | Create Table                        |",
-            "+-------+-------------------------------------+",
-            "| s     | CREATE TABLE `s` (                  |",
-            "|       |   `a` INT,                          |",
-            "|       | ) ENGINE=fuse COMMENT='test create' |",
-            "+-------+-------------------------------------+",
-        ],
-        name: "internal options should not be shown in fuse engine",
-    };
-
-    let cases = vec![normal_case, internal_opt, internal_opts_after_insert];
+    let cases = vec![normal_case, internal_opt];
 
     for case in cases {
         for stmt in case.create_stmt {

--- a/tests/suites/0_stateless/06_show/06_0001_show_create_table.result
+++ b/tests/suites/0_stateless/06_show/06_0001_show_create_table.result
@@ -1,2 +1,2 @@
-a	CREATE TABLE `a` (\n  `a` BIGINT,\n  `b` INT DEFAULT 3,\n  `c` VARCHAR DEFAULT 'x',\n  `d` SMALLINT NULL,\n  `e` DATE,\n) ENGINE=Null
-b	CREATE TABLE `b` (\n  `a` BIGINT,\n  `b` INT NULL DEFAULT NULL,\n  `c` VARCHAR,\n  `d` SMALLINT UNSIGNED NULL,\n  `e` DATE DEFAULT today(),\n) ENGINE=Null COMMENT='test b'
+a	CREATE TABLE `a` (\n  `a` BIGINT,\n  `b` INT DEFAULT 3,\n  `c` VARCHAR DEFAULT 'x',\n  `d` SMALLINT NULL,\n  `e` DATE\n) ENGINE=Null
+b	CREATE TABLE `b` (\n  `a` BIGINT,\n  `b` INT NULL DEFAULT NULL,\n  `c` VARCHAR,\n  `d` SMALLINT UNSIGNED NULL,\n  `e` DATE DEFAULT today()\n) ENGINE=Null COMMENT='test b'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Add  snapshot_location back to show create table
* Trim the last `,`
```
    "+-------+-------------------------------------+",
    "| Table | Create Table                        |",
    "+-------+-------------------------------------+",
    "| t     | CREATE TABLE `t` (                  |",
    "|       |   `a` INT,                          |",
    "|       | ) ENGINE=fuse COMMENT='test create' |",
    "+-------+-------------------------------------+",
    
    ->
    
    "+-------+-------------------------------------+",
    "| Table | Create Table                        |",
    "+-------+-------------------------------------+",
    "| t     | CREATE TABLE `t` (                  |",
    "|       |   `a` INT                           |",
    "|       | ) ENGINE=fuse COMMENT='test create' |",
    "+-------+-------------------------------------+",
```

## Changelog

- New Feature


## Related Issues

Fixes #4975

