### PR TITLE
minor(planner): add `context.get_cluster().is_empty()` condition to solid the code

### DIFF
--- a/query/src/servers/clickhouse/interactive_worker_base.rs
+++ b/query/src/servers/clickhouse/interactive_worker_base.rs
@@ -42,6 +42,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use super::writers::from_clickhouse_block;
 use crate::interpreters::InterpreterFactory;
+use crate::interpreters::SelectInterpreterV2;
 use crate::pipelines::new::processors::port::OutputPort;
 use crate::pipelines::new::processors::SyncReceiverCkSource;
 use crate::pipelines::new::SourcePipeBuilder;
@@ -75,12 +76,12 @@ impl InteractiveWorkerBase {
                 // It has select plan, so we do not need to consume data from client
                 // data is from server and insert into server, just behave like select query
                 if insert.has_select_plan() {
-                    return Self::process_select_query(plan, ctx).await;
+                    return Self::process_select_query(plan, ctx, query).await;
                 }
 
                 Self::process_insert_query(insert.clone(), ch_ctx, ctx).await
             }
-            _ => Self::process_select_query(plan, ctx).await,
+            _ => Self::process_select_query(plan, ctx, query).await,
         }
     }
 
@@ -162,9 +163,19 @@ impl InteractiveWorkerBase {
     pub async fn process_select_query(
         plan: PlanNode,
         ctx: Arc<QueryContext>,
+        query: &str,
     ) -> Result<Receiver<BlockItem>> {
         let start = Instant::now();
-        let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
+        let settings = ctx.get_settings();
+        let interpreter = if settings.get_enable_new_processor_framework()? != 0
+            && ctx.get_cluster().is_empty()
+            && settings.get_enable_planner_v2()? != 0
+        {
+            // Use new planner
+            SelectInterpreterV2::try_create(ctx.clone(), query)?
+        } else {
+            InterpreterFactory::get(ctx.clone(), plan)?
+        };
         let name = interpreter.name().to_string();
         histogram!(
             super::clickhouse_metrics::METRIC_INTERPRETER_USEDTIME,

--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -295,6 +295,7 @@ impl<W: std::io::Write> InteractiveWorkerBase<W> {
 
                 let interpreter: Arc<dyn Interpreter> =
                     if settings.get_enable_new_processor_framework()? != 0
+                        && context.get_cluster().is_empty()
                         && settings.get_enable_planner_v2()? != 0
                         && matches!(plan, PlanNode::Select(..))
                     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently `cluster select with new processor` is not ready, so add a determination of whether the cluster is empty to solid the code
## Changelog

- others

## Related Issues

Fixes #issue

