### PR TITLE
ISSUE-5033: Use config item "--max-query-log-size" as the max_row setting of QueryLogTable

### DIFF
--- a/query/src/catalogs/impls/immutable_catalog.rs
+++ b/query/src/catalogs/impls/immutable_catalog.rs
@@ -53,13 +53,13 @@ pub struct ImmutableCatalog {
 }
 
 impl ImmutableCatalog {
-    pub async fn try_create_with_config(_conf: &Config) -> Result<Self> {
+    pub async fn try_create_with_config(conf: &Config) -> Result<Self> {
         // The global db meta.
         let mut sys_db_meta = InMemoryMetas::create(SYS_DB_ID_BEGIN, SYS_TBL_ID_BEGIN);
         sys_db_meta.init_db("system");
         sys_db_meta.init_db("INFORMATION_SCHEMA");
 
-        let sys_db = SystemDatabase::create(&mut sys_db_meta);
+        let sys_db = SystemDatabase::create(&mut sys_db_meta, conf);
         let info_schema_db = InformationSchemaDatabase::create(&mut sys_db_meta);
 
         Ok(Self {

--- a/query/src/databases/system/system_database.rs
+++ b/query/src/databases/system/system_database.rs
@@ -19,6 +19,7 @@ use common_meta_types::DatabaseInfo;
 use common_meta_types::DatabaseMeta;
 
 use crate::catalogs::InMemoryMetas;
+use crate::configs::Config;
 use crate::databases::Database;
 use crate::storages::system;
 use crate::storages::Table;
@@ -29,7 +30,7 @@ pub struct SystemDatabase {
 }
 
 impl SystemDatabase {
-    pub fn create(sys_db_meta: &mut InMemoryMetas) -> Self {
+    pub fn create(sys_db_meta: &mut InMemoryMetas, config: &Config) -> Self {
         let table_list: Vec<Arc<dyn Table>> = vec![
             system::OneTable::create(sys_db_meta.next_table_id()),
             system::FunctionsTable::create(sys_db_meta.next_table_id()),
@@ -46,7 +47,10 @@ impl SystemDatabase {
             system::ColumnsTable::create(sys_db_meta.next_table_id()),
             system::UsersTable::create(sys_db_meta.next_table_id()),
             system::WarehousesTable::create(sys_db_meta.next_table_id()),
-            Arc::new(system::QueryLogTable::create(sys_db_meta.next_table_id())),
+            Arc::new(system::QueryLogTable::create(
+                sys_db_meta.next_table_id(),
+                config.query.max_query_log_size as i32,
+            )),
             system::EnginesTable::create(sys_db_meta.next_table_id()),
             system::RolesTable::create(sys_db_meta.next_table_id()),
         ];

--- a/query/src/storages/system/query_log_table.rs
+++ b/query/src/storages/system/query_log_table.rs
@@ -48,7 +48,7 @@ pub struct QueryLogTable {
 }
 
 impl QueryLogTable {
-    pub fn create(table_id: u64) -> Self {
+    pub fn create(table_id: u64, max_rows: i32) -> Self {
         let schema = DataSchemaRefExt::create(vec![
             // Type.
             DataField::new("log_type", i8::to_data_type()),
@@ -114,14 +114,9 @@ impl QueryLogTable {
 
         QueryLogTable {
             table_info,
-            max_rows: 200000,
+            max_rows,
             data: Arc::new(RwLock::new(VecDeque::new())),
         }
-    }
-
-    #[allow(dead_code)]
-    pub fn set_max_rows(&mut self, max: i32) {
-        self.max_rows = max;
     }
 }
 

--- a/query/tests/it/storages/system/query_log_table.rs
+++ b/query/tests/it/storages/system/query_log_table.rs
@@ -30,8 +30,9 @@ async fn test_query_log_table() -> Result<()> {
     let ctx = crate::tests::create_query_context().await?;
     ctx.get_settings().set_max_threads(2)?;
 
-    let mut query_log = QueryLogTable::create(0);
-    query_log.set_max_rows(2);
+    let max_rows = 2;
+    let table_id = 0;
+    let query_log = QueryLogTable::create(table_id, max_rows);
     let schema = query_log.schema();
     let table: Arc<dyn Table> = Arc::new(query_log);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

use config item "--max-query-log-size" as the max_row setting of QueryLogTable.

the value specified for `max-query-log-size`, e.g.

`./target/debug/databend-query --max-query-log-size=100`

will be used as the value of filed `max_rows` of `QueryLogTable`



## Changelog

- Improvement

## Related Issues

Fixes #5033 

