### PR TITLE
fix(parser): allow to omit semicolon

### DIFF
--- a/common/ast/src/parser/statement.rs
+++ b/common/ast/src/parser/statement.rs
@@ -24,14 +24,11 @@ use crate::parser::util::*;
 use crate::rule;
 
 pub fn statements(i: Input) -> IResult<Vec<Statement>> {
-    let stmt = map(
+    map(
         rule! {
-            #statement ~ ";"
+            #statement ~ ";"? ~ &EOI
         },
-        |(stmt, _)| stmt,
-    );
-    rule!(
-        #stmt+
+        |(stmt, _, _)| vec![stmt],
     )(i)
 }
 

--- a/common/ast/tests/it/parser.rs
+++ b/common/ast/tests/it/parser.rs
@@ -69,7 +69,7 @@ fn test_statement() {
     let mut mint = Mint::new("tests/it/testdata");
     let mut file = mint.new_goldenfile("statement.txt").unwrap();
     let cases = &[
-        r#"show tables;"#,
+        r#"show tables"#,
         r#"show processlist;"#,
         r#"show create table a.b;"#,
         r#"explain analyze select a from b;"#,

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -1,5 +1,5 @@
 ---------- Input ----------
-show tables;
+show tables
 ---------- Output ---------
 SHOW TABLES
 ---------- AST ------------


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- make the semicolon on the statements optional

## Changelog

- Bug Fix
- Improvement

## Related Issues

closes https://github.com/datafuselabs/databend/issues/5044

