### PR TITLE
feat(httphandler):  remove backtrace from response and log it.

### DIFF
--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -214,7 +214,10 @@ pub(crate) async fn query_handler(
                 resp,
             )))
         }
-        Err(e) => Ok(Json(QueryResponse::fail_to_start_sql(query_id, &e))),
+        Err(e) => {
+            tracing::error!("Fail to start sql, Error: {:?}", e);
+            Ok(Json(QueryResponse::fail_to_start_sql(query_id, &e)))
+        }
     }
 }
 

--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -52,8 +52,6 @@ pub fn make_final_uri(query_id: &str) -> String {
 pub struct QueryError {
     pub code: u16,
     pub message: String,
-    pub backtrace: Option<String>,
-    // TODO(youngsofun): add other info more friendly to client
 }
 
 impl QueryError {
@@ -61,7 +59,6 @@ impl QueryError {
         QueryError {
             code: e.code(),
             message: e.message(),
-            backtrace: e.backtrace().map(|b| b.to_string()),
         }
     }
 }

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -117,8 +117,8 @@ impl Executor {
             });
 
             if let Err(e) = reason {
-                if e.code() != ErrorCode::AbortedSession("").code()
-                    && e.code() != ErrorCode::AbortedQuery("").code()
+                if e.code() != ErrorCode::aborted_session_code()
+                    && e.code() != ErrorCode::aborted_query_code()
                 {
                     // query state can be pulled multi times, only log it once
                     tracing::error!("Query Error: {:?}", e);

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -112,9 +112,18 @@ impl Executor {
                 .map_err(|e| tracing::error!("interpreter.finish error: {:?}", e));
             guard.state = Stopped(ExecuteStopped {
                 progress,
-                reason,
+                reason: reason.clone(),
                 stop_time: Instant::now(),
             });
+
+            if let Err(e) = reason {
+                if e.code() != ErrorCode::AbortedSession("").code()
+                    && e.code() != ErrorCode::AbortedQuery("").code()
+                {
+                    // query state can be pulled multi times, only log it once
+                    tracing::error!("Query Error: {:?}", e);
+                }
+            }
         };
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

although most errors can be found in query_log. log it anyway for：

1. some errors may not be covered in query_log 
2. more convenient to read for debug
3. log itself may be used for analysis

note：

1.  errors that lead to HTTP error code already logged in middleware


## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

part of https://github.com/datafuselabs/databend/issues/4876


