### PR TITLE
fix doc parser

### DIFF
--- a/common/functions/src/rdoc/function_doc_asset.rs
+++ b/common/functions/src/rdoc/function_doc_asset.rs
@@ -80,10 +80,10 @@ impl FunctionDocAsset {
         options.insert(Options::ENABLE_HEADING_ATTRIBUTES);
         let parser = Parser::new_ext(data, options);
 
-        let title_regex =
-            TITLE_REGEXP.get_or_init(|| Regex::new(r#"title:\s*(?P<title>\S+)"#).unwrap());
+        let title_regex = TITLE_REGEXP
+            .get_or_init(|| Regex::new(r#"title:\s*(?P<title>(\S+(\s\S+)?))"#).unwrap());
         let title_alias_regexp = TITLE_ALIAS_REGEXP
-            .get_or_init(|| Regex::new(r#"title_includes\s*:\s*(?P<title>\S+)"#).unwrap());
+            .get_or_init(|| Regex::new(r#"title_includes\s*:\s*(?P<title>((\S+\s?)*))"#).unwrap());
 
         let mut stage = MarkdownStage::Title;
         let mut inside_head = false;
@@ -114,7 +114,11 @@ impl FunctionDocAsset {
                                     let title = title.as_str();
                                     keys.push(title.to_lowercase());
                                 }
-                            } else if let Some(caps) = title_alias_regexp.captures(txt) {
+                            }
+                        } else if txt.starts_with("title_includes:") {
+                            stage = MarkdownStage::Title;
+
+                            if let Some(caps) = title_alias_regexp.captures(txt) {
                                 if let Some(aliases) = caps.get(1) {
                                     let aliases = aliases.as_str();
                                     let aliases =


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix doc parser. 

## Changelog

- Bug Fix

When I fix #4615, PR: #4843, 

I find that the regular expression can't match titles with spaces such as "not like", "not regexp". 

And  the regular expression also can't match multiple titles. For example, in docs/doc/30-reference/20-functions/30-datetime-functions/addinterval.md, there is a line like "title_includes: addYears, addMonths, addDays, addHours, addMinutes, addSeconds", the regular expression can't match the space between "addYears," and "addMonths", so the parse result is not right. 

## Related Issues

Fixes #4615 

