### PR TITLE
feat(planner): support more aggregate syntax

### DIFF
--- a/query/src/sql/exec/expression_builder.rs
+++ b/query/src/sql/exec/expression_builder.rs
@@ -33,6 +33,7 @@ impl<'a> ExpressionBuilder<'a> {
     pub fn build(&self, scalar: &Scalar) -> Result<Expression> {
         match scalar {
             Scalar::ColumnRef { index, .. } => self.build_column_ref(*index),
+            Scalar::Literal { data_value } => self.build_literal(data_value),
             Scalar::Equal { left, right } => {
                 self.build_binary_operator(left, right, "=".to_string())
             }
@@ -52,6 +53,10 @@ impl<'a> ExpressionBuilder<'a> {
             column.name.as_str(),
             index,
         )))
+    }
+
+    pub fn build_literal(&self, data_value: &DataValue) -> Result<Expression> {
+        Ok(Expression::create_literal(data_value.clone()))
     }
 
     pub fn build_binary_operator(

--- a/query/src/sql/planner/binder/aggregate.rs
+++ b/query/src/sql/planner/binder/aggregate.rs
@@ -1,0 +1,87 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_ast::ast::Expr;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::sql::binder::scalar::ScalarBinder;
+use crate::sql::binder::scalar_common::find_aggregate_scalars_from_bind_context;
+use crate::sql::binder::Binder;
+use crate::sql::optimizer::SExpr;
+use crate::sql::plans::AggregatePlan;
+use crate::sql::plans::Scalar;
+use crate::sql::BindContext;
+use crate::sql::ScalarExprRef;
+
+impl Binder {
+    pub(crate) fn analyze_aggregate(
+        &self,
+        output_context: &BindContext,
+        input_context: &mut BindContext,
+    ) -> Result<()> {
+        let mut agg_expr: Vec<ScalarExprRef> = Vec::new();
+        for agg_scalar in find_aggregate_scalars_from_bind_context(output_context)? {
+            match agg_scalar {
+                Scalar::AggregateFunction {
+                    func_name,
+                    distinct,
+                    params,
+                    args,
+                    data_type,
+                    nullable,
+                } => agg_expr.push(Arc::new(Scalar::AggregateFunction {
+                    func_name,
+                    distinct,
+                    params,
+                    args,
+                    data_type,
+                    nullable,
+                })),
+                _ => {
+                    return Err(ErrorCode::LogicalError(
+                        "scalar expr must be Aggregation scalar expr",
+                    ))
+                }
+            }
+        }
+        input_context.agg_scalar_exprs = Some(agg_expr);
+        Ok(())
+    }
+
+    pub(super) fn bind_group_by(
+        &mut self,
+        group_by_expr: &[Expr],
+        input_context: &mut BindContext,
+    ) -> Result<()> {
+        let scalar_binder = ScalarBinder::new();
+        let group_expr = group_by_expr
+            .iter()
+            .map(|expr| scalar_binder.bind_expr(expr, input_context))
+            .collect::<Result<Vec<ScalarExprRef>>>();
+
+        let aggregate_plan = AggregatePlan {
+            group_expr: group_expr?,
+            agg_expr: input_context.agg_scalar_exprs.as_ref().unwrap().clone(),
+        };
+        let new_expr = SExpr::create_unary(
+            aggregate_plan.into(),
+            input_context.expression.clone().unwrap(),
+        );
+        input_context.expression = Some(new_expr);
+        Ok(())
+    }
+}

--- a/query/src/sql/planner/binder/mod.rs
+++ b/query/src/sql/planner/binder/mod.rs
@@ -27,6 +27,7 @@ use crate::sql::optimizer::SExpr;
 use crate::sql::planner::metadata::Metadata;
 use crate::storages::Table;
 
+mod aggregate;
 mod bind_context;
 mod project;
 mod scalar;

--- a/query/src/sql/planner/binder/scalar.rs
+++ b/query/src/sql/planner/binder/scalar.rs
@@ -155,7 +155,11 @@ impl ScalarBinder {
 
         let scalar_binder = ScalarBinder::new();
         let mut scalar_exprs = Vec::with_capacity(args.len());
+        let mut arg_col_name = Vec::with_capacity(args.len());
         for arg in args.iter() {
+            if let Expr::ColumnRef { column, .. } = arg {
+                arg_col_name.push(column.clone().name);
+            }
             scalar_exprs.push(
                 scalar_binder
                     .bind_expr(arg, bind_context)?
@@ -170,6 +174,9 @@ impl ScalarBinder {
 
         let mut fields = Vec::with_capacity(col_bindings.len());
         for col_binding in col_bindings.iter() {
+            if !arg_col_name.contains(&col_binding.column_name) {
+                continue;
+            }
             fields.push(DataField::new(
                 col_binding.column_name.as_str(),
                 col_binding.data_type.clone(),

--- a/query/src/sql/planner/binder/scalar_visitor.rs
+++ b/query/src/sql/planner/binder/scalar_visitor.rs
@@ -55,7 +55,7 @@ pub trait ScalarVisitor: Sized {
                                     stack.push(RecursionProcessing::Call(left));
                                     stack.push(RecursionProcessing::Call(right));
                                 }
-                                Scalar::ColumnRef { .. } => {}
+                                Scalar::ColumnRef { .. } | Scalar::Literal { .. } => {}
                             };
 
                             visitor

--- a/query/src/sql/planner/binder/select.rs
+++ b/query/src/sql/planner/binder/select.rs
@@ -66,7 +66,8 @@ impl Binder {
 
         self.analyze_aggregate(&output_context, &mut input_context)?;
 
-        if !stmt.group_by.is_empty() {
+        if !input_context.agg_scalar_exprs.as_ref().unwrap().is_empty() || !stmt.group_by.is_empty()
+        {
             self.bind_group_by(&stmt.group_by, &mut input_context)?;
             output_context.expression = input_context.expression.clone();
         }

--- a/query/src/sql/planner/metadata.rs
+++ b/query/src/sql/planner/metadata.rs
@@ -162,6 +162,7 @@ impl Metadata {
                 Ok(format_field_name(column.name.as_str(), idx))
             }
             Expr::Literal(literal) => Ok(format!("{}", literal)),
+            Expr::CountAll => Ok("count()".to_string()),
             Expr::FunctionCall {
                 name,
                 distinct,

--- a/query/src/sql/planner/metadata.rs
+++ b/query/src/sql/planner/metadata.rs
@@ -167,7 +167,7 @@ impl Metadata {
                 distinct,
                 args,
                 ..
-            } => self.create_function_display_name(name.as_str(), distinct, args),
+            } => self.create_function_display_name(name.name.as_str(), distinct, args),
             _ => Err(ErrorCode::LogicalError(format!(
                 "{expr} doesn't implement get_expr_display_string"
             ))),

--- a/query/src/sql/planner/metadata.rs
+++ b/query/src/sql/planner/metadata.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use common_ast::ast::Expr;
+use common_ast::ast::Literal;
 use common_datavalues::prelude::*;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -138,10 +139,13 @@ impl Metadata {
         distinct: &bool,
         args: &[Expr],
     ) -> Result<String> {
-        let names: Vec<String> = args
-            .iter()
-            .map(|arg| self.get_expr_display_string(arg, false))
-            .collect::<Result<_>>()?;
+        let mut names = Vec::new();
+        if !optimize_remove_count_args(fun, *distinct, args) {
+            names = args
+                .iter()
+                .map(|arg| self.get_expr_display_string(arg, false))
+                .collect::<Result<Vec<String>>>()?;
+        }
         Ok(match distinct {
             true => format!("{}({}{})", fun, "distinct ", names.join(",")),
             false => format!("{}({}{})", fun, "", names.join(",")),
@@ -157,15 +161,16 @@ impl Metadata {
                 let idx = self.column_idx_by_column_name(column.name.as_str())?;
                 Ok(format_field_name(column.name.as_str(), idx))
             }
+            Expr::Literal(literal) => Ok(format!("{}", literal)),
             Expr::FunctionCall {
                 name,
                 distinct,
                 args,
                 ..
-            } => self.create_function_display_name(name.name.as_str(), distinct, args),
-            _ => Err(ErrorCode::LogicalError(
-                "{expr} doesn't implement get_expr_display_string",
-            )),
+            } => self.create_function_display_name(name.as_str(), distinct, args),
+            _ => Err(ErrorCode::LogicalError(format!(
+                "{expr} doesn't implement get_expr_display_string"
+            ))),
         }
     }
 
@@ -208,4 +213,12 @@ impl Metadata {
         }
         table_index
     }
+}
+
+pub fn optimize_remove_count_args(name: &str, distinct: bool, args: &[Expr]) -> bool {
+    name.eq_ignore_ascii_case("count")
+        && !distinct
+        && args
+            .iter()
+            .all(|expr| matches!(expr, Expr::Literal(literal) if *literal!=Literal::Null))
 }

--- a/query/src/sql/planner/plans/scalar.rs
+++ b/query/src/sql/planner/plans/scalar.rs
@@ -28,6 +28,9 @@ pub enum Scalar {
         data_type: DataTypeImpl,
         nullable: bool,
     },
+    Literal {
+        data_value: DataValue,
+    },
     Equal {
         left: Box<Scalar>,
         right: Box<Scalar>,
@@ -56,6 +59,7 @@ impl ScalarExpr for Scalar {
                 nullable,
                 ..
             } => (data_type.clone(), *nullable),
+            Scalar::Literal { data_value } => (data_value.data_type(), data_value.is_null()),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support the following syntax
- `select sum(a) from t;`
- `select count(a) from t;`
- `select count() from t`;
- `select count(1) from t`;
-  `select count(*) from t`;
- `select count() from t group by a`;
- `select count(1) from t group by a`;

## Changelog

- New Feature

## Related Issues

Fixes #issue

