### PR TITLE
chore(QueryContext): make QueryContex as the first parameter

### DIFF
--- a/query/src/api/rpc/flight_dispatcher.rs
+++ b/query/src/api/rpc/flight_dispatcher.rs
@@ -221,10 +221,10 @@ impl DatabendQueryFlightDispatcher {
         let stages_notify = self.stages_notify.clone();
 
         let flight_scatter = T::try_create(
+            query_context.clone(),
             action.get_plan().schema(),
             action.get_scatter_expression(),
             action.get_sinks().len(),
-            query_context.clone(),
         )?;
 
         query_context.try_spawn(

--- a/query/src/api/rpc/flight_scatter.rs
+++ b/query/src/api/rpc/flight_scatter.rs
@@ -22,10 +22,10 @@ use common_planners::Expression;
 use crate::sessions::QueryContext;
 pub trait FlightScatter: Sized {
     fn try_create(
+        ctx: Arc<QueryContext>,
         schema: DataSchemaRef,
         expr: Option<Expression>,
         num: usize,
-        ctx: Arc<QueryContext>,
     ) -> Result<Self>;
 
     fn execute(&self, data_block: &DataBlock) -> Result<Vec<DataBlock>>;

--- a/query/src/api/rpc/flight_scatter_broadcast.rs
+++ b/query/src/api/rpc/flight_scatter_broadcast.rs
@@ -28,10 +28,10 @@ pub struct BroadcastFlightScatter {
 
 impl FlightScatter for BroadcastFlightScatter {
     fn try_create(
+        _: Arc<QueryContext>,
         _: DataSchemaRef,
         _: Option<Expression>,
         num: usize,
-        _: Arc<QueryContext>,
     ) -> Result<Self> {
         Ok(BroadcastFlightScatter {
             scattered_size: num,

--- a/query/src/api/rpc/flight_scatter_hash.rs
+++ b/query/src/api/rpc/flight_scatter_hash.rs
@@ -32,10 +32,10 @@ pub struct HashFlightScatter {
 
 impl FlightScatter for HashFlightScatter {
     fn try_create(
+        ctx: Arc<QueryContext>,
         schema: DataSchemaRef,
         expr: Option<Expression>,
         num: usize,
-        ctx: Arc<QueryContext>,
     ) -> common_exception::Result<Self> {
         match expr {
             None => Err(ErrorCode::LogicalError(
@@ -64,7 +64,7 @@ impl HashFlightScatter {
         ctx: Arc<QueryContext>,
     ) -> Result<Self> {
         let expression = Self::expr_action(num, expr);
-        let indices_expr_executor = Self::expr_executor(schema, &expression, ctx)?;
+        let indices_expr_executor = Self::expr_executor(ctx, schema, &expression)?;
         indices_expr_executor.validate()?;
 
         Ok(HashFlightScatter {
@@ -79,17 +79,17 @@ impl HashFlightScatter {
     }
 
     fn expr_executor(
+        ctx: Arc<QueryContext>,
         schema: DataSchemaRef,
         expr: &Expression,
-        ctx: Arc<QueryContext>,
     ) -> Result<ExpressionExecutor> {
         ExpressionExecutor::try_create(
+            ctx,
             "indices expression in FlightScatterByHash",
             schema,
             Self::indices_expr_schema(&expr.column_name()),
             vec![expr.clone()],
             false,
-            ctx,
         )
     }
 

--- a/query/src/optimizers/optimizer_constant_folding.rs
+++ b/query/src/optimizers/optimizer_constant_folding.rs
@@ -81,12 +81,12 @@ impl ConstantFoldingImpl {
         let output_fields = vec![expr.to_data_field(schema)?];
         let output_schema = DataSchemaRefExt::create(output_fields);
         ExpressionExecutor::try_create(
+            ctx,
             "Constant folding optimizer.",
             schema.clone(),
             output_schema,
             vec![expr],
             false,
-            ctx,
         )
     }
 

--- a/query/src/pipelines/new/processors/transforms/transform_addon.rs
+++ b/query/src/pipelines/new/processors/transforms/transform_addon.rs
@@ -74,12 +74,12 @@ where Self: Transform
         }
         let schema_after_default_expr = Arc::new(DataSchema::new(default_expr_fields.clone()));
         let expression_executor = ExpressionExecutor::try_create(
+            ctx,
             "stream_addon",
             input_schema,
             schema_after_default_expr,
             default_exprs,
             true,
-            ctx,
         )?;
 
         Ok(Transformer::create(input, output, Self {

--- a/query/src/pipelines/new/processors/transforms/transform_expression.rs
+++ b/query/src/pipelines/new/processors/transforms/transform_expression.rs
@@ -46,12 +46,12 @@ where Self: Transform
         ctx: Arc<QueryContext>,
     ) -> Result<ProcessorPtr> {
         let executor = ExpressionExecutor::try_create(
+            ctx,
             "expression executor",
             input_schema,
             output_schema,
             exprs,
             ALIAS_PROJECT,
-            ctx,
         )?;
         executor.validate()?;
 

--- a/query/src/pipelines/new/processors/transforms/transform_filter.rs
+++ b/query/src/pipelines/new/processors/transforms/transform_filter.rs
@@ -64,12 +64,12 @@ where Self: Transform
         let expr_schema = DataSchemaRefExt::create(vec![expr_field]);
 
         ExpressionExecutor::try_create(
+            ctx,
             "filter expression executor",
             schema.clone(),
             expr_schema,
             vec![expr.clone()],
             false,
-            ctx,
         )
     }
 

--- a/query/src/pipelines/processors/pipeline_builder.rs
+++ b/query/src/pipelines/processors/pipeline_builder.rs
@@ -142,10 +142,10 @@ impl PipelineBuilder {
         let mut pipeline = self.visit(&*plan.input)?;
         pipeline.add_simple_transform(|| {
             Ok(Box::new(ExpressionTransform::try_create(
+                self.ctx.clone(),
                 plan.input.schema(),
                 plan.schema.clone(),
                 plan.exprs.clone(),
-                self.ctx.clone(),
             )?))
         })?;
         Ok(pipeline)
@@ -220,9 +220,9 @@ impl PipelineBuilder {
         let mut pipeline = self.visit(&*node.input)?;
         pipeline.add_simple_transform(|| {
             Ok(Box::new(WhereTransform::try_create(
+                self.ctx.clone(),
                 node.schema(),
                 node.predicate.clone(),
-                self.ctx.clone(),
             )?))
         })?;
         Ok(pipeline)
@@ -232,9 +232,9 @@ impl PipelineBuilder {
         let mut pipeline = self.visit(&*node.input)?;
         pipeline.add_simple_transform(|| {
             Ok(Box::new(HavingTransform::try_create(
+                self.ctx.clone(),
                 node.schema(),
                 node.predicate.clone(),
-                self.ctx.clone(),
             )?))
         })?;
         Ok(pipeline)

--- a/query/src/pipelines/transforms/streams/stream_addon.rs
+++ b/query/src/pipelines/transforms/streams/stream_addon.rs
@@ -75,12 +75,12 @@ impl AddOnStream {
 
         let schema_after_default_expr = Arc::new(DataSchema::new(default_expr_fields.clone()));
         let expression_executor = ExpressionExecutor::try_create(
+            ctx,
             "stream_addon",
             input_schema,
             schema_after_default_expr,
             default_exprs,
             true,
-            ctx,
         )?;
 
         Ok(AddOnStream {

--- a/query/src/pipelines/transforms/transform_expression.rs
+++ b/query/src/pipelines/transforms/transform_expression.rs
@@ -48,18 +48,18 @@ pub struct ExpressionTransform {
 
 impl ExpressionTransform {
     pub fn try_create(
+        ctx: Arc<QueryContext>,
         input_schema: DataSchemaRef,
         output_schema: DataSchemaRef,
         exprs: Vec<Expression>,
-        ctx: Arc<QueryContext>,
     ) -> Result<Self> {
         let executor = ExpressionExecutor::try_create(
+            ctx,
             "expression executor",
             input_schema,
             output_schema,
             exprs,
             false,
-            ctx,
         )?;
         executor.validate()?;
 

--- a/query/src/pipelines/transforms/transform_expression_executor.rs
+++ b/query/src/pipelines/transforms/transform_expression_executor.rs
@@ -44,12 +44,12 @@ pub struct ExpressionExecutor {
 
 impl ExpressionExecutor {
     pub fn try_create(
+        ctx: Arc<QueryContext>,
         description: &str,
         input_schema: DataSchemaRef,
         output_schema: DataSchemaRef,
         exprs: Vec<Expression>,
         alias_project: bool,
-        ctx: Arc<QueryContext>,
     ) -> Result<Self> {
         let chain = ExpressionChain::try_create(input_schema.clone(), &exprs)?;
 

--- a/query/src/pipelines/transforms/transform_filter.rs
+++ b/query/src/pipelines/transforms/transform_filter.rs
@@ -41,9 +41,9 @@ pub struct FilterTransform<const HAVING: bool> {
 
 impl<const HAVING: bool> FilterTransform<HAVING> {
     pub fn try_create(
+        ctx: Arc<QueryContext>,
         schema: DataSchemaRef,
         predicate: Expression,
-        ctx: Arc<QueryContext>,
     ) -> Result<Self> {
         let predicate_executor = Self::expr_executor(&schema, &predicate, ctx)?;
         predicate_executor.validate()?;
@@ -64,12 +64,12 @@ impl<const HAVING: bool> FilterTransform<HAVING> {
         let expr_schema = DataSchemaRefExt::create(vec![expr_field]);
 
         ExpressionExecutor::try_create(
+            ctx,
             "filter expression executor",
             schema.clone(),
             expr_schema,
             vec![expr.clone()],
             false,
-            ctx,
         )
     }
 

--- a/query/src/pipelines/transforms/transform_projection.rs
+++ b/query/src/pipelines/transforms/transform_projection.rs
@@ -42,12 +42,12 @@ impl ProjectionTransform {
         ctx: Arc<QueryContext>,
     ) -> Result<Self> {
         let executor = ExpressionExecutor::try_create(
+            ctx,
             "projection executor",
             input_schema,
             output_schema,
             exprs,
             true,
-            ctx,
         )?;
 
         Ok(ProjectionTransform {

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -66,7 +66,7 @@ pub(crate) struct ExecuteRunning {
     // used to kill query
     session: SessionRef,
     // mainly used to get progress for now
-    context: Arc<QueryContext>,
+    ctx: Arc<QueryContext>,
     interpreter: Arc<dyn Interpreter>,
 }
 
@@ -84,7 +84,7 @@ pub(crate) struct Executor {
 impl Executor {
     pub(crate) fn get_progress(&self) -> Option<ProgressValues> {
         match &self.state {
-            Running(r) => Some(r.context.get_scan_progress_value()),
+            Running(r) => Some(r.ctx.get_scan_progress_value()),
             Stopped(f) => f.progress.clone(),
         }
     }
@@ -100,7 +100,7 @@ impl Executor {
         let mut guard = this.write().await;
         if let Running(r) = &guard.state {
             // release session
-            let progress = Some(r.context.get_scan_progress_value());
+            let progress = Some(r.ctx.get_scan_progress_value());
             if kill {
                 r.session.force_kill_query();
             }
@@ -173,7 +173,7 @@ impl ExecuteState {
 
         let running_state = ExecuteRunning {
             session,
-            context: ctx.clone(),
+            ctx: ctx.clone(),
             interpreter: interpreter.clone(),
         };
         let executor = Arc::new(RwLock::new(Executor {

--- a/query/src/sql/planner/binder/mod.rs
+++ b/query/src/sql/planner/binder/mod.rs
@@ -43,17 +43,17 @@ mod select;
 /// - Validate expressions
 /// - Build `Metadata`
 pub struct Binder {
+    ctx: Arc<QueryContext>,
     catalog: Arc<dyn Catalog>,
     metadata: Metadata,
-    context: Arc<QueryContext>,
 }
 
 impl Binder {
-    pub fn new(catalog: Arc<dyn Catalog>, context: Arc<QueryContext>) -> Self {
+    pub fn new(ctx: Arc<QueryContext>, catalog: Arc<dyn Catalog>) -> Self {
         Binder {
+            ctx,
             catalog,
             metadata: Metadata::create(),
-            context,
         }
     }
 

--- a/query/src/sql/planner/binder/select.rs
+++ b/query/src/sql/planner/binder/select.rs
@@ -82,19 +82,18 @@ impl Binder {
                 let database = database
                     .as_ref()
                     .map(|ident| ident.name.clone())
-                    .unwrap_or_else(|| self.context.get_current_database());
+                    .unwrap_or_else(|| self.ctx.get_current_database());
                 let table = table.name.clone();
                 // TODO: simply normalize table name to lower case, maybe use a more reasonable way
                 let table = table.to_lowercase();
-                let tenant = self.context.get_tenant();
+                let tenant = self.ctx.get_tenant();
 
                 // Resolve table with catalog
                 let table_meta: Arc<dyn Table> = self
                     .resolve_data_source(tenant.as_str(), database.as_str(), table.as_str())
                     .await?;
-                let (statistics, parts) = table_meta
-                    .read_partitions(self.context.clone(), None)
-                    .await?;
+                let (statistics, parts) =
+                    table_meta.read_partitions(self.ctx.clone(), None).await?;
                 let source = ReadDataSourcePlan {
                     source_info: SourceInfo::TableSource(table_meta.get_table_info().clone()),
                     scan_fields: None,

--- a/query/src/sql/planner/mod.rs
+++ b/query/src/sql/planner/mod.rs
@@ -39,12 +39,12 @@ pub use metadata::TableEntry;
 use crate::pipelines::new::NewPipeline;
 
 pub struct Planner {
-    context: Arc<QueryContext>,
+    ctx: Arc<QueryContext>,
 }
 
 impl Planner {
-    pub fn new(context: Arc<QueryContext>) -> Self {
-        Planner { context }
+    pub fn new(ctx: Arc<QueryContext>) -> Self {
+        Planner { ctx }
     }
 
     pub async fn plan_sql<'a>(&mut self, sql: &'a str) -> Result<NewPipeline> {
@@ -56,7 +56,7 @@ impl Planner {
         }
 
         // Step 2: bind AST with catalog, and generate a pure logical SExpr
-        let binder = Binder::new(self.context.get_catalog(), self.context.clone());
+        let binder = Binder::new(self.ctx.clone(), self.ctx.get_catalog());
         let bind_result = binder.bind(&stmts[0]).await?;
 
         // Step 3: optimize the SExpr with optimizers, and generate optimized physical SExpr
@@ -66,7 +66,7 @@ impl Planner {
         // Step 4: build executable Pipeline with SExpr
         let result_columns = bind_result.bind_context.result_columns();
         let pb = PipelineBuilder::new(
-            self.context.clone(),
+            self.ctx.clone(),
             result_columns,
             bind_result.metadata,
             optimized_expr,

--- a/query/src/sql/statements/value_source.rs
+++ b/query/src/sql/statements/value_source.rs
@@ -236,12 +236,12 @@ async fn exprs_to_datavalue(
     let dummy = DataSchemaRefExt::create(vec![DataField::new("dummy", u8::to_data_type())]);
     let one_row_block = DataBlock::create(dummy.clone(), vec![Series::from_data(vec![1u8])]);
     let executor = ExpressionExecutor::try_create(
+        ctx,
         "Insert into from values",
         dummy,
         schema.clone(),
         expressions,
         true,
-        ctx,
     )?;
 
     let res = executor.execute(&one_row_block)?;

--- a/query/src/storages/fuse/operations/optimize.rs
+++ b/query/src/storages/fuse/operations/optimize.rs
@@ -74,10 +74,10 @@ impl FuseTable {
 
         // blocks to be removed
         let prev_blocks: HashSet<String> = self
-            .blocks_of(seg_delta.iter().map(|i| **i), ctx.clone())
+            .blocks_of(ctx.clone(), seg_delta.iter().map(|i| **i))
             .await?;
         let current_blocks: HashSet<String> = self
-            .blocks_of(current_segments.iter().copied(), ctx.clone())
+            .blocks_of(ctx.clone(), current_segments.iter().copied())
             .await?;
         let block_delta = prev_blocks.difference(&current_blocks);
 
@@ -113,9 +113,9 @@ impl FuseTable {
 
     async fn blocks_of(
         &self,
+        ctx: Arc<QueryContext>,
         //locations: impl Iterator<Item = impl AsRef<Location>>,
         locations: impl Iterator<Item = &Location>,
-        ctx: Arc<QueryContext>,
     ) -> Result<HashSet<String>> {
         let mut result = HashSet::new();
         let reader = MetaReaders::segment_info_reader(ctx.as_ref());

--- a/query/src/storages/fuse/operations/read_partitions.rs
+++ b/query/src/storages/fuse/operations/read_partitions.rs
@@ -45,7 +45,7 @@ impl FuseTable {
                 }
                 let schema = self.table_info.schema();
                 let block_metas = BlockPruner::new(snapshot.clone())
-                    .apply(schema, &push_downs, ctx.as_ref())
+                    .apply(ctx.as_ref(), schema, &push_downs)
                     .await?;
 
                 let partitions_scanned = block_metas.len();

--- a/query/src/storages/fuse/pruning/block_pruner.rs
+++ b/query/src/storages/fuse/pruning/block_pruner.rs
@@ -45,15 +45,15 @@ impl BlockPruner {
     #[tracing::instrument(level = "debug", name="block_pruner_apply", skip(self, schema, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     pub async fn apply(
         &self,
+        ctx: &QueryContext,
         schema: DataSchemaRef,
         push_down: &Option<Extras>,
-        ctx: &QueryContext,
     ) -> Result<Vec<BlockMeta>> {
         let block_pred: Pred = match push_down {
             Some(exprs) if !exprs.filters.is_empty() => {
                 // for the time being, we only handle the first expr
                 let verifiable_expression =
-                    RangeFilter::try_create(&exprs.filters[0], schema, Arc::new(ctx.clone()))?;
+                    RangeFilter::try_create(Arc::new(ctx.clone()), &exprs.filters[0], schema)?;
                 Box::new(move |v: &BlockStatistics| verifiable_expression.eval(v))
             }
             _ => Box::new(|_: &BlockStatistics| Ok(true)),

--- a/query/src/storages/index/bloom_filter.rs
+++ b/query/src/storages/index/bloom_filter.rs
@@ -105,7 +105,7 @@ impl BloomFilterIndexer {
     ///
     /// All input blocks should be belong to a Parquet file, e.g. the block array represents the parquet file in memory.
     #[allow(dead_code)]
-    pub fn try_create(source_data_blocks: &[DataBlock], ctx: Arc<QueryContext>) -> Result<Self> {
+    pub fn try_create(ctx: Arc<QueryContext>, source_data_blocks: &[DataBlock]) -> Result<Self> {
         let seed = Self::create_seed();
         Self::try_create_with_seed(source_data_blocks, seed, ctx)
     }
@@ -513,12 +513,12 @@ impl BloomFilter {
             Box::new(Expression::create_scalar_function("city64WithSeed", args)),
         );
         let expr_executor = ExpressionExecutor::try_create(
+            ctx,
             "calculate cityhash64",
             input_schema.clone(),
             output_schema,
             vec![expr],
             true,
-            ctx,
         )?;
 
         let data_block = DataBlock::create(input_schema, vec![column.clone()]);

--- a/query/src/storages/index/range_filter.rs
+++ b/query/src/storages/index/range_filter.rs
@@ -53,9 +53,9 @@ pub struct RangeFilter {
 
 impl RangeFilter {
     pub fn try_create(
+        ctx: Arc<QueryContext>,
         expr: &Expression,
         schema: DataSchemaRef,
-        ctx: Arc<QueryContext>,
     ) -> Result<Self> {
         let mut stat_columns: StatColumns = Vec::new();
         let verifiable_expr = build_verifiable_expr(expr, &schema, &mut stat_columns);
@@ -68,12 +68,12 @@ impl RangeFilter {
         let output_fields = vec![verifiable_expr.to_data_field(&input_schema)?];
         let output_schema = DataSchemaRefExt::create(output_fields);
         let expr_executor = ExpressionExecutor::try_create(
+            ctx,
             "verifiable expression executor in RangeFilter",
             input_schema.clone(),
             output_schema,
             vec![verifiable_expr],
             false,
-            ctx,
         )?;
 
         Ok(Self {

--- a/query/src/storages/system/table.rs
+++ b/query/src/storages/system/table.rs
@@ -107,9 +107,9 @@ impl<TTable: 'static + SyncSystemTable> Table for SyncOneBlockSystemTable<TTable
         let inner_table = self.inner_table.clone();
         pipeline.add_pipe(NewPipe::SimplePipe {
             processors: vec![SystemTableSyncSource::create(
+                ctx,
                 output.clone(),
                 inner_table,
-                ctx,
             )?],
             inputs_port: vec![],
             outputs_port: vec![output],
@@ -129,13 +129,13 @@ impl<TTable: 'static + SyncSystemTable> SystemTableSyncSource<TTable>
 where Self: SyncSource
 {
     pub fn create(
+        ctx: Arc<QueryContext>,
         output: Arc<OutputPort>,
         inner: Arc<TTable>,
-        context: Arc<QueryContext>,
     ) -> Result<ProcessorPtr> {
-        SyncSourcer::create(context.clone(), output, SystemTableSyncSource::<TTable> {
+        SyncSourcer::create(ctx.clone(), output, SystemTableSyncSource::<TTable> {
             inner,
-            context,
+            context: ctx,
             finished: false,
         })
     }

--- a/query/tests/it/pipelines/transforms/transform_expression.rs
+++ b/query/tests/it/pipelines/transforms/transform_expression.rs
@@ -43,10 +43,10 @@ async fn test_transform_expression() -> Result<()> {
         let ctx = create_query_context().await?;
         pipeline.add_simple_transform(move || {
             Ok(Box::new(ExpressionTransform::try_create(
+                ctx.clone(),
                 plan.input.schema(),
                 plan.schema.clone(),
                 plan.exprs.clone(),
-                ctx.clone(),
             )?))
         })?;
     }

--- a/query/tests/it/pipelines/transforms/transform_filter.rs
+++ b/query/tests/it/pipelines/transforms/transform_filter.rs
@@ -41,9 +41,9 @@ async fn test_transform_filter() -> Result<()> {
         let ctx = create_query_context().await?;
         pipeline.add_simple_transform(|| {
             Ok(Box::new(WhereTransform::try_create(
+                ctx.clone(),
                 plan.input.schema(),
                 plan.predicate.clone(),
-                ctx.clone(),
             )?))
         })?;
     }

--- a/query/tests/it/pipelines/transforms/transform_limit_by.rs
+++ b/query/tests/it/pipelines/transforms/transform_limit_by.rs
@@ -44,10 +44,10 @@ async fn test_transform_limit_by() -> Result<()> {
         let ctx = create_query_context().await?;
         pipeline.add_simple_transform(|| {
             Ok(Box::new(ExpressionTransform::try_create(
+                ctx.clone(),
                 plan.input.schema(),
                 plan.schema.clone(),
                 plan.exprs.clone(),
-                ctx.clone(),
             )?))
         })?;
 

--- a/query/tests/it/pipelines/transforms/transform_projection.rs
+++ b/query/tests/it/pipelines/transforms/transform_projection.rs
@@ -40,10 +40,10 @@ async fn test_transform_projection() -> Result<()> {
         let ctx = create_query_context().await?;
         pipeline.add_simple_transform(|| {
             Ok(Box::new(ExpressionTransform::try_create(
+                ctx.clone(),
                 plan.input.schema(),
                 plan.schema.clone(),
                 plan.expr.clone(),
-                ctx.clone(),
             )?))
         })?;
         pipeline.add_simple_transform(|| {

--- a/query/tests/it/storages/fuse/pruning.rs
+++ b/query/tests/it/storages/fuse/pruning.rs
@@ -48,7 +48,7 @@ async fn apply_block_pruning(
     ctx: Arc<QueryContext>,
 ) -> Result<Vec<BlockMeta>> {
     BlockPruner::new(table_snapshot)
-        .apply(schema, push_down, ctx.as_ref())
+        .apply(ctx.as_ref(), schema, push_down)
         .await
 }
 

--- a/query/tests/it/storages/index/range_filter.rs
+++ b/query/tests/it/storages/index/range_filter.rs
@@ -173,7 +173,7 @@ async fn test_range_filter() -> Result<()> {
 
     let ctx = create_query_context().await?;
     for test in tests {
-        let prune = RangeFilter::try_create(&test.expr, schema.clone(), ctx.clone())?;
+        let prune = RangeFilter::try_create(ctx.clone(), &test.expr, schema.clone())?;
 
         match prune.eval(&stats) {
             Ok(actual) => assert_eq!(test.expect, actual, "{:#?}", test.name),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Make QueryContex as the first parameter
* Rename `context` to `ctx` in sql

## Changelog

- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

