### PR TITLE
feat(planner): Support `TableFunction` in new planner

### DIFF
--- a/common/ast/src/ast/query.rs
+++ b/common/ast/src/ast/query.rs
@@ -126,7 +126,7 @@ pub enum TableReference {
         alias: Option<TableAlias>,
     },
     // `TABLE(expr)[ AS alias ]`
-    SetReturningFunction {
+    TableFunction {
         name: Identifier,
         params: Vec<Expr>,
         alias: Option<TableAlias>,
@@ -219,7 +219,7 @@ impl Display for TableReference {
                     write!(f, " AS {alias}")?;
                 }
             }
-            TableReference::SetReturningFunction {
+            TableReference::TableFunction {
                 name,
                 params,
                 alias,

--- a/common/ast/src/parser/query.rs
+++ b/common/ast/src/parser/query.rs
@@ -118,7 +118,7 @@ pub fn table_reference(i: Input) -> IResult<TableReference> {
         #joined_tables
         | #parenthesized_joined_tables
         | #subquery
-        | #set_returning_function
+        | #table_function
         | #aliased_table
     )(i)
 }
@@ -153,7 +153,7 @@ pub fn table_alias(i: Input) -> IResult<TableAlias> {
     )(i)
 }
 
-pub fn set_returning_function(i: Input) -> IResult<TableReference> {
+pub fn table_function(i: Input) -> IResult<TableReference> {
     map(
         rule! {
             #ident ~ "(" ~ #comma_separated_list0(expr) ~ ")" ~ #table_alias?
@@ -207,7 +207,7 @@ pub fn joined_tables(i: Input) -> IResult<TableReference> {
         rule!(
             #parenthesized_joined_tables
             | #subquery
-            | #set_returning_function
+            | #table_function
             | #aliased_table
         )(i)
     };

--- a/common/ast/src/parser/query.rs
+++ b/common/ast/src/parser/query.rs
@@ -114,7 +114,7 @@ pub fn select_target(i: Input) -> IResult<SelectTarget> {
 }
 
 pub fn table_reference(i: Input) -> IResult<TableReference> {
-    rule! (
+    rule!(
         #joined_tables
         | #parenthesized_joined_tables
         | #subquery
@@ -158,7 +158,7 @@ pub fn set_returning_function(i: Input) -> IResult<TableReference> {
         rule! {
             #ident ~ "(" ~ #comma_separated_list0(expr) ~ ")" ~ #table_alias?
         },
-        |(name, _, params, _, alias)| TableReference::SetReturningFunction {
+        |(name, _, params, _, alias)| TableReference::TableFunction {
             name,
             params,
             alias,
@@ -204,7 +204,7 @@ pub fn joined_tables(i: Input) -> IResult<TableReference> {
     }
 
     let table_ref_without_join = |i| {
-        rule! (
+        rule!(
             #parenthesized_joined_tables
             | #subquery
             | #set_returning_function

--- a/query/src/sql/exec/mod.rs
+++ b/query/src/sql/exec/mod.rs
@@ -216,6 +216,7 @@ impl PipelineBuilder {
         let table = self.ctx.build_table_from_source_plan(&plan)?;
         self.ctx.try_set_partitions(plan.parts.clone())?;
         table.read2(self.ctx.clone(), &plan, &mut self.pipeline)?;
+
         let columns: Vec<IndexType> = scan.columns.iter().cloned().collect();
         let projections: Vec<Expression> = columns
             .iter()

--- a/query/src/sql/planner/binder/mod.rs
+++ b/query/src/sql/planner/binder/mod.rs
@@ -58,14 +58,19 @@ impl Binder {
     }
 
     pub async fn bind<'a>(mut self, stmt: &Statement<'a>) -> Result<BindResult> {
-        let bind_context = self.bind_statement(stmt).await?;
+        let init_bind_context = BindContext::create();
+        let bind_context = self.bind_statement(stmt, &init_bind_context).await?;
         Ok(BindResult::create(bind_context, self.metadata))
     }
 
-    async fn bind_statement<'a>(&mut self, stmt: &Statement<'a>) -> Result<BindContext> {
+    async fn bind_statement<'a>(
+        &mut self,
+        stmt: &Statement<'a>,
+        bind_context: &BindContext,
+    ) -> Result<BindContext> {
         match stmt {
             Statement::Query(query) => {
-                let bind_context = self.bind_query(query).await?;
+                let bind_context = self.bind_query(query, bind_context).await?;
                 Ok(bind_context)
             }
             _ => todo!(),

--- a/query/src/sql/planner/binder/scalar.rs
+++ b/query/src/sql/planner/binder/scalar.rs
@@ -205,7 +205,7 @@ impl ScalarBinder {
 
 pub type ScalarExprRef = Arc<dyn ScalarExpr>;
 
-pub trait ScalarExpr: Any {
+pub trait ScalarExpr: Any + Sync + Send {
     /// Get return type and nullability
     fn data_type(&self) -> (DataTypeImpl, bool);
 

--- a/query/src/sql/planner/binder/select.rs
+++ b/query/src/sql/planner/binder/select.rs
@@ -23,8 +23,6 @@ use common_ast::ast::TableReference;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::Expression;
-use common_planners::ReadDataSourcePlan;
-use common_planners::SourceInfo;
 
 use crate::sql::optimizer::SExpr;
 use crate::sql::planner::binder::scalar::ScalarBinder;
@@ -48,7 +46,7 @@ impl Binder {
         bind_context: &BindContext,
     ) -> Result<BindContext> {
         match &query.body {
-            SetExpr::Select(stmt) => self.bind_select_stmt(stmt, &bind_context).await,
+            SetExpr::Select(stmt) => self.bind_select_stmt(stmt, bind_context).await,
             SetExpr::Query(stmt) => self.bind_query(stmt, bind_context).await,
             _ => todo!(),
         }
@@ -161,7 +159,7 @@ impl Binder {
 
                 let mut result = self.bind_base_table(table_index).await?;
                 if let Some(alias) = alias {
-                    result.apply_table_alias(&table.name(), alias)?;
+                    result.apply_table_alias(table.name(), alias)?;
                 }
                 Ok(result)
             }

--- a/query/src/sql/planner/binder/select.rs
+++ b/query/src/sql/planner/binder/select.rs
@@ -20,7 +20,9 @@ use common_ast::ast::Query;
 use common_ast::ast::SelectStmt;
 use common_ast::ast::SetExpr;
 use common_ast::ast::TableReference;
+use common_exception::ErrorCode;
 use common_exception::Result;
+use common_planners::Expression;
 use common_planners::ReadDataSourcePlan;
 use common_planners::SourceInfo;
 
@@ -31,23 +33,35 @@ use crate::sql::planner::binder::Binder;
 use crate::sql::planner::binder::ColumnBinding;
 use crate::sql::plans::FilterPlan;
 use crate::sql::plans::LogicalGet;
+use crate::sql::plans::Scalar;
 use crate::sql::IndexType;
+use crate::sql::ScalarExprRef;
 use crate::storages::Table;
+use crate::storages::ToReadDataSourcePlan;
+use crate::table_functions::TableFunction;
 
 impl Binder {
     #[async_recursion]
-    pub(super) async fn bind_query(&mut self, query: &Query) -> Result<BindContext> {
+    pub(super) async fn bind_query(
+        &mut self,
+        query: &Query,
+        bind_context: &BindContext,
+    ) -> Result<BindContext> {
         match &query.body {
-            SetExpr::Select(stmt) => self.bind_select_stmt(stmt).await,
-            SetExpr::Query(stmt) => self.bind_query(stmt).await,
+            SetExpr::Select(stmt) => self.bind_select_stmt(stmt, &bind_context).await,
+            SetExpr::Query(stmt) => self.bind_query(stmt, bind_context).await,
             _ => todo!(),
         }
         // TODO: support ORDER BY
     }
 
-    pub(super) async fn bind_select_stmt(&mut self, stmt: &SelectStmt) -> Result<BindContext> {
+    pub(super) async fn bind_select_stmt(
+        &mut self,
+        stmt: &SelectStmt,
+        bind_context: &BindContext,
+    ) -> Result<BindContext> {
         let mut input_context = if let Some(from) = &stmt.from {
-            self.bind_table_reference(from).await?
+            self.bind_table_reference(from, bind_context).await?
         } else {
             BindContext::create()
         };
@@ -72,7 +86,11 @@ impl Binder {
         Ok(output_context)
     }
 
-    async fn bind_table_reference(&mut self, stmt: &TableReference) -> Result<BindContext> {
+    async fn bind_table_reference(
+        &mut self,
+        stmt: &TableReference,
+        bind_context: &BindContext,
+    ) -> Result<BindContext> {
         match stmt {
             TableReference::Table {
                 database,
@@ -92,22 +110,58 @@ impl Binder {
                 let table_meta: Arc<dyn Table> = self
                     .resolve_data_source(tenant.as_str(), database.as_str(), table.as_str())
                     .await?;
-                let (statistics, parts) =
-                    table_meta.read_partitions(self.ctx.clone(), None).await?;
-                let source = ReadDataSourcePlan {
-                    source_info: SourceInfo::TableSource(table_meta.get_table_info().clone()),
-                    scan_fields: None,
-                    parts,
-                    statistics,
-                    description: format!("read source from table {table}"),
-                    tbl_args: None,
-                    push_downs: None,
-                };
+                let source = table_meta.read_plan(self.ctx.clone(), None).await?;
                 let table_index = self.metadata.add_table(database, table_meta, source);
 
                 let mut result = self.bind_base_table(table_index).await?;
                 if let Some(alias) = alias {
                     result.apply_table_alias(&table, alias)?;
+                }
+                Ok(result)
+            }
+            TableReference::TableFunction {
+                name,
+                params,
+                alias,
+            } => {
+                let scalar_binder = ScalarBinder::new();
+                let args = params
+                    .iter()
+                    .map(|arg| scalar_binder.bind_expr(arg, bind_context))
+                    .collect::<Result<Vec<ScalarExprRef>>>()?;
+                let expressions = args
+                    .into_iter()
+                    .map(|scalar| {
+                        let scalar = scalar.as_any().downcast_ref::<Scalar>().unwrap();
+                        match scalar {
+                            Scalar::Literal { data_value } => Ok(Expression::Literal {
+                                value: data_value.clone(),
+                                column_name: None,
+                                data_type: data_value.data_type(),
+                            }),
+                            _ => Err(ErrorCode::UnImplement(format!(
+                                "Unsupported table argument type: {:?}",
+                                scalar
+                            ))),
+                        }
+                    })
+                    .collect::<Result<Vec<Expression>>>()?;
+
+                let table_args = Some(expressions);
+
+                let table_meta: Arc<dyn TableFunction> = self
+                    .catalog
+                    .get_table_function(name.name.as_str(), table_args)?;
+                let table = table_meta.as_table();
+
+                let source = table.read_plan(self.ctx.clone(), None).await?;
+                let table_index =
+                    self.metadata
+                        .add_table("system".to_string(), table.clone(), source);
+
+                let mut result = self.bind_base_table(table_index).await?;
+                if let Some(alias) = alias {
+                    result.apply_table_alias(&table.name(), alias)?;
                 }
                 Ok(result)
             }

--- a/query/src/sql/planner/plans/scalar.rs
+++ b/query/src/sql/planner/plans/scalar.rs
@@ -21,7 +21,7 @@ use common_datavalues::DataValue;
 use crate::sql::planner::binder::ScalarExpr;
 use crate::sql::IndexType;
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Scalar {
     ColumnRef {
         index: IndexType,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
Support `TableFunction`s in new planner, e.g. `numbers`.

## Changelog

- New Feature

## Related Issues

Fixes #5134 

