### PR TITLE
Bump version of dependencies `arrow2` and `parquet2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,8 +131,8 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.10.1"
-source = "git+https://github.com/datafuse-extras/arrow2?rev=36b0824#36b08249dd03c8b8f88f454158fcf3401c647a49"
+version = "0.11.1"
+source = "git+https://github.com/datafuse-extras/arrow2?rev=2d70fbf46fd37f4ef532945c588be69a71998e44#2d70fbf46fd37f4ef532945c588be69a71998e44"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -4303,8 +4303,8 @@ dependencies = [
 
 [[package]]
 name = "parquet2"
-version = "0.10.3"
-source = "git+https://github.com/datafuse-extras/parquet2?rev=daae989#daae98961c5b6243465f176518d849d9297fdb74"
+version = "0.12.0"
+source = "git+https://github.com/datafuse-extras/parquet2?rev=03c108b#03c108bfcae58a6ba2b6a54132888dea964b3950"
 dependencies = [
  "async-stream",
  "bitpacking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,5 +67,5 @@ object = { opt-level = 3 }
 rustc-demangle = { opt-level = 3 }
 
 [patch.crates-io]
-parquet2 = { version = "0.10", optional = true, git = "https://github.com/datafuse-extras/parquet2", rev = "daae989" }
+parquet2 = { version = "0.12", optional = true, git = "https://github.com/datafuse-extras/parquet2", rev = "03c108b" }
 chrono = { git = "https://github.com/datafuse-extras/chrono", rev = "279f590" }

--- a/common/arrow/Cargo.toml
+++ b/common/arrow/Cargo.toml
@@ -31,11 +31,11 @@ simd = ["arrow/simd"]
 arrow = { package = "arrow2", git = "https://github.com/datafuse-extras/arrow2", default-features = false, features = [
     "io_parquet",
     "io_parquet_compression",
-], rev = "36b0824" }
+], rev = "2d70fbf46fd37f4ef532945c588be69a71998e44" }
 
 # Crates.io dependencies
 arrow-format = { version = "0.4.0", features = ["flight-data", "flight-service", "ipc"] }
 futures = "0.3.21"
-parquet2 = { version = "0.10.3", default_features = false }
+parquet2 = { version = "0.12", default_features = false }
 
 [dev-dependencies]

--- a/common/arrow/src/parquet_read.rs
+++ b/common/arrow/src/parquet_read.rs
@@ -29,7 +29,7 @@ fn get_field_columns<'a>(
 ) -> Vec<&'a ColumnChunkMetaData> {
     columns
         .iter()
-        .filter(|x| x.descriptor().path_in_schema()[0] == field_name)
+        .filter(|x| x.descriptor().path_in_schema[0] == field_name)
         .collect()
 }
 

--- a/common/arrow/src/parquet_write.rs
+++ b/common/arrow/src/parquet_write.rs
@@ -44,9 +44,8 @@ where
 
     file_writer.start()?;
     for group in row_groups {
-        let (group, len) = group?;
-        file_writer.write(group, len)?;
+        file_writer.write(group?)?;
     }
-    let (size, _writer, file_meta_data) = file_writer.end_ext(None)?;
+    let (size, file_meta_data) = file_writer.end_ext(None)?;
     Ok((size, file_meta_data))
 }

--- a/common/streams/tests/it/sources/source_parquet.rs
+++ b/common/streams/tests/it/sources/source_parquet.rs
@@ -14,6 +14,10 @@
 
 use std::fs::File;
 
+use common_arrow::arrow::io::parquet::write::RowGroupIterator;
+use common_arrow::arrow::io::parquet::write::Version;
+use common_arrow::arrow::io::parquet::write::WriteOptions;
+use common_arrow::parquet::compression::CompressionOptions;
 use common_base::tokio;
 use common_datablocks::assert_blocks_eq;
 use common_datablocks::DataBlock;
@@ -36,10 +40,9 @@ async fn test_source_parquet() -> Result<()> {
 
     let arrow_schema = schema.to_arrow();
 
-    use common_arrow::arrow::io::parquet::write::*;
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Lz4Raw,
+        compression: CompressionOptions::Lz4Raw,
         version: Version::V2,
     };
 
@@ -58,6 +61,12 @@ async fn test_source_parquet() -> Result<()> {
     let name = "test-parquet";
     let dir = tempfile::tempdir().unwrap();
 
+    use common_arrow::parquet::write::WriteOptions as FileWriteOption;
+    let file_options = FileWriteOption {
+        write_statistics: false,
+        version: Version::V2,
+    };
+
     // write test parquet
     // write test parquet
     let (len, _file_meta) = {
@@ -66,7 +75,7 @@ async fn test_source_parquet() -> Result<()> {
         let path = dir.path().join(name);
         let mut writer = File::create(path).unwrap();
 
-        common_arrow::write_parquet_file(&mut writer, row_groups, arrow_schema, options)
+        common_arrow::write_parquet_file(&mut writer, row_groups, arrow_schema, file_options)
             .map_err(|e| ErrorCode::ParquetError(e.to_string()))?
     };
 

--- a/query/src/storages/fuse/io/read/block_reader.rs
+++ b/query/src/storages/fuse/io/read/block_reader.rs
@@ -24,7 +24,8 @@ use common_arrow::parquet::compression::Compression as ParquetCompression;
 use common_arrow::parquet::metadata::ColumnDescriptor;
 use common_arrow::parquet::metadata::SchemaDescriptor;
 use common_arrow::parquet::read::BasicDecompressor;
-use common_arrow::parquet::read::PageIterator;
+use common_arrow::parquet::read::PageMetaData;
+use common_arrow::parquet::read::PageReader;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
@@ -75,24 +76,28 @@ impl BlockReader {
         meta: &ColumnMeta,
         chunk: Vec<u8>,
         rows: usize,
-        descriptor: &ColumnDescriptor,
+        column_descriptor: &ColumnDescriptor,
         field: Field,
         compression: &Compression,
     ) -> Result<ArrayIter<'static>> {
-        let pages = PageIterator::new(
+        let page_meta_data = PageMetaData {
+            column_start: meta.offset,
+            num_values: meta.num_values as i64,
+            compression: Self::to_parquet_compression(compression),
+            descriptor: column_descriptor.descriptor.clone(),
+        };
+        let pages = PageReader::new_with_page_meta(
             std::io::Cursor::new(chunk),
-            meta.num_values as i64,
-            Self::to_parquet_compression(compression),
-            descriptor.clone(),
+            page_meta_data,
             Arc::new(|_, _| true),
             vec![],
         );
 
-        let descriptor_type = descriptor.type_();
+        let primitive_type = &column_descriptor.descriptor.primitive_type;
         let decompressor = BasicDecompressor::new(pages, vec![]);
         Ok(column_iter_to_arrays(
             vec![decompressor],
-            vec![descriptor_type],
+            vec![primitive_type],
             field,
             rows,
         )?)
@@ -131,7 +136,7 @@ impl BlockReader {
         for (i, column_chunk) in chunks.into_iter().enumerate() {
             let idx = *col_idx[i];
             let field = self.arrow_schema.fields[idx].clone();
-            let column_descriptor = self.parquet_schema_descriptor.column(idx);
+            let column_descriptor = &self.parquet_schema_descriptor.columns()[idx];
             let column_meta = &part.columns_meta[&idx];
             columns_array_iter.push(Self::to_deserialize(
                 column_meta,
@@ -160,7 +165,7 @@ impl BlockReader {
         for (index, column_chunk) in chunks.into_iter().enumerate() {
             let index = self.projection[index];
             let field = self.arrow_schema.fields[index].clone();
-            let column_descriptor = self.parquet_schema_descriptor.column(index);
+            let column_descriptor = &self.parquet_schema_descriptor.columns()[index];
             let column_meta = &part.columns_meta[&index];
             columns_array_iter.push(Self::to_deserialize(
                 column_meta,
@@ -174,11 +179,7 @@ impl BlockReader {
 
         let mut deserializer = RowGroupDeserializer::new(columns_array_iter, num_rows, None);
 
-        match deserializer.next() {
-            None => Err(ErrorCode::ParquetError("fail to get a chunk")),
-            Some(Err(cause)) => Err(ErrorCode::from(cause)),
-            Some(Ok(chunk)) => DataBlock::from_chunk(&self.projected_schema, &chunk),
-        }
+        self.try_next_block(&mut deserializer)
     }
 
     pub async fn read_columns_data(&self, part: PartInfoPtr) -> Result<Vec<Vec<u8>>> {
@@ -203,7 +204,7 @@ impl BlockReader {
             let mut chunk = vec![0; length as usize];
             let mut r = o.range_reader(offset..offset + length).await?;
             r.read_exact(&mut chunk).await?;
-            Result::Ok(chunk)
+            Ok(chunk)
         });
 
         match handler.await {
@@ -219,9 +220,11 @@ impl BlockReader {
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn read(&self, part: PartInfoPtr) -> Result<DataBlock> {
         let (num_rows, columns_array_iter) = self.read_columns(part).await?;
-
         let mut deserializer = RowGroupDeserializer::new(columns_array_iter, num_rows, None);
+        self.try_next_block(&mut deserializer)
+    }
 
+    fn try_next_block(&self, deserializer: &mut RowGroupDeserializer) -> Result<DataBlock> {
         match deserializer.next() {
             None => Err(ErrorCode::ParquetError("fail to get a chunk")),
             Some(Err(cause)) => Err(ErrorCode::from(cause)),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- arrow2 upgraded to version `0.11.1`, commit 2d70fbf
- parquet2 upgraded to version `0.12`
  `git = "https://github.com/datafuse-extras/parquet2", rev = "03c108b"`
  
## Changelog


- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #5008 

