### PR TITLE
[meta] rename CreateDatabaseReply.database_id to db_id; TableIdent.version to seq

### DIFF
--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -68,7 +68,7 @@ impl MetaApiTestSuite {
             let res = mt.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert_eq!(1, res.database_id, "first database id is 1");
+            assert_eq!(1, res.db_id, "first database id is 1");
         }
 
         tracing::info!("--- create db1 again with if_not_exists=false");
@@ -111,7 +111,7 @@ impl MetaApiTestSuite {
             let res = mt.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert_eq!(1, res.database_id, "db1 id is 1");
+            assert_eq!(1, res.db_id, "db1 id is 1");
         }
 
         tracing::info!("--- get db1");
@@ -141,7 +141,7 @@ impl MetaApiTestSuite {
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
             assert_eq!(
-                4, res.database_id,
+                4, res.db_id,
                 "second database id is 4: seq increment but no used"
             );
         }
@@ -224,8 +224,8 @@ impl MetaApiTestSuite {
             let res = mt.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert_eq!(1, res.database_id, "first database id is 1");
-            res.database_id
+            assert_eq!(1, res.db_id, "first database id is 1");
+            res.db_id
         };
 
         tracing::info!("--- tenant1 create db2");
@@ -245,12 +245,8 @@ impl MetaApiTestSuite {
             let res = mt.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert!(
-                res.database_id > db_id_1,
-                "second database id is > {}",
-                db_id_1
-            );
-            res.database_id
+            assert!(res.db_id > db_id_1, "second database id is > {}", db_id_1);
+            res.db_id
         };
 
         tracing::info!("--- tenant2 create db1");
@@ -270,8 +266,8 @@ impl MetaApiTestSuite {
             let res = mt.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert!(res.database_id > db_id_2, "third database id > {}", db_id_2);
-            res.database_id
+            assert!(res.db_id > db_id_2, "third database id > {}", db_id_2);
+            res.db_id
         };
 
         tracing::info!("--- tenant1 get db1");
@@ -354,12 +350,12 @@ impl MetaApiTestSuite {
         let tenant = "tenant1";
         {
             let res = self.create_database(mt, tenant, "db1", "eng1").await?;
-            assert_eq!(1, res.database_id);
-            db_ids.push(res.database_id);
+            assert_eq!(1, res.db_id);
+            db_ids.push(res.db_id);
 
             let res = self.create_database(mt, tenant, "db2", "eng2").await?;
-            assert!(res.database_id > 1);
-            db_ids.push(res.database_id);
+            assert!(res.db_id > 1);
+            db_ids.push(res.db_id);
         }
 
         tracing::info!("--- list_databases");
@@ -392,17 +388,17 @@ impl MetaApiTestSuite {
         let mut db_ids = vec![];
         {
             let res = self.create_database(mt, tenant1, "db1", "eng1").await?;
-            assert_eq!(1, res.database_id);
-            db_ids.push(res.database_id);
+            assert_eq!(1, res.db_id);
+            db_ids.push(res.db_id);
 
             let res = self.create_database(mt, tenant1, "db2", "eng2").await?;
-            assert!(res.database_id > 1);
-            db_ids.push(res.database_id);
+            assert!(res.db_id > 1);
+            db_ids.push(res.db_id);
         }
 
         let db_id_3 = {
             let res = self.create_database(mt, tenant2, "db3", "eng1").await?;
-            res.database_id
+            res.db_id
         };
 
         tracing::info!("--- get_databases by tenant1");
@@ -531,7 +527,7 @@ impl MetaApiTestSuite {
             let res = mt.create_database(plan).await?;
             tracing::info!("create database res: {:?}", res);
 
-            assert_eq!(1, res.database_id, "first database id is 1");
+            assert_eq!(1, res.db_id, "first database id is 1");
         }
 
         tracing::info!("--- create tb2 and get table");
@@ -554,7 +550,7 @@ impl MetaApiTestSuite {
                 let tb_id = res.table_id;
 
                 let got = mt.get_table((tenant, db_name, tbl_name).into()).await?;
-                let seq = got.ident.version;
+                let seq = got.ident.seq;
 
                 let ident = TableIdent::new(tb_id, seq);
 
@@ -810,7 +806,7 @@ impl MetaApiTestSuite {
                 //     rename-table should not change the seq.
                 ident: TableIdent {
                     table_id: tb_ident.table_id,
-                    version: got.ident.version,
+                    seq: got.ident.seq,
                 },
                 desc: format!("'{}'.'{}'.'{}'", tenant, db_name, new_tbl_name),
                 name: new_tbl_name.into(),
@@ -857,7 +853,7 @@ impl MetaApiTestSuite {
 
             let got = mt.get_table((tenant, db_name, tbl_name).into()).await?;
             assert_ne!(tb_ident.table_id, got.ident.table_id);
-            assert_ne!(tb_ident.version, got.ident.version);
+            assert_ne!(tb_ident.seq, got.ident.seq);
             got.ident.clone()
         };
 
@@ -944,7 +940,7 @@ impl MetaApiTestSuite {
                 //   ident: tb_ident2,
                 ident: TableIdent {
                     table_id: tb_ident2.table_id,
-                    version: got.ident.version,
+                    seq: got.ident.seq,
                 },
                 desc: format!("'{}'.'{}'.'{}'", tenant, new_db_name, new_tbl_name),
                 name: new_tbl_name.into(),
@@ -995,7 +991,7 @@ impl MetaApiTestSuite {
             let res = mt.create_database(plan).await?;
             tracing::info!("create database res: {:?}", res);
 
-            assert_eq!(1, res.database_id, "first database id is 1");
+            assert_eq!(1, res.db_id, "first database id is 1");
         }
 
         tracing::info!("--- create and get table");
@@ -1018,7 +1014,7 @@ impl MetaApiTestSuite {
                 let tb_id = res.table_id;
 
                 let got = mt.get_table((tenant, db_name, tbl_name).into()).await?;
-                let seq = got.ident.version;
+                let seq = got.ident.seq;
 
                 let ident = TableIdent::new(tb_id, seq);
 
@@ -1054,7 +1050,7 @@ impl MetaApiTestSuite {
                     .upsert_table_option(UpsertTableOptionReq::new(
                         &TableIdent {
                             table_id: table.ident.table_id,
-                            version: table.ident.version - 1,
+                            seq: table.ident.seq - 1,
                         },
                         "key1",
                         "val2",
@@ -1079,7 +1075,7 @@ impl MetaApiTestSuite {
                     .upsert_table_option(UpsertTableOptionReq::new(
                         &TableIdent {
                             table_id: 1024,
-                            version: table.ident.version - 1,
+                            seq: table.ident.seq - 1,
                         },
                         "key1",
                         "val2",
@@ -1218,7 +1214,7 @@ impl MetaApiTestSuite {
         tracing::info!("--- prepare db");
         {
             let res = self.create_database(mt, tenant, db_name, "eng1").await?;
-            assert_eq!(1, res.database_id, "first database id is 1");
+            assert_eq!(1, res.db_id, "first database id is 1");
         }
 
         tracing::info!("--- create 2 tables: tb1 tb2");
@@ -1463,7 +1459,7 @@ impl MetaApiTestSuite {
             let res = node_a.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert_eq!(1, res.database_id, "first database id is 1");
+            assert_eq!(1, res.db_id, "first database id is 1");
         }
 
         tracing::info!("--- get db1 on node_b");

--- a/common/meta/grpc/src/meta_client_on_kv_impl.rs
+++ b/common/meta/grpc/src/meta_client_on_kv_impl.rs
@@ -98,7 +98,7 @@ impl MetaApi for MetaClientOnKV {
 
             if db_id_seq > 0 {
                 return if req.if_not_exists {
-                    Ok(CreateDatabaseReply { database_id: db_id })
+                    Ok(CreateDatabaseReply { db_id })
                 } else {
                     Err(MetaError::AppError(AppError::DatabaseAlreadyExists(
                         DatabaseAlreadyExists::new(
@@ -134,7 +134,7 @@ impl MetaApi for MetaClientOnKV {
                 );
 
                 if succ {
-                    return Ok(CreateDatabaseReply { database_id: db_id });
+                    return Ok(CreateDatabaseReply { db_id });
                 }
             }
         }
@@ -582,7 +582,7 @@ impl MetaApi for MetaClientOnKV {
         let tb_info = TableInfo {
             ident: TableIdent {
                 table_id,
-                version: tb_meta_seq,
+                seq: tb_meta_seq,
             },
             desc: tenant_dbname_tbname.to_string(),
             name: tenant_dbname_tbname.table_name.clone(),
@@ -640,7 +640,7 @@ impl MetaApi for MetaClientOnKV {
                 let tb_info = TableInfo {
                     ident: TableIdent {
                         table_id: ids[i],
-                        version: seq_meta.seq,
+                        seq: seq_meta.seq,
                     },
                     desc: format!(
                         "'{}'.'{}'",

--- a/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
+++ b/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
@@ -91,7 +91,7 @@ impl MetaApi for StateMachine {
             return Err(MetaError::from(ae));
         }
 
-        Ok(CreateDatabaseReply { database_id: db_id })
+        Ok(CreateDatabaseReply { db_id })
     }
 
     async fn drop_database(&self, req: DropDatabaseReq) -> Result<DropDatabaseReply, MetaError> {

--- a/common/meta/types/src/database.rs
+++ b/common/meta/types/src/database.rs
@@ -115,7 +115,7 @@ impl Display for CreateDatabaseReq {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct CreateDatabaseReply {
-    pub database_id: u64,
+    pub db_id: u64,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -129,7 +129,6 @@ pub use meta_storage_errors::UnknownShare;
 pub use meta_storage_errors::UnknownTable;
 pub use meta_storage_errors::UnknownTableId;
 pub use operation::MetaId;
-pub use operation::MetaVersion;
 pub use operation::Operation;
 pub use principal_identity::PrincipalIdentity;
 pub use protobuf::txn_condition;

--- a/common/meta/types/src/operation.rs
+++ b/common/meta/types/src/operation.rs
@@ -16,7 +16,6 @@
 
 use std::fmt::Debug;
 
-pub type MetaVersion = u64;
 pub type MetaId = u64;
 
 /// An operation that updates a field, delete it, or leave it as is.

--- a/common/meta/types/src/table.rs
+++ b/common/meta/types/src/table.rs
@@ -27,7 +27,6 @@ use maplit::hashmap;
 
 use crate::database::DatabaseNameIdent;
 use crate::MatchSeq;
-use crate::MetaVersion;
 
 /// Globally unique identifier of a version of TableMeta.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Default)]
@@ -35,26 +34,25 @@ pub struct TableIdent {
     /// Globally unique id to identify a table.
     pub table_id: u64,
 
-    /// version of this table snapshot.
+    /// seq AKA version of this table snapshot.
     ///
-    /// Any change to a table causes the version to increment, e.g. insert or delete rows, update schema etc.
-    /// But renaming a table should not affect the version, since the table itself does not change.
-    /// The tuple (database_id, table_id, version) identifies a unique and consistent table snapshot.
+    /// Any change to a table causes the seq to increment, e.g. insert or delete rows, update schema etc.
+    /// But renaming a table should not affect the seq, since the table itself does not change.
+    /// The tuple (table_id, seq) identifies a unique and consistent table snapshot.
     ///
-    /// A version is not guaranteed to be consecutive.
-    ///
-    pub version: MetaVersion,
+    /// A seq is not guaranteed to be consecutive.
+    pub seq: u64,
 }
 
 impl TableIdent {
-    pub fn new(table_id: u64, version: MetaVersion) -> Self {
-        TableIdent { table_id, version }
+    pub fn new(table_id: u64, seq: u64) -> Self {
+        TableIdent { table_id, seq }
     }
 }
 
 impl Display for TableIdent {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "table_id:{}, ver:{}", self.table_id, self.version)
+        write!(f, "table_id:{}, ver:{}", self.table_id, self.seq)
     }
 }
 
@@ -367,7 +365,7 @@ impl UpsertTableOptionReq {
     ) -> UpsertTableOptionReq {
         UpsertTableOptionReq {
             table_id: table_ident.table_id,
-            seq: MatchSeq::Exact(table_ident.version),
+            seq: MatchSeq::Exact(table_ident.seq),
             options: hashmap! {key.into() => Some(value.into())},
         }
     }

--- a/common/proto-conv/src/from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/from_to_protobuf_impl.rs
@@ -203,7 +203,7 @@ impl FromToProto<pb::TableIdent> for mt::TableIdent {
 
         let v = Self {
             table_id: p.table_id,
-            version: p.seq,
+            seq: p.seq,
         };
         Ok(v)
     }
@@ -212,7 +212,7 @@ impl FromToProto<pb::TableIdent> for mt::TableIdent {
         let p = pb::TableIdent {
             ver: VER,
             table_id: self.table_id,
-            seq: self.version,
+            seq: self.seq,
         };
 
         Ok(p)

--- a/common/proto-conv/tests/it/proto_conv.rs
+++ b/common/proto-conv/tests/it/proto_conv.rs
@@ -52,7 +52,7 @@ fn new_table_info() -> mt::TableInfo {
     mt::TableInfo {
         ident: mt::TableIdent {
             table_id: 5,
-            version: 6,
+            seq: 6,
         },
         desc: "foo".to_string(),
         name: "bar".to_string(),
@@ -245,7 +245,7 @@ fn test_load_old() -> anyhow::Result<()> {
         let want = mt::TableInfo {
             ident: mt::TableIdent {
                 table_id: 5,
-                version: 6,
+                seq: 6,
             },
             desc: "foo".to_string(),
             name: "bar".to_string(),

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -100,7 +100,7 @@ impl RequestHandler<CreateDatabaseReq> for ActionHandler {
 
         Ok(CreateDatabaseReply {
             // TODO(xp): return DatabaseInfo?
-            database_id: db_id,
+            db_id,
         })
     }
 }

--- a/query/src/catalogs/impls/mutable_catalog.rs
+++ b/query/src/catalogs/impls/mutable_catalog.rs
@@ -176,7 +176,7 @@ impl Catalog for MutableCatalog {
         // Initial the database after creating.
         let db_info = Arc::new(DatabaseInfo {
             ident: DatabaseIdent {
-                db_id: res.database_id,
+                db_id: res.db_id,
                 seq: 0, // TODO
             },
             name_ident: req.name_ident.clone(),
@@ -184,9 +184,7 @@ impl Catalog for MutableCatalog {
         });
         let database = self.build_db_instance(&db_info)?;
         database.init_database(&req.name_ident.tenant).await?;
-        Ok(CreateDatabaseReply {
-            database_id: res.database_id,
-        })
+        Ok(CreateDatabaseReply { db_id: res.db_id })
     }
 
     async fn drop_database(&self, req: DropDatabaseReq) -> Result<()> {

--- a/query/src/storages/fuse/operations/commit.rs
+++ b/query/src/storages/fuse/operations/commit.rs
@@ -254,7 +254,7 @@ impl FuseTable {
         self::utils::gather_legacy_options(table_info, &mut options);
 
         let table_id = table_info.ident.table_id;
-        let table_version = table_info.ident.version;
+        let table_version = table_info.ident.seq;
         let req = UpsertTableOptionReq {
             table_id,
             seq: MatchSeq::Exact(table_version),

--- a/query/tests/it/storages/fuse/table.rs
+++ b/query/tests/it/storages/fuse/table.rs
@@ -56,9 +56,9 @@ async fn test_fuse_table_normal_case() -> Result<()> {
             .await?;
 
         // get the latest tbl
-        let prev_version = table.get_table_info().ident.version;
+        let prev_version = table.get_table_info().ident.seq;
         table = fixture.latest_default_table().await?;
-        assert_ne!(prev_version, table.get_table_info().ident.version);
+        assert_ne!(prev_version, table.get_table_info().ident.seq);
 
         let (stats, parts) = table.read_partitions(ctx.clone(), None).await?;
         assert_eq!(stats.read_rows, num_blocks * rows_per_block);
@@ -113,9 +113,9 @@ async fn test_fuse_table_normal_case() -> Result<()> {
             .await?;
 
         // get the latest tbl
-        let prev_version = table.get_table_info().ident.version;
+        let prev_version = table.get_table_info().ident.seq;
         let table = fixture.latest_default_table().await?;
-        assert_ne!(prev_version, table.get_table_info().ident.version);
+        assert_ne!(prev_version, table.get_table_info().ident.seq);
 
         let (stats, parts) = table.read_partitions(ctx.clone(), None).await?;
         assert_eq!(stats.read_rows, num_blocks * rows_per_block);
@@ -173,11 +173,11 @@ async fn test_fuse_table_truncate() -> Result<()> {
     };
 
     // 1. truncate empty table
-    let prev_version = table.get_table_info().ident.version;
+    let prev_version = table.get_table_info().ident.seq;
     let r = table.truncate(ctx.clone(), truncate_plan.clone()).await;
     let table = fixture.latest_default_table().await?;
     // no side effects
-    assert_eq!(prev_version, table.get_table_info().ident.version);
+    assert_eq!(prev_version, table.get_table_info().ident.seq);
     assert!(r.is_ok());
 
     // 2. truncate table which has data
@@ -194,9 +194,9 @@ async fn test_fuse_table_truncate() -> Result<()> {
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 
     // get the latest tbl
-    let prev_version = table.get_table_info().ident.version;
+    let prev_version = table.get_table_info().ident.seq;
     let table = fixture.latest_default_table().await?;
-    assert_ne!(prev_version, table.get_table_info().ident.version);
+    assert_ne!(prev_version, table.get_table_info().ident.seq);
 
     // ensure data ingested
     let (stats, _) = table
@@ -209,9 +209,9 @@ async fn test_fuse_table_truncate() -> Result<()> {
     assert!(r.is_ok());
 
     // get the latest tbl
-    let prev_version = table.get_table_info().ident.version;
+    let prev_version = table.get_table_info().ident.seq;
     let table = fixture.latest_default_table().await?;
-    assert_ne!(prev_version, table.get_table_info().ident.version);
+    assert_ne!(prev_version, table.get_table_info().ident.seq);
     let (stats, parts) = table
         .read_partitions(ctx.clone(), source_plan.push_downs.clone())
         .await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [meta] rename CreateDatabaseReply.database_id to db_id; TableIdent.version to seq


- Fix: #5189
## Changelog







## Related Issues