### PR TITLE
[metasrv] disable `share` APIs

### DIFF
--- a/common/meta/api/src/meta_api.rs
+++ b/common/meta/api/src/meta_api.rs
@@ -17,19 +17,14 @@ use std::sync::Arc;
 
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::CreateDatabaseReq;
-use common_meta_types::CreateShareReply;
-use common_meta_types::CreateShareReq;
 use common_meta_types::CreateTableReply;
 use common_meta_types::CreateTableReq;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
-use common_meta_types::DropShareReply;
-use common_meta_types::DropShareReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
 use common_meta_types::GetDatabaseReq;
-use common_meta_types::GetShareReq;
 use common_meta_types::GetTableReq;
 use common_meta_types::ListDatabaseReq;
 use common_meta_types::ListTableReq;
@@ -37,7 +32,6 @@ use common_meta_types::MetaError;
 use common_meta_types::MetaId;
 use common_meta_types::RenameTableReply;
 use common_meta_types::RenameTableReq;
-use common_meta_types::ShareInfo;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
@@ -84,12 +78,14 @@ pub trait MetaApi: Send + Sync {
         req: UpsertTableOptionReq,
     ) -> Result<UpsertTableOptionReply, MetaError>;
 
-    // share
-    async fn create_share(&self, req: CreateShareReq) -> Result<CreateShareReply, MetaError>;
-
-    async fn drop_share(&self, req: DropShareReq) -> Result<DropShareReply, MetaError>;
-
-    async fn get_share(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError>;
+    // TODO: Disabled temporarily: Consider move them to another trait such as `ShareApi` or else.
+    //       Since `share` has nothing really to do with database or table.
+    // // share
+    // async fn create_share(&self, req: CreateShareReq) -> Result<CreateShareReply, MetaError>;
+    //
+    // async fn drop_share(&self, req: DropShareReq) -> Result<DropShareReply, MetaError>;
+    //
+    // async fn get_share(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError>;
 
     fn name(&self) -> String;
 }

--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -19,15 +19,12 @@ use common_datavalues::prelude::*;
 use common_exception::ErrorCode;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::CreateDatabaseReq;
-use common_meta_types::CreateShareReq;
 use common_meta_types::CreateTableReq;
 use common_meta_types::DatabaseMeta;
 use common_meta_types::DatabaseNameIdent;
 use common_meta_types::DropDatabaseReq;
-use common_meta_types::DropShareReq;
 use common_meta_types::DropTableReq;
 use common_meta_types::GetDatabaseReq;
-use common_meta_types::GetShareReq;
 use common_meta_types::GetTableReq;
 use common_meta_types::ListDatabaseReq;
 use common_meta_types::ListTableReq;
@@ -1268,140 +1265,141 @@ impl MetaApiTestSuite {
         Ok(())
     }
 
-    pub async fn share_create_get_drop<MT: MetaApi>(&self, mt: &MT) -> anyhow::Result<()> {
-        let tenant1 = "tenant1";
-        let share_name1 = "share1";
-        let share_name2 = "share2";
-        tracing::info!("--- create {}", share_name1);
-        {
-            let req = CreateShareReq {
-                if_not_exists: false,
-                tenant: tenant1.to_string(),
-                share_name: share_name1.to_string(),
-            };
-
-            let res = mt.create_share(req).await;
-            tracing::info!("create share res: {:?}", res);
-            let res = res.unwrap();
-            assert_eq!(1, res.share_id, "first share id is 1");
-        }
-
-        tracing::info!("--- get share1");
-        {
-            let res = mt.get_share(GetShareReq::new(tenant1, share_name1)).await;
-            tracing::debug!("get present share res: {:?}", res);
-            let res = res?;
-            assert_eq!(1, res.id, "db1 id is 1");
-            assert_eq!(
-                share_name1.to_string(),
-                res.name,
-                "share1.db is {}",
-                share_name1
-            );
-        }
-
-        tracing::info!("--- create share1 again with if_not_exists=false");
-        {
-            let req = CreateShareReq {
-                if_not_exists: false,
-                tenant: tenant1.to_string(),
-                share_name: share_name1.to_string(),
-            };
-
-            let res = mt.create_share(req).await;
-            tracing::info!("create share res: {:?}", res);
-            let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::ShareAlreadyExists("").code(),
-                ErrorCode::from(err).code()
-            );
-        }
-
-        tracing::info!("--- create share1 again with if_not_exists=true");
-        {
-            let req = CreateShareReq {
-                if_not_exists: true,
-                tenant: tenant1.to_string(),
-                share_name: share_name1.to_string(),
-            };
-
-            let res = mt.create_share(req).await;
-            tracing::info!("create database res: {:?}", res);
-
-            let res = res.unwrap();
-            assert_eq!(1, res.share_id, "share1 id is 1");
-        }
-
-        tracing::info!("--- create share2");
-        {
-            let req = CreateShareReq {
-                if_not_exists: false,
-                tenant: tenant1.to_string(),
-                share_name: share_name2.to_string(),
-            };
-
-            let res = mt.create_share(req).await;
-            tracing::info!("create share res: {:?}", res);
-            let res = res.unwrap();
-            assert_eq!(2, res.share_id, "second share id is 2 ");
-        }
-
-        tracing::info!("--- get share2");
-        {
-            let res = mt.get_share(GetShareReq::new(tenant1, share_name2)).await?;
-            assert_eq!(2, res.id, "share2 id is 2");
-            assert_eq!(
-                share_name2.to_string(),
-                res.name,
-                "share2.name is {}",
-                share_name2
-            );
-        }
-
-        tracing::info!("--- get absent share");
-        {
-            let res = mt.get_share(GetShareReq::new(tenant1, "absent")).await;
-            tracing::debug!("=== get absent share res: {:?}", res);
-            assert!(res.is_err());
-            let err = res.unwrap_err();
-            let err_code = ErrorCode::from(err);
-
-            assert_eq!(ErrorCode::unknown_share_code(), err_code.code());
-            assert!(err_code.message().contains("absent"));
-        }
-
-        tracing::info!("--- drop share2");
-        {
-            mt.drop_share(DropShareReq {
-                if_exists: false,
-                tenant: tenant1.to_string(),
-                share_name: share_name2.to_string(),
-            })
-            .await?;
-        }
-
-        tracing::info!("--- get share2 should not found");
-        {
-            let res = mt.get_share(GetShareReq::new(tenant1, share_name2)).await;
-            let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownShare("").code(),
-                ErrorCode::from(err).code()
-            );
-        }
-
-        tracing::info!("--- drop share2 with if_exists=true returns no error");
-        {
-            mt.drop_share(DropShareReq {
-                if_exists: true,
-                tenant: tenant1.to_string(),
-                share_name: share_name2.to_string(),
-            })
-            .await?;
-        }
-
-        Ok(())
-    }
+    // pub async fn share_create_get_drop<MT: MetaApi>(&self, mt: &MT) -> anyhow::Result<()> {
+    //     let tenant1 = "tenant1";
+    //     let share_name1 = "share1";
+    //     let share_name2 = "share2";
+    //     tracing::info!("--- create {}", share_name1);
+    //     {
+    //         let req = CreateShareReq {
+    //             if_not_exists: false,
+    //             tenant: tenant1.to_string(),
+    //             share_name: share_name1.to_string(),
+    //         };
+    //
+    //         let res = mt.create_share(req).await;
+    //         tracing::info!("create share res: {:?}", res);
+    //         let res = res.unwrap();
+    //         assert_eq!(1, res.share_id, "first share id is 1");
+    //     }
+    //
+    //     tracing::info!("--- get share1");
+    //     {
+    //         let res = mt.get_share(GetShareReq::new(tenant1, share_name1)).await;
+    //         tracing::debug!("get present share res: {:?}", res);
+    //         let res = res?;
+    //         assert_eq!(1, res.id, "db1 id is 1");
+    //         assert_eq!(
+    //             share_name1.to_string(),
+    //             res.name,
+    //             "share1.db is {}",
+    //             share_name1
+    //         );
+    //     }
+    //
+    //     tracing::info!("--- create share1 again with if_not_exists=false");
+    //     {
+    //         let req = CreateShareReq {
+    //             if_not_exists: false,
+    //             tenant: tenant1.to_string(),
+    //             share_name: share_name1.to_string(),
+    //         };
+    //
+    //         let res = mt.create_share(req).await;
+    //         tracing::info!("create share res: {:?}", res);
+    //         let err = res.unwrap_err();
+    //         assert_eq!(
+    //             ErrorCode::ShareAlreadyExists("").code(),
+    //             ErrorCode::from(err).code()
+    //         );
+    //     }
+    //
+    //     tracing::info!("--- create share1 again with if_not_exists=true");
+    //     {
+    //         let req = CreateShareReq {
+    //             if_not_exists: true,
+    //             tenant: tenant1.to_string(),
+    //             share_name: share_name1.to_string(),
+    //         };
+    //
+    //         let res = mt.create_share(req).await;
+    //         tracing::info!("create database res: {:?}", res);
+    //
+    //         let res = res.unwrap();
+    //         assert_eq!(1, res.share_id, "share1 id is 1");
+    //     }
+    //
+    //     tracing::info!("--- create share2");
+    //     {
+    //         let req = CreateShareReq {
+    //             if_not_exists: false,
+    //             tenant: tenant1.to_string(),
+    //             share_name: share_name2.to_string(),
+    //         };
+    //
+    //         let res = mt.create_share(req).await;
+    //         tracing::info!("create share res: {:?}", res);
+    //         let res = res.unwrap();
+    //         assert_eq!(2, res.share_id, "second share id is 2 ");
+    //     }
+    //
+    //     tracing::info!("--- get share2");
+    //     {
+    //         let res = mt.get_share(GetShareReq::new(tenant1, share_name2)).await?;
+    //         assert_eq!(2, res.id, "share2 id is 2");
+    //         assert_eq!(
+    //             share_name2.to_string(),
+    //             res.name,
+    //             "share2.name is {}",
+    //             share_name2
+    //         );
+    //     }
+    //
+    //     tracing::info!("--- get absent share");
+    //     {
+    //         let res = mt.get_share(GetShareReq::new(tenant1, "absent")).await;
+    //         tracing::debug!("=== get absent share res: {:?}", res);
+    //         assert!(res.is_err());
+    //         let err = res.unwrap_err();
+    //         let err_code = ErrorCode::from(err);
+    //
+    //         assert_eq!(ErrorCode::unknown_share_code(), err_code.code());
+    //         assert!(err_code.message().contains("absent"));
+    //     }
+    //
+    //     tracing::info!("--- drop share2");
+    //     {
+    //         mt.drop_share(DropShareReq {
+    //             if_exists: false,
+    //             tenant: tenant1.to_string(),
+    //             share_name: share_name2.to_string(),
+    //         })
+    //         .await?;
+    //     }
+    //
+    //     tracing::info!("--- get share2 should not found");
+    //     {
+    //         let res = mt.get_share(GetShareReq::new(tenant1, share_name2)).await;
+    //         let err = res.unwrap_err();
+    //         assert_eq!(
+    //             ErrorCode::UnknownShare("").code(),
+    //             ErrorCode::from(err).code()
+    //         );
+    //     }
+    //
+    //     tracing::info!("--- drop share2 with if_exists=true returns no error");
+    //     {
+    //         mt.drop_share(DropShareReq {
+    //             if_exists: true,
+    //             tenant: tenant1.to_string(),
+    //             share_name: share_name2.to_string(),
+    //         })
+    //         .await?;
+    //     }
+    //
+    //     Ok(())
+    // }
+    //
 }
 
 impl MetaApiTestSuite {

--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -68,7 +68,7 @@ impl MetaApiTestSuite {
             let res = mt.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert_eq!(1, res.database_id, "first database id is 1");
+            assert_eq!(1, res.db_id, "first database id is 1");
         }
 
         tracing::info!("--- create db1 again with if_not_exists=false");
@@ -111,7 +111,7 @@ impl MetaApiTestSuite {
             let res = mt.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert_eq!(1, res.database_id, "db1 id is 1");
+            assert_eq!(1, res.db_id, "db1 id is 1");
         }
 
         tracing::info!("--- get db1");
@@ -141,7 +141,7 @@ impl MetaApiTestSuite {
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
             assert_eq!(
-                4, res.database_id,
+                4, res.db_id,
                 "second database id is 4: seq increment but no used"
             );
         }
@@ -224,8 +224,8 @@ impl MetaApiTestSuite {
             let res = mt.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert_eq!(1, res.database_id, "first database id is 1");
-            res.database_id
+            assert_eq!(1, res.db_id, "first database id is 1");
+            res.db_id
         };
 
         tracing::info!("--- tenant1 create db2");
@@ -245,12 +245,8 @@ impl MetaApiTestSuite {
             let res = mt.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert!(
-                res.database_id > db_id_1,
-                "second database id is > {}",
-                db_id_1
-            );
-            res.database_id
+            assert!(res.db_id > db_id_1, "second database id is > {}", db_id_1);
+            res.db_id
         };
 
         tracing::info!("--- tenant2 create db1");
@@ -270,8 +266,8 @@ impl MetaApiTestSuite {
             let res = mt.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert!(res.database_id > db_id_2, "third database id > {}", db_id_2);
-            res.database_id
+            assert!(res.db_id > db_id_2, "third database id > {}", db_id_2);
+            res.db_id
         };
 
         tracing::info!("--- tenant1 get db1");
@@ -354,12 +350,12 @@ impl MetaApiTestSuite {
         let tenant = "tenant1";
         {
             let res = self.create_database(mt, tenant, "db1", "eng1").await?;
-            assert_eq!(1, res.database_id);
-            db_ids.push(res.database_id);
+            assert_eq!(1, res.db_id);
+            db_ids.push(res.db_id);
 
             let res = self.create_database(mt, tenant, "db2", "eng2").await?;
-            assert!(res.database_id > 1);
-            db_ids.push(res.database_id);
+            assert!(res.db_id > 1);
+            db_ids.push(res.db_id);
         }
 
         tracing::info!("--- list_databases");
@@ -392,17 +388,17 @@ impl MetaApiTestSuite {
         let mut db_ids = vec![];
         {
             let res = self.create_database(mt, tenant1, "db1", "eng1").await?;
-            assert_eq!(1, res.database_id);
-            db_ids.push(res.database_id);
+            assert_eq!(1, res.db_id);
+            db_ids.push(res.db_id);
 
             let res = self.create_database(mt, tenant1, "db2", "eng2").await?;
-            assert!(res.database_id > 1);
-            db_ids.push(res.database_id);
+            assert!(res.db_id > 1);
+            db_ids.push(res.db_id);
         }
 
         let db_id_3 = {
             let res = self.create_database(mt, tenant2, "db3", "eng1").await?;
-            res.database_id
+            res.db_id
         };
 
         tracing::info!("--- get_databases by tenant1");
@@ -531,7 +527,7 @@ impl MetaApiTestSuite {
             let res = mt.create_database(plan).await?;
             tracing::info!("create database res: {:?}", res);
 
-            assert_eq!(1, res.database_id, "first database id is 1");
+            assert_eq!(1, res.db_id, "first database id is 1");
         }
 
         tracing::info!("--- create tb2 and get table");
@@ -554,7 +550,7 @@ impl MetaApiTestSuite {
                 let tb_id = res.table_id;
 
                 let got = mt.get_table((tenant, db_name, tbl_name).into()).await?;
-                let seq = got.ident.version;
+                let seq = got.ident.seq;
 
                 let ident = TableIdent::new(tb_id, seq);
 
@@ -810,7 +806,7 @@ impl MetaApiTestSuite {
                 //     rename-table should not change the seq.
                 ident: TableIdent {
                     table_id: tb_ident.table_id,
-                    version: got.ident.version,
+                    seq: got.ident.seq,
                 },
                 desc: format!("'{}'.'{}'.'{}'", tenant, db_name, new_tbl_name),
                 name: new_tbl_name.into(),
@@ -857,7 +853,7 @@ impl MetaApiTestSuite {
 
             let got = mt.get_table((tenant, db_name, tbl_name).into()).await?;
             assert_ne!(tb_ident.table_id, got.ident.table_id);
-            assert_ne!(tb_ident.version, got.ident.version);
+            assert_ne!(tb_ident.seq, got.ident.seq);
             got.ident.clone()
         };
 
@@ -944,7 +940,7 @@ impl MetaApiTestSuite {
                 //   ident: tb_ident2,
                 ident: TableIdent {
                     table_id: tb_ident2.table_id,
-                    version: got.ident.version,
+                    seq: got.ident.seq,
                 },
                 desc: format!("'{}'.'{}'.'{}'", tenant, new_db_name, new_tbl_name),
                 name: new_tbl_name.into(),
@@ -995,7 +991,7 @@ impl MetaApiTestSuite {
             let res = mt.create_database(plan).await?;
             tracing::info!("create database res: {:?}", res);
 
-            assert_eq!(1, res.database_id, "first database id is 1");
+            assert_eq!(1, res.db_id, "first database id is 1");
         }
 
         tracing::info!("--- create and get table");
@@ -1018,7 +1014,7 @@ impl MetaApiTestSuite {
                 let tb_id = res.table_id;
 
                 let got = mt.get_table((tenant, db_name, tbl_name).into()).await?;
-                let seq = got.ident.version;
+                let seq = got.ident.seq;
 
                 let ident = TableIdent::new(tb_id, seq);
 
@@ -1054,7 +1050,7 @@ impl MetaApiTestSuite {
                     .upsert_table_option(UpsertTableOptionReq::new(
                         &TableIdent {
                             table_id: table.ident.table_id,
-                            version: table.ident.version - 1,
+                            seq: table.ident.seq - 1,
                         },
                         "key1",
                         "val2",
@@ -1079,7 +1075,7 @@ impl MetaApiTestSuite {
                     .upsert_table_option(UpsertTableOptionReq::new(
                         &TableIdent {
                             table_id: 1024,
-                            version: table.ident.version - 1,
+                            seq: table.ident.seq - 1,
                         },
                         "key1",
                         "val2",
@@ -1138,7 +1134,7 @@ impl MetaApiTestSuite {
             let res = mt.create_database(plan).await?;
             tracing::info!("create database res: {:?}", res);
 
-            assert_eq!(1, res.database_id, "first database id is 1");
+            assert_eq!(1, res.db_id, "first database id is 1");
         }
 
         tracing::info!("--- create and get table");
@@ -1161,7 +1157,7 @@ impl MetaApiTestSuite {
                 let tb_id = res.table_id;
 
                 let got = mt.get_table((tenant, db_name, tbl_name).into()).await?;
-                let seq = got.ident.version;
+                let seq = got.ident.seq;
 
                 let ident = TableIdent::new(tb_id, seq);
 
@@ -1218,7 +1214,7 @@ impl MetaApiTestSuite {
         tracing::info!("--- prepare db");
         {
             let res = self.create_database(mt, tenant, db_name, "eng1").await?;
-            assert_eq!(1, res.database_id, "first database id is 1");
+            assert_eq!(1, res.db_id, "first database id is 1");
         }
 
         tracing::info!("--- create 2 tables: tb1 tb2");
@@ -1463,7 +1459,7 @@ impl MetaApiTestSuite {
             let res = node_a.create_database(req).await;
             tracing::info!("create database res: {:?}", res);
             let res = res.unwrap();
-            assert_eq!(1, res.database_id, "first database id is 1");
+            assert_eq!(1, res.db_id, "first database id is 1");
         }
 
         tracing::info!("--- get db1 on node_b");

--- a/common/meta/embedded/src/meta_api_impl.rs
+++ b/common/meta/embedded/src/meta_api_impl.rs
@@ -18,19 +18,14 @@ use async_trait::async_trait;
 use common_meta_api::MetaApi;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::CreateDatabaseReq;
-use common_meta_types::CreateShareReply;
-use common_meta_types::CreateShareReq;
 use common_meta_types::CreateTableReply;
 use common_meta_types::CreateTableReq;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
-use common_meta_types::DropShareReply;
-use common_meta_types::DropShareReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
 use common_meta_types::GetDatabaseReq;
-use common_meta_types::GetShareReq;
 use common_meta_types::GetTableReq;
 use common_meta_types::ListDatabaseReq;
 use common_meta_types::ListTableReq;
@@ -38,7 +33,6 @@ use common_meta_types::MetaError;
 use common_meta_types::MetaId;
 use common_meta_types::RenameTableReply;
 use common_meta_types::RenameTableReq;
-use common_meta_types::ShareInfo;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
@@ -126,23 +120,23 @@ impl MetaApi for MetaEmbedded {
         Ok(reply)
     }
 
-    async fn create_share(&self, req: CreateShareReq) -> Result<CreateShareReply, MetaError> {
-        let sm = self.inner.lock().await;
-        let reply = sm.create_share(req).await?;
-        Ok(reply)
-    }
-
-    async fn drop_share(&self, req: DropShareReq) -> Result<DropShareReply, MetaError> {
-        let sm = self.inner.lock().await;
-        let reply = sm.drop_share(req).await?;
-        Ok(reply)
-    }
-
-    async fn get_share(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
-        let sm = self.inner.lock().await;
-        let reply = sm.get_share(req).await?;
-        Ok(reply)
-    }
+    // async fn create_share(&self, req: CreateShareReq) -> Result<CreateShareReply, MetaError> {
+    //     let sm = self.inner.lock().await;
+    //     let reply = sm.create_share(req).await?;
+    //     Ok(reply)
+    // }
+    //
+    // async fn drop_share(&self, req: DropShareReq) -> Result<DropShareReply, MetaError> {
+    //     let sm = self.inner.lock().await;
+    //     let reply = sm.drop_share(req).await?;
+    //     Ok(reply)
+    // }
+    //
+    // async fn get_share(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
+    //     let sm = self.inner.lock().await;
+    //     let reply = sm.get_share(req).await?;
+    //     Ok(reply)
+    // }
 
     fn name(&self) -> String {
         "meta-embedded".to_string()

--- a/common/meta/embedded/tests/it/meta_api_impl.rs
+++ b/common/meta/embedded/tests/it/meta_api_impl.rs
@@ -66,8 +66,8 @@ async fn test_meta_embedded_table_list() -> anyhow::Result<()> {
     MetaApiTestSuite {}.table_list(&mt).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_meta_embedded_share_create_get_dro() -> anyhow::Result<()> {
-    let mt = MetaEmbedded::new_temp().await?;
-    MetaApiTestSuite {}.share_create_get_drop(&mt).await
-}
+// #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+// async fn test_meta_embedded_share_create_get_dro() -> anyhow::Result<()> {
+//     let mt = MetaEmbedded::new_temp().await?;
+//     MetaApiTestSuite {}.share_create_get_drop(&mt).await
+// }

--- a/common/meta/grpc/src/grpc_action.rs
+++ b/common/meta/grpc/src/grpc_action.rs
@@ -79,8 +79,7 @@ pub enum MetaGrpcReadReq {
     GetTableExt(GetTableExtReq),
     ListTables(ListTableReq),
 
-    GetShare(GetShareReq),
-
+    // GetShare(GetShareReq),
     GetKV(GetKVAction),
     MGetKV(MGetKVAction),
     PrefixListKV(PrefixListReq),

--- a/common/meta/grpc/src/meta_api_impl.rs
+++ b/common/meta/grpc/src/meta_api_impl.rs
@@ -17,19 +17,14 @@ use std::sync::Arc;
 use common_meta_api::MetaApi;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::CreateDatabaseReq;
-use common_meta_types::CreateShareReply;
-use common_meta_types::CreateShareReq;
 use common_meta_types::CreateTableReply;
 use common_meta_types::CreateTableReq;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
-use common_meta_types::DropShareReply;
-use common_meta_types::DropShareReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
 use common_meta_types::GetDatabaseReq;
-use common_meta_types::GetShareReq;
 use common_meta_types::GetTableReq;
 use common_meta_types::ListDatabaseReq;
 use common_meta_types::ListTableReq;
@@ -37,7 +32,6 @@ use common_meta_types::MetaError;
 use common_meta_types::MetaId;
 use common_meta_types::RenameTableReply;
 use common_meta_types::RenameTableReq;
-use common_meta_types::ShareInfo;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
@@ -106,16 +100,17 @@ impl MetaApi for MetaGrpcClient {
         self.do_write(req).await
     }
 
-    async fn create_share(&self, req: CreateShareReq) -> Result<CreateShareReply, MetaError> {
-        self.do_write(req).await
-    }
-
-    async fn drop_share(&self, req: DropShareReq) -> Result<DropShareReply, MetaError> {
-        self.do_write(req).await
-    }
-    async fn get_share(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
-        self.do_read(req).await
-    }
+    // async fn create_share(&self, req: CreateShareReq) -> Result<CreateShareReply, MetaError> {
+    //     self.do_write(req).await
+    // }
+    //
+    // async fn drop_share(&self, req: DropShareReq) -> Result<DropShareReply, MetaError> {
+    //     self.do_write(req).await
+    // }
+    //
+    // async fn get_share(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
+    //     self.do_read(req).await
+    // }
 
     fn name(&self) -> String {
         "MetaGrpcClient".to_string()

--- a/common/meta/grpc/src/meta_client_on_kv_impl.rs
+++ b/common/meta/grpc/src/meta_client_on_kv_impl.rs
@@ -24,8 +24,6 @@ use common_meta_types::AppError;
 use common_meta_types::ConditionResult;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::CreateDatabaseReq;
-use common_meta_types::CreateShareReply;
-use common_meta_types::CreateShareReq;
 use common_meta_types::CreateTableReply;
 use common_meta_types::CreateTableReq;
 use common_meta_types::DBIdTableName;
@@ -37,12 +35,9 @@ use common_meta_types::DatabaseMeta;
 use common_meta_types::DatabaseNameIdent;
 use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
-use common_meta_types::DropShareReply;
-use common_meta_types::DropShareReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
 use common_meta_types::GetDatabaseReq;
-use common_meta_types::GetShareReq;
 use common_meta_types::GetTableReq;
 use common_meta_types::ListDatabaseReq;
 use common_meta_types::ListTableReq;
@@ -53,7 +48,6 @@ use common_meta_types::MetaId;
 use common_meta_types::Operation;
 use common_meta_types::RenameTableReply;
 use common_meta_types::RenameTableReq;
-use common_meta_types::ShareInfo;
 use common_meta_types::TableAlreadyExists;
 use common_meta_types::TableId;
 use common_meta_types::TableIdent;
@@ -753,16 +747,17 @@ impl MetaApi for MetaClientOnKV {
         }
     }
 
-    async fn create_share(&self, _req: CreateShareReq) -> Result<CreateShareReply, MetaError> {
-        todo!()
-    }
-
-    async fn drop_share(&self, _req: DropShareReq) -> Result<DropShareReply, MetaError> {
-        todo!()
-    }
-    async fn get_share(&self, _req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
-        todo!()
-    }
+    // async fn create_share(&self, _req: CreateShareReq) -> Result<CreateShareReply, MetaError> {
+    //     todo!()
+    // }
+    //
+    // async fn drop_share(&self, _req: DropShareReq) -> Result<DropShareReply, MetaError> {
+    //     todo!()
+    // }
+    //
+    // async fn get_share(&self, _req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
+    //     todo!()
+    // }
 
     fn name(&self) -> String {
         "MetaClientOnKV".to_string()

--- a/common/meta/grpc/src/meta_client_on_kv_impl.rs
+++ b/common/meta/grpc/src/meta_client_on_kv_impl.rs
@@ -98,7 +98,7 @@ impl MetaApi for MetaClientOnKV {
 
             if db_id_seq > 0 {
                 return if req.if_not_exists {
-                    Ok(CreateDatabaseReply { database_id: db_id })
+                    Ok(CreateDatabaseReply { db_id })
                 } else {
                     Err(MetaError::AppError(AppError::DatabaseAlreadyExists(
                         DatabaseAlreadyExists::new(
@@ -134,7 +134,7 @@ impl MetaApi for MetaClientOnKV {
                 );
 
                 if succ {
-                    return Ok(CreateDatabaseReply { database_id: db_id });
+                    return Ok(CreateDatabaseReply { db_id });
                 }
             }
         }
@@ -582,7 +582,7 @@ impl MetaApi for MetaClientOnKV {
         let tb_info = TableInfo {
             ident: TableIdent {
                 table_id,
-                version: tb_meta_seq,
+                seq: tb_meta_seq,
             },
             desc: tenant_dbname_tbname.to_string(),
             name: tenant_dbname_tbname.table_name.clone(),
@@ -640,7 +640,7 @@ impl MetaApi for MetaClientOnKV {
                 let tb_info = TableInfo {
                     ident: TableIdent {
                         table_id: ids[i],
-                        version: seq_meta.seq,
+                        seq: seq_meta.seq,
                     },
                     desc: format!(
                         "'{}'.'{}'",

--- a/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
+++ b/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
@@ -91,7 +91,7 @@ impl MetaApi for StateMachine {
             return Err(MetaError::from(ae));
         }
 
-        Ok(CreateDatabaseReply { database_id: db_id })
+        Ok(CreateDatabaseReply { db_id })
     }
 
     async fn drop_database(&self, req: DropDatabaseReq) -> Result<DropDatabaseReply, MetaError> {

--- a/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
+++ b/common/meta/raft-store/src/state_machine/sm_meta_api_impl.rs
@@ -22,8 +22,6 @@ use common_meta_types::Change;
 use common_meta_types::Cmd;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::CreateDatabaseReq;
-use common_meta_types::CreateShareReply;
-use common_meta_types::CreateShareReq;
 use common_meta_types::CreateTableReply;
 use common_meta_types::CreateTableReq;
 use common_meta_types::DatabaseAlreadyExists;
@@ -33,12 +31,9 @@ use common_meta_types::DatabaseMeta;
 use common_meta_types::DatabaseNameIdent;
 use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
-use common_meta_types::DropShareReply;
-use common_meta_types::DropShareReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
 use common_meta_types::GetDatabaseReq;
-use common_meta_types::GetShareReq;
 use common_meta_types::GetTableReq;
 use common_meta_types::ListDatabaseReq;
 use common_meta_types::ListTableReq;
@@ -47,15 +42,12 @@ use common_meta_types::MetaId;
 use common_meta_types::MetaStorageError;
 use common_meta_types::RenameTableReply;
 use common_meta_types::RenameTableReq;
-use common_meta_types::ShareAlreadyExists;
-use common_meta_types::ShareInfo;
 use common_meta_types::TableAlreadyExists;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_meta_types::TableVersionMismatched;
 use common_meta_types::UnknownDatabase;
-use common_meta_types::UnknownShare;
 use common_meta_types::UnknownTable;
 use common_meta_types::UnknownTableId;
 use common_meta_types::UpsertTableOptionReply;
@@ -338,56 +330,56 @@ impl MetaApi for StateMachine {
         Ok(UpsertTableOptionReply {})
     }
 
-    async fn create_share(&self, req: CreateShareReq) -> Result<CreateShareReply, MetaError> {
-        let share_name = &req.share_name;
-        let if_not_exists = req.if_not_exists;
-
-        tracing::info!("create share: {:}: {:?}", &req.tenant, &share_name);
-
-        let res = self.sm_tree.txn(true, |t| {
-            let r = self.apply_cmd(&Cmd::CreateShare(req.clone()), &t)?;
-            Ok(r)
-        })?;
-
-        let mut ch: Change<ShareInfo, u64> = res.try_into().unwrap();
-        let share_id = ch.ident.take().unwrap();
-        let (prev, result) = ch.unpack_data();
-
-        assert!(result.is_some());
-
-        if prev.is_some() && !if_not_exists {
-            let ae = AppError::from(ShareAlreadyExists::new(share_name, "create share"));
-            Err(MetaError::from(ae))
-        } else {
-            Ok(CreateShareReply { share_id })
-        }
-    }
-
-    async fn drop_share(&self, req: DropShareReq) -> Result<DropShareReply, MetaError> {
-        let share_name = &req.share_name;
-        let if_exists = req.if_exists;
-
-        let res = self.sm_tree.txn(true, |t| {
-            let r = self.apply_cmd(&Cmd::DropShare(req.clone()), &t)?;
-            Ok(r)
-        })?;
-
-        assert!(res.result().is_none());
-
-        if res.prev().is_none() && !if_exists {
-            let ae = AppError::from(UnknownShare::new(share_name, "drop share"));
-            return Err(MetaError::from(ae));
-        }
-
-        Ok(DropShareReply {})
-    }
-
-    async fn get_share(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
-        let share_id = self.get_share_id(&req.tenant, &req.share_name)?;
-        let seq_share_info = self.get_share_info_by_id(&share_id)?;
-        Ok(Arc::new(seq_share_info.data))
-    }
-
+    // async fn create_share(&self, req: CreateShareReq) -> Result<CreateShareReply, MetaError> {
+    //     let share_name = &req.share_name;
+    //     let if_not_exists = req.if_not_exists;
+    //
+    //     tracing::info!("create share: {:}: {:?}", &req.tenant, &share_name);
+    //
+    //     let res = self.sm_tree.txn(true, |t| {
+    //         let r = self.apply_cmd(&Cmd::CreateShare(req.clone()), &t)?;
+    //         Ok(r)
+    //     })?;
+    //
+    //     let mut ch: Change<ShareInfo, u64> = res.try_into().unwrap();
+    //     let share_id = ch.ident.take().unwrap();
+    //     let (prev, result) = ch.unpack_data();
+    //
+    //     assert!(result.is_some());
+    //
+    //     if prev.is_some() && !if_not_exists {
+    //         let ae = AppError::from(ShareAlreadyExists::new(share_name, "create share"));
+    //         Err(MetaError::from(ae))
+    //     } else {
+    //         Ok(CreateShareReply { share_id })
+    //     }
+    // }
+    //
+    // async fn drop_share(&self, req: DropShareReq) -> Result<DropShareReply, MetaError> {
+    //     let share_name = &req.share_name;
+    //     let if_exists = req.if_exists;
+    //
+    //     let res = self.sm_tree.txn(true, |t| {
+    //         let r = self.apply_cmd(&Cmd::DropShare(req.clone()), &t)?;
+    //         Ok(r)
+    //     })?;
+    //
+    //     assert!(res.result().is_none());
+    //
+    //     if res.prev().is_none() && !if_exists {
+    //         let ae = AppError::from(UnknownShare::new(share_name, "drop share"));
+    //         return Err(MetaError::from(ae));
+    //     }
+    //
+    //     Ok(DropShareReply {})
+    // }
+    //
+    // async fn get_share(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
+    //     let share_id = self.get_share_id(&req.tenant, &req.share_name)?;
+    //     let seq_share_info = self.get_share_info_by_id(&share_id)?;
+    //     Ok(Arc::new(seq_share_info.data))
+    // }
+    //
     fn name(&self) -> String {
         "StateMachine".to_string()
     }

--- a/common/meta/raft-store/tests/it/state_machine/meta_api_impl.rs
+++ b/common/meta/raft-store/tests/it/state_machine/meta_api_impl.rs
@@ -100,12 +100,12 @@ async fn test_meta_embedded_table_list() -> anyhow::Result<()> {
     MetaApiTestSuite {}.table_list(&sm).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_meta_embedded_share_create_get_drop() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_raft_store_ut!();
-    let _ent = ut_span.enter();
-    let tc = new_raft_test_context();
-    let sm = StateMachine::open(&tc.raft_config, 1).await?;
-
-    MetaApiTestSuite {}.share_create_get_drop(&sm).await
-}
+// #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+// async fn test_meta_embedded_share_create_get_drop() -> anyhow::Result<()> {
+//     let (_log_guards, ut_span) = init_raft_store_ut!();
+//     let _ent = ut_span.enter();
+//     let tc = new_raft_test_context();
+//     let sm = StateMachine::open(&tc.raft_config, 1).await?;
+//
+//     MetaApiTestSuite {}.share_create_get_drop(&sm).await
+// }

--- a/common/meta/types/src/database.rs
+++ b/common/meta/types/src/database.rs
@@ -115,7 +115,7 @@ impl Display for CreateDatabaseReq {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct CreateDatabaseReply {
-    pub database_id: u64,
+    pub db_id: u64,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -129,7 +129,6 @@ pub use meta_storage_errors::UnknownShare;
 pub use meta_storage_errors::UnknownTable;
 pub use meta_storage_errors::UnknownTableId;
 pub use operation::MetaId;
-pub use operation::MetaVersion;
 pub use operation::Operation;
 pub use principal_identity::PrincipalIdentity;
 pub use protobuf::txn_condition;

--- a/common/meta/types/src/message.rs
+++ b/common/meta/types/src/message.rs
@@ -30,7 +30,6 @@ use crate::Endpoint;
 use crate::GetDatabaseReq;
 use crate::GetKVActionReply;
 use crate::GetKVReq;
-use crate::GetShareReq;
 use crate::GetTableReq;
 use crate::ListDatabaseReq;
 use crate::ListKVReq;
@@ -81,8 +80,7 @@ pub enum ForwardRequestBody {
     GetKV(GetKVReq),
     MGetKV(MGetKVReq),
     ListKV(ListKVReq),
-
-    GetShare(GetShareReq),
+    // GetShare(GetShareReq),
 }
 
 /// A request that is forwarded from one raft node to another

--- a/common/meta/types/src/operation.rs
+++ b/common/meta/types/src/operation.rs
@@ -16,7 +16,6 @@
 
 use std::fmt::Debug;
 
-pub type MetaVersion = u64;
 pub type MetaId = u64;
 
 /// An operation that updates a field, delete it, or leave it as is.

--- a/common/meta/types/src/table.rs
+++ b/common/meta/types/src/table.rs
@@ -27,7 +27,6 @@ use maplit::hashmap;
 
 use crate::database::DatabaseNameIdent;
 use crate::MatchSeq;
-use crate::MetaVersion;
 
 /// Globally unique identifier of a version of TableMeta.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Default)]
@@ -35,26 +34,25 @@ pub struct TableIdent {
     /// Globally unique id to identify a table.
     pub table_id: u64,
 
-    /// version of this table snapshot.
+    /// seq AKA version of this table snapshot.
     ///
-    /// Any change to a table causes the version to increment, e.g. insert or delete rows, update schema etc.
-    /// But renaming a table should not affect the version, since the table itself does not change.
-    /// The tuple (database_id, table_id, version) identifies a unique and consistent table snapshot.
+    /// Any change to a table causes the seq to increment, e.g. insert or delete rows, update schema etc.
+    /// But renaming a table should not affect the seq, since the table itself does not change.
+    /// The tuple (table_id, seq) identifies a unique and consistent table snapshot.
     ///
-    /// A version is not guaranteed to be consecutive.
-    ///
-    pub version: MetaVersion,
+    /// A seq is not guaranteed to be consecutive.
+    pub seq: u64,
 }
 
 impl TableIdent {
-    pub fn new(table_id: u64, version: MetaVersion) -> Self {
-        TableIdent { table_id, version }
+    pub fn new(table_id: u64, seq: u64) -> Self {
+        TableIdent { table_id, seq }
     }
 }
 
 impl Display for TableIdent {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "table_id:{}, ver:{}", self.table_id, self.version)
+        write!(f, "table_id:{}, ver:{}", self.table_id, self.seq)
     }
 }
 
@@ -367,7 +365,7 @@ impl UpsertTableOptionReq {
     ) -> UpsertTableOptionReq {
         UpsertTableOptionReq {
             table_id: table_ident.table_id,
-            seq: MatchSeq::Exact(table_ident.version),
+            seq: MatchSeq::Exact(table_ident.seq),
             options: hashmap! {key.into() => Some(value.into())},
         }
     }

--- a/common/proto-conv/src/from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/from_to_protobuf_impl.rs
@@ -203,7 +203,7 @@ impl FromToProto<pb::TableIdent> for mt::TableIdent {
 
         let v = Self {
             table_id: p.table_id,
-            version: p.seq,
+            seq: p.seq,
         };
         Ok(v)
     }
@@ -212,7 +212,7 @@ impl FromToProto<pb::TableIdent> for mt::TableIdent {
         let p = pb::TableIdent {
             ver: VER,
             table_id: self.table_id,
-            seq: self.version,
+            seq: self.seq,
         };
 
         Ok(p)

--- a/common/proto-conv/tests/it/proto_conv.rs
+++ b/common/proto-conv/tests/it/proto_conv.rs
@@ -52,7 +52,7 @@ fn new_table_info() -> mt::TableInfo {
     mt::TableInfo {
         ident: mt::TableIdent {
             table_id: 5,
-            version: 6,
+            seq: 6,
         },
         desc: "foo".to_string(),
         name: "bar".to_string(),
@@ -245,7 +245,7 @@ fn test_load_old() -> anyhow::Result<()> {
         let want = mt::TableInfo {
             ident: mt::TableIdent {
                 table_id: 5,
-                version: 6,
+                seq: 6,
             },
             desc: "foo".to_string(),
             name: "bar".to_string(),

--- a/metasrv/src/executor/action_handler.rs
+++ b/metasrv/src/executor/action_handler.rs
@@ -129,13 +129,11 @@ impl ActionHandler {
             MetaGrpcReadReq::GetTableExt(a) => {
                 let r = self.handle(a).await;
                 RaftReply::from(r)
-            }
-
-            // share
-            MetaGrpcReadReq::GetShare(a) => {
-                let r = self.handle(a).await;
-                RaftReply::from(r)
-            }
+            } // // share
+              // MetaGrpcReadReq::GetShare(a) => {
+              //     let r = self.handle(a).await;
+              //     RaftReply::from(r)
+              // }
         }
     }
 

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -43,7 +43,6 @@ use common_meta_types::DropShareReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
 use common_meta_types::GetDatabaseReq;
-use common_meta_types::GetShareReq;
 use common_meta_types::GetTableReq;
 use common_meta_types::ListDatabaseReq;
 use common_meta_types::ListTableReq;
@@ -374,10 +373,10 @@ impl RequestHandler<DropShareReq> for ActionHandler {
     }
 }
 
-#[async_trait::async_trait]
-impl RequestHandler<GetShareReq> for ActionHandler {
-    async fn handle(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
-        let res = self.meta_node.consistent_read(req).await?;
-        Ok(res)
-    }
-}
+// #[async_trait::async_trait]
+// impl RequestHandler<GetShareReq> for ActionHandler {
+//     async fn handle(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
+//         let res = self.meta_node.consistent_read(req).await?;
+//         Ok(res)
+//     }
+// }

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -100,7 +100,7 @@ impl RequestHandler<CreateDatabaseReq> for ActionHandler {
 
         Ok(CreateDatabaseReply {
             // TODO(xp): return DatabaseInfo?
-            database_id: db_id,
+            db_id,
         })
     }
 }

--- a/metasrv/src/meta_service/meta_leader.rs
+++ b/metasrv/src/meta_service/meta_leader.rs
@@ -106,12 +106,11 @@ impl<'a> MetaLeader<'a> {
                 let sm = self.meta_node.get_state_machine().await;
                 let res = sm.prefix_list_kv(&req.prefix).await?;
                 Ok(ForwardResponse::ListKV(res))
-            }
-            ForwardRequestBody::GetShare(req) => {
-                let sm = self.meta_node.get_state_machine().await;
-                let res = sm.get_share(req).await?;
-                Ok(ForwardResponse::ShareInfo(res))
-            }
+            } // ForwardRequestBody::GetShare(req) => {
+              //     let sm = self.meta_node.get_state_machine().await;
+              //     let res = sm.get_share(req).await?;
+              //     Ok(ForwardResponse::ShareInfo(res))
+              // }
         }
     }
 

--- a/metasrv/tests/it/grpc/metasrv_grpc_meta_api.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_meta_api.rs
@@ -121,17 +121,17 @@ async fn test_meta_api_table_list() -> anyhow::Result<()> {
     MetaApiTestSuite {}.table_list(&client).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_meta_api_share_create_get_drop() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
-    let (_tc, addr) = start_metasrv().await?;
-
-    let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
-
-    MetaApiTestSuite {}.share_create_get_drop(&client).await
-}
+// #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+// async fn test_meta_api_share_create_get_drop() -> anyhow::Result<()> {
+//     let (_log_guards, ut_span) = init_meta_ut!();
+//     let _ent = ut_span.enter();
+//
+//     let (_tc, addr) = start_metasrv().await?;
+//
+//     let client = MetaGrpcClient::try_create(addr.as_str(), "root", "xxx", None, None).await?;
+//
+//     MetaApiTestSuite {}.share_create_get_drop(&client).await
+// }
 
 // TODO(xp): uncomment following tests when the function is ready
 // ------------------------------------------------------------

--- a/query/src/catalogs/backends/meta_backend.rs
+++ b/query/src/catalogs/backends/meta_backend.rs
@@ -19,19 +19,14 @@ use std::time::Duration;
 use common_meta_api::MetaApi;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::CreateDatabaseReq;
-use common_meta_types::CreateShareReply;
-use common_meta_types::CreateShareReq;
 use common_meta_types::CreateTableReply;
 use common_meta_types::CreateTableReq;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::DropDatabaseReply;
 use common_meta_types::DropDatabaseReq;
-use common_meta_types::DropShareReply;
-use common_meta_types::DropShareReq;
 use common_meta_types::DropTableReply;
 use common_meta_types::DropTableReq;
 use common_meta_types::GetDatabaseReq;
-use common_meta_types::GetShareReq;
 use common_meta_types::GetTableReq;
 use common_meta_types::ListDatabaseReq;
 use common_meta_types::ListTableReq;
@@ -39,7 +34,6 @@ use common_meta_types::MetaError;
 use common_meta_types::MetaId;
 use common_meta_types::RenameTableReply;
 use common_meta_types::RenameTableReq;
-use common_meta_types::ShareInfo;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
@@ -171,20 +165,20 @@ impl MetaApi for MetaBackend {
             .await
     }
 
-    async fn create_share(&self, req: CreateShareReq) -> Result<CreateShareReply, MetaError> {
-        self.query_backend(move |cli| async move { cli.create_share(req).await })
-            .await
-    }
-
-    async fn drop_share(&self, req: DropShareReq) -> Result<DropShareReply, MetaError> {
-        self.query_backend(move |cli| async move { cli.drop_share(req).await })
-            .await
-    }
-
-    async fn get_share(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
-        self.query_backend(move |cli| async move { cli.get_share(req).await })
-            .await
-    }
+    // async fn create_share(&self, req: CreateShareReq) -> Result<CreateShareReply, MetaError> {
+    //     self.query_backend(move |cli| async move { cli.create_share(req).await })
+    //         .await
+    // }
+    //
+    // async fn drop_share(&self, req: DropShareReq) -> Result<DropShareReply, MetaError> {
+    //     self.query_backend(move |cli| async move { cli.drop_share(req).await })
+    //         .await
+    // }
+    //
+    // async fn get_share(&self, req: GetShareReq) -> Result<Arc<ShareInfo>, MetaError> {
+    //     self.query_backend(move |cli| async move { cli.get_share(req).await })
+    //         .await
+    // }
 
     fn name(&self) -> String {
         "meta-remote".to_owned()

--- a/query/src/catalogs/impls/mutable_catalog.rs
+++ b/query/src/catalogs/impls/mutable_catalog.rs
@@ -176,7 +176,7 @@ impl Catalog for MutableCatalog {
         // Initial the database after creating.
         let db_info = Arc::new(DatabaseInfo {
             ident: DatabaseIdent {
-                db_id: res.database_id,
+                db_id: res.db_id,
                 seq: 0, // TODO
             },
             name_ident: req.name_ident.clone(),
@@ -184,9 +184,7 @@ impl Catalog for MutableCatalog {
         });
         let database = self.build_db_instance(&db_info)?;
         database.init_database(&req.name_ident.tenant).await?;
-        Ok(CreateDatabaseReply {
-            database_id: res.database_id,
-        })
+        Ok(CreateDatabaseReply { db_id: res.db_id })
     }
 
     async fn drop_database(&self, req: DropDatabaseReq) -> Result<()> {

--- a/query/src/storages/fuse/operations/commit.rs
+++ b/query/src/storages/fuse/operations/commit.rs
@@ -254,7 +254,7 @@ impl FuseTable {
         self::utils::gather_legacy_options(table_info, &mut options);
 
         let table_id = table_info.ident.table_id;
-        let table_version = table_info.ident.version;
+        let table_version = table_info.ident.seq;
         let req = UpsertTableOptionReq {
             table_id,
             seq: MatchSeq::Exact(table_version),

--- a/query/tests/it/storages/fuse/table.rs
+++ b/query/tests/it/storages/fuse/table.rs
@@ -56,9 +56,9 @@ async fn test_fuse_table_normal_case() -> Result<()> {
             .await?;
 
         // get the latest tbl
-        let prev_version = table.get_table_info().ident.version;
+        let prev_version = table.get_table_info().ident.seq;
         table = fixture.latest_default_table().await?;
-        assert_ne!(prev_version, table.get_table_info().ident.version);
+        assert_ne!(prev_version, table.get_table_info().ident.seq);
 
         let (stats, parts) = table.read_partitions(ctx.clone(), None).await?;
         assert_eq!(stats.read_rows, num_blocks * rows_per_block);
@@ -113,9 +113,9 @@ async fn test_fuse_table_normal_case() -> Result<()> {
             .await?;
 
         // get the latest tbl
-        let prev_version = table.get_table_info().ident.version;
+        let prev_version = table.get_table_info().ident.seq;
         let table = fixture.latest_default_table().await?;
-        assert_ne!(prev_version, table.get_table_info().ident.version);
+        assert_ne!(prev_version, table.get_table_info().ident.seq);
 
         let (stats, parts) = table.read_partitions(ctx.clone(), None).await?;
         assert_eq!(stats.read_rows, num_blocks * rows_per_block);
@@ -173,11 +173,11 @@ async fn test_fuse_table_truncate() -> Result<()> {
     };
 
     // 1. truncate empty table
-    let prev_version = table.get_table_info().ident.version;
+    let prev_version = table.get_table_info().ident.seq;
     let r = table.truncate(ctx.clone(), truncate_plan.clone()).await;
     let table = fixture.latest_default_table().await?;
     // no side effects
-    assert_eq!(prev_version, table.get_table_info().ident.version);
+    assert_eq!(prev_version, table.get_table_info().ident.seq);
     assert!(r.is_ok());
 
     // 2. truncate table which has data
@@ -194,9 +194,9 @@ async fn test_fuse_table_truncate() -> Result<()> {
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 
     // get the latest tbl
-    let prev_version = table.get_table_info().ident.version;
+    let prev_version = table.get_table_info().ident.seq;
     let table = fixture.latest_default_table().await?;
-    assert_ne!(prev_version, table.get_table_info().ident.version);
+    assert_ne!(prev_version, table.get_table_info().ident.seq);
 
     // ensure data ingested
     let (stats, _) = table
@@ -209,9 +209,9 @@ async fn test_fuse_table_truncate() -> Result<()> {
     assert!(r.is_ok());
 
     // get the latest tbl
-    let prev_version = table.get_table_info().ident.version;
+    let prev_version = table.get_table_info().ident.seq;
     let table = fixture.latest_default_table().await?;
-    assert_ne!(prev_version, table.get_table_info().ident.version);
+    assert_ne!(prev_version, table.get_table_info().ident.seq);
     let (stats, parts) = table
         .read_partitions(ctx.clone(), source_plan.push_downs.clone())
         .await?;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] disable `share` APIs
- Fix: #5190


##### [meta] rename CreateDatabaseReply.database_id to db_id; TableIdent.version to seq
- Fix: #5189

## Changelog







## Related Issues