### PR TITLE
chore: Make cargo clippy --all-targets happy

### DIFF
--- a/common/macros/src/lib.rs
+++ b/common/macros/src/lib.rs
@@ -17,17 +17,14 @@ mod malloc_sizeof;
 
 synstructure::decl_derive!([MallocSizeOf, attributes(ignore_malloc_size_of, conditional_malloc_size_of)] => malloc_sizeof::malloc_size_of_derive);
 
-#[allow(unused)]
 use proc_macro::TokenStream;
 
 #[proc_macro_attribute]
-#[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub fn databend_main(args: TokenStream, item: TokenStream) -> TokenStream {
     async_entrypoint::async_main(args, item)
 }
 
 #[proc_macro_attribute]
-#[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub fn databend_test(args: TokenStream, item: TokenStream) -> TokenStream {
     async_entrypoint::async_test(args, item)
 }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Address warning about:

```shell
warning: function is never used: `token_stream_with_error`
  --> common/macros/src/async_entrypoint.rs:19:4
   |
19 | fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error) -> TokenStream {
   |    ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: function is never used: `async_main`
  --> common/macros/src/async_entrypoint.rs:24:8
   |
24 | pub fn async_main(_args: TokenStream, item: TokenStream) -> TokenStream {
   |        ^^^^^^^^^^

warning: function is never used: `async_test`
  --> common/macros/src/async_entrypoint.rs:37:8
   |
37 | pub fn async_test(_args: TokenStream, item: TokenStream) -> TokenStream {
   |        ^^^^^^^^^^

warning: function is never used: `parse_knobs`
  --> common/macros/src/async_entrypoint.rs:50:4
   |
50 | fn parse_knobs(mut input: syn::ItemFn, is_test: bool, has_tracker: bool) -> TokenStream {
   |    ^^^^^^^^^^^

warning: `common-macros` (lib test) generated 4 warnings
```

## Changelog

- Improvement


