### PR TITLE
feat(doc): add Array(T) docs

### DIFF
--- a/docs/doc/30-reference/10-data-types/50-data-type-array-types.md
+++ b/docs/doc/30-reference/10-data-types/50-data-type-array-types.md
@@ -1,0 +1,45 @@
+---
+title: Array(T)
+description: Array of defined data type.
+---
+
+## Array(T) Data Types
+
+ARRAY(T) consists of defined variable-length inner T data type values, which is very similar to a semi-structured ARRAY, except that the inner data type needs to be defined rather than arbitrary. T can be any data type.
+
+### Example
+
+```sql
+CREATE TABLE array_int64_table(arr ARRAY(INT64) NULL);
+```
+
+```sql
+DESC array_int64_table;
+```
+
+Insert two values into the table, `[1,2,3,4]`, `[5,6,7,8]`:
+```sql
+INSERT INTO array_int64_table VALUES([1,2,3,4]),([5,6,7,8]);
+```
+
+Get all elements of the array:
+```sql
+SELECT arr FROM array_int64_table;
++--------------+
+| arr          |
++--------------+
+| [1, 2, 3, 4] |
+| [5, 6, 7, 8] |
++--------------+
+```
+
+Get the element at index 0 of the array:
+```sql
+SELECT arr[0] FROM array_int64_table;
++--------+
+| arr[0] |
++--------+
+|      1 |
+|      5 |
++--------+
+```

--- a/docs/doc/30-reference/10-data-types/index.md
+++ b/docs/doc/30-reference/10-data-types/index.md
@@ -10,6 +10,7 @@ Databend supports SQL data types in several categories:
 * [Date & Time Data Types](20-data-type-time-date-types.md)
 * [String Data Types](30-data-type-string-types.md)
 * [Semi-structured Data Types](40-data-type-semi-structured-types.md)
+* [Array(T) Data Types](50-data-type-array-types.md)
 
 ## General-Purpose Data Types
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add `Array(T)` docs

We can provide two types of arrays.
- `Array(T)` is used to store data with the pre-defined inner data type, similar to [ClickHouse's `Array(T)`](https://clickhouse.com/docs/en/sql-reference/data-types/array). 
- The semi-structured `Array` is used to store JSON-type data.

## Changelog

- Documentation

## Related Issues

Fixes #issue

