### PR TITLE
docs: Algolia enforce using databend-rs as prefix

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -167,7 +167,7 @@ const config = {
             algolia: {
                 appId: 'RL7MS9PKE8',
                 apiKey: '78bb6be96bb0361a4be9dab6bd83936c',
-                indexName: 'databend-rs',
+                indexName: 'databend-rs-docs',
                 contextualSearch: true,
             }
         }),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The new upgrade from Algolia enforce us to use databend-rs as prefix instead of name.

So we will migrate to `databend-rs-docs`.

## Changelog

- Documentation


