### PR TITLE
refine(planner): remove `OrderExpr` from Scalar

### DIFF
--- a/query/src/sql/exec/expression_builder.rs
+++ b/query/src/sql/exec/expression_builder.rs
@@ -25,7 +25,6 @@ use crate::sql::plans::ComparisonExpr;
 use crate::sql::plans::ConstantExpr;
 use crate::sql::plans::FunctionCall;
 use crate::sql::plans::OrExpr;
-use crate::sql::plans::OrderExpr;
 use crate::sql::plans::Scalar;
 use crate::sql::IndexType;
 use crate::sql::Metadata;
@@ -107,22 +106,6 @@ impl<'a> ExpressionBuilder<'a> {
                     expr: Box::new(arg),
                     data_type: target_type.clone(),
                     pg_style: false,
-                })
-            }
-            Scalar::Order(OrderExpr {
-                expr,
-                asc,
-                nulls_first,
-            }) => {
-                let expr = self.build(expr)?;
-                let asc = asc.unwrap_or(true);
-                // NULLS FIRST is the default for DESC order, and NULLS LAST otherwise
-                let nulls_first = nulls_first.unwrap_or(!asc);
-                Ok(Expression::Sort {
-                    expr: Box::new(expr.clone()),
-                    asc,
-                    nulls_first,
-                    origin_expr: Box::new(expr),
                 })
             }
         }

--- a/query/src/sql/planner/binder/scalar_visitor.rs
+++ b/query/src/sql/planner/binder/scalar_visitor.rs
@@ -20,7 +20,6 @@ use crate::sql::plans::CastExpr;
 use crate::sql::plans::ComparisonExpr;
 use crate::sql::plans::FunctionCall;
 use crate::sql::plans::OrExpr;
-use crate::sql::plans::OrderExpr;
 use crate::sql::plans::Scalar;
 
 /// Controls how the visitor recursion should proceed.
@@ -78,9 +77,6 @@ pub trait ScalarVisitor: Sized {
                                 Scalar::BoundColumnRef(_) | Scalar::ConstantExpr(_) => {}
                                 Scalar::Cast(CastExpr { argument, .. }) => {
                                     stack.push(RecursionProcessing::Call(argument))
-                                }
-                                Scalar::Order(OrderExpr { expr, .. }) => {
-                                    stack.push(RecursionProcessing::Call(expr))
                                 }
                             }
 

--- a/query/src/sql/planner/binder/sort.rs
+++ b/query/src/sql/planner/binder/sort.rs
@@ -19,9 +19,8 @@ use common_exception::Result;
 use crate::sql::binder::scalar::ScalarBinder;
 use crate::sql::binder::Binder;
 use crate::sql::optimizer::SExpr;
-use crate::sql::plans::OrderExpr;
 use crate::sql::plans::Scalar;
-use crate::sql::plans::Scalar::Order;
+use crate::sql::plans::SortItem;
 use crate::sql::plans::SortPlan;
 use crate::sql::BindContext;
 
@@ -39,12 +38,12 @@ impl Binder {
 
         let mut order_by_items = Vec::with_capacity(order_by_exprs.len());
         for (idx, order_by_expr) in order_by_exprs.iter().enumerate() {
-            let order_by_item = OrderExpr {
-                expr: Box::new(order_by_expr.0.clone()),
+            let order_by_item = SortItem {
+                expr: order_by_expr.0.clone(),
                 asc: order_by[idx].asc,
                 nulls_first: order_by[idx].nulls_first,
             };
-            order_by_items.push(Order(order_by_item));
+            order_by_items.push(order_by_item);
         }
         let sort_plan = SortPlan {
             items: order_by_items,

--- a/query/src/sql/planner/plans/mod.rs
+++ b/query/src/sql/planner/plans/mod.rs
@@ -36,6 +36,7 @@ pub use physical_scan::PhysicalScan;
 pub use project::ProjectItem;
 pub use project::ProjectPlan;
 pub use scalar::*;
+pub use sort::SortItem;
 pub use sort::SortPlan;
 
 use crate::sql::optimizer::PhysicalProperty;

--- a/query/src/sql/planner/plans/scalar.rs
+++ b/query/src/sql/planner/plans/scalar.rs
@@ -49,7 +49,6 @@ pub enum Scalar {
     AggregateFunction(AggregateFunction),
     FunctionCall(FunctionCall),
     Cast(CastExpr),
-    Order(OrderExpr),
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -248,24 +247,5 @@ impl ScalarExpr for CastExpr {
 
     fn used_columns(&self) -> ColumnSet {
         self.argument.used_columns()
-    }
-}
-
-#[derive(Clone, PartialEq, Debug)]
-pub struct OrderExpr {
-    pub expr: Box<Scalar>,
-    // Optional `ASC` or `DESC`
-    pub asc: Option<bool>,
-    // Optional `NULLS FIRST` or `NULLS LAST`
-    pub nulls_first: Option<bool>,
-}
-
-impl ScalarExpr for OrderExpr {
-    fn data_type(&self) -> DataTypeImpl {
-        todo!()
-    }
-
-    fn used_columns(&self) -> ColumnSet {
-        self.expr.used_columns()
     }
 }

--- a/query/src/sql/planner/plans/sort.rs
+++ b/query/src/sql/planner/plans/sort.rs
@@ -25,7 +25,14 @@ use crate::sql::plans::Scalar;
 
 #[derive(Clone, Debug)]
 pub struct SortPlan {
-    pub items: Vec<Scalar>,
+    pub items: Vec<SortItem>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SortItem {
+    pub expr: Scalar,
+    pub asc: Option<bool>,
+    pub nulls_first: Option<bool>,
 }
 
 impl BasePlan for SortPlan {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`OrderBy` doesn't do any evaluation, so it shouldn't be in `Scalar`.
Move all `OrderBy` related information to `SortPlan`.

## Changelog

- Improvement

## Related Issues

Fixes #issue

