### PR TITLE
feature(planner): Support subqueries in new planner

### DIFF
--- a/query/src/sql/exec/expression_builder.rs
+++ b/query/src/sql/exec/expression_builder.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_datavalues::DataValue;
+use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::Expression;
 
@@ -108,6 +109,7 @@ impl<'a> ExpressionBuilder<'a> {
                     pg_style: false,
                 })
             }
+            Scalar::SubqueryExpr(_) => Err(ErrorCode::UnImplement("Unsupported subquery expr")),
         }
     }
 
@@ -165,7 +167,7 @@ impl<'a> ExpressionBuilder<'a> {
                     left: Box::new(self.normalize_aggr_to_col(*left)?),
                     op,
                     right: Box::new(self.normalize_aggr_to_col(*right)?),
-                })
+                });
             }
             Expression::AggregateFunction { .. } => {
                 let col_name = expr.column_name();
@@ -178,7 +180,7 @@ impl<'a> ExpressionBuilder<'a> {
                         .iter()
                         .map(|arg| self.normalize_aggr_to_col(arg.clone()))
                         .collect::<Result<Vec<Expression>>>()?,
-                })
+                });
             }
             _ => {}
         }

--- a/query/src/sql/exec/expression_builder.rs
+++ b/query/src/sql/exec/expression_builder.rs
@@ -162,28 +162,23 @@ impl<'a> ExpressionBuilder<'a> {
     // Transform aggregator expression to column expression
     pub(crate) fn normalize_aggr_to_col(&self, expr: Expression) -> Result<Expression> {
         match expr.clone() {
-            Expression::BinaryExpression { left, op, right } => {
-                return Ok(Expression::BinaryExpression {
-                    left: Box::new(self.normalize_aggr_to_col(*left)?),
-                    op,
-                    right: Box::new(self.normalize_aggr_to_col(*right)?),
-                });
-            }
+            Expression::BinaryExpression { left, op, right } => Ok(Expression::BinaryExpression {
+                left: Box::new(self.normalize_aggr_to_col(*left)?),
+                op,
+                right: Box::new(self.normalize_aggr_to_col(*right)?),
+            }),
             Expression::AggregateFunction { .. } => {
                 let col_name = expr.column_name();
-                return Ok(Expression::Column(col_name));
+                Ok(Expression::Column(col_name))
             }
-            Expression::ScalarFunction { op, args } => {
-                return Ok(Expression::ScalarFunction {
-                    op,
-                    args: args
-                        .iter()
-                        .map(|arg| self.normalize_aggr_to_col(arg.clone()))
-                        .collect::<Result<Vec<Expression>>>()?,
-                });
-            }
-            _ => {}
+            Expression::ScalarFunction { op, args } => Ok(Expression::ScalarFunction {
+                op,
+                args: args
+                    .iter()
+                    .map(|arg| self.normalize_aggr_to_col(arg.clone()))
+                    .collect::<Result<Vec<Expression>>>()?,
+            }),
+            _ => Ok(expr),
         }
-        Ok(expr)
     }
 }

--- a/query/src/sql/planner/binder/aggregate.rs
+++ b/query/src/sql/planner/binder/aggregate.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use common_ast::ast::Expr;
-use common_datavalues::DataTypeImpl;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
@@ -62,16 +61,16 @@ impl Binder {
         Ok(())
     }
 
-    pub(super) fn bind_group_by(
+    pub(super) async fn bind_group_by(
         &mut self,
         group_by_expr: &[Expr],
         input_context: &mut BindContext,
     ) -> Result<()> {
-        let scalar_binder = ScalarBinder::new(input_context);
-        let group_expr = group_by_expr
-            .iter()
-            .map(|expr| scalar_binder.bind_expr(expr))
-            .collect::<Result<Vec<(Scalar, DataTypeImpl)>>>()?;
+        let scalar_binder = ScalarBinder::new(input_context, self.ctx.clone());
+        let mut group_expr = vec![];
+        for expr in group_by_expr.iter() {
+            group_expr.push(scalar_binder.bind_expr(expr).await?);
+        }
 
         let aggregate_plan = AggregatePlan {
             group_expr: group_expr.into_iter().map(|(scalar, _)| scalar).collect(),

--- a/query/src/sql/planner/binder/aggregate.rs
+++ b/query/src/sql/planner/binder/aggregate.rs
@@ -53,7 +53,7 @@ impl Binder {
                 _ => {
                     return Err(ErrorCode::LogicalError(
                         "scalar expr must be Aggregation scalar expr",
-                    ))
+                    ));
                 }
             }
         }
@@ -67,7 +67,7 @@ impl Binder {
         input_context: &mut BindContext,
     ) -> Result<()> {
         let scalar_binder = ScalarBinder::new(input_context, self.ctx.clone());
-        let mut group_expr = vec![];
+        let mut group_expr = Vec::with_capacity(group_by_expr.len());
         for expr in group_by_expr.iter() {
             group_expr.push(scalar_binder.bind_expr(expr).await?);
         }

--- a/query/src/sql/planner/binder/bind_context.rs
+++ b/query/src/sql/planner/binder/bind_context.rs
@@ -40,7 +40,7 @@ pub struct ColumnBinding {
 }
 
 /// `BindContext` stores all the free variables in a query and tracks the context of binding procedure.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct BindContext {
     _parent: Option<Box<BindContext>>,
     pub columns: Vec<ColumnBinding>,
@@ -62,7 +62,7 @@ impl BindContext {
         Self::default()
     }
 
-    fn new_with_parent(parent: Box<BindContext>) -> Self {
+    pub fn with_parent(parent: Box<BindContext>) -> Self {
         BindContext {
             _parent: Some(parent),
             columns: vec![],
@@ -74,7 +74,7 @@ impl BindContext {
 
     /// Generate a new BindContext and take current BindContext as its parent.
     pub fn push(self) -> Self {
-        Self::new_with_parent(Box::new(self))
+        Self::with_parent(Box::new(self))
     }
 
     /// Returns all column bindings in current scope.

--- a/query/src/sql/planner/binder/join.rs
+++ b/query/src/sql/planner/binder/join.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use async_recursion::async_recursion;
 use common_ast::ast::Expr;
 use common_ast::ast::Join;
@@ -21,6 +23,7 @@ use common_datavalues::type_coercion::merge_types;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
+use crate::sessions::QueryContext;
 use crate::sql::binder::scalar_common::split_conjunctions;
 use crate::sql::binder::scalar_common::split_equivalent_predicate;
 use crate::sql::binder::scalar_common::wrap_cast_if_needed;
@@ -55,13 +58,20 @@ impl Binder {
         let mut left_join_conditions: Vec<Scalar> = vec![];
         let mut right_join_conditions: Vec<Scalar> = vec![];
         let mut other_conditions: Vec<Scalar> = vec![];
-        let join_condition_resolver =
-            JoinConditionResolver::new(&left_child, &right_child, &bind_context, &join.condition);
-        join_condition_resolver.resolve(
-            &mut left_join_conditions,
-            &mut right_join_conditions,
-            &mut other_conditions,
-        )?;
+        let join_condition_resolver = JoinConditionResolver::new(
+            self.ctx.clone(),
+            &left_child,
+            &right_child,
+            &bind_context,
+            &join.condition,
+        );
+        join_condition_resolver
+            .resolve(
+                &mut left_join_conditions,
+                &mut right_join_conditions,
+                &mut other_conditions,
+            )
+            .await?;
 
         match &join.op {
             JoinOperator::Inner => {
@@ -126,6 +136,8 @@ impl Binder {
 }
 
 struct JoinConditionResolver<'a> {
+    ctx: Arc<QueryContext>,
+
     left_context: &'a BindContext,
     right_context: &'a BindContext,
     join_context: &'a BindContext,
@@ -134,12 +146,14 @@ struct JoinConditionResolver<'a> {
 
 impl<'a> JoinConditionResolver<'a> {
     pub fn new(
+        ctx: Arc<QueryContext>,
         left_context: &'a BindContext,
         right_context: &'a BindContext,
         join_context: &'a BindContext,
         join_condition: &'a JoinCondition,
     ) -> Self {
         Self {
+            ctx,
             left_context,
             right_context,
             join_context,
@@ -147,7 +161,7 @@ impl<'a> JoinConditionResolver<'a> {
         }
     }
 
-    pub fn resolve(
+    pub async fn resolve(
         &self,
         left_join_conditions: &mut Vec<Scalar>,
         right_join_conditions: &mut Vec<Scalar>,
@@ -160,7 +174,8 @@ impl<'a> JoinConditionResolver<'a> {
                     left_join_conditions,
                     right_join_conditions,
                     other_join_conditions,
-                )?;
+                )
+                .await?;
             }
             JoinCondition::Using(_) => {
                 return Err(ErrorCode::UnImplement("USING clause is not supported yet. Please specify join condition with ON clause."));
@@ -175,15 +190,15 @@ impl<'a> JoinConditionResolver<'a> {
         Ok(())
     }
 
-    fn resolve_on(
+    async fn resolve_on(
         &self,
         condition: &Expr,
         left_join_conditions: &mut Vec<Scalar>,
         right_join_conditions: &mut Vec<Scalar>,
         other_join_conditions: &mut Vec<Scalar>,
     ) -> Result<()> {
-        let scalar_binder = ScalarBinder::new(self.join_context);
-        let (scalar, _) = scalar_binder.bind_expr(condition)?;
+        let scalar_binder = ScalarBinder::new(self.join_context, self.ctx.clone());
+        let (scalar, _) = scalar_binder.bind_expr(condition).await?;
         let conjunctions = split_conjunctions(&scalar);
 
         for expr in conjunctions.iter() {
@@ -192,12 +207,13 @@ impl<'a> JoinConditionResolver<'a> {
                 left_join_conditions,
                 right_join_conditions,
                 other_join_conditions,
-            )?;
+            )
+            .await?;
         }
         Ok(())
     }
 
-    fn resolve_predicate(
+    async fn resolve_predicate(
         &self,
         predicate: &Scalar,
         left_join_conditions: &mut Vec<Scalar>,

--- a/query/src/sql/planner/binder/project.rs
+++ b/query/src/sql/planner/binder/project.rs
@@ -69,8 +69,7 @@ impl Binder {
     /// For scalar expressions and aggregate expressions, we will register new columns for
     /// them in `Metadata`. And notice that, the semantic of aggregate expressions won't be checked
     /// in this function.
-    #[allow(unreachable_patterns)]
-    pub(super) fn normalize_select_list(
+    pub(super) async fn normalize_select_list(
         &mut self,
         select_list: &[SelectTarget],
         has_order_by: bool,
@@ -108,8 +107,8 @@ impl Binder {
                     }
                 }
                 SelectTarget::AliasedExpr { expr, alias } => {
-                    let scalar_binder = ScalarBinder::new(input_context);
-                    let (bound_expr, data_type) = scalar_binder.bind_expr(expr)?;
+                    let scalar_binder = ScalarBinder::new(input_context, self.ctx.clone());
+                    let (bound_expr, data_type) = scalar_binder.bind_expr(expr).await?;
 
                     // If alias is not specified, we will generate a name for the scalar expression.
                     let expr_name = match alias {

--- a/query/src/sql/planner/binder/scalar.rs
+++ b/query/src/sql/planner/binder/scalar.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_ast::ast::Expr;
 use common_datavalues::DataTypeImpl;
 use common_exception::Result;
 
+use crate::sessions::QueryContext;
 use crate::sql::planner::binder::BindContext;
 use crate::sql::planner::semantic::TypeChecker;
 use crate::sql::plans::Scalar;
@@ -23,15 +26,16 @@ use crate::sql::plans::Scalar;
 /// Helper for binding scalar expression with `BindContext`.
 pub struct ScalarBinder<'a> {
     bind_context: &'a BindContext,
+    ctx: Arc<QueryContext>,
 }
 
 impl<'a> ScalarBinder<'a> {
-    pub fn new(bind_context: &'a BindContext) -> Self {
-        ScalarBinder { bind_context }
+    pub fn new(bind_context: &'a BindContext, ctx: Arc<QueryContext>) -> Self {
+        ScalarBinder { bind_context, ctx }
     }
 
-    pub fn bind_expr(&self, expr: &Expr) -> Result<(Scalar, DataTypeImpl)> {
-        let type_checker = TypeChecker::new(self.bind_context);
-        type_checker.resolve(expr, None)
+    pub async fn bind_expr(&self, expr: &Expr) -> Result<(Scalar, DataTypeImpl)> {
+        let type_checker = TypeChecker::new(self.bind_context, self.ctx.clone());
+        type_checker.resolve(expr, None).await
     }
 }

--- a/query/src/sql/planner/binder/scalar_visitor.rs
+++ b/query/src/sql/planner/binder/scalar_visitor.rs
@@ -19,7 +19,6 @@ use crate::sql::plans::AndExpr;
 use crate::sql::plans::CastExpr;
 use crate::sql::plans::ComparisonExpr;
 use crate::sql::plans::FunctionCall;
-use crate::sql::plans::OrExpr;
 use crate::sql::plans::Scalar;
 
 /// Controls how the visitor recursion should proceed.
@@ -78,6 +77,7 @@ pub trait ScalarVisitor: Sized {
                                 Scalar::Cast(CastExpr { argument, .. }) => {
                                     stack.push(RecursionProcessing::Call(argument))
                                 }
+                                Scalar::SubqueryExpr(_) => {}
                             }
 
                             visitor

--- a/query/src/sql/planner/binder/scalar_visitor.rs
+++ b/query/src/sql/planner/binder/scalar_visitor.rs
@@ -19,6 +19,7 @@ use crate::sql::plans::AndExpr;
 use crate::sql::plans::CastExpr;
 use crate::sql::plans::ComparisonExpr;
 use crate::sql::plans::FunctionCall;
+use crate::sql::plans::OrExpr;
 use crate::sql::plans::Scalar;
 
 /// Controls how the visitor recursion should proceed.

--- a/query/src/sql/planner/binder/select.rs
+++ b/query/src/sql/planner/binder/select.rs
@@ -22,7 +22,6 @@ use common_ast::ast::SelectStmt;
 use common_ast::ast::SelectTarget;
 use common_ast::ast::SetExpr;
 use common_ast::ast::TableReference;
-use common_datavalues::DataTypeImpl;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::Expression;
@@ -45,7 +44,7 @@ use crate::table_functions::TableFunction;
 
 impl Binder {
     #[async_recursion]
-    pub(super) async fn bind_query(
+    pub(crate) async fn bind_query(
         &mut self,
         query: &Query,
         bind_context: &BindContext,
@@ -70,7 +69,8 @@ impl Binder {
                 .as_ref()
                 .ok_or_else(|| ErrorCode::SemanticError("Order by should have order by columns"))?
                 .clone();
-            self.bind_order_by(&query.order_by, &mut bind_context)?;
+            self.bind_order_by(&query.order_by, &mut bind_context)
+                .await?;
             bind_context.columns = bind_context_cols;
         }
 
@@ -94,23 +94,26 @@ impl Binder {
         };
 
         if let Some(expr) = &stmt.selection {
-            self.bind_where(expr, &mut input_context, false)?;
+            self.bind_where(expr, &mut input_context, false).await?;
         }
 
         // Output of current `SELECT` statement.
-        let mut output_context =
-            self.normalize_select_list(&stmt.select_list, has_order_by, &input_context)?;
+
+        let mut output_context = self
+            .normalize_select_list(&stmt.select_list, has_order_by, &input_context)
+            .await?;
 
         self.analyze_aggregate(&output_context, &mut input_context)?;
 
         if !input_context.agg_scalar_exprs.as_ref().unwrap().is_empty() || !stmt.group_by.is_empty()
         {
-            self.bind_group_by(&stmt.group_by, &mut input_context)?;
+            self.bind_group_by(&stmt.group_by, &mut input_context)
+                .await?;
             output_context.expression = input_context.expression.clone();
         }
 
         if let Some(expr) = &stmt.having {
-            self.bind_where(expr, &mut input_context, true)?;
+            self.bind_where(expr, &mut input_context, true).await?;
             output_context.expression = input_context.expression.clone();
         }
 
@@ -199,11 +202,12 @@ impl Binder {
                 params,
                 alias,
             } => {
-                let scalar_binder = ScalarBinder::new(bind_context);
-                let args = params
-                    .iter()
-                    .map(|arg| scalar_binder.bind_expr(arg))
-                    .collect::<Result<Vec<(Scalar, DataTypeImpl)>>>()?;
+                let scalar_binder = ScalarBinder::new(bind_context, self.ctx.clone());
+                let mut args = vec![];
+                for arg in params.iter() {
+                    args.push(scalar_binder.bind_expr(arg).await?);
+                }
+
                 let expressions = args
                     .into_iter()
                     .map(|(scalar, _)| match scalar {
@@ -272,14 +276,14 @@ impl Binder {
         Ok(bind_context)
     }
 
-    pub(super) fn bind_where(
+    pub(super) async fn bind_where(
         &mut self,
         expr: &Expr,
         bind_context: &mut BindContext,
         is_having: bool,
     ) -> Result<()> {
-        let scalar_binder = ScalarBinder::new(bind_context);
-        let (scalar, _) = scalar_binder.bind_expr(expr)?;
+        let scalar_binder = ScalarBinder::new(bind_context, self.ctx.clone());
+        let (scalar, _) = scalar_binder.bind_expr(expr).await?;
         let filter_plan = FilterPlan {
             predicates: split_conjunctions(&scalar),
             is_having,

--- a/query/src/sql/planner/binder/select.rs
+++ b/query/src/sql/planner/binder/select.rs
@@ -203,7 +203,7 @@ impl Binder {
                 alias,
             } => {
                 let scalar_binder = ScalarBinder::new(bind_context, self.ctx.clone());
-                let mut args = vec![];
+                let mut args = Vec::with_capacity(params.len());
                 for arg in params.iter() {
                     args.push(scalar_binder.bind_expr(arg).await?);
                 }

--- a/query/src/sql/planner/binder/sort.rs
+++ b/query/src/sql/planner/binder/sort.rs
@@ -13,28 +13,26 @@
 // limitations under the License.
 
 use common_ast::ast::OrderByExpr;
-use common_datavalues::DataTypeImpl;
 use common_exception::Result;
 
 use crate::sql::binder::scalar::ScalarBinder;
 use crate::sql::binder::Binder;
 use crate::sql::optimizer::SExpr;
-use crate::sql::plans::Scalar;
 use crate::sql::plans::SortItem;
 use crate::sql::plans::SortPlan;
 use crate::sql::BindContext;
 
 impl Binder {
-    pub(super) fn bind_order_by(
+    pub(super) async fn bind_order_by(
         &mut self,
         order_by: &[OrderByExpr],
         bind_context: &mut BindContext,
     ) -> Result<()> {
-        let scalar_binder = ScalarBinder::new(bind_context);
-        let order_by_exprs = order_by
-            .iter()
-            .map(|expr| scalar_binder.bind_expr(&expr.expr))
-            .collect::<Result<Vec<(Scalar, DataTypeImpl)>>>()?;
+        let scalar_binder = ScalarBinder::new(bind_context, self.ctx.clone());
+        let mut order_by_exprs = vec![];
+        for expr in order_by {
+            order_by_exprs.push(scalar_binder.bind_expr(&expr.expr).await?);
+        }
 
         let mut order_by_items = Vec::with_capacity(order_by_exprs.len());
         for (idx, order_by_expr) in order_by_exprs.iter().enumerate() {

--- a/query/src/sql/planner/plans/scalar.rs
+++ b/query/src/sql/planner/plans/scalar.rs
@@ -22,6 +22,8 @@ use enum_dispatch::enum_dispatch;
 
 use crate::sql::binder::ColumnBinding;
 use crate::sql::optimizer::ColumnSet;
+use crate::sql::optimizer::SExpr;
+use crate::sql::BindContext;
 
 #[enum_dispatch]
 pub trait ScalarExpr {
@@ -49,6 +51,7 @@ pub enum Scalar {
     AggregateFunction(AggregateFunction),
     FunctionCall(FunctionCall),
     Cast(CastExpr),
+    SubqueryExpr(SubqueryExpr),
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -247,5 +250,29 @@ impl ScalarExpr for CastExpr {
 
     fn used_columns(&self) -> ColumnSet {
         self.argument.used_columns()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SubqueryExpr {
+    pub subquery: SExpr,
+    pub data_type: DataTypeImpl,
+    pub allow_multi_rows: bool,
+    pub output_context: Box<BindContext>,
+}
+
+impl ScalarExpr for SubqueryExpr {
+    fn data_type(&self) -> DataTypeImpl {
+        self.data_type.clone()
+    }
+
+    fn used_columns(&self) -> ColumnSet {
+        todo!()
+    }
+}
+
+impl PartialEq for SubqueryExpr {
+    fn eq(&self, _other: &Self) -> bool {
+        false
     }
 }

--- a/query/src/sql/planner/semantic/type_check.rs
+++ b/query/src/sql/planner/semantic/type_check.rs
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_ast::ast::BinaryOperator;
 use common_ast::ast::Expr;
 use common_ast::ast::Literal;
+use common_ast::ast::Query;
 use common_ast::ast::UnaryOperator;
 use common_datavalues::BooleanType;
 use common_datavalues::DataField;
@@ -26,6 +29,8 @@ use common_functions::aggregates::AggregateFunctionFactory;
 use common_functions::scalars::CastFunction;
 use common_functions::scalars::FunctionFactory;
 
+use crate::sessions::QueryContext;
+use crate::sql::binder::Binder;
 use crate::sql::planner::metadata::optimize_remove_count_args;
 use crate::sql::plans::AggregateFunction;
 use crate::sql::plans::AndExpr;
@@ -37,6 +42,7 @@ use crate::sql::plans::ConstantExpr;
 use crate::sql::plans::FunctionCall;
 use crate::sql::plans::OrExpr;
 use crate::sql::plans::Scalar;
+use crate::sql::plans::SubqueryExpr;
 use crate::sql::BindContext;
 
 /// A helper for type checking.
@@ -50,18 +56,20 @@ use crate::sql::BindContext;
 /// argument types of expressions, or unresolvable columns.
 pub struct TypeChecker<'a> {
     bind_context: &'a BindContext,
+    ctx: Arc<QueryContext>,
 }
 
 impl<'a> TypeChecker<'a> {
-    pub fn new(bind_context: &'a BindContext) -> Self {
-        Self { bind_context }
+    pub fn new(bind_context: &'a BindContext, ctx: Arc<QueryContext>) -> Self {
+        Self { bind_context, ctx }
     }
 
     /// Resolve types of `expr` with given `required_type`.
     /// If `required_type` is None, then there is no requirement of return type.
     ///
     /// TODO(leiysky): choose correct overloads of functions with given required_type and arguments
-    pub fn resolve(
+    #[async_recursion::async_recursion]
+    pub async fn resolve(
         &self,
         expr: &Expr,
         required_type: Option<DataTypeImpl>,
@@ -88,6 +96,7 @@ impl<'a> TypeChecker<'a> {
                 };
 
                 self.resolve_function(func_name.as_str(), &[&**expr], required_type)
+                    .await
             }
 
             Expr::InList { expr, list, not } => {
@@ -102,6 +111,7 @@ impl<'a> TypeChecker<'a> {
                     args.push(expr);
                 }
                 self.resolve_function(func_name.as_str(), &args, required_type)
+                    .await
             }
 
             Expr::Between {
@@ -113,16 +123,12 @@ impl<'a> TypeChecker<'a> {
                 if !*not {
                     // Rewrite `expr BETWEEN low AND high`
                     // into `expr >= low AND expr <= high`
-                    let (ge_func, _) = self.resolve_function(
-                        ">=",
-                        &[&**expr, &**low],
-                        Some(BooleanType::new_impl()),
-                    )?;
-                    let (le_func, _) = self.resolve_function(
-                        "<=",
-                        &[&**expr, &**high],
-                        Some(BooleanType::new_impl()),
-                    )?;
+                    let (ge_func, _) = self
+                        .resolve_function(">=", &[&**expr, &**low], Some(BooleanType::new_impl()))
+                        .await?;
+                    let (le_func, _) = self
+                        .resolve_function("<=", &[&**expr, &**high], Some(BooleanType::new_impl()))
+                        .await?;
                     Ok((
                         AndExpr {
                             left: Box::new(ge_func),
@@ -134,16 +140,12 @@ impl<'a> TypeChecker<'a> {
                 } else {
                     // Rewrite `expr NOT BETWEEN low AND high`
                     // into `expr < low OR expr > high`
-                    let (lt_func, _) = self.resolve_function(
-                        "<",
-                        &[&**expr, &**low],
-                        Some(BooleanType::new_impl()),
-                    )?;
-                    let (gt_func, _) = self.resolve_function(
-                        ">",
-                        &[&**expr, &**high],
-                        Some(BooleanType::new_impl()),
-                    )?;
+                    let (lt_func, _) = self
+                        .resolve_function("<", &[&**expr, &**low], Some(BooleanType::new_impl()))
+                        .await?;
+                    let (gt_func, _) = self
+                        .resolve_function(">", &[&**expr, &**high], Some(BooleanType::new_impl()))
+                        .await?;
                     Ok((
                         OrExpr {
                             left: Box::new(lt_func),
@@ -157,14 +159,15 @@ impl<'a> TypeChecker<'a> {
 
             Expr::BinaryOp { op, left, right } => {
                 self.resolve_binary_op(op, &**left, &**right, required_type)
+                    .await
             }
 
-            Expr::UnaryOp { op, expr } => self.resolve_unary_op(op, &**expr, required_type),
+            Expr::UnaryOp { op, expr } => self.resolve_unary_op(op, &**expr, required_type).await,
 
             Expr::Cast {
                 expr, target_type, ..
             } => {
-                let (scalar, data_type) = self.resolve(expr, required_type)?;
+                let (scalar, data_type) = self.resolve(expr, required_type).await?;
                 let cast_func = CastFunction::create_try(
                     "",
                     target_type.to_string().as_str(),
@@ -199,6 +202,7 @@ impl<'a> TypeChecker<'a> {
                 }
 
                 self.resolve_function("substring", &arguments, required_type)
+                    .await
             }
 
             Expr::Literal(literal) => {
@@ -222,10 +226,11 @@ impl<'a> TypeChecker<'a> {
                         .iter()
                         .map(|literal| self.parse_literal(literal, None))
                         .collect::<Result<Vec<DataValue>>>()?;
-                    let arguments = args
-                        .iter()
-                        .map(|arg| self.resolve(arg, None))
-                        .collect::<Result<Vec<_>>>()?;
+
+                    let mut arguments = vec![];
+                    for arg in args.iter() {
+                        arguments.push(self.resolve(arg, None).await?);
+                    }
 
                     let data_fields = arguments
                         .iter()
@@ -258,7 +263,7 @@ impl<'a> TypeChecker<'a> {
                     ))
                 } else {
                     // Scalar function
-                    self.resolve_function(func_name, &args, required_type)
+                    self.resolve_function(func_name, &args, required_type).await
                 }
             }
 
@@ -278,6 +283,8 @@ impl<'a> TypeChecker<'a> {
                 ))
             }
 
+            Expr::Subquery(subquery) => self.resolve_subquery(subquery, false, None).await,
+
             _ => Err(ErrorCode::UnImplement(format!(
                 "Unsupported expr: {:?}",
                 expr
@@ -286,18 +293,20 @@ impl<'a> TypeChecker<'a> {
     }
 
     /// Resolve function call.
-    pub fn resolve_function(
+    pub async fn resolve_function(
         &self,
         func_name: &str,
         arguments: &[&Expr],
-        required_type: Option<DataTypeImpl>,
+        _required_type: Option<DataTypeImpl>,
     ) -> Result<(Scalar, DataTypeImpl)> {
-        let (args, arg_types): (Vec<Scalar>, Vec<DataTypeImpl>) = arguments
-            .iter()
-            .map(|expr| self.resolve(expr, required_type.clone()))
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .unzip();
+        let mut args = vec![];
+        let mut arg_types = vec![];
+
+        for argument in arguments {
+            let (arg, arg_type) = self.resolve(argument, None).await?;
+            args.push(arg);
+            arg_types.push(arg_type);
+        }
 
         let arg_types_ref: Vec<&DataTypeImpl> = arg_types.iter().collect();
 
@@ -317,7 +326,7 @@ impl<'a> TypeChecker<'a> {
     /// Resolve binary expressions. Most of the binary expressions
     /// would be transformed into `FunctionCall`, except comparison
     /// expressions, conjunction(`AND`) and disjunction(`OR`).
-    pub fn resolve_binary_op(
+    pub async fn resolve_binary_op(
         &self,
         op: &BinaryOperator,
         left: &Expr,
@@ -343,6 +352,7 @@ impl<'a> TypeChecker<'a> {
             | BinaryOperator::BitwiseXor
             | BinaryOperator::Xor => {
                 self.resolve_function(op.to_string().as_str(), &[left, right], required_type)
+                    .await
             }
             BinaryOperator::Gt
             | BinaryOperator::Lt
@@ -351,8 +361,8 @@ impl<'a> TypeChecker<'a> {
             | BinaryOperator::Eq
             | BinaryOperator::NotEq => {
                 let op = ComparisonOp::try_from(op)?;
-                let (left, _) = self.resolve(left, None)?;
-                let (right, _) = self.resolve(right, None)?;
+                let (left, _) = self.resolve(left, None).await?;
+                let (right, _) = self.resolve(right, None).await?;
 
                 Ok((
                     ComparisonExpr {
@@ -365,8 +375,8 @@ impl<'a> TypeChecker<'a> {
                 ))
             }
             BinaryOperator::And => {
-                let (left, _) = self.resolve(left, Some(BooleanType::new_impl()))?;
-                let (right, _) = self.resolve(right, Some(BooleanType::new_impl()))?;
+                let (left, _) = self.resolve(left, Some(BooleanType::new_impl())).await?;
+                let (right, _) = self.resolve(right, Some(BooleanType::new_impl())).await?;
 
                 Ok((
                     AndExpr {
@@ -378,8 +388,8 @@ impl<'a> TypeChecker<'a> {
                 ))
             }
             BinaryOperator::Or => {
-                let (left, _) = self.resolve(left, Some(BooleanType::new_impl()))?;
-                let (right, _) = self.resolve(right, Some(BooleanType::new_impl()))?;
+                let (left, _) = self.resolve(left, Some(BooleanType::new_impl())).await?;
+                let (right, _) = self.resolve(right, Some(BooleanType::new_impl())).await?;
 
                 Ok((
                     OrExpr {
@@ -394,13 +404,44 @@ impl<'a> TypeChecker<'a> {
     }
 
     /// Resolve unary expressions.
-    pub fn resolve_unary_op(
+    pub async fn resolve_unary_op(
         &self,
         op: &UnaryOperator,
         child: &Expr,
         required_type: Option<DataTypeImpl>,
     ) -> Result<(Scalar, DataTypeImpl)> {
         self.resolve_function(op.to_string().as_str(), &[child], required_type)
+            .await
+    }
+
+    pub async fn resolve_subquery(
+        &self,
+        subquery: &Query,
+        allow_multi_rows: bool,
+        _required_type: Option<DataTypeImpl>,
+    ) -> Result<(Scalar, DataTypeImpl)> {
+        let mut binder = Binder::new(self.ctx.clone(), self.ctx.get_catalogs());
+
+        // Create new `BindContext` with current `bind_context` as its parent, so we can resolve outer columns.
+        let bind_context = BindContext::with_parent(Box::new(self.bind_context.clone()));
+        let output_context = binder.bind_query(subquery, &bind_context).await?;
+
+        if output_context.columns.len() > 1 {
+            return Err(ErrorCode::SemanticError(
+                "Scalar subquery must return only one column",
+            ));
+        }
+
+        let data_type = output_context.columns[0].data_type.clone();
+
+        let subquery_expr = SubqueryExpr {
+            subquery: output_context.expression.clone().unwrap(),
+            data_type: data_type.clone(),
+            output_context: Box::new(output_context),
+            allow_multi_rows,
+        };
+
+        Ok((subquery_expr.into(), data_type))
     }
 
     /// Resolve literal values.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support planning subqueries. The execution part will be done in other PRs.

## Changelog

- New Feature

## Related Issues

Part of #5210 
