### PR TITLE
feat(planner): display error with source span

### DIFF
--- a/common/ast/src/ast/mod.rs
+++ b/common/ast/src/ast/mod.rs
@@ -23,15 +23,17 @@ pub use expr::*;
 pub use query::*;
 pub use statement::*;
 
+use crate::parser::token::Token;
+
 // Identifier of table name or column name.
 #[derive(Debug, Clone, PartialEq)]
-pub struct Identifier {
+pub struct Identifier<'a> {
     pub name: String,
     pub quote: Option<char>,
-    // TODO(andylokandy): add span or token
+    pub span: Token<'a>,
 }
 
-impl Display for Identifier {
+impl<'a> Display for Identifier<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some(c) = self.quote {
             write!(f, "{}", c)?;

--- a/common/ast/src/ast/statement.rs
+++ b/common/ast/src/ast/statement.rs
@@ -34,126 +34,126 @@ pub enum Statement<'a> {
         kind: ExplainKind,
         query: Box<Statement<'a>>,
     },
-    Query(Box<Query>),
+    Query(Box<Query<'a>>),
 
     // Databases
     ShowDatabases {
-        limit: Option<ShowLimit>,
+        limit: Option<ShowLimit<'a>>,
     },
     ShowCreateDatabase {
-        database: Identifier,
+        database: Identifier<'a>,
     },
     CreateDatabase {
         if_not_exists: bool,
-        database: Identifier,
+        database: Identifier<'a>,
         engine: Engine,
         options: Vec<SQLProperty>,
     },
     DropDatabase {
         if_exists: bool,
-        database: Identifier,
+        database: Identifier<'a>,
     },
     UseDatabase {
-        database: Identifier,
+        database: Identifier<'a>,
     },
 
     // Tables
     ShowTables {
-        database: Option<Identifier>,
+        database: Option<Identifier<'a>>,
         full: bool,
-        limit: Option<ShowLimit>,
+        limit: Option<ShowLimit<'a>>,
     },
     ShowCreateTable {
-        database: Option<Identifier>,
-        table: Identifier,
+        database: Option<Identifier<'a>>,
+        table: Identifier<'a>,
     },
     ShowTablesStatus {
-        database: Option<Identifier>,
-        limit: Option<ShowLimit>,
+        database: Option<Identifier<'a>>,
+        limit: Option<ShowLimit<'a>>,
     },
     CreateTable {
         if_not_exists: bool,
-        database: Option<Identifier>,
-        table: Identifier,
-        source: Option<CreateTableSource>,
+        database: Option<Identifier<'a>>,
+        table: Identifier<'a>,
+        source: Option<CreateTableSource<'a>>,
         engine: Engine,
-        cluster_by: Vec<Expr>,
-        as_query: Option<Box<Query>>,
+        cluster_by: Vec<Expr<'a>>,
+        as_query: Option<Box<Query<'a>>>,
         comment: Option<String>,
     },
     // Describe schema of a table
     // Like `SHOW CREATE TABLE`
     Describe {
-        catalog: Option<Identifier>,
-        database: Option<Identifier>,
-        table: Identifier,
+        catalog: Option<Identifier<'a>>,
+        database: Option<Identifier<'a>>,
+        table: Identifier<'a>,
     },
     DropTable {
         if_exists: bool,
-        database: Option<Identifier>,
-        table: Identifier,
+        database: Option<Identifier<'a>>,
+        table: Identifier<'a>,
     },
     AlterTable {
         if_exists: bool,
-        database: Option<Identifier>,
-        table: Identifier,
-        action: AlterTableAction,
+        database: Option<Identifier<'a>>,
+        table: Identifier<'a>,
+        action: AlterTableAction<'a>,
     },
     RenameTable {
-        database: Option<Identifier>,
-        table: Identifier,
-        new_table: Identifier,
+        database: Option<Identifier<'a>>,
+        table: Identifier<'a>,
+        new_table: Identifier<'a>,
     },
     TruncateTable {
-        database: Option<Identifier>,
-        table: Identifier,
+        database: Option<Identifier<'a>>,
+        table: Identifier<'a>,
         purge: bool,
     },
     OptimizeTable {
-        database: Option<Identifier>,
-        table: Identifier,
+        database: Option<Identifier<'a>>,
+        table: Identifier<'a>,
         action: Option<OptimizeTableAction>,
     },
 
     // Views
     CreateView {
         if_not_exists: bool,
-        database: Option<Identifier>,
-        view: Identifier,
-        query: Box<Query>,
+        database: Option<Identifier<'a>>,
+        view: Identifier<'a>,
+        query: Box<Query<'a>>,
     },
     AlterView {
-        database: Option<Identifier>,
-        view: Identifier,
-        query: Box<Query>,
+        database: Option<Identifier<'a>>,
+        view: Identifier<'a>,
+        query: Box<Query<'a>>,
     },
     DropView {
         if_exists: bool,
-        database: Option<Identifier>,
-        view: Identifier,
+        database: Option<Identifier<'a>>,
+        view: Identifier<'a>,
     },
 
     ShowSettings,
     ShowProcessList,
     ShowMetrics,
     ShowFunctions {
-        limit: Option<ShowLimit>,
+        limit: Option<ShowLimit<'a>>,
     },
 
     KillStmt {
         kill_target: KillTarget,
-        object_id: Identifier,
+        object_id: Identifier<'a>,
     },
 
     SetVariable {
-        variable: Identifier,
+        variable: Identifier<'a>,
         value: Literal,
     },
 
     Insert {
-        database: Option<Identifier>,
-        table: Identifier,
-        columns: Vec<Identifier>,
+        database: Option<Identifier<'a>>,
+        table: Identifier<'a>,
+        columns: Vec<Identifier<'a>>,
         source: InsertSource<'a>,
         overwrite: bool,
     },
@@ -180,19 +180,19 @@ pub enum Statement<'a> {
     // UDF
     CreateUDF {
         if_not_exists: bool,
-        udf_name: Identifier,
-        parameters: Vec<Identifier>,
-        definition: Box<Expr>,
+        udf_name: Identifier<'a>,
+        parameters: Vec<Identifier<'a>>,
+        definition: Box<Expr<'a>>,
         description: Option<String>,
     },
     DropUDF {
         if_exists: bool,
-        udf_name: Identifier,
+        udf_name: Identifier<'a>,
     },
     AlterUDF {
-        udf_name: Identifier,
-        parameters: Vec<Identifier>,
-        definition: Box<Expr>,
+        udf_name: Identifier<'a>,
+        parameters: Vec<Identifier<'a>>,
+        definition: Box<Expr<'a>>,
         description: Option<String>,
     },
 }
@@ -208,15 +208,15 @@ pub enum ExplainKind {
 pub enum InsertSource<'a> {
     Streaming { format: String },
     Values { values_tokens: &'a [Token<'a>] },
-    Select { query: Box<Query> },
+    Select { query: Box<Query<'a>> },
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum CreateTableSource {
-    Columns(Vec<ColumnDefinition>),
+pub enum CreateTableSource<'a> {
+    Columns(Vec<ColumnDefinition<'a>>),
     Like {
-        database: Option<Identifier>,
-        table: Identifier,
+        database: Option<Identifier<'a>>,
+        table: Identifier<'a>,
     },
 }
 
@@ -236,22 +236,22 @@ pub struct SQLProperty {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum ShowLimit {
+pub enum ShowLimit<'a> {
     Like { pattern: String },
-    Where { selection: Box<Expr> },
+    Where { selection: Box<Expr<'a>> },
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ColumnDefinition {
-    pub name: Identifier,
+pub struct ColumnDefinition<'a> {
+    pub name: Identifier<'a>,
     pub data_type: TypeName,
     pub nullable: bool,
-    pub default_expr: Option<Box<Expr>>,
+    pub default_expr: Option<Box<Expr<'a>>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum AlterTableAction {
-    RenameTable { new_table: Identifier },
+pub enum AlterTableAction<'a> {
+    RenameTable { new_table: Identifier<'a> },
     // TODO(wuzhiguo): AddColumn etc
 }
 
@@ -282,7 +282,7 @@ pub enum RoleOption {
     NoConfigReload,
 }
 
-impl Display for ShowLimit {
+impl<'a> Display for ShowLimit<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ShowLimit::Like { pattern } => write!(f, "LIKE {pattern}"),
@@ -291,7 +291,7 @@ impl Display for ShowLimit {
     }
 }
 
-impl Display for ColumnDefinition {
+impl<'a> Display for ColumnDefinition<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{} {}", self.name, self.data_type)?;
         if self.nullable {

--- a/common/ast/src/parser/error.rs
+++ b/common/ast/src/parser/error.rs
@@ -143,12 +143,56 @@ impl<'a> Error<'a> {
             backtrace: input.1,
         }
     }
+}
 
-    pub fn to_labels(&self) -> Vec<(Span, String)> {
+impl From<ParseIntError> for ErrorKind {
+    fn from(err: ParseIntError) -> Self {
+        let msg = match err.kind() {
+            IntErrorKind::InvalidDigit => {
+                "unable to parse number because it contains invalid characters"
+            }
+            IntErrorKind::PosOverflow => "unable to parse number because it positive overflowed",
+            IntErrorKind::NegOverflow => "unable to parse number because it negative overflowed",
+            _ => "unable to parse number",
+        };
+        ErrorKind::Other(msg)
+    }
+}
+
+pub trait DisplayError {
+    type Message;
+
+    fn display_error(&self, message: Self::Message) -> String;
+}
+
+impl<'a> DisplayError for Token<'a> {
+    type Message = String;
+
+    fn display_error(&self, message: String) -> String {
+        pretty_print_error(self.source, vec![(self.span.clone(), message)])
+    }
+}
+
+impl<'a, 'b> DisplayError for &'b [Token<'a>] {
+    type Message = String;
+
+    fn display_error(&self, message: String) -> String {
+        assert!(!self.is_empty());
+        let source = self.first().unwrap().source;
+        let span_start = self.first().unwrap().span.start;
+        let span_end = self.last().unwrap().span.end;
+        pretty_print_error(source, vec![(span_start..span_end, message)])
+    }
+}
+
+impl<'a> DisplayError for Error<'a> {
+    type Message = ();
+
+    fn display_error(&self, _: ()) -> String {
         let inner = &*self.backtrace.inner.borrow();
         let inner = match inner {
             Some(inner) => inner,
-            None => return vec![],
+            None => return String::new(),
         };
 
         let mut lables = vec![];
@@ -210,25 +254,11 @@ impl<'a> Error<'a> {
                 .map(|(span, msg)| (span.span.clone(), format!("while parsing {}", msg))),
         );
 
-        lables
+        pretty_print_error(self.span.source, lables)
     }
 }
 
-impl From<ParseIntError> for ErrorKind {
-    fn from(err: ParseIntError) -> Self {
-        let msg = match err.kind() {
-            IntErrorKind::InvalidDigit => {
-                "unable to parse number because it contains invalid characters"
-            }
-            IntErrorKind::PosOverflow => "unable to parse number because it positive overflowed",
-            IntErrorKind::NegOverflow => "unable to parse number because it negative overflowed",
-            _ => "unable to parse number",
-        };
-        ErrorKind::Other(msg)
-    }
-}
-
-pub fn pretty_print_error(source: &str, lables: Vec<(Span, String)>) -> String {
+fn pretty_print_error(source: &str, lables: Vec<(Span, String)>) -> String {
     use codespan_reporting::diagnostic::Diagnostic;
     use codespan_reporting::diagnostic::Label;
     use codespan_reporting::files::SimpleFile;

--- a/common/ast/src/parser/statement.rs
+++ b/common/ast/src/parser/statement.rs
@@ -438,9 +438,9 @@ pub fn statement(i: Input) -> IResult<Statement> {
 
 pub fn column_def(i: Input) -> IResult<ColumnDefinition> {
     #[derive(Clone)]
-    enum ColumnConstraint {
+    enum ColumnConstraint<'a> {
         Nullable(bool),
-        DefaultExpr(Box<Expr>),
+        DefaultExpr(Box<Expr<'a>>),
     }
 
     let nullable = alt((

--- a/common/ast/src/parser/token.rs
+++ b/common/ast/src/parser/token.rs
@@ -19,9 +19,9 @@ use logos::Logos;
 use logos::Span;
 
 pub use self::TokenKind::*;
-use crate::parser::error::pretty_print_error;
+use crate::parser::error::DisplayError;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Token<'a> {
     pub source: &'a str,
     pub kind: TokenKind,
@@ -31,6 +31,12 @@ pub struct Token<'a> {
 impl<'a> Token<'a> {
     pub fn text(&self) -> &'a str {
         &self.source[self.span.clone()]
+    }
+}
+
+impl<'a> std::fmt::Debug for Token<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}({:?})", self.kind, self.span)
     }
 }
 
@@ -56,11 +62,13 @@ impl<'a> Iterator for Tokenizer<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         match self.lexer.next() {
             Some(kind) if kind == TokenKind::Error => {
-                let rest_span = self.lexer.span().start..self.source.len();
-                let lables = vec![(rest_span, "unable to recognize the rest tokens".to_owned())];
-                Some(Err(ErrorCode::SyntaxException(pretty_print_error(
-                    self.source,
-                    lables,
+                let rest_span = Token {
+                    source: self.source,
+                    kind: TokenKind::Error,
+                    span: self.lexer.span().start..self.source.len(),
+                };
+                Some(Err(ErrorCode::SyntaxException(rest_span.display_error(
+                    "unable to recognize the rest tokens".to_string(),
                 ))))
             }
             Some(kind) => Some(Ok(Token {

--- a/common/ast/src/parser/util.rs
+++ b/common/ast/src/parser/util.rs
@@ -301,6 +301,6 @@ impl<'a> nom::Slice<RangeFrom<usize>> for Input<'a> {
 
 impl<'a> nom::Slice<RangeFull> for Input<'a> {
     fn slice(&self, _: RangeFull) -> Self {
-        Input(self.0, self.1)
+        *self
     }
 }

--- a/common/ast/tests/it/parser.rs
+++ b/common/ast/tests/it/parser.rs
@@ -14,8 +14,8 @@
 
 use std::io::Write;
 
-use common_ast::parser::error::pretty_print_error;
 use common_ast::parser::error::Backtrace;
+use common_ast::parser::error::DisplayError as _;
 use common_ast::parser::expr::*;
 use common_ast::parser::parse_sql;
 use common_ast::parser::query::*;
@@ -45,9 +45,7 @@ macro_rules! test_parse {
                 writeln!($file, "\n").unwrap();
             }
             Err(nom::Err::Error(err) | nom::Err::Failure(err)) => {
-                let report = pretty_print_error($source, err.to_labels())
-                    .trim_end()
-                    .to_string();
+                let report = err.display_error(()).trim_end().to_string();
                 writeln!($file, "---------- Input ----------").unwrap();
                 writeln!($file, "{}", $source).unwrap();
                 writeln!($file, "---------- Output ---------").unwrap();

--- a/common/ast/tests/it/testdata/expr.txt
+++ b/common/ast/tests/it/testdata/expr.txt
@@ -9,6 +9,7 @@ ColumnRef {
     column: Identifier {
         name: "a",
         quote: None,
+        span: Ident(0..1),
     },
 }
 
@@ -96,6 +97,7 @@ FunctionCall {
     name: Identifier {
         name: "typeof",
         quote: None,
+        span: Ident(0..6),
     },
     args: [
         BinaryOp {
@@ -177,6 +179,7 @@ BinaryOp {
             column: Identifier {
                 name: "a",
                 quote: None,
+                span: Ident(4..5),
             },
         },
         right: ColumnRef {
@@ -185,11 +188,13 @@ BinaryOp {
                 Identifier {
                     name: "c",
                     quote: None,
+                    span: Ident(8..9),
                 },
             ),
             column: Identifier {
                 name: "d",
                 quote: None,
+                span: Ident(10..11),
             },
         },
     },
@@ -209,6 +214,7 @@ BinaryOp {
         column: Identifier {
             name: "number",
             quote: None,
+            span: Ident(0..6),
         },
     },
     right: Literal(
@@ -231,6 +237,7 @@ Between {
         column: Identifier {
             name: "col1",
             quote: None,
+            span: Ident(0..4),
         },
     },
     low: Literal(
@@ -257,6 +264,7 @@ FunctionCall {
     name: Identifier {
         name: "sum",
         quote: None,
+        span: Ident(0..3),
     },
     args: [
         ColumnRef {
@@ -265,6 +273,7 @@ FunctionCall {
             column: Identifier {
                 name: "col1",
                 quote: None,
+                span: Ident(4..8),
             },
         },
     ],
@@ -284,6 +293,7 @@ FunctionCall {
         quote: Some(
             '"',
         ),
+        span: QuotedIdent(0..8),
     },
     args: [],
     params: [],
@@ -300,6 +310,7 @@ FunctionCall {
     name: Identifier {
         name: "random",
         quote: None,
+        span: Ident(0..6),
     },
     args: [],
     params: [],
@@ -316,6 +327,7 @@ FunctionCall {
     name: Identifier {
         name: "covar_samp",
         quote: None,
+        span: Ident(0..10),
     },
     args: [
         ColumnRef {
@@ -324,6 +336,7 @@ FunctionCall {
             column: Identifier {
                 name: "number",
                 quote: None,
+                span: Ident(11..17),
             },
         },
         ColumnRef {
@@ -332,6 +345,7 @@ FunctionCall {
             column: Identifier {
                 name: "number",
                 quote: None,
+                span: Ident(19..25),
             },
         },
     ],
@@ -351,6 +365,7 @@ Cast {
         column: Identifier {
             name: "col1",
             quote: None,
+            span: Ident(5..9),
         },
     },
     target_type: UInt64,
@@ -370,6 +385,7 @@ TryCast {
         column: Identifier {
             name: "col1",
             quote: None,
+            span: Ident(9..13),
         },
     },
     target_type: UInt64,
@@ -413,6 +429,7 @@ Extract {
         column: Identifier {
             name: "d",
             quote: None,
+            span: Ident(18..19),
         },
     },
 }
@@ -435,6 +452,7 @@ Position {
         column: Identifier {
             name: "str",
             quote: None,
+            span: Ident(16..19),
         },
     },
 }
@@ -452,6 +470,7 @@ Substring {
         column: Identifier {
             name: "a",
             quote: None,
+            span: Ident(10..11),
         },
     },
     substring_from: Some(
@@ -461,6 +480,7 @@ Substring {
             column: Identifier {
                 name: "b",
                 quote: None,
+                span: Ident(17..18),
             },
         },
     ),
@@ -471,6 +491,7 @@ Substring {
             column: Identifier {
                 name: "c",
                 quote: None,
+                span: Ident(23..24),
             },
         },
     ),
@@ -489,6 +510,7 @@ Substring {
         column: Identifier {
             name: "a",
             quote: None,
+            span: Ident(10..11),
         },
     },
     substring_from: Some(
@@ -498,6 +520,7 @@ Substring {
             column: Identifier {
                 name: "b",
                 quote: None,
+                span: Ident(13..14),
             },
         },
     ),
@@ -508,6 +531,7 @@ Substring {
             column: Identifier {
                 name: "c",
                 quote: None,
+                span: Ident(16..17),
             },
         },
     ),
@@ -526,6 +550,7 @@ Cast {
         column: Identifier {
             name: "col1",
             quote: None,
+            span: Ident(0..4),
         },
     },
     target_type: UInt8,
@@ -547,6 +572,7 @@ MapAccess {
                 column: Identifier {
                     name: "arr",
                     quote: None,
+                    span: Ident(1..4),
                 },
             },
             accessor: Bracket {
@@ -559,6 +585,7 @@ MapAccess {
             key: Identifier {
                 name: "a",
                 quote: None,
+                span: Ident(8..9),
             },
         },
     },
@@ -566,6 +593,7 @@ MapAccess {
         key: Identifier {
             name: "b",
             quote: None,
+            span: Ident(11..12),
         },
     },
 }
@@ -584,6 +612,7 @@ MapAccess {
             column: Identifier {
                 name: "arr",
                 quote: None,
+                span: Ident(0..3),
             },
         },
         accessor: Bracket {
@@ -613,6 +642,7 @@ BinaryOp {
         column: Identifier {
             name: "a",
             quote: None,
+            span: Ident(0..1),
         },
     },
     right: Literal(
@@ -636,17 +666,20 @@ BinaryOp {
                 Identifier {
                     name: "G",
                     quote: None,
+                    span: Ident(0..1),
                 },
             ),
             table: Some(
                 Identifier {
                     name: "E",
                     quote: None,
+                    span: Ident(2..3),
                 },
             ),
             column: Identifier {
                 name: "B",
                 quote: None,
+                span: Ident(4..5),
             },
         },
         not: true,
@@ -658,6 +691,7 @@ BinaryOp {
             column: Identifier {
                 name: "col1",
                 quote: None,
+                span: Ident(22..26),
             },
         },
         low: ColumnRef {
@@ -666,6 +700,7 @@ BinaryOp {
             column: Identifier {
                 name: "col2",
                 quote: None,
+                span: Ident(39..43),
             },
         },
         high: BinaryOp {
@@ -683,6 +718,7 @@ BinaryOp {
                     column: Identifier {
                         name: "col3",
                         quote: None,
+                        span: Ident(53..57),
                     },
                 },
             },
@@ -691,6 +727,7 @@ BinaryOp {
                 name: Identifier {
                     name: "sum",
                     quote: None,
+                    span: Ident(63..66),
                 },
                 args: [
                     ColumnRef {
@@ -699,6 +736,7 @@ BinaryOp {
                         column: Identifier {
                             name: "col4",
                             quote: None,
+                            span: Ident(67..71),
                         },
                     },
                 ],
@@ -722,6 +760,7 @@ BinaryOp {
         name: Identifier {
             name: "sum",
             quote: None,
+            span: Ident(0..3),
         },
         args: [
             Case {
@@ -735,11 +774,13 @@ BinaryOp {
                                 Identifier {
                                     name: "n2",
                                     quote: None,
+                                    span: Ident(14..16),
                                 },
                             ),
                             column: Identifier {
                                 name: "n_name",
                                 quote: None,
+                                span: Ident(17..23),
                             },
                         },
                         right: Literal(
@@ -756,6 +797,7 @@ BinaryOp {
                         column: Identifier {
                             name: "ol_amount",
                             quote: None,
+                            span: Ident(41..50),
                         },
                     },
                 ],
@@ -780,6 +822,7 @@ BinaryOp {
                     name: Identifier {
                         name: "sum",
                         quote: None,
+                        span: Ident(75..78),
                     },
                     args: [
                         ColumnRef {
@@ -788,6 +831,7 @@ BinaryOp {
                             column: Identifier {
                                 name: "ol_amount",
                                 quote: None,
+                                span: Ident(79..88),
                             },
                         },
                     ],
@@ -813,6 +857,7 @@ BinaryOp {
                 name: Identifier {
                     name: "sum",
                     quote: None,
+                    span: Ident(106..109),
                 },
                 args: [
                     ColumnRef {
@@ -821,6 +866,7 @@ BinaryOp {
                         column: Identifier {
                             name: "ol_amount",
                             quote: None,
+                            span: Ident(110..119),
                         },
                     },
                 ],
@@ -864,6 +910,7 @@ BinaryOp {
                                     column: Identifier {
                                         name: "p_partkey",
                                         quote: None,
+                                        span: Ident(0..9),
                                     },
                                 },
                                 right: ColumnRef {
@@ -872,6 +919,7 @@ BinaryOp {
                                     column: Identifier {
                                         name: "l_partkey",
                                         quote: None,
+                                        span: Ident(12..21),
                                     },
                                 },
                             },
@@ -883,6 +931,7 @@ BinaryOp {
                                     column: Identifier {
                                         name: "p_brand",
                                         quote: None,
+                                        span: Ident(38..45),
                                     },
                                 },
                                 right: Literal(
@@ -899,6 +948,7 @@ BinaryOp {
                                 column: Identifier {
                                     name: "p_container",
                                     quote: None,
+                                    span: Ident(75..86),
                                 },
                             },
                             list: [
@@ -934,6 +984,7 @@ BinaryOp {
                             column: Identifier {
                                 name: "l_quantity",
                                 quote: None,
+                                span: Ident(149..159),
                             },
                         },
                         right: Cast {
@@ -955,6 +1006,7 @@ BinaryOp {
                         column: Identifier {
                             name: "l_quantity",
                             quote: None,
+                            span: Ident(188..198),
                         },
                     },
                     right: Cast {
@@ -983,6 +1035,7 @@ BinaryOp {
                     column: Identifier {
                         name: "p_size",
                         quote: None,
+                        span: Ident(244..250),
                     },
                 },
                 low: Cast {
@@ -1013,6 +1066,7 @@ BinaryOp {
                 column: Identifier {
                     name: "l_shipmode",
                     quote: None,
+                    span: Ident(321..331),
                 },
             },
             list: [
@@ -1038,6 +1092,7 @@ BinaryOp {
             column: Identifier {
                 name: "l_shipinstruct",
                 quote: None,
+                span: Ident(370..384),
             },
         },
         right: Literal(

--- a/common/ast/tests/it/testdata/query.txt
+++ b/common/ast/tests/it/testdata/query.txt
@@ -4,8 +4,38 @@ select * from customer inner join orders on a = b limit 1
 SELECT * FROM customer INNER JOIN orders ON a = b LIMIT 1
 ---------- AST ------------
 Query {
+    span: [
+        SELECT(0..6),
+        Multiply(7..8),
+        FROM(9..13),
+        Ident(14..22),
+        INNER(23..28),
+        JOIN(29..33),
+        Ident(34..40),
+        ON(41..43),
+        Ident(44..45),
+        Eq(46..47),
+        Ident(48..49),
+        LIMIT(50..55),
+        LiteralNumber(56..57),
+    ],
     body: Select(
         SelectStmt {
+            span: [
+                SELECT(0..6),
+                Multiply(7..8),
+                FROM(9..13),
+                Ident(14..22),
+                INNER(23..28),
+                JOIN(29..33),
+                Ident(34..40),
+                ON(41..43),
+                Ident(44..45),
+                Eq(46..47),
+                Ident(48..49),
+                LIMIT(50..55),
+                LiteralNumber(56..57),
+            ],
             distinct: false,
             select_list: [
                 QualifiedName(
@@ -27,6 +57,7 @@ Query {
                                     column: Identifier {
                                         name: "a",
                                         quote: None,
+                                        span: Ident(44..45),
                                     },
                                 },
                                 right: ColumnRef {
@@ -35,6 +66,7 @@ Query {
                                     column: Identifier {
                                         name: "b",
                                         quote: None,
+                                        span: Ident(48..49),
                                     },
                                 },
                             },
@@ -45,6 +77,7 @@ Query {
                             table: Identifier {
                                 name: "customer",
                                 quote: None,
+                                span: Ident(14..22),
                             },
                             alias: None,
                         },
@@ -54,6 +87,7 @@ Query {
                             table: Identifier {
                                 name: "orders",
                                 quote: None,
+                                span: Ident(34..40),
                             },
                             alias: None,
                         },
@@ -83,8 +117,42 @@ select * from customer inner join orders on a = b limit 2 offset 3
 SELECT * FROM customer INNER JOIN orders ON a = b LIMIT 2 OFFSET 3
 ---------- AST ------------
 Query {
+    span: [
+        SELECT(0..6),
+        Multiply(7..8),
+        FROM(9..13),
+        Ident(14..22),
+        INNER(23..28),
+        JOIN(29..33),
+        Ident(34..40),
+        ON(41..43),
+        Ident(44..45),
+        Eq(46..47),
+        Ident(48..49),
+        LIMIT(50..55),
+        LiteralNumber(56..57),
+        OFFSET(58..64),
+        LiteralNumber(65..66),
+    ],
     body: Select(
         SelectStmt {
+            span: [
+                SELECT(0..6),
+                Multiply(7..8),
+                FROM(9..13),
+                Ident(14..22),
+                INNER(23..28),
+                JOIN(29..33),
+                Ident(34..40),
+                ON(41..43),
+                Ident(44..45),
+                Eq(46..47),
+                Ident(48..49),
+                LIMIT(50..55),
+                LiteralNumber(56..57),
+                OFFSET(58..64),
+                LiteralNumber(65..66),
+            ],
             distinct: false,
             select_list: [
                 QualifiedName(
@@ -106,6 +174,7 @@ Query {
                                     column: Identifier {
                                         name: "a",
                                         quote: None,
+                                        span: Ident(44..45),
                                     },
                                 },
                                 right: ColumnRef {
@@ -114,6 +183,7 @@ Query {
                                     column: Identifier {
                                         name: "b",
                                         quote: None,
+                                        span: Ident(48..49),
                                     },
                                 },
                             },
@@ -124,6 +194,7 @@ Query {
                             table: Identifier {
                                 name: "customer",
                                 quote: None,
+                                span: Ident(14..22),
                             },
                             alias: None,
                         },
@@ -133,6 +204,7 @@ Query {
                             table: Identifier {
                                 name: "orders",
                                 quote: None,
+                                span: Ident(34..40),
                             },
                             alias: None,
                         },
@@ -168,8 +240,28 @@ select * from customer natural full join orders
 SELECT * FROM customer NATURAL FULL OUTER JOIN orders
 ---------- AST ------------
 Query {
+    span: [
+        SELECT(0..6),
+        Multiply(7..8),
+        FROM(9..13),
+        Ident(14..22),
+        NATURAL(23..30),
+        FULL(31..35),
+        JOIN(36..40),
+        Ident(41..47),
+    ],
     body: Select(
         SelectStmt {
+            span: [
+                SELECT(0..6),
+                Multiply(7..8),
+                FROM(9..13),
+                Ident(14..22),
+                NATURAL(23..30),
+                FULL(31..35),
+                JOIN(36..40),
+                Ident(41..47),
+            ],
             distinct: false,
             select_list: [
                 QualifiedName(
@@ -189,6 +281,7 @@ Query {
                             table: Identifier {
                                 name: "customer",
                                 quote: None,
+                                span: Ident(14..22),
                             },
                             alias: None,
                         },
@@ -198,6 +291,7 @@ Query {
                             table: Identifier {
                                 name: "orders",
                                 quote: None,
+                                span: Ident(41..47),
                             },
                             alias: None,
                         },
@@ -221,8 +315,42 @@ select * from customer natural join orders left outer join detail using (id)
 SELECT * FROM customer NATURAL INNER JOIN orders LEFT OUTER JOIN detail USING(id)
 ---------- AST ------------
 Query {
+    span: [
+        SELECT(0..6),
+        Multiply(7..8),
+        FROM(9..13),
+        Ident(14..22),
+        NATURAL(23..30),
+        JOIN(31..35),
+        Ident(36..42),
+        LEFT(43..47),
+        OUTER(48..53),
+        JOIN(54..58),
+        Ident(59..65),
+        USING(66..71),
+        LParen(72..73),
+        Ident(73..75),
+        RParen(75..76),
+    ],
     body: Select(
         SelectStmt {
+            span: [
+                SELECT(0..6),
+                Multiply(7..8),
+                FROM(9..13),
+                Ident(14..22),
+                NATURAL(23..30),
+                JOIN(31..35),
+                Ident(36..42),
+                LEFT(43..47),
+                OUTER(48..53),
+                JOIN(54..58),
+                Ident(59..65),
+                USING(66..71),
+                LParen(72..73),
+                Ident(73..75),
+                RParen(75..76),
+            ],
             distinct: false,
             select_list: [
                 QualifiedName(
@@ -240,6 +368,7 @@ Query {
                                 Identifier {
                                     name: "id",
                                     quote: None,
+                                    span: Ident(73..75),
                                 },
                             ],
                         ),
@@ -253,6 +382,7 @@ Query {
                                     table: Identifier {
                                         name: "customer",
                                         quote: None,
+                                        span: Ident(14..22),
                                     },
                                     alias: None,
                                 },
@@ -262,6 +392,7 @@ Query {
                                     table: Identifier {
                                         name: "orders",
                                         quote: None,
+                                        span: Ident(36..42),
                                     },
                                     alias: None,
                                 },
@@ -273,6 +404,7 @@ Query {
                             table: Identifier {
                                 name: "detail",
                                 quote: None,
+                                span: Ident(59..65),
                             },
                             alias: None,
                         },
@@ -311,8 +443,146 @@ select c_count, count(*) as custdist, sum(c_acctbal) as totacctbal
 SELECT c_count, COUNT(*) AS custdist, sum(c_acctbal) AS totacctbal FROM customer CROSS JOIN orders AS ODS CROSS JOIN (SELECT c_custkey, count(o_orderkey) FROM customer LEFT OUTER JOIN orders ON c_custkey = o_custkey AND o_comment NOT LIKE '%:1%:2%' GROUP BY c_custkey) AS c_orders GROUP BY c_count ORDER BY custdist DESC, c_count ASC, totacctbal LIMIT 10, totacctbal
 ---------- AST ------------
 Query {
+    span: [
+        SELECT(0..6),
+        Ident(7..14),
+        Comma(14..15),
+        COUNT(16..21),
+        LParen(21..22),
+        Multiply(22..23),
+        RParen(23..24),
+        AS(25..27),
+        Ident(28..36),
+        Comma(36..37),
+        Ident(38..41),
+        LParen(41..42),
+        Ident(42..51),
+        RParen(51..52),
+        AS(53..55),
+        Ident(56..66),
+        FROM(79..83),
+        Ident(84..92),
+        Comma(92..93),
+        Ident(94..100),
+        Ident(101..104),
+        Comma(104..105),
+        LParen(122..123),
+        SELECT(144..150),
+        Ident(175..184),
+        Comma(184..185),
+        COUNT(210..215),
+        LParen(215..216),
+        Ident(216..226),
+        RParen(226..227),
+        FROM(248..252),
+        Ident(277..285),
+        LEFT(286..290),
+        OUTER(291..296),
+        JOIN(297..301),
+        Ident(302..308),
+        ON(309..311),
+        Ident(340..349),
+        Eq(350..351),
+        Ident(352..361),
+        AND(390..393),
+        Ident(394..403),
+        NOT(404..407),
+        LIKE(408..412),
+        QuotedIdent(413..422),
+        GROUP(443..448),
+        BY(449..451),
+        Ident(476..485),
+        RParen(502..503),
+        AS(504..506),
+        Ident(507..515),
+        GROUP(528..533),
+        BY(534..536),
+        Ident(537..544),
+        ORDER(557..562),
+        BY(563..565),
+        Ident(566..574),
+        DESC(575..579),
+        Comma(579..580),
+        Ident(581..588),
+        ASC(589..592),
+        Comma(592..593),
+        Ident(594..604),
+        LIMIT(617..622),
+        LiteralNumber(623..625),
+        Comma(625..626),
+        Ident(627..637),
+    ],
     body: Select(
         SelectStmt {
+            span: [
+                SELECT(0..6),
+                Ident(7..14),
+                Comma(14..15),
+                COUNT(16..21),
+                LParen(21..22),
+                Multiply(22..23),
+                RParen(23..24),
+                AS(25..27),
+                Ident(28..36),
+                Comma(36..37),
+                Ident(38..41),
+                LParen(41..42),
+                Ident(42..51),
+                RParen(51..52),
+                AS(53..55),
+                Ident(56..66),
+                FROM(79..83),
+                Ident(84..92),
+                Comma(92..93),
+                Ident(94..100),
+                Ident(101..104),
+                Comma(104..105),
+                LParen(122..123),
+                SELECT(144..150),
+                Ident(175..184),
+                Comma(184..185),
+                COUNT(210..215),
+                LParen(215..216),
+                Ident(216..226),
+                RParen(226..227),
+                FROM(248..252),
+                Ident(277..285),
+                LEFT(286..290),
+                OUTER(291..296),
+                JOIN(297..301),
+                Ident(302..308),
+                ON(309..311),
+                Ident(340..349),
+                Eq(350..351),
+                Ident(352..361),
+                AND(390..393),
+                Ident(394..403),
+                NOT(404..407),
+                LIKE(408..412),
+                QuotedIdent(413..422),
+                GROUP(443..448),
+                BY(449..451),
+                Ident(476..485),
+                RParen(502..503),
+                AS(504..506),
+                Ident(507..515),
+                GROUP(528..533),
+                BY(534..536),
+                Ident(537..544),
+                ORDER(557..562),
+                BY(563..565),
+                Ident(566..574),
+                DESC(575..579),
+                Comma(579..580),
+                Ident(581..588),
+                ASC(589..592),
+                Comma(592..593),
+                Ident(594..604),
+                LIMIT(617..622),
+                LiteralNumber(623..625),
+                Comma(625..626),
+                Ident(627..637),
+            ],
             distinct: false,
             select_list: [
                 AliasedExpr {
@@ -322,6 +592,7 @@ Query {
                         column: Identifier {
                             name: "c_count",
                             quote: None,
+                            span: Ident(7..14),
                         },
                     },
                     alias: None,
@@ -332,6 +603,7 @@ Query {
                         Identifier {
                             name: "custdist",
                             quote: None,
+                            span: Ident(28..36),
                         },
                     ),
                 },
@@ -341,6 +613,7 @@ Query {
                         name: Identifier {
                             name: "sum",
                             quote: None,
+                            span: Ident(38..41),
                         },
                         args: [
                             ColumnRef {
@@ -349,6 +622,7 @@ Query {
                                 column: Identifier {
                                     name: "c_acctbal",
                                     quote: None,
+                                    span: Ident(42..51),
                                 },
                             },
                         ],
@@ -358,6 +632,7 @@ Query {
                         Identifier {
                             name: "totacctbal",
                             quote: None,
+                            span: Ident(56..66),
                         },
                     ),
                 },
@@ -377,6 +652,7 @@ Query {
                                     table: Identifier {
                                         name: "customer",
                                         quote: None,
+                                        span: Ident(84..92),
                                     },
                                     alias: None,
                                 },
@@ -386,12 +662,14 @@ Query {
                                     table: Identifier {
                                         name: "orders",
                                         quote: None,
+                                        span: Ident(94..100),
                                     },
                                     alias: Some(
                                         TableAlias {
                                             name: Identifier {
                                                 name: "ODS",
                                                 quote: None,
+                                                span: Ident(101..104),
                                             },
                                             columns: [],
                                         },
@@ -401,8 +679,62 @@ Query {
                         ),
                         right: Subquery {
                             subquery: Query {
+                                span: [
+                                    SELECT(144..150),
+                                    Ident(175..184),
+                                    Comma(184..185),
+                                    COUNT(210..215),
+                                    LParen(215..216),
+                                    Ident(216..226),
+                                    RParen(226..227),
+                                    FROM(248..252),
+                                    Ident(277..285),
+                                    LEFT(286..290),
+                                    OUTER(291..296),
+                                    JOIN(297..301),
+                                    Ident(302..308),
+                                    ON(309..311),
+                                    Ident(340..349),
+                                    Eq(350..351),
+                                    Ident(352..361),
+                                    AND(390..393),
+                                    Ident(394..403),
+                                    NOT(404..407),
+                                    LIKE(408..412),
+                                    QuotedIdent(413..422),
+                                    GROUP(443..448),
+                                    BY(449..451),
+                                    Ident(476..485),
+                                ],
                                 body: Select(
                                     SelectStmt {
+                                        span: [
+                                            SELECT(144..150),
+                                            Ident(175..184),
+                                            Comma(184..185),
+                                            COUNT(210..215),
+                                            LParen(215..216),
+                                            Ident(216..226),
+                                            RParen(226..227),
+                                            FROM(248..252),
+                                            Ident(277..285),
+                                            LEFT(286..290),
+                                            OUTER(291..296),
+                                            JOIN(297..301),
+                                            Ident(302..308),
+                                            ON(309..311),
+                                            Ident(340..349),
+                                            Eq(350..351),
+                                            Ident(352..361),
+                                            AND(390..393),
+                                            Ident(394..403),
+                                            NOT(404..407),
+                                            LIKE(408..412),
+                                            QuotedIdent(413..422),
+                                            GROUP(443..448),
+                                            BY(449..451),
+                                            Ident(476..485),
+                                        ],
                                         distinct: false,
                                         select_list: [
                                             AliasedExpr {
@@ -412,6 +744,7 @@ Query {
                                                     column: Identifier {
                                                         name: "c_custkey",
                                                         quote: None,
+                                                        span: Ident(175..184),
                                                     },
                                                 },
                                                 alias: None,
@@ -422,6 +755,7 @@ Query {
                                                     name: Identifier {
                                                         name: "count",
                                                         quote: None,
+                                                        span: COUNT(210..215),
                                                     },
                                                     args: [
                                                         ColumnRef {
@@ -430,6 +764,7 @@ Query {
                                                             column: Identifier {
                                                                 name: "o_orderkey",
                                                                 quote: None,
+                                                                span: Ident(216..226),
                                                             },
                                                         },
                                                     ],
@@ -453,6 +788,7 @@ Query {
                                                                     column: Identifier {
                                                                         name: "c_custkey",
                                                                         quote: None,
+                                                                        span: Ident(340..349),
                                                                     },
                                                                 },
                                                                 right: ColumnRef {
@@ -461,6 +797,7 @@ Query {
                                                                     column: Identifier {
                                                                         name: "o_custkey",
                                                                         quote: None,
+                                                                        span: Ident(352..361),
                                                                     },
                                                                 },
                                                             },
@@ -472,6 +809,7 @@ Query {
                                                                     column: Identifier {
                                                                         name: "o_comment",
                                                                         quote: None,
+                                                                        span: Ident(394..403),
                                                                     },
                                                                 },
                                                                 right: Literal(
@@ -488,6 +826,7 @@ Query {
                                                         table: Identifier {
                                                             name: "customer",
                                                             quote: None,
+                                                            span: Ident(277..285),
                                                         },
                                                         alias: None,
                                                     },
@@ -497,6 +836,7 @@ Query {
                                                         table: Identifier {
                                                             name: "orders",
                                                             quote: None,
+                                                            span: Ident(302..308),
                                                         },
                                                         alias: None,
                                                     },
@@ -511,6 +851,7 @@ Query {
                                                 column: Identifier {
                                                     name: "c_custkey",
                                                     quote: None,
+                                                    span: Ident(476..485),
                                                 },
                                             },
                                         ],
@@ -526,6 +867,7 @@ Query {
                                     name: Identifier {
                                         name: "c_orders",
                                         quote: None,
+                                        span: Ident(507..515),
                                     },
                                     columns: [],
                                 },
@@ -542,6 +884,7 @@ Query {
                     column: Identifier {
                         name: "c_count",
                         quote: None,
+                        span: Ident(537..544),
                     },
                 },
             ],
@@ -556,6 +899,7 @@ Query {
                 column: Identifier {
                     name: "custdist",
                     quote: None,
+                    span: Ident(566..574),
                 },
             },
             asc: Some(
@@ -570,6 +914,7 @@ Query {
                 column: Identifier {
                     name: "c_count",
                     quote: None,
+                    span: Ident(581..588),
                 },
             },
             asc: Some(
@@ -584,6 +929,7 @@ Query {
                 column: Identifier {
                     name: "totacctbal",
                     quote: None,
+                    span: Ident(594..604),
                 },
             },
             asc: None,
@@ -602,6 +948,7 @@ Query {
             column: Identifier {
                 name: "totacctbal",
                 quote: None,
+                span: Ident(627..637),
             },
         },
     ],

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -28,11 +28,13 @@ ShowCreateTable {
         Identifier {
             name: "a",
             quote: None,
+            span: Ident(18..19),
         },
     ),
     table: Identifier {
         name: "b",
         quote: None,
+        span: Ident(20..21),
     },
 }
 
@@ -46,8 +48,20 @@ Explain {
     kind: Pipeline,
     query: Query(
         Query {
+            span: [
+                SELECT(17..23),
+                Ident(24..25),
+                FROM(26..30),
+                Ident(31..32),
+            ],
             body: Select(
                 SelectStmt {
+                    span: [
+                        SELECT(17..23),
+                        Ident(24..25),
+                        FROM(26..30),
+                        Ident(31..32),
+                    ],
                     distinct: false,
                     select_list: [
                         AliasedExpr {
@@ -57,6 +71,7 @@ Explain {
                                 column: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(24..25),
                                 },
                             },
                             alias: None,
@@ -69,6 +84,7 @@ Explain {
                             table: Identifier {
                                 name: "b",
                                 quote: None,
+                                span: Ident(31..32),
                             },
                             alias: None,
                         },
@@ -97,6 +113,7 @@ Describe {
     table: Identifier {
         name: "a",
         quote: None,
+        span: Ident(9..10),
     },
 }
 
@@ -112,6 +129,7 @@ Describe {
     table: Identifier {
         name: "a",
         quote: None,
+        span: Ident(9..10),
     },
 }
 
@@ -125,6 +143,7 @@ Describe {
     table: Identifier {
         name: "b",
         quote: None,
+        span: Ident(21..22),
     },
 }
 
@@ -140,11 +159,13 @@ CreateTable {
         Identifier {
             name: "a",
             quote: None,
+            span: Ident(27..28),
         },
     ),
     table: Identifier {
         name: "b",
         quote: None,
+        span: Ident(29..30),
     },
     source: Some(
         Columns(
@@ -153,6 +174,7 @@ CreateTable {
                     name: Identifier {
                         name: "c",
                         quote: None,
+                        span: Ident(32..33),
                     },
                     data_type: Int32,
                     nullable: false,
@@ -168,6 +190,7 @@ CreateTable {
                     name: Identifier {
                         name: "b",
                         quote: None,
+                        span: Ident(62..63),
                     },
                     data_type: String,
                     nullable: false,
@@ -194,11 +217,13 @@ CreateTable {
         Identifier {
             name: "a",
             quote: None,
+            span: Ident(27..28),
         },
     ),
     table: Identifier {
         name: "b",
         quote: None,
+        span: Ident(29..30),
     },
     source: Some(
         Columns(
@@ -207,6 +232,7 @@ CreateTable {
                     name: Identifier {
                         name: "c",
                         quote: None,
+                        span: Ident(32..33),
                     },
                     data_type: Int32,
                     nullable: false,
@@ -222,6 +248,7 @@ CreateTable {
                     name: Identifier {
                         name: "b",
                         quote: None,
+                        span: Ident(62..63),
                     },
                     data_type: String,
                     nullable: false,
@@ -234,8 +261,20 @@ CreateTable {
     cluster_by: [],
     as_query: Some(
         Query {
+            span: [
+                SELECT(76..82),
+                Multiply(83..84),
+                FROM(85..89),
+                Ident(90..91),
+            ],
             body: Select(
                 SelectStmt {
+                    span: [
+                        SELECT(76..82),
+                        Multiply(83..84),
+                        FROM(85..89),
+                        Ident(90..91),
+                    ],
                     distinct: false,
                     select_list: [
                         QualifiedName(
@@ -251,6 +290,7 @@ CreateTable {
                             table: Identifier {
                                 name: "t",
                                 quote: None,
+                                span: Ident(90..91),
                             },
                             alias: None,
                         },
@@ -280,11 +320,13 @@ CreateTable {
         Identifier {
             name: "a",
             quote: None,
+            span: Ident(13..14),
         },
     ),
     table: Identifier {
         name: "b",
         quote: None,
+        span: Ident(15..16),
     },
     source: Some(
         Like {
@@ -292,11 +334,13 @@ CreateTable {
                 Identifier {
                     name: "c",
                     quote: None,
+                    span: Ident(22..23),
                 },
             ),
             table: Identifier {
                 name: "d",
                 quote: None,
+                span: Ident(24..25),
             },
         },
     ),
@@ -318,6 +362,7 @@ CreateTable {
     table: Identifier {
         name: "t",
         quote: None,
+        span: Ident(13..14),
     },
     source: Some(
         Like {
@@ -325,6 +370,7 @@ CreateTable {
             table: Identifier {
                 name: "t2",
                 quote: None,
+                span: Ident(20..22),
             },
         },
     ),
@@ -345,6 +391,7 @@ TruncateTable {
     table: Identifier {
         name: "a",
         quote: None,
+        span: Ident(15..16),
     },
     purge: false,
 }
@@ -362,11 +409,13 @@ TruncateTable {
             quote: Some(
                 '"',
             ),
+            span: QuotedIdent(15..18),
         },
     ),
     table: Identifier {
         name: "b",
         quote: None,
+        span: Ident(19..20),
     },
     purge: false,
 }
@@ -383,6 +432,7 @@ DropTable {
     table: Identifier {
         name: "a",
         quote: None,
+        span: Ident(11..12),
     },
 }
 
@@ -398,6 +448,7 @@ DropTable {
         Identifier {
             name: "a",
             quote: None,
+            span: Ident(21..22),
         },
     ),
     table: Identifier {
@@ -405,6 +456,7 @@ DropTable {
         quote: Some(
             '"',
         ),
+        span: QuotedIdent(23..26),
     },
 }
 
@@ -420,6 +472,7 @@ UseDatabase {
         quote: Some(
             '"',
         ),
+        span: QuotedIdent(4..7),
     },
 }
 
@@ -434,6 +487,7 @@ CreateDatabase {
     database: Identifier {
         name: "a",
         quote: None,
+        span: Ident(30..31),
     },
     engine: Null,
     options: [],
@@ -451,6 +505,7 @@ CreateTable {
     table: Identifier {
         name: "c",
         quote: None,
+        span: Ident(13..14),
     },
     source: Some(
         Columns(
@@ -459,6 +514,7 @@ CreateTable {
                     name: Identifier {
                         name: "a",
                         quote: None,
+                        span: Ident(15..16),
                     },
                     data_type: DateTime {
                         precision: None,
@@ -470,6 +526,7 @@ CreateTable {
                     name: Identifier {
                         name: "b",
                         quote: None,
+                        span: Ident(32..33),
                     },
                     data_type: DateTime {
                         precision: Some(
@@ -499,6 +556,7 @@ TruncateTable {
     table: Identifier {
         name: "test",
         quote: None,
+        span: Ident(15..19),
     },
     purge: false,
 }
@@ -514,11 +572,13 @@ TruncateTable {
         Identifier {
             name: "test_db",
             quote: None,
+            span: Ident(15..22),
         },
     ),
     table: Identifier {
         name: "test",
         quote: None,
+        span: Ident(23..27),
     },
     purge: false,
 }
@@ -535,6 +595,7 @@ DropTable {
     table: Identifier {
         name: "table1",
         quote: None,
+        span: Ident(11..17),
     },
 }
 
@@ -550,6 +611,7 @@ DropTable {
     table: Identifier {
         name: "table1",
         quote: None,
+        span: Ident(21..27),
     },
 }
 
@@ -565,6 +627,7 @@ CreateTable {
     table: Identifier {
         name: "t",
         quote: None,
+        span: Ident(13..14),
     },
     source: Some(
         Columns(
@@ -573,6 +636,7 @@ CreateTable {
                     name: Identifier {
                         name: "c1",
                         quote: None,
+                        span: Ident(15..17),
                     },
                     data_type: Int32,
                     nullable: true,
@@ -582,6 +646,7 @@ CreateTable {
                     name: Identifier {
                         name: "c2",
                         quote: None,
+                        span: Ident(28..30),
                     },
                     data_type: Int64,
                     nullable: true,
@@ -591,6 +656,7 @@ CreateTable {
                     name: Identifier {
                         name: "c3",
                         quote: None,
+                        span: Ident(44..46),
                     },
                     data_type: String,
                     nullable: true,
@@ -617,6 +683,7 @@ CreateTable {
     table: Identifier {
         name: "t",
         quote: None,
+        span: Ident(13..14),
     },
     source: Some(
         Columns(
@@ -625,6 +692,7 @@ CreateTable {
                     name: Identifier {
                         name: "c1",
                         quote: None,
+                        span: Ident(15..17),
                     },
                     data_type: Int32,
                     nullable: false,
@@ -634,6 +702,7 @@ CreateTable {
                     name: Identifier {
                         name: "c2",
                         quote: None,
+                        span: Ident(32..34),
                     },
                     data_type: Int64,
                     nullable: false,
@@ -643,6 +712,7 @@ CreateTable {
                     name: Identifier {
                         name: "c3",
                         quote: None,
+                        span: Ident(52..54),
                     },
                     data_type: String,
                     nullable: false,
@@ -669,6 +739,7 @@ CreateTable {
     table: Identifier {
         name: "t",
         quote: None,
+        span: Ident(13..14),
     },
     source: Some(
         Columns(
@@ -677,6 +748,7 @@ CreateTable {
                     name: Identifier {
                         name: "c1",
                         quote: None,
+                        span: Ident(15..17),
                     },
                     data_type: Int32,
                     nullable: false,
@@ -708,6 +780,7 @@ DropDatabase {
     database: Identifier {
         name: "db1",
         quote: None,
+        span: Ident(24..27),
     },
 }
 
@@ -719,8 +792,66 @@ SELECT DISTINCT a, COUNT(*) FROM t WHERE a = 1 AND b - 1 < a GROUP BY a HAVING a
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            DISTINCT(7..15),
+            Ident(16..17),
+            Comma(17..18),
+            COUNT(19..24),
+            LParen(24..25),
+            Multiply(25..26),
+            RParen(26..27),
+            FROM(28..32),
+            Ident(33..34),
+            WHERE(35..40),
+            Ident(41..42),
+            Eq(43..44),
+            LiteralNumber(45..46),
+            AND(47..50),
+            Ident(51..52),
+            Minus(53..54),
+            LiteralNumber(55..56),
+            Lt(57..58),
+            Ident(59..60),
+            GROUP(61..66),
+            BY(67..69),
+            Ident(70..71),
+            HAVING(72..78),
+            Ident(79..80),
+            Eq(81..82),
+            LiteralNumber(83..84),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    DISTINCT(7..15),
+                    Ident(16..17),
+                    Comma(17..18),
+                    COUNT(19..24),
+                    LParen(24..25),
+                    Multiply(25..26),
+                    RParen(26..27),
+                    FROM(28..32),
+                    Ident(33..34),
+                    WHERE(35..40),
+                    Ident(41..42),
+                    Eq(43..44),
+                    LiteralNumber(45..46),
+                    AND(47..50),
+                    Ident(51..52),
+                    Minus(53..54),
+                    LiteralNumber(55..56),
+                    Lt(57..58),
+                    Ident(59..60),
+                    GROUP(61..66),
+                    BY(67..69),
+                    Ident(70..71),
+                    HAVING(72..78),
+                    Ident(79..80),
+                    Eq(81..82),
+                    LiteralNumber(83..84),
+                ],
                 distinct: true,
                 select_list: [
                     AliasedExpr {
@@ -730,6 +861,7 @@ Query(
                             column: Identifier {
                                 name: "a",
                                 quote: None,
+                                span: Ident(16..17),
                             },
                         },
                         alias: None,
@@ -746,6 +878,7 @@ Query(
                         table: Identifier {
                             name: "t",
                             quote: None,
+                            span: Ident(33..34),
                         },
                         alias: None,
                     },
@@ -761,6 +894,7 @@ Query(
                                 column: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(41..42),
                                 },
                             },
                             right: Literal(
@@ -779,6 +913,7 @@ Query(
                                     column: Identifier {
                                         name: "b",
                                         quote: None,
+                                        span: Ident(51..52),
                                     },
                                 },
                                 right: Literal(
@@ -793,6 +928,7 @@ Query(
                                 column: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(59..60),
                                 },
                             },
                         },
@@ -805,6 +941,7 @@ Query(
                         column: Identifier {
                             name: "a",
                             quote: None,
+                            span: Ident(70..71),
                         },
                     },
                 ],
@@ -817,6 +954,7 @@ Query(
                             column: Identifier {
                                 name: "a",
                                 quote: None,
+                                span: Ident(79..80),
                             },
                         },
                         right: Literal(
@@ -842,8 +980,20 @@ SELECT * FROM t4
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..16),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..16),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -859,6 +1009,7 @@ Query(
                         table: Identifier {
                             name: "t4",
                             quote: None,
+                            span: Ident(14..16),
                         },
                         alias: None,
                     },
@@ -882,8 +1033,24 @@ SELECT * FROM aa.bb
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..16),
+            Period(16..17),
+            Ident(17..19),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..16),
+                    Period(16..17),
+                    Ident(17..19),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -899,11 +1066,13 @@ Query(
                             Identifier {
                                 name: "aa",
                                 quote: None,
+                                span: Ident(14..16),
                             },
                         ),
                         table: Identifier {
                             name: "bb",
                             quote: None,
+                            span: Ident(17..19),
                         },
                         alias: None,
                     },
@@ -927,8 +1096,28 @@ SELECT * FROM a CROSS JOIN b CROSS JOIN c
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..15),
+            Comma(15..16),
+            Ident(17..18),
+            Comma(18..19),
+            Ident(20..21),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..15),
+                    Comma(15..16),
+                    Ident(17..18),
+                    Comma(18..19),
+                    Ident(20..21),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -952,6 +1141,7 @@ Query(
                                         table: Identifier {
                                             name: "a",
                                             quote: None,
+                                            span: Ident(14..15),
                                         },
                                         alias: None,
                                     },
@@ -961,6 +1151,7 @@ Query(
                                         table: Identifier {
                                             name: "b",
                                             quote: None,
+                                            span: Ident(17..18),
                                         },
                                         alias: None,
                                     },
@@ -972,6 +1163,7 @@ Query(
                                 table: Identifier {
                                     name: "c",
                                     quote: None,
+                                    span: Ident(20..21),
                                 },
                                 alias: None,
                             },
@@ -997,8 +1189,40 @@ SELECT * FROM a INNER JOIN b ON a.a = b.a
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..15),
+            JOIN(16..20),
+            Ident(21..22),
+            ON(23..25),
+            Ident(26..27),
+            Period(27..28),
+            Ident(28..29),
+            Eq(30..31),
+            Ident(32..33),
+            Period(33..34),
+            Ident(34..35),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..15),
+                    JOIN(16..20),
+                    Ident(21..22),
+                    ON(23..25),
+                    Ident(26..27),
+                    Period(27..28),
+                    Ident(28..29),
+                    Eq(30..31),
+                    Ident(32..33),
+                    Period(33..34),
+                    Ident(34..35),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -1020,11 +1244,13 @@ Query(
                                             Identifier {
                                                 name: "a",
                                                 quote: None,
+                                                span: Ident(26..27),
                                             },
                                         ),
                                         column: Identifier {
                                             name: "a",
                                             quote: None,
+                                            span: Ident(28..29),
                                         },
                                     },
                                     right: ColumnRef {
@@ -1033,11 +1259,13 @@ Query(
                                             Identifier {
                                                 name: "b",
                                                 quote: None,
+                                                span: Ident(32..33),
                                             },
                                         ),
                                         column: Identifier {
                                             name: "a",
                                             quote: None,
+                                            span: Ident(34..35),
                                         },
                                     },
                                 },
@@ -1048,6 +1276,7 @@ Query(
                                 table: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(14..15),
                                 },
                                 alias: None,
                             },
@@ -1057,6 +1286,7 @@ Query(
                                 table: Identifier {
                                     name: "b",
                                     quote: None,
+                                    span: Ident(21..22),
                                 },
                                 alias: None,
                             },
@@ -1082,8 +1312,44 @@ SELECT * FROM a LEFT OUTER JOIN b ON a.a = b.a
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..15),
+            LEFT(16..20),
+            OUTER(21..26),
+            JOIN(27..31),
+            Ident(32..33),
+            ON(34..36),
+            Ident(37..38),
+            Period(38..39),
+            Ident(39..40),
+            Eq(41..42),
+            Ident(43..44),
+            Period(44..45),
+            Ident(45..46),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..15),
+                    LEFT(16..20),
+                    OUTER(21..26),
+                    JOIN(27..31),
+                    Ident(32..33),
+                    ON(34..36),
+                    Ident(37..38),
+                    Period(38..39),
+                    Ident(39..40),
+                    Eq(41..42),
+                    Ident(43..44),
+                    Period(44..45),
+                    Ident(45..46),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -1105,11 +1371,13 @@ Query(
                                             Identifier {
                                                 name: "a",
                                                 quote: None,
+                                                span: Ident(37..38),
                                             },
                                         ),
                                         column: Identifier {
                                             name: "a",
                                             quote: None,
+                                            span: Ident(39..40),
                                         },
                                     },
                                     right: ColumnRef {
@@ -1118,11 +1386,13 @@ Query(
                                             Identifier {
                                                 name: "b",
                                                 quote: None,
+                                                span: Ident(43..44),
                                             },
                                         ),
                                         column: Identifier {
                                             name: "a",
                                             quote: None,
+                                            span: Ident(45..46),
                                         },
                                     },
                                 },
@@ -1133,6 +1403,7 @@ Query(
                                 table: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(14..15),
                                 },
                                 alias: None,
                             },
@@ -1142,6 +1413,7 @@ Query(
                                 table: Identifier {
                                     name: "b",
                                     quote: None,
+                                    span: Ident(32..33),
                                 },
                                 alias: None,
                             },
@@ -1167,8 +1439,44 @@ SELECT * FROM a RIGHT OUTER JOIN b ON a.a = b.a
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..15),
+            RIGHT(16..21),
+            OUTER(22..27),
+            JOIN(28..32),
+            Ident(33..34),
+            ON(35..37),
+            Ident(38..39),
+            Period(39..40),
+            Ident(40..41),
+            Eq(42..43),
+            Ident(44..45),
+            Period(45..46),
+            Ident(46..47),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..15),
+                    RIGHT(16..21),
+                    OUTER(22..27),
+                    JOIN(28..32),
+                    Ident(33..34),
+                    ON(35..37),
+                    Ident(38..39),
+                    Period(39..40),
+                    Ident(40..41),
+                    Eq(42..43),
+                    Ident(44..45),
+                    Period(45..46),
+                    Ident(46..47),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -1190,11 +1498,13 @@ Query(
                                             Identifier {
                                                 name: "a",
                                                 quote: None,
+                                                span: Ident(38..39),
                                             },
                                         ),
                                         column: Identifier {
                                             name: "a",
                                             quote: None,
+                                            span: Ident(40..41),
                                         },
                                     },
                                     right: ColumnRef {
@@ -1203,11 +1513,13 @@ Query(
                                             Identifier {
                                                 name: "b",
                                                 quote: None,
+                                                span: Ident(44..45),
                                             },
                                         ),
                                         column: Identifier {
                                             name: "a",
                                             quote: None,
+                                            span: Ident(46..47),
                                         },
                                     },
                                 },
@@ -1218,6 +1530,7 @@ Query(
                                 table: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(14..15),
                                 },
                                 alias: None,
                             },
@@ -1227,6 +1540,7 @@ Query(
                                 table: Identifier {
                                     name: "b",
                                     quote: None,
+                                    span: Ident(33..34),
                                 },
                                 alias: None,
                             },
@@ -1252,8 +1566,44 @@ SELECT * FROM a FULL OUTER JOIN b ON a.a = b.a
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..15),
+            FULL(16..20),
+            OUTER(21..26),
+            JOIN(27..31),
+            Ident(32..33),
+            ON(34..36),
+            Ident(37..38),
+            Period(38..39),
+            Ident(39..40),
+            Eq(41..42),
+            Ident(43..44),
+            Period(44..45),
+            Ident(45..46),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..15),
+                    FULL(16..20),
+                    OUTER(21..26),
+                    JOIN(27..31),
+                    Ident(32..33),
+                    ON(34..36),
+                    Ident(37..38),
+                    Period(38..39),
+                    Ident(39..40),
+                    Eq(41..42),
+                    Ident(43..44),
+                    Period(44..45),
+                    Ident(45..46),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -1275,11 +1625,13 @@ Query(
                                             Identifier {
                                                 name: "a",
                                                 quote: None,
+                                                span: Ident(37..38),
                                             },
                                         ),
                                         column: Identifier {
                                             name: "a",
                                             quote: None,
+                                            span: Ident(39..40),
                                         },
                                     },
                                     right: ColumnRef {
@@ -1288,11 +1640,13 @@ Query(
                                             Identifier {
                                                 name: "b",
                                                 quote: None,
+                                                span: Ident(43..44),
                                             },
                                         ),
                                         column: Identifier {
                                             name: "a",
                                             quote: None,
+                                            span: Ident(45..46),
                                         },
                                     },
                                 },
@@ -1303,6 +1657,7 @@ Query(
                                 table: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(14..15),
                                 },
                                 alias: None,
                             },
@@ -1312,6 +1667,7 @@ Query(
                                 table: Identifier {
                                     name: "b",
                                     quote: None,
+                                    span: Ident(32..33),
                                 },
                                 alias: None,
                             },
@@ -1337,8 +1693,42 @@ SELECT * FROM a INNER JOIN b ON a.a = b.a
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..15),
+            INNER(16..21),
+            JOIN(22..26),
+            Ident(27..28),
+            ON(29..31),
+            Ident(32..33),
+            Period(33..34),
+            Ident(34..35),
+            Eq(36..37),
+            Ident(38..39),
+            Period(39..40),
+            Ident(40..41),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..15),
+                    INNER(16..21),
+                    JOIN(22..26),
+                    Ident(27..28),
+                    ON(29..31),
+                    Ident(32..33),
+                    Period(33..34),
+                    Ident(34..35),
+                    Eq(36..37),
+                    Ident(38..39),
+                    Period(39..40),
+                    Ident(40..41),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -1360,11 +1750,13 @@ Query(
                                             Identifier {
                                                 name: "a",
                                                 quote: None,
+                                                span: Ident(32..33),
                                             },
                                         ),
                                         column: Identifier {
                                             name: "a",
                                             quote: None,
+                                            span: Ident(34..35),
                                         },
                                     },
                                     right: ColumnRef {
@@ -1373,11 +1765,13 @@ Query(
                                             Identifier {
                                                 name: "b",
                                                 quote: None,
+                                                span: Ident(38..39),
                                             },
                                         ),
                                         column: Identifier {
                                             name: "a",
                                             quote: None,
+                                            span: Ident(40..41),
                                         },
                                     },
                                 },
@@ -1388,6 +1782,7 @@ Query(
                                 table: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(14..15),
                                 },
                                 alias: None,
                             },
@@ -1397,6 +1792,7 @@ Query(
                                 table: Identifier {
                                     name: "b",
                                     quote: None,
+                                    span: Ident(27..28),
                                 },
                                 alias: None,
                             },
@@ -1422,8 +1818,36 @@ SELECT * FROM a LEFT OUTER JOIN b USING(a)
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..15),
+            LEFT(16..20),
+            OUTER(21..26),
+            JOIN(27..31),
+            Ident(32..33),
+            USING(34..39),
+            LParen(39..40),
+            Ident(40..41),
+            RParen(41..42),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..15),
+                    LEFT(16..20),
+                    OUTER(21..26),
+                    JOIN(27..31),
+                    Ident(32..33),
+                    USING(34..39),
+                    LParen(39..40),
+                    Ident(40..41),
+                    RParen(41..42),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -1441,6 +1865,7 @@ Query(
                                     Identifier {
                                         name: "a",
                                         quote: None,
+                                        span: Ident(40..41),
                                     },
                                 ],
                             ),
@@ -1450,6 +1875,7 @@ Query(
                                 table: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(14..15),
                                 },
                                 alias: None,
                             },
@@ -1459,6 +1885,7 @@ Query(
                                 table: Identifier {
                                     name: "b",
                                     quote: None,
+                                    span: Ident(32..33),
                                 },
                                 alias: None,
                             },
@@ -1484,8 +1911,36 @@ SELECT * FROM a RIGHT OUTER JOIN b USING(a)
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..15),
+            RIGHT(16..21),
+            OUTER(22..27),
+            JOIN(28..32),
+            Ident(33..34),
+            USING(35..40),
+            LParen(40..41),
+            Ident(41..42),
+            RParen(42..43),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..15),
+                    RIGHT(16..21),
+                    OUTER(22..27),
+                    JOIN(28..32),
+                    Ident(33..34),
+                    USING(35..40),
+                    LParen(40..41),
+                    Ident(41..42),
+                    RParen(42..43),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -1503,6 +1958,7 @@ Query(
                                     Identifier {
                                         name: "a",
                                         quote: None,
+                                        span: Ident(41..42),
                                     },
                                 ],
                             ),
@@ -1512,6 +1968,7 @@ Query(
                                 table: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(14..15),
                                 },
                                 alias: None,
                             },
@@ -1521,6 +1978,7 @@ Query(
                                 table: Identifier {
                                     name: "b",
                                     quote: None,
+                                    span: Ident(33..34),
                                 },
                                 alias: None,
                             },
@@ -1546,8 +2004,36 @@ SELECT * FROM a FULL OUTER JOIN b USING(a)
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..15),
+            FULL(16..20),
+            OUTER(21..26),
+            JOIN(27..31),
+            Ident(32..33),
+            USING(34..39),
+            LParen(39..40),
+            Ident(40..41),
+            RParen(41..42),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..15),
+                    FULL(16..20),
+                    OUTER(21..26),
+                    JOIN(27..31),
+                    Ident(32..33),
+                    USING(34..39),
+                    LParen(39..40),
+                    Ident(40..41),
+                    RParen(41..42),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -1565,6 +2051,7 @@ Query(
                                     Identifier {
                                         name: "a",
                                         quote: None,
+                                        span: Ident(40..41),
                                     },
                                 ],
                             ),
@@ -1574,6 +2061,7 @@ Query(
                                 table: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(14..15),
                                 },
                                 alias: None,
                             },
@@ -1583,6 +2071,7 @@ Query(
                                 table: Identifier {
                                     name: "b",
                                     quote: None,
+                                    span: Ident(32..33),
                                 },
                                 alias: None,
                             },
@@ -1608,8 +2097,34 @@ SELECT * FROM a INNER JOIN b USING(a)
 ---------- AST ------------
 Query(
     Query {
+        span: [
+            SELECT(0..6),
+            Multiply(7..8),
+            FROM(9..13),
+            Ident(14..15),
+            INNER(16..21),
+            JOIN(22..26),
+            Ident(27..28),
+            USING(29..34),
+            LParen(34..35),
+            Ident(35..36),
+            RParen(36..37),
+        ],
         body: Select(
             SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    Multiply(7..8),
+                    FROM(9..13),
+                    Ident(14..15),
+                    INNER(16..21),
+                    JOIN(22..26),
+                    Ident(27..28),
+                    USING(29..34),
+                    LParen(34..35),
+                    Ident(35..36),
+                    RParen(36..37),
+                ],
                 distinct: false,
                 select_list: [
                     QualifiedName(
@@ -1627,6 +2142,7 @@ Query(
                                     Identifier {
                                         name: "a",
                                         quote: None,
+                                        span: Ident(35..36),
                                     },
                                 ],
                             ),
@@ -1636,6 +2152,7 @@ Query(
                                 table: Identifier {
                                     name: "a",
                                     quote: None,
+                                    span: Ident(14..15),
                                 },
                                 alias: None,
                             },
@@ -1645,6 +2162,7 @@ Query(
                                 table: Identifier {
                                     name: "b",
                                     quote: None,
+                                    span: Ident(27..28),
                                 },
                                 alias: None,
                             },
@@ -1673,74 +2191,33 @@ Insert {
     table: Identifier {
         name: "t",
         quote: None,
+        span: Ident(12..13),
     },
     columns: [
         Identifier {
             name: "c1",
             quote: None,
+            span: Ident(15..17),
         },
         Identifier {
             name: "c2",
             quote: None,
+            span: Ident(19..21),
         },
     ],
     source: Values {
         values_tokens: [
-            Token {
-                source: "insert into t (c1, c2) values (1, 2), (3, 4);",
-                kind: LParen,
-                span: 30..31,
-            },
-            Token {
-                source: "insert into t (c1, c2) values (1, 2), (3, 4);",
-                kind: LiteralNumber,
-                span: 31..32,
-            },
-            Token {
-                source: "insert into t (c1, c2) values (1, 2), (3, 4);",
-                kind: Comma,
-                span: 32..33,
-            },
-            Token {
-                source: "insert into t (c1, c2) values (1, 2), (3, 4);",
-                kind: LiteralNumber,
-                span: 34..35,
-            },
-            Token {
-                source: "insert into t (c1, c2) values (1, 2), (3, 4);",
-                kind: RParen,
-                span: 35..36,
-            },
-            Token {
-                source: "insert into t (c1, c2) values (1, 2), (3, 4);",
-                kind: Comma,
-                span: 36..37,
-            },
-            Token {
-                source: "insert into t (c1, c2) values (1, 2), (3, 4);",
-                kind: LParen,
-                span: 38..39,
-            },
-            Token {
-                source: "insert into t (c1, c2) values (1, 2), (3, 4);",
-                kind: LiteralNumber,
-                span: 39..40,
-            },
-            Token {
-                source: "insert into t (c1, c2) values (1, 2), (3, 4);",
-                kind: Comma,
-                span: 40..41,
-            },
-            Token {
-                source: "insert into t (c1, c2) values (1, 2), (3, 4);",
-                kind: LiteralNumber,
-                span: 42..43,
-            },
-            Token {
-                source: "insert into t (c1, c2) values (1, 2), (3, 4);",
-                kind: RParen,
-                span: 43..44,
-            },
+            LParen(30..31),
+            LiteralNumber(31..32),
+            Comma(32..33),
+            LiteralNumber(34..35),
+            RParen(35..36),
+            Comma(36..37),
+            LParen(38..39),
+            LiteralNumber(39..40),
+            Comma(40..41),
+            LiteralNumber(42..43),
+            RParen(43..44),
         ],
     },
     overwrite: false,
@@ -1757,6 +2234,7 @@ Insert {
     table: Identifier {
         name: "t",
         quote: None,
+        span: Ident(18..19),
     },
     columns: [],
     source: Streaming {
@@ -1776,12 +2254,25 @@ Insert {
     table: Identifier {
         name: "t",
         quote: None,
+        span: Ident(18..19),
     },
     columns: [],
     source: Select {
         query: Query {
+            span: [
+                SELECT(20..26),
+                Multiply(27..28),
+                FROM(29..33),
+                Ident(34..36),
+            ],
             body: Select(
                 SelectStmt {
+                    span: [
+                        SELECT(20..26),
+                        Multiply(27..28),
+                        FROM(29..33),
+                        Ident(34..36),
+                    ],
                     distinct: false,
                     select_list: [
                         QualifiedName(
@@ -1797,6 +2288,7 @@ Insert {
                             table: Identifier {
                                 name: "t2",
                                 quote: None,
+                                span: Ident(34..36),
                             },
                             alias: None,
                         },

--- a/query/src/sql/planner/binder/aggregate.rs
+++ b/query/src/sql/planner/binder/aggregate.rs
@@ -61,9 +61,9 @@ impl Binder {
         Ok(())
     }
 
-    pub(super) async fn bind_group_by(
+    pub(super) async fn bind_group_by<'a>(
         &mut self,
-        group_by_expr: &[Expr],
+        group_by_expr: &[Expr<'a>],
         input_context: &mut BindContext,
     ) -> Result<()> {
         let scalar_binder = ScalarBinder::new(input_context, self.ctx.clone());

--- a/query/src/sql/planner/binder/aggregate.rs
+++ b/query/src/sql/planner/binder/aggregate.rs
@@ -25,7 +25,7 @@ use crate::sql::plans::AggregatePlan;
 use crate::sql::plans::Scalar;
 use crate::sql::BindContext;
 
-impl Binder {
+impl<'a> Binder {
     pub(crate) fn analyze_aggregate(
         &self,
         output_context: &BindContext,
@@ -61,7 +61,7 @@ impl Binder {
         Ok(())
     }
 
-    pub(super) async fn bind_group_by<'a>(
+    pub(super) async fn bind_group_by(
         &mut self,
         group_by_expr: &[Expr<'a>],
         input_context: &mut BindContext,

--- a/query/src/sql/planner/binder/join.rs
+++ b/query/src/sql/planner/binder/join.rs
@@ -37,12 +37,12 @@ use crate::sql::plans::Scalar;
 use crate::sql::plans::ScalarExpr;
 use crate::sql::BindContext;
 
-impl Binder {
+impl<'a> Binder {
     #[async_recursion]
     pub(super) async fn bind_join(
         &mut self,
         bind_context: &BindContext,
-        join: &Join,
+        join: &Join<'a>,
     ) -> Result<BindContext> {
         let left_child = self.bind_table_reference(&join.left, bind_context).await?;
         let right_child = self.bind_table_reference(&join.right, bind_context).await?;

--- a/query/src/sql/planner/binder/join.rs
+++ b/query/src/sql/planner/binder/join.rs
@@ -141,7 +141,7 @@ struct JoinConditionResolver<'a> {
     left_context: &'a BindContext,
     right_context: &'a BindContext,
     join_context: &'a BindContext,
-    join_condition: &'a JoinCondition,
+    join_condition: &'a JoinCondition<'a>,
 }
 
 impl<'a> JoinConditionResolver<'a> {
@@ -150,7 +150,7 @@ impl<'a> JoinConditionResolver<'a> {
         left_context: &'a BindContext,
         right_context: &'a BindContext,
         join_context: &'a BindContext,
-        join_condition: &'a JoinCondition,
+        join_condition: &'a JoinCondition<'a>,
     ) -> Self {
         Self {
             ctx,
@@ -192,7 +192,7 @@ impl<'a> JoinConditionResolver<'a> {
 
     async fn resolve_on(
         &self,
-        condition: &Expr,
+        condition: &Expr<'a>,
         left_join_conditions: &mut Vec<Scalar>,
         right_join_conditions: &mut Vec<Scalar>,
         other_join_conditions: &mut Vec<Scalar>,

--- a/query/src/sql/planner/binder/mod.rs
+++ b/query/src/sql/planner/binder/mod.rs
@@ -48,7 +48,7 @@ pub struct Binder {
     metadata: Metadata,
 }
 
-impl Binder {
+impl<'a> Binder {
     pub fn new(ctx: Arc<QueryContext>, catalogs: Arc<CatalogManager>) -> Self {
         Binder {
             ctx,
@@ -57,13 +57,13 @@ impl Binder {
         }
     }
 
-    pub async fn bind<'a>(mut self, stmt: &Statement<'a>) -> Result<BindResult> {
+    pub async fn bind(mut self, stmt: &Statement<'a>) -> Result<BindResult> {
         let init_bind_context = BindContext::new();
         let bind_context = self.bind_statement(stmt, &init_bind_context).await?;
         Ok(BindResult::create(bind_context, self.metadata))
     }
 
-    async fn bind_statement<'a>(
+    async fn bind_statement(
         &mut self,
         stmt: &Statement<'a>,
         bind_context: &BindContext,

--- a/query/src/sql/planner/binder/project.rs
+++ b/query/src/sql/planner/binder/project.rs
@@ -27,7 +27,7 @@ use crate::sql::plans::ProjectItem;
 use crate::sql::plans::ProjectPlan;
 use crate::sql::plans::Scalar;
 
-impl Binder {
+impl<'a> Binder {
     /// Try to build a `ProjectPlan` to satisfy `output_context`.
     /// If `output_context` can already be satisfied by `input_context`(e.g. `SELECT * FROM t`),
     /// then it won't build a `ProjectPlan`.
@@ -69,7 +69,7 @@ impl Binder {
     /// For scalar expressions and aggregate expressions, we will register new columns for
     /// them in `Metadata`. And notice that, the semantic of aggregate expressions won't be checked
     /// in this function.
-    pub(super) async fn normalize_select_list<'a>(
+    pub(super) async fn normalize_select_list(
         &mut self,
         select_list: &[SelectTarget<'a>],
         has_order_by: bool,

--- a/query/src/sql/planner/binder/project.rs
+++ b/query/src/sql/planner/binder/project.rs
@@ -69,9 +69,9 @@ impl Binder {
     /// For scalar expressions and aggregate expressions, we will register new columns for
     /// them in `Metadata`. And notice that, the semantic of aggregate expressions won't be checked
     /// in this function.
-    pub(super) async fn normalize_select_list(
+    pub(super) async fn normalize_select_list<'a>(
         &mut self,
-        select_list: &[SelectTarget],
+        select_list: &[SelectTarget<'a>],
         has_order_by: bool,
         input_context: &BindContext,
     ) -> Result<BindContext> {
@@ -89,7 +89,7 @@ impl Binder {
                         match indirection {
                             Indirection::Identifier(ident) => {
                                 let mut column_binding =
-                                    input_context.resolve_column(None, ident.name.clone())?;
+                                    input_context.resolve_column(None, ident)?;
                                 column_binding.column_name = ident.name.clone();
                                 output_context.add_column_binding(column_binding);
                             }

--- a/query/src/sql/planner/binder/scalar.rs
+++ b/query/src/sql/planner/binder/scalar.rs
@@ -34,7 +34,7 @@ impl<'a> ScalarBinder<'a> {
         ScalarBinder { bind_context, ctx }
     }
 
-    pub async fn bind_expr(&self, expr: &Expr) -> Result<(Scalar, DataTypeImpl)> {
+    pub async fn bind_expr(&self, expr: &Expr<'a>) -> Result<(Scalar, DataTypeImpl)> {
         let type_checker = TypeChecker::new(self.bind_context, self.ctx.clone());
         type_checker.resolve(expr, None).await
     }

--- a/query/src/sql/planner/binder/sort.rs
+++ b/query/src/sql/planner/binder/sort.rs
@@ -22,10 +22,10 @@ use crate::sql::plans::SortItem;
 use crate::sql::plans::SortPlan;
 use crate::sql::BindContext;
 
-impl Binder {
+impl<'a> Binder {
     pub(super) async fn bind_order_by(
         &mut self,
-        order_by: &[OrderByExpr],
+        order_by: &[OrderByExpr<'a>],
         bind_context: &mut BindContext,
     ) -> Result<()> {
         let scalar_binder = ScalarBinder::new(bind_context, self.ctx.clone());

--- a/query/src/sql/planner/semantic/type_check.rs
+++ b/query/src/sql/planner/semantic/type_check.rs
@@ -71,7 +71,7 @@ impl<'a> TypeChecker<'a> {
     #[async_recursion::async_recursion]
     pub async fn resolve(
         &self,
-        expr: &Expr,
+        expr: &Expr<'a>,
         required_type: Option<DataTypeImpl>,
     ) -> Result<(Scalar, DataTypeImpl)> {
         match expr {
@@ -82,7 +82,7 @@ impl<'a> TypeChecker<'a> {
             } => {
                 let column = self
                     .bind_context
-                    .resolve_column(table.clone().map(|ident| ident.name), column.name.clone())?;
+                    .resolve_column(table.clone().map(|ident| ident.name), column)?;
                 let data_type = column.data_type.clone();
 
                 Ok((BoundColumnRef { column }.into(), data_type))
@@ -296,7 +296,7 @@ impl<'a> TypeChecker<'a> {
     pub async fn resolve_function(
         &self,
         func_name: &str,
-        arguments: &[&Expr],
+        arguments: &[&Expr<'a>],
         _required_type: Option<DataTypeImpl>,
     ) -> Result<(Scalar, DataTypeImpl)> {
         let mut args = vec![];
@@ -329,8 +329,8 @@ impl<'a> TypeChecker<'a> {
     pub async fn resolve_binary_op(
         &self,
         op: &BinaryOperator,
-        left: &Expr,
-        right: &Expr,
+        left: &Expr<'a>,
+        right: &Expr<'a>,
         required_type: Option<DataTypeImpl>,
     ) -> Result<(Scalar, DataTypeImpl)> {
         match op {
@@ -407,7 +407,7 @@ impl<'a> TypeChecker<'a> {
     pub async fn resolve_unary_op(
         &self,
         op: &UnaryOperator,
-        child: &Expr,
+        child: &Expr<'a>,
         required_type: Option<DataTypeImpl>,
     ) -> Result<(Scalar, DataTypeImpl)> {
         self.resolve_function(op.to_string().as_str(), &[child], required_type)
@@ -416,7 +416,7 @@ impl<'a> TypeChecker<'a> {
 
     pub async fn resolve_subquery(
         &self,
-        subquery: &Query,
+        subquery: &Query<'a>,
         allow_multi_rows: bool,
         _required_type: Option<DataTypeImpl>,
     ) -> Result<(Scalar, DataTypeImpl)> {

--- a/tests/suites/0_stateless/20+_others/20_0002_planner_v2_display_error.result
+++ b/tests/suites/0_stateless/20+_others/20_0002_planner_v2_display_error.result
@@ -1,0 +1,14 @@
+ERROR 1105 (HY000) at line 4: Code: 1065, displayText = error: 
+  --> SQL:1:8
+  |
+1 | select aa from t
+  |        ^^ column doesn't exist
+
+.
+ERROR 1105 (HY000) at line 5: Code: 1065, displayText = error: 
+  --> SQL:1:1
+  |
+1 | select *
+  | ^^^^^^^^ SELECT * with no tables specified is not valid
+
+.

--- a/tests/suites/0_stateless/20+_others/20_0002_planner_v2_display_error.sql
+++ b/tests/suites/0_stateless/20+_others/20_0002_planner_v2_display_error.sql
@@ -1,0 +1,5 @@
+set enable_planner_v2 = 1;
+
+create table t(a int, b int);
+select aa from t;
+select *;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```diff
// V1
- ERROR 1105 (HY000) at line 4: Code: 1058, displayText = Unknown column aa.
- ERROR 1105 (HY000) at line 5: Code: 1015, displayText = SELECT * with no tables specified is not valid (while in analyze select projection).

// V2
+ ERROR 1105 (HY000) at line 4: Code: 1065, displayText = error: 
+   --> SQL:1:8
+   |
+ 1 | select aa from t
+   |        ^^ column doesn't exist
+ 
+ .
+ ERROR 1105 (HY000) at line 5: Code: 1065, displayText = error: 
+   --> SQL:1:1
+   |
+ 1 | select *
+   | ^^^^^^^^ SELECT * with no tables specified is not valid
+ 
+ .
```

## Changelog

- New Feature

