### PR TITLE
feat(function): change retention return type from Variant to Array<T>

### DIFF
--- a/common/datavalues/src/columns/array/mutable.rs
+++ b/common/datavalues/src/columns/array/mutable.rs
@@ -24,7 +24,7 @@ pub struct MutableArrayColumn {
     inner_data_type: DataTypeImpl,
     last_offset: usize,
     offsets: Vec<i64>,
-    inner_column: Box<dyn MutableColumn>,
+    pub inner_column: Box<dyn MutableColumn>,
 }
 
 impl MutableArrayColumn {

--- a/common/functions/src/aggregates/aggregate_retention.rs
+++ b/common/functions/src/aggregates/aggregate_retention.rs
@@ -21,7 +21,6 @@ use common_datavalues::prelude::*;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_io::prelude::*;
-use serde_json::json;
 
 use super::aggregate_function::AggregateFunction;
 use super::aggregate_function::AggregateFunctionRef;
@@ -66,7 +65,7 @@ impl AggregateFunction for AggregateRetentionFunction {
     }
 
     fn return_type(&self) -> Result<DataTypeImpl> {
-        Ok(VariantValue::to_data_type())
+        Ok(ArrayType::new_impl(UInt8Type::new_impl()))
     }
 
     fn init_state(&self, place: StateAddr) {
@@ -142,18 +141,20 @@ impl AggregateFunction for AggregateRetentionFunction {
         array: &mut dyn common_datavalues::MutableColumn,
     ) -> Result<()> {
         let state = place.get::<AggregateRetentionState>();
-        let builder: &mut MutableObjectColumn<VariantValue> =
-            Series::check_get_mutable_column(array)?;
-        let mut vec: Vec<u8> = vec![0; self.events_size as usize];
+        let builder: &mut MutableArrayColumn = Series::check_get_mutable_column(array)?;
+        let inner_column: &mut MutablePrimitiveColumn<u8> =
+            Series::check_get_mutable_column(builder.inner_column.as_mut())?;
         if state.events & 1 == 1 {
-            vec[0] = 1;
+            inner_column.append_value(1u8);
             for i in 1..self.events_size {
                 if state.events & (1 << i) != 0 {
-                    vec[i as usize] = 1;
+                    inner_column.append_value(1u8);
+                } else {
+                    inner_column.append_value(0u8);
                 }
             }
         }
-        builder.append_value(VariantValue::from(json!(vec)));
+        builder.add_offset(self.events_size as usize);
         Ok(())
     }
 

--- a/tests/suites/0_stateless/02_function/02_0000_function_aggregate_retention.sql
+++ b/tests/suites/0_stateless/02_function/02_0000_function_aggregate_retention.sql
@@ -6,8 +6,8 @@ INSERT INTO retention_test SELECT '2018-08-06', number FROM numbers(80);
 INSERT INTO retention_test SELECT '2018-08-07', number FROM numbers(50);
 INSERT INTO retention_test SELECT '2018-08-08', number FROM numbers(60);
 
-SELECT sum(r[0]::TINYINT) as r1, sum(r[1]::TINYINT) as r2 FROM (SELECT uid, retention(date = '2018-08-06', date = '2018-08-07') AS r FROM retention_test WHERE date = '2018-08-06' or date = '2018-08-07' GROUP BY uid);
-SELECT sum(r[0]::TINYINT) as r1, sum(r[1]::TINYINT) as r2 FROM (SELECT uid, retention(date = '2018-08-06', date = '2018-08-08') AS r FROM retention_test WHERE date = '2018-08-06' or date = '2018-08-08' GROUP BY uid);
-SELECT sum(r[0]::TINYINT) as r1, sum(r[1]::TINYINT) as r2, sum(r[2]::TINYINT) as r3 FROM (SELECT uid, retention(date = '2018-08-06', date = '2018-08-07', date = '2018-08-08') AS r FROM retention_test GROUP BY uid);
+SELECT sum(r[0]) as r1, sum(r[1]) as r2 FROM (SELECT uid, retention(date = '2018-08-06', date = '2018-08-07') AS r FROM retention_test WHERE date = '2018-08-06' or date = '2018-08-07' GROUP BY uid);
+SELECT sum(r[0]) as r1, sum(r[1]) as r2 FROM (SELECT uid, retention(date = '2018-08-06', date = '2018-08-08') AS r FROM retention_test WHERE date = '2018-08-06' or date = '2018-08-08' GROUP BY uid);
+SELECT sum(r[0]) as r1, sum(r[1]) as r2, sum(r[2]) as r3 FROM (SELECT uid, retention(date = '2018-08-06', date = '2018-08-07', date = '2018-08-08') AS r FROM retention_test GROUP BY uid);
 
 DROP TABLE retention_test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Now the get method of Array<T> is supported.

We can change the return type of retention function from Variant to Array<T>.

## Changelog

- New Feature

## Related Issues

Fixes #5226 

