### PR TITLE
feature(planner): Support some scalar expressions in new planner

### DIFF
--- a/query/src/sql/exec/expression_builder.rs
+++ b/query/src/sql/exec/expression_builder.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_datavalues::DataSchemaRef;
+use common_datavalues::DataTypeImpl;
 use common_datavalues::DataValue;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -67,7 +68,9 @@ impl<'a> ExpressionBuilder<'a> {
             Scalar::BoundColumnRef(BoundColumnRef { column }) => {
                 self.build_column_ref(column.index)
             }
-            Scalar::ConstantExpr(ConstantExpr { value }) => self.build_literal(value),
+            Scalar::ConstantExpr(ConstantExpr { value, data_type }) => {
+                self.build_literal(value, data_type)
+            }
             Scalar::ComparisonExpr(ComparisonExpr { op, left, right }) => {
                 self.build_binary_operator(left, right, op.to_func_name())
             }
@@ -134,8 +137,16 @@ impl<'a> ExpressionBuilder<'a> {
         )))
     }
 
-    pub fn build_literal(&self, data_value: &DataValue) -> Result<Expression> {
-        Ok(Expression::create_literal(data_value.clone()))
+    pub fn build_literal(
+        &self,
+        data_value: &DataValue,
+        data_type: &DataTypeImpl,
+    ) -> Result<Expression> {
+        Ok(Expression::Literal {
+            value: data_value.clone(),
+            column_name: None,
+            data_type: data_type.clone(),
+        })
     }
 
     pub fn build_binary_operator(

--- a/query/src/sql/planner/binder/limit.rs
+++ b/query/src/sql/planner/binder/limit.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_ast::ast::Expr;
+use common_datavalues::DataType;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
@@ -34,8 +35,11 @@ impl<'a> Binder {
 
         let limit_cnt = match limit {
             Some(Expr::Literal { span: _, lit: x }) => {
-                let data = type_checker.resolve_literal(x, None)?.as_u64()?;
-                Some(data as usize)
+                let (value, data_type) = type_checker.resolve_literal(x, None)?;
+                if !data_type.data_type_id().is_integer() {
+                    return Err(ErrorCode::IllegalDataType("Unsupported limit type"));
+                }
+                Some(value.as_u64()? as usize)
             }
             Some(_) => {
                 return Err(ErrorCode::IllegalDataType("Unsupported limit type"));
@@ -44,8 +48,11 @@ impl<'a> Binder {
         };
 
         let offset_cnt = if let Some(Expr::Literal { span: _, lit: x }) = offset {
-            let data = type_checker.resolve_literal(x, None)?.as_u64()?;
-            data as usize
+            let (value, data_type) = type_checker.resolve_literal(x, None)?;
+            if !data_type.data_type_id().is_integer() {
+                return Err(ErrorCode::IllegalDataType("Unsupported limit type"));
+            }
+            value.as_u64()? as usize
         } else {
             0
         };

--- a/query/src/sql/planner/binder/select.rs
+++ b/query/src/sql/planner/binder/select.rs
@@ -224,11 +224,13 @@ impl<'a> Binder {
                 let expressions = args
                     .into_iter()
                     .map(|(scalar, _)| match scalar {
-                        Scalar::ConstantExpr(ConstantExpr { value }) => Ok(Expression::Literal {
-                            value: value.clone(),
-                            column_name: None,
-                            data_type: value.data_type(),
-                        }),
+                        Scalar::ConstantExpr(ConstantExpr { value, data_type }) => {
+                            Ok(Expression::Literal {
+                                value,
+                                column_name: None,
+                                data_type,
+                            })
+                        }
                         _ => Err(ErrorCode::UnImplement(format!(
                             "Unsupported table argument type: {:?}",
                             scalar

--- a/query/src/sql/planner/plans/scalar.rs
+++ b/query/src/sql/planner/plans/scalar.rs
@@ -72,11 +72,13 @@ impl ScalarExpr for BoundColumnRef {
 #[derive(Clone, PartialEq, Debug)]
 pub struct ConstantExpr {
     pub value: DataValue,
+
+    pub data_type: DataTypeImpl,
 }
 
 impl ScalarExpr for ConstantExpr {
     fn data_type(&self) -> DataTypeImpl {
-        self.value.data_type()
+        self.data_type.clone()
     }
 
     fn used_columns(&self) -> ColumnSet {

--- a/query/src/sql/planner/semantic/type_check.rs
+++ b/query/src/sql/planner/semantic/type_check.rs
@@ -500,10 +500,7 @@ impl<'a> TypeChecker<'a> {
                     .await
             }
 
-            UnaryOperator::Not => {
-                self.resolve_function(op.to_string().as_str(), &[child], required_type)
-                    .await
-            }
+            UnaryOperator::Not => self.resolve_function("not", &[child], required_type).await,
         }
     }
 

--- a/tests/suites/0_stateless/02_function/02_0012_function_datetimes_tz.sql
+++ b/tests/suites/0_stateless/02_function/02_0012_function_datetimes_tz.sql
@@ -14,6 +14,7 @@ insert into table tt values ('2021-04-30 22:48:00'), (to_timestamp('2021-04-30 2
 select * from tt;
 set timezone = 'Asia/Shanghai';
 select * from tt;
+drop table tt;
 -- number function
 -- 1619820000000000 = 2021-04-30 22:00:00
 select "====NUMBER_FUNCTION====";

--- a/tests/suites/0_stateless/20+_others/20_0001_planner_v2.result
+++ b/tests/suites/0_stateless/20+_others/20_0001_planner_v2.result
@@ -12,9 +12,12 @@
 ====ALIAS====
 0	1
 0	1
+====SCALAR_EXPRESSION====
+1	13
 ====COMPARISON====
 5
 ====CAST====
+5
 5
 ====BINARY_OPERATOR====
 -0.75

--- a/tests/suites/0_stateless/20+_others/20_0001_planner_v2.sql
+++ b/tests/suites/0_stateless/20+_others/20_0001_planner_v2.sql
@@ -7,6 +7,9 @@ select '====ALIAS====';
 select number as a, number + 1 as b from numbers(1);
 select number as a, number + 1 as b from numbers(1) group by a, number order by number;
 
+select '====SCALAR_EXPRESSION====';
+select interval '1' day, extract(day from to_date('2022-05-13'));
+
 -- Comparison expressions
 select '====COMPARISON====';
 select * from numbers(10) where number between 1 and 9 and number > 2 and number < 8 and number is not null and number = 5 and number >= 5 and number <= 5;
@@ -14,6 +17,7 @@ select * from numbers(10) where number between 1 and 9 and number > 2 and number
 -- Cast expression
 select '====CAST====';
 select * from numbers(10) where cast(number as string) = '5';
+select * from numbers(10) where try_cast(number as string) = '5';
 
 -- Binary operator
 select '====BINARY_OPERATOR====';


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Support `TRY_CAST`
- Support `EXTRACT`
- Support `INTERVAL` literal
- Fix unary operators

## Changelog

- New Feature

