### PR TITLE
chore(parser): use datavalues::IntervalType instead of DateTimeField

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,7 @@ dependencies = [
  "async-trait",
  "codespan-reporting",
  "common-base",
+ "common-datavalues",
  "common-exception",
  "common-functions",
  "common-meta-types",

--- a/common/ast/Cargo.toml
+++ b/common/ast/Cargo.toml
@@ -12,6 +12,7 @@ test = false
 
 [dependencies] # In alphabetical order
 # Workspace dependencies
+common-datavalues = { path = "../datavalues" }
 common-exception = { path = "../exception" }
 common-functions = { path = "../functions" }
 common-meta-types = { path = "../meta/types" }

--- a/common/ast/src/ast/expr.rs
+++ b/common/ast/src/ast/expr.rs
@@ -15,6 +15,8 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
 
+use common_datavalues::IntervalKind;
+
 use crate::ast::write_comma_separated_list;
 use crate::ast::write_period_separated_list;
 use crate::ast::Identifier;
@@ -84,10 +86,10 @@ pub enum Expr<'a> {
         expr: Box<Expr<'a>>,
         target_type: TypeName,
     },
-    /// EXTRACT(DateTimeField FROM <expr>)
+    /// EXTRACT(IntervalKind FROM <expr>)
     Extract {
         span: &'a [Token<'a>],
-        field: DateTimeField,
+        kind: IntervalKind,
         expr: Box<Expr<'a>>,
     },
     /// POSITION(<expr> IN <expr>)
@@ -204,33 +206,7 @@ pub enum TypeName {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Interval {
     pub value: String,
-    pub field: DateTimeField,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum DateTimeField {
-    Year,
-    Month,
-    Week,
-    Day,
-    Hour,
-    Minute,
-    Second,
-    Century,
-    Decade,
-    Dow,
-    Doy,
-    Epoch,
-    Isodow,
-    Isoyear,
-    Julian,
-    Microseconds,
-    Millenium,
-    Milliseconds,
-    Quarter,
-    Timezone,
-    TimezoneHour,
-    TimezoneMinute,
+    pub kind: IntervalKind,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -474,35 +450,6 @@ impl Display for TypeName {
     }
 }
 
-impl Display for DateTimeField {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        f.write_str(match self {
-            DateTimeField::Year => "YEAR",
-            DateTimeField::Month => "MONTH",
-            DateTimeField::Week => "WEEK",
-            DateTimeField::Day => "DAY",
-            DateTimeField::Hour => "HOUR",
-            DateTimeField::Minute => "MINUTE",
-            DateTimeField::Second => "SECOND",
-            DateTimeField::Century => "CENTURY",
-            DateTimeField::Decade => "DECADE",
-            DateTimeField::Dow => "DOW",
-            DateTimeField::Doy => "DOY",
-            DateTimeField::Epoch => "EPOCH",
-            DateTimeField::Isodow => "ISODOW",
-            DateTimeField::Isoyear => "ISOYEAR",
-            DateTimeField::Julian => "JULIAN",
-            DateTimeField::Microseconds => "MICROSECONDS",
-            DateTimeField::Millenium => "MILLENIUM",
-            DateTimeField::Milliseconds => "MILLISECONDS",
-            DateTimeField::Quarter => "QUARTER",
-            DateTimeField::Timezone => "TIMEZONE",
-            DateTimeField::TimezoneHour => "TIMEZONE_HOUR",
-            DateTimeField::TimezoneMinute => "TIMEZONE_MINUTE",
-        })
-    }
-}
-
 impl Display for TrimWhere {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.write_str(match self {
@@ -533,7 +480,7 @@ impl Display for Literal {
                 write!(f, "CURRENT_TIMESTAMP")
             }
             Literal::Interval(interval) => {
-                write!(f, "INTERVAL {} {}", interval.value, interval.field)
+                write!(f, "INTERVAL {} {}", interval.value, interval.kind)
             }
             Literal::Null => {
                 write!(f, "NULL")
@@ -628,7 +575,9 @@ impl<'a> Display for Expr<'a> {
             } => {
                 write!(f, "TRY_CAST({expr} AS {target_type})")?;
             }
-            Expr::Extract { field, expr, .. } => {
+            Expr::Extract {
+                kind: field, expr, ..
+            } => {
                 write!(f, "EXTRACT({field} FROM {expr})")?;
             }
             Expr::Position {

--- a/common/ast/src/parser/expr.rs
+++ b/common/ast/src/parser/expr.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_datavalues::IntervalKind;
 use itertools::Itertools;
 use nom::branch::alt;
 use nom::combinator::consumed;
@@ -196,9 +197,9 @@ pub enum ExprElement<'a> {
     },
     /// `::<type_name>` expression
     PgCast { target_type: TypeName },
-    /// EXTRACT(DateTimeField FROM <expr>)
+    /// EXTRACT(IntervalKind FROM <expr>)
     Extract {
-        field: DateTimeField,
+        field: IntervalKind,
         expr: Box<Expr<'a>>,
     },
     /// POSITION(<expr> IN <expr>)
@@ -335,7 +336,7 @@ impl<'a, I: Iterator<Item = WithSpan<'a>>> PrattParser<I> for ExprParser {
             },
             ExprElement::Extract { field, expr } => Expr::Extract {
                 span: elem.span.0,
-                field,
+                kind: field,
                 expr,
             },
             ExprElement::Position {
@@ -571,7 +572,7 @@ pub fn expr_element(i: Input) -> IResult<WithSpan> {
     );
     let extract = map(
         rule! {
-            EXTRACT ~ ^"(" ~ ^#date_time_field ~ ^FROM ~ ^#subexpr(0) ~ ^")"
+            EXTRACT ~ ^"(" ~ ^#interval_kind ~ ^FROM ~ ^#subexpr(0) ~ ^")"
         },
         |(_, _, field, _, expr, _)| ExprElement::Extract {
             field,
@@ -813,9 +814,9 @@ pub fn literal(i: Input) -> IResult<Literal> {
     ));
     let interval = map(
         rule! {
-            INTERVAL ~ #literal_string ~ #date_time_field
+            INTERVAL ~ #literal_string ~ #interval_kind
         },
-        |(_, value, field)| Literal::Interval(Interval { value, field }),
+        |(_, value, field)| Literal::Interval(Interval { value, kind: field }),
     );
     let current_timestamp = value(Literal::CurrentTimestamp, rule! { CURRENT_TIMESTAMP });
     let null = value(Literal::Null, rule! { NULL });
@@ -910,58 +911,26 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
     )(i)
 }
 
-pub fn date_time_field(i: Input) -> IResult<DateTimeField> {
-    let year = value(DateTimeField::Year, rule! { YEAR });
-    let month = value(DateTimeField::Month, rule! { MONTH });
-    let week = value(DateTimeField::Week, rule! { WEEK });
-    let day = value(DateTimeField::Day, rule! { DAY });
-    let hour = value(DateTimeField::Hour, rule! { HOUR });
-    let minute = value(DateTimeField::Minute, rule! { MINUTE });
-    let second = value(DateTimeField::Second, rule! { SECOND });
-    let century = value(DateTimeField::Century, rule! { CENTURY });
-    let decade = value(DateTimeField::Decade, rule! { DECADE });
-    let doy = value(DateTimeField::Doy, rule! { DOY });
-    let dow = value(DateTimeField::Dow, rule! { DOW });
-    let epoch = value(DateTimeField::Epoch, rule! { EPOCH });
-    let isodow = value(DateTimeField::Isodow, rule! { ISODOW });
-    let isoyear = value(DateTimeField::Isoyear, rule! { ISOYEAR });
-    let julian = value(DateTimeField::Julian, rule! { JULIAN });
-    let microseconds = value(DateTimeField::Microseconds, rule! { MICROSECONDS });
-    let millenium = value(DateTimeField::Millenium, rule! { MILLENIUM });
-    let milliseconds = value(DateTimeField::Milliseconds, rule! { MILLISECONDS });
-    let quarter = value(DateTimeField::Quarter, rule! { QUARTER });
-    let timezone = value(DateTimeField::Timezone, rule! { TIMEZONE });
-    let timezone_hour = value(DateTimeField::TimezoneHour, rule! { TIMEZONE_HOUR });
-    let timezone_minute = value(DateTimeField::TimezoneMinute, rule! { TIMEZONE_MINUTE });
+pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
+    let year = value(IntervalKind::Year, rule! { YEAR });
+    let month = value(IntervalKind::Month, rule! { MONTH });
+    let day = value(IntervalKind::Day, rule! { DAY });
+    let hour = value(IntervalKind::Hour, rule! { HOUR });
+    let minute = value(IntervalKind::Minute, rule! { MINUTE });
+    let second = value(IntervalKind::Second, rule! { SECOND });
+    let doy = value(IntervalKind::Doy, rule! { DOY });
+    let dow = value(IntervalKind::Dow, rule! { DOW });
 
-    alt((
-        rule!(
-            #year
-            | #month
-            | #week
-            | #day
-            | #hour
-            | #minute
-            | #second
-            | #century
-            | #decade
-            | #doy
-            | #dow
-        ),
-        rule!(
-            #epoch
-            | #isodow
-            | #isoyear
-            | #julian
-            | #microseconds
-            | #millenium
-            | #milliseconds
-            | #quarter
-            | #timezone
-            | #timezone_hour
-            | #timezone_minute
-        ),
-    ))(i)
+    rule!(
+        #year
+        | #month
+        | #day
+        | #hour
+        | #minute
+        | #second
+        | #doy
+        | #dow
+    )(i)
 }
 
 pub fn map_access(i: Input) -> IResult<MapAccessor> {

--- a/common/ast/tests/it/testdata/expr.txt
+++ b/common/ast/tests/it/testdata/expr.txt
@@ -637,7 +637,7 @@ Extract {
         Ident(18..19),
         RParen(19..20),
     ],
-    field: Year,
+    kind: Year,
     expr: ColumnRef {
         span: [
             Ident(18..19),

--- a/common/datavalues/src/types/type_interval.rs
+++ b/common/datavalues/src/types/type_interval.rs
@@ -36,6 +36,8 @@ pub enum IntervalKind {
     Hour,
     Minute,
     Second,
+    Doy,
+    Dow,
 }
 
 impl fmt::Display for IntervalKind {
@@ -47,6 +49,8 @@ impl fmt::Display for IntervalKind {
             IntervalKind::Hour => "HOUR",
             IntervalKind::Minute => "MINUTE",
             IntervalKind::Second => "SECOND",
+            IntervalKind::Doy => "DOY",
+            IntervalKind::Dow => "DOW",
         })
     }
 }
@@ -60,6 +64,8 @@ impl From<String> for IntervalKind {
             "HOUR" => IntervalKind::Hour,
             "MINUTE" => IntervalKind::Minute,
             "SECOND" => IntervalKind::Second,
+            "DOY" => IntervalKind::Doy,
+            "DOW" => IntervalKind::Dow,
             _ => unreachable!(),
         }
     }

--- a/common/datavalues/src/types/type_interval.rs
+++ b/common/datavalues/src/types/type_interval.rs
@@ -28,7 +28,7 @@ pub struct IntervalType {
     kind: IntervalKind,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum IntervalKind {
     Year,
     Month,

--- a/common/proto-conv/src/data_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/data_from_to_protobuf_impl.rs
@@ -443,6 +443,8 @@ impl FromToProto<pb::IntervalKind> for dv::IntervalKind {
             pb::IntervalKind::Hour => dv::IntervalKind::Hour,
             pb::IntervalKind::Minute => dv::IntervalKind::Minute,
             pb::IntervalKind::Second => dv::IntervalKind::Second,
+            pb::IntervalKind::Doy => dv::IntervalKind::Doy,
+            pb::IntervalKind::Dow => dv::IntervalKind::Dow,
         };
 
         Ok(dv_kind)
@@ -456,6 +458,8 @@ impl FromToProto<pb::IntervalKind> for dv::IntervalKind {
             dv::IntervalKind::Hour => pb::IntervalKind::Hour,
             dv::IntervalKind::Minute => pb::IntervalKind::Minute,
             dv::IntervalKind::Second => pb::IntervalKind::Second,
+            dv::IntervalKind::Doy => pb::IntervalKind::Doy,
+            dv::IntervalKind::Dow => pb::IntervalKind::Dow,
         };
         Ok(pb_kind)
     }

--- a/common/protos/proto/datatype.proto
+++ b/common/protos/proto/datatype.proto
@@ -94,6 +94,8 @@ enum IntervalKind {
   Hour = 3;
   Minute = 4;
   Second = 5;
+  Doy = 6;
+  Dow = 7;
 }
 message IntervalType {
   uint64 ver = 100;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- remove `DateTimeField` and use datavalues::IntervalType instead

## Changelog

- Improvement


