### PR TITLE
Feature: add more metrics in metasrv

### DIFF
--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -58,7 +58,11 @@ use crate::meta_service::meta_leader::MetaLeader;
 use crate::meta_service::ForwardRequestBody;
 use crate::meta_service::JoinRequest;
 use crate::meta_service::RaftServiceImpl;
+use crate::metrics::incr_meta_metrics_leader_change;
+use crate::metrics::incr_meta_metrics_read_failed;
 use crate::metrics::set_meta_metrics_has_leader;
+use crate::metrics::set_meta_metrics_is_leader;
+use crate::metrics::set_meta_metrics_proposals_applied;
 use crate::network::Network;
 use crate::store::MetaRaftStore;
 use crate::watcher::WatcherManager;
@@ -361,6 +365,7 @@ impl MetaNode {
         // TODO: every state change triggers add_non_voter!!!
         let mut running_rx = mn.running_rx.clone();
         let mut jh = mn.join_handles.lock().await;
+        let mut current_leader: Option<u64> = None;
 
         // TODO: reduce dependency: it does not need all of the fields in MetaNode
         let mn = mn.clone();
@@ -382,6 +387,17 @@ impl MetaNode {
                         if changed.is_ok() {
                             let mm = metrics_rx.borrow().clone();
                             if let Some(cur) = mm.current_leader {
+                                // if current leader has changed?
+                                if let Some(leader) = current_leader {
+                                    if cur != leader {
+                                        current_leader = Some(cur);
+                                        incr_meta_metrics_leader_change();
+                                    }
+                                } else {
+                                    current_leader = Some(cur);
+                                    incr_meta_metrics_leader_change();
+                                }
+
                                 if cur == mn.sto.id {
                                     // TODO: check result
                                     let _rst = mn.add_configured_non_voters().await;
@@ -393,10 +409,17 @@ impl MetaNode {
                                             _rst
                                         );
                                     }
+                                    set_meta_metrics_is_leader(true);
+                                } else {
+                                    set_meta_metrics_is_leader(false);
                                 }
                                 set_meta_metrics_has_leader(true);
                             } else {
                                 set_meta_metrics_has_leader(false);
+                                set_meta_metrics_is_leader(false);
+                            }
+                            if let Some(last_applied) = mm.last_applied {
+                                set_meta_metrics_proposals_applied(last_applied.index);
                             }
                         } else {
                             // shutting down
@@ -605,18 +628,29 @@ impl MetaNode {
         ForwardResponse: TryInto<Reply>,
         <ForwardResponse as TryInto<Reply>>::Error: std::fmt::Display,
     {
-        let res = self
+        match self
             .handle_forwardable_request(ForwardRequest {
                 forward_to_leader: 1,
                 body: req.into(),
             })
-            .await?;
+            .await
+        {
+            Err(e) => {
+                incr_meta_metrics_read_failed();
+                Err(e)
+            }
+            Ok(res) => {
+                let res: Reply = res.try_into().map_err(|e| {
+                    incr_meta_metrics_read_failed();
+                    MetaRaftError::ConsistentReadError(format!(
+                        "consistent read recv invalid reply: {}",
+                        e
+                    ))
+                })?;
 
-        let res: Reply = res.try_into().map_err(|e| {
-            MetaRaftError::ConsistentReadError(format!("consistent read recv invalid reply: {}", e))
-        })?;
-
-        Ok(res)
+                Ok(res)
+            }
+        }
     }
 
     #[tracing::instrument(level = "debug", skip(self, req), fields(target=%req.forward_to_leader))]

--- a/metasrv/src/metrics/meta_metrics.rs
+++ b/metasrv/src/metrics/meta_metrics.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Once;
 
+use common_metrics::Counter;
 use common_metrics::Gauge;
 use common_metrics::MetricOption;
 use once_cell::sync::OnceCell;
@@ -23,6 +24,13 @@ pub const SERVER_SUBSYSTEM: &str = "server";
 
 pub struct MetaMetrics {
     has_leader: Option<Gauge>,
+    is_leader: Option<Gauge>,
+    leader_changes: Option<Counter>,
+    applying_snapshot: Option<Gauge>,
+    proposals_applied: Option<Gauge>,
+    proposals_pending: Option<Gauge>,
+    proposals_failed: Option<Gauge>,
+    read_failed: Option<Gauge>,
 }
 
 static INSTANCE: OnceCell<MetaMetrics> = OnceCell::new();
@@ -35,7 +43,16 @@ impl Default for MetaMetrics {
 
 impl MetaMetrics {
     pub fn new() -> MetaMetrics {
-        MetaMetrics { has_leader: None }
+        MetaMetrics {
+            has_leader: None,
+            is_leader: None,
+            leader_changes: None,
+            applying_snapshot: None,
+            proposals_applied: None,
+            proposals_pending: None,
+            proposals_failed: None,
+            read_failed: None,
+        }
     }
 
     pub fn instance() -> &'static MetaMetrics {
@@ -44,20 +61,124 @@ impl MetaMetrics {
 
     /// Init all meta metrics.
     pub fn register(self: &mut MetaMetrics) {
-        // add has_leader metric
-        let has_leader = MetricOption::new(
+        self.has_leader = Some(common_metrics::register_gauge(MetricOption::new(
             "has_leader".to_string(),
             META_NAMESPACE.to_string(),
             SERVER_SUBSYSTEM.to_string(),
             "Whether or not a leader exists.".to_string(),
-        );
-        self.has_leader = Some(common_metrics::register_gauge(has_leader));
+        )));
+
+        self.is_leader = Some(common_metrics::register_gauge(MetricOption::new(
+            "is_leader".to_string(),
+            META_NAMESPACE.to_string(),
+            SERVER_SUBSYSTEM.to_string(),
+            "Whether or not this node is current leader.".to_string(),
+        )));
+
+        self.leader_changes = Some(common_metrics::register_counter(MetricOption::new(
+            "leader_changes_seen_total".to_string(),
+            META_NAMESPACE.to_string(),
+            SERVER_SUBSYSTEM.to_string(),
+            "Number of leader changes seen.".to_string(),
+        )));
+
+        self.applying_snapshot = Some(common_metrics::register_gauge(MetricOption::new(
+            "applying_snapshot".to_string(),
+            META_NAMESPACE.to_string(),
+            SERVER_SUBSYSTEM.to_string(),
+            "Whether or not applying snapshot.".to_string(),
+        )));
+
+        self.proposals_applied = Some(common_metrics::register_gauge(MetricOption::new(
+            "proposals_applied".to_string(),
+            META_NAMESPACE.to_string(),
+            SERVER_SUBSYSTEM.to_string(),
+            "Total number of consensus proposals applied.".to_string(),
+        )));
+
+        self.proposals_pending = Some(common_metrics::register_gauge(MetricOption::new(
+            "proposals_pending".to_string(),
+            META_NAMESPACE.to_string(),
+            SERVER_SUBSYSTEM.to_string(),
+            "Current number of pending proposals.".to_string(),
+        )));
+
+        self.proposals_failed = Some(common_metrics::register_gauge(MetricOption::new(
+            "proposals_failed".to_string(),
+            META_NAMESPACE.to_string(),
+            SERVER_SUBSYSTEM.to_string(),
+            "Current number of failed proposals seen.".to_string(),
+        )));
+
+        self.read_failed = Some(common_metrics::register_gauge(MetricOption::new(
+            "read_failed".to_string(),
+            META_NAMESPACE.to_string(),
+            SERVER_SUBSYSTEM.to_string(),
+            "Current number of failed read seen.".to_string(),
+        )));
     }
 
     pub fn has_leader(has_leader: bool) {
         if let Some(instance) = INSTANCE.get() {
             let a = instance.has_leader.as_ref().unwrap();
             a.set(if has_leader { 1.0 } else { 0.0 });
+        }
+    }
+
+    pub fn is_leader(is_leader: bool) {
+        if let Some(instance) = INSTANCE.get() {
+            let a = instance.is_leader.as_ref().unwrap();
+            a.set(if is_leader { 1.0 } else { 0.0 });
+        }
+    }
+
+    pub fn incr_leader_change() {
+        if let Some(instance) = INSTANCE.get() {
+            let a = instance.leader_changes.as_ref().unwrap();
+            a.increment(1);
+        }
+    }
+
+    pub fn incr_applying_snapshot(cnt: i32) {
+        if let Some(instance) = INSTANCE.get() {
+            let a = instance.applying_snapshot.as_ref().unwrap();
+            if cnt > 0 {
+                a.increment(cnt as f64);
+            } else {
+                a.decrement(cnt as f64);
+            }
+        }
+    }
+
+    pub fn set_proposals_applied(proposals_applied: u64) {
+        if let Some(instance) = INSTANCE.get() {
+            let a = instance.proposals_applied.as_ref().unwrap();
+            a.set(proposals_applied as f64);
+        }
+    }
+
+    pub fn incr_proposals_pending(cnt: i32) {
+        if let Some(instance) = INSTANCE.get() {
+            let a = instance.proposals_pending.as_ref().unwrap();
+            if cnt > 0 {
+                a.increment(cnt as f64);
+            } else {
+                a.decrement(cnt as f64);
+            }
+        }
+    }
+
+    pub fn incr_proposals_failed() {
+        if let Some(instance) = INSTANCE.get() {
+            let a = instance.proposals_failed.as_ref().unwrap();
+            a.increment(1_f64);
+        }
+    }
+
+    pub fn incr_read_failed() {
+        if let Some(instance) = INSTANCE.get() {
+            let a = instance.read_failed.as_ref().unwrap();
+            a.increment(1_f64);
         }
     }
 }
@@ -77,4 +198,32 @@ fn init_meta_recorder() {
 
 pub fn set_meta_metrics_has_leader(has_leader: bool) {
     MetaMetrics::has_leader(has_leader);
+}
+
+pub fn set_meta_metrics_is_leader(is_leader: bool) {
+    MetaMetrics::is_leader(is_leader);
+}
+
+pub fn incr_meta_metrics_leader_change() {
+    MetaMetrics::incr_leader_change();
+}
+
+pub fn incr_meta_metrics_applying_snapshot(cnt: i32) {
+    MetaMetrics::incr_applying_snapshot(cnt);
+}
+
+pub fn set_meta_metrics_proposals_applied(proposals_applied: u64) {
+    MetaMetrics::set_proposals_applied(proposals_applied);
+}
+
+pub fn incr_meta_metrics_proposals_pending(cnt: i32) {
+    MetaMetrics::incr_proposals_pending(cnt);
+}
+
+pub fn incr_meta_metrics_proposals_failed() {
+    MetaMetrics::incr_proposals_failed();
+}
+
+pub fn incr_meta_metrics_read_failed() {
+    MetaMetrics::incr_read_failed();
 }

--- a/metasrv/src/metrics/mod.rs
+++ b/metasrv/src/metrics/mod.rs
@@ -15,7 +15,14 @@
 mod meta_metrics;
 mod metric_service;
 
+pub use meta_metrics::incr_meta_metrics_applying_snapshot;
+pub use meta_metrics::incr_meta_metrics_leader_change;
+pub use meta_metrics::incr_meta_metrics_proposals_failed;
+pub use meta_metrics::incr_meta_metrics_proposals_pending;
+pub use meta_metrics::incr_meta_metrics_read_failed;
 pub use meta_metrics::init_meta_metrics_recorder;
 pub use meta_metrics::set_meta_metrics_has_leader;
+pub use meta_metrics::set_meta_metrics_is_leader;
+pub use meta_metrics::set_meta_metrics_proposals_applied;
 pub use meta_metrics::MetaMetrics;
 pub use metric_service::MetricService;

--- a/metasrv/src/store/meta_raft_store.rs
+++ b/metasrv/src/store/meta_raft_store.rs
@@ -53,6 +53,7 @@ use openraft::SnapshotMeta;
 use openraft::StorageError;
 
 use crate::export::vec_kv_to_json;
+use crate::metrics::incr_meta_metrics_applying_snapshot;
 use crate::store::ToStorageError;
 use crate::Opened;
 
@@ -403,6 +404,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaRaftStore {
 
     #[tracing::instrument(level = "debug", skip(self), fields(id=self.id))]
     async fn begin_receiving_snapshot(&self) -> Result<Box<Self::SnapshotData>, StorageError> {
+        incr_meta_metrics_applying_snapshot(1);
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
@@ -418,6 +420,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaRaftStore {
             { snapshot_size = snapshot.get_ref().len() },
             "decoding snapshot for installation"
         );
+        incr_meta_metrics_applying_snapshot(-1);
 
         let new_snapshot = Snapshot {
             meta: meta.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add more metrics in metasrv:`is_leader`, `leader_changes`,`applying_snapshot`,`proposals_applied`,`proposals_pending`,`proposals_failed`,`read_failed`.

## Changelog

- New Feature

## Related Issues

part of [metrics API providing requests/sec, active watchers, outstanding(uncommitted) raft logs, number of raft logs, state machine size etc. · Issue #4938 · datafuselabs/databend](https://github.com/datafuselabs/databend/issues/4938)

