### PR TITLE
[meta] fix: query enables embedded meta only when meta.address is configured to be empty. Do not check endponit. Some user does not have endpoints in their old config

### DIFF
--- a/query/src/catalogs/default/mutable_catalog.rs
+++ b/query/src/catalogs/default/mutable_catalog.rs
@@ -83,7 +83,12 @@ impl MutableCatalog {
     /// MetaEmbedded
     /// ```
     pub async fn try_create_with_config(conf: Config) -> Result<Self> {
-        let local_mode = conf.meta.address.is_empty() || conf.meta.endpoints.is_empty();
+        // - `address` is an old config that accept only one address.
+        // - `endpoints` accepts multiple endpoint candidates.
+        //
+        // If either of these two is configured(non-empty), use remote metasrv.
+        // Otherwise, use a local embedded meta
+        let local_mode = conf.meta.address.is_empty() && conf.meta.endpoints.is_empty();
 
         let meta: Arc<dyn SchemaApi> = if local_mode {
             tracing::info!("use embedded meta");


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [meta] fix: query enables embedded meta only when meta.address is configured to be empty. Do not check endponit. Some user does not have endpoints in their old config

## Changelog


- Bug Fix




## Related Issues