### PR TITLE
feat(metasrv): add metrics to http service

### DIFF
--- a/metasrv/src/api/http/v1/metrics.rs
+++ b/metasrv/src/api/http/v1/metrics.rs
@@ -1,0 +1,38 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use poem::web::Data;
+use poem::web::Json;
+use serde_json;
+
+use crate::meta_service::MetaNode;
+
+/// GET /v1/metrics
+///
+/// return the metrics.
+/// The response content is the same as `MetaMetrics` in metrics/meta_metrics.rs
+#[poem::handler]
+pub async fn metrics_handler(
+    meta_node: Data<&Arc<MetaNode>>,
+) -> poem::Result<Json<serde_json::Value>> {
+    let metrics = meta_node.raft.metrics().borrow().clone();
+
+    let has_leader = matches!(metrics.current_leader, Some(_));
+
+    Ok(Json(serde_json::json!({
+        "has_leader": has_leader,
+    })))
+}

--- a/metasrv/src/api/http/v1/mod.rs
+++ b/metasrv/src/api/http/v1/mod.rs
@@ -15,3 +15,4 @@
 pub mod cluster_state;
 pub mod config;
 pub mod health;
+pub mod metrics;

--- a/metasrv/src/api/http_service.rs
+++ b/metasrv/src/api/http_service.rs
@@ -56,6 +56,10 @@ impl HttpService {
                 get(super::http::v1::cluster_state::state_handler),
             )
             .at(
+                "/v1/metrics",
+                get(super::http::v1::metrics::metrics_handler),
+            )
+            .at(
                 "/debug/home",
                 get(super::http::debug::home::debug_home_handler),
             )

--- a/metasrv/tests/it/api/http/metrics.rs
+++ b/metasrv/tests/it/api/http/metrics.rs
@@ -1,0 +1,64 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_base::base::tokio;
+use databend_meta::api::http::v1::metrics::metrics_handler;
+use databend_meta::meta_service::MetaNode;
+use poem::get;
+use poem::http::Method;
+use poem::http::StatusCode;
+use poem::http::Uri;
+use poem::Endpoint;
+use poem::EndpointExt;
+use poem::Request;
+use poem::Route;
+use pretty_assertions::assert_eq;
+
+use crate::init_meta_ut;
+use crate::tests::service::MetaSrvTestContext;
+
+#[tokio::test]
+async fn test_metrics() -> common_exception::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    let tc = MetaSrvTestContext::new(0);
+
+    let meta_node = MetaNode::start(&tc.config.raft_config).await?;
+
+    let cluster_router = Route::new()
+        .at("/v1/metrics", get(metrics_handler))
+        .data(meta_node.clone());
+    let response = cluster_router
+        .call(
+            Request::builder()
+                .uri(Uri::from_static("/v1/metrics"))
+                .method(Method::GET)
+                .finish(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().into_vec().await.unwrap();
+    let metrics =
+        serde_json::from_str::<serde_json::Value>(String::from_utf8_lossy(&body).as_ref())?;
+
+    metrics["has_leader"].as_bool().unwrap();
+
+    meta_node.stop().await?;
+
+    Ok(())
+}

--- a/metasrv/tests/it/api/http/mod.rs
+++ b/metasrv/tests/it/api/http/mod.rs
@@ -15,3 +15,4 @@
 pub mod cluster_state_test;
 pub mod config;
 pub mod health;
+pub mod metrics;


### PR DESCRIPTION
Signed-off-by: RinChanNOWWW <hzy427@gmail.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add new http api "/metrics" which returns the raft metrics.

Like:

```json
{
    "running_state": {
        "Ok": null
    },
    "id": 1,
    "state": "Leader",
    "current_term": 1,
    "last_log_index": 2,
    "last_applied": {
        "term": 1,
        "index": 2
    },
    "current_leader": 1,
    "membership_config": {
        "log_id": {
            "term": 0,
            "index": 0
        },
        "membership": {
            "configs": [
                [
                    1
                ]
            ],
            "all_nodes": [
                1
            ]
        }
    },
    "snapshot": null,
    "leader_metrics": {
        "replication": {}
    }
}
```

![image](https://user-images.githubusercontent.com/33975039/168472940-3ad21026-ca3b-468a-abba-9076de61c93b.png)


## Changelog

- New Feature

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/4311

