### PR TITLE
improvement: add `rows_limit` for sort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5907,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.13.1-alpha.0"
-source = "git+https://github.com/b41sh/sqlparser-rs?rev=6630165#6630165bc2b21c88ab2d9c010122ad368a99f19a"
+source = "git+https://github.com/datafuse-extras/sqlparser-rs?rev=619e3b6#619e3b66d0a3b7eaaed69a66d452b37a5488dca4"
 dependencies = [
  "hashbrown 0.12.0",
  "log",

--- a/query/src/pipelines/new/processors/transforms/aggregator/aggregator_single_key.rs
+++ b/query/src/pipelines/new/processors/transforms/aggregator/aggregator_single_key.rs
@@ -27,8 +27,8 @@ use common_datavalues::ScalarColumn;
 use common_datavalues::ScalarColumnBuilder;
 use common_datavalues::Series;
 use common_datavalues::StringColumn;
+use common_exception::ErrorCode;
 use common_exception::Result;
-use common_functions::aggregates::get_layout_offsets;
 use common_functions::aggregates::AggregateFunctionRef;
 use common_functions::aggregates::StateAddr;
 
@@ -55,10 +55,9 @@ impl<const FINAL: bool> SingleStateAggregator<FINAL> {
     pub fn try_create(params: &Arc<AggregatorParams>) -> Result<Self> {
         assert!(!params.offsets_aggregate_states.is_empty());
         let arena = Bump::new();
-
-        let mut offsets_aggregate_states = Vec::with_capacity(params.aggregate_functions.len());
-        let layout =
-            get_layout_offsets(&params.aggregate_functions, &mut offsets_aggregate_states)?;
+        let layout = params
+            .layout
+            .ok_or_else(|| ErrorCode::LayoutError("layout shouldn't be None"))?;
         let get_places = || -> Vec<StateAddr> {
             let place: StateAddr = arena.alloc_layout(layout).into();
             params
@@ -66,7 +65,7 @@ impl<const FINAL: bool> SingleStateAggregator<FINAL> {
                 .iter()
                 .enumerate()
                 .map(|(idx, func)| {
-                    let arg_place = place.next(offsets_aggregate_states[idx]);
+                    let arg_place = place.next(params.offsets_aggregate_states[idx]);
                     func.init_state(arg_place);
                     arg_place
                 })

--- a/query/src/sql/exec/mod.rs
+++ b/query/src/sql/exec/mod.rs
@@ -73,8 +73,9 @@ pub struct PipelineBuilder {
     metadata: Metadata,
     result_columns: Vec<(IndexType, String)>,
     expression: SExpr,
-
     pipelines: Vec<NewPipeline>,
+    limit: Option<usize>,
+    offset: usize,
 }
 
 impl PipelineBuilder {
@@ -89,8 +90,9 @@ impl PipelineBuilder {
             metadata,
             result_columns,
             expression,
-
             pipelines: vec![],
+            limit: None,
+            offset: 0,
         }
     }
 
@@ -540,8 +542,7 @@ impl PipelineBuilder {
             )
         })?;
 
-        //TODO(xudong963): Add rows_limit
-
+        let rows_limit = self.limit.map(|limit| limit + self.offset);
         // processor 1: block ---> sort_stream
         // processor 2: block ---> sort_stream
         // processor 3: block ---> sort_stream
@@ -549,7 +550,7 @@ impl PipelineBuilder {
             TransformSortPartial::try_create(
                 transform_input_port,
                 transform_output_port,
-                None,
+                rows_limit,
                 get_sort_descriptions(&output_schema, expressions.as_slice())?,
             )
         })?;
@@ -562,7 +563,7 @@ impl PipelineBuilder {
                 transform_input_port,
                 transform_output_port,
                 SortMergeCompactor::new(
-                    None,
+                    rows_limit,
                     get_sort_descriptions(&output_schema, expressions.as_slice())?,
                 ),
             )
@@ -579,7 +580,7 @@ impl PipelineBuilder {
                 transform_input_port,
                 transform_output_port,
                 SortMergeCompactor::new(
-                    None,
+                    rows_limit,
                     get_sort_descriptions(&output_schema, expressions.as_slice())?,
                 ),
             )
@@ -594,6 +595,8 @@ impl PipelineBuilder {
         input_schema: DataSchemaRef,
         pipeline: &mut NewPipeline,
     ) -> Result<DataSchemaRef> {
+        self.limit = limit_plan.limit;
+        self.offset = limit_plan.offset;
         pipeline.resize(1)?;
 
         pipeline.add_transform(|transform_input_port, transform_output_port| {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. `Limit` in the new planner had been introduced in https://github.com/datafuselabs/databend/pull/5301, so the ticket will solve the todo about `rows_limit`.
2. [directly use `layout` and `offsets_aggregate_states` in params](https://github.com/datafuselabs/databend/pull/5403/commits/e9836f4b58d9081f2111ea43b713ce418d445d11)

## Changelog

- Improvement

## Related Issues

Fixes #issue

