### PR TITLE
ci: MacOS's stateless standalone has been disabled

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,7 +9,8 @@ queue_rules:
       - check-success=test_unit
       - check-success=test_metactl
       - check-success=test_stateless_standalone_linux
-      - check-success=test_stateless_standalone_macos
+      # MacOS's stateless standalone has been disabled.
+      # - check-success=test_stateless_standalone_macos
       - check-success=test_stateless_cluster_linux
       - check-success=test_stateless_cluster_macos
       - check-success=test_stateful_standalone


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR fix mergify can't merge PR.

## Changelog

- Build/Testing/CI

