### PR TITLE
fix(test): fix httphandler flaky test.

### DIFF
--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -233,10 +233,8 @@ async fn test_pagination() -> Result<()> {
     assert_eq!(result.next_uri, Some(next_uri));
     assert!(result.stats.scan_progress.is_some());
     assert!(result.schema.is_some());
-    assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
 
-    // get page, support retry
-    for page in 0..4 {
+    for page in 0..5 {
         let uri = make_page_uri(query_id, page);
 
         let (status, result) = get_uri_checked(&ep, &uri).await?;
@@ -245,8 +243,8 @@ async fn test_pagination() -> Result<()> {
         assert_eq!(result.data.len(), 2, "{:?}", result);
         assert!(result.schema.is_some());
         assert!(result.stats.scan_progress.is_some());
-        assert_eq!(result.state, ExecuteStateKind::Succeeded);
-        if page == 5 {
+        if page == 4 {
+            assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
             assert!(result.next_uri.is_none());
         } else {
             assert!(result.next_uri.is_some());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix https://github.com/datafuselabs/databend/pull/5409#issuecomment-1128379748

@Xuanwo 
the first HTTP request return as long as a page of 2 rows is generated, maybe before the SQL finish running and  `succeed` state is set, depending on the task scheduling,  although `select * from numbers(10)`  should run very fast.




## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues


