### PR TITLE
fix(query): Fix test_query_log when RUST_BACKTRACE is not set

### DIFF
--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -468,11 +468,13 @@ async fn test_query_log() -> Result<()> {
         result
     );
     assert!(
-        result.data[0][3]
-            .as_str()
-            .unwrap()
-            .to_lowercase()
-            .contains("backtrace"),
+        result.data[0][3].as_str().unwrap().to_lowercase().contains(
+            if let Ok(_) = std::env::var("RUST_BACKTRACE") {
+                "backtrace"
+            } else {
+                "<disabled>"
+            }
+        ),
         "{:?}",
         result
     );

--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -469,7 +469,7 @@ async fn test_query_log() -> Result<()> {
     );
     assert!(
         result.data[0][3].as_str().unwrap().to_lowercase().contains(
-            if let Ok(_) = std::env::var("RUST_BACKTRACE") {
+            if std::env::var("RUST_BACKTRACE").is_ok() {
                 "backtrace"
             } else {
                 "<disabled>"


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

See discussion: https://github.com/datafuselabs/databend/discussions/5415

## Changelog

- Bug Fix

