### PR TITLE
[meta/client] workaround: temporarily disable conn pool until cross-runtime hanging is fixed

### DIFF
--- a/common/base/src/containers/pool.rs
+++ b/common/base/src/containers/pool.rs
@@ -84,6 +84,10 @@ where
         }
     }
 
+    pub fn item_manager(&self) -> &Mgr {
+        &self.manager
+    }
+
     /// Return an raw pool item.
     ///
     /// The returned one may be an uninitialized one, i.e., it contains a None.

--- a/common/meta/grpc/src/grpc_client.rs
+++ b/common/meta/grpc/src/grpc_client.rs
@@ -180,7 +180,11 @@ impl MetaGrpcClient {
             if (*eps).is_empty() {
                 return Err(MetaError::InvalidConfig("endpoints is empty".to_string()));
             }
-            self.conn_pool.get(&*eps).await?
+            // TODO(xp): use the client across runtime hangs the application.
+            //           Temporarily disable reusing a client.
+            //           See: https://github.com/datafuselabs/databend/runs/6367049291?check_suite_focus=true
+            // self.conn_pool.get(&*eps).await?
+            self.conn_pool.item_manager().build(&*eps).await?
         };
         tracing::info!("connecting with channel: {:?}", channel);
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [meta/client] workaround: temporarily disable conn pool until cross-runtime hanging is fixed

## Changelog







## Related Issues