### PR TITLE
feat(function): Support variant as function

### DIFF
--- a/common/functions/src/scalars/semi_structureds/as_type.rs
+++ b/common/functions/src/scalars/semi_structureds/as_type.rs
@@ -1,0 +1,175 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use common_arrow::arrow::bitmap::MutableBitmap;
+use common_datavalues::prelude::*;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::scalars::FactoryCreator;
+use crate::scalars::Function;
+use crate::scalars::FunctionContext;
+use crate::scalars::FunctionDescription;
+use crate::scalars::FunctionFeatures;
+
+#[derive(Clone)]
+pub struct AsFunction {
+    display_name: String,
+    data_type: DataTypeImpl,
+    type_id: TypeID,
+}
+
+impl AsFunction {
+    pub fn try_create(
+        display_name: String,
+        type_id: TypeID,
+        args: &[&DataTypeImpl],
+    ) -> Result<Box<dyn Function>> {
+        Ok(Box::new(AsFunction {
+            display_name,
+            data_type: args[0].clone(),
+            type_id,
+        }))
+    }
+}
+
+impl Function for AsFunction {
+    fn name(&self) -> &str {
+        self.display_name.as_str()
+    }
+
+    fn return_type(&self) -> DataTypeImpl {
+        if !self.data_type.data_type_id().is_variant() {
+            return NullType::arc();
+        }
+        match self.type_id {
+            TypeID::Boolean => NullableType::new_impl(BooleanType::new_impl()),
+            TypeID::Int64 => NullableType::new_impl(Int64Type::new_impl()),
+            TypeID::Float64 => NullableType::new_impl(Float64Type::new_impl()),
+            TypeID::String => NullableType::new_impl(StringType::new_impl()),
+            TypeID::VariantArray => NullableType::new_impl(VariantArrayType::new_impl()),
+            TypeID::VariantObject => NullableType::new_impl(VariantObjectType::new_impl()),
+            _ => unreachable!(),
+        }
+    }
+
+    fn eval(
+        &self,
+        _func_ctx: FunctionContext,
+        columns: &ColumnsWithField,
+        input_rows: usize,
+    ) -> Result<ColumnRef> {
+        if !columns[0].field().data_type().data_type_id().is_variant() {
+            return NullType::arc().create_constant_column(&DataValue::Null, input_rows);
+        }
+
+        let variant_column: &VariantColumn = if columns[0].column().is_const() {
+            let const_column: &ConstColumn = Series::check_get(columns[0].column())?;
+            Series::check_get(const_column.inner())?
+        } else {
+            Series::check_get(columns[0].column())?
+        };
+
+        match self.type_id {
+            TypeID::Boolean => {
+                let mut builder = NullableColumnBuilder::<bool>::with_capacity(input_rows);
+                for val in variant_column.scalar_iter() {
+                    match val.as_bool() {
+                        Some(v) => builder.append(v, true),
+                        None => builder.append_null(),
+                    }
+                }
+                return Ok(builder.build(input_rows));
+            }
+            TypeID::Int64 => {
+                let mut builder = NullableColumnBuilder::<i64>::with_capacity(input_rows);
+                for val in variant_column.scalar_iter() {
+                    match val.as_i64() {
+                        Some(v) => builder.append(v, true),
+                        None => builder.append_null(),
+                    }
+                }
+                return Ok(builder.build(input_rows));
+            }
+            TypeID::Float64 => {
+                let mut builder = NullableColumnBuilder::<f64>::with_capacity(input_rows);
+                for val in variant_column.scalar_iter() {
+                    match val.as_f64() {
+                        Some(v) => builder.append(v, true),
+                        None => builder.append_null(),
+                    }
+                }
+                return Ok(builder.build(input_rows));
+            }
+            TypeID::String => {
+                let mut builder = NullableColumnBuilder::<Vu8>::with_capacity(input_rows);
+                for val in variant_column.scalar_iter() {
+                    match val.as_str() {
+                        Some(v) => builder.append(v.as_bytes(), true),
+                        None => builder.append_null(),
+                    }
+                }
+                return Ok(builder.build(input_rows));
+            }
+            TypeID::VariantArray => {
+                let mut bitmap = MutableBitmap::with_capacity(input_rows);
+                bitmap.extend_constant(input_rows, true);
+                for (i, val) in variant_column.scalar_iter().enumerate() {
+                    if !val.is_array() {
+                        bitmap.set(i, false);
+                    }
+                }
+                return Ok(NullableColumn::wrap_inner(
+                    variant_column.arc(),
+                    bitmap.into(),
+                ));
+            }
+            TypeID::VariantObject => {
+                let mut bitmap = MutableBitmap::with_capacity(input_rows);
+                bitmap.extend_constant(input_rows, true);
+                for (i, val) in variant_column.scalar_iter().enumerate() {
+                    if !val.is_object() {
+                        bitmap.set(i, false);
+                    }
+                }
+                return Ok(NullableColumn::wrap_inner(
+                    variant_column.arc(),
+                    bitmap.into(),
+                ));
+            }
+            _ => {
+                return Err(ErrorCode::UnknownFunction(format!(
+                    "Unsupported Function {} as {}",
+                    self.display_name, self.type_id
+                )));
+            }
+        }
+    }
+}
+
+impl fmt::Display for AsFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}()", self.display_name)
+    }
+}
+
+pub fn as_function_creator(type_id: TypeID) -> FunctionDescription {
+    let creator: FactoryCreator = Box::new(move |display_name, args| {
+        AsFunction::try_create(display_name.to_string(), type_id, args)
+    });
+
+    FunctionDescription::creator(creator).features(FunctionFeatures::default().num_arguments(1))
+}

--- a/common/functions/src/scalars/semi_structureds/mod.rs
+++ b/common/functions/src/scalars/semi_structureds/mod.rs
@@ -14,6 +14,7 @@
 
 mod array_get;
 mod array_length;
+mod as_type;
 mod check_json;
 mod get;
 mod get_path;
@@ -25,6 +26,7 @@ mod semi_structured;
 
 pub use array_get::ArrayGetFunction;
 pub use array_length::ArrayLengthFunction;
+pub use as_type::as_function_creator;
 pub use check_json::CheckJsonFunction;
 pub use get::GetFunction;
 pub use get::GetIgnoreCaseFunction;

--- a/common/functions/src/scalars/semi_structureds/semi_structured.rs
+++ b/common/functions/src/scalars/semi_structureds/semi_structured.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_datavalues::TypeID;
+
+use super::as_type::as_function_creator;
 use super::get::GetFunction;
 use super::get::GetIgnoreCaseFunction;
 use super::get_path::GetPathFunction;
@@ -26,6 +29,12 @@ pub struct SemiStructuredFunction;
 
 impl SemiStructuredFunction {
     pub fn register(factory: &mut FunctionFactory) {
+        factory.register("as_boolean", as_function_creator(TypeID::Boolean));
+        factory.register("as_integer", as_function_creator(TypeID::Int64));
+        factory.register("as_float", as_function_creator(TypeID::Float64));
+        factory.register("as_string", as_function_creator(TypeID::String));
+        factory.register("as_array", as_function_creator(TypeID::VariantArray));
+        factory.register("as_object", as_function_creator(TypeID::VariantObject));
         factory.register("parse_json", ParseJsonFunction::desc());
         factory.register("try_parse_json", TryParseJsonFunction::desc());
         factory.register("check_json", CheckJsonFunction::desc());

--- a/common/functions/tests/it/scalars/semi_structureds/as_type.rs
+++ b/common/functions/tests/it/scalars/semi_structureds/as_type.rs
@@ -1,0 +1,153 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_datavalues::prelude::*;
+use common_exception::Result;
+use serde_json::json;
+
+use crate::scalars::scalar_function_test::test_scalar_functions;
+use crate::scalars::scalar_function_test::ScalarFunctionTest;
+
+#[test]
+fn test_as_boolean_function() -> Result<()> {
+    let tests = vec![
+        ScalarFunctionTest {
+            name: "test_as_boolean",
+            columns: vec![
+                Series::from_data(vec![
+                    VariantValue::from(json!(true)),
+                    VariantValue::from(json!(false)),
+                    VariantValue::from(json!(123)),
+                    VariantValue::from(json!(12.34)),
+                    VariantValue::from(json!("abc")),
+                    VariantValue::from(json!([1,2,3])),
+                    VariantValue::from(json!({"a":"b"})),
+                ]),
+            ],
+            expect: Series::from_data(vec![Some(true), Some(false), None, None, None, None, None]),
+            error: "",
+        },
+    ];
+    test_scalar_functions("as_boolean", &tests)
+}
+
+fn test_as_integer_function() -> Result<()> {
+    let tests = vec![
+        ScalarFunctionTest {
+            name: "test_as_integer",
+            columns: vec![
+                Series::from_data(vec![
+                    VariantValue::from(json!(true)),
+                    VariantValue::from(json!(false)),
+                    VariantValue::from(json!(123)),
+                    VariantValue::from(json!(12.34)),
+                    VariantValue::from(json!("abc")),
+                    VariantValue::from(json!([1,2,3])),
+                    VariantValue::from(json!({"a":"b"})),
+                ]),
+            ],
+            expect: Series::from_data(vec![None, None, Some(123), None, None, None, None]),
+            error: "",
+        },
+    ];
+    test_scalar_functions("as_integer", &tests)
+}
+
+fn test_as_float_function() -> Result<()> {
+    let tests = vec![
+        ScalarFunctionTest {
+            name: "test_as_float",
+            columns: vec![
+                Series::from_data(vec![
+                    VariantValue::from(json!(true)),
+                    VariantValue::from(json!(false)),
+                    VariantValue::from(json!(123)),
+                    VariantValue::from(json!(12.34)),
+                    VariantValue::from(json!("abc")),
+                    VariantValue::from(json!([1,2,3])),
+                    VariantValue::from(json!({"a":"b"})),
+                ]),
+            ],
+            expect: Series::from_data(vec![None, None, Some(123.0), Some(12.34), None, None, None]),
+            error: "",
+        },
+    ];
+    test_scalar_functions("as_float", &tests)
+}
+
+fn test_as_string_function() -> Result<()> {
+    let tests = vec![
+        ScalarFunctionTest {
+            name: "test_as_string",
+            columns: vec![
+                Series::from_data(vec![
+                    VariantValue::from(json!(true)),
+                    VariantValue::from(json!(false)),
+                    VariantValue::from(json!(123)),
+                    VariantValue::from(json!(12.34)),
+                    VariantValue::from(json!("abc")),
+                    VariantValue::from(json!([1,2,3])),
+                    VariantValue::from(json!({"a":"b"})),
+                ]),
+            ],
+            expect: Series::from_data(vec![None, None, None, None, Some("abc"), None, None]),
+            error: "",
+        },
+    ];
+    test_scalar_functions("as_string", &tests)
+}
+
+fn test_as_array_function() -> Result<()> {
+    let tests = vec![
+        ScalarFunctionTest {
+            name: "test_as_array",
+            columns: vec![
+                Series::from_data(vec![
+                    VariantValue::from(json!(true)),
+                    VariantValue::from(json!(false)),
+                    VariantValue::from(json!(123)),
+                    VariantValue::from(json!(12.34)),
+                    VariantValue::from(json!("abc")),
+                    VariantValue::from(json!([1,2,3])),
+                    VariantValue::from(json!({"a":"b"})),
+                ]),
+            ],
+            expect: Series::from_data(vec![None, None, None, None, None, Some(VariantValue::from(json!([1,2,3]))), None]),
+            error: "",
+        },
+    ];
+    test_scalar_functions("as_array", &tests)
+}
+
+fn test_as_object_function() -> Result<()> {
+    let tests = vec![
+        ScalarFunctionTest {
+            name: "test_as_object_function",
+            columns: vec![
+                Series::from_data(vec![
+                    VariantValue::from(json!(true)),
+                    VariantValue::from(json!(false)),
+                    VariantValue::from(json!(123)),
+                    VariantValue::from(json!(12.34)),
+                    VariantValue::from(json!("abc")),
+                    VariantValue::from(json!([1,2,3])),
+                    VariantValue::from(json!({"a":"b"})),
+                ]),
+            ],
+            expect: Series::from_data(vec![None, None, None, None, None, None, Some(VariantValue::from(json!({"a":"b"})))]),
+            error: "",
+        },
+    ];
+    test_scalar_functions("as_object", &tests)
+}

--- a/docs/doc/30-reference/20-functions/110-semi-structured-functions/as_type.md
+++ b/docs/doc/30-reference/20-functions/110-semi-structured-functions/as_type.md
@@ -1,0 +1,80 @@
+---
+title: As_<Type>
+---
+
+Strict casting `VARIANT` values to other data types.
+If the input data type is not `VARIANT`, the output is `NULL`.
+If the type of value in the `VARIANT` does not match the output value, the output is `NULL`.
+
+## Syntax
+
+```sql
+AS_BOOLEAN( <variant> )
+AS_INTEGER( <variant> )
+AS_FLOAT( <variant> )
+AS_STRING( <variant> )
+AS_ARRAY( <variant> )
+AS_OBJECT( <variant> )
+```
+
+## Arguments
+
+| Arguments   | Description |
+| ----------- | ----------- |
+| `<variant>` | The VARIANT value
+
+## Return Type
+
+- AS_BOOLEAN: Boolean
+- AS_INTEGER: Int64
+- AS_FLOAT:   Float64
+- AS_STRING:  String
+- AS_ARRAY:   Array
+- AS_OBJECT:  Object
+
+## Examples
+
+```sql
+SELECT as_boolean(parse_json('true'));
++--------------------------------+
+| as_boolean(parse_json('true')) |
++--------------------------------+
+| 1                              |
++--------------------------------+
+
+SELECT as_integer(parse_json('123'));
++-------------------------------+
+| as_integer(parse_json('123')) |
++-------------------------------+
+| 123                           |
++-------------------------------+
+
+SELECT as_float(parse_json('12.34'));
++-------------------------------+
+| as_float(parse_json('12.34')) |
++-------------------------------+
+| 12.34                         |
++-------------------------------+
+
+SELECT as_string(parse_json('"abc"'));
++--------------------------------+
+| as_string(parse_json('"abc"')) |
++--------------------------------+
+| abc                            |
++--------------------------------+
+
+SELECT as_array(parse_json('[1,2,3]'));
++---------------------------------+
+| as_array(parse_json('[1,2,3]')) |
++---------------------------------+
+| [1,2,3]                         |
++---------------------------------+
+
+SELECT as_object(parse_json('{"k":"v","a":"b"}'));
++--------------------------------------------+
+| as_object(parse_json('{"k":"v","a":"b"}')) |
++--------------------------------------------+
+| {"k":"v","a":"b"}                          |
++--------------------------------------------+
+
+```

--- a/docs/doc/30-reference/20-functions/110-semi-structured-functions/get.md
+++ b/docs/doc/30-reference/20-functions/110-semi-structured-functions/get.md
@@ -11,10 +11,10 @@ The value is returned as a `Variant` or `NULL` if either of the arguments is `NU
 
 ```sql
 GET( <array>, <index> )
-get( <variant>, <index> )
+GET( <variant>, <index> )
 
-get( <object>, <field_name> )
-get( <variant>, <field_name> )
+GET( <object>, <field_name> )
+GET( <variant>, <field_name> )
 ```
 
 ## Arguments

--- a/tests/suites/0_stateless/02_function/02_0056_function_semi_structureds_as.result
+++ b/tests/suites/0_stateless/02_function/02_0056_function_semi_structureds_as.result
@@ -1,0 +1,25 @@
+==as_boolean==
+1
+0
+==as_integer==
+123
+456
+==as_float==
+12.34
+56.78
+==as_string==
+abc
+xyz
+==as_array==
+[1,2,3]
+["a","b","c"]
+==as_object==
+{"a":"b"}
+{"k":123}
+==as from table==
+1	true	1	NULL	NULL	NULL	NULL	NULL
+2	123	NULL	123	123	NULL	NULL	NULL
+3	45.67	NULL	NULL	45.67	NULL	NULL	NULL
+4	"abc"	NULL	NULL	NULL	abc	NULL	NULL
+5	[1,2,3]	NULL	NULL	NULL	NULL	[1,2,3]	NULL
+6	{"a":"b"}	NULL	NULL	NULL	NULL	NULL	{"a":"b"}

--- a/tests/suites/0_stateless/02_function/02_0056_function_semi_structureds_as.sql
+++ b/tests/suites/0_stateless/02_function/02_0056_function_semi_structureds_as.sql
@@ -1,0 +1,41 @@
+select '==as_boolean==';
+select as_boolean(parse_json('true'));
+select as_boolean(parse_json('false'));
+
+select '==as_integer==';
+select as_integer(parse_json('123'));
+select as_integer(parse_json('456'));
+
+select '==as_float==';
+select as_float(parse_json('12.34'));
+select as_float(parse_json('56.78'));
+
+select '==as_string==';
+select as_string(parse_json('"abc"'));
+select as_string(parse_json('"xyz"'));
+
+select '==as_array==';
+select as_array(parse_json('[1,2,3]'));
+select as_array(parse_json('["a","b","c"]'));
+
+select '==as_object==';
+select as_object(parse_json('{"a":"b"}'));
+select as_object(parse_json('{"k":123}'));
+
+DROP DATABASE IF EXISTS db1;
+CREATE DATABASE db1;
+USE db1;
+
+CREATE TABLE IF NOT EXISTS t1(id Int null, v Variant null) Engine = Fuse;
+
+insert into t1 select 1, parse_json('true');
+insert into t1 select 2, parse_json('123');
+insert into t1 select 3, parse_json('45.67');
+insert into t1 select 4, parse_json('"abc"');
+insert into t1 select 5, parse_json('[1,2,3]');
+insert into t1 select 6, parse_json('{"a":"b"}');
+
+select '==as from table==';
+select id, v, as_boolean(v), as_integer(v), as_float(v), as_string(v), as_array(v), as_object(v) from t1 order by id asc;
+
+DROP DATABASE db1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support `as` function to cast the variant value to target data type.
Refer to snowflake's [as function](https://docs.snowflake.com/en/sql-reference/functions/as.html)  

include the following functions:
```sql
AS_BOOLEAN( <variant> )
AS_INTEGER( <variant> )
AS_FLOAT( <variant> )
AS_STRING( <variant> )
AS_ARRAY( <variant> )
AS_OBJECT( <variant> )
```

## Changelog

- New Feature
- Build/Testing/CI
- Documentation

## Related Issues

part of #5428

