### PR TITLE
MySQL Handler Kill Query

### DIFF
--- a/docs/doc/30-reference/30-sql/60-kill/kill-query.md
+++ b/docs/doc/30-reference/30-sql/60-kill/kill-query.md
@@ -7,7 +7,7 @@ Attempts to forcibly terminate the currently running queries.
 ## Syntax
 
 ```
-KILL QUERY|CONNECTION <query_id>
+KILL QUERY|CONNECTION <session_id>
 ```
 
 ## Examples

--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -71,7 +71,13 @@ impl<W: std::io::Write + Send + Sync> AsyncMysqlShim<W> for InteractiveWorker<W>
     }
 
     fn connect_id(&self) -> u32 {
-        u32::from_le_bytes([0x08, 0x00, 0x00, 0x00])
+        match self.session.get_mysql_conn_id() {
+            Some(conn_id) => conn_id,
+            None => {
+                //default conn id
+                u32::from_le_bytes([0x08, 0x00, 0x00, 0x00])
+            }
+        }
     }
 
     fn default_auth_plugin(&self) -> &str {

--- a/query/src/sessions/query_ctx.rs
+++ b/query/src/sessions/query_ctx.rs
@@ -351,6 +351,18 @@ impl QueryContext {
             .await
     }
 
+    // Get session id by mysql connection id.
+    pub async fn get_id_by_mysql_conn_id(
+        self: &Arc<Self>,
+        conn_id: &Option<u32>,
+    ) -> Option<String> {
+        self.shared
+            .session
+            .get_session_manager()
+            .get_id_by_mysql_conn_id(conn_id)
+            .await
+    }
+
     // Get all the processes list info.
     pub async fn get_processes_info(self: &Arc<Self>) -> Vec<ProcessInfo> {
         self.shared

--- a/query/src/sessions/session.rs
+++ b/query/src/sessions/session.rs
@@ -50,6 +50,7 @@ pub struct Session {
     session_settings: Settings,
     #[ignore_malloc_size_of = "insignificant"]
     status: Arc<RwLock<SessionStatus>>,
+    pub(in crate::sessions) mysql_connection_id: Option<u32>,
 }
 
 impl Session {
@@ -58,12 +59,12 @@ impl Session {
         id: String,
         typ: SessionType,
         session_mgr: Arc<SessionManager>,
+        mysql_connection_id: Option<u32>,
     ) -> Result<Arc<Session>> {
         let session_ctx = Arc::new(SessionContext::try_create(conf.clone())?);
         let session_settings = Settings::try_create(&conf)?;
         let ref_count = Arc::new(AtomicUsize::new(0));
         let status = Arc::new(Default::default());
-
         Ok(Arc::new(Session {
             id,
             typ: RwLock::new(typ),
@@ -72,7 +73,12 @@ impl Session {
             session_ctx,
             session_settings,
             status,
+            mysql_connection_id,
         }))
+    }
+
+    pub fn get_mysql_conn_id(self: &Arc<Self>) -> Option<u32> {
+        self.mysql_connection_id
     }
 
     pub fn get_id(self: &Arc<Self>) -> String {

--- a/query/src/sessions/session_info.rs
+++ b/query/src/sessions/session_info.rs
@@ -36,6 +36,7 @@ pub struct ProcessInfo {
     pub memory_usage: i64,
     pub dal_metrics: Option<DalMetrics>,
     pub scan_progress_value: Option<ProgressValues>,
+    pub mysql_connection_id: Option<u32>,
 }
 
 impl Session {
@@ -67,6 +68,7 @@ impl Session {
             memory_usage,
             dal_metrics: Session::query_dal_metrics(status),
             scan_progress_value: Session::query_scan_progress_value(status),
+            mysql_connection_id: self.mysql_connection_id,
         }
     }
 

--- a/query/src/storages/system/processes_table.rs
+++ b/query/src/storages/system/processes_table.rs
@@ -57,6 +57,7 @@ impl AsyncSystemTable for ProcessesTable {
         let mut processes_dal_metrics_write_bytes = Vec::with_capacity(processes_info.len());
         let mut processes_scan_progress_read_rows = Vec::with_capacity(processes_info.len());
         let mut processes_scan_progress_read_bytes = Vec::with_capacity(processes_info.len());
+        let mut processes_mysql_connection_id = Vec::with_capacity(processes_info.len());
 
         for process_info in &processes_info {
             processes_id.push(process_info.id.clone().into_bytes());
@@ -77,6 +78,7 @@ impl AsyncSystemTable for ProcessesTable {
                 ProcessesTable::process_scan_progress_values(&process_info.scan_progress_value);
             processes_scan_progress_read_rows.push(scan_progress_read_rows);
             processes_scan_progress_read_bytes.push(scan_progress_read_bytes);
+            processes_mysql_connection_id.push(process_info.mysql_connection_id);
         }
 
         Ok(DataBlock::create(self.table_info.schema(), vec![
@@ -92,6 +94,7 @@ impl AsyncSystemTable for ProcessesTable {
             Series::from_data(processes_dal_metrics_write_bytes),
             Series::from_data(processes_scan_progress_read_rows),
             Series::from_data(processes_scan_progress_read_bytes),
+            Series::from_data(processes_mysql_connection_id),
         ]))
     }
 }
@@ -111,6 +114,7 @@ impl ProcessesTable {
             DataField::new_nullable("dal_metrics_write_bytes", u64::to_data_type()),
             DataField::new_nullable("scan_progress_read_rows", u64::to_data_type()),
             DataField::new_nullable("scan_progress_read_bytes", u64::to_data_type()),
+            DataField::new_nullable("mysql_connection_id", u32::to_data_type()),
         ]);
 
         let table_info = TableInfo {

--- a/query/tests/it/servers/mysql/mysql_handler.rs
+++ b/query/tests/it/servers/mysql/mysql_handler.rs
@@ -62,7 +62,7 @@ async fn test_rejected_session_with_sequence() -> Result<()> {
             Ok(_) => panic!("Expected rejected connection"),
             Err(error) => {
                 assert_eq!(error.code(), 1067);
-                assert_eq!(error.message(), "Reject connection, cause: Server error: `ERROR HY000 (1815): The current accept connection has exceeded mysql_handler_thread_num config'");
+                assert_eq!(error.message(), "Reject connection, cause: Server error: `ERROR HY000 (1815): The current accept connection has exceeded max_active_sessions config'");
             }
         };
 
@@ -99,7 +99,7 @@ async fn test_rejected_session_with_parallel() -> Result<()> {
                 Err(error) => {
                     destroy_barrier.wait().await;
                     assert_eq!(error.code(), 1067);
-                    assert_eq!(error.message(), "Reject connection, cause: Server error: `ERROR HY000 (1815): The current accept connection has exceeded mysql_handler_thread_num config'");
+                    assert_eq!(error.message(), "Reject connection, cause: Server error: `ERROR HY000 (1815): The current accept connection has exceeded max_active_sessions config'");
                     CreateServerResult::Rejected
                 }
             }

--- a/query/tests/it/sessions/session.rs
+++ b/query/tests/it/sessions/session.rs
@@ -30,6 +30,7 @@ async fn test_session() -> Result<()> {
         String::from("test-001"),
         SessionType::Dummy,
         session_manager,
+        None,
     )
     .await?;
 
@@ -75,6 +76,7 @@ async fn test_session_in_management_mode() -> Result<()> {
         String::from("test-001"),
         SessionType::Dummy,
         session_manager,
+        None,
     )
     .await?;
 

--- a/query/tests/it/sessions/session_setting.rs
+++ b/query/tests/it/sessions/session_setting.rs
@@ -29,6 +29,7 @@ async fn test_session_setting() -> Result<()> {
         String::from("test-001"),
         SessionType::Dummy,
         session_manager,
+        None,
     )
     .await?;
 

--- a/scripts/ci/ci-run-stateful-tests-standalone-s3.sh
+++ b/scripts/ci/ci-run-stateful-tests-standalone-s3.sh
@@ -15,6 +15,9 @@ export STORAGE_S3_ENDPOINT_URL=http://127.0.0.1:9900
 export STORAGE_S3_ACCESS_KEY_ID=minioadmin
 export STORAGE_S3_SECRET_ACCESS_KEY=minioadmin
 
+echo "Install dependence"
+python3 -m pip install --quiet mysql-connector-python
+
 echo "calling test suite"
 echo "Starting standalone DatabendQuery(debug)"
 ./scripts/ci/deploy/databend-query-standalone.sh

--- a/tests/suites/1_stateful/02_query/02_0000_kill_query.py
+++ b/tests/suites/1_stateful/02_query/02_0000_kill_query.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import os
+import time
+import mysql.connector
+import sys
+import signal
+
+CURDIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, os.path.join(CURDIR, '../../../helpers'))
+
+from native_client import NativeClient
+from native_client import prompt
+
+log = None
+
+with NativeClient(name='client1>') as client1:
+    client1.expect(prompt)
+
+    client1.send('SET enable_new_processor_framework=0;')
+    client1.expect('')
+    client1.send('SELECT * FROM numbers(999999999);')
+    client1.expect(prompt)
+
+with NativeClient(name='client2>') as client2:
+    client2.expect(prompt)
+
+    # client1 send long query, client select the long query and kill it
+    # Use to mock in MySQL Client press Ctrl C to intercept a long query.
+    mydb = mysql.connector.connect(host="127.0.0.1",
+                                   user="root",
+                                   passwd="root",
+                                   port="3307")
+    mycursor = mydb.cursor()
+    mycursor.execute("SELECT mysql_connection_id FROM system.processes WHERE extra_info LIKE '%select * from numbers(999999999)%'")
+    res = mycursor.fetchone()
+    kill_query = 'kill query ' + str(res[0]) + ';'
+    client2.send(kill_query)
+    client2.expect(prompt)
+    time.sleep(5)
+    mycursor.execute("SELECT * FROM system.processes WHERE extra_info LIKE '%select * from numbers(999999999)%' AND extra_info NOT LIKE '%system.processes%'")
+    res = mycursor.fetchone()
+    assert res is None


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

MySQL Client support according to "Ctrl C" interrupt a long query.
Link to discussion: https://github.com/datafuselabs/databend/discussions/5405

## Changelog

- New Feature

## Related Issues

Fixes #4871

