### PR TITLE
serializer without tmp alloc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,6 +942,7 @@ dependencies = [
  "common-io",
  "common-macros",
  "criterion",
+ "csv-core",
  "dyn-clone",
  "enum_dispatch",
  "itertools",
@@ -956,6 +957,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "streaming-iterator",
 ]
 
 [[package]]

--- a/common/datavalues/Cargo.toml
+++ b/common/datavalues/Cargo.toml
@@ -35,6 +35,8 @@ paste = "1.0.7"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 smallvec = { version = "1.8.0", features = ["write"] }
+streaming-iterator = "0.1.5"
+csv-core = "0.1.10"
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/common/datavalues/Cargo.toml
+++ b/common/datavalues/Cargo.toml
@@ -58,3 +58,7 @@ harness = false
 [[bench]]
 name = "data_type"
 harness = false
+
+[[bench]]
+name = "csv"
+harness = false

--- a/common/datavalues/benches/csv.rs
+++ b/common/datavalues/benches/csv.rs
@@ -6,40 +6,118 @@ use common_datavalues::Series;
 use common_datavalues::SeriesFrom;
 use criterion::criterion_group;
 use criterion::criterion_main;
+use criterion::BenchmarkId;
 use criterion::Criterion;
+use rand::distributions::Alphanumeric;
 use rand::rngs::StdRng;
 use rand::Rng;
 use rand::SeedableRng;
 
-fn add_benchmark(c: &mut Criterion) {
-    (10..=21).step_by(2).for_each(|log2_size| {
+type ColumnCreator = fn(usize, Option<f32>, usize) -> ColumnRef;
+
+fn bench_name(typ: &str, null_name: &str, f_name: &str) -> String {
+    format!("{}({})_{}", typ, null_name, f_name)
+}
+
+fn add_group(c: &mut Criterion, typ: &str, creator: ColumnCreator, item_size: usize) {
+    let mut group = c.benchmark_group(typ);
+    //let range = (10..=14);
+    let range = (10..=21);
+    range.step_by(2).for_each(|log2_size| {
         let size = 2usize.pow(log2_size);
-        let col = create_primitive_array(size);
-        c.bench_function(
-            &format!("i32 2^{} not null, write_by_row", log2_size),
-            |b| {
-                b.iter(|| csv::write_by_row(&col));
-            },
-        );
-        c.bench_function(
-            &format!("i32 2^{} not null, write_iterator", log2_size),
-            |b| {
-                b.iter(|| csv::write_iterator(&col));
-            },
-        );
+        for null_density in [None, Some(0.1)] {
+            let null_name = match null_density {
+                None => "not_nullable".to_string(),
+                Some(f) => format!("null={}", f),
+            };
+
+            let col = creator(size, null_density, item_size);
+            group.bench_with_input(
+                BenchmarkId::new(bench_name(typ, &null_name, "index"), size),
+                &log2_size,
+                |b, _| {
+                    b.iter(|| csv::write_by_row(&col));
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new(bench_name(typ, &null_name, "iter"), size),
+                &log2_size,
+                |b, _| {
+                    b.iter(|| csv::write_iterator(&col));
+                },
+            );
+        }
     });
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    add_group(c, "i32", create_primitive_array, 1);
+    for strlen in [10, 100, 1000] {
+        let typ = format!("str[{}]", strlen);
+        add_group(c, &typ, create_string_array, strlen);
+    }
+}
+
+pub fn create_primitive_array(
+    size: usize,
+    null_density: Option<f32>,
+    _item_size: usize,
+) -> ColumnRef {
+    let mut rng = StdRng::seed_from_u64(3);
+    match null_density {
+        None => {
+            let v = (0..size).map(|_| rng.gen()).collect::<Vec<i32>>();
+            Series::from_data(v)
+        }
+        Some(null_density) => {
+            let v = (0..size)
+                .map(|_| {
+                    if rng.gen::<f32>() < null_density {
+                        None
+                    } else {
+                        Some(rng.gen())
+                    }
+                })
+                .collect::<Vec<Option<i32>>>();
+            Series::from_data(v)
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn create_string_array(size: usize, null_density: Option<f32>, item_size: usize) -> ColumnRef {
+    let mut rng = StdRng::seed_from_u64(3);
+    match null_density {
+        None => {
+            let vec: Vec<String> = (0..item_size)
+                .map(|_| {
+                    (&mut rng)
+                        .sample_iter(&Alphanumeric)
+                        .take(size)
+                        .map(char::from)
+                        .collect::<String>()
+                })
+                .collect();
+            Series::from_data(vec)
+        }
+        Some(null_density) => {
+            let vec: Vec<_> = (0..item_size)
+                .map(|_| {
+                    if rng.gen::<f32>() < null_density {
+                        None
+                    } else {
+                        let value = (&mut rng)
+                            .sample_iter(&Alphanumeric)
+                            .take(size)
+                            .collect::<Vec<u8>>();
+                        Some(value)
+                    }
+                })
+                .collect();
+            Series::from_data(vec)
+        }
+    }
 }
 
 criterion_group!(benches, add_benchmark);
 criterion_main!(benches);
-
-pub fn create_primitive_array(size: usize) -> ColumnRef {
-    let mut rng = seedable_rng();
-
-    let v = (0..size).map(|_| rng.gen()).collect::<Vec<i32>>();
-    Series::from_data(v)
-}
-
-pub fn seedable_rng() -> StdRng {
-    StdRng::seed_from_u64(42)
-}

--- a/common/datavalues/benches/csv.rs
+++ b/common/datavalues/benches/csv.rs
@@ -1,0 +1,45 @@
+extern crate core;
+
+use common_datavalues::serializations::formats::csv;
+use common_datavalues::ColumnRef;
+use common_datavalues::Series;
+use common_datavalues::SeriesFrom;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use rand::rngs::StdRng;
+use rand::Rng;
+use rand::SeedableRng;
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=21).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+        let col = create_primitive_array(size);
+        c.bench_function(
+            &format!("i32 2^{} not null, write_by_row", log2_size),
+            |b| {
+                b.iter(|| csv::write_by_row(&col));
+            },
+        );
+        c.bench_function(
+            &format!("i32 2^{} not null, write_iterator", log2_size),
+            |b| {
+                b.iter(|| csv::write_iterator(&col));
+            },
+        );
+    });
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);
+
+pub fn create_primitive_array(size: usize) -> ColumnRef {
+    let mut rng = seedable_rng();
+
+    let v = (0..size).map(|_| rng.gen()).collect::<Vec<i32>>();
+    Series::from_data(v)
+}
+
+pub fn seedable_rng() -> StdRng {
+    StdRng::seed_from_u64(42)
+}

--- a/common/datavalues/benches/csv.rs
+++ b/common/datavalues/benches/csv.rs
@@ -46,6 +46,13 @@ fn add_group(c: &mut Criterion, typ: &str, creator: ColumnCreator, item_size: us
                     b.iter(|| csv::write_iterator(&col));
                 },
             );
+            group.bench_with_input(
+                BenchmarkId::new(bench_name(typ, &null_name, "embedded"), size),
+                &log2_size,
+                |b, _| {
+                    b.iter(|| csv::write_embedded(&col));
+                },
+            );
         }
     });
 }

--- a/common/datavalues/benches/csv.rs
+++ b/common/datavalues/benches/csv.rs
@@ -39,13 +39,13 @@ fn add_group(c: &mut Criterion, typ: &str, creator: ColumnCreator, item_size: us
                     b.iter(|| csv::write_by_row(&col));
                 },
             );
-            group.bench_with_input(
-                BenchmarkId::new(bench_name(typ, &null_name, "iter"), size),
-                &log2_size,
-                |b, _| {
-                    b.iter(|| csv::write_iterator(&col));
-                },
-            );
+            // group.bench_with_input(
+            //     BenchmarkId::new(bench_name(typ, &null_name, "iter"), size),
+            //     &log2_size,
+            //     |b, _| {
+            //         b.iter(|| csv::write_iterator(&col));
+            //     },
+            // );
             group.bench_with_input(
                 BenchmarkId::new(bench_name(typ, &null_name, "embedded"), size),
                 &log2_size,
@@ -59,7 +59,7 @@ fn add_group(c: &mut Criterion, typ: &str, creator: ColumnCreator, item_size: us
 
 fn add_benchmark(c: &mut Criterion) {
     add_group(c, "i32", create_primitive_array, 1);
-    for strlen in [10, 100, 1000] {
+    for strlen in [10, 100] {
         let typ = format!("str[{}]", strlen);
         add_group(c, &typ, create_string_array, strlen);
     }

--- a/common/datavalues/src/columns/array/mod.rs
+++ b/common/datavalues/src/columns/array/mod.rs
@@ -179,6 +179,11 @@ impl ScalarColumn for ArrayColumn {
         ArrayValueRef::Indexed { column: self, idx }
     }
 
+    #[inline]
+    fn get_data_owned(&self, idx: usize) -> Self::OwnedItem {
+        self.get(idx).into()
+    }
+
     fn scalar_iter(&self) -> Self::Iterator<'_> {
         ArrayValueIter::new(self)
     }

--- a/common/datavalues/src/columns/primitive/mod.rs
+++ b/common/datavalues/src/columns/primitive/mod.rs
@@ -336,6 +336,9 @@ where
     fn get_data(&self, idx: usize) -> Self::RefItem<'_> {
         self.values[idx]
     }
+    fn get_data_owned(&self, idx: usize) -> Self::OwnedItem {
+        self.values[idx].clone()
+    }
 
     fn scalar_iter(&self) -> Self::Iterator<'_> {
         self.iter().copied()

--- a/common/datavalues/src/scalars/column.rs
+++ b/common/datavalues/src/scalars/column.rs
@@ -34,6 +34,9 @@ where for<'a> Self::OwnedItem: Scalar<RefType<'a> = Self::RefItem<'a>>
     // Note: get_data has bad performance, avoid call this function inside the loop
     // Use `iter` instead
     fn get_data(&self, idx: usize) -> Self::RefItem<'_>;
+    fn get_data_owned(&self, _idx: usize) -> Self::OwnedItem {
+        unimplemented!()
+    }
 
     /// Get iterator of this column.
     fn scalar_iter(&self) -> Self::Iterator<'_>;

--- a/common/datavalues/src/types/serializations/formats/csv.rs
+++ b/common/datavalues/src/types/serializations/formats/csv.rs
@@ -1,0 +1,81 @@
+use common_io::prelude::FormatSettings;
+
+use crate::ColumnRef;
+use crate::DataType;
+use crate::TypeSerializer;
+
+#[allow(dead_code)]
+pub fn write_vec(col: &ColumnRef) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(1000 * 1000);
+
+    let s = col.data_type().create_serializer();
+    let v = s
+        .serialize_column(&col, &FormatSettings::default())
+        .unwrap();
+    for field in v {
+        buf.extend_from_slice(&field.as_bytes());
+    }
+    buf
+}
+
+pub fn write_by_row(col: &ColumnRef) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(1000 * 1000);
+    let rows = col.len();
+    let s = col.data_type().create_serializer();
+    let f = &FormatSettings::default();
+    for row in 0..rows {
+        s.write_csv_field(col, row, &mut buf, f).unwrap();
+    }
+    buf
+}
+
+pub fn write_iterator(col: &ColumnRef) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(1000 * 1000);
+
+    let s = col.data_type().create_serializer();
+    let mut stream = s.serialize_csv(&col, &FormatSettings::default()).unwrap();
+    while let Some(field) = stream.next() {
+        buf.extend_from_slice(field);
+    }
+    buf
+}
+
+#[test]
+fn test_2() -> Result<()> {
+    use crate::Series;
+    use crate::SeriesFrom;
+    let col = Series::from_data(vec![12u8, 23u8, 34u8]);
+    let exp = [49, 50, 50, 51, 51, 52];
+    assert_eq!(write_iterator(&col), exp);
+    assert_eq!(write_by_row(&col), exp);
+    Ok(())
+}
+
+#[test]
+fn test_s() -> Result<()> {
+    use crate::Series;
+    use crate::SeriesFrom;
+    use crate::TypeSerializer;
+    // let col = Series::from_data(vec![true, false, true]);
+    // let col = Series::from_data(vec!["a", "a", "bc"]);
+    // let col = Series::from_data(vec![12, 23, 34]);
+    let col = Series::from_data(vec![12u8, 23u8, 34u8]);
+
+    println!("{:?}", col);
+    let s = col.data_type().create_serializer();
+    let mut stream = s.serialize_csv(&col, &FormatSettings::default())?;
+    println!("{:?}", stream.next());
+    println!("{:?}", stream.next());
+    println!("{:?}", stream.next());
+    println!("{:?}", stream.next());
+
+    let col = Series::from_data(vec![Some(12), None, Some(34)]);
+    println!("{:?}", col);
+    let s = col.data_type().create_serializer();
+    let mut stream = s.serialize_csv(&col, &FormatSettings::default())?;
+    println!("{:?}", stream.next());
+    println!("{:?}", stream.next());
+    println!("{:?}", stream.next());
+    println!("{:?}", stream.next());
+    Ok(())
+}

--- a/common/datavalues/src/types/serializations/formats/csv.rs
+++ b/common/datavalues/src/types/serializations/formats/csv.rs
@@ -1,3 +1,4 @@
+use common_exception::Result;
 use common_io::prelude::FormatSettings;
 
 use crate::ColumnRef;
@@ -41,18 +42,28 @@ pub fn write_iterator(col: &ColumnRef) -> Vec<u8> {
 }
 
 #[test]
-fn test_2() -> Result<()> {
+fn test_writers() -> Result<()> {
     use crate::Series;
     use crate::SeriesFrom;
     let col = Series::from_data(vec![12u8, 23u8, 34u8]);
     let exp = [49, 50, 50, 51, 51, 52];
     assert_eq!(write_iterator(&col), exp);
     assert_eq!(write_by_row(&col), exp);
+
+    let col = Series::from_data(vec!["12", "34"]);
+    let exp = "1234".to_string().as_bytes().to_vec();
+    assert_eq!(write_iterator(&col), exp);
+    assert_eq!(write_by_row(&col), exp);
+
+    let col = Series::from_data(vec![Some(12u8), None, Some(34u8)]);
+    let exp = [49, 50, 0, 51, 52];
+    assert_eq!(write_iterator(&col), exp);
+    assert_eq!(write_by_row(&col), exp);
     Ok(())
 }
 
 #[test]
-fn test_s() -> Result<()> {
+fn test_debug() -> Result<()> {
     use crate::Series;
     use crate::SeriesFrom;
     use crate::TypeSerializer;

--- a/common/datavalues/src/types/serializations/formats/iterators.rs
+++ b/common/datavalues/src/types/serializations/formats/iterators.rs
@@ -1,0 +1,186 @@
+pub use streaming_iterator::StreamingIterator;
+
+pub struct NullInfo<F>
+where F: Fn(usize) -> bool
+{
+    pub(crate) is_nullable: bool,
+    pub(crate) is_null: F,
+    pub(crate) null_value: Vec<u8>,
+}
+
+impl<F> NullInfo<F>
+where F: Fn(usize) -> bool
+{
+    pub fn new(is_null: F, null_value: Vec<u8>) -> Self {
+        Self {
+            is_nullable: true,
+            is_null,
+            null_value,
+        }
+    }
+    pub fn not_nullable(is_null: F) -> Self {
+        Self {
+            is_nullable: true,
+            is_null,
+            null_value: vec![],
+        }
+    }
+}
+
+pub struct BufStreamingIterator<I, F, T>
+where
+    I: Iterator<Item = T>,
+    F: FnMut(T, &mut Vec<u8>),
+{
+    iterator: I,
+    f: F,
+    buffer: Vec<u8>,
+    is_valid: bool,
+}
+
+pub fn new_it<'a, I, F, T, F2>(
+    iterator: I,
+    f: F,
+    buffer: Vec<u8>,
+    nullable: NullInfo<F2>,
+) -> Box<dyn StreamingIterator<Item = [u8]> + 'a>
+where
+    I: Iterator<Item = T> + 'a,
+    F: FnMut(T, &mut Vec<u8>) + 'a,
+    T: 'a,
+    F2: Fn(usize) -> bool + 'a,
+{
+    if nullable.is_nullable {
+        Box::new(NullableBufStreamingIterator::new(
+            iterator, f, buffer, nullable,
+        ))
+    } else {
+        Box::new(BufStreamingIterator::new(iterator, f, buffer))
+    }
+}
+
+impl<I, F, T> BufStreamingIterator<I, F, T>
+where
+    I: Iterator<Item = T>,
+    F: FnMut(T, &mut Vec<u8>),
+{
+    #[inline]
+    pub fn new(iterator: I, f: F, buffer: Vec<u8>) -> Self {
+        Self {
+            iterator,
+            f,
+            buffer,
+            is_valid: false,
+        }
+    }
+}
+
+impl<I, F, T> StreamingIterator for BufStreamingIterator<I, F, T>
+where
+    I: Iterator<Item = T>,
+    F: FnMut(T, &mut Vec<u8>),
+{
+    type Item = [u8];
+
+    #[inline]
+    fn advance(&mut self) {
+        let a = self.iterator.next();
+        if let Some(a) = a {
+            self.is_valid = true;
+            self.buffer.clear();
+            (self.f)(a, &mut self.buffer);
+        } else {
+            self.is_valid = false;
+        }
+    }
+
+    #[inline]
+    fn get(&self) -> Option<&Self::Item> {
+        if self.is_valid {
+            Some(&self.buffer)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iterator.size_hint()
+    }
+}
+
+pub struct NullableBufStreamingIterator<I, F, F2, T>
+where
+    I: Iterator<Item = T>,
+    F: FnMut(T, &mut Vec<u8>),
+    F2: Fn(usize) -> bool,
+{
+    iterator: I,
+    f: F,
+    buffer: Vec<u8>,
+    is_valid: bool,
+    cursor: usize,
+    //is_null: F2,
+    //null_value: Vec<u8>
+    null: NullInfo<F2>,
+}
+
+impl<I, F, F2, T> NullableBufStreamingIterator<I, F, F2, T>
+where
+    I: Iterator<Item = T>,
+    F: FnMut(T, &mut Vec<u8>),
+    F2: Fn(usize) -> bool,
+{
+    pub fn new(iterator: I, f: F, buffer: Vec<u8>, null: NullInfo<F2>) -> Self {
+        //pub fn new(iterator: I, f: F, buffer: Vec<u8>,  is_null: F2, null_value: Vec<u8>) -> Self {
+        Self {
+            iterator,
+            f,
+            buffer,
+            is_valid: false,
+            null,
+            // is_null, null_value,
+            cursor: 0,
+        }
+    }
+}
+
+impl<I, F, F2, T> StreamingIterator for NullableBufStreamingIterator<I, F, F2, T>
+where
+    I: Iterator<Item = T>,
+    F: FnMut(T, &mut Vec<u8>),
+    F2: Fn(usize) -> bool,
+{
+    type Item = [u8];
+
+    #[inline]
+    fn advance(&mut self) {
+        let a = self.iterator.next();
+        if let Some(a) = a {
+            self.is_valid = true;
+            self.buffer.clear();
+            if (self.null.is_null)(self.cursor) {
+                self.buffer.extend_from_slice(&self.null.null_value)
+            } else {
+                (self.f)(a, &mut self.buffer);
+            }
+        } else {
+            self.is_valid = false;
+        }
+        self.cursor += 1;
+    }
+
+    #[inline]
+    fn get(&self) -> Option<&Self::Item> {
+        if self.is_valid {
+            Some(&self.buffer)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iterator.size_hint()
+    }
+}

--- a/common/datavalues/src/types/serializations/formats/mod.rs
+++ b/common/datavalues/src/types/serializations/formats/mod.rs
@@ -1,1 +1,20 @@
+pub mod csv;
 pub mod iterators;
+
+#[inline]
+pub fn lexical_to_bytes_mut_no_clear<N: lexical_core::ToLexical>(n: N, buf: &mut Vec<u8>) {
+    buf.reserve(N::FORMATTED_SIZE_DECIMAL);
+    let len0 = buf.len();
+    unsafe {
+        // JUSTIFICATION
+        //  Benefit
+        //      Allows using the faster serializer lexical core and convert to string
+        //  Soundness
+        //      Length of buf is set as written length afterwards. lexical_core
+        //      creates a valid string, so doesn't need to be checked.
+        let slice =
+            std::slice::from_raw_parts_mut(buf.as_mut_ptr().add(len0), buf.capacity() - len0);
+        let len = lexical_core::write(n, slice).len();
+        buf.set_len(len0 + len);
+    }
+}

--- a/common/datavalues/src/types/serializations/formats/mod.rs
+++ b/common/datavalues/src/types/serializations/formats/mod.rs
@@ -1,0 +1,1 @@
+pub mod iterators;

--- a/common/datavalues/src/types/serializations/mod.rs
+++ b/common/datavalues/src/types/serializations/mod.rs
@@ -47,6 +47,15 @@ pub use variant::*;
 
 use crate::serializations::formats::iterators::NullInfo;
 
+pub trait ColSerializer: Send + Sync {
+    fn write_csv_field(
+        &self,
+        row_num: usize,
+        buf: &mut Vec<u8>,
+        format: &FormatSettings,
+    ) -> Result<()>;
+}
+
 #[enum_dispatch]
 pub trait TypeSerializer: Send + Sync {
     fn serialize_value(&self, value: &DataValue, format: &FormatSettings) -> Result<String>;
@@ -126,6 +135,13 @@ pub trait TypeSerializer: Send + Sync {
     where
         F2: Fn(usize) -> bool + 'a,
     {
+        Err(ErrorCode::UnImplement(""))
+    }
+
+    fn get_csv_serializer<'a>(
+        &self,
+        _column: &'a ColumnRef,
+    ) -> Result<Box<dyn ColSerializer + 'a>> {
         Err(ErrorCode::UnImplement(""))
     }
 }

--- a/common/datavalues/src/types/serializations/mod.rs
+++ b/common/datavalues/src/types/serializations/mod.rs
@@ -90,6 +90,16 @@ pub trait TypeSerializer: Send + Sync {
 
     fn write_csv_field<'a>(
         &self,
+        column: &ColumnRef,
+        row_num: usize,
+        buf: &mut Vec<u8>,
+        format: &FormatSettings,
+    ) -> Result<()> {
+        self.write_csv_field_not_null(column, row_num, buf, format)
+    }
+
+    fn write_csv_field_not_null<'a>(
+        &self,
         _column: &ColumnRef,
         _row_num: usize,
         _buf: &mut Vec<u8>,

--- a/common/datavalues/src/types/serializations/mod.rs
+++ b/common/datavalues/src/types/serializations/mod.rs
@@ -88,6 +88,16 @@ pub trait TypeSerializer: Send + Sync {
         ))
     }
 
+    fn write_csv_field<'a>(
+        &self,
+        _column: &ColumnRef,
+        _row_num: usize,
+        _buf: &mut Vec<u8>,
+        _format: &FormatSettings,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
     fn serialize_csv<'a>(
         &self,
         column: &'a ColumnRef,
@@ -99,9 +109,9 @@ pub trait TypeSerializer: Send + Sync {
 
     fn serialize_csv_inner<'a, F2>(
         &self,
-        column: &'a ColumnRef,
-        format: &FormatSettings,
-        nullable: NullInfo<F2>,
+        _column: &'a ColumnRef,
+        _format: &FormatSettings,
+        _nullable: NullInfo<F2>,
     ) -> Result<Box<dyn StreamingIterator<Item = [u8]> + 'a>>
     where
         F2: Fn(usize) -> bool + 'a,
@@ -134,30 +144,4 @@ pub enum TypeSerializerImpl {
     Array(ArraySerializer),
     Struct(StructSerializer),
     Variant(VariantSerializer),
-}
-
-#[test]
-fn test_s() -> Result<()> {
-    use crate::TypeSerializer;
-    let col = Series::from_data(vec![true, false, true]);
-    let col = Series::from_data(vec!["a", "a", "bc"]);
-    let col = Series::from_data(vec![12, 23, 34]);
-
-    println!("{:?}", col);
-    let s = col.data_type().create_serializer();
-    let mut stream = s.serialize_csv(&col, &FormatSettings::default())?;
-    println!("{:?}", stream.next());
-    println!("{:?}", stream.next());
-    println!("{:?}", stream.next());
-    println!("{:?}", stream.next());
-
-    let col = Series::from_data(vec![Some(12), None, Some(34)]);
-    println!("{:?}", col);
-    let s = col.data_type().create_serializer();
-    let mut stream = s.serialize_csv(&col, &FormatSettings::default())?;
-    println!("{:?}", stream.next());
-    println!("{:?}", stream.next());
-    println!("{:?}", stream.next());
-    println!("{:?}", stream.next());
-    Ok(())
 }

--- a/common/datavalues/src/types/serializations/nullable.rs
+++ b/common/datavalues/src/types/serializations/nullable.rs
@@ -114,6 +114,23 @@ impl TypeSerializer for NullableSerializer {
         it
     }
 
+    fn write_csv_field<'a>(
+        &self,
+        column: &ColumnRef,
+        row_num: usize,
+        buf: &mut Vec<u8>,
+        format: &FormatSettings,
+    ) -> Result<()> {
+        let column: &NullableColumn = Series::check_get(&column)?;
+        if !column.null_at(row_num) {
+            self.inner
+                .write_csv_field_not_null(column.inner(), row_num, buf, format)?;
+        } else {
+            buf.extend_from_slice(&format.csv_null);
+        }
+        Ok(())
+    }
+
     fn serialize_csv_inner<'a, F2>(
         &self,
         _column: &'a ColumnRef,

--- a/common/datavalues/src/types/serializations/nullable.rs
+++ b/common/datavalues/src/types/serializations/nullable.rs
@@ -123,10 +123,11 @@ impl TypeSerializer for NullableSerializer {
         buf: &mut Vec<u8>,
         format: &FormatSettings,
     ) -> Result<()> {
-        let column: &NullableColumn = Series::check_get(&column)?;
+        let column: &NullableColumn = Series::check_get(&column).unwrap();
         if !column.null_at(row_num) {
             self.inner
-                .write_csv_field_not_null(column.inner(), row_num, buf, format)?;
+                .write_csv_field_not_null(column.inner(), row_num, buf, format)
+                .unwrap();
         } else {
             buf.extend_from_slice(&format.csv_null);
         }
@@ -170,7 +171,7 @@ impl<'a> ColSerializer for NullableColSerializer<'a> {
         format: &FormatSettings,
     ) -> Result<()> {
         if self.validity.get_bit(row_num) {
-            self.inner.write_csv_field(row_num, buf, format)?;
+            self.inner.write_csv_field(row_num, buf, format).unwrap();
         } else {
             buf.extend_from_slice(&format.csv_null);
         }

--- a/common/datavalues/src/types/serializations/nullable.rs
+++ b/common/datavalues/src/types/serializations/nullable.rs
@@ -116,9 +116,9 @@ impl TypeSerializer for NullableSerializer {
 
     fn serialize_csv_inner<'a, F2>(
         &self,
-        column: &'a ColumnRef,
-        format: &FormatSettings,
-        nullable: NullInfo<F2>,
+        _column: &'a ColumnRef,
+        _format: &FormatSettings,
+        _nullable: NullInfo<F2>,
     ) -> Result<Box<dyn StreamingIterator<Item = [u8]> + 'a>>
     where
         F2: Fn(usize) -> bool + 'a,

--- a/common/datavalues/src/types/serializations/number.rs
+++ b/common/datavalues/src/types/serializations/number.rs
@@ -144,4 +144,31 @@ where T: PrimitiveType
         lexical_to_bytes_mut_no_clear(v, buf);
         Ok(())
     }
+
+    fn get_csv_serializer<'a>(&self, column: &'a ColumnRef) -> Result<Box<dyn ColSerializer + 'a>> {
+        let column2: &PrimitiveColumn<T> = Series::check_get(&column)?;
+        let s = NumberColSerialize {
+            values: column2.values(),
+        };
+        Ok(Box::new(s))
+    }
+}
+
+#[derive(Clone)]
+pub struct NumberColSerialize<'a, T: PrimitiveType> {
+    pub(crate) values: &'a [T],
+}
+
+impl<'a, T> ColSerializer for NumberColSerialize<'a, T>
+where T: PrimitiveType + lexical_core::ToLexical
+{
+    fn write_csv_field(
+        &self,
+        row_num: usize,
+        buf: &mut Vec<u8>,
+        _format: &FormatSettings,
+    ) -> Result<()> {
+        lexical_to_bytes_mut_no_clear(self.values[row_num].clone(), buf);
+        Ok(())
+    }
 }

--- a/common/datavalues/src/types/serializations/number.rs
+++ b/common/datavalues/src/types/serializations/number.rs
@@ -132,7 +132,7 @@ where T: PrimitiveType
         ))
     }
 
-    fn write_csv_field(
+    fn write_csv_field_not_null(
         &self,
         column: &ColumnRef,
         row_num: usize,

--- a/common/datavalues/src/types/serializations/number.rs
+++ b/common/datavalues/src/types/serializations/number.rs
@@ -139,8 +139,10 @@ where T: PrimitiveType
         buf: &mut Vec<u8>,
         _format: &FormatSettings,
     ) -> Result<()> {
-        let col: &<T as Scalar>::ColumnType = unsafe { Series::static_cast(&column) };
-        let v = col.get_data_owned(row_num);
+        //let col: &<T as Scalar>::ColumnType = unsafe { Series::static_cast(&column) };
+        //let v = col.get_data_owned(row_num);
+        let col: &PrimitiveColumn<T> = Series::check_get(&column).unwrap();
+        let v = unsafe { col.value_unchecked(row_num) };
         lexical_to_bytes_mut_no_clear(v, buf);
         Ok(())
     }

--- a/common/datavalues/src/types/serializations/string.rs
+++ b/common/datavalues/src/types/serializations/string.rs
@@ -166,4 +166,28 @@ impl TypeSerializer for StringSerializer {
         buf.extend_from_slice(col.get_data(row_num));
         Ok(())
     }
+
+    //  move it to DataType later
+    fn get_csv_serializer<'a>(&self, column: &'a ColumnRef) -> Result<Box<dyn ColSerializer + 'a>> {
+        let col: &StringColumn = Series::check_get(&column)?;
+        let s = StringColSerializer { col };
+        Ok(Box::new(s))
+    }
+}
+
+#[derive(Clone)]
+pub struct StringColSerializer<'a> {
+    pub(crate) col: &'a StringColumn,
+}
+
+impl<'a> ColSerializer for StringColSerializer<'a> {
+    fn write_csv_field(
+        &self,
+        row_num: usize,
+        buf: &mut Vec<u8>,
+        _format: &FormatSettings,
+    ) -> Result<()> {
+        buf.extend_from_slice(unsafe { self.col.value_unchecked(row_num) });
+        Ok(())
+    }
 }

--- a/common/io/src/format_settings.rs
+++ b/common/io/src/format_settings.rs
@@ -28,6 +28,7 @@ pub struct FormatSettings {
     pub skip_header: bool,
     pub compression: Compression,
     pub timezone: Tz,
+    pub csv_null: Vec<u8>,
 }
 
 impl Default for FormatSettings {
@@ -39,6 +40,7 @@ impl Default for FormatSettings {
             skip_header: false,
             compression: Compression::None,
             timezone: "UTC".parse::<Tz>().unwrap(),
+            csv_null: vec![b'\0'], // for test
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

- [x] verified with nullable and numbers，string
- [ ] bench: index vs iterator
- [ ] some refactor 
- [ ] block writer interface
- [ ] other common types:, bool, date ..

current serializer return Vec of **tmp strings**. 
arrow2 reuse buf in [streaming iterator.](https://docs.rs/streaming-iterator/latest/streaming_iterator/)
 https://github.com/jorgecarleitao/arrow2/blob/47edf30128/src/io/csv/write/serialize.rs

the first commit is to findout a way to adopting streaming-iterator to our datavalues( especially for nullable column).

this pr reported a improvement of 20% -25%
https://github.com/jorgecarleitao/arrow2/pull/382
need bench to know how much faster it will be for us.



## Changelog


- Performance Improvement


## Related Issues

Fixes #issue

