### PR TITLE
fix(httphandler): req should return as soon as results is exhausted.

### DIFF
--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -99,9 +99,11 @@ pub struct QueryResponse {
 impl QueryResponse {
     pub(crate) fn from_internal(id: String, r: HttpQueryResponseInternal) -> QueryResponse {
         let state = r.state.clone();
-        let (data, next_url) = match r.data {
-            Some(d) => (d.page.data, d.next_page_no.map(|n| make_page_uri(&id, n))),
-            None => (JsonBlock::empty(), None),
+        let (data, next_url) = match (state.state, r.data) {
+            (ExecuteStateKind::Succeeded | ExecuteStateKind::Running, Some(d)) => {
+                (d.page.data, d.next_page_no.map(|n| make_page_uri(&id, n)))
+            }
+            _ => (JsonBlock::empty(), None),
         };
         let schema = data.schema().clone();
         let session_id = r.session_id.clone();

--- a/query/src/servers/http/v1/query/block_buffer.rs
+++ b/query/src/servers/http/v1/query/block_buffer.rs
@@ -99,23 +99,27 @@ impl BlockBufferInner {
         Ok(())
     }
 
-    async fn pop(&mut self) -> Option<BlockDataOrInfo> {
-        let b = self.blocks.pop_front()?;
-        self.curr_rows -= b.num_rows();
-        Some(b)
+    async fn pop(&mut self) -> (Option<BlockDataOrInfo>, bool) {
+        let block = self.blocks.pop_front();
+        if let Some(ref b) = block {
+            self.curr_rows -= b.num_rows();
+        }
+        let done = self.is_pop_done();
+        (block, done)
+    }
+
+    fn is_pop_done(&self) -> bool {
+        self.push_stopped && self.blocks.is_empty()
     }
 
     fn stop_push(&mut self) {
-        self.push_stopped = true
+        self.push_stopped = true;
+        self.block_notify.notify_one();
     }
 
     pub fn stop_pop(&mut self) {
         self.pop_stopped = true;
         self.blocks.truncate(0)
-    }
-
-    fn pop_done(&self) -> bool {
-        self.push_stopped && self.blocks.is_empty()
     }
 }
 
@@ -146,8 +150,8 @@ impl BlockBuffer {
         guard.init_reader(ctx, schema)
     }
 
-    pub async fn pop(self: &Arc<Self>) -> Result<Option<DataBlock>> {
-        let block = {
+    pub async fn pop(self: &Arc<Self>) -> Result<(Option<DataBlock>, bool)> {
+        let (block, done) = {
             let mut guard = self.buffer.lock().await;
             guard.pop().await
         };
@@ -165,7 +169,7 @@ impl BlockBuffer {
                 }
             },
         };
-        Ok(r)
+        Ok((r, done))
     }
 
     pub async fn push(self: &Arc<Self>, block: DataBlock, part_info: PartInfoPtr) {
@@ -183,8 +187,8 @@ impl BlockBuffer {
         guard.stop_pop()
     }
 
-    pub async fn pop_done(self: &Arc<Self>) -> bool {
+    pub async fn is_pop_done(self: &Arc<Self>) -> bool {
         let guard = self.buffer.lock().await;
-        guard.pop_done()
+        guard.is_pop_done()
     }
 }

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -180,10 +180,12 @@ impl ExecuteState {
 
         let executor_clone = executor.clone();
         let ctx_clone = ctx.clone();
+        let block_notify = block_buffer.block_notify.clone();
         ctx.try_spawn(async move {
             if let Err(err) =
                 execute(interpreter, ctx_clone, block_buffer, executor_clone.clone()).await
             {
+                block_notify.notify_one();
                 let kill = err.message().starts_with("aborted");
                 Executor::stop(&executor_clone, Err(err), kill).await
             };
@@ -230,6 +232,7 @@ async fn execute(
                 block_buffer.push(block.clone(), part_ptr).await;
             }
             Err(err) => {
+                block_buffer.stop_push().await;
                 if let Some(writer) = result_table_writer {
                     writer.abort().await?;
                 }

--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -455,11 +455,13 @@ async fn test_query_log() -> Result<()> {
     let (status, result) = post_sql_to_endpoint(&ep, sql, 1).await?;
     assert_eq!(status, StatusCode::OK, "{:?}", result);
     assert!(result.error.is_none(), "{:?}", result);
+    assert!(result.next_uri.is_none(), "{:?}", result);
     assert!(result.data.is_empty(), "{:?}", result);
 
     let (status, result) = post_sql_to_endpoint(&ep, sql, 1).await?;
     assert_eq!(status, StatusCode::OK, "{:?}", result);
     assert!(result.error.is_some(), "{:?}", result);
+    assert!(result.next_uri.is_none(), "{:?}", result);
 
     let sql = "select query_text, exception_code, exception_text, stack_trace  from system.query_log where log_type=3";
     let (status, result) = post_sql_to_endpoint(&ep, sql, 1).await?;

--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -96,6 +96,24 @@ async fn test_simple_sql() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_return_when_finish() -> Result<()> {
+    let sql = "select * from numbers(1)";
+    let wait_time_secs = 5;
+    let start_time = std::time::Instant::now();
+    let (status, result) = post_sql(sql, wait_time_secs).await?;
+    let duration = start_time.elapsed().as_secs_f64();
+    assert_eq!(status, StatusCode::OK, "{:?}", result);
+    assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
+    // should not wait until wait_time_secs even if there is no more data
+    assert!(
+        duration < 1.0,
+        "duration {} is too large than expect",
+        duration
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_bad_sql() -> Result<()> {
     let sql = "bad sql";
     let ep = create_endpoint();

--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -944,7 +944,7 @@ async fn test_download() -> Result<()> {
 
     // succeeded query
     let resp = download(&ep, &result.id).await;
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status(), StatusCode::OK, "{:?}", resp);
     let exp = "0\t1\n1\t2\n";
     assert_eq!(resp.into_body().into_string().await.unwrap(), exp);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

1.  carry `bool done` aside block when `pop()` 
2.  notify when `stop_push()`
3.  not return data and next_url when error.


## Changelog

- Bug Fix

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/5456

