### PR TITLE
feature(planner): Translate subquery into apply operator

### DIFF
--- a/query/src/sql/exec/data_schema_builder.rs
+++ b/query/src/sql/exec/data_schema_builder.rs
@@ -23,21 +23,21 @@ use crate::sql::plans::EvalScalar;
 use crate::sql::plans::PhysicalScan;
 use crate::sql::plans::Project;
 use crate::sql::IndexType;
-use crate::sql::Metadata;
+use crate::sql::MetadataRef;
 
-pub struct DataSchemaBuilder<'a> {
-    metadata: &'a Metadata,
+pub struct DataSchemaBuilder {
+    metadata: MetadataRef,
 }
 
-impl<'a> DataSchemaBuilder<'a> {
-    pub fn new(metadata: &'a Metadata) -> Self {
+impl DataSchemaBuilder {
+    pub fn new(metadata: MetadataRef) -> Self {
         DataSchemaBuilder { metadata }
     }
 
     pub fn build_project(&self, plan: &Project) -> Result<DataSchemaRef> {
         let mut fields = Vec::with_capacity(plan.columns.len());
         for index in plan.columns.iter() {
-            let column_entry = self.metadata.column(*index);
+            let column_entry = self.metadata.read().unwrap().column(*index).clone();
             let field_name = format_field_name(column_entry.name.as_str(), *index);
             let field = DataField::new(field_name.as_str(), column_entry.data_type.clone());
             fields.push(field);
@@ -53,7 +53,7 @@ impl<'a> DataSchemaBuilder<'a> {
     ) -> Result<DataSchemaRef> {
         let mut fields = input_schema.fields().clone();
         for item in plan.items.iter() {
-            let column_entry = self.metadata.column(item.index);
+            let column_entry = self.metadata.read().unwrap().column(item.index).clone();
             let field_name = format_field_name(column_entry.name.as_str(), item.index);
             let field = DataField::new(field_name.as_str(), column_entry.data_type.clone());
             fields.push(field);
@@ -65,7 +65,7 @@ impl<'a> DataSchemaBuilder<'a> {
     pub fn build_physical_scan(&self, plan: &PhysicalScan) -> Result<DataSchemaRef> {
         let mut fields: Vec<DataField> = vec![];
         for index in plan.columns.iter() {
-            let column_entry = self.metadata.column(*index);
+            let column_entry = self.metadata.read().unwrap().column(*index).clone();
             let field_name = format_field_name(column_entry.name.as_str(), *index);
             let field = DataField::new(field_name.as_str(), column_entry.data_type.clone());
             fields.push(field);
@@ -77,7 +77,7 @@ impl<'a> DataSchemaBuilder<'a> {
     pub fn build_canonical_schema(&self, columns: &[IndexType]) -> DataSchemaRef {
         let mut fields: Vec<DataField> = vec![];
         for index in columns {
-            let column_entry = self.metadata.column(*index);
+            let column_entry = self.metadata.read().unwrap().column(*index).clone();
             let field_name = column_entry.name.clone();
             let field = DataField::new(field_name.as_str(), column_entry.data_type.clone());
             fields.push(field);

--- a/query/src/sql/exec/data_schema_builder.rs
+++ b/query/src/sql/exec/data_schema_builder.rs
@@ -37,7 +37,7 @@ impl DataSchemaBuilder {
     pub fn build_project(&self, plan: &Project) -> Result<DataSchemaRef> {
         let mut fields = Vec::with_capacity(plan.columns.len());
         for index in plan.columns.iter() {
-            let column_entry = self.metadata.read().unwrap().column(*index).clone();
+            let column_entry = self.metadata.read().column(*index).clone();
             let field_name = format_field_name(column_entry.name.as_str(), *index);
             let field = DataField::new(field_name.as_str(), column_entry.data_type.clone());
             fields.push(field);
@@ -53,7 +53,7 @@ impl DataSchemaBuilder {
     ) -> Result<DataSchemaRef> {
         let mut fields = input_schema.fields().clone();
         for item in plan.items.iter() {
-            let column_entry = self.metadata.read().unwrap().column(item.index).clone();
+            let column_entry = self.metadata.read().column(item.index).clone();
             let field_name = format_field_name(column_entry.name.as_str(), item.index);
             let field = DataField::new(field_name.as_str(), column_entry.data_type.clone());
             fields.push(field);
@@ -65,7 +65,7 @@ impl DataSchemaBuilder {
     pub fn build_physical_scan(&self, plan: &PhysicalScan) -> Result<DataSchemaRef> {
         let mut fields: Vec<DataField> = vec![];
         for index in plan.columns.iter() {
-            let column_entry = self.metadata.read().unwrap().column(*index).clone();
+            let column_entry = self.metadata.read().column(*index).clone();
             let field_name = format_field_name(column_entry.name.as_str(), *index);
             let field = DataField::new(field_name.as_str(), column_entry.data_type.clone());
             fields.push(field);
@@ -77,7 +77,7 @@ impl DataSchemaBuilder {
     pub fn build_canonical_schema(&self, columns: &[IndexType]) -> DataSchemaRef {
         let mut fields: Vec<DataField> = vec![];
         for index in columns {
-            let column_entry = self.metadata.read().unwrap().column(*index).clone();
+            let column_entry = self.metadata.read().column(*index).clone();
             let field_name = column_entry.name.clone();
             let field = DataField::new(field_name.as_str(), column_entry.data_type.clone());
             fields.push(field);

--- a/query/src/sql/exec/expression_builder.rs
+++ b/query/src/sql/exec/expression_builder.rs
@@ -42,7 +42,7 @@ impl ExpressionBuilder {
 
     pub fn build_and_rename(&self, scalar: &Scalar, index: IndexType) -> Result<Expression> {
         let expr = self.build(scalar)?;
-        let name = self.metadata.read().unwrap().column(index).name.clone();
+        let name = self.metadata.read().column(index).name.clone();
         Ok(Expression::Alias(
             format_field_name(name.as_str(), index),
             Box::new(expr),
@@ -116,7 +116,7 @@ impl ExpressionBuilder {
     }
 
     pub fn build_column_ref(&self, index: IndexType) -> Result<Expression> {
-        let name = self.metadata.read().unwrap().column(index).name.clone();
+        let name = self.metadata.read().column(index).name.clone();
         Ok(Expression::Column(format_field_name(name.as_str(), index)))
     }
 

--- a/query/src/sql/exec/expression_builder.rs
+++ b/query/src/sql/exec/expression_builder.rs
@@ -29,22 +29,22 @@ use crate::sql::plans::FunctionCall;
 use crate::sql::plans::OrExpr;
 use crate::sql::plans::Scalar;
 use crate::sql::IndexType;
-use crate::sql::Metadata;
+use crate::sql::MetadataRef;
 
-pub struct ExpressionBuilder<'a> {
-    metadata: &'a Metadata,
+pub struct ExpressionBuilder {
+    metadata: MetadataRef,
 }
 
-impl<'a> ExpressionBuilder<'a> {
-    pub fn create(metadata: &'a Metadata) -> Self {
+impl ExpressionBuilder {
+    pub fn create(metadata: MetadataRef) -> Self {
         ExpressionBuilder { metadata }
     }
 
     pub fn build_and_rename(&self, scalar: &Scalar, index: IndexType) -> Result<Expression> {
         let expr = self.build(scalar)?;
-        let column = self.metadata.column(index);
+        let name = self.metadata.read().unwrap().column(index).name.clone();
         Ok(Expression::Alias(
-            format_field_name(column.name.as_str(), index),
+            format_field_name(name.as_str(), index),
             Box::new(expr),
         ))
     }
@@ -116,11 +116,8 @@ impl<'a> ExpressionBuilder<'a> {
     }
 
     pub fn build_column_ref(&self, index: IndexType) -> Result<Expression> {
-        let column = self.metadata.column(index);
-        Ok(Expression::Column(format_field_name(
-            column.name.as_str(),
-            index,
-        )))
+        let name = self.metadata.read().unwrap().column(index).name.clone();
+        Ok(Expression::Column(format_field_name(name.as_str(), index)))
     }
 
     pub fn build_literal(

--- a/query/src/sql/exec/mod.rs
+++ b/query/src/sql/exec/mod.rs
@@ -100,13 +100,7 @@ impl PipelineBuilder {
     }
 
     fn get_field_name(&self, column_index: IndexType) -> String {
-        let name = &self
-            .metadata
-            .read()
-            .unwrap()
-            .column(column_index)
-            .name
-            .clone();
+        let name = &self.metadata.read().column(column_index).name.clone();
         format_field_name(name.as_str(), column_index)
     }
 
@@ -131,7 +125,7 @@ impl PipelineBuilder {
         let mut projections = Vec::with_capacity(self.result_columns.len());
         let mut output_fields = Vec::with_capacity(self.result_columns.len());
         for (index, name) in self.result_columns.iter() {
-            let column_entry = self.metadata.read().unwrap().column(*index).clone();
+            let column_entry = self.metadata.read().column(*index).clone();
             projections.push(Expression::Alias(
                 name.clone(),
                 Box::new(Expression::Column(self.get_field_name(*index))),
@@ -327,12 +321,7 @@ impl PipelineBuilder {
         scan: &PhysicalScan,
         pipeline: &mut NewPipeline,
     ) -> Result<DataSchemaRef> {
-        let table_entry = self
-            .metadata
-            .read()
-            .unwrap()
-            .table(scan.table_index)
-            .clone();
+        let table_entry = self.metadata.read().table(scan.table_index).clone();
         let plan = table_entry.source;
 
         let table = self.ctx.build_table_from_source_plan(&plan)?;
@@ -342,7 +331,7 @@ impl PipelineBuilder {
         let projections: Vec<Expression> = columns
             .iter()
             .map(|index| {
-                let name = self.metadata.read().unwrap().column(*index).name.clone();
+                let name = self.metadata.read().column(*index).name.clone();
                 Expression::Alias(
                     self.get_field_name(*index),
                     Box::new(Expression::Column(name)),

--- a/query/src/sql/exec/util.rs
+++ b/query/src/sql/exec/util.rs
@@ -18,7 +18,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 
 use crate::sql::optimizer::SExpr;
-use crate::sql::plans::BasePlan;
+use crate::sql::plans::Operator;
 use crate::sql::IndexType;
 
 // Check if all plans in an expression are physical plans

--- a/query/src/sql/optimizer/cascades/mod.rs
+++ b/query/src/sql/optimizer/cascades/mod.rs
@@ -29,7 +29,7 @@ use crate::sql::optimizer::rule::RuleSet;
 use crate::sql::optimizer::rule::TransformState;
 use crate::sql::optimizer::RequiredProperty;
 use crate::sql::optimizer::SExpr;
-use crate::sql::plans::BasePlan;
+use crate::sql::plans::Operator;
 use crate::sql::IndexType;
 
 /// A cascades-style search engine to enumerate possible alternations of a relational expression and

--- a/query/src/sql/optimizer/m_expr.rs
+++ b/query/src/sql/optimizer/m_expr.rs
@@ -19,8 +19,8 @@ use crate::sql::optimizer::pattern_extractor::PatternExtractor;
 use crate::sql::optimizer::rule::RulePtr;
 use crate::sql::optimizer::rule::TransformState;
 use crate::sql::optimizer::SExpr;
-use crate::sql::plans::BasePlan;
-use crate::sql::plans::BasePlanImpl;
+use crate::sql::plans::Operator;
+use crate::sql::plans::RelOperator;
 use crate::sql::IndexType;
 
 /// `MExpr` is abbreviation of multiple expression, which is the representation of relational
@@ -28,12 +28,12 @@ use crate::sql::IndexType;
 #[derive(Clone)]
 pub struct MExpr {
     group_index: IndexType,
-    plan: BasePlanImpl,
+    plan: RelOperator,
     children: Vec<IndexType>,
 }
 
 impl MExpr {
-    pub fn create(group_index: IndexType, plan: BasePlanImpl, children: Vec<IndexType>) -> Self {
+    pub fn create(group_index: IndexType, plan: RelOperator, children: Vec<IndexType>) -> Self {
         MExpr {
             group_index,
             plan,
@@ -49,7 +49,7 @@ impl MExpr {
         self.group_index
     }
 
-    pub fn plan(&self) -> BasePlanImpl {
+    pub fn plan(&self) -> RelOperator {
         self.plan.clone()
     }
 

--- a/query/src/sql/optimizer/mod.rs
+++ b/query/src/sql/optimizer/mod.rs
@@ -31,6 +31,7 @@ pub use optimize_context::OptimizeContext;
 pub use pattern_extractor::PatternExtractor;
 pub use property::ColumnSet;
 pub use property::PhysicalProperty;
+pub use property::RelExpr;
 pub use property::RelationalProperty;
 pub use property::RequiredProperty;
 pub use s_expr::SExpr;

--- a/query/src/sql/optimizer/property/builder.rs
+++ b/query/src/sql/optimizer/property/builder.rs
@@ -1,0 +1,74 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::sql::optimizer::MExpr;
+use crate::sql::optimizer::Memo;
+use crate::sql::optimizer::RelationalProperty;
+use crate::sql::optimizer::SExpr;
+use crate::sql::plans::Operator;
+
+/// A helper to access children of `SExpr` and `MExpr` in
+/// a unified view.
+pub enum RelExpr<'a> {
+    SExpr { expr: &'a SExpr },
+    MExpr { expr: &'a MExpr, memo: &'a Memo },
+}
+
+impl<'a> RelExpr<'a> {
+    pub fn with_s_expr(s_expr: &'a SExpr) -> Self {
+        Self::SExpr { expr: s_expr }
+    }
+
+    pub fn with_m_expr(m_expr: &'a MExpr, memo: &'a Memo) -> Self {
+        Self::MExpr { expr: m_expr, memo }
+    }
+
+    pub fn derive_relational_prop(&self) -> Result<RelationalProperty> {
+        let plan = match self {
+            RelExpr::SExpr { expr } => expr.plan(),
+            RelExpr::MExpr { expr, .. } => expr.plan(),
+        };
+
+        if let Some(logical) = plan.as_logical() {
+            let prop = logical.derive_relational_prop(self)?;
+            Ok(prop)
+        } else {
+            Err(ErrorCode::LogicalError(
+                "Cannot derive relational property from physical plan".to_string(),
+            ))
+        }
+    }
+
+    pub fn derive_relational_prop_child(&self, index: usize) -> Result<RelationalProperty> {
+        match self {
+            RelExpr::SExpr { expr } => {
+                let child = expr.child(index)?;
+                let rel_expr = RelExpr::with_s_expr(child);
+                rel_expr.derive_relational_prop()
+            }
+            RelExpr::MExpr { expr, memo } => memo
+                .group(expr.group_index())
+                .relational_prop()
+                .cloned()
+                .ok_or_else(|| {
+                    ErrorCode::LogicalError(
+                        "Relational property should have been filled".to_string(),
+                    )
+                }),
+        }
+    }
+}

--- a/query/src/sql/optimizer/property/mod.rs
+++ b/query/src/sql/optimizer/property/mod.rs
@@ -57,21 +57,5 @@ pub struct RelationalProperty {
     pub outer_columns: ColumnSet,
 }
 
-impl RelationalProperty {
-    // pub fn output_columns(&self) -> &ColumnSet {
-    //     &self.output_columns
-    // }
-
-    // pub fn outer_columns(&self) -> &ColumnSet {
-    //     &self.outer_columns
-    // }
-}
-
 #[derive(Default, Clone)]
 pub struct PhysicalProperty {}
-
-impl PhysicalProperty {
-    pub fn create() -> Self {
-        PhysicalProperty {}
-    }
-}

--- a/query/src/sql/optimizer/property/mod.rs
+++ b/query/src/sql/optimizer/property/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2022 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod builder;
+
 use std::collections::HashSet;
+
+pub use builder::RelExpr;
 
 use crate::sql::common::IndexType;
 
@@ -43,23 +47,24 @@ impl RequiredProperty {
         _physical_prop: &PhysicalProperty,
     ) -> bool {
         self.required_columns()
-            .is_subset(relational_prop.output_columns())
+            .is_subset(&relational_prop.output_columns)
     }
 }
 
 #[derive(Default, Clone)]
 pub struct RelationalProperty {
-    output_columns: ColumnSet,
+    pub output_columns: ColumnSet,
+    pub outer_columns: ColumnSet,
 }
 
 impl RelationalProperty {
-    pub fn create(output_columns: ColumnSet) -> Self {
-        RelationalProperty { output_columns }
-    }
+    // pub fn output_columns(&self) -> &ColumnSet {
+    //     &self.output_columns
+    // }
 
-    pub fn output_columns(&self) -> &ColumnSet {
-        &self.output_columns
-    }
+    // pub fn outer_columns(&self) -> &ColumnSet {
+    //     &self.outer_columns
+    // }
 }
 
 #[derive(Default, Clone)]

--- a/query/src/sql/optimizer/s_expr.rs
+++ b/query/src/sql/optimizer/s_expr.rs
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::sql::plans::BasePlan;
-use crate::sql::plans::BasePlanImpl;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::sql::plans::Operator;
 use crate::sql::plans::PlanType;
+use crate::sql::plans::RelOperator;
 use crate::sql::IndexType;
 
 /// `SExpr` is abbreviation of single expression, which is a tree of relational operators.
 #[derive(Clone, Debug)]
 pub struct SExpr {
-    plan: BasePlanImpl,
+    plan: RelOperator,
     children: Vec<SExpr>,
 
     original_group: Option<IndexType>,
@@ -28,7 +31,7 @@ pub struct SExpr {
 
 impl SExpr {
     pub fn create(
-        plan: BasePlanImpl,
+        plan: RelOperator,
         children: Vec<SExpr>,
         original_group: Option<IndexType>,
     ) -> Self {
@@ -39,24 +42,30 @@ impl SExpr {
         }
     }
 
-    pub fn create_unary(plan: BasePlanImpl, child: SExpr) -> Self {
+    pub fn create_unary(plan: RelOperator, child: SExpr) -> Self {
         Self::create(plan, vec![child], None)
     }
 
-    pub fn create_binary(plan: BasePlanImpl, left_child: SExpr, right_child: SExpr) -> Self {
+    pub fn create_binary(plan: RelOperator, left_child: SExpr, right_child: SExpr) -> Self {
         Self::create(plan, vec![left_child, right_child], None)
     }
 
-    pub fn create_leaf(plan: BasePlanImpl) -> Self {
+    pub fn create_leaf(plan: RelOperator) -> Self {
         Self::create(plan, vec![], None)
     }
 
-    pub fn plan(&self) -> BasePlanImpl {
+    pub fn plan(&self) -> RelOperator {
         self.plan.clone()
     }
 
     pub fn children(&self) -> &[SExpr] {
         &self.children
+    }
+
+    pub fn child(&self, n: usize) -> Result<&SExpr> {
+        self.children
+            .get(n)
+            .ok_or_else(|| ErrorCode::LogicalError(format!("Invalid children index: {}", n)))
     }
 
     pub fn arity(&self) -> usize {

--- a/query/src/sql/planner/binder/aggregate.rs
+++ b/query/src/sql/planner/binder/aggregate.rs
@@ -29,6 +29,7 @@ use crate::sql::binder::select::SelectList;
 use crate::sql::binder::Binder;
 use crate::sql::binder::ColumnBinding;
 use crate::sql::optimizer::SExpr;
+use crate::sql::planner::metadata::MetadataRef;
 use crate::sql::planner::semantic::GroupingChecker;
 use crate::sql::plans::AggregateFunction;
 use crate::sql::plans::AggregatePlan;
@@ -44,7 +45,6 @@ use crate::sql::plans::Scalar;
 use crate::sql::plans::ScalarExpr;
 use crate::sql::plans::ScalarItem;
 use crate::sql::BindContext;
-use crate::sql::Metadata;
 
 #[derive(Default, Clone, PartialEq, Debug)]
 pub struct AggregateInfo {
@@ -77,11 +77,11 @@ pub struct AggregateInfo {
 
 struct AggregateRewriter<'a> {
     pub bind_context: &'a mut BindContext,
-    pub metadata: &'a mut Metadata,
+    pub metadata: MetadataRef,
 }
 
 impl<'a> AggregateRewriter<'a> {
-    pub fn new(bind_context: &'a mut BindContext, metadata: &'a mut Metadata) -> Self {
+    pub fn new(bind_context: &'a mut BindContext, metadata: MetadataRef) -> Self {
         Self {
             bind_context,
             metadata,
@@ -146,9 +146,11 @@ impl<'a> AggregateRewriter<'a> {
 
         for (i, arg) in aggregate.args.iter().enumerate() {
             let name = format!("{}_arg_{}", &aggregate.func_name, i);
-            let index = self
-                .metadata
-                .add_column(name.clone(), arg.data_type(), None);
+            let index =
+                self.metadata
+                    .write()
+                    .unwrap()
+                    .add_column(name.clone(), arg.data_type(), None);
 
             // Generate a ColumnBinding for each argument of aggregates
             let column_binding = ColumnBinding {
@@ -173,7 +175,7 @@ impl<'a> AggregateRewriter<'a> {
             });
         }
 
-        let index = self.metadata.add_column(
+        let index = self.metadata.write().unwrap().add_column(
             aggregate.display_name.clone(),
             aggregate.return_type.clone(),
             None,
@@ -210,7 +212,7 @@ impl<'a> Binder {
         select_list: &mut SelectList<'a>,
     ) -> Result<()> {
         for item in select_list.items.iter_mut() {
-            let mut rewriter = AggregateRewriter::new(bind_context, &mut self.metadata);
+            let mut rewriter = AggregateRewriter::new(bind_context, self.metadata.clone());
             let new_scalar = rewriter.visit(&item.scalar)?;
             item.scalar = new_scalar;
         }
@@ -225,9 +227,10 @@ impl<'a> Binder {
         bind_context: &mut BindContext,
         having: &Expr<'a>,
     ) -> Result<Scalar> {
-        let scalar_binder = ScalarBinder::new(bind_context, self.ctx.clone());
-        let (scalar, _) = scalar_binder.bind_expr(having).await?;
-        let mut rewriter = AggregateRewriter::new(bind_context, &mut self.metadata);
+        let mut scalar_binder =
+            ScalarBinder::new(bind_context, self.ctx.clone(), self.metadata.clone());
+        let (scalar, _) = scalar_binder.bind(having).await?;
+        let mut rewriter = AggregateRewriter::new(bind_context, self.metadata.clone());
         rewriter.visit(&scalar)
     }
 
@@ -347,9 +350,10 @@ impl<'a> Binder {
             }
 
             // Resolve scalar item and alias item
-            let scalar_binder = ScalarBinder::new(bind_context, self.ctx.clone());
+            let mut scalar_binder =
+                ScalarBinder::new(bind_context, self.ctx.clone(), self.metadata.clone());
             let (scalar_expr, data_type) = scalar_binder
-                .bind_expr(expr)
+                .bind(expr)
                 .await
                 .or_else(|e| Self::resolve_alias_item(expr, available_aliases, e))?;
 
@@ -370,8 +374,11 @@ impl<'a> Binder {
             {
                 *index
             } else {
-                self.metadata
-                    .add_column(group_item_name.clone(), data_type.clone(), None)
+                self.metadata.write().unwrap().add_column(
+                    group_item_name.clone(),
+                    data_type.clone(),
+                    None,
+                )
             };
 
             bind_context.aggregate_info.group_items.push(ScalarItem {

--- a/query/src/sql/planner/binder/aggregate.rs
+++ b/query/src/sql/planner/binder/aggregate.rs
@@ -146,11 +146,10 @@ impl<'a> AggregateRewriter<'a> {
 
         for (i, arg) in aggregate.args.iter().enumerate() {
             let name = format!("{}_arg_{}", &aggregate.func_name, i);
-            let index =
-                self.metadata
-                    .write()
-                    .unwrap()
-                    .add_column(name.clone(), arg.data_type(), None);
+            let index = self
+                .metadata
+                .write()
+                .add_column(name.clone(), arg.data_type(), None);
 
             // Generate a ColumnBinding for each argument of aggregates
             let column_binding = ColumnBinding {
@@ -175,7 +174,7 @@ impl<'a> AggregateRewriter<'a> {
             });
         }
 
-        let index = self.metadata.write().unwrap().add_column(
+        let index = self.metadata.write().add_column(
             aggregate.display_name.clone(),
             aggregate.return_type.clone(),
             None,
@@ -374,11 +373,9 @@ impl<'a> Binder {
             {
                 *index
             } else {
-                self.metadata.write().unwrap().add_column(
-                    group_item_name.clone(),
-                    data_type.clone(),
-                    None,
-                )
+                self.metadata
+                    .write()
+                    .add_column(group_item_name.clone(), data_type.clone(), None)
             };
 
             bind_context.aggregate_info.group_items.push(ScalarItem {

--- a/query/src/sql/planner/binder/bind_context.rs
+++ b/query/src/sql/planner/binder/bind_context.rs
@@ -42,7 +42,7 @@ pub struct ColumnBinding {
 /// `BindContext` stores all the free variables in a query and tracks the context of binding procedure.
 #[derive(Clone, Default, Debug)]
 pub struct BindContext {
-    _parent: Option<Box<BindContext>>,
+    parent: Option<Box<BindContext>>,
     pub columns: Vec<ColumnBinding>,
 
     pub aggregate_info: AggregateInfo,
@@ -60,7 +60,7 @@ impl BindContext {
 
     pub fn with_parent(parent: Box<BindContext>) -> Self {
         BindContext {
-            _parent: Some(parent),
+            parent: Some(parent),
             columns: vec![],
             aggregate_info: Default::default(),
             in_grouping: false,
@@ -108,21 +108,39 @@ impl BindContext {
         table: Option<String>,
         column: &Identifier,
     ) -> Result<ColumnBinding> {
-        // TODO: lookup parent context to support correlated subquery
         let mut result = vec![];
-        if let Some(table) = table {
+
+        let mut bind_context: &BindContext = self;
+        // Lookup parent context to support correlated subquery
+        loop {
             for column_binding in self.columns.iter() {
-                if let Some(table_name) = &column_binding.table_name {
-                    if table_name == &table && column_binding.column_name == column.name {
+                match (&table, &column_binding.table_name) {
+                    // No qualified table name specified
+                    (None, None) | (None, Some(_))
+                        if column.name.to_lowercase() == column_binding.column_name =>
+                    {
                         result.push(column_binding.clone());
                     }
+
+                    // Qualified column reference
+                    (Some(table), Some(table_name))
+                        if table == table_name
+                            && column.name.to_lowercase() == column_binding.column_name =>
+                    {
+                        result.push(column_binding.clone());
+                    }
+                    _ => {}
                 }
             }
-        } else {
-            for column_binding in self.columns.iter() {
-                if column_binding.column_name == column.name {
-                    result.push(column_binding.clone());
-                }
+
+            if !result.is_empty() {
+                break;
+            }
+
+            if let Some(ref parent) = bind_context.parent {
+                bind_context = parent;
+            } else {
+                break;
             }
         }
 

--- a/query/src/sql/planner/binder/limit.rs
+++ b/query/src/sql/planner/binder/limit.rs
@@ -31,7 +31,7 @@ impl<'a> Binder {
         limit: Option<&Expr<'a>>,
         offset: &Option<Expr<'a>>,
     ) -> Result<SExpr> {
-        let type_checker = TypeChecker::new(bind_context, self.ctx.clone());
+        let type_checker = TypeChecker::new(bind_context, self.ctx.clone(), self.metadata.clone());
 
         let limit_cnt = match limit {
             Some(Expr::Literal { span: _, lit: x }) => {

--- a/query/src/sql/planner/binder/mod.rs
+++ b/query/src/sql/planner/binder/mod.rs
@@ -107,11 +107,10 @@ impl<'a> Binder {
         column_name: String,
         data_type: DataTypeImpl,
     ) -> ColumnBinding {
-        let index =
-            self.metadata
-                .write()
-                .unwrap()
-                .add_column(column_name.clone(), data_type.clone(), None);
+        let index = self
+            .metadata
+            .write()
+            .add_column(column_name.clone(), data_type.clone(), None);
         ColumnBinding {
             table_name,
             column_name,

--- a/query/src/sql/planner/binder/mod.rs
+++ b/query/src/sql/planner/binder/mod.rs
@@ -21,10 +21,11 @@ use common_ast::ast::Statement;
 use common_datavalues::DataTypeImpl;
 use common_exception::Result;
 
+use self::subquery::SubqueryRewriter;
 use crate::catalogs::CatalogManager;
 use crate::sessions::QueryContext;
 use crate::sql::optimizer::SExpr;
-use crate::sql::planner::metadata::Metadata;
+use crate::sql::planner::metadata::MetadataRef;
 use crate::storages::Table;
 
 mod aggregate;
@@ -38,6 +39,7 @@ mod scalar_common;
 mod scalar_visitor;
 mod select;
 mod sort;
+mod subquery;
 mod table;
 
 /// Binder is responsible to transform AST of a query into a canonical logical SExpr.
@@ -50,22 +52,28 @@ mod table;
 pub struct Binder {
     ctx: Arc<QueryContext>,
     catalogs: Arc<CatalogManager>,
-    metadata: Metadata,
+    metadata: MetadataRef,
 }
 
 impl<'a> Binder {
-    pub fn new(ctx: Arc<QueryContext>, catalogs: Arc<CatalogManager>) -> Self {
+    pub fn new(
+        ctx: Arc<QueryContext>,
+        catalogs: Arc<CatalogManager>,
+        metadata: MetadataRef,
+    ) -> Self {
         Binder {
             ctx,
             catalogs,
-            metadata: Metadata::create(),
+            metadata,
         }
     }
 
     pub async fn bind(mut self, stmt: &Statement<'a>) -> Result<BindResult> {
         let init_bind_context = BindContext::new();
-        let (s_expr, bind_context) = self.bind_statement(&init_bind_context, stmt).await?;
-        Ok(BindResult::create(s_expr, bind_context, self.metadata))
+        let (mut s_expr, bind_context) = self.bind_statement(&init_bind_context, stmt).await?;
+        let mut rewriter = SubqueryRewriter::new();
+        s_expr = rewriter.rewrite(&s_expr)?;
+        Ok(BindResult::create(s_expr, bind_context))
     }
 
     async fn bind_statement(
@@ -99,9 +107,11 @@ impl<'a> Binder {
         column_name: String,
         data_type: DataTypeImpl,
     ) -> ColumnBinding {
-        let index = self
-            .metadata
-            .add_column(column_name.clone(), data_type.clone(), None);
+        let index =
+            self.metadata
+                .write()
+                .unwrap()
+                .add_column(column_name.clone(), data_type.clone(), None);
         ColumnBinding {
             table_name,
             column_name,
@@ -115,15 +125,13 @@ impl<'a> Binder {
 pub struct BindResult {
     pub s_expr: SExpr,
     pub bind_context: BindContext,
-    pub metadata: Metadata,
 }
 
 impl BindResult {
-    pub fn create(s_expr: SExpr, bind_context: BindContext, metadata: Metadata) -> Self {
+    pub fn create(s_expr: SExpr, bind_context: BindContext) -> Self {
         BindResult {
             s_expr,
             bind_context,
-            metadata,
         }
     }
 }

--- a/query/src/sql/planner/binder/project.rs
+++ b/query/src/sql/planner/binder/project.rs
@@ -165,8 +165,9 @@ impl<'a> Binder {
                     }
                 }
                 SelectTarget::AliasedExpr { expr, alias } => {
-                    let scalar_binder = ScalarBinder::new(input_context, self.ctx.clone());
-                    let (bound_expr, _) = scalar_binder.bind_expr(expr).await?;
+                    let mut scalar_binder =
+                        ScalarBinder::new(input_context, self.ctx.clone(), self.metadata.clone());
+                    let (bound_expr, _) = scalar_binder.bind(expr).await?;
 
                     // If alias is not specified, we will generate a name for the scalar expression.
                     let expr_name = match alias {

--- a/query/src/sql/planner/binder/scalar.rs
+++ b/query/src/sql/planner/binder/scalar.rs
@@ -20,6 +20,7 @@ use common_exception::Result;
 
 use crate::sessions::QueryContext;
 use crate::sql::planner::binder::BindContext;
+use crate::sql::planner::metadata::MetadataRef;
 use crate::sql::planner::semantic::TypeChecker;
 use crate::sql::plans::Scalar;
 
@@ -27,15 +28,25 @@ use crate::sql::plans::Scalar;
 pub struct ScalarBinder<'a> {
     bind_context: &'a BindContext,
     ctx: Arc<QueryContext>,
+    metadata: MetadataRef,
 }
 
 impl<'a> ScalarBinder<'a> {
-    pub fn new(bind_context: &'a BindContext, ctx: Arc<QueryContext>) -> Self {
-        ScalarBinder { bind_context, ctx }
+    pub fn new(
+        bind_context: &'a BindContext,
+        ctx: Arc<QueryContext>,
+        metadata: MetadataRef,
+    ) -> Self {
+        ScalarBinder {
+            bind_context,
+            ctx,
+            metadata,
+        }
     }
 
-    pub async fn bind_expr(&self, expr: &Expr<'a>) -> Result<(Scalar, DataTypeImpl)> {
-        let mut type_checker = TypeChecker::new(self.bind_context, self.ctx.clone());
+    pub async fn bind(&mut self, expr: &Expr<'a>) -> Result<(Scalar, DataTypeImpl)> {
+        let mut type_checker =
+            TypeChecker::new(self.bind_context, self.ctx.clone(), self.metadata.clone());
         type_checker.resolve(expr, None).await
     }
 }

--- a/query/src/sql/planner/binder/select.rs
+++ b/query/src/sql/planner/binder/select.rs
@@ -53,7 +53,7 @@ impl<'a> Binder {
         let (mut s_expr, mut from_context) = if let Some(from) = &stmt.from {
             self.bind_table_reference(bind_context, from).await?
         } else {
-            self.bind_one_table(stmt).await?
+            self.bind_one_table(bind_context, stmt).await?
         };
 
         if let Some(expr) = &stmt.selection {
@@ -157,8 +157,9 @@ impl<'a> Binder {
         expr: &Expr<'a>,
         child: SExpr,
     ) -> Result<SExpr> {
-        let scalar_binder = ScalarBinder::new(bind_context, self.ctx.clone());
-        let (scalar, _) = scalar_binder.bind_expr(expr).await?;
+        let mut scalar_binder =
+            ScalarBinder::new(bind_context, self.ctx.clone(), self.metadata.clone());
+        let (scalar, _) = scalar_binder.bind(expr).await?;
         let filter_plan = FilterPlan {
             predicates: split_conjunctions(&scalar),
             is_having: false,

--- a/query/src/sql/planner/binder/subquery.rs
+++ b/query/src/sql/planner/binder/subquery.rs
@@ -1,0 +1,233 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::sql::binder::ColumnBinding;
+use crate::sql::optimizer::SExpr;
+use crate::sql::plans::AndExpr;
+use crate::sql::plans::BoundColumnRef;
+use crate::sql::plans::CastExpr;
+use crate::sql::plans::CrossApply;
+use crate::sql::plans::FunctionCall;
+use crate::sql::plans::RelOperator;
+use crate::sql::plans::Scalar;
+use crate::sql::plans::SubqueryExpr;
+use crate::sql::plans::SubqueryType;
+
+/// Rewrite subquery into `Apply` operator
+pub struct SubqueryRewriter;
+
+impl SubqueryRewriter {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn rewrite(&mut self, s_expr: &SExpr) -> Result<SExpr> {
+        match s_expr.plan() {
+            RelOperator::EvalScalar(mut plan) => {
+                let input = self.rewrite(s_expr.child(0)?)?;
+
+                let mut expr = input;
+                for item in plan.items.iter_mut() {
+                    let (scalar, subqueries) = self.try_extract_subquery(&item.scalar)?;
+                    item.scalar = scalar;
+                    for subquery in subqueries {
+                        expr = self.build_apply(&expr, &subquery)?;
+                    }
+                }
+
+                Ok(SExpr::create_unary(s_expr.plan(), expr))
+            }
+            RelOperator::Filter(mut plan) => {
+                let input = self.rewrite(s_expr.child(0)?)?;
+
+                let mut expr = input;
+                for pred in plan.predicates.iter_mut() {
+                    let (scalar, subqueries) = self.try_extract_subquery(pred)?;
+                    *pred = scalar;
+                    for subquery in subqueries {
+                        expr = self.build_apply(&expr, &subquery)?;
+                    }
+                }
+
+                Ok(SExpr::create_unary(s_expr.plan(), expr))
+            }
+            RelOperator::Aggregate(mut plan) => {
+                let input = self.rewrite(s_expr.child(0)?)?;
+
+                let mut expr = input;
+                for item in plan.group_items.iter_mut() {
+                    let (scalar, subqueries) = self.try_extract_subquery(&item.scalar)?;
+                    item.scalar = scalar;
+                    for subquery in subqueries {
+                        expr = self.build_apply(&expr, &subquery)?;
+                    }
+                }
+
+                for item in plan.aggregate_functions.iter_mut() {
+                    let (scalar, subqueries) = self.try_extract_subquery(&item.scalar)?;
+                    item.scalar = scalar;
+                    for subquery in subqueries {
+                        expr = self.build_apply(&expr, &subquery)?;
+                    }
+                }
+
+                Ok(SExpr::create_unary(s_expr.plan(), expr))
+            }
+
+            RelOperator::LogicalInnerJoin(_) => Ok(SExpr::create_binary(
+                s_expr.plan(),
+                self.rewrite(s_expr.child(0)?)?,
+                self.rewrite(s_expr.child(1)?)?,
+            )),
+
+            RelOperator::Project(_) | RelOperator::Limit(_) | RelOperator::Sort(_) => Ok(
+                SExpr::create_unary(s_expr.plan(), self.rewrite(s_expr.child(0)?)?),
+            ),
+
+            RelOperator::LogicalGet(_) => Ok(s_expr.clone()),
+
+            RelOperator::CrossApply(_)
+            | RelOperator::PhysicalHashJoin(_)
+            | RelOperator::Pattern(_)
+            | RelOperator::PhysicalScan(_) => Err(ErrorCode::LogicalError("Invalid plan type")),
+        }
+    }
+
+    pub fn build_apply(&mut self, left: &SExpr, subquery: &SubqueryExpr) -> Result<SExpr> {
+        match subquery.typ {
+            SubqueryType::Scalar => {
+                let apply = CrossApply {
+                    correlated_columns: subquery.outer_columns.clone(),
+                };
+                Ok(SExpr::create_binary(
+                    apply.into(),
+                    left.clone(),
+                    subquery.subquery.clone(),
+                ))
+            }
+            _ => Err(ErrorCode::LogicalError(format!(
+                "Unsupported subquery type: {:?}",
+                &subquery.typ
+            ))),
+        }
+    }
+
+    /// Try to extract subquery from a scalar expression. Returns replaced scalar expression
+    /// and the subqueries.
+    fn try_extract_subquery(&mut self, scalar: &Scalar) -> Result<(Scalar, Vec<SubqueryExpr>)> {
+        match scalar {
+            Scalar::BoundColumnRef(_) => Ok((scalar.clone(), vec![])),
+
+            Scalar::ConstantExpr(_) => Ok((scalar.clone(), vec![])),
+
+            Scalar::AndExpr(expr) => {
+                let (left, result_left) = self.try_extract_subquery(&expr.left)?;
+                let (right, result_right) = self.try_extract_subquery(&expr.right)?;
+                Ok((
+                    AndExpr {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    }
+                    .into(),
+                    vec![result_left, result_right].concat(),
+                ))
+            }
+
+            Scalar::OrExpr(expr) => {
+                let (left, result_left) = self.try_extract_subquery(&expr.left)?;
+                let (right, result_right) = self.try_extract_subquery(&expr.right)?;
+                Ok((
+                    AndExpr {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    }
+                    .into(),
+                    vec![result_left, result_right].concat(),
+                ))
+            }
+
+            Scalar::ComparisonExpr(expr) => {
+                let (left, result_left) = self.try_extract_subquery(&expr.left)?;
+                let (right, result_right) = self.try_extract_subquery(&expr.right)?;
+                Ok((
+                    AndExpr {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    }
+                    .into(),
+                    vec![result_left, result_right].concat(),
+                ))
+            }
+
+            Scalar::AggregateFunction(_) => Ok((scalar.clone(), vec![])),
+
+            Scalar::FunctionCall(func) => {
+                let mut args = vec![];
+                let mut s_exprs = vec![];
+                for arg in func.arguments.iter() {
+                    let (scalar, mut subquery) = self.try_extract_subquery(arg)?;
+                    args.push(scalar);
+                    s_exprs.append(&mut subquery);
+                }
+
+                let expr: Scalar = FunctionCall {
+                    arguments: args,
+                    func_name: func.func_name.clone(),
+                    arg_types: func.arg_types.clone(),
+                    return_type: func.return_type.clone(),
+                }
+                .into();
+
+                Ok((expr, s_exprs))
+            }
+
+            Scalar::Cast(cast) => {
+                let (scalar, s_exprs) = self.try_extract_subquery(&cast.argument)?;
+                Ok((
+                    CastExpr {
+                        argument: Box::new(scalar),
+                        from_type: cast.from_type.clone(),
+                        target_type: cast.target_type.clone(),
+                    }
+                    .into(),
+                    s_exprs,
+                ))
+            }
+
+            Scalar::SubqueryExpr(subquery) => {
+                // Extract the subquery and replace it with the ColumnBinding from it.
+                let column = subquery
+                    .output_context
+                    .columns
+                    .get(0)
+                    .ok_or_else(|| ErrorCode::LogicalError("Invalid subquery"))?;
+                let name = format!("subquery_{}", column.index);
+                let column_ref = ColumnBinding {
+                    table_name: None,
+                    column_name: name,
+                    index: column.index,
+                    data_type: subquery.data_type.clone(),
+                    visible_in_unqualified_wildcard: false,
+                };
+
+                Ok((BoundColumnRef { column: column_ref }.into(), vec![
+                    subquery.clone()
+                ]))
+            }
+        }
+    }
+}

--- a/query/src/sql/planner/binder/table.rs
+++ b/query/src/sql/planner/binder/table.rs
@@ -61,7 +61,7 @@ impl<'a> Binder {
             .resolve_data_source(tenant.as_str(), catalog, database, "one")
             .await?;
         let source = table_meta.read_plan(self.ctx.clone(), None).await?;
-        let table_index = self.metadata.write().unwrap().add_table(
+        let table_index = self.metadata.write().add_table(
             CATALOG_DEFAULT.to_owned(),
             database.to_string(),
             table_meta,
@@ -114,7 +114,6 @@ impl<'a> Binder {
                 let table_index = self
                     .metadata
                     .write()
-                    .unwrap()
                     .add_table(catalog, database, table_meta, source);
 
                 let (s_expr, mut bind_context) = self.bind_base_table(bind_context, table_index)?;
@@ -162,7 +161,7 @@ impl<'a> Binder {
                 let table = table_meta.as_table();
 
                 let source = table.read_plan(self.ctx.clone(), None).await?;
-                let table_index = self.metadata.write().unwrap().add_table(
+                let table_index = self.metadata.write().add_table(
                     CATALOG_DEFAULT.to_string(),
                     "system".to_string(),
                     table.clone(),
@@ -192,7 +191,7 @@ impl<'a> Binder {
         table_index: IndexType,
     ) -> Result<(SExpr, BindContext)> {
         let mut bind_context = BindContext::with_parent(Box::new(bind_context.clone()));
-        let metadata = self.metadata.read().unwrap();
+        let metadata = self.metadata.read();
         let columns = metadata.columns_by_table_index(table_index);
         let table = metadata.table(table_index);
         for column in columns.iter() {

--- a/query/src/sql/planner/metadata.rs
+++ b/query/src/sql/planner/metadata.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::sync::RwLock;
 
 use common_ast::ast::Expr;
 use common_ast::ast::Literal;
@@ -21,6 +22,8 @@ use common_planners::ReadDataSourcePlan;
 
 use crate::sql::common::IndexType;
 use crate::storages::Table;
+
+pub type MetadataRef = Arc<RwLock<Metadata>>;
 
 #[derive(Clone)]
 pub struct TableEntry {

--- a/query/src/sql/planner/metadata.rs
+++ b/query/src/sql/planner/metadata.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::sync::RwLock;
 
 use common_ast::ast::Expr;
 use common_ast::ast::Literal;
+use common_base::infallible::RwLock;
 use common_datavalues::prelude::*;
 use common_planners::ReadDataSourcePlan;
 

--- a/query/src/sql/planner/mod.rs
+++ b/query/src/sql/planner/mod.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::sync::RwLock;
 
 use common_ast::parser::error::Backtrace;
 use common_ast::parser::parse_sql;
 use common_ast::parser::tokenize_sql;
+use common_base::infallible::RwLock;
 use common_exception::ErrorCode;
 use common_exception::Result;
 pub use plans::ScalarExpr;

--- a/query/src/sql/planner/mod.rs
+++ b/query/src/sql/planner/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::sync::RwLock;
 
 use common_ast::parser::error::Backtrace;
 use common_ast::parser::parse_sql;
@@ -35,6 +36,7 @@ mod semantic;
 
 pub use metadata::ColumnEntry;
 pub use metadata::Metadata;
+pub use metadata::MetadataRef;
 pub use metadata::TableEntry;
 
 use crate::pipelines::new::NewPipeline;
@@ -59,7 +61,8 @@ impl Planner {
         }
 
         // Step 2: bind AST with catalog, and generate a pure logical SExpr
-        let binder = Binder::new(self.ctx.clone(), self.ctx.get_catalogs());
+        let metadata = Arc::new(RwLock::new(Metadata::create()));
+        let binder = Binder::new(self.ctx.clone(), self.ctx.get_catalogs(), metadata.clone());
         let bind_result = binder.bind(&stmts[0]).await?;
 
         // Step 3: optimize the SExpr with optimizers, and generate optimized physical SExpr
@@ -71,7 +74,7 @@ impl Planner {
         let pb = PipelineBuilder::new(
             self.ctx.clone(),
             result_columns,
-            bind_result.metadata,
+            metadata.clone(),
             optimized_expr,
         );
         let pipelines = pb.spawn()?;

--- a/query/src/sql/planner/plans/aggregate.rs
+++ b/query/src/sql/planner/plans/aggregate.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
+use common_exception::Result;
 
+use crate::sql::optimizer::ColumnSet;
 use crate::sql::optimizer::PhysicalProperty;
+use crate::sql::optimizer::RelExpr;
 use crate::sql::optimizer::RelationalProperty;
 use crate::sql::optimizer::SExpr;
-use crate::sql::plans::BasePlan;
 use crate::sql::plans::LogicalPlan;
+use crate::sql::plans::Operator;
 use crate::sql::plans::PhysicalPlan;
 use crate::sql::plans::PlanType;
 use crate::sql::plans::ScalarItem;
@@ -33,7 +35,7 @@ pub struct AggregatePlan {
     pub from_distinct: bool,
 }
 
-impl BasePlan for AggregatePlan {
+impl Operator for AggregatePlan {
     fn plan_type(&self) -> PlanType {
         PlanType::Aggregate
     }
@@ -46,16 +48,12 @@ impl BasePlan for AggregatePlan {
         true
     }
 
-    fn as_physical(&self) -> Option<&dyn PhysicalPlan> {
-        todo!()
-    }
-
     fn as_logical(&self) -> Option<&dyn LogicalPlan> {
-        todo!()
+        Some(self)
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
+    fn as_physical(&self) -> Option<&dyn PhysicalPlan> {
+        Some(self)
     }
 }
 
@@ -66,7 +64,28 @@ impl PhysicalPlan for AggregatePlan {
 }
 
 impl LogicalPlan for AggregatePlan {
-    fn compute_relational_prop(&self, _expression: &SExpr) -> RelationalProperty {
-        todo!()
+    fn derive_relational_prop<'a>(&self, rel_expr: &RelExpr<'a>) -> Result<RelationalProperty> {
+        let input_prop = rel_expr.derive_relational_prop_child(0)?;
+
+        // Derive output columns
+        let mut output_columns = ColumnSet::new();
+        for group_item in self.group_items.iter() {
+            output_columns.insert(group_item.index);
+        }
+        for agg in self.aggregate_functions.iter() {
+            output_columns.insert(agg.index);
+        }
+
+        // Derive outer columns
+        let outer_columns = input_prop
+            .outer_columns
+            .difference(&output_columns)
+            .cloned()
+            .collect();
+
+        Ok(RelationalProperty {
+            output_columns,
+            outer_columns,
+        })
     }
 }

--- a/query/src/sql/planner/plans/filter.rs
+++ b/query/src/sql/planner/plans/filter.rs
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
+use common_exception::Result;
 
+use crate::sql::optimizer::ColumnSet;
 use crate::sql::optimizer::PhysicalProperty;
+use crate::sql::optimizer::RelExpr;
 use crate::sql::optimizer::RelationalProperty;
 use crate::sql::optimizer::SExpr;
-use crate::sql::plans::BasePlan;
 use crate::sql::plans::LogicalPlan;
+use crate::sql::plans::Operator;
 use crate::sql::plans::PhysicalPlan;
 use crate::sql::plans::PlanType;
 use crate::sql::plans::Scalar;
+use crate::sql::plans::ScalarExpr;
 
 #[derive(Clone, Debug)]
 pub struct FilterPlan {
@@ -30,7 +33,7 @@ pub struct FilterPlan {
     pub is_having: bool,
 }
 
-impl BasePlan for FilterPlan {
+impl Operator for FilterPlan {
     fn plan_type(&self) -> PlanType {
         PlanType::Filter
     }
@@ -44,15 +47,11 @@ impl BasePlan for FilterPlan {
     }
 
     fn as_physical(&self) -> Option<&dyn PhysicalPlan> {
-        todo!()
+        Some(self)
     }
 
     fn as_logical(&self) -> Option<&dyn LogicalPlan> {
-        todo!()
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
+        Some(self)
     }
 }
 
@@ -63,7 +62,25 @@ impl PhysicalPlan for FilterPlan {
 }
 
 impl LogicalPlan for FilterPlan {
-    fn compute_relational_prop(&self, _expression: &SExpr) -> RelationalProperty {
-        todo!()
+    fn derive_relational_prop<'a>(&self, rel_expr: &RelExpr<'a>) -> Result<RelationalProperty> {
+        let input_prop = rel_expr.derive_relational_prop_child(0)?;
+        let output_columns = input_prop.output_columns;
+
+        // Derive outer columns
+        let mut outer_columns = input_prop.outer_columns;
+        for scalar in self.predicates.iter() {
+            let used_columns = scalar.used_columns();
+            let outer = used_columns
+                .difference(&output_columns)
+                .cloned()
+                .collect::<ColumnSet>();
+            outer_columns = outer_columns.union(&outer).cloned().collect();
+        }
+        outer_columns = outer_columns.difference(&output_columns).cloned().collect();
+
+        Ok(RelationalProperty {
+            output_columns,
+            outer_columns,
+        })
     }
 }

--- a/query/src/sql/planner/plans/hash_join.rs
+++ b/query/src/sql/planner/plans/hash_join.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
-
 use crate::sql::optimizer::PhysicalProperty;
 use crate::sql::optimizer::SExpr;
-use crate::sql::plans::BasePlan;
 use crate::sql::plans::LogicalPlan;
+use crate::sql::plans::Operator;
 use crate::sql::plans::PhysicalPlan;
 use crate::sql::plans::PlanType;
 use crate::sql::plans::Scalar;
@@ -28,7 +26,7 @@ pub struct PhysicalHashJoin {
     pub probe_keys: Vec<Scalar>,
 }
 
-impl BasePlan for PhysicalHashJoin {
+impl Operator for PhysicalHashJoin {
     fn plan_type(&self) -> PlanType {
         PlanType::PhysicalHashJoin
     }
@@ -47,10 +45,6 @@ impl BasePlan for PhysicalHashJoin {
 
     fn as_logical(&self) -> Option<&dyn LogicalPlan> {
         None
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/query/src/sql/planner/plans/logical_get.rs
+++ b/query/src/sql/planner/plans/logical_get.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
+use common_exception::Result;
 
 use crate::sql::optimizer::ColumnSet;
+use crate::sql::optimizer::RelExpr;
 use crate::sql::optimizer::RelationalProperty;
-use crate::sql::optimizer::SExpr;
-use crate::sql::plans::BasePlan;
 use crate::sql::plans::LogicalPlan;
+use crate::sql::plans::Operator;
 use crate::sql::plans::PhysicalPlan;
 use crate::sql::plans::PlanType;
 use crate::sql::IndexType;
@@ -29,7 +29,7 @@ pub struct LogicalGet {
     pub columns: ColumnSet,
 }
 
-impl BasePlan for LogicalGet {
+impl Operator for LogicalGet {
     fn plan_type(&self) -> PlanType {
         PlanType::LogicalGet
     }
@@ -42,21 +42,20 @@ impl BasePlan for LogicalGet {
         true
     }
 
+    fn as_logical(&self) -> Option<&dyn LogicalPlan> {
+        Some(self)
+    }
+
     fn as_physical(&self) -> Option<&dyn PhysicalPlan> {
         None
-    }
-
-    fn as_logical(&self) -> Option<&dyn LogicalPlan> {
-        todo!()
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
 impl LogicalPlan for LogicalGet {
-    fn compute_relational_prop(&self, _expression: &SExpr) -> RelationalProperty {
-        todo!()
+    fn derive_relational_prop<'a>(&self, _rel_expr: &RelExpr<'a>) -> Result<RelationalProperty> {
+        Ok(RelationalProperty {
+            output_columns: self.columns.clone(),
+            outer_columns: Default::default(),
+        })
     }
 }

--- a/query/src/sql/planner/plans/pattern.rs
+++ b/query/src/sql/planner/plans/pattern.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
-
-use crate::sql::plans::BasePlan;
 use crate::sql::plans::LogicalPlan;
+use crate::sql::plans::Operator;
 use crate::sql::plans::PhysicalPlan;
 use crate::sql::plans::PlanType;
 
@@ -24,7 +22,7 @@ pub struct PatternPlan {
     pub plan_type: PlanType,
 }
 
-impl BasePlan for PatternPlan {
+impl Operator for PatternPlan {
     fn plan_type(&self) -> PlanType {
         self.plan_type.clone()
     }
@@ -47,9 +45,5 @@ impl BasePlan for PatternPlan {
 
     fn as_logical(&self) -> Option<&dyn LogicalPlan> {
         None
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }

--- a/query/src/sql/planner/plans/physical_scan.rs
+++ b/query/src/sql/planner/plans/physical_scan.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
-
 use crate::sql::optimizer::ColumnSet;
 use crate::sql::optimizer::PhysicalProperty;
 use crate::sql::optimizer::SExpr;
-use crate::sql::plans::BasePlan;
 use crate::sql::plans::LogicalPlan;
+use crate::sql::plans::Operator;
 use crate::sql::plans::PhysicalPlan;
 use crate::sql::plans::PlanType;
 use crate::sql::IndexType;
@@ -29,7 +27,7 @@ pub struct PhysicalScan {
     pub columns: ColumnSet,
 }
 
-impl BasePlan for PhysicalScan {
+impl Operator for PhysicalScan {
     fn plan_type(&self) -> PlanType {
         PlanType::PhysicalScan
     }
@@ -48,10 +46,6 @@ impl BasePlan for PhysicalScan {
 
     fn as_logical(&self) -> Option<&dyn LogicalPlan> {
         None
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/query/src/sql/planner/plans/scalar.rs
+++ b/query/src/sql/planner/plans/scalar.rs
@@ -260,10 +260,21 @@ impl ScalarExpr for CastExpr {
 }
 
 #[derive(Clone, Debug)]
+pub enum SubqueryType {
+    Any,
+    All,
+    Scalar,
+    Exists,
+    NotExists,
+}
+
+#[derive(Clone, Debug)]
 pub struct SubqueryExpr {
+    pub typ: SubqueryType,
     pub subquery: SExpr,
     pub data_type: DataTypeImpl,
     pub allow_multi_rows: bool,
+    pub outer_columns: ColumnSet,
     pub output_context: Box<BindContext>,
 }
 
@@ -273,7 +284,7 @@ impl ScalarExpr for SubqueryExpr {
     }
 
     fn used_columns(&self) -> ColumnSet {
-        todo!()
+        self.outer_columns.clone()
     }
 }
 

--- a/query/src/sql/planner/plans/sort.rs
+++ b/query/src/sql/planner/plans/sort.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
+use common_exception::Result;
 
 use crate::sql::optimizer::PhysicalProperty;
+use crate::sql::optimizer::RelExpr;
 use crate::sql::optimizer::RelationalProperty;
 use crate::sql::optimizer::SExpr;
-use crate::sql::plans::BasePlan;
 use crate::sql::plans::LogicalPlan;
+use crate::sql::plans::Operator;
 use crate::sql::plans::PhysicalPlan;
 use crate::sql::plans::PlanType;
 use crate::sql::IndexType;
@@ -35,7 +36,7 @@ pub struct SortItem {
     pub nulls_first: Option<bool>,
 }
 
-impl BasePlan for SortPlan {
+impl Operator for SortPlan {
     fn plan_type(&self) -> PlanType {
         PlanType::Sort
     }
@@ -49,15 +50,11 @@ impl BasePlan for SortPlan {
     }
 
     fn as_physical(&self) -> Option<&dyn PhysicalPlan> {
-        todo!()
+        Some(self)
     }
 
     fn as_logical(&self) -> Option<&dyn LogicalPlan> {
-        todo!()
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
+        Some(self)
     }
 }
 
@@ -68,7 +65,7 @@ impl PhysicalPlan for SortPlan {
 }
 
 impl LogicalPlan for SortPlan {
-    fn compute_relational_prop(&self, _expression: &SExpr) -> RelationalProperty {
-        todo!()
+    fn derive_relational_prop<'a>(&self, rel_expr: &RelExpr<'a>) -> Result<RelationalProperty> {
+        rel_expr.derive_relational_prop_child(0)
     }
 }

--- a/query/tests/it/sql/optimizer/pattern_extractor.rs
+++ b/query/tests/it/sql/optimizer/pattern_extractor.rs
@@ -16,7 +16,7 @@ use databend_query::sql::optimizer::MExpr;
 use databend_query::sql::optimizer::Memo;
 use databend_query::sql::optimizer::PatternExtractor;
 use databend_query::sql::optimizer::SExpr;
-use databend_query::sql::plans::BasePlan;
+use databend_query::sql::plans::Operator;
 use databend_query::sql::plans::PatternPlan;
 use databend_query::sql::plans::PlanType;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Translate subqueries into apply operators, so we can represent all the subqueries(correlated or uncorrelated) with relational algebra.

Besides, this PR also refines the property derivation mechanism with `RelExpr`.

## Changelog

- New Feature

## Related Issues

Part of #5210 

