### PR TITLE
feature(planner): Common tree structure formatter for plan display

### DIFF
--- a/query/src/sql/optimizer/cascades/mod.rs
+++ b/query/src/sql/optimizer/cascades/mod.rs
@@ -180,7 +180,7 @@ impl CascadesOptimizer {
                 // }
 
                 let children = self.optimize_m_expr(m_expr, required_prop)?;
-                let result = SExpr::create(plan, children, None);
+                let result = SExpr::create(plan.clone(), children, None);
                 return Ok(result);
             }
         }

--- a/query/src/sql/optimizer/heuristic/mod.rs
+++ b/query/src/sql/optimizer/heuristic/mod.rs
@@ -47,7 +47,7 @@ impl HeuristicOptimizer {
         for expr in s_expr.children() {
             optimized_children.push(self.optimize_expression(expr)?);
         }
-        let optimized_expr = SExpr::create(s_expr.plan(), optimized_children, None);
+        let optimized_expr = SExpr::create(s_expr.plan().clone(), optimized_children, None);
         let result = self.apply_transform_rules(&optimized_expr, &self.rules)?;
 
         Ok(result)

--- a/query/src/sql/optimizer/m_expr.rs
+++ b/query/src/sql/optimizer/m_expr.rs
@@ -49,8 +49,8 @@ impl MExpr {
         self.group_index
     }
 
-    pub fn plan(&self) -> RelOperator {
-        self.plan.clone()
+    pub fn plan(&self) -> &RelOperator {
+        &self.plan
     }
 
     pub fn children(&self) -> &Vec<IndexType> {

--- a/query/src/sql/optimizer/memo.rs
+++ b/query/src/sql/optimizer/memo.rs
@@ -88,7 +88,7 @@ impl Memo {
 
         let plan = expression.plan();
 
-        let group_expression = MExpr::create(group_index, plan, children_group);
+        let group_expression = MExpr::create(group_index, plan.clone(), children_group);
         self.insert_m_expr(group_index, group_expression)?;
 
         Ok(group_index)

--- a/query/src/sql/optimizer/pattern_extractor.rs
+++ b/query/src/sql/optimizer/pattern_extractor.rs
@@ -33,7 +33,7 @@ impl PatternExtractor {
         if pattern.is_pattern() {
             // Pattern operator is `Pattern`, we can return current operator.
             return vec![SExpr::create(
-                m_expr.plan(),
+                m_expr.plan().clone(),
                 vec![],
                 Some(m_expr.group_index()),
             )];
@@ -84,7 +84,7 @@ impl PatternExtractor {
 
         if cursors.is_empty() {
             results.push(SExpr::create(
-                m_expr.plan(),
+                m_expr.plan().clone(),
                 vec![],
                 Some(m_expr.group_index()),
             ));
@@ -97,7 +97,7 @@ impl PatternExtractor {
                 children.push(candidates[index][*cursor].clone());
             }
             results.push(SExpr::create(
-                m_expr.plan(),
+                m_expr.plan().clone(),
                 children,
                 Some(m_expr.group_index()),
             ));

--- a/query/src/sql/optimizer/rule/rule_implement_get.rs
+++ b/query/src/sql/optimizer/rule/rule_implement_get.rs
@@ -48,7 +48,7 @@ impl Rule for RuleImplementGet {
     }
 
     fn apply(&self, expression: &SExpr, state: &mut TransformState) -> Result<()> {
-        let plan = expression.plan();
+        let plan = expression.plan().clone();
         let logical_get: LogicalGet = plan.try_into()?;
 
         let result = SExpr::create_leaf(

--- a/query/src/sql/optimizer/rule/rule_implement_hash_join.rs
+++ b/query/src/sql/optimizer/rule/rule_implement_hash_join.rs
@@ -60,7 +60,7 @@ impl Rule for RuleImplementHashJoin {
     }
 
     fn apply(&self, expression: &SExpr, state: &mut TransformState) -> Result<()> {
-        let plan = expression.plan();
+        let plan = expression.plan().clone();
         let logical_inner_join: LogicalInnerJoin = plan.try_into()?;
 
         let result = SExpr::create(

--- a/query/src/sql/optimizer/s_expr.rs
+++ b/query/src/sql/optimizer/s_expr.rs
@@ -54,8 +54,8 @@ impl SExpr {
         Self::create(plan, vec![], None)
     }
 
-    pub fn plan(&self) -> RelOperator {
-        self.plan.clone()
+    pub fn plan(&self) -> &RelOperator {
+        &self.plan
     }
 
     pub fn children(&self) -> &[SExpr] {

--- a/query/src/sql/planner/binder/subquery.rs
+++ b/query/src/sql/planner/binder/subquery.rs
@@ -36,7 +36,7 @@ impl SubqueryRewriter {
     }
 
     pub fn rewrite(&mut self, s_expr: &SExpr) -> Result<SExpr> {
-        match s_expr.plan() {
+        match s_expr.plan().clone() {
             RelOperator::EvalScalar(mut plan) => {
                 let input = self.rewrite(s_expr.child(0)?)?;
 
@@ -49,7 +49,7 @@ impl SubqueryRewriter {
                     }
                 }
 
-                Ok(SExpr::create_unary(s_expr.plan(), expr))
+                Ok(SExpr::create_unary(s_expr.plan().clone(), expr))
             }
             RelOperator::Filter(mut plan) => {
                 let input = self.rewrite(s_expr.child(0)?)?;
@@ -63,7 +63,7 @@ impl SubqueryRewriter {
                     }
                 }
 
-                Ok(SExpr::create_unary(s_expr.plan(), expr))
+                Ok(SExpr::create_unary(s_expr.plan().clone(), expr))
             }
             RelOperator::Aggregate(mut plan) => {
                 let input = self.rewrite(s_expr.child(0)?)?;
@@ -85,17 +85,17 @@ impl SubqueryRewriter {
                     }
                 }
 
-                Ok(SExpr::create_unary(s_expr.plan(), expr))
+                Ok(SExpr::create_unary(s_expr.plan().clone(), expr))
             }
 
             RelOperator::LogicalInnerJoin(_) => Ok(SExpr::create_binary(
-                s_expr.plan(),
+                s_expr.plan().clone(),
                 self.rewrite(s_expr.child(0)?)?,
                 self.rewrite(s_expr.child(1)?)?,
             )),
 
             RelOperator::Project(_) | RelOperator::Limit(_) | RelOperator::Sort(_) => Ok(
-                SExpr::create_unary(s_expr.plan(), self.rewrite(s_expr.child(0)?)?),
+                SExpr::create_unary(s_expr.plan().clone(), self.rewrite(s_expr.child(0)?)?),
             ),
 
             RelOperator::LogicalGet(_) => Ok(s_expr.clone()),

--- a/query/src/sql/planner/format/display_rel_operator.rs
+++ b/query/src/sql/planner/format/display_rel_operator.rs
@@ -1,0 +1,300 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Display;
+
+use common_datavalues::format_data_type_sql;
+
+use super::FormatTreeNode;
+use crate::sql::optimizer::SExpr;
+use crate::sql::plans::AggregatePlan;
+use crate::sql::plans::AndExpr;
+use crate::sql::plans::ComparisonExpr;
+use crate::sql::plans::ComparisonOp;
+use crate::sql::plans::CrossApply;
+use crate::sql::plans::EvalScalar;
+use crate::sql::plans::FilterPlan;
+use crate::sql::plans::LimitPlan;
+use crate::sql::plans::LogicalGet;
+use crate::sql::plans::LogicalInnerJoin;
+use crate::sql::plans::PhysicalHashJoin;
+use crate::sql::plans::PhysicalScan;
+use crate::sql::plans::Project;
+use crate::sql::plans::RelOperator;
+use crate::sql::plans::Scalar;
+use crate::sql::plans::SortPlan;
+use crate::sql::MetadataRef;
+
+pub struct FormatContext {
+    metadata: MetadataRef,
+    rel_operator: RelOperator,
+}
+
+impl SExpr {
+    pub fn to_format_tree(&self, metadata: &MetadataRef) -> FormatTreeNode<FormatContext> {
+        let children: Vec<FormatTreeNode<FormatContext>> = self
+            .children()
+            .iter()
+            .map(|child| child.to_format_tree(metadata))
+            .collect();
+
+        FormatTreeNode::with_children(
+            FormatContext {
+                metadata: metadata.clone(),
+                rel_operator: self.plan().clone(),
+            },
+            children,
+        )
+    }
+}
+
+impl Display for FormatContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.rel_operator {
+            RelOperator::LogicalGet(op) => format_logical_get(f, &self.metadata, op),
+            RelOperator::LogicalInnerJoin(op) => format_logical_inner_join(f, &self.metadata, op),
+            RelOperator::PhysicalScan(op) => format_physical_scan(f, &self.metadata, op),
+            RelOperator::PhysicalHashJoin(op) => format_hash_join(f, &self.metadata, op),
+            RelOperator::Project(op) => format_project(f, &self.metadata, op),
+            RelOperator::EvalScalar(op) => format_eval_scalar(f, &self.metadata, op),
+            RelOperator::Filter(op) => format_filter(f, &self.metadata, op),
+            RelOperator::Aggregate(op) => format_aggregate(f, &self.metadata, op),
+            RelOperator::Sort(op) => format_sort(f, &self.metadata, op),
+            RelOperator::Limit(op) => format_limit(f, &self.metadata, op),
+            RelOperator::CrossApply(op) => format_cross_apply(f, &self.metadata, op),
+            RelOperator::Pattern(_) => write!(f, "Pattern"),
+        }
+    }
+}
+
+pub fn format_scalar(metadata: &MetadataRef, scalar: &Scalar) -> String {
+    match scalar {
+        Scalar::BoundColumnRef(column_ref) => column_ref.column.column_name.clone(),
+        Scalar::ConstantExpr(constant) => constant.value.to_string(),
+        Scalar::AndExpr(and) => format!(
+            "{} AND {}",
+            format_scalar(metadata, &and.left),
+            format_scalar(metadata, &and.right)
+        ),
+        Scalar::OrExpr(or) => format!(
+            "{} OR {}",
+            format_scalar(metadata, &or.left),
+            format_scalar(metadata, &or.right)
+        ),
+        Scalar::ComparisonExpr(comp) => format!(
+            "{} {} {}",
+            format_scalar(metadata, &comp.left),
+            comp.op.to_func_name(),
+            format_scalar(metadata, &comp.right)
+        ),
+        Scalar::AggregateFunction(agg) => agg.display_name.clone(),
+        Scalar::FunctionCall(func) => {
+            format!(
+                "{}({})",
+                &func.func_name,
+                func.arguments
+                    .iter()
+                    .map(|arg| { format_scalar(metadata, arg) })
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            )
+        }
+        Scalar::Cast(cast) => {
+            format!(
+                "CAST({} AS {})",
+                format_scalar(metadata, &cast.argument),
+                format_data_type_sql(&cast.target_type)
+            )
+        }
+        Scalar::SubqueryExpr(_) => "SUBQUERY".to_string(),
+    }
+}
+
+pub fn format_logical_get(
+    f: &mut std::fmt::Formatter<'_>,
+    metadata: &MetadataRef,
+    op: &LogicalGet,
+) -> std::fmt::Result {
+    let table = metadata.read().table(op.table_index).clone();
+    write!(
+        f,
+        "LogicalGet: {}.{}.{}",
+        &table.catalog, &table.database, &table.name
+    )
+}
+
+pub fn format_logical_inner_join(
+    f: &mut std::fmt::Formatter<'_>,
+    metadata: &MetadataRef,
+    op: &LogicalInnerJoin,
+) -> std::fmt::Result {
+    let preds: Vec<Scalar> = op
+        .left_conditions
+        .iter()
+        .zip(op.right_conditions.iter())
+        .map(|(left, right)| {
+            ComparisonExpr {
+                op: ComparisonOp::Equal,
+                left: Box::new(left.clone()),
+                right: Box::new(right.clone()),
+            }
+            .into()
+        })
+        .collect();
+    let pred: Scalar = preds.iter().fold(preds[0].clone(), |prev, next| {
+        Scalar::AndExpr(AndExpr {
+            left: Box::new(prev),
+            right: Box::new(next.clone()),
+        })
+    });
+    write!(f, "LogicalInnerJoin: {}", format_scalar(metadata, &pred))
+}
+
+pub fn format_hash_join(
+    f: &mut std::fmt::Formatter<'_>,
+    metadata: &MetadataRef,
+    op: &PhysicalHashJoin,
+) -> std::fmt::Result {
+    let build_keys = op
+        .build_keys
+        .iter()
+        .map(|scalar| format_scalar(metadata, scalar))
+        .collect::<Vec<String>>()
+        .join(", ");
+    let probe_keys = op
+        .probe_keys
+        .iter()
+        .map(|scalar| format_scalar(metadata, scalar))
+        .collect::<Vec<String>>()
+        .join(", ");
+    write!(
+        f,
+        "PhysicalHashJoin: build keys: [{}], probe keys: [{}]",
+        build_keys, probe_keys
+    )
+}
+
+pub fn format_physical_scan(
+    f: &mut std::fmt::Formatter<'_>,
+    metadata: &MetadataRef,
+    op: &PhysicalScan,
+) -> std::fmt::Result {
+    let table = metadata.read().table(op.table_index).clone();
+    write!(
+        f,
+        "PhysicalScan: {}.{}.{}",
+        &table.catalog, &table.database, &table.name
+    )
+}
+
+pub fn format_project(
+    f: &mut std::fmt::Formatter<'_>,
+    _metadata: &MetadataRef,
+    _op: &Project,
+) -> std::fmt::Result {
+    write!(f, "Project")
+}
+
+pub fn format_eval_scalar(
+    f: &mut std::fmt::Formatter<'_>,
+    metadata: &MetadataRef,
+    op: &EvalScalar,
+) -> std::fmt::Result {
+    let scalars = op
+        .items
+        .iter()
+        .map(|item| format_scalar(metadata, &item.scalar))
+        .collect::<Vec<String>>()
+        .join(", ");
+    write!(f, "EvalScalar: [{}]", scalars)
+}
+
+pub fn format_filter(
+    f: &mut std::fmt::Formatter<'_>,
+    metadata: &MetadataRef,
+    op: &FilterPlan,
+) -> std::fmt::Result {
+    let scalars = op
+        .predicates
+        .iter()
+        .map(|scalar| format_scalar(metadata, scalar))
+        .collect::<Vec<String>>()
+        .join(", ");
+    write!(f, "Filter: [{}]", scalars)
+}
+
+pub fn format_aggregate(
+    f: &mut std::fmt::Formatter<'_>,
+    metadata: &MetadataRef,
+    op: &AggregatePlan,
+) -> std::fmt::Result {
+    let group_items = op
+        .group_items
+        .iter()
+        .map(|item| format_scalar(metadata, &item.scalar))
+        .collect::<Vec<String>>()
+        .join(", ");
+    let agg_funcs = op
+        .aggregate_functions
+        .iter()
+        .map(|item| format_scalar(metadata, &item.scalar))
+        .collect::<Vec<String>>()
+        .join(", ");
+    write!(
+        f,
+        "Aggregate: group items: [{}], aggregate functions: [{}]",
+        group_items, agg_funcs
+    )
+}
+
+pub fn format_sort(
+    f: &mut std::fmt::Formatter<'_>,
+    metadata: &MetadataRef,
+    op: &SortPlan,
+) -> std::fmt::Result {
+    let scalars = op
+        .items
+        .iter()
+        .map(|item| {
+            let name = metadata.read().column(item.index).name.clone();
+            format!(
+                "{} {}",
+                name,
+                if item.asc.unwrap_or(false) {
+                    "ASC"
+                } else {
+                    "DESC"
+                }
+            )
+        })
+        .collect::<Vec<String>>()
+        .join(", ");
+    write!(f, "Sort: [{}]", scalars)
+}
+
+pub fn format_limit(
+    f: &mut std::fmt::Formatter<'_>,
+    _metadata: &MetadataRef,
+    _op: &LimitPlan,
+) -> std::fmt::Result {
+    write!(f, "Limit")
+}
+
+pub fn format_cross_apply(
+    f: &mut std::fmt::Formatter<'_>,
+    _metadata: &MetadataRef,
+    _op: &CrossApply,
+) -> std::fmt::Result {
+    write!(f, "CrossApply")
+}

--- a/query/src/sql/planner/format/indent_format.rs
+++ b/query/src/sql/planner/format/indent_format.rs
@@ -12,26 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod display_rel_operator;
 use std::fmt::Display;
-mod indent_format;
+use std::fmt::Write;
 
-pub struct FormatTreeNode<T: Display> {
-    payload: T,
-    children: Vec<Self>,
-}
+use common_exception::Result;
+
+use super::FormatTreeNode;
+
+static INDENT_SIZE: usize = 4;
 
 impl<T> FormatTreeNode<T>
 where T: Display
 {
-    pub fn new(payload: T) -> Self {
-        Self {
-            payload,
-            children: vec![],
-        }
+    pub fn format_indent(&self) -> Result<String> {
+        let mut buf = String::new();
+        self.format_indent_impl(0, &mut buf)?;
+        Ok(buf)
     }
 
-    pub fn with_children(payload: T, children: Vec<Self>) -> Self {
-        Self { payload, children }
+    fn format_indent_impl(&self, indent: usize, f: &mut String) -> Result<()> {
+        writeln!(f, "{}{}", " ".repeat(indent), &self.payload).unwrap();
+        for child in self.children.iter() {
+            child.format_indent_impl(indent + INDENT_SIZE, f)?;
+        }
+        Ok(())
     }
 }

--- a/query/src/sql/planner/format/mod.rs
+++ b/query/src/sql/planner/format/mod.rs
@@ -1,0 +1,13 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/query/src/sql/planner/mod.rs
+++ b/query/src/sql/planner/mod.rs
@@ -35,6 +35,8 @@ mod metadata;
 pub mod plans;
 mod semantic;
 
+pub use binder::ColumnBinding;
+pub use format::FormatTreeNode;
 pub use metadata::ColumnEntry;
 pub use metadata::Metadata;
 pub use metadata::MetadataRef;

--- a/query/src/sql/planner/mod.rs
+++ b/query/src/sql/planner/mod.rs
@@ -30,6 +30,7 @@ pub use crate::sql::planner::binder::BindContext;
 use crate::sql::planner::binder::Binder;
 
 pub(crate) mod binder;
+mod format;
 mod metadata;
 pub mod plans;
 mod semantic;

--- a/query/tests/it/sql/mod.rs
+++ b/query/tests/it/sql/mod.rs
@@ -17,5 +17,6 @@ mod expr_parser;
 mod optimizer;
 mod parsers;
 mod plan_parser;
+mod planner;
 mod sql_parser;
 mod statements;

--- a/query/tests/it/sql/planner/format/mod.rs
+++ b/query/tests/it/sql/planner/format/mod.rs
@@ -1,0 +1,181 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_base::infallible::RwLock;
+use common_datavalues::BooleanType;
+use common_datavalues::DataSchemaRefExt;
+use common_datavalues::DataValue;
+use common_meta_types::TableIdent;
+use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
+use common_planners::ReadDataSourcePlan;
+use common_planners::SourceInfo;
+use common_planners::Statistics;
+use databend_query::sql::optimizer::SExpr;
+use databend_query::sql::plans::BoundColumnRef;
+use databend_query::sql::plans::ConstantExpr;
+use databend_query::sql::plans::FilterPlan;
+use databend_query::sql::plans::FunctionCall;
+use databend_query::sql::plans::PhysicalHashJoin;
+use databend_query::sql::plans::PhysicalScan;
+use databend_query::sql::ColumnBinding;
+use databend_query::sql::Metadata;
+use databend_query::storages::Table;
+
+struct DummyTable {
+    table_info: TableInfo,
+}
+
+impl DummyTable {
+    pub fn new(table_name: String) -> Self {
+        Self {
+            table_info: TableInfo {
+                ident: TableIdent::new(0, 0),
+                desc: "".to_string(),
+                name: table_name,
+                meta: TableMeta {
+                    schema: DataSchemaRefExt::create(vec![]),
+                    ..Default::default()
+                },
+            },
+        }
+    }
+}
+
+impl Table for DummyTable {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn get_table_info(&self) -> &TableInfo {
+        &self.table_info
+    }
+}
+
+fn get_dummy_read_source() -> ReadDataSourcePlan {
+    ReadDataSourcePlan {
+        catalog: "".to_string(),
+        source_info: SourceInfo::TableSource(TableInfo {
+            ident: TableIdent::new(0, 0),
+            desc: "".to_string(),
+            name: "".to_string(),
+            meta: TableMeta {
+                schema: DataSchemaRefExt::create(vec![]),
+                ..Default::default()
+            },
+        }),
+        scan_fields: None,
+        parts: vec![],
+        statistics: Statistics {
+            read_rows: 0,
+            read_bytes: 0,
+            partitions_scanned: 0,
+            partitions_total: 0,
+            is_exact: false,
+        },
+        description: "".to_string(),
+        tbl_args: None,
+        push_downs: None,
+    }
+}
+
+#[test]
+fn test_format() {
+    let mut metadata = Metadata::create();
+    let col1 = metadata.add_column("col1".to_string(), BooleanType::new_impl(), None);
+    let col2 = metadata.add_column("col2".to_string(), BooleanType::new_impl(), None);
+    let tab1 = metadata.add_table(
+        "catalog".to_string(),
+        "database".to_string(),
+        Arc::new(DummyTable::new("table".to_string())),
+        get_dummy_read_source(),
+    );
+
+    let s_expr = SExpr::create_binary(
+        PhysicalHashJoin {
+            build_keys: vec![FunctionCall {
+                func_name: "plus".to_string(),
+                arg_types: vec![],
+                arguments: vec![
+                    BoundColumnRef {
+                        column: ColumnBinding {
+                            table_name: None,
+                            column_name: "col1".to_string(),
+                            index: col1,
+                            data_type: BooleanType::new_impl(),
+                            visible_in_unqualified_wildcard: false,
+                        },
+                    }
+                    .into(),
+                    ConstantExpr {
+                        value: DataValue::UInt64(123),
+                        data_type: BooleanType::new_impl(),
+                    }
+                    .into(),
+                ],
+                return_type: BooleanType::new_impl(),
+            }
+            .into()],
+            probe_keys: vec![BoundColumnRef {
+                column: ColumnBinding {
+                    table_name: None,
+                    column_name: "col2".to_string(),
+                    index: col2,
+                    data_type: BooleanType::new_impl(),
+                    visible_in_unqualified_wildcard: false,
+                },
+            }
+            .into()],
+        }
+        .into(),
+        SExpr::create_unary(
+            FilterPlan {
+                predicates: vec![ConstantExpr {
+                    value: DataValue::Boolean(true),
+                    data_type: BooleanType::new_impl(),
+                }
+                .into()],
+                is_having: false,
+            }
+            .into(),
+            SExpr::create_leaf(
+                PhysicalScan {
+                    table_index: tab1,
+                    columns: Default::default(),
+                }
+                .into(),
+            ),
+        ),
+        SExpr::create_leaf(
+            PhysicalScan {
+                table_index: tab1,
+                columns: Default::default(),
+            }
+            .into(),
+        ),
+    );
+
+    let metadata_ref = Arc::new(RwLock::new(metadata));
+
+    let tree = s_expr.to_format_tree(&metadata_ref);
+    let result = tree.format_indent().unwrap();
+    let expect = r#"PhysicalHashJoin: build keys: [plus(col1, 123)], probe keys: [col2]
+    Filter: [true]
+        PhysicalScan: catalog.database.table
+    PhysicalScan: catalog.database.table
+"#;
+    assert_eq!(result.as_str(), expect);
+}

--- a/query/tests/it/sql/planner/mod.rs
+++ b/query/tests/it/sql/planner/mod.rs
@@ -12,26 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod display_rel_operator;
-use std::fmt::Display;
-mod indent_format;
-
-pub struct FormatTreeNode<T: Display> {
-    payload: T,
-    children: Vec<Self>,
-}
-
-impl<T> FormatTreeNode<T>
-where T: Display
-{
-    pub fn new(payload: T) -> Self {
-        Self {
-            payload,
-            children: vec![],
-        }
-    }
-
-    pub fn with_children(payload: T, children: Vec<Self>) -> Self {
-        Self { payload, children }
-    }
-}
+mod format;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Introduce a common formatting mechanism for tree stucture, so we can exploit it to imlement `EXPLAIN` and so on.

A indent format is implemented, here's an example:
```
PhysicalHashJoin: build keys: [plus(col1, 123)], probe keys: [col2]
    Filter: [true]
        PhysicalScan: catalog.database.table
    PhysicalScan: catalog.database.table
```

## Changelog

- New Feature

## Related Issues

Close #5491 
