### PR TITLE
fix(scripts): deploy minio in k8s failed

### DIFF
--- a/scripts/kubernetes/minio-sample.yaml
+++ b/scripts/kubernetes/minio-sample.yaml
@@ -1,4 +1,26 @@
 ---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: minio-pv-volume
+  labels:
+    type: local
+spec:
+  storageClassName: local-storage
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -7,6 +29,7 @@ metadata:
   labels:
     app: minio-storage-claim
 spec:
+  storageClassName: local-storage
   # Read more about access modes here:
   # http://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes
   accessModes:


### PR DESCRIPTION
Signed-off-by: hantmac <hantmac@outlook.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
Add `StorageClass` and `PV` yaml for deploying databend in k8s cluster.
Fix `PVC` definition.

## Changelog

- Bug Fix

## Related Issues

Fixes [ #issue](https://github.com/datafuselabs/databend/issues/5524)

