### PR TITLE
feat: data time travel "select at"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6014,6 +6014,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.13.1-alpha.0"
+source = "git+https://github.com/datafuse-extras/sqlparser-rs?rev=7d74a3c#7d74a3c5fc78f8d0c0f7e4e7e14d7058f94d8841"
 dependencies = [
  "hashbrown 0.12.0",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6014,7 +6014,6 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.13.1-alpha.0"
-source = "git+https://github.com/datafuse-extras/sqlparser-rs?rev=45ead90#45ead90755aa86d5ff3f0faaa6c112d057b3494a"
 dependencies = [
  "hashbrown 0.12.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ members = [
     "tools/fuzz",
     "tools/metactl",
 ]
-exclude = ["patch/sqlparser-rs"]
 
 [profile.release]
 debug = 1
@@ -67,6 +66,3 @@ rustc-demangle = { opt-level = 3 }
 [patch.crates-io]
 parquet2 = { version = "0.12", optional = true, git = "https://github.com/datafuse-extras/parquet2", rev = "03c108b" }
 chrono = { git = "https://github.com/datafuse-extras/chrono", rev = "279f590" }
-
-[patch.'https://github.com/datafuse-extras/sqlparser-rs']
-sqlparser = { path = './patch/sqlparser-rs' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "tools/fuzz",
     "tools/metactl",
 ]
+exclude = ["patch/sqlparser-rs"]
 
 [profile.release]
 debug = 1
@@ -66,3 +67,6 @@ rustc-demangle = { opt-level = 3 }
 [patch.crates-io]
 parquet2 = { version = "0.12", optional = true, git = "https://github.com/datafuse-extras/parquet2", rev = "03c108b" }
 chrono = { git = "https://github.com/datafuse-extras/chrono", rev = "279f590" }
+
+[patch.'https://github.com/datafuse-extras/sqlparser-rs']
+sqlparser = { path = './patch/sqlparser-rs' }

--- a/common/ast/Cargo.toml
+++ b/common/ast/Cargo.toml
@@ -21,7 +21,7 @@ common-meta-types = { path = "../meta/types" }
 # TODO(andylokandy): Use the version from crates.io once
 # https://github.com/brendanzab/codespan/pull/331 is released.
 codespan-reporting = { git = "https://github.com/brendanzab/codespan", rev = "c84116f5" }
-sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "45ead90" }
+sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "7d74a3c" }
 
 # Crates.io dependencies
 async-trait = "0.1.53"

--- a/common/exception/Cargo.toml
+++ b/common/exception/Cargo.toml
@@ -25,4 +25,4 @@ tonic = "=0.6.2"
 
 # Github dependencies
 bincode = { git = "https://github.com/datafuse-extras/bincode", rev = "fd3f9ff" }
-sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "45ead90" }
+sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "7d74a3c" }

--- a/common/functions/Cargo.toml
+++ b/common/functions/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0.79"
 sha1 = "0.10.1"
 sha2 = "0.10.2"
 simdutf8 = "0.1.4"
-sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "45ead90" }
+sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "7d74a3c" }
 strength_reduce = "0.2.3"
 twox-hash = "1.6.2"
 uuid = { version = "0.8.2", features = ["v4"] }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -56,7 +56,7 @@ common-tracing = { path = "../common/tracing" }
 bincode = { git = "https://github.com/datafuse-extras/bincode", rev = "fd3f9ff" }
 opensrv-clickhouse = { git = "https://github.com/datafuselabs/opensrv", rev = "15786d3", package = "opensrv-clickhouse" }
 opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "967477f1", package = "opensrv-mysql" }
-sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "45ead90" }
+sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "7d74a3c" }
 
 # Crates.io dependencies
 ahash = "0.7.6"

--- a/query/src/storages/fuse/io/read/meta_readers.rs
+++ b/query/src/storages/fuse/io/read/meta_readers.rs
@@ -106,7 +106,7 @@ impl<'a> TableSnapshotReader<'a> {
         location: String,
         format_version: u64,
         location_gen: TableMetaLocationGenerator,
-    ) -> Pin<Box<dyn futures::stream::Stream<Item = Result<Arc<TableSnapshot>>> + 'a>> {
+    ) -> Pin<Box<dyn futures::stream::Stream<Item = Result<Arc<TableSnapshot>>> + 'a + Send>> {
         let stream = stream::try_unfold(
             (self, location_gen, Some((location, format_version))),
             |(reader, gen, next)| async move {

--- a/query/src/storages/fuse/operations/navigate.rs
+++ b/query/src/storages/fuse/operations/navigate.rs
@@ -25,14 +25,42 @@ use futures::TryStreamExt;
 use crate::sessions::QueryContext;
 use crate::sql::OPT_KEY_SNAPSHOT_LOCATION;
 use crate::storages::fuse::io::MetaReaders;
+use crate::storages::fuse::meta::TableSnapshot;
 use crate::storages::fuse::FuseTable;
 
 impl FuseTable {
-    pub async fn navigate(
+    pub async fn navigate_to_time_point(
         &self,
         ctx: &Arc<QueryContext>,
         time_point: DateTime<Utc>,
     ) -> Result<Arc<FuseTable>> {
+        self.find(ctx.as_ref(), |snapshot| {
+            if let Some(ts) = snapshot.timestamp {
+                ts <= time_point
+            } else {
+                false
+            }
+        })
+        .await
+    }
+    pub async fn navigate_to_snapshot(
+        &self,
+        ctx: &QueryContext,
+        snapshot_id: &str,
+    ) -> Result<Arc<FuseTable>> {
+        self.find(ctx, |snapshot| {
+            snapshot
+                .snapshot_id
+                .to_simple()
+                .to_string()
+                .as_str()
+                .starts_with(snapshot_id)
+        })
+        .await
+    }
+
+    pub async fn find<P>(&self, ctx: &QueryContext, mut pred: P) -> Result<Arc<FuseTable>>
+    where P: FnMut(&TableSnapshot) -> bool {
         let snapshot_location = if let Some(loc) = self.snapshot_loc() {
             loc
         } else {
@@ -56,12 +84,9 @@ impl FuseTable {
         // Find the instant which matches ths given `time_point`.
         let mut instant = None;
         while let Some(snapshot) = snapshots.try_next().await? {
-            if let Some(ts) = snapshot.timestamp {
-                // break on the first one
-                if ts <= time_point {
-                    instant = Some(snapshot);
-                    break;
-                }
+            if pred(snapshot.as_ref()) {
+                instant = Some(snapshot);
+                break;
             }
         }
 

--- a/query/src/storages/storage_table.rs
+++ b/query/src/storages/storage_table.rs
@@ -29,6 +29,7 @@ use common_planners::ReadDataSourcePlan;
 use common_planners::Statistics;
 use common_planners::TruncateTablePlan;
 use common_streams::SendableDataBlockStream;
+use sqlparser::ast::Instant;
 
 use crate::pipelines::new::NewPipeline;
 use crate::sessions::QueryContext;
@@ -147,6 +148,18 @@ pub trait Table: Sync + Send {
 
     async fn statistics(&self, _ctx: Arc<QueryContext>) -> Result<Option<TableStatistics>> {
         Ok(None)
+    }
+
+    async fn navigate_to(
+        &self,
+        _ctx: Arc<QueryContext>,
+        _instant: &Instant,
+    ) -> Result<Arc<dyn Table>> {
+        Err(ErrorCode::UnImplement(format!(
+            "table {},  of engine type {}, do not support time travel",
+            self.name(),
+            self.get_table_info().engine(),
+        )))
     }
 }
 

--- a/query/tests/it/sql/parsers/mod.rs
+++ b/query/tests/it/sql/parsers/mod.rs
@@ -16,6 +16,7 @@ mod parser_call;
 mod parser_copy;
 mod parser_database;
 mod parser_optimize;
+mod parser_select_table_at;
 mod parser_show;
 mod parser_stage;
 mod parser_table;

--- a/query/tests/it/sql/parsers/parser_select_table_at.rs
+++ b/query/tests/it/sql/parsers/parser_select_table_at.rs
@@ -1,0 +1,84 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use common_exception::Result;
+use databend_query::sql::statements::AlterTableAction;
+use databend_query::sql::statements::DfAlterTable;
+use databend_query::sql::statements::DfCreateTable;
+use databend_query::sql::statements::DfDescribeTable;
+use databend_query::sql::statements::DfDropTable;
+use databend_query::sql::statements::DfQueryStatement;
+use databend_query::sql::statements::DfRenameTable;
+use databend_query::sql::statements::DfShowCreateTable;
+use databend_query::sql::statements::DfTruncateTable;
+use databend_query::sql::*;
+use sqlparser::ast::*;
+
+use crate::sql::sql_parser::*;
+
+#[test]
+fn select_table_at() -> Result<()> {
+    {
+        let sql = "select * from t at(snapshot => '0de4865bba874065905625e5db6024c1');";
+        let expected = DfStatement::Query(Box::new(DfQueryStatement {
+            distinct: false,
+            from: vec![TableWithJoins {
+                relation: TableFactor::Table {
+                    name: ObjectName {
+                        0: vec![Ident {
+                            value: "t".to_owned(),
+                            quote_style: None,
+                        }],
+                    },
+                    alias: None,
+                    args: vec![],
+                    with_hints: vec![],
+                    instant: Some(Instant::SnapshotID(
+                        "0de4865bba874065905625e5db6024c1".to_owned(),
+                    )),
+                },
+                joins: vec![],
+            }],
+            projection: vec![SelectItem::Wildcard],
+            selection: None,
+            group_by: vec![],
+            having: None,
+            order_by: vec![],
+            limit: None,
+            offset: None,
+            format: None,
+        }));
+        expect_parse_ok(sql, expected)?;
+    }
+
+    {
+        let sql = "select * from t at( => '0de4865bba874065905625e5db6024c1');";
+        expect_parse_err(
+            sql,
+            "sql parser error: Expected SNAPSHOT, found: =>".to_string(),
+        )?;
+    }
+
+    {
+        let sql = "select * from t at( SNAPSHOT => );";
+        expect_parse_err(
+            sql,
+            "sql parser error: Expected snapshot id, found: )".to_string(),
+        )?;
+    }
+
+    Ok(())
+}

--- a/query/tests/it/sql/parsers/parser_table.rs
+++ b/query/tests/it/sql/parsers/parser_table.rs
@@ -129,6 +129,7 @@ fn create_table() -> Result<()> {
                     alias: None,
                     args: vec![],
                     with_hints: vec![],
+                    instant: None,
                 },
                 joins: vec![],
             }],

--- a/query/tests/it/storages/fuse/operations/navigate.rs
+++ b/query/tests/it/storages/fuse/operations/navigate.rs
@@ -101,7 +101,7 @@ async fn test_fuse_navigate() -> Result<()> {
         .unwrap()
         .sub(chrono::Duration::milliseconds(1));
     // navigate from the instant that is just one ms before the timestamp of the latest snapshot
-    let tbl = fuse_table.navigate(&ctx, instant).await?;
+    let tbl = fuse_table.navigate_to_time_point(&ctx, instant).await?;
 
     // check we got the snapshot of the first insertion
     assert_eq!(first_snapshot, tbl.snapshot_loc().unwrap());
@@ -113,7 +113,7 @@ async fn test_fuse_navigate() -> Result<()> {
         .unwrap()
         .sub(chrono::Duration::milliseconds(1));
     // navigate from the instant that is just one ms before the timestamp of the last insertion
-    let res = fuse_table.navigate(&ctx, instant).await;
+    let res = fuse_table.navigate_to_time_point(&ctx, instant).await;
     match res {
         Ok(_) => panic!("historical data should not exist"),
         Err(e) => assert_eq!(e.code(), ErrorCode::table_historical_data_not_found_code()),
@@ -152,7 +152,7 @@ async fn test_fuse_historical_table_is_read_only() -> Result<()> {
         .timestamp
         .unwrap()
         .add(chrono::Duration::milliseconds(1));
-    let tbl = fuse_table.navigate(&ctx, instant).await?;
+    let tbl = fuse_table.navigate_to_time_point(&ctx, instant).await?;
 
     // check append2
     let res = tbl.append2(ctx.clone(), &mut NewPipeline::create());

--- a/tests/logictest/http_connector.py
+++ b/tests/logictest/http_connector.py
@@ -98,10 +98,10 @@ class HttpConnector():
         self._database = database
         self._session_max_idle_time = 300
         self._session = None
-        self._additonal_headers = dict() 
+        self._additonal_headers = dict()
         e = environs.Env()
         if os.getenv("ADDITIONAL_HEADERS") is not None:
-            self._additonal_headers = e.dict("ADDITIONAL_HEADERS") 
+            self._additonal_headers = e.dict("ADDITIONAL_HEADERS")
 
     def query(self, statement, session=None):
         url = "http://{}:{}/v1/query/".format(self._host, self._port)

--- a/tests/logictest/logictest.py
+++ b/tests/logictest/logictest.py
@@ -296,7 +296,8 @@ class SuiteRunner(object):
         try:
             f = format_value(actual, len(statement.s_type.query_type))
         except Exception:
-            log.warning("{} statement type is query but return nothing".format(statement))
+            log.warning("{} statement type is query but return nothing".format(
+                statement))
             raise
         assert statement.results is not None and len(
             statement.results) > 0, "No result found {}".format(statement)

--- a/tests/suites/0_stateless/12_time_travel/12_0004_time_travel_select_at.result
+++ b/tests/suites/0_stateless/12_time_travel/12_0004_time_travel_select_at.result
@@ -1,0 +1,5 @@
+two insertions
+latest snapshot should contain 3 rows
+3
+counting the data set of first insertion, which should contains 2 rows
+2

--- a/tests/suites/0_stateless/12_time_travel/12_0004_time_travel_select_at.sh
+++ b/tests/suites/0_stateless/12_time_travel/12_0004_time_travel_select_at.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+
+## Create table t12_0004
+echo "create table t12_0004(c int)" | $MYSQL_CLIENT_CONNECT
+echo "two insertions"
+echo "insert into t12_0004 values(1),(2)" | $MYSQL_CLIENT_CONNECT
+echo "insert into t12_0004 values(3)" | $MYSQL_CLIENT_CONNECT
+echo "latest snapshot should contain 3 rows"
+echo "select count(*)  from t12_0004" | $MYSQL_CLIENT_CONNECT
+
+## Get the previous snapshot id of the latest snapshot
+#SNAPSHOT_ID=$(echo "select previous_snapshot_id fuse_snapshot('default','t12_0004') where row_count=3 " | mysql -h127.0.0.1 -P3307 -uroot -s)
+SNAPSHOT_ID=$(echo "select previous_snapshot_id from fuse_snapshot('default','t12_0004') where row_count=3 " | $MYSQL_CLIENT_CONNECT)
+
+## Get segments
+echo "counting the data set of first insertion, which should contains 2 rows"
+echo "select count(*) from t12_0004 at (snapshot => '$SNAPSHOT_ID')" | $MYSQL_CLIENT_CONNECT
+
+## Drop table.
+echo "drop table  t12_0004" | $MYSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Basic `select at` syntax supports, **Legacy Parser ONLY**

`select * from t12_0004 at (snapshot => "98ec833d7806463ba71cfb6a13fa12c3");`

~~~
mysql> create table t12_0004(c int);
Query OK, 0 rows affected (0.09 sec)
Read 0 rows, 0.00 B in 0.045 sec., 0 rows/sec., 0.00 B/sec.

mysql> insert into t12_0004 values(1),(2);
Query OK, 0 rows affected (0.04 sec)
Read 2 rows, 8.00 B in 0.028 sec., 71.33 rows/sec., 285.32 B/sec.

mysql> insert into t12_0004 values(3);
Query OK, 0 rows affected (0.06 sec)
Read 1 rows, 4.00 B in 0.029 sec., 34.72 rows/sec., 138.89 B/sec.

mysql> select * from t12_0004;
+------+
| c    |
+------+
|    1 |
|    2 |
|    3 |
+------+
3 rows in set (0.04 sec)
Read 3 rows, 12.00 B in 0.006 sec., 486.07 rows/sec., 1.90 KiB/sec.

mysql> select * from fuse_snapshot('default', 't12_0004');
+----------------------------------+-----------------------------------------------------+----------------+----------------------------------+---------------+-------------+-----------+--------------------+------------------+
| snapshot_id                      | snapshot_location                                   | format_version | previous_snapshot_id             | segment_count | block_count | row_count | bytes_uncompressed | bytes_compressed |
+----------------------------------+-----------------------------------------------------+----------------+----------------------------------+---------------+-------------+-----------+--------------------+------------------+
| 1e046191e45848b5b59e414811930d95 | 1/1583/_ss/1e046191e45848b5b59e414811930d95_v1.json |              1 | 98ec833d7806463ba71cfb6a13fa12c3 |             2 |           2 |         3 |                 12 |              372 |
| 98ec833d7806463ba71cfb6a13fa12c3 | 1/1583/_ss/98ec833d7806463ba71cfb6a13fa12c3_v1.json |              1 | NULL                             |             1 |           1 |         2 |                  8 |              188 |
+----------------------------------+-----------------------------------------------------+----------------+----------------------------------+---------------+-------------+-----------+--------------------+------------------+
2 rows in set (0.03 sec)
Read 2 rows, 366.00 B in 0.007 sec., 305.18 rows/sec., 54.54 KiB/sec.

mysql> select * from t12_0004 at (snapshot => "98ec833d7806463ba71cfb6a13fa12c3");
+------+
| c    |
+------+
|    1 |
|    2 |
+------+
2 rows in set (0.03 sec)
Read 2 rows, 8.00 B in 0.005 sec., 427.27 rows/sec., 1.67 KiB/sec.
~~~

## Changelog

- New Feature
- Documentation
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #5516

