### PR TITLE
feat: `drop table .. all`

### DIFF
--- a/common/ast/src/ast/statement.rs
+++ b/common/ast/src/ast/statement.rs
@@ -97,6 +97,7 @@ pub enum Statement<'a> {
         if_exists: bool,
         database: Option<Identifier<'a>>,
         table: Identifier<'a>,
+        all: bool,
     },
     AlterTable {
         if_exists: bool,
@@ -503,12 +504,16 @@ impl<'a> Display for Statement<'a> {
                 if_exists,
                 database,
                 table,
+                all,
             } => {
                 write!(f, "DROP TABLE ")?;
                 if *if_exists {
                     write!(f, "IF EXISTS ")?;
                 }
                 write_period_separated_list(f, database.iter().chain(Some(table)))?;
+                if *all {
+                    write!(f, " ALL")?;
+                }
             }
             Statement::AlterTable {
                 if_exists,

--- a/common/ast/src/parser/statement.rs
+++ b/common/ast/src/parser/statement.rs
@@ -176,12 +176,13 @@ pub fn statement(i: Input) -> IResult<Statement> {
     );
     let drop_table = map(
         rule! {
-            DROP ~ TABLE ~ ( IF ~ EXISTS )? ~ ( #ident ~ "." )? ~ #ident
+            DROP ~ TABLE ~ ( IF ~ EXISTS )? ~ ( #ident ~ "." )? ~ #ident ~ ( ALL )?
         },
-        |(_, _, opt_if_exists, opt_database, table)| Statement::DropTable {
+        |(_, _, opt_if_exists, opt_database, table, opt_all)| Statement::DropTable {
             if_exists: opt_if_exists.is_some(),
             database: opt_database.map(|(database, _)| database),
             table,
+            all: opt_all.is_some(),
         },
     );
     let alter_table = map(

--- a/common/ast/tests/it/testdata/statement-error.txt
+++ b/common/ast/tests/it/testdata/statement-error.txt
@@ -44,7 +44,7 @@ error:
   --> SQL:1:15
   |
 1 | drop table if a.b
-  |               ^ expected `EXISTS`, `.`, or `;`
+  |               ^ expected `EXISTS`, `.`, `ALL`, or `;`
 
 
 ---------- Input ----------

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -445,6 +445,7 @@ DropTable {
         quote: None,
         span: Ident(11..12),
     },
+    all: false,
 }
 
 
@@ -469,6 +470,7 @@ DropTable {
         ),
         span: QuotedString(23..26),
     },
+    all: false,
 }
 
 
@@ -608,6 +610,7 @@ DropTable {
         quote: None,
         span: Ident(11..17),
     },
+    all: false,
 }
 
 
@@ -624,6 +627,7 @@ DropTable {
         quote: None,
         span: Ident(21..27),
     },
+    all: false,
 }
 
 

--- a/common/planners/src/plan_table_drop.rs
+++ b/common/planners/src/plan_table_drop.rs
@@ -27,6 +27,7 @@ pub struct DropTablePlan {
     pub db: String,
     /// The table name
     pub table: String,
+    pub all: bool,
 }
 
 impl DropTablePlan {

--- a/query/src/interpreters/interpreter_table_drop.rs
+++ b/query/src/interpreters/interpreter_table_drop.rs
@@ -19,6 +19,7 @@ use common_exception::Result;
 use common_meta_types::GrantObject;
 use common_meta_types::UserPrivilegeType;
 use common_planners::DropTablePlan;
+use common_planners::TruncateTablePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
@@ -76,6 +77,21 @@ impl Interpreter for DropTableInterpreter {
 
         let catalog = self.ctx.get_catalog(catalog_name)?;
         catalog.drop_table(self.plan.clone().into()).await?;
+
+        if let Some(tbl) = tbl {
+            // if `plan.all`, truncate, then purge the historical data
+            if self.plan.all {
+                // errors of truncation are ignored
+                let _ = tbl
+                    .truncate(self.ctx.clone(), TruncateTablePlan {
+                        catalog: self.plan.catalog.clone(),
+                        db: self.plan.db.clone(),
+                        table: self.plan.table.clone(),
+                        purge: true,
+                    })
+                    .await;
+            }
+        }
 
         Ok(Box::pin(DataBlockStream::create(
             self.plan.schema(),

--- a/query/src/sql/parsers/parser_table.rs
+++ b/query/src/sql/parsers/parser_table.rs
@@ -105,9 +105,12 @@ impl<'a> DfParser<'a> {
         let if_exists = self.parser.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
         let table_name = self.parser.parse_object_name()?;
 
+        let all = self.parser.parse_keyword(Keyword::ALL);
+
         let drop = DfDropTable {
             if_exists,
             name: table_name,
+            all,
         };
 
         Ok(DfStatement::DropTable(drop))

--- a/query/src/sql/statements/statement_drop_table.rs
+++ b/query/src/sql/statements/statement_drop_table.rs
@@ -29,6 +29,7 @@ use crate::sql::statements::AnalyzedResult;
 pub struct DfDropTable {
     pub if_exists: bool,
     pub name: ObjectName,
+    pub all: bool,
 }
 
 #[async_trait::async_trait]
@@ -36,6 +37,7 @@ impl AnalyzableStatement for DfDropTable {
     #[tracing::instrument(level = "debug", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
     async fn analyze(&self, ctx: Arc<QueryContext>) -> Result<AnalyzedResult> {
         let if_exists = self.if_exists;
+        let all = self.all;
         let tenant = ctx.get_tenant();
         let (catalog, db, table) = resolve_table(&ctx, &self.name, "DROP TABLE")?;
 
@@ -46,6 +48,7 @@ impl AnalyzableStatement for DfDropTable {
                 catalog,
                 db,
                 table,
+                all,
             },
         ))))
     }

--- a/query/tests/it/sql/parsers/parser_table.rs
+++ b/query/tests/it/sql/parsers/parser_table.rs
@@ -187,6 +187,7 @@ fn drop_table() -> Result<()> {
         let expected = DfStatement::DropTable(DfDropTable {
             if_exists: false,
             name: ObjectName(vec![Ident::new("t1")]),
+            all: false,
         });
         expect_parse_ok(sql, expected)?;
     }
@@ -196,6 +197,17 @@ fn drop_table() -> Result<()> {
         let expected = DfStatement::DropTable(DfDropTable {
             if_exists: true,
             name: ObjectName(vec![Ident::new("t1")]),
+            all: false,
+        });
+        expect_parse_ok(sql, expected)?;
+    }
+
+    {
+        let sql = "DROP TABLE t1 all";
+        let expected = DfStatement::DropTable(DfDropTable {
+            if_exists: false,
+            name: ObjectName(vec![Ident::new("t1")]),
+            all: true,
         });
         expect_parse_ok(sql, expected)?;
     }

--- a/query/tests/it/storages/fuse/operations/purge_drop.rs
+++ b/query/tests/it/storages/fuse/operations/purge_drop.rs
@@ -17,6 +17,7 @@ use common_base::base::tokio;
 use common_exception::Result;
 
 use crate::storages::fuse::table_test_fixture::append_sample_data;
+use crate::storages::fuse::table_test_fixture::check_data_dir;
 use crate::storages::fuse::table_test_fixture::execute_command;
 use crate::storages::fuse::table_test_fixture::TestFixture;
 
@@ -33,5 +34,30 @@ async fn test_fuse_snapshot_truncate_in_drop_stmt() -> Result<()> {
     // let's Drop
     let qry = format!("drop table '{}'.'{}'", db, tbl);
     execute_command(ctx.clone(), qry.as_str()).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fuse_snapshot_truncate_in_drop_all_stmt() -> Result<()> {
+    let fixture = TestFixture::new().await;
+    let db = fixture.default_db_name();
+    let tbl = fixture.default_table_name();
+    let ctx = fixture.ctx();
+    fixture.create_default_table().await?;
+
+    // ingests some test data
+    append_sample_data(1, &fixture).await?;
+    // let's Drop
+    let qry = format!("drop table '{}'.'{}' all", db, tbl);
+    execute_command(ctx.clone(), qry.as_str()).await?;
+
+    check_data_dir(
+        &fixture,
+        "drop table: there should be 1 snapshot, 0 segment/block",
+        1,
+        0,
+        0,
+    )
+    .await;
     Ok(())
 }

--- a/tests/suites/0_stateless/05_ddl/05_0000_ddl_drop_tables.sql
+++ b/tests/suites/0_stateless/05_ddl/05_0000_ddl_drop_tables.sql
@@ -7,9 +7,3 @@ DROP TABLE IF EXISTS t;
 DROP TABLE t; -- {ErrorCode 1025}
 
 DROP TABLE system.null; -- {ErrorCode 1002}
-
-CREATE TABLE t(c1 int) ENGINE = Null;
-DROP TABLE t ALL;
-
-CREATE TABLE t(c1 int) ENGINE = Fuse;
-DROP TABLE t ALL;

--- a/tests/suites/0_stateless/05_ddl/05_0000_ddl_drop_tables.sql
+++ b/tests/suites/0_stateless/05_ddl/05_0000_ddl_drop_tables.sql
@@ -7,3 +7,9 @@ DROP TABLE IF EXISTS t;
 DROP TABLE t; -- {ErrorCode 1025}
 
 DROP TABLE system.null; -- {ErrorCode 1002}
+
+CREATE TABLE t(c1 int) ENGINE = Null;
+DROP TABLE t ALL;
+
+CREATE TABLE t(c1 int) ENGINE = Fuse;
+DROP TABLE t ALL;

--- a/tests/suites/0_stateless/13_ddl_incompatible/13_0001_ddl_drop_table_full.sql
+++ b/tests/suites/0_stateless/13_ddl_incompatible/13_0001_ddl_drop_table_full.sql
@@ -1,0 +1,12 @@
+DROP DATABASE IF EXISTS db_13_0001;
+CREATE DATABASE db_13_0001;
+USE db_13_0001;
+
+-- new SQL syntax that not backward compatible
+CREATE TABLE t(c1 int) ENGINE = Null;
+DROP TABLE t ALL;
+
+CREATE TABLE t(c1 int) ENGINE = Fuse;
+DROP TABLE t ALL;
+
+DROP database db_13_0001;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`drop table .. all` **Legacy Parser ONLY**

Besides removing table metadata from KV server,  with the option `all`, the stmt will truncate table data and purge them as well.

## Changelog


- Improvement
- Documentation
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #5613

