### PR TITLE
feat(parser): `undrop table` & `show tables history` for new parser

### DIFF
--- a/common/ast/src/ast/statement.rs
+++ b/common/ast/src/ast/statement.rs
@@ -67,6 +67,7 @@ pub enum Statement<'a> {
         database: Option<Identifier<'a>>,
         full: bool,
         limit: Option<ShowLimit<'a>>,
+        with_history: bool,
     },
     ShowCreateTable {
         database: Option<Identifier<'a>>,
@@ -95,6 +96,10 @@ pub enum Statement<'a> {
     },
     DropTable {
         if_exists: bool,
+        database: Option<Identifier<'a>>,
+        table: Identifier<'a>,
+    },
+    UnDropTable {
         database: Option<Identifier<'a>>,
         table: Identifier<'a>,
     },
@@ -421,12 +426,16 @@ impl<'a> Display for Statement<'a> {
                 database,
                 full,
                 limit,
+                with_history,
             } => {
                 write!(f, "SHOW")?;
                 if *full {
                     write!(f, " FULL")?;
                 }
                 write!(f, " TABLES")?;
+                if *with_history {
+                    write!(f, " HISTORY")?;
+                }
                 if let Some(database) = database {
                     write!(f, " FROM {database}")?;
                 }
@@ -508,6 +517,10 @@ impl<'a> Display for Statement<'a> {
                 if *if_exists {
                     write!(f, "IF EXISTS ")?;
                 }
+                write_period_separated_list(f, database.iter().chain(Some(table)))?;
+            }
+            Statement::UnDropTable { database, table } => {
+                write!(f, "UNDROP TABLE ")?;
                 write_period_separated_list(f, database.iter().chain(Some(table)))?;
             }
             Statement::AlterTable {

--- a/common/ast/src/parser/statement.rs
+++ b/common/ast/src/parser/statement.rs
@@ -102,12 +102,13 @@ pub fn statement(i: Input) -> IResult<Statement> {
     );
     let show_tables = map(
         rule! {
-            SHOW ~ FULL? ~ TABLES ~ ( FROM ~ ^#ident )? ~ #show_limit?
+            SHOW ~ FULL? ~ TABLES ~ HISTORY? ~ ( FROM ~ ^#ident )? ~ #show_limit?
         },
-        |(_, opt_full, _, opt_database, limit)| Statement::ShowTables {
+        |(_, opt_full, _, opt_history, opt_database, limit)| Statement::ShowTables {
             database: opt_database.map(|(_, database)| database),
             full: opt_full.is_some(),
             limit,
+            with_history: opt_history.is_some(),
         },
     );
     let show_create_table = map(
@@ -180,6 +181,15 @@ pub fn statement(i: Input) -> IResult<Statement> {
         },
         |(_, _, opt_if_exists, opt_database, table)| Statement::DropTable {
             if_exists: opt_if_exists.is_some(),
+            database: opt_database.map(|(database, _)| database),
+            table,
+        },
+    );
+    let undrop_table = map(
+        rule! {
+            UNDROP ~ TABLE ~ ( #ident ~ "." )? ~ #ident
+        },
+        |(_, _, opt_database, table)| Statement::UnDropTable {
             database: opt_database.map(|(database, _)| database),
             table,
         },
@@ -421,6 +431,7 @@ pub fn statement(i: Input) -> IResult<Statement> {
             | #create_table : "`CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [ENGINE = <engine>]`"
             | #describe : "`DESCRIBE [<database>.]<table>`"
             | #drop_table : "`DROP TABLE [IF EXISTS] [<database>.]<table>`"
+            | #undrop_table : "`UNDROP TABLE [<database>.]<table>`"
             | #alter_table : "`ALTER TABLE [<database>.]<table> <action>`"
             | #rename_table : "`RENAME TABLE [<database>.]<table> TO <new_table>`"
             | #truncate_table : "`TRUNCATE TABLE [<database>.]<table> [PURGE]`"

--- a/common/ast/src/parser/token.rs
+++ b/common/ast/src/parser/token.rs
@@ -374,6 +374,8 @@ pub enum TokenKind {
     GROUP,
     #[token("HAVING", ignore(ascii_case))]
     HAVING,
+    #[token("HISTORY", ignore(ascii_case))]
+    HISTORY,
     #[token("HOUR", ignore(ascii_case))]
     HOUR,
     #[token("IDENTIFIED", ignore(ascii_case))]
@@ -572,6 +574,8 @@ pub enum TokenKind {
     UINT64,
     #[token("UINT8", ignore(ascii_case))]
     UINT8,
+    #[token("UNDROP", ignore(ascii_case))]
+    UNDROP,
     #[token("UNSIGNED", ignore(ascii_case))]
     UNSIGNED,
     #[token("URL", ignore(ascii_case))]

--- a/common/ast/tests/it/parser.rs
+++ b/common/ast/tests/it/parser.rs
@@ -138,7 +138,7 @@ fn test_statements_in_legacy_suites() {
         // TODO(andylokandy): support all cases eventually
         // Remove currently unimplemented cases
         let file_str = regex::Regex::new(
-            "(?i).*(SLAVE|MASTER|COMMIT|START|ROLLBACK|FIELDS|GRANT|COPY|ROLE|STAGE|ENGINES|UNDROP|HISTORY).*\n",
+            "(?i).*(SLAVE|MASTER|COMMIT|START|ROLLBACK|FIELDS|GRANT|COPY|ROLE|STAGE|ENGINES).*\n",
         )
         .unwrap()
         .replace_all(&file_str, "")

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -7,6 +7,7 @@ ShowTables {
     database: None,
     full: false,
     limit: None,
+    with_history: false,
 }
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`undrop table` & `show tables history` for new parser

## Changelog


- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

