### PR TITLE
[metasrv] do not assert protocol_version to be 0, to make it compatible with query that sends protocol_version

### DIFF
--- a/metasrv/src/api/grpc/grpc_service.rs
+++ b/metasrv/src/api/grpc/grpc_service.rs
@@ -98,7 +98,7 @@ impl MetaService for MetaServiceImpl {
             protocol_version,
             payload,
         } = req;
-        assert_eq!(protocol_version, 0); // todo(ariesdevil): define server version, return un compatible error.
+        let _ = protocol_version;
         let auth = BasicAuth::decode(&*payload).map_err(|e| Status::internal(e.to_string()))?;
 
         let user = "root";


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] do not assert protocol_version to be 0, to make it compatible with query that sends protocol_version

## Changelog







## Related Issues