### PR TITLE
fix(parser): allow mysql-style hex number and single-item array

### DIFF
--- a/common/ast/src/parser/expr.rs
+++ b/common/ast/src/parser/expr.rs
@@ -1027,25 +1027,16 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
 }
 
 pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
-    let year = value(IntervalKind::Year, rule! { YEAR });
-    let month = value(IntervalKind::Month, rule! { MONTH });
-    let day = value(IntervalKind::Day, rule! { DAY });
-    let hour = value(IntervalKind::Hour, rule! { HOUR });
-    let minute = value(IntervalKind::Minute, rule! { MINUTE });
-    let second = value(IntervalKind::Second, rule! { SECOND });
-    let doy = value(IntervalKind::Doy, rule! { DOY });
-    let dow = value(IntervalKind::Dow, rule! { DOW });
-
-    rule!(
-        #year
-        | #month
-        | #day
-        | #hour
-        | #minute
-        | #second
-        | #doy
-        | #dow
-    )(i)
+    alt((
+        value(IntervalKind::Year, rule! { YEAR }),
+        value(IntervalKind::Month, rule! { MONTH }),
+        value(IntervalKind::Day, rule! { DAY }),
+        value(IntervalKind::Hour, rule! { HOUR }),
+        value(IntervalKind::Minute, rule! { MINUTE }),
+        value(IntervalKind::Second, rule! { SECOND }),
+        value(IntervalKind::Doy, rule! { DOY }),
+        value(IntervalKind::Dow, rule! { DOW }),
+    ))(i)
 }
 
 pub fn map_access(i: Input) -> IResult<MapAccessor> {

--- a/common/ast/src/parser/token.rs
+++ b/common/ast/src/parser/token.rs
@@ -115,6 +115,7 @@ pub enum TokenKind {
     QuotedString,
 
     #[regex(r"[xX]'[a-fA-F0-9]*'")]
+    #[regex(r"0[xX][a-fA-F0-9]+")]
     LiteralHex,
 
     #[regex(r"[0-9]+")]

--- a/common/ast/src/parser/util.rs
+++ b/common/ast/src/parser/util.rs
@@ -163,8 +163,13 @@ pub fn literal_u64(i: Input) -> IResult<u64> {
 pub fn comma_separated_list0<'a, T>(
     item: impl FnMut(Input<'a>) -> IResult<'a, T>,
 ) -> impl FnMut(Input<'a>) -> IResult<'a, Vec<T>> {
-    // TODO: fork one
     separated_list0(match_text(","), item)
+}
+
+pub fn comma_separated_list0_allow_trailling<'a, T>(
+    item: impl FnMut(Input<'a>) -> IResult<'a, T>,
+) -> impl FnMut(Input<'a>) -> IResult<'a, Vec<T>> {
+    nom::multi::separated_list0(match_text(","), item)
 }
 
 pub fn comma_separated_list1<'a, T>(

--- a/common/ast/tests/it/parser.rs
+++ b/common/ast/tests/it/parser.rs
@@ -241,13 +241,21 @@ fn test_expr() {
     let cases = &[
         r#"a"#,
         r#"'I''m who I\'m.'"#,
-        r#"'\776 \n \t \u0053'"#,
+        r#"'\776 \n \t \u0053 \xaa'"#,
+        r#"char(0xD0, 0xBF, 0xD1)"#,
         r#"-1"#,
         r#"(1,)"#,
         r#"(1,2)"#,
         r#"(1,2,)"#,
+        r#"[1]"#,
+        r#"[1,]"#,
+        r#"[[1]]"#,
+        r#"[[1],[2]]"#,
+        r#"[[[1,2,3],[4,5,6]],[[7,8,9]]][0][1][2]"#,
         r#"typeof(1 + 2)"#,
         r#"- - + + - 1 + + - 2"#,
+        r#"0XFF + 0xff + 0xa + x'ffff'"#,
+        r#"1 - -(- - -1)"#,
         r#"1 + a * c.d"#,
         r#"number % 2"#,
         r#"`t`:k1.k2"#,
@@ -292,6 +300,8 @@ fn test_expr_error() {
         r#"5 * (a and ) 1"#,
         r#"a + +"#,
         r#"CAST(col1 AS foo)"#,
+        // TODO(andylokandy): This is a bug being tracking in https://github.com/segeljakt/pratt/issues/7
+        r#"1 a"#,
         r#"CAST(col1)"#,
         r#"G.E.B IS NOT NULL AND
             col1 NOT BETWEEN col2 AND

--- a/common/ast/tests/it/testdata/expr-error.txt
+++ b/common/ast/tests/it/testdata/expr-error.txt
@@ -38,6 +38,21 @@ error:
 
 
 ---------- Input ----------
+1 a
+---------- Output ---------
+1
+---------- AST ------------
+Literal {
+    span: [
+        LiteralNumber(0..1),
+    ],
+    lit: Number(
+        "1",
+    ),
+}
+
+
+---------- Input ----------
 CAST(col1)
 ---------- Output ---------
 error: 

--- a/common/ast/tests/it/testdata/expr.txt
+++ b/common/ast/tests/it/testdata/expr.txt
@@ -33,18 +33,70 @@ Literal {
 
 
 ---------- Input ----------
-'\776 \n \t \u0053'
+'\776 \n \t \u0053 \xaa'
 ---------- Output ---------
 'Ǿ 
- 	 S'
+ 	 S ª'
 ---------- AST ------------
 Literal {
     span: [
-        QuotedString(0..19),
+        QuotedString(0..24),
     ],
     lit: String(
-        "Ǿ \n \t S",
+        "Ǿ \n \t S ª",
     ),
+}
+
+
+---------- Input ----------
+char(0xD0, 0xBF, 0xD1)
+---------- Output ---------
+char(0xD0, 0xBF, 0xD1)
+---------- AST ------------
+FunctionCall {
+    span: [
+        Ident(0..4),
+        LParen(4..5),
+        LiteralHex(5..9),
+        Comma(9..10),
+        LiteralHex(11..15),
+        Comma(15..16),
+        LiteralHex(17..21),
+        RParen(21..22),
+    ],
+    distinct: false,
+    name: Identifier {
+        name: "char",
+        quote: None,
+        span: Ident(0..4),
+    },
+    args: [
+        Literal {
+            span: [
+                LiteralHex(5..9),
+            ],
+            lit: Number(
+                "0xD0",
+            ),
+        },
+        Literal {
+            span: [
+                LiteralHex(11..15),
+            ],
+            lit: Number(
+                "0xBF",
+            ),
+        },
+        Literal {
+            span: [
+                LiteralHex(17..21),
+            ],
+            lit: Number(
+                "0xD1",
+            ),
+        },
+    ],
+    params: [],
 }
 
 
@@ -164,6 +216,381 @@ Tuple {
 
 
 ---------- Input ----------
+[1]
+---------- Output ---------
+[1]
+---------- AST ------------
+Array {
+    span: [
+        LBracket(0..1),
+        LiteralNumber(1..2),
+        RBracket(2..3),
+    ],
+    exprs: [
+        Literal {
+            span: [
+                LBracket(0..1),
+                LiteralNumber(1..2),
+                RBracket(2..3),
+            ],
+            lit: Number(
+                "1",
+            ),
+        },
+    ],
+}
+
+
+---------- Input ----------
+[1,]
+---------- Output ---------
+[1]
+---------- AST ------------
+Array {
+    span: [
+        LBracket(0..1),
+        LiteralNumber(1..2),
+        Comma(2..3),
+        RBracket(3..4),
+    ],
+    exprs: [
+        Literal {
+            span: [
+                LiteralNumber(1..2),
+            ],
+            lit: Number(
+                "1",
+            ),
+        },
+    ],
+}
+
+
+---------- Input ----------
+[[1]]
+---------- Output ---------
+[[1]]
+---------- AST ------------
+Array {
+    span: [
+        LBracket(0..1),
+        LBracket(1..2),
+        LiteralNumber(2..3),
+        RBracket(3..4),
+        RBracket(4..5),
+    ],
+    exprs: [
+        Array {
+            span: [
+                LBracket(1..2),
+                LiteralNumber(2..3),
+                RBracket(3..4),
+            ],
+            exprs: [
+                Literal {
+                    span: [
+                        LBracket(1..2),
+                        LiteralNumber(2..3),
+                        RBracket(3..4),
+                    ],
+                    lit: Number(
+                        "1",
+                    ),
+                },
+            ],
+        },
+    ],
+}
+
+
+---------- Input ----------
+[[1],[2]]
+---------- Output ---------
+[[1], [2]]
+---------- AST ------------
+Array {
+    span: [
+        LBracket(0..1),
+        LBracket(1..2),
+        LiteralNumber(2..3),
+        RBracket(3..4),
+        Comma(4..5),
+        LBracket(5..6),
+        LiteralNumber(6..7),
+        RBracket(7..8),
+        RBracket(8..9),
+    ],
+    exprs: [
+        Array {
+            span: [
+                LBracket(1..2),
+                LiteralNumber(2..3),
+                RBracket(3..4),
+            ],
+            exprs: [
+                Literal {
+                    span: [
+                        LBracket(1..2),
+                        LiteralNumber(2..3),
+                        RBracket(3..4),
+                    ],
+                    lit: Number(
+                        "1",
+                    ),
+                },
+            ],
+        },
+        Array {
+            span: [
+                LBracket(5..6),
+                LiteralNumber(6..7),
+                RBracket(7..8),
+            ],
+            exprs: [
+                Literal {
+                    span: [
+                        LBracket(5..6),
+                        LiteralNumber(6..7),
+                        RBracket(7..8),
+                    ],
+                    lit: Number(
+                        "2",
+                    ),
+                },
+            ],
+        },
+    ],
+}
+
+
+---------- Input ----------
+[[[1,2,3],[4,5,6]],[[7,8,9]]][0][1][2]
+---------- Output ---------
+[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9]]][0][1][2]
+---------- AST ------------
+MapAccess {
+    span: [
+        LBracket(35..36),
+        LiteralNumber(36..37),
+        RBracket(37..38),
+    ],
+    expr: MapAccess {
+        span: [
+            LBracket(32..33),
+            LiteralNumber(33..34),
+            RBracket(34..35),
+        ],
+        expr: MapAccess {
+            span: [
+                LBracket(29..30),
+                LiteralNumber(30..31),
+                RBracket(31..32),
+            ],
+            expr: Array {
+                span: [
+                    LBracket(0..1),
+                    LBracket(1..2),
+                    LBracket(2..3),
+                    LiteralNumber(3..4),
+                    Comma(4..5),
+                    LiteralNumber(5..6),
+                    Comma(6..7),
+                    LiteralNumber(7..8),
+                    RBracket(8..9),
+                    Comma(9..10),
+                    LBracket(10..11),
+                    LiteralNumber(11..12),
+                    Comma(12..13),
+                    LiteralNumber(13..14),
+                    Comma(14..15),
+                    LiteralNumber(15..16),
+                    RBracket(16..17),
+                    RBracket(17..18),
+                    Comma(18..19),
+                    LBracket(19..20),
+                    LBracket(20..21),
+                    LiteralNumber(21..22),
+                    Comma(22..23),
+                    LiteralNumber(23..24),
+                    Comma(24..25),
+                    LiteralNumber(25..26),
+                    RBracket(26..27),
+                    RBracket(27..28),
+                    RBracket(28..29),
+                ],
+                exprs: [
+                    Array {
+                        span: [
+                            LBracket(1..2),
+                            LBracket(2..3),
+                            LiteralNumber(3..4),
+                            Comma(4..5),
+                            LiteralNumber(5..6),
+                            Comma(6..7),
+                            LiteralNumber(7..8),
+                            RBracket(8..9),
+                            Comma(9..10),
+                            LBracket(10..11),
+                            LiteralNumber(11..12),
+                            Comma(12..13),
+                            LiteralNumber(13..14),
+                            Comma(14..15),
+                            LiteralNumber(15..16),
+                            RBracket(16..17),
+                            RBracket(17..18),
+                        ],
+                        exprs: [
+                            Array {
+                                span: [
+                                    LBracket(2..3),
+                                    LiteralNumber(3..4),
+                                    Comma(4..5),
+                                    LiteralNumber(5..6),
+                                    Comma(6..7),
+                                    LiteralNumber(7..8),
+                                    RBracket(8..9),
+                                ],
+                                exprs: [
+                                    Literal {
+                                        span: [
+                                            LiteralNumber(3..4),
+                                        ],
+                                        lit: Number(
+                                            "1",
+                                        ),
+                                    },
+                                    Literal {
+                                        span: [
+                                            LiteralNumber(5..6),
+                                        ],
+                                        lit: Number(
+                                            "2",
+                                        ),
+                                    },
+                                    Literal {
+                                        span: [
+                                            LiteralNumber(7..8),
+                                        ],
+                                        lit: Number(
+                                            "3",
+                                        ),
+                                    },
+                                ],
+                            },
+                            Array {
+                                span: [
+                                    LBracket(10..11),
+                                    LiteralNumber(11..12),
+                                    Comma(12..13),
+                                    LiteralNumber(13..14),
+                                    Comma(14..15),
+                                    LiteralNumber(15..16),
+                                    RBracket(16..17),
+                                ],
+                                exprs: [
+                                    Literal {
+                                        span: [
+                                            LiteralNumber(11..12),
+                                        ],
+                                        lit: Number(
+                                            "4",
+                                        ),
+                                    },
+                                    Literal {
+                                        span: [
+                                            LiteralNumber(13..14),
+                                        ],
+                                        lit: Number(
+                                            "5",
+                                        ),
+                                    },
+                                    Literal {
+                                        span: [
+                                            LiteralNumber(15..16),
+                                        ],
+                                        lit: Number(
+                                            "6",
+                                        ),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    Array {
+                        span: [
+                            LBracket(19..20),
+                            LBracket(20..21),
+                            LiteralNumber(21..22),
+                            Comma(22..23),
+                            LiteralNumber(23..24),
+                            Comma(24..25),
+                            LiteralNumber(25..26),
+                            RBracket(26..27),
+                            RBracket(27..28),
+                        ],
+                        exprs: [
+                            Array {
+                                span: [
+                                    LBracket(20..21),
+                                    LiteralNumber(21..22),
+                                    Comma(22..23),
+                                    LiteralNumber(23..24),
+                                    Comma(24..25),
+                                    LiteralNumber(25..26),
+                                    RBracket(26..27),
+                                ],
+                                exprs: [
+                                    Literal {
+                                        span: [
+                                            LiteralNumber(21..22),
+                                        ],
+                                        lit: Number(
+                                            "7",
+                                        ),
+                                    },
+                                    Literal {
+                                        span: [
+                                            LiteralNumber(23..24),
+                                        ],
+                                        lit: Number(
+                                            "8",
+                                        ),
+                                    },
+                                    Literal {
+                                        span: [
+                                            LiteralNumber(25..26),
+                                        ],
+                                        lit: Number(
+                                            "9",
+                                        ),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            accessor: Bracket {
+                key: Number(
+                    "0",
+                ),
+            },
+        },
+        accessor: Bracket {
+            key: Number(
+                "1",
+            ),
+        },
+    },
+    accessor: Bracket {
+        key: Number(
+            "2",
+        ),
+    },
+}
+
+
+---------- Input ----------
 typeof(1 + 2)
 ---------- Output ---------
 typeof(1 + 2)
@@ -274,6 +701,116 @@ UnaryOp {
                                 },
                             },
                         },
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+---------- Input ----------
+0XFF + 0xff + 0xa + x'ffff'
+---------- Output ---------
+0XFF + 0xff + 0xa + x'ffff'
+---------- AST ------------
+BinaryOp {
+    span: [
+        Plus(18..19),
+    ],
+    op: Plus,
+    left: BinaryOp {
+        span: [
+            Plus(12..13),
+        ],
+        op: Plus,
+        left: BinaryOp {
+            span: [
+                Plus(5..6),
+            ],
+            op: Plus,
+            left: Literal {
+                span: [
+                    LiteralHex(0..4),
+                ],
+                lit: Number(
+                    "0XFF",
+                ),
+            },
+            right: Literal {
+                span: [
+                    LiteralHex(7..11),
+                ],
+                lit: Number(
+                    "0xff",
+                ),
+            },
+        },
+        right: Literal {
+            span: [
+                LiteralHex(14..17),
+            ],
+            lit: Number(
+                "0xa",
+            ),
+        },
+    },
+    right: Literal {
+        span: [
+            LiteralHex(20..27),
+        ],
+        lit: Number(
+            "x'ffff'",
+        ),
+    },
+}
+
+
+---------- Input ----------
+1 - -(- - -1)
+---------- Output ---------
+1 - - - - - 1
+---------- AST ------------
+BinaryOp {
+    span: [
+        Minus(2..3),
+    ],
+    op: Minus,
+    left: Literal {
+        span: [
+            LiteralNumber(0..1),
+        ],
+        lit: Number(
+            "1",
+        ),
+    },
+    right: UnaryOp {
+        span: [
+            Minus(4..5),
+        ],
+        op: Minus,
+        expr: UnaryOp {
+            span: [
+                Minus(6..7),
+            ],
+            op: Minus,
+            expr: UnaryOp {
+                span: [
+                    Minus(8..9),
+                ],
+                op: Minus,
+                expr: UnaryOp {
+                    span: [
+                        Minus(10..11),
+                    ],
+                    op: Minus,
+                    expr: Literal {
+                        span: [
+                            LiteralNumber(11..12),
+                        ],
+                        lit: Number(
+                            "1",
+                        ),
                     },
                 },
             },


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Distinguish map access `[1]` and array literal `[1]` based on its previous element.
- Accept hexadecimal numbers in MySQL style like `0xff`.
- Make `DataTime` an alias of `Timestamp`.

## Changelog

- New Feature
- Bug Fix

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/5643

