### PR TITLE
feat(query): Fail fast if the underlying storage is not available

### DIFF
--- a/common/exception/src/exception_code.rs
+++ b/common/exception/src/exception_code.rs
@@ -228,7 +228,8 @@ build_exceptions! {
 build_exceptions! {
     StorageNotFound(3001),
     StoragePermissionDenied(3002),
-    StorageOther(4000)
+    StorageUnavailable(3901),
+    StorageOther(4000),
 }
 
 // Cache errors [4001, 5000].

--- a/query/tests/it/storages/system/configs_table.rs
+++ b/query/tests/it/storages/system/configs_table.rs
@@ -20,6 +20,11 @@ use databend_query::storages::system::ConfigsTable;
 use databend_query::storages::ToReadDataSourcePlan;
 use futures::TryStreamExt;
 use pretty_assertions::assert_eq;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_configs_table() -> Result<()> {
@@ -112,8 +117,17 @@ async fn test_configs_table() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_configs_table_redact() -> Result<()> {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("HEAD"))
+        .and(path("/test/.opendal"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&mock_server)
+        .await;
+
     let mut conf = crate::tests::ConfigBuilder::create().config();
     conf.storage.params = StorageParams::S3(StorageS3Config {
+        region: "us-east-2".to_string(),
+        endpoint_url: mock_server.uri(),
         bucket: "test".to_string(),
         access_key_id: "access_key_id".to_string(),
         secret_access_key: "secret_access_key".to_string(),
@@ -129,6 +143,11 @@ async fn test_configs_table_redact() -> Result<()> {
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 4);
+
+    let endpoint_url_link = format!(
+        "| storage | s3.endpoint_url                      | {:<24}  |             |",
+        mock_server.uri()
+    );
 
     let expected = vec![
         "+---------+--------------------------------------+---------------------------+-------------+",
@@ -193,14 +212,15 @@ async fn test_configs_table_redact() -> Result<()> {
         "| storage | num_cpus                             | 0                         |             |",
         "| storage | s3.access_key_id                     | ******_id                 |             |",
         "| storage | s3.bucket                            | test                      |             |",
-        "| storage | s3.endpoint_url                      | https://s3.amazonaws.com  |             |",
+        &endpoint_url_link,
         "| storage | s3.master_key                        |                           |             |",
-        "| storage | s3.region                            |                           |             |",
+        "| storage | s3.region                            | us-east-2                 |             |",
         "| storage | s3.root                              |                           |             |",
         "| storage | s3.secret_access_key                 | ******key                 |             |",
         "| storage | type                                 | s3                        |             |",
         "+---------+--------------------------------------+---------------------------+-------------+",
     ];
+
     common_datablocks::assert_blocks_sorted_eq(expected, result.as_slice());
     Ok(())
 }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

It is possible that our users will have misconfigured storage. They could misspell the endpoint URL, or their K8s config map is not updated, or AWS STS doesn't return the updated token.

This PR will add a check after constructing the OpenDAL operator to know whether the current storage is functional. If not, we will return the error directly instead of keep running.

- For local setup, users can check their config quicker instead of while they are running queries.
- For K8S and cloud setup, databend-query will be restarted automatically until all config updated or reach the deadline.

> Thanks to the new API `Operator::check()` introduced in `OpenDAL` v0.7 

There is a demo of users forget to config aws access key:

![B21GORawHl](https://user-images.githubusercontent.com/5351546/170924952-124363db-1f81-4342-94e0-f3112ad48cef.png)



## Changelog

- New Feature



