### PR TITLE
fix(user):  fix 'create user if not exists' fail when user exists

### DIFF
--- a/common/planners/src/plan_user_create.rs
+++ b/common/planners/src/plan_user_create.rs
@@ -25,6 +25,7 @@ pub struct CreateUserPlan {
     pub user: UserIdentity,
     pub auth_info: AuthInfo,
     pub user_option: UserOption,
+    pub if_not_exists: bool,
 }
 
 impl CreateUserPlan {

--- a/query/src/interpreters/interpreter_user_create.rs
+++ b/query/src/interpreters/interpreter_user_create.rs
@@ -64,7 +64,9 @@ impl Interpreter for CreateUserInterpreter {
             quota: UserQuota::no_limit(),
             option: plan.user_option,
         };
-        user_mgr.add_user(&tenant, user_info, false).await?;
+        user_mgr
+            .add_user(&tenant, user_info, plan.if_not_exists)
+            .await?;
 
         Ok(Box::pin(DataBlockStream::create(
             self.plan.schema(),

--- a/query/src/sql/statements/statement_create_user.rs
+++ b/query/src/sql/statements/statement_create_user.rs
@@ -108,6 +108,7 @@ impl AnalyzableStatement for DfCreateUser {
                     &self.auth_option.by_value,
                 )?,
                 user_option,
+                if_not_exists: self.if_not_exists,
             },
         ))))
     }

--- a/tests/suites/0_stateless/05_ddl/05_0004_ddl_create_user.sql
+++ b/tests/suites/0_stateless/05_ddl/05_0004_ddl_create_user.sql
@@ -3,3 +3,4 @@ CREATE USER 'test-a'@'localhost' IDENTIFIED BY 'password'; -- {ErrorCode 2202}
 CREATE USER 'test-b'@'localhost' IDENTIFIED WITH sha256_password BY 'password';
 CREATE USER 'test-c'@'localhost' IDENTIFIED WITH double_sha1_password BY 'password';
 CREATE USER 'test-d@localhost' IDENTIFIED WITH sha256_password BY 'password';
+CREATE USER IF NOT EXISTS 'test-d@localhost' IDENTIFIED WITH sha256_password BY 'password';


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add `if_not_exists` field in `CreateUserPlan` and pass it to `CreateUserInterpreter`.

## Changelog

- Bug Fix

## Related Issues

Fixes #5582 

