### PR TITLE
[metasrv] config: raft_advertise_host default value should by default be the host name of the running machine, instead of literal "localhost"

### DIFF
--- a/metasrv/src/bin/metasrv.rs
+++ b/metasrv/src/bin/metasrv.rs
@@ -102,13 +102,26 @@ fn run_cmd(conf: &Config) -> bool {
             println!("version: {}", METASRV_SEMVER.deref());
             println!("min-compatible-client-version: {}", MIN_METACLI_SEMVER);
         }
+        "show-config" => {
+            println!(
+                "config:\n{}",
+                pretty(&conf).unwrap_or_else(|e| format!("error format config: {}", e))
+            );
+        }
         _ => {
             eprintln!("Invalid cmd: {}", conf.cmd);
             eprintln!("Available cmds:");
             eprintln!("  --cmd ver");
             eprintln!("    Print version and min compatible meta-client version");
+            eprintln!("  --cmd show-config");
+            eprintln!("    Print effective config");
         }
     }
 
     true
+}
+
+fn pretty<T>(v: &T) -> Result<String, serde_json::Error>
+where T: serde::Serialize {
+    serde_json::to_string_pretty(v)
 }

--- a/metasrv/src/configs/outer_v0.rs
+++ b/metasrv/src/configs/outer_v0.rs
@@ -15,6 +15,7 @@
 use std::env;
 
 use clap::Parser;
+use common_meta_raft_store::config::get_default_raft_advertise_host;
 use common_meta_raft_store::config::RaftConfig as InnerRaftConfig;
 use common_meta_types::MetaError;
 use common_meta_types::MetaResult;
@@ -35,6 +36,7 @@ pub struct Config {
     ///
     /// Supported commands:
     /// - `ver`: print version and quit.
+    /// - `show-config`: print effective config and quit.
     #[clap(long, default_value = "")]
     pub cmd: String,
 
@@ -277,7 +279,7 @@ pub struct RaftConfig {
     /// This host should be stored in raft store and be replicated to the raft cluster,
     /// i.e., when calling add_node().
     /// Use `localhost` by default.
-    #[clap(long, default_value = "localhost")]
+    #[clap(long, default_value_t = get_default_raft_advertise_host())]
     pub raft_advertise_host: String,
 
     /// The listening port for metadata communication.


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] config: raft_advertise_host default value should by default be the host name of the running machine, instead of literal "localhost"
Add another command: `--cmd show-config` to display the **effective** config
to metasrv.

The **effective** config can be thought as being built in 4 steps:

- Build the config instance `conf` initialized with default values.

- Apply config.toml to `conf`.

- Apply environment variable config to `conf`.

- Apply CLI arg config to `conf`.

## Changelog







## Related Issues