### PR TITLE
[metasrv] ci: test-compat downloads config file for old query

### DIFF
--- a/.github/actions/test_compat/action.yml
+++ b/.github/actions/test_compat/action.yml
@@ -41,4 +41,7 @@ runs:
           metasrv/_logs*/
           query/_logs*/
           store/_logs*/
+          .databend/
+          query.log
+          metasrv.log
           nohup.out


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] ci: test-compat downloads config file for old query
And for test-compat, only config one metasrv endpoints for it.

- Fix a query-config caused compatibility failure found in: #5732

## Changelog





- Build/Testing/CI

## Related Issues