### PR TITLE
[common/exception] refactor: add ErrorCode::set_backtrace() for keeping the original bt when converting MetaError to ErrorCode

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -40,6 +40,41 @@ impl ToString for ErrorCodeBacktrace {
     }
 }
 
+impl From<&str> for ErrorCodeBacktrace {
+    fn from(s: &str) -> Self {
+        Self::Serialized(Arc::new(s.to_string()))
+    }
+}
+impl From<String> for ErrorCodeBacktrace {
+    fn from(s: String) -> Self {
+        Self::Serialized(Arc::new(s))
+    }
+}
+
+impl From<Arc<String>> for ErrorCodeBacktrace {
+    fn from(s: Arc<String>) -> Self {
+        Self::Serialized(s)
+    }
+}
+
+impl From<Backtrace> for ErrorCodeBacktrace {
+    fn from(bt: Backtrace) -> Self {
+        Self::Origin(Arc::new(bt))
+    }
+}
+
+impl From<&Backtrace> for ErrorCodeBacktrace {
+    fn from(bt: &Backtrace) -> Self {
+        Self::Serialized(Arc::new(bt.to_string()))
+    }
+}
+
+impl From<Arc<Backtrace>> for ErrorCodeBacktrace {
+    fn from(bt: Arc<Backtrace>) -> Self {
+        Self::Origin(bt)
+    }
+}
+
 #[derive(Error)]
 pub struct ErrorCode {
     code: u16,
@@ -80,6 +115,16 @@ impl ErrorCode {
             cause: self.cause,
             backtrace: self.backtrace,
         }
+    }
+
+    /// Set backtrace info for this error.
+    ///
+    /// Useful when trying to keep original backtrace
+    pub fn set_backtrace(mut self, bt: Option<impl Into<ErrorCodeBacktrace>>) -> Self {
+        if let Some(b) = bt {
+            self.backtrace = Some(b.into());
+        }
+        self
     }
 
     pub fn backtrace(&self) -> Option<ErrorCodeBacktrace> {

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(backtrace)]
+
 //! This crate defines data types used in meta data storage service.
 
 mod applied_state;

--- a/common/meta/types/src/meta_errors_into.rs
+++ b/common/meta/types/src/meta_errors_into.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::error::Error;
 use std::fmt::Display;
 
 use anyerror::AnyError;
@@ -34,24 +35,33 @@ impl From<MetaError> for ErrorCode {
             // Except application error and part of network error,
             // all other errors are not handleable and can only be converted to a fatal error.
             //
-            MetaError::MetaRaftError(e) => ErrorCode::MetaServiceError(e.to_string()),
-            MetaError::MetaStorageError(e) => ErrorCode::MetaServiceError(e.to_string()),
-            MetaError::MetaResultError(e) => ErrorCode::MetaServiceError(e.to_string()),
-            MetaError::InvalidConfig(e) => ErrorCode::MetaServiceError(e),
-            MetaError::MetaStoreAlreadyExists(e) => {
-                ErrorCode::MetaServiceError(format!("meta store already exists: {}", e))
+            MetaError::MetaRaftError(raft_err) => ErrorCode::MetaServiceError(raft_err.to_string())
+                .set_backtrace(raft_err.backtrace()),
+            MetaError::MetaStorageError(sto_err) => {
+                ErrorCode::MetaServiceError(sto_err.to_string()).set_backtrace(sto_err.backtrace())
             }
-            MetaError::MetaStoreNotFound => {
-                ErrorCode::MetaServiceError("MetaStoreNotFound".to_string())
+            MetaError::MetaResultError(res_err) => {
+                ErrorCode::MetaServiceError(res_err.to_string()).set_backtrace(res_err.backtrace())
             }
-            MetaError::StartMetaServiceError(e) => ErrorCode::MetaServiceError(e),
-            MetaError::ConcurrentSnapshotInstall(e) => ErrorCode::MetaServiceError(e),
-            MetaError::MetaServiceError(e) => ErrorCode::MetaServiceError(e),
-            MetaError::IllegalRoleInfoFormat(e) => ErrorCode::MetaServiceError(e),
-            MetaError::IllegalUserInfoFormat(e) => ErrorCode::MetaServiceError(e),
-            MetaError::SerdeError(e) => ErrorCode::MetaServiceError(e.to_string()),
-            MetaError::EncodeError(e) => ErrorCode::MetaServiceError(e.to_string()),
-            MetaError::Fatal(e) => ErrorCode::MetaServiceError(e.to_string()),
+            MetaError::InvalidConfig(err_str) => ErrorCode::MetaServiceError(err_str),
+            MetaError::MetaStoreAlreadyExists(node_id) => {
+                ErrorCode::MetaServiceError(format!("meta store already exists: {}", node_id))
+            }
+            MetaError::MetaStoreNotFound => ErrorCode::MetaServiceError("MetaStoreNotFound"),
+            MetaError::StartMetaServiceError(err_str) => ErrorCode::MetaServiceError(err_str),
+            MetaError::ConcurrentSnapshotInstall(err_str) => ErrorCode::MetaServiceError(err_str),
+            MetaError::MetaServiceError(err_str) => ErrorCode::MetaServiceError(err_str),
+            MetaError::IllegalRoleInfoFormat(err_str) => ErrorCode::MetaServiceError(err_str),
+            MetaError::IllegalUserInfoFormat(err_str) => ErrorCode::MetaServiceError(err_str),
+            MetaError::SerdeError(ae) => {
+                ErrorCode::MetaServiceError(ae.to_string()).set_backtrace(ae.backtrace())
+            }
+            MetaError::EncodeError(ae) => {
+                ErrorCode::MetaServiceError(ae.to_string()).set_backtrace(ae.backtrace())
+            }
+            MetaError::Fatal(ae) => {
+                ErrorCode::MetaServiceError(ae.to_string()).set_backtrace(ae.backtrace())
+            }
         }
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [common/exception] refactor: add ErrorCode::set_backtrace() for keeping the original bt when converting MetaError to ErrorCode

## Changelog




- Improvement


## Related Issues