### PR TITLE
fix: ensure builtin roles on create user by jwt

### DIFF
--- a/query/src/users/auth/auth_mgr.rs
+++ b/query/src/users/auth/auth_mgr.rs
@@ -74,6 +74,7 @@ impl AuthMgr {
                             user_info.grants.grant_role(role);
                         }
                     }
+                    self.user_mgr.ensure_builtin_roles(&tenant).await?;
                     self.user_mgr
                         .add_user(&tenant, user_info.clone(), true)
                         .await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

the builtin roles was initialized on CREATE USER statement, but it's not get initialized on creating user by jwt auth.

this PR initialize the builtin roles on the jwt auth, so the user created by JWT can be granted with the account_admin role.

## Changelog

- Bug Fix

## Related Issues

Fixes #issue

