### PR TITLE
feat(meta): Output [binary] in debug message instead

### DIFF
--- a/common/meta/types/src/operation.rs
+++ b/common/meta/types/src/operation.rs
@@ -15,15 +15,26 @@
 //! This crate defines data types used in meta data storage service.
 
 use std::fmt::Debug;
+use std::fmt::Formatter;
 
 pub type MetaId = u64;
 
 /// An operation that updates a field, delete it, or leave it as is.
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub enum Operation<T> {
     Update(T),
     Delete,
     AsIs,
+}
+
+impl<T> Debug for Operation<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Operation::Update(_) => f.debug_tuple("Update").field(&"[binary]").finish(),
+            Operation::Delete => f.debug_tuple("Delete").finish(),
+            Operation::AsIs => f.debug_tuple("AsIs").finish(),
+        }
+    }
 }
 
 impl<T> From<Option<T>> for Operation<T>

--- a/common/meta/types/src/seq_value.rs
+++ b/common/meta/types/src/seq_value.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::TryInto;
+use std::fmt::Formatter;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -27,11 +28,22 @@ pub struct KVMeta {
 }
 
 /// Some value bound with a seq number
-#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Default, Clone, Eq, PartialEq)]
 pub struct SeqV<T = Vec<u8>> {
     pub seq: u64,
     pub meta: Option<KVMeta>,
     pub data: T,
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for SeqV<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut de = f.debug_struct("SeqV");
+        de.field("seq", &self.seq);
+        de.field("meta", &self.meta);
+        de.field("data", &"[binary]");
+
+        de.finish()
+    }
 }
 
 pub trait IntoSeqV<T> {


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This will make developers' live easier:

### Before

![image](https://user-images.githubusercontent.com/5351546/171611641-8567c654-df53-4c15-9328-9956ee0bb1fa.png)

![image](https://user-images.githubusercontent.com/5351546/171611650-b6d2f2aa-cf12-4a78-aa84-8ef481c04f7e.png)

### After

![image](https://user-images.githubusercontent.com/5351546/171611666-1196db83-da3f-4b4f-be9f-858eeae3d6d3.png)

![image](https://user-images.githubusercontent.com/5351546/171611672-baa32eaa-39c0-4876-ba75-9767605e12f2.png)

We will output `[binary]` in logs instead so that our logs will not be polluted by non-sense binaries, for example:

![image](https://user-images.githubusercontent.com/5351546/171611862-2292acff-59f6-4712-b99f-d5f50e34bf99.png)


## Changelog

- New Feature


