### PR TITLE
chore(improvement): --version or -V show the binary release commit info

### DIFF
--- a/metasrv/src/configs/outer_v0.rs
+++ b/metasrv/src/configs/outer_v0.rs
@@ -27,9 +27,10 @@ use serfig::collectors::from_self;
 use serfig::parsers::Toml;
 
 use super::inner::Config as InnerConfig;
+use crate::version::METASRV_COMMIT_VERSION;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Parser)]
-#[clap(about, version, author)]
+#[clap(about, version = &**METASRV_COMMIT_VERSION, author)]
 #[serde(default)]
 pub struct Config {
     /// Run a command

--- a/query/src/config/outer_v0.rs
+++ b/query/src/config/outer_v0.rs
@@ -39,6 +39,7 @@ use super::inner::Config as InnerConfig;
 use super::inner::HiveCatalogConfig as InnerHiveCatalogConfig;
 use super::inner::MetaConfig as InnerMetaConfig;
 use super::inner::QueryConfig as InnerQueryConfig;
+use crate::DATABEND_COMMIT_VERSION;
 
 /// Outer config for `query`.
 ///
@@ -52,7 +53,7 @@ use super::inner::QueryConfig as InnerQueryConfig;
 /// Only adding new fields is allowed.
 /// This same rules should be applied to all fields of this struct.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Parser)]
-#[clap(about, version, author)]
+#[clap(about, version = &**DATABEND_COMMIT_VERSION, author)]
 #[serde(default)]
 pub struct Config {
     /// Run a command and quit

--- a/tools/metactl/src/main.rs
+++ b/tools/metactl/src/main.rs
@@ -30,6 +30,7 @@ use common_meta_sled_store::init_sled_db;
 use common_tracing::init_global_tracing;
 use databend_meta::export::deserialize_to_kv_variant;
 use databend_meta::export::serialize_kv_variant;
+use databend_meta::version::METASRV_COMMIT_VERSION;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::net::TcpSocket;
@@ -38,7 +39,7 @@ use tokio::net::TcpSocket;
 ///
 /// We should make metactl config keeps backward compatibility too.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Parser)]
-#[clap(about, version, author)]
+#[clap(about, version = &**METASRV_COMMIT_VERSION, author)]
 struct Config {
     /// Run a command
     #[clap(long, default_value = "")]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```
$ ./target/debug/databend-meta --version
databend-meta v0.7.69-nightly-0fe675e-simd(1.63.0-nightly-2022-06-03T03:08:32.84573831Z)
$ ./target/debug/databend-meta -V
databend-meta v0.7.69-nightly-0fe675e-simd(1.63.0-nightly-2022-06-03T03:08:32.84573831Z)


$ ./target/debug/databend-metactl --version
databend-metactl v0.7.69-nightly-0fe675e-simd(1.63.0-nightly-2022-06-03T03:08:32.84573831Z)
$ ./target/debug/databend-metactl -V
databend-metactl v0.7.69-nightly-0fe675e-simd(1.63.0-nightly-2022-06-03T03:08:32.84573831Z)


$ ./target/debug/databend-query --version
databend-query v0.7.69-nightly-0fe675e-simd(rust-1.63.0-nightly-2022-06-03T02:31:31.187404703Z)
$ ./target/debug/databend-query -V
databend-query v0.7.69-nightly-0fe675e-simd(rust-1.63.0-nightly-2022-06-03T02:31:31.187404703Z)
```

## Changelog

- Improvement


## Related Issues

Fixes #5747

