### PR TITLE
fix: push release image to datafuselabs/databend:latest

### DIFF
--- a/.github/actions/publish_image/action.yml
+++ b/.github/actions/publish_image/action.yml
@@ -7,9 +7,6 @@ inputs:
   dockerhub_token:
     description: "The token of dockerhub"
     required: true
-  dockerhub_namespace:
-    description: "The namespace of dockerhub"
-    required: true
   target:
     description: ""
     required: true
@@ -47,7 +44,7 @@ runs:
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: ${{ inputs.dockerhub_namespace }}/databend:master # assume latest tag is the latest release tag
+        tags: datafuselabs/databend:master # assume latest tag is the latest release tag
         platforms: ${{ inputs.platform }}
         context: .
         file: ./docker/Dockerfile

--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -144,14 +144,14 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_NAMESPACE }}/databend:${{ steps.get_version.outputs.VERSION }}
+          tags: datafuselabs/databend:latest,datafuselabs/databend:${{ steps.get_version.outputs.VERSION }}
           platforms: linux/amd64
           context: .
           file: ./docker/Dockerfile
           build-args: VERSION=${{ steps.get_version.outputs.VERSION }}
 
   release_docker_separate:
-    name: docker image seperated for k8s service
+    name: docker image seperated
     runs-on: ubuntu-latest
     needs: publish_linux
     strategy:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -153,6 +153,5 @@ jobs:
         with:
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
-          dockerhub_namespace: ${{ secrets.DOCKERHUB_NAMESPACE }}
           target: ${{ matrix.config.target }}
           platform: ${{ matrix.config.platform }}

--- a/docker/databend-query-docker.toml
+++ b/docker/databend-query-docker.toml
@@ -31,7 +31,7 @@ tenant_id = "test_tenant"
 cluster_id = "test_cluster"
 
 [log]
-level = "DEBUG"
+level = "INFO"
 dir = "./.databend/logs"
 
 [meta]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The secret `DOCKERHUB_NAMESPACE` could be deleted.

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

