### PR TITLE
feature(planner): Support `CREATE TABLE` statement in new planner

### DIFF
--- a/common/ast/src/ast/mod.rs
+++ b/common/ast/src/ast/mod.rs
@@ -70,3 +70,16 @@ fn write_comma_separated_list(
     }
     Ok(())
 }
+
+fn write_space_seperated_list(
+    f: &mut Formatter<'_>,
+    items: impl IntoIterator<Item = impl Display>,
+) -> std::fmt::Result {
+    for (i, item) in items.into_iter().enumerate() {
+        if i > 0 {
+            write!(f, " ")?;
+        }
+        write!(f, "{}", item)?;
+    }
+    Ok(())
+}

--- a/common/ast/src/ast/statement.rs
+++ b/common/ast/src/ast/statement.rs
@@ -18,6 +18,7 @@ use std::fmt::Formatter;
 use common_meta_types::AuthType;
 use common_meta_types::UserIdentity;
 
+use super::write_space_seperated_list;
 use super::Expr;
 use crate::ast::expr::Literal;
 use crate::ast::expr::TypeName;
@@ -77,16 +78,7 @@ pub enum Statement<'a> {
         database: Option<Identifier<'a>>,
         limit: Option<ShowLimit<'a>>,
     },
-    CreateTable {
-        if_not_exists: bool,
-        database: Option<Identifier<'a>>,
-        table: Identifier<'a>,
-        source: Option<CreateTableSource<'a>>,
-        engine: Engine,
-        cluster_by: Vec<Expr<'a>>,
-        as_query: Option<Box<Query<'a>>>,
-        comment: Option<String>,
-    },
+    CreateTable(CreateTableStmt<'a>),
     // Describe schema of a table
     // Like `SHOW CREATE TABLE`
     Describe {
@@ -223,12 +215,46 @@ pub enum InsertSource<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct CreateTableStmt<'a> {
+    pub if_not_exists: bool,
+    pub database: Option<Identifier<'a>>,
+    pub table: Identifier<'a>,
+    pub source: Option<CreateTableSource<'a>>,
+    pub table_options: Vec<TableOption>,
+    pub cluster_by: Vec<Expr<'a>>,
+    pub as_query: Option<Box<Query<'a>>>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum CreateTableSource<'a> {
     Columns(Vec<ColumnDefinition<'a>>),
     Like {
         database: Option<Identifier<'a>>,
         table: Identifier<'a>,
     },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TableOption {
+    Engine(Engine),
+    Comment(String),
+}
+
+impl TableOption {
+    pub fn option_key(&self) -> String {
+        match self {
+            TableOption::Engine(_) => "ENGINE".to_string(),
+            TableOption::Comment(_) => "COMMENT".to_string(),
+        }
+    }
+
+    pub fn option_value(&self) -> String {
+        match self {
+            TableOption::Engine(engine) => engine.to_string(),
+            TableOption::Comment(comment) => comment.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -319,6 +345,15 @@ impl<'a> Display for ColumnDefinition<'a> {
             write!(f, " DEFAULT {default_expr}")?;
         }
         Ok(())
+    }
+}
+
+impl Display for TableOption {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TableOption::Engine(engine) => write!(f, "ENGINE = {engine}"),
+            TableOption::Comment(comment) => write!(f, "COMMENT = {comment}"),
+        }
     }
 }
 
@@ -457,16 +492,16 @@ impl<'a> Display for Statement<'a> {
                     write!(f, " {limit}")?;
                 }
             }
-            Statement::CreateTable {
+            Statement::CreateTable(CreateTableStmt {
                 if_not_exists,
                 database,
                 table,
                 source,
-                engine,
+                table_options,
                 comment,
                 cluster_by,
                 as_query,
-            } => {
+            }) => {
                 write!(f, "CREATE TABLE ")?;
                 if *if_not_exists {
                     write!(f, "IF NOT EXISTS ")?;
@@ -484,9 +519,10 @@ impl<'a> Display for Statement<'a> {
                     }
                     None => (),
                 }
-                if *engine != Engine::Null {
-                    write!(f, " ENGINE = {engine}")?;
-                }
+
+                // Format table options
+                write_space_seperated_list(f, table_options.iter())?;
+
                 if let Some(comment) = comment {
                     write!(f, " COMMENT = {comment}")?;
                 }

--- a/common/ast/src/parser/statement.rs
+++ b/common/ast/src/parser/statement.rs
@@ -134,7 +134,7 @@ pub fn statement(i: Input) -> IResult<Statement> {
             CREATE ~ TABLE ~ ( IF ~ NOT ~ EXISTS )?
             ~ ( #ident ~ "." )? ~ #ident
             ~ #create_table_source?
-            ~ #engine?
+            ~ ( #table_option )*
             ~ ( COMMENT ~ "=" ~ #literal_string )?
             ~ ( CLUSTER ~ ^BY ~ ^"(" ~ ^#comma_separated_list1(expr) ~ ^")" )?
             ~ ( AS ~ ^#query )?
@@ -146,23 +146,23 @@ pub fn statement(i: Input) -> IResult<Statement> {
             opt_database,
             table,
             source,
-            opt_engine,
+            table_options,
             opt_comment,
             opt_cluster_by,
             opt_as_query,
         )| {
-            Statement::CreateTable {
+            Statement::CreateTable(CreateTableStmt {
                 if_not_exists: opt_if_not_exists.is_some(),
                 database: opt_database.map(|(database, _)| database),
                 table,
                 source,
-                engine: opt_engine.unwrap_or(Engine::Null),
+                table_options,
                 comment: opt_comment.map(|(_, _, comment)| comment),
                 cluster_by: opt_cluster_by
                     .map(|(_, _, _, exprs, _)| exprs)
                     .unwrap_or_default(),
                 as_query: opt_as_query.map(|(_, query)| Box::new(query)),
-            }
+            })
         },
     );
     let describe = map(
@@ -429,7 +429,7 @@ pub fn statement(i: Input) -> IResult<Statement> {
             | #show_tables : "`SHOW [FULL] TABLES [FROM <database>] [<show_limit>]`"
             | #show_create_table : "`SHOW CREATE TABLE [<database>.]<table>`"
             | #show_tables_status : "`SHOW TABLES STATUS [FROM <database>] [<show_limit>]`"
-            | #create_table : "`CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [ENGINE = <engine>]`"
+            | #create_table : "`CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`"
             | #describe : "`DESCRIBE [<database>.]<table>`"
             | #drop_table : "`DROP TABLE [IF EXISTS] [<database>.]<table>`"
             | #undrop_table : "`UNDROP TABLE [<database>.]<table>`"
@@ -614,6 +614,18 @@ pub fn show_limit(i: Input) -> IResult<ShowLimit> {
         #limit_like
         | #limit_where
     )(i)
+}
+
+pub fn table_option(i: Input) -> IResult<TableOption> {
+    alt((
+        map(engine, TableOption::Engine),
+        map(
+            rule! {
+                COMMENT ~ ^"=" ~ #literal_string
+            },
+            |(_, _, comment)| TableOption::Comment(comment),
+        ),
+    ))(i)
 }
 
 pub fn engine(i: Input) -> IResult<Engine> {

--- a/common/ast/tests/it/testdata/statement-error.txt
+++ b/common/ast/tests/it/testdata/statement-error.txt
@@ -7,7 +7,7 @@ error:
 1 | create table a.b (c integer not null 1, b float(10))
   | ------                               ^ expected `)`, `NULL`, `NOT`, `DEFAULT`, or `,`
   | |                                     
-  | while parsing `CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [ENGINE = <engine>]`
+  | while parsing `CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
 
 
 ---------- Input ----------
@@ -19,7 +19,7 @@ error:
 1 | create table a (c float(10))
   | ------                 ^ expected `)`, `NULL`, `NOT`, `DEFAULT`, or `,`
   | |                       
-  | while parsing `CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [ENGINE = <engine>]`
+  | while parsing `CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
 
 
 ---------- Input ----------
@@ -34,7 +34,7 @@ error:
   | |               | expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 25 more ...
   | |               | while parsing type name
   | |               while parsing `<column name> <type> [NOT NULL | NULL] [DEFAULT <default value>]`
-  | while parsing `CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [ENGINE = <engine>]`
+  | while parsing `CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
 
 
 ---------- Input ----------

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -159,60 +159,62 @@ create table if not exists a.b (c integer not null default 1, b varchar);
 ---------- Output ---------
 CREATE TABLE IF NOT EXISTS a.b (c Int32 NOT NULL DEFAULT 1, b STRING NOT NULL)
 ---------- AST ------------
-CreateTable {
-    if_not_exists: true,
-    database: Some(
-        Identifier {
-            name: "a",
-            quote: None,
-            span: Ident(27..28),
-        },
-    ),
-    table: Identifier {
-        name: "b",
-        quote: None,
-        span: Ident(29..30),
-    },
-    source: Some(
-        Columns(
-            [
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "c",
-                        quote: None,
-                        span: Ident(32..33),
-                    },
-                    data_type: Int32,
-                    nullable: false,
-                    default_expr: Some(
-                        Literal {
-                            span: [
-                                LiteralInteger(59..60),
-                            ],
-                            lit: Integer(
-                                1,
-                            ),
-                        },
-                    ),
-                },
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "b",
-                        quote: None,
-                        span: Ident(62..63),
-                    },
-                    data_type: String,
-                    nullable: false,
-                    default_expr: None,
-                },
-            ],
+CreateTable(
+    CreateTableStmt {
+        if_not_exists: true,
+        database: Some(
+            Identifier {
+                name: "a",
+                quote: None,
+                span: Ident(27..28),
+            },
         ),
-    ),
-    engine: Null,
-    cluster_by: [],
-    as_query: None,
-    comment: None,
-}
+        table: Identifier {
+            name: "b",
+            quote: None,
+            span: Ident(29..30),
+        },
+        source: Some(
+            Columns(
+                [
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "c",
+                            quote: None,
+                            span: Ident(32..33),
+                        },
+                        data_type: Int32,
+                        nullable: false,
+                        default_expr: Some(
+                            Literal {
+                                span: [
+                                    LiteralInteger(59..60),
+                                ],
+                                lit: Integer(
+                                    1,
+                                ),
+                            },
+                        ),
+                    },
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "b",
+                            quote: None,
+                            span: Ident(62..63),
+                        },
+                        data_type: String,
+                        nullable: false,
+                        default_expr: None,
+                    },
+                ],
+            ),
+        ),
+        table_options: [],
+        cluster_by: [],
+        as_query: None,
+        comment: None,
+    },
+)
 
 
 ---------- Input ----------
@@ -220,107 +222,109 @@ create table if not exists a.b (c integer default 1 not null, b varchar) as sele
 ---------- Output ---------
 CREATE TABLE IF NOT EXISTS a.b (c Int32 NOT NULL DEFAULT 1, b STRING NOT NULL) AS SELECT * FROM t
 ---------- AST ------------
-CreateTable {
-    if_not_exists: true,
-    database: Some(
-        Identifier {
-            name: "a",
-            quote: None,
-            span: Ident(27..28),
-        },
-    ),
-    table: Identifier {
-        name: "b",
-        quote: None,
-        span: Ident(29..30),
-    },
-    source: Some(
-        Columns(
-            [
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "c",
-                        quote: None,
-                        span: Ident(32..33),
-                    },
-                    data_type: Int32,
-                    nullable: false,
-                    default_expr: Some(
-                        Literal {
-                            span: [
-                                LiteralInteger(50..51),
-                            ],
-                            lit: Integer(
-                                1,
-                            ),
-                        },
-                    ),
-                },
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "b",
-                        quote: None,
-                        span: Ident(62..63),
-                    },
-                    data_type: String,
-                    nullable: false,
-                    default_expr: None,
-                },
-            ],
+CreateTable(
+    CreateTableStmt {
+        if_not_exists: true,
+        database: Some(
+            Identifier {
+                name: "a",
+                quote: None,
+                span: Ident(27..28),
+            },
         ),
-    ),
-    engine: Null,
-    cluster_by: [],
-    as_query: Some(
-        Query {
-            span: [
-                SELECT(76..82),
-                Multiply(83..84),
-                FROM(85..89),
-                Ident(90..91),
-            ],
-            body: Select(
-                SelectStmt {
-                    span: [
-                        SELECT(76..82),
-                        Multiply(83..84),
-                        FROM(85..89),
-                        Ident(90..91),
-                    ],
-                    distinct: false,
-                    select_list: [
-                        QualifiedName(
-                            [
-                                Star,
-                            ],
-                        ),
-                    ],
-                    from: [
-                        Table {
-                            catalog: None,
-                            database: None,
-                            table: Identifier {
-                                name: "t",
-                                quote: None,
-                                span: Ident(90..91),
-                            },
-                            alias: None,
-                            travel_point: None,
-                        },
-                    ],
-                    selection: None,
-                    group_by: [],
-                    having: None,
-                },
-            ),
-            order_by: [],
-            limit: [],
-            offset: None,
-            format: None,
+        table: Identifier {
+            name: "b",
+            quote: None,
+            span: Ident(29..30),
         },
-    ),
-    comment: None,
-}
+        source: Some(
+            Columns(
+                [
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "c",
+                            quote: None,
+                            span: Ident(32..33),
+                        },
+                        data_type: Int32,
+                        nullable: false,
+                        default_expr: Some(
+                            Literal {
+                                span: [
+                                    LiteralInteger(50..51),
+                                ],
+                                lit: Integer(
+                                    1,
+                                ),
+                            },
+                        ),
+                    },
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "b",
+                            quote: None,
+                            span: Ident(62..63),
+                        },
+                        data_type: String,
+                        nullable: false,
+                        default_expr: None,
+                    },
+                ],
+            ),
+        ),
+        table_options: [],
+        cluster_by: [],
+        as_query: Some(
+            Query {
+                span: [
+                    SELECT(76..82),
+                    Multiply(83..84),
+                    FROM(85..89),
+                    Ident(90..91),
+                ],
+                body: Select(
+                    SelectStmt {
+                        span: [
+                            SELECT(76..82),
+                            Multiply(83..84),
+                            FROM(85..89),
+                            Ident(90..91),
+                        ],
+                        distinct: false,
+                        select_list: [
+                            QualifiedName(
+                                [
+                                    Star,
+                                ],
+                            ),
+                        ],
+                        from: [
+                            Table {
+                                catalog: None,
+                                database: None,
+                                table: Identifier {
+                                    name: "t",
+                                    quote: None,
+                                    span: Ident(90..91),
+                                },
+                                alias: None,
+                                travel_point: None,
+                            },
+                        ],
+                        selection: None,
+                        group_by: [],
+                        having: None,
+                    },
+                ),
+                order_by: [],
+                limit: [],
+                offset: None,
+                format: None,
+            },
+        ),
+        comment: None,
+    },
+)
 
 
 ---------- Input ----------
@@ -328,71 +332,79 @@ create table a.b like c.d;
 ---------- Output ---------
 CREATE TABLE a.b LIKE c.d
 ---------- AST ------------
-CreateTable {
-    if_not_exists: false,
-    database: Some(
-        Identifier {
-            name: "a",
-            quote: None,
-            span: Ident(13..14),
-        },
-    ),
-    table: Identifier {
-        name: "b",
-        quote: None,
-        span: Ident(15..16),
-    },
-    source: Some(
-        Like {
-            database: Some(
-                Identifier {
-                    name: "c",
-                    quote: None,
-                    span: Ident(22..23),
-                },
-            ),
-            table: Identifier {
-                name: "d",
+CreateTable(
+    CreateTableStmt {
+        if_not_exists: false,
+        database: Some(
+            Identifier {
+                name: "a",
                 quote: None,
-                span: Ident(24..25),
+                span: Ident(13..14),
             },
+        ),
+        table: Identifier {
+            name: "b",
+            quote: None,
+            span: Ident(15..16),
         },
-    ),
-    engine: Null,
-    cluster_by: [],
-    as_query: None,
-    comment: None,
-}
+        source: Some(
+            Like {
+                database: Some(
+                    Identifier {
+                        name: "c",
+                        quote: None,
+                        span: Ident(22..23),
+                    },
+                ),
+                table: Identifier {
+                    name: "d",
+                    quote: None,
+                    span: Ident(24..25),
+                },
+            },
+        ),
+        table_options: [],
+        cluster_by: [],
+        as_query: None,
+        comment: None,
+    },
+)
 
 
 ---------- Input ----------
 create table t like t2 engine = memory;
 ---------- Output ---------
-CREATE TABLE t LIKE t2 ENGINE = MEMORY
+CREATE TABLE t LIKE t2ENGINE = MEMORY
 ---------- AST ------------
-CreateTable {
-    if_not_exists: false,
-    database: None,
-    table: Identifier {
-        name: "t",
-        quote: None,
-        span: Ident(13..14),
-    },
-    source: Some(
-        Like {
-            database: None,
-            table: Identifier {
-                name: "t2",
-                quote: None,
-                span: Ident(20..22),
-            },
+CreateTable(
+    CreateTableStmt {
+        if_not_exists: false,
+        database: None,
+        table: Identifier {
+            name: "t",
+            quote: None,
+            span: Ident(13..14),
         },
-    ),
-    engine: Memory,
-    cluster_by: [],
-    as_query: None,
-    comment: None,
-}
+        source: Some(
+            Like {
+                database: None,
+                table: Identifier {
+                    name: "t2",
+                    quote: None,
+                    span: Ident(20..22),
+                },
+            },
+        ),
+        table_options: [
+            Engine(
+                Memory,
+            ),
+        ],
+        cluster_by: [],
+        as_query: None,
+        comment: None,
+    },
+)
 
 
 ---------- Input ----------
@@ -515,51 +527,53 @@ create table c(a DateTime null, b DateTime(3));
 ---------- Output ---------
 CREATE TABLE c (a DATETIME NULL, b DATETIME(3) NOT NULL)
 ---------- AST ------------
-CreateTable {
-    if_not_exists: false,
-    database: None,
-    table: Identifier {
-        name: "c",
-        quote: None,
-        span: Ident(13..14),
-    },
-    source: Some(
-        Columns(
-            [
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "a",
-                        quote: None,
-                        span: Ident(15..16),
+CreateTable(
+    CreateTableStmt {
+        if_not_exists: false,
+        database: None,
+        table: Identifier {
+            name: "c",
+            quote: None,
+            span: Ident(13..14),
+        },
+        source: Some(
+            Columns(
+                [
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "a",
+                            quote: None,
+                            span: Ident(15..16),
+                        },
+                        data_type: DateTime {
+                            precision: None,
+                        },
+                        nullable: true,
+                        default_expr: None,
                     },
-                    data_type: DateTime {
-                        precision: None,
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "b",
+                            quote: None,
+                            span: Ident(32..33),
+                        },
+                        data_type: DateTime {
+                            precision: Some(
+                                3,
+                            ),
+                        },
+                        nullable: false,
+                        default_expr: None,
                     },
-                    nullable: true,
-                    default_expr: None,
-                },
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "b",
-                        quote: None,
-                        span: Ident(32..33),
-                    },
-                    data_type: DateTime {
-                        precision: Some(
-                            3,
-                        ),
-                    },
-                    nullable: false,
-                    default_expr: None,
-                },
-            ],
+                ],
+            ),
         ),
-    ),
-    engine: Null,
-    cluster_by: [],
-    as_query: None,
-    comment: None,
-}
+        table_options: [],
+        cluster_by: [],
+        as_query: None,
+        comment: None,
+    },
+)
 
 
 ---------- Input ----------
@@ -639,55 +653,57 @@ CREATE TABLE t(c1 int null, c2 bigint null, c3 varchar null);
 ---------- Output ---------
 CREATE TABLE t (c1 Int32 NULL, c2 Int64 NULL, c3 STRING NULL)
 ---------- AST ------------
-CreateTable {
-    if_not_exists: false,
-    database: None,
-    table: Identifier {
-        name: "t",
-        quote: None,
-        span: Ident(13..14),
-    },
-    source: Some(
-        Columns(
-            [
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "c1",
-                        quote: None,
-                        span: Ident(15..17),
+CreateTable(
+    CreateTableStmt {
+        if_not_exists: false,
+        database: None,
+        table: Identifier {
+            name: "t",
+            quote: None,
+            span: Ident(13..14),
+        },
+        source: Some(
+            Columns(
+                [
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "c1",
+                            quote: None,
+                            span: Ident(15..17),
+                        },
+                        data_type: Int32,
+                        nullable: true,
+                        default_expr: None,
                     },
-                    data_type: Int32,
-                    nullable: true,
-                    default_expr: None,
-                },
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "c2",
-                        quote: None,
-                        span: Ident(28..30),
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "c2",
+                            quote: None,
+                            span: Ident(28..30),
+                        },
+                        data_type: Int64,
+                        nullable: true,
+                        default_expr: None,
                     },
-                    data_type: Int64,
-                    nullable: true,
-                    default_expr: None,
-                },
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "c3",
-                        quote: None,
-                        span: Ident(44..46),
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "c3",
+                            quote: None,
+                            span: Ident(44..46),
+                        },
+                        data_type: String,
+                        nullable: true,
+                        default_expr: None,
                     },
-                    data_type: String,
-                    nullable: true,
-                    default_expr: None,
-                },
-            ],
+                ],
+            ),
         ),
-    ),
-    engine: Null,
-    cluster_by: [],
-    as_query: None,
-    comment: None,
-}
+        table_options: [],
+        cluster_by: [],
+        as_query: None,
+        comment: None,
+    },
+)
 
 
 ---------- Input ----------
@@ -695,55 +711,57 @@ CREATE TABLE t(c1 int not null, c2 bigint not null, c3 varchar not null);
 ---------- Output ---------
 CREATE TABLE t (c1 Int32 NOT NULL, c2 Int64 NOT NULL, c3 STRING NOT NULL)
 ---------- AST ------------
-CreateTable {
-    if_not_exists: false,
-    database: None,
-    table: Identifier {
-        name: "t",
-        quote: None,
-        span: Ident(13..14),
-    },
-    source: Some(
-        Columns(
-            [
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "c1",
-                        quote: None,
-                        span: Ident(15..17),
+CreateTable(
+    CreateTableStmt {
+        if_not_exists: false,
+        database: None,
+        table: Identifier {
+            name: "t",
+            quote: None,
+            span: Ident(13..14),
+        },
+        source: Some(
+            Columns(
+                [
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "c1",
+                            quote: None,
+                            span: Ident(15..17),
+                        },
+                        data_type: Int32,
+                        nullable: false,
+                        default_expr: None,
                     },
-                    data_type: Int32,
-                    nullable: false,
-                    default_expr: None,
-                },
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "c2",
-                        quote: None,
-                        span: Ident(32..34),
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "c2",
+                            quote: None,
+                            span: Ident(32..34),
+                        },
+                        data_type: Int64,
+                        nullable: false,
+                        default_expr: None,
                     },
-                    data_type: Int64,
-                    nullable: false,
-                    default_expr: None,
-                },
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "c3",
-                        quote: None,
-                        span: Ident(52..54),
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "c3",
+                            quote: None,
+                            span: Ident(52..54),
+                        },
+                        data_type: String,
+                        nullable: false,
+                        default_expr: None,
                     },
-                    data_type: String,
-                    nullable: false,
-                    default_expr: None,
-                },
-            ],
+                ],
+            ),
         ),
-    ),
-    engine: Null,
-    cluster_by: [],
-    as_query: None,
-    comment: None,
-}
+        table_options: [],
+        cluster_by: [],
+        as_query: None,
+        comment: None,
+    },
+)
 
 
 ---------- Input ----------
@@ -751,44 +769,46 @@ CREATE TABLE t(c1 int default 1);
 ---------- Output ---------
 CREATE TABLE t (c1 Int32 NOT NULL DEFAULT 1)
 ---------- AST ------------
-CreateTable {
-    if_not_exists: false,
-    database: None,
-    table: Identifier {
-        name: "t",
-        quote: None,
-        span: Ident(13..14),
-    },
-    source: Some(
-        Columns(
-            [
-                ColumnDefinition {
-                    name: Identifier {
-                        name: "c1",
-                        quote: None,
-                        span: Ident(15..17),
-                    },
-                    data_type: Int32,
-                    nullable: false,
-                    default_expr: Some(
-                        Literal {
-                            span: [
-                                LiteralInteger(30..31),
-                            ],
-                            lit: Integer(
-                                1,
-                            ),
+CreateTable(
+    CreateTableStmt {
+        if_not_exists: false,
+        database: None,
+        table: Identifier {
+            name: "t",
+            quote: None,
+            span: Ident(13..14),
+        },
+        source: Some(
+            Columns(
+                [
+                    ColumnDefinition {
+                        name: Identifier {
+                            name: "c1",
+                            quote: None,
+                            span: Ident(15..17),
                         },
-                    ),
-                },
-            ],
+                        data_type: Int32,
+                        nullable: false,
+                        default_expr: Some(
+                            Literal {
+                                span: [
+                                    LiteralInteger(30..31),
+                                ],
+                                lit: Integer(
+                                    1,
+                                ),
+                            },
+                        ),
+                    },
+                ],
+            ),
         ),
-    ),
-    engine: Null,
-    cluster_by: [],
-    as_query: None,
-    comment: None,
-}
+        table_options: [],
+        cluster_by: [],
+        as_query: None,
+        comment: None,
+    },
+)
 
 
 ---------- Input ----------

--- a/common/planners/src/plan_table_create.rs
+++ b/common/planners/src/plan_table_create.rs
@@ -19,7 +19,6 @@ use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::TableMeta;
 use common_meta_app::schema::TableNameIdent;
 
-use crate::Expression;
 use crate::PlanNode;
 
 pub type TableOptions = BTreeMap<String, String>;
@@ -36,7 +35,7 @@ pub struct CreateTablePlan {
 
     pub table_meta: TableMeta,
 
-    pub cluster_keys: Vec<Expression>,
+    pub cluster_keys: Vec<String>,
     pub as_select: Option<Box<PlanNode>>,
 }
 

--- a/query/src/interpreters/interpreter_factory_v2.rs
+++ b/query/src/interpreters/interpreter_factory_v2.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_exception::Result;
 
+use super::CreateTableInterpreter;
 use super::ExplainInterpreterV2;
 use super::InterpreterPtr;
 use super::SelectInterpreterV2;
@@ -31,7 +32,10 @@ pub struct InterpreterFactoryV2;
 impl InterpreterFactoryV2 {
     /// Check if statement is supported by InterpreterFactoryV2
     pub fn check(stmt: &DfStatement) -> bool {
-        matches!(stmt, DfStatement::Query(_) | DfStatement::Explain(_))
+        matches!(
+            stmt,
+            DfStatement::Query(_) | DfStatement::Explain(_) | DfStatement::CreateTable(_)
+        )
     }
 
     pub fn get(ctx: Arc<QueryContext>, plan: &Plan) -> Result<InterpreterPtr> {
@@ -48,6 +52,9 @@ impl InterpreterFactoryV2 {
             ),
             Plan::Explain { kind, plan } => {
                 ExplainInterpreterV2::try_create(ctx, *plan.clone(), kind.clone())
+            }
+            Plan::CreateTable(create_table) => {
+                CreateTableInterpreter::try_create(ctx, create_table.clone())
             }
         }?;
         Ok(inner)

--- a/query/src/sql/optimizer/mod.rs
+++ b/query/src/sql/optimizer/mod.rs
@@ -55,6 +55,7 @@ pub fn optimize(plan: Plan) -> Result<Plan> {
             kind,
             plan: Box::new(optimize(*plan)?),
         }),
+        Plan::CreateTable(_) => Ok(plan),
     }
 }
 

--- a/query/src/sql/planner/binder/ddl/mod.rs
+++ b/query/src/sql/planner/binder/ddl/mod.rs
@@ -12,21 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_exception::Result;
-
-use crate::sql::plans::Plan;
-
-impl Plan {
-    pub fn format_indent(&self) -> Result<String> {
-        match self {
-            Plan::Query {
-                s_expr, metadata, ..
-            } => s_expr.to_format_tree(metadata).format_indent(),
-            Plan::Explain { kind, plan } => {
-                let result = plan.format_indent()?;
-                Ok(format!("{:?}:\n{}", kind, result))
-            }
-            Plan::CreateTable(create_table) => Ok(format!("{:?}", create_table)),
-        }
-    }
-}
+mod table;

--- a/query/src/sql/planner/binder/ddl/table.rs
+++ b/query/src/sql/planner/binder/ddl/table.rs
@@ -1,0 +1,237 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use common_ast::ast::CreateTableSource;
+use common_ast::ast::CreateTableStmt;
+use common_ast::ast::Engine;
+use common_ast::ast::Expr;
+use common_ast::ast::TableOption;
+use common_datavalues::DataField;
+use common_datavalues::DataSchemaRef;
+use common_datavalues::DataSchemaRefExt;
+use common_datavalues::NullableType;
+use common_datavalues::TypeFactory;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_meta_app::schema::TableMeta;
+use common_planners::CreateTablePlan;
+
+use crate::sql::binder::scalar::ScalarBinder;
+use crate::sql::binder::Binder;
+use crate::sql::is_reserved_opt_key;
+use crate::sql::plans::Plan;
+use crate::sql::BindContext;
+use crate::sql::ColumnBinding;
+use crate::sql::OPT_KEY_DATABASE_ID;
+
+impl<'a> Binder {
+    /// Basically copied from `DfCreateTable::table_meta `
+    async fn analyze_create_table_schema(
+        &self,
+        source: &CreateTableSource<'a>,
+    ) -> Result<DataSchemaRef> {
+        let bind_context = BindContext::new();
+        match source {
+            CreateTableSource::Columns(columns) => {
+                let mut scalar_binder =
+                    ScalarBinder::new(&bind_context, self.ctx.clone(), self.metadata.clone());
+                let mut fields = Vec::with_capacity(columns.len());
+                for column in columns.iter() {
+                    let name = column.name.name.clone();
+                    let mut data_type = TypeFactory::instance()
+                        .get(column.data_type.to_string())?
+                        .clone();
+                    if column.nullable {
+                        data_type = NullableType::new_impl(data_type);
+                    }
+                    let field = DataField::new(name.as_str(), data_type).with_default_expr({
+                        if let Some(default_expr) = &column.default_expr {
+                            scalar_binder.bind(default_expr).await?;
+                            Some(default_expr.to_string())
+                        } else {
+                            None
+                        }
+                    });
+                    fields.push(field);
+                }
+                Ok(DataSchemaRefExt::create(fields))
+            }
+            CreateTableSource::Like { database, table } => {
+                let catalog = self.ctx.get_current_catalog();
+                let database = database.as_ref().map_or_else(
+                    || self.ctx.get_current_catalog(),
+                    |ident| ident.name.clone(),
+                );
+                let table_name = table.name.as_str();
+                let table = self
+                    .ctx
+                    .get_table(catalog.as_str(), database.as_str(), table_name)
+                    .await?;
+                Ok(table.schema())
+            }
+        }
+    }
+
+    fn insert_table_option_with_validation(
+        &self,
+        options: &mut BTreeMap<String, String>,
+        key: String,
+        value: String,
+    ) -> Result<()> {
+        if is_reserved_opt_key(&key) {
+            Err(ErrorCode::BadOption(format!("the following table options are reserved, please do not specify them in the CREATE TABLE statement: {}",
+                        key
+                        )))
+        } else if options.insert(key.clone(), value).is_some() {
+            Err(ErrorCode::BadOption(format!(
+                "Duplicated table option: {key}"
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn validate_expr(&self, schema: DataSchemaRef, expr: &Expr<'a>) -> Result<()> {
+        // Build a temporary BindContext to resolve the expr
+        let mut bind_context = BindContext::new();
+        for field in schema.fields() {
+            let column = ColumnBinding {
+                table_name: None,
+                column_name: field.name().clone(),
+                // A dummy index is fine, since we won't actually evaluate the expression
+                index: 0,
+                data_type: field.data_type().clone(),
+                visible_in_unqualified_wildcard: false,
+            };
+            bind_context.columns.push(column);
+        }
+
+        let mut scalar_binder =
+            ScalarBinder::new(&bind_context, self.ctx.clone(), self.metadata.clone());
+        scalar_binder.bind(expr).await?;
+
+        Ok(())
+    }
+
+    pub(in crate::sql::planner::binder) async fn bind_create_table(
+        &mut self,
+        stmt: &CreateTableStmt<'a>,
+    ) -> Result<Plan> {
+        let catalog = self.ctx.get_current_catalog();
+        let database = stmt
+            .database
+            .as_ref()
+            .map(|ident| ident.name.to_lowercase())
+            .unwrap_or_else(|| self.ctx.get_current_database());
+        let table = stmt.table.name.to_lowercase();
+
+        // Take FUSE engine as default engine
+        let mut engine = Engine::Fuse;
+        let mut table_options: BTreeMap<String, String> = BTreeMap::new();
+        for table_option in stmt.table_options.iter() {
+            match table_option {
+                TableOption::Engine(table_engine) => {
+                    engine = table_engine.clone();
+                }
+                TableOption::Comment(comment) => self.insert_table_option_with_validation(
+                    &mut table_options,
+                    "COMMENT".to_string(),
+                    comment.clone(),
+                )?,
+            }
+        }
+
+        // Build table schema
+        let schema = match (&stmt.source, &stmt.as_query) {
+            (Some(source), None) => {
+                // `CREATE TABLE` without `AS SELECT ...`
+                self.analyze_create_table_schema(source).await?
+            }
+            (None, Some(query)) => {
+                // `CREATE TABLE AS SELECT ...` without column definitions
+                let init_bind_context = BindContext::new();
+                let (_s_expr, bind_context) = self.bind_query(&init_bind_context, query).await?;
+                let fields = bind_context
+                    .columns
+                    .iter()
+                    .map(|column_binding| {
+                        DataField::new(
+                            column_binding.column_name.as_str(),
+                            column_binding.data_type.clone(),
+                        )
+                    })
+                    .collect();
+                DataSchemaRefExt::create(fields)
+            }
+            // TODO(leiysky): Support `CREATE TABLE AS SELECT` with specified column definitions
+            _ => Err(ErrorCode::UnImplement("Unsupported CREATE TABLE statement"))?,
+        };
+
+        let mut meta = TableMeta {
+            schema: schema.clone(),
+            engine: engine.to_string(),
+            options: table_options.clone(),
+            ..Default::default()
+        };
+
+        if engine == Engine::Fuse {
+            // Currently, [Table] can not accesses its database id yet, thus
+            // here we keep the db id as an entry of `table_meta.options`.
+            //
+            // To make the unit/stateless test cases (`show create ..`) easier,
+            // here we care about the FUSE engine only.
+            //
+            // Later, when database id is kept, let say in `TableInfo`, we can
+            // safely eliminate this "FUSE" constant and the table meta option entry.
+            let catalog = self.ctx.get_catalog(catalog.as_str())?;
+            let db = catalog
+                .get_database(self.ctx.get_tenant().as_str(), database.as_str())
+                .await?;
+            let db_id = db.get_db_info().ident.db_id;
+            meta.options
+                .insert(OPT_KEY_DATABASE_ID.to_owned(), db_id.to_string());
+        }
+
+        // Validate cluster keys and build the `cluster_keys` of `TableMeta`
+        let mut cluster_keys = Vec::with_capacity(stmt.cluster_by.len());
+        for cluster_key in stmt.cluster_by.iter() {
+            self.validate_expr(schema.clone(), cluster_key).await?;
+            cluster_keys.push(cluster_key.to_string());
+        }
+        if !cluster_keys.is_empty() {
+            let order_keys_sql = format!("({})", cluster_keys.join(", "));
+            meta.cluster_keys = Some(order_keys_sql);
+        }
+
+        let plan = CreateTablePlan {
+            if_not_exists: stmt.if_not_exists,
+            tenant: self.ctx.get_tenant(),
+            catalog,
+            db: database,
+            table,
+            table_meta: meta,
+            cluster_keys,
+            as_select: if stmt.as_query.is_some() {
+                Err(ErrorCode::UnImplement(
+                    "Unsupported CREATE TABLE ... AS ...",
+                ))?
+            } else {
+                None
+            },
+        };
+        Ok(Plan::CreateTable(plan))
+    }
+}

--- a/query/src/sql/planner/binder/mod.rs
+++ b/query/src/sql/planner/binder/mod.rs
@@ -33,6 +33,7 @@ use crate::storages::Table;
 
 mod aggregate;
 mod bind_context;
+mod ddl;
 mod distinct;
 mod join;
 mod limit;
@@ -101,6 +102,11 @@ impl<'a> Binder {
                     kind: kind.clone(),
                     plan: Box::new(plan),
                 })
+            }
+
+            Statement::CreateTable(stmt) => {
+                let plan = self.bind_create_table(stmt).await?;
+                Ok(plan)
             }
 
             _ => Err(ErrorCode::UnImplement(format!(

--- a/query/src/sql/planner/plans/mod.rs
+++ b/query/src/sql/planner/plans/mod.rs
@@ -31,6 +31,7 @@ mod sort;
 pub use aggregate::AggregatePlan;
 pub use apply::CrossApply;
 use common_ast::ast::ExplainKind;
+use common_planners::CreateTablePlan;
 pub use eval_scalar::EvalScalar;
 pub use eval_scalar::ScalarItem;
 pub use filter::FilterPlan;
@@ -66,4 +67,7 @@ pub enum Plan {
         kind: ExplainKind,
         plan: Box<Plan>,
     },
+
+    // DDL
+    CreateTable(CreateTablePlan),
 }

--- a/query/src/sql/statements/statement_create_table.rs
+++ b/query/src/sql/statements/statement_create_table.rs
@@ -117,7 +117,7 @@ impl AnalyzableStatement for DfCreateTable {
                 db,
                 table,
                 table_meta,
-                cluster_keys,
+                cluster_keys: self.cluster_keys.iter().map(ToString::to_string).collect(),
                 as_select: as_select_plan_node,
             }),
         )))

--- a/query/tests/it/storages/fuse/table_test_fixture.rs
+++ b/query/tests/it/storages/fuse/table_test_fixture.rs
@@ -23,7 +23,6 @@ use common_io::prelude::StorageFsConfig;
 use common_io::prelude::StorageParams;
 use common_meta_app::schema::DatabaseMeta;
 use common_meta_app::schema::TableMeta;
-use common_planners::col;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
 use common_planners::Expression;
@@ -139,7 +138,7 @@ impl TestFixture {
                 ..Default::default()
             },
             as_select: None,
-            cluster_keys: vec![col("id")],
+            cluster_keys: vec!["id".to_string()],
         }
     }
 

--- a/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.result
+++ b/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.result
@@ -1,0 +1,27 @@
+2
+4
+====BEGIN TEST CREATE TABLE LIKE STATEMENT====
+8
+a	INT	NO	0	
+b	INT	YES	NULL	
+====END TEST CREATE TABLE LIKE STATEMENT====
+====TIMESTAMP====
+====CREATE ALL DATA TYPE TABLE====
+tiny	TINYINT	NO	0	
+tiny_unsigned	TINYINT UNSIGNED	NO	0	
+smallint	SMALLINT	NO	0	
+smallint_unsigned	SMALLINT UNSIGNED	NO	0	
+int	INT	NO	0	
+int_unsigned	INT UNSIGNED	NO	0	
+bigint	BIGINT	NO	0	
+bigint_unsigned	BIGINT UNSIGNED	NO	0	
+float	FLOAT	NO	0	
+double	DOUBLE	NO	0	
+date	DATE	NO	0	
+datetime	TIMESTAMP(6)	NO	0	
+ts	TIMESTAMP(6)	NO	0	
+str	VARCHAR	NO	3	
+bool	BOOLEAN	NO	false	
+arr	ARRAY	NO	[]	
+obj	OBJECT	NO	{}	
+variant	VARIANT	NO	null	

--- a/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.sql
+++ b/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.sql
@@ -1,0 +1,82 @@
+set enable_planner_v2 = 1;
+
+DROP TABLE IF EXISTS t;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+DROP TABLE IF EXISTS t4;
+
+CREATE TABLE t(c1 int) ENGINE = Null;
+
+-- As part of the functionality of time travel, system.tables now
+-- - contains dropped-tables
+-- - has an extra column `dropped_on`
+-- it is NOT backward compatible.
+--
+-- The following case is moved to 20_005_system_tables_with_dropped
+--SELECT COUNT(1) from system.tables where name = 't' and database = 'default' and dropped_on = 'NULL';
+
+CREATE TABLE IF NOT EXISTS t(c1 int) ENGINE = Null;
+CREATE TABLE t(c1 int) ENGINE = Null; -- {ErrorCode 2302}
+
+
+create table t2(a int,b int) engine=Memory;
+insert into t2 values(1,1),(2,2);
+select a+b from t2;
+
+create table t2(a int,b int) engine=Memory; -- {ErrorCode 2302}
+create table t2(a int,b int) engine=Memory; -- {ErrorCode 2302}
+create table t2(a INT auto_increment); -- {ErrorCode 1005}
+
+create table t3(a int,b int) engine=Memory CLUSTER BY(a); -- {ErrorCode 2703}
+
+
+create table t3(`a` int) ENGINE = Null;
+create table t4(a int) ENGINE = Null;
+
+DROP TABLE IF EXISTS t;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+DROP TABLE IF EXISTS t4;
+
+-- prepare test databases for testing 'create table like' and 'as select' statements.
+CREATE DATABASE db1;
+CREATE DATABASE db2;
+CREATE TABLE db1.test1(a INT, b INT null) ENGINE=memory;
+INSERT INTO db1.test1 VALUES (1, 2), (2, 3), (3, 4);
+
+SELECT '====BEGIN TEST CREATE TABLE LIKE STATEMENT====';
+-- test 'create table like' statement, expect db2.test2 has the same schema with db1.test1.
+CREATE TABLE db2.test2 LIKE db1.test1 ENGINE=fuse;
+INSERT INTO db2.test2 VALUES (3, 5);
+SELECT a+b FROM db2.test2;
+-- check the schema of db2.test2, it should be the same as db1.test1, column 'a' is not nullable.
+DESCRIBE db2.test2;
+SELECT '====END TEST CREATE TABLE LIKE STATEMENT====';
+
+-- SELECT '====BEGIN TEST CREATE TABLE AS SELECT STATEMENT====';
+-- -- test 'create table as select' statement, expect db2.test3 has the data from db1.test1 with casting
+-- CREATE TABLE db2.test3(a Varchar null, y Varchar null) ENGINE=fuse AS SELECT * FROM db1.test1;
+-- DESCRIBE db2.test3;
+-- SELECT a FROM db2.test3;
+-- CREATE TABLE db2.test4(a Varchar null, y Varchar null) ENGINE=fuse AS SELECT b, a FROM db1.test1;
+-- DESCRIBE db2.test4;
+-- SELECT a FROM db2.test4;
+-- CREATE TABLE db2.test5(a Varchar null, y Varchar null) ENGINE=fuse AS SELECT b FROM db1.test1;
+-- SELECT a FROM db2.test5;
+-- SELECT '====END TEST CREATE TABLE AS SELECT STATEMENT====';
+
+
+SELECT '====TIMESTAMP====';
+create table db2.test6(id Int8, created timestamp  DEFAULT today() + a); -- {ErrorCode 1065}
+create table db2.test6(id Int8, created timestamp  DEFAULT today() + 3);
+
+
+SELECT '====CREATE ALL DATA TYPE TABLE====';
+create table db2.test7(tiny TINYINT, tiny_unsigned TINYINT UNSIGNED, smallint SMALLINT, smallint_unsigned SMALLINT UNSIGNED, int INT, int_unsigned INT UNSIGNED, bigint BIGINT, bigint_unsigned BIGINT UNSIGNED,float FLOAT, double DOUBLE, date DATE, datetime DATETIME, ts TIMESTAMP, str VARCHAR default '3', bool BOOLEAN, arr ARRAY, obj OBJECT, variant VARIANT);
+desc db2.test7;
+
+-- clean up test databases
+DROP DATABASE db1;
+DROP DATABASE db2;
+
+CREATE TABLE system.test; -- {ErrorCode 1002}

--- a/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.sql
+++ b/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.sql
@@ -25,7 +25,6 @@ select a+b from t2;
 
 create table t2(a int,b int) engine=Memory; -- {ErrorCode 2302}
 create table t2(a int,b int) engine=Memory; -- {ErrorCode 2302}
-create table t2(a INT auto_increment); -- {ErrorCode 1005}
 
 create table t3(a int,b int) engine=Memory CLUSTER BY(a); -- {ErrorCode 2703}
 
@@ -67,7 +66,6 @@ SELECT '====END TEST CREATE TABLE LIKE STATEMENT====';
 
 
 SELECT '====TIMESTAMP====';
-create table db2.test6(id Int8, created timestamp  DEFAULT today() + a); -- {ErrorCode 1065}
 create table db2.test6(id Int8, created timestamp  DEFAULT today() + 3);
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`CREATE TABLE ... AS SELECT ...` is blocked by #5780 

## Changelog

- New Feature

## Related Issues


Close #5735 