### PR TITLE
[meta] feature: protobuf message has to persist `MIN_COMPATIBLE_VER` in it

### DIFF
--- a/common/proto-conv/src/config_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/config_from_to_protobuf_impl.rs
@@ -20,13 +20,14 @@ use common_protos::pb;
 use crate::check_ver;
 use crate::FromToProto;
 use crate::Incompatible;
+use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
 impl FromToProto<pb::S3StorageConfig> for StorageParams {
     fn from_pb(p: pb::S3StorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
         // TODO: config will have it's own version flags in the future.
-        check_ver(p.version)?;
+        check_ver(p.version, p.min_compatible)?;
 
         Ok(Self::S3(StorageS3Config {
             region: p.region,
@@ -43,6 +44,7 @@ impl FromToProto<pb::S3StorageConfig> for StorageParams {
         if let StorageParams::S3(v) = self {
             Ok(pb::S3StorageConfig {
                 version: VER,
+                min_compatible: MIN_COMPATIBLE_VER,
                 region: v.region.clone(),
                 endpoint_url: v.endpoint_url.clone(),
                 access_key_id: v.access_key_id.clone(),
@@ -63,7 +65,7 @@ impl FromToProto<pb::FsStorageConfig> for StorageParams {
     fn from_pb(p: pb::FsStorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
         // TODO: config will have it's own version flags in the future.
-        check_ver(p.version)?;
+        check_ver(p.version, p.min_compatible)?;
 
         Ok(Self::Fs(StorageFsConfig { root: p.root }))
     }
@@ -72,6 +74,7 @@ impl FromToProto<pb::FsStorageConfig> for StorageParams {
         if let StorageParams::Fs(v) = self {
             Ok(pb::FsStorageConfig {
                 version: VER,
+                min_compatible: MIN_COMPATIBLE_VER,
                 root: v.root.clone(),
             })
         } else {

--- a/common/proto-conv/src/data_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/data_from_to_protobuf_impl.rs
@@ -27,11 +27,12 @@ use num::FromPrimitive;
 use crate::check_ver;
 use crate::FromToProto;
 use crate::Incompatible;
+use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
 impl FromToProto<pb::DataSchema> for dv::DataSchema {
     fn from_pb(p: pb::DataSchema) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let mut fs = Vec::with_capacity(p.fields.len());
         for f in p.fields.into_iter() {
@@ -50,6 +51,7 @@ impl FromToProto<pb::DataSchema> for dv::DataSchema {
 
         let p = pb::DataSchema {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             fields: fs,
             metadata: self.meta().clone(),
         };
@@ -59,7 +61,7 @@ impl FromToProto<pb::DataSchema> for dv::DataSchema {
 
 impl FromToProto<pb::DataField> for dv::DataField {
     fn from_pb(p: pb::DataField) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let v = dv::DataField::new(
             &p.name,
@@ -74,6 +76,7 @@ impl FromToProto<pb::DataField> for dv::DataField {
     fn to_pb(&self) -> Result<pb::DataField, Incompatible> {
         let p = pb::DataField {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             name: self.name().clone(),
             default_expr: self.default_expr().cloned(),
             data_type: Some(self.data_type().to_pb()?),
@@ -84,7 +87,7 @@ impl FromToProto<pb::DataField> for dv::DataField {
 
 impl FromToProto<pb::DataType> for dv::DataTypeImpl {
     fn from_pb(p: pb::DataType) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let dt = match p.dt {
             None => {
@@ -136,6 +139,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::NullableType(Box::new(inn))),
                 };
                 Ok(v)
@@ -143,6 +147,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::Boolean(_) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::BoolType(pb::Empty {})),
                 };
                 Ok(v)
@@ -150,6 +155,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::Int8(_) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::Int8Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -157,6 +163,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::Int16(_) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::Int16Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -164,6 +171,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::Int32(_) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::Int32Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -171,6 +179,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::Int64(_) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::Int64Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -178,6 +187,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt8(_) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::Uint8Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -185,6 +195,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt16(_) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::Uint16Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -192,6 +203,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt32(_) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::Uint32Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -199,6 +211,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt64(_) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::Uint64Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -206,6 +219,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::Float32(_) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::Float32Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -213,6 +227,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::Float64(_) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::Float64Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -220,6 +235,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::Date(_x) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::DateType(pb::Empty {})),
                 };
                 Ok(v)
@@ -229,6 +245,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::TimestampType(inn)),
                 };
                 Ok(v)
@@ -236,6 +253,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
             dv::DataTypeImpl::String(_x) => {
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::StringType(pb::Empty {})),
                 };
                 Ok(v)
@@ -245,6 +263,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::StructType(inn)),
                 };
                 Ok(v)
@@ -254,6 +273,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::ArrayType(Box::new(inn))),
                 };
                 Ok(v)
@@ -263,6 +283,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::VariantType(inn)),
                 };
                 Ok(p)
@@ -272,6 +293,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::VariantArrayType(inn)),
                 };
                 Ok(p)
@@ -281,6 +303,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::VariantObjectType(inn)),
                 };
                 Ok(p)
@@ -290,6 +313,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
+                    min_compatible: MIN_COMPATIBLE_VER,
                     dt: Some(Dt::IntervalType(inn)),
                 };
                 Ok(p)
@@ -301,7 +325,7 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
 impl FromToProto<pb::NullableType> for dv::NullableType {
     fn from_pb(p: pb::NullableType) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let inner = p.inner.ok_or_else(|| Incompatible {
             reason: "NullableType.inner can not be None".to_string(),
@@ -318,6 +342,7 @@ impl FromToProto<pb::NullableType> for dv::NullableType {
 
         let p = pb::NullableType {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             inner: Some(Box::new(inner_pb_type)),
         };
 
@@ -328,7 +353,7 @@ impl FromToProto<pb::NullableType> for dv::NullableType {
 impl FromToProto<pb::Timestamp> for dv::TimestampType {
     fn from_pb(p: pb::Timestamp) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
         let v = dv::TimestampType::create(p.precision as usize);
         Ok(v)
     }
@@ -336,6 +361,7 @@ impl FromToProto<pb::Timestamp> for dv::TimestampType {
     fn to_pb(&self) -> Result<pb::Timestamp, Incompatible> {
         let p = pb::Timestamp {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             precision: self.precision() as u64,
             // tz: self.tz().cloned(),
         };
@@ -347,7 +373,7 @@ impl FromToProto<pb::Timestamp> for dv::TimestampType {
 impl FromToProto<pb::Struct> for dv::StructType {
     fn from_pb(p: pb::Struct) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
         let names = p.names.clone();
 
         let mut types = Vec::with_capacity(p.types.len());
@@ -369,6 +395,7 @@ impl FromToProto<pb::Struct> for dv::StructType {
 
         let p = pb::Struct {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
 
             names,
             types,
@@ -381,7 +408,7 @@ impl FromToProto<pb::Struct> for dv::StructType {
 impl FromToProto<pb::Array> for dv::ArrayType {
     fn from_pb(p: pb::Array) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let inner = p.inner.ok_or_else(|| Incompatible {
             reason: "Array.inner can not be None".to_string(),
@@ -398,6 +425,7 @@ impl FromToProto<pb::Array> for dv::ArrayType {
 
         let p = pb::Array {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             inner: Some(Box::new(inner_pb_type)),
         };
 
@@ -408,13 +436,16 @@ impl FromToProto<pb::Array> for dv::ArrayType {
 impl FromToProto<pb::VariantArray> for dv::VariantArrayType {
     fn from_pb(p: pb::VariantArray) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         Ok(Self {})
     }
 
     fn to_pb(&self) -> Result<pb::VariantArray, Incompatible> {
-        let p = pb::VariantArray { ver: VER };
+        let p = pb::VariantArray {
+            ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
+        };
         Ok(p)
     }
 }
@@ -422,13 +453,16 @@ impl FromToProto<pb::VariantArray> for dv::VariantArrayType {
 impl FromToProto<pb::VariantObject> for dv::VariantObjectType {
     fn from_pb(p: pb::VariantObject) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         Ok(Self {})
     }
 
     fn to_pb(&self) -> Result<pb::VariantObject, Incompatible> {
-        let p = pb::VariantObject { ver: VER };
+        let p = pb::VariantObject {
+            ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
+        };
         Ok(p)
     }
 }
@@ -467,7 +501,7 @@ impl FromToProto<pb::IntervalKind> for dv::IntervalKind {
 impl FromToProto<pb::IntervalType> for dv::IntervalType {
     fn from_pb(p: pb::IntervalType) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let pb_kind: pb::IntervalKind =
             FromPrimitive::from_i32(p.kind).ok_or_else(|| Incompatible {
@@ -482,6 +516,7 @@ impl FromToProto<pb::IntervalType> for dv::IntervalType {
         let pb_kind = self.kind().to_pb()?;
         let p = pb::IntervalType {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             kind: pb_kind as i32,
         };
         Ok(p)
@@ -491,13 +526,16 @@ impl FromToProto<pb::IntervalType> for dv::IntervalType {
 impl FromToProto<pb::Variant> for dv::VariantType {
     fn from_pb(p: pb::Variant) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         Ok(Self {})
     }
 
     fn to_pb(&self) -> Result<pb::Variant, Incompatible> {
-        let p = pb::Variant { ver: VER };
+        let p = pb::Variant {
+            ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
+        };
         Ok(p)
     }
 }

--- a/common/proto-conv/src/database_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/database_from_to_protobuf_impl.rs
@@ -24,11 +24,12 @@ use crate::check_ver;
 use crate::missing;
 use crate::FromToProto;
 use crate::Incompatible;
+use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
 impl FromToProto<pb::DatabaseInfo> for mt::DatabaseInfo {
     fn from_pb(p: pb::DatabaseInfo) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let meta = match p.meta {
             None => {
@@ -53,6 +54,7 @@ impl FromToProto<pb::DatabaseInfo> for mt::DatabaseInfo {
     fn to_pb(&self) -> Result<pb::DatabaseInfo, Incompatible> {
         let p = pb::DatabaseInfo {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             ident: Some(self.ident.to_pb()?),
             name_ident: Some(self.name_ident.to_pb()?),
             meta: Some(self.meta.to_pb()?),
@@ -63,7 +65,7 @@ impl FromToProto<pb::DatabaseInfo> for mt::DatabaseInfo {
 
 impl FromToProto<pb::DatabaseNameIdent> for mt::DatabaseNameIdent {
     fn from_pb(p: pb::DatabaseNameIdent) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let v = Self {
             tenant: p.tenant,
@@ -75,6 +77,7 @@ impl FromToProto<pb::DatabaseNameIdent> for mt::DatabaseNameIdent {
     fn to_pb(&self) -> Result<pb::DatabaseNameIdent, Incompatible> {
         let p = pb::DatabaseNameIdent {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             tenant: self.tenant.clone(),
             db_name: self.db_name.clone(),
         };
@@ -84,7 +87,7 @@ impl FromToProto<pb::DatabaseNameIdent> for mt::DatabaseNameIdent {
 
 impl FromToProto<pb::DatabaseIdent> for mt::DatabaseIdent {
     fn from_pb(p: pb::DatabaseIdent) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let v = Self {
             db_id: p.db_id,
@@ -96,6 +99,7 @@ impl FromToProto<pb::DatabaseIdent> for mt::DatabaseIdent {
     fn to_pb(&self) -> Result<pb::DatabaseIdent, Incompatible> {
         let p = pb::DatabaseIdent {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             db_id: self.db_id,
             seq: self.seq,
         };
@@ -105,7 +109,7 @@ impl FromToProto<pb::DatabaseIdent> for mt::DatabaseIdent {
 
 impl FromToProto<pb::DatabaseMeta> for mt::DatabaseMeta {
     fn from_pb(p: pb::DatabaseMeta) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let v = Self {
             engine: p.engine,
@@ -125,6 +129,7 @@ impl FromToProto<pb::DatabaseMeta> for mt::DatabaseMeta {
     fn to_pb(&self) -> Result<pb::DatabaseMeta, Incompatible> {
         let p = pb::DatabaseMeta {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             engine: self.engine.clone(),
             engine_options: self.engine_options.clone(),
             options: self.options.clone(),
@@ -142,7 +147,7 @@ impl FromToProto<pb::DatabaseMeta> for mt::DatabaseMeta {
 
 impl FromToProto<pb::DbIdList> for mt::DbIdList {
     fn from_pb(p: pb::DbIdList) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let v = Self { id_list: p.ids };
         Ok(v)
@@ -151,6 +156,7 @@ impl FromToProto<pb::DbIdList> for mt::DbIdList {
     fn to_pb(&self) -> Result<pb::DbIdList, Incompatible> {
         let p = pb::DbIdList {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             ids: self.id_list.clone(),
         };
         Ok(p)

--- a/common/proto-conv/src/lib.rs
+++ b/common/proto-conv/src/lib.rs
@@ -30,4 +30,5 @@ pub use from_to_protobuf::FromToProto;
 pub use from_to_protobuf::Incompatible;
 pub use util::check_ver;
 pub use util::missing;
+pub use util::MIN_COMPATIBLE_VER;
 pub use util::VER;

--- a/common/proto-conv/src/table_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/table_from_to_protobuf_impl.rs
@@ -26,11 +26,12 @@ use common_protos::pb;
 use crate::check_ver;
 use crate::FromToProto;
 use crate::Incompatible;
+use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
 impl FromToProto<pb::TableInfo> for mt::TableInfo {
     fn from_pb(p: pb::TableInfo) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let ident = match p.ident {
             None => {
@@ -54,6 +55,7 @@ impl FromToProto<pb::TableInfo> for mt::TableInfo {
     fn to_pb(&self) -> Result<pb::TableInfo, Incompatible> {
         let p = pb::TableInfo {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             ident: Some(self.ident.to_pb()?),
             desc: self.desc.clone(),
             name: self.name.clone(),
@@ -65,7 +67,7 @@ impl FromToProto<pb::TableInfo> for mt::TableInfo {
 
 impl FromToProto<pb::TableNameIdent> for mt::TableNameIdent {
     fn from_pb(p: pb::TableNameIdent) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let v = Self {
             tenant: p.tenant,
@@ -78,6 +80,7 @@ impl FromToProto<pb::TableNameIdent> for mt::TableNameIdent {
     fn to_pb(&self) -> Result<pb::TableNameIdent, Incompatible> {
         let p = pb::TableNameIdent {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             tenant: self.tenant.clone(),
             db_name: self.db_name.clone(),
             table_name: self.table_name.clone(),
@@ -88,7 +91,7 @@ impl FromToProto<pb::TableNameIdent> for mt::TableNameIdent {
 
 impl FromToProto<pb::TableIdent> for mt::TableIdent {
     fn from_pb(p: pb::TableIdent) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let v = Self {
             table_id: p.table_id,
@@ -100,6 +103,7 @@ impl FromToProto<pb::TableIdent> for mt::TableIdent {
     fn to_pb(&self) -> Result<pb::TableIdent, Incompatible> {
         let p = pb::TableIdent {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             table_id: self.table_id,
             seq: self.seq,
         };
@@ -110,7 +114,7 @@ impl FromToProto<pb::TableIdent> for mt::TableIdent {
 
 impl FromToProto<pb::TableMeta> for mt::TableMeta {
     fn from_pb(p: pb::TableMeta) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let schema = match p.schema {
             None => {
@@ -146,6 +150,7 @@ impl FromToProto<pb::TableMeta> for mt::TableMeta {
     fn to_pb(&self) -> Result<pb::TableMeta, Incompatible> {
         let p = pb::TableMeta {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             schema: Some(self.schema.to_pb()?),
             engine: self.engine.clone(),
             engine_options: self.engine_options.clone(),
@@ -166,7 +171,7 @@ impl FromToProto<pb::TableMeta> for mt::TableMeta {
 
 impl FromToProto<pb::TableStatistics> for mt::TableStatistics {
     fn from_pb(p: pb::TableStatistics) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let v = Self {
             number_of_rows: p.number_of_rows,
@@ -181,6 +186,7 @@ impl FromToProto<pb::TableStatistics> for mt::TableStatistics {
     fn to_pb(&self) -> Result<pb::TableStatistics, Incompatible> {
         let p = pb::TableStatistics {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             number_of_rows: self.number_of_rows,
             data_bytes: self.data_bytes,
             compressed_data_bytes: self.compressed_data_bytes,
@@ -192,7 +198,7 @@ impl FromToProto<pb::TableStatistics> for mt::TableStatistics {
 
 impl FromToProto<pb::TableIdList> for mt::TableIdList {
     fn from_pb(p: pb::TableIdList) -> Result<Self, Incompatible> {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let v = Self { id_list: p.ids };
         Ok(v)
@@ -201,6 +207,7 @@ impl FromToProto<pb::TableIdList> for mt::TableIdList {
     fn to_pb(&self) -> Result<pb::TableIdList, Incompatible> {
         let p = pb::TableIdList {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             ids: self.id_list.clone(),
         };
         Ok(p)

--- a/common/proto-conv/src/user_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/user_from_to_protobuf_impl.rs
@@ -28,12 +28,13 @@ use num::FromPrimitive;
 use crate::check_ver;
 use crate::FromToProto;
 use crate::Incompatible;
+use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
 impl FromToProto<pb::AuthInfo> for mt::AuthInfo {
     fn from_pb(p: pb::AuthInfo) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         match p.info {
             Some(pb::auth_info::Info::None(pb::auth_info::None {})) => Ok(mt::AuthInfo::None),
@@ -65,14 +66,18 @@ impl FromToProto<pb::AuthInfo> for mt::AuthInfo {
                 hash_method: *hash_method as i32,
             })),
         };
-        Ok(pb::AuthInfo { ver: VER, info })
+        Ok(pb::AuthInfo {
+            ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
+            info,
+        })
     }
 }
 
 impl FromToProto<pb::UserOption> for mt::UserOption {
     fn from_pb(p: pb::UserOption) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let flags = BitFlags::<mt::UserOptionFlag, u64>::from_bits(p.flags);
         match flags {
@@ -88,6 +93,7 @@ impl FromToProto<pb::UserOption> for mt::UserOption {
     fn to_pb(&self) -> Result<pb::UserOption, Incompatible> {
         Ok(pb::UserOption {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             flags: self.flags().bits(),
         })
     }
@@ -96,7 +102,7 @@ impl FromToProto<pb::UserOption> for mt::UserOption {
 impl FromToProto<pb::UserQuota> for mt::UserQuota {
     fn from_pb(p: pb::UserQuota) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         Ok(Self {
             max_cpu: p.max_cpu,
@@ -108,6 +114,7 @@ impl FromToProto<pb::UserQuota> for mt::UserQuota {
     fn to_pb(&self) -> Result<pb::UserQuota, Incompatible> {
         Ok(pb::UserQuota {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             max_cpu: self.max_cpu,
             max_memory_in_bytes: self.max_memory_in_bytes,
             max_storage_in_bytes: self.max_storage_in_bytes,
@@ -118,7 +125,7 @@ impl FromToProto<pb::UserQuota> for mt::UserQuota {
 impl FromToProto<pb::GrantObject> for mt::GrantObject {
     fn from_pb(p: pb::GrantObject) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         match p.object {
             Some(pb::grant_object::Object::Global(pb::grant_object::GrantGlobalObject {})) => {
@@ -158,14 +165,18 @@ impl FromToProto<pb::GrantObject> for mt::GrantObject {
                 },
             )),
         };
-        Ok(pb::GrantObject { ver: VER, object })
+        Ok(pb::GrantObject {
+            ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
+            object,
+        })
     }
 }
 
 impl FromToProto<pb::GrantEntry> for mt::GrantEntry {
     fn from_pb(p: pb::GrantEntry) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let privileges = BitFlags::<mt::UserPrivilegeType, u64>::from_bits(p.privileges);
         match privileges {
@@ -186,6 +197,7 @@ impl FromToProto<pb::GrantEntry> for mt::GrantEntry {
     fn to_pb(&self) -> Result<pb::GrantEntry, Incompatible> {
         Ok(pb::GrantEntry {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             object: Some(self.object().to_pb()?),
             privileges: self.privileges().bits(),
         })
@@ -195,7 +207,7 @@ impl FromToProto<pb::GrantEntry> for mt::GrantEntry {
 impl FromToProto<pb::UserGrantSet> for mt::UserGrantSet {
     fn from_pb(p: pb::UserGrantSet) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let mut entries = Vec::new();
         for entry in p.entries.iter() {
@@ -221,6 +233,7 @@ impl FromToProto<pb::UserGrantSet> for mt::UserGrantSet {
 
         Ok(pb::UserGrantSet {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             entries,
             roles,
         })
@@ -230,7 +243,7 @@ impl FromToProto<pb::UserGrantSet> for mt::UserGrantSet {
 impl FromToProto<pb::UserInfo> for mt::UserInfo {
     fn from_pb(p: pb::UserInfo) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         Ok(mt::UserInfo {
             name: p.name.clone(),
@@ -253,6 +266,7 @@ impl FromToProto<pb::UserInfo> for mt::UserInfo {
     fn to_pb(&self) -> Result<pb::UserInfo, Incompatible> {
         Ok(pb::UserInfo {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             name: self.name.clone(),
             hostname: self.hostname.clone(),
             auth_info: Some(mt::AuthInfo::to_pb(&self.auth_info)?),
@@ -411,7 +425,7 @@ impl FromToProto<pb::user_stage_info::StageParams> for mt::StageParams {
 impl FromToProto<pb::user_stage_info::FileFormatOptions> for mt::FileFormatOptions {
     fn from_pb(p: pb::user_stage_info::FileFormatOptions) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
 
         let format = mt::StageFileFormatType::from_pb(
             FromPrimitive::from_i32(p.format).ok_or_else(|| Incompatible {
@@ -439,6 +453,7 @@ impl FromToProto<pb::user_stage_info::FileFormatOptions> for mt::FileFormatOptio
         let compression = mt::StageFileCompression::to_pb(&self.compression)? as i32;
         Ok(pb::user_stage_info::FileFormatOptions {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             format,
             skip_header: self.skip_header,
             field_delimiter: self.field_delimiter.clone(),
@@ -528,7 +543,7 @@ impl FromToProto<pb::user_stage_info::CopyOptions> for mt::CopyOptions {
 impl FromToProto<pb::UserStageInfo> for mt::UserStageInfo {
     fn from_pb(p: pb::UserStageInfo) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver)?;
+        check_ver(p.ver, p.min_compatible)?;
         Ok(mt::UserStageInfo {
             stage_name: p.stage_name.clone(),
             stage_type: mt::StageType::from_pb(FromPrimitive::from_i32(p.stage_type).ok_or_else(
@@ -558,6 +573,7 @@ impl FromToProto<pb::UserStageInfo> for mt::UserStageInfo {
     fn to_pb(&self) -> Result<pb::UserStageInfo, Incompatible> {
         Ok(pb::UserStageInfo {
             ver: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
             stage_name: self.stage_name.clone(),
             stage_type: mt::StageType::to_pb(&self.stage_type)? as i32,
             stage_params: Some(mt::StageParams::to_pb(&self.stage_params)?),

--- a/common/proto-conv/src/util.rs
+++ b/common/proto-conv/src/util.rs
@@ -15,14 +15,22 @@
 use crate::Incompatible;
 
 pub const VER: u64 = 1;
-const OLDEST_COMPATIBLE_VER: u64 = 1;
+pub const MIN_COMPATIBLE_VER: u64 = 1;
 
-pub fn check_ver(ver: u64) -> Result<(), Incompatible> {
-    if ver > VER || ver < OLDEST_COMPATIBLE_VER {
+pub fn check_ver(msg_ver: u64, msg_min_compatible: u64) -> Result<(), Incompatible> {
+    if VER < msg_min_compatible {
         return Err(Incompatible {
             reason: format!(
-                "ver={} is not compatible with [{}, {}]",
-                ver, OLDEST_COMPATIBLE_VER, VER
+                "executable ver={} is smaller than the message min compatible ver: {}",
+                VER, msg_min_compatible
+            ),
+        });
+    }
+    if msg_ver < MIN_COMPATIBLE_VER {
+        return Err(Incompatible {
+            reason: format!(
+                "message ver={} is smaller than executable min compatible ver: {}",
+                msg_ver, MIN_COMPATIBLE_VER
             ),
         });
     }

--- a/common/proto-conv/tests/it/proto_conv.rs
+++ b/common/proto-conv/tests/it/proto_conv.rs
@@ -138,11 +138,25 @@ fn test_incompatible() -> anyhow::Result<()> {
     let db_info = new_db_info();
     let mut p = db_info.to_pb()?;
     p.ver = 2;
+    p.min_compatible = 2;
 
     let res = mt::DatabaseInfo::from_pb(p);
     assert_eq!(
         Incompatible {
-            reason: s("ver=2 is not compatible with [1, 1]")
+            reason: s("executable ver=1 is smaller than the message min compatible ver: 2")
+        },
+        res.unwrap_err()
+    );
+
+    let db_info = new_db_info();
+    let mut p = db_info.to_pb()?;
+    p.ver = 0;
+    p.min_compatible = 0;
+
+    let res = mt::DatabaseInfo::from_pb(p);
+    assert_eq!(
+        Incompatible {
+            reason: s("message ver=0 is smaller than executable min compatible ver: 1")
         },
         res.unwrap_err()
     );

--- a/common/proto-conv/tests/it/user_proto_conv.rs
+++ b/common/proto-conv/tests/it/user_proto_conv.rs
@@ -114,11 +114,12 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let user_info = test_user_info();
         let mut p = user_info.to_pb()?;
         p.ver = 2;
+        p.min_compatible = 2;
 
         let res = mt::UserInfo::from_pb(p);
         assert_eq!(
             Incompatible {
-                reason: s("ver=2 is not compatible with [1, 1]")
+                reason: s("executable ver=1 is smaller than the message min compatible ver: 2")
             },
             res.unwrap_err()
         );
@@ -128,11 +129,12 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let user_stage_info = test_user_stage_info();
         let mut p = user_stage_info.to_pb()?;
         p.ver = 2;
+        p.min_compatible = 2;
 
         let res = mt::UserStageInfo::from_pb(p);
         assert_eq!(
             Incompatible {
-                reason: s("ver=2 is not compatible with [1, 1]")
+                reason: s("executable ver=1 is smaller than the message min compatible ver: 2")
             },
             res.unwrap_err()
         );

--- a/common/protos/proto/config.proto
+++ b/common/protos/proto/config.proto
@@ -18,6 +18,7 @@ package databend_proto;
 
 message S3StorageConfig {
   uint64 version = 100;
+  uint64 min_compatible = 101;
 
   string region = 1;
   string endpoint_url = 2;
@@ -30,6 +31,7 @@ message S3StorageConfig {
 
 message FsStorageConfig {
   uint64 version = 100;
+  uint64 min_compatible = 101;
 
   string root = 1;
 }

--- a/common/protos/proto/datatype.proto
+++ b/common/protos/proto/datatype.proto
@@ -19,6 +19,7 @@ package databend_proto;
 // An enumeration of all supported data types.
 message DataType {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   oneof dt {
     NullableType nullable_type = 1;
@@ -49,6 +50,7 @@ message DataType {
 // Such a column allows to contain `null` elements
 message NullableType {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   // The type for the non-null element.
   DataType inner = 1;
@@ -57,6 +59,7 @@ message NullableType {
 // Timestamp data type with customizable precision and timezone: `tz`.
 message Timestamp {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   /// The time resolution is determined by the precision parameter, range from 0
   /// to 9 Typically are used - 0 (seconds) 3 (milliseconds), 6 (microseconds),
@@ -67,6 +70,7 @@ message Timestamp {
 // Struct is similar to a `map` with fixed keys.
 message Struct {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   // Struct field names.
   repeated string names = 1;
@@ -78,14 +82,21 @@ message Struct {
 // Array contains multiple elements of the same type.
 message Array {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   // The type of the elements
   DataType inner = 1;
 }
 
-message VariantArray { uint64 ver = 100; }
+message VariantArray {
+  uint64 ver = 100;
+  uint64 min_compatible = 101;
+}
 
-message VariantObject { uint64 ver = 100; }
+message VariantObject {
+  uint64 ver = 100;
+  uint64 min_compatible = 101;
+}
 
 enum IntervalKind {
   Year = 0;
@@ -99,12 +110,16 @@ enum IntervalKind {
 }
 message IntervalType {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   IntervalKind kind = 1;
 }
 
 // Something under developing.:)
-message Variant { uint64 ver = 100; }
+message Variant {
+  uint64 ver = 100;
+  uint64 min_compatible = 101;
+}
 
 // Place holder type for primitive types
 message Empty {}

--- a/common/protos/proto/metadata.proto
+++ b/common/protos/proto/metadata.proto
@@ -21,6 +21,7 @@ import "datatype.proto";
 // Complete database info.
 message DatabaseInfo {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   DatabaseIdent ident = 1;
   DatabaseNameIdent name_ident = 2;
@@ -32,6 +33,7 @@ message DatabaseInfo {
 // same instance.
 message DatabaseNameIdent {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   // The user this db belongs to
   string tenant = 1;
@@ -46,6 +48,7 @@ message DatabaseNameIdent {
 // I.e., the tuple `(db_id, seq)` always identifies the same instance.
 message DatabaseIdent {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   uint64 db_id = 1;
 
@@ -56,6 +59,7 @@ message DatabaseIdent {
 // DatabaseMeta is a container of all non-identity information.
 message DatabaseMeta {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   // Database engine, like github engine.
   string engine = 5;
@@ -82,6 +86,7 @@ message DatabaseMeta {
 // Save db name id list history.
 message DbIdList {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   repeated uint64 ids = 1;
 }
@@ -89,6 +94,7 @@ message DbIdList {
 // Complete table info.
 message TableInfo {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   TableIdent ident = 1;
 
@@ -114,6 +120,7 @@ message TableInfo {
 // instance.
 message TableNameIdent {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   // The user this table belongs to.
   string tenant = 1;
@@ -131,6 +138,7 @@ message TableNameIdent {
 // I.e., the tuple `(db_id, seq)` always identifies the same instance.
 message TableIdent {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   uint64 table_id = 1;
 
@@ -141,6 +149,7 @@ message TableIdent {
 // TableMeta is a container of all non-identity information.
 message TableMeta {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   // Table schema, i.e., columns definition.
   DataSchema schema = 1;
@@ -176,6 +185,7 @@ message TableMeta {
 // Save table name id list history.
 message TableIdList {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   repeated uint64 ids = 1;
 }
@@ -183,6 +193,7 @@ message TableIdList {
 // The schema of a table, such as column data types and other meta info.
 message DataSchema {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   // Fields in the table
   repeated DataField fields = 1;
@@ -195,6 +206,7 @@ message DataSchema {
 message TableStatistics {
 
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   // Number of rows
   uint64 number_of_rows = 1;
@@ -212,6 +224,7 @@ message TableStatistics {
 // One field, AKA column
 message DataField {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   // The name of this column.
   string name = 1;

--- a/common/protos/proto/user.proto
+++ b/common/protos/proto/user.proto
@@ -21,6 +21,7 @@ import "config.proto";
 
 message AuthInfo {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   message None {}
   message Password {
@@ -43,6 +44,7 @@ message AuthInfo {
 
 message GrantObject {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   message GrantGlobalObject {}
 
@@ -66,18 +68,24 @@ message GrantObject {
 
 message GrantEntry {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
+
   GrantObject object = 1;
   uint64 privileges = 2;
 }
 
 message UserGrantSet {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
+
   repeated GrantEntry entries = 1;
   map<string, bool> roles = 2;
 }
 
 message UserQuota {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
+
   uint64 max_cpu = 1;
   uint64 max_memory_in_bytes = 2;
   uint64 max_storage_in_bytes = 3;
@@ -85,11 +93,14 @@ message UserQuota {
 
 message UserOption {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
+
   uint64 flags = 1;
 }
 
 message UserInfo {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   string name = 1;
   string hostname = 2;
@@ -101,6 +112,7 @@ message UserInfo {
 
 message UserStageInfo {
   uint64 ver = 100;
+  uint64 min_compatible = 101;
 
   enum StageType {
     Interval = 0;
@@ -140,6 +152,7 @@ message UserStageInfo {
 
   message FileFormatOptions {
     uint64 ver = 100;
+    uint64 min_compatible = 101;
 
     StageFileFormatType format = 1;
     // Number of lines at the start of the file to skip.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [meta] feature: protobuf message has to persist `MIN_COMPATIBLE_VER` in it

**Non-breaking** meta-protobuf change.

This way to let old query be able to decide if it is safe to load data
written by a newer query executable.

- Fix: #5784

## Changelog

- New Feature





## Related Issues