### PR TITLE
fix(query): Fix read array(string) from fuse engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,8 +137,8 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.11.2"
-source = "git+https://github.com/datafuse-extras/arrow2?rev=48a3087#48a308772fcc18fce890447b0bfa30611fc813e6"
+version = "0.12.0"
+source = "git+https://github.com/datafuse-extras/arrow2?rev=6608071#660807164be0afe71b8ce2868bc3a6a6a00db608"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -153,13 +153,12 @@ dependencies = [
  "hash_hasher",
  "indexmap",
  "itertools",
+ "json-deserializer",
  "lexical-core",
  "multiversion",
  "num-traits",
  "parquet2",
  "regex",
- "serde",
- "serde_json",
  "simdutf8",
  "streaming-iterator",
  "strength_reduce",
@@ -3374,6 +3373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-deserializer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47631885425c482fcf2dc4b182fc973c3c5b81a8f43a028055559bd24cccfa6e"
+
+[[package]]
 name = "jsonwebtoken"
 version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4678,8 +4683,8 @@ dependencies = [
 
 [[package]]
 name = "parquet2"
-version = "0.12.0"
-source = "git+https://github.com/datafuse-extras/parquet2?rev=03c108b#03c108bfcae58a6ba2b6a54132888dea964b3950"
+version = "0.13.0"
+source = "git+https://github.com/datafuse-extras/parquet2?rev=68f8646#68f8646b752fba409ce765d5349d069acbb984cf"
 dependencies = [
  "async-stream",
  "bitpacking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,5 +65,5 @@ object = { opt-level = 3 }
 rustc-demangle = { opt-level = 3 }
 
 [patch.crates-io]
-parquet2 = { version = "0.12", optional = true, git = "https://github.com/datafuse-extras/parquet2", rev = "03c108b" }
+parquet2 = { version = "0.13", optional = true, git = "https://github.com/datafuse-extras/parquet2", rev = "68f8646" }
 chrono = { git = "https://github.com/datafuse-extras/chrono", rev = "279f590" }

--- a/common/arrow/Cargo.toml
+++ b/common/arrow/Cargo.toml
@@ -21,7 +21,7 @@ arrow-default = [
     "arrow/compute_filter",
 ]
 default = ["arrow-default", "parquet-default"]
-parquet-default = ["parquet2/stream", "parquet2/lz4"]
+parquet-default = ["parquet2/lz4"]
 simd = ["arrow/simd"]
 
 [dependencies] # In alphabetical order
@@ -31,11 +31,11 @@ simd = ["arrow/simd"]
 arrow = { package = "arrow2", git = "https://github.com/datafuse-extras/arrow2", default-features = false, features = [
     "io_parquet",
     "io_parquet_compression",
-], rev = "48a3087" }
+], rev = "6608071" }
 
 # Crates.io dependencies
 arrow-format = { version = "0.6.0", features = ["flight-data", "flight-service", "ipc"] }
 futures = "0.3.21"
-parquet2 = { version = "0.12", default_features = false }
+parquet2 = { version = "0.13", default_features = false }
 
 [dev-dependencies]

--- a/common/arrow/src/parquet_write.rs
+++ b/common/arrow/src/parquet_write.rs
@@ -42,7 +42,6 @@ where
     let created_by = Some("Arrow2 - Native Rust implementation of Arrow".to_string());
     let mut file_writer = FileWriter::new(writer, parquet_schema, options, created_by);
 
-    file_writer.start()?;
     for group in row_groups {
         file_writer.write(group?)?;
     }

--- a/common/datavalues/src/columns/object/mod.rs
+++ b/common/datavalues/src/columns/object/mod.rs
@@ -131,8 +131,8 @@ impl<T: ObjectType> Column for ObjectColumn<T> {
 
         Arc::new(LargeBinaryArray::from_data(
             self.data_type().arrow_type(),
-            Buffer::from_slice(offsets),
-            Buffer::from_slice(values),
+            Buffer::from(offsets),
+            Buffer::from(values),
             None,
         ))
     }

--- a/common/meta/app/Cargo.toml
+++ b/common/meta/app/Cargo.toml
@@ -29,7 +29,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 once_cell = "1.10.0"
 prost = "=0.9.0"
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = "1.0.79"
 sha1 = "0.10.1"
 sha2 = "0.10.2"

--- a/tests/suites/0_stateless/03_dml/03_0023_insert_into_array.sql
+++ b/tests/suites/0_stateless/03_dml/03_0023_insert_into_array.sql
@@ -4,7 +4,7 @@ USE db1;
 
 select '==Array(UInt8)==';
 
-CREATE TABLE IF NOT EXISTS t1(id Int, arr Array(UInt8)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t1(id Int, arr Array(UInt8)) Engine = Fuse;
 
 INSERT INTO t1 (id, arr) VALUES(1, [1,2,3]), (2, [254,255]);
 
@@ -13,7 +13,7 @@ select arr[0], arr[1] from t1;
 
 select '==Array(UInt16)==';
 
-CREATE TABLE IF NOT EXISTS t2(id Int, arr Array(UInt16)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t2(id Int, arr Array(UInt16)) Engine = Fuse;
 
 INSERT INTO t2 (id, arr) VALUES(1, [1,2,3]), (2, [65534,65535]);
 
@@ -22,7 +22,7 @@ select arr[0], arr[1] from t2;
 
 select '==Array(UInt32)==';
 
-CREATE TABLE IF NOT EXISTS t3(id Int, arr Array(UInt32)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t3(id Int, arr Array(UInt32)) Engine = Fuse;
 
 INSERT INTO t3 (id, arr) VALUES(1, [1,2,3]), (2, [4294967294,4294967295]);
 
@@ -31,7 +31,7 @@ select arr[0], arr[1] from t3;
 
 select '==Array(UInt64)==';
 
-CREATE TABLE IF NOT EXISTS t4(id Int, arr Array(UInt64)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t4(id Int, arr Array(UInt64)) Engine = Fuse;
 
 INSERT INTO t4 (id, arr) VALUES(1, [1,2,3]), (2, [18446744073709551614,18446744073709551615]);
 
@@ -40,7 +40,7 @@ select arr[0], arr[1] from t4;
 
 select '==Array(Int8)==';
 
-CREATE TABLE IF NOT EXISTS t5(id Int, arr Array(Int8)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t5(id Int, arr Array(Int8)) Engine = Fuse;
 
 INSERT INTO t5 (id, arr) VALUES(1, [1,2,3]), (2, [-128,127]);
 
@@ -49,7 +49,7 @@ select arr[0], arr[1] from t5;
 
 select '==Array(Int16)==';
 
-CREATE TABLE IF NOT EXISTS t6(id Int, arr Array(Int16)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t6(id Int, arr Array(Int16)) Engine = Fuse;
 
 INSERT INTO t6 (id, arr) VALUES(1, [1,2,3]), (2, [-32768,32767]);
 
@@ -58,7 +58,7 @@ select arr[0], arr[1] from t6;
 
 select '==Array(Int32)==';
 
-CREATE TABLE IF NOT EXISTS t7(id Int, arr Array(Int32)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t7(id Int, arr Array(Int32)) Engine = Fuse;
 
 INSERT INTO t7 (id, arr) VALUES(1, [1,2,3]), (2, [-2147483648,2147483647]);
 
@@ -67,7 +67,7 @@ select arr[0], arr[1] from t7;
 
 select '==Array(Int64)==';
 
-CREATE TABLE IF NOT EXISTS t8(id Int, arr Array(Int64)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t8(id Int, arr Array(Int64)) Engine = Fuse;
 
 INSERT INTO t8 (id, arr) VALUES(1, [1,2,3]), (2, [-9223372036854775808,9223372036854775807]);
 
@@ -76,7 +76,7 @@ select arr[0], arr[1] from t8;
 
 select '==Array(Float32)==';
 
-CREATE TABLE IF NOT EXISTS t9(id Int, arr Array(Float32)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t9(id Int, arr Array(Float32)) Engine = Fuse;
 
 INSERT INTO t9 (id, arr) VALUES(1, [1.1,1.2,1.3]), (2, [-1.1,-1.2,-1.3]);
 
@@ -85,7 +85,7 @@ select arr[0], arr[1] from t9;
 
 select '==Array(Float64)==';
 
-CREATE TABLE IF NOT EXISTS t10(id Int, arr Array(Float64)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t10(id Int, arr Array(Float64)) Engine = Fuse;
 
 INSERT INTO t10 (id, arr) VALUES(1, [1.1,1.2,1.3]), (2, [-1.1,-1.2,-1.3]);
 
@@ -94,7 +94,7 @@ select arr[0], arr[1] from t10;
 
 select '==Array(Boolean)==';
 
-CREATE TABLE IF NOT EXISTS t11(id Int, arr Array(Bool)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t11(id Int, arr Array(Bool)) Engine = Fuse;
 
 INSERT INTO t11 (id, arr) VALUES(1, [true, true]), (2, [false, false]), (3, [true, false]), (4, [false, true]);
 
@@ -103,7 +103,7 @@ select arr[0], arr[1] from t11;
 
 select '==Array(Date)==';
 
-CREATE TABLE IF NOT EXISTS t12(id Int, arr Array(Date)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t12(id Int, arr Array(Date)) Engine = Fuse;
 
 INSERT INTO t12 (id, arr) VALUES(1, ['2021-01-01', '2022-01-01']), (2, ['1990-12-01', '2030-01-12']);
 INSERT INTO t12 (id, arr) VALUES(3, ['1000000-01-01', '2000000-01-01']); -- {ErrorCode 1010}
@@ -113,7 +113,7 @@ select arr[0], arr[1] from t12;
 
 select '==Array(Timestamp)==';
 
-CREATE TABLE IF NOT EXISTS t13(id Int, arr Array(Timestamp)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t13(id Int, arr Array(Timestamp)) Engine = Fuse;
 
 INSERT INTO t13 (id, arr) VALUES(1, ['2021-01-01 01:01:01', '2022-01-01 01:01:01']), (2, ['1990-12-01 10:11:12', '2030-01-12 22:00:00']);
 INSERT INTO t13 (id, arr) VALUES(3, ['1000000-01-01 01:01:01', '2000000-01-01 01:01:01']); -- {ErrorCode 1010}
@@ -123,7 +123,7 @@ select arr[0], arr[1] from t13;
 
 select '==Array(String)==';
 
-CREATE TABLE IF NOT EXISTS t14(id Int, arr Array(String)) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t14(id Int, arr Array(String)) Engine = Fuse;
 
 INSERT INTO t14 (id, arr) VALUES(1, ['aa', 'bb']), (2, ['cc', 'dd']);
 
@@ -132,7 +132,7 @@ select arr[0], arr[1] from t14;
 
 select '==Array(String) Nullable==';
 
-CREATE TABLE IF NOT EXISTS t15(id Int, arr Array(String) Null) Engine = Memory;
+CREATE TABLE IF NOT EXISTS t15(id Int, arr Array(String) Null) Engine = Fuse;
 
 INSERT INTO t15 (id, arr) VALUES(1, ['aa', 'bb']), (2, ['cc', 'dd']), (3, null), (4, ['ee', 'ff']);
 
@@ -141,7 +141,7 @@ select arr[0], arr[1] from t15;
 
 select '==Array(Int64) Nullable==';
 
-CREATE TABLE IF NOT EXISTS t16(id Int, arr Array(Int64) Null) Engine = fuse;
+CREATE TABLE IF NOT EXISTS t16(id Int, arr Array(Int64) Null) Engine = Fuse;
 
 INSERT INTO t16 (id, arr) VALUES(1, [1,2,3,4]), (2, [5,6,7,8]), (3, null);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix read array(string) from fuse engine

- Upgrade `arrow2` to version 0.12.0
- Upgrade `parquet2` to version 0.13.0

## Changelog

- Bug Fix

## Related Issues

Fixes #5564

