### PR TITLE
feature(planner): Migrate CREATE USER statement to new planner

### DIFF
--- a/common/ast/src/ast/statement.rs
+++ b/common/ast/src/ast/statement.rs
@@ -17,6 +17,8 @@ use std::fmt::Formatter;
 
 use common_meta_types::AuthType;
 use common_meta_types::UserIdentity;
+use common_meta_types::UserOption;
+use common_meta_types::UserOptionFlag;
 
 use super::write_space_seperated_list;
 use super::Expr;
@@ -162,12 +164,7 @@ pub enum Statement<'a> {
     },
 
     // User
-    CreateUser {
-        if_not_exists: bool,
-        user: UserIdentity,
-        auth_option: AuthOption,
-        role_options: Vec<RoleOption>,
-    },
+    CreateUser(CreateUserStmt),
     AlterUser {
         // None means current user
         user: Option<UserIdentity>,
@@ -311,6 +308,14 @@ pub enum KillTarget {
     Connection,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateUserStmt {
+    pub if_not_exists: bool,
+    pub user: UserIdentity,
+    pub auth_option: AuthOption,
+    pub role_options: Vec<RoleOption>,
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct AuthOption {
     pub auth_type: Option<AuthType>,
@@ -323,6 +328,25 @@ pub enum RoleOption {
     NoTenantSetting,
     ConfigReload,
     NoConfigReload,
+}
+
+impl RoleOption {
+    pub fn apply(&self, option: &mut UserOption) {
+        match self {
+            Self::TenantSetting => {
+                option.set_option_flag(UserOptionFlag::TenantSetting);
+            }
+            Self::NoTenantSetting => {
+                option.unset_option_flag(UserOptionFlag::TenantSetting);
+            }
+            Self::ConfigReload => {
+                option.set_option_flag(UserOptionFlag::ConfigReload);
+            }
+            Self::NoConfigReload => {
+                option.unset_option_flag(UserOptionFlag::ConfigReload);
+            }
+        }
+    }
 }
 
 impl<'a> Display for ShowLimit<'a> {
@@ -713,12 +737,12 @@ impl<'a> Display for Statement<'a> {
                     InsertSource::Select { query } => write!(f, " {query}")?,
                 }
             }
-            Statement::CreateUser {
+            Statement::CreateUser(CreateUserStmt {
                 if_not_exists,
                 user,
                 auth_option,
                 role_options,
-            } => {
+            }) => {
                 write!(f, "CREATE USER")?;
                 if *if_not_exists {
                     write!(f, " IF NOT EXISTS")?;

--- a/common/ast/src/parser/statement.rs
+++ b/common/ast/src/parser/statement.rs
@@ -320,7 +320,7 @@ pub fn statement(i: Input) -> IResult<Statement> {
             ~ ( WITH ~ ^#role_option+ )?
         },
         |(_, _, opt_if_not_exists, user, _, opt_auth_type, opt_password, opt_role_options)| {
-            Statement::CreateUser {
+            Statement::CreateUser(CreateUserStmt {
                 if_not_exists: opt_if_not_exists.is_some(),
                 user,
                 auth_option: AuthOption {
@@ -330,7 +330,7 @@ pub fn statement(i: Input) -> IResult<Statement> {
                 role_options: opt_role_options
                     .map(|(_, role_options)| role_options)
                     .unwrap_or_default(),
-            }
+            })
         },
     );
     let alter_user = map(

--- a/common/ast/tests/it/parser.rs
+++ b/common/ast/tests/it/parser.rs
@@ -104,6 +104,7 @@ fn test_statement() {
         r#"insert into table t format json;"#,
         r#"insert into table t select * from t2;"#,
         r#"select parse_json('{"k1": [0, 1, 2]}').k1[0];"#,
+        r#"create user 'test-e'@'localhost' identified by 'password';"#,
     ];
 
     for case in cases {
@@ -168,6 +169,7 @@ fn test_statement_error() {
         r#"drop a"#,
         r#"insert into t format"#,
         r#"alter database system x rename to db"#,
+        r#"create user 'test-e'@'localhost' identified bi 'password';"#,
     ];
 
     for case in cases {

--- a/common/ast/tests/it/testdata/statement-error.txt
+++ b/common/ast/tests/it/testdata/statement-error.txt
@@ -103,3 +103,13 @@ error:
   | while parsing `ALTER DATABASE [IF EXISTS] <action>`
 
 
+---------- Input ----------
+create user 'test-e'@'localhost' identified bi 'password';
+---------- Output ---------
+error: 
+  --> SQL:1:45
+  |
+1 | create user 'test-e'@'localhost' identified bi 'password';
+  |                                             ^^ expected `WITH`, `BY`, or `;`
+
+

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -2592,3 +2592,26 @@ Query(
 )
 
 
+---------- Input ----------
+create user 'test-e'@'localhost' identified by 'password';
+---------- Output ---------
+CREATE USER 'test-e'@'localhost' IDENTIFIED BY 'password'
+---------- AST ------------
+CreateUser(
+    CreateUserStmt {
+        if_not_exists: false,
+        user: UserIdentity {
+            username: "test-e",
+            hostname: "localhost",
+        },
+        auth_option: AuthOption {
+            auth_type: None,
+            password: Some(
+                "password",
+            ),
+        },
+        role_options: [],
+    },
+)
+
+

--- a/common/meta/types/src/user_auth.rs
+++ b/common/meta/types/src/user_auth.rs
@@ -126,6 +126,12 @@ impl AuthInfo {
         AuthInfo::new(auth_type, auth_string)
     }
 
+    pub fn create2(auth_type: &Option<AuthType>, auth_string: &Option<String>) -> Result<AuthInfo> {
+        let default = AuthType::DoubleSha1Password;
+        let auth_type = auth_type.clone().unwrap_or(default);
+        AuthInfo::new(auth_type, auth_string)
+    }
+
     pub fn alter(
         &self,
         auth_type: &Option<String>,

--- a/query/src/interpreters/interpreter_factory_v2.rs
+++ b/query/src/interpreters/interpreter_factory_v2.rs
@@ -23,6 +23,7 @@ use super::SelectInterpreterV2;
 use super::ShowMetricsInterpreter;
 use super::ShowProcessListInterpreter;
 use super::ShowSettingsInterpreter;
+use crate::interpreters::CreateUserInterpreter;
 use crate::sessions::QueryContext;
 use crate::sql::plans::Plan;
 use crate::sql::DfStatement;
@@ -67,6 +68,9 @@ impl InterpreterFactoryV2 {
             Plan::ShowMetrics => ShowMetricsInterpreter::try_create(ctx),
             Plan::ShowProcessList => ShowProcessListInterpreter::try_create(ctx),
             Plan::ShowSettings => ShowSettingsInterpreter::try_create(ctx),
+            Plan::CreateUser(create_user) => {
+                CreateUserInterpreter::try_create(ctx, *create_user.clone())
+            }
         }?;
         Ok(inner)
     }

--- a/query/src/sql/optimizer/mod.rs
+++ b/query/src/sql/optimizer/mod.rs
@@ -57,9 +57,11 @@ pub fn optimize(plan: Plan) -> Result<Plan> {
         }),
 
         // Passthrough
-        Plan::ShowMetrics | Plan::ShowProcessList | Plan::ShowSettings | Plan::CreateTable(_) => {
-            Ok(plan)
-        }
+        Plan::ShowMetrics
+        | Plan::ShowProcessList
+        | Plan::ShowSettings
+        | Plan::CreateTable(_)
+        | Plan::CreateUser(_) => Ok(plan),
     }
 }
 

--- a/query/src/sql/planner/binder/ddl/mod.rs
+++ b/query/src/sql/planner/binder/ddl/mod.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 mod table;
+mod user;

--- a/query/src/sql/planner/binder/ddl/user.rs
+++ b/query/src/sql/planner/binder/ddl/user.rs
@@ -1,0 +1,41 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_ast::ast::CreateUserStmt;
+use common_exception::Result;
+use common_meta_types::AuthInfo;
+use common_meta_types::UserOption;
+use common_planners::CreateUserPlan;
+
+use crate::sql::binder::Binder;
+use crate::sql::plans::Plan;
+
+impl Binder {
+    pub(in crate::sql::planner::binder) async fn bind_create_user(
+        &mut self,
+        stmt: &CreateUserStmt,
+    ) -> Result<Plan> {
+        let mut user_option = UserOption::default();
+        for option in &stmt.role_options {
+            option.apply(&mut user_option);
+        }
+        let plan = CreateUserPlan {
+            user: stmt.user.clone(),
+            auth_info: AuthInfo::create2(&stmt.auth_option.auth_type, &stmt.auth_option.password)?,
+            user_option,
+            if_not_exists: stmt.if_not_exists,
+        };
+        Ok(Plan::CreateUser(Box::new(plan)))
+    }
+}

--- a/query/src/sql/planner/binder/mod.rs
+++ b/query/src/sql/planner/binder/mod.rs
@@ -112,6 +112,10 @@ impl<'a> Binder {
             Statement::ShowMetrics => Ok(Plan::ShowMetrics),
             Statement::ShowProcessList => Ok(Plan::ShowProcessList),
             Statement::ShowSettings => Ok(Plan::ShowSettings),
+            Statement::CreateUser(stmt) => {
+                let plan = self.bind_create_user(stmt).await?;
+                Ok(plan)
+            }
 
             _ => Err(ErrorCode::UnImplement(format!(
                 "UnImplemented stmt {stmt} in binder"

--- a/query/src/sql/planner/format/display_plan.rs
+++ b/query/src/sql/planner/format/display_plan.rs
@@ -30,6 +30,7 @@ impl Plan {
             Plan::ShowMetrics => Ok("SHOW METRICS".to_string()),
             Plan::ShowProcessList => Ok("SHOW PROCESSLIST".to_string()),
             Plan::ShowSettings => Ok("SHOW SETTINGS".to_string()),
+            Plan::CreateUser(create_user) => Ok(format!("{:?}", create_user)),
         }
     }
 }

--- a/query/src/sql/planner/plans/mod.rs
+++ b/query/src/sql/planner/plans/mod.rs
@@ -32,6 +32,7 @@ pub use aggregate::AggregatePlan;
 pub use apply::CrossApply;
 use common_ast::ast::ExplainKind;
 use common_planners::CreateTablePlan;
+use common_planners::CreateUserPlan;
 pub use eval_scalar::EvalScalar;
 pub use eval_scalar::ScalarItem;
 pub use filter::FilterPlan;
@@ -75,4 +76,7 @@ pub enum Plan {
     ShowMetrics,
     ShowProcessList,
     ShowSettings,
+
+    // DCL
+    CreateUser(Box<CreateUserPlan>),
 }

--- a/tests/suites/0_stateless/05_ddl/05_0004_ddl_create_user_v2.sql
+++ b/tests/suites/0_stateless/05_ddl/05_0004_ddl_create_user_v2.sql
@@ -1,0 +1,17 @@
+set enable_planner_v2 = 1;
+DROP USER IF EXISTS 'test-a'@'localhost';
+DROP USER IF EXISTS 'test-b'@'localhost';
+DROP USER IF EXISTS 'test-c'@'localhost';
+DROP USER IF EXISTS 'test-d@localhost';
+
+CREATE USER 'test-a'@'localhost' IDENTIFIED BY 'password';
+CREATE USER 'test-a'@'localhost' IDENTIFIED BY 'password'; -- {ErrorCode 2202}
+CREATE USER 'test-b'@'localhost' IDENTIFIED WITH sha256_password BY 'password';
+CREATE USER 'test-c'@'localhost' IDENTIFIED WITH double_sha1_password BY 'password';
+CREATE USER 'test-d@localhost' IDENTIFIED WITH sha256_password BY 'password';
+CREATE USER IF NOT EXISTS 'test-d@localhost' IDENTIFIED WITH sha256_password BY 'password';
+
+DROP USER 'test-a'@'localhost';
+DROP USER 'test-b'@'localhost';
+DROP USER 'test-c'@'localhost';
+DROP USER 'test-d@localhost';


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Migrate create user to new planner

## Changelog

- New Feature

## Related Issues

Fixes #5777

