### PR TITLE
feature(planner): Migrate DROP USER statement to new planner

### DIFF
--- a/common/ast/tests/it/parser.rs
+++ b/common/ast/tests/it/parser.rs
@@ -106,6 +106,7 @@ fn test_statement() {
         r#"insert into table t select * from t2;"#,
         r#"select parse_json('{"k1": [0, 1, 2]}').k1[0];"#,
         r#"create user 'test-e'@'localhost' identified by 'password';"#,
+        r#"drop user if exists 'test-j'@'localhost';"#,
     ];
 
     for case in cases {
@@ -171,6 +172,7 @@ fn test_statement_error() {
         r#"insert into t format"#,
         r#"alter database system x rename to db"#,
         r#"create user 'test-e'@'localhost' identified bi 'password';"#,
+        r#"drop usar if exists 'test-j'@'localhost';"#,
     ];
 
     for case in cases {

--- a/common/ast/tests/it/testdata/statement-error.txt
+++ b/common/ast/tests/it/testdata/statement-error.txt
@@ -113,3 +113,13 @@ error:
   |                                             ^^ expected `WITH`, `BY`, or `;`
 
 
+---------- Input ----------
+drop usar if exists 'test-j'@'localhost';
+---------- Output ---------
+error: 
+  --> SQL:1:6
+  |
+1 | drop usar if exists 'test-j'@'localhost';
+  |      ^^^^ expected `DATABASE`, `SCHEMA`, `TABLE`, `VIEW`, `USER`, or `FUNCTION`
+
+

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -2730,3 +2730,17 @@ CreateUser(
 )
 
 
+---------- Input ----------
+drop user if exists 'test-j'@'localhost';
+---------- Output ---------
+DROP USER IF EXISTS 'test-j'@'localhost'
+---------- AST ------------
+DropUser {
+    if_exists: true,
+    user: UserIdentity {
+        username: "test-j",
+        hostname: "localhost",
+    },
+}
+
+

--- a/query/src/interpreters/interpreter_factory_v2.rs
+++ b/query/src/interpreters/interpreter_factory_v2.rs
@@ -25,6 +25,7 @@ use super::ShowMetricsInterpreter;
 use super::ShowProcessListInterpreter;
 use super::ShowSettingsInterpreter;
 use crate::interpreters::CreateUserInterpreter;
+use crate::interpreters::DropUserInterpreter;
 use crate::sessions::QueryContext;
 use crate::sql::plans::Plan;
 use crate::sql::DfStatement;
@@ -76,6 +77,7 @@ impl InterpreterFactoryV2 {
             Plan::CreateView(create_view) => {
                 CreateViewInterpreter::try_create(ctx, *create_view.clone())
             }
+            Plan::DropUser(drop_user) => DropUserInterpreter::try_create(ctx, *drop_user.clone()),
         }?;
         Ok(inner)
     }

--- a/query/src/sql/optimizer/mod.rs
+++ b/query/src/sql/optimizer/mod.rs
@@ -62,7 +62,8 @@ pub fn optimize(plan: Plan) -> Result<Plan> {
         | Plan::ShowSettings
         | Plan::CreateTable(_)
         | Plan::CreateUser(_)
-        | Plan::CreateView(_) => Ok(plan),
+        | Plan::CreateView(_)
+        | Plan::DropUser(_) => Ok(plan),
     }
 }
 

--- a/query/src/sql/planner/binder/mod.rs
+++ b/query/src/sql/planner/binder/mod.rs
@@ -22,6 +22,7 @@ use common_ast::ast::TimeTravelPoint;
 use common_datavalues::DataTypeImpl;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_planners::DropUserPlan;
 
 use self::subquery::SubqueryRewriter;
 use super::plans::Plan;
@@ -119,6 +120,14 @@ impl<'a> Binder {
             Statement::CreateView(stmt) => {
                 let plan = self.bind_create_view(stmt).await?;
                 Ok(plan)
+            }
+
+            Statement::DropUser { if_exists, user } => {
+                let plan = DropUserPlan {
+                    if_exists: *if_exists,
+                    user: user.clone(),
+                };
+                Ok(Plan::DropUser(Box::new(plan)))
             }
 
             _ => Err(ErrorCode::UnImplement(format!(

--- a/query/src/sql/planner/format/display_plan.rs
+++ b/query/src/sql/planner/format/display_plan.rs
@@ -32,6 +32,7 @@ impl Plan {
             Plan::ShowSettings => Ok("SHOW SETTINGS".to_string()),
             Plan::CreateUser(create_user) => Ok(format!("{:?}", create_user)),
             Plan::CreateView(create_view) => Ok(format!("{:?}", create_view)),
+            Plan::DropUser(drop_user) => Ok(format!("{:?}", drop_user)),
         }
     }
 }

--- a/query/src/sql/planner/plans/mod.rs
+++ b/query/src/sql/planner/plans/mod.rs
@@ -34,6 +34,7 @@ use common_ast::ast::ExplainKind;
 use common_planners::CreateTablePlan;
 use common_planners::CreateUserPlan;
 use common_planners::CreateViewPlan;
+use common_planners::DropUserPlan;
 pub use eval_scalar::EvalScalar;
 pub use eval_scalar::ScalarItem;
 pub use filter::FilterPlan;
@@ -81,4 +82,5 @@ pub enum Plan {
 
     // DCL
     CreateUser(Box<CreateUserPlan>),
+    DropUser(Box<DropUserPlan>),
 }

--- a/tests/suites/0_stateless/05_ddl/05_0007_ddl_drop_user_v2.sql
+++ b/tests/suites/0_stateless/05_ddl/05_0007_ddl_drop_user_v2.sql
@@ -1,0 +1,14 @@
+set enable_planner_v2=1;
+DROP USER 'test-j'@'localhost'; -- {ErrorCode 2201}
+DROP USER IF EXISTS 'test-j'@'localhost';
+
+
+CREATE USER 'test-j'@'localhost' IDENTIFIED BY 'password';
+DROP USER 'test-j'@'localhost';
+DROP USER IF EXISTS 'test-j'@'localhost';
+
+CREATE USER 'test-l'@'localhost' IDENTIFIED WITH sha256_password BY 'password';
+DROP USER 'test-l'@'localhost';
+DROP USER IF EXISTS 'test-l'@'localhost';
+DROP USER IF EXISTS 'test-l'@'localhost';
+DROP USER IF EXISTS 'test-l'@'localhost';


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Migrate drop user to new planner

## Changelog

- New Feature

## Related Issues

 #5777

