### PR TITLE
fix: remove incompatible modification of chunk compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "parquet2"
 version = "0.13.0"
-source = "git+https://github.com/datafuse-extras/parquet2?branch=parquet2-0.13-patch1#68f8646b752fba409ce765d5349d069acbb984cf"
+source = "git+https://github.com/datafuse-extras/parquet2?branch=parquet2-0.13-patch2#10b3ca0e1038dc243ef3f80d5abe19c0f9e54c7c"
 dependencies = [
  "async-stream",
  "bitpacking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,5 +65,5 @@ object = { opt-level = 3 }
 rustc-demangle = { opt-level = 3 }
 
 [patch.crates-io]
-parquet2 = { version = "0.13", optional = true, git = "https://github.com/datafuse-extras/parquet2", branch = "parquet2-0.13-patch1" }
+parquet2 = { version = "0.13", optional = true, git = "https://github.com/datafuse-extras/parquet2", branch = "parquet2-0.13-patch2" }
 chrono = { git = "https://github.com/datafuse-extras/chrono", rev = "279f590" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The modifications introduced in 

- pr #5806 

is highly suspicious to be not parquet standard compatible.

Luckily, the issue that pr #5806 trying to fix has already been fixed by parquet v0.13. 

Thus we switch to the patched branch of parquet v0.13:

https://github.com/datafuse-extras/parquet2/commits/parquet2-0.13-patch2

## Changelog


- Bug Fix
- Documentation
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

