### PR TITLE
ci: Make macOS checks optional

### DIFF
--- a/.github/actions/build_debug_hive/action.yml
+++ b/.github/actions/build_debug_hive/action.yml
@@ -1,0 +1,51 @@
+name: "Build Debug"
+description: "Build with debug profile"
+inputs:
+  github_token:
+    description: "Github Token"
+    required: true
+  target:
+    description: ""
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Maximize build space
+      uses: ./.github/actions/cleanup
+
+    - uses: arduino/setup-protoc@v1
+      if: "contains(inputs.target, 'apple')"
+      with:
+        version: "3.x"
+        repo-token: ${{ inputs.github_token }}
+
+    - shell: bash
+      if: "contains(inputs.target, 'apple')"
+      run: rustup target add ${{ inputs.target }}
+
+    - shell: bash
+      if: "contains(inputs.target, 'apple')"
+      run: brew install thrift
+
+    - name: Setup Build Tool
+      if: "contains(inputs.target, 'linux')"
+      uses: ./.github/actions/setup_build_tool
+      with:
+        image: ${{ inputs.target }}
+
+    - shell: bash
+      run: cargo build --target ${{ inputs.target }} --bin databend-query --features hive
+
+    - shell: bash
+      if: "contains(inputs.target, 'linux')"
+      run: readelf -p .comment ./target/${{ inputs.target }}/debug/databend-query
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: debug-${{ github.sha }}-${{ inputs.target }}-hive
+        path: ./target/${{ inputs.target }}/debug/databend-*
+
+    # for cache
+    - shell: bash
+      run: cargo metadata --all-features --format-version 1 > ./target/metadata.json

--- a/.github/actions/test_stateful_hive_standalone/action.yml
+++ b/.github/actions/test_stateful_hive_standalone/action.yml
@@ -20,18 +20,15 @@ runs:
       with:
         image: ${{ inputs.target }}
 
-    # If you need to reset the cache version, increment the number after `v`
-    - uses: Swatinem/rust-cache@v1
+    - uses: actions/download-artifact@v2
       with:
-        sharedKey: debug-hive-${{ inputs.target }}-v2
+        name: ${{ inputs.profile }}-${{ github.sha }}-${{ inputs.target }}-hive
+        path: ./target/debug
 
-    # for the time being, only databend-query is needed
-    - shell: bash
-      run: cargo build --bin databend-query --features hive
-
-    # for cache
-    - shell: bash
-      run: cargo metadata --all-features --format-version 1 > ./target/metadata.json
+    - name: Set up file as executable
+      shell: bash
+      run: |
+        chmod +x ./target/debug/databend-*
 
     # hive cluster setup
     - name: Hive Cluster Setup

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,33 +5,18 @@ queue_rules:
 
       # Must write expected checks explicitly
       # Reference: https://docs.mergify.com/conditions/#validating-all-status-checks
+      # We only require linux checks to pass
       - check-success=check
       - check-success=test_unit
       - check-success=test_metactl
       - check-success=test_stateless_standalone_linux
-      # MacOS's stateless standalone has been disabled.
-      # - check-success=test_stateless_standalone_macos
       - check-success=test_stateless_cluster_linux
-      - check-success=test_stateless_cluster_macos
       - check-success=test_stateful_standalone
 
 pull_request_rules:
-  - name: put bug fix pr to queue with high priority
+  - name: put bug fix pr to queue
     conditions:
       - "#approved-reviews-by>=2"
-      - check-success=check
-      - label=pr-bugfix
-
-    actions:
-      queue:
-        name: shared_queue
-
-  - name: put other pr to queue
-    conditions:
-      - "#approved-reviews-by>=2"
-      - check-success=check
-      - label!=pr-bugfix
-
     actions:
       queue:
         name: shared_queue

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -40,7 +40,6 @@ jobs:
 
   build_macos:
     runs-on: macos-11
-    needs: check
     strategy:
       matrix:
         target:
@@ -58,7 +57,6 @@ jobs:
 
   build_linux:
     runs-on: [self-hosted, x64, Linux]
-    needs: check
     strategy:
       matrix:
         target:
@@ -75,7 +73,6 @@ jobs:
 
   test_unit:
     runs-on: [self-hosted, x64, Linux]
-    needs: check
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -168,6 +168,21 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/test_stateful_standalone
 
+  build_linux_hive:
+    runs-on: [ self-hosted, x64, Linux ]
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # fetch all tags,  metasrv and metaclient need tag as its version.
+          fetch-depth: 0
+      - uses: ./.github/actions/build_debug_hive
+        with:
+          target: ${{ matrix.target }}
+
   test_stateful_hive_standalone:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -185,6 +185,7 @@ jobs:
 
   test_stateful_hive_standalone:
     runs-on: ubuntu-latest
+    needs: build_linux_hive
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -39,6 +39,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   build_macos:
+    name: "build_macos(optional)"
     runs-on: macos-11
     strategy:
       matrix:
@@ -131,6 +132,7 @@ jobs:
       - uses: ./.github/actions/test_stateless_cluster_linux
 
   test_stateless_cluster_macos:
+    name: "test_stateless_cluster_macos(optional)"
     runs-on: macos-11
     needs: build_macos
     steps:
@@ -141,6 +143,7 @@ jobs:
       - uses: ./.github/actions/test_stateless_cluster_macos
 
   test_sqllogic_standalone_macos:
+    name: "test_sqllogic_standalone_macos(optional)"
     runs-on: macos-11
     needs: build_macos
     steps:

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -170,7 +170,6 @@ jobs:
 
   test_stateful_hive_standalone:
     runs-on: ubuntu-latest
-    needs: check
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -30,7 +30,6 @@ jobs:
 
   build_macos:
     runs-on: macos-11
-    needs: check
     strategy:
       matrix:
         target:
@@ -48,7 +47,6 @@ jobs:
 
   build_linux:
     runs-on: [self-hosted, x64, Linux]
-    needs: check
     strategy:
       matrix:
         target:
@@ -65,7 +63,6 @@ jobs:
 
   test_unit:
     runs-on: [self-hosted, x64, Linux]
-    needs: check
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Implement https://github.com/datafuselabs/databend/discussions/5880

This PR:

- Make macOS checks optional, so we can merge a PR without waiting for macOS.
- Remove requirement of check before embarking into merge queue, reduce the time for mergeing
- Remove requirement of CI check, so all tasks can run concurrently.

## Changelog

- Build/Testing/CI


