### PR TITLE
fix(query): fix parser for incomplete data on fallback

### DIFF
--- a/query/src/sql/statements/value_source.rs
+++ b/query/src/sql/statements/value_source.rs
@@ -131,6 +131,8 @@ impl ValueSource {
                 for deser in desers.iter_mut().take(pop_count) {
                     deser.pop_data_value()?;
                 }
+                // rollback to get full data
+                reader.rollback_to_checkpoint()?;
                 skip_to_next_row(reader, 1)?;
 
                 // Parse from expression and append all columns.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

continue with pr #5870. If we deserialize `dataValue` failed and fall back to using SQL parser, the data may be incomplete.


## Changelog

- Bug Fix

## Related Issues

Fixes #issue

