### PR TITLE
clickhouse http handler support TsvWithNamesAndTypes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,8 +947,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b103d85ca6e209388771bfb7aa6b68a7aeec4afbf6f0a0264bfbf50360e5212e"
 dependencies = [
  "crossterm",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "unicode-width",
 ]
 
@@ -2080,6 +2080,8 @@ dependencies = [
  "sha2 0.10.2",
  "smallvec",
  "sqlparser",
+ "strum 0.24.0",
+ "strum_macros 0.24.0",
  "temp-env",
  "tempfile",
  "thiserror",
@@ -6421,12 +6423,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 
 [[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+
+[[package]]
 name = "strum_macros"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -111,6 +111,8 @@ serfig = "0.0.2"
 sha1 = "0.10.1"
 sha2 = "0.10.2"
 smallvec = { version = "1.8.0", features = ["write"] }
+strum = "0.24"
+strum_macros = "0.24"
 tempfile = { version = "3.3.0", optional = true }
 thiserror = "1.0.30"
 threadpool = "1.8.1"

--- a/query/src/formats/format_factory.rs
+++ b/query/src/formats/format_factory.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -20,16 +21,19 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_io::prelude::FormatSettings;
 use once_cell::sync::Lazy;
+use strum::IntoEnumIterator;
 
 use crate::formats::format::InputFormat;
 use crate::formats::format_csv::CsvInputFormat;
 use crate::formats::format_parquet::ParquetInputFormat;
+use crate::formats::output_format::OutputFormatType;
 
 pub type InputFormatFactoryCreator =
     Box<dyn Fn(&str, DataSchemaRef, FormatSettings) -> Result<Box<dyn InputFormat>> + Send + Sync>;
 
 pub struct FormatFactory {
     case_insensitive_desc: HashMap<String, InputFormatFactoryCreator>,
+    outputs: BTreeMap<String, OutputFormatType>,
 }
 
 static FORMAT_FACTORY: Lazy<Arc<FormatFactory>> = Lazy::new(|| {
@@ -38,6 +42,7 @@ static FORMAT_FACTORY: Lazy<Arc<FormatFactory>> = Lazy::new(|| {
     CsvInputFormat::register(&mut format_factory);
     ParquetInputFormat::register(&mut format_factory);
 
+    format_factory.register_outputs();
     Arc::new(format_factory)
 });
 
@@ -45,6 +50,7 @@ impl FormatFactory {
     pub(in crate::formats::format_factory) fn create() -> FormatFactory {
         FormatFactory {
             case_insensitive_desc: Default::default(),
+            outputs: Default::default(),
         }
     }
 
@@ -74,5 +80,37 @@ impl FormatFactory {
             })?;
 
         creator(origin_name, schema, settings)
+    }
+
+    pub fn get_output(&self, name: &str) -> Result<OutputFormatType> {
+        self.outputs
+            .get(&name.to_lowercase())
+            .cloned()
+            .ok_or_else(|| ErrorCode::UnknownFormat(format!("Unsupported formats: {}", name)))
+    }
+
+    fn register_output(&mut self, typ: OutputFormatType) {
+        let base_name = format!("{:?}", typ);
+        let mut names = typ.base_alias();
+        names.push(base_name);
+        for n in &names {
+            self.register_output_by_name(n.clone(), typ);
+            if let Some(t) = typ.with_names() {
+                self.register_output_by_name(n.to_string() + "WithNames", t);
+            }
+            if let Some(t) = typ.with_names_and_types() {
+                self.register_output_by_name(n.to_string() + "WithNamesAndTypes", t);
+            }
+        }
+    }
+
+    fn register_output_by_name(&mut self, name: String, typ: OutputFormatType) {
+        self.outputs.insert(name.to_lowercase(), typ);
+    }
+
+    fn register_outputs(&mut self) {
+        for t in OutputFormatType::iter() {
+            self.register_output(t)
+        }
     }
 }

--- a/query/src/formats/output_format_ndjson.rs
+++ b/query/src/formats/output_format_ndjson.rs
@@ -21,15 +21,15 @@ use common_io::prelude::FormatSettings;
 use crate::formats::output_format::OutputFormat;
 
 #[derive(Default)]
-pub struct NDJsonOutputFormat {}
+pub struct JsonEachRowOutputFormat {}
 
-impl NDJsonOutputFormat {
+impl JsonEachRowOutputFormat {
     pub fn create(_schema: DataSchemaRef) -> Self {
         Self {}
     }
 }
 
-impl OutputFormat for NDJsonOutputFormat {
+impl OutputFormat for JsonEachRowOutputFormat {
     fn serialize_block(&mut self, block: &DataBlock, format: &FormatSettings) -> Result<Vec<u8>> {
         let rows_size = block.column(0).len();
 

--- a/query/src/servers/http/clickhouse_handler.rs
+++ b/query/src/servers/http/clickhouse_handler.rs
@@ -85,13 +85,15 @@ async fn execute(
         };
     let mut data_stream = ctx.try_create_abortable(data_stream)?;
     let format_setting = ctx.get_format_settings()?;
-    let mut fmt = OutputFormatType::Tsv;
+    let mut fmt = OutputFormatType::TSV;
     if let Some(format) = format {
         fmt = OutputFormatType::from_str(format.as_str())?;
     }
 
     let mut output_format = fmt.create_format(plan.schema());
+    let header = output_format.serialize_prefix(&format_setting);
     let stream = stream! {
+        yield header;
         while let Some(block) = data_stream.next().await {
             match block{
                 Ok(block) => {
@@ -100,9 +102,7 @@ async fn execute(
                 Err(err) => yield(Err(err)),
             };
         }
-
         yield output_format.finalize();
-
         let _ = interpreter
             .finish()
             .await
@@ -155,6 +155,7 @@ pub async fn clickhouse_handler_post(
 
     let (plan, format, input_stream) = if sql.is_empty() {
         sql = body.into_string().await?;
+        tracing::debug!("receive clickhouse post, body= {:?},", sql);
         let (plan, format) = PlanParser::parse_with_format(ctx.clone(), &sql)
             .await
             .map_err(BadRequest)?;

--- a/query/tests/it/formats/format_factory.rs
+++ b/query/tests/it/formats/format_factory.rs
@@ -1,0 +1,37 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::Result;
+use databend_query::formats::output_format::OutputFormatType;
+use databend_query::formats::FormatFactory;
+use strum::IntoEnumIterator;
+
+#[test]
+fn test_outputs() -> Result<()> {
+    let factory = FormatFactory::instance();
+    for t in OutputFormatType::iter() {
+        let name = t.to_string();
+        assert_eq!(factory.get_output(&name)?.to_string(), name);
+    }
+    assert_eq!(factory.get_output("NDJson")?, OutputFormatType::JsonEachRow);
+    assert_eq!(
+        factory.get_output("TabSeparatedWithNames")?,
+        OutputFormatType::TSVWithNames
+    );
+    assert_eq!(
+        factory.get_output("TabSeparatedWithNamesAndTypes")?,
+        OutputFormatType::TSVWithNamesAndTypes
+    );
+    Ok(())
+}

--- a/query/tests/it/formats/mod.rs
+++ b/query/tests/it/formats/mod.rs
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 mod format_csv;
+mod format_factory;
 mod output_format_tcsv;

--- a/query/tests/it/formats/output_format_tcsv.rs
+++ b/query/tests/it/formats/output_format_tcsv.rs
@@ -64,32 +64,51 @@ fn test_data_block(is_nullable: bool) -> Result<()> {
     let mut format_setting = FormatSettings::default();
 
     {
-        let fmt = OutputFormatType::Tsv;
-        let mut formater = fmt.create_format(schema.clone());
-        let buffer = formater.serialize_block(&block, &format_setting)?;
+        let fmt = OutputFormatType::TSV;
+        let mut formatter = fmt.create_format(schema.clone());
+        let buffer = formatter.serialize_block(&block, &format_setting)?;
 
-        let csv_block = String::from_utf8(buffer)?;
+        let tsv_block = String::from_utf8(buffer)?;
         let expect = "1\ta\t1\t1.1\t1970-01-02\n\
                             2\tb\t1\t2.2\t1970-01-03\n\
                             3\tc\t0\t3.3\t1970-01-04\n";
-        assert_eq!(&csv_block, expect);
+        assert_eq!(&tsv_block, expect);
+
+        let fmt = OutputFormatType::TSVWithNames;
+        let formatter = fmt.create_format(schema.clone());
+        let buffer = formatter.serialize_prefix(&format_setting)?;
+        let tsv_block = String::from_utf8(buffer)?;
+        let names = "c1\tc2\tc3\tc4\tc5\n".to_string();
+        assert_eq!(tsv_block, names);
+
+        let fmt = OutputFormatType::TSVWithNamesAndTypes;
+        let formatter = fmt.create_format(schema.clone());
+        let buffer = formatter.serialize_prefix(&format_setting)?;
+        let tsv_block = String::from_utf8(buffer)?;
+
+        let types = if is_nullable {
+            "Nullable(Int32)\tNullable(String)\tNullable(Boolean)\tNullable(Float64)\tNullable(Date)\n"
+                .to_string()
+        } else {
+            "Int32\tString\tBoolean\tFloat64\tDate\n".to_string()
+        };
+        assert_eq!(tsv_block, names + &types);
     }
 
     {
         format_setting.record_delimiter = vec![b'%'];
         format_setting.field_delimiter = vec![b'$'];
 
-        let fmt = OutputFormatType::Csv;
-        let mut formater = fmt.create_format(schema);
-        let buffer = formater.serialize_block(&block, &format_setting)?;
+        let fmt = OutputFormatType::CSV;
+        let mut formatter = fmt.create_format(schema);
+        let buffer = formatter.serialize_block(&block, &format_setting)?;
 
-        let json_block = String::from_utf8(buffer)?;
+        let csv_block = String::from_utf8(buffer)?;
         let expect = "1$\"a\"$1$1.1$\"1970-01-02\"%\
                             2$\"b\"$1$2.2$\"1970-01-03\"%\
                             3$\"c\"$0$3.3$\"1970-01-04\"%";
-        assert_eq!(&json_block, expect);
+        assert_eq!(&csv_block, expect);
     }
-
     Ok(())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

basic support for TsvWithNamesAndTypes,

1. use FormatFactory only for `name-> enum OutputFormatType` , more freedom and less code to handle the following:
  - case_insensitive
  - alias (TSV, TabSeperated), (NDJSON, JSONEachrow)
   - "withName and withNameAndFormat" suffix
2. OutputFormatType is used as a unique id (no alias) to carry around(after sql parse) and ease ops like match, cmp, define capabilities
    -  it also make it very clear to see all supported formats in the code.
4.  use OutputFormatType to create dyn OutputFormat
5.  TsvWithNamesAndTypes implemented with constant generics,  make the code more uniform thanks to @zhang2014 



## Changelog

- New Feature

## Related Issues

Fixes #issue

