### PR TITLE
ci: Don't need to wait for macOS for publishing image

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -160,7 +160,6 @@ jobs:
       - test_stateless_cluster_linux
       - test_stateful_standalone
       - test_sqllogic_standalone_linux
-      - test_sqllogic_standalone_macos
     strategy:
       matrix:
         config:


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Don't need to wait for macOS for publishing image

## Changelog

- Build/Testing/CI

## Related Issues

Fixes #issue

