### PR TITLE
feat: http handler return write/result progress.

### DIFF
--- a/docs/doc/30-reference/00-api/00-rest.md
+++ b/docs/doc/30-reference/00-api/00-rest.md
@@ -77,6 +77,14 @@ you are expected to get JSON like this (formatted):
       "rows": 100000000,
       "bytes": 800000000
     },
+    "write_progress": {
+      "rows": 0,
+      "bytes": 0
+    },
+    "result_progress": {
+      "rows": 0,
+      "bytes": 0 
+    },
     "running_time_ms": 466.85395800000003
   },
   "stats_uri": "/v1/query/3cd25ab7-c3a4-42ce-9e02-e1b354d91f06",

--- a/query/src/servers/http/v1/http_query_handlers.rs
+++ b/query/src/servers/http/v1/http_query_handlers.rs
@@ -14,7 +14,6 @@
 
 use std::str::FromStr;
 
-use common_base::base::ProgressValues;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_io::prelude::FormatSettings;
@@ -41,6 +40,7 @@ use super::query::ExecuteStateKind;
 use super::query::HttpQueryRequest;
 use super::query::HttpQueryResponseInternal;
 use crate::formats::output_format::OutputFormatType;
+use crate::servers::http::v1::query::Progresses;
 use crate::servers::http::v1::HttpQueryContext;
 use crate::servers::http::v1::JsonBlock;
 use crate::sessions::SessionType;
@@ -79,7 +79,8 @@ impl QueryError {
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct QueryStats {
-    pub scan_progress: Option<ProgressValues>,
+    #[serde(flatten)]
+    pub progresses: Progresses,
     pub running_time_ms: f64,
 }
 
@@ -112,7 +113,7 @@ impl QueryResponse {
         let schema = data.schema().clone();
         let session_id = r.session_id.clone();
         let stats = QueryStats {
-            scan_progress: state.scan_progress.clone(),
+            progresses: state.progresses.clone(),
             running_time_ms: state.running_time_ms,
         };
         QueryResponse {

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -63,6 +63,23 @@ pub enum ExecuteStateKind {
     Succeeded,
 }
 
+#[derive(Clone, Serialize, Deserialize, Default, Debug)]
+pub struct Progresses {
+    pub scan_progress: ProgressValues,
+    pub write_progress: ProgressValues,
+    pub result_progress: ProgressValues,
+}
+
+impl Progresses {
+    fn from_context(ctx: &Arc<QueryContext>) -> Self {
+        Progresses {
+            scan_progress: ctx.get_scan_progress_value(),
+            write_progress: ctx.get_write_progress_value(),
+            result_progress: ctx.get_result_progress_value(),
+        }
+    }
+}
+
 pub enum ExecuteState {
     Running(ExecuteRunning),
     Stopped(ExecuteStopped),
@@ -89,7 +106,7 @@ pub struct ExecuteRunning {
 }
 
 pub struct ExecuteStopped {
-    progress: Option<ProgressValues>,
+    stats: Progresses,
     reason: Result<()>,
     stop_time: Instant,
 }
@@ -100,10 +117,10 @@ pub struct Executor {
 }
 
 impl Executor {
-    pub(crate) fn get_progress(&self) -> Option<ProgressValues> {
+    pub(crate) fn get_progress(&self) -> Progresses {
         match &self.state {
-            Running(r) => Some(r.ctx.get_scan_progress_value()),
-            Stopped(f) => f.progress.clone(),
+            Running(r) => Progresses::from_context(&r.ctx),
+            Stopped(f) => f.stats.clone(),
         }
     }
 
@@ -118,7 +135,6 @@ impl Executor {
         let mut guard = this.write().await;
         if let Running(r) = &guard.state {
             // release session
-            let progress = Some(r.ctx.get_scan_progress_value());
             if kill {
                 r.session.force_kill_query();
             }
@@ -129,7 +145,7 @@ impl Executor {
                 .await
                 .map_err(|e| tracing::error!("interpreter.finish error: {:?}", e));
             guard.state = Stopped(ExecuteStopped {
-                progress,
+                stats: Progresses::from_context(&r.ctx),
                 reason: reason.clone(),
                 stop_time: Instant::now(),
             });

--- a/query/src/servers/http/v1/query/http_query.rs
+++ b/query/src/servers/http/v1/query/http_query.rs
@@ -20,13 +20,13 @@ use std::time::Instant;
 use common_base::base::tokio;
 use common_base::base::tokio::sync::Mutex as TokioMutex;
 use common_base::base::tokio::sync::RwLock;
-use common_base::base::ProgressValues;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_io::prelude::FormatSettings;
 use serde::Deserialize;
 
 use super::HttpQueryContext;
+use crate::servers::http::v1::query::execute_state::Progresses;
 use crate::servers::http::v1::query::expirable::Expirable;
 use crate::servers::http::v1::query::expirable::ExpiringState;
 use crate::servers::http::v1::query::http_query_manager::HttpQueryConfig;
@@ -123,7 +123,7 @@ impl Default for HttpSession {
 #[derive(Debug, Clone)]
 pub struct ResponseState {
     pub running_time_ms: f64,
-    pub scan_progress: Option<ProgressValues>,
+    pub progresses: Progresses,
     pub state: ExecuteStateKind,
     pub error: Option<ErrorCode>,
 }
@@ -255,7 +255,7 @@ impl HttpQuery {
         let (exe_state, err) = state.state.extract();
         ResponseState {
             running_time_ms: state.elapsed().as_secs_f64() * 1000.0,
-            scan_progress: state.get_progress(),
+            progresses: state.get_progress(),
             state: exe_state,
             error: err,
         }

--- a/query/src/servers/http/v1/query/mod.rs
+++ b/query/src/servers/http/v1/query/mod.rs
@@ -24,6 +24,7 @@ pub(crate) use execute_state::ExecuteState;
 pub use execute_state::ExecuteStateKind;
 pub(crate) use execute_state::Executor;
 pub use execute_state::HttpQueryHandle;
+pub use execute_state::Progresses;
 pub use http_query::HttpQuery;
 pub use http_query::HttpQueryRequest;
 pub use http_query::HttpQueryResponseInternal;

--- a/query/tests/it/servers/http/http_query_handlers.rs
+++ b/query/tests/it/servers/http/http_query_handlers.rs
@@ -100,7 +100,6 @@ async fn test_simple_sql(v2: u64) -> Result<()> {
     assert_eq!(result.data.len(), 10, "{:?}", result);
     assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
     assert!(result.next_uri.is_none(), "{:?}", result);
-    assert!(result.stats.scan_progress.is_some(), "{:?}", result);
     assert!(result.schema.is_some(), "{:?}", result);
     assert_eq!(
         result.schema.as_ref().unwrap().fields().len(),
@@ -118,7 +117,6 @@ async fn test_simple_sql(v2: u64) -> Result<()> {
     assert_eq!(result.data.len(), 0, "{:?}", result);
     assert!(result.next_uri.is_none(), "{:?}", result);
     assert!(result.schema.is_some(), "{:?}", result);
-    assert!(result.stats.scan_progress.is_some(), "{:?}", result);
     assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
 
     // get page, support retry
@@ -130,7 +128,6 @@ async fn test_simple_sql(v2: u64) -> Result<()> {
         assert_eq!(result.data.len(), 10, "{:?}", result);
         assert!(result.next_uri.is_none(), "{:?}", result);
         assert!(result.schema.is_some(), "{:?}", result);
-        assert!(result.stats.scan_progress.is_some(), "{:?}", result);
         assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
     }
 
@@ -221,7 +218,6 @@ async fn test_bad_sql() -> Result<()> {
     assert_eq!(result.data.len(), 0, "{:?}", result);
     assert!(result.next_uri.is_none(), "{:?}", result);
     assert_eq!(result.state, ExecuteStateKind::Failed, "{:?}", result);
-    assert!(result.stats.scan_progress.is_none(), "{:?}", result);
     assert!(result.schema.is_none(), "{:?}", result);
 
     let sql = "select query_text, exception_code, exception_text, stack_trace from system.query_log where log_type=3";
@@ -268,7 +264,6 @@ async fn test_wait_time_secs() -> Result<()> {
     assert!(result.error.is_none(), "{:?}", result);
     assert_eq!(result.data.len(), 0, "{:?}", result);
     assert_eq!(result.next_uri, Some(next_uri.clone()), "{:?}", result);
-    assert!(result.stats.scan_progress.is_some(), "{:?}", result);
     assert!(result.schema.is_some(), "{:?}", result);
 
     let mut uri = make_page_uri(query_id, 0);
@@ -278,7 +273,6 @@ async fn test_wait_time_secs() -> Result<()> {
         let (status, result) = get_uri_checked(&ep, &uri).await?;
         assert_eq!(status, StatusCode::OK, "{:?}", result);
         assert!(result.error.is_none(), "{:?}", result);
-        assert!(result.stats.scan_progress.is_some(), "{:?}", result);
         num_row += result.data.len();
         match &result.next_uri {
             Some(next_uri) => {
@@ -336,7 +330,6 @@ async fn test_pagination(v2: u64) -> Result<()> {
     assert!(result.error.is_none(), "{:?}", result);
     assert_eq!(result.data.len(), 2, "{:?}", result);
     assert_eq!(result.next_uri, Some(next_uri), "{:?}", result);
-    assert!(result.stats.scan_progress.is_some(), "{:?}", result);
     assert!(result.schema.is_some(), "{:?}", result);
 
     for page in 0..5 {
@@ -348,7 +341,6 @@ async fn test_pagination(v2: u64) -> Result<()> {
         assert!(result.error.is_none(), "{:?}", msg());
         assert_eq!(result.data.len(), 2, "{:?}", msg());
         assert!(result.schema.is_some(), "{:?}", result);
-        assert!(result.stats.scan_progress.is_some(), "{:?}", msg());
         if page == 4 {
             expect_end(&ep, result).await?;
         } else {
@@ -364,7 +356,6 @@ async fn test_pagination(v2: u64) -> Result<()> {
     assert_eq!(result.data.len(), 0, "{:?}", result);
     assert!(result.next_uri.is_none(), "{:?}", result);
     assert!(result.schema.is_some(), "{:?}", result);
-    assert!(result.stats.scan_progress.is_some(), "{:?}", result);
     assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
 
     // get page not expected
@@ -430,7 +421,6 @@ async fn test_http_session() -> Result<()> {
     assert!(result.error.is_none(), "{:?}", result);
     assert_eq!(result.data.len(), 0, "{:?}", result);
     assert_eq!(result.next_uri, None, "{:?}", result);
-    assert!(result.stats.scan_progress.is_some(), "{:?}", result);
     assert!(result.schema.is_some(), "{:?}", result);
     assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
     let session_id = &result.session_id.unwrap();
@@ -531,7 +521,6 @@ async fn test_system_tables() -> Result<()> {
             "{}",
             error_message
         );
-        assert!(result.stats.scan_progress.is_some(), "{:?}", result);
         assert!(result.next_uri.is_none(), "{:?}", result);
         assert!(result.schema.is_some(), "{:?}", result);
     }
@@ -543,18 +532,23 @@ async fn test_insert() -> Result<()> {
     let route = create_endpoint();
 
     let sqls = vec![
-        ("create table t(a int) engine=fuse", 0),
-        ("insert into t(a) values (1),(2)", 0),
-        ("select * from t", 2),
+        ("create table t(a int) engine=fuse", 0, 0),
+        ("insert into t(a) values (1),(2)", 0, 2),
+        ("select * from t", 2, 0),
     ];
 
-    for (sql, data_len) in sqls {
+    for (sql, data_len, rows_written) in sqls {
         let json = serde_json::json!({"sql": sql.to_string(), "pagination": {"wait_time_secs": 3}});
         let (status, result) = post_json_to_endpoint(&route, &json).await?;
         assert_eq!(status, StatusCode::OK, "{:?}", result);
         assert!(result.error.is_none(), "{:?}", result.error);
         assert_eq!(result.data.len(), data_len, "{:?}", result);
         assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
+        assert_eq!(
+            result.stats.progresses.write_progress.rows as usize, rows_written,
+            "{:?}",
+            result
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
```
   "scan_progress": {
      "rows": 100000000,
      "bytes": 800000000
    },
```

to 
```
   "scan_progress": {
      "rows": 100000000,
      "bytes": 800000000
    },
    "write_progress": {
      "rows": 0,
      "bytes": 0
    },
    "result_progress": {
      "rows": 0,
      "bytes": 0 
    },
```

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

