### PR TITLE
feat: transient fuse table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ fmt:
 
 lint:
 	cargo fmt
-	cargo clippy --all -- -D warnings
+	cargo clippy --workspace --all-targets -- -D warnings
 	# Cargo.toml file formatter(make setup to install)
 	taplo fmt
 	# Python file formatter(make setup to install)

--- a/common/ast/src/ast/statement.rs
+++ b/common/ast/src/ast/statement.rs
@@ -231,6 +231,7 @@ pub struct CreateTableStmt<'a> {
     pub cluster_by: Vec<Expr<'a>>,
     pub as_query: Option<Box<Query<'a>>>,
     pub comment: Option<String>,
+    pub transient: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -752,8 +753,13 @@ impl<'a> Display for Statement<'a> {
                 comment,
                 cluster_by,
                 as_query,
+                transient,
             }) => {
-                write!(f, "CREATE TABLE ")?;
+                write!(f, "CREATE ")?;
+                if *transient {
+                    write!(f, "TRANSIENT ")?;
+                }
+                write!(f, "TABLE ")?;
                 if *if_not_exists {
                     write!(f, "IF NOT EXISTS ")?;
                 }

--- a/common/ast/src/parser/statement.rs
+++ b/common/ast/src/parser/statement.rs
@@ -207,7 +207,7 @@ pub fn statement(i: Input) -> IResult<Statement> {
     );
     let create_table = map(
         rule! {
-            CREATE ~ TABLE ~ ( IF ~ NOT ~ EXISTS )?
+            CREATE ~ TRANSIENT? ~ TABLE ~ ( IF ~ NOT ~ EXISTS )?
             ~ #peroid_separated_idents_1_to_3
             ~ #create_table_source?
             ~ ( #table_option )*
@@ -217,6 +217,7 @@ pub fn statement(i: Input) -> IResult<Statement> {
         },
         |(
             _,
+            opt_transient,
             _,
             opt_if_not_exists,
             (catalog, database, table),
@@ -238,6 +239,7 @@ pub fn statement(i: Input) -> IResult<Statement> {
                     .map(|(_, _, _, exprs, _)| exprs)
                     .unwrap_or_default(),
                 as_query: opt_as_query.map(|(_, query)| Box::new(query)),
+                transient: opt_transient.is_some(),
             })
         },
     );

--- a/common/ast/src/parser/token.rs
+++ b/common/ast/src/parser/token.rs
@@ -591,6 +591,8 @@ pub enum TokenKind {
     TOKEN,
     #[token("TRAILING", ignore(ascii_case))]
     TRAILING,
+    #[token("TRANSIENT", ignore(ascii_case))]
+    TRANSIENT,
     #[token("TRIM", ignore(ascii_case))]
     TRIM,
     #[token("TRUE", ignore(ascii_case))]

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -225,6 +225,7 @@ CreateTable(
         cluster_by: [],
         as_query: None,
         comment: None,
+        transient: false,
     },
 )
 
@@ -336,6 +337,7 @@ CreateTable(
             },
         ),
         comment: None,
+        transient: false,
     },
 )
 
@@ -382,6 +384,7 @@ CreateTable(
         cluster_by: [],
         as_query: None,
         comment: None,
+        transient: false,
     },
 )
 
@@ -420,6 +423,7 @@ CreateTable(
         cluster_by: [],
         as_query: None,
         comment: None,
+        transient: false,
     },
 )
 
@@ -721,6 +725,7 @@ CreateTable(
         cluster_by: [],
         as_query: None,
         comment: None,
+        transient: false,
     },
 )
 
@@ -1152,6 +1157,7 @@ CreateTable(
         cluster_by: [],
         as_query: None,
         comment: None,
+        transient: false,
     },
 )
 
@@ -1211,6 +1217,7 @@ CreateTable(
         cluster_by: [],
         as_query: None,
         comment: None,
+        transient: false,
     },
 )
 
@@ -1259,6 +1266,7 @@ CreateTable(
         cluster_by: [],
         as_query: None,
         comment: None,
+        transient: false,
     },
 )
 

--- a/query/src/catalogs/default/mutable_catalog.rs
+++ b/query/src/catalogs/default/mutable_catalog.rs
@@ -172,7 +172,7 @@ impl Catalog for MutableCatalog {
     async fn create_database(&self, req: CreateDatabaseReq) -> Result<CreateDatabaseReply> {
         // Create database.
         let res = self.ctx.meta.create_database(req.clone()).await?;
-        tracing::error!(
+        tracing::info!(
             "db name: {}, engine: {}",
             &req.name_ident.db_name,
             &req.meta.engine

--- a/query/src/sql/parsers/parser_table.rs
+++ b/query/src/sql/parsers/parser_table.rs
@@ -42,7 +42,10 @@ use crate::sql::DfStatement;
 
 impl<'a> DfParser<'a> {
     // Create table.
-    pub(crate) fn parse_create_table(&mut self) -> Result<DfStatement<'a>, ParserError> {
+    pub(crate) fn parse_create_table(
+        &mut self,
+        transient: bool,
+    ) -> Result<DfStatement<'a>, ParserError> {
         let if_not_exists =
             self.parser
                 .parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
@@ -71,7 +74,11 @@ impl<'a> DfParser<'a> {
         }
 
         // parse table options: https://dev.mysql.com/doc/refman/8.0/en/create-table.html
-        let options = self.parse_options()?;
+        let mut options = self.parse_options()?;
+
+        if transient {
+            options.insert("TRANSIENT".to_owned(), "T".to_owned());
+        }
 
         let mut query = None;
         if let Token::Word(Word { keyword, .. }) = self.parser.peek_token() {

--- a/query/src/sql/planner/binder/ddl/table.rs
+++ b/query/src/sql/planner/binder/ddl/table.rs
@@ -143,6 +143,7 @@ impl<'a> Binder {
             cluster_by,
             as_query,
             comment: _,
+            transient,
         } = stmt;
 
         let catalog = catalog
@@ -169,6 +170,11 @@ impl<'a> Binder {
                     comment.clone(),
                 )?,
             }
+        }
+
+        // If table is TRANSIENT, set a flag in table option
+        if *transient {
+            options.insert("TRANSIENT".to_owned(), "T".to_owned());
         }
 
         // Build table schema

--- a/query/src/sql/sql_parser.rs
+++ b/query/src/sql/sql_parser.rs
@@ -252,17 +252,33 @@ impl<'a> DfParser<'a> {
             Token::Word(w) => {
                 //TODO:make stage to sql parser keyword
                 match w.keyword {
-                    Keyword::TABLE => self.parse_create_table(),
+                    Keyword::TABLE => self.parse_create_table(false),
                     Keyword::DATABASE | Keyword::SCHEMA => self.parse_create_database(),
                     Keyword::USER => self.parse_create_user(),
                     Keyword::ROLE => self.parse_create_role(),
                     Keyword::FUNCTION => self.parse_create_udf(),
                     Keyword::STAGE => self.parse_create_stage(),
                     Keyword::VIEW => self.parse_create_view(),
+                    Keyword::NoKeyword if w.value.as_str().to_uppercase() == "TRANSIENT" => {
+                        self.parse_create_transient_table()
+                    }
                     _ => self.expected("create statement", Token::Word(w)),
                 }
             }
             unexpected => self.expected("create statement", unexpected),
+        }
+    }
+
+    fn parse_create_transient_table(&mut self) -> Result<DfStatement<'a>, ParserError> {
+        let next_token = self.parser.next_token();
+        if let Token::Word(word) = next_token {
+            if word.keyword == Keyword::TABLE {
+                self.parse_create_table(true)
+            } else {
+                self.expected("create transient TABLE", Token::Word(word))
+            }
+        } else {
+            self.expected("create transient TABLE", next_token)
         }
     }
 

--- a/query/src/storages/fuse/fuse_table.rs
+++ b/query/src/storages/fuse/fuse_table.rs
@@ -219,11 +219,8 @@ impl FuseTable {
         }
     }
 
-    fn transient(&self) -> bool {
-        self.table_info
-            .meta
-            .engine_options
-            .contains_key("TRANSIENT")
+    pub fn transient(&self) -> bool {
+        self.table_info.meta.options.contains_key("TRANSIENT")
     }
 }
 

--- a/query/src/storages/fuse/fuse_table.rs
+++ b/query/src/storages/fuse/fuse_table.rs
@@ -218,6 +218,13 @@ impl FuseTable {
             }
         }
     }
+
+    fn transient(&self) -> bool {
+        self.table_info
+            .meta
+            .engine_options
+            .contains_key("TRANSIENT")
+    }
 }
 
 #[async_trait::async_trait]

--- a/query/src/storages/fuse/operations/commit.rs
+++ b/query/src/storages/fuse/operations/commit.rs
@@ -103,8 +103,8 @@ impl FuseTable {
                             let keep_last_snapshot = true;
                             // Removes history, if table is transient
                             // Errors of GC, if any, are ignored,
-                            if let Err(e) = self.do_gc(&ctx, true).await {
-                                warn!("GC for transient table not success (this is not a permanent error, GC task can be picked up later");
+                            if let Err(e) = self.do_gc(&ctx, keep_last_snapshot).await {
+                                warn!("GC for transient table not success (this is not a permanent error, GC task can be picked up later. the error : {}", e);
                             } else {
                                 info!("GC for transient table done");
                             }

--- a/query/tests/it/sql/parsers/parser_copy.rs
+++ b/query/tests/it/sql/parsers/parser_copy.rs
@@ -66,7 +66,7 @@ fn copy_from_external_test() -> Result<()> {
         if test.err.is_empty() {
             expect_parse_ok(test.query, DfStatement::Copy(test.expect.unwrap()))?;
         } else {
-            expect_parse_err(test.query, test.err.to_string())?;
+            expect_parse_err(test.query, test.err)?;
         }
     }
 

--- a/query/tests/it/sql/parsers/parser_optimize.rs
+++ b/query/tests/it/sql/parsers/parser_optimize.rs
@@ -71,8 +71,7 @@ fn optimize_table() -> Result<()> {
         let sql = "optimize TABLE t1 unacceptable";
         expect_parse_err(
             sql,
-            "sql parser error: Expected one of PURGE, COMPACT, ALL, found: unacceptable"
-                .to_string(),
+            "sql parser error: Expected one of PURGE, COMPACT, ALL, found: unacceptable",
         )?;
     }
 
@@ -80,8 +79,7 @@ fn optimize_table() -> Result<()> {
         let sql = "optimize TABLE t1 (";
         expect_parse_err(
             sql,
-            "sql parser error: Expected Nothing, or one of PURGE, COMPACT, ALL, found: ("
-                .to_string(),
+            "sql parser error: Expected Nothing, or one of PURGE, COMPACT, ALL, found: (",
         )?;
     }
 

--- a/query/tests/it/sql/parsers/parser_select_table_at.rs
+++ b/query/tests/it/sql/parsers/parser_select_table_at.rs
@@ -54,18 +54,12 @@ fn select_table_at() -> Result<()> {
 
     {
         let sql = "select * from t at( => '0de4865bba874065905625e5db6024c1');";
-        expect_parse_err(
-            sql,
-            "sql parser error: Expected SNAPSHOT, found: =>".to_string(),
-        )?;
+        expect_parse_err(sql, "sql parser error: Expected SNAPSHOT, found: =>")?;
     }
 
     {
         let sql = "select * from t at( SNAPSHOT => );";
-        expect_parse_err(
-            sql,
-            "sql parser error: Expected snapshot id, found: )".to_string(),
-        )?;
+        expect_parse_err(sql, "sql parser error: Expected snapshot id, found: )")?;
     }
 
     Ok(())

--- a/query/tests/it/sql/sql_parser.rs
+++ b/query/tests/it/sql/sql_parser.rs
@@ -51,8 +51,9 @@ pub fn expect_synonym_parse_eq(sql: &str, sql2: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn expect_parse_err(sql: &str, expected: String) -> Result<()> {
+pub fn expect_parse_err(sql: &str, expected: impl AsRef<str>) -> Result<()> {
     let result = DfParser::parse_sql(sql, SessionType::Dummy);
+    let expected = expected.as_ref();
     assert!(result.is_err(), "'{}' SHOULD BE '{}'", sql, expected);
     assert_eq!(
         result.unwrap_err().message(),

--- a/tests/logictest/suites/gen/09_fuse_engine/09_0016_transient_table
+++ b/tests/logictest/suites/gen/09_fuse_engine/09_0016_transient_table
@@ -1,0 +1,40 @@
+statement ok
+DROP DATABASE IF EXISTS db1;
+
+statement ok
+CREATE DATABASE db1;
+
+statement ok
+USE db1;
+
+statement ok
+CREATE TRANSIENT TABLE IF NOT EXISTS t09_0016(a int);
+
+statement ok
+INSERT INTO t09_0016 VALUES(1);
+
+statement ok
+INSERT INTO t09_0016 VALUES(2);
+
+statement ok
+INSERT INTO t09_0016 VALUES(3);
+
+statement query I
+select *  from t09_0015 order a;
+
+--
+1
+2
+3
+
+statement query I
+select count(*) from fuse_snapshot('default', 't09_0015');
+
+--
+1
+
+statement ok
+DROP TABLE t09_0016;
+
+statement ok
+DROP DATABASE db1;

--- a/tests/logictest/suites/gen/09_fuse_engine/09_0016_transient_table
+++ b/tests/logictest/suites/gen/09_fuse_engine/09_0016_transient_table
@@ -20,17 +20,15 @@ statement ok
 INSERT INTO t09_0016 VALUES(3);
 
 statement query I
-select * from t09_0016 order by a;
+select count(*) from t09_0016;
 
---
-1
-2
+----
 3
 
 statement query I
 select count(*) from fuse_snapshot('db1', 't09_0016');
 
---
+----
 1
 
 statement ok

--- a/tests/logictest/suites/gen/09_fuse_engine/09_0016_transient_table
+++ b/tests/logictest/suites/gen/09_fuse_engine/09_0016_transient_table
@@ -20,7 +20,7 @@ statement ok
 INSERT INTO t09_0016 VALUES(3);
 
 statement query I
-select *  from t09_0015 order a;
+select *  from t09_0016 order by a;
 
 --
 1

--- a/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables.result
+++ b/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables.result
@@ -42,3 +42,22 @@ bool	BOOLEAN	NO	false
 arr	ARRAY	NO	[]	
 obj	OBJECT	NO	{}	
 variant	VARIANT	NO	null	
+====CREATE TRANSIENT TABLE====
+tiny	TINYINT	NO	0	
+tiny_unsigned	TINYINT UNSIGNED	NO	0	
+smallint	SMALLINT	NO	0	
+smallint_unsigned	SMALLINT UNSIGNED	NO	0	
+int	INT	NO	0	
+int_unsigned	INT UNSIGNED	NO	0	
+bigint	BIGINT	NO	0	
+bigint_unsigned	BIGINT UNSIGNED	NO	0	
+float	FLOAT	NO	0	
+double	DOUBLE	NO	0	
+date	DATE	NO	0	
+datetime	TIMESTAMP(6)	NO	0	
+ts	TIMESTAMP(6)	NO	0	
+str	VARCHAR	NO	3	
+bool	BOOLEAN	NO	false	
+arr	ARRAY	NO	[]	
+obj	OBJECT	NO	{}	
+variant	VARIANT	NO	null	

--- a/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables.sql
+++ b/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables.sql
@@ -74,6 +74,9 @@ SELECT '====CREATE ALL DATA TYPE TABLE====';
 create table db2.test7(tiny TINYINT, tiny_unsigned TINYINT UNSIGNED, smallint SMALLINT, smallint_unsigned SMALLINT UNSIGNED, int INT, int_unsigned INT UNSIGNED, bigint BIGINT, bigint_unsigned BIGINT UNSIGNED,float FLOAT, double DOUBLE, date DATE, datetime DATETIME, ts TIMESTAMP, str VARCHAR default '3', bool BOOLEAN, arr ARRAY, obj OBJECT, variant VARIANT);
 desc db2.test7;
 
+SELECT '====CREATE TRANSIENT TABLE====';
+create transient table db2.test8(tiny TINYINT, tiny_unsigned TINYINT UNSIGNED, smallint SMALLINT, smallint_unsigned SMALLINT UNSIGNED, int INT, int_unsigned INT UNSIGNED, bigint BIGINT, bigint_unsigned BIGINT UNSIGNED,float FLOAT, double DOUBLE, date DATE, datetime DATETIME, ts TIMESTAMP, str VARCHAR default '3', bool BOOLEAN, arr ARRAY, obj OBJECT, variant VARIANT);
+desc db2.test8;
 
 -- clean up test databases
 DROP DATABASE db1;

--- a/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.result
+++ b/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.result
@@ -25,3 +25,22 @@ bool	BOOLEAN	NO	false
 arr	ARRAY	NO	[]	
 obj	OBJECT	NO	{}	
 variant	VARIANT	NO	null	
+====CREATE TRANSIENT TABLE====
+tiny	TINYINT	NO	0	
+tiny_unsigned	TINYINT UNSIGNED	NO	0	
+smallint	SMALLINT	NO	0	
+smallint_unsigned	SMALLINT UNSIGNED	NO	0	
+int	INT	NO	0	
+int_unsigned	INT UNSIGNED	NO	0	
+bigint	BIGINT	NO	0	
+bigint_unsigned	BIGINT UNSIGNED	NO	0	
+float	FLOAT	NO	0	
+double	DOUBLE	NO	0	
+date	DATE	NO	0	
+datetime	TIMESTAMP(6)	NO	0	
+ts	TIMESTAMP(6)	NO	0	
+str	VARCHAR	NO	3	
+bool	BOOLEAN	NO	false	
+arr	ARRAY	NO	[]	
+obj	OBJECT	NO	{}	
+variant	VARIANT	NO	null	

--- a/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.sql
+++ b/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.sql
@@ -73,6 +73,11 @@ SELECT '====CREATE ALL DATA TYPE TABLE====';
 create table db2.test7(tiny TINYINT, tiny_unsigned TINYINT UNSIGNED, smallint SMALLINT, smallint_unsigned SMALLINT UNSIGNED, int INT, int_unsigned INT UNSIGNED, bigint BIGINT, bigint_unsigned BIGINT UNSIGNED,float FLOAT, double DOUBLE, date DATE, datetime DATETIME, ts TIMESTAMP, str VARCHAR default '3', bool BOOLEAN, arr ARRAY, obj OBJECT, variant VARIANT);
 desc db2.test7;
 
+
+SELECT '====CREATE TRANSIENT TABLE====';
+create transient table db2.test8(tiny TINYINT, tiny_unsigned TINYINT UNSIGNED, smallint SMALLINT, smallint_unsigned SMALLINT UNSIGNED, int INT, int_unsigned INT UNSIGNED, bigint BIGINT, bigint_unsigned BIGINT UNSIGNED,float FLOAT, double DOUBLE, date DATE, datetime DATETIME, ts TIMESTAMP, str VARCHAR default '3', bool BOOLEAN, arr ARRAY, obj OBJECT, variant VARIANT);
+desc db2.test8;
+
 -- clean up test databases
 DROP DATABASE db1;
 DROP DATABASE db2;

--- a/tests/suites/0_stateless/09_fuse_engine/09_0016_transient_table.result
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0016_transient_table.result
@@ -1,0 +1,8 @@
+-- create transient table
+-- 3 insertions
+-- check ingestion
+1
+2
+3
+-- check history count, there should be only one snapshot left
+1

--- a/tests/suites/0_stateless/09_fuse_engine/09_0016_transient_table.sql
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0016_transient_table.sql
@@ -1,40 +1,22 @@
-statement ok
 DROP DATABASE IF EXISTS db1;
 
-statement ok
 CREATE DATABASE db1;
 
-statement ok
 USE db1;
 
-statement ok
+select '-- create transient table';
 CREATE TRANSIENT TABLE IF NOT EXISTS t09_0016(a int);
 
-statement ok
+select '-- 3 insertions';
 INSERT INTO t09_0016 VALUES(1);
-
-statement ok
 INSERT INTO t09_0016 VALUES(2);
-
-statement ok
 INSERT INTO t09_0016 VALUES(3);
 
-statement query I
+select '-- check ingestion';
 select * from t09_0016 order by a;
 
---
-1
-2
-3
+select '-- check history count, there should be only one snapshot left';
+select count(*)=1 from fuse_snapshot('db1', 't09_0016');
 
-statement query I
-select count(*) from fuse_snapshot('db1', 't09_0016');
-
---
-1
-
-statement ok
 DROP TABLE t09_0016;
-
-statement ok
 DROP DATABASE db1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The new statement `CREATE TRANSIENT TABLE...`:
- for FUSE table, during commit, no historical data will be kept
  or more precisely: GC will be triggered immediately after the commit
- for table engine other than fuse, nothing different

example: 

~~~
mysql> use default;
Database changed
mysql> CREATE TRANSIENT TABLE t (c bigint);
Query OK, 0 rows affected (0.03 sec)
Read 0 rows, 0.00 B in 0.006 sec., 0 rows/sec., 0.00 B/sec.

mysql> insert into t values(1);
Query OK, 0 rows affected (0.02 sec)
Read 1 rows, 8.00 B in 0.011 sec., 91.64 rows/sec., 733.14 B/sec.

mysql> insert into t values(2);
Query OK, 0 rows affected (0.04 sec)
Read 1 rows, 8.00 B in 0.013 sec., 78.42 rows/sec., 627.38 B/sec.

mysql> insert into t values(3);
Query OK, 0 rows affected (0.02 sec)
Read 1 rows, 8.00 B in 0.013 sec., 77.94 rows/sec., 623.53 B/sec.

mysql> select count(*) from fuse_snapshot('default', 't');
+---------+
| count() |
+---------+
|       1 |    <-- ***instead of 3 snapshots, only one snapshot is kept***
+---------+
1 row in set (0.06 sec)
Read 1 rows, 211.00 B in 0.008 sec., 129.64 rows/sec., 26.71 KiB/sec.
----
~~~



- [x] transient table commit
- [x] parser, planner (legacy and v2)
- [x] ut and it
- [x] concurrent insertion test
   shamefully done manually



## Changelog

- New Feature
- Documentation
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

