### PR TITLE
ISSUE-5981: truncate the string value for cluster statis

### DIFF
--- a/query/src/storages/fuse/statistics/accumulator.rs
+++ b/query/src/storages/fuse/statistics/accumulator.rs
@@ -297,6 +297,8 @@ impl BlockStatistics {
             let col = block.column(*key);
 
             let mut left = col.get_checked(0)?;
+            // To avoid high cardinality, for the string column,
+            // cluster statistics uses only the first 5 bytes.
             if let DataValue::String(v) = &left {
                 let l = v.len() as usize;
                 let e = if l < 5 { l } else { 5 };

--- a/query/src/storages/fuse/statistics/accumulator.rs
+++ b/query/src/storages/fuse/statistics/accumulator.rs
@@ -295,8 +295,22 @@ impl BlockStatistics {
 
         for key in cluster_key_index.iter() {
             let col = block.column(*key);
-            min.push(col.get_checked(0)?);
-            max.push(col.get_checked(col.len() - 1)?);
+
+            let mut left = col.get_checked(0)?;
+            if let DataValue::String(v) = &left {
+                let l = v.len() as usize;
+                let e = if l < 5 { l } else { 5 };
+                left = DataValue::from(&v[0..e]);
+            }
+            min.push(left);
+
+            let mut right = col.get_checked(col.len() - 1)?;
+            if let DataValue::String(v) = &right {
+                let l = v.len() as usize;
+                let e = if l < 5 { l } else { 5 };
+                right = DataValue::from(&v[0..e]);
+            }
+            max.push(right);
         }
 
         Ok(Some(ClusterStatistics {

--- a/query/tests/it/storages/fuse/statistics.rs
+++ b/query/tests/it/storages/fuse/statistics.rs
@@ -21,6 +21,7 @@ use databend_query::storages::fuse::statistics::accumulator;
 use databend_query::storages::fuse::statistics::reducers;
 use databend_query::storages::fuse::statistics::StatisticsAccumulator;
 
+use crate::storages::fuse::statistics::accumulator::BlockStatistics;
 use crate::storages::fuse::table_test_fixture::TestFixture;
 
 #[test]
@@ -67,5 +68,30 @@ fn test_ft_stats_accumulator() -> common_exception::Result<()> {
     }
     assert_eq!(10, stats_acc.blocks_statistics.len());
     // TODO more cases here pls
+    Ok(())
+}
+
+#[test]
+fn test_ft_stats_cluster_stats() -> common_exception::Result<()> {
+    let schema = DataSchemaRefExt::create(vec![
+        DataField::new("a", i32::to_data_type()),
+        DataField::new("b", Vu8::to_data_type()),
+    ]);
+    let blocks = DataBlock::create(schema, vec![
+        Series::from_data(vec![1i32, 2, 3]),
+        Series::from_data(vec!["123456", "234567", "345678"]),
+    ]);
+    let stats = BlockStatistics::clusters_statistics(0, vec![0], blocks.clone())?;
+    assert!(stats.is_some());
+    let stats = stats.unwrap();
+    assert_eq!(vec![DataValue::Int64(1)], stats.min);
+    assert_eq!(vec![DataValue::Int64(3)], stats.max);
+
+    let stats = BlockStatistics::clusters_statistics(1, vec![1], blocks)?;
+    assert!(stats.is_some());
+    let stats = stats.unwrap();
+    assert_eq!(vec![DataValue::String(b"12345".to_vec())], stats.min);
+    assert_eq!(vec![DataValue::String(b"34567".to_vec())], stats.max);
+
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

To avoid high cardinality, for each string column,  clustering uses only the first 5 bytes.  

## Changelog

- Improvement

## Related Issues

Fixes #5981

