### PR TITLE
improve(planner): Split `EXPLAIN` result by lines

### DIFF
--- a/query/src/interpreters/interpreter_explain_v2.rs
+++ b/query/src/interpreters/interpreter_explain_v2.rs
@@ -100,7 +100,8 @@ impl ExplainInterpreterV2 {
 
     pub async fn explain_syntax(&self, plan: &Plan) -> Result<Vec<DataBlock>> {
         let result = plan.format_indent()?;
-        let formatted_plan = Series::from_data(vec![result]);
+        let line_splitted_result: Vec<&str> = result.lines().collect();
+        let formatted_plan = Series::from_data(line_splitted_result);
         Ok(vec![DataBlock::create(self.schema.clone(), vec![
             formatted_plan,
         ])])

--- a/tests/suites/0_stateless/20+_others/20_0001_planner_v2.result
+++ b/tests/suites/0_stateless/20+_others/20_0001_planner_v2.result
@@ -309,7 +309,9 @@ abc
 8
 9
 ===Explain===
-Project: [a]\n    Filter: [a > 0]\n        Scan: default.default.t1\n
+Project: [a]
+    Filter: [a > 0]
+        Scan: default.default.t1
 ===Explain Pipeline===
 ProjectionTransform × 1 processor
   ProjectionTransform × 1 processor


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

After this pr:
```
mysql> explain select number + 1 as a from numbers(1) where number = 1;
+------------------------------------------+
| explain                                  |
+------------------------------------------+
| Project: [a]                             |
|     EvalScalar: [+(number, 1)]           |
|         Filter: [number = 1]             |
|             Scan: default.system.numbers |
+------------------------------------------+
4 rows in set (0.03 sec)
Read 0 rows, 0.00 B in 0.001 sec., 0 rows/sec., 0.00 B/sec.

mysql>
```

## Changelog

- Improvement


