### PR TITLE
Fix:  native build with sse42 capability

### DIFF
--- a/common/io/src/position.rs
+++ b/common/io/src/position.rs
@@ -381,17 +381,13 @@ fn position_sse42<
 
             if POSITIVE {
                 if _mm_cmpestrc::<0>(chars_set, chars_count, bytes, 16) > 0 {
-                    return index + _mm_cmpestri::<0>(chars_set, chars_count, bytes, 16);
+                    return index + _mm_cmpestri::<0>(chars_set, chars_count, bytes, 16) as usize;
                 }
             } else {
                 if _mm_cmpestrc::<_SIDD_NEGATIVE_POLARITY>(chars_set, chars_count, bytes, 16) > 0 {
                     return index
-                        + _mm_cmpestri::<_SIDD_NEGATIVE_POLARITY>(
-                            chars_set,
-                            chars_count,
-                            bytes,
-                            16,
-                        );
+                        + _mm_cmpestri::<_SIDD_NEGATIVE_POLARITY>(chars_set, chars_count, bytes, 16)
+                            as usize;
                 }
             }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix a minor compile error, if built with `-C target-cpu=native`, and the host has sse42 capability

- Not sure if CI has sse42
- unit test and stateless test works in the local dev box 
   - CPU has sse42 flag
   - release build with "-C target-cpu=native"

## Changelog


- Bug Fix
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #6000

