### PR TITLE
Migrate `show functions` to new planner

### DIFF
--- a/query/src/interpreters/interpreter_factory_v2.rs
+++ b/query/src/interpreters/interpreter_factory_v2.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_exception::ErrorCode;
 use common_exception::Result;
 
 use super::*;
@@ -55,6 +56,7 @@ impl InterpreterFactoryV2 {
                 | DfStatement::TruncateTable(_)
                 | DfStatement::OptimizeTable(_)
                 | DfStatement::DropView(_)
+                | DfStatement::ShowFunctions(_)
                 | DfStatement::ShowMetrics(_)
                 | DfStatement::ShowProcessList(_)
                 | DfStatement::ShowSettings(_)
@@ -86,10 +88,6 @@ impl InterpreterFactoryV2 {
             Plan::Explain { kind, plan } => {
                 ExplainInterpreterV2::try_create(ctx, *plan.clone(), kind.clone())
             }
-
-            Plan::ShowMetrics => ShowMetricsInterpreter::try_create(ctx),
-            Plan::ShowProcessList => ShowProcessListInterpreter::try_create(ctx),
-            Plan::ShowSettings => ShowSettingsInterpreter::try_create(ctx),
 
             // Databases
             Plan::ShowDatabases(show_databases) => {
@@ -181,6 +179,15 @@ impl InterpreterFactoryV2 {
             }
             Plan::DropStage(s) => DropUserStageInterpreter::try_create(ctx, *s.clone()),
             Plan::RemoveStage(s) => RemoveUserStageInterpreter::try_create(ctx, *s.clone()),
+
+            // Shows
+            Plan::ShowMetrics => ShowMetricsInterpreter::try_create(ctx),
+            Plan::ShowProcessList => ShowProcessListInterpreter::try_create(ctx),
+            Plan::ShowSettings => ShowSettingsInterpreter::try_create(ctx),
+
+            Plan::ShowFunction(_) => Err(ErrorCode::UnImplement(
+                "SHOW FUNCTIONS should be rewritten to SELECT at binding phase",
+            )),
         }?;
         Ok(inner)
     }

--- a/query/src/interpreters/interpreter_factory_v2.rs
+++ b/query/src/interpreters/interpreter_factory_v2.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use common_exception::ErrorCode;
 use common_exception::Result;
 
 use super::*;
@@ -93,9 +92,6 @@ impl InterpreterFactoryV2 {
             Plan::ShowMetrics => ShowMetricsInterpreter::try_create(ctx),
             Plan::ShowProcessList => ShowProcessListInterpreter::try_create(ctx),
             Plan::ShowSettings => ShowSettingsInterpreter::try_create(ctx),
-            Plan::ShowFunction(_) => Err(ErrorCode::UnImplement(
-                "SHOW FUNCTIONS should be rewritten to SELECT at binding phase",
-            )),
 
             // Databases
             Plan::ShowDatabases(show_databases) => {

--- a/query/src/interpreters/interpreter_factory_v2.rs
+++ b/query/src/interpreters/interpreter_factory_v2.rs
@@ -89,6 +89,14 @@ impl InterpreterFactoryV2 {
                 ExplainInterpreterV2::try_create(ctx, *plan.clone(), kind.clone())
             }
 
+            // Shows
+            Plan::ShowMetrics => ShowMetricsInterpreter::try_create(ctx),
+            Plan::ShowProcessList => ShowProcessListInterpreter::try_create(ctx),
+            Plan::ShowSettings => ShowSettingsInterpreter::try_create(ctx),
+            Plan::ShowFunction(_) => Err(ErrorCode::UnImplement(
+                "SHOW FUNCTIONS should be rewritten to SELECT at binding phase",
+            )),
+
             // Databases
             Plan::ShowDatabases(show_databases) => {
                 ShowDatabasesInterpreter::try_create(ctx, *show_databases.clone())
@@ -179,15 +187,6 @@ impl InterpreterFactoryV2 {
             }
             Plan::DropStage(s) => DropUserStageInterpreter::try_create(ctx, *s.clone()),
             Plan::RemoveStage(s) => RemoveUserStageInterpreter::try_create(ctx, *s.clone()),
-
-            // Shows
-            Plan::ShowMetrics => ShowMetricsInterpreter::try_create(ctx),
-            Plan::ShowProcessList => ShowProcessListInterpreter::try_create(ctx),
-            Plan::ShowSettings => ShowSettingsInterpreter::try_create(ctx),
-
-            Plan::ShowFunction(_) => Err(ErrorCode::UnImplement(
-                "SHOW FUNCTIONS should be rewritten to SELECT at binding phase",
-            )),
         }?;
         Ok(inner)
     }

--- a/query/src/sql/planner/binder/mod.rs
+++ b/query/src/sql/planner/binder/mod.rs
@@ -48,6 +48,7 @@ mod scalar;
 mod scalar_common;
 mod scalar_visitor;
 mod select;
+mod show;
 mod sort;
 mod subquery;
 mod table;
@@ -105,6 +106,10 @@ impl<'a> Binder {
                 kind: kind.clone(),
                 plan: Box::new(self.bind_statement(bind_context, query).await?),
             },
+
+            Statement::ShowFunctions { limit } => {
+                self.bind_show_functions(bind_context, limit).await?
+            }
 
             Statement::ShowMetrics => Plan::ShowMetrics,
             Statement::ShowProcessList => Plan::ShowProcessList,

--- a/query/src/sql/planner/binder/show.rs
+++ b/query/src/sql/planner/binder/show.rs
@@ -1,0 +1,54 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_ast::ast::ShowLimit;
+use common_ast::parser::error::Backtrace;
+use common_ast::parser::parse_sql;
+use common_ast::parser::tokenize_sql;
+use common_exception::Result;
+
+use crate::sql::plans::Plan;
+use crate::sql::BindContext;
+use crate::sql::Binder;
+
+impl<'a> Binder {
+    pub(super) async fn bind_show_functions(
+        &mut self,
+        bind_context: &BindContext,
+        limit: &Option<ShowLimit<'a>>,
+    ) -> Result<Plan> {
+        // rewrite show functions to select * from system.functions ...
+        let query = format!("SELECT name, is_builtin, is_aggregate, definition, description FROM system.functions {} ORDER BY name", 
+            match limit {
+                None => {
+                    "".to_string()
+                }
+                Some(predicate) => {
+                    match predicate {
+                        ShowLimit::Like { pattern } => {
+                            format!("WHERE name LIKE '{}'", pattern)
+                        }
+                        ShowLimit::Where { selection } => {
+                            format!("WHERE {}", selection)
+                        }
+                    }
+                }
+            }
+        );
+        let tokens = tokenize_sql(query.as_str())?;
+        let backtrace = Backtrace::new();
+        let stmts = parse_sql(&tokens, &backtrace)?;
+        self.bind_statement(bind_context, &stmts[0]).await
+    }
+}

--- a/query/src/sql/planner/format/display_plan.rs
+++ b/query/src/sql/planner/format/display_plan.rs
@@ -27,10 +27,6 @@ impl Plan {
                 Ok(format!("{:?}:\n{}", kind, result))
             }
 
-            Plan::ShowMetrics => Ok("SHOW METRICS".to_string()),
-            Plan::ShowProcessList => Ok("SHOW PROCESSLIST".to_string()),
-            Plan::ShowSettings => Ok("SHOW SETTINGS".to_string()),
-
             // Databases
             Plan::ShowDatabases(show_databases) => Ok(format!("{:?}", show_databases)),
             Plan::ShowCreateDatabase(show_create_database) => {
@@ -81,6 +77,12 @@ impl Plan {
             Plan::CreateStage(create_stage) => Ok(format!("{:?}", create_stage)),
             Plan::DropStage(s) => Ok(format!("{:?}", s)),
             Plan::RemoveStage(s) => Ok(format!("{:?}", s)),
+
+            // Shows
+            Plan::ShowFunction(show_func) => Ok(format!("{:?}", show_func)),
+            Plan::ShowMetrics => Ok("SHOW METRICS".to_string()),
+            Plan::ShowProcessList => Ok("SHOW PROCESSLIST".to_string()),
+            Plan::ShowSettings => Ok("SHOW SETTINGS".to_string()),
         }
     }
 }

--- a/query/src/sql/planner/format/display_plan.rs
+++ b/query/src/sql/planner/format/display_plan.rs
@@ -79,7 +79,6 @@ impl Plan {
             Plan::RemoveStage(s) => Ok(format!("{:?}", s)),
 
             // Shows
-            Plan::ShowFunction(show_func) => Ok(format!("{:?}", show_func)),
             Plan::ShowMetrics => Ok("SHOW METRICS".to_string()),
             Plan::ShowProcessList => Ok("SHOW PROCESSLIST".to_string()),
             Plan::ShowSettings => Ok("SHOW SETTINGS".to_string()),

--- a/query/src/sql/planner/plans/mod.rs
+++ b/query/src/sql/planner/plans/mod.rs
@@ -68,6 +68,7 @@ pub enum Plan {
     },
 
     // System
+    ShowFunction(Box<ShowFunctionsPlan>),
     ShowMetrics,
     ShowProcessList,
     ShowSettings,

--- a/query/src/sql/planner/plans/mod.rs
+++ b/query/src/sql/planner/plans/mod.rs
@@ -68,7 +68,6 @@ pub enum Plan {
     },
 
     // System
-    ShowFunction(Box<ShowFunctionsPlan>),
     ShowMetrics,
     ShowProcessList,
     ShowSettings,

--- a/tests/suites/0_stateless/06_show/06_0005_show_functions_v2.result
+++ b/tests/suites/0_stateless/06_show/06_0005_show_functions_v2.result
@@ -1,0 +1,8 @@
+today	1	0		Returns current date.
+todayofmonth	1	0		Converts a date or date with time to a UInt8 number containing the number of the day of the month (1-31).
+todayofweek	1	0		Converts a date or date with time to a UInt8 number containing the number of the day of the week (Monday is 1, and Sunday is 7).
+todayofyear	1	0		Converts a date or date with time to a UInt16 number containing the number of the day of the year (1-366).
+today	1	0		Returns current date.
+todayofmonth	1	0		Converts a date or date with time to a UInt8 number containing the number of the day of the month (1-31).
+todayofweek	1	0		Converts a date or date with time to a UInt8 number containing the number of the day of the week (Monday is 1, and Sunday is 7).
+todayofyear	1	0		Converts a date or date with time to a UInt16 number containing the number of the day of the year (1-366).

--- a/tests/suites/0_stateless/06_show/06_0005_show_functions_v2.sql
+++ b/tests/suites/0_stateless/06_show/06_0005_show_functions_v2.sql
@@ -1,0 +1,4 @@
+set enable_planner_v2 = 1;
+
+SHOW FUNCTIONS LIKE 'today%';
+SHOW FUNCTIONS WHERE name LIKE 'today%';


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Migrate `show functions` to new planner.

## Changelog
Migrate `show functions` to new planner.

## Related Issues

Fixes #5899

