### PR TITLE
fix: cluster_key -> current_cluster_key

### DIFF
--- a/query/src/storages/system/tables_table.rs
+++ b/query/src/storages/system/tables_table.rs
@@ -101,7 +101,7 @@ impl AsyncSystemTable for TablesTable {
             .map(|(_, v)| {
                 v.get_table_info()
                     .meta
-                    .cluster_key
+                    .current_cluster_key
                     .clone()
                     .unwrap_or_else(|| "".to_owned())
             })


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: cluster_key -> current_cluster_key

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

