### PR TITLE
feat(planner): support ORDER BY column ordinal

### DIFF
--- a/query/src/sql/planner/binder/aggregate.rs
+++ b/query/src/sql/planner/binder/aggregate.rs
@@ -409,7 +409,7 @@ impl<'a> Binder {
         let index = index as usize - 1;
         if index >= select_list.items.len() {
             return Err(ErrorCode::SemanticError(expr.span().display_error(
-                format!("GROUP BY position {} is not in select list", index),
+                format!("GROUP BY position {} is not in select list", index + 1),
             )));
         }
         let item = select_list

--- a/query/src/sql/planner/binder/sort.rs
+++ b/query/src/sql/planner/binder/sort.rs
@@ -16,6 +16,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 use common_ast::ast::Expr;
+use common_ast::ast::Literal;
 use common_ast::ast::OrderByExpr;
 use common_ast::parser::error::DisplayError;
 use common_exception::ErrorCode;
@@ -35,12 +36,13 @@ use crate::sql::plans::SortItem;
 use crate::sql::BindContext;
 use crate::sql::IndexType;
 
-pub struct OrderItems<'a> {
-    items: Vec<OrderItem<'a>>,
+pub struct OrderItems {
+    items: Vec<OrderItem>,
 }
 
-pub struct OrderItem<'a> {
-    pub order_expr: &'a OrderByExpr<'a>,
+pub struct OrderItem {
+    pub asc: Option<bool>,
+    pub nulls_first: Option<bool>,
     pub index: IndexType,
     pub name: String,
     // True if item reference a alias scalar expression in select list
@@ -55,7 +57,7 @@ impl<'a> Binder {
         projections: &[ColumnBinding],
         order_by: &'a [OrderByExpr<'a>],
         distinct: bool,
-    ) -> Result<OrderItems<'a>> {
+    ) -> Result<OrderItems> {
         let mut order_items = Vec::with_capacity(order_by.len());
         for order in order_by {
             if let Expr::ColumnRef {
@@ -70,7 +72,8 @@ impl<'a> Binder {
                 for item in projections.iter() {
                     if item.column_name == ident.name {
                         order_items.push(OrderItem {
-                            order_expr: order,
+                            asc: order.asc,
+                            nulls_first: order.nulls_first,
                             index: item.index,
                             name: item.column_name.clone(),
                             need_project: scalar_items.get(&item.index).map_or(
@@ -99,9 +102,28 @@ impl<'a> Binder {
                     }
                 })?;
                 order_items.push(OrderItem {
-                    order_expr: order,
+                    asc: order.asc,
+                    nulls_first: order.nulls_first,
                     name: column.column_name.clone(),
                     index: column.index,
+                    need_project: false,
+                });
+            } else if let Expr::Literal {
+                lit: Literal::Integer(index),
+                ..
+            } = &order.expr
+            {
+                let index = *index as usize - 1;
+                if index >= projections.len() {
+                    return Err(ErrorCode::SemanticError(order.expr.span().display_error(
+                        format!("ORDER BY position {} is not in select list", index + 1),
+                    )));
+                }
+                order_items.push(OrderItem {
+                    asc: order.asc,
+                    nulls_first: order.nulls_first,
+                    name: projections[index].column_name.clone(),
+                    index: projections[index].index,
                     need_project: false,
                 });
             } else {
@@ -119,7 +141,7 @@ impl<'a> Binder {
     pub(super) async fn bind_order_by(
         &mut self,
         from_context: &BindContext,
-        order_by: OrderItems<'a>,
+        order_by: OrderItems,
         scalar_items: &mut HashMap<IndexType, ScalarItem>,
         child: SExpr,
     ) -> Result<SExpr> {
@@ -140,8 +162,8 @@ impl<'a> Binder {
             }
             let order_by_item = SortItem {
                 index: order.index,
-                asc: order.order_expr.asc,
-                nulls_first: order.order_expr.nulls_first,
+                asc: order.asc,
+                nulls_first: order.nulls_first,
             };
             order_by_items.push(order_by_item);
         }

--- a/tests/suites/0_stateless/20+_others/20_0001_planner_v2.result
+++ b/tests/suites/0_stateless/20+_others/20_0001_planner_v2.result
@@ -163,6 +163,10 @@ NULL	2	3
 7
 8
 9
+2	3
+1	2
+2
+1
 ====SELECT_WITHOUT_FROM====
 2
 8

--- a/tests/suites/0_stateless/20+_others/20_0001_planner_v2.sql
+++ b/tests/suites/0_stateless/20+_others/20_0001_planner_v2.sql
@@ -139,6 +139,8 @@ SELECT number%3 as c1, number%2 as c2 FROM numbers_mt (10) order by c1, number d
 SELECT SUM(number) AS s FROM numbers_mt(10) GROUP BY number ORDER BY s;
 create table t3(a int, b int);
 insert into t3 values(1,2),(2,3);
+select * from t3 order by 2 desc;
+select a from t3 order by 1 desc;
 drop table t;
 drop table t1;
 drop table t2;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support order by column ordinal:
```sql
mysql> select * from t1 order by 3;
ERROR 1105 (HY000): Code: 1065, displayText = error:
  --> SQL:1:27
  |
1 | select * from t1 order by 3
  |                           ^ ORDER BY position 3 is not in select list

.
mysql> select * from t1 order by 2 desc;
+------+------+
| a    | b    |
+------+------+
|    2 |    3 |
|    1 |    2 |
+------+------+
2 rows in set (0.03 sec)
Read 2 rows, 16.00 B in 0.003 sec., 697.3 rows/sec., 5.45 KiB/sec.

mysql> select a from t1 order by 1 desc;
+------+
| a    |
+------+
|    2 |
|    1 |
+------+
2 rows in set (0.03 sec)
Read 2 rows, 16.00 B in 0.003 sec., 788.31 rows/sec., 6.16 KiB/sec.
```

## Changelog

- New Feature

## Related Issues

Fixes #6023 

