### PR TITLE
fix: add_profile shoud return 0 if no items found in profile

### DIFF
--- a/scripts/setup/dev_setup.sh
+++ b/scripts/setup/dev_setup.sh
@@ -10,7 +10,7 @@ cd "$SCRIPT_PATH/../.." || exit
 
 function add_to_profile {
 	eval "$1"
-	FOUND=$(grep -c "$1" <"${HOME}/.profile")
+	FOUND=$(grep -c "$1" "${HOME}/.profile" || true)
 	if [ "$FOUND" == "0" ]; then
 		echo "$1" >>"${HOME}"/.profile
 	fi


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add_profile should return 0 even if no items are found in `~/.profile`

## Changelog


- Bug Fix
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

