### PR TITLE
feat(ci): export JAVA_HOME/lib/server as LD_LIB_PATH

### DIFF
--- a/docker/build-tool/base/Dockerfile
+++ b/docker/build-tool/base/Dockerfile
@@ -38,6 +38,7 @@ RUN curl -qL https://github.com/rui314/mold/releases/download/v1.2.1/mold-1.2.1-
     ln -sf /usr/local/bin/mold /usr/bin/$(uname -m)-linux-gnu-ld
 
 ENV JAVA_HOME /opt/java
+ENV LD_LIBRARY_PATH /opt/java/lib/server
 ENV RUSTUP_HOME /opt/rust/rustup
 ENV CARGO_HOME /opt/rust/cargo
 ENV PATH /opt/rust/cargo/bin:/opt/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

To make  `storage hdfs` work at runtime, docker build tool should add jvm related path to LD_LIBRARY_PATH

## Changelog

- New Feature
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

