### PR TITLE
feature(parser): stop parsing at insert statement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4238,9 +4238,9 @@ dependencies = [
 
 [[package]]
 name = "nom-rule"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c5f75e2f95ede19929b28ea8f9afeb804e5397f1d5c550c18e94b264202911"
+checksum = "ea8dd3c6d80d1e61031aecc5fdfaf4b7d2324dbd94d575ac12f94e5d6856c2d4"
 dependencies = [
  "nom",
  "pratt",

--- a/common/ast/Cargo.toml
+++ b/common/ast/Cargo.toml
@@ -29,7 +29,7 @@ fast-float = "0.2"
 itertools = "0.10"
 logos = "0.12.0"
 nom = "7.1.1"
-nom-rule = "0.2.2"
+nom-rule = "0.3.0"
 pratt = "0.3.0"
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"

--- a/common/ast/src/ast/statement.rs
+++ b/common/ast/src/ast/statement.rs
@@ -432,9 +432,16 @@ pub enum KillTarget {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum InsertSource<'a> {
-    Streaming { format: String },
-    Values { values_tokens: &'a [Token<'a>] },
-    Select { query: Box<Query<'a>> },
+    Streaming {
+        format: String,
+        rest_tokens: &'a [Token<'a>],
+    },
+    Values {
+        rest_tokens: &'a [Token<'a>],
+    },
+    Select {
+        query: Box<Query<'a>>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -603,12 +610,20 @@ impl<'a> Display for Statement<'a> {
                     write!(f, ")")?;
                 }
                 match source {
-                    InsertSource::Streaming { format } => write!(f, " FORMAT {format}")?,
-                    InsertSource::Values { values_tokens } => write!(
+                    InsertSource::Streaming {
+                        format,
+                        rest_tokens,
+                    } => write!(
+                        f,
+                        " FORMAT {format} {}",
+                        &rest_tokens[0].source[rest_tokens.first().unwrap().span.start
+                            ..rest_tokens.last().unwrap().span.end]
+                    )?,
+                    InsertSource::Values { rest_tokens } => write!(
                         f,
                         " VALUES {}",
-                        &values_tokens[0].source[values_tokens.first().unwrap().span.start
-                            ..values_tokens.last().unwrap().span.end]
+                        &rest_tokens[0].source[rest_tokens.first().unwrap().span.start
+                            ..rest_tokens.last().unwrap().span.end]
                     )?,
                     InsertSource::Select { query } => write!(f, " {query}")?,
                 }

--- a/common/ast/src/parser/statement.rs
+++ b/common/ast/src/parser/statement.rs
@@ -19,6 +19,7 @@ use common_meta_types::UserIdentity;
 use nom::branch::alt;
 use nom::combinator::map;
 use nom::combinator::value;
+use nom::Slice;
 
 use super::error::ErrorKind;
 use crate::ast::*;
@@ -32,12 +33,19 @@ pub fn statements(i: Input) -> IResult<Vec<Statement>> {
     let stmt = map(statement, Some);
     let eoi = map(rule! { &EOI }, |_| None);
 
-    map(
-        rule!(
-            #separated_list1(rule! { ";"+ }, rule! { #stmt | #eoi }) ~ &EOI
+    alt((
+        map(
+            rule!(
+                #separated_list1(rule! { ";"+ }, rule! { #stmt | #eoi }) ~ &EOI
+            ),
+            |(stmts, _)| stmts.into_iter().flatten().collect(),
         ),
-        |(stmts, _)| stmts.into_iter().flatten().collect(),
-    )(i)
+        // `INSERT INTO ... FORMAT ...` and `INSERT INTO ... VALUES` statements will
+        // stop the parser immediately and return the rest tokens by `InsertSource`.
+        //
+        // This is a hack to make it able to parse a large streaming insert statement.
+        map(insert_statement, |insert_stmt| vec![insert_stmt]),
+    ))(i)
 }
 
 pub fn statement(i: Input) -> IResult<Statement> {
@@ -53,24 +61,6 @@ pub fn statement(i: Input) -> IResult<Statement> {
                 _ => unreachable!(),
             },
             query: Box::new(statement),
-        },
-    );
-    let insert = map(
-        rule! {
-            INSERT ~ ( INTO | OVERWRITE ) ~ TABLE?
-            ~ #peroid_separated_idents_1_to_3
-            ~ ( "(" ~ #comma_separated_list1(ident) ~ ")" )?
-            ~ #insert_source
-        },
-        |(_, overwrite, _, (catalog, database, table), opt_columns, source)| Statement::Insert {
-            catalog,
-            database,
-            table,
-            columns: opt_columns
-                .map(|(_, columns, _)| columns)
-                .unwrap_or_default(),
-            source,
-            overwrite: overwrite.kind == OVERWRITE,
         },
     );
     let show_settings = value(Statement::ShowSettings, rule! { SHOW ~ SETTINGS });
@@ -599,7 +589,6 @@ pub fn statement(i: Input) -> IResult<Statement> {
         rule!(
             #map(query, |query| Statement::Query(Box::new(query)))
             | #explain : "`EXPLAIN [PIPELINE | GRAPH] <statement>`"
-            | #insert : "`INSERT INTO [TABLE] <table> [(<column>, ...)] (FORMAT <format> | VALUES <values> | <query>)`"
             | #show_settings : "`SHOW SETTINGS`"
             | #show_stages : "`SHOW STAGES`"
             | #show_process_list : "`SHOW PROCESSLIST`"
@@ -655,6 +644,68 @@ pub fn statement(i: Input) -> IResult<Statement> {
     ))(i)
 }
 
+pub fn insert_statement(i: Input) -> IResult<Statement> {
+    map(
+        rule! {
+            INSERT ~ ( INTO | OVERWRITE ) ~ TABLE?
+            ~ #peroid_separated_idents_1_to_3
+            ~ ( "(" ~ #comma_separated_list1(ident) ~ ")" )?
+            ~ #insert_source
+            : "`INSERT INTO [TABLE] <table> [(<column>, ...)] (FORMAT <format> | VALUES <values> | <query>)`"
+        },
+        |(_, overwrite, _, (catalog, database, table), opt_columns, source)| Statement::Insert {
+            catalog,
+            database,
+            table,
+            columns: opt_columns
+                .map(|(_, columns, _)| columns)
+                .unwrap_or_default(),
+            source,
+            overwrite: overwrite.kind == OVERWRITE,
+        },
+    )(i)
+}
+
+pub fn insert_source(i: Input) -> IResult<InsertSource> {
+    let streaming = map(
+        rule! {
+            FORMAT ~ #ident ~ #rest_tokens
+        },
+        |(_, format, rest_tokens)| InsertSource::Streaming {
+            format: format.name,
+            rest_tokens,
+        },
+    );
+    let values = map(
+        rule! {
+            VALUES ~ #rest_tokens
+        },
+        |(_, rest_tokens)| InsertSource::Values { rest_tokens },
+    );
+    let query = map(
+        rule! {
+            #query ~ ( ";" | &EOI )
+        },
+        |(query, _)| InsertSource::Select {
+            query: Box::new(query),
+        },
+    );
+
+    rule!(
+        #streaming
+        | #values
+        | #query
+    )(i)
+}
+
+pub fn rest_tokens<'a>(i: Input<'a>) -> IResult<&'a [Token]> {
+    if i.last().map(|token| token.kind) == Some(EOI) {
+        Ok((i.slice(i.len() - 1..), i.slice(..i.len() - 1).0))
+    } else {
+        Ok((i.slice(i.len()..), i.0))
+    }
+}
+
 pub fn column_def(i: Input) -> IResult<ColumnDefinition> {
     #[derive(Clone)]
     enum ColumnConstraint<'a> {
@@ -705,32 +756,6 @@ pub fn column_def(i: Input) -> IResult<ColumnDefinition> {
             }
             def
         },
-    )(i)
-}
-
-pub fn insert_source(i: Input) -> IResult<InsertSource> {
-    let streaming = map(
-        rule! {
-            FORMAT ~ #ident
-        },
-        |(_, format)| InsertSource::Streaming {
-            format: format.name,
-        },
-    );
-    let values = map(
-        rule! {
-            VALUES ~ #values_tokens
-        },
-        |(_, values_tokens)| InsertSource::Values { values_tokens },
-    );
-    let query = map(query, |query| InsertSource::Select {
-        query: Box::new(query),
-    });
-
-    rule!(
-        #streaming
-        | #values
-        | #query
     )(i)
 }
 
@@ -884,15 +909,6 @@ pub fn database_engine(i: Input) -> IResult<DatabaseEngine> {
         },
         |(_, _, engine)| engine,
     )(i)
-}
-
-pub fn values_tokens(i: Input) -> IResult<&[Token]> {
-    let semicolon_pos = i
-        .iter()
-        .position(|token| token.text() == ";")
-        .unwrap_or(i.len() - 1);
-    let (value_tokens, rest_tokens) = i.0.split_at(semicolon_pos);
-    Ok((Input(rest_tokens, i.1), value_tokens))
 }
 
 pub fn role_option(i: Input) -> IResult<RoleOption> {

--- a/common/ast/tests/it/parser.rs
+++ b/common/ast/tests/it/parser.rs
@@ -165,6 +165,11 @@ fn test_statements_in_legacy_suites() {
         .unwrap()
         .replace_all(&file_str, "")
         .into_owned();
+        // Remove insert statements
+        let file_str = regex::Regex::new("(?i).*INSERT INTO[^;]*.*\n")
+            .unwrap()
+            .replace_all(&file_str, "")
+            .into_owned();
 
         let tokens = tokenize_sql(&file_str).unwrap();
         let backtrace = Backtrace::new();

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -2840,7 +2840,7 @@ Query(
 ---------- Input ----------
 insert into t (c1, c2) values (1, 2), (3, 4);
 ---------- Output ---------
-INSERT INTO t (c1, c2) VALUES (1, 2), (3, 4)
+INSERT INTO t (c1, c2) VALUES (1, 2), (3, 4);
 ---------- AST ------------
 Insert {
     catalog: None,
@@ -2863,7 +2863,7 @@ Insert {
         },
     ],
     source: Values {
-        values_tokens: [
+        rest_tokens: [
             LParen(30..31),
             LiteralInteger(31..32),
             Comma(32..33),
@@ -2875,6 +2875,7 @@ Insert {
             Comma(40..41),
             LiteralInteger(42..43),
             RParen(43..44),
+            SemiColon(44..45),
         ],
     },
     overwrite: false,
@@ -2884,7 +2885,7 @@ Insert {
 ---------- Input ----------
 insert into table t format json;
 ---------- Output ---------
-INSERT INTO t FORMAT json
+INSERT INTO t FORMAT json ;
 ---------- AST ------------
 Insert {
     catalog: None,
@@ -2897,6 +2898,9 @@ Insert {
     columns: [],
     source: Streaming {
         format: "json",
+        rest_tokens: [
+            SemiColon(31..32),
+        ],
     },
     overwrite: false,
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`INSERT INTO ... FORMAT ...` and `INSERT INTO ... VALUES` statements will stop the parser immediately and return the rest tokens by `InsertSource`. This is a hack to make it able to parse a large streaming insert statement.

## Changelog

- New Feature

## Related Issues


