### PR TITLE
feat: support date_sub

### DIFF
--- a/common/ast/src/ast/expr.rs
+++ b/common/ast/src/ast/expr.rs
@@ -173,6 +173,12 @@ pub enum Expr<'a> {
         interval: Box<Expr<'a>>,
         unit: IntervalKind,
     },
+    DateSub {
+        span: &'a [Token<'a>],
+        date: Box<Expr<'a>>,
+        interval: Box<Expr<'a>>,
+        unit: IntervalKind,
+    },
     /// NULLIF(<expr>, <expr>)
     NullIf {
         span: &'a [Token<'a>],
@@ -306,6 +312,7 @@ impl<'a> Expr<'a> {
             Expr::Array { span, .. } => span,
             Expr::Interval { span, .. } => span,
             Expr::DateAdd { span, .. } => span,
+            Expr::DateSub { span, .. } => span,
             Expr::NullIf { span, .. } => span,
             Expr::IfNull { span, .. } => span,
         }
@@ -727,6 +734,14 @@ impl<'a> Display for Expr<'a> {
                 ..
             } => {
                 write!(f, "DATE_ADD({date}, INTERVAL {interval} {unit})")?;
+            }
+            Expr::DateSub {
+                date,
+                interval,
+                unit,
+                ..
+            } => {
+                write!(f, "DATE_SUB({date}, INTERVAL {interval} {unit})")?;
             }
             Expr::NullIf { expr1, expr2, .. } => {
                 write!(f, "NULLIF({expr1}, {expr2})")?;

--- a/common/ast/src/parser/token.rs
+++ b/common/ast/src/parser/token.rs
@@ -309,6 +309,8 @@ pub enum TokenKind {
     DATE,
     #[token("DATE_ADD", ignore(ascii_case))]
     DATE_ADD,
+    #[token("DATE_SUB", ignore(ascii_case))]
+    DATE_SUB,
     #[token("DATETIME", ignore(ascii_case))]
     DATETIME,
     #[token("DAY", ignore(ascii_case))]
@@ -850,6 +852,7 @@ impl TokenKind {
             // | TokenKind::WINDOW
             | TokenKind::WITH
             | TokenKind::DATE_ADD
+            | TokenKind::DATE_SUB
             if !after_as => true,
             _ => false
         }

--- a/common/ast/tests/it/testdata/expr-error.txt
+++ b/common/ast/tests/it/testdata/expr-error.txt
@@ -54,7 +54,7 @@ error:
   --> SQL:1:10
   |
 1 | CAST(col1)
-  | ----     ^ expected `AS`, `,`, `(`, `.`, `IS`, `NOT`, or 51 more ...
+  | ----     ^ expected `AS`, `,`, `(`, `.`, `IS`, `NOT`, or 52 more ...
   | |         
   | while parsing `CAST(... AS ...)`
   | while parsing expression

--- a/query/src/sql/planner/semantic/type_check.rs
+++ b/query/src/sql/planner/semantic/type_check.rs
@@ -496,6 +496,26 @@ impl<'a> TypeChecker<'a> {
                 self.resolve_date_add(span, date, interval, unit, required_type)
                     .await?
             }
+            Expr::DateSub {
+                span,
+                date,
+                interval,
+                unit,
+                ..
+            } => {
+                self.resolve_date_add(
+                    span,
+                    date,
+                    &Expr::UnaryOp {
+                        span,
+                        op: UnaryOperator::Minus,
+                        expr: interval.clone(),
+                    },
+                    unit,
+                    required_type,
+                )
+                .await?
+            }
             Expr::Trim {
                 span,
                 expr,

--- a/tests/suites/0_stateless/02_function/02_0012_function_datetimes.sql
+++ b/tests/suites/0_stateless/02_function/02_0012_function_datetimes.sql
@@ -235,8 +235,9 @@ insert into t values('2022-04-02 15:10:28.221', '2022-04-02 15:10:28.221', '1000
 select * from t order by b;
 drop table t;
 
--- select '===date_add===';
 -- set enable_planner_v2=1;
+
+-- select '===date_add===';
 -- select date_add(to_date(18321), 1, YEAR);
 -- select date_add(to_date(18321), -1, YEAR);
 -- select date_add(to_date(18321), 1, SECOND);
@@ -244,6 +245,16 @@ drop table t;
 -- create table t(a int);
 -- insert into t values(1), (2);
 -- select date_add(to_date(18321), a, YEAR) from t;
+-- drop table t;
+
+-- select '===date_sub===';
+-- select date_sub(to_date(18321), 1, YEAR);
+-- select date_sub(to_date(18321), -1, YEAR);
+-- select date_sub(to_date(18321), 1, SECOND);
+
+-- create table t(a int);
+-- insert into t values(1), (2);
+-- select date_sub(to_date(18321), a, YEAR) from t;
 -- drop table t;
 
 -- set enable_planner_v2=0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

support `date_sub`

- [x] ast
- [x] planner rewrite
- [x] stateless tests (not enable, but pass)

```sql
set enable_planner_v2=1;

select '===date_sub===';
select date_sub(to_date(18321), 1, YEAR);
select date_sub(to_date(18321), -1, YEAR);
select date_sub(to_date(18321), 1, SECOND);

create table t(a int);
insert into t values(1), (2);
select date_sub(to_date(18321), a, YEAR) from t;
drop table t;

set enable_planner_v2=0;
```

```
===date_sub===
2019-02-28
2021-02-28
2020-02-28 23:59:59.000000
2019-02-28
2018-02-28
```

## Changelog

- New Feature

## Related Issues

Fixes #6014 

