### PR TITLE
[meta] fix memory leak with tracing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,6 +1985,7 @@ dependencies = [
  "clap 3.1.18",
  "common-base",
  "common-meta-api",
+ "common-meta-app",
  "common-meta-grpc",
  "common-meta-types",
  "databend-meta",
@@ -4495,8 +4496,8 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.6.4"
-source = "git+https://github.com/datafuselabs/openraft?rev=f633756d60152d171909aea56f80d18905cd4002#f633756d60152d171909aea56f80d18905cd4002"
+version = "0.7.0-alpha.1"
+source = "git+https://github.com/datafuselabs/openraft?rev=v0.7.0-alpha.1#1bc3ded67976fdbe1380ee62bf07de75e50a31cb"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/common/meta/app/Cargo.toml
+++ b/common/meta/app/Cargo.toml
@@ -16,7 +16,7 @@ common-exception = { path = "../../exception" }
 common-io = { path = "../../io" }
 common-meta-types = { path = "../types" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "f633756d60152d171909aea56f80d18905cd4002" }
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.1" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyerror = "0.1.6"

--- a/common/meta/sled-store/Cargo.toml
+++ b/common/meta/sled-store/Cargo.toml
@@ -15,7 +15,7 @@ test = false
 common-meta-types = { path = "../types" }
 common-tracing = { path = "../../tracing" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "f633756d60152d171909aea56f80d18905cd4002" }
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.1" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyhow = "1.0.56"

--- a/common/meta/types/Cargo.toml
+++ b/common/meta/types/Cargo.toml
@@ -15,7 +15,7 @@ common-datavalues = { path = "../../datavalues" }
 common-exception = { path = "../../exception" }
 common-io = { path = "../../io" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "f633756d60152d171909aea56f80d18905cd4002" }
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.1" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyerror = "0.1.6"

--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -60,11 +60,11 @@ static GLOBAL_UT_LOG_GUARD: Lazy<Arc<Mutex<Option<Vec<WorkerGuard>>>>> =
 /// A local tracing collection(maybe for testing) can be done with a local jaeger server.
 /// To report tracing data and view it:
 ///   docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
-///   RUST_LOG=trace cargo test
+///   DATABEND_JAEGER=on RUST_LOG=trace cargo test
 ///   open http://localhost:16686/
 ///
 /// To adjust batch sending delay, use `OTEL_BSP_SCHEDULE_DELAY`:
-/// RUST_LOG=trace OTEL_BSP_SCHEDULE_DELAY=1 cargo test
+/// DATABEND_JAEGER=on RUST_LOG=trace OTEL_BSP_SCHEDULE_DELAY=1 cargo test
 ///
 // TODO(xp): use DATABEND_JAEGER to assign jaeger server address.
 pub fn init_global_tracing(app_name: &str, dir: &str, level: &str) -> Vec<WorkerGuard> {
@@ -81,12 +81,18 @@ pub fn init_global_tracing(app_name: &str, dir: &str, level: &str) -> Vec<Worker
     guards.push(rolling_writer_guard);
 
     // Jaeger layer.
-    global::set_text_map_propagator(TraceContextPropagator::new());
-    let tracer = opentelemetry_jaeger::new_pipeline()
-        .with_service_name(app_name)
-        .install_batch(opentelemetry::runtime::Tokio)
-        .expect("install");
-    let jaeger_layer = Some(tracing_opentelemetry::layer().with_tracer(tracer));
+    let mut jaeger_layer = None;
+    let fuse_jaeger_env = env::var("DATABEND_JAEGER").unwrap_or_else(|_| "".to_string());
+    if !fuse_jaeger_env.is_empty() {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+
+        let tracer = opentelemetry_jaeger::new_pipeline()
+            .with_service_name(app_name)
+            .install_batch(opentelemetry::runtime::Tokio)
+            .expect("install");
+
+        jaeger_layer = Some(tracing_opentelemetry::layer().with_tracer(tracer));
+    }
 
     // Use env RUST_LOG to initialize log if present.
     // Otherwise, use the specified level.

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -19,6 +19,7 @@ test = false
 
 [features]
 default = ["simd"]
+memory-profiling = ["common-base/memory-profiling"]
 simd = ["common-arrow/simd"]
 tokio-console = ["common-tracing/console", "common-base/tracing"]
 
@@ -56,7 +57,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde-bridge = "0.0.3"
 serde_json = "1.0.79"
 serfig = "0.0.2"
-tempfile = "3.3.0"
+tempfile = { version = "3.3.0" }
 tokio-stream = "0.1.8"
 tonic = { version = "=0.7.2", features = ["tls"] }
 tonic-reflection = "=0.4.0"

--- a/metasrv/src/api/http/debug/jeprof.rs
+++ b/metasrv/src/api/http/debug/jeprof.rs
@@ -1,0 +1,47 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_base::mem_allocator::dump_profile;
+use common_exception::ErrorCode;
+use poem::error::InternalServerError;
+use poem::http::StatusCode;
+use poem::web::IntoResponse;
+use poem::web::Query;
+use poem::Error;
+use tempfile::Builder;
+
+#[poem::handler]
+pub async fn debug_jeprof_dump_handler(
+    _req: Option<Query<String>>,
+) -> poem::Result<impl IntoResponse> {
+    let tmp_file = Builder::new()
+        .prefix("heap_dump_")
+        .suffix(".prof")
+        .tempfile()
+        .map_err(InternalServerError)?;
+
+    let path = tmp_file.path();
+    let body = dump_profile(&path.to_string_lossy()).map_err(|e| {
+        Error::new(
+            ErrorCode::from(e.to_string().as_str()),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+    })?;
+    let body_len = body.len();
+
+    Ok(body.with_header("content-length", body_len).with_header(
+        "Content-Disposition",
+        format!("attachment; filename=\"{}\"", &path.to_string_lossy()),
+    ))
+}

--- a/metasrv/src/api/http/debug/mod.rs
+++ b/metasrv/src/api/http/debug/mod.rs
@@ -15,4 +15,7 @@
 pub mod home;
 pub mod pprof;
 
+#[cfg(feature = "memory-profiling")]
+pub mod jeprof;
+
 pub use home::PProfRequest;

--- a/metasrv/src/api/http_service.rs
+++ b/metasrv/src/api/http_service.rs
@@ -44,7 +44,8 @@ impl HttpService {
     }
 
     fn build_router(&self) -> impl Endpoint {
-        Route::new()
+        #[cfg_attr(not(feature = "memory-profiling"), allow(unused_mut))]
+        let mut route = Route::new()
             .at("/v1/health", get(super::http::v1::health::health_handler))
             .at("/v1/config", get(super::http::v1::config::config_handler))
             .at(
@@ -66,9 +67,21 @@ impl HttpService {
             .at(
                 "/debug/pprof/profile",
                 get(super::http::debug::pprof::debug_pprof_handler),
-            )
-            .data(self.meta_node.clone())
-            .data(self.cfg.clone())
+            );
+
+        #[cfg(feature = "memory-profiling")]
+        {
+            route = route.at(
+                // to follow the conversions of jepref, we arrange the path in
+                // this way, so that jeprof could be invoked like:
+                //   `jeprof ./target/debug/databend-meta http://localhost:28002/debug/mem`
+                // and jeprof will translate the above url into sth like:
+                //    "http://localhost:28002/debug/mem/pprof/profile?seconds=30"
+                "/debug/mem/pprof/profile",
+                get(super::http::debug::jeprof::debug_jeprof_dump_handler),
+            );
+        };
+        route.data(self.meta_node.clone()).data(self.cfg.clone())
     }
 
     fn build_tls(config: &Config) -> Result<RustlsConfig> {

--- a/tools/metabench/Cargo.toml
+++ b/tools/metabench/Cargo.toml
@@ -16,6 +16,7 @@ test = false
 # Workspace dependencies
 common-base = { path = "../../common/base" }
 common-meta-api = { path = "../../common/meta/api" }
+common-meta-app = { path = "../../common/meta/app" }
 common-meta-grpc = { path = "../../common/meta/grpc" }
 common-meta-types = { path = "../../common/meta/types" }
 databend-meta = { path = "../../metasrv" }

--- a/tools/metabench/src/main.rs
+++ b/tools/metabench/src/main.rs
@@ -12,11 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::sync::Arc;
 use std::time::Instant;
 
 use clap::Parser;
 use common_base::base::tokio;
 use common_meta_api::KVApi;
+use common_meta_api::SchemaApi;
+use common_meta_app::schema::CreateDatabaseReq;
+use common_meta_app::schema::CreateTableReq;
+use common_meta_app::schema::DatabaseNameIdent;
+use common_meta_app::schema::GetTableReq;
+use common_meta_app::schema::TableNameIdent;
+use common_meta_app::schema::UpsertTableOptionReq;
+use common_meta_grpc::ClientHandle;
 use common_meta_grpc::MetaGrpcClient;
 use common_meta_types::MatchSeq;
 use common_meta_types::Operation;
@@ -39,6 +50,10 @@ struct Config {
 
     #[clap(long, env = "METASRV_GRPC_API_ADDRESS", default_value = "")]
     pub grpc_api_address: String,
+
+    /// The RPC to benchmark: "upsert_kv": send kv-api upsert_kv, "table": create db, table and upsert_table_option;
+    #[clap(long, default_value = "upsert_kv")]
+    pub rpc: String,
 }
 
 #[tokio::main]
@@ -57,6 +72,7 @@ async fn main() {
     while client_num < config.client {
         client_num += 1;
         let addr = config.grpc_api_address.clone();
+        let typ = config.rpc.clone();
 
         let handle = tokio::spawn(async move {
             let client =
@@ -65,14 +81,15 @@ async fn main() {
                 return;
             }
             let client = client.unwrap();
-            for i in 0..config.number {
-                let node_key = format!("{}-{}", client_num, i);
-                let seq = MatchSeq::Any;
-                let value = Operation::Update(b"v3".to_vec());
 
-                let _res = client
-                    .upsert_kv(UpsertKVReq::new(&node_key, seq, value, None))
-                    .await;
+            for i in 0..config.number {
+                if typ == "upsert_kv" {
+                    benchmark_upsert(&client, client_num, i).await;
+                } else if typ == "table" {
+                    benchmark_table(&client, client_num, i).await;
+                } else {
+                    unreachable!("Invalid config.rpc: {}", typ);
+                }
             }
         });
         handles.push(handle)
@@ -88,4 +105,73 @@ async fn main() {
         config.number,
         end.duration_since(start).as_millis()
     );
+}
+
+async fn benchmark_upsert(client: &Arc<ClientHandle>, client_num: u32, i: u32) {
+    let node_key = format!("{}-{}", client_num, i);
+    let seq = MatchSeq::Any;
+    let value = Operation::Update(b"v3".to_vec());
+
+    let res = client
+        .upsert_kv(UpsertKVReq::new(&node_key, seq, value, None))
+        .await;
+
+    print_res(i, "upsert_kv", &res);
+}
+
+async fn benchmark_table(client: &Arc<ClientHandle>, client_num: u32, i: u32) {
+    let res = client
+        .create_database(CreateDatabaseReq {
+            if_not_exists: false,
+            name_ident: DatabaseNameIdent {
+                tenant: format!("tenant-{}", client_num),
+                db_name: format!("db-{}", client_num),
+            },
+            meta: Default::default(),
+        })
+        .await;
+
+    print_res(i, "create_db", &res);
+
+    let res = client
+        .create_table(CreateTableReq {
+            if_not_exists: true,
+            name_ident: TableNameIdent {
+                tenant: format!("tenant-{}", client_num),
+                db_name: format!("db-{}", client_num),
+                table_name: format!("table-{}", client_num),
+            },
+            table_meta: Default::default(),
+        })
+        .await;
+
+    print_res(i, "create_table", &res);
+
+    let res = client
+        .get_table(GetTableReq::new(
+            format!("tenant-{}", client_num),
+            format!("db-{}", client_num),
+            format!("table-{}", client_num),
+        ))
+        .await;
+
+    print_res(i, "get_table", &res);
+
+    let t = res.unwrap();
+
+    let res = client
+        .upsert_table_option(UpsertTableOptionReq {
+            table_id: t.ident.table_id,
+            seq: MatchSeq::GE(t.ident.seq),
+            options: Default::default(),
+        })
+        .await;
+
+    print_res(i, "upsert_table_option", &res);
+}
+
+fn print_res<D: Debug>(i: u32, typ: impl Display, res: &D) {
+    if i % 100 == 0 {
+        println!("{:>10}-th {} result: {:?}", i, typ, res);
+    }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [meta] fix memory leak with tracing.

There two memory leak:

- Using span.enter() in a async block.

  This inappropriate usage is in openraft.
  Update openraft to `0.7.1-alpha.1` to solve it:

  Openraft change log in this commit:

  -   Fixed: [a0a94af7](https://github.com/datafuselabs/openraft/commit/a0a94af7612bd9aaae5a5404325887b16d7a96ae) span.enter() in async loop causes memory leak; by 张炎泼; 2022-06-17

      It is explained in:
      https://onesignal.com/blog/solving-memory-leaks-in-rust/

- Jaeger buffers tracing logs if the receiving server is not online:

  Solve this issue by enabling jaeger by environment variable.

Other changes:

- Feature: add jemalloc memory profiling support: /debug/mem/pprof/profile.

  See: https://databend.rs/doc/faq/how-to-profiling#memory-profiling

- `metabench` supports multiple rpc benchmark: `upsert_kv` or `table` operations

## Changelog







## Related Issues