### PR TITLE
feat(query): Configurable repr of float denormals in output formats.

### DIFF
--- a/common/io/src/format_settings.rs
+++ b/common/io/src/format_settings.rs
@@ -31,9 +31,12 @@ pub struct FormatSettings {
     pub true_bytes: Vec<u8>,
     pub false_bytes: Vec<u8>,
     pub null_bytes: Vec<u8>,
+    pub nan_bytes: Vec<u8>,
+    pub inf_bytes: Vec<u8>,
 
     pub csv_null_bytes: Vec<u8>,
     pub tsv_null_bytes: Vec<u8>,
+    pub json_quote_denormals: bool,
 }
 
 impl Default for FormatSettings {
@@ -48,8 +51,11 @@ impl Default for FormatSettings {
             true_bytes: vec![b'1'],
             false_bytes: vec![b'0'],
             null_bytes: vec![b'N', b'U', b'L', b'L'],
+            nan_bytes: vec![b'N', b'a', b'N'],
+            inf_bytes: vec![b'i', b'n', b'f'],
             csv_null_bytes: vec![b'\\', b'N'],
             tsv_null_bytes: vec![b'\\', b'N'],
+            json_quote_denormals: false,
         }
     }
 }

--- a/query/src/formats/output_format_json_each_row.rs
+++ b/query/src/formats/output_format_json_each_row.rs
@@ -27,10 +27,22 @@ pub struct JsonEachRowOutputFormat {
 
 impl JsonEachRowOutputFormat {
     pub fn create(_schema: DataSchemaRef, format_settings: FormatSettings) -> Self {
-        let format_settings = FormatSettings {
-            null_bytes: vec![b'n', b'u', b'l', b'l'],
-            ..format_settings
+        let format_settings = if format_settings.json_quote_denormals {
+            FormatSettings {
+                null_bytes: vec![b'n', b'u', b'l', b'l'],
+                inf_bytes: vec![b'\"', b'i', b'n', b'f', b'\"'],
+                nan_bytes: vec![b'\"', b'n', b'a', b'n', b'\"'],
+                ..format_settings
+            }
+        } else {
+            FormatSettings {
+                null_bytes: vec![b'n', b'u', b'l', b'l'],
+                inf_bytes: vec![b'n', b'u', b'l', b'l'],
+                nan_bytes: vec![b'n', b'u', b'l', b'l'],
+                ..format_settings
+            }
         };
+
         Self { format_settings }
     }
 }

--- a/query/tests/it/formats/mod.rs
+++ b/query/tests/it/formats/mod.rs
@@ -14,5 +14,6 @@
 
 mod format_csv;
 mod format_factory;
+mod output_format_json_each_row;
 mod output_format_tcsv;
 mod output_format_utils;

--- a/query/tests/it/formats/mod.rs
+++ b/query/tests/it/formats/mod.rs
@@ -15,3 +15,4 @@
 mod format_csv;
 mod format_factory;
 mod output_format_tcsv;
+mod output_format_utils;

--- a/query/tests/it/formats/output_format_json_each_row.rs
+++ b/query/tests/it/formats/output_format_json_each_row.rs
@@ -1,0 +1,130 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_datablocks::DataBlock;
+use common_datavalues::prelude::*;
+use common_exception::Result;
+use common_io::prelude::FormatSettings;
+use databend_query::formats::output_format::OutputFormatType;
+use pretty_assertions::assert_eq;
+
+use crate::formats::output_format_utils::get_simple_block;
+
+fn test_data_block(is_nullable: bool) -> Result<()> {
+    let block = get_simple_block(is_nullable)?;
+    let schema = block.schema().clone();
+    let format_setting = FormatSettings::default();
+
+    {
+        let fmt = OutputFormatType::JsonEachRow;
+        let mut formatter = fmt.create_format(schema, format_setting);
+        let buffer = formatter.serialize_block(&block)?;
+
+        let tsv_block = String::from_utf8(buffer)?;
+        let expect = r#"{"c1":1,"c2":"a","c3":1,"c4":1.1,"c5":"1970-01-02"}
+{"c1":2,"c2":"b\"","c3":1,"c4":2.2,"c5":"1970-01-03"}
+{"c1":3,"c2":"c'","c3":0,"c4":3.3,"c5":"1970-01-04"}
+"#;
+        assert_eq!(&tsv_block, expect);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_null() -> Result<()> {
+    let format_setting = FormatSettings::default();
+
+    let schema = DataSchemaRefExt::create(vec![
+        DataField::new_nullable("c1", i32::to_data_type()),
+        DataField::new_nullable("c2", i32::to_data_type()),
+    ]);
+
+    let columns = vec![
+        Series::from_data(vec![Some(1i32), None, Some(3)]),
+        Series::from_data(vec![None, Some(2i32), None]),
+    ];
+
+    let block = DataBlock::create(schema.clone(), columns);
+
+    {
+        let fmt = OutputFormatType::JsonEachRow;
+        let mut formatter = fmt.create_format(schema, format_setting);
+        let buffer = formatter.serialize_block(&block)?;
+
+        let tsv_block = String::from_utf8(buffer)?;
+        let expect = r#"{"c1":1,"c2":null}
+{"c1":null,"c2":2}
+{"c1":3,"c2":null}
+"#;
+        assert_eq!(&tsv_block, expect);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_denormal() -> Result<()> {
+    let format_setting = FormatSettings::default();
+    let schema = DataSchemaRefExt::create(vec![
+        DataField::new("c1", f32::to_data_type()),
+        DataField::new("c2", f32::to_data_type()),
+    ]);
+
+    let columns = vec![
+        Series::from_data(vec![1f32, f32::NAN]),
+        Series::from_data(vec![f32::INFINITY, f32::NEG_INFINITY]),
+    ];
+
+    let block = DataBlock::create(schema.clone(), columns);
+
+    {
+        let fmt = OutputFormatType::JsonEachRow;
+        let mut formatter = fmt.create_format(schema.clone(), format_setting);
+        let buffer = formatter.serialize_block(&block)?;
+
+        let tsv_block = String::from_utf8(buffer)?;
+        let expect = r#"{"c1":1.0,"c2":null}
+{"c1":null,"c2":null}
+"#;
+        assert_eq!(&tsv_block, expect);
+    }
+
+    {
+        let format_setting = FormatSettings {
+            json_quote_denormals: true,
+            ..FormatSettings::default()
+        };
+        let fmt = OutputFormatType::JsonEachRow;
+        let mut formatter = fmt.create_format(schema, format_setting);
+        let buffer = formatter.serialize_block(&block)?;
+
+        let tsv_block = String::from_utf8(buffer)?;
+        let expect = r#"{"c1":1.0,"c2":"inf"}
+{"c1":"nan","c2":"inf"}
+"#;
+        assert_eq!(&tsv_block, expect);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_data_block_nullable() -> Result<()> {
+    test_data_block(true)
+}
+
+#[test]
+fn test_data_block_not_nullable() -> Result<()> {
+    test_data_block(false)
+}

--- a/query/tests/it/formats/output_format_utils.rs
+++ b/query/tests/it/formats/output_format_utils.rs
@@ -1,0 +1,60 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_arrow::arrow::bitmap::MutableBitmap;
+use common_datablocks::DataBlock;
+use common_datavalues::prelude::*;
+use common_exception::Result;
+
+pub fn get_simple_block(is_nullable: bool) -> Result<DataBlock> {
+    let schema = match is_nullable {
+        false => DataSchemaRefExt::create(vec![
+            DataField::new("c1", i32::to_data_type()),
+            DataField::new("c2", Vu8::to_data_type()),
+            DataField::new("c3", bool::to_data_type()),
+            DataField::new("c4", f64::to_data_type()),
+            DataField::new("c5", DateType::new_impl()),
+        ]),
+        true => DataSchemaRefExt::create(vec![
+            DataField::new_nullable("c1", i32::to_data_type()),
+            DataField::new_nullable("c2", Vu8::to_data_type()),
+            DataField::new_nullable("c3", bool::to_data_type()),
+            DataField::new_nullable("c4", f64::to_data_type()),
+            DataField::new_nullable("c5", DateType::new_impl()),
+        ]),
+    };
+
+    let mut columns = vec![
+        Series::from_data(vec![1i32, 2, 3]),
+        Series::from_data(vec!["a", "b\"", "c'"]),
+        Series::from_data(vec![true, true, false]),
+        Series::from_data(vec![1.1f64, 2.2, 3.3]),
+        Series::from_data(vec![1_i32, 2_i32, 3_i32]),
+    ];
+
+    if is_nullable {
+        columns = columns
+            .iter()
+            .map(|c| {
+                let mut validity = MutableBitmap::new();
+                validity.extend_constant(c.len(), true);
+                NullableColumn::wrap_inner(c.clone(), Some(validity.into()))
+            })
+            .collect();
+    }
+
+    let block = DataBlock::create(schema, columns);
+
+    Ok(block)
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

following clickhouse conversion

1.  JSON write `null`
2.  tsv/csv write `nan`, `inf`

## Changelog

- New Feature

## Related Issues

Fixes #issue

