### PR TITLE
fix(query): http handler pipeline execute.

### DIFF
--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -399,14 +399,15 @@ impl HttpQueryHandle {
             inputs_port: vec![input],
             processors: vec![sink],
         });
-        let pipeline_executor =
-            PipelineCompleteExecutor::try_create(async_runtime.clone(), root_pipeline)?;
+
         let async_runtime_clone = async_runtime.clone();
         let run = move || -> Result<()> {
             for pipeline in pipelines {
                 let executor = PipelineExecutor::create(async_runtime_clone.clone(), pipeline)?;
                 executor.execute()?;
             }
+            let pipeline_executor =
+                PipelineCompleteExecutor::try_create(async_runtime_clone, root_pipeline)?;
             pipeline_executor.execute()
         };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

root_pipleline executor should be inited after the child pipelines are executed.

## Changelog


- Not for changelog (changelog entry is not required)

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/6054