### PR TITLE
Doc: Order by column position

### DIFF
--- a/docs/doc/30-reference/30-sql/20-query-syntax/dml-select.md
+++ b/docs/doc/30-reference/30-sql/20-query-syntax/dml-select.md
@@ -16,7 +16,7 @@ SELECT
     [GROUP BY {{col_name | expr | position}, ...
     | extended_grouping_expr}]
     [HAVING expr]
-    [ORDER BY {col_name | expr} [ASC | DESC], ...]
+    [ORDER BY {col_name | expr | col_alias | col_position} [ASC | DESC], ...]
     [LIMIT row_count]
     [OFFSET row_count]
     ]
@@ -92,9 +92,10 @@ SELECT number%2 as c1, number%3 as c2, MAX(number) as max FROM numbers(10000) GR
 +------+------+------+
 ```
 
-## ORDER By Clause
+## ORDER BY Clause
 
 ```sql
+--Sort by column name in ascending order.
 SELECT number FROM numbers(5) ORDER BY number ASC;
 +--------+
 | number |
@@ -106,6 +107,7 @@ SELECT number FROM numbers(5) ORDER BY number ASC;
 |      4 |
 +--------+
 
+--Sort by column name in descending order.
 SELECT number FROM numbers(5) ORDER BY number DESC;
 +--------+
 | number |
@@ -117,6 +119,7 @@ SELECT number FROM numbers(5) ORDER BY number DESC;
 |      0 |
 +--------+
 
+--Sort by column alias.
 SELECT number%2 AS c1, number%3 AS c2  FROM numbers(5) ORDER BY c1 ASC, c2 DESC;
 +------+------+
 | c1   | c2   |
@@ -127,6 +130,24 @@ SELECT number%2 AS c1, number%3 AS c2  FROM numbers(5) ORDER BY c1 ASC, c2 DESC;
 |    1 |    1 |
 |    1 |    0 |
 +------+------+
+
+--Sort by column position in the SELECT list
+SELECT * FROM t1 ORDER BY 2 DESC;
++------+------+
+| a    | b    |
++------+------+
+|    2 |    3 |
+|    1 |    2 |
++------+------+
+
+SELECT a FROM t1 ORDER BY 1 DESC;
++------+
+| a    |
++------+
+|    2 |
+|    1 |
++------+
+
 ```
 
 ## LIMIT Clause


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- added syntax and examples for **order by column position**.
- added notes to the existing **order by** examples.
- added syntax for **order by column alias** as well, as I see an example already exists on the page.

## Changelog

- Documentation

## Related Issues

Fixes #issue

