### PR TITLE
fix(docker): fix certificates dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,11 @@
 FROM ubuntu:22.04
 
+RUN apt-get update -y && \
+    apt-get install -y apt-transport-https ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/cache/apt/*
+
 COPY ./target/release/databend-query /databend-query
 COPY ./target/release/databend-meta /databend-meta
 COPY ./docker/databend-query-docker.toml /databend-query.toml

--- a/docker/stateless/Dockerfile
+++ b/docker/stateless/Dockerfile
@@ -12,6 +12,8 @@ COPY --from=builder /app/tests /tests
 RUN apt-get update -y \
     && env DEBIAN_FRONTEND=noninteractive \
         apt-get install --yes --no-install-recommends \
+            apt-transport-https \
+            ca-certificates \
             brotli \
             expect \
             zstd \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add missing certificates dependencies to Dockerfile

## Changelog

- Bug Fix

## Related Issues

Fixes #6134

