### PR TITLE
Fix(storage): Adjust table snapshot timestamp precision to micro second

### DIFF
--- a/query/src/storages/fuse/meta/v1/snapshot.rs
+++ b/query/src/storages/fuse/meta/v1/snapshot.rs
@@ -35,7 +35,8 @@ pub struct TableSnapshot {
     /// id of snapshot
     pub snapshot_id: SnapshotId,
 
-    /// previous snapshot
+    /// timestamp of this snapshot
+    //  for backward compatibility, `Option` is used
     pub timestamp: Option<DateTime<Utc>>,
 
     /// previous snapshot
@@ -67,15 +68,13 @@ impl TableSnapshot {
         segments: Vec<Location>,
         cluster_key_meta: Option<ClusterKey>,
     ) -> Self {
-        // timestamp of the snapshot should always larger than the previous one's
         let now = Utc::now();
-        let mut timestamp = Some(now);
-        if let Some(prev_instant) = prev_timestamp {
-            if prev_instant > &now {
-                // if local time is smaller, use the timestamp of previous snapshot, plus 1 ms
-                timestamp = Some(prev_instant.add(chrono::Duration::milliseconds(1)))
-            }
-        };
+        // make snapshot timestamp monotonically increased
+        let adjusted_timestamp = util::monotonically_increased_timestamp(now, prev_timestamp);
+
+        // trim timestamp to micro seconds
+        let trimmed_timestamp = util::trim_timestamp_to_micro_second(adjusted_timestamp);
+        let timestamp = Some(trimmed_timestamp);
 
         Self {
             format_version: TableSnapshot::VERSION,
@@ -108,5 +107,35 @@ impl From<v0::TableSnapshot> for TableSnapshot {
             segments: s.segments.into_iter().map(|l| (l, 0)).collect(),
             cluster_key_meta: None,
         }
+    }
+}
+
+mod util {
+    use chrono::Datelike;
+    use chrono::TimeZone;
+    use chrono::Timelike;
+
+    use super::*;
+    pub fn trim_timestamp_to_micro_second(ts: DateTime<Utc>) -> DateTime<Utc> {
+        Utc.ymd(ts.year(), ts.month(), ts.day()).and_hms_micro(
+            ts.hour(),
+            ts.minute(),
+            ts.second(),
+            ts.timestamp_subsec_micros(),
+        )
+    }
+
+    pub fn monotonically_increased_timestamp(
+        timestamp: DateTime<Utc>,
+        previous_timestamp: &Option<DateTime<Utc>>,
+    ) -> DateTime<Utc> {
+        if let Some(prev_instant) = previous_timestamp {
+            // timestamp of the snapshot should always larger than the previous one's
+            if prev_instant > &timestamp {
+                // if local time is smaller, use the timestamp of previous snapshot, plus 1 ms
+                return prev_instant.add(chrono::Duration::milliseconds(1));
+            }
+        }
+        timestamp
     }
 }

--- a/tests/suites/0_stateless/12_time_travel/12_0004_time_travel_select_at.result
+++ b/tests/suites/0_stateless/12_time_travel/12_0004_time_travel_select_at.result
@@ -1,9 +1,9 @@
 two insertions
 latest snapshot should contain 3 rows
 3
-counting the data set of first insertion, which should contains 2 rows
+counting the data set of first insertion, which should contain 2 rows
 2
-planner_v2: counting the data set of first insertion, which should contains 2 rows
+planner_v2: counting the data set of first insertion, which should contain 2 rows
 2
-planner_v2: counting the data set of fisrt insertion by timestamp, which should contains 2 rows
+planner_v2: counting the data set of first insertion by timestamp, which should contains 2 rows
 2

--- a/tests/suites/0_stateless/12_time_travel/12_0004_time_travel_select_at.sh
+++ b/tests/suites/0_stateless/12_time_travel/12_0004_time_travel_select_at.sh
@@ -9,31 +9,26 @@ echo "create table t12_0004(c int)" | $MYSQL_CLIENT_CONNECT
 echo "two insertions"
 echo "insert into t12_0004 values(1),(2)" | $MYSQL_CLIENT_CONNECT
 
-# Ensure there is a small interval between two insertions, for time travel
-sleep 0.001
-
 echo "insert into t12_0004 values(3)" | $MYSQL_CLIENT_CONNECT
 echo "latest snapshot should contain 3 rows"
 echo "select count(*)  from t12_0004" | $MYSQL_CLIENT_CONNECT
 
 ## Get the previous snapshot id of the latest snapshot
-#SNAPSHOT_ID=$(echo "select previous_snapshot_id fuse_snapshot('default','t12_0004') where row_count=3 " | mysql -h127.0.0.1 -P3307 -uroot -s)
 SNAPSHOT_ID=$(echo "select previous_snapshot_id from fuse_snapshot('default','t12_0004') where row_count=3 " | $MYSQL_CLIENT_CONNECT)
 
-echo "counting the data set of first insertion, which should contains 2 rows"
+echo "counting the data set of first insertion, which should contain 2 rows"
 echo "select count(*) from t12_0004 at (snapshot => '$SNAPSHOT_ID')" | $MYSQL_CLIENT_CONNECT
 
-echo "planner_v2: counting the data set of first insertion, which should contains 2 rows"
+echo "planner_v2: counting the data set of first insertion, which should contain 2 rows"
 echo "set enable_planner_v2 = 1;select count(t.c) from t12_0004 at (snapshot => '$SNAPSHOT_ID') as t" | $MYSQL_CLIENT_CONNECT
 
 
 # Get a time point at/after the first insertion.
-# Cannot directly use the timestamp of first insertion, because the time precision of snapshot is higher than timestamp(6). So +1μs.
+TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't12_0004') where row_count=2" | $MYSQL_CLIENT_CONNECT)
 
-TIMEPOINT=$(echo "select cast(timestamp as BIGINT) + 1 from fuse_snapshot('default', 't12_0004') where row_count=2" | $MYSQL_CLIENT_CONNECT)
-
-echo "planner_v2: counting the data set of fisrt insertion by timestamp, which should contains 2 rows"
-echo "set enable_planner_v2 = 1;select count(t.c) from t12_0004 at (TIMESTAMP => $TIMEPOINT::TIMESTAMP) as t" | $MYSQL_CLIENT_CONNECT
+echo "planner_v2: counting the data set of first insertion by timestamp, which should contains 2 rows"
+#echo "set enable_planner_v2 = 1;select count(t.c) from t12_0004 at (TIMESTAMP => $TIMEPOINT::TIMESTAMP) as t" | $MYSQL_CLIENT_CONNECT
+echo "set enable_planner_v2 = 1;select count(t.c) from t12_0004 at (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP) as t" | $MYSQL_CLIENT_CONNECT
 
 ## Drop table.
 echo "drop table t12_0004" | $MYSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Adjust table snapshot timestamp precision to microsecond
  - to be consistent with the precision of SQL timestamp expression 
  - make time travel by timestamp user friendly
- Tweak stateless test script accordingly 

A Quick demo of usage: 

~~~sql
mysql> use default;
Database changed
mysql> create table demo(c varchar);
Query OK, 0 rows affected (0.06 sec)

mysql> insert into demo values('batch1.1'),('batch1.2');
Query OK, 0 rows affected (0.05 sec)

mysql> insert into demo values('batch2.1');
Query OK, 0 rows affected (0.04 sec)

mysql> select timestamp from fuse_snapshot('default', 'demo'); --show snapshot timestamps
+----------------------------+
| timestamp                  |
+----------------------------+
| 2022-06-22 08:58:54.509008 |
| 2022-06-22 08:58:36.254458 |
+----------------------------+
2 rows in set (0.03 sec)
Read 2 rows, 388.00 B in 0.007 sec., 301.83 rows/sec., 57.18 KiB/sec.

mysql> set enable_planner_v2 = 1;  -- time travel of form "select ... from .. at" only supported by planner_v2
Query OK, 0 rows affected (0.03 sec)

mysql> -- travel to the last insertion
mysql> select * from demo at (TIMESTAMP => '2022-06-22 08:58:54.509008'::TIMESTAMP); 
+----------+
| c        |
+----------+
| batch1.1 |
| batch1.2 |
| batch2.1 |
+----------+
3 rows in set (0.03 sec)
Read 3 rows, 64.00 B in 0.004 sec., 677.3 rows/sec., 14.11 KiB/sec.

mysql> -- travel to the first insertion
mysql> select * from demo at (TIMESTAMP => '2022-06-22 08:58:36.254458'::TIMESTAMP); 
+----------+
| c        |
+----------+
| batch1.1 |
| batch1.2 |
+----------+
2 rows in set (0.06 sec)
Read 2 rows, 40.00 B in 0.004 sec., 454.48 rows/sec., 8.88 KiB/sec.

mysql> -- travel to the previous snapshot which is nearest to the given timestamp
mysql> select * from demo at (TIMESTAMP => '2022-06-22 08:58:54.509007'::TIMESTAMP); 
+----------+
| c        |
+----------+
| batch1.1 |
| batch1.2 |
+----------+
2 rows in set (0.03 sec)
Read 2 rows, 40.00 B in 0.004 sec., 493.9 rows/sec., 9.65 KiB/sec.
~~~

## Changelog


- Improvement
- Documentation
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #6121

