### PR TITLE
Improvement(query): fix datatype different cause mysql session distroy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7079,6 +7079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix datatype different cause mysql session distroy.

Before Sundy's pr fix https://github.com/datafuselabs/databend/pull/5980 NULLIF function could cause MySQL session destory.

Because in `Series::check_get(col)?;`  return a err and 

1. not finish the RowWriter.
2. server does not send anything to the client.

So should use match arm, if find the expr return Err(e) , finish the RowWriter and then return Ok(()).

BTW, we should return Ok(()) because we should not destory the session when cause these err.

### Test

I has already rollback Sundy's pr and then test on my laptop. But I don't know how to test the pr on the newest commit version.

```SQL
'root'@mysqldb 21:27:39 [(none)]> set enable_planner_v2=1;
Query OK, 0 rows affected (0.03 sec)
Read 0 rows, 0.00 B in 0.002 sec., 0 rows/sec., 0.00 B/sec.

'root'@mysqldb 21:27:48 [(none)]> SELECT NULLIF(1, 1);
ERROR 1105 (HY000): Code: 1058, displayText = downcast column error, column type: "Null", expected column: "common_datavalues::columns::nullable::NullableColumn".
'root'@mysqldb 21:27:50 [(none)]> SELECT NULLIF(1, 1);
ERROR 1105 (HY000): Code: 1058, displayText = downcast column error, column type: "Null", expected column: "common_datavalues::columns::nullable::NullableColumn".
'root'@mysqldb 21:27:51 [(none)]> SELECT NULLIF(1, 1);
ERROR 1105 (HY000): Code: 1058, displayText = downcast column error, column type: "Null", expected column: "common_datavalues::columns::nullable::NullableColumn".

```

## Changelog

- Improvement


## Related Issues

Fixes #5959

https://github.com/datafuselabs/databend/issues/5959#issuecomment-1154949825

