### PR TITLE
chore(dep): change rust-goldenfile's source to datafuse-extras

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2860,7 +2860,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "goldenfile"
 version = "1.3.0"
-source = "git+https://github.com/psiace/rust-goldenfile?rev=16c5783#16c5783dd13253fed80d40851fd6774256a9c6a8"
+source = "git+https://github.com/datafuse-extras/rust-goldenfile?rev=16c5783#16c5783dd13253fed80d40851fd6774256a9c6a8"
 dependencies = [
  "similar-asserts",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,6 @@ rustc-demangle = { opt-level = 3 }
 parquet2 = { version = "0.13", optional = true, git = "https://github.com/datafuse-extras/parquet2", branch = "parquet2-0.13-patch2" }
 chrono = { git = "https://github.com/datafuse-extras/chrono", rev = "279f590" }
 # https://github.com/calder/rust-goldenfile/pull/7
-goldenfile = { git = "https://github.com/psiace/rust-goldenfile", rev = "16c5783" }
+goldenfile = { git = "https://github.com/datafuse-extras/rust-goldenfile", rev = "16c5783" }
 # https://github.com/tikv/pprof-rs/issues/138
 pprof = { git = "https://github.com/datafuse-extras/pprof-rs", rev = "78b890f" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

change rust-goldenfile's source to datafuse-extras

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

