### PR TITLE
Improvement: limit push down for table `fuse_snapshot` & proc `system$fuse_snapshot`

### DIFF
--- a/query/src/storages/fuse/table_functions/fuse_segments/fuse_segment.rs
+++ b/query/src/storages/fuse/table_functions/fuse_segments/fuse_segment.rs
@@ -43,11 +43,13 @@ impl<'a> FuseSegment<'a> {
         let snapshot_location = tbl.snapshot_loc();
         let snapshot_version = tbl.snapshot_format_version();
         let reader = MetaReaders::table_snapshot_reader(self.ctx.as_ref());
+        let limit = None;
         let snapshots = reader
             .read_snapshot_history(
                 snapshot_location,
                 snapshot_version,
                 tbl.meta_location_generator().clone(),
+                limit,
             )
             .await?;
 

--- a/query/src/storages/fuse/table_functions/fuse_snapshots/fuse_snapshot.rs
+++ b/query/src/storages/fuse/table_functions/fuse_snapshots/fuse_snapshot.rs
@@ -33,7 +33,7 @@ impl<'a> FuseSnapshot<'a> {
         Self { ctx, table }
     }
 
-    pub async fn get_history(&self) -> Result<DataBlock> {
+    pub async fn get_history(&self, limit: Option<usize>) -> Result<DataBlock> {
         let tbl = self.table;
         let snapshot_location = tbl.snapshot_loc();
         let snapshot_version = tbl.snapshot_format_version();
@@ -43,6 +43,7 @@ impl<'a> FuseSnapshot<'a> {
                 snapshot_location,
                 snapshot_version,
                 tbl.meta_location_generator().clone(),
+                limit,
             )
             .await?;
         self.snapshots_to_block(snapshots, snapshot_version)

--- a/query/tests/it/interpreters/interpreter_call.rs
+++ b/query/tests/it/interpreters/interpreter_call.rs
@@ -54,7 +54,7 @@ async fn test_call_fuse_snapshot_interpreter() -> Result<()> {
         assert_eq!(executor.name(), "CallInterpreter");
         let res = executor.execute(None).await;
         assert_eq!(res.is_err(), true);
-        let expect = "Code: 1028, displayText = Function `FUSE_SNAPSHOT` expect to have 2 arguments, but got 0.";
+        let expect = "Code: 1028, displayText = Function `FUSE_SNAPSHOT` expect to have [2, 3] arguments, but got 0.";
         assert_eq!(expect, res.err().unwrap().to_string());
     }
 

--- a/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.result
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.result
@@ -2,11 +2,13 @@ limit 1 using new planner
 1
 limit 0 using new planner
 0
-limit 1 using new planner
+limit 1 using old planner
 1
-limit 0 using new planner
+limit 0 using old planner
 0
-limit 1 using new planner and stored procedure
+limit 1 using stored procedure
 1
-limit 1 using new planner and stored procedure
+limit 0 using stored procedure
 0
+no limits using stored procedure, expects 2
+2

--- a/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.result
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.result
@@ -10,5 +10,11 @@ limit 1 using stored procedure
 1
 limit 0 using stored procedure
 0
+limit 0 using stored procedure, limit as string
+0
 no limits using stored procedure, expects 2
 2
+invalid limit, negative value
+0
+invalid limit, no numeric
+0

--- a/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.result
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.result
@@ -15,6 +15,6 @@ limit 0 using stored procedure, limit as string
 no limits using stored procedure, expects 2
 2
 invalid limit, negative value
-0
+ERROR 1105 (HY000) at line 1: Code: 1005, displayText = sql parser error: Expected a value, found: -.
 invalid limit, no numeric
-0
+ERROR 1105 (HY000) at line 1: Code: 1002, displayText = invalid digit found in string.

--- a/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.result
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.result
@@ -1,0 +1,12 @@
+limit 1 using new planner
+1
+limit 0 using new planner
+0
+limit 1 using new planner
+1
+limit 0 using new planner
+0
+limit 1 using new planner and stored procedure
+1
+limit 1 using new planner and stored procedure
+0

--- a/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.sh
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+
+## setup
+echo "create table t09_0017(c int)" | $MYSQL_CLIENT_CONNECT
+echo "insert into t09_0017 values(1)" | $MYSQL_CLIENT_CONNECT
+echo "insert into t09_0017 values(2)" | $MYSQL_CLIENT_CONNECT
+
+## test limit clause
+echo "limit 1 using new planner"
+echo "set enable_planner_v2 = 1; select * from fuse_snapshot('default', 't09_0017') limit 1" | $MYSQL_CLIENT_CONNECT | wc -l
+echo "limit 0 using new planner"
+echo "set enable_planner_v2 = 1; select * from fuse_snapshot('default', 't09_0017') limit 0" | $MYSQL_CLIENT_CONNECT | wc -l
+
+echo "limit 1 using new planner"
+echo "set enable_planner_v2 = 0; select * from fuse_snapshot('default', 't09_0017') limit 1" | $MYSQL_CLIENT_CONNECT | wc -l
+echo "limit 0 using new planner"
+echo "set enable_planner_v2 = 0; select * from fuse_snapshot('default', 't09_0017') limit 0" | $MYSQL_CLIENT_CONNECT | wc -l
+
+echo "limit 1 using new planner and stored procedure"
+echo "call system\$fuse_snapshot('default', 't09_0017', 1)" | $MYSQL_CLIENT_CONNECT | wc -l
+echo "limit 1 using new planner and stored procedure"
+echo "call system\$fuse_snapshot('default', 't09_0017', 0)" | $MYSQL_CLIENT_CONNECT | wc -l
+## Drop table.
+echo "drop table  t09_0017" | $MYSQL_CLIENT_CONNECT

--- a/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.sh
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.sh
@@ -24,7 +24,13 @@ echo "limit 1 using stored procedure"
 echo "call system\$fuse_snapshot('default', 't09_0017', 1)" | $MYSQL_CLIENT_CONNECT | wc -l
 echo "limit 0 using stored procedure"
 echo "call system\$fuse_snapshot('default', 't09_0017', 0)" | $MYSQL_CLIENT_CONNECT | wc -l
+echo "limit 0 using stored procedure, limit as string"
+echo "call system\$fuse_snapshot('default', 't09_0017', '0')" | $MYSQL_CLIENT_CONNECT | wc -l
 echo "no limits using stored procedure, expects 2"
 echo "call system\$fuse_snapshot('default', 't09_0017')" | $MYSQL_CLIENT_CONNECT | wc -l
+echo "invalid limit, negative value"
+echo "call system\$fuse_snapshot('default', 't09_0017', -1)" | $MYSQL_CLIENT_CONNECT
+echo "invalid limit, no numeric"
+echo "call system\$fuse_snapshot('default', 't09_0017', "a")" | $MYSQL_CLIENT_CONNECT
 ## Drop table.
 echo "drop table  t09_0017" | $MYSQL_CLIENT_CONNECT

--- a/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.sh
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.sh
@@ -15,14 +15,16 @@ echo "set enable_planner_v2 = 1; select * from fuse_snapshot('default', 't09_001
 echo "limit 0 using new planner"
 echo "set enable_planner_v2 = 1; select * from fuse_snapshot('default', 't09_0017') limit 0" | $MYSQL_CLIENT_CONNECT | wc -l
 
-echo "limit 1 using new planner"
+echo "limit 1 using old planner"
 echo "set enable_planner_v2 = 0; select * from fuse_snapshot('default', 't09_0017') limit 1" | $MYSQL_CLIENT_CONNECT | wc -l
-echo "limit 0 using new planner"
+echo "limit 0 using old planner"
 echo "set enable_planner_v2 = 0; select * from fuse_snapshot('default', 't09_0017') limit 0" | $MYSQL_CLIENT_CONNECT | wc -l
 
-echo "limit 1 using new planner and stored procedure"
+echo "limit 1 using stored procedure"
 echo "call system\$fuse_snapshot('default', 't09_0017', 1)" | $MYSQL_CLIENT_CONNECT | wc -l
-echo "limit 1 using new planner and stored procedure"
+echo "limit 0 using stored procedure"
 echo "call system\$fuse_snapshot('default', 't09_0017', 0)" | $MYSQL_CLIENT_CONNECT | wc -l
+echo "no limits using stored procedure, expects 2"
+echo "call system\$fuse_snapshot('default', 't09_0017')" | $MYSQL_CLIENT_CONNECT | wc -l
 ## Drop table.
 echo "drop table  t09_0017" | $MYSQL_CLIENT_CONNECT

--- a/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.sh
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0017_func_fuse_snapshot_history_limit.sh
@@ -29,8 +29,8 @@ echo "call system\$fuse_snapshot('default', 't09_0017', '0')" | $MYSQL_CLIENT_CO
 echo "no limits using stored procedure, expects 2"
 echo "call system\$fuse_snapshot('default', 't09_0017')" | $MYSQL_CLIENT_CONNECT | wc -l
 echo "invalid limit, negative value"
-echo "call system\$fuse_snapshot('default', 't09_0017', -1)" | $MYSQL_CLIENT_CONNECT
+echo "call system\$fuse_snapshot('default', 't09_0017', -1)" | $MYSQL_CLIENT_CONNECT 2>&1
 echo "invalid limit, no numeric"
-echo "call system\$fuse_snapshot('default', 't09_0017', "a")" | $MYSQL_CLIENT_CONNECT
+echo "call system\$fuse_snapshot('default', 't09_0017', "a")" | $MYSQL_CLIENT_CONNECT 2>&1
 ## Drop table.
 echo "drop table  t09_0017" | $MYSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

limit push down for table `fuse_snapshot` & proc `system$fuse_snapshot`

- for "table function" `fuse_snapshot`
   while fetching snapshots, the `limit` that has been pushed down will be respected: no longer traverse all the historical snapshots unconditionally
- For stored procedure `system$fuse_snapshot`
  Anther optional argument is introduced, where the limit can be specified, e.g.
  `call system$fuse_snapshot('default', 'tbl', 1)`

## Changelog

- Improvement
- Documentation
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

