### PR TITLE
chore(deps): bump pprof again for musl 1.2.3

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,6 +13,7 @@ queue_rules:
       # Reference: https://docs.mergify.com/conditions/#validating-all-status-checks
       # We only require linux checks to pass
       - check-success=check
+      - check-success=build_musl
       - check-success=test_unit
       - check-success=test_metactl
       - check-success=test_stateless_standalone_linux

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -63,6 +63,22 @@ jobs:
           target: ${{ matrix.target }}
           profile: debug
 
+  build_musl:
+    runs-on: [self-hosted, x64, Linux]
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # fetch all tags,  metasrv and metaclient need tag as its version.
+          fetch-depth: 0
+      - uses: ./.github/actions/build_debug
+        with:
+          target: ${{ matrix.target }}
+
   test_unit:
     runs-on: [self-hosted, x64, Linux]
     steps:

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -63,8 +63,9 @@ jobs:
           target: ${{ matrix.target }}
           profile: debug
 
+
   build_musl:
-    runs-on: [self-hosted, x64, Linux]
+    runs-on: [self-hosted, x64, Linux, development]
     strategy:
       matrix:
         target:
@@ -75,9 +76,10 @@ jobs:
         with:
           # fetch all tags,  metasrv and metaclient need tag as its version.
           fetch-depth: 0
-      - uses: ./.github/actions/build_debug
+      - uses: ./.github/actions/build_linux
         with:
           target: ${{ matrix.target }}
+          profile: debug
 
   test_unit:
     runs-on: [self-hosted, x64, Linux]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4983,7 +4983,8 @@ dependencies = [
 [[package]]
 name = "pprof"
 version = "0.9.1"
-source = "git+https://github.com/datafuse-extras/pprof-rs?rev=78b890f#78b890feea2c71227ce8670549f46b53ada6b4f0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97149c0eacaa6b8f8cedea99f68bb3a0517fa20f8de8d8c24c1a810f38d235d"
 dependencies = [
  "backtrace",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,11 +2130,11 @@ checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
 
 [[package]]
 name = "debugid"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
- "uuid 0.8.2",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -4982,9 +4982,9 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97149c0eacaa6b8f8cedea99f68bb3a0517fa20f8de8d8c24c1a810f38d235d"
+checksum = "1bba88ee898c63351101af3e60c66c5398c517681ce533eef8caff10ecf11ec1"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -6331,21 +6331,21 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic-common"
-version = "8.8.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f551f902d5642e58039aee6a9021a61037926af96e071816361644983966f540"
+checksum = "9ea2ab8b85d27d49d184438b4b77fbd521b385cc9c5c802f60e784f2df25a03d"
 dependencies = [
  "debugid",
  "memmap2",
  "stable_deref_trait",
- "uuid 0.8.2",
+ "uuid 1.1.2",
 ]
 
 [[package]]
 name = "symbolic-demangle"
-version = "8.8.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4564ca7b4e6eb14105aa8bbbce26e080f6b5d9c4373e67167ab31f7b86443750"
+checksum = "7939b15a1c62633d1fce17f8a7b668312eaa2d3b117bf4ced5e6e77870c43b6a"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,5 +70,3 @@ parquet2 = { version = "0.13", optional = true, git = "https://github.com/datafu
 chrono = { git = "https://github.com/datafuse-extras/chrono", rev = "279f590" }
 # https://github.com/calder/rust-goldenfile/pull/7
 goldenfile = { git = "https://github.com/datafuse-extras/rust-goldenfile", rev = "16c5783" }
-# https://github.com/tikv/pprof-rs/issues/138
-pprof = { git = "https://github.com/datafuse-extras/pprof-rs", rev = "78b890f" }

--- a/common/base/Cargo.toml
+++ b/common/base/Cargo.toml
@@ -35,7 +35,7 @@ hyper = "0.14.19"
 libc = { version = "0.2.126", optional = true }
 parking_lot = "0.12.1"
 poem = { version = "1.3.31", features = ["rustls"] }
-pprof = { version = "0.9.1", features = [
+pprof = { version = "0.10.0", features = [
     "flamegraph",
     "protobuf-codec",
     "protobuf",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

After https://github.com/datafuselabs/databend/pull/6165, musl 1.2.3 is included in our build tools.

It is not possible to revert old commits as we have since modified them.

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

