### PR TITLE
website: Add public as static

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -10,6 +10,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
     title: 'Databend',
+    staticDirectories: ['static', '../docs/public'],
     tagline: 'The modern Cloud Data Warehouse, activate your object storage(S3, Azure Blob, or MinIO) for real-time analytics.',
     url: 'https://databend.rs',
     baseUrl: '/',


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR add `docs/public` as website static, so that we can refer to docs' images by `/img/api/api-handler-mysql.png`.

All content under `docs/public` will be copied to root of website.

## Changelog

- Documentation
