### PR TITLE
[common/tracing] optionally disable stdout logging: metactl export data to stdout thus has to disable stdout logging

### DIFF
--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -48,7 +48,12 @@ pub fn init_default_ut_tracing() {
 
     START.call_once(|| {
         let mut g = GLOBAL_UT_LOG_GUARD.as_ref().lock().unwrap();
-        *g = Some(init_global_tracing("unittest", "_logs_unittest", "DEBUG"));
+        *g = Some(init_global_tracing(
+            "unittest",
+            "_logs_unittest",
+            "DEBUG",
+            None,
+        ));
     });
 }
 
@@ -67,7 +72,12 @@ static GLOBAL_UT_LOG_GUARD: Lazy<Arc<Mutex<Option<Vec<WorkerGuard>>>>> =
 /// DATABEND_JAEGER=on RUST_LOG=trace OTEL_BSP_SCHEDULE_DELAY=1 cargo test
 ///
 // TODO(xp): use DATABEND_JAEGER to assign jaeger server address.
-pub fn init_global_tracing(app_name: &str, dir: &str, level: &str) -> Vec<WorkerGuard> {
+pub fn init_global_tracing(
+    app_name: &str,
+    dir: &str,
+    level: &str,
+    enable_stdout: Option<bool>,
+) -> Vec<WorkerGuard> {
     let mut guards = vec![];
 
     // Enable log compatible layer to convert log record to tracing span.
@@ -94,12 +104,18 @@ pub fn init_global_tracing(app_name: &str, dir: &str, level: &str) -> Vec<Worker
         jaeger_layer = Some(tracing_opentelemetry::layer().with_tracer(tracer));
     }
 
+    let stdout_layer = if enable_stdout == Some(true) {
+        Some(fmt::layer().with_ansi(atty::is(atty::Stream::Stdout)))
+    } else {
+        None
+    };
+
     // Use env RUST_LOG to initialize log if present.
     // Otherwise, use the specified level.
     let directives = env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_x| level.to_string());
     let env_filter = EnvFilter::new(directives);
     let subscriber = Registry::default()
-        .with(fmt::layer().with_ansi(atty::is(atty::Stream::Stdout)))
+        .with(stdout_layer)
         .with(env_filter)
         .with(JsonStorageLayer)
         .with(file_logging_layer)

--- a/docs/doc/50-manage/00-metasrv/20-metasrv-add-remove-node.md
+++ b/docs/doc/50-manage/00-metasrv/20-metasrv-add-remove-node.md
@@ -84,4 +84,3 @@ E.g., `curl -s localhost:28101/v1/cluster/nodes` will display the members in a c
   }
 ]
 ```
-

--- a/metasrv/src/bin/metasrv.rs
+++ b/metasrv/src/bin/metasrv.rs
@@ -43,6 +43,7 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
         "databend-meta",
         conf.log_dir.as_str(),
         conf.log_level.as_str(),
+        None,
     );
 
     tracing::info!("Databend-meta version: {}", METASRV_COMMIT_VERSION.as_str());

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -534,6 +534,7 @@ impl MetaNode {
         )))
     }
 
+    /// Join an existent cluster if `--join` is specified and this meta node is just created, i.e., not opening an already initialized store.
     #[tracing::instrument(level = "info", skip(conf, self))]
     pub async fn join_cluster(&self, conf: &RaftConfig, grpc_api_addr: String) -> MetaResult<()> {
         if conf.join.is_empty() {
@@ -549,6 +550,7 @@ impl MetaNode {
         }
 
         let addrs = &conf.join;
+
         // Joining cluster has to use advertise host instead of listen host.
         let advertise_endpoint = conf.raft_api_advertise_host_endpoint();
         #[allow(clippy::never_loop)]

--- a/query/bin/databend-query.rs
+++ b/query/bin/databend-query.rs
@@ -57,6 +57,7 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
         app_name.as_str(),
         conf.log.dir.as_str(),
         conf.log.level.as_str(),
+        None,
     );
 
     init_default_metrics_recorder();

--- a/tools/metactl/src/main.rs
+++ b/tools/metactl/src/main.rs
@@ -186,7 +186,7 @@ async fn main() -> anyhow::Result<()> {
     let config = Config::parse();
     let raft_config = &config.raft_config;
 
-    let _guards = init_global_tracing("metactl", "./_metactl_log", &config.log_level);
+    let _guards = init_global_tracing("metactl", "./_metactl_log", &config.log_level, Some(false));
 
     eprintln!();
     eprintln!("███╗   ███╗███████╗████████╗ █████╗        ██████╗████████╗██╗     ");


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [common/tracing] optionally disable stdout logging: metactl export data to stdout thus has to disable stdout logging

- Fix: #6099

## Changelog







## Related Issues