### PR TITLE
[metasrv] Refactor: remove unused get RPC.

### DIFF
--- a/common/meta/types/proto/meta.proto
+++ b/common/meta/types/proto/meta.proto
@@ -19,12 +19,6 @@ package meta;
 import "request.proto";
 
 message Empty {}
-message GetRequest { string key = 1; }
-
-message GetReply {
-  bool ok = 1;
-  string value = 2;
-}
 
 message RaftRequest { string data = 1; }
 
@@ -150,7 +144,6 @@ message TxnReply {
 service RaftService {
 
   rpc Write(RaftRequest) returns (RaftReply) {}
-  rpc Get(GetRequest) returns (GetReply) {}
 
   /// Forward a request to other
   rpc Forward(RaftRequest) returns (RaftReply) {}

--- a/common/meta/types/src/message.rs
+++ b/common/meta/types/src/message.rs
@@ -59,6 +59,8 @@ pub struct LeaveRequest {
     Serialize, Deserialize, Debug, Clone, PartialEq, derive_more::From, derive_more::TryInto,
 )]
 pub enum ForwardRequestBody {
+    Ping,
+
     Join(JoinRequest),
     Leave(LeaveRequest),
 
@@ -87,6 +89,9 @@ impl ForwardRequest {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, derive_more::TryInto)]
 #[allow(clippy::large_enum_variant)]
 pub enum ForwardResponse {
+    #[try_into(ignore)]
+    Pong,
+
     Join(()),
     Leave(()),
     AppliedState(AppliedState),

--- a/metasrv/src/meta_service/meta_leader.rs
+++ b/metasrv/src/meta_service/meta_leader.rs
@@ -59,6 +59,8 @@ impl<'a> MetaLeader<'a> {
         tracing::debug!("handle_forwardable_req: {:?}", req);
 
         match req.body {
+            ForwardRequestBody::Ping => Ok(ForwardResponse::Pong),
+
             ForwardRequestBody::Join(join_req) => {
                 self.join(join_req).await?;
                 Ok(ForwardResponse::Join(()))

--- a/metasrv/src/meta_service/meta_service_impl.rs
+++ b/metasrv/src/meta_service/meta_service_impl.rs
@@ -21,8 +21,6 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use common_meta_types::protobuf::raft_service_server::RaftService;
-use common_meta_types::protobuf::GetReply;
-use common_meta_types::protobuf::GetRequest;
 use common_meta_types::protobuf::RaftReply;
 use common_meta_types::protobuf::RaftRequest;
 use common_meta_types::AppliedState;
@@ -107,23 +105,6 @@ impl RaftService for RaftServiceImpl {
 
         let raft_reply = RaftReply::from(res);
         return Ok(tonic::Response::new(raft_reply));
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn get(
-        &self,
-        request: tonic::Request<GetRequest>,
-    ) -> Result<tonic::Response<GetReply>, tonic::Status> {
-        // TODO(xp): this method should be removed along with DFS
-        common_tracing::extract_remote_span_as_parent(&request);
-
-        // let req = request.into_inner();
-        let rst = GetReply {
-            ok: false,
-            value: "".into(),
-        };
-
-        Ok(tonic::Response::new(rst))
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/metasrv/tests/it/tests/service.rs
+++ b/metasrv/tests/it/tests/service.rs
@@ -23,7 +23,8 @@ use common_meta_grpc::ClientHandle;
 use common_meta_grpc::MetaGrpcClient;
 use common_meta_sled_store::openraft::NodeId;
 use common_meta_types::protobuf::raft_service_client::RaftServiceClient;
-use common_meta_types::protobuf::GetRequest;
+use common_meta_types::ForwardRequest;
+use common_meta_types::ForwardRequestBody;
 use common_tracing::tracing;
 use databend_meta::api::GrpcServer;
 use databend_meta::configs;
@@ -184,11 +185,12 @@ impl MetaSrvTestContext {
     pub async fn assert_raft_server_connection(&self) -> anyhow::Result<()> {
         let mut client = self.raft_client().await?;
 
-        let req = tonic::Request::new(GetRequest {
-            key: "ensure-connection".into(),
-        });
-        let rst = client.get(req).await?.into_inner();
-        assert_eq!("", rst.value, "connected");
+        let req = ForwardRequest {
+            forward_to_leader: 0,
+            body: ForwardRequestBody::Ping,
+        };
+
+        client.forward(req).await?;
         Ok(())
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] Refactor: remove unused get RPC.

It is designed for DFS, which is no longer needed.

## Changelog







## Related Issues