### PR TITLE
ci(mergify): Push PR into queue when it passed all checks

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -21,9 +21,17 @@ queue_rules:
       - check-success=test_sqllogic_standalone_linux
 
 pull_request_rules:
+  # Push PR into queue when it passes all checks
   - name: put bug fix pr to queue
     conditions:
       - "#approved-reviews-by>=2"
+      - check-success=check
+      - check-success=test_unit
+      - check-success=test_metactl
+      - check-success=test_stateless_standalone_linux
+      - check-success=test_stateless_cluster_linux
+      - check-success=test_stateful_standalone_linux
+      - check-success=test_sqllogic_standalone_linux
     actions:
       queue:
         name: shared_queue


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci(mergify): Push PR into queue when it passed all checks

## Changelog

- Build/Testing/CI


## Related Issues

Fixes #issue

