### PR TITLE
[metasrv] fix: add step instruction to tests/metactl/test-metactl;

### DIFF
--- a/tests/metactl/test-metactl.sh
+++ b/tests/metactl/test-metactl.sh
@@ -12,23 +12,39 @@ grpc_exported="$SCRIPT_PATH/exported"
 
 chmod +x ./target/${BUILD_PROFILE}/databend-metactl
 
+
+echo " === import into $meta_dir"
 cat $meta_json |
     ./target/${BUILD_PROFILE}/databend-metactl --import --raft-dir "$meta_dir"
 
 sleep 1
 
+
+echo " === export from $meta_dir"
 ./target/${BUILD_PROFILE}/databend-metactl --export --raft-dir "$meta_dir" >$exported
 
+
+echo " === check backup date $meta_json and exported $exported"
 diff $meta_json $exported
 
+
+echo " === start a single node databend-meta"
 # test export from grpc
 chmod +x ./target/${BUILD_PROFILE}/databend-meta
 ./target/${BUILD_PROFILE}/databend-meta --single &
 METASRV_PID=$!
 echo $METASRV_PID
-sleep 0.5
+sleep 1
 
+
+echo " === export data from a running databend-meta to $grpc_exported"
 ./target/${BUILD_PROFILE}/databend-metactl --export --grpc-api-address "127.0.0.1:9191" >$grpc_exported
+
+echo " === exported file data start..."
+cat $grpc_exported 
+echo " === exported file data end"
+
+echo " === check if there is a node record in it"
 grep -Fxq '["raft_state",{"RaftStateKV":{"key":"Id","value":{"NodeId":0}}}]' $grpc_exported
 
 kill $METASRV_PID


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] fix: add step instruction to tests/metactl/test-metactl;

- Fix: The slepp time 0.5 is too short: metactl may start to export before databend-meta finishes starting up.
  Which is found in:
  https://github.com/datafuselabs/databend/pull/6225
  https://github.com/datafuselabs/databend/runs/7050529664?check_suite_focus=true

## Changelog


- Bug Fix




## Related Issues