### PR TITLE
Bump opendal to v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4352,9 +4352,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendal"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc4f8511adde5177e4c8292b5209e7f8d712cae1c01eb517b95eb97f9d06917"
+checksum = "e9e982034fd0b4f142efba461604f5ccb1fb1f962c4e84c8e44ce369f0e3d1f2"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -4374,6 +4374,7 @@ dependencies = [
  "minitrace",
  "once_cell",
  "parking_lot 0.12.1",
+ "percent-encoding",
  "pin-project",
  "quick-xml",
  "reqsign",
@@ -5475,9 +5476,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f087f6f10eeed170005b95c43222ba9006a6bad46da78bf7121f1c74f22a289"
+checksum = "9a6b48d7d1f390bcb0149b4d7a3022f5a927fca173c19413ba17e74936716e39"
 dependencies = [
  "anyhow",
  "backon",

--- a/common/contexts/Cargo.toml
+++ b/common/contexts/Cargo.toml
@@ -12,5 +12,5 @@ test = false
 common-base = { path = "../base" }
 
 async-trait = "0.1.56"
-opendal = { version = "0.9.0", features = ["retry"] }
+opendal = { version = "0.9.1", features = ["retry"] }
 time = "0.3.10"

--- a/common/io/Cargo.toml
+++ b/common/io/Cargo.toml
@@ -29,7 +29,7 @@ chrono-tz = "0.6.1"
 futures = "0.3.21"
 lexical-core = "0.8.5"
 micromarshal = "0.1.0"
-opendal = { version = "0.9.0", features = ["retry"] }
+opendal = { version = "0.9.1", features = ["retry"] }
 serde = { version = "1.0.137", features = ["derive"] }
 time = "0.3.10"
 

--- a/common/streams/Cargo.toml
+++ b/common/streams/Cargo.toml
@@ -29,7 +29,7 @@ async-trait = "0.1.56"
 chrono-tz = "0.6.1"
 csv-async = "1.2.4"
 futures = "0.3.21"
-opendal = { version = "0.9.0", features = ["retry", "compress"] }
+opendal = { version = "0.9.1", features = ["retry", "compress"] }
 pin-project-lite = "0.2.9"
 serde_json = { version = "1.0.81", default-features = false, features = ["preserve_order"] }
 tempfile = "3.3.0"

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -91,7 +91,7 @@ num = "0.4.0"
 num_cpus = "1.13.1"
 octocrab = "0.16.0"
 once_cell = "1.12.0"
-opendal = { version = "0.9.0", features = ["retry", "compress"] }
+opendal = { version = "0.9.1", features = ["retry", "compress"] }
 opensrv-clickhouse = "0.1.0"
 opensrv-mysql = "0.1.0"
 openssl = { version = "0.10.40", features = ["vendored"] }

--- a/query/src/interpreters/interpreter_common.rs
+++ b/query/src/interpreters/interpreter_common.rs
@@ -149,7 +149,7 @@ pub async fn list_files_from_dal(
         .map(|(name, meta)| StageFile {
             path: name,
             size: meta.content_length(),
-            md5: meta.content_md5(),
+            md5: meta.content_md5().map(str::to_string),
             last_modified: meta
                 .last_modified()
                 .map_or(Utc::now(), |t| Utc.timestamp(t.unix_timestamp(), 0)),

--- a/query/src/servers/http/v1/stage.rs
+++ b/query/src/servers/http/v1/stage.rs
@@ -113,7 +113,7 @@ pub async fn upload_to_stage(
             let file = StageFile {
                 path: file_path,
                 size: meta.content_length(),
-                md5: meta.content_md5(),
+                md5: meta.content_md5().map(str::to_string),
                 last_modified: meta.last_modified().map_or(DateTime::default(), |t| {
                     Utc.timestamp(t.unix_timestamp(), 0)
                 }),

--- a/query/src/sessions/session_mgr.rs
+++ b/query/src/sessions/session_mgr.rs
@@ -389,7 +389,7 @@ impl SessionManager {
         let op = op.with_backoff(backon::ExponentialBackoff::default());
         // OpenDAL will send a real request to underlying storage to check whether it works or not.
         // If this check failed, it's highly possible that the users have configured it wrongly.
-        op.check(".databend").await.map_err(|e| {
+        op.check().await.map_err(|e| {
             ErrorCode::StorageUnavailable(format!(
                 "current configured storage is not available: {e}"
             ))

--- a/tests/suites/1_stateful/01_load/01_0001_upload_to_stage.result
+++ b/tests/suites/1_stateful/01_load/01_0001_upload_to_stage.result
@@ -1,2 +1,2 @@
-books.csv 91 NULL
-test/books.csv 91 NULL
+books.csv 91 65305e8ac93284a59fe2cfa911d9c3d9
+test/books.csv 91 65305e8ac93284a59fe2cfa911d9c3d9

--- a/tests/suites/1_stateful/01_load_v2/01_0001_upload_to_stage.result
+++ b/tests/suites/1_stateful/01_load_v2/01_0001_upload_to_stage.result
@@ -1,2 +1,2 @@
-books.csv 91 NULL
-test/books.csv 91 NULL
+books.csv 91 65305e8ac93284a59fe2cfa911d9c3d9
+test/books.csv 91 65305e8ac93284a59fe2cfa911d9c3d9


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

OpenDAL has released v0.9.1: https://github.com/datafuselabs/opendal/discussions/401

With this release, we will fix the following issues:

- Fix https://github.com/datafuselabs/databend/issues/6119
- Fix #6139 
- Fix #5993 

## Changelog

- Bug Fix


