### PR TITLE
fix: deletion of null values

### DIFF
--- a/common/datablocks/tests/it/kernels/data_block_filter.rs
+++ b/common/datablocks/tests/it/kernels/data_block_filter.rs
@@ -146,8 +146,8 @@ fn test_filter_try_as_const_bool() -> Result<()> {
         fn const_val(v: bool) {
             let const_col = ConstColumn::new(Series::from_data(vec![v]), 6);
             let predicate: Arc<dyn Column> = Arc::new(const_col);
-            let block = DataBlock::try_as_const_bool(&predicate);
-            assert!(matches!(block, Ok(Some(p)) if p == v));
+            let r = DataBlock::try_as_const_bool(&predicate);
+            assert!(matches!(r, Ok(Some(p)) if p == v));
         }
         // const values, should return Some(val)
         const_val(true);
@@ -156,16 +156,16 @@ fn test_filter_try_as_const_bool() -> Result<()> {
     {
         // non-const value, should return None
         let predicate = Series::from_data(vec![false]);
-        let block = DataBlock::try_as_const_bool(&predicate);
-        assert!(matches!(block, Ok(None)));
+        let r = DataBlock::try_as_const_bool(&predicate);
+        assert!(matches!(r, Ok(None)));
     }
 
     {
         // const non-bool column , should return Err
         let const_col = ConstColumn::new(Series::from_data(vec![vec![1]]), 6);
         let predicate: Arc<dyn Column> = Arc::new(const_col);
-        let block = DataBlock::try_as_const_bool(&predicate);
-        assert!(matches!(block, Err(_)));
+        let r = DataBlock::try_as_const_bool(&predicate);
+        assert!(matches!(r, Err(_)));
     }
     Ok(())
 }

--- a/common/datablocks/tests/it/kernels/data_block_filter.rs
+++ b/common/datablocks/tests/it/kernels/data_block_filter.rs
@@ -139,3 +139,33 @@ fn test_filter_all_const_data_block() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_filter_try_as_const_bool() -> Result<()> {
+    {
+        fn const_val(v: bool) {
+            let const_col = ConstColumn::new(Series::from_data(vec![v]), 6);
+            let predicate: Arc<dyn Column> = Arc::new(const_col);
+            let block = DataBlock::try_as_const_bool(&predicate);
+            assert!(matches!(block, Ok(Some(p)) if p == v));
+        }
+        // const values, should return Some(val)
+        const_val(true);
+        const_val(false);
+    }
+    {
+        // non-const value, should return None
+        let predicate = Series::from_data(vec![false]);
+        let block = DataBlock::try_as_const_bool(&predicate);
+        assert!(matches!(block, Ok(None)));
+    }
+
+    {
+        // const non-bool column , should return Err
+        let const_col = ConstColumn::new(Series::from_data(vec![vec![1]]), 6);
+        let predicate: Arc<dyn Column> = Arc::new(const_col);
+        let block = DataBlock::try_as_const_bool(&predicate);
+        assert!(matches!(block, Err(_)));
+    }
+    Ok(())
+}

--- a/query/src/interpreters/interpreter_delete.rs
+++ b/query/src/interpreters/interpreter_delete.rs
@@ -56,9 +56,7 @@ impl Interpreter for DeleteInterpreter {
         &self,
         _input_stream: Option<SendableDataBlockStream>,
     ) -> Result<SendableDataBlockStream> {
-        // TODO
-        // 1. check privilege
-        // 2. optimize the plan, at least constant folding?
+        // TODO check privilege
         let catalog_name = self.plan.catalog_name.as_str();
         let db_name = self.plan.database_name.as_str();
         let tbl_name = self.plan.table_name.as_str();

--- a/query/src/storages/fuse/io/read/block_reader.rs
+++ b/query/src/storages/fuse/io/read/block_reader.rs
@@ -152,7 +152,6 @@ impl BlockReader {
             let idx = *col_idx[i];
             let field = self.arrow_schema.fields[idx].clone();
             let column_descriptor = &self.parquet_schema_descriptor.columns()[idx];
-            //let column_meta = &part.columns_meta[&idx];
             let column_meta = &meta
                 .col_metas
                 .get(&(i as u32))

--- a/query/src/storages/fuse/operations/mod.rs
+++ b/query/src/storages/fuse/operations/mod.rs
@@ -27,6 +27,7 @@ mod truncate;
 pub mod util;
 
 pub use fuse_sink::FuseTableSink;
+pub use mutation::delete_from_block;
 pub use operation_log::AppendOperationLogEntry;
 pub use operation_log::TableOperationLog;
 pub use util::column_metas;

--- a/query/src/storages/fuse/operations/mutation/block_filter.rs
+++ b/query/src/storages/fuse/operations/mutation/block_filter.rs
@@ -46,7 +46,8 @@ pub async fn delete_from_block(
             // - if the `filter_expr` is of "constant" function:
             //   for the whole block, whether all of the rows should be kept or dropped
             // - but, the expr may NOT be deterministic, e.g.
-            //   A nullary non-constant func, which returns true, false or NULL randomly
+            //   A nullary non-constant func, which returns (values convertable to) true, false or NULL randomly
+            //   e.g. delete from t now()
             all_the_columns_ids(table)
         } else {
             filter_column_ids
@@ -61,6 +62,7 @@ pub async fn delete_from_block(
     let expr_field = filter_expr.to_data_field(&schema)?;
     let expr_schema = DataSchemaRefExt::create(vec![expr_field]);
 
+    // get the filter
     let expr_exec = ExpressionExecutor::try_create(
         ctx.clone(),
         "filter expression executor (delete) ",
@@ -72,23 +74,25 @@ pub async fn delete_from_block(
     let filter_result = expr_exec.execute(&data_block)?;
 
     let predicates = DataBlock::cast_to_nonull_boolean(filter_result.column(0))?;
-    if predicates.is_const() {
-        let flag = predicates.get_bool(0)?;
-        return if flag {
+    // shortcut, if predicates is const boolean (or can be cast to boolean)
+    if let Some(const_bool) = DataBlock::try_as_const_bool(&predicates)? {
+        return if const_bool {
+            // all the rows should be removed
             Ok(Deletion::Remains(DataBlock::empty_with_schema(
                 data_block.schema().clone(),
             )))
         } else {
-            //return Ok(DataBlock::empty_with_schema(data_block.schema().clone()));
+            // none of the rows should be removed
             Ok(Deletion::NothingDeleted)
         };
     }
 
+    // reverse the filter
     let boolean_col: &BooleanColumn = Series::check_get(&predicates)?;
     let values = boolean_col.values();
-    let boolean_col = BooleanColumn::from_arrow_data(values.not());
+    let filter = BooleanColumn::from_arrow_data(values.not());
 
-    // read the whole block
+    // read the whole block if necessary
     let whole_block = if filtering_whole_block {
         data_block
     } else {
@@ -97,11 +101,11 @@ pub async fn delete_from_block(
         whole_block_reader.read_with_block_meta(block_meta).await?
     };
 
-    // returns the data remains after deletion
-    //let data_block = DataBlock::filter_block_with_bool_column(whole_block, filter_result.column(0))?;
-    let data_block = DataBlock::filter_block_with_bool_column(whole_block, &boolean_col)?;
+    // filter out rows
+    let data_block = DataBlock::filter_block_with_bool_column(whole_block, &filter)?;
 
     let res = if data_block.num_rows() == block_meta.row_count as usize {
+        // false positive, nothing removed indeed
         Deletion::NothingDeleted
     } else {
         Deletion::Remains(data_block)

--- a/tests/suites/0_stateless/03_dml/03_0025_delete_from.result
+++ b/tests/suites/0_stateless/03_dml/03_0025_delete_from.result
@@ -7,3 +7,18 @@ other rows should be kept
 1
 deleted unconditionally
 1
+nullable column cases
+delete with condition "const false" -- all 3 rows should be kept
+1
+normal deletion
+expects one row deleted
+1
+expects null valued row kept
+1
+delete all null valued rows
+expects no null valued row kept
+1
+expects 1 null valued row kept
+1
+deleted unconditionally (with const true)
+1

--- a/tests/suites/0_stateless/03_dml/03_0025_delete_from.result
+++ b/tests/suites/0_stateless/03_dml/03_0025_delete_from.result
@@ -8,7 +8,7 @@ other rows should be kept
 deleted unconditionally
 1
 nullable column cases
-delete with condition "const false" -- all 3 rows should be kept
+delete with condition "const false"
 1
 normal deletion
 expects one row deleted
@@ -21,4 +21,6 @@ expects no null valued row kept
 expects 1 null valued row kept
 1
 deleted unconditionally (with const true)
+1
+deleted with nullary expr now()
 1

--- a/tests/suites/0_stateless/03_dml/03_0025_delete_from.sql
+++ b/tests/suites/0_stateless/03_dml/03_0025_delete_from.sql
@@ -22,4 +22,35 @@ select 'deleted unconditionally';
 delete from t;
 select count(*) = 0 from t;
 
+drop table t all;
+
+-- setup
+select 'nullable column cases';
+create table t (c Int null);
+insert into t values (1),(2),(NULL);
+
+select 'delete with condition "const false" -- all 3 rows should be kept';
+delete from t where 1 = 0;
+select count(*) = 3 from t;
+
+select 'normal deletion';
+delete from t where c = 1;
+select 'expects one row deleted';
+select count(*) = 2 from t;
+select 'expects null valued row kept';
+select count(*) = 1 from t where c IS NULL;
+
+select 'delete all null valued rows';
+delete from t where c IS NULL;
+select 'expects no null valued row kept';
+select count(*) = 0 from t where c IS NULL;
+select 'expects 1 null valued row kept';
+select count(*) = 1 from t where c IS NOT NULL;
+
+select 'deleted unconditionally (with const true)';
+delete from t where 1 = 1;
+select count(*) = 0 from t;
+
+drop table t all;
+
 DROP DATABASE db1;

--- a/tests/suites/0_stateless/03_dml/03_0025_delete_from.sql
+++ b/tests/suites/0_stateless/03_dml/03_0025_delete_from.sql
@@ -29,7 +29,7 @@ select 'nullable column cases';
 create table t (c Int null);
 insert into t values (1),(2),(NULL);
 
-select 'delete with condition "const false" -- all 3 rows should be kept';
+select 'delete with condition "const false"';
 delete from t where 1 = 0;
 select count(*) = 3 from t;
 
@@ -49,6 +49,11 @@ select count(*) = 1 from t where c IS NOT NULL;
 
 select 'deleted unconditionally (with const true)';
 delete from t where 1 = 1;
+select count(*) = 0 from t;
+
+insert into t values (1),(2),(NULL);
+select 'deleted with nullary expr now()';
+delete from t where now();
 select count(*) = 0 from t;
 
 drop table t all;

--- a/tests/suites/0_stateless/03_dml/03_0025_delete_from_v2.result
+++ b/tests/suites/0_stateless/03_dml/03_0025_delete_from_v2.result
@@ -7,3 +7,18 @@ other rows should be kept
 1
 deleted unconditionally
 1
+nullable column cases
+delete with condition "const false" -- all 3 rows should be kept
+1
+normal deletion
+expects one row deleted
+1
+expects null valued row kept
+1
+delete all null valued rows
+expects no null valued row kept
+1
+expects 1 null valued row kept
+1
+deleted unconditionally (with const true)
+1

--- a/tests/suites/0_stateless/03_dml/03_0025_delete_from_v2.result
+++ b/tests/suites/0_stateless/03_dml/03_0025_delete_from_v2.result
@@ -8,7 +8,7 @@ other rows should be kept
 deleted unconditionally
 1
 nullable column cases
-delete with condition "const false" -- all 3 rows should be kept
+delete with condition "const false"
 1
 normal deletion
 expects one row deleted
@@ -21,4 +21,6 @@ expects no null valued row kept
 expects 1 null valued row kept
 1
 deleted unconditionally (with const true)
+1
+deleted with nullary expr now()
 1

--- a/tests/suites/0_stateless/03_dml/03_0025_delete_from_v2.sql
+++ b/tests/suites/0_stateless/03_dml/03_0025_delete_from_v2.sql
@@ -31,7 +31,7 @@ select 'nullable column cases';
 create table t (c Int null);
 insert into t values (1),(2),(NULL);
 
-select 'delete with condition "const false" -- all 3 rows should be kept';
+select 'delete with condition "const false"';
 delete from t where 1 = 0;
 select count(*) = 3 from t;
 
@@ -51,6 +51,11 @@ select count(*) = 1 from t where c IS NOT NULL;
 
 select 'deleted unconditionally (with const true)';
 delete from t where 1 = 1;
+select count(*) = 0 from t;
+
+insert into t values (1),(2),(NULL);
+select 'deleted with nullary expr now()';
+delete from t where now();
 select count(*) = 0 from t;
 
 drop table t all;

--- a/tests/suites/0_stateless/03_dml/03_0025_delete_from_v2.sql
+++ b/tests/suites/0_stateless/03_dml/03_0025_delete_from_v2.sql
@@ -24,4 +24,35 @@ select 'deleted unconditionally';
 delete from t;
 select count(*) = 0 from t;
 
+drop table t all;
+
+-- setup
+select 'nullable column cases';
+create table t (c Int null);
+insert into t values (1),(2),(NULL);
+
+select 'delete with condition "const false" -- all 3 rows should be kept';
+delete from t where 1 = 0;
+select count(*) = 3 from t;
+
+select 'normal deletion';
+delete from t where c = 1;
+select 'expects one row deleted';
+select count(*) = 2 from t;
+select 'expects null valued row kept';
+select count(*) = 1 from t where c IS NULL;
+
+select 'delete all null valued rows';
+delete from t where c IS NULL;
+select 'expects no null valued row kept';
+select count(*) = 0 from t where c IS NULL;
+select 'expects 1 null valued row kept';
+select count(*) = 1 from t where c IS NOT NULL;
+
+select 'deleted unconditionally (with const true)';
+delete from t where 1 = 1;
+select count(*) = 0 from t;
+
+drop table t all;
+
 DROP DATABASE db1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fixing issue 
- https://github.com/datafuselabs/databend/issues/6275

by inverse the result of filter result, instead of the filter expression.

~~~sql
mysql> create table t(c int null);
Query OK, 0 rows affected (0.06 sec)

mysql> insert into t values(1), (2), (NULL);
Query OK, 0 rows affected (0.06 sec)

mysql> delete from t where c=1;
Query OK, 0 rows affected (0.06 sec)

mysql> select * from t;
+------+
| c    |
+------+
|    2 |
| NULL |
+------+
2 rows in set (0.03 sec)
Read 2 rows, 8.00 B in 0.006 sec., 346.05 rows/sec., 1.35 KiB/sec.

mysql> delete from t where c is null;
Query OK, 0 rows affected (0.05 sec)

mysql> select * from t;
+------+
| c    |
+------+
|    2 |
+------+
1 row in set (0.06 sec)
Read 1 rows, 4.00 B in 0.005 sec., 197.37 rows/sec., 789.48 B/sec.

mysql> delete from t where 1=1;
Query OK, 0 rows affected (0.05 sec)

mysql> select * from t;
Query OK, 0 rows affected (0.03 sec)
~~~

## Changelog

- Bug Fix
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #6275

