### PR TITLE
chore(metrics): add metrics for `databend-query/clusters`

### DIFF
--- a/query/src/clusters/metrics.rs
+++ b/query/src/clusters/metrics.rs
@@ -18,3 +18,5 @@ pub static METRIC_CLUSTER_DISCOVERED_NODE_GAUGE: &str = "cluster.discovered_node
 
 pub static METRIC_LABEL_LOCAL_ID: &str = "local_id";
 pub static METRIC_LABEL_FLIGHT_ADDRESS: &str = "flight_address";
+pub static METRIC_LABEL_CLUSTER_ID: &str = "cluster_id";
+pub static METRIC_LABEL_TENANT_ID: &str = "tenant_id";

--- a/query/src/clusters/metrics.rs
+++ b/query/src/clusters/metrics.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod cluster;
-mod metrics;
+pub static METRIC_CLUSTER_HEARTBEAT_COUNT: &str = "cluster.heartbeat.count";
+pub static METRIC_CLUSTER_ERROR_COUNT: &str = "cluster.error.count";
+pub static METRIC_CLUSTER_DISCOVERED_NODE_GAUGE: &str = "cluster.discovered_node.gauge";
 
-pub use cluster::Cluster;
-pub use cluster::ClusterDiscovery;
+pub static METRIC_LABEL_LOCAL_ID: &str = "local_id";
+pub static METRIC_LABEL_FLIGHT_ADDRESS: &str = "flight_address";


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add some metrics for `databend-query/clusters`. Partially #5716 

Metrics added:
- HeartBeat failure count
- Error count in ClusterDiscovery
- Discovered node count in the cluster

Note: I am not sure if we need to add the labels for `cluster_id` and `tenant_id`. If so, we may need to add the corresponding fields to `ClusterDiscovery` and `ClusterHeartBeat` struct. 

## Changelog
- Not for changelog (changelog entry is not required)

## Related Issues

Partially of #5716 
