### PR TITLE
ci(mergify): Only embark PR while it's ready for review

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -23,9 +23,10 @@ queue_rules:
 
 pull_request_rules:
   # Push PR into queue when it passes all checks
-  - name: put bug fix pr to queue
+  - name: put approved pr to queue
     conditions:
       - "#approved-reviews-by>=2"
+      - -draft
       - check-success=check
       - check-success=test_unit
       - check-success=test_metactl
@@ -41,6 +42,7 @@ pull_request_rules:
   - name: ping author on conflicts
     conditions:
       - conflict
+      - -draft
       - "#approved-reviews-by >= 2"
     actions:
       comment:
@@ -63,6 +65,7 @@ pull_request_rules:
   - name: Check PR description
     conditions:
       - author!=Mergify
+      - -draft
       - '-body~=I hereby agree to the terms of the CLA available at: https:\/\/databend\.rs\/dev\/policies\/cla\/'
       - "-body~=Summary"
       - "-body~=Changelog"


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci(mergify): Only embark PR while it's ready for review

## Changelog

- Build/Testing/CI


