### PR TITLE
ci(mergify): Fix build_musl not used correctly

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,7 +13,8 @@ queue_rules:
       # Reference: https://docs.mergify.com/conditions/#validating-all-status-checks
       # We only require linux checks to pass
       - check-success=check
-      - check-success=build_musl
+      - check-success=build_musl (x86_64-unknown-linux-musl)
+      - check-success=build_musl (aarch64-unknown-linux-musl)
       - check-success=test_unit
       - check-success=test_metactl
       - check-success=test_stateless_standalone_linux
@@ -28,6 +29,8 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - -draft
       - check-success=check
+      - check-success=build_musl (x86_64-unknown-linux-musl)
+      - check-success=build_musl (aarch64-unknown-linux-musl)
       - check-success=test_unit
       - check-success=test_metactl
       - check-success=test_stateless_standalone_linux


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci(mergify): Fix build_musl not used correctly

## Changelog

- Build/Testing/CI


