### PR TITLE
Improve(deserializer): fix nullable csv deser

### DIFF
--- a/common/datavalues/src/types/deserializations/nullable.rs
+++ b/common/datavalues/src/types/deserializations/nullable.rs
@@ -69,6 +69,20 @@ impl TypeDeserializer for NullableDeserializer {
         }
     }
 
+    fn de_text_json<R: BufferRead>(
+        &mut self,
+        reader: &mut R,
+        format: &FormatSettings,
+    ) -> Result<()> {
+        if reader.ignore_insensitive_bytes(b"null")? {
+            self.de_default(format);
+            return Ok(());
+        }
+        self.inner.de_text_json(reader, format)?;
+        self.bitmap.push(true);
+        Ok(())
+    }
+
     // TODO: support null text setting
     fn de_text<R: BufferRead>(&mut self, reader: &mut R, format: &FormatSettings) -> Result<()> {
         if reader.ignore_insensitive_bytes(b"null")? {
@@ -91,6 +105,27 @@ impl TypeDeserializer for NullableDeserializer {
         }
         self.inner.de_text_quoted(reader, format)?;
         self.bitmap.push(true);
+        Ok(())
+    }
+
+    fn de_text_csv<R: BufferRead>(
+        &mut self,
+        reader: &mut R,
+        format: &FormatSettings,
+    ) -> Result<()> {
+        if reader.eof()? {
+            self.de_default(format);
+        } else {
+            reader.ignore_insensitive_bytes(b"null")?;
+            let buffer = reader.fill_buf()?;
+            if !buffer.is_empty() && (buffer[0] == b'\r' || buffer[0] == b'\n' || buffer[0] == b',')
+            {
+                self.de_default(format);
+            } else {
+                self.inner.de_text_csv(reader, format)?;
+                self.bitmap.push(true);
+            }
+        }
         Ok(())
     }
 

--- a/common/io/src/buffer/buffer_read_datetime_ext.rs
+++ b/common/io/src/buffer/buffer_read_datetime_ext.rs
@@ -57,10 +57,12 @@ where R: BufferRead
             .map_err_to_code(ErrorCode::BadBytes, || "Cannot convert value to utf8")?;
         let res = tz
             .datetime_from_str(v, "%Y-%m-%d %H:%M:%S%.f")
+            .or_else(|_| tz.datetime_from_str(v, "%Y-%m-%dT%H:%M:%S"))
             .map_err_to_code(ErrorCode::BadBytes, || {
                 format!("Cannot parse value:{:?} to DateTime type", v)
             })?;
 
+        self.ignore(|b| b == b'z' || b == b'Z')?;
         if self.ignore_byte(b'.')? {
             buf.clear();
             let size = self.keep_read(&mut buf, |f| (b'0'..=b'9').contains(&f))?;

--- a/query/src/formats/format_csv.rs
+++ b/query/src/formats/format_csv.rs
@@ -241,7 +241,7 @@ impl InputFormat for CsvInputFormat {
                 }
             } else {
                 if (!memory_reader.ignore_white_spaces_and_byte(b'\n')?
-                    & !memory_reader.ignore_white_spaces_and_byte(b'\r')?)
+                    && !memory_reader.ignore_white_spaces_and_byte(b'\r')?)
                     && !memory_reader.eof()?
                 {
                     return Err(ErrorCode::BadBytes(format!(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Improve deserializer

1. support datetime`%Y-%m-%dT%H:%M:%S` pattern
2. fix nullable deserializer


## Changelog

 
- Bug Fix
 

## Related Issues

Fixes #issue

