### PR TITLE
[meta/schemaapi] refactor: introduce trait AsKVApi to upcast a SchemaApi to KVApi when a test needs both SchemaApi and KVApi

### DIFF
--- a/common/meta/api/src/kv_api.rs
+++ b/common/meta/api/src/kv_api.rs
@@ -72,3 +72,13 @@ impl<U: KVApi, T: Deref<Target = U> + Send + Sync> KVApi for T {
         self.deref().transaction(txn).await
     }
 }
+
+pub trait AsKVApi {
+    fn as_kv_api(&self) -> &dyn KVApi;
+}
+
+impl<T: KVApi> AsKVApi for T {
+    fn as_kv_api(&self) -> &dyn KVApi {
+        self
+    }
+}

--- a/common/meta/api/src/lib.rs
+++ b/common/meta/api/src/lib.rs
@@ -23,6 +23,7 @@ mod schema_api_impl;
 mod schema_api_keys;
 mod schema_api_test_suite;
 
+pub use kv_api::AsKVApi;
 pub use kv_api::KVApi;
 pub use kv_api::KVApiBuilder;
 pub use kv_api_key::KVApiKey;

--- a/common/meta/embedded/tests/it/schema_api_impl.rs
+++ b/common/meta/embedded/tests/it/schema_api_impl.rs
@@ -100,7 +100,7 @@ async fn test_meta_embedded_table_list() -> anyhow::Result<()> {
 async fn test_meta_embedded_table_drop_out_of_retention_time_history() -> anyhow::Result<()> {
     let mt = MetaEmbedded::new_temp().await?;
     SchemaApiTestSuite {}
-        .table_drop_out_of_retention_time_history(&mt, &mt)
+        .table_drop_out_of_retention_time_history(&mt)
         .await
 }
 
@@ -108,7 +108,7 @@ async fn test_meta_embedded_table_drop_out_of_retention_time_history() -> anyhow
 async fn test_meta_embedded_database_drop_out_of_retention_time_history() -> anyhow::Result<()> {
     let mt = MetaEmbedded::new_temp().await?;
     SchemaApiTestSuite {}
-        .database_drop_out_of_retention_time_history(&mt, &mt)
+        .database_drop_out_of_retention_time_history(&mt)
         .await
 }
 
@@ -116,7 +116,7 @@ async fn test_meta_embedded_database_drop_out_of_retention_time_history() -> any
 async fn test_meta_embedded_database_gc_out_of_retention_time() -> anyhow::Result<()> {
     let mt = MetaEmbedded::new_temp().await?;
     SchemaApiTestSuite {}
-        .database_gc_out_of_retention_time(&mt, &mt)
+        .database_gc_out_of_retention_time(&mt)
         .await
 }
 
@@ -124,7 +124,7 @@ async fn test_meta_embedded_database_gc_out_of_retention_time() -> anyhow::Resul
 async fn test_meta_embedded_table_gc_out_of_retention_time() -> anyhow::Result<()> {
     let mt = MetaEmbedded::new_temp().await?;
     SchemaApiTestSuite {}
-        .table_gc_out_of_retention_time(&mt, &mt)
+        .table_gc_out_of_retention_time(&mt)
         .await
 }
 

--- a/common/meta/raft-store/tests/it/state_machine/schema_api_impl.rs
+++ b/common/meta/raft-store/tests/it/state_machine/schema_api_impl.rs
@@ -153,7 +153,7 @@ async fn test_meta_embedded_table_drop_out_of_retention_time_history() -> anyhow
     let sm = StateMachine::open(&tc.raft_config, 1).await?;
 
     SchemaApiTestSuite {}
-        .table_drop_out_of_retention_time_history(&sm, &sm)
+        .table_drop_out_of_retention_time_history(&sm)
         .await
 }
 
@@ -165,7 +165,7 @@ async fn test_meta_embedded_database_drop_out_of_retention_time_history() -> any
     let sm = StateMachine::open(&tc.raft_config, 1).await?;
 
     SchemaApiTestSuite {}
-        .database_drop_out_of_retention_time_history(&sm, &sm)
+        .database_drop_out_of_retention_time_history(&sm)
         .await
 }
 
@@ -177,7 +177,7 @@ async fn test_meta_embedded_database_gc_out_of_retention_time() -> anyhow::Resul
     let sm = StateMachine::open(&tc.raft_config, 1).await?;
 
     SchemaApiTestSuite {}
-        .database_gc_out_of_retention_time(&sm, &sm)
+        .database_gc_out_of_retention_time(&sm)
         .await
 }
 
@@ -189,7 +189,7 @@ async fn test_meta_embedded_table_gc_out_of_retention_time() -> anyhow::Result<(
     let sm = StateMachine::open(&tc.raft_config, 1).await?;
 
     SchemaApiTestSuite {}
-        .table_gc_out_of_retention_time(&sm, &sm)
+        .table_gc_out_of_retention_time(&sm)
         .await
 }
 

--- a/metasrv/tests/it/grpc/metasrv_grpc_schema_api.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_schema_api.rs
@@ -231,7 +231,7 @@ async fn test_meta_gpc_client_table_drop_out_of_retention_time_history() -> anyh
     )?;
 
     SchemaApiTestSuite {}
-        .table_drop_out_of_retention_time_history(client.as_ref(), client.as_ref())
+        .table_drop_out_of_retention_time_history(client.as_ref())
         .await
 }
 
@@ -252,7 +252,7 @@ async fn test_meta_gpc_client_database_drop_out_of_retention_time_history() -> a
     )?;
 
     SchemaApiTestSuite {}
-        .database_drop_out_of_retention_time_history(client.as_ref(), client.as_ref())
+        .database_drop_out_of_retention_time_history(client.as_ref())
         .await
 }
 
@@ -273,7 +273,7 @@ async fn test_meta_gpc_client_database_gc_out_of_retention_time() -> anyhow::Res
     )?;
 
     SchemaApiTestSuite {}
-        .database_gc_out_of_retention_time(client.as_ref(), client.as_ref())
+        .database_gc_out_of_retention_time(client.as_ref())
         .await
 }
 
@@ -294,7 +294,7 @@ async fn test_meta_gpc_client_table_gc_out_of_retention_time() -> anyhow::Result
     )?;
 
     SchemaApiTestSuite {}
-        .table_gc_out_of_retention_time(client.as_ref(), client.as_ref())
+        .table_gc_out_of_retention_time(client.as_ref())
         .await
 }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [meta/schemaapi] refactor: introduce trait AsKVApi to upcast a SchemaApi to KVApi when a test needs both SchemaApi and KVApi

## Changelog




- Improvement


## Related Issues