### PR TITLE
Revert "chore: try to bump jemalloc and fix musl link"

### DIFF
--- a/.github/actions/build_linux/action.yml
+++ b/.github/actions/build_linux/action.yml
@@ -15,13 +15,6 @@ runs:
       with:
         image: ${{ inputs.target }}
 
-    - name: Set musl rustflags
-      if: contains(inputs.target, 'musl')
-      shell: bash
-      run: |
-        flags="-C target-feature=-crt-static"
-        echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV
-
     - name: Build Debug
       if: inputs.profile == 'debug'
       shell: bash

--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Set musl rustflags
         if: matrix.platform == 'musl'
         run: |
-          flags="-C link-arg=-Wl,--compress-debug-sections=zlib-gabi -C target-feature=-crt-static"
+          flags="-C link-arg=-Wl,--compress-debug-sections=zlib-gabi"
           echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV
       - name: Build Binary
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6612,9 +6612,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.5.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
+checksum = "eb833c46ecbf8b6daeccb347cefcabf9c1beb5c9b0f853e1cec45632d9963e69"
 dependencies = [
  "libc",
  "paste",
@@ -6623,9 +6623,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.1+5.3.0-patched"
+version = "0.4.3+5.2.1-patched.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931e876f91fed0827f863a2d153897790da0b24d882c721a79cb3beb0b903261"
+checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
 dependencies = [
  "cc",
  "fs_extra",

--- a/common/base/Cargo.toml
+++ b/common/base/Cargo.toml
@@ -43,8 +43,8 @@ pprof = { version = "0.10.0", features = [
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = { version = "1.0.81", default-features = false, features = ["raw_value"] }
 serde_yaml = { version = "0.8.24", default-features = false }
-tikv-jemalloc-ctl = { version = "0.5.0", optional = true }
-tikv-jemalloc-sys = "0.5.0"
+tikv-jemalloc-ctl = { version = "0.4.2", optional = true }
+tikv-jemalloc-sys = "0.4.3"
 tokio = { version = "1.19.2", features = ["full"] }
 toml = { version = "0.5.9", default-features = false }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Reverts datafuselabs/databend#6268

The musl binary does not work properly with the new rustflags enabled

## Changelog

- Not for changelog (changelog entry is not required)

