### PR TITLE
[doc ] fix link 404 of volcengine ecs

### DIFF
--- a/docs/doc/70-performance/07-volcengine-tos-performance.md
+++ b/docs/doc/70-performance/07-volcengine-tos-performance.md
@@ -7,7 +7,7 @@ description:
 
 :::tip
 
-* Hardware: **[Volcengine](https://www.volcengine.com/product/**ecs**)**(ecs.g1ie.8xlarge), 32 vCPU
+* Hardware: **[Volcengine](https://www.volcengine.com/product/ecs)**(ecs.g1ie.8xlarge), 32 vCPU
 * Storage: [TOS](https://www.volcengine.com/product/tos) (cn-beijing)
 * Dataset: [ontime](https://transtats.bts.gov/PREZIP/), 60.8 GB Raw CSV Data, 202687654 records
 * Databend: [v0.7.88-nightly](https://github.com/datafuselabs/databend/releases/tag/v0.7.32-nightly)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix link 404 of volcengine ecs. ref: https://databend.rs/doc/performance/volcengine-tos-performance

## Changelog

- Documentation

## Related Issues

Fixes #issue

