### PR TITLE
Feature: add cluster status doc, refactor restore new cluster test, r…

### DIFF
--- a/docs/doc/50-manage/00-metasrv/60-metasrv-status.md
+++ b/docs/doc/50-manage/00-metasrv/60-metasrv-status.md
@@ -1,0 +1,63 @@
+---
+title: Databend Meta Cluster Status
+sidebar_label: Meta Service Status
+description: 
+  Databend Meta Service Cluster Status
+---
+
+## Cluster Status
+
+The simplest way to see the cluster status is to cURL the status HTTP API `HTTP_ADDRESS:HTTP_PORT/v1/status`, the API will return json format of cluster status(after pretty formating):
+
+``` json
+{
+    "id":1,
+    "endpoint":"localhost:29103",
+    "db_size":1050036,
+    "state":"Leader",
+    "is_leader":true,
+    "current_term":46,
+    "last_log_index":14,
+    "last_applied":{
+        "term":46,
+        "index":14
+    },
+    "leader":{
+        "name":"1",
+        "endpoint":{
+            "addr":"localhost",
+            "port":29103
+        },
+        "grpc_api_addr":"0.0.0.0:19191"
+    },
+    "voters":[
+        {
+            "name":"1",
+            "endpoint":{
+                "addr":"localhost",
+                "port":29103
+            },
+            "grpc_api_addr":"0.0.0.0:19191"
+        },
+        {
+            "name":"2",
+            "endpoint":{
+                "addr":"localhost",
+                "port":29203
+            },
+            "grpc_api_addr":"0.0.0.0:29191"
+        },
+        {
+            "name":"3",
+            "endpoint":{
+                "addr":"localhost",
+                "port":29303
+            },
+            "grpc_api_addr":"0.0.0.0:39191"
+        }
+    ],
+    "non_voters":[
+
+    ]
+}
+```

--- a/metasrv/src/api/http/v1/cluster_state.rs
+++ b/metasrv/src/api/http/v1/cluster_state.rs
@@ -37,7 +37,7 @@ pub async fn nodes_handler(meta_node: Data<&Arc<MetaNode>>) -> poem::Result<impl
 }
 
 #[poem::handler]
-pub async fn state_handler(meta_node: Data<&Arc<MetaNode>>) -> poem::Result<impl IntoResponse> {
+pub async fn status_handler(meta_node: Data<&Arc<MetaNode>>) -> poem::Result<impl IntoResponse> {
     let status = meta_node.get_status().await.map_err(|e| {
         poem::Error::from_string(
             format!("failed to get status: {}", e),

--- a/metasrv/src/api/http_service.rs
+++ b/metasrv/src/api/http_service.rs
@@ -54,8 +54,8 @@ impl HttpService {
                 get(super::http::v1::cluster_state::nodes_handler),
             )
             .at(
-                "/v1/cluster/state",
-                get(super::http::v1::cluster_state::state_handler),
+                "/v1/cluster/status",
+                get(super::http::v1::cluster_state::status_handler),
             )
             .at(
                 "/v1/metrics",

--- a/metasrv/tests/it/api/http/cluster_state_test.rs
+++ b/metasrv/tests/it/api/http/cluster_state_test.rs
@@ -23,7 +23,7 @@ use common_base::base::Stoppable;
 use common_meta_types::Node;
 use common_tracing::tracing;
 use databend_meta::api::http::v1::cluster_state::nodes_handler;
-use databend_meta::api::http::v1::cluster_state::state_handler;
+use databend_meta::api::http::v1::cluster_state::status_handler;
 use databend_meta::api::HttpService;
 use databend_meta::meta_service::MetaNode;
 use poem::get;
@@ -102,12 +102,12 @@ async fn test_cluster_state() -> common_exception::Result<()> {
         .await?;
 
     let cluster_router = Route::new()
-        .at("/cluster/state", get(state_handler))
+        .at("/cluster/status", get(status_handler))
         .data(meta_node1.clone());
     let response = cluster_router
         .call(
             Request::builder()
-                .uri(Uri::from_static("/cluster/state"))
+                .uri(Uri::from_static("/cluster/status"))
                 .method(Method::GET)
                 .finish(),
         )

--- a/metasrv/tests/it/api/http/cluster_state_test.rs
+++ b/metasrv/tests/it/api/http/cluster_state_test.rs
@@ -155,7 +155,7 @@ async fn test_http_service_cluster_state() -> common_exception::Result<()> {
     let mut srv = HttpService::create(tc1.config, meta_node1);
 
     // test cert is issued for "localhost"
-    let state_url = format!("https://{}:30003/v1/cluster/state", TEST_CN_NAME);
+    let state_url = format!("https://{}:30003/v1/cluster/status", TEST_CN_NAME);
     let node_url = format!("https://{}:30003/v1/cluster/nodes", TEST_CN_NAME);
 
     // load cert
@@ -173,7 +173,7 @@ async fn test_http_service_cluster_state() -> common_exception::Result<()> {
     assert!(resp.is_ok());
     let resp = resp.unwrap();
     assert!(resp.status().is_success());
-    assert_eq!("/v1/cluster/state", resp.url().path());
+    assert_eq!("/v1/cluster/status", resp.url().path());
     let state_json = resp.json::<serde_json::Value>().await.unwrap();
     assert_eq!(state_json["voters"].as_array().unwrap().len(), 2);
     assert_eq!(state_json["non_voters"].as_array().unwrap().len(), 0);

--- a/tests/metactl/config/new-databend-meta-node-1.toml
+++ b/tests/metactl/config/new-databend-meta-node-1.toml
@@ -6,7 +6,7 @@ admin_api_address  = "0.0.0.0:28101"
 grpc_api_address   = "0.0.0.0:19191"
 
 [raft_config]
-id            = 1
+id            = 4
 raft_dir      = "./.databend/new_meta1"
 raft_api_port = 29103
 

--- a/tests/metactl/config/new-databend-meta-node-2.toml
+++ b/tests/metactl/config/new-databend-meta-node-2.toml
@@ -6,7 +6,7 @@ admin_api_address  = "0.0.0.0:28201"
 grpc_api_address   = "0.0.0.0:29191"
 
 [raft_config]
-id            = 2
+id            = 5
 raft_dir      = "./.databend/new_meta2"
 raft_api_port = 29203
 

--- a/tests/metactl/config/new-databend-meta-node-3.toml
+++ b/tests/metactl/config/new-databend-meta-node-3.toml
@@ -6,7 +6,7 @@ admin_api_address  = "0.0.0.0:28301"
 grpc_api_address   = "0.0.0.0:39191"
 
 [raft_config]
-id            = 3
+id            = 6
 raft_dir      = "./.databend/new_meta3"
 raft_api_port = 29303
 

--- a/tests/metactl/test-metactl-restore-new-cluster.sh
+++ b/tests/metactl/test-metactl-restore-new-cluster.sh
@@ -17,7 +17,7 @@ python3 scripts/ci/wait_tcp.py --timeout 5 --port 28202
 nohup ./target/debug/databend-meta --config-file=./tests/metactl/config/databend-meta-node-3.toml &
 python3 scripts/ci/wait_tcp.py --timeout 5 --port 28302
 
-curl -sL http://127.0.0.1:28101/v1/cluster/state
+curl -sL http://127.0.0.1:28101/v1/cluster/status
 
 echo "stop 3 meta node cluster"
 killall databend-meta
@@ -31,9 +31,9 @@ echo "export meta node data"
 rm -fr .databend/
 
 echo "import old meta node data to new cluster"
-./target/debug/databend-metactl --import --raft-dir ./.databend/new_meta1 --id=1 --db meta.db --initial-cluster 1=localhost:29103,0.0.0.0:19191 2=localhost:29203,0.0.0.0:29191 3=localhost:29303,0.0.0.0:39191
-./target/debug/databend-metactl --import --raft-dir ./.databend/new_meta2 --id=2 --db meta.db --initial-cluster 1=localhost:29103,0.0.0.0:19191 2=localhost:29203,0.0.0.0:29191 3=localhost:29303,0.0.0.0:39191
-./target/debug/databend-metactl --import --raft-dir ./.databend/new_meta3 --id=3 --db meta.db --initial-cluster 1=localhost:29103,0.0.0.0:19191 2=localhost:29203,0.0.0.0:29191 3=localhost:29303,0.0.0.0:39191
+./target/debug/databend-metactl --import --raft-dir ./.databend/new_meta1 --id=4 --db meta.db --initial-cluster 4=localhost:29103,0.0.0.0:19191 5=localhost:29203,0.0.0.0:29191 6=localhost:29303,0.0.0.0:39191
+./target/debug/databend-metactl --import --raft-dir ./.databend/new_meta2 --id=5 --db meta.db --initial-cluster 4=localhost:29103,0.0.0.0:19191 5=localhost:29203,0.0.0.0:29191 6=localhost:29303,0.0.0.0:39191
+./target/debug/databend-metactl --import --raft-dir ./.databend/new_meta3 --id=6 --db meta.db --initial-cluster 4=localhost:29103,0.0.0.0:19191 5=localhost:29203,0.0.0.0:29191 6=localhost:29303,0.0.0.0:39191
 
 echo "start 3 new meta node cluster"
 nohup ./target/debug/databend-meta --config-file=./tests/metactl/config/new-databend-meta-node-1.toml &
@@ -46,6 +46,6 @@ nohup ./target/debug/databend-meta --config-file=./tests/metactl/config/new-data
 python3 scripts/ci/wait_tcp.py --timeout 5 --port 39191
 
 echo "check new cluster state"
-curl -sL http://127.0.0.1:28101/v1/cluster/state | grep "\"voters\":\[{\"name\":\"1\",\"endpoint\":{\"addr\":\"localhost\",\"port\":29103},\"grpc_api_addr\":\"0.0.0.0:19191\"},{\"name\":\"2\",\"endpoint\":{\"addr\":\"localhost\",\"port\":29203},\"grpc_api_addr\":\"0.0.0.0:29191\"},{\"name\":\"3\",\"endpoint\":{\"addr\":\"localhost\",\"port\":29303},\"grpc_api_addr\":\"0.0.0.0:39191\"}\]"
+curl -sL http://127.0.0.1:28101/v1/cluster/status | grep "\"voters\":\[{\"name\":\"4\",\"endpoint\":{\"addr\":\"localhost\",\"port\":29103},\"grpc_api_addr\":\"0.0.0.0:19191\"},{\"name\":\"5\",\"endpoint\":{\"addr\":\"localhost\",\"port\":29203},\"grpc_api_addr\":\"0.0.0.0:29191\"},{\"name\":\"6\",\"endpoint\":{\"addr\":\"localhost\",\"port\":29303},\"grpc_api_addr\":\"0.0.0.0:39191\"}\]"
 
 killall databend-meta

--- a/tools/metactl/src/snapshot.rs
+++ b/tools/metactl/src/snapshot.rs
@@ -73,7 +73,7 @@ pub async fn import_data(config: &Config) -> anyhow::Result<()> {
     clear()?;
     let max_log_id = import_from(config.db.clone())?;
 
-    if config.initial_cluster.is_empty() || config.raft_config.id == 0 {
+    if config.initial_cluster.is_empty() {
         return Ok(());
     }
     init_new_cluster(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. add /cluster/status doc.
2. rename /cluster/state api to /cluster/status
3. refactor restore meta data to new cluster test.
4. when import meta data as init new cluster, id can be 0.

## Changelog

- Improvement
- Documentation

## Related Issues

Fixes #issue

