### PR TITLE
improve(planner): optimize exists subquery

### DIFF
--- a/query/src/sql/optimizer/heuristic/subquery_rewriter.rs
+++ b/query/src/sql/optimizer/heuristic/subquery_rewriter.rs
@@ -35,6 +35,7 @@ use crate::sql::plans::CrossApply;
 use crate::sql::plans::EvalScalar;
 use crate::sql::plans::FunctionCall;
 use crate::sql::plans::JoinType;
+use crate::sql::plans::Limit;
 use crate::sql::plans::LogicalInnerJoin;
 use crate::sql::plans::Max1Row;
 use crate::sql::plans::OrExpr;
@@ -169,11 +170,18 @@ impl SubqueryRewriter {
                         return Ok((result, UnnestResult::SimpleJoin));
                     }
                 }
+                let mut subquery_expr = subquery.subquery.clone();
+                // Wrap Limit to current subquery
+                let limit = Limit {
+                    limit: Some(1),
+                    offset: 0,
+                };
+                subquery_expr = SExpr::create_unary(limit.into(), subquery_expr.clone());
 
-                // We will rewrite EXISTS subquery into the form `COUNT(*) > 0`.
+                // We will rewrite EXISTS subquery into the form `COUNT(*) = 1`.
                 // In contrast, NOT EXISTS subquery will be rewritten into `COUNT(*) = 0`.
                 // For example, `EXISTS(SELECT a FROM t WHERE a > 1)` will be rewritten into
-                // `(SELECT COUNT(*) > 0 FROM t WHERE a > 1)`
+                // `(SELECT COUNT(*) = 1 FROM t WHERE a > 1 LIMIT 1)`.
                 let agg_func = AggregateFunctionFactory::instance().get("count", vec![], vec![])?;
                 let agg_func_index = self.metadata.write().add_column(
                     "count(*)".to_string(),
@@ -198,18 +206,14 @@ impl SubqueryRewriter {
                     from_distinct: false,
                 };
 
-                // COUNT(*) > 0 or COUNT(*) = 0
+                // COUNT(*) = 1 or COUNT(*) = 0
                 let compare_index = self.metadata.write().add_column(
                     "subquery".to_string(),
                     BooleanType::new_impl(),
                     None,
                 );
                 let compare = ComparisonExpr {
-                    op: if subquery.typ == SubqueryType::Exists {
-                        ComparisonOp::GT
-                    } else {
-                        ComparisonOp::Equal
-                    },
+                    op: ComparisonOp::Equal,
                     left: Box::new(
                         BoundColumnRef {
                             column: ColumnBinding {
@@ -224,7 +228,11 @@ impl SubqueryRewriter {
                     ),
                     right: Box::new(
                         ConstantExpr {
-                            value: DataValue::Int64(0),
+                            value: if SubqueryType::Exists == subquery.typ {
+                                DataValue::Int64(1)
+                            } else {
+                                DataValue::Int64(0)
+                            },
                             data_type: agg_func.return_type()?,
                         }
                         .into(),
@@ -243,13 +251,13 @@ impl SubqueryRewriter {
                 };
 
                 // Project
-                //     EvalScalar: COUNT(*) > 0 or COUNT(*) = 0
+                //     EvalScalar: COUNT(*) = 1 or COUNT(*) = 0
                 //         Aggregate: COUNT(*)
                 let rewritten_subquery = SExpr::create_unary(
                     project.into(),
                     SExpr::create_unary(
                         eval_scalar.into(),
-                        SExpr::create_unary(agg.into(), subquery.subquery.clone()),
+                        SExpr::create_unary(agg.into(), subquery_expr.clone()),
                     ),
                 );
 

--- a/query/src/sql/planner/format/display_rel_operator.rs
+++ b/query/src/sql/planner/format/display_rel_operator.rs
@@ -332,9 +332,10 @@ pub fn format_sort(
 pub fn format_limit(
     f: &mut std::fmt::Formatter<'_>,
     _metadata: &MetadataRef,
-    _op: &Limit,
+    op: &Limit,
 ) -> std::fmt::Result {
-    write!(f, "Limit")
+    let limit = if let Some(val) = op.limit { val } else { 0 };
+    write!(f, "Limit: [{}], Offset: [{}]", limit, op.offset)
 }
 
 pub fn format_cross_apply(

--- a/query/tests/it/sql/optimizer/heuristic/testdata/subquery.test
+++ b/query/tests/it/sql/optimizer/heuristic/testdata/subquery.test
@@ -25,10 +25,11 @@ Project: [number]
         Scan: default.system.numbers
         Project: [subquery]
             Filter: [subquery_3]
-                EvalScalar: [count(*) > 0]
+                EvalScalar: [count(*) = 1]
                     Aggregate: group items: [], aggregate functions: [count(*)]
-                        Filter: [numbers.number = 0]
-                            Scan: default.system.numbers
+                        Limit: [1], Offset: [0]
+                            Filter: [numbers.number = 0]
+                                Scan: default.system.numbers
 
 
 # Uncorrelated subquery


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. optimize exists subquery
2. fix `limit` display

Before:
```sql
mysql> select  avg(a.number) from numbers(1000000) as a  where EXISTS ( select number from numbers(1000000000));
+---------------+
| avg(a.number) |
+---------------+
|      499999.5 |
+---------------+
1 row in set (5.48 sec)
Read 1001000000 rows, 7.46 GiB in 5.442 sec., 183.96 million rows/sec., 1.37 GiB/sec.
```

Now:
```sql
mysql> select  avg(a.number) from numbers(1000000) as a  where EXISTS ( select number from numbers(1000000000));
+---------------+
| avg(a.number) |
+---------------+
|      499999.5 |
+---------------+
1 row in set (3.13 sec)
Read 1100000 rows, 8.39 MiB in 3.099 sec., 355.01 thousand rows/sec., 2.71 MiB/sec.
```

## Changelog

- Improvement

## Related Issues

Fixes #issue

