### PR TITLE
chore: add default tags for sentry

### DIFF
--- a/query/bin/databend-query.rs
+++ b/query/bin/databend-query.rs
@@ -48,10 +48,14 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
     if conf.meta.address.is_empty() {
         MetaEmbedded::init_global_meta_store(conf.meta.embedded_dir.clone()).await?;
     }
-
+    let tenant = conf.query.tenant_id.clone();
+    let cluster_id = conf.query.cluster_id.clone();
+    let flight_addr = conf.query.flight_api_address.clone();
     let app_name = format!(
         "databend-query-{}-{}@{}",
-        conf.query.tenant_id, conf.query.cluster_id, conf.query.flight_api_address
+        tenant.clone(),
+        cluster_id.clone(),
+        flight_addr.clone()
     );
 
     let mut _sentry_guard = None;
@@ -65,11 +69,15 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
                     .unwrap_or_else(|_| panic!("`{}` was defined but could not be parsed", s))
             })
             .unwrap_or(0.0);
+
         _sentry_guard = Some(sentry::init((bend_sentry_env, sentry::ClientOptions {
             release: common_tracing::databend_semver!(),
             traces_sample_rate,
             ..Default::default()
         })));
+        sentry::configure_scope(|scope| scope.set_tag("tenant", tenant));
+        sentry::configure_scope(|scope| scope.set_tag("cluster_id", cluster_id));
+        sentry::configure_scope(|scope| scope.set_tag("address", flight_addr));
     }
 
     //let _guards = init_tracing_with_file(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add some high cardinal tags for sentry to track on problem
1. tenant
2. cluster id
3. flight address

## Changelog


- Improvement

## Related Issues

Fixes #issue

