### PR TITLE
show query support format

### DIFF
--- a/common/ast/src/ast/statements/statement.rs
+++ b/common/ast/src/ast/statements/statement.rs
@@ -152,6 +152,12 @@ pub enum Statement<'a> {
     },
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct StatementMsg<'a> {
+    pub(crate) stmt: Statement<'a>,
+    pub(crate) format: Option<String>,
+}
+
 impl<'a> Display for Statement<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/common/ast/src/parser/mod.rs
+++ b/common/ast/src/parser/mod.rs
@@ -41,9 +41,9 @@ pub fn tokenize_sql(sql: &str) -> Result<Vec<Token>> {
 pub fn parse_sql<'a>(
     sql_tokens: &'a [Token<'a>],
     backtrace: &'a Backtrace<'a>,
-) -> Result<Statement<'a>> {
+) -> Result<(Statement<'a>, Option<String>)> {
     match statement(Input(sql_tokens, backtrace)) {
-        Ok((rest, stmts)) if rest[0].kind == TokenKind::EOI => Ok(stmts),
+        Ok((rest, stmts)) if rest[0].kind == TokenKind::EOI => Ok((stmts.stmt, stmts.format)),
         Ok((rest, _)) => Err(ErrorCode::SyntaxException(
             rest[0].display_error("unable to parse rest of the sql".to_string()),
         )),

--- a/common/ast/tests/it/parser.rs
+++ b/common/ast/tests/it/parser.rs
@@ -62,11 +62,16 @@ fn test_statement() {
     let mut mint = Mint::new("tests/it/testdata");
     let mut file = mint.new_goldenfile("statement.txt").unwrap();
     let cases = &[
+        r#"show databases"#,
+        r#"show databases format TabSeparatedWithNamesAndTypes;"#,
         r#"show tables"#,
+        r#"show tables format TabSeparatedWithNamesAndTypes;"#,
         r#"show processlist;"#,
         r#"show create table a.b;"#,
+        r#"show create table a.b format TabSeparatedWithNamesAndTypes;"#,
         r#"explain pipeline select a from b;"#,
         r#"describe a;"#,
+        r#"describe a format TabSeparatedWithNamesAndTypes;"#,
         r#"create table if not exists a.b (c integer not null default 1, b varchar);"#,
         r#"create table if not exists a.b (c integer default 1 not null, b varchar) as select * from t;"#,
         r#"create table a.b like c.d;"#,
@@ -209,7 +214,7 @@ fn test_statement() {
     for case in cases {
         let tokens = tokenize_sql(case).unwrap();
         let backtrace = Backtrace::new();
-        let stmt = parse_sql(&tokens, &backtrace).unwrap();
+        let (stmt, fmt) = parse_sql(&tokens, &backtrace).unwrap();
         writeln!(file, "---------- Input ----------").unwrap();
         writeln!(file, "{}", case).unwrap();
         writeln!(file, "---------- Output ---------").unwrap();
@@ -217,6 +222,10 @@ fn test_statement() {
         writeln!(file, "---------- AST ------------").unwrap();
         writeln!(file, "{:#?}", stmt).unwrap();
         writeln!(file, "\n").unwrap();
+        if fmt.is_some() {
+            writeln!(file, "---------- FORMAT ------------").unwrap();
+            writeln!(file, "{:#?}", fmt).unwrap();
+        }
     }
 }
 
@@ -234,6 +243,7 @@ fn test_statement_error() {
         r#"truncate a"#,
         r#"drop a"#,
         r#"insert into t format"#,
+        r#"show tables format"#,
         r#"alter database system x rename to db"#,
         r#"create user 'test-e'@'localhost' identified bi 'password';"#,
         r#"drop usar if exists 'test-j'@'localhost';"#,

--- a/common/ast/tests/it/testdata/statement-error.txt
+++ b/common/ast/tests/it/testdata/statement-error.txt
@@ -44,7 +44,7 @@ error:
   --> SQL:1:15
   |
 1 | drop table if a.b
-  |               ^ expected `EXISTS`, `.`, `ALL`, or `;`
+  |               ^ expected `EXISTS`, `.`, `ALL`, `FORMAT`, or `;`
 
 
 ---------- Input ----------
@@ -54,7 +54,7 @@ error:
   --> SQL:1:21
   |
 1 | truncate table a.b.c.d
-  |                     ^ expected `PURGE` or `;`
+  |                     ^ expected `PURGE`, `FORMAT`, or `;`
 
 
 ---------- Input ----------
@@ -92,6 +92,16 @@ error:
 
 
 ---------- Input ----------
+show tables format
+---------- Output ---------
+error: 
+  --> SQL:1:19
+  |
+1 | show tables format
+  |                   ^ expected <Ident> or <QuotedString>
+
+
+---------- Input ----------
 alter database system x rename to db
 ---------- Output ---------
 error: 
@@ -110,7 +120,7 @@ error:
   --> SQL:1:45
   |
 1 | create user 'test-e'@'localhost' identified bi 'password';
-  |                                             ^^ expected `WITH`, `BY`, or `;`
+  |                                             ^^ expected `WITH`, `BY`, `FORMAT`, or `;`
 
 
 ---------- Input ----------
@@ -130,7 +140,7 @@ error:
   --> SQL:1:33
   |
 1 | alter user 'test-e'@'localhost' identifie by 'new-password';
-  |                                 ^^^^^^^^^ expected `IDENTIFIED`, `WITH`, or `;`
+  |                                 ^^^^^^^^^ expected `IDENTIFIED`, `WITH`, `FORMAT`, or `;`
 
 
 ---------- Input ----------
@@ -140,7 +150,7 @@ error:
   --> SQL:1:19
   |
 1 | create role 'test'@'localhost';
-  |                   ^ expected `;`
+  |                   ^ expected `FORMAT` or `;`
 
 
 ---------- Input ----------
@@ -150,7 +160,7 @@ error:
   --> SQL:1:17
   |
 1 | drop role 'test'@'localhost';
-  |                 ^ expected `;`
+  |                 ^ expected `FORMAT` or `;`
 
 
 ---------- Input ----------
@@ -257,7 +267,7 @@ error:
   --> SQL:1:38
   |
 1 | COPY INTO mytable FROM 's3://bucket' CREDENTIAL = ();
-  |                                      ^^^^^^^^^^ expected `CREDENTIALS`, `ENCRYPTION`, `FILES`, `PATTERN`, `FILE_FORMAT`, `VALIDATION_MODE`, or 2 more ...
+  |                                      ^^^^^^^^^^ expected `CREDENTIALS`, `ENCRYPTION`, `FILES`, `PATTERN`, `FILE_FORMAT`, `VALIDATION_MODE`, or 3 more ...
 
 
 ---------- Input ----------
@@ -267,6 +277,6 @@ error:
   --> SQL:1:33
   |
 1 | COPY INTO mytable FROM @mystage CREDENTIALS = ();
-  |                                 ^^^^^^^^^^^ expected `FILES`, `PATTERN`, `FILE_FORMAT`, `VALIDATION_MODE`, `SIZE_LIMIT`, or `;`
+  |                                 ^^^^^^^^^^^ expected `FILES`, `PATTERN`, `FILE_FORMAT`, `VALIDATION_MODE`, `SIZE_LIMIT`, `FORMAT`, or 1 more ...
 
 

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -1,4 +1,32 @@
 ---------- Input ----------
+show databases
+---------- Output ---------
+SHOW DATABASES
+---------- AST ------------
+ShowDatabases(
+    ShowDatabasesStmt {
+        limit: None,
+    },
+)
+
+
+---------- Input ----------
+show databases format TabSeparatedWithNamesAndTypes;
+---------- Output ---------
+SHOW DATABASES
+---------- AST ------------
+ShowDatabases(
+    ShowDatabasesStmt {
+        limit: None,
+    },
+)
+
+
+---------- FORMAT ------------
+Some(
+    "TabSeparatedWithNamesAndTypes",
+)
+---------- Input ----------
 show tables
 ---------- Output ---------
 SHOW TABLES
@@ -13,6 +41,25 @@ ShowTables(
 )
 
 
+---------- Input ----------
+show tables format TabSeparatedWithNamesAndTypes;
+---------- Output ---------
+SHOW TABLES
+---------- AST ------------
+ShowTables(
+    ShowTablesStmt {
+        database: None,
+        full: false,
+        limit: None,
+        with_history: false,
+    },
+)
+
+
+---------- FORMAT ------------
+Some(
+    "TabSeparatedWithNamesAndTypes",
+)
 ---------- Input ----------
 show processlist;
 ---------- Output ---------
@@ -45,6 +92,34 @@ ShowCreateTable(
 )
 
 
+---------- Input ----------
+show create table a.b format TabSeparatedWithNamesAndTypes;
+---------- Output ---------
+SHOW CREATE TABLE a.b
+---------- AST ------------
+ShowCreateTable(
+    ShowCreateTableStmt {
+        catalog: None,
+        database: Some(
+            Identifier {
+                name: "a",
+                quote: None,
+                span: Ident(18..19),
+            },
+        ),
+        table: Identifier {
+            name: "b",
+            quote: None,
+            span: Ident(20..21),
+        },
+    },
+)
+
+
+---------- FORMAT ------------
+Some(
+    "TabSeparatedWithNamesAndTypes",
+)
 ---------- Input ----------
 explain pipeline select a from b;
 ---------- Output ---------
@@ -131,6 +206,28 @@ DescribeTable(
 )
 
 
+---------- Input ----------
+describe a format TabSeparatedWithNamesAndTypes;
+---------- Output ---------
+DESCRIBE a
+---------- AST ------------
+DescribeTable(
+    DescribeTableStmt {
+        catalog: None,
+        database: None,
+        table: Identifier {
+            name: "a",
+            quote: None,
+            span: Ident(9..10),
+        },
+    },
+)
+
+
+---------- FORMAT ------------
+Some(
+    "TabSeparatedWithNamesAndTypes",
+)
 ---------- Input ----------
 create table if not exists a.b (c integer not null default 1, b varchar);
 ---------- Output ---------

--- a/query/src/servers/http/clickhouse_handler.rs
+++ b/query/src/servers/http/clickhouse_handler.rs
@@ -262,9 +262,10 @@ pub async fn clickhouse_handler_get(
         && stmts.get(0).map_or(false, InterpreterFactoryV2::check)
     {
         let mut planner = Planner::new(context.clone());
-        let (plan, _) = planner.plan_sql(&sql).await.map_err(BadRequest)?;
+        let (plan, _, fmt) = planner.plan_sql(&sql).await.map_err(BadRequest)?;
+        let format = get_format_with_default(fmt, default_format)?;
+        let format = get_format_from_plan(&plan, format)?;
 
-        let format = get_format_from_plan(&plan, default_format)?;
         context.attach_query_str(&sql);
         execute_v2(context, plan, format, None, params)
             .await
@@ -343,8 +344,9 @@ pub async fn clickhouse_handler_post(
         && stmts.get(0).map_or(false, InterpreterFactoryV2::check)
     {
         let mut planner = Planner::new(ctx.clone());
-        let (plan, _) = planner.plan_sql(&sql).await.map_err(BadRequest)?;
-        let format = get_format_from_plan(&plan, default_format)?;
+        let (plan, _, fmt) = planner.plan_sql(&sql).await.map_err(BadRequest)?;
+        let format = get_format_with_default(fmt, default_format)?;
+        let format = get_format_from_plan(&plan, format)?;
         ctx.attach_query_str(&sql);
         execute_v2(ctx, plan, format, None, params)
             .await

--- a/query/src/servers/http/v1/query/execute_state.rs
+++ b/query/src/servers/http/v1/query/execute_state.rs
@@ -196,7 +196,7 @@ impl ExecuteState {
             && matches!(stmts.get(0), Some(DfStatement::Query(_)))
         {
             let mut planner = Planner::new(ctx.clone());
-            let (plan, _) = planner.plan_sql(sql).await?;
+            let (plan, _, _) = planner.plan_sql(sql).await?;
             let interpreter = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
 
             // Write Start to query log table.

--- a/query/src/sql/planner/binder/copy.rs
+++ b/query/src/sql/planner/binder/copy.rs
@@ -343,8 +343,8 @@ impl<'a> Binder {
             format!("SELECT * FROM {src_catalog_name}.{src_database_name}.{src_table_name}");
         let tokens = tokenize_sql(&subquery)?;
         let backtrace = Backtrace::new();
-        let sub_stmt = parse_sql(&tokens, &backtrace)?;
-
+        let sub_stmt_msg = parse_sql(&tokens, &backtrace)?;
+        let sub_stmt = sub_stmt_msg.0;
         let query = match &sub_stmt {
             Statement::Query(query) => {
                 self.bind_statement(bind_context, &Statement::Query(query.clone()))
@@ -392,8 +392,8 @@ impl<'a> Binder {
             format!("SELECT * FROM {src_catalog_name}.{src_database_name}.{src_table_name}");
         let tokens = tokenize_sql(&subquery)?;
         let backtrace = Backtrace::new();
-        let sub_stmt = parse_sql(&tokens, &backtrace)?;
-
+        let sub_stmt_msg = parse_sql(&tokens, &backtrace)?;
+        let sub_stmt = sub_stmt_msg.0;
         let query = match &sub_stmt {
             Statement::Query(query) => {
                 self.bind_statement(bind_context, &Statement::Query(query.clone()))

--- a/query/src/sql/planner/binder/show.rs
+++ b/query/src/sql/planner/binder/show.rs
@@ -48,7 +48,7 @@ impl<'a> Binder {
         );
         let tokens = tokenize_sql(query.as_str())?;
         let backtrace = Backtrace::new();
-        let stmt = parse_sql(&tokens, &backtrace)?;
+        let (stmt, _) = parse_sql(&tokens, &backtrace)?;
         self.bind_statement(bind_context, &stmt).await
     }
 }

--- a/query/src/sql/planner/binder/table.rs
+++ b/query/src/sql/planner/binder/table.rs
@@ -134,7 +134,7 @@ impl<'a> Binder {
                             .ok_or_else(|| ErrorCode::LogicalError("Invalid VIEW object"))?;
                         let tokens = tokenize_sql(query.as_str())?;
                         let backtrace = Backtrace::new();
-                        let stmt = parse_sql(&tokens, &backtrace)?;
+                        let (stmt, _) = parse_sql(&tokens, &backtrace)?;
                         if let Statement::Query(query) = &stmt {
                             self.bind_query(bind_context, query).await
                         } else {

--- a/query/src/sql/planner/mod.rs
+++ b/query/src/sql/planner/mod.rs
@@ -50,11 +50,11 @@ impl Planner {
         Planner { ctx }
     }
 
-    pub async fn plan_sql(&mut self, sql: &str) -> Result<(Plan, MetadataRef)> {
+    pub async fn plan_sql(&mut self, sql: &str) -> Result<(Plan, MetadataRef, Option<String>)> {
         // Step 1: parse SQL text into AST
         let tokens = tokenize_sql(sql)?;
         let backtrace = Backtrace::new();
-        let stmt = parse_sql(&tokens, &backtrace)?;
+        let (stmt, format) = parse_sql(&tokens, &backtrace)?;
 
         // Step 2: bind AST with catalog, and generate a pure logical SExpr
         let metadata = Arc::new(RwLock::new(Metadata::create()));
@@ -64,6 +64,6 @@ impl Planner {
         // Step 3: optimize the SExpr with optimizers, and generate optimized physical SExpr
         let optimized_plan = optimize(self.ctx.clone(), plan)?;
 
-        Ok((optimized_plan, metadata.clone()))
+        Ok((optimized_plan, metadata.clone(), format))
     }
 }

--- a/query/tests/it/interpreters/interpreter_table_create.rs
+++ b/query/tests/it/interpreters/interpreter_table_create.rs
@@ -109,7 +109,7 @@ async fn test_create_table_interpreter() -> Result<()> {
             c varchar(255) comment 'c', d smallint comment 'd', e Date comment 'e')\
             Engine = Null COMMENT = 'test create'";
         let mut planner = Planner::new(ctx.clone());
-        let (plan, _) = planner.plan_sql(query).await?;
+        let (plan, _, _) = planner.plan_sql(query).await?;
         let interpreter = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
 
         assert!(interpreter.execute(None).await.is_ok());

--- a/query/tests/it/interpreters/interpreter_table_show_create.rs
+++ b/query/tests/it/interpreters/interpreter_table_show_create.rs
@@ -154,7 +154,7 @@ async fn interpreter_show_create_table_with_comments_test() -> Result<()> {
     for case in cases {
         for stmt in case.create_stmt {
             // create table in the new planner to support column comment.
-            let (plan, _) = planner.plan_sql(stmt).await?;
+            let (plan, _, _) = planner.plan_sql(stmt).await?;
             let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
             let _ = executor.execute(None).await?;
         }

--- a/query/tests/it/sql/optimizer/heuristic/mod.rs
+++ b/query/tests/it/sql/optimizer/heuristic/mod.rs
@@ -42,7 +42,7 @@ pub(super) struct Suite {
 async fn run_test(ctx: Arc<QueryContext>, suite: &Suite) -> Result<String> {
     let tokens = tokenize_sql(&suite.query)?;
     let bt = Backtrace::new();
-    let stmt = parse_sql(&tokens, &bt)?;
+    let (stmt, _) = parse_sql(&tokens, &bt)?;
     let binder = Binder::new(
         ctx.clone(),
         ctx.get_catalogs(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Actually we have three ideas:

1. For every should support format cause's query modify the planner but that will modify so many planner code.

2. In clickhouse handler token the SQL and use nom cut the FORMAT keyword and then get the format value. But it has a bad case like this: select `format` from default.`format` format xxx;

3. In this pr, all of the statement is #statment_body and the format is always at the last of the statement body. So we just need to modify the final rule.

## Changelog

- New Feature

## Related Issues

Fixes #6298

