### PR TITLE
feat(ast): add span info for `TableReference`

### DIFF
--- a/common/ast/src/ast/query.rs
+++ b/common/ast/src/ast/query.rs
@@ -132,6 +132,7 @@ pub enum TimeTravelPoint<'a> {
 pub enum TableReference<'a> {
     // Table name
     Table {
+        span: &'a [Token<'a>],
         catalog: Option<Identifier<'a>>,
         database: Option<Identifier<'a>>,
         table: Identifier<'a>,
@@ -140,16 +141,21 @@ pub enum TableReference<'a> {
     },
     // Derived table, which can be a subquery or joined tables or combination of them
     Subquery {
+        span: &'a [Token<'a>],
         subquery: Box<Query<'a>>,
         alias: Option<TableAlias<'a>>,
     },
     // `TABLE(expr)[ AS alias ]`
     TableFunction {
+        span: &'a [Token<'a>],
         name: Identifier<'a>,
         params: Vec<Expr<'a>>,
         alias: Option<TableAlias<'a>>,
     },
-    Join(Join<'a>),
+    Join {
+        span: &'a [Token<'a>],
+        join: Join<'a>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -222,6 +228,7 @@ impl<'a> Display for TableReference<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             TableReference::Table {
+                span: _,
                 catalog,
                 database,
                 table,
@@ -245,13 +252,18 @@ impl<'a> Display for TableReference<'a> {
                     write!(f, " AS {alias}")?;
                 }
             }
-            TableReference::Subquery { subquery, alias } => {
+            TableReference::Subquery {
+                span: _,
+                subquery,
+                alias,
+            } => {
                 write!(f, "({subquery})")?;
                 if let Some(alias) = alias {
                     write!(f, " AS {alias}")?;
                 }
             }
             TableReference::TableFunction {
+                span: _,
                 name,
                 params,
                 alias,
@@ -263,7 +275,7 @@ impl<'a> Display for TableReference<'a> {
                     write!(f, " AS {alias}")?;
                 }
             }
-            TableReference::Join(join) => {
+            TableReference::Join { span: _, join } => {
                 write!(f, "{}", join.left)?;
                 if join.condition == JoinCondition::Natural {
                     write!(f, " NATURAL")?;

--- a/common/ast/src/parser/query.rs
+++ b/common/ast/src/parser/query.rs
@@ -97,10 +97,10 @@ pub fn table_reference(i: Input) -> IResult<TableReference> {
 
 pub fn aliased_table(i: Input) -> IResult<TableReference> {
     map(
-        rule! {
+        consumed(rule! {
             #ident ~ ( "." ~ #ident )? ~ ( "." ~ #ident )? ~ #travel_point? ~ #table_alias?
-        },
-        |(fst, snd, third, travel_point, alias)| {
+        }),
+        |(input, (fst, snd, third, travel_point, alias))| {
             let (catalog, database, table) = match (fst, snd, third) {
                 (catalog, Some((_, database)), Some((_, table))) => {
                     (Some(catalog), Some(database), table)
@@ -111,6 +111,7 @@ pub fn aliased_table(i: Input) -> IResult<TableReference> {
             };
 
             TableReference::Table {
+                span: input.0,
                 catalog,
                 database,
                 table,
@@ -154,10 +155,11 @@ pub fn table_alias(i: Input) -> IResult<TableAlias> {
 
 pub fn table_function(i: Input) -> IResult<TableReference> {
     map(
-        rule! {
+        consumed(rule! {
             #ident ~ "(" ~ #comma_separated_list0(expr) ~ ")" ~ #table_alias?
-        },
-        |(name, _, params, _, alias)| TableReference::TableFunction {
+        }),
+        |(input, (name, _, params, _, alias))| TableReference::TableFunction {
+            span: input.0,
             name,
             params,
             alias,
@@ -167,10 +169,11 @@ pub fn table_function(i: Input) -> IResult<TableReference> {
 
 pub fn subquery(i: Input) -> IResult<TableReference> {
     map(
-        rule! {
+        consumed(rule! {
             ( #parenthesized_query | #query ) ~ #table_alias?
-        },
-        |(subquery, alias)| TableReference::Subquery {
+        }),
+        |(input, (subquery, alias))| TableReference::Subquery {
+            span: input.0,
             subquery: Box::new(subquery),
             alias,
         },
@@ -246,22 +249,25 @@ pub fn joined_tables(i: Input) -> IResult<TableReference> {
     );
 
     map(
-        rule!(
+        consumed(rule!(
             #table_ref_without_join ~ ( #join | #natural_join )+
-        ),
-        |(fst, joins)| {
+        )),
+        |(input, (fst, joins))| {
             joins.into_iter().fold(fst, |acc, elem| {
                 let JoinElement {
                     op,
                     condition,
                     right,
                 } = elem;
-                TableReference::Join(Join {
-                    op,
-                    condition,
-                    left: Box::new(acc),
-                    right,
-                })
+                TableReference::Join {
+                    span: input.0,
+                    join: Join {
+                        op,
+                        condition,
+                        left: Box::new(acc),
+                        right,
+                    },
+                }
             })
         },
     )(i)

--- a/query/src/sql/planner/binder/select.rs
+++ b/query/src/sql/planner/binder/select.rs
@@ -67,13 +67,14 @@ impl<'a> Binder {
                 .from
                 .iter()
                 .cloned()
-                .reduce(|left, right| {
-                    TableReference::Join(Join {
+                .reduce(|left, right| TableReference::Join {
+                    span: &[],
+                    join: Join {
                         op: JoinOperator::CrossJoin,
                         condition: JoinCondition::None,
                         left: Box::new(left),
                         right: Box::new(right),
-                    })
+                    },
                 })
                 .unwrap();
             self.bind_table_reference(bind_context, &cross_joins)

--- a/query/src/sql/planner/binder/table.rs
+++ b/query/src/sql/planner/binder/table.rs
@@ -87,6 +87,7 @@ impl<'a> Binder {
     ) -> Result<(SExpr, BindContext)> {
         match table_ref {
             TableReference::Table {
+                span: _,
                 catalog,
                 database,
                 table,
@@ -163,6 +164,7 @@ impl<'a> Binder {
                 }
             }
             TableReference::TableFunction {
+                span: _,
                 name,
                 params,
                 alias,
@@ -214,8 +216,12 @@ impl<'a> Binder {
                 }
                 Ok((s_expr, bind_context))
             }
-            TableReference::Join(join) => self.bind_join(bind_context, join).await,
-            TableReference::Subquery { subquery, alias } => {
+            TableReference::Join { span: _, join } => self.bind_join(bind_context, join).await,
+            TableReference::Subquery {
+                span: _,
+                subquery,
+                alias,
+            } => {
                 let (s_expr, mut bind_context) = self.bind_query(bind_context, subquery).await?;
                 if let Some(alias) = alias {
                     bind_context.apply_table_alias(alias)?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add span info for every enum item in `TableReference` just like in `Expr`.

## Changelog

- Improvement

## Related Issues

Close #6005.

