### PR TITLE
ci: Bump rust toolchain of build tools

### DIFF
--- a/scripts/setup/rust-toolchain.toml
+++ b/scripts/setup/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-05-19"
+channel = "nightly-2022-06-30"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Bump rust toolchain of build tools

Part of https://github.com/datafuselabs/databend/pull/6375

## Changelog

- Build/Testing/CI


