### PR TITLE
Revert "ci: Bump rust toolchain of build tools"

### DIFF
--- a/scripts/setup/rust-toolchain.toml
+++ b/scripts/setup/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-06-30"
+channel = "nightly-2022-05-19"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This reverts commit 3a90b72c738f424b159a16ce94ca3288bd6a0a40.

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Revert "ci: Bump rust toolchain of build tools"

## Changelog

- Build/Testing/CI


