### PR TITLE
fix(metasrv): openraft: wrong range when searching for membership entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4392,8 +4392,8 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.7.0-alpha.1"
-source = "git+https://github.com/datafuselabs/openraft?rev=v0.7.0-alpha.1#1bc3ded67976fdbe1380ee62bf07de75e50a31cb"
+version = "0.7.0-alpha.2"
+source = "git+https://github.com/datafuselabs/openraft?rev=v0.7.0-alpha.2#b291f440265232d6e9b46b3ed8e58f566685f905"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/common/meta/app/Cargo.toml
+++ b/common/meta/app/Cargo.toml
@@ -16,7 +16,7 @@ common-exception = { path = "../../exception" }
 common-io = { path = "../../io" }
 common-meta-types = { path = "../types" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.1" }
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.2" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyerror = "0.1.6"

--- a/common/meta/sled-store/Cargo.toml
+++ b/common/meta/sled-store/Cargo.toml
@@ -15,7 +15,7 @@ test = false
 common-meta-types = { path = "../types" }
 common-tracing = { path = "../../tracing" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.1" }
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.2" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyhow = "1.0.58"

--- a/common/meta/types/Cargo.toml
+++ b/common/meta/types/Cargo.toml
@@ -15,7 +15,7 @@ common-datavalues = { path = "../../datavalues" }
 common-exception = { path = "../../exception" }
 common-io = { path = "../../io" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.1" }
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.2" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyerror = "0.1.6"

--- a/tools/metactl/Cargo.toml
+++ b/tools/metactl/Cargo.toml
@@ -22,7 +22,7 @@ common-meta-sled-store = { path = "../../common/meta/sled-store" }
 common-meta-types = { path = "../../common/meta/types" }
 common-tracing = { path = "../../common/tracing" }
 databend-meta = { path = "../../metasrv" }
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.1" }
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.2" }
 
 # Crates.io dependencies
 anyhow = "1.0.58"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] fix: openraft: wrong range when searching for membership entries

Fix: datafuselabs/openraft#424 wrong range when searching for membership entries: `[end-step, end)`.

The iterating range searching for membership log entries should be
`[end-step, end)`, not `[start, end)`.
With this bug it will return duplicated membership entries.

- Bug: datafuselabs/openraft#424

## Changelog


- Bug Fix




## Related Issues