### PR TITLE
ci: Add post checks for CLA and Semantic PR

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -50,18 +50,6 @@ pull_request_rules:
         message: |
           This pull request has merge conflicts that must be resolved before it can be merged. @{{author}} please update it 🙏.
 
-  # Welcome new contributors
-  - name: Welcome new contributor
-    conditions:
-      - author!=Mergify
-    actions:
-      comment:
-        message: |
-          Thanks for the contribution!
-          I have applied any labels matching special text in your PR Changelog.
-
-          Please review the labels and make any necessary changes.
-
   # Check if PR description contains CLA
   - name: Check PR description
     conditions:
@@ -83,11 +71,42 @@ pull_request_rules:
 
           Summary about this PR
 
-          Fixes #issue
+          Close #issue
           ```
 
-  # Check if PR title contain valid tags
-  - name: Check PR title
+  # Check if PR description contain CLA
+  - name: CLA Check
+    conditions:
+      - or:
+          - author=Mergify
+          - and:
+              - 'body~=I hereby agree to the terms of the CLA available at: https:\/\/databend\.rs\/dev\/policies\/cla\/'
+              - "body~=Summary"
+    actions:
+      post_check:
+        title: |
+          {% if check_succeed %}
+          Description contains CLA
+          {% else %}
+          Description doesn't contain CLA
+          {% endif %}
+        summary: |
+          {% if not check_succeed %}
+          Pull request description must contain [CLA](https://databend.rs/doc/contributing/good-pr) like the following:
+
+          ```
+          I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/
+
+          ## Summary
+
+          Summary about this PR
+
+          Close #issue
+          ```
+          {% endif %}
+
+  # Check if PR title contain valid types
+  - name: Comment PR if title not semantic
     conditions:
       - author!=Mergify
       - -draft
@@ -101,11 +120,11 @@ pull_request_rules:
 
           ```
           fix(query): fix group by string bug
-            ^--^  ^------------^
-            |     |
-            |     +-> Summary in present tense.
+            ^         ^---------------------^
+            |         |
+            |         +-> Summary in present tense.
             |
-          +-------> Type: feat, fix, refactor, ci, build, docs, website, chore
+            +-------> Type: feat, fix, refactor, ci, build, docs, website, chore
           ```
 
           Valid types:
@@ -116,6 +135,45 @@ pull_request_rules:
           - `ci|build`: this PR changes build/testing/ci steps
           - `docs|website`: this PR changes the documents or websites
           - `chore`: this PR only has small changes that no need to record
+
+  # Check if PR title contain valid types
+  - name: Semantic PR Check
+    conditions:
+      - or:
+          - author=Mergify
+          - 'title~=^(feat|fix|refactor|ci|build|docs|website|chore)(\(.*\))?:'
+    actions:
+      post_check:
+        title: |
+          {% if check_succeed %}
+          Title follows Semantic PR
+          {% else %}
+          Title does not follow Semantic PR
+          {% endif %}
+        summary: |
+          {% if not check_succeed %}
+          Pull request title must follow [Semantic PR](https://databend.rs/doc/contributing/good-pr)
+
+          Valid format:
+
+          ```
+          fix(query): fix group by string bug
+            ^         ^---------------------^
+            |         |
+            |         +-> Summary in present tense.
+            |
+            +-------> Type: feat, fix, refactor, ci, build, docs, website, chore
+          ```
+
+          Valid types:
+
+          - `feat`: this PR introduces a new feature to the codebase
+          - `fix`: this PR patches a bug in codebase
+          - `refactor`: this PR changes the code base without new features or bugfix
+          - `ci|build`: this PR changes build/testing/ci steps
+          - `docs|website`: this PR changes the documents or websites
+          - `chore`: this PR only has small changes that no need to record
+          {% endif %}
 
   # Assign pr label based of tags
   - name: label on New Feature


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Add post checks for CLA and Semantic PR
