### PR TITLE
feat(query): support all JsonEachRowOutputFormat variants.

### DIFF
--- a/query/src/formats/output_format.rs
+++ b/query/src/formats/output_format.rs
@@ -31,6 +31,13 @@ use crate::formats::output_format_csv::CSVWithNamesOutputFormat;
 use crate::formats::output_format_csv::TSVOutputFormat;
 use crate::formats::output_format_csv::TSVWithNamesAndTypesOutputFormat;
 use crate::formats::output_format_csv::TSVWithNamesOutputFormat;
+use crate::formats::output_format_json_each_row::JsonCompactEachRowOutputFormat;
+use crate::formats::output_format_json_each_row::JsonCompactEachRowWithNamesAndTypesOutputFormat;
+use crate::formats::output_format_json_each_row::JsonCompactEachRowWithNamesOutputFormat;
+use crate::formats::output_format_json_each_row::JsonCompactStringsEachRowOutputFormat;
+use crate::formats::output_format_json_each_row::JsonCompactStringsEachRowWithNamesAndTypesOutputFormat;
+use crate::formats::output_format_json_each_row::JsonCompactStringsEachRowWithNamesOutputFormat;
+use crate::formats::output_format_json_each_row::JsonStringsEachRowOutputFormat;
 use crate::formats::FormatFactory;
 
 pub trait OutputFormat: Send {
@@ -70,6 +77,13 @@ pub enum OutputFormatType {
     TSVWithNamesAndTypes,
     Parquet,
     JsonEachRow,
+    JsonStringsEachRow,
+    JsonCompactEachRow,
+    JsonCompactStringsEachRow,
+    JsonCompactEachRowWithNames,
+    JsonCompactEachRowWithNamesAndTypes,
+    JsonCompactStringsEachRowWithNames,
+    JsonCompactStringsEachRowWithNamesAndTypes,
     Values,
 }
 
@@ -84,6 +98,12 @@ impl OutputFormatType {
         match self {
             OutputFormatType::CSV => Some(OutputFormatType::CSVWithNames),
             OutputFormatType::TSV => Some(OutputFormatType::TSVWithNames),
+            OutputFormatType::JsonCompactEachRow => {
+                Some(OutputFormatType::JsonCompactEachRowWithNames)
+            }
+            OutputFormatType::JsonCompactStringsEachRow => {
+                Some(OutputFormatType::JsonCompactStringsEachRowWithNames)
+            }
             _ => None,
         }
     }
@@ -92,6 +112,12 @@ impl OutputFormatType {
         match self {
             OutputFormatType::CSV => Some(OutputFormatType::CSVWithNamesAndTypes),
             OutputFormatType::TSV => Some(OutputFormatType::TSVWithNamesAndTypes),
+            OutputFormatType::JsonCompactEachRow => {
+                Some(OutputFormatType::JsonCompactEachRowWithNamesAndTypes)
+            }
+            OutputFormatType::JsonCompactStringsEachRow => {
+                Some(OutputFormatType::JsonCompactStringsEachRowWithNamesAndTypes)
+            }
             _ => None,
         }
     }
@@ -114,7 +140,16 @@ impl OutputFormatType {
                 "text/csv; charset=UTF-8; header=present"
             }
             OutputFormatType::Parquet => "application/octet-stream",
-            OutputFormatType::JsonEachRow => "application/json; charset=UTF-8",
+            OutputFormatType::JsonEachRow
+            | OutputFormatType::JsonStringsEachRow
+            | OutputFormatType::JsonCompactEachRow
+            | OutputFormatType::JsonCompactEachRowWithNames
+            | OutputFormatType::JsonCompactEachRowWithNamesAndTypes
+            | OutputFormatType::JsonCompactStringsEachRow
+            | OutputFormatType::JsonCompactStringsEachRowWithNames
+            | OutputFormatType::JsonCompactStringsEachRowWithNamesAndTypes => {
+                "application/x-ndjson; charset=UTF-8"
+            }
             _ => "text/plain; charset=UTF-8",
         }
         .to_string()
@@ -148,6 +183,30 @@ impl OutputFormatType {
             OutputFormatType::JsonEachRow => {
                 Box::new(JsonEachRowOutputFormat::create(schema, format_setting))
             }
+            OutputFormatType::JsonStringsEachRow => Box::new(
+                JsonStringsEachRowOutputFormat::create(schema, format_setting),
+            ),
+            OutputFormatType::JsonCompactEachRow => Box::new(
+                JsonCompactEachRowOutputFormat::create(schema, format_setting),
+            ),
+            OutputFormatType::JsonCompactStringsEachRow => Box::new(
+                JsonCompactStringsEachRowOutputFormat::create(schema, format_setting),
+            ),
+            OutputFormatType::JsonCompactEachRowWithNames => Box::new(
+                JsonCompactEachRowWithNamesOutputFormat::create(schema, format_setting),
+            ),
+            OutputFormatType::JsonCompactEachRowWithNamesAndTypes => Box::new(
+                JsonCompactEachRowWithNamesAndTypesOutputFormat::create(schema, format_setting),
+            ),
+            OutputFormatType::JsonCompactStringsEachRowWithNames => Box::new(
+                JsonCompactStringsEachRowWithNamesOutputFormat::create(schema, format_setting),
+            ),
+            OutputFormatType::JsonCompactStringsEachRowWithNamesAndTypes => Box::new(
+                JsonCompactStringsEachRowWithNamesAndTypesOutputFormat::create(
+                    schema,
+                    format_setting,
+                ),
+            ),
             OutputFormatType::Values => {
                 Box::new(ValuesOutputFormat::create(schema, format_setting))
             }

--- a/tests/suites/0_stateless/14_clickhouse_http_handler/14_0002_select_formats.result
+++ b/tests/suites/0_stateless/14_clickhouse_http_handler/14_0002_select_formats.result
@@ -1,13 +1,45 @@
+----tsv
 0,"0",1
 1,"1",2
 2,"2",3
+----csv
 0	0	1
 1	1	2
 2	2	3
-{"number":0,"number::VARCHAR":"0","(number + 1)":1}
-{"number":1,"number::VARCHAR":"1","(number + 1)":2}
-{"number":2,"number::VARCHAR":"2","(number + 1)":3}
-----regexp_like
+----tsv header escape
 regexp_like(\'fo\nfo\', \'^fo$\')
 Boolean
 0
+----NDJSON
+{"number":0,"number::VARCHAR":"0"}
+{"number":1,"number::VARCHAR":"1"}
+----JSONEachRow
+{"number":0,"number::VARCHAR":"0"}
+{"number":1,"number::VARCHAR":"1"}
+----JSONStringsEachRow
+{"number":"0","number::VARCHAR":"0"}
+{"number":"1","number::VARCHAR":"1"}
+----JSONCompactEachRow
+[0,"0"]
+[1,"1"]
+----JSONCompactEachRowWithNames
+["number","number::VARCHAR"]
+[0,"0"]
+[1,"1"]
+----JSONCompactEachRowWithNamesAndTypes
+["number","number::VARCHAR"]
+["UInt64","String"]
+[0,"0"]
+[1,"1"]
+----JSONCompactStringsEachRow
+["0","0"]
+["1","1"]
+----JSONCompactStringsEachRowWithNames
+["number","number::VARCHAR"]
+["0","0"]
+["1","1"]
+----JSONCompactStringsEachRowWithNamesAndTypes
+["number","number::VARCHAR"]
+["UInt64","String"]
+["0","0"]
+["1","1"]

--- a/tests/suites/0_stateless/14_clickhouse_http_handler/14_0002_select_formats.sh
+++ b/tests/suites/0_stateless/14_clickhouse_http_handler/14_0002_select_formats.sh
@@ -4,13 +4,38 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 
+echo "----tsv"
 curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d 'select number, number::varchar, number + 1 from numbers(3) FORMAT CSV'
 
-
+echo "----csv"
 curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d 'select number, number::varchar, number + 1 from numbers(3) FORMAT TSV'
 
-
-curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d 'select number, number::varchar, number + 1 from numbers(3) FORMAT NDJSON'
-
-echo "----regexp_like"
+echo "----tsv header escape"
 curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d "select regexp_like('fo\nfo', '^fo$') FORMAT TabSeparatedWithNamesAndTypes"
+
+echo "----NDJSON"
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d 'select number, number::varchar from numbers(2) FORMAT NDJSON'
+
+echo "----JSONEachRow"
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d "select number, number::varchar from numbers(2) FORMAT JSONEachRow"
+
+echo "----JSONStringsEachRow"
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d "select number, number::varchar from numbers(2) FORMAT JSONStringsEachRow"
+
+echo "----JSONCompactEachRow"
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d "select number, number::varchar from numbers(2) FORMAT JSONCompactEachRow"
+
+echo "----JSONCompactEachRowWithNames"
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d "select number, number::varchar from numbers(2) FORMAT JSONCompactEachRowWithNames"
+
+echo "----JSONCompactEachRowWithNamesAndTypes"
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d "select number, number::varchar from numbers(2) FORMAT JSONCompactEachRowWithNamesAndTypes"
+
+echo "----JSONCompactStringsEachRow"
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d "select number, number::varchar from numbers(2) FORMAT JSONCompactStringsEachRow"
+
+echo "----JSONCompactStringsEachRowWithNames"
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d "select number, number::varchar from numbers(2) FORMAT JSONCompactStringsEachRowWithNames"
+
+echo "----JSONCompactStringsEachRowWithNamesAndTypes"
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d "select number, number::varchar from numbers(2) FORMAT JSONCompactStringsEachRowWithNamesAndTypes"

--- a/tests/suites/0_stateless/14_clickhouse_http_handler/14_0002_select_formats.sh
+++ b/tests/suites/0_stateless/14_clickhouse_http_handler/14_0002_select_formats.sh
@@ -4,13 +4,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 
-curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/clickhouse" -d 'select number, number::varchar, number + 1 from numbers(3) FORMAT CSV'
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d 'select number, number::varchar, number + 1 from numbers(3) FORMAT CSV'
 
 
-curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/clickhouse" -d 'select number, number::varchar, number + 1 from numbers(3) FORMAT TSV'
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d 'select number, number::varchar, number + 1 from numbers(3) FORMAT TSV'
 
 
-curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/clickhouse" -d 'select number, number::varchar, number + 1 from numbers(3) FORMAT NDJSON'
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d 'select number, number::varchar, number + 1 from numbers(3) FORMAT NDJSON'
 
 echo "----regexp_like"
-curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/clickhouse" -d "select regexp_like('fo\nfo', '^fo$') FORMAT TabSeparatedWithNamesAndTypes"
+curl -s -u root: -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}" -d "select regexp_like('fo\nfo', '^fo$') FORMAT TabSeparatedWithNamesAndTypes"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- 2 basic dimensions:
   -  STRINGS:  if true, write quoted string for all type of values.
   -  COMPACT: true/false ->use array/dict for each row,
-  COMPACT formats  have extension types withNames and withNameAndFormats.

https://clickhouse.com/docs/en/interfaces/formats
