### PR TITLE
ci: Enable cargo sparse-registry

### DIFF
--- a/.github/actions/build_linux/action.yml
+++ b/.github/actions/build_linux/action.yml
@@ -18,12 +18,12 @@ runs:
     - name: Build Debug
       if: inputs.profile == 'debug'
       shell: bash
-      run: cargo build --target ${{ inputs.target }}
+      run: cargo -Z sparse-registry build --target ${{ inputs.target }}
 
     - name: Build Release
       if: inputs.profile == 'release'
       shell: bash
-      run: cargo build --target ${{ inputs.target }} --release
+      run: cargo -Z sparse-registry build --target ${{ inputs.target }} --release
 
     - shell: bash
       run: readelf -p .comment ./target/${{ inputs.target }}/${{ inputs.profile }}/databend-query

--- a/.github/actions/build_linux_hive/action.yml
+++ b/.github/actions/build_linux_hive/action.yml
@@ -18,12 +18,12 @@ runs:
     - name: Build Debug
       if: inputs.profile == 'debug'
       shell: bash
-      run: cargo build --target ${{ inputs.target }} --bin databend-query --features hive
+      run: cargo -Z sparse-registry build --target ${{ inputs.target }} --bin databend-query --features hive
 
     - name: Build Release
       if: inputs.profile == 'release'
       shell: bash
-      run: cargo build --target ${{ inputs.target }} --bin databend-query --features hive --release
+      run: cargo -Z sparse-registry build --target ${{ inputs.target }} --bin databend-query --features hive --release
 
     - shell: bash
       run: readelf -p .comment ./target/${{ inputs.target }}/${{ inputs.profile }}/databend-query

--- a/.github/actions/build_macos/action.yml
+++ b/.github/actions/build_macos/action.yml
@@ -19,12 +19,12 @@ runs:
     - name: Build Debug
       if: inputs.profile == 'debug'
       shell: bash
-      run: cargo build --target ${{ inputs.target }}
+      run: cargo -Z sparse-registry build --target ${{ inputs.target }}
 
     - name: Build Release
       if: inputs.profile == 'release'
       shell: bash
-      run: cargo build --target ${{ inputs.target }} --release
+      run: cargo -Z sparse-registry build --target ${{ inputs.target }} --release
 
     - name: Upload artifact
       uses: ./.github/actions/artifact_upload

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Clippy
       shell: bash
-      run: cargo clippy --workspace --all-targets -- -D warnings
+      run: cargo -Z sparse-registry clippy --workspace --all-targets -- -D warnings
 
     - name: Audit dependencies
       shell: bash

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -33,12 +33,12 @@ runs:
     - name: Audit dependencies
       shell: bash
       if: "!contains(github.event.head_commit.message, 'skip audit')"
-      run: cargo audit --db ./target/advisory-db
+      run: cargo -Z sparse-registry audit --db ./target/advisory-db
 
     - name: Check udeps
       shell: bash
       if: "!contains(github.event.head_commit.message, 'skip udeps')"
-      run: cargo udeps --workspace
+      run: cargo -Z sparse-registry udeps --workspace
 
     - name: Check toml format
       shell: bash

--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -14,7 +14,7 @@ runs:
         bypass_env_vars: RUSTFLAGS,RUSTDOCFLAGS,RUST_TEST_THREADS,RUST_LOG,RUST_BACKTRACE
 
     - shell: bash
-      run: cargo test --no-fail-fast
+      run: cargo -Z sparse-registry test --no-fail-fast
       env:
         RUST_TEST_THREADS: "2"
         RUST_LOG: ERROR


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR is a reply to [Call for testing: Cargo sparse-registry](https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html)

We will test:

- Whether sparse-registry works correctly
- If sparse-registry faster than git-based registry
- If sparse-registry works well with many git deps (we have about 15 git deps).

Let's go!
