### PR TITLE
fix(build-tool): musl include path for c module

### DIFF
--- a/docker/build-tool/musl/Dockerfile
+++ b/docker/build-tool/musl/Dockerfile
@@ -15,6 +15,6 @@ RUN curl -sSfLo /tmp/musl-cross-make.tar.gz https://github.com/richfelker/musl-c
     rm -rf /tmp/musl-cross-make-* && \
     rm -f /tmp/musl-cross-make.tar.gz
 
+ENV C_INCLUDE_PATH /usr/local/${ARCH}-linux-musl/include/
 RUN rustup target add ${ARCH}-unknown-linux-musl
-RUN ln -s ${ARCH}-linux-musl-gcc /usr/local/bin/musl-gcc
 RUN printf "[target.${ARCH}-unknown-linux-musl]\nlinker = \"${ARCH}-linux-musl-gcc\"\n" > ${CARGO_HOME}/config


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add env C_INCLUDE_PATH to musl build-tool image

for: https://github.com/datafuselabs/databend/pull/6389
