### PR TITLE
docs(jaeger): update the doc how to use jaeger

### DIFF
--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -67,13 +67,13 @@ static GLOBAL_UT_LOG_GUARD: Lazy<Arc<Mutex<Option<Vec<WorkerGuard>>>>> =
 /// A local tracing collection(maybe for testing) can be done with a local jaeger server.
 /// To report tracing data and view it:
 ///   docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
-///   DATABEND_JAEGER=on RUST_LOG=trace cargo test
+///   DATABEND_JAEGER_AGENT_ENDPOINT=localhost:6831 RUST_LOG=trace cargo test
 ///   open http://localhost:16686/
 ///
 /// To adjust batch sending delay, use `OTEL_BSP_SCHEDULE_DELAY`:
-/// DATABEND_JAEGER=on RUST_LOG=trace OTEL_BSP_SCHEDULE_DELAY=1 cargo test
+/// DATABEND_JAEGER_AGENT_ENDPOINT=localhost:6831 RUST_LOG=trace OTEL_BSP_SCHEDULE_DELAY=1 cargo test
 ///
-// TODO(xp): use DATABEND_JAEGER to assign jaeger server address.
+// TODO(xp): use DATABEND_JAEGER_AGENT_ENDPOINT to assign jaeger server address.
 pub fn init_global_tracing(
     app_name: &str,
     dir: &str,

--- a/docs/doc/100-faq/20-how-to-tracing.md
+++ b/docs/doc/100-faq/20-how-to-tracing.md
@@ -158,7 +158,7 @@ Jun 10 16:40:36.168 DEBUG ThreadId(309) databend_query::pipelines::transforms::t
 ### Start Databend
 
 ```
-LOG_LEVEL=DEBUG ./databend-query
+DATABEND_JAEGER_AGENT_ENDPOINT=localhost:6831 ./databend-query
 ```
 
 ### Start jaeger


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
after https://github.com/datafuselabs/databend/pull/6340/,   "DATABEND_JAEGER" is replaced by  "DATABEND_JAEGER_AGENT_ENDPOINT" , we should update the doc and show how to use it.  for a newbie, may do't know how to set "DATABEND_JAEGER_AGENT_ENDPOINT"