### PR TITLE
chore: do not include instance ip:port into app_name

### DIFF
--- a/query/bin/databend-query.rs
+++ b/query/bin/databend-query.rs
@@ -51,12 +51,7 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
     let tenant = conf.query.tenant_id.clone();
     let cluster_id = conf.query.cluster_id.clone();
     let flight_addr = conf.query.flight_api_address.clone();
-    let app_name = format!(
-        "databend-query-{}-{}@{}",
-        tenant.clone(),
-        cluster_id.clone(),
-        flight_addr.clone()
-    );
+    let app_name = format!("databend-query-{}-{}", &tenant, &cluster_id);
 
     let mut _sentry_guard = None;
     let bend_sentry_env = env::var("DATABEND_SENTRY_DSN").unwrap_or_else(|_| "".to_string());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

tracing could aggregate the traces from the same app together, so we can find the strange traces by our eyes.

including the host:port in app_name could seperate the traces in fragments like this, which reduced readability.

this PR removes the host:port part in the app_name, allows to read the traces by tenant + cluster.




