### PR TITLE
fix(jaeger) split package to send big package to jaeger

### DIFF
--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -102,6 +102,7 @@ pub fn init_global_tracing(
         let tracer = opentelemetry_jaeger::new_pipeline()
             .with_service_name(app_name)
             .with_agent_endpoint(jaeger_agent_endpoint)
+            .with_auto_split_batch(true)
             .install_batch(opentelemetry::runtime::Tokio)
             .expect("install");
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
when using jaeger to track databend, I always see "jaeger: thrift agent failed with message too long" and  set OTEL_BSP_MAX_EXPORT_BATCH_SIZE to a larger value does't take much affect.  we could use "with_auto_split_batch" to split big packages.
