### PR TITLE
remove keyword table from func is_reserved_ident

### DIFF
--- a/common/ast/src/parser/token.rs
+++ b/common/ast/src/parser/token.rs
@@ -947,7 +947,7 @@ impl TokenKind {
             // | TokenKind::SIMILAR
             | TokenKind::SOME
             // | TokenKind::SYMMETRIC
-            | TokenKind::TABLE
+            // | TokenKind::TABLE
             // | TokenKind::TABLESAMPLE
             | TokenKind::THEN
             | TokenKind::TRAILING

--- a/tests/suites/0_stateless/20+_others/20_0001_planner_v2.result
+++ b/tests/suites/0_stateless/20+_others/20_0001_planner_v2.result
@@ -426,3 +426,10 @@ NULL	NULL	NULL	1
 1
 1	2
 2	3
+====WITH_KEYWORD====
+system	settings	default	VARCHAR			
+system	settings	description	VARCHAR			
+system	settings	level	VARCHAR			
+system	settings	name	VARCHAR			
+system	settings	type	VARCHAR			
+system	settings	value	VARCHAR			

--- a/tests/suites/0_stateless/20+_others/20_0001_planner_v2.sql
+++ b/tests/suites/0_stateless/20+_others/20_0001_planner_v2.sql
@@ -367,5 +367,9 @@ select * from t1 where t1.a not in (select t2.a from t2);
 select * from t1 where t1.a in (select t2.a from t2);
 drop table t1;
 drop table t2;
+
+-- Query has keyword
+SELECT '====WITH_KEYWORD====';
+SELECT database, table, name, type, default_kind as default_type, default_expression, comment FROM system.columns  WHERE database LIKE 'system'  AND table LIKE 'settings' ORDER BY name;
 set enable_planner_v2 = 0;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Now we use the old parser to parse SQL first and then try to use planner v2.

So maybe some SQL will fail in planner v2 but success in planner v1.

In issue #6455 we find this bug. So in this pr, we fix it.


Fixes #6455
