### PR TITLE
ci: Disable merge queue to reduce CI usage

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,11 +1,5 @@
 queue_rules:
   - name: shared_queue
-    # Enable speculative_checks and batch size so that we can rollup
-    # enqueued PRs at the same time instead of one by one.
-    #
-    # Reference: https://docs.mergify.com/actions/queue/#id4
-    speculative_checks: 2
-    batch_size: 5
     conditions:
       - "#approved-reviews-by>=2"
 
@@ -27,14 +21,6 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=2"
       - -draft
-      - check-success=check
-      - check-success~=^build_(aarch64|x86_64)_musl$
-      - check-success=test_unit
-      - check-success=test_metactl
-      - check-success=test_stateless_standalone_linux
-      - check-success=test_stateless_cluster_linux
-      - check-success=test_stateful_standalone_linux
-      - check-success=test_sqllogic_standalone_linux
     actions:
       queue:
         name: shared_queue


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Disable merge queue to reduce CI usage

Merge queue is not suitable for our usage case, let's disable it.
