### PR TITLE
fix : ArrayRef's namespace should be common_arrow

### DIFF
--- a/query/src/pipelines/new/processors/transforms/transform_window_func.rs
+++ b/query/src/pipelines/new/processors/transforms/transform_window_func.rs
@@ -17,9 +17,9 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use bumpalo::Bump;
-use common_arrow::arrow::array::ArrayRef;
 use common_arrow::arrow::compute::partition::lexicographical_partition_ranges;
 use common_arrow::arrow::compute::sort::SortColumn;
+use common_arrow::ArrayRef;
 use common_datablocks::DataBlock;
 use common_datavalues::ColumnRef;
 use common_datavalues::ColumnWithField;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix main branch compilation error: 

change `common_arrow::arrow::array::ArrayRef` to `common_arrow::ArrayRef`

Fixes #issue
