### PR TITLE
fix(cluster): use max threads as exchange source pipe size

### DIFF
--- a/query/src/api/rpc/exchange/exchange_manager.rs
+++ b/query/src/api/rpc/exchange/exchange_manager.rs
@@ -657,8 +657,11 @@ impl QueryCoordinator {
             return ExchangeSource::via_exchange(rx, &exchange_params, pipeline);
         }
 
+        let settings = self.ctx.get_settings();
+        let max_threads = settings.get_max_threads()? as usize;
+        let max_threads = std::cmp::max(max_threads, 1);
         // Add exchange data subscriber.
-        ExchangeSource::create_source(rx, schema, pipeline)
+        ExchangeSource::create_source(rx, schema, pipeline, max_threads)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(cluster): use max threads as exchange source pipe size

Fixes #issue
