### PR TITLE
feat(query): format date/datetime/enum in query log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,7 @@ dependencies = [
  "serde",
  "serde-bridge",
  "serde_json",
+ "serde_repr",
  "serfig",
  "sha1",
  "sha2 0.10.2",
@@ -6286,6 +6287,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -116,6 +116,7 @@ sentry = "0.27.0"
 serde = { version = "1.0.137", features = ["derive"] }
 serde-bridge = "0.0.3"
 serde_json = "1.0.81"
+serde_repr = "0.1.8"
 serfig = "0.0.2"
 sha1 = "0.10.1"
 sha2 = "0.10.2"

--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -45,7 +45,7 @@ table_disk_cache_mb_size = 10240
 [log]
 level = "ERROR"
 dir = "./.databend/logs"
-query_enabled = false
+query_enabled = true
 
 [meta]
 # To enable embedded meta-store, set address to "".


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

to make it consistent with schema of `system.query_log`

```
{"log_type":1,"handler_type":"MySQL","tenant_id":"test_tenant","cluster_id":"test_cluster","sql_user":"root","query_id":"41b25d04-f6a5-4cd5-abe4-d6dfca69bf0f","query_kind":"ShowPlan","query_text":"show databases","event_date":"2022-07-12","event_time":"2022-07-12 08:38:55.773809","current_database":"default","databases":"","tables":"","columns":"","projections":"","written_rows":0,"written_bytes":0,"written_io_bytes":0,"written_io_bytes_cost_ms":0,"scan_rows":0,"scan_bytes":0,"scan_io_bytes":0,"scan_io_bytes_cost_ms":0,"scan_partitions":0,"total_partitions":0,"result_rows":0,"result_bytes":0,"cpu_usage":10,"memory_usage":1666,"client_info":"","client_address":"127.0.0.1:54978","exception_code":0,"exception":"","stack_trace":"","server_version":"","extra":""}
{"log_type":2,"handler_type":"MySQL","tenant_id":"test_tenant","cluster_id":"test_cluster","sql_user":"root","query_id":"41b25d04-f6a5-4cd5-abe4-d6dfca69bf0f","query_kind":"ShowPlan","query_text":"show databases","event_date":"2022-07-12","event_time":"2022-07-12 08:38:55.791744","current_database":"default","databases":"","tables":"","columns":"","projections":"","written_rows":0,"written_bytes":0,"written_io_bytes":0,"written_io_bytes_cost_ms":0,"scan_rows":3,"scan_bytes":63,"scan_io_bytes":0,"scan_io_bytes_cost_ms":0,"scan_partitions":0,"total_partitions":0,"result_rows":3,"result_bytes":63,"cpu_usage":10,"memory_usage":1666,"client_info":"","client_address":"127.0.0.1:54978","exception_code":0,"exception":"","stack_trace":"","server_version":"","extra":""}
```

Fixes #issue
