### PR TITLE
fix: big query hang with clickhouse

### DIFF
--- a/query/src/servers/clickhouse/interactive_worker.rs
+++ b/query/src/servers/clickhouse/interactive_worker.rs
@@ -74,11 +74,6 @@ impl ClickHouseSession for InteractiveWorker {
     }
 
     // TODO: remove it
-    fn server_display_name(&self) -> &str {
-        "databend"
-    }
-
-    // TODO: remove it
     fn dbms_version_major(&self) -> u64 {
         2021
     }
@@ -89,8 +84,9 @@ impl ClickHouseSession for InteractiveWorker {
     }
 
     // TODO: remove it
-    fn dbms_version_patch(&self) -> u64 {
-        0
+    // the MIN_SERVER_REVISION for suggestions is 54406
+    fn dbms_tcp_protocol_version(&self) -> u64 {
+        54405
     }
 
     // TODO: remove it
@@ -99,9 +95,18 @@ impl ClickHouseSession for InteractiveWorker {
     }
 
     // TODO: remove it
-    // the MIN_SERVER_REVISION for suggestions is 54406
-    fn dbms_tcp_protocol_version(&self) -> u64 {
-        54405
+    fn server_display_name(&self) -> &str {
+        "databend"
+    }
+
+    // TODO: remove it
+    fn dbms_version_patch(&self) -> u64 {
+        0
+    }
+
+    // TODO: remove it
+    fn get_progress(&self) -> opensrv_clickhouse::types::Progress {
+        unimplemented!()
     }
 
     async fn authenticate(&self, user: &str, password: &[u8], client_addr: &str) -> bool {
@@ -145,10 +150,5 @@ impl ClickHouseSession for InteractiveWorker {
                 false
             }
         }
-    }
-
-    // TODO: remove it
-    fn get_progress(&self) -> opensrv_clickhouse::types::Progress {
-        unimplemented!()
     }
 }

--- a/query/src/servers/clickhouse/writers/query_writer.rs
+++ b/query/src/servers/clickhouse/writers/query_writer.rs
@@ -24,7 +24,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_io::prelude::FormatSettings;
 use common_tracing::tracing;
-use futures::channel::mpsc::Receiver;
+use futures::channel::mpsc::UnboundedReceiver;
 use futures::StreamExt;
 use opensrv_clickhouse::connection::Connection;
 use opensrv_clickhouse::errors::Error as CHError;
@@ -51,7 +51,7 @@ impl<'a> QueryWriter<'a> {
 
     pub async fn write(
         &mut self,
-        receiver: Result<Receiver<BlockItem>>,
+        receiver: Result<UnboundedReceiver<BlockItem>>,
         format: &FormatSettings,
     ) -> Result<()> {
         match receiver {
@@ -103,7 +103,7 @@ impl<'a> QueryWriter<'a> {
 
     async fn write_data(
         &mut self,
-        mut receiver: Receiver<BlockItem>,
+        mut receiver: UnboundedReceiver<BlockItem>,
         format: &FormatSettings,
     ) -> Result<()> {
         loop {
@@ -140,7 +140,7 @@ pub fn to_clickhouse_err(res: ErrorCode) -> opensrv_clickhouse::errors::Error {
 }
 
 pub fn from_clickhouse_err(res: opensrv_clickhouse::errors::Error) -> ErrorCode {
-    ErrorCode::LogicalError(format!("clickhouse-srv expception: {:?}", res))
+    ErrorCode::LogicalError(format!("clickhouse-srv exception: {:?}", res))
 }
 
 pub fn to_clickhouse_block(block: DataBlock, format: &FormatSettings) -> Result<Block> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Now the big query that is executed with clickhouse tcp client will hang, we find it relates to the receiver buffer.

So set it to unbounded buffer.

Fixes #6535
