### PR TITLE
fix: range delete panic and incorrect statistics (of in_memory_size)

### DIFF
--- a/query/src/storages/fuse/operations/delete.rs
+++ b/query/src/storages/fuse/operations/delete.rs
@@ -23,8 +23,8 @@ use common_tracing::tracing::debug;
 use crate::sessions::QueryContext;
 use crate::storages::fuse::meta::TableSnapshot;
 use crate::storages::fuse::operations::mutation::delete_from_block;
-use crate::storages::fuse::operations::mutation::mutations_collector::Deletion;
-use crate::storages::fuse::operations::mutation::mutations_collector::DeletionCollector;
+use crate::storages::fuse::operations::mutation::deletion_mutator::Deletion;
+use crate::storages::fuse::operations::mutation::deletion_mutator::DeletionMutator;
 use crate::storages::fuse::pruning::BlockPruner;
 use crate::storages::fuse::FuseTable;
 use crate::storages::Table;
@@ -69,7 +69,7 @@ impl FuseTable {
         plan: &DeletePlan,
     ) -> Result<()> {
         let mut deletion_collector =
-            DeletionCollector::try_create(ctx.as_ref(), &self.meta_location_generator, snapshot)?;
+            DeletionMutator::try_create(ctx.as_ref(), &self.meta_location_generator, snapshot)?;
         let schema = self.table_info.schema();
         // TODO refine pruner
         let extras = Extras {
@@ -108,7 +108,7 @@ impl FuseTable {
     async fn commit_deletion(
         &self,
         ctx: &QueryContext,
-        del_holder: DeletionCollector<'_>,
+        del_holder: DeletionMutator<'_>,
         catalog_name: &str,
     ) -> Result<()> {
         let (new_snapshot, loc) = del_holder.into_new_snapshot().await?;

--- a/query/src/storages/fuse/operations/mod.rs
+++ b/query/src/storages/fuse/operations/mod.rs
@@ -29,6 +29,7 @@ pub mod util;
 
 pub use fuse_sink::FuseTableSink;
 pub use mutation::delete_from_block;
+pub use mutation::DeletionMutator;
 pub use operation_log::AppendOperationLogEntry;
 pub use operation_log::TableOperationLog;
 pub use util::column_metas;

--- a/query/src/storages/fuse/operations/mutation/block_filter.rs
+++ b/query/src/storages/fuse/operations/mutation/block_filter.rs
@@ -25,7 +25,7 @@ use common_planners::Expression;
 use crate::pipelines::transforms::ExpressionExecutor;
 use crate::sessions::QueryContext;
 use crate::storages::fuse::meta::BlockMeta;
-use crate::storages::fuse::operations::mutation::mutations_collector::Deletion;
+use crate::storages::fuse::operations::mutation::deletion_mutator::Deletion;
 use crate::storages::fuse::FuseTable;
 
 pub async fn delete_from_block(

--- a/query/src/storages/fuse/operations/mutation/deletion_mutator.rs
+++ b/query/src/storages/fuse/operations/mutation/deletion_mutator.rs
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
 
 use common_datablocks::DataBlock;
@@ -44,7 +45,7 @@ pub struct Replacement {
 
 pub type SegmentIndex = usize;
 
-pub struct DeletionCollector<'a> {
+pub struct DeletionMutator<'a> {
     mutations: HashMap<SegmentIndex, Vec<Replacement>>,
     ctx: &'a QueryContext,
     location_generator: &'a TableMetaLocationGenerator,
@@ -52,7 +53,7 @@ pub struct DeletionCollector<'a> {
     data_accessor: Operator,
 }
 
-impl<'a> DeletionCollector<'a> {
+impl<'a> DeletionMutator<'a> {
     pub fn try_create(
         ctx: &'a QueryContext,
         location_generator: &'a TableMetaLocationGenerator,
@@ -71,6 +72,14 @@ impl<'a> DeletionCollector<'a> {
     pub async fn into_new_snapshot(self) -> Result<(TableSnapshot, String)> {
         let snapshot = self.base_snapshot;
         let mut new_snapshot = TableSnapshot::from_previous(snapshot);
+
+        // takes away the segments, they are being mutated
+        let mut segments_editor = HashMap::<_, _, RandomState>::from_iter(
+            std::mem::take(&mut new_snapshot.segments)
+                .into_iter()
+                .enumerate(),
+        );
+
         let segment_reader = MetaReaders::segment_info_reader(self.ctx);
 
         let segment_info_cache = self
@@ -84,9 +93,12 @@ impl<'a> DeletionCollector<'a> {
         );
 
         for (seg_idx, replacements) in self.mutations {
-            let seg_loc = &snapshot.segments[seg_idx];
-            let segment = segment_reader.read(&seg_loc.0, None, seg_loc.1).await?;
+            let segment = {
+                let (path, version) = &snapshot.segments[seg_idx];
+                segment_reader.read(&path, None, *version).await?
+            };
 
+            // collects the block locations of the segment being modified
             let block_positions = segment
                 .blocks
                 .iter()
@@ -94,8 +106,17 @@ impl<'a> DeletionCollector<'a> {
                 .map(|(idx, meta)| (&meta.location, idx))
                 .collect::<HashMap<_, _>>();
 
+            // prepare the new segment, which will replace the modified segment
             let mut new_segment = SegmentInfo::new(segment.blocks.clone(), segment.summary.clone());
 
+            // apply modification
+
+            //  take away the blocks, they are being mutated
+            let mut block_editor = HashMap::<_, _, RandomState>::from_iter(
+                std::mem::take(&mut new_segment.blocks)
+                    .into_iter()
+                    .enumerate(),
+            );
             for replacement in replacements {
                 let position = block_positions
                     .get(&replacement.original_block_loc)
@@ -106,27 +127,31 @@ impl<'a> DeletionCollector<'a> {
                         ))
                     })?;
                 if let Some(block_meta) = replacement.new_block_meta {
-                    new_segment.blocks[*position] = block_meta;
+                    //new_segment.blocks[*position] = block_meta;
+                    block_editor.insert(*position, block_meta);
                 } else {
-                    new_segment.blocks.remove(*position);
+                    //new_segment.blocks.remove(*position);
+                    block_editor.remove(position);
                 }
             }
+            new_segment.blocks = block_editor.into_values().collect();
 
             if new_segment.blocks.is_empty() {
                 // remove the segment if no blocks there
-                new_snapshot.segments.remove(seg_idx);
+                segments_editor.remove(&seg_idx);
             } else {
                 let new_summary = reduce_block_metas(&new_segment.blocks)?;
                 new_segment.summary = new_summary;
                 let new_segment_location = seg_writer.write_segment(new_segment).await?;
-                new_snapshot.segments[seg_idx] = new_segment_location;
+                segments_editor.insert(seg_idx, new_segment_location);
             }
         }
 
-        let mut new_segment_summaries = vec![];
+        new_snapshot.segments = segments_editor.into_values().collect();
+
+        let mut new_segment_summaries = Vec::with_capacity(new_snapshot.segments.len());
         for (loc, ver) in &new_snapshot.segments {
             let seg = segment_reader.read(loc, None, *ver).await?;
-            // only need the summary, drop the reference to segment ASAP
             new_segment_summaries.push(seg.summary.clone())
         }
 
@@ -143,9 +168,8 @@ impl<'a> DeletionCollector<'a> {
         Ok((new_snapshot, snapshot_loc))
     }
 
-    /// Replaces
-    ///  the block located at `block_location` of segment indexed by `seg_idx`
-    /// With a new block `r`
+    /// Records the replacements:  
+    ///  the block located at `block_location` of segment indexed by `seg_idx` with a new block
     pub async fn replace_with(
         &mut self,
         seg_idx: usize,

--- a/query/src/storages/fuse/operations/read_partitions.rs
+++ b/query/src/storages/fuse/operations/read_partitions.rs
@@ -157,9 +157,8 @@ impl FuseTable {
 
             statistics.read_rows += rows;
             for projection_index in indices {
-                let column_stats = &block_meta.col_stats;
-                let column_stats = &column_stats[&(*projection_index as u32)];
-                statistics.read_bytes += column_stats.in_memory_size as usize;
+                let col_metas = &block_meta.col_metas[&(*projection_index as u32)];
+                statistics.read_bytes += col_metas.len as usize;
             }
 
             if remaining > rows {

--- a/query/src/storages/fuse/statistics/reducers.rs
+++ b/query/src/storages/fuse/statistics/reducers.rs
@@ -26,18 +26,16 @@ use crate::storages::index::ColumnStatistics;
 use crate::storages::index::StatisticsOfColumns;
 
 pub fn reduce_block_statistics<T: Borrow<StatisticsOfColumns>>(
-    stats: &[T],
+    stats_of_columns: &[T],
 ) -> Result<StatisticsOfColumns> {
     // Combine statistics of a column into `Vec`, that is:
     // from : `&[HashMap<ColumnId, ColumnStatistics>]`
     // to   : `HashMap<ColumnId, Vec<&ColumnStatistics>)>`
-    let col_stat_list = stats.iter().fold(HashMap::new(), |acc, item| {
+    let col_to_stats_lit = stats_of_columns.iter().fold(HashMap::new(), |acc, item| {
         item.borrow().iter().fold(
             acc,
-            |mut acc: HashMap<ColumnId, Vec<&ColumnStatistics>>, (col_id, stats)| {
-                acc.entry(*col_id)
-                    .or_insert_with(|| vec![stats])
-                    .push(stats);
+            |mut acc: HashMap<ColumnId, Vec<&ColumnStatistics>>, (col_id, col_stats)| {
+                acc.entry(*col_id).or_default().push(col_stats);
                 acc
             },
         )
@@ -46,8 +44,8 @@ pub fn reduce_block_statistics<T: Borrow<StatisticsOfColumns>>(
     // Reduce the `Vec<&ColumnStatistics` into ColumnStatistics`, i.e.:
     // from : `HashMap<ColumnId, Vec<&ColumnStatistics>)>`
     // to   : `type BlockStatistics = HashMap<ColumnId, ColumnStatistics>`
-    let len = stats.len();
-    col_stat_list
+    let len = stats_of_columns.len();
+    col_to_stats_lit
         .iter()
         .try_fold(HashMap::with_capacity(len), |mut acc, (id, stats)| {
             let mut min_stats = Vec::with_capacity(stats.len());

--- a/query/tests/it/storages/fuse/operations/mod.rs
+++ b/query/tests/it/storages/fuse/operations/mod.rs
@@ -14,6 +14,7 @@
 //
 
 mod commit;
+mod mutation;
 mod navigate;
 mod optimize;
 mod purge_drop;

--- a/query/tests/it/storages/fuse/operations/mutation/deletion_mutator.rs
+++ b/query/tests/it/storages/fuse/operations/mutation/deletion_mutator.rs
@@ -50,7 +50,7 @@ async fn test_deletion_mutator_multiple_empty_segments() -> Result<()> {
     let seg_writer = SegmentWriter::new(&data_accessor, &location_generator, &segment_info_cache);
 
     let gen_test_seg = || async {
-        // generates test segment, which contains only one block
+        // generates test segment, each of them contains only one block
         // structures are filled with arbitrary values, no effects for this test case
         let block_id = Uuid::new_v4().simple().to_string();
         let location = (block_id, DataBlock::VERSION);
@@ -91,7 +91,7 @@ async fn test_deletion_mutator_multiple_empty_segments() -> Result<()> {
     // clear half of the segments
     for (i, _) in test_segment_locations.iter().enumerate().take(100) {
         if i % 2 == 0 {
-            // remove block from segment (segment only contains one block)
+            // empty the segment (segment only contains one block)
             mutator
                 .replace_with(i, test_block_locations[i].clone(), DataBlock::empty())
                 .await?;

--- a/query/tests/it/storages/fuse/operations/mutation/deletion_mutator.rs
+++ b/query/tests/it/storages/fuse/operations/mutation/deletion_mutator.rs
@@ -1,0 +1,112 @@
+//  Copyright 2022 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::collections::hash_map::RandomState;
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use common_base::base::tokio;
+use common_datablocks::DataBlock;
+use common_datavalues::DataSchema;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use databend_query::storages::fuse::io::SegmentWriter;
+use databend_query::storages::fuse::io::TableMetaLocationGenerator;
+use databend_query::storages::fuse::meta::BlockMeta;
+use databend_query::storages::fuse::meta::SegmentInfo;
+use databend_query::storages::fuse::meta::Statistics;
+use databend_query::storages::fuse::meta::TableSnapshot;
+use databend_query::storages::fuse::meta::Versioned;
+use databend_query::storages::fuse::operations::DeletionMutator;
+use uuid::Uuid;
+
+use crate::storages::fuse::table_test_fixture::TestFixture;
+
+/// [issue#6570](https://github.com/datafuselabs/databend/issues/6570)
+/// During deletion, there might be multiple segments become empty
+
+#[tokio::test]
+async fn test_deletion_mutator_multiple_empty_segments() -> Result<()> {
+    // generates a batch of segments, and delete blocks from them
+    // so that half of the segments will be empty
+
+    let fixture = TestFixture::new().await;
+    let ctx = fixture.ctx();
+    let location_generator = TableMetaLocationGenerator::with_prefix("_prefix".to_owned());
+
+    let segment_info_cache = ctx.get_storage_cache_manager().get_table_segment_cache();
+    let data_accessor = ctx.get_storage_operator()?;
+    let seg_writer = SegmentWriter::new(&data_accessor, &location_generator, &segment_info_cache);
+
+    let gen_test_seg = || async {
+        // generates test segment, which contains only one block
+        // structures are filled with arbitrary values, no effects for this test case
+        let block_id = Uuid::new_v4().simple().to_string();
+        let location = (block_id, DataBlock::VERSION);
+        let test_block_meta = BlockMeta::new(
+            1,
+            1,
+            1,
+            HashMap::default(),
+            HashMap::default(),
+            None,
+            location.clone(),
+        );
+        let segment = SegmentInfo::new(vec![test_block_meta], Statistics::default());
+        Ok::<_, ErrorCode>((seg_writer.write_segment(segment).await?, location))
+    };
+
+    // generates 100 segments, for each segment, contains one block
+    let mut test_segment_locations = vec![];
+    let mut test_block_locations = vec![];
+    for _ in 0..100 {
+        let (segment_location, block_location) = gen_test_seg().await?;
+        test_segment_locations.push(segment_location);
+        test_block_locations.push(block_location);
+    }
+
+    let base_snapshot = TableSnapshot::new(
+        Uuid::new_v4(),
+        &None,
+        None,
+        DataSchema::empty(),
+        Statistics::default(),
+        test_segment_locations.clone(),
+        None,
+    );
+
+    let mut mutator = DeletionMutator::try_create(&ctx, &location_generator, &base_snapshot)?;
+
+    // clear half of the segments
+    for (i, _) in test_segment_locations.iter().enumerate().take(100) {
+        if i % 2 == 0 {
+            // remove block from segment (segment only contains one block)
+            mutator
+                .replace_with(i, test_block_locations[i].clone(), DataBlock::empty())
+                .await?;
+        }
+    }
+
+    let (new_snapshot, _) = mutator.into_new_snapshot().await?;
+
+    // half segments left after deletion
+    assert_eq!(new_snapshot.segments.len(), 50);
+
+    // new_segments should be a subset of test_segments in our case (no partial deletion of segment)
+    let new_segments = HashSet::<_, RandomState>::from_iter(new_snapshot.segments.into_iter());
+    let test_segments = HashSet::from_iter(test_segment_locations.into_iter());
+    assert!(new_segments.is_subset(&test_segments));
+
+    Ok(())
+}

--- a/query/tests/it/storages/fuse/operations/mutation/mod.rs
+++ b/query/tests/it/storages/fuse/operations/mutation/mod.rs
@@ -12,10 +12,4 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-pub mod block_filter;
-pub mod compact_mutator;
-pub mod deletion_mutator;
-
-pub use block_filter::delete_from_block;
-pub use compact_mutator::CompactMutator;
-pub use deletion_mutator::DeletionMutator;
+mod deletion_mutator;

--- a/query/tests/it/storages/fuse/statistics.rs
+++ b/query/tests/it/storages/fuse/statistics.rs
@@ -65,7 +65,7 @@ fn test_reduce_block_statistics_in_memory_size() -> common_exception::Result<()>
             Some((idx, ColumnStatistics {
                 min: DataValue::Null,
                 max: DataValue::Null,
-                unset_bits: 1,
+                null_count: 1,
                 in_memory_size: 1,
             }))
         })
@@ -85,7 +85,7 @@ fn test_reduce_block_statistics_in_memory_size() -> common_exception::Result<()>
         // for each column, the reduced value of in_memory_size should be 1 + 1
         assert_eq!(col_stats.in_memory_size, 2);
         // for each column, the reduced value of null_count should be 1 + 1
-        assert_eq!(col_stats.unset_bits, 2);
+        assert_eq!(col_stats.null_count, 2);
     }
     Ok(())
 }

--- a/query/tests/it/storages/fuse/statistics.rs
+++ b/query/tests/it/storages/fuse/statistics.rs
@@ -19,6 +19,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use databend_query::storages::fuse::statistics::accumulator;
 use databend_query::storages::fuse::statistics::reducers;
+use databend_query::storages::index::ColumnStatistics;
 
 use crate::storages::fuse::statistics::accumulator::BlockStatistics;
 use crate::storages::fuse::table_test_fixture::TestFixture;
@@ -53,6 +54,39 @@ fn test_ft_stats_col_stats_reduce() -> common_exception::Result<()> {
     let col_stats = r.get(&0).unwrap();
     assert_eq!(col_stats.min, DataValue::Int64(val_start_with as i64));
     assert_eq!(col_stats.max, DataValue::Int64(num_of_blocks as i64));
+    Ok(())
+}
+
+#[test]
+fn test_reduce_block_statistics_in_memory_size() -> common_exception::Result<()> {
+    let iter = |mut idx| {
+        std::iter::from_fn(move || {
+            idx += 1;
+            Some((idx, ColumnStatistics {
+                min: DataValue::Null,
+                max: DataValue::Null,
+                unset_bits: 1,
+                in_memory_size: 1,
+            }))
+        })
+    };
+
+    let num_of_cols = 100;
+    // combine two statistics
+    let col_stats_left = HashMap::from_iter(iter(0).take(num_of_cols));
+    let col_stats_right = HashMap::from_iter(iter(0).take(num_of_cols));
+    let r = reducers::reduce_block_statistics(&[col_stats_left, col_stats_right])?;
+    assert_eq!(num_of_cols, r.len());
+    // there should be 100 columns in the result
+    for idx in 1..=100 {
+        let col_stats = r.get(&idx);
+        assert!(col_stats.is_some());
+        let col_stats = col_stats.unwrap();
+        // for each column, the reduced value of in_memory_size should be 1 + 1
+        assert_eq!(col_stats.in_memory_size, 2);
+        // for each column, the reduced value of null_count should be 1 + 1
+        assert_eq!(col_stats.unset_bits, 2);
+    }
     Ok(())
 }
 

--- a/tests/logictest/clickhouse_connector.py
+++ b/tests/logictest/clickhouse_connector.py
@@ -44,7 +44,8 @@ class ClickhouseConnector():
                 return sql  #  do nothing
 
         if self._session is None:
-            engine = create_engine(self._uri, connect_args=self._additonal_headers)
+            engine = create_engine(self._uri,
+                                   connect_args=self._additonal_headers)
             self._session = make_session(engine)
         log.debug(parseSQL(statement))
         return self._session.execute(parseSQL(statement))

--- a/tests/logictest/suites/gen/08_optimizer/08_0001_optimizer_statistics_exact
+++ b/tests/logictest/suites/gen/08_optimizer/08_0001_optimizer_statistics_exact
@@ -22,7 +22,7 @@ explain select 1 from t;
 ----  
 Projection: 1:UInt8
   Expression: 1:UInt8 (Before Projection)
-    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
 
 statement query T 
 explain select 1 + 1 from t;
@@ -30,7 +30,7 @@ explain select 1 + 1 from t;
 ----  
 Projection: (1 + 1):UInt16
   Expression: 2:UInt16 (Before Projection)
-    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
 
 statement query T 
 explain select now() from t;
@@ -38,7 +38,7 @@ explain select now() from t;
 ----  
 Projection: now():Timestamp(6)
   Expression: now():Timestamp(6) (Before Projection)
-    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
 
 statement query T 
 explain select sum(a) from t;
@@ -47,7 +47,7 @@ explain select sum(a) from t;
 Projection: sum(a):Nullable(Int64)
   AggregatorFinal: groupBy=[[]], aggr=[[sum(a)]]
     AggregatorPartial: groupBy=[[]], aggr=[[sum(a)]]
-      ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+      ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
 
 statement ok
 DROP TABLE IF EXISTS t;

--- a/tests/logictest/suites/gen/09_fuse_engine/09_0012_pushdown_limit
+++ b/tests/logictest/suites/gen/09_fuse_engine/09_0012_pushdown_limit
@@ -15,7 +15,7 @@ explain select * from t09_0012;
 
 ----  
 Projection: c:Nullable(Int32)
-  ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0]]
+  ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0]]
 
 statement query T 
 explain select * from t09_0012 limit 1;
@@ -23,7 +23,7 @@ explain select * from t09_0012 limit 1;
 ----  
 Limit: 1
   Projection: c:Nullable(Int32)
-    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 1]
+    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 1]
 
 statement query T 
 explain select * from t09_0012 limit 2;
@@ -31,7 +31,7 @@ explain select * from t09_0012 limit 2;
 ----  
 Limit: 2
   Projection: c:Nullable(Int32)
-    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 2]
+    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 2]
 
 statement query T 
 explain select * from t09_0012 limit 3;
@@ -39,7 +39,7 @@ explain select * from t09_0012 limit 3;
 ----  
 Limit: 3
   Projection: c:Nullable(Int32)
-    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 3]
+    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 3]
 
 statement query T 
 explain select * from t09_0012 limit 4;
@@ -47,7 +47,7 @@ explain select * from t09_0012 limit 4;
 ----  
 Limit: 4
   Projection: c:Nullable(Int32)
-    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 4]
+    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 4]
 
 statement query T 
 explain select * from t09_0012 limit 0;
@@ -63,7 +63,7 @@ explain select * from t09_0012 limit 5;
 ----  
 Limit: 5
   Projection: c:Nullable(Int32)
-    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 5]
+    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 5]
 
 statement query T 
 explain select * from t09_0012 where c > 2 limit 1;
@@ -72,7 +72,7 @@ explain select * from t09_0012 where c > 2 limit 1;
 Limit: 1
   Projection: c:Nullable(Int32)
     Filter: (c > 2)
-      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 1]
+      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 1]
 
 statement query T 
 explain select * from t09_0012 where c > 2 limit 2;
@@ -81,7 +81,7 @@ explain select * from t09_0012 where c > 2 limit 2;
 Limit: 2
   Projection: c:Nullable(Int32)
     Filter: (c > 2)
-      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 2]
+      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 2]
 
 statement query T 
 explain select * from t09_0012 where c > 2 limit 3;
@@ -90,7 +90,7 @@ explain select * from t09_0012 where c > 2 limit 3;
 Limit: 3
   Projection: c:Nullable(Int32)
     Filter: (c > 2)
-      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 3]
+      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 3]
 
 statement query T 
 explain select * from t09_0012 where c > 4 limit 1;

--- a/tests/suites/0_stateless/08_optimizer/08_0001_optimizer_statistics_exact.result
+++ b/tests/suites/0_stateless/08_optimizer/08_0001_optimizer_statistics_exact.result
@@ -4,14 +4,14 @@ Projection: count():UInt64
       ReadDataSource: scan schema: [dummy:UInt8], statistics: [read_rows: 1, read_bytes: 1, partitions_scanned: 1, partitions_total: 1]
 Projection: 1:UInt8
   Expression: 1:UInt8 (Before Projection)
-    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
 Projection: (1 + 1):UInt16
   Expression: 2:UInt16 (Before Projection)
-    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
 Projection: now():Timestamp(6)
   Expression: now():Timestamp(6) (Before Projection)
-    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
 Projection: sum(a):Nullable(Int64)
   AggregatorFinal: groupBy=[[]], aggr=[[sum(a)]]
     AggregatorPartial: groupBy=[[]], aggr=[[sum(a)]]
-      ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+      ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]

--- a/tests/suites/0_stateless/08_optimizer/08_0001_optimizer_statistics_exact_cluster.result
+++ b/tests/suites/0_stateless/08_optimizer/08_0001_optimizer_statistics_exact_cluster.result
@@ -4,15 +4,15 @@ Projection: count():UInt64
       ReadDataSource: scan schema: [dummy:UInt8], statistics: [read_rows: 1, read_bytes: 1, partitions_scanned: 1, partitions_total: 1]
 Projection: 1:UInt8
   Expression: 1:UInt8 (Before Projection)
-    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
 Projection: (1 + 1):UInt16
   Expression: 2:UInt16 (Before Projection)
-    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
 Projection: now():Timestamp(6)
   Expression: now():Timestamp(6) (Before Projection)
-    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+    ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
 Projection: sum(a):Nullable(Int64)
   AggregatorFinal: groupBy=[[]], aggr=[[sum(a)]]
     RedistributeStage[expr: 0]
       AggregatorPartial: groupBy=[[]], aggr=[[sum(a)]]
-        ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 4, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]
+        ReadDataSource: scan schema: [a:Int32;N], statistics: [read_rows: 1, read_bytes: 29, partitions_scanned: 1, partitions_total: 1], push_downs: [projections: [0]]

--- a/tests/suites/0_stateless/09_fuse_engine/09_0009_remote_explain.result
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0009_remote_explain.result
@@ -1,3 +1,3 @@
 Projection: a:Nullable(UInt32), b:Nullable(UInt64), c:Nullable(String)
   Filter: (a > 3)
-    ReadDataSource: scan schema: [a:UInt32;N, b:UInt64;N, c:String;N], statistics: [read_rows: 2, read_bytes: 56, partitions_scanned: 1, partitions_total: 3], push_downs: [projections: [0, 1, 2], filters: [(a > 3)]]
+    ReadDataSource: scan schema: [a:UInt32;N, b:UInt64;N, c:String;N], statistics: [read_rows: 2, read_bytes: 113, partitions_scanned: 1, partitions_total: 3], push_downs: [projections: [0, 1, 2], filters: [(a > 3)]]

--- a/tests/suites/0_stateless/09_fuse_engine/09_0009_remote_explain_cluster.result
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0009_remote_explain_cluster.result
@@ -1,3 +1,3 @@
 Projection: a:Nullable(UInt32), b:Nullable(UInt64), c:Nullable(String)
   Filter: (a > 3)
-    ReadDataSource: scan schema: [a:UInt32;N, b:UInt64;N, c:String;N], statistics: [read_rows: 2, read_bytes: 56, partitions_scanned: 1, partitions_total: 3], push_downs: [projections: [0, 1, 2], filters: [(a > 3)]]
+    ReadDataSource: scan schema: [a:UInt32;N, b:UInt64;N, c:String;N], statistics: [read_rows: 2, read_bytes: 113, partitions_scanned: 1, partitions_total: 3], push_downs: [projections: [0, 1, 2], filters: [(a > 3)]]

--- a/tests/suites/0_stateless/09_fuse_engine/09_0012_pushdown_limit.result
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0012_pushdown_limit.result
@@ -1,35 +1,35 @@
 Projection: c:Nullable(Int32)
-  ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0]]
+  ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0]]
 Limit: 1
   Projection: c:Nullable(Int32)
-    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 1]
+    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 1]
 Limit: 2
   Projection: c:Nullable(Int32)
-    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 2]
+    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 2]
 Limit: 3
   Projection: c:Nullable(Int32)
-    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 3]
+    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 3]
 Limit: 4
   Projection: c:Nullable(Int32)
-    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 4]
+    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 4]
 Limit: 0
   Projection: c:Nullable(Int32)
     ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 0, read_bytes: 0, partitions_scanned: 0, partitions_total: 0], push_downs: [projections: [0], limit: 0]
 Limit: 5
   Projection: c:Nullable(Int32)
-    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 5]
+    ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 5]
 Limit: 1
   Projection: c:Nullable(Int32)
     Filter: (c > 2)
-      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 1]
+      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 1]
 Limit: 2
   Projection: c:Nullable(Int32)
     Filter: (c > 2)
-      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 2]
+      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 2]
 Limit: 3
   Projection: c:Nullable(Int32)
     Filter: (c > 2)
-      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 3]
+      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 3]
 Limit: 1
   Projection: c:Nullable(Int32)
     Filter: (c > 4)

--- a/tests/suites/0_stateless/09_fuse_engine/09_0012_pushdown_limit_cluster.result
+++ b/tests/suites/0_stateless/09_fuse_engine/09_0012_pushdown_limit_cluster.result
@@ -1,21 +1,21 @@
 Projection: c:Nullable(Int32)
-  ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0]]
+  ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0]]
 Limit: 1
   RedistributeStage[expr: 0]
     Projection: c:Nullable(Int32)
-      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 1]
+      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 1]
 Limit: 2
   RedistributeStage[expr: 0]
     Projection: c:Nullable(Int32)
-      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 2]
+      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], limit: 2]
 Limit: 3
   RedistributeStage[expr: 0]
     Projection: c:Nullable(Int32)
-      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 3]
+      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 3]
 Limit: 4
   RedistributeStage[expr: 0]
     Projection: c:Nullable(Int32)
-      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 4]
+      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 4]
 Limit: 0
   RedistributeStage[expr: 0]
     Projection: c:Nullable(Int32)
@@ -23,22 +23,22 @@ Limit: 0
 Limit: 5
   RedistributeStage[expr: 0]
     Projection: c:Nullable(Int32)
-      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 16, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 5]
+      ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 4, read_bytes: 66, partitions_scanned: 2, partitions_total: 2], push_downs: [projections: [0], limit: 5]
 Limit: 1
   RedistributeStage[expr: 0]
     Projection: c:Nullable(Int32)
       Filter: (c > 2)
-        ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 1]
+        ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 1]
 Limit: 2
   RedistributeStage[expr: 0]
     Projection: c:Nullable(Int32)
       Filter: (c > 2)
-        ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 2]
+        ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 2]
 Limit: 3
   RedistributeStage[expr: 0]
     Projection: c:Nullable(Int32)
       Filter: (c > 2)
-        ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 8, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 3]
+        ReadDataSource: scan schema: [c:Int32;N], statistics: [read_rows: 2, read_bytes: 33, partitions_scanned: 1, partitions_total: 2], push_downs: [projections: [0], filters: [(c > 2)], limit: 3]
 Limit: 1
   RedistributeStage[expr: 0]
     Projection: c:Nullable(Int32)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- fix range deletion panic

> Dring deletion, multiple segments may become empty, while removing those segments from the snapshot, the index being used is NOT correct in some cases. this may lead to an index out of bound err, or even worse, silently deleting incorrect segments.

- incorrect statistics of block `in_memory_size`

  compressed/unpressed size of block/segment/table are not effected

- use column size(length in bytes, of column persistent in file), instead of column's `in_memory_size` for statistics of read_plan phase

Fixes #6570
