### PR TITLE
fix: remove unsupported IntervalType in DateTrunc

### DIFF
--- a/common/ast/src/parser/expr.rs
+++ b/common/ast/src/parser/expr.rs
@@ -925,7 +925,7 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
             | #cast : "`CAST(... AS ...)`"
             | #date_add: "`DATE_ADD(..., ..., (YEAR| MONTH | DAY | HOUR | MINUTE | SECOND | DOY | DOW))`"
             | #date_sub: "`DATE_SUB(..., ..., (YEAR| MONTH | DAY | HOUR | MINUTE | SECOND | DOY | DOW))`"
-            | #date_trunc: "`DATE_TRUNC((YEAR | MONTH | DAY | HOUR | MINUTE | SECOND | DOY | DOW), ...)`"
+            | #date_trunc: "`DATE_TRUNC((YEAR | MONTH | DAY | HOUR | MINUTE | SECOND), ...)`"
             | #interval: "`INTERVAL ... (YEAR| MONTH | DAY | HOUR | MINUTE | SECOND | DOY | DOW)`"
             | #pg_cast : "`::<type_name>`"
             | #extract : "`EXTRACT((YEAR | MONTH | DAY | HOUR | MINUTE | SECOND) FROM ...)`"

--- a/common/exception/src/exception_code.rs
+++ b/common/exception/src/exception_code.rs
@@ -212,7 +212,6 @@ build_exceptions! {
     IllegalUDFFormat(2601),
     UnknownUDF(2602),
     UdfAlreadyExists(2603),
-    UnsupportedIntervalKind(2604),
 
     // Database error codes.
     UnknownDatabaseEngine(2701),

--- a/query/src/sql/planner/semantic/type_check.rs
+++ b/query/src/sql/planner/semantic/type_check.rs
@@ -1244,7 +1244,7 @@ impl<'a> TypeChecker<'a> {
                 )
                 .await
             }
-            _ => Err(ErrorCode::UnsupportedIntervalKind("Only these interval types are currently supported: year, month, day, hour, minute, second")),
+            _ => Err(ErrorCode::SemanticError(span.display_error("Only these interval types are currently supported: [year, month, day, hour, minute, second]".to_string()))),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Remove unsupported IntervalType in DateTrunc

Fixes #issue

_Originally posted by @sundy-li in https://github.com/datafuselabs/databend/issues/6528#issuecomment-1181498136_