### PR TITLE
fix(metactl): extend sleep time before exporting data from a running databend-meta

### DIFF
--- a/tests/metactl/test-metactl.sh
+++ b/tests/metactl/test-metactl.sh
@@ -34,7 +34,7 @@ chmod +x ./target/${BUILD_PROFILE}/databend-meta
 ./target/${BUILD_PROFILE}/databend-meta --single &
 METASRV_PID=$!
 echo $METASRV_PID
-sleep 1
+sleep 3
 
 
 echo " === export data from a running databend-meta to $grpc_exported"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### test(metactl): extend sleep time before exporting data from a running databend-meta

It looks like `metactl --export` already starts to run before
`databend-meta` finishing setup listening ports:

https://github.com/datafuselabs/databend/runs/7333992815?check_suite_focus=true

```text
export meta dir from remote: 127.0.0.1:9191
 === exported file data start...
 === exported file data end
 === check if there is a node record in it

...

2022-07-14T05:16:21.908938Z  INFO databend_meta::api::grpc_server: gRPC addr: 127.0.0.1:9191
2022-07-14T05:16:21.909459Z  INFO databend_meta::api::grpc_server: metasrv starts to wait for stop signal: 127.0.0.1:9191
2022-07-14T05:16:21.909477Z  INFO databend_meta::api::grpc_server: Done GrpcServer::start
```

To fix flaky test in: https://github.com/datafuselabs/databend/pull/6617

- Fix: #6619

## Changelog







## Related Issues