### PR TITLE
feat: add created/dropped metrics to datablock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,6 +1082,7 @@ dependencies = [
  "common-datavalues",
  "common-exception",
  "common-io",
+ "common-metrics",
  "parking_lot 0.12.1",
  "pretty_assertions",
  "primitive-types",

--- a/common/datablocks/Cargo.toml
+++ b/common/datablocks/Cargo.toml
@@ -17,6 +17,7 @@ common-base = { path = "../base" }
 common-datavalues = { path = "../datavalues" }
 common-exception = { path = "../exception" }
 common-io = { path = "../io" }
+common-metrics = { path = "../metrics" }
 
 # Github dependencies
 

--- a/common/datablocks/src/data_block.rs
+++ b/common/datablocks/src/data_block.rs
@@ -46,11 +46,13 @@ impl DataBlock {
                 .map(|c| c.data_type())
                 .collect::<Vec<DataTypeImpl>>()
         );
+        super::metrics::incr_data_block_created();
         DataBlock { schema, columns }
     }
 
     #[inline]
     pub fn empty() -> Self {
+        super::metrics::incr_data_block_created();
         DataBlock {
             schema: Arc::new(DataSchema::empty()),
             columns: vec![],
@@ -64,6 +66,7 @@ impl DataBlock {
             let col = f.data_type().create_column(&[]).unwrap();
             columns.push(col)
         }
+        super::metrics::incr_data_block_created();
         DataBlock { schema, columns }
     }
 
@@ -257,5 +260,11 @@ impl fmt::Debug for DataBlock {
 impl Default for DataBlock {
     fn default() -> Self {
         Self::empty()
+    }
+}
+
+impl Drop for DataBlock {
+    fn drop(&mut self) {
+        super::metrics::incr_data_block_dropped()
     }
 }

--- a/common/datablocks/src/data_block.rs
+++ b/common/datablocks/src/data_block.rs
@@ -25,7 +25,7 @@ use common_exception::Result;
 
 use crate::pretty_format_blocks;
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct DataBlock {
     schema: DataSchemaRef,
     columns: Vec<ColumnRef>,
@@ -254,6 +254,12 @@ impl fmt::Debug for DataBlock {
         let formatted = pretty_format_blocks(&[self.clone()]).expect("Pretty format batches error");
         let lines: Vec<&str> = formatted.trim().lines().collect();
         write!(f, "\n{:#?}\n", lines)
+    }
+}
+
+impl Clone for DataBlock {
+    fn clone(&self) -> Self {
+        Self::create(self.schema.clone(), self.columns.clone())
     }
 }
 

--- a/common/datablocks/src/metrics.rs
+++ b/common/datablocks/src/metrics.rs
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use metrics::counter;
+use common_metrics::label_counter_with_val_and_labels;
 
 pub static METRIC_DATA_BLOCK_CREATED: &str = "data_block_created_total";
 pub static METRIC_DATA_BLOCK_DROPPED: &str = "data_block_dropped_total";
 
-fn incr_created_counter() {
-    counter!(super::metrics::METRIC_DATA_BLOCK_CREATED, 1);
+#[inline]
+pub fn incr_data_block_created() {
+    label_counter_with_val_and_labels(METRIC_DATA_BLOCK_CREATED, vec![], 1);
 }
 
-fn incr_dropped_counter() {
-    counter!(super::metrics::METRIC_DATA_BLOCK_DROPPED, 1);
+#[inline]
+pub fn incr_data_block_dropped() {
+    label_counter_with_val_and_labels(METRIC_DATA_BLOCK_DROPPED, vec![], 1);
 }

--- a/common/datablocks/src/metrics.rs
+++ b/common/datablocks/src/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2022 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(hash_raw_entry)]
-#![feature(trusted_len)]
-#![feature(generic_associated_types)]
+use metrics::counter;
 
-mod data_block;
-mod data_block_debug;
-mod kernels;
-mod memory;
-mod metrics;
-mod utils;
+pub static METRIC_DATA_BLOCK_CREATED: &str = "data_block_created_total";
+pub static METRIC_DATA_BLOCK_DROPPED: &str = "data_block_dropped_total";
 
-pub use data_block::DataBlock;
-pub use data_block_debug::*;
-pub use kernels::*;
-pub use memory::InMemoryData;
-pub use utils::*;
+fn incr_created_counter() {
+    counter!(super::metrics::METRIC_DATA_BLOCK_CREATED, 1);
+}
+
+fn incr_dropped_counter() {
+    counter!(super::metrics::METRIC_DATA_BLOCK_DROPPED, 1);
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

this PR adds created/dropped metrics to DataBlock, we can get how many living DataBlocks by these two metrics, may help us diagnose some OOM issues.