### PR TITLE
chore(build-tool): revert to use symlink instead of env for musl CC

### DIFF
--- a/docker/build-tool/musl/Dockerfile
+++ b/docker/build-tool/musl/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sSfLo /tmp/musl-cross-make.tar.gz https://github.com/richfelker/musl-c
     rm -rf /tmp/musl-cross-make-* && \
     rm -f /tmp/musl-cross-make.tar.gz
 
-ENV CC /usr/local/bin/${ARCH}-linux-musl-cc
 ENV C_INCLUDE_PATH /usr/local/${ARCH}-linux-musl/include/
+RUN ln -s ${ARCH}-linux-musl-gcc /usr/local/bin/musl-gcc
 RUN rustup target add ${ARCH}-unknown-linux-musl
 RUN printf "[target.${ARCH}-unknown-linux-musl]\nlinker = \"${ARCH}-linux-musl-gcc\"\n" > ${CARGO_HOME}/config


### PR DESCRIPTION
This reverts commit 8ece4d6e39aac39bc2b0b18f5725d5cc9c6d9972.

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Fixes #issue
