### PR TITLE
feat(expr): allow function to return runtime error

### DIFF
--- a/common/expression/src/display.rs
+++ b/common/expression/src/display.rs
@@ -66,7 +66,7 @@ impl Display for Chunk {
             let row: Vec<_> = self
                 .columns()
                 .iter()
-                .map(|col| col.index(index).to_string())
+                .map(|col| col.index(index).unwrap().to_string())
                 .map(Cell::new)
                 .collect();
             table.add_row(row);

--- a/common/expression/src/evaluator.rs
+++ b/common/expression/src/evaluator.rs
@@ -47,6 +47,7 @@ impl Evaluator {
                 Ok(Value::Column(self.input_columns.columns()[*id].clone()))
             }
             Expr::FunctionCall {
+                span,
                 function,
                 args,
                 generics,
@@ -65,7 +66,7 @@ impl Evaluator {
                         .all_equal()
                 );
                 let cols_ref = cols.iter().map(Value::as_ref).collect::<Vec<_>>();
-                Ok((function.eval)(cols_ref.as_slice(), generics))
+                (function.eval)(cols_ref.as_slice(), generics).map_err(|msg| (span.clone(), msg))
             }
             Expr::Cast {
                 span,

--- a/common/expression/src/type_check.rs
+++ b/common/expression/src/type_check.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::fmt::Write;
 
 use itertools::Itertools;
 
@@ -118,12 +119,19 @@ pub fn check_function(
         }
     }
 
-    let msg = if candidates.is_empty() {
+    let mut msg = if params.is_empty() {
         format!(
             "no overload satisfies `{name}({})`",
             args_type.iter().map(ToString::to_string).join(", ")
         )
     } else {
+        format!(
+            "no overload satisfies `{name}({})({})`",
+            params.iter().join(", "),
+            args_type.iter().map(ToString::to_string).join(", ")
+        )
+    };
+    if !candidates.is_empty() {
         let candidates_sig: Vec<_> = candidates
             .iter()
             .map(|(_, func)| func.signature.to_string())
@@ -137,12 +145,12 @@ pub fn check_function(
             .map(|(sig, (_, reason))| format!("  {sig:<max_len$}  : {reason}"))
             .join("\n");
 
-        format!(
-            "no overload satisfies `{name}({})`\n\n\
-            has tried possible overloads:\n{}",
-            args_type.iter().map(ToString::to_string).join(", "),
+        write!(
+            &mut msg,
+            "\n\nhas tried possible overloads:\n{}",
             candidates_fail_reason
         )
+        .unwrap();
     };
 
     Err((span, msg))

--- a/common/expression/src/types.rs
+++ b/common/expression/src/types.rs
@@ -94,7 +94,7 @@ pub trait ArgType: ValueType {
     fn full_domain(generics: &GenericMap) -> Self::Domain;
 
     fn column_len<'a>(col: &'a Self::Column) -> usize;
-    fn index_column<'a>(col: &'a Self::Column, index: usize) -> Self::ScalarRef<'a>;
+    fn index_column<'a>(col: &'a Self::Column, index: usize) -> Option<Self::ScalarRef<'a>>;
     fn slice_column<'a>(col: &'a Self::Column, range: Range<usize>) -> Self::Column;
     fn iter_column<'a>(col: &'a Self::Column) -> Self::ColumnIterator<'a>;
     fn column_from_iter(

--- a/common/expression/src/types/array.rs
+++ b/common/expression/src/types/array.rs
@@ -97,11 +97,14 @@ impl<T: ArgType> ArgType for ArrayType<T> {
         offsets.len()
     }
 
-    fn index_column<'a>((col, offsets): &'a Self::Column, index: usize) -> Self::ScalarRef<'a> {
-        T::slice_column(
+    fn index_column<'a>(
+        (col, offsets): &'a Self::Column,
+        index: usize,
+    ) -> Option<Self::ScalarRef<'a>> {
+        Some(T::slice_column(
             col,
             (offsets[index] as usize)..(offsets[index + 1] as usize),
-        )
+        ))
     }
 
     fn slice_column<'a>((col, offsets): &'a Self::Column, range: Range<usize>) -> Self::Column {

--- a/common/expression/src/types/boolean.rs
+++ b/common/expression/src/types/boolean.rs
@@ -93,8 +93,8 @@ impl ArgType for BooleanType {
         col.len()
     }
 
-    fn index_column<'a>(col: &'a Self::Column, index: usize) -> Self::ScalarRef<'a> {
-        col.get(index).unwrap()
+    fn index_column<'a>(col: &'a Self::Column, index: usize) -> Option<Self::ScalarRef<'a>> {
+        col.get(index)
     }
 
     fn slice_column<'a>(col: &'a Self::Column, range: Range<usize>) -> Self::Column {

--- a/common/expression/src/types/empty_array.rs
+++ b/common/expression/src/types/empty_array.rs
@@ -86,8 +86,8 @@ impl ArgType for EmptyArrayType {
         *len
     }
 
-    fn index_column<'a>(len: &'a Self::Column, index: usize) -> Self::ScalarRef<'a> {
-        assert!(index < *len, "index {index} out of 0..{len}");
+    fn index_column<'a>(len: &'a Self::Column, index: usize) -> Option<Self::ScalarRef<'a>> {
+        if index < *len { Some(()) } else { None }
     }
 
     fn slice_column<'a>(len: &'a Self::Column, range: Range<usize>) -> Self::Column {

--- a/common/expression/src/types/generic.rs
+++ b/common/expression/src/types/generic.rs
@@ -82,7 +82,7 @@ impl<const INDEX: usize> ArgType for GenericType<INDEX> {
         col.len()
     }
 
-    fn index_column<'a>(col: &'a Self::Column, index: usize) -> Self::ScalarRef<'a> {
+    fn index_column<'a>(col: &'a Self::Column, index: usize) -> Option<Self::ScalarRef<'a>> {
         col.index(index)
     }
 

--- a/common/expression/src/types/null.rs
+++ b/common/expression/src/types/null.rs
@@ -93,8 +93,8 @@ impl ArgType for NullType {
         *len
     }
 
-    fn index_column<'a>(len: &'a Self::Column, index: usize) -> Self::ScalarRef<'a> {
-        assert!(index < *len, "index {index} out of 0..{len}")
+    fn index_column<'a>(len: &'a Self::Column, index: usize) -> Option<Self::ScalarRef<'a>> {
+        if index < *len { Some(()) } else { None }
     }
 
     fn slice_column<'a>(len: &'a Self::Column, range: Range<usize>) -> Self::Column {

--- a/common/expression/src/types/nullable.rs
+++ b/common/expression/src/types/nullable.rs
@@ -115,13 +115,16 @@ impl<T: ArgType> ArgType for NullableType<T> {
         validity.len()
     }
 
-    fn index_column<'a>((col, validity): &'a Self::Column, index: usize) -> Self::ScalarRef<'a> {
-        let scalar = T::index_column(col, index);
-        if validity.get(index).unwrap() {
+    fn index_column<'a>(
+        (col, validity): &'a Self::Column,
+        index: usize,
+    ) -> Option<Self::ScalarRef<'a>> {
+        let scalar = T::index_column(col, index)?;
+        Some(if validity.get(index).unwrap() {
             Some(scalar)
         } else {
             None
-        }
+        })
     }
 
     fn slice_column<'a>((col, validity): &'a Self::Column, range: Range<usize>) -> Self::Column {

--- a/common/expression/src/types/number.rs
+++ b/common/expression/src/types/number.rs
@@ -101,8 +101,8 @@ impl<T: Number> ArgType for NumberType<T> {
         col.len()
     }
 
-    fn index_column<'a>(col: &'a Self::Column, index: usize) -> Self::ScalarRef<'a> {
-        col[index]
+    fn index_column<'a>(col: &'a Self::Column, index: usize) -> Option<Self::ScalarRef<'a>> {
+        col.get(index).cloned()
     }
 
     fn slice_column<'a>(col: &'a Self::Column, range: Range<usize>) -> Self::Column {

--- a/common/expression/src/types/string.rs
+++ b/common/expression/src/types/string.rs
@@ -88,8 +88,15 @@ impl ArgType for StringType {
         offsets.len() - 1
     }
 
-    fn index_column<'a>((data, offsets): &'a Self::Column, index: usize) -> Self::ScalarRef<'a> {
-        &data[(offsets[index] as usize)..(offsets[index + 1] as usize)]
+    fn index_column<'a>(
+        (data, offsets): &'a Self::Column,
+        index: usize,
+    ) -> Option<Self::ScalarRef<'a>> {
+        if index + 1 < offsets.len() {
+            Some(&data[(offsets[index] as usize)..(offsets[index + 1] as usize)])
+        } else {
+            None
+        }
     }
 
     fn slice_column<'a>((data, offsets): &'a Self::Column, range: Range<usize>) -> Self::Column {

--- a/common/expression/tests/it/main.rs
+++ b/common/expression/tests/it/main.rs
@@ -490,10 +490,11 @@ fn builtin_functions() -> FunctionRegistry {
         FunctionProperty::default(),
         |item_domain, _| Some(item_domain.clone()),
         |array, idx, output| {
-            Ok(output.push(
-                array
-                    .index(idx as usize)
-                    .ok_or_else(|| format!("index out of bounds: the len is {} but the index is {}", array.len(), idx))?))
+            let item = array
+                .index(idx as usize)
+                .ok_or_else(|| format!("index out of bounds: the len is {} but the index is {}", array.len(), idx))?;
+            output.push(item);
+            Ok(())
         },
     );
 

--- a/common/expression/tests/it/testdata/eval-fail.txt
+++ b/common/expression/tests/it/testdata/eval-fail.txt
@@ -1,0 +1,16 @@
+error: 
+  --> SQL:1:1
+  |
+1 | get(create_array(1, 2), 2)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the len is 2 but the index is 2
+
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | get(create_array(a, b), idx)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the len is 2 but the index is 2
+
+
+

--- a/common/expression/tests/it/testdata/tyck-fail.txt
+++ b/common/expression/tests/it/testdata/tyck-fail.txt
@@ -22,10 +22,10 @@ error:
 
 
 error: 
-  --> SQL:1:1
+  --> SQL:1:10
   |
-1 | bool_not('a')
-  | ^^^^^^^^^^^^^ no overload satisfies `bool_not(String)`
+1 | bool_not(bool_not('a'))
+  |          ^^^^^^^^^^^^^ no overload satisfies `bool_not(String)`
 
 has tried possible overloads:
   bool_not(NULL) :: NULL                  : unable to unify `String` with `NULL`
@@ -86,7 +86,7 @@ error:
   --> SQL:1:1
   |
 1 | get_tuple(1)(create_tuple(true))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no overload satisfies `get_tuple((Boolean,))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no overload satisfies `get_tuple(1)((Boolean,))`
 
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- allow function to return runtime error
- `Column::index()` returns `Option` instead of panic
- test throwing error in `get(Array(T0), Int16) :: T0`

Tracked in https://github.com/datafuselabs/databend/issues/6547
