### PR TITLE
feat(expr): support user-defined `CAST` and `TRY_CAST`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,8 @@ dependencies = [
  "enum-as-inner",
  "goldenfile",
  "itertools",
+ "match-template",
+ "num-traits",
 ]
 
 [[package]]
@@ -4131,6 +4133,17 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "match-template"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c334ac67725febd94c067736ac46ef1c7cacf1c743ca14b9f917c2df2c20acd8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "match_cfg"

--- a/common/ast/src/ast/expr.rs
+++ b/common/ast/src/ast/expr.rs
@@ -263,6 +263,7 @@ pub enum TypeName {
     Timestamp,
     String,
     Array { item_type: Option<Box<TypeName>> },
+    Tuple { fields_type: Vec<TypeName> },
     Object,
     Variant,
     Nullable(Box<TypeName>),
@@ -541,6 +542,15 @@ impl Display for TypeName {
                 write!(f, "ARRAY")?;
                 if let Some(item_type) = item_type {
                     write!(f, "({})", *item_type)?;
+                }
+            }
+            TypeName::Tuple { fields_type } => {
+                write!(f, "(")?;
+                write_comma_separated_list(f, fields_type)?;
+                if fields_type.len() == 1 {
+                    write!(f, ",)")?;
+                } else {
+                    write!(f, ")")?;
                 }
             }
             TypeName::Object => {

--- a/common/ast/src/parser/expr.rs
+++ b/common/ast/src/parser/expr.rs
@@ -1139,6 +1139,10 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
             item_type: opt_item_type.map(|(_, opt_item_type, _)| Box::new(opt_item_type)),
         },
     );
+    let ty_tuple = map(
+        rule! { "(" ~ #comma_separated_list1(type_name) ~ ")" },
+        |(_, fields_type, _)| TypeName::Tuple { fields_type },
+    );
     let ty_date = value(TypeName::Date, rule! { DATE });
     let ty_datetime = map(
         rule! { DATETIME ~ ( "(" ~ #literal_u64 ~ ")" )? },
@@ -1167,6 +1171,7 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
             | #ty_float32
             | #ty_float64
             | #ty_array
+            | #ty_tuple
             | #ty_date
             | #ty_datetime
             | #ty_timestamp

--- a/common/ast/tests/it/parser.rs
+++ b/common/ast/tests/it/parser.rs
@@ -415,6 +415,7 @@ fn test_expr() {
         r#"covar_samp(number, number)"#,
         r#"CAST(col1 AS BIGINT UNSIGNED)"#,
         r#"TRY_CAST(col1 AS BIGINT UNSIGNED)"#,
+        r#"TRY_CAST(col1 AS (BIGINT UNSIGNED NULL, BOOLEAN))"#,
         r#"trim(leading 'abc' from 'def')"#,
         r#"extract(year from d)"#,
         r#"position('a' in str)"#,

--- a/common/ast/tests/it/testdata/expr-error.txt
+++ b/common/ast/tests/it/testdata/expr-error.txt
@@ -31,7 +31,7 @@ error:
 1 | CAST(col1 AS foo)
   | ----         ^^^
   | |            |
-  | |            expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 25 more ...
+  | |            expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 26 more ...
   | |            while parsing type name
   | while parsing `CAST(... AS ...)`
   | while parsing expression

--- a/common/ast/tests/it/testdata/expr.txt
+++ b/common/ast/tests/it/testdata/expr.txt
@@ -1404,6 +1404,49 @@ TryCast {
 
 
 ---------- Input ----------
+TRY_CAST(col1 AS (BIGINT UNSIGNED NULL, BOOLEAN))
+---------- Output ---------
+TRY_CAST(col1 AS (UInt64 NULL, BOOLEAN))
+---------- AST ------------
+TryCast {
+    span: [
+        TRY_CAST(0..8),
+        LParen(8..9),
+        Ident(9..13),
+        AS(14..16),
+        LParen(17..18),
+        BIGINT(18..24),
+        UNSIGNED(25..33),
+        NULL(34..38),
+        Comma(38..39),
+        BOOLEAN(40..47),
+        RParen(47..48),
+        RParen(48..49),
+    ],
+    expr: ColumnRef {
+        span: [
+            Ident(9..13),
+        ],
+        database: None,
+        table: None,
+        column: Identifier {
+            name: "col1",
+            quote: None,
+            span: Ident(9..13),
+        },
+    },
+    target_type: Tuple {
+        fields_type: [
+            Nullable(
+                UInt64,
+            ),
+            Boolean,
+        ],
+    },
+}
+
+
+---------- Input ----------
 trim(leading 'abc' from 'def')
 ---------- Output ---------
 TRIM(LEADING 'abc' FROM 'def')

--- a/common/ast/tests/it/testdata/statement-error.txt
+++ b/common/ast/tests/it/testdata/statement-error.txt
@@ -31,7 +31,7 @@ error:
 1 | create table a (c varch)
   | ------          - ^^^^^
   | |               | |
-  | |               | expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 25 more ...
+  | |               | expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 26 more ...
   | |               | while parsing type name
   | |               while parsing `<column name> <type> [DEFAULT <default value>] [COMMENT '<comment>']`
   | while parsing `CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`

--- a/common/expression/Cargo.toml
+++ b/common/expression/Cargo.toml
@@ -20,6 +20,8 @@ chrono-tz = "0.6.1"
 comfy-table = "6"
 enum-as-inner = "0.4"
 itertools = "0.10"
+num-traits = "0.2"
+match-template = "0.0.1"
 
 [dev-dependencies]
 common-ast = { path = "../ast" }

--- a/common/expression/Cargo.toml
+++ b/common/expression/Cargo.toml
@@ -20,8 +20,8 @@ chrono-tz = "0.6.1"
 comfy-table = "6"
 enum-as-inner = "0.4"
 itertools = "0.10"
-num-traits = "0.2"
 match-template = "0.0.1"
+num-traits = "0.2"
 
 [dev-dependencies]
 common-ast = { path = "../ast" }

--- a/common/expression/src/evaluator.rs
+++ b/common/expression/src/evaluator.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_arrow::arrow::bitmap;
+use common_arrow::arrow::bitmap::MutableBitmap;
 use itertools::Itertools;
+use num_traits::ToPrimitive;
 
 use crate::chunk::Chunk;
 use crate::error::Result;
@@ -34,6 +37,7 @@ use crate::values::Column;
 use crate::values::ColumnBuilder;
 use crate::values::Scalar;
 use crate::values::Value;
+use crate::with_number_type;
 
 pub struct Evaluator {
     pub input_columns: Chunk,
@@ -75,294 +79,38 @@ impl Evaluator {
                 dest_type,
             } => {
                 let value = self.run(expr)?;
-                self.run_cast(value, dest_type, span.clone())
+                match value {
+                    Value::Scalar(scalar) => Ok(Value::Scalar(self.run_cast_scalar(
+                        span.clone(),
+                        scalar,
+                        dest_type,
+                    )?)),
+                    Value::Column(col) => Ok(Value::Column(self.run_cast_column(
+                        span.clone(),
+                        col,
+                        dest_type,
+                    )?)),
+                }
             }
-        }
-    }
-
-    pub fn run_cast(
-        &self,
-        input: Value<AnyType>,
-        dest_type: &DataType,
-        span: Span,
-    ) -> Result<Value<AnyType>> {
-        match input {
-            Value::Scalar(scalar) => match (scalar, dest_type) {
-                (Scalar::Null, DataType::Nullable(_)) => Ok(Value::Scalar(Scalar::Null)),
-                (Scalar::EmptyArray, DataType::Array(dest_ty)) => {
-                    let column = ColumnBuilder::with_capacity(dest_ty, 0).build();
-                    Ok(Value::Scalar(Scalar::Array(column)))
+            Expr::TryCast {
+                span,
+                expr,
+                dest_type,
+            } => {
+                let value = self.run(expr)?;
+                match value {
+                    Value::Scalar(scalar) => Ok(Value::Scalar(self.run_try_cast_scalar(
+                        span.clone(),
+                        scalar,
+                        dest_type,
+                    ))),
+                    Value::Column(col) => Ok(Value::Column(self.run_try_cast_column(
+                        span.clone(),
+                        col,
+                        dest_type,
+                    ))),
                 }
-                (scalar, DataType::Nullable(dest_ty)) => {
-                    self.run_cast(Value::Scalar(scalar), dest_ty, span)
-                }
-                (Scalar::Array(array), DataType::Array(dest_ty)) => {
-                    let array = self
-                        .run_cast(Value::Column(array), dest_ty, span)?
-                        .into_column()
-                        .ok()
-                        .unwrap();
-                    Ok(Value::Scalar(Scalar::Array(array)))
-                }
-                (Scalar::UInt8(val), DataType::UInt16) => {
-                    Ok(Value::Scalar(Scalar::UInt16(val as u16)))
-                }
-                (Scalar::UInt8(val), DataType::UInt32) => {
-                    Ok(Value::Scalar(Scalar::UInt32(val as u32)))
-                }
-                (Scalar::UInt16(val), DataType::UInt32) => {
-                    Ok(Value::Scalar(Scalar::UInt32(val as u32)))
-                }
-                (Scalar::UInt8(val), DataType::UInt64) => {
-                    Ok(Value::Scalar(Scalar::UInt64(val as u64)))
-                }
-                (Scalar::UInt16(val), DataType::UInt64) => {
-                    Ok(Value::Scalar(Scalar::UInt64(val as u64)))
-                }
-                (Scalar::UInt32(val), DataType::UInt64) => {
-                    Ok(Value::Scalar(Scalar::UInt64(val as u64)))
-                }
-                (Scalar::Int8(val), DataType::Int16) => {
-                    Ok(Value::Scalar(Scalar::Int16(val as i16)))
-                }
-                (Scalar::UInt8(val), DataType::Int16) => {
-                    Ok(Value::Scalar(Scalar::Int16(val as i16)))
-                }
-                (Scalar::Int8(val), DataType::Int32) => {
-                    Ok(Value::Scalar(Scalar::Int32(val as i32)))
-                }
-                (Scalar::Int16(val), DataType::Int32) => {
-                    Ok(Value::Scalar(Scalar::Int32(val as i32)))
-                }
-                (Scalar::UInt8(val), DataType::Int32) => {
-                    Ok(Value::Scalar(Scalar::Int32(val as i32)))
-                }
-                (Scalar::UInt16(val), DataType::Int32) => {
-                    Ok(Value::Scalar(Scalar::Int32(val as i32)))
-                }
-                (Scalar::Int8(val), DataType::Int64) => {
-                    Ok(Value::Scalar(Scalar::Int64(val as i64)))
-                }
-                (Scalar::Int16(val), DataType::Int64) => {
-                    Ok(Value::Scalar(Scalar::Int64(val as i64)))
-                }
-                (Scalar::Int32(val), DataType::Int64) => {
-                    Ok(Value::Scalar(Scalar::Int64(val as i64)))
-                }
-                (Scalar::UInt8(val), DataType::Int64) => {
-                    Ok(Value::Scalar(Scalar::Int64(val as i64)))
-                }
-                (Scalar::UInt16(val), DataType::Int64) => {
-                    Ok(Value::Scalar(Scalar::Int64(val as i64)))
-                }
-                (Scalar::UInt32(val), DataType::Int64) => {
-                    Ok(Value::Scalar(Scalar::Int64(val as i64)))
-                }
-                (Scalar::Int8(val), DataType::Float32) => {
-                    Ok(Value::Scalar(Scalar::Float32(val as f32)))
-                }
-                (Scalar::Int16(val), DataType::Float32) => {
-                    Ok(Value::Scalar(Scalar::Float32(val as f32)))
-                }
-                (Scalar::UInt8(val), DataType::Float32) => {
-                    Ok(Value::Scalar(Scalar::Float32(val as f32)))
-                }
-                (Scalar::UInt16(val), DataType::Float32) => {
-                    Ok(Value::Scalar(Scalar::Float32(val as f32)))
-                }
-                (Scalar::Int8(val), DataType::Float64) => {
-                    Ok(Value::Scalar(Scalar::Float64(val as f64)))
-                }
-                (Scalar::Int16(val), DataType::Float64) => {
-                    Ok(Value::Scalar(Scalar::Float64(val as f64)))
-                }
-                (Scalar::Int32(val), DataType::Float64) => {
-                    Ok(Value::Scalar(Scalar::Float64(val as f64)))
-                }
-                (Scalar::UInt8(val), DataType::Float64) => {
-                    Ok(Value::Scalar(Scalar::Float64(val as f64)))
-                }
-                (Scalar::UInt16(val), DataType::Float64) => {
-                    Ok(Value::Scalar(Scalar::Float64(val as f64)))
-                }
-                (Scalar::UInt32(val), DataType::Float64) => {
-                    Ok(Value::Scalar(Scalar::Float64(val as f64)))
-                }
-                (Scalar::Float32(val), DataType::Float64) => {
-                    Ok(Value::Scalar(Scalar::Float64(val as f64)))
-                }
-                (scalar @ Scalar::Boolean(_), DataType::Boolean)
-                | (scalar @ Scalar::String(_), DataType::String)
-                | (scalar @ Scalar::UInt8(_), DataType::UInt8)
-                | (scalar @ Scalar::UInt16(_), DataType::UInt16)
-                | (scalar @ Scalar::UInt32(_), DataType::UInt32)
-                | (scalar @ Scalar::UInt64(_), DataType::UInt64)
-                | (scalar @ Scalar::Int8(_), DataType::Int8)
-                | (scalar @ Scalar::Int16(_), DataType::Int16)
-                | (scalar @ Scalar::Int32(_), DataType::Int32)
-                | (scalar @ Scalar::Int64(_), DataType::Int64)
-                | (scalar @ Scalar::Float32(_), DataType::Float32)
-                | (scalar @ Scalar::Float64(_), DataType::Float64)
-                | (scalar @ Scalar::Null, DataType::Null)
-                | (scalar @ Scalar::EmptyArray, DataType::EmptyArray) => Ok(Value::Scalar(scalar)),
-                (scalar, dest_ty) => Err((
-                    span,
-                    (format!("unable to cast scalar {} to {dest_ty}", scalar.as_ref())),
-                )),
-            },
-            Value::Column(col) => match (col, dest_type) {
-                (Column::Null { len }, DataType::Nullable(_)) => {
-                    let mut builder = ColumnBuilder::with_capacity(dest_type, len);
-                    for _ in 0..len {
-                        builder.push_default();
-                    }
-                    Ok(Value::Column(builder.build()))
-                }
-                (Column::EmptyArray { len }, DataType::Array(dest_ty)) => {
-                    Ok(Value::Column(Column::Array {
-                        array: Box::new(ColumnBuilder::with_capacity(dest_ty, 0).build()),
-                        offsets: vec![0; len + 1].into(),
-                    }))
-                }
-                (Column::Nullable { column, validity }, DataType::Nullable(dest_ty)) => {
-                    let column = self
-                        .run_cast(Value::Column(*column), dest_ty, span)?
-                        .into_column()
-                        .ok()
-                        .unwrap();
-                    Ok(Value::Column(Column::Nullable {
-                        column: Box::new(column),
-                        validity,
-                    }))
-                }
-                (col, DataType::Nullable(dest_ty)) => {
-                    let column = self
-                        .run_cast(Value::Column(col), dest_ty, span)?
-                        .into_column()
-                        .ok()
-                        .unwrap();
-                    Ok(Value::Column(Column::Nullable {
-                        validity: constant_bitmap(true, column.len()).into(),
-                        column: Box::new(column),
-                    }))
-                }
-                (Column::Array { array, offsets }, DataType::Array(dest_ty)) => {
-                    let array = self
-                        .run_cast(Value::Column(*array), dest_ty, span)?
-                        .into_column()
-                        .ok()
-                        .unwrap();
-                    Ok(Value::Column(Column::Array {
-                        array: Box::new(array),
-                        offsets,
-                    }))
-                }
-                (Column::UInt8(column), DataType::UInt16) => Ok(Value::Column(Column::UInt16(
-                    column.iter().map(|v| *v as u16).collect(),
-                ))),
-                (Column::UInt8(column), DataType::UInt32) => Ok(Value::Column(Column::UInt32(
-                    column.iter().map(|v| *v as u32).collect(),
-                ))),
-                (Column::UInt16(column), DataType::UInt32) => Ok(Value::Column(Column::UInt32(
-                    column.iter().map(|v| *v as u32).collect(),
-                ))),
-                (Column::UInt8(column), DataType::UInt64) => Ok(Value::Column(Column::UInt64(
-                    column.iter().map(|v| *v as u64).collect(),
-                ))),
-                (Column::UInt16(column), DataType::UInt64) => Ok(Value::Column(Column::UInt64(
-                    column.iter().map(|v| *v as u64).collect(),
-                ))),
-                (Column::UInt32(column), DataType::UInt64) => Ok(Value::Column(Column::UInt64(
-                    column.iter().map(|v| *v as u64).collect(),
-                ))),
-                (Column::Int8(column), DataType::Int16) => Ok(Value::Column(Column::Int16(
-                    column.iter().map(|v| *v as i16).collect(),
-                ))),
-                (Column::UInt8(column), DataType::Int16) => Ok(Value::Column(Column::Int16(
-                    column.iter().map(|v| *v as i16).collect(),
-                ))),
-                (Column::Int8(column), DataType::Int32) => Ok(Value::Column(Column::Int32(
-                    column.iter().map(|v| *v as i32).collect(),
-                ))),
-                (Column::Int16(column), DataType::Int32) => Ok(Value::Column(Column::Int32(
-                    column.iter().map(|v| *v as i32).collect(),
-                ))),
-                (Column::UInt8(column), DataType::Int32) => Ok(Value::Column(Column::Int32(
-                    column.iter().map(|v| *v as i32).collect(),
-                ))),
-                (Column::UInt16(column), DataType::Int32) => Ok(Value::Column(Column::Int32(
-                    column.iter().map(|v| *v as i32).collect(),
-                ))),
-                (Column::Int8(column), DataType::Int64) => Ok(Value::Column(Column::Int64(
-                    column.iter().map(|v| *v as i64).collect(),
-                ))),
-                (Column::Int16(column), DataType::Int64) => Ok(Value::Column(Column::Int64(
-                    column.iter().map(|v| *v as i64).collect(),
-                ))),
-                (Column::Int32(column), DataType::Int64) => Ok(Value::Column(Column::Int64(
-                    column.iter().map(|v| *v as i64).collect(),
-                ))),
-                (Column::UInt8(column), DataType::Int64) => Ok(Value::Column(Column::Int64(
-                    column.iter().map(|v| *v as i64).collect(),
-                ))),
-                (Column::UInt16(column), DataType::Int64) => Ok(Value::Column(Column::Int64(
-                    column.iter().map(|v| *v as i64).collect(),
-                ))),
-                (Column::UInt32(column), DataType::Int64) => Ok(Value::Column(Column::Int64(
-                    column.iter().map(|v| *v as i64).collect(),
-                ))),
-                (Column::Int8(column), DataType::Float32) => Ok(Value::Column(Column::Float32(
-                    column.iter().map(|v| *v as f32).collect(),
-                ))),
-                (Column::Int16(column), DataType::Float32) => Ok(Value::Column(Column::Float32(
-                    column.iter().map(|v| *v as f32).collect(),
-                ))),
-                (Column::UInt8(column), DataType::Float32) => Ok(Value::Column(Column::Float32(
-                    column.iter().map(|v| *v as f32).collect(),
-                ))),
-                (Column::UInt16(column), DataType::Float32) => Ok(Value::Column(Column::Float32(
-                    column.iter().map(|v| *v as f32).collect(),
-                ))),
-                (Column::Int8(column), DataType::Float64) => Ok(Value::Column(Column::Float64(
-                    column.iter().map(|v| *v as f64).collect(),
-                ))),
-                (Column::Int16(column), DataType::Float64) => Ok(Value::Column(Column::Float64(
-                    column.iter().map(|v| *v as f64).collect(),
-                ))),
-                (Column::Int32(column), DataType::Float64) => Ok(Value::Column(Column::Float64(
-                    column.iter().map(|v| *v as f64).collect(),
-                ))),
-                (Column::UInt8(column), DataType::Float64) => Ok(Value::Column(Column::Float64(
-                    column.iter().map(|v| *v as f64).collect(),
-                ))),
-                (Column::UInt16(column), DataType::Float64) => Ok(Value::Column(Column::Float64(
-                    column.iter().map(|v| *v as f64).collect(),
-                ))),
-                (Column::UInt32(column), DataType::Float64) => Ok(Value::Column(Column::Float64(
-                    column.iter().map(|v| *v as f64).collect(),
-                ))),
-                (Column::Float32(column), DataType::Float64) => Ok(Value::Column(Column::Float64(
-                    column.iter().map(|v| *v as f64).collect(),
-                ))),
-                (col @ Column::Boolean(_), DataType::Boolean)
-                | (col @ Column::String { .. }, DataType::String)
-                | (col @ Column::UInt8(_), DataType::UInt8)
-                | (col @ Column::UInt16(_), DataType::UInt16)
-                | (col @ Column::UInt32(_), DataType::UInt32)
-                | (col @ Column::UInt64(_), DataType::UInt64)
-                | (col @ Column::Int8(_), DataType::Int8)
-                | (col @ Column::Int16(_), DataType::Int16)
-                | (col @ Column::Int32(_), DataType::Int32)
-                | (col @ Column::Int64(_), DataType::Int64)
-                | (col @ Column::Float32(_), DataType::Float32)
-                | (col @ Column::Float64(_), DataType::Float64)
-                | (col @ Column::Null { .. }, DataType::Null)
-                | (col @ Column::EmptyArray { .. }, DataType::EmptyArray) => Ok(Value::Column(col)),
-                (col, dest_ty) => Err((
-                    span,
-                    (format!("unable to cast column {col:?} to {dest_ty}")),
-                )),
-            },
+            }
         }
     }
 
@@ -383,6 +131,301 @@ impl Evaluator {
             Literal::String(val) => Scalar::String(val.clone()),
         }
     }
+
+    pub fn run_cast_scalar(
+        &self,
+        span: Span,
+        scalar: Scalar,
+        dest_type: &DataType,
+    ) -> Result<Scalar> {
+        match (scalar, dest_type) {
+            (Scalar::Null, DataType::Nullable(_)) => Ok(Scalar::Null),
+            (Scalar::EmptyArray, DataType::Array(dest_ty)) => {
+                let new_column = ColumnBuilder::with_capacity(dest_ty, 0).build();
+                Ok(Scalar::Array(new_column))
+            }
+            (scalar, DataType::Nullable(dest_ty)) => self.run_cast_scalar(span, scalar, dest_ty),
+            (Scalar::Array(array), DataType::Array(dest_ty)) => {
+                let new_array = self.run_cast_column(span, array, dest_ty)?;
+                Ok(Scalar::Array(new_array))
+            }
+            (Scalar::Tuple(fields), DataType::Tuple(fields_ty)) => {
+                let new_fields = fields
+                    .into_iter()
+                    .zip(fields_ty.iter())
+                    .map(|(field, dest_ty)| self.run_cast_scalar(span.clone(), field, dest_ty))
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(Scalar::Tuple(new_fields))
+            }
+
+            // identical types
+            (scalar @ Scalar::Null, DataType::Null)
+            | (scalar @ Scalar::EmptyArray, DataType::EmptyArray)
+            | (scalar @ Scalar::Boolean(_), DataType::Boolean)
+            | (scalar @ Scalar::String(_), DataType::String) => Ok(scalar),
+
+            (scalar, dest_ty) => {
+                // number types
+                with_number_type!(SRC_TYPE, match scalar {
+                    Scalar::SRC_TYPE(value) => {
+                        with_number_type!(DEST_TYPE, match dest_ty {
+                            DataType::DEST_TYPE => {
+                                let src_info = DataType::SRC_TYPE.number_type_info().unwrap();
+                                let dest_info = DataType::DEST_TYPE.number_type_info().unwrap();
+                                if src_info.can_lossless_cast_to(dest_info) {
+                                    return Ok(Scalar::DEST_TYPE(value as _));
+                                } else {
+                                    let value = num_traits::cast::cast(value).ok_or_else(|| {
+                                        (
+                                            span.clone(),
+                                            format!(
+                                                "unable to cast {} to {}",
+                                                scalar.as_ref(),
+                                                stringify!(DEST_TYPE)
+                                            ),
+                                        )
+                                    })?;
+                                    return Ok(Scalar::DEST_TYPE(value));
+                                }
+                            }
+                            _ => (),
+                        })
+                    }
+                    _ => (),
+                });
+
+                // failure cases
+                Err((
+                    span,
+                    (format!("unable to cast {} to {dest_ty}", scalar.as_ref())),
+                ))
+            }
+        }
+    }
+
+    pub fn run_cast_column(
+        &self,
+        span: Span,
+        column: Column,
+        dest_type: &DataType,
+    ) -> Result<Column> {
+        match (column, dest_type) {
+            (Column::Null { len }, DataType::Nullable(_)) => {
+                let mut builder = ColumnBuilder::with_capacity(dest_type, len);
+                for _ in 0..len {
+                    builder.push_default();
+                }
+                Ok(builder.build())
+            }
+            (Column::EmptyArray { len }, DataType::Array(_)) => {
+                let mut builder = ColumnBuilder::with_capacity(dest_type, len);
+                for _ in 0..len {
+                    builder.push_default();
+                }
+                Ok(builder.build())
+            }
+            (Column::Nullable { column, validity }, DataType::Nullable(dest_ty)) => {
+                let column = self.run_cast_column(span, *column, dest_ty)?;
+                Ok(Column::Nullable {
+                    column: Box::new(column),
+                    validity,
+                })
+            }
+            (col, DataType::Nullable(dest_ty)) => {
+                let column = self.run_cast_column(span, col, dest_ty)?;
+                Ok(Column::Nullable {
+                    validity: constant_bitmap(true, column.len()).into(),
+                    column: Box::new(column),
+                })
+            }
+            (Column::Array { array, offsets }, DataType::Array(dest_ty)) => {
+                let array = self.run_cast_column(span, *array, dest_ty)?;
+                Ok(Column::Array {
+                    array: Box::new(array),
+                    offsets,
+                })
+            }
+            (Column::Tuple { fields, len }, DataType::Tuple(fields_ty)) => {
+                let new_fields = fields
+                    .into_iter()
+                    .zip(fields_ty)
+                    .map(|(field, field_ty)| self.run_cast_column(span.clone(), field, field_ty))
+                    .collect::<Result<_>>()?;
+                Ok(Column::Tuple {
+                    fields: new_fields,
+                    len,
+                })
+            }
+
+            // identical types
+            (col @ Column::Null { .. }, DataType::Null)
+            | (col @ Column::EmptyArray { .. }, DataType::EmptyArray)
+            | (col @ Column::Boolean(_), DataType::Boolean)
+            | (col @ Column::String { .. }, DataType::String) => Ok(col),
+
+            (col, dest_ty) => {
+                // number types
+                with_number_type!(SRC_TYPE, match &col {
+                    Column::SRC_TYPE(col) => {
+                        with_number_type!(DEST_TYPE, match dest_ty {
+                            DataType::DEST_TYPE => {
+                                let src_info = DataType::SRC_TYPE.number_type_info().unwrap();
+                                let dest_info = DataType::DEST_TYPE.number_type_info().unwrap();
+                                if src_info.can_lossless_cast_to(dest_info) {
+                                    let new_col = col.iter().map(|x| *x as _).collect::<Vec<_>>();
+                                    return Ok(Column::DEST_TYPE(new_col.into()));
+                                } else {
+                                    let mut new_col = Vec::with_capacity(col.len());
+                                    for &val in col.iter() {
+                                        let new_val =
+                                            num_traits::cast::cast(val).ok_or_else(|| {
+                                                (
+                                                    span.clone(),
+                                                    format!(
+                                                        "unable to cast {} to {}",
+                                                        val,
+                                                        stringify!(DEST_TYPE)
+                                                    ),
+                                                )
+                                            })?;
+                                        new_col.push(new_val);
+                                    }
+                                    return Ok(Column::DEST_TYPE(new_col.into()));
+                                }
+                            }
+                            _ => (),
+                        })
+                    }
+                    _ => (),
+                });
+
+                // failure cases
+                Err((span, (format!("unable to cast {col:?} to {dest_ty}"))))
+            }
+        }
+    }
+
+    pub fn run_try_cast_scalar(&self, span: Span, scalar: Scalar, dest_type: &DataType) -> Scalar {
+        let inner_type: &DataType = dest_type.as_nullable().unwrap();
+        self.run_cast_scalar(span, scalar, inner_type)
+            .unwrap_or(Scalar::Null)
+    }
+
+    pub fn run_try_cast_column(&self, span: Span, column: Column, dest_type: &DataType) -> Column {
+        let inner_type: &DataType = dest_type.as_nullable().unwrap();
+        match (column, inner_type) {
+            (_, DataType::Null | DataType::Nullable(_)) => {
+                unreachable!("inner type can not be nullable")
+            }
+            (Column::Null { len }, _) => {
+                let mut builder = ColumnBuilder::with_capacity(dest_type, len);
+                for _ in 0..len {
+                    builder.push_default();
+                }
+                builder.build()
+            }
+            (Column::EmptyArray { len }, DataType::Array(_)) => {
+                let mut builder = ColumnBuilder::with_capacity(dest_type, len);
+                for _ in 0..len {
+                    builder.push_default();
+                }
+                builder.build()
+            }
+            (Column::Nullable { column, validity }, _) => {
+                let (new_col, new_validity) = self
+                    .run_try_cast_column(span, *column, dest_type)
+                    .into_nullable()
+                    .unwrap();
+                Column::Nullable {
+                    column: new_col,
+                    validity: bitmap::or(&validity, &new_validity),
+                }
+            }
+            (Column::Array { array, offsets }, DataType::Array(dest_ty)) => {
+                let new_array = self.run_try_cast_column(span, *array, dest_ty);
+                let new_col = Column::Array {
+                    array: Box::new(new_array),
+                    offsets,
+                };
+                Column::Nullable {
+                    validity: constant_bitmap(true, new_col.len()).into(),
+                    column: Box::new(new_col),
+                }
+            }
+            (Column::Tuple { fields, len }, DataType::Tuple(fields_ty)) => {
+                let new_fields = fields
+                    .into_iter()
+                    .zip(fields_ty)
+                    .map(|(field, field_ty)| {
+                        self.run_try_cast_column(span.clone(), field, field_ty)
+                    })
+                    .collect();
+                let new_col = Column::Tuple {
+                    fields: new_fields,
+                    len,
+                };
+                Column::Nullable {
+                    validity: constant_bitmap(true, len).into(),
+                    column: Box::new(new_col),
+                }
+            }
+
+            // identical types
+            (col @ Column::Boolean(_), DataType::Boolean)
+            | (col @ Column::String { .. }, DataType::String)
+            | (col @ Column::EmptyArray { .. }, DataType::EmptyArray) => Column::Nullable {
+                validity: constant_bitmap(true, col.len()).into(),
+                column: Box::new(col),
+            },
+
+            (col, dest_ty) => {
+                // number types
+                with_number_type!(SRC_TYPE, match &col {
+                    Column::SRC_TYPE(col) => {
+                        with_number_type!(DEST_TYPE, match dest_ty {
+                            DataType::DEST_TYPE => {
+                                let src_info = DataType::SRC_TYPE.number_type_info().unwrap();
+                                let dest_info = DataType::DEST_TYPE.number_type_info().unwrap();
+                                if src_info.can_lossless_cast_to(dest_info) {
+                                    let new_col = col.iter().map(|x| *x as _).collect::<Vec<_>>();
+                                    return Column::Nullable {
+                                        validity: constant_bitmap(true, new_col.len()).into(),
+                                        column: Box::new(Column::DEST_TYPE(new_col.into())),
+                                    };
+                                } else {
+                                    let mut new_col = Vec::with_capacity(col.len());
+                                    let mut validity = MutableBitmap::with_capacity(col.len());
+                                    for &val in col.iter() {
+                                        if let Some(new_val) = num_traits::cast::cast(val) {
+                                            new_col.push(new_val);
+                                            validity.push(true);
+                                        } else {
+                                            new_col.push(Default::default());
+                                            validity.push(false);
+                                        }
+                                    }
+                                    return Column::Nullable {
+                                        validity: validity.into(),
+                                        column: Box::new(Column::DEST_TYPE(new_col.into())),
+                                    };
+                                }
+                            }
+                            _ => (),
+                        })
+                    }
+                    _ => (),
+                });
+
+                // failure cases
+                let len = col.len();
+                let mut builder = ColumnBuilder::with_capacity(dest_type, len);
+                for _ in 0..len {
+                    builder.push_default();
+                }
+                builder.build()
+            }
+        }
+    }
 }
 
 pub struct DomainCalculator {
@@ -400,7 +443,15 @@ impl DomainCalculator {
                 dest_type,
             } => {
                 let domain = self.calculate(expr)?;
-                self.calculate_cast(&domain, dest_type, span.clone())
+                self.calculate_cast(span.clone(), &domain, dest_type)
+            }
+            Expr::TryCast {
+                span,
+                expr,
+                dest_type,
+            } => {
+                let domain = self.calculate(expr)?;
+                Ok(self.calculate_try_cast(span.clone(), &domain, dest_type))
             }
             Expr::FunctionCall {
                 function,
@@ -471,16 +522,18 @@ impl DomainCalculator {
 
     pub fn calculate_cast(
         &self,
-        input: &Domain,
-        dest_type: &DataType,
         span: Span,
+        domain: &Domain,
+        dest_type: &DataType,
     ) -> Result<Domain> {
-        match (input, dest_type) {
+        match (domain, dest_type) {
             (
                 Domain::Nullable(NullableDomain { value: None, .. }),
                 DataType::Null | DataType::Nullable(_),
-            ) => Ok(input.clone()),
-            (Domain::Array(None), DataType::EmptyArray | DataType::Array(_)) => Ok(input.clone()),
+            ) => Ok(domain.clone()),
+            (Domain::Array(None), DataType::EmptyArray | DataType::Array(_)) => {
+                Ok(Domain::Array(None))
+            }
             (
                 Domain::Nullable(NullableDomain {
                     has_null,
@@ -489,29 +542,39 @@ impl DomainCalculator {
                 DataType::Nullable(ty),
             ) => Ok(Domain::Nullable(NullableDomain {
                 has_null: *has_null,
-                value: Some(Box::new(self.calculate_cast(value, ty, span)?)),
+                value: Some(Box::new(self.calculate_cast(span, value, ty)?)),
             })),
             (domain, DataType::Nullable(ty)) => Ok(Domain::Nullable(NullableDomain {
                 has_null: false,
-                value: Some(Box::new(self.calculate_cast(domain, ty, span)?)),
+                value: Some(Box::new(self.calculate_cast(span, domain, ty)?)),
             })),
             (Domain::Array(Some(domain)), DataType::Array(ty)) => Ok(Domain::Array(Some(
-                Box::new(self.calculate_cast(domain, ty, span)?),
+                Box::new(self.calculate_cast(span, domain, ty)?),
             ))),
+            (Domain::Tuple(fields), DataType::Tuple(fields_ty)) => Ok(Domain::Tuple(
+                fields
+                    .iter()
+                    .zip(fields_ty)
+                    .map(|(field, ty)| self.calculate_cast(span.clone(), field, ty))
+                    .collect::<Result<Vec<_>>>()?,
+            )),
+
+            // identical types
+            (Domain::Boolean(_), DataType::Boolean) | (Domain::String(_), DataType::String) => {
+                Ok(domain.clone())
+            }
+
+            // number types
+            (Domain::UInt(UIntDomain { min, max }), DataType::UInt8) => {
+                Ok(Domain::UInt(UIntDomain {
+                    min: (*min).min(u8::MAX as u64),
+                    max: (*max).min(u8::MAX as u64),
+                }))
+            }
             (Domain::UInt(UIntDomain { min, max }), DataType::UInt16) => {
                 Ok(Domain::UInt(UIntDomain {
                     min: (*min).min(u16::MAX as u64),
                     max: (*max).min(u16::MAX as u64),
-                }))
-            }
-            (Domain::Int(IntDomain { min, max }), DataType::Int16) => Ok(Domain::Int(IntDomain {
-                min: (*min).max(i16::MIN as i64).min(i16::MAX as i64),
-                max: (*max).max(i16::MIN as i64).min(i16::MAX as i64),
-            })),
-            (Domain::UInt(UIntDomain { min, max }), DataType::Int16) => {
-                Ok(Domain::Int(IntDomain {
-                    min: (*min).min(i16::MAX as u64) as i64,
-                    max: (*max).min(i16::MAX as u64) as i64,
                 }))
             }
             (Domain::UInt(UIntDomain { min, max }), DataType::UInt32) => {
@@ -520,77 +583,344 @@ impl DomainCalculator {
                     max: (*max).min(u32::MAX as u64),
                 }))
             }
-            (Domain::Int(IntDomain { min, max }), DataType::Int32) => Ok(Domain::Int(IntDomain {
-                min: (*min).max(i32::MIN as i64).min(i32::MAX as i64),
-                max: (*max).max(i32::MIN as i64).min(i32::MAX as i64),
+            (Domain::UInt(_), DataType::UInt64) => Ok(domain.clone()),
+            (Domain::UInt(UIntDomain { min, max }), DataType::Int8) => Ok(Domain::Int(IntDomain {
+                min: (*min).min(i8::MAX as u64) as i64,
+                max: (*max).min(i8::MAX as u64) as i64,
             })),
+            (Domain::UInt(UIntDomain { min, max }), DataType::Int16) => {
+                Ok(Domain::Int(IntDomain {
+                    min: (*min).min(i16::MAX as u64) as i64,
+                    max: (*max).min(i16::MAX as u64) as i64,
+                }))
+            }
             (Domain::UInt(UIntDomain { min, max }), DataType::Int32) => {
                 Ok(Domain::Int(IntDomain {
                     min: (*min).min(i32::MAX as u64) as i64,
                     max: (*max).min(i32::MAX as u64) as i64,
                 }))
             }
-            (Domain::UInt(UIntDomain { min, max }), DataType::UInt64) => {
-                Ok(Domain::UInt(UIntDomain {
-                    min: (*min).min(u64::MAX),
-                    max: (*max).min(u64::MAX),
-                }))
-            }
-            (Domain::Int(IntDomain { min, max }), DataType::Int64) => Ok(Domain::Int(IntDomain {
-                min: (*min).max(i64::MIN).min(i64::MAX),
-                max: (*max).max(i64::MIN).min(i64::MAX),
-            })),
             (Domain::UInt(UIntDomain { min, max }), DataType::Int64) => {
                 Ok(Domain::Int(IntDomain {
                     min: (*min).min(i64::MAX as u64) as i64,
                     max: (*max).min(i64::MAX as u64) as i64,
                 }))
             }
-            (Domain::Int(IntDomain { min, max }), DataType::Float32) => {
+            (Domain::UInt(UIntDomain { min, max }), DataType::Float32 | DataType::Float64) => {
                 Ok(Domain::Float(FloatDomain {
-                    min: (*min as f64).max(f32::MIN as f64).min(f32::MAX as f64),
-                    max: (*max as f64).max(f32::MIN as f64).min(f32::MAX as f64),
+                    min: *min as f64,
+                    max: *max as f64,
                 }))
             }
-            (Domain::UInt(UIntDomain { min, max }), DataType::Float32) => {
+
+            (Domain::Int(IntDomain { min, max }), DataType::UInt8) => {
+                Ok(Domain::UInt(UIntDomain {
+                    min: (*min).clamp(0, u8::MAX as i64) as u64,
+                    max: (*max).clamp(0, u8::MAX as i64) as u64,
+                }))
+            }
+            (Domain::Int(IntDomain { min, max }), DataType::UInt16) => {
+                Ok(Domain::UInt(UIntDomain {
+                    min: (*min).clamp(0, u16::MAX as i64) as u64,
+                    max: (*max).clamp(0, u16::MAX as i64) as u64,
+                }))
+            }
+            (Domain::Int(IntDomain { min, max }), DataType::UInt32) => {
+                Ok(Domain::UInt(UIntDomain {
+                    min: (*min).clamp(0, u32::MAX as i64) as u64,
+                    max: (*max).clamp(0, u32::MAX as i64) as u64,
+                }))
+            }
+            (Domain::Int(IntDomain { min, max }), DataType::UInt64) => {
+                Ok(Domain::UInt(UIntDomain {
+                    min: (*min).max(0) as u64,
+                    max: (*max).max(0) as u64,
+                }))
+            }
+            (Domain::Int(IntDomain { min, max }), DataType::Int8) => Ok(Domain::Int(IntDomain {
+                min: (*min).clamp(i8::MIN as i64, i8::MAX as i64),
+                max: (*max).clamp(i8::MIN as i64, i8::MAX as i64),
+            })),
+            (Domain::Int(IntDomain { min, max }), DataType::Int16) => Ok(Domain::Int(IntDomain {
+                min: (*min).clamp(i16::MIN as i64, i16::MAX as i64),
+                max: (*max).clamp(i16::MIN as i64, i16::MAX as i64),
+            })),
+            (Domain::Int(IntDomain { min, max }), DataType::Int32) => Ok(Domain::Int(IntDomain {
+                min: (*min).clamp(i32::MIN as i64, i32::MAX as i64),
+                max: (*max).clamp(i32::MIN as i64, i32::MAX as i64),
+            })),
+            (Domain::Int(_), DataType::Int64) => Ok(domain.clone()),
+            (Domain::Int(IntDomain { min, max }), DataType::Float32 | DataType::Float64) => {
                 Ok(Domain::Float(FloatDomain {
-                    min: (*min as f64).max(f32::MIN as f64).min(f32::MAX as f64),
-                    max: (*max as f64).max(f32::MIN as f64).min(f32::MAX as f64),
+                    min: (*min) as f64,
+                    max: (*max) as f64,
+                }))
+            }
+
+            (Domain::Float(FloatDomain { min, max }), DataType::UInt8) => {
+                Ok(Domain::UInt(UIntDomain {
+                    min: (*min).round().clamp(0.0, u8::MAX as f64) as u64,
+                    max: (*max).round().clamp(0.0, u8::MAX as f64) as u64,
+                }))
+            }
+            (Domain::Float(FloatDomain { min, max }), DataType::UInt16) => {
+                Ok(Domain::UInt(UIntDomain {
+                    min: (*min).round().clamp(0.0, u16::MAX as f64) as u64,
+                    max: (*max).round().clamp(0.0, u16::MAX as f64) as u64,
+                }))
+            }
+            (Domain::Float(FloatDomain { min, max }), DataType::UInt32) => {
+                Ok(Domain::UInt(UIntDomain {
+                    min: (*min).round().clamp(0.0, u32::MAX as f64) as u64,
+                    max: (*max).round().clamp(0.0, u32::MAX as f64) as u64,
+                }))
+            }
+            (Domain::Float(FloatDomain { min, max }), DataType::UInt64) => {
+                Ok(Domain::UInt(UIntDomain {
+                    min: (*min).round().clamp(0.0, u64::MAX as f64) as u64,
+                    max: (*max).round().clamp(0.0, u64::MAX as f64) as u64,
+                }))
+            }
+            (Domain::Float(FloatDomain { min, max }), DataType::Int8) => {
+                Ok(Domain::Int(IntDomain {
+                    min: (*min).round().clamp(i8::MIN as f64, i8::MAX as f64) as i64,
+                    max: (*max).round().clamp(i8::MIN as f64, i8::MAX as f64) as i64,
+                }))
+            }
+            (Domain::Float(FloatDomain { min, max }), DataType::Int16) => {
+                Ok(Domain::Int(IntDomain {
+                    min: (*min).round().clamp(i16::MIN as f64, i16::MAX as f64) as i64,
+                    max: (*max).round().clamp(i16::MIN as f64, i16::MAX as f64) as i64,
+                }))
+            }
+            (Domain::Float(FloatDomain { min, max }), DataType::Int32) => {
+                Ok(Domain::Int(IntDomain {
+                    min: (*min).round().clamp(i32::MIN as f64, i32::MAX as f64) as i64,
+                    max: (*max).round().clamp(i32::MIN as f64, i32::MAX as f64) as i64,
+                }))
+            }
+            (Domain::Float(FloatDomain { min, max }), DataType::Int64) => {
+                Ok(Domain::Int(IntDomain {
+                    min: (*min).round().clamp(i64::MIN as f64, i64::MAX as f64) as i64,
+                    max: (*max).round().clamp(i64::MIN as f64, i64::MAX as f64) as i64,
                 }))
             }
             (Domain::Float(FloatDomain { min, max }), DataType::Float32) => {
                 Ok(Domain::Float(FloatDomain {
-                    min: (*min).min(f32::MAX as f64),
-                    max: (*max).min(f32::MAX as f64),
+                    min: (*min).clamp(f32::MIN as f64, f32::MAX as f64),
+                    max: (*max).clamp(f32::MIN as f64, f32::MAX as f64),
                 }))
             }
-            (Domain::Int(IntDomain { min, max }), DataType::Float64) => {
-                Ok(Domain::Float(FloatDomain {
-                    min: (*min as f64).max(f64::MIN).min(f64::MAX),
-                    max: (*max as f64).max(f64::MIN).min(f64::MAX),
-                }))
+            (Domain::Float(_), DataType::Float64) => Ok(domain.clone()),
+
+            // failure cases
+            (domain, dest_ty) => Err((span, (format!("unable to cast {domain} to {dest_ty}",)))),
+        }
+    }
+
+    pub fn calculate_try_cast(&self, span: Span, domain: &Domain, dest_type: &DataType) -> Domain {
+        let inner_type: &DataType = dest_type.as_nullable().unwrap();
+        match (domain, inner_type) {
+            (_, DataType::Null | DataType::Nullable(_)) => {
+                unreachable!("inner type cannot be nullable")
             }
-            (Domain::UInt(UIntDomain { min, max }), DataType::Float64) => {
-                Ok(Domain::Float(FloatDomain {
-                    min: (*min as f64).max(f64::MIN).min(f64::MAX),
-                    max: (*max as f64).max(f64::MIN).min(f64::MAX),
-                }))
+            (Domain::Array(None), DataType::EmptyArray | DataType::Array(_)) => {
+                Domain::Nullable(NullableDomain {
+                    has_null: false,
+                    value: Some(Box::new(Domain::Array(None))),
+                })
             }
-            (Domain::Float(FloatDomain { min, max }), DataType::Float64) => {
-                Ok(Domain::Float(FloatDomain {
-                    min: (*min).min(f64::MAX),
-                    max: (*max).min(f64::MAX),
-                }))
+            (
+                Domain::Nullable(NullableDomain {
+                    has_null,
+                    value: Some(value),
+                }),
+                _,
+            ) => {
+                let inner_domain = self
+                    .calculate_try_cast(span, value, dest_type)
+                    .into_nullable()
+                    .unwrap();
+                Domain::Nullable(NullableDomain {
+                    has_null: *has_null || inner_domain.has_null,
+                    value: inner_domain.value,
+                })
+            }
+            (Domain::Array(Some(domain)), DataType::Array(ty)) => {
+                let inner_domain = self.calculate_try_cast(span, domain, ty);
+                Domain::Nullable(NullableDomain {
+                    has_null: false,
+                    value: Some(Box::new(Domain::Array(Some(Box::new(inner_domain))))),
+                })
+            }
+            (Domain::Tuple(fields), DataType::Tuple(fields_ty)) => {
+                let new_fields = fields
+                    .iter()
+                    .zip(fields_ty)
+                    .map(|(field, ty)| self.calculate_try_cast(span.clone(), field, ty))
+                    .collect();
+                Domain::Nullable(NullableDomain {
+                    has_null: false,
+                    value: Some(Box::new(Domain::Tuple(new_fields))),
+                })
             }
 
-            (Domain::Boolean(_), DataType::Boolean)
-            | (Domain::String(_), DataType::String)
-            | (Domain::UInt(_), DataType::UInt8)
-            | (Domain::Int(_), DataType::Int8) => Ok(input.clone()),
-            (domain, dest_ty) => Err((
-                span,
-                (format!("unable to cast domain {domain} to {dest_ty}",)),
-            )),
+            // identical types
+            (Domain::Boolean(_), DataType::Boolean) | (Domain::String(_), DataType::String) => {
+                Domain::Nullable(NullableDomain {
+                    has_null: false,
+                    value: Some(Box::new(domain.clone())),
+                })
+            }
+
+            // numeric types
+            (
+                Domain::UInt(_),
+                DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64,
+            ) => {
+                let new_domain = self.calculate_cast(span, domain, inner_type).unwrap();
+                Domain::Nullable(NullableDomain {
+                    has_null: *domain != new_domain,
+                    value: Some(Box::new(new_domain)),
+                })
+            }
+            (
+                Domain::UInt(UIntDomain { min, max }),
+                DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64,
+            ) => {
+                let new_domain = self
+                    .calculate_cast(span, domain, inner_type)
+                    .unwrap()
+                    .into_int()
+                    .unwrap();
+                let has_null = min.to_i64().filter(|min| *min == new_domain.min).is_none()
+                    || max.to_i64().filter(|max| *max == new_domain.max).is_none();
+                Domain::Nullable(NullableDomain {
+                    has_null,
+                    value: Some(Box::new(Domain::Int(new_domain))),
+                })
+            }
+            (Domain::UInt(UIntDomain { min, max }), DataType::Float32 | DataType::Float64) => {
+                let new_domain = self
+                    .calculate_cast(span, domain, inner_type)
+                    .unwrap()
+                    .into_float()
+                    .unwrap();
+                let has_null = (*min)
+                    .to_f64()
+                    .filter(|min| *min == new_domain.min)
+                    .is_none()
+                    || (*max)
+                        .to_f64()
+                        .filter(|max| *max == new_domain.max)
+                        .is_none();
+                Domain::Nullable(NullableDomain {
+                    has_null,
+                    value: Some(Box::new(Domain::Float(new_domain))),
+                })
+            }
+            (
+                Domain::Int(IntDomain { min, max }),
+                DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64,
+            ) => {
+                let new_domain = self
+                    .calculate_cast(span, domain, inner_type)
+                    .unwrap()
+                    .into_u_int()
+                    .unwrap();
+                let has_null = min.to_u64().filter(|min| *min == new_domain.min).is_none()
+                    || max.to_u64().filter(|max| *max == new_domain.max).is_none();
+                Domain::Nullable(NullableDomain {
+                    has_null,
+                    value: Some(Box::new(Domain::UInt(new_domain))),
+                })
+            }
+            (
+                Domain::Int(_),
+                DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64,
+            ) => {
+                let new_domain = self.calculate_cast(span, domain, inner_type).unwrap();
+                Domain::Nullable(NullableDomain {
+                    has_null: *domain != new_domain,
+                    value: Some(Box::new(new_domain)),
+                })
+            }
+            (Domain::Int(IntDomain { min, max }), DataType::Float32 | DataType::Float64) => {
+                let new_domain = self
+                    .calculate_cast(span, domain, inner_type)
+                    .unwrap()
+                    .into_float()
+                    .unwrap();
+                let has_null = (*min)
+                    .to_f64()
+                    .filter(|min| *min == new_domain.min)
+                    .is_none()
+                    || (*max)
+                        .to_f64()
+                        .filter(|max| *max == new_domain.max)
+                        .is_none();
+                Domain::Nullable(NullableDomain {
+                    has_null,
+                    value: Some(Box::new(Domain::Float(new_domain))),
+                })
+            }
+            (
+                Domain::Float(FloatDomain { min, max }),
+                DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64,
+            ) => {
+                let new_domain = self
+                    .calculate_cast(span, domain, inner_type)
+                    .unwrap()
+                    .into_u_int()
+                    .unwrap();
+                let has_null = (*min)
+                    .to_u64()
+                    .filter(|min| *min == new_domain.min)
+                    .is_none()
+                    || (*max)
+                        .to_u64()
+                        .filter(|max| *max == new_domain.max)
+                        .is_none();
+                Domain::Nullable(NullableDomain {
+                    has_null,
+                    value: Some(Box::new(Domain::UInt(new_domain))),
+                })
+            }
+            (
+                Domain::Float(FloatDomain { min, max }),
+                DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64,
+            ) => {
+                let new_domain = self
+                    .calculate_cast(span, domain, inner_type)
+                    .unwrap()
+                    .into_int()
+                    .unwrap();
+                let has_null = (*min)
+                    .to_i64()
+                    .filter(|min| *min == new_domain.min)
+                    .is_none()
+                    || (*max)
+                        .to_i64()
+                        .filter(|max| *max == new_domain.max)
+                        .is_none();
+                Domain::Nullable(NullableDomain {
+                    has_null,
+                    value: Some(Box::new(Domain::Int(new_domain))),
+                })
+            }
+            (Domain::Float(_), DataType::Float32 | DataType::Float64) => {
+                let new_domain = self.calculate_cast(span, domain, inner_type).unwrap();
+                Domain::Nullable(NullableDomain {
+                    has_null: false,
+                    value: Some(Box::new(new_domain)),
+                })
+            }
+
+            // failure cases
+            _ => Domain::Nullable(NullableDomain {
+                has_null: true,
+                value: None,
+            }),
         }
     }
 }

--- a/common/expression/src/evaluator.rs
+++ b/common/expression/src/evaluator.rs
@@ -606,7 +606,14 @@ impl DomainCalculator {
                     max: (*max).min(i64::MAX as u64) as i64,
                 }))
             }
-            (Domain::UInt(UIntDomain { min, max }), DataType::Float32 | DataType::Float64) => {
+            (Domain::UInt(UIntDomain { min, max }), DataType::Float32) => {
+                // Cast to f32 and then to f64 to round to the nearest f32 value.
+                Ok(Domain::Float(FloatDomain {
+                    min: *min as f32 as f64,
+                    max: *max as f32 as f64,
+                }))
+            }
+            (Domain::UInt(UIntDomain { min, max }), DataType::Float64) => {
                 Ok(Domain::Float(FloatDomain {
                     min: *min as f64,
                     max: *max as f64,
@@ -650,7 +657,14 @@ impl DomainCalculator {
                 max: (*max).clamp(i32::MIN as i64, i32::MAX as i64),
             })),
             (Domain::Int(_), DataType::Int64) => Ok(domain.clone()),
-            (Domain::Int(IntDomain { min, max }), DataType::Float32 | DataType::Float64) => {
+            (Domain::Int(IntDomain { min, max }), DataType::Float32) => {
+                // Cast to f32 and then to f64 to round to the nearest f32 value.
+                Ok(Domain::Float(FloatDomain {
+                    min: (*min) as f32 as f64,
+                    max: (*max) as f32 as f64,
+                }))
+            }
+            (Domain::Int(IntDomain { min, max }), DataType::Float64) => {
                 Ok(Domain::Float(FloatDomain {
                     min: (*min) as f64,
                     max: (*max) as f64,
@@ -707,8 +721,9 @@ impl DomainCalculator {
             }
             (Domain::Float(FloatDomain { min, max }), DataType::Float32) => {
                 Ok(Domain::Float(FloatDomain {
-                    min: (*min).clamp(f32::MIN as f64, f32::MAX as f64),
-                    max: (*max).clamp(f32::MIN as f64, f32::MAX as f64),
+                    // Cast to f32 and back to f64 to round to the nearest f32 value.
+                    min: (*min).clamp(f32::MIN as f64, f32::MAX as f64) as f32 as f64,
+                    max: (*max).clamp(f32::MIN as f64, f32::MAX as f64) as f32 as f64,
                 }))
             }
             (Domain::Float(_), DataType::Float64) => Ok(domain.clone()),

--- a/common/expression/src/expression.rs
+++ b/common/expression/src/expression.rs
@@ -31,12 +31,16 @@ pub enum RawExpr {
         id: usize,
         data_type: DataType,
     },
-    // TODO: support user cast
-    // Cast {
-    //     is_try: bool,
-    //     expr: Box<Expr>,
-    //     dest_type: DataType,
-    // },
+    Cast {
+        span: Span,
+        expr: Box<RawExpr>,
+        dest_type: DataType,
+    },
+    TryCast {
+        span: Span,
+        expr: Box<RawExpr>,
+        dest_type: DataType,
+    },
     FunctionCall {
         span: Span,
         name: String,
@@ -57,7 +61,11 @@ pub enum Expr {
     },
     Cast {
         span: Span,
-        // is_try: bool,
+        expr: Box<Expr>,
+        dest_type: DataType,
+    },
+    TryCast {
+        span: Span,
         expr: Box<Expr>,
         dest_type: DataType,
     },

--- a/common/expression/src/function.rs
+++ b/common/expression/src/function.rs
@@ -176,7 +176,7 @@ impl FunctionRegistry {
     {
         let has_nullable = &[I1::data_type(), O::data_type()]
             .iter()
-            .any(|ty| ty.as_nullable().is_some());
+            .any(|ty| ty.as_nullable().is_some() || ty.is_null());
 
         assert!(
             !has_nullable,
@@ -230,7 +230,7 @@ impl FunctionRegistry {
     {
         let has_nullable = &[I1::data_type(), O::data_type()]
             .iter()
-            .any(|ty| ty.as_nullable().is_some());
+            .any(|ty| ty.as_nullable().is_some() || ty.is_null());
 
         assert!(
             !has_nullable,
@@ -306,7 +306,7 @@ impl FunctionRegistry {
     {
         let has_nullable = &[I1::data_type(), I2::data_type(), O::data_type()]
             .iter()
-            .any(|ty| ty.as_nullable().is_some());
+            .any(|ty| ty.as_nullable().is_some() || ty.is_null());
 
         assert!(
             !has_nullable,
@@ -372,7 +372,7 @@ impl FunctionRegistry {
     {
         let has_nullable = &[I1::data_type(), I2::data_type(), O::data_type()]
             .iter()
-            .any(|ty| ty.as_nullable().is_some());
+            .any(|ty| ty.as_nullable().is_some() || ty.is_null());
 
         assert!(
             !has_nullable,

--- a/common/expression/src/lib.rs
+++ b/common/expression/src/lib.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(const_try)]
 #![feature(generic_associated_types)]
 #![feature(iterator_try_reduce)]
+#![feature(const_fmt_arguments_new)]
 #![feature(box_patterns)]
 #![feature(associated_type_defaults)]
 #![allow(clippy::len_without_is_empty)]

--- a/common/expression/src/property.rs
+++ b/common/expression/src/property.rs
@@ -35,7 +35,7 @@ impl FunctionProperty {
     }
 }
 
-#[derive(Debug, Clone, EnumAsInner)]
+#[derive(Debug, Clone, PartialEq, EnumAsInner)]
 pub enum Domain {
     Int(IntDomain),
     UInt(UIntDomain),
@@ -47,31 +47,31 @@ pub enum Domain {
     Tuple(Vec<Domain>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntDomain {
     pub min: i64,
     pub max: i64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UIntDomain {
     pub min: u64,
     pub max: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FloatDomain {
     pub min: f64,
     pub max: f64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BooleanDomain {
     pub has_false: bool,
     pub has_true: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StringDomain {
     pub min: Vec<u8>,
     pub max: Option<Vec<u8>>,
@@ -88,6 +88,12 @@ impl<T: ValueType> Clone for NullableDomain<T> {
             has_null: self.has_null,
             value: self.value.clone(),
         }
+    }
+}
+
+impl<T: ValueType> PartialEq for NullableDomain<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.has_null == other.has_null && self.value == other.value
     }
 }
 

--- a/common/expression/src/type_check.rs
+++ b/common/expression/src/type_check.rs
@@ -26,24 +26,6 @@ use crate::function::FunctionRegistry;
 use crate::function::FunctionSignature;
 use crate::types::DataType;
 
-impl DataType {
-    fn number_type_info(&self) -> Option<(i8, bool, bool)> {
-        match self {
-            DataType::UInt8 => Some((1, false, false)),
-            DataType::UInt16 => Some((2, false, false)),
-            DataType::UInt32 => Some((4, false, false)),
-            DataType::UInt64 => Some((8, false, false)),
-            DataType::Int8 => Some((1, true, false)),
-            DataType::Int16 => Some((2, true, false)),
-            DataType::Int32 => Some((4, true, false)),
-            DataType::Int64 => Some((8, true, false)),
-            DataType::Float32 => Some((4, true, true)),
-            DataType::Float64 => Some((8, true, true)),
-            _ => None,
-        }
-    }
-}
-
 pub fn check(ast: &RawExpr, fn_registry: &FunctionRegistry) -> Result<(Expr, DataType)> {
     match ast {
         RawExpr::Literal { span, lit } => {
@@ -67,6 +49,39 @@ pub fn check(ast: &RawExpr, fn_registry: &FunctionRegistry) -> Result<(Expr, Dat
             },
             data_type.clone(),
         )),
+        RawExpr::Cast {
+            span,
+            expr,
+            dest_type,
+        } => {
+            let (expr, _) = check(expr, fn_registry)?;
+            Ok((
+                Expr::Cast {
+                    span: span.clone(),
+                    expr: Box::new(expr),
+                    dest_type: dest_type.clone(),
+                },
+                dest_type.clone(),
+            ))
+        }
+        RawExpr::TryCast {
+            span,
+            expr,
+            dest_type,
+        } => {
+            let (expr, _) = check(expr, fn_registry)?;
+
+            let dest_type = wrap_nullable_for_try_cast(span.clone(), dest_type)?;
+
+            Ok((
+                Expr::TryCast {
+                    span: span.clone(),
+                    expr: Box::new(expr),
+                    dest_type: dest_type.clone(),
+                },
+                dest_type,
+            ))
+        }
         RawExpr::FunctionCall {
             span,
             name,
@@ -93,6 +108,23 @@ pub fn check(ast: &RawExpr, fn_registry: &FunctionRegistry) -> Result<(Expr, Dat
                 fn_registry,
             )
         }
+    }
+}
+
+fn wrap_nullable_for_try_cast(span: Span, ty: &DataType) -> Result<DataType> {
+    match ty {
+        DataType::Null => Err((span, "TRY_CAST() to NULL is not supported".to_string())),
+        DataType::Nullable(_) => Ok(ty.clone()),
+        DataType::Array(inner_ty) => Ok(DataType::Nullable(Box::new(DataType::Array(Box::new(
+            wrap_nullable_for_try_cast(span, inner_ty)?,
+        ))))),
+        DataType::Tuple(fields_ty) => Ok(DataType::Nullable(Box::new(DataType::Tuple(
+            fields_ty
+                .iter()
+                .map(|ty| wrap_nullable_for_try_cast(span.clone(), ty))
+                .collect::<Result<Vec<_>>>()?,
+        )))),
+        _ => Ok(DataType::Nullable(Box::new(ty.clone()))),
     }
 }
 
@@ -306,7 +338,7 @@ pub fn unify(src_ty: &DataType, dest_ty: &DataType) -> Result<Subsitution> {
                 .unwrap_or_else(Subsitution::empty);
             Ok(subst)
         }
-        (src_ty, dest_ty) if can_cast_to(src_ty, dest_ty) => Ok(Subsitution::empty()),
+        (src_ty, dest_ty) if can_auto_cast_to(src_ty, dest_ty) => Ok(Subsitution::empty()),
         _ => Err((
             None,
             (format!("unable to unify `{}` with `{}`", src_ty, dest_ty)),
@@ -314,20 +346,20 @@ pub fn unify(src_ty: &DataType, dest_ty: &DataType) -> Result<Subsitution> {
     }
 }
 
-// TODO: should support fallable casts
-pub fn can_cast_to(src_ty: &DataType, dest_ty: &DataType) -> bool {
+pub fn can_auto_cast_to(src_ty: &DataType, dest_ty: &DataType) -> bool {
     match (src_ty, dest_ty) {
         (src_ty, dest_ty) if src_ty == dest_ty => true,
         (DataType::Null, DataType::Nullable(_)) => true,
         (DataType::EmptyArray, DataType::Array(_)) => true,
-        (DataType::Nullable(src_ty), DataType::Nullable(dest_ty)) => can_cast_to(src_ty, dest_ty),
-        (src_ty, DataType::Nullable(dest_ty)) => can_cast_to(src_ty, dest_ty),
-        (DataType::Array(src_ty), DataType::Array(dest_ty)) => can_cast_to(src_ty, dest_ty),
+        (DataType::Nullable(src_ty), DataType::Nullable(dest_ty)) => {
+            can_auto_cast_to(src_ty, dest_ty)
+        }
+        (src_ty, DataType::Nullable(dest_ty)) => can_auto_cast_to(src_ty, dest_ty),
+        (DataType::Array(src_ty), DataType::Array(dest_ty)) => can_auto_cast_to(src_ty, dest_ty),
         (src_ty, dest_ty) => match (src_ty.number_type_info(), dest_ty.number_type_info()) {
-            (Some((size1, b1, false)), Some((size2, b2, false))) if b1 == b2 => size1 <= size2,
-            (Some((size1, false, false)), Some((size2, true, false))) if size2 > size1 => true,
-            (Some((size1, _, true)), Some((size2, _, true))) => size1 <= size2,
-            (Some((size1, _, false)), Some((size2, _, true))) if size2 > size1 => true,
+            (Some(src_num_info), Some(dest_num_info)) => {
+                src_num_info.can_lossless_cast_to(dest_num_info)
+            }
             _ => false,
         },
     }
@@ -350,20 +382,9 @@ pub fn common_super_type(ty1: DataType, ty2: DataType) -> Option<DataType> {
             Some(DataType::Array(Box::new(common_super_type(ty1, ty2)?)))
         }
         (ty1, ty2) => match (ty1.number_type_info(), ty2.number_type_info()) {
-            (Some((size1, b1, false)), Some((size2, b2, false))) if b1 == b2 => {
-                (size1 >= size2).then(|| Some(ty1)).unwrap_or(Some(ty2))
-            }
-            (Some((size1, false, false)), Some((size2, true, false))) if size2 > size1 => Some(ty2),
-            (Some((size1, true, false)), Some((size2, false, false))) if size1 > size2 => Some(ty1),
-            (Some((1, _, false)), Some((1, _, false))) => Some(DataType::Int16),
-            (Some((2, _, false)), Some((2, _, false))) => Some(DataType::Int32),
-            (Some((4, _, false)), Some((4, _, false))) => Some(DataType::Int64),
-            (Some((size1, _, true)), Some((size2, _, true))) => {
-                (size1 >= size2).then(|| Some(ty1)).unwrap_or(Some(ty2))
-            }
-            (Some((size1, _, false)), Some((size2, _, true))) if size2 > size1 => Some(ty2),
-            (Some((size1, _, true)), Some((size2, _, false))) if size1 > size2 => Some(ty1),
-            (Some((4, _, _)), Some((4, _, _))) => Some(DataType::Float64),
+            (Some(num_info_1), Some(num_info_2)) => num_info_1
+                .lossless_super_type(num_info_2)
+                .map(DataType::new_number),
             _ => None,
         },
     }

--- a/common/expression/src/types.rs
+++ b/common/expression/src/types.rs
@@ -72,7 +72,7 @@ pub trait ValueType: Sized + 'static {
     type Scalar: Debug + Clone;
     type ScalarRef<'a>: Debug + Clone;
     type Column: Debug + Clone;
-    type Domain: Debug + Clone;
+    type Domain: Debug + Clone + PartialEq;
 
     fn to_owned_scalar<'a>(scalar: Self::ScalarRef<'a>) -> Self::Scalar;
     fn to_scalar_ref<'a>(scalar: &'a Self::Scalar) -> Self::ScalarRef<'a>;
@@ -116,4 +116,228 @@ pub trait ArgType: ValueType {
     fn append_builder(builder: &mut Self::ColumnBuilder, other_builder: &Self::ColumnBuilder);
     fn build_column(builder: Self::ColumnBuilder) -> Self::Column;
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NumberTypeInfo {
+    pub is_float: bool,
+    pub is_signed: bool,
+    pub bit_width: u8,
+}
+
+impl DataType {
+    pub const fn new_number(info: NumberTypeInfo) -> Self {
+        match info {
+            NumberTypeInfo {
+                is_float: false,
+                is_signed: false,
+                bit_width: 8,
+            } => DataType::UInt8,
+            NumberTypeInfo {
+                is_float: false,
+                is_signed: false,
+                bit_width: 16,
+            } => DataType::UInt16,
+            NumberTypeInfo {
+                is_float: false,
+                is_signed: false,
+                bit_width: 32,
+            } => DataType::UInt32,
+            NumberTypeInfo {
+                is_float: false,
+                is_signed: false,
+                bit_width: 64,
+            } => DataType::UInt64,
+            NumberTypeInfo {
+                is_float: false,
+                is_signed: true,
+                bit_width: 8,
+            } => DataType::Int8,
+            NumberTypeInfo {
+                is_float: false,
+                is_signed: true,
+                bit_width: 16,
+            } => DataType::Int16,
+            NumberTypeInfo {
+                is_float: false,
+                is_signed: true,
+                bit_width: 32,
+            } => DataType::Int32,
+            NumberTypeInfo {
+                is_float: false,
+                is_signed: true,
+                bit_width: 64,
+            } => DataType::Int64,
+            NumberTypeInfo {
+                is_float: true,
+                is_signed: true,
+                bit_width: 32,
+            } => DataType::Float32,
+            NumberTypeInfo {
+                is_float: true,
+                is_signed: true,
+                bit_width: 64,
+            } => DataType::Float64,
+            _ => panic!("unsupported numeric type"),
+        }
+    }
+
+    pub const fn number_type_info(&self) -> Option<NumberTypeInfo> {
+        match self {
+            DataType::UInt8 => Some(NumberTypeInfo {
+                is_float: false,
+                is_signed: false,
+                bit_width: 8,
+            }),
+            DataType::UInt16 => Some(NumberTypeInfo {
+                is_float: false,
+                is_signed: false,
+                bit_width: 16,
+            }),
+            DataType::UInt32 => Some(NumberTypeInfo {
+                is_float: false,
+                is_signed: false,
+                bit_width: 32,
+            }),
+            DataType::UInt64 => Some(NumberTypeInfo {
+                is_float: false,
+                is_signed: false,
+                bit_width: 64,
+            }),
+            DataType::Int8 => Some(NumberTypeInfo {
+                is_float: false,
+                is_signed: true,
+                bit_width: 8,
+            }),
+            DataType::Int16 => Some(NumberTypeInfo {
+                is_float: false,
+                is_signed: true,
+                bit_width: 16,
+            }),
+            DataType::Int32 => Some(NumberTypeInfo {
+                is_float: false,
+                is_signed: true,
+                bit_width: 32,
+            }),
+            DataType::Int64 => Some(NumberTypeInfo {
+                is_float: false,
+                is_signed: true,
+                bit_width: 64,
+            }),
+            DataType::Float32 => Some(NumberTypeInfo {
+                is_float: true,
+                is_signed: true,
+                bit_width: 32,
+            }),
+            DataType::Float64 => Some(NumberTypeInfo {
+                is_float: true,
+                is_signed: true,
+                bit_width: 64,
+            }),
+            _ => None,
+        }
+    }
+}
+
+impl NumberTypeInfo {
+    pub const fn can_lossless_cast_to(self, dest: Self) -> bool {
+        match (self.is_float, dest.is_float) {
+            (true, true) => self.bit_width <= dest.bit_width,
+            (true, false) => false,
+            (false, true) => self.bit_width < dest.bit_width,
+            (false, false) => match (self.is_signed, dest.is_signed) {
+                (true, true) | (false, false) => self.bit_width <= dest.bit_width,
+                (false, true) => {
+                    if let Some(self_next_bit_width) = next_bit_width(self.bit_width) {
+                        self_next_bit_width <= dest.bit_width
+                    } else {
+                        false
+                    }
+                }
+                (true, false) => false,
+            },
+        }
+    }
+
+    pub const fn lossless_super_type(self, other: Self) -> Option<Self> {
+        Some(match (self.is_float, other.is_float) {
+            (true, true) => NumberTypeInfo {
+                is_float: true,
+                is_signed: true,
+                bit_width: max_bit_with(self.bit_width, other.bit_width),
+            },
+            (true, false) => NumberTypeInfo {
+                is_float: true,
+                is_signed: true,
+                bit_width: if let Some(next_other_bit_width) = next_bit_width(other.bit_width) {
+                    max_bit_with(self.bit_width, next_other_bit_width)
+                } else {
+                    return None;
+                },
+            },
+            (false, true) => NumberTypeInfo {
+                is_float: true,
+                is_signed: true,
+                bit_width: if let Some(next_self_bit_width) = next_bit_width(self.bit_width) {
+                    max_bit_with(next_self_bit_width, other.bit_width)
+                } else {
+                    return None;
+                },
+            },
+            (false, false) => match (self.is_signed, other.is_signed) {
+                (true, true) => NumberTypeInfo {
+                    is_float: false,
+                    is_signed: true,
+                    bit_width: max_bit_with(self.bit_width, other.bit_width),
+                },
+                (false, false) => NumberTypeInfo {
+                    is_float: false,
+                    is_signed: false,
+                    bit_width: max_bit_with(self.bit_width, other.bit_width),
+                },
+                (false, true) => NumberTypeInfo {
+                    is_float: false,
+                    is_signed: true,
+                    bit_width: if let Some(next_other_bit_width) = next_bit_width(other.bit_width) {
+                        max_bit_with(self.bit_width, next_other_bit_width)
+                    } else {
+                        return None;
+                    },
+                },
+                (true, false) => NumberTypeInfo {
+                    is_float: false,
+                    is_signed: true,
+                    bit_width: if let Some(next_self_bit_width) = next_bit_width(self.bit_width) {
+                        max_bit_with(next_self_bit_width, other.bit_width)
+                    } else {
+                        return None;
+                    },
+                },
+            },
+        })
+    }
+}
+
+const fn next_bit_width(width: u8) -> Option<u8> {
+    match width {
+        8 => Some(16),
+        16 => Some(32),
+        32 => Some(64),
+        64 => None,
+        _ => panic!("invalid bit width"),
+    }
+}
+
+const fn max_bit_with(lhs: u8, rhs: u8) -> u8 {
+    if lhs > rhs { lhs } else { rhs }
+}
+
+#[macro_export]
+macro_rules! with_number_type {
+    ($t:tt, $($tail:tt)*) => {{
+        match_template::match_template! {
+            $t = [UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, Float32, Float64],
+            $($tail)*
+        }
+    }}
 }

--- a/common/expression/src/types/number.rs
+++ b/common/expression/src/types/number.rs
@@ -33,7 +33,7 @@ use crate::values::Scalar;
 
 pub trait Number: 'static {
     type Storage: NativeType;
-    type Domain: Debug + Clone;
+    type Domain: Debug + Clone + PartialEq;
 
     fn data_type() -> DataType;
     fn try_downcast_scalar(scalar: &Scalar) -> Option<Self::Storage>;

--- a/common/expression/tests/it/testdata/eval-fail.txt
+++ b/common/expression/tests/it/testdata/eval-fail.txt
@@ -14,3 +14,11 @@ error:
 
 
 
+error: 
+  --> SQL:1:1
+  |
+1 | CAST(a AS UINT16)
+  | ^^^^^^^^^^^^^^^^^ unable to cast -4 to UInt16
+
+
+

--- a/common/expression/tests/it/testdata/run-pass.txt
+++ b/common/expression/tests/it/testdata/run-pass.txt
@@ -8,7 +8,7 @@ output         : false
 
 ast            : bool_and(null, false)
 raw expr       : bool_and(NULL, false)
-checked expr   : bool_and<NULL, Boolean NULL>(NULL, cast<dest_type=Boolean NULL>(false))
+checked expr   : bool_and<NULL, Boolean NULL>(NULL, CAST(false AS Boolean NULL))
 output type    : NULL
 output domain  : {NULL}
 output         : NULL
@@ -16,7 +16,7 @@ output         : NULL
 
 ast            : plus(a, 10)
 raw expr       : plus(ColumnRef(0)::UInt8 NULL, 10_u8)
-checked expr   : plus<Int16 NULL, Int16 NULL>(cast<dest_type=Int16 NULL>(ColumnRef(0)), cast<dest_type=Int16 NULL>(10_u8))
+checked expr   : plus<Int16 NULL, Int16 NULL>(CAST(ColumnRef(0) AS Int16 NULL), CAST(10_u8 AS Int16 NULL))
 evaluation:
 +--------+--------------------+--------------------+
 |        | a                  | Output             |
@@ -38,7 +38,7 @@ evaluation (internal):
 
 ast            : plus(a, b)
 raw expr       : plus(ColumnRef(0)::UInt8 NULL, ColumnRef(1)::UInt8 NULL)
-checked expr   : plus<Int16 NULL, Int16 NULL>(cast<dest_type=Int16 NULL>(ColumnRef(0)), cast<dest_type=Int16 NULL>(ColumnRef(1)))
+checked expr   : plus<Int16 NULL, Int16 NULL>(CAST(ColumnRef(0) AS Int16 NULL), CAST(ColumnRef(1) AS Int16 NULL))
 evaluation:
 +--------+--------------------+------------------+--------------------+
 |        | a                  | b                | Output             |
@@ -61,7 +61,7 @@ evaluation (internal):
 
 ast            : plus(a, b)
 raw expr       : plus(ColumnRef(0)::UInt8 NULL, ColumnRef(1)::NULL)
-checked expr   : plus<Int16 NULL, NULL>(cast<dest_type=Int16 NULL>(ColumnRef(0)), ColumnRef(1))
+checked expr   : plus<Int16 NULL, NULL>(CAST(ColumnRef(0) AS Int16 NULL), ColumnRef(1))
 evaluation:
 +--------+--------------------+--------+--------+
 |        | a                  | b      | Output |
@@ -84,7 +84,7 @@ evaluation (internal):
 
 ast            : minus(a, 10)
 raw expr       : minus(ColumnRef(0)::UInt8 NULL, 10_u8)
-checked expr   : minus<Int32 NULL, Int32 NULL>(cast<dest_type=Int32 NULL>(ColumnRef(0)), cast<dest_type=Int32 NULL>(10_u8))
+checked expr   : minus<Int32 NULL, Int32 NULL>(CAST(ColumnRef(0) AS Int32 NULL), CAST(10_u8 AS Int32 NULL))
 evaluation:
 +--------+--------------------+------------------+
 |        | a                  | Output           |
@@ -106,7 +106,7 @@ evaluation (internal):
 
 ast            : minus(a, b)
 raw expr       : minus(ColumnRef(0)::UInt16 NULL, ColumnRef(1)::Int16 NULL)
-checked expr   : minus<Int32 NULL, Int32 NULL>(cast<dest_type=Int32 NULL>(ColumnRef(0)), cast<dest_type=Int32 NULL>(ColumnRef(1)))
+checked expr   : minus<Int32 NULL, Int32 NULL>(CAST(ColumnRef(0) AS Int32 NULL), CAST(ColumnRef(1) AS Int32 NULL))
 evaluation:
 +--------+--------------------+------------------+-------------------+
 |        | a                  | b                | Output            |
@@ -129,7 +129,7 @@ evaluation (internal):
 
 ast            : minus(a, b)
 raw expr       : minus(ColumnRef(0)::UInt8 NULL, ColumnRef(1)::NULL)
-checked expr   : minus<Int32 NULL, NULL>(cast<dest_type=Int32 NULL>(ColumnRef(0)), ColumnRef(1))
+checked expr   : minus<Int32 NULL, NULL>(CAST(ColumnRef(0) AS Int32 NULL), ColumnRef(1))
 evaluation:
 +--------+--------------------+--------+--------+
 |        | a                  | b      | Output |
@@ -152,7 +152,7 @@ evaluation (internal):
 
 ast            : multiply(a, 10)
 raw expr       : multiply(ColumnRef(0)::UInt8 NULL, 10_u8)
-checked expr   : multiply<Int64 NULL, Int64 NULL>(cast<dest_type=Int64 NULL>(ColumnRef(0)), cast<dest_type=Int64 NULL>(10_u8))
+checked expr   : multiply<Int64 NULL, Int64 NULL>(CAST(ColumnRef(0) AS Int64 NULL), CAST(10_u8 AS Int64 NULL))
 evaluation:
 +--------+--------------------+-------------------------------------------------------+
 |        | a                  | Output                                                |
@@ -174,7 +174,7 @@ evaluation (internal):
 
 ast            : multiply(a, b)
 raw expr       : multiply(ColumnRef(0)::UInt16 NULL, ColumnRef(1)::Int16 NULL)
-checked expr   : multiply<Int64 NULL, Int64 NULL>(cast<dest_type=Int64 NULL>(ColumnRef(0)), cast<dest_type=Int64 NULL>(ColumnRef(1)))
+checked expr   : multiply<Int64 NULL, Int64 NULL>(CAST(ColumnRef(0) AS Int64 NULL), CAST(ColumnRef(1) AS Int64 NULL))
 evaluation:
 +--------+--------------------+------------------+-------------------------------------------------------+
 |        | a                  | b                | Output                                                |
@@ -197,7 +197,7 @@ evaluation (internal):
 
 ast            : multiply(a, b)
 raw expr       : multiply(ColumnRef(0)::UInt32 NULL, ColumnRef(1)::Int32 NULL)
-checked expr   : multiply<Int64 NULL, Int64 NULL>(cast<dest_type=Int64 NULL>(ColumnRef(0)), cast<dest_type=Int64 NULL>(ColumnRef(1)))
+checked expr   : multiply<Int64 NULL, Int64 NULL>(CAST(ColumnRef(0) AS Int64 NULL), CAST(ColumnRef(1) AS Int64 NULL))
 evaluation:
 +--------+--------------------+------------------+-------------------------------------------------------+
 |        | a                  | b                | Output                                                |
@@ -220,7 +220,7 @@ evaluation (internal):
 
 ast            : multiply(a, b)
 raw expr       : multiply(ColumnRef(0)::UInt8 NULL, ColumnRef(1)::NULL)
-checked expr   : multiply<Int64 NULL, NULL>(cast<dest_type=Int64 NULL>(ColumnRef(0)), ColumnRef(1))
+checked expr   : multiply<Int64 NULL, NULL>(CAST(ColumnRef(0) AS Int64 NULL), ColumnRef(1))
 evaluation:
 +--------+--------------------+--------+--------+
 |        | a                  | b      | Output |
@@ -243,17 +243,17 @@ evaluation (internal):
 
 ast            : divide(a, 10)
 raw expr       : divide(ColumnRef(0)::UInt8 NULL, 10_u8)
-checked expr   : divide<Float32 NULL, Float32 NULL>(cast<dest_type=Float32 NULL>(ColumnRef(0)), cast<dest_type=Float32 NULL>(10_u8))
+checked expr   : divide<Float32 NULL, Float32 NULL>(CAST(ColumnRef(0) AS Float32 NULL), CAST(10_u8 AS Float32 NULL))
 evaluation:
-+--------+--------------------+-----------------------------------------------------------------------------------------------+
-|        | a                  | Output                                                                                        |
-+--------+--------------------+-----------------------------------------------------------------------------------------------+
-| Type   | UInt8 NULL         | Float32 NULL                                                                                  |
-| Domain | {10..=12} ∪ {NULL} | {-340282346638528860000000000000000000000..=340282346638528860000000000000000000000} ∪ {NULL} |
-| Row 0  | NULL               | NULL                                                                                          |
-| Row 1  | 11                 | 1.1                                                                                           |
-| Row 2  | NULL               | NULL                                                                                          |
-+--------+--------------------+-----------------------------------------------------------------------------------------------+
++--------+--------------------+-----------------------------------------------------------+
+|        | a                  | Output                                                    |
++--------+--------------------+-----------------------------------------------------------+
+| Type   | UInt8 NULL         | Float32 NULL                                              |
+| Domain | {10..=12} ∪ {NULL} | {-3.4028234663852886e38..=3.4028234663852886e38} ∪ {NULL} |
+| Row 0  | NULL               | NULL                                                      |
+| Row 1  | 11                 | 1.1                                                       |
+| Row 2  | NULL               | NULL                                                      |
++--------+--------------------+-----------------------------------------------------------+
 evaluation (internal):
 +--------+-----------------------------------------------------------------------+
 | Column | Data                                                                  |
@@ -265,17 +265,17 @@ evaluation (internal):
 
 ast            : divide(a, b)
 raw expr       : divide(ColumnRef(0)::UInt16 NULL, ColumnRef(1)::Int16 NULL)
-checked expr   : divide<Float32 NULL, Float32 NULL>(cast<dest_type=Float32 NULL>(ColumnRef(0)), cast<dest_type=Float32 NULL>(ColumnRef(1)))
+checked expr   : divide<Float32 NULL, Float32 NULL>(CAST(ColumnRef(0) AS Float32 NULL), CAST(ColumnRef(1) AS Float32 NULL))
 evaluation:
-+--------+--------------------+------------------+-----------------------------------------------------------------------------------------------+
-|        | a                  | b                | Output                                                                                        |
-+--------+--------------------+------------------+-----------------------------------------------------------------------------------------------+
-| Type   | UInt16 NULL        | Int16 NULL       | Float32 NULL                                                                                  |
-| Domain | {10..=12} ∪ {NULL} | {1..=3} ∪ {NULL} | {-340282346638528860000000000000000000000..=340282346638528860000000000000000000000} ∪ {NULL} |
-| Row 0  | NULL               | NULL             | NULL                                                                                          |
-| Row 1  | 11                 | 2                | 5.5                                                                                           |
-| Row 2  | NULL               | 3                | NULL                                                                                          |
-+--------+--------------------+------------------+-----------------------------------------------------------------------------------------------+
++--------+--------------------+------------------+-----------------------------------------------------------+
+|        | a                  | b                | Output                                                    |
++--------+--------------------+------------------+-----------------------------------------------------------+
+| Type   | UInt16 NULL        | Int16 NULL       | Float32 NULL                                              |
+| Domain | {10..=12} ∪ {NULL} | {1..=3} ∪ {NULL} | {-3.4028234663852886e38..=3.4028234663852886e38} ∪ {NULL} |
+| Row 0  | NULL               | NULL             | NULL                                                      |
+| Row 1  | 11                 | 2                | 5.5                                                       |
+| Row 2  | NULL               | 3                | NULL                                                      |
++--------+--------------------+------------------+-----------------------------------------------------------+
 evaluation (internal):
 +--------+------------------------------------------------------------------------+
 | Column | Data                                                                   |
@@ -288,7 +288,7 @@ evaluation (internal):
 
 ast            : divide(a, b)
 raw expr       : divide(ColumnRef(0)::UInt8 NULL, ColumnRef(1)::NULL)
-checked expr   : divide<Float32 NULL, NULL>(cast<dest_type=Float32 NULL>(ColumnRef(0)), ColumnRef(1))
+checked expr   : divide<Float32 NULL, NULL>(CAST(ColumnRef(0) AS Float32 NULL), ColumnRef(1))
 evaluation:
 +--------+--------------------+--------+--------+
 |        | a                  | b      | Output |
@@ -311,17 +311,17 @@ evaluation (internal):
 
 ast            : avg(a, 10)
 raw expr       : avg(ColumnRef(0)::UInt8 NULL, 10_u8)
-checked expr   : avg<Float64 NULL, Float64 NULL>(cast<dest_type=Float64 NULL>(ColumnRef(0)), cast<dest_type=Float64 NULL>(10_u8))
+checked expr   : avg<Float64 NULL, Float64 NULL>(CAST(ColumnRef(0) AS Float64 NULL), CAST(10_u8 AS Float64 NULL))
 evaluation:
-+--------+--------------------+--------------------+
-|        | a                  | Output             |
-+--------+--------------------+--------------------+
-| Type   | UInt8 NULL         | Float64 NULL       |
-| Domain | {10..=12} ∪ {NULL} | {10..=11} ∪ {NULL} |
-| Row 0  | NULL               | NULL               |
-| Row 1  | 11                 | 10.5               |
-| Row 2  | NULL               | NULL               |
-+--------+--------------------+--------------------+
++--------+--------------------+------------------------+
+|        | a                  | Output                 |
++--------+--------------------+------------------------+
+| Type   | UInt8 NULL         | Float64 NULL           |
+| Domain | {10..=12} ∪ {NULL} | {10.0..=11.0} ∪ {NULL} |
+| Row 0  | NULL               | NULL                   |
+| Row 1  | 11                 | 10.5                   |
+| Row 2  | NULL               | NULL                   |
++--------+--------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -333,7 +333,7 @@ evaluation (internal):
 
 ast            : avg(a, b)
 raw expr       : avg(ColumnRef(0)::UInt16 NULL, ColumnRef(1)::Int16 NULL)
-checked expr   : avg<Float64 NULL, Float64 NULL>(cast<dest_type=Float64 NULL>(ColumnRef(0)), cast<dest_type=Float64 NULL>(ColumnRef(1)))
+checked expr   : avg<Float64 NULL, Float64 NULL>(CAST(ColumnRef(0) AS Float64 NULL), CAST(ColumnRef(1) AS Float64 NULL))
 evaluation:
 +--------+--------------------+------------------+----------------------+
 |        | a                  | b                | Output               |
@@ -356,7 +356,7 @@ evaluation (internal):
 
 ast            : avg(a, b)
 raw expr       : avg(ColumnRef(0)::UInt32 NULL, ColumnRef(1)::Int32 NULL)
-checked expr   : avg<Float64 NULL, Float64 NULL>(cast<dest_type=Float64 NULL>(ColumnRef(0)), cast<dest_type=Float64 NULL>(ColumnRef(1)))
+checked expr   : avg<Float64 NULL, Float64 NULL>(CAST(ColumnRef(0) AS Float64 NULL), CAST(ColumnRef(1) AS Float64 NULL))
 evaluation:
 +--------+--------------------+------------------+----------------------+
 |        | a                  | b                | Output               |
@@ -379,17 +379,17 @@ evaluation (internal):
 
 ast            : avg(a, b)
 raw expr       : avg(ColumnRef(0)::Float32 NULL, ColumnRef(1)::Int32 NULL)
-checked expr   : avg<Float64 NULL, Float64 NULL>(cast<dest_type=Float64 NULL>(ColumnRef(0)), cast<dest_type=Float64 NULL>(ColumnRef(1)))
+checked expr   : avg<Float64 NULL, Float64 NULL>(CAST(ColumnRef(0) AS Float64 NULL), CAST(ColumnRef(1) AS Float64 NULL))
 evaluation:
-+--------+--------------------+------------------+----------------------+
-|        | a                  | b                | Output               |
-+--------+--------------------+------------------+----------------------+
-| Type   | Float32 NULL       | Int32 NULL       | Float64 NULL         |
-| Domain | {10..=12} ∪ {NULL} | {1..=3} ∪ {NULL} | {5.5..=7.5} ∪ {NULL} |
-| Row 0  | NULL               | NULL             | NULL                 |
-| Row 1  | 11                 | 2                | 6.5                  |
-| Row 2  | NULL               | 3                | NULL                 |
-+--------+--------------------+------------------+----------------------+
++--------+------------------------+------------------+----------------------+
+|        | a                      | b                | Output               |
++--------+------------------------+------------------+----------------------+
+| Type   | Float32 NULL           | Int32 NULL       | Float64 NULL         |
+| Domain | {10.0..=12.0} ∪ {NULL} | {1..=3} ∪ {NULL} | {5.5..=7.5} ∪ {NULL} |
+| Row 0  | NULL                   | NULL             | NULL                 |
+| Row 1  | 11.0                   | 2                | 6.5                  |
+| Row 2  | NULL                   | 3                | NULL                 |
++--------+------------------------+------------------+----------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -402,17 +402,17 @@ evaluation (internal):
 
 ast            : avg(a, b)
 raw expr       : avg(ColumnRef(0)::Float32 NULL, ColumnRef(1)::Float64 NULL)
-checked expr   : avg<Float64 NULL, Float64 NULL>(cast<dest_type=Float64 NULL>(ColumnRef(0)), ColumnRef(1))
+checked expr   : avg<Float64 NULL, Float64 NULL>(CAST(ColumnRef(0) AS Float64 NULL), ColumnRef(1))
 evaluation:
-+--------+--------------------+------------------+----------------------+
-|        | a                  | b                | Output               |
-+--------+--------------------+------------------+----------------------+
-| Type   | Float32 NULL       | Float64 NULL     | Float64 NULL         |
-| Domain | {10..=12} ∪ {NULL} | {1..=3} ∪ {NULL} | {5.5..=7.5} ∪ {NULL} |
-| Row 0  | NULL               | NULL             | NULL                 |
-| Row 1  | 11                 | 2                | 6.5                  |
-| Row 2  | NULL               | 3                | NULL                 |
-+--------+--------------------+------------------+----------------------+
++--------+------------------------+----------------------+----------------------+
+|        | a                      | b                    | Output               |
++--------+------------------------+----------------------+----------------------+
+| Type   | Float32 NULL           | Float64 NULL         | Float64 NULL         |
+| Domain | {10.0..=12.0} ∪ {NULL} | {1.0..=3.0} ∪ {NULL} | {5.5..=7.5} ∪ {NULL} |
+| Row 0  | NULL                   | NULL                 | NULL                 |
+| Row 1  | 11.0                   | 2.0                  | 6.5                  |
+| Row 2  | NULL                   | 3.0                  | NULL                 |
++--------+------------------------+----------------------+----------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -425,7 +425,7 @@ evaluation (internal):
 
 ast            : multiply(a, b)
 raw expr       : multiply(ColumnRef(0)::Int8 NULL, ColumnRef(1)::NULL)
-checked expr   : multiply<Int64 NULL, NULL>(cast<dest_type=Int64 NULL>(ColumnRef(0)), ColumnRef(1))
+checked expr   : multiply<Int64 NULL, NULL>(CAST(ColumnRef(0) AS Int64 NULL), ColumnRef(1))
 evaluation:
 +--------+--------------------+--------+--------+
 |        | a                  | b      | Output |
@@ -492,9 +492,9 @@ evaluation (internal):
 +--------+-----------------+
 
 
-ast            : least(10, 20, 30, 40)
-raw expr       : least(10_u8, 20_u8, 30_u8, 40_u8)
-checked expr   : least<Int16, Int16, Int16, Int16>(cast<dest_type=Int16>(10_u8), cast<dest_type=Int16>(20_u8), cast<dest_type=Int16>(30_u8), cast<dest_type=Int16>(40_u8))
+ast            : least(10, CAST(20 as Int8), 30, 40)
+raw expr       : least(10_u8, CAST(20_u8 AS Int8), 30_u8, 40_u8)
+checked expr   : least<Int16, Int16, Int16, Int16>(CAST(10_u8 AS Int16), CAST(CAST(20_u8 AS Int8) AS Int16), CAST(30_u8 AS Int16), CAST(40_u8 AS Int16))
 output type    : Int16
 output domain  : {10..=10}
 output         : 10
@@ -568,7 +568,7 @@ output         : []
 
 ast            : create_array(null, true)
 raw expr       : create_array(NULL, true)
-checked expr   : create_array<T0=Boolean NULL><T0, T0>(cast<dest_type=Boolean NULL>(NULL), cast<dest_type=Boolean NULL>(true))
+checked expr   : create_array<T0=Boolean NULL><T0, T0>(CAST(NULL AS Boolean NULL), CAST(true AS Boolean NULL))
 output type    : Array(Boolean NULL)
 output domain  : [{TRUE} ∪ {NULL}]
 output         : [NULL, true]
@@ -601,7 +601,7 @@ evaluation (internal):
 
 ast            : create_array(create_array(a, b), null, null)
 raw expr       : create_array(create_array(ColumnRef(0)::Int16, ColumnRef(1)::Int16), NULL, NULL)
-checked expr   : create_array<T0=Array(Int16) NULL><T0, T0, T0>(cast<dest_type=Array(Int16) NULL>(create_array<T0=Int16><T0, T0>(ColumnRef(0), ColumnRef(1))), cast<dest_type=Array(Int16) NULL>(NULL), cast<dest_type=Array(Int16) NULL>(NULL))
+checked expr   : create_array<T0=Array(Int16) NULL><T0, T0, T0>(CAST(create_array<T0=Int16><T0, T0>(ColumnRef(0), ColumnRef(1)) AS Array(Int16) NULL), CAST(NULL AS Array(Int16) NULL), CAST(NULL AS Array(Int16) NULL))
 evaluation:
 +--------+---------+---------+--------------------------+
 |        | a       | b       | Output                   |
@@ -626,7 +626,7 @@ evaluation (internal):
 
 ast            : get(a, b)
 raw expr       : get(ColumnRef(0)::Array(Int16), ColumnRef(1)::UInt8)
-checked expr   : get<T0=Int16><Array(T0), Int16>(ColumnRef(0), cast<dest_type=Int16>(ColumnRef(1)))
+checked expr   : get<T0=Int16><Array(T0), Int16>(ColumnRef(0), CAST(ColumnRef(1) AS Int16))
 evaluation:
 +--------+----------------------------------------------------------------------------------+---------+----------+
 |        | a                                                                                | b       | Output   |
@@ -651,7 +651,7 @@ evaluation (internal):
 
 ast            : get(a, b)
 raw expr       : get(ColumnRef(0)::Array(Array(Int16)), ColumnRef(1)::UInt8)
-checked expr   : get<T0=Array(Int16)><Array(T0), Int16>(ColumnRef(0), cast<dest_type=Int16>(ColumnRef(1)))
+checked expr   : get<T0=Array(Int16)><Array(T0), Int16>(ColumnRef(0), CAST(ColumnRef(1) AS Int16))
 evaluation:
 +--------+----------------------------------------------------------------------------------------------------------------+---------+----------------------+
 |        | a                                                                                                              | b       | Output               |
@@ -672,5 +672,153 @@ evaluation (internal):
 | b      | UInt8([0, 1, 2, 3, 4])                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | Output | Array { array: Int16([0, 1, 2, 3, 4, 25, 26, 27, 28, 29, 50, 51, 52, 53, 54, 70, 71, 72, 73, 74, 95, 96, 97, 98, 99]), offsets: [0, 5, 10, 15, 20, 25] }                                                                                                                                                                                                                                                                                                                                                                                                                      |
 +--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : TRY_CAST(a AS UINT8)
+raw expr       : TRY_CAST(ColumnRef(0)::UInt16 AS UInt8)
+checked expr   : TRY_CAST(ColumnRef(0) AS UInt8 NULL)
+evaluation:
++--------+------------+--------------------+
+|        | a          | Output             |
++--------+------------+--------------------+
+| Type   | UInt16     | UInt8 NULL         |
+| Domain | {0..=1024} | {0..=255} ∪ {NULL} |
+| Row 0  | 0          | 0                  |
+| Row 1  | 64         | 64                 |
+| Row 2  | 255        | 255                |
+| Row 3  | 512        | NULL               |
+| Row 4  | 1024       | NULL               |
++--------+------------+--------------------+
+evaluation (internal):
++--------+------------------------------------------------------------------------+
+| Column | Data                                                                   |
++--------+------------------------------------------------------------------------+
+| a      | UInt16([0, 64, 255, 512, 1024])                                        |
+| Output | Nullable { column: UInt8([0, 64, 255, 0, 0]), validity: [0b___00111] } |
++--------+------------------------------------------------------------------------+
+
+
+ast            : TRY_CAST(a AS UINT16)
+raw expr       : TRY_CAST(ColumnRef(0)::Int16 AS UInt16)
+checked expr   : TRY_CAST(ColumnRef(0) AS UInt16 NULL)
+evaluation:
++--------+----------+------------------+
+|        | a        | Output           |
++--------+----------+------------------+
+| Type   | Int16    | UInt16 NULL      |
+| Domain | {-4..=3} | {0..=3} ∪ {NULL} |
+| Row 0  | 0        | 0                |
+| Row 1  | 1        | 1                |
+| Row 2  | 2        | 2                |
+| Row 3  | 3        | 3                |
+| Row 4  | -4       | NULL             |
++--------+----------+------------------+
+evaluation (internal):
++--------+----------------------------------------------------------------------+
+| Column | Data                                                                 |
++--------+----------------------------------------------------------------------+
+| a      | Int16([0, 1, 2, 3, -4])                                              |
+| Output | Nullable { column: UInt16([0, 1, 2, 3, 0]), validity: [0b___01111] } |
++--------+----------------------------------------------------------------------+
+
+
+ast            : TRY_CAST(a AS INT64)
+raw expr       : TRY_CAST(ColumnRef(0)::Int16 AS Int64)
+checked expr   : TRY_CAST(ColumnRef(0) AS Int64 NULL)
+evaluation:
++--------+----------+------------+
+|        | a        | Output     |
++--------+----------+------------+
+| Type   | Int16    | Int64 NULL |
+| Domain | {-4..=3} | {-4..=3}   |
+| Row 0  | 0        | 0          |
+| Row 1  | 1        | 1          |
+| Row 2  | 2        | 2          |
+| Row 3  | 3        | 3          |
+| Row 4  | -4       | -4         |
++--------+----------+------------+
+evaluation (internal):
++--------+----------------------------------------------------------------------+
+| Column | Data                                                                 |
++--------+----------------------------------------------------------------------+
+| a      | Int16([0, 1, 2, 3, -4])                                              |
+| Output | Nullable { column: Int64([0, 1, 2, 3, -4]), validity: [0b___11111] } |
++--------+----------------------------------------------------------------------+
+
+
+ast            : create_tuple(TRY_CAST(a AS FLOAT32), TRY_CAST(a AS INT32), TRY_CAST(b AS FLOAT32), TRY_CAST(b AS INT32))
+raw expr       : create_tuple(TRY_CAST(ColumnRef(0)::UInt64 AS Float32), TRY_CAST(ColumnRef(0)::UInt64 AS Int32), TRY_CAST(ColumnRef(1)::Float64 AS Float32), TRY_CAST(ColumnRef(1)::Float64 AS Int32))
+checked expr   : create_tuple<Float32 NULL, Int32 NULL, Float32 NULL, Int32 NULL>(TRY_CAST(ColumnRef(0) AS Float32 NULL), TRY_CAST(ColumnRef(0) AS Int32 NULL), TRY_CAST(ColumnRef(1) AS Float32 NULL), TRY_CAST(ColumnRef(1) AS Int32 NULL))
+evaluation:
++--------+----------------------------+----------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+|        | a                          | b                                                  | Output                                                                                                                                            |
++--------+----------------------------+----------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| Type   | UInt64                     | Float64                                            | (Float32 NULL, Int32 NULL, Float32 NULL, Int32 NULL)                                                                                              |
+| Domain | {0..=18446744073709551615} | {-1.7976931348623157e308..=1.7976931348623157e308} | ({0.0..=1.8446744073709552e19}, {0..=2147483647} ∪ {NULL}, {-3.4028234663852886e38..=3.4028234663852886e38}, {-2147483648..=2147483647} ∪ {NULL}) |
+| Row 0  | 0                          | 0.0                                                | (0.0, 0, 0.0, 0)                                                                                                                                  |
+| Row 1  | 1                          | 4294967295.0                                       | (1.0, 1, 4294967300.0, NULL)                                                                                                                      |
+| Row 2  | 255                        | 1.8446744073709552e19                              | (255.0, 255, 1.8446744e19, NULL)                                                                                                                  |
+| Row 3  | 65535                      | -1.7976931348623157e308                            | (65535.0, 65535, -inf, NULL)                                                                                                                      |
+| Row 4  | 4294967295                 | 1.7976931348623157e308                             | (4294967300.0, NULL, inf, NULL)                                                                                                                   |
+| Row 5  | 18446744073709551615       | inf                                                | (1.8446744e19, NULL, inf, NULL)                                                                                                                   |
++--------+----------------------------+----------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                                                                                                                                                                                    |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| a      | UInt64([0, 1, 255, 65535, 4294967295, 18446744073709551615])                                                                                                                                                                                                                                                                                                                                            |
+| b      | Float64([0.0, 4294967295.0, 1.8446744073709552e19, -1.7976931348623157e308, 1.7976931348623157e308, inf])                                                                                                                                                                                                                                                                                               |
+| Output | Tuple { fields: [Nullable { column: Float32([0.0, 1.0, 255.0, 65535.0, 4294967300.0, 1.8446744e19]), validity: [0b__111111] }, Nullable { column: Int32([0, 1, 255, 65535, 0, 0]), validity: [0b__001111] }, Nullable { column: Float32([0.0, 4294967300.0, 1.8446744e19, -inf, inf, inf]), validity: [0b__111111] }, Nullable { column: Int32([0, 0, 0, 0, 0, 0]), validity: [0b__000001] }], len: 6 } |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : TRY_CAST(create_array(create_array(a, b), null, null) AS Array(Array(Int8)))
+raw expr       : TRY_CAST(create_array(create_array(ColumnRef(0)::Int16, ColumnRef(1)::Int16), NULL, NULL) AS Array(Array(Int8)))
+checked expr   : TRY_CAST(create_array<T0=Array(Int16) NULL><T0, T0, T0>(CAST(create_array<T0=Int16><T0, T0>(ColumnRef(0), ColumnRef(1)) AS Array(Int16) NULL), CAST(NULL AS Array(Int16) NULL), CAST(NULL AS Array(Int16) NULL)) AS Array(Array(Int8 NULL) NULL) NULL)
+evaluation:
++--------+-----------+------------+------------------------------------+
+|        | a         | b          | Output                             |
++--------+-----------+------------+------------------------------------+
+| Type   | Int16     | Int16      | Array(Array(Int8 NULL) NULL) NULL  |
+| Domain | {0..=255} | {-129..=0} | [[{-128..=127} ∪ {NULL}] ∪ {NULL}] |
+| Row 0  | 0         | 0          | [[0, 0], [], []]                   |
+| Row 1  | 1         | -1         | [[1, -1], [], []]                  |
+| Row 2  | 2         | -127       | [[2, -127], [], []]                |
+| Row 3  | 127       | -128       | [[127, -128], [], []]              |
+| Row 4  | 255       | -129       | [[NULL, NULL], [], []]             |
++--------+-----------+------------+------------------------------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                                                                                                                        |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| a      | Int16([0, 1, 2, 127, 255])                                                                                                                                                                                                                                                                                                                  |
+| b      | Int16([0, -1, -127, -128, -129])                                                                                                                                                                                                                                                                                                            |
+| Output | Nullable { column: Array { array: Nullable { column: Array { array: Nullable { column: Int8([0, 0, 1, -1, 2, -127, 127, -128, 0, 0]), validity: [0b11111111, 0b______00] }, offsets: [0, 2, 2, 2, 4, 4, 4, 6, 6, 6, 8, 8, 8, 10, 10, 10] }, validity: [0b11111111, 0b_1111111] }, offsets: [0, 3, 6, 9, 12, 15] }, validity: [0b___11111] } |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : TRY_CAST(create_tuple(a, b, NULL) AS (Int8, UInt8, Boolean NULL))
+raw expr       : TRY_CAST(create_tuple(ColumnRef(0)::Int16, ColumnRef(1)::Int16, NULL) AS (Int8, UInt8, Boolean NULL))
+checked expr   : TRY_CAST(create_tuple<Int16, Int16, NULL>(ColumnRef(0), ColumnRef(1), NULL) AS (Int8 NULL, UInt8 NULL, Boolean NULL) NULL)
+evaluation:
++--------+-----------+------------+------------------------------------------------+
+|        | a         | b          | Output                                         |
++--------+-----------+------------+------------------------------------------------+
+| Type   | Int16     | Int16      | (Int8 NULL, UInt8 NULL, Boolean NULL) NULL     |
+| Domain | {0..=255} | {-129..=1} | ({0..=127} ∪ {NULL}, {0..=1} ∪ {NULL}, {NULL}) |
+| Row 0  | 0         | 0          | (0, 0, NULL)                                   |
+| Row 1  | 1         | 1          | (1, 1, NULL)                                   |
+| Row 2  | 2         | -127       | (2, NULL, NULL)                                |
+| Row 3  | 127       | -128       | (127, NULL, NULL)                              |
+| Row 4  | 256       | -129       | (NULL, NULL, NULL)                             |
++--------+-----------+------------+------------------------------------------------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                                                                   |
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| a      | Int16([0, 1, 2, 127, 256])                                                                                                                                                                                                                                                             |
+| b      | Int16([0, 1, -127, -128, -129])                                                                                                                                                                                                                                                        |
+| Output | Nullable { column: Tuple { fields: [Nullable { column: Int8([0, 1, 2, 127, 0]), validity: [0b___01111] }, Nullable { column: UInt8([0, 1, 0, 0, 0]), validity: [0b___00011] }, Nullable { column: Boolean([0b___00000]), validity: [0b___00000] }], len: 5 }, validity: [0b___11111] } |
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Support `CAST` and `TRY_CAST`
- Allow cast between any number types. Once precision downgrade is detected during evaluation, while `CAST` will abort the execution and throw an error, `TRY_CAST` will just silently replace that single scalar with NULL.
- Note that `TRY_CAST` will wrap its dest type into nullable. For example, the return type of `TRY_CAST(a AS Int8)` is `Int8 NULL`, and the return type of `TRY_CAST(a AS Array(Int8))` is `Array(Int8 NULL) NULL`.

Tracked in https://github.com/datafuselabs/databend/issues/6547
