### PR TITLE
fix: adhoc fix session leak

### DIFF
--- a/query/src/servers/clickhouse/interactive_worker.rs
+++ b/query/src/servers/clickhouse/interactive_worker.rs
@@ -50,12 +50,10 @@ impl ClickHouseSession for InteractiveWorker {
 
         let session = self.session.clone();
         let get_query_result = InteractiveWorkerBase::do_query(ctx, session);
-        let query_ctx = self
+        let format = self
             .session
-            .get_shared_query_context()
-            .await
+            .get_format_settings()
             .map_err(to_clickhouse_err)?;
-        let format = query_ctx.get_format_settings().map_err(to_clickhouse_err)?;
         if let Err(cause) = query_writer.write(get_query_result.await, &format).await {
             let new_error = cause.add_message(&ctx.state.query);
             return Err(to_clickhouse_err(new_error));

--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -187,11 +187,7 @@ impl<W: std::io::Write + Send + Sync> AsyncMysqlShim<W> for InteractiveWorker<W>
         let instant = Instant::now();
         let blocks = self.base.do_query(query).await;
 
-        let format = self
-            .session
-            .get_shared_query_context()
-            .await?
-            .get_format_settings()?;
+        let format = self.session.get_format_settings()?;
         let mut write_result = writer.write(blocks, &format);
 
         if let Err(cause) = write_result {

--- a/query/src/sessions/query_ctx.rs
+++ b/query/src/sessions/query_ctx.rs
@@ -62,7 +62,6 @@ use crate::clusters::Cluster;
 use crate::servers::http::v1::HttpQueryHandle;
 use crate::sessions::ProcessInfo;
 use crate::sessions::QueryContextShared;
-use crate::sessions::Session;
 use crate::sessions::SessionRef;
 use crate::sessions::Settings;
 use crate::storages::cache::CacheManager;
@@ -338,7 +337,7 @@ impl QueryContext {
     }
 
     pub fn get_format_settings(&self) -> Result<FormatSettings> {
-        self.shared.get_format_settings()
+        self.shared.session.get_format_settings()
     }
 
     pub fn get_config(&self) -> Config {
@@ -372,8 +371,8 @@ impl QueryContext {
     }
 
     // Get the current session.
-    pub fn get_current_session(self: &Arc<Self>) -> Arc<Session> {
-        self.shared.session.clone()
+    pub fn get_current_session(self: &Arc<Self>) -> SessionRef {
+        SessionRef::create(self.shared.session.clone())
     }
 
     // Get one session by session id.

--- a/query/src/sessions/session.rs
+++ b/query/src/sessions/session.rs
@@ -16,9 +16,11 @@ use std::net::SocketAddr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
+use chrono_tz::Tz;
 use common_base::mem_allocator::malloc_size;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_io::prelude::FormatSettings;
 use common_macros::MallocSizeOf;
 use common_meta_types::GrantObject;
 use common_meta_types::UserInfo;
@@ -151,6 +153,34 @@ impl Session {
         self.session_ctx
             .set_query_context_shared(Some(shared.clone()));
         Ok(shared)
+    }
+
+    pub fn get_format_settings(&self) -> Result<FormatSettings> {
+        let settings = &self.session_settings;
+        let mut format = FormatSettings::default();
+        if let SessionType::HTTPQuery = self.get_type() {
+            format.false_bytes = vec![b'f', b'a', b'l', b's', b'e'];
+            format.true_bytes = vec![b't', b'r', b'u', b'e'];
+        }
+        {
+            format.record_delimiter = settings.get_record_delimiter()?;
+            format.field_delimiter = settings.get_field_delimiter()?;
+            format.empty_as_default = settings.get_empty_as_default()? > 0;
+            format.skip_header = settings.get_skip_header()? > 0;
+
+            let tz = String::from_utf8(settings.get_timezone()?).map_err(|_| {
+                ErrorCode::LogicalError("Timezone has been checked and should be valid.")
+            })?;
+            format.timezone = tz.parse::<Tz>().map_err(|_| {
+                ErrorCode::InvalidTimezone("Timezone has been checked and should be valid")
+            })?;
+
+            let compress = String::from_utf8(settings.get_compression()?).map_err(|_| {
+                ErrorCode::UnknownCompressionType("Compress type must be valid utf-8")
+            })?;
+            format.compression = compress.parse()?
+        }
+        Ok(format)
     }
 
     pub fn get_current_query_id(&self) -> Option<String> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix session leak, to detect it, just wrap `Arc<Session>` to `SessionWrapper` as following, then check the new and drop are paired:
```rust
pub struct SessionWrapper {
    id: usize,
    session: Arc<Session>,
}

impl SessionWrapper {
    pub fn new(s: Arc<Session>) -> Self {
        let backtrace = Backtrace::force_capture();
        let backtrace = format!("{:?}", backtrace);
        let id = GlobalSequence::next();
        println!(
            "session wrapper {} new: {}-{}",
            id,
            Arc::strong_count(&s),
            backtrace
        );
        Self { id, session: s }
    }
}

impl Clone for SessionWrapper {
    fn clone(&self) -> Self {
        Self::new(self.session.clone())
    }
}

impl Drop for SessionWrapper {
    fn drop(&mut self) {
        let backtrace = Backtrace::force_capture();
        let backtrace = format!("{:?}", backtrace);
        println!(
            "session wrapper {} dropped: {}-{}",
            self.id,
            Arc::strong_count(&self.session),
            backtrace
        );
    }
}

impl Deref for SessionWrapper {
    type Target = Arc<Session>;

    fn deref(&self) -> &Self::Target {
        &(self.session)
    }
}
```

**NOTE**: this is just an ad-hoc fix, the refactoring of session module will be done related to [this issue](https://github.com/datafuselabs/databend/issues/5679)

Fixes #6560  
