### PR TITLE
ci: Add rules for docs PR

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,18 +15,37 @@ queue_rules:
       - check-success=test_stateful_standalone_linux
       - check-success=test_sqllogic_standalone_linux
 
+  - name: docs_queue
+      conditions:
+        - "#approved-reviews-by>=1"
+
+        # Docs queue only requires Vercel passing.
+        - check-success=Vercel
+
 pull_request_rules:
   # Push PR into queue when it passes all checks
-  - name: put approved pr to queue
+  - name: Put into shared queue
     conditions:
       - "#approved-reviews-by>=2"
       - -draft
+      - label!=pr-doc
     actions:
       queue:
         name: shared_queue
 
+  # Push docs PR into docs queue
+  - name: Put into docs queue
+    conditions:
+      - "#approved-reviews-by>=1"
+      - -draft
+      - label=pr-doc
+      - check-success=Vercel
+    actions:
+      queue:
+        name: docs_queue
+
   # If there is a conflict in an approved PR, ping the author.
-  - name: ping author on conflicts
+  - name: Ping author on conflicts
     conditions:
       - conflict
       - -draft

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -16,11 +16,11 @@ queue_rules:
       - check-success=test_sqllogic_standalone_linux
 
   - name: docs_queue
-      conditions:
-        - "#approved-reviews-by>=1"
+    conditions:
+      - "#approved-reviews-by>=1"
 
-        # Docs queue only requires Vercel passing.
-        - check-success=Vercel
+      # Docs queue only requires Vercel passing.
+      - check-success=Vercel
 
 pull_request_rules:
   # Push PR into queue when it passes all checks


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR adds a rule for docs PR.

After this change, our docs PR only needs to pass the `Vercel` check.
