### PR TITLE
fix(query): bug in FileSplitter skip header.

### DIFF
--- a/common/io/src/format_settings.rs
+++ b/common/io/src/format_settings.rs
@@ -39,6 +39,9 @@ pub struct FormatSettings {
     pub tsv_null_bytes: Vec<u8>,
     pub json_quote_denormals: bool,
     pub json_escape_forward_slashes: bool,
+
+    pub input_buffer_size: usize,
+    pub decompress_buffer_size: usize,
 }
 
 impl Default for FormatSettings {
@@ -60,6 +63,8 @@ impl Default for FormatSettings {
             tsv_null_bytes: vec![b'\\', b'N'],
             json_quote_denormals: false,
             json_escape_forward_slashes: true,
+            input_buffer_size: 1024 * 1024,
+            decompress_buffer_size: 1024 * 1024,
         }
     }
 }

--- a/query/src/pipelines/processors/mod.rs
+++ b/query/src/pipelines/processors/mod.rs
@@ -29,6 +29,8 @@ pub use sources::AsyncSourcer;
 pub use sources::BlocksSource;
 pub use sources::Deserializer;
 pub use sources::EmptySource;
+pub use sources::FileSplitter;
+pub use sources::FileSplitterState;
 pub use sources::MultiFileSplitter;
 pub use sources::OperatorInfo;
 pub use sources::StreamSource;

--- a/query/src/pipelines/processors/sources/file_splitter.rs
+++ b/query/src/pipelines/processors/sources/file_splitter.rs
@@ -60,12 +60,17 @@ impl FileSplitter {
         compress_algorithm: Option<CompressAlgorithm>,
     ) -> FileSplitter {
         let decoder = compress_algorithm.map(DecompressDecoder::new);
+        let decompress_buf = if decoder.is_some() {
+            vec![0; format_settings.decompress_buffer_size]
+        } else {
+            vec![]
+        };
         FileSplitter {
             state: FileSplitterState::NeedData,
             rows_to_skip: format_settings.skip_header,
             reader: Box::new(reader),
-            input_buf: vec![0; 1024 * 1024],
-            decompress_buf: vec![0; 1024 * 1024],
+            input_buf: vec![0; format_settings.input_buffer_size],
+            decompress_buf,
             decoder,
             input_format: input_format.clone(),
             format_state: input_format.create_state(),

--- a/query/src/pipelines/processors/sources/file_splitter.rs
+++ b/query/src/pipelines/processors/sources/file_splitter.rs
@@ -29,7 +29,7 @@ use opendal::io_util::DecompressDecoder;
 use opendal::io_util::DecompressState;
 
 #[derive(Copy, Clone)]
-pub enum State {
+pub enum FileSplitterState {
     NeedData,
     ReceivedData(usize),
     NeedFlush,
@@ -40,7 +40,7 @@ pub enum State {
 pub struct FileSplitter {
     input_format: Arc<dyn InputFormat>,
 
-    state: State,
+    state: FileSplitterState,
 
     reader: Box<dyn AsyncRead + Send + Unpin>,
     input_buf: Vec<u8>,
@@ -61,7 +61,7 @@ impl FileSplitter {
     ) -> FileSplitter {
         let decoder = compress_algorithm.map(DecompressDecoder::new);
         FileSplitter {
-            state: State::NeedData,
+            state: FileSplitterState::NeedData,
             rows_to_skip: format_settings.skip_header,
             reader: Box::new(reader),
             input_buf: vec![0; 1024 * 1024],
@@ -72,12 +72,11 @@ impl FileSplitter {
         }
     }
 
-    pub fn state(&self) -> State {
+    pub fn state(&self) -> FileSplitterState {
         self.state
     }
 
     fn split(&mut self, size: usize, output_splits: &mut VecDeque<Vec<u8>>) -> Result<()> {
-        // let data = &self.input_buf[..size];
         if self.decoder.is_some() {
             self.dec_and_split(size, output_splits)
         } else {
@@ -204,9 +203,9 @@ impl FileSplitter {
         }
 
         self.state = if n > 0 {
-            State::ReceivedData(n)
+            FileSplitterState::ReceivedData(n)
         } else {
-            State::NeedFlush
+            FileSplitterState::NeedFlush
         };
         Ok(())
     }
@@ -216,22 +215,22 @@ impl FileSplitter {
         output_splits: &mut VecDeque<Vec<u8>>,
         progress_values: &mut ProgressValues,
     ) -> Result<()> {
-        match replace(&mut self.state, State::NeedData) {
-            State::ReceivedData(size) => {
+        match replace(&mut self.state, FileSplitterState::NeedData) {
+            FileSplitterState::ReceivedData(size) => {
                 self.split(size, output_splits)?;
                 progress_values.bytes += size
             }
-            State::NeedFlush => {
+            FileSplitterState::NeedFlush => {
                 self.flush(output_splits);
-                self.state = State::Finished;
+                self.state = FileSplitterState::Finished;
             }
             _ => return self.wrong_state(),
         }
         Ok(())
     }
 
-    pub(crate) async fn async_process(&mut self) -> Result<()> {
-        if let State::NeedData = replace(&mut self.state, State::NeedData) {
+    pub async fn async_process(&mut self) -> Result<()> {
+        if let FileSplitterState::NeedData = replace(&mut self.state, FileSplitterState::NeedData) {
             self.fill().await
         } else {
             self.wrong_state()

--- a/query/src/pipelines/processors/sources/file_splitter.rs
+++ b/query/src/pipelines/processors/sources/file_splitter.rs
@@ -108,13 +108,11 @@ impl FileSplitter {
         let mut data_slice = data;
 
         if *rows_to_skip > 0 {
-            let len = data_slice.len();
-            let mut skip_size = 0;
-            while *rows_to_skip > 0 {
-                skip_size += input_format.skip_header(data_slice, format_state, 1)?;
-                *rows_to_skip -= 1;
-            }
-            if skip_size < len {
+            let skip_size =
+                input_format.skip_header(data_slice, format_state, *rows_to_skip as usize)?;
+            let skip_rows = input_format.read_row_num(format_state)?;
+            if skip_rows == *rows_to_skip as usize {
+                *rows_to_skip = 0;
                 *format_state = input_format.create_state();
                 data_slice = &data_slice[skip_size..];
             } else {

--- a/query/src/pipelines/processors/sources/mod.rs
+++ b/query/src/pipelines/processors/sources/mod.rs
@@ -29,6 +29,8 @@ pub use async_source::AsyncSourcer;
 pub use blocks_source::BlocksSource;
 pub use deserializer::Deserializer;
 pub use empty_source::EmptySource;
+pub use file_splitter::FileSplitter;
+pub use file_splitter::FileSplitterState;
 pub use multi_file_splitter::MultiFileSplitter;
 pub use multi_file_splitter::OperatorInfo;
 pub use stream_source::StreamSource;

--- a/query/src/pipelines/processors/sources/multi_file_splitter.rs
+++ b/query/src/pipelines/processors/sources/multi_file_splitter.rs
@@ -30,7 +30,7 @@ use opendal::Operator;
 use parking_lot::Mutex;
 
 use super::file_splitter::FileSplitter;
-use super::file_splitter::State;
+use super::file_splitter::FileSplitterState;
 use crate::pipelines::processors::port::OutputPort;
 use crate::pipelines::processors::processor::Event;
 use crate::pipelines::processors::processor::ProcessorPtr;
@@ -160,10 +160,10 @@ impl Processor for MultiFileSplitter {
         match &self.current_file {
             None => Ok(Event::Async),
             Some(splitter) => match &splitter.state() {
-                State::NeedData => Ok(Event::Async),
-                State::Finished => Ok(Event::Async),
-                State::ReceivedData(_) => Ok(Event::Sync),
-                State::NeedFlush => Ok(Event::Sync),
+                FileSplitterState::NeedData => Ok(Event::Async),
+                FileSplitterState::Finished => Ok(Event::Async),
+                FileSplitterState::ReceivedData(_) => Ok(Event::Sync),
+                FileSplitterState::NeedFlush => Ok(Event::Sync),
             },
         }
     }
@@ -173,7 +173,7 @@ impl Processor for MultiFileSplitter {
         let current = self.current_file.as_mut().unwrap();
         let mut output_splits = VecDeque::default();
         current.process(&mut output_splits, &mut progress_values)?;
-        if matches!(current.state(), State::Finished) {
+        if matches!(current.state(), FileSplitterState::Finished) {
             self.current_file = None;
         }
         self.output_splits.extend(output_splits.into_iter());

--- a/query/tests/it/pipelines/processors/file_splitter.rs
+++ b/query/tests/it/pipelines/processors/file_splitter.rs
@@ -1,0 +1,65 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use common_base::base::tokio;
+use common_base::base::ProgressValues;
+use common_datavalues::DataField;
+use common_datavalues::DataSchema;
+use common_datavalues::StringType;
+use common_exception::Result;
+use common_formats::format_csv::CsvInputFormat;
+use common_io::prelude::FormatSettings;
+use databend_query::pipelines::processors::FileSplitter;
+use databend_query::pipelines::processors::FileSplitterState;
+use futures_util::io::Cursor;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_split_csv_with_header() -> Result<()> {
+    // data
+    let contents = r#""a","b"
+v1,v2
+v3,v4
+"#
+    .as_bytes();
+    let reader = Cursor::new(contents);
+    let fields = vec![
+        DataField::new("c1", StringType::new_impl()),
+        DataField::new("c2", StringType::new_impl()),
+    ];
+    let schema = Arc::new(DataSchema::new(fields));
+
+    // set up
+    let format_settings = FormatSettings {
+        skip_header: 1,
+        input_buffer_size: 1,
+        ..Default::default()
+    };
+    let file_format =
+        CsvInputFormat::try_create("", schema.clone(), Default::default(), 0, 1, 1024)?;
+    let mut splitter = FileSplitter::create(reader, file_format, format_settings, None);
+
+    // run
+    let mut output_splits: VecDeque<Vec<u8>> = VecDeque::new();
+    let mut progress = ProgressValues::default();
+    while !matches!(splitter.state(), FileSplitterState::Finished) {
+        splitter.async_process().await?;
+        splitter.process(&mut output_splits, &mut progress)?;
+    }
+    let exp = VecDeque::from(vec![b"v1,v2\nv3,v4\n".to_vec()]);
+    assert_eq!(output_splits, exp);
+    Ok(())
+}

--- a/query/tests/it/pipelines/processors/mod.rs
+++ b/query/tests/it/pipelines/processors/mod.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod file_splitter;
 mod port_test;
 mod resize;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

occur one header is not all read in the first read.


Fixes #issue
