### PR TITLE
chore: disable macos logic test

### DIFF
--- a/.github/workflows/dev-macos.yml
+++ b/.github/workflows/dev-macos.yml
@@ -52,10 +52,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/test_stateless_cluster_macos
 
-  test_sqllogic_standalone_macos:
-    name: "test_sqllogic_standalone_macos(optional)"
-    runs-on: macos-11
-    needs: build_macos
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/test_sqllogic_standalone_macos
+  # https://github.com/datafuselabs/databend/issues/6614
+  # test_sqllogic_standalone_macos:
+  #   name: "test_sqllogic_standalone_macos(optional)"
+  #   runs-on: macos-11
+  #   needs: build_macos
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: ./.github/actions/test_sqllogic_standalone_macos


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Flaky error cause macos ci failed too much, disable it for now
issue here:  https://github.com/datafuselabs/databend/issues/6614

Fixes #issue
