### PR TITLE
fix(query): Fix values source `skip_to_next_row`

### DIFF
--- a/common/ast/src/ast/expr.rs
+++ b/common/ast/src/ast/expr.rs
@@ -259,8 +259,7 @@ pub enum TypeName {
     Float32,
     Float64,
     Date,
-    DateTime { precision: Option<u64> },
-    Timestamp,
+    Timestamp { precision: Option<u64> },
     String,
     Array { item_type: Option<Box<TypeName>> },
     Object,
@@ -525,14 +524,11 @@ impl Display for TypeName {
             TypeName::Date => {
                 write!(f, "DATE")?;
             }
-            TypeName::DateTime { precision } => {
-                write!(f, "DATETIME")?;
+            TypeName::Timestamp { precision } => {
+                write!(f, "Timestamp")?;
                 if let Some(precision) = precision {
                     write!(f, "({})", *precision)?;
                 }
-            }
-            TypeName::Timestamp => {
-                write!(f, "TIMESTAMP")?;
             }
             TypeName::String => {
                 write!(f, "STRING")?;

--- a/common/ast/src/parser/expr.rs
+++ b/common/ast/src/parser/expr.rs
@@ -1141,12 +1141,11 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
     );
     let ty_date = value(TypeName::Date, rule! { DATE });
     let ty_datetime = map(
-        rule! { DATETIME ~ ( "(" ~ #literal_u64 ~ ")" )? },
-        |(_, opt_precision)| TypeName::DateTime {
+        rule! { (DATETIME | TIMESTAMP) ~ ( "(" ~ #literal_u64 ~ ")" )? },
+        |(_, opt_precision)| TypeName::Timestamp {
             precision: opt_precision.map(|(_, precision, _)| precision),
         },
     );
-    let ty_timestamp = value(TypeName::Timestamp, rule! { TIMESTAMP });
     let ty_string = value(
         TypeName::String,
         rule! { ( STRING | VARCHAR ) ~ ( "(" ~ #literal_u64 ~ ")" )? },
@@ -1169,7 +1168,6 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
             | #ty_array
             | #ty_date
             | #ty_datetime
-            | #ty_timestamp
             | #ty_string
             | #ty_object
             | #ty_variant

--- a/common/ast/tests/it/testdata/statement.txt
+++ b/common/ast/tests/it/testdata/statement.txt
@@ -744,7 +744,7 @@ DropDatabase(
 ---------- Input ----------
 create table c(a DateTime null, b DateTime(3));
 ---------- Output ---------
-CREATE TABLE c (a DATETIME NULL, b DATETIME(3) NOT NULL)
+CREATE TABLE c (a Timestamp NULL, b Timestamp(3) NOT NULL)
 ---------- AST ------------
 CreateTable(
     CreateTableStmt {
@@ -766,7 +766,7 @@ CreateTable(
                             span: Ident(15..16),
                         },
                         data_type: Nullable(
-                            DateTime {
+                            Timestamp {
                                 precision: None,
                             },
                         ),
@@ -779,7 +779,7 @@ CreateTable(
                             quote: None,
                             span: Ident(32..33),
                         },
-                        data_type: DateTime {
+                        data_type: Timestamp {
                             precision: Some(
                                 3,
                             ),

--- a/query/src/sql/planner/binder/insert.rs
+++ b/query/src/sql/planner/binder/insert.rs
@@ -356,6 +356,7 @@ pub fn skip_to_next_row<R: BufferRead>(
     let _ = reader.ignore_white_spaces()?;
 
     let mut quoted = false;
+    let mut escaped = false;
 
     while balance > 0 {
         let buffer = reader.fill_buf()?;
@@ -373,8 +374,15 @@ pub fn skip_to_next_row<R: BufferRead>(
             let c = buffer[it];
             reader.consume(it + 1);
 
+            if it == 0 && escaped {
+                escaped = false;
+                continue;
+            }
+            escaped = false;
+
             match c {
                 b'\\' => {
+                    escaped = true;
                     continue;
                 }
                 b'\'' => {
@@ -394,6 +402,7 @@ pub fn skip_to_next_row<R: BufferRead>(
                 _ => {}
             }
         } else {
+            escaped = false;
             reader.consume(size);
         }
     }

--- a/query/src/sql/statements/value_source.rs
+++ b/query/src/sql/statements/value_source.rs
@@ -185,7 +185,7 @@ pub fn skip_to_next_row<R: BufferRead>(
             let c = buffer[it];
             reader.consume(it + 1);
 
-            if it == 0 && escaped && c == b'\'' {
+            if it == 0 && escaped {
                 escaped = false;
                 continue;
             }
@@ -213,6 +213,7 @@ pub fn skip_to_next_row<R: BufferRead>(
                 _ => {}
             }
         } else {
+            escaped = false;
             reader.consume(size);
         }
     }

--- a/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.sql
+++ b/tests/suites/0_stateless/05_ddl/05_0000_ddl_create_tables_v2.sql
@@ -76,7 +76,7 @@ desc db2.test7;
 
 
 SELECT '====CREATE TRANSIENT TABLE====';
-create transient table db2.test8(tiny TINYINT, tiny_unsigned TINYINT UNSIGNED, smallint SMALLINT, smallint_unsigned SMALLINT UNSIGNED, int INT, int_unsigned INT UNSIGNED, bigint BIGINT, bigint_unsigned BIGINT UNSIGNED,float FLOAT, double DOUBLE, date DATE, datetime DATETIME, ts TIMESTAMP, str VARCHAR default '3', bool BOOLEAN, arr ARRAY, obj OBJECT, variant VARIANT);
+create transient table db2.test8(tiny TINYINT, tiny_unsigned TINYINT UNSIGNED, smallint SMALLINT, smallint_unsigned SMALLINT UNSIGNED, int INT, int_unsigned INT UNSIGNED, bigint BIGINT, bigint_unsigned BIGINT UNSIGNED,float FLOAT, double DOUBLE, date DATE, datetime DATETIME, ts TIMESTAMP(6), str VARCHAR default '3', bool BOOLEAN, arr ARRAY, obj OBJECT, variant VARIANT);
 desc db2.test8;
 
 -- clean up test databases


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

1.  Fix values source `skip_to_next_row` escape flag bug.
2. Uniform `DateTime` & `Timestamp` in the new parser.

Fixes #6569 
