### PR TITLE
chore: disable logic test artifact upload

### DIFF
--- a/.github/actions/test_sqllogic_standalone_linux/action.yml
+++ b/.github/actions/test_sqllogic_standalone_linux/action.yml
@@ -29,8 +29,8 @@ runs:
       run: |
         bash ./scripts/ci/ci-run-sqllogic-tests.sh
 
-    - name: Upload failure
-      if: failure()
-      uses: ./.github/actions/artifact_failure
-      with:
-        name: test-sqllogic-standalone-linux
+    # - name: Upload failure
+    #   if: failure()
+    #   uses: ./.github/actions/artifact_failure
+    #   with:
+    #     name: test-sqllogic-standalone-linux

--- a/.github/actions/test_sqllogic_standalone_macos/action.yml
+++ b/.github/actions/test_sqllogic_standalone_macos/action.yml
@@ -29,8 +29,8 @@ runs:
       run: |
         bash ./scripts/ci/ci-run-sqllogic-tests.sh
 
-    - name: Upload failure
-      if: failure()
-      uses: ./.github/actions/artifact_failure
-      with:
-        name: test-sqllogic-standalone-macos
+    # - name: Upload failure
+    #   if: failure()
+    #   uses: ./.github/actions/artifact_failure
+    #   with:
+    #     name: test-sqllogic-standalone-macos


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Seems runner output is enough for debug including query debug logs and logic test stdout logs, logic test do not need to upload logs files when failed.

Fixes #issue
