### PR TITLE
ci: Use self-host runner for unit test

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -65,7 +65,8 @@ jobs:
           profile: release
 
   test_unit:
-    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    runs-on: [self-hosted, X64, Linux]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Github Hosted Runner always OOM while running unit test, let's use self-host runner instead.
