### PR TITLE
refactor(ci): add more args option to logictests

### DIFF
--- a/tests/logictest/clickhouse_runner.py
+++ b/tests/logictest/clickhouse_runner.py
@@ -8,8 +8,8 @@ import clickhouse_connector
 
 class TestClickhouse(logictest.SuiteRunner, ABC):
 
-    def __init__(self, kind, pattern):
-        super().__init__(kind, pattern)
+    def __init__(self, kind, args):
+        super().__init__(kind, args)
         self._ch = None
 
     def get_connection(self):

--- a/tests/logictest/http_connector.py
+++ b/tests/logictest/http_connector.py
@@ -52,8 +52,7 @@ def format_result(results):
             if buf == "":
                 buf = str(item)
             else:
-                buf = buf + " " + str(
-                    item)  # every item seperate by space
+                buf = buf + " " + str(item)  # every item seperate by space
         if len(buf) == 0:
             # empty line in results will replace with tab
             buf = "\t"
@@ -189,7 +188,7 @@ class HttpConnector(object):
                 try:
                     resp = requests.get(url="http://{}:{}{}".format(
                         self._host, self._port, response['next_uri']),
-                        headers=self.make_headers())
+                                        headers=self.make_headers())
                     response = json.loads(resp.content)
                     log.debug(
                         f"Sql in progress, fetch next_uri content: {response}")
@@ -224,6 +223,7 @@ class HttpConnector(object):
 
     def get_query_option(self):
         return self._query_option
+
 
 # if __name__ == '__main__':
 #     from config import http_config

--- a/tests/logictest/http_runner.py
+++ b/tests/logictest/http_runner.py
@@ -6,8 +6,8 @@ import http_connector
 
 class TestHttp(logictest.SuiteRunner, ABC):
 
-    def __init__(self, kind, pattern):
-        super().__init__(kind, pattern)
+    def __init__(self, kind, args):
+        super().__init__(kind, args)
         self._http = None
 
     def get_connection(self):

--- a/tests/logictest/logictest.py
+++ b/tests/logictest/logictest.py
@@ -291,25 +291,26 @@ class SuiteRunner(object):
         self.statement_files.sort()
 
     def execute(self):
-        # batch execute use single session
-        if callable(getattr(self, "batch_execute")):
-            # case batch
-            for (file_path, suite_name) in self.statement_files:
-                log.info(
-                    f"Run query with the same session every suite file, suite file path:{file_path}"
-                )
-                statement_list = list()
-                for state in get_statements(file_path, suite_name):
-                    statement_list.append(state)
-                self.batch_execute(statement_list)
-        else:
-            # case one by one
-            for (file_path, suite_name) in self.statement_files:
-                log.info(
-                    f"Run query without session every statements, suite file path:{file_path}"
-                )
-                for state in get_statements(file_path, suite_name):
-                    for i in range(0, self.args.test_runs):
+        for i in range(0, self.args.test_runs):
+            # batch execute use single session
+            if callable(getattr(self, "batch_execute")):
+                # case batch
+                for (file_path, suite_name) in self.statement_files:
+                    log.info(
+                        f"Run query with the same session every suite file, suite file path:{file_path}"
+                    )
+                    statement_list = list()
+                    for state in get_statements(file_path, suite_name):
+                        statement_list.append(state)
+                    
+                    self.batch_execute(statement_list)
+            else:
+                # case one by one
+                for (file_path, suite_name) in self.statement_files:
+                    log.info(
+                        f"Run query without session every statements, suite file path:{file_path}"
+                    )
+                    for state in get_statements(file_path, suite_name):
                         self.execute_statement(state)
 
     def execute_statement(self, statement):

--- a/tests/logictest/logictest.py
+++ b/tests/logictest/logictest.py
@@ -269,7 +269,7 @@ class SuiteRunner(object):
             if os.path.isfile(filename):
                 base_name = os.path.basename(filename)
                 dirs = os.path.dirname(filename).split('/')
-                
+
                 if self.args.skip_dir and any(
                         s in dirs for s in self.args.skip_dir):
                     continue
@@ -309,7 +309,8 @@ class SuiteRunner(object):
                     f"Run query without session every statements, suite file path:{file_path}"
                 )
                 for state in get_statements(file_path, suite_name):
-                    self.execute_statement(state)
+                    for i in range(0, self.args.test_runs):
+                        self.execute_statement(state)
 
     def execute_statement(self, statement):
         if self.kind not in statement.runs_on:

--- a/tests/logictest/logictest.py
+++ b/tests/logictest/logictest.py
@@ -249,7 +249,7 @@ def safe_execute(method, *info):
 @six.add_metaclass(abc.ABCMeta)
 class SuiteRunner(object):
 
-    def __init__(self, kind, pattern):
+    def __init__(self, kind, args):
         self.label = None
         self.retry_time = 3
         self.driver = None
@@ -258,24 +258,33 @@ class SuiteRunner(object):
         self.kind = kind
         self.show_query_on_execution = True
         self.on_error_return = False
-        self.pattern = pattern
+        self.dir = dir
+        self.args = args
 
     # return all files under the path
     # format: a list of file absolute path and name(relative path)
     def fetch_files(self):
-        skip_files = os.getenv("SKIP_TEST_FILES")
-        skip_tests = skip_files.split(",") if skip_files is not None else []
-        log.debug(f"Skip test file list {skip_tests}")
+        log.debug(f"Skip test file list {self.args.skip}")
         for filename in glob.iglob(f'{self.path}/**', recursive=True):
             if os.path.isfile(filename):
-                if os.path.basename(filename) in skip_tests:
+                base_name = os.path.basename(filename)
+                dirs = os.path.dirname(filename).split('/')
+                
+                if self.args.skip_dir and any(
+                        s in dirs for s in self.args.skip_dir):
+                    continue
+
+                if self.args.run_dir and not any(s in dirs
+                                                 for s in self.args.run_dir):
+                    continue
+
+                if self.args.skip and any(
+                    [re.search(r, base_name) for r in self.args.skip]):
                     log.info(f"Skip test file {filename}")
                     continue
 
-                if not self.pattern or any([
-                        re.search(r,
-                                  filename.split("/")[-1]) for r in self.pattern
-                ]):
+                if not self.args.pattern or any(
+                    [re.search(r, base_name) for r in self.args.pattern]):
                     self.statement_files.append(
                         (filename, os.path.relpath(filename, self.path)))
 

--- a/tests/logictest/main.py
+++ b/tests/logictest/main.py
@@ -15,19 +15,19 @@ def run(args):
     Run tests
     """
     if not args.disable_mysql_test:
-        mysql_test = TestMySQL("mysql", args.pattern)
+        mysql_test = TestMySQL("mysql", args)
         mysql_test.set_driver(mysql_config)
         mysql_test.set_label("mysql")
         mysql_test.run_sql_suite()
 
     if not args.disable_http_test:
-        http = TestHttp("http", args.pattern)
+        http = TestHttp("http", args)
         http.set_driver(http_config)
         http.set_label("http")
         http.run_sql_suite()
 
     if not args.disable_clickhouse_test:
-        http = TestClickhouse("clickhouse", args.pattern)
+        http = TestClickhouse("clickhouse", args)
         http.set_driver(clickhouse_config)
         http.set_label("clickhouse")
         http.run_sql_suite()
@@ -50,6 +50,26 @@ if __name__ == '__main__':
     parser.add_argument('pattern',
                         nargs='*',
                         help='Optional test case name regex')
+
+    parser.add_argument(
+        '--test-runs',
+        default=1,
+        nargs='?',
+        type=int,
+        help='Run each test many times (useful for e.g. flaky check)')
+
+    parser.add_argument('--skip',
+                        nargs='+',
+                        default=os.environ.get('SKIP_TEST_FILES'),
+                        help="Skip these tests via case name regex")
+
+    parser.add_argument('--skip-dir',
+                        nargs='+',
+                        help="Skip all these tests in the dir")
+
+    parser.add_argument('--run-dir',
+                        nargs='+',
+                        help="Only run these tests in the dir")
 
     args = parser.parse_args()
     run(args)

--- a/tests/logictest/mysql_runner.py
+++ b/tests/logictest/mysql_runner.py
@@ -20,8 +20,8 @@ class StringConverter(MySQLConverter):
 
 class TestMySQL(logictest.SuiteRunner, ABC):
 
-    def __init__(self, kind, pattern):
-        super().__init__(kind, pattern)
+    def __init__(self, kind, args):
+        super().__init__(kind, args)
         self._connection = None
 
     def reset_connection(self):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

add more args option to logictests

```
➜ python main.py -h
usage: main.py [-h] [--disable-mysql-test] [--disable-http-test] [--disable-clickhouse-test] [--test-runs [TEST_RUNS]] [--skip SKIP [SKIP ...]] [--skip-dir SKIP_DIR [SKIP_DIR ...]]
               [--run-dir RUN_DIR [RUN_DIR ...]]
               [pattern ...]

databend sqlogical tests

positional arguments:
  pattern               Optional test case name regex

options:
  -h, --help            show this help message and exit
  --disable-mysql-test  Disable mysql handler test
  --disable-http-test   Disable http handler test
  --disable-clickhouse-test
                        Disable clickhouse handler test
  --test-runs [TEST_RUNS]
                        Run each test many times (useful for e.g. flaky check)
  --skip SKIP [SKIP ...]
                        Skip these tests via case name regex
  --skip-dir SKIP_DIR [SKIP_DIR ...]
                        Skip all these tests in the dir
  --run-dir RUN_DIR [RUN_DIR ...]
                        Only run these tests in the dir
```

Fixes #issue
