### PR TITLE
fix: mysql return 'Empty Set' when result set is empty

### DIFF
--- a/query/src/interpreters/interpreter_factory_interceptor.rs
+++ b/query/src/interpreters/interpreter_factory_interceptor.rs
@@ -21,6 +21,7 @@ use common_streams::ErrorStream;
 use common_streams::ProgressStream;
 use common_streams::SendableDataBlockStream;
 use parking_lot::Mutex;
+use common_datavalues::DataSchemaRef;
 
 use crate::interpreters::access::ManagementModeAccess;
 use crate::interpreters::Interpreter;
@@ -61,6 +62,10 @@ impl InterceptorInterpreter {
 impl Interpreter for InterceptorInterpreter {
     fn name(&self) -> &str {
         self.inner.name()
+    }
+
+    fn schema(&self) -> DataSchemaRef {
+        self.inner.schema()
     }
 
     async fn execute(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix mysql server not return 'Empty Set' when result set is empty:

```sql
mysql> create database test_db;
Query OK, 0 rows affected (0.03 sec)

mysql> create table t3(a bool, b int);
Query OK, 0 rows affected (0.03 sec)

mysql> insert into t3 values (false, 1), (true, 2);
Query OK, 0 rows affected (0.04 sec)

mysql> set enable_planner_v2 = 0;
Query OK, 0 rows affected (0.02 sec)

---------- not return empty set -----------
mysql> select * from t3 where t3.b > 2; 
Query OK, 0 rows affected (0.04 sec)

mysql> set enable_planner_v2 = 1;
Query OK, 0 rows affected (0.02 sec)

mysql> select * from t3 where t3.b > 2;
Empty set (0.03 sec)
Read 2 rows, 9.00 B in 0.008 sec., 257.51 rows/sec., 1.13 KiB/sec.
```

