### PR TITLE
fix(planner): count aggregation function in subquery

### DIFF
--- a/query/src/sql/optimizer/heuristic/decorrelate.rs
+++ b/query/src/sql/optimizer/heuristic/decorrelate.rs
@@ -23,6 +23,7 @@ use common_exception::Result;
 
 use crate::sql::binder::wrap_cast_if_needed;
 use crate::sql::binder::JoinCondition;
+use crate::sql::optimizer::heuristic::subquery_rewriter::FlattenInfo;
 use crate::sql::optimizer::heuristic::subquery_rewriter::SubqueryRewriter;
 use crate::sql::optimizer::heuristic::subquery_rewriter::UnnestResult;
 use crate::sql::optimizer::ColumnSet;
@@ -269,12 +270,14 @@ impl SubqueryRewriter {
         &mut self,
         left: &SExpr,
         subquery: &SubqueryExpr,
+        flatten_info: &mut FlattenInfo,
         is_conjunctive_predicate: bool,
     ) -> Result<(SExpr, UnnestResult)> {
         match subquery.typ {
             SubqueryType::Scalar => {
                 let correlated_columns = subquery.outer_columns.clone();
-                let flatten_plan = self.flatten(&subquery.subquery, &correlated_columns)?;
+                let flatten_plan =
+                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info)?;
                 // Construct single join
                 let mut left_conditions = Vec::with_capacity(correlated_columns.len());
                 let mut right_conditions = Vec::with_capacity(correlated_columns.len());
@@ -301,7 +304,8 @@ impl SubqueryRewriter {
                     }
                 }
                 let correlated_columns = subquery.outer_columns.clone();
-                let flatten_plan = self.flatten(&subquery.subquery, &correlated_columns)?;
+                let flatten_plan =
+                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info)?;
                 // Construct mark join
                 let mut left_conditions = Vec::with_capacity(correlated_columns.len());
                 let mut right_conditions = Vec::with_capacity(correlated_columns.len());
@@ -332,7 +336,8 @@ impl SubqueryRewriter {
             }
             SubqueryType::Any => {
                 let correlated_columns = subquery.outer_columns.clone();
-                let flatten_plan = self.flatten(&subquery.subquery, &correlated_columns)?;
+                let flatten_plan =
+                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info)?;
                 let rel_expr = RelExpr::with_s_expr(&flatten_plan);
                 let mut left_conditions = Vec::with_capacity(correlated_columns.len());
                 let mut right_conditions = Vec::with_capacity(correlated_columns.len());
@@ -407,7 +412,12 @@ impl SubqueryRewriter {
         }
     }
 
-    fn flatten(&mut self, plan: &SExpr, correlated_columns: &ColumnSet) -> Result<SExpr> {
+    fn flatten(
+        &mut self,
+        plan: &SExpr,
+        correlated_columns: &ColumnSet,
+        flatten_info: &mut FlattenInfo,
+    ) -> Result<SExpr> {
         let rel_expr = RelExpr::with_s_expr(plan);
         let prop = rel_expr.derive_relational_prop()?;
         if prop.outer_columns.is_empty() {
@@ -459,7 +469,8 @@ impl SubqueryRewriter {
 
         match plan.plan() {
             RelOperator::Project(project) => {
-                let flatten_plan = self.flatten(plan.child(0)?, correlated_columns)?;
+                let flatten_plan =
+                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
                 let mut columns = HashSet::with_capacity(project.columns.len());
                 for column_idx in project.columns.iter() {
                     let scalar = {
@@ -486,7 +497,8 @@ impl SubqueryRewriter {
                 ))
             }
             RelOperator::EvalScalar(eval_scalar) => {
-                let flatten_plan = self.flatten(plan.child(0)?, correlated_columns)?;
+                let flatten_plan =
+                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
                 let mut items = Vec::with_capacity(eval_scalar.items.len());
                 for item in eval_scalar.items.iter() {
                     let new_item = ScalarItem {
@@ -519,7 +531,8 @@ impl SubqueryRewriter {
                 ))
             }
             RelOperator::Filter(filter) => {
-                let flatten_plan = self.flatten(plan.child(0)?, correlated_columns)?;
+                let flatten_plan =
+                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
                 let mut predicates = Vec::with_capacity(filter.predicates.len());
                 for predicate in filter.predicates.iter() {
                     predicates.push(self.flatten_scalar(predicate, correlated_columns)?);
@@ -533,8 +546,10 @@ impl SubqueryRewriter {
             }
             RelOperator::LogicalInnerJoin(join) => {
                 // Currently, we don't support join conditions contain subquery
-                let left_flatten_plan = self.flatten(plan.child(0)?, correlated_columns)?;
-                let right_flatten_plan = self.flatten(plan.child(1)?, correlated_columns)?;
+                let left_flatten_plan =
+                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
+                let right_flatten_plan =
+                    self.flatten(plan.child(1)?, correlated_columns, flatten_info)?;
                 Ok(SExpr::create_binary(
                     LogicalInnerJoin {
                         left_conditions: join.left_conditions.clone(),
@@ -550,7 +565,8 @@ impl SubqueryRewriter {
                 ))
             }
             RelOperator::Aggregate(aggregate) => {
-                let flatten_plan = self.flatten(plan.child(0)?, correlated_columns)?;
+                let flatten_plan =
+                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
                 let mut group_items = Vec::with_capacity(aggregate.group_items.len());
                 for item in aggregate.group_items.iter() {
                     let scalar = self.flatten_scalar(&item.scalar, correlated_columns)?;
@@ -582,6 +598,13 @@ impl SubqueryRewriter {
                 let mut agg_items = Vec::with_capacity(aggregate.aggregate_functions.len());
                 for item in aggregate.aggregate_functions.iter() {
                     let scalar = self.flatten_scalar(&item.scalar, correlated_columns)?;
+                    if let Scalar::AggregateFunction(AggregateFunction { func_name, .. }) = &scalar
+                    {
+                        if func_name.eq_ignore_ascii_case("count") || func_name.eq("count_distinct")
+                        {
+                            flatten_info.from_count_func = true;
+                        }
+                    }
                     agg_items.push(ScalarItem {
                         scalar,
                         index: item.index,
@@ -600,7 +623,8 @@ impl SubqueryRewriter {
             }
             RelOperator::Sort(_) | RelOperator::Limit(_) => {
                 // Currently, we don't support sort and limit contain subquery.
-                let flatten_plan = self.flatten(plan.child(0)?, correlated_columns)?;
+                let flatten_plan =
+                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
                 Ok(SExpr::create_unary(plan.plan().clone(), flatten_plan))
             }
 

--- a/query/src/sql/planner/binder/scalar_common.rs
+++ b/query/src/sql/planner/binder/scalar_common.rs
@@ -23,6 +23,7 @@ use crate::sql::plans::BoundColumnRef;
 use crate::sql::plans::CastExpr;
 use crate::sql::plans::ComparisonExpr;
 use crate::sql::plans::ComparisonOp;
+use crate::sql::plans::FunctionCall;
 use crate::sql::plans::OrExpr;
 use crate::sql::plans::Scalar;
 use crate::sql::plans::ScalarExpr;
@@ -172,6 +173,9 @@ pub fn contain_subquery(scalar: &Scalar) -> bool {
         }
         Scalar::OrExpr(OrExpr { left, right, .. }) => {
             contain_subquery(left) || contain_subquery(right)
+        }
+        Scalar::FunctionCall(FunctionCall { arguments, .. }) => {
+            arguments.iter().any(contain_subquery)
         }
         _ => false,
     }

--- a/query/tests/it/sql/optimizer/heuristic/testdata/subquery.test
+++ b/query/tests/it/sql/optimizer/heuristic/testdata/subquery.test
@@ -2,19 +2,20 @@
 select t.number from numbers(1) as t, numbers(1) as t1 where t.number = (select count(*) from numbers(1) as t2, numbers(1) as t3 where t.number = t2.number)
 ----
 Project: [number (#0)]
-    HashJoin: SINGLE, build keys: [subquery_6 (#6), multi_if(is_null(scalar_subquery_4 (#4)), 0, scalar_subquery_4 (#4))], probe keys: [subquery_0 (#0), t.number (#0)], join filters: []
-        CrossJoin
-            Scan: default.system.numbers
-            Scan: default.system.numbers
-        Project: [COUNT(*) (#4),number (#6)]
-            EvalScalar: [COUNT(*) (#5)]
-                Aggregate(Final): group items: [subquery_6 (#6)], aggregate functions: [COUNT(*)]
-                    Aggregate(Partial): group items: [subquery_6 (#6)], aggregate functions: [COUNT(*)]
-                        HashJoin: INNER, build keys: [t2.number (#2)], probe keys: [subquery_6 (#6)], join filters: []
-                            Scan: default.system.numbers
-                            CrossJoin
+    Filter: [t.number (#0) = multi_if(is_null(scalar_subquery_4 (#4)), 0, scalar_subquery_4 (#4))]
+        HashJoin: SINGLE, build keys: [subquery_6 (#6)], probe keys: [subquery_0 (#0)], join filters: []
+            CrossJoin
+                Scan: default.system.numbers
+                Scan: default.system.numbers
+            Project: [COUNT(*) (#4),number (#6)]
+                EvalScalar: [COUNT(*) (#5)]
+                    Aggregate(Final): group items: [subquery_6 (#6)], aggregate functions: [COUNT(*)]
+                        Aggregate(Partial): group items: [subquery_6 (#6)], aggregate functions: [COUNT(*)]
+                            HashJoin: INNER, build keys: [t2.number (#2)], probe keys: [subquery_6 (#6)], join filters: []
                                 Scan: default.system.numbers
-                                Scan: default.system.numbers
+                                CrossJoin
+                                    Scan: default.system.numbers
+                                    Scan: default.system.numbers
 
 
 # Exists correlated subquery with joins
@@ -118,12 +119,12 @@ Project: [number (#0)]
 select t.number from numbers(1) as t, numbers(1) as t1 where (select count(*) = 1 from numbers(1) where t.number = number) and t.number = t1.number
 ----
 Project: [number (#0)]
-    HashJoin: SINGLE, build keys: [subquery_5 (#5)], probe keys: [subquery_0 (#0)], join filters: []
-        HashJoin: INNER, build keys: [t1.number (#1)], probe keys: [t.number (#0)], join filters: []
-            Scan: default.system.numbers
-            Scan: default.system.numbers
-        Project: [COUNT(*) = 1 (#3),number (#5)]
-            Filter: [multi_if(is_null(scalar_subquery_3 (#3)), 0, scalar_subquery_3 (#3))]
+    Filter: [multi_if(is_null(scalar_subquery_3 (#3)), 0, scalar_subquery_3 (#3))]
+        HashJoin: SINGLE, build keys: [subquery_5 (#5)], probe keys: [subquery_0 (#0)], join filters: []
+            HashJoin: INNER, build keys: [t1.number (#1)], probe keys: [t.number (#0)], join filters: []
+                Scan: default.system.numbers
+                Scan: default.system.numbers
+            Project: [COUNT(*) = 1 (#3),number (#5)]
                 EvalScalar: [COUNT(*) (#4) = 1]
                     Aggregate(Final): group items: [subquery_5 (#5)], aggregate functions: [COUNT(*)]
                         Aggregate(Partial): group items: [subquery_5 (#5)], aggregate functions: [COUNT(*)]

--- a/query/tests/it/sql/optimizer/heuristic/testdata/subquery.test
+++ b/query/tests/it/sql/optimizer/heuristic/testdata/subquery.test
@@ -2,20 +2,19 @@
 select t.number from numbers(1) as t, numbers(1) as t1 where t.number = (select count(*) from numbers(1) as t2, numbers(1) as t3 where t.number = t2.number)
 ----
 Project: [number (#0)]
-    Filter: [t.number (#0) = scalar_subquery_4 (#4)]
-        HashJoin: SINGLE, build keys: [subquery_6 (#6)], probe keys: [subquery_0 (#0)], join filters: []
-            CrossJoin
-                Scan: default.system.numbers
-                Scan: default.system.numbers
-            Project: [COUNT(*) (#4),number (#6)]
-                EvalScalar: [COUNT(*) (#5)]
-                    Aggregate(Final): group items: [subquery_6 (#6)], aggregate functions: [COUNT(*)]
-                        Aggregate(Partial): group items: [subquery_6 (#6)], aggregate functions: [COUNT(*)]
-                            HashJoin: INNER, build keys: [t2.number (#2)], probe keys: [subquery_6 (#6)], join filters: []
+    HashJoin: SINGLE, build keys: [subquery_6 (#6), multi_if(is_null(scalar_subquery_4 (#4)), 0, scalar_subquery_4 (#4))], probe keys: [subquery_0 (#0), t.number (#0)], join filters: []
+        CrossJoin
+            Scan: default.system.numbers
+            Scan: default.system.numbers
+        Project: [COUNT(*) (#4),number (#6)]
+            EvalScalar: [COUNT(*) (#5)]
+                Aggregate(Final): group items: [subquery_6 (#6)], aggregate functions: [COUNT(*)]
+                    Aggregate(Partial): group items: [subquery_6 (#6)], aggregate functions: [COUNT(*)]
+                        HashJoin: INNER, build keys: [t2.number (#2)], probe keys: [subquery_6 (#6)], join filters: []
+                            Scan: default.system.numbers
+                            CrossJoin
                                 Scan: default.system.numbers
-                                CrossJoin
-                                    Scan: default.system.numbers
-                                    Scan: default.system.numbers
+                                Scan: default.system.numbers
 
 
 # Exists correlated subquery with joins
@@ -119,12 +118,12 @@ Project: [number (#0)]
 select t.number from numbers(1) as t, numbers(1) as t1 where (select count(*) = 1 from numbers(1) where t.number = number) and t.number = t1.number
 ----
 Project: [number (#0)]
-    Filter: [scalar_subquery_3 (#3)]
-        HashJoin: SINGLE, build keys: [subquery_5 (#5)], probe keys: [subquery_0 (#0)], join filters: []
-            HashJoin: INNER, build keys: [t1.number (#1)], probe keys: [t.number (#0)], join filters: []
-                Scan: default.system.numbers
-                Scan: default.system.numbers
-            Project: [COUNT(*) = 1 (#3),number (#5)]
+    HashJoin: SINGLE, build keys: [subquery_5 (#5)], probe keys: [subquery_0 (#0)], join filters: []
+        HashJoin: INNER, build keys: [t1.number (#1)], probe keys: [t.number (#0)], join filters: []
+            Scan: default.system.numbers
+            Scan: default.system.numbers
+        Project: [COUNT(*) = 1 (#3),number (#5)]
+            Filter: [multi_if(is_null(scalar_subquery_3 (#3)), 0, scalar_subquery_3 (#3))]
                 EvalScalar: [COUNT(*) (#4) = 1]
                     Aggregate(Final): group items: [subquery_5 (#5)], aggregate functions: [COUNT(*)]
                         Aggregate(Partial): group items: [subquery_5 (#5)], aggregate functions: [COUNT(*)]

--- a/tests/logictest/suites/query/subquery.test
+++ b/tests/logictest/suites/query/subquery.test
@@ -583,7 +583,28 @@ ORDER BY c.c_id, o.o_id
 5  NULL  NULL
 6  90    WA
 
+onlyif mysql
+statement query IT
+SELECT
+    c_id,
+    (SELECT count(*) FROM o WHERE o.c_id=c.c_id)
+FROM c
+ORDER BY c_id;
 
+----
+1  3
+2  3
+3  0
+4  2
+5  0
+6  1
+
+onlyif mysql
+statement query I
+SELECT max((SELECT count(*) FROM o WHERE o.c_id=c.c_id)) FROM c;
+
+----
+3
 
 onlyif mysql
 statement ok

--- a/tests/logictest/suites/query/subquery.test
+++ b/tests/logictest/suites/query/subquery.test
@@ -584,7 +584,7 @@ ORDER BY c.c_id, o.o_id
 6  90    WA
 
 onlyif mysql
-statement query IT
+statement query II
 SELECT
     c_id,
     (SELECT count(*) FROM o WHERE o.c_id=c.c_id)
@@ -605,6 +605,22 @@ SELECT max((SELECT count(*) FROM o WHERE o.c_id=c.c_id)) FROM c;
 
 ----
 3
+
+onlyif mysql
+statement query IT
+SELECT
+    c.c_id,
+    (SELECT ship FROM o WHERE o.c_id=c.c_id ORDER BY ship LIMIT 1) IS NOT NULL
+FROM c
+ORDER BY c.c_id
+
+----
+1  1
+2  0
+3  0
+4  0
+5  0
+6  0
 
 onlyif mysql
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

For scalar subquery, we'll convert it to single join.

Single join is similar to left outer join, if there isn't matched row in the right side, we'll add **NULL** value for the right side.

But for **count** aggregation function, NULL values should be 0.

Fixes #issue
