### PR TITLE
feat(planner): Support `HAVING` without aggregate

### DIFF
--- a/query/src/sql/planner/binder/aggregate.rs
+++ b/query/src/sql/planner/binder/aggregate.rs
@@ -18,20 +18,17 @@ use std::collections::HashMap;
 use common_ast::ast::Expr;
 use common_ast::ast::Literal;
 use common_ast::ast::SelectTarget;
-use common_ast::parser::token::Token;
 use common_ast::DisplayError;
 use common_datavalues::DataTypeImpl;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
-use super::scalar_common::split_conjunctions;
 use crate::sql::binder::scalar::ScalarBinder;
 use crate::sql::binder::select::SelectList;
 use crate::sql::binder::Binder;
 use crate::sql::binder::ColumnBinding;
 use crate::sql::optimizer::SExpr;
 use crate::sql::planner::metadata::MetadataRef;
-use crate::sql::planner::semantic::GroupingChecker;
 use crate::sql::plans::Aggregate;
 use crate::sql::plans::AggregateFunction;
 use crate::sql::plans::AggregateMode;
@@ -40,7 +37,6 @@ use crate::sql::plans::BoundColumnRef;
 use crate::sql::plans::CastExpr;
 use crate::sql::plans::ComparisonExpr;
 use crate::sql::plans::EvalScalar;
-use crate::sql::plans::Filter;
 use crate::sql::plans::FunctionCall;
 use crate::sql::plans::OrExpr;
 use crate::sql::plans::Scalar;
@@ -77,7 +73,7 @@ pub struct AggregateInfo {
     pub group_items_map: HashMap<String, usize>,
 }
 
-struct AggregateRewriter<'a> {
+pub(super) struct AggregateRewriter<'a> {
     pub bind_context: &'a mut BindContext,
     pub metadata: MetadataRef,
 }
@@ -233,20 +229,6 @@ impl<'a> Binder {
         Ok(())
     }
 
-    /// Analyze aggregates in having clause, this will rewrite aggregate functions.
-    /// See `AggregateRewriter` for more details.
-    pub(super) async fn analyze_aggregate_having(
-        &mut self,
-        bind_context: &mut BindContext,
-        having: &Expr<'a>,
-    ) -> Result<(Scalar, &'a [Token<'a>])> {
-        let mut scalar_binder =
-            ScalarBinder::new(bind_context, self.ctx.clone(), self.metadata.clone());
-        let (scalar, _) = scalar_binder.bind(having).await?;
-        let mut rewriter = AggregateRewriter::new(bind_context, self.metadata.clone());
-        Ok((rewriter.visit(&scalar)?, having.span()))
-    }
-
     /// We have supported three kinds of `group by` items:
     ///
     ///   - Index, a integral literal, e.g. `GROUP BY 1`. It choose the 1st item in select as
@@ -322,26 +304,6 @@ impl<'a> Binder {
         new_expr = SExpr::create_unary(aggregate_plan.into(), new_expr);
 
         Ok(new_expr)
-    }
-
-    pub(super) async fn bind_having(
-        &mut self,
-        bind_context: &BindContext,
-        having: Scalar,
-        span: &'a [Token<'a>],
-        child: SExpr,
-    ) -> Result<SExpr> {
-        let mut grouping_checker = GroupingChecker::new(bind_context);
-        let scalar = grouping_checker.resolve(&having, Some(span))?;
-
-        let predicates = split_conjunctions(&scalar);
-
-        let filter = Filter {
-            predicates,
-            is_having: true,
-        };
-
-        Ok(SExpr::create_unary(filter.into(), child))
     }
 
     async fn resolve_group_items(

--- a/query/src/sql/planner/binder/having.rs
+++ b/query/src/sql/planner/binder/having.rs
@@ -1,0 +1,70 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_ast::ast::Expr;
+use common_ast::parser::token::Token;
+use common_exception::Result;
+
+use crate::sql::binder::aggregate::AggregateRewriter;
+use crate::sql::binder::split_conjunctions;
+use crate::sql::binder::ScalarBinder;
+use crate::sql::optimizer::SExpr;
+use crate::sql::planner::semantic::GroupingChecker;
+use crate::sql::plans::Filter;
+use crate::sql::plans::Scalar;
+use crate::sql::BindContext;
+use crate::sql::Binder;
+
+impl<'a> Binder {
+    /// Analyze aggregates in having clause, this will rewrite aggregate functions.
+    /// See `AggregateRewriter` for more details.
+    pub(super) async fn analyze_aggregate_having(
+        &mut self,
+        bind_context: &mut BindContext,
+        having: &Expr<'a>,
+    ) -> Result<(Scalar, &'a [Token<'a>])> {
+        let mut scalar_binder =
+            ScalarBinder::new(bind_context, self.ctx.clone(), self.metadata.clone());
+        let (scalar, _) = scalar_binder.bind(having).await?;
+        let mut rewriter = AggregateRewriter::new(bind_context, self.metadata.clone());
+        Ok((rewriter.visit(&scalar)?, having.span()))
+    }
+
+    pub(super) async fn bind_having(
+        &mut self,
+        bind_context: &BindContext,
+        having: Scalar,
+        span: &'a [Token<'a>],
+        child: SExpr,
+    ) -> Result<SExpr> {
+        let scalar = if bind_context.in_grouping {
+            // If we are in grouping context, we will perform the grouping check
+            let mut grouping_checker = GroupingChecker::new(bind_context);
+            grouping_checker.resolve(&having, Some(span))?
+        } else {
+            // Otherwise we just fallback to a normal selection as `WHERE` clause.
+            // This follows behavior of MySQL and Snowflake.
+            having
+        };
+
+        let predicates = split_conjunctions(&scalar);
+
+        let filter = Filter {
+            predicates,
+            is_having: true,
+        };
+
+        Ok(SExpr::create_unary(filter.into(), child))
+    }
+}

--- a/query/src/sql/planner/binder/mod.rs
+++ b/query/src/sql/planner/binder/mod.rs
@@ -49,6 +49,7 @@ mod copy;
 mod ddl;
 mod delete;
 mod distinct;
+mod having;
 mod insert;
 mod join;
 mod kill;

--- a/query/src/sql/planner/binder/select.rs
+++ b/query/src/sql/planner/binder/select.rs
@@ -117,17 +117,15 @@ impl<'a> Binder {
             )
             .await?;
 
-        if !from_context.aggregate_info.aggregate_functions.is_empty()
-            || !stmt.group_by.is_empty()
-            || stmt.having.is_some()
+        if !from_context.aggregate_info.aggregate_functions.is_empty() || !stmt.group_by.is_empty()
         {
             s_expr = self.bind_aggregate(&mut from_context, s_expr).await?;
+        }
 
-            if let Some((having, span)) = having {
-                s_expr = self
-                    .bind_having(&from_context, having, span, s_expr)
-                    .await?;
-            }
+        if let Some((having, span)) = having {
+            s_expr = self
+                .bind_having(&from_context, having, span, s_expr)
+                .await?;
         }
 
         if stmt.distinct {

--- a/tests/logictest/suites/query/having.test
+++ b/tests/logictest/suites/query/having.test
@@ -1,0 +1,14 @@
+statement ok
+set enable_planner_v2 = 1;
+
+statement query I
+select * from numbers(10) having number = 1;
+
+----
+1
+
+statement query I
+select sum(number) from numbers(10) group by number % 2 having avg(number) = 5;
+
+----
+25


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Before this PR, we don't allow using `HAVING` clause in a non-aggregate query, which follows the behavior of standard SQL.

After this PR, `HAVING` will become the same as a `WHERE` clause if there is no aggregation, so we can support queries like `select * from t having a = 1`.
