### PR TITLE
refactor: Switch to bincode-org/bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,10 +473,21 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
-source = "git+https://github.com/datafuse-extras/bincode?rev=fd3f9ff#fd3f9fff35b5c682ea15a9b997c7114303685b64"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f609ceb2c41b0d0277314a789ef0e7eb14593d5485f7c67320bed3924ebb1b33"
 dependencies = [
+ "bincode_derive",
  "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913287a8f3e00db4c7ae1b87e9b9b8cebd6b89217eaadfc281fa5c897da35dc3"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -7817,6 +7828,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757cfbfe0d17ee6f22fe97e536d463047d451b47cf9d11e2b7d1398b0ef274dd"
 
 [[package]]
 name = "waker-fn"

--- a/common/exception/Cargo.toml
+++ b/common/exception/Cargo.toml
@@ -14,6 +14,7 @@ test = false
 common-arrow = { path = "../arrow" }
 
 anyhow = "1.0.58"
+bincode = { version = "2.0.0-rc.1", features = ["serde", "std", "alloc"] }
 octocrab = "0.16.0"
 paste = "1.0.7"
 prost = "0.10.4"
@@ -24,5 +25,4 @@ time = "0.3.10"
 tonic = "0.7.2"
 
 # Github dependencies
-bincode = { git = "https://github.com/datafuse-extras/bincode", rev = "fd3f9ff" }
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "7f246e3" }

--- a/common/exception/src/exception_into.rs
+++ b/common/exception/src/exception_into.rs
@@ -94,9 +94,37 @@ impl From<common_arrow::arrow::error::Error> for ErrorCode {
     }
 }
 
-impl From<Box<bincode::ErrorKind>> for ErrorCode {
-    fn from(error: Box<bincode::ErrorKind>) -> Self {
+impl From<bincode::error::EncodeError> for ErrorCode {
+    fn from(error: bincode::error::EncodeError) -> Self {
         ErrorCode::from_std_error(error)
+    }
+}
+
+impl From<bincode::error::DecodeError> for ErrorCode {
+    fn from(error: bincode::error::DecodeError) -> Self {
+        ErrorCode::from_std_error(error)
+    }
+}
+
+impl From<bincode::serde::EncodeError> for ErrorCode {
+    fn from(error: bincode::serde::EncodeError) -> Self {
+        ErrorCode::create(
+            1002,
+            format!("{error:?}"),
+            None,
+            Some(ErrorCodeBacktrace::Origin(Arc::new(Backtrace::capture()))),
+        )
+    }
+}
+
+impl From<bincode::serde::DecodeError> for ErrorCode {
+    fn from(error: bincode::serde::DecodeError) -> Self {
+        ErrorCode::create(
+            1002,
+            format!("{error:?}"),
+            None,
+            Some(ErrorCodeBacktrace::Origin(Arc::new(Backtrace::capture()))),
+        )
     }
 }
 

--- a/common/io/Cargo.toml
+++ b/common/io/Cargo.toml
@@ -16,10 +16,8 @@ test = false
 # Workspace dependencies
 common-exception = { path = "../exception" }
 
-# Github dependencies
-bincode = { git = "https://github.com/datafuse-extras/bincode", rev = "fd3f9ff" }
-
 # Crates.io dependencies
+bincode = { version = "2.0.0-rc.1", features = ["serde", "std"] }
 bytes = "1.1.0"
 chrono = "0.4.19"
 chrono-tz = "0.6.1"

--- a/common/io/src/utils.rs
+++ b/common/io/src/utils.rs
@@ -14,7 +14,6 @@
 
 use std::cmp;
 
-use bincode::Options;
 use bytes::BufMut;
 use common_exception::Result;
 
@@ -69,11 +68,8 @@ pub fn serialize_into_buf<W: bytes::BufMut, T: serde::Serialize>(
     buf: &mut W,
     value: &T,
 ) -> Result<()> {
-    let writer = BufMut::writer(buf);
-    bincode::DefaultOptions::new()
-        .with_fixint_encoding()
-        .with_varint_length_offset_encoding()
-        .serialize_into(writer, value)?;
+    let mut writer = BufMut::writer(buf);
+    bincode::serde::encode_into_std_write(value, &mut writer, bincode::config::standard())?;
 
     Ok(())
 }
@@ -81,10 +77,7 @@ pub fn serialize_into_buf<W: bytes::BufMut, T: serde::Serialize>(
 /// bincode deserialize_from wrap with optimized config
 #[inline]
 pub fn deserialize_from_slice<T: serde::de::DeserializeOwned>(slice: &mut &[u8]) -> Result<T> {
-    let value = bincode::DefaultOptions::new()
-        .with_fixint_encoding()
-        .with_varint_length_offset_encoding()
-        .deserialize_from(slice)?;
+    let (value, _) = bincode::serde::decode_from_slice(slice, bincode::config::standard())?;
 
     Ok(value)
 }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -66,7 +66,6 @@ common-users = { path = "../common/users" }
 
 # Github dependencies
 async-trait = { git = "https://github.com/datafuse-extras/async-trait", rev = "f0b0fd5" }
-bincode = { git = "https://github.com/datafuse-extras/bincode", rev = "fd3f9ff" }
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "7f246e3" }
 
 # Crates.io dependencies
@@ -78,6 +77,7 @@ async-stream = "0.3.3"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 backon = "0.0.2"
 base64 = "0.13.0"
+bincode = "2.0.0-rc.1"
 bit-vec = { version = "0.6.3", features = ["serde_std"] }
 bumpalo = "3.10.0"
 byteorder = "1.4.3"

--- a/query/src/storages/index/bloom_filter.rs
+++ b/query/src/storages/index/bloom_filter.rs
@@ -626,7 +626,7 @@ impl BloomFilter {
 
     /// Serialize the bloom filter to byte vector.
     pub fn to_vec(&self) -> Result<Vec<u8>> {
-        match bincode::serialize(self) {
+        match bincode::serde::encode_to_vec(self, bincode::config::standard()) {
             Ok(v) => Ok(v),
             Err(e) => Err(ErrorCode::StorageOther(format!(
                 "bincode serialization error: {} ",
@@ -637,8 +637,8 @@ impl BloomFilter {
 
     /// Deserialize from a byte slice and return a bloom filter.
     pub fn from_vec(bytes: &[u8]) -> Result<Self> {
-        match bincode::deserialize::<BloomFilter>(bytes) {
-            Ok(bloom_filter) => Ok(bloom_filter),
+        match bincode::serde::decode_from_slice(bytes, bincode::config::standard()) {
+            Ok((bloom_filter, _)) => Ok(bloom_filter),
             Err(e) => Err(ErrorCode::StorageOther(format!(
                 "bincode deserialization error: {} ",
                 e


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR is the adoption of the `Upstream First` rule.

We will switch to `bincode-org/bincode` instead of our own fork. After this PR, we don't need to maintain our fork https://github.com/datafuse-extras/bincode anymore.

Reference: https://github.com/bincode-org/bincode/issues/564

Part of https://github.com/datafuselabs/databend/issues/6926