### PR TITLE
chore: try support io-uring for meta

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,8 @@
 [advisories]
 ignore = [
+    # rio: v0.9.4 https://rustsec.org/advisories/RUSTSEC-2020-0021
+    # allows a use-after-free buffer access when a future is leaked
+    "RUSTSEC-2020-0021",
     # time: Potential segfault in the time crate
     # We are not accected by this CVE.
     # And there is no actions we can take, waiting for upstream.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6067,6 +6067,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rio"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e98c25665909853c07874301124482754434520ab572ac6a22e90366de6685b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ritelinked"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6737,6 +6746,7 @@ dependencies = [
  "libc",
  "log",
  "parking_lot 0.11.2",
+ "rio",
 ]
 
 [[package]]

--- a/common/meta/embedded/Cargo.toml
+++ b/common/meta/embedded/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2021"
 doctest = false
 test = false
 
+[features]
+io-uring = ["common-meta-sled-store/io-uring", "common-meta-raft-store/io-uring"]
+
 [dependencies]
 # Workspace dependencies
 common-base = { path = "../../base" }

--- a/common/meta/raft-store/Cargo.toml
+++ b/common/meta/raft-store/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2021"
 doctest = false
 test = false
 
+[features]
+io-uring = ["common-meta-sled-store/io-uring"]
+
 [dependencies]
 common-exception = { path = "../../exception" }
 common-grpc = { path = "../../grpc" }

--- a/common/meta/sled-store/Cargo.toml
+++ b/common/meta/sled-store/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2021"
 doctest = false
 test = false
 
+[features]
+io-uring = ["sled/io_uring"]
+
 [dependencies]
 common-meta-types = { path = "../types" }
 

--- a/common/meta/store/Cargo.toml
+++ b/common/meta/store/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2021"
 doctest = false
 test = false
 
+[features]
+io-uring = ["common-meta-embedded/io-uring"]
+
 [dependencies]
 # Workspace dependencies
 common-exception = { path = "../../exception" }

--- a/common/users/Cargo.toml
+++ b/common/users/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2021"
 doctest = false
 test = false
 
+[features]
+io-uring = ["common-meta-store/io-uring"]
+
 [dependencies] # In alphabetical order
 # Workspace dependencies
 common-base = { path = "../base" }

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -22,6 +22,12 @@ default = ["simd"]
 memory-profiling = ["common-base/memory-profiling", "common-http/memory-profiling"]
 simd = ["common-arrow/simd"]
 tokio-console = ["common-tracing/console", "common-base/tracing"]
+io-uring = [
+    "sled/io_uring",
+    "common-meta-store/io-uring",
+    "common-meta-sled-store/io-uring",
+    "common-meta-raft-store/io-uring",
+]
 
 [dependencies]
 # Workspace dependencies

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -24,6 +24,12 @@ tokio-console = ["common-tracing/console", "common-base/tracing"]
 memory-profiling = ["common-base/memory-profiling", "common-http/memory-profiling", "tempfile"]
 storage-hdfs = ["opendal/services-hdfs", "common-storage/storage-hdfs"]
 hive = ["common-hive-meta-store", "thrift", "storage-hdfs", "common-config/hive"]
+io-uring = [
+    "common-meta-embedded/io-uring",
+    "common-meta-store/io-uring",
+    "common-meta-sled-store/io-uring",
+    "common-meta-raft-store/io-uring",
+]
 
 [dependencies]
 # Workspace dependencies

--- a/tools/metactl/Cargo.toml
+++ b/tools/metactl/Cargo.toml
@@ -12,6 +12,13 @@ name = "databend-metactl"
 doctest = false
 test = false
 
+[features]
+io-uring = [
+    "common-meta-sled-store/io-uring",
+    "common-meta-raft-store/io-uring",
+    "databend-meta/io-uring",
+]
+
 [dependencies]
 # Workspace dependencies
 common-base = { path = "../../common/base" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

try enable io-uring for meta, so add a feature named `io-uring`

- common-meta-sled-store
- common-meta-raft-store
- common-meta-embedded
- common-meta-store
- databend-meta
- databend-query

ref: https://github.com/datafuselabs/databend/issues/6910#issuecomment-1201016123

Fixes #issue
