### PR TITLE
fix: Bump opendal to fix aws s3 continuation-token incorrect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4787,9 +4787,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendal"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470a35200a050b8dd34d4713ba32d9e145c363115e989860ea03e784a5040533"
+checksum = "f795048c5dfeedf0ccf718e0000f848fc41daf8f68e2d0eb7687c68da481d725"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/common/catalog/Cargo.toml
+++ b/common/catalog/Cargo.toml
@@ -28,6 +28,6 @@ common-users = { path = "../users" }
 
 async-trait = "0.1.56"
 dyn-clone = "1.0.6"
-opendal = { version = "0.11.3", features = ["retry"] }
+opendal = { version = "0.11.4", features = ["retry"] }
 parking_lot = "0.12.1"
 time = "0.3.10"

--- a/common/config/Cargo.toml
+++ b/common/config/Cargo.toml
@@ -19,7 +19,7 @@ common-tracing = { path = "../tracing" }
 async-trait = "0.1.56"
 clap = { version = "3.2.5", features = ["derive", "env"] }
 once_cell = "1.12.0"
-opendal = { version = "0.11.3", features = ["retry", "compress"] }
+opendal = { version = "0.11.4", features = ["retry", "compress"] }
 semver = "1.0.10"
 serde = { version = "1.0.137", features = ["derive"] }
 serfig = "0.0.2"

--- a/common/contexts/Cargo.toml
+++ b/common/contexts/Cargo.toml
@@ -12,5 +12,5 @@ test = false
 common-base = { path = "../base" }
 
 async-trait = "0.1.56"
-opendal = { version = "0.11.3", features = ["retry"] }
+opendal = { version = "0.11.4", features = ["retry"] }
 time = "0.3.10"

--- a/common/settings/Cargo.toml
+++ b/common/settings/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = "0.3.21"
 itertools = "0.10.3"
 num_cpus = "1.13.1"
 once_cell = "1.12.0"
-opendal = { version = "0.11.3", features = ["retry"] }
+opendal = { version = "0.11.4", features = ["retry"] }
 parking_lot = "0.12.1"
 semver = "1.0.10"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/common/storage/Cargo.toml
+++ b/common/storage/Cargo.toml
@@ -12,6 +12,6 @@ storage-hdfs = ["opendal/services-hdfs"]
 [dependencies]
 anyhow = "1.0.58"
 globiter = "0.1.0"
-opendal = { version = "0.11.3", features = ["retry", "services-http"] }
+opendal = { version = "0.11.4", features = ["retry", "services-http"] }
 percent-encoding = "2.1.0"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/common/streams/Cargo.toml
+++ b/common/streams/Cargo.toml
@@ -33,4 +33,4 @@ serde_json = { version = "1.0.81", default-features = false, features = ["preser
 tempfile = "3.3.0"
 
 [dev-dependencies]
-opendal = { version = "0.11.3", features = ["retry", "compress"] }
+opendal = { version = "0.11.4", features = ["retry", "compress"] }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -108,7 +108,7 @@ num = "0.4.0"
 num_cpus = "1.13.1"
 octocrab = "0.16.0"
 once_cell = "1.12.0"
-opendal = { version = "0.11.3", features = ["retry", "compress"] }
+opendal = { version = "0.11.4", features = ["retry", "compress"] }
 opensrv-clickhouse = "0.1.0"
 opensrv-mysql = "0.1.0"
 openssl = { version = "0.10.40", features = ["vendored"] }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: Bump opendal to fix aws s3 continuation-token incorrect


FYI: https://github.com/datafuselabs/opendal/issues/490