### PR TITLE
chore(query): Disable overflow-checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ debug = true
 
 [profile.dev]
 split-debuginfo = "unpacked"
+overflow-checks = false
 
 [profile.dev.package]
 addr2line = { opt-level = 3 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Disable `overflow-checks` which may break ci tests.

SQL:	`SELECT AVG(UserID) FROM hits; `
![origin_img_v2_1ae12281-7a9f-421d-a70d-cb023939970g](https://user-images.githubusercontent.com/3325189/182509394-bfa3fc71-162c-446f-b066-ddb32354e576.jpg)


Fixes #issue
