### PR TITLE
fix: Switch chrono upstream to chronotope/chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,14 +797,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
-source = "git+https://github.com/datafuse-extras/chrono?rev=279f590#279f5907879c9618767e5501ac01f79d5b7a4b38"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
 dependencies = [
- "libc",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,3 @@ rustc-demangle = { opt-level = 3 }
 
 [patch.crates-io]
 parquet2 = { version = "0.14.1", optional = true, git = "https://github.com/datafuse-extras/parquet2", rev = "3a468fc3c4" }
-chrono = { git = "https://github.com/datafuse-extras/chrono", rev = "279f590" }

--- a/common/datavalues/Cargo.toml
+++ b/common/datavalues/Cargo.toml
@@ -20,7 +20,7 @@ primitive-types = "0.11.1"
 # Github dependencies
 
 # Crates.io dependencies
-chrono = "0.4.19"
+chrono = "0.4.20"
 chrono-tz = "0.6.1"
 dyn-clone = "1.0.6"
 enum_dispatch = "0.3.8"

--- a/common/io/Cargo.toml
+++ b/common/io/Cargo.toml
@@ -19,7 +19,7 @@ common-exception = { path = "../exception" }
 # Crates.io dependencies
 bincode = { version = "2.0.0-rc.1", features = ["serde", "std"] }
 bytes = "1.1.0"
-chrono = "0.4.19"
+chrono = "0.4.20"
 chrono-tz = "0.6.1"
 futures = "0.3.21"
 lexical-core = "0.8.5"

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -88,7 +88,7 @@ bit-vec = { version = "0.6.3", features = ["serde_std"] }
 bumpalo = "3.10.0"
 byteorder = "1.4.3"
 bytes = "1.1.0"
-chrono = "0.4.19"
+chrono = "0.4.20"
 chrono-tz = "0.6.1"
 clap = { version = "3.2.5", features = ["derive", "env"] }
 dyn-clone = "1.0.6"

--- a/tools/fuzz/Cargo.toml
+++ b/tools/fuzz/Cargo.toml
@@ -18,4 +18,3 @@ arbitrary = "1.1.3"
 
 [patch.crates-io]
 parquet2 = { version = "0.14.1", optional = true, git = "https://github.com/datafuse-extras/parquet2", rev = "3a468fc3c4" }
-chrono = { git = "https://github.com/datafuse-extras/chrono", rev = "279f590" }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fixed https://github.com/datafuselabs/databend/issues/6928

Thanks for the hard work of `chrono`'s new maintainers: @djc and @esheppa.

We can remove our own fork and switch to `chronotope/chrono` now.

Let's go upstream first!
