### PR TITLE
ci(fuse-table): add data types test to fuse-compat test

### DIFF
--- a/tests/fuse-compat/compat-logictest/fuse_compat_read
+++ b/tests/fuse-compat/compat-logictest/fuse_compat_read
@@ -1,6 +1,80 @@
 statement query I
-select a+b from t;
+select c_bool      FROM fuse_compat_table;
 
 ----
-2
-4
+0
+
+statement query I
+select c_tinyint   FROM fuse_compat_table;
+
+----
+127
+
+statement query I
+select c_smallint  FROM fuse_compat_table;
+
+----
+3267
+
+statement query I
+select c_int       FROM fuse_compat_table;
+
+----
+2147483647
+
+
+statement query I
+select c_bigint    FROM fuse_compat_table;
+
+----
+9223372036854775807
+
+
+statement query F
+select c_float     FROM fuse_compat_table;
+
+----
+3.4
+
+statement query F
+select c_double    FROM fuse_compat_table;
+
+----
+1.7
+
+statement query T
+select c_date      FROM fuse_compat_table;
+
+----
+9999-12-31
+
+statement query T
+select c_timestamp FROM fuse_compat_table;
+
+----
+1991-01-01 00:00:00.000000
+
+statement query T
+select c_varchar   FROM fuse_compat_table;
+
+----
+varchar
+
+
+statement query T
+select c_array     FROM fuse_compat_table;
+
+----
+[1,2,3,["a","b","c"]]
+
+statement query T
+select c_object    FROM fuse_compat_table;
+
+----
+{"a":1,"b":{"c":2}}
+
+statement query T
+select c_variant   FROM fuse_compat_table;
+
+----
+[1,{"a":1,"b":{"c":2}}]

--- a/tests/fuse-compat/compat-logictest/fuse_compat_write
+++ b/tests/fuse-compat/compat-logictest/fuse_compat_write
@@ -1,8 +1,36 @@
 statement ok
-DROP TABLE IF EXISTS t;
+DROP TABLE IF EXISTS fuse_compat_table;
 
 statement ok
-create table t(a int,b int) Engine = Fuse;
+CREATE TABLE fuse_compat_table (
+        c_bool BOOL,
+        c_tinyint TINYINT,
+        c_smallint SMALLINT,
+        c_int INT,
+        c_bigint BIGINT,
+        c_float FLOAT,
+        c_double DOUBLE,
+        c_date DATE,
+        c_timestamp TIMESTAMP,
+        c_varchar VARCHAR,
+        c_array ARRAY,
+        c_object OBJECT,
+        c_variant VARIANT
+) Engine = Fuse;
 
 statement ok
-insert into t values(1,1),(2,2);
+INSERT INTO fuse_compat_table VALUES(
+        0,
+        127,
+        3267,
+        2147483647,
+        9223372036854775807,
+        3.4,
+        1.7,
+        '9999-12-31',
+        '1991-01-01 00:00:00',
+        'varchar',
+        parse_json('[1,2,3,["a","b","c"]]'),
+        parse_json('{"a":1,"b":{"c":2}}'),
+        parse_json('[1,{"a":1,"b":{"c":2}}]')
+);


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### ci(fuse-table): add data types test to fuse-compat test

- Fix: #6557

## Changelog







## Related Issues