### PR TITLE
refactor: refactor add\remove share accounts API

### DIFF
--- a/common/exception/src/exception_code.rs
+++ b/common/exception/src/exception_code.rs
@@ -223,8 +223,8 @@ build_exceptions! {
     ShareAlreadyExists(2705),
     UnknownShare(2706),
     UnknownShareId(2707),
-    ShareAccountAlreadyExists(2708),
-    UnknownShareAccount(2709),
+    ShareAccountsAlreadyExists(2708),
+    UnknownShareAccounts(2709),
     WrongShareObject(2710),
 
     // Variable error codes.

--- a/common/meta/api/src/share_api.rs
+++ b/common/meta/api/src/share_api.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_meta_app::share::AddShareAccountReply;
-use common_meta_app::share::AddShareAccountReq;
+use common_meta_app::share::AddShareAccountsReply;
+use common_meta_app::share::AddShareAccountsReq;
 use common_meta_app::share::CreateShareReply;
 use common_meta_app::share::CreateShareReq;
 use common_meta_app::share::DropShareReply;
@@ -22,8 +22,8 @@ use common_meta_app::share::GetShareGrantObjectReply;
 use common_meta_app::share::GetShareGrantObjectReq;
 use common_meta_app::share::GrantShareObjectReply;
 use common_meta_app::share::GrantShareObjectReq;
-use common_meta_app::share::RemoveShareAccountReply;
-use common_meta_app::share::RemoveShareAccountReq;
+use common_meta_app::share::RemoveShareAccountsReply;
+use common_meta_app::share::RemoveShareAccountsReq;
 use common_meta_app::share::RevokeShareObjectReply;
 use common_meta_app::share::RevokeShareObjectReq;
 use common_meta_app::share::ShowShareReply;
@@ -46,11 +46,14 @@ pub trait ShareApi: Sync + Send {
         req: RevokeShareObjectReq,
     ) -> MetaResult<RevokeShareObjectReply>;
 
-    async fn add_share_account(&self, req: AddShareAccountReq) -> MetaResult<AddShareAccountReply>;
-    async fn remove_share_account(
+    async fn add_share_accounts(
         &self,
-        req: RemoveShareAccountReq,
-    ) -> MetaResult<RemoveShareAccountReply>;
+        req: AddShareAccountsReq,
+    ) -> MetaResult<AddShareAccountsReply>;
+    async fn remove_share_accounts(
+        &self,
+        req: RemoveShareAccountsReq,
+    ) -> MetaResult<RemoveShareAccountsReply>;
 
     async fn get_share_grant_objects(
         &self,

--- a/common/meta/api/src/share_api_impl.rs
+++ b/common/meta/api/src/share_api_impl.rs
@@ -350,7 +350,7 @@ impl<KV: KVApi> ShareApi for KV {
                 return Err(MetaError::AppError(AppError::ShareAccountsAlreadyExists(
                     ShareAccountsAlreadyExists::new(
                         req.share_name.share_name,
-                        req.accounts,
+                        &req.accounts,
                         "share accounts already exists",
                     ),
                 )));
@@ -472,7 +472,7 @@ impl<KV: KVApi> ShareApi for KV {
 
             if remove_share_account_keys_and_seqs.is_empty() {
                 return Err(MetaError::AppError(AppError::UnknownShareAccounts(
-                    UnknownShareAccounts::new(req.accounts, share_id, "unknown share account"),
+                    UnknownShareAccounts::new(&req.accounts, share_id, "unknown share account"),
                 )));
             }
 
@@ -1003,7 +1003,7 @@ fn share_account_meta_has_to_exist(
 
         Err(MetaError::AppError(AppError::UnknownShareAccounts(
             UnknownShareAccounts::new(
-                vec![name_key.account.clone()],
+                &[name_key.account.clone()],
                 name_key.share_id,
                 format!("{}: {}", msg, name_key),
             ),

--- a/common/meta/api/src/share_api_test_suite.rs
+++ b/common/meta/api/src/share_api_test_suite.rs
@@ -216,6 +216,39 @@ impl ShareApiTestSuite {
         let create_on = Utc::now();
         let if_exists = true;
 
+        info!("--- add and remove account with not exist share");
+        {
+            let req = AddShareAccountsReq {
+                share_name: share_name.clone(),
+                share_on,
+                if_exists: false,
+                accounts: vec![account.to_string()],
+            };
+
+            // get share meta and check account has been added
+            let res = mt.add_share_accounts(req).await;
+            assert!(res.is_err());
+            let err = res.unwrap_err();
+            assert_eq!(
+                ErrorCode::UnknownShare("").code(),
+                ErrorCode::from(err).code()
+            );
+
+            let req = RemoveShareAccountsReq {
+                share_name: share_name.clone(),
+                if_exists: false,
+                accounts: vec![account2.to_string()],
+            };
+
+            let res = mt.remove_share_accounts(req).await;
+            assert!(res.is_err());
+            let err = res.unwrap_err();
+            assert_eq!(
+                ErrorCode::UnknownShare("").code(),
+                ErrorCode::from(err).code()
+            );
+        }
+
         info!("--- prepare share1");
         {
             let req = CreateShareReq {

--- a/common/meta/api/src/share_api_test_suite.rs
+++ b/common/meta/api/src/share_api_test_suite.rs
@@ -20,12 +20,12 @@ use common_meta_app::schema::DatabaseMeta;
 use common_meta_app::schema::DatabaseNameIdent;
 use common_meta_app::schema::TableMeta;
 use common_meta_app::schema::TableNameIdent;
-use common_meta_app::share::AddShareAccountReq;
+use common_meta_app::share::AddShareAccountsReq;
 use common_meta_app::share::CreateShareReq;
 use common_meta_app::share::DropShareReq;
 use common_meta_app::share::GetShareGrantObjectReq;
 use common_meta_app::share::GrantShareObjectReq;
-use common_meta_app::share::RemoveShareAccountReq;
+use common_meta_app::share::RemoveShareAccountsReq;
 use common_meta_app::share::RevokeShareObjectReq;
 use common_meta_app::share::ShareAccountNameIdent;
 use common_meta_app::share::ShareGrantObject;
@@ -214,6 +214,7 @@ impl ShareApiTestSuite {
         let share_id: u64;
         let share_on = Utc::now();
         let create_on = Utc::now();
+        let if_exists = true;
 
         info!("--- prepare share1");
         {
@@ -233,17 +234,17 @@ impl ShareApiTestSuite {
 
         info!("--- add account account1");
         {
-            let req = AddShareAccountReq {
+            let req = AddShareAccountsReq {
                 share_name: share_name.clone(),
                 share_on,
-                account: account.to_string(),
+                if_exists,
+                accounts: vec![account.to_string()],
             };
 
             // get share meta and check account has been added
-            let res = mt.add_share_account(req).await;
+            let res = mt.add_share_accounts(req).await;
             info!("add share account res: {:?}", res);
-            let res = res.unwrap();
-            assert_eq!(res.share_id, share_id);
+            assert!(res.is_ok());
 
             let (_share_meta_seq, share_meta) =
                 get_share_meta_by_id_or_err(mt.as_kv_api(), share_id, "").await?;
@@ -286,33 +287,34 @@ impl ShareApiTestSuite {
 
         info!("--- add account account1 again");
         {
-            let req = AddShareAccountReq {
+            let req = AddShareAccountsReq {
                 share_name: share_name.clone(),
                 share_on,
-                account: account.to_string(),
+                if_exists,
+                accounts: vec![account.to_string()],
             };
 
-            let res = mt.add_share_account(req).await;
+            let res = mt.add_share_accounts(req).await;
             info!("add share account res: {:?}", res);
             let err = res.unwrap_err();
             assert_eq!(
-                ErrorCode::ShareAccountAlreadyExists("").code(),
+                ErrorCode::ShareAccountsAlreadyExists("").code(),
                 ErrorCode::from(err).code()
             );
         }
 
         info!("--- add account account2");
         {
-            let req = AddShareAccountReq {
+            let req = AddShareAccountsReq {
                 share_name: share_name.clone(),
                 share_on,
-                account: account2.to_string(),
+                if_exists,
+                accounts: vec![account2.to_string()],
             };
 
-            let res = mt.add_share_account(req).await;
+            let res = mt.add_share_accounts(req).await;
             info!("add share account res: {:?}", res);
-            let res = res.unwrap();
-            assert_eq!(res.share_id, share_id);
+            assert!(res.is_ok());
 
             let (_share_meta_seq, share_meta) =
                 get_share_meta_by_id_or_err(mt.as_kv_api(), share_id, "").await?;
@@ -343,12 +345,13 @@ impl ShareApiTestSuite {
 
         info!("--- remove account account2");
         {
-            let req = RemoveShareAccountReq {
-                share_id,
-                account: account2.to_string(),
+            let req = RemoveShareAccountsReq {
+                share_name: share_name.clone(),
+                if_exists,
+                accounts: vec![account2.to_string()],
             };
 
-            let res = mt.remove_share_account(req).await;
+            let res = mt.remove_share_accounts(req).await;
             info!("remove share account res: {:?}", res);
             assert!(res.is_ok());
 
@@ -365,7 +368,7 @@ impl ShareApiTestSuite {
             let res = get_share_account_meta_or_err(mt.as_kv_api(), &share_account_name, "").await;
             let err = res.unwrap_err();
             assert_eq!(
-                ErrorCode::UnknownShareAccount("").code(),
+                ErrorCode::UnknownShareAccounts("").code(),
                 ErrorCode::from(err).code()
             );
         }
@@ -388,7 +391,7 @@ impl ShareApiTestSuite {
             let res = get_share_account_meta_or_err(mt.as_kv_api(), &share_account_name, "").await;
             let err = res.unwrap_err();
             assert_eq!(
-                ErrorCode::UnknownShareAccount("").code(),
+                ErrorCode::UnknownShareAccounts("").code(),
                 ErrorCode::from(err).code()
             );
         }

--- a/common/meta/app/src/share/mod.rs
+++ b/common/meta/app/src/share/mod.rs
@@ -15,8 +15,8 @@
 #[allow(clippy::module_inception)]
 mod share;
 
-pub use share::AddShareAccountReply;
-pub use share::AddShareAccountReq;
+pub use share::AddShareAccountsReply;
+pub use share::AddShareAccountsReq;
 pub use share::CreateShareReply;
 pub use share::CreateShareReq;
 pub use share::DropShareReply;
@@ -25,8 +25,8 @@ pub use share::GetShareGrantObjectReply;
 pub use share::GetShareGrantObjectReq;
 pub use share::GrantShareObjectReply;
 pub use share::GrantShareObjectReq;
-pub use share::RemoveShareAccountReply;
-pub use share::RemoveShareAccountReq;
+pub use share::RemoveShareAccountsReply;
+pub use share::RemoveShareAccountsReq;
 pub use share::RevokeShareObjectReply;
 pub use share::RevokeShareObjectReq;
 pub use share::ShareAccountMeta;

--- a/common/meta/app/src/share/share.rs
+++ b/common/meta/app/src/share/share.rs
@@ -88,25 +88,25 @@ pub struct DropShareReq {
 pub struct DropShareReply {}
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct AddShareAccountReq {
+pub struct AddShareAccountsReq {
     pub share_name: ShareNameIdent,
-    pub account: String,
+    pub if_exists: bool,
+    pub accounts: Vec<String>,
     pub share_on: DateTime<Utc>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct AddShareAccountReply {
-    pub share_id: u64,
+pub struct AddShareAccountsReply {}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct RemoveShareAccountsReq {
+    pub share_name: ShareNameIdent,
+    pub if_exists: bool,
+    pub accounts: Vec<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct RemoveShareAccountReq {
-    pub account: String,
-    pub share_id: u64,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct RemoveShareAccountReply {}
+pub struct RemoveShareAccountsReply {}
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ShowShareOfReq {

--- a/common/meta/types/src/app_error.rs
+++ b/common/meta/types/src/app_error.rs
@@ -283,39 +283,43 @@ impl ShareAlreadyExists {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
-#[error("ShareAccountAlreadyExists: {share_name} while {context}")]
-pub struct ShareAccountAlreadyExists {
+#[error("ShareAccountsAlreadyExists: {share_name} while {context}")]
+pub struct ShareAccountsAlreadyExists {
     share_name: String,
-    account: String,
+    accounts: Vec<String>,
     context: String,
 }
 
-impl ShareAccountAlreadyExists {
+impl ShareAccountsAlreadyExists {
     pub fn new(
         share_name: impl Into<String>,
-        account: impl Into<String>,
+        accounts: impl Into<Vec<String>>,
         context: impl Into<String>,
     ) -> Self {
         Self {
             share_name: share_name.into(),
-            account: account.into(),
+            accounts: accounts.into(),
             context: context.into(),
         }
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
-#[error("UnknownShareAccount: {account} {share_id} while {context}")]
-pub struct UnknownShareAccount {
-    account: String,
+#[error("UnknownShareAccounts: {share_id} while {context}")]
+pub struct UnknownShareAccounts {
+    accounts: Vec<String>,
     share_id: u64,
     context: String,
 }
 
-impl UnknownShareAccount {
-    pub fn new(account: impl Into<String>, share_id: u64, context: impl Into<String>) -> Self {
+impl UnknownShareAccounts {
+    pub fn new(
+        accounts: impl Into<Vec<String>>,
+        share_id: u64,
+        context: impl Into<String>,
+    ) -> Self {
         Self {
-            account: account.into(),
+            accounts: accounts.into(),
             share_id,
             context: context.into(),
         }
@@ -448,10 +452,10 @@ pub enum AppError {
     UnknownShareId(#[from] UnknownShareId),
 
     #[error(transparent)]
-    ShareAccountAlreadyExists(#[from] ShareAccountAlreadyExists),
+    ShareAccountsAlreadyExists(#[from] ShareAccountsAlreadyExists),
 
     #[error(transparent)]
-    UnknownShareAccount(#[from] UnknownShareAccount),
+    UnknownShareAccounts(#[from] UnknownShareAccounts),
 
     #[error(transparent)]
     WrongShareObject(#[from] WrongShareObject),
@@ -535,20 +539,20 @@ impl AppErrorMessage for UnknownShareId {
     }
 }
 
-impl AppErrorMessage for ShareAccountAlreadyExists {
+impl AppErrorMessage for ShareAccountsAlreadyExists {
     fn message(&self) -> String {
         format!(
-            "Share account for ({},{}) already exists",
-            self.share_name, self.account
+            "Share accounts for ({},{:?}) already exists",
+            self.share_name, self.accounts
         )
     }
 }
 
-impl AppErrorMessage for UnknownShareAccount {
+impl AppErrorMessage for UnknownShareAccounts {
     fn message(&self) -> String {
         format!(
-            "Unknown share account for ({},{})",
-            self.account, self.share_id
+            "Unknown share account for ({:?},{})",
+            self.accounts, self.share_id
         )
     }
 }
@@ -631,10 +635,10 @@ impl From<AppError> for ErrorCode {
             AppError::ShareAlreadyExists(err) => ErrorCode::ShareAlreadyExists(err.message()),
             AppError::UnknownShare(err) => ErrorCode::UnknownShare(err.message()),
             AppError::UnknownShareId(err) => ErrorCode::UnknownShareId(err.message()),
-            AppError::ShareAccountAlreadyExists(err) => {
-                ErrorCode::ShareAccountAlreadyExists(err.message())
+            AppError::ShareAccountsAlreadyExists(err) => {
+                ErrorCode::ShareAccountsAlreadyExists(err.message())
             }
-            AppError::UnknownShareAccount(err) => ErrorCode::UnknownShareAccount(err.message()),
+            AppError::UnknownShareAccounts(err) => ErrorCode::UnknownShareAccounts(err.message()),
             AppError::WrongShareObject(err) => ErrorCode::WrongShareObject(err.message()),
             AppError::TxnRetryMaxTimes(err) => ErrorCode::TxnRetryMaxTimes(err.message()),
         }

--- a/common/meta/types/src/app_error.rs
+++ b/common/meta/types/src/app_error.rs
@@ -293,7 +293,7 @@ pub struct ShareAccountsAlreadyExists {
 impl ShareAccountsAlreadyExists {
     pub fn new(
         share_name: impl Into<String>,
-        accounts: impl Into<Vec<String>>,
+        accounts: &[String],
         context: impl Into<String>,
     ) -> Self {
         Self {
@@ -313,11 +313,7 @@ pub struct UnknownShareAccounts {
 }
 
 impl UnknownShareAccounts {
-    pub fn new(
-        accounts: impl Into<Vec<String>>,
-        share_id: u64,
-        context: impl Into<String>,
-    ) -> Self {
+    pub fn new(accounts: &[String], share_id: u64, context: impl Into<String>) -> Self {
         Self {
             accounts: accounts.into(),
             share_id,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor: refactor add\remove share accounts API, support op more then one account per API.

Fixes #issue
