### PR TITLE
refactor(proto-conv): pb::S3StorageConfig should be decoded into StorageS3Config, instead of into enum StorageParams

### DIFF
--- a/common/proto-conv/src/config_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/config_from_to_protobuf_impl.rs
@@ -14,7 +14,6 @@
 
 use common_protos::pb;
 use common_storage::StorageFsConfig;
-use common_storage::StorageParams;
 use common_storage::StorageS3Config;
 
 use crate::check_ver;
@@ -23,13 +22,12 @@ use crate::Incompatible;
 use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
-impl FromToProto<pb::S3StorageConfig> for StorageParams {
+impl FromToProto<pb::S3StorageConfig> for StorageS3Config {
     fn from_pb(p: pb::S3StorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
-        // TODO: config will have it's own version flags in the future.
         check_ver(p.version, p.min_compatible)?;
 
-        Ok(Self::S3(StorageS3Config {
+        Ok(StorageS3Config {
             region: p.region,
             endpoint_url: p.endpoint_url,
             access_key_id: p.access_key_id,
@@ -39,52 +37,39 @@ impl FromToProto<pb::S3StorageConfig> for StorageParams {
             master_key: p.master_key,
             disable_credential_loader: p.disable_credential_loader,
             enable_virtual_host_style: p.enable_virtual_host_style,
-        }))
+        })
     }
 
     fn to_pb(&self) -> Result<pb::S3StorageConfig, Incompatible> {
-        if let StorageParams::S3(v) = self {
-            Ok(pb::S3StorageConfig {
-                version: VER,
-                min_compatible: MIN_COMPATIBLE_VER,
-                region: v.region.clone(),
-                endpoint_url: v.endpoint_url.clone(),
-                access_key_id: v.access_key_id.clone(),
-                secret_access_key: v.secret_access_key.clone(),
-                bucket: v.bucket.clone(),
-                root: v.root.clone(),
-                master_key: v.master_key.clone(),
-                disable_credential_loader: v.disable_credential_loader,
-                enable_virtual_host_style: v.enable_virtual_host_style,
-            })
-        } else {
-            Err(Incompatible {
-                reason: "storage type mismatch".to_string(),
-            })
-        }
+        Ok(pb::S3StorageConfig {
+            version: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
+            region: self.region.clone(),
+            endpoint_url: self.endpoint_url.clone(),
+            access_key_id: self.access_key_id.clone(),
+            secret_access_key: self.secret_access_key.clone(),
+            bucket: self.bucket.clone(),
+            root: self.root.clone(),
+            master_key: self.master_key.clone(),
+            disable_credential_loader: self.disable_credential_loader,
+            enable_virtual_host_style: self.enable_virtual_host_style,
+        })
     }
 }
 
-impl FromToProto<pb::FsStorageConfig> for StorageParams {
+impl FromToProto<pb::FsStorageConfig> for StorageFsConfig {
     fn from_pb(p: pb::FsStorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
-        // TODO: config will have it's own version flags in the future.
         check_ver(p.version, p.min_compatible)?;
 
-        Ok(Self::Fs(StorageFsConfig { root: p.root }))
+        Ok(StorageFsConfig { root: p.root })
     }
 
     fn to_pb(&self) -> Result<pb::FsStorageConfig, Incompatible> {
-        if let StorageParams::Fs(v) = self {
-            Ok(pb::FsStorageConfig {
-                version: VER,
-                min_compatible: MIN_COMPATIBLE_VER,
-                root: v.root.clone(),
-            })
-        } else {
-            Err(Incompatible {
-                reason: "storage type mismatch".to_string(),
-            })
-        }
+        Ok(pb::FsStorageConfig {
+            version: VER,
+            min_compatible: MIN_COMPATIBLE_VER,
+            root: self.root.clone(),
+        })
     }
 }

--- a/common/proto-conv/src/user_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/user_from_to_protobuf_impl.rs
@@ -23,7 +23,9 @@ use common_datavalues::chrono::DateTime;
 use common_datavalues::chrono::Utc;
 use common_meta_types as mt;
 use common_protos::pb;
+use common_storage::StorageFsConfig;
 use common_storage::StorageParams;
+use common_storage::StorageS3Config;
 use enumflags2::BitFlags;
 use num::FromPrimitive;
 
@@ -402,10 +404,10 @@ impl FromToProto<pb::user_stage_info::StageStorage> for StorageParams {
     where Self: Sized {
         match p.storage {
             Some(pb::user_stage_info::stage_storage::Storage::S3(s)) => {
-                Ok(StorageParams::from_pb(s)?)
+                Ok(StorageParams::S3(StorageS3Config::from_pb(s)?))
             }
             Some(pb::user_stage_info::stage_storage::Storage::Fs(s)) => {
-                Ok(StorageParams::from_pb(s)?)
+                Ok(StorageParams::Fs(StorageFsConfig::from_pb(s)?))
             }
             None => Err(Incompatible {
                 reason: "StageStorage.storage cannot be None".to_string(),
@@ -415,15 +417,11 @@ impl FromToProto<pb::user_stage_info::StageStorage> for StorageParams {
 
     fn to_pb(&self) -> Result<pb::user_stage_info::StageStorage, Incompatible> {
         match self {
-            StorageParams::S3(_) => Ok(pb::user_stage_info::StageStorage {
-                storage: Some(pb::user_stage_info::stage_storage::Storage::S3(
-                    self.to_pb()?,
-                )),
+            StorageParams::S3(v) => Ok(pb::user_stage_info::StageStorage {
+                storage: Some(pb::user_stage_info::stage_storage::Storage::S3(v.to_pb()?)),
             }),
-            StorageParams::Fs(_) => Ok(pb::user_stage_info::StageStorage {
-                storage: Some(pb::user_stage_info::stage_storage::Storage::Fs(
-                    self.to_pb()?,
-                )),
+            StorageParams::Fs(v) => Ok(pb::user_stage_info::StageStorage {
+                storage: Some(pb::user_stage_info::stage_storage::Storage::Fs(v.to_pb()?)),
             }),
             _ => todo!("other stage storage are not supported"),
         }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(proto-conv): pb::S3StorageConfig should be decoded into StorageS3Config, instead of into enum StorageParams

## Changelog







## Related Issues