### PR TITLE
refactor(proto-conv): trait FromToPB use associated type instead of type parameter

### DIFF
--- a/common/meta/api/src/schema_api_test_suite.rs
+++ b/common/meta/api/src/schema_api_test_suite.rs
@@ -193,13 +193,13 @@ async fn delete_test_data(
     Ok(())
 }
 
-async fn get_test_data<PB, T>(
+async fn get_test_data<T>(
     kv_api: &(impl KVApi + ?Sized),
     key: &impl KVApiKey,
 ) -> Result<T, MetaError>
 where
-    PB: common_protos::prost::Message + Default,
-    T: FromToProto<PB>,
+    T: FromToProto,
+    T::PB: common_protos::prost::Message + Default,
 {
     let res = kv_api.get_kv(&key.to_key()).await?;
     if let Some(res) = res {

--- a/common/proto-conv/src/config_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/config_from_to_protobuf_impl.rs
@@ -22,7 +22,9 @@ use crate::Incompatible;
 use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
-impl FromToProto<pb::S3StorageConfig> for StorageS3Config {
+impl FromToProto for StorageS3Config {
+    type PB = pb::S3StorageConfig;
+
     fn from_pb(p: pb::S3StorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.version, p.min_compatible)?;
@@ -57,7 +59,9 @@ impl FromToProto<pb::S3StorageConfig> for StorageS3Config {
     }
 }
 
-impl FromToProto<pb::FsStorageConfig> for StorageFsConfig {
+impl FromToProto for StorageFsConfig {
+    type PB = pb::FsStorageConfig;
+
     fn from_pb(p: pb::FsStorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.version, p.min_compatible)?;

--- a/common/proto-conv/src/data_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/data_from_to_protobuf_impl.rs
@@ -30,7 +30,8 @@ use crate::Incompatible;
 use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
-impl FromToProto<pb::DataSchema> for dv::DataSchema {
+impl FromToProto for dv::DataSchema {
+    type PB = pb::DataSchema;
     fn from_pb(p: pb::DataSchema) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -59,7 +60,8 @@ impl FromToProto<pb::DataSchema> for dv::DataSchema {
     }
 }
 
-impl FromToProto<pb::DataField> for dv::DataField {
+impl FromToProto for dv::DataField {
+    type PB = pb::DataField;
     fn from_pb(p: pb::DataField) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -85,7 +87,8 @@ impl FromToProto<pb::DataField> for dv::DataField {
     }
 }
 
-impl FromToProto<pb::DataType> for dv::DataTypeImpl {
+impl FromToProto for dv::DataTypeImpl {
+    type PB = pb::DataType;
     fn from_pb(p: pb::DataType) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -322,7 +325,8 @@ impl FromToProto<pb::DataType> for dv::DataTypeImpl {
     }
 }
 
-impl FromToProto<pb::NullableType> for dv::NullableType {
+impl FromToProto for dv::NullableType {
+    type PB = pb::NullableType;
     fn from_pb(p: pb::NullableType) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -350,7 +354,8 @@ impl FromToProto<pb::NullableType> for dv::NullableType {
     }
 }
 
-impl FromToProto<pb::Timestamp> for dv::TimestampType {
+impl FromToProto for dv::TimestampType {
+    type PB = pb::Timestamp;
     fn from_pb(p: pb::Timestamp) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -370,7 +375,8 @@ impl FromToProto<pb::Timestamp> for dv::TimestampType {
     }
 }
 
-impl FromToProto<pb::Struct> for dv::StructType {
+impl FromToProto for dv::StructType {
+    type PB = pb::Struct;
     fn from_pb(p: pb::Struct) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -414,7 +420,8 @@ impl FromToProto<pb::Struct> for dv::StructType {
     }
 }
 
-impl FromToProto<pb::Array> for dv::ArrayType {
+impl FromToProto for dv::ArrayType {
+    type PB = pb::Array;
     fn from_pb(p: pb::Array) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -442,7 +449,8 @@ impl FromToProto<pb::Array> for dv::ArrayType {
     }
 }
 
-impl FromToProto<pb::VariantArray> for dv::VariantArrayType {
+impl FromToProto for dv::VariantArrayType {
+    type PB = pb::VariantArray;
     fn from_pb(p: pb::VariantArray) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -459,7 +467,8 @@ impl FromToProto<pb::VariantArray> for dv::VariantArrayType {
     }
 }
 
-impl FromToProto<pb::VariantObject> for dv::VariantObjectType {
+impl FromToProto for dv::VariantObjectType {
+    type PB = pb::VariantObject;
     fn from_pb(p: pb::VariantObject) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -476,7 +485,8 @@ impl FromToProto<pb::VariantObject> for dv::VariantObjectType {
     }
 }
 
-impl FromToProto<pb::IntervalKind> for dv::IntervalKind {
+impl FromToProto for dv::IntervalKind {
+    type PB = pb::IntervalKind;
     fn from_pb(p: pb::IntervalKind) -> Result<Self, Incompatible>
     where Self: Sized {
         let dv_kind = match p {
@@ -507,7 +517,8 @@ impl FromToProto<pb::IntervalKind> for dv::IntervalKind {
         Ok(pb_kind)
     }
 }
-impl FromToProto<pb::IntervalType> for dv::IntervalType {
+impl FromToProto for dv::IntervalType {
+    type PB = pb::IntervalType;
     fn from_pb(p: pb::IntervalType) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -532,7 +543,8 @@ impl FromToProto<pb::IntervalType> for dv::IntervalType {
     }
 }
 
-impl FromToProto<pb::Variant> for dv::VariantType {
+impl FromToProto for dv::VariantType {
+    type PB = pb::Variant;
     fn from_pb(p: pb::Variant) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -549,7 +561,9 @@ impl FromToProto<pb::Variant> for dv::VariantType {
     }
 }
 
-impl FromToProto<String> for DateTime<Utc> {
+impl FromToProto for DateTime<Utc> {
+    type PB = String;
+
     fn from_pb(p: String) -> Result<Self, Incompatible> {
         let v = DateTime::<Utc>::from_str(&p).map_err(|e| Incompatible {
             reason: format!("DateTime error: {}", e),

--- a/common/proto-conv/src/database_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/database_from_to_protobuf_impl.rs
@@ -28,7 +28,8 @@ use crate::Incompatible;
 use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
-impl FromToProto<pb::DatabaseNameIdent> for mt::DatabaseNameIdent {
+impl FromToProto for mt::DatabaseNameIdent {
+    type PB = pb::DatabaseNameIdent;
     fn from_pb(p: pb::DatabaseNameIdent) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -50,7 +51,8 @@ impl FromToProto<pb::DatabaseNameIdent> for mt::DatabaseNameIdent {
     }
 }
 
-impl FromToProto<pb::DatabaseMeta> for mt::DatabaseMeta {
+impl FromToProto for mt::DatabaseMeta {
+    type PB = pb::DatabaseMeta;
     fn from_pb(p: pb::DatabaseMeta) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -90,7 +92,8 @@ impl FromToProto<pb::DatabaseMeta> for mt::DatabaseMeta {
     }
 }
 
-impl FromToProto<pb::DbIdList> for mt::DbIdList {
+impl FromToProto for mt::DbIdList {
+    type PB = pb::DbIdList;
     fn from_pb(p: pb::DbIdList) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 

--- a/common/proto-conv/src/share_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/share_from_to_protobuf_impl.rs
@@ -30,7 +30,8 @@ use crate::Incompatible;
 use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
-impl FromToProto<pb::ShareNameIdent> for mt::ShareNameIdent {
+impl FromToProto for mt::ShareNameIdent {
+    type PB = pb::ShareNameIdent;
     fn from_pb(p: pb::ShareNameIdent) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -52,7 +53,8 @@ impl FromToProto<pb::ShareNameIdent> for mt::ShareNameIdent {
     }
 }
 
-impl FromToProto<pb::ShareGrantObject> for mt::ShareGrantObject {
+impl FromToProto for mt::ShareGrantObject {
+    type PB = pb::ShareGrantObject;
     fn from_pb(p: pb::ShareGrantObject) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -88,7 +90,8 @@ impl FromToProto<pb::ShareGrantObject> for mt::ShareGrantObject {
     }
 }
 
-impl FromToProto<pb::ShareGrantEntry> for mt::ShareGrantEntry {
+impl FromToProto for mt::ShareGrantEntry {
+    type PB = pb::ShareGrantEntry;
     fn from_pb(p: pb::ShareGrantEntry) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -127,7 +130,8 @@ impl FromToProto<pb::ShareGrantEntry> for mt::ShareGrantEntry {
     }
 }
 
-impl FromToProto<pb::ShareMeta> for mt::ShareMeta {
+impl FromToProto for mt::ShareMeta {
+    type PB = pb::ShareMeta;
     fn from_pb(p: pb::ShareMeta) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -177,7 +181,8 @@ impl FromToProto<pb::ShareMeta> for mt::ShareMeta {
     }
 }
 
-impl FromToProto<pb::ShareAccountMeta> for mt::ShareAccountMeta {
+impl FromToProto for mt::ShareAccountMeta {
+    type PB = pb::ShareAccountMeta;
     fn from_pb(p: pb::ShareAccountMeta) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;

--- a/common/proto-conv/src/table_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/table_from_to_protobuf_impl.rs
@@ -29,7 +29,8 @@ use crate::Incompatible;
 use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
-impl FromToProto<pb::TableInfo> for mt::TableInfo {
+impl FromToProto for mt::TableInfo {
+    type PB = pb::TableInfo;
     fn from_pb(p: pb::TableInfo) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -65,7 +66,8 @@ impl FromToProto<pb::TableInfo> for mt::TableInfo {
     }
 }
 
-impl FromToProto<pb::TableNameIdent> for mt::TableNameIdent {
+impl FromToProto for mt::TableNameIdent {
+    type PB = pb::TableNameIdent;
     fn from_pb(p: pb::TableNameIdent) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -89,7 +91,8 @@ impl FromToProto<pb::TableNameIdent> for mt::TableNameIdent {
     }
 }
 
-impl FromToProto<pb::DbIdTableName> for mt::DBIdTableName {
+impl FromToProto for mt::DBIdTableName {
+    type PB = pb::DbIdTableName;
     fn from_pb(p: pb::DbIdTableName) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -111,7 +114,8 @@ impl FromToProto<pb::DbIdTableName> for mt::DBIdTableName {
     }
 }
 
-impl FromToProto<pb::TableIdent> for mt::TableIdent {
+impl FromToProto for mt::TableIdent {
+    type PB = pb::TableIdent;
     fn from_pb(p: pb::TableIdent) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -134,7 +138,8 @@ impl FromToProto<pb::TableIdent> for mt::TableIdent {
     }
 }
 
-impl FromToProto<pb::TableMeta> for mt::TableMeta {
+impl FromToProto for mt::TableMeta {
+    type PB = pb::TableMeta;
     fn from_pb(p: pb::TableMeta) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -197,7 +202,8 @@ impl FromToProto<pb::TableMeta> for mt::TableMeta {
     }
 }
 
-impl FromToProto<pb::TableStatistics> for mt::TableStatistics {
+impl FromToProto for mt::TableStatistics {
+    type PB = pb::TableStatistics;
     fn from_pb(p: pb::TableStatistics) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 
@@ -224,7 +230,8 @@ impl FromToProto<pb::TableStatistics> for mt::TableStatistics {
     }
 }
 
-impl FromToProto<pb::TableIdList> for mt::TableIdList {
+impl FromToProto for mt::TableIdList {
+    type PB = pb::TableIdList;
     fn from_pb(p: pb::TableIdList) -> Result<Self, Incompatible> {
         check_ver(p.ver, p.min_compatible)?;
 

--- a/common/proto-conv/src/user_from_to_protobuf_impl.rs
+++ b/common/proto-conv/src/user_from_to_protobuf_impl.rs
@@ -35,7 +35,8 @@ use crate::Incompatible;
 use crate::MIN_COMPATIBLE_VER;
 use crate::VER;
 
-impl FromToProto<pb::AuthInfo> for mt::AuthInfo {
+impl FromToProto for mt::AuthInfo {
+    type PB = pb::AuthInfo;
     fn from_pb(p: pb::AuthInfo) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -78,7 +79,8 @@ impl FromToProto<pb::AuthInfo> for mt::AuthInfo {
     }
 }
 
-impl FromToProto<pb::UserOption> for mt::UserOption {
+impl FromToProto for mt::UserOption {
+    type PB = pb::UserOption;
     fn from_pb(p: pb::UserOption) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -101,7 +103,8 @@ impl FromToProto<pb::UserOption> for mt::UserOption {
     }
 }
 
-impl FromToProto<pb::UserQuota> for mt::UserQuota {
+impl FromToProto for mt::UserQuota {
+    type PB = pb::UserQuota;
     fn from_pb(p: pb::UserQuota) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -124,7 +127,8 @@ impl FromToProto<pb::UserQuota> for mt::UserQuota {
     }
 }
 
-impl FromToProto<pb::GrantObject> for mt::GrantObject {
+impl FromToProto for mt::GrantObject {
+    type PB = pb::GrantObject;
     fn from_pb(p: pb::GrantObject) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -175,7 +179,8 @@ impl FromToProto<pb::GrantObject> for mt::GrantObject {
     }
 }
 
-impl FromToProto<pb::GrantEntry> for mt::GrantEntry {
+impl FromToProto for mt::GrantEntry {
+    type PB = pb::GrantEntry;
     fn from_pb(p: pb::GrantEntry) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -204,7 +209,8 @@ impl FromToProto<pb::GrantEntry> for mt::GrantEntry {
     }
 }
 
-impl FromToProto<pb::UserGrantSet> for mt::UserGrantSet {
+impl FromToProto for mt::UserGrantSet {
+    type PB = pb::UserGrantSet;
     fn from_pb(p: pb::UserGrantSet) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -240,7 +246,8 @@ impl FromToProto<pb::UserGrantSet> for mt::UserGrantSet {
     }
 }
 
-impl FromToProto<pb::UserInfo> for mt::UserInfo {
+impl FromToProto for mt::UserInfo {
+    type PB = pb::UserInfo;
     fn from_pb(p: pb::UserInfo) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -277,7 +284,8 @@ impl FromToProto<pb::UserInfo> for mt::UserInfo {
     }
 }
 
-impl FromToProto<pb::UserIdentity> for mt::UserIdentity {
+impl FromToProto for mt::UserIdentity {
+    type PB = pb::UserIdentity;
     fn from_pb(p: pb::UserIdentity) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -298,7 +306,8 @@ impl FromToProto<pb::UserIdentity> for mt::UserIdentity {
     }
 }
 
-impl FromToProto<pb::user_stage_info::StageFileFormatType> for mt::StageFileFormatType {
+impl FromToProto for mt::StageFileFormatType {
+    type PB = pb::user_stage_info::StageFileFormatType;
     fn from_pb(p: pb::user_stage_info::StageFileFormatType) -> Result<Self, Incompatible>
     where Self: Sized {
         match p {
@@ -331,7 +340,8 @@ impl FromToProto<pb::user_stage_info::StageFileFormatType> for mt::StageFileForm
     }
 }
 
-impl FromToProto<pb::user_stage_info::StageFileCompression> for mt::StageFileCompression {
+impl FromToProto for mt::StageFileCompression {
+    type PB = pb::user_stage_info::StageFileCompression;
     fn from_pb(p: pb::user_stage_info::StageFileCompression) -> Result<Self, Incompatible>
     where Self: Sized {
         match p {
@@ -382,7 +392,8 @@ impl FromToProto<pb::user_stage_info::StageFileCompression> for mt::StageFileCom
     }
 }
 
-impl FromToProto<pb::user_stage_info::StageType> for mt::StageType {
+impl FromToProto for mt::StageType {
+    type PB = pb::user_stage_info::StageType;
     fn from_pb(p: pb::user_stage_info::StageType) -> Result<Self, Incompatible>
     where Self: Sized {
         match p {
@@ -399,7 +410,8 @@ impl FromToProto<pb::user_stage_info::StageType> for mt::StageType {
     }
 }
 
-impl FromToProto<pb::user_stage_info::StageStorage> for StorageParams {
+impl FromToProto for StorageParams {
+    type PB = pb::user_stage_info::StageStorage;
     fn from_pb(p: pb::user_stage_info::StageStorage) -> Result<Self, Incompatible>
     where Self: Sized {
         match p.storage {
@@ -428,7 +440,8 @@ impl FromToProto<pb::user_stage_info::StageStorage> for StorageParams {
     }
 }
 
-impl FromToProto<pb::user_stage_info::StageParams> for mt::StageParams {
+impl FromToProto for mt::StageParams {
+    type PB = pb::user_stage_info::StageParams;
     fn from_pb(p: pb::user_stage_info::StageParams) -> Result<Self, Incompatible>
     where Self: Sized {
         Ok(mt::StageParams {
@@ -445,7 +458,8 @@ impl FromToProto<pb::user_stage_info::StageParams> for mt::StageParams {
     }
 }
 
-impl FromToProto<pb::user_stage_info::FileFormatOptions> for mt::FileFormatOptions {
+impl FromToProto for mt::FileFormatOptions {
+    type PB = pb::user_stage_info::FileFormatOptions;
     fn from_pb(p: pb::user_stage_info::FileFormatOptions) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -486,7 +500,8 @@ impl FromToProto<pb::user_stage_info::FileFormatOptions> for mt::FileFormatOptio
     }
 }
 
-impl FromToProto<pb::user_stage_info::OnErrorMode> for mt::OnErrorMode {
+impl FromToProto for mt::OnErrorMode {
+    type PB = pb::user_stage_info::OnErrorMode;
     fn from_pb(p: pb::user_stage_info::OnErrorMode) -> Result<Self, Incompatible>
     where Self: Sized {
         match p.mode {
@@ -536,7 +551,8 @@ impl FromToProto<pb::user_stage_info::OnErrorMode> for mt::OnErrorMode {
     }
 }
 
-impl FromToProto<pb::user_stage_info::CopyOptions> for mt::CopyOptions {
+impl FromToProto for mt::CopyOptions {
+    type PB = pb::user_stage_info::CopyOptions;
     fn from_pb(p: pb::user_stage_info::CopyOptions) -> Result<Self, Incompatible>
     where Self: Sized {
         let on_error = mt::OnErrorMode::from_pb(p.on_error.ok_or_else(|| Incompatible {
@@ -563,7 +579,8 @@ impl FromToProto<pb::user_stage_info::CopyOptions> for mt::CopyOptions {
     }
 }
 
-impl FromToProto<pb::UserStageInfo> for mt::UserStageInfo {
+impl FromToProto for mt::UserStageInfo {
+    type PB = pb::UserStageInfo;
     fn from_pb(p: pb::UserStageInfo) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;
@@ -617,7 +634,8 @@ impl FromToProto<pb::UserStageInfo> for mt::UserStageInfo {
     }
 }
 
-impl FromToProto<pb::StageFile> for mt::StageFile {
+impl FromToProto for mt::StageFile {
+    type PB = pb::StageFile;
     fn from_pb(p: pb::StageFile) -> Result<Self, Incompatible>
     where Self: Sized {
         check_ver(p.ver, p.min_compatible)?;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(proto-conv): trait FromToPB use associated type instead of type parameter

Change trait signature `FromToProto<PB: prost::Message>` to

```rust
trait FromToProto {
    type PB;
}
```

When impl `FromToProto` for a rust type, there should be only one
protobuf type that is convert from and to it. I.e, the protobuf type is
determined by rust type.
Thus `PB` should be a associated type.

Otherwise, there could be two protobuf types bounded to one rust type(e.g., `impl
FromToProto<A> for T` and `impl FromToProto<B> for T`), which is
potentially invalid: when converting rust type to protobuf type, it does
not know which it should be converted to.

## Changelog







## Related Issues