### PR TITLE
refactor(meta-api): merge TableIdGen, DatabaseIdGen and ShareIdGen into one id-generator key

### DIFF
--- a/common/meta/api/src/id_generator.rs
+++ b/common/meta/api/src/id_generator.rs
@@ -1,0 +1,130 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use crate::kv_api_key::check_segment;
+use crate::kv_api_key::check_segment_absent;
+use crate::kv_api_key::check_segment_present;
+use crate::schema_api_keys::ID_GEN_DATABASE;
+use crate::schema_api_keys::ID_GEN_TABLE;
+use crate::share_api_keys::ID_GEN_SHARE;
+use crate::KVApiKey;
+use crate::KVApiKeyError;
+
+pub(crate) const PREFIX_ID_GEN: &str = "__fd_id_gen";
+
+/// Key for resource id generator
+///
+/// This is a special key for an application to generate unique id with KVApi.
+/// Generating an id by updating a record in KVApi and retrieve the seq number.
+/// A seq number is monotonically incremental in KVApi.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdGenerator {
+    pub resource: String,
+}
+
+impl IdGenerator {
+    /// Create a key for generating table id with KVApi
+    pub fn table_id() -> Self {
+        Self {
+            resource: ID_GEN_TABLE.to_string(),
+        }
+    }
+
+    /// Create a key for generating database id with KVApi
+    pub fn database_id() -> Self {
+        Self {
+            resource: ID_GEN_DATABASE.to_string(),
+        }
+    }
+
+    /// Create a key for generating share id with KVApi
+    pub fn share_id() -> Self {
+        Self {
+            resource: ID_GEN_SHARE.to_string(),
+        }
+    }
+}
+
+impl KVApiKey for IdGenerator {
+    const PREFIX: &'static str = PREFIX_ID_GEN;
+
+    fn to_key(&self) -> String {
+        format!("{}/{}", Self::PREFIX, self.resource)
+    }
+
+    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+        let mut elts = s.split('/');
+
+        let prefix = check_segment_present(elts.next(), 0, s)?;
+        check_segment(prefix, 0, Self::PREFIX)?;
+
+        let resource = check_segment_present(elts.next(), 1, s)?;
+
+        check_segment_absent(elts.next(), 2, s)?;
+
+        Ok(IdGenerator {
+            resource: resource.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod t {
+    use crate::id_generator::IdGenerator;
+    use crate::KVApiKey;
+
+    #[test]
+    fn test_id_generator() -> anyhow::Result<()> {
+        // Table id generator
+        {
+            let g = IdGenerator::table_id();
+            let k = g.to_key();
+            assert_eq!("__fd_id_gen/table_id", k);
+
+            let t2 = IdGenerator::from_key(&k)?;
+            assert_eq!(g, t2);
+        }
+
+        // Database id generator
+        {
+            let g = IdGenerator::database_id();
+            let k = g.to_key();
+            assert_eq!("__fd_id_gen/database_id", k);
+
+            let t2 = IdGenerator::from_key(&k)?;
+            assert_eq!(g, t2);
+        }
+
+        // Share id generator
+        {
+            let g = IdGenerator::share_id();
+            let k = g.to_key();
+            assert_eq!("__fd_id_gen/share_id", k);
+
+            let t2 = IdGenerator::from_key(&k)?;
+            assert_eq!(g, t2);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_id_generator_from_key_error() -> anyhow::Result<()> {
+        assert!(IdGenerator::from_key("__fd_id_gen").is_err());
+        assert!(IdGenerator::from_key("__fd_id_gen/foo/bar").is_err());
+
+        assert!(IdGenerator::from_key("__foo/table_id").is_err());
+        Ok(())
+    }
+}

--- a/common/meta/api/src/lib.rs
+++ b/common/meta/api/src/lib.rs
@@ -16,6 +16,7 @@
 extern crate common_meta_types;
 
 mod id;
+mod id_generator;
 mod kv_api;
 mod kv_api_key;
 mod kv_api_test_suite;
@@ -30,6 +31,7 @@ mod share_api_keys;
 mod share_api_test_suite;
 
 pub use id::Id;
+pub(crate) use id_generator::IdGenerator;
 pub use kv_api::get_start_and_end_of_prefix;
 pub use kv_api::prefix_of_string;
 pub use kv_api::ApiBuilder;
@@ -55,13 +57,9 @@ pub use kv_api_utils::txn_op_put;
 pub use kv_api_utils::TXN_MAX_RETRY_TIMES;
 pub use schema_api::SchemaApi;
 pub(crate) use schema_api_impl::get_db_or_err;
-pub use schema_api_keys::DatabaseIdGen;
-pub use schema_api_keys::TableIdGen;
-pub(crate) use schema_api_keys::PREFIX_ID_GEN;
 pub use schema_api_test_suite::SchemaApiTestSuite;
 pub use share_api::ShareApi;
 pub(crate) use share_api_impl::get_share_account_meta_or_err;
 pub(crate) use share_api_impl::get_share_id_to_name_or_err;
 pub(crate) use share_api_impl::get_share_meta_by_id_or_err;
-pub use share_api_keys::ShareIdGen;
 pub use share_api_test_suite::ShareApiTestSuite;

--- a/common/meta/api/src/schema_api_impl.rs
+++ b/common/meta/api/src/schema_api_impl.rs
@@ -103,11 +103,10 @@ use crate::table_has_to_exist;
 use crate::txn_cond_seq;
 use crate::txn_op_del;
 use crate::txn_op_put;
-use crate::DatabaseIdGen;
+use crate::IdGenerator;
 use crate::KVApi;
 use crate::KVApiKey;
 use crate::SchemaApi;
-use crate::TableIdGen;
 use crate::TXN_MAX_RETRY_TIMES;
 
 const DEFAULT_DATA_RETENTION_SECONDS: i64 = 24 * 60 * 60;
@@ -173,7 +172,7 @@ impl<KV: KVApi> SchemaApi for KV {
             // append db_id into _fd_db_id_list/<tenant>/<db_name>
             // (db_id) -> (tenant,db_name)
 
-            let db_id = fetch_id(self, DatabaseIdGen {}).await?;
+            let db_id = fetch_id(self, IdGenerator::database_id()).await?;
             let id_key = DatabaseId { db_id };
             let id_to_name_key = DatabaseIdToName { db_id };
 
@@ -784,7 +783,7 @@ impl<KV: KVApi> SchemaApi for KV {
             // append table_id into _fd_table_id_list/db_id/table_name
             // (table_id) -> table_name
 
-            let table_id = fetch_id(self, TableIdGen {}).await?;
+            let table_id = fetch_id(self, IdGenerator::table_id()).await?;
 
             let tbid = TableId { table_id };
 

--- a/common/meta/api/src/schema_api_keys.rs
+++ b/common/meta/api/src/schema_api_keys.rs
@@ -14,8 +14,6 @@
 
 //! Defines structured keys used by SchemaApi
 
-use std::fmt::Debug;
-
 use common_meta_app::schema::CountTablesKey;
 use common_meta_app::schema::DBIdTableName;
 use common_meta_app::schema::DatabaseId;
@@ -42,18 +40,12 @@ const PREFIX_DB_ID_LIST: &str = "__fd_db_id_list";
 const PREFIX_TABLE: &str = "__fd_table";
 const PREFIX_TABLE_BY_ID: &str = "__fd_table_by_id";
 const PREFIX_TABLE_ID_LIST: &str = "__fd_table_id_list";
-pub(crate) const PREFIX_ID_GEN: &str = "__fd_id_gen";
 const PREFIX_TABLE_COUNT: &str = "__fd_table_count";
 const PREFIX_DATABASE_ID_TO_NAME: &str = "__fd_database_id_to_name";
 const PREFIX_TABLE_ID_TO_NAME: &str = "__fd_table_id_to_name";
 
-/// Key for database id generator
-#[derive(Debug, Clone)]
-pub struct DatabaseIdGen {}
-
-/// Key for table id generator
-#[derive(Debug, Clone)]
-pub struct TableIdGen {}
+pub(crate) const ID_GEN_TABLE: &str = "table_id";
+pub(crate) const ID_GEN_DATABASE: &str = "database_id";
 
 /// __fd_database/<tenant>/<db_name> -> <db_id>
 impl KVApiKey for DatabaseNameIdent {
@@ -276,30 +268,6 @@ impl KVApiKey for TableIdListKey {
             db_id,
             table_name: tb_name,
         })
-    }
-}
-
-impl KVApiKey for DatabaseIdGen {
-    const PREFIX: &'static str = PREFIX_ID_GEN;
-
-    fn to_key(&self) -> String {
-        format!("{}/database_id", Self::PREFIX)
-    }
-
-    fn from_key(_s: &str) -> Result<Self, KVApiKeyError> {
-        unimplemented!()
-    }
-}
-
-impl KVApiKey for TableIdGen {
-    const PREFIX: &'static str = PREFIX_ID_GEN;
-
-    fn to_key(&self) -> String {
-        format!("{}/table_id", Self::PREFIX)
-    }
-
-    fn from_key(_s: &str) -> Result<Self, KVApiKeyError> {
-        unimplemented!()
     }
 }
 

--- a/common/meta/api/src/share_api_impl.rs
+++ b/common/meta/api/src/share_api_impl.rs
@@ -68,6 +68,7 @@ use crate::fetch_id;
 use crate::get_db_or_err;
 use crate::get_struct_value;
 use crate::get_u64_value;
+use crate::id_generator::IdGenerator;
 use crate::send_txn;
 use crate::serialize_struct;
 use crate::serialize_u64;
@@ -77,7 +78,6 @@ use crate::txn_op_del;
 use crate::txn_op_put;
 use crate::KVApi;
 use crate::ShareApi;
-use crate::ShareIdGen;
 use crate::TXN_MAX_RETRY_TIMES;
 
 /// ShareApi is implemented upon KVApi.
@@ -154,7 +154,7 @@ impl<KV: KVApi> ShareApi for KV {
             // (share_id) -> share_meta
             // (share) -> (tenant,share_name)
 
-            let share_id = fetch_id(self, ShareIdGen {}).await?;
+            let share_id = fetch_id(self, IdGenerator::share_id()).await?;
             let id_key = ShareId { share_id };
             let id_to_name_key = ShareIdToName { share_id };
 

--- a/common/meta/api/src/share_api_keys.rs
+++ b/common/meta/api/src/share_api_keys.rs
@@ -28,28 +28,13 @@ use kv_api_key::unescape;
 use crate::kv_api_key;
 use crate::KVApiKey;
 use crate::KVApiKeyError;
-use crate::PREFIX_ID_GEN;
 
 const PREFIX_SHARE: &str = "__fd_share";
 const PREFIX_SHARE_ID: &str = "__fd_share_id";
 const PREFIX_SHARE_ID_TO_NAME: &str = "__fd_share_id_to_name";
 const PREFIX_SHARE_ACCOUNT_ID: &str = "__fd_share_account_id";
 
-/// Key for share id generator
-#[derive(Debug, Clone)]
-pub struct ShareIdGen {}
-
-impl KVApiKey for ShareIdGen {
-    const PREFIX: &'static str = PREFIX_ID_GEN;
-
-    fn to_key(&self) -> String {
-        format!("{}/share_id", Self::PREFIX)
-    }
-
-    fn from_key(_s: &str) -> Result<Self, KVApiKeyError> {
-        unimplemented!()
-    }
-}
+pub(crate) const ID_GEN_SHARE: &str = "share_id";
 
 /// __fd_share/<tenant>/<share_name> -> <share_id>
 impl KVApiKey for ShareNameIdent {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta-api): merge TableIdGen, DatabaseIdGen and ShareIdGen into one id-generator key

## Changelog







## Related Issues