### PR TITLE
refactor: get_share_grant_objects API should return name instead of id

### DIFF
--- a/common/meta/api/src/share_api_impl.rs
+++ b/common/meta/api/src/share_api_impl.rs
@@ -809,7 +809,7 @@ async fn get_object_name_from_id(
         }
         ShareGrantObject::Table(table_id) => {
             let table_id_key = TableIdToName { table_id };
-            let (_db_name_seq, table_name): (_, Option<DBIdTableName>) =
+            let (_db_id_table_name_seq, table_name): (_, Option<DBIdTableName>) =
                 get_struct_value(kv_api, &table_id_key).await?;
             match table_name {
                 Some(table_name) => Ok(Some(ShareGrantObjectName::Table(

--- a/common/meta/api/src/share_api_impl.rs
+++ b/common/meta/api/src/share_api_impl.rs
@@ -803,8 +803,8 @@ async fn get_object_name_from_id(
             let (_db_name_seq, db_name): (_, Option<DatabaseNameIdent>) =
                 get_struct_value(kv_api, &db_id_key).await?;
             match db_name {
-                Some(db_name) => return Ok(Some(ShareGrantObjectName::Database(db_name.db_name))),
-                None => return Ok(None),
+                Some(db_name) => Ok(Some(ShareGrantObjectName::Database(db_name.db_name))),
+                None => Ok(None),
             }
         }
         ShareGrantObject::Table(table_id) => {
@@ -812,13 +812,11 @@ async fn get_object_name_from_id(
             let (_db_name_seq, table_name): (_, Option<DBIdTableName>) =
                 get_struct_value(kv_api, &table_id_key).await?;
             match table_name {
-                Some(table_name) => {
-                    return Ok(Some(ShareGrantObjectName::Table(
-                        database_name.as_ref().unwrap().to_string(),
-                        table_name.table_name,
-                    )));
-                }
-                None => return Ok(None),
+                Some(table_name) => Ok(Some(ShareGrantObjectName::Table(
+                    database_name.as_ref().unwrap().to_string(),
+                    table_name.table_name,
+                ))),
+                None => Ok(None),
             }
         }
     }

--- a/common/meta/api/src/share_api_test_suite.rs
+++ b/common/meta/api/src/share_api_test_suite.rs
@@ -787,7 +787,6 @@ impl ShareApiTestSuite {
             tenant: tenant.to_string(),
             share_name: share1.to_string(),
         };
-        let db_id: u64;
 
         info!("--- get unknown share");
         {
@@ -847,7 +846,6 @@ impl ShareApiTestSuite {
 
             let res = mt.create_database(plan).await?;
             info!("create database res: {:?}", res);
-            db_id = res.db_id;
 
             let req = CreateTableReq {
                 if_not_exists: false,
@@ -913,7 +911,10 @@ impl ShareApiTestSuite {
             let res = res.unwrap();
             assert_eq!(res.objects.len(), 1);
             let entry = res.objects.get(0).unwrap();
-            assert_eq!(entry.object, ShareGrantObject::Database(db_id));
+            assert_eq!(
+                entry.object,
+                ShareGrantObjectName::Database(db_name.to_string())
+            );
         }
 
         info!("--- get all share objects");

--- a/common/meta/api/src/share_api_test_suite.rs
+++ b/common/meta/api/src/share_api_test_suite.rs
@@ -901,9 +901,10 @@ impl ShareApiTestSuite {
 
         info!("--- get share with db1");
         {
+            let name = ShareGrantObjectName::Database(db_name.to_string());
             let req = GetShareGrantObjectReq {
                 share_name: share_name.clone(),
-                object: Some(ShareGrantObjectName::Database(db_name.to_string())),
+                object: Some(name.clone()),
             };
 
             let res = mt.get_share_grant_objects(req).await;
@@ -911,10 +912,23 @@ impl ShareApiTestSuite {
             let res = res.unwrap();
             assert_eq!(res.objects.len(), 1);
             let entry = res.objects.get(0).unwrap();
-            assert_eq!(
-                entry.object,
-                ShareGrantObjectName::Database(db_name.to_string())
-            );
+            assert_eq!(entry.object, name,);
+        }
+
+        info!("--- get share with table1");
+        {
+            let name = ShareGrantObjectName::Table(db_name.to_string(), tbl_name.to_string());
+            let req = GetShareGrantObjectReq {
+                share_name: share_name.clone(),
+                object: Some(name.clone()),
+            };
+
+            let res = mt.get_share_grant_objects(req).await;
+            info!("get_share_grant_objects res: {:?}", res);
+            let res = res.unwrap();
+            assert_eq!(res.objects.len(), 1);
+            let entry = res.objects.get(0).unwrap();
+            assert_eq!(entry.object, name);
         }
 
         info!("--- get all share objects");

--- a/common/meta/app/src/share/mod.rs
+++ b/common/meta/app/src/share/mod.rs
@@ -36,6 +36,7 @@ pub use share::ShareGrantObject;
 pub use share::ShareGrantObjectName;
 pub use share::ShareGrantObjectPrivilege;
 pub use share::ShareGrantObjectSeqAndId;
+pub use share::ShareGrantReplyObject;
 pub use share::ShareId;
 pub use share::ShareIdToName;
 pub use share::ShareIdent;

--- a/common/meta/app/src/share/share.rs
+++ b/common/meta/app/src/share/share.rs
@@ -175,9 +175,16 @@ pub struct GetShareGrantObjectReq {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct ShareGrantReplyObject {
+    pub object: ShareGrantObjectName,
+    pub privileges: BitFlags<ShareGrantObjectPrivilege>,
+    pub grant_on: DateTime<Utc>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct GetShareGrantObjectReply {
     pub share_name: ShareNameIdent,
-    pub objects: Vec<ShareGrantEntry>,
+    pub objects: Vec<ShareGrantReplyObject>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor: get_share_grant_objects API should return name instead of id

Fixes #issue
