### PR TITLE
fix(hive): fix table column name and parquet column name may not case…

### DIFF
--- a/common/storages/hive/src/hive_parquet_block_reader.rs
+++ b/common/storages/hive/src/hive_parquet_block_reader.rs
@@ -108,7 +108,9 @@ impl HiveParquetBlockReader {
         let column_meta: Vec<&ColumnChunkMetaData> = row_group
             .columns()
             .iter()
-            .filter(|x| x.descriptor().path_in_schema[0] == field_name)
+            .filter(|x| {
+                x.descriptor().path_in_schema[0].to_lowercase() == field_name.to_lowercase()
+            })
             .collect();
         if column_meta.is_empty() {
             return Err(ErrorCode::ParquetError(format!(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
fix the cases table column name is 'A', while parquet file column name is 'a'