### PR TITLE
refactor(meta-service): upgrade some critical debug level logging to info level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5055,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.7.0-alpha.4"
-source = "git+https://github.com/datafuselabs/openraft?rev=v0.7.0-alpha.4#b0abc4b067d65cbf3449b35a5de3db27ef3872f4"
+source = "git+https://github.com/datafuselabs/openraft?rev=v0.7.0-alpha.5#f1cc23fab4ef4b6cd58630c3311b3e930c479d48"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -55,7 +55,7 @@ tonic = "0.7.2"
 tracing = "0.1.35"
 url = "2.2.2"
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.4" }
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.5" }
 
 [[bin]]
 name = "databend-meta"

--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -208,7 +208,7 @@ async fn init_new_cluster(
         },
     };
 
-    // contruct Membership log entry
+    // construct Membership log entry
     {
         // insert last membership log
         log_id.index += 1;

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -44,7 +44,7 @@ use tonic::Request;
 use tonic::Response;
 use tonic::Status;
 use tonic::Streaming;
-use tracing::debug;
+use tracing::info;
 
 use crate::executor::ActionHandler;
 use crate::meta_service::meta_service_impl::GrpcStream;
@@ -156,7 +156,7 @@ impl MetaService for MetaServiceImpl {
 
         add_meta_metrics_meta_request_inflights(1);
 
-        debug!("Receive write_action: {:?}", action);
+        info!("Receive write_action: {:?}", action);
 
         let body = self.action_handler.execute_write(action).await;
 
@@ -177,7 +177,7 @@ impl MetaService for MetaServiceImpl {
 
         add_meta_metrics_meta_request_inflights(1);
 
-        debug!("Receive read_action: {:?}", action);
+        info!("Receive read_action: {:?}", action);
 
         let res = self.action_handler.execute_read(action).await;
 
@@ -239,7 +239,7 @@ impl MetaService for MetaServiceImpl {
 
         let request = request.into_inner();
 
-        debug!("Receive txn_request: {:?}", request);
+        info!("Receive txn_request: {:?}", request);
 
         let body = self.action_handler.execute_txn(request).await;
         add_meta_metrics_meta_request_inflights(-1);

--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -32,6 +32,7 @@ use common_meta_types::Node;
 use common_meta_types::NodeId;
 use openraft::raft::ClientWriteRequest;
 use tracing::debug;
+use tracing::info;
 
 use crate::meta_service::ForwardRequestBody;
 use crate::meta_service::JoinRequest;
@@ -216,14 +217,14 @@ impl<'a> MetaLeader<'a> {
     /// TODO(xp): elaborate the UnknownError, e.g. LeaderLostError
     #[tracing::instrument(level = "debug", skip(self, entry))]
     pub async fn write(&self, entry: LogEntry) -> Result<AppliedState, MetaError> {
-        debug!(entry = debug(&entry), "write LogEntry");
+        info!("write LogEntry: {:?}", entry);
         let write_rst = self
             .meta_node
             .raft
             .client_write(ClientWriteRequest::new(EntryPayload::Normal(entry)))
             .await;
 
-        debug!("raft.client_write rst: {:?}", write_rst);
+        info!("raft.client_write rst: {:?}", write_rst);
 
         match write_rst {
             Ok(resp) => {

--- a/src/meta/service/src/meta_service/meta_node_kv_api_impl.rs
+++ b/src/meta/service/src/meta_service/meta_node_kv_api_impl.rs
@@ -29,7 +29,7 @@ use common_meta_types::TxnReply;
 use common_meta_types::TxnRequest;
 use common_meta_types::UpsertKVReply;
 use common_meta_types::UpsertKVReq;
-use tracing::debug;
+use tracing::info;
 
 use crate::meta_service::MetaNode;
 
@@ -96,7 +96,7 @@ impl KVApi for MetaNode {
 
     #[tracing::instrument(level = "debug", skip(self, txn))]
     async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, MetaError> {
-        debug!(txn = display(&txn), "MetaNode::transaction()");
+        info!("MetaNode::transaction(): {}", txn);
         let ent = LogEntry {
             txid: None,
             cmd: Cmd::Transaction(txn),

--- a/src/meta/service/src/network.rs
+++ b/src/meta/service/src/network.rs
@@ -36,6 +36,7 @@ use openraft::RaftNetwork;
 use tonic::client::GrpcService;
 use tonic::transport::channel::Channel;
 use tracing::debug;
+use tracing::info;
 
 use crate::metrics::incr_meta_metrics_active_peers;
 use crate::metrics::incr_meta_metrics_fail_connections_to_peer;
@@ -150,7 +151,7 @@ impl RaftNetwork<LogEntry> for Network {
         target: NodeId,
         rpc: InstallSnapshotRequest,
     ) -> anyhow::Result<InstallSnapshotResponse> {
-        debug!("install_snapshot req to: id={}", target);
+        info!("install_snapshot req to: id={}", target);
 
         let start = Instant::now();
         let (mut client, endpoint) = self.make_client(&target).await?;
@@ -160,7 +161,7 @@ impl RaftNetwork<LogEntry> for Network {
         incr_meta_metrics_snapshot_send_inflights_to_peer(&target, 1);
 
         let resp = client.install_snapshot(req).await;
-        debug!("install_snapshot resp from: id={}: {:?}", target, resp);
+        info!("install_snapshot resp from: id={}: {:?}", target, resp);
 
         if resp.is_err() {
             incr_meta_metrics_sent_failure_to_peer(&target);
@@ -182,7 +183,7 @@ impl RaftNetwork<LogEntry> for Network {
 
     #[tracing::instrument(level = "debug", skip(self), fields(id=self.sto.id))]
     async fn send_vote(&self, target: NodeId, rpc: VoteRequest) -> anyhow::Result<VoteResponse> {
-        debug!("vote: req to: target={} {:?}", target, rpc);
+        info!("vote: req to: target={} {:?}", target, rpc);
 
         let (mut client, endpoint) = self.make_client(&target).await?;
         let req = common_tracing::inject_span_to_tonic_request(rpc);
@@ -190,7 +191,7 @@ impl RaftNetwork<LogEntry> for Network {
         self.incr_meta_metrics_sent_bytes_to_peer(&target, req.get_ref());
 
         let resp = client.vote(req).await;
-        debug!("vote: resp from target={} {:?}", target, resp);
+        info!("vote: resp from target={} {:?}", target, resp);
 
         if resp.is_err() {
             incr_meta_metrics_sent_failure_to_peer(&target);

--- a/src/meta/service/src/store/store_bare.rs
+++ b/src/meta/service/src/store/store_bare.rs
@@ -51,7 +51,6 @@ use openraft::LogId;
 use openraft::RaftStorage;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
-use tracing::debug;
 use tracing::error;
 use tracing::info;
 
@@ -185,7 +184,7 @@ impl RaftStoreBare {
 
         let new_sm_id = sm_id + 1;
 
-        debug!("snapshot data len: {}", data.len());
+        info!("snapshot data len: {}", data.len());
 
         let snap: SerializableSnapshot = serde_json::from_slice(data)?;
 
@@ -455,7 +454,7 @@ impl RaftStorage<LogEntry, AppliedState> for RaftStoreBare {
             *current_snapshot = Some(snapshot);
         }
 
-        debug!(snapshot_size = snapshot_size, "log compaction complete");
+        info!(snapshot_size = snapshot_size, "log compaction complete");
 
         Ok(openraft::storage::Snapshot {
             meta: snap_meta,
@@ -477,7 +476,7 @@ impl RaftStorage<LogEntry, AppliedState> for RaftStoreBare {
     ) -> Result<StateMachineChanges, StorageError> {
         // TODO(xp): disallow installing a snapshot with smaller last_applied.
 
-        debug!(
+        info!(
             { snapshot_size = snapshot.get_ref().len() },
             "decoding snapshot for installation"
         );
@@ -488,7 +487,7 @@ impl RaftStorage<LogEntry, AppliedState> for RaftStoreBare {
             data: snapshot.into_inner(),
         };
 
-        debug!("snapshot meta: {:?}", meta);
+        info!("snapshot meta: {:?}", meta);
 
         // Replace state machine with the new one
         let res = self.install_snapshot(&new_snapshot.data).await;

--- a/src/meta/sled-store/Cargo.toml
+++ b/src/meta/sled-store/Cargo.toml
@@ -17,7 +17,7 @@ io-uring = ["sled/io_uring"]
 [dependencies]
 common-meta-types = { path = "../types" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.4" }
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.5" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyhow = "1.0.58"

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -15,7 +15,7 @@ common-datavalues = { path = "../../common/datavalues" }
 common-exception = { path = "../../common/exception" }
 common-storage = { path = "../../common/storage" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.4" }
+openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.0-alpha.5" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyerror = "0.1.6"

--- a/tests/logictest/complete.py
+++ b/tests/logictest/complete.py
@@ -11,6 +11,7 @@ from http_connector import format_result
 
 target_dir = "./"
 
+
 def parse_sql_file(source_file):
     sqls = list()
     f = open(source_file, encoding='UTF-8')
@@ -34,12 +35,13 @@ def parse_sql_file(source_file):
     f.close()
     return sqls
 
+
 def parse_logictest_file(source_file):
     parsing_statement = False
     sqls = list()
     f = open(source_file, encoding='UTF-8')
-    sql_content = "" 
-        
+    sql_content = ""
+
     for line in f.readlines():
         if is_empty_line(line):
             if parsing_statement:
@@ -77,6 +79,7 @@ def parse_logictest_file(source_file):
 
     f.close()
     return sqls
+
 
 def get_sql_from_file(source_file):
     if ".sql" in os.path.basename(source_file):
@@ -118,7 +121,9 @@ def gen_suite_from_sql(sqls, dest_file):
                         continue
                     rows.append(str(v))
                 results.append(rows)
-            statements.append(f"statement query {options}\n{sql}\n\n----\n{format_result(results)}\n")
+            statements.append(
+                f"statement query {options}\n{sql}\n\n----\n{format_result(results)}\n"
+            )
         except mysql.connector.Error as err:
             statements.append(f"statement ok\n{sql}\n\n")
 
@@ -150,9 +155,11 @@ def run(args):
 
 
 if __name__ == '__main__':
-    parser = ArgumentParser(description='databend sqllogictest auto-complete tools(from *.sql files or logictest files)')
-    parser.add_argument('--source-file',
-                        help='Path to suites source file')
+    parser = ArgumentParser(
+        description=
+        'databend sqllogictest auto-complete tools(from *.sql files or logictest files)'
+    )
+    parser.add_argument('--source-file', help='Path to suites source file')
 
     parser.add_argument('--dest-file',
                         default="./auto",
@@ -163,25 +170,17 @@ if __name__ == '__main__':
                         default=False,
                         help='Show sql from source file')
 
-    parser.add_argument('--mysql-user',
-                        default="root",
-                        help='Mysql user')
+    parser.add_argument('--mysql-user', default="root", help='Mysql user')
 
-    parser.add_argument('--mysql-host',
-                        default="127.0.0.1",
-                        help='Mysql host')
+    parser.add_argument('--mysql-host', default="127.0.0.1", help='Mysql host')
 
-    parser.add_argument('--mysql-port',
-                        default="3307",
-                        help='Mysql port')
+    parser.add_argument('--mysql-port', default="3307", help='Mysql port')
 
-    parser.add_argument('--mysql-passwd',
-                        default="root",
-                        help='Mysql password')
+    parser.add_argument('--mysql-passwd', default="root", help='Mysql password')
 
     parser.add_argument('--mysql-database',
                         default="default",
                         help='Mysql default database')
-    
+
     args = parser.parse_args()
     run(args)


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta-service): upgrade some critical debug level logging to info level

Upgrade openraft to [v0.7.0-alpha.5](https://github.com/datafuselabs/openraft/tree/v0.7.0-alpha.5), in which log level are adjusted too.

- Fix: #7116

## Changelog







## Related Issues