### PR TITLE
chore: catch RuntimeError exception convert to LogicError

### DIFF
--- a/tests/logictest/logictest.py
+++ b/tests/logictest/logictest.py
@@ -352,8 +352,12 @@ class SuiteRunner(object):
 
     # expect the query just return ok
     def assert_execute_ok(self, statement):
-        actual = safe_execute(lambda: self.execute_ok(statement.text),
-                              statement)
+        try:
+            actual = safe_execute(lambda: self.execute_ok(statement.text), statement)
+        except Exception as err:
+            raise LogicError(runner=self.kind,
+                             message=str(err),
+                             errorType="statement ok execute with exception")
         if actual is not None:
             raise LogicError(runner=self.kind,
                              message=str(statement),
@@ -377,7 +381,12 @@ class SuiteRunner(object):
         if statement.s_type.query_type == "skipped":
             log.debug(f"{statement.text} statement is skipped")
             return
-        actual = safe_execute(lambda: self.execute_query(statement), statement)
+        try:
+            actual = safe_execute(lambda: self.execute_query(statement), statement)
+        except Exception as err:
+            raise LogicError(runner=self.kind,
+                             message=str(err),
+                             errorType="statement query execute with exception")
         try:
             f = format_value(actual, len(statement.s_type.query_type))
         except Exception:
@@ -410,8 +419,12 @@ class SuiteRunner(object):
 
     # expect the query just return error
     def assert_execute_error(self, statement):
-        actual = safe_execute(lambda: self.execute_error(statement.text),
-                              statement)
+        try:
+            actual = safe_execute(lambda: self.execute_error(statement.text), statement)
+        except Exception as err:
+            raise LogicError(runner=self.kind,
+                             message=str(err),
+                             errorType="statement error execute with exception")
         if actual is None:
             raise LogicError(
                 message=


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix the following case when executing with an exception, only show exception without runner info.

![origin_img_v2_e9d05bdb-6160-47b7-a080-26c588307b2g](https://user-images.githubusercontent.com/10904090/184793993-316c0812-0838-459a-add9-893c57bf98cf.jpg)

Catch RuntimeError and convert to LogicError.

Fixes #issue
