### PR TITLE
chore: disable mode dir when running core suites

### DIFF
--- a/scripts/ci/ci-run-sqllogic-tests.sh
+++ b/scripts/ci/ci-run-sqllogic-tests.sh
@@ -16,7 +16,7 @@ fi
 echo "Run suites using argument: $RUN_DIR"
 
 echo "Starting databend-sqllogic tests"
-python3 main.py $RUN_DIR
+python3 main.py --skip-dir=mode $RUN_DIR
 
 echo "Starting databend-sqllogic mode standalone"
 python3 main.py --suite suites/mode --run-dir standalone


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The production workflow will run all suites, but we using mode dir to test cluster and standalone mode.
So the ci scripts need to control running arguments. 

Fixes #issue
