### PR TITLE
refactor: bump opendal to v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ name = "common-metrics"
 version = "0.1.0"
 dependencies = [
  "common-exception",
- "metrics",
+ "metrics 0.19.0",
  "metrics-exporter-prometheus",
  "once_cell",
  "parking_lot 0.12.1",
@@ -2502,7 +2502,7 @@ dependencies = [
  "jwtk",
  "lz4",
  "maplit",
- "metrics",
+ "metrics 0.19.0",
  "mysql_async",
  "naive-cityhash",
  "nom",
@@ -4455,7 +4455,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142c53885123b68d94108295a09d4afe1a1388ed95b54d5dacd9a454753030f2"
 dependencies = [
  "ahash",
- "metrics-macros",
+ "metrics-macros 0.5.1",
+]
+
+[[package]]
+name = "metrics"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
+dependencies = [
+ "ahash",
+ "metrics-macros 0.6.0",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -4465,7 +4476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953cbbb6f9ba4b9304f4df79b98cdc9d14071ed93065a9fca11c00c5d9181b66"
 dependencies = [
  "indexmap",
- "metrics",
+ "metrics 0.19.0",
  "metrics-util",
  "parking_lot 0.11.2",
  "quanta",
@@ -4484,6 +4495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "metrics-util"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4493,7 +4515,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.11.2",
- "metrics",
+ "metrics 0.19.0",
  "num_cpus",
  "parking_lot 0.11.2",
  "quanta",
@@ -4987,6 +5009,7 @@ dependencies = [
  "isahc-opendal-workaround",
  "log",
  "md5",
+ "metrics 0.20.1",
  "once_cell",
  "parking_lot 0.12.1",
  "percent-encoding",
@@ -4999,6 +5022,7 @@ dependencies = [
  "thiserror",
  "time 0.3.13",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -5585,6 +5609,12 @@ name = "pom"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b303a15aeda678da614ab23306232dbd282d532f8c5919cedd41b66b9dc96560"
 
 [[package]]
 name = "pprof"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ name = "common-metrics"
 version = "0.1.0"
 dependencies = [
  "common-exception",
- "metrics 0.19.0",
+ "metrics",
  "metrics-exporter-prometheus",
  "once_cell",
  "parking_lot 0.12.1",
@@ -2502,7 +2502,7 @@ dependencies = [
  "jwtk",
  "lz4",
  "maplit",
- "metrics 0.19.0",
+ "metrics",
  "mysql_async",
  "naive-cityhash",
  "nom",
@@ -4455,18 +4455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142c53885123b68d94108295a09d4afe1a1388ed95b54d5dacd9a454753030f2"
 dependencies = [
  "ahash",
- "metrics-macros 0.5.1",
-]
-
-[[package]]
-name = "metrics"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
-dependencies = [
- "ahash",
- "metrics-macros 0.6.0",
- "portable-atomic",
+ "metrics-macros",
 ]
 
 [[package]]
@@ -4476,7 +4465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953cbbb6f9ba4b9304f4df79b98cdc9d14071ed93065a9fca11c00c5d9181b66"
 dependencies = [
  "indexmap",
- "metrics 0.19.0",
+ "metrics",
  "metrics-util",
  "parking_lot 0.11.2",
  "quanta",
@@ -4495,17 +4484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "metrics-util"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4515,7 +4493,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.11.2",
- "metrics 0.19.0",
+ "metrics",
  "num_cpus",
  "parking_lot 0.11.2",
  "quanta",
@@ -4541,51 +4519,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "minitrace"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a07fdf302cc0591c97eb45939550ddaddd9962e400c20b319aa16c244cb1f16"
-dependencies = [
- "crossbeam",
- "futures",
- "minitrace-macro",
- "minstant",
- "once_cell",
- "parking_lot 0.11.2",
- "pin-project",
- "retain_mut",
-]
-
-[[package]]
-name = "minitrace-macro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4132dfe6097f4a90c0bbb34be0687c38d14303dd2e74f8442ae80e9bc5a34c47"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "minstant"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb320648b7883b43ce5dfbc5c6f4a84038194c3f67b4fcb7d05c994e6006557"
-dependencies = [
- "ctor",
- "libc",
- "wasi 0.7.0",
 ]
 
 [[package]]
@@ -5030,9 +4969,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendal"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9facd3f01e493eb20d0ca2324c77c4cead41c3cf1e2e5f4414ffdbb1710b5343"
+checksum = "0c060aacce95fbe4a415b4ec6855d2c02b93b407eae07f8ceba3c475fedaed21"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -5048,8 +4987,6 @@ dependencies = [
  "isahc-opendal-workaround",
  "log",
  "md5",
- "metrics 0.20.1",
- "minitrace",
  "once_cell",
  "parking_lot 0.12.1",
  "percent-encoding",
@@ -5058,6 +4995,7 @@ dependencies = [
  "radix_trie",
  "reqsign",
  "serde",
+ "serde_json",
  "thiserror",
  "time 0.3.13",
  "tokio",
@@ -5647,12 +5585,6 @@ name = "pom"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
-
-[[package]]
-name = "portable-atomic"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa09d53386a2226b0d1d8c1110c1e25d029d37cce6fcfdf9e1d4d26a6ab3326"
 
 [[package]]
 name = "pprof"
@@ -8164,12 +8096,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "wasi"

--- a/src/common/catalog/Cargo.toml
+++ b/src/common/catalog/Cargo.toml
@@ -27,5 +27,5 @@ common-users = { path = "../users" }
 
 async-trait = "0.1.56"
 dyn-clone = "1.0.6"
-opendal = { version = "0.13.0", features = ["retry"] }
+opendal = { version = "0.13.0", features = ["layers-retry"] }
 parking_lot = "0.12.1"

--- a/src/common/catalog/Cargo.toml
+++ b/src/common/catalog/Cargo.toml
@@ -27,5 +27,5 @@ common-users = { path = "../users" }
 
 async-trait = "0.1.56"
 dyn-clone = "1.0.6"
-opendal = { version = "0.12.0", features = ["retry"] }
+opendal = { version = "0.13.0", features = ["retry"] }
 parking_lot = "0.12.1"

--- a/src/common/config/Cargo.toml
+++ b/src/common/config/Cargo.toml
@@ -18,7 +18,7 @@ common-tracing = { path = "../tracing" }
 
 clap = { version = "3.2.5", features = ["derive", "env"] }
 once_cell = "1.12.0"
-opendal = { version = "0.12.0", features = ["retry", "compress"], optional = true }
+opendal = { version = "0.13.0", features = ["retry", "compress"], optional = true }
 semver = "1.0.10"
 serde = { version = "1.0.137", features = ["derive"] }
 serfig = "0.0.2"

--- a/src/common/config/Cargo.toml
+++ b/src/common/config/Cargo.toml
@@ -18,7 +18,7 @@ common-tracing = { path = "../tracing" }
 
 clap = { version = "3.2.5", features = ["derive", "env"] }
 once_cell = "1.12.0"
-opendal = { version = "0.13.0", features = ["retry", "compress"], optional = true }
+opendal = { version = "0.13.0", features = ["layers-retry", "compress"], optional = true }
 semver = "1.0.10"
 serde = { version = "1.0.137", features = ["derive"] }
 serfig = "0.0.2"

--- a/src/common/contexts/Cargo.toml
+++ b/src/common/contexts/Cargo.toml
@@ -12,4 +12,4 @@ test = false
 common-base = { path = "../base" }
 
 async-trait = "0.1.56"
-opendal = { version = "0.12.0", features = ["retry"] }
+opendal = { version = "0.13.0", features = ["retry"] }

--- a/src/common/contexts/Cargo.toml
+++ b/src/common/contexts/Cargo.toml
@@ -12,4 +12,4 @@ test = false
 common-base = { path = "../base" }
 
 async-trait = "0.1.56"
-opendal = { version = "0.13.0", features = ["retry"] }
+opendal = { version = "0.13.0", features = ["layers-retry"] }

--- a/src/common/pipeline/sources/Cargo.toml
+++ b/src/common/pipeline/sources/Cargo.toml
@@ -23,5 +23,5 @@ common-streams = { path = "../../streams" }
 async-trait = { git = "https://github.com/datafuse-extras/async-trait", rev = "f0b0fd5" }
 futures = "0.3.21"
 futures-util = "0.3.21"
-opendal = { version = "0.13.0", features = ["retry", "compress"] }
+opendal = { version = "0.13.0", features = ["layers-retry", "compress"] }
 parking_lot = "0.12.1"

--- a/src/common/pipeline/sources/Cargo.toml
+++ b/src/common/pipeline/sources/Cargo.toml
@@ -23,5 +23,5 @@ common-streams = { path = "../../streams" }
 async-trait = { git = "https://github.com/datafuse-extras/async-trait", rev = "f0b0fd5" }
 futures = "0.3.21"
 futures-util = "0.3.21"
-opendal = { version = "0.12.0", features = ["retry"] }
+opendal = { version = "0.13.0", features = ["retry", "compress"] }
 parking_lot = "0.12.1"

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -12,6 +12,6 @@ storage-hdfs = ["opendal/services-hdfs"]
 [dependencies]
 anyhow = "1.0.58"
 globiter = "0.1.0"
-opendal = { version = "0.13.0", features = ["retry", "services-http"] }
+opendal = { version = "0.13.0", features = ["layers-retry", "services-http"] }
 percent-encoding = "2.1.0"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -12,6 +12,6 @@ storage-hdfs = ["opendal/services-hdfs"]
 [dependencies]
 anyhow = "1.0.58"
 globiter = "0.1.0"
-opendal = { version = "0.12.0", features = ["retry", "services-http"] }
+opendal = { version = "0.13.0", features = ["retry", "services-http"] }
 percent-encoding = "2.1.0"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/src/common/storages/fuse/Cargo.toml
+++ b/src/common/storages/fuse/Cargo.toml
@@ -37,7 +37,7 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 chrono = "0.4.19"
 futures = "0.3.21"
 futures-util = "0.3.21"
-opendal = { version = "0.13.0", features = ["retry"] }
+opendal = { version = "0.13.0", features = ["layers-retry"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 tracing = "0.1.35"

--- a/src/common/storages/fuse/Cargo.toml
+++ b/src/common/storages/fuse/Cargo.toml
@@ -37,7 +37,7 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 chrono = "0.4.19"
 futures = "0.3.21"
 futures-util = "0.3.21"
-opendal = { version = "0.12.0", features = ["retry"] }
+opendal = { version = "0.13.0", features = ["retry"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 tracing = "0.1.35"

--- a/src/common/storages/hive/Cargo.toml
+++ b/src/common/storages/hive/Cargo.toml
@@ -31,7 +31,7 @@ common-storages-util = { path = "../util" }
 async-recursion = "1.0.0"
 async-trait = "0.1.56"
 futures = "0.3.21"
-opendal = { version = "0.12.0", features = ["retry"] }
+opendal = { version = "0.13.0", features = ["retry"] }
 serde = { version = "1.0.137", features = ["derive"] }
 thrift = "0.15.0"
 tracing = "0.1.35"

--- a/src/common/storages/hive/Cargo.toml
+++ b/src/common/storages/hive/Cargo.toml
@@ -31,7 +31,7 @@ common-storages-util = { path = "../util" }
 async-recursion = "1.0.0"
 async-trait = "0.1.56"
 futures = "0.3.21"
-opendal = { version = "0.13.0", features = ["retry"] }
+opendal = { version = "0.13.0", features = ["layers-retry"] }
 serde = { version = "1.0.137", features = ["derive"] }
 thrift = "0.15.0"
 tracing = "0.1.35"

--- a/src/common/storages/preludes/Cargo.toml
+++ b/src/common/storages/preludes/Cargo.toml
@@ -49,7 +49,7 @@ itertools = "0.10.3"
 num_cpus = "1.13.1"
 octocrab = "0.16.0"
 once_cell = "1.12.0"
-opendal = { version = "0.13.0", features = ["retry"] }
+opendal = { version = "0.13.0", features = ["layers-retry"] }
 parking_lot = "0.12.1"
 reqwest = "0.11.11"
 semver = "1.0.10"

--- a/src/common/storages/preludes/Cargo.toml
+++ b/src/common/storages/preludes/Cargo.toml
@@ -49,7 +49,7 @@ itertools = "0.10.3"
 num_cpus = "1.13.1"
 octocrab = "0.16.0"
 once_cell = "1.12.0"
-opendal = { version = "0.12.0", features = ["retry"] }
+opendal = { version = "0.13.0", features = ["retry"] }
 parking_lot = "0.12.1"
 reqwest = "0.11.11"
 semver = "1.0.10"

--- a/src/common/streams/Cargo.toml
+++ b/src/common/streams/Cargo.toml
@@ -33,4 +33,4 @@ serde_json = { version = "1.0.81", default-features = false, features = ["preser
 tempfile = "3.3.0"
 
 [dev-dependencies]
-opendal = { version = "0.13.0", features = ["retry", "compress"] }
+opendal = { version = "0.13.0", features = ["layers-retry", "compress"] }

--- a/src/common/streams/Cargo.toml
+++ b/src/common/streams/Cargo.toml
@@ -33,4 +33,4 @@ serde_json = { version = "1.0.81", default-features = false, features = ["preser
 tempfile = "3.3.0"
 
 [dev-dependencies]
-opendal = { version = "0.12.0", features = ["retry", "compress"] }
+opendal = { version = "0.13.0", features = ["retry", "compress"] }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -110,7 +110,7 @@ num = "0.4.0"
 num_cpus = "1.13.1"
 octocrab = "0.16.0"
 once_cell = "1.12.0"
-opendal = { version = "0.12.0", features = ["retry", "compress"] }
+opendal = { version = "0.13.0", features = ["retry", "compress"] }
 opensrv-mysql = "0.2.0"
 openssl = { version = "0.10.40", features = ["vendored"] }
 parking_lot = "0.12.1"

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -110,7 +110,7 @@ num = "0.4.0"
 num_cpus = "1.13.1"
 octocrab = "0.16.0"
 once_cell = "1.12.0"
-opendal = { version = "0.13.0", features = ["retry", "compress"] }
+opendal = { version = "0.13.0", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
 opensrv-mysql = "0.2.0"
 openssl = { version = "0.10.40", features = ["vendored"] }
 parking_lot = "0.12.1"

--- a/src/query/service/src/sessions/session_mgr.rs
+++ b/src/query/service/src/sessions/session_mgr.rs
@@ -38,6 +38,7 @@ use futures::StreamExt;
 use opendal::layers::LoggingLayer;
 use opendal::layers::MetricsLayer;
 use opendal::layers::RetryLayer;
+use opendal::layers::TracingLayer;
 use opendal::Operator;
 use parking_lot::RwLock;
 use tracing::debug;
@@ -418,6 +419,7 @@ impl SessionManager {
         let op = init_operator(&conf.storage.params)?
             .layer(RetryLayer::new(ExponentialBackoff::default()))
             .layer(LoggingLayer)
+            .layer(TracingLayer)
             .layer(MetricsLayer);
         // OpenDAL will send a real request to underlying storage to check whether it works or not.
         // If this check failed, it's highly possible that the users have configured it wrongly.

--- a/tests/logictest/logictest.py
+++ b/tests/logictest/logictest.py
@@ -353,7 +353,8 @@ class SuiteRunner(object):
     # expect the query just return ok
     def assert_execute_ok(self, statement):
         try:
-            actual = safe_execute(lambda: self.execute_ok(statement.text), statement)
+            actual = safe_execute(lambda: self.execute_ok(statement.text),
+                                  statement)
         except Exception as err:
             raise LogicError(runner=self.kind,
                              message=str(err),
@@ -382,7 +383,8 @@ class SuiteRunner(object):
             log.debug(f"{statement.text} statement is skipped")
             return
         try:
-            actual = safe_execute(lambda: self.execute_query(statement), statement)
+            actual = safe_execute(lambda: self.execute_query(statement),
+                                  statement)
         except Exception as err:
             raise LogicError(runner=self.kind,
                              message=str(err),
@@ -420,7 +422,8 @@ class SuiteRunner(object):
     # expect the query just return error
     def assert_execute_error(self, statement):
         try:
-            actual = safe_execute(lambda: self.execute_error(statement.text), statement)
+            actual = safe_execute(lambda: self.execute_error(statement.text),
+                                  statement)
         except Exception as err:
             raise LogicError(runner=self.kind,
                              message=str(err),


### PR DESCRIPTION
Signed-off-by: ClSlaid <cailue@bupt.edu.cn>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR will bump the dependency of OpenDAL to v0.13.0

Part of #7151 
