### PR TITLE
chore: production logictest run base and ydb only

### DIFF
--- a/.github/actions/test_sqllogic_standalone_macos/action.yml
+++ b/.github/actions/test_sqllogic_standalone_macos/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: ""
     required: true
     default: "x86_64-apple-darwin"
+  dirs:
+    description: "logic test suites dirs"
+    required: true
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -27,7 +31,7 @@ runs:
     - name: Run sqllogic Tests with Standalone mode with embedded meta-store
       shell: bash
       run: |
-        bash ./scripts/ci/ci-run-sqllogic-tests.sh
+        bash ./scripts/ci/ci-run-sqllogic-tests.sh ${{ inputs.dirs }}
 
     # - name: Upload failure
     #   if: failure()

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -129,6 +129,7 @@ jobs:
       - uses: ./.github/actions/test_sqllogic_standalone_macos
         with:
           profile: release
+          dirs: "base ydb"
 
   test_sqllogic_standalone_linux:
     runs-on: ubuntu-latest
@@ -138,3 +139,4 @@ jobs:
       - uses: ./.github/actions/test_sqllogic_standalone_linux
         with:
           profile: release
+          dirs: "base ydb"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Suites of crdb are still in progress, maybe impact the other test, and need to be fixed later.

Fixes #issue
