### PR TITLE
fix: statements `desc share` and `show shares` may have resultset

### DIFF
--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -67,6 +67,8 @@ fn has_result_set_by_plan(plan: &Plan) -> bool {
             | Plan::Call(_)
             | Plan::ShowCreateDatabase(_)
             | Plan::ShowCreateTable(_)
+            | Plan::DescShare(_)
+            | Plan::ShowShares(_)
             | Plan::DescribeTable(_)
             | Plan::ShowGrants(_)
             | Plan::ListStage(_)

--- a/tests/suites/0_stateless/06_show/06_0009_show_shares.result
+++ b/tests/suites/0_stateless/06_show/06_0009_show_shares.result
@@ -1,0 +1,1 @@
+yyyy-mm-dd HH:MM:SS	OUTBOUND	test_share		test_tenant

--- a/tests/suites/0_stateless/06_show/06_0009_show_shares.result_filter
+++ b/tests/suites/0_stateless/06_show/06_0009_show_shares.result_filter
@@ -1,0 +1,2 @@
+\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d[.]\d+ UTC
+yyyy-mm-dd HH:MM:SS

--- a/tests/suites/0_stateless/06_show/06_0009_show_shares.sql
+++ b/tests/suites/0_stateless/06_show/06_0009_show_shares.sql
@@ -1,0 +1,11 @@
+DROP DATABASE IF EXISTS show_shares;
+CREATE DATABASE show_shares;
+
+USE show_shares;
+
+create share test_share;
+
+show shares;
+
+
+DROP DATABASE IF EXISTS show_shares;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- add `Plan::DescShare` and `Plan::ShowShares` to the may-have-non-empty-result-set list
- add a simple stateless test case
  since there is a non-deterministic column in the test resultset, and stateless-test supports regex filter
  
  NOTE: 

  tried adding a case :
     `create share a` and then `desc share a`, expecting descriptions of share a.
  but failed. 
  A simple investigation shows that an empty resultset is returned. Not sure if this is expected. thus this case is excluded.

Fixes #issue
