### PR TITLE
refactor(meta): reduce long span info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5029,8 +5029,8 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.7.1"
-source = "git+https://github.com/datafuselabs/openraft?rev=v0.7.1#19fa9f0cff9e4245cb60409ee0a21d4b0b69b49a"
+version = "0.7.2"
+source = "git+https://github.com/drmingdrmer/openraft?rev=v0.7.2-alpha.1#03324cbf6ccd1dbe6453ec172a47a0f5d03bf3c7"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -55,7 +55,7 @@ tonic = "0.7.2"
 tracing = "0.1.35"
 url = "2.2.2"
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.1" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", rev = "v0.7.2-alpha.1" }
 
 [[bin]]
 name = "databend-meta"

--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -311,7 +311,7 @@ impl MetaNode {
     /// Optionally boot a single node cluster.
     /// 1. If `open` is `Some`, try to open an existent one.
     /// 2. If `create` is `Some`, try to create an one in non-voter mode.
-    #[tracing::instrument(level = "debug", skip(config), fields(config_id=config.config_id.as_str()))]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn open_create_boot(
         config: &RaftConfig,
         open: Option<()>,
@@ -319,6 +319,11 @@ impl MetaNode {
         is_initialize: bool,
         node: Node,
     ) -> MetaResult<Arc<MetaNode>> {
+        info!(
+            "open_create_boot, config: {:?}, open: {:?}, create: {:?}, is_initialize: {}, node: {:?}",
+            config, open, create, is_initialize, node
+        );
+
         let mut config = config.clone();
 
         // Always disable fsync on mac.

--- a/src/meta/service/src/network.rs
+++ b/src/meta/service/src/network.rs
@@ -117,13 +117,17 @@ impl Network {
 
 #[async_trait]
 impl RaftNetwork<LogEntry> for Network {
-    #[tracing::instrument(level = "debug", skip(self), fields(id=self.sto.id, rpc=%rpc.summary()))]
+    #[tracing::instrument(level = "debug", skip_all, fields(id=self.sto.id, target=target))]
     async fn send_append_entries(
         &self,
         target: NodeId,
         rpc: AppendEntriesRequest<LogEntry>,
     ) -> anyhow::Result<AppendEntriesResponse> {
-        debug!("append_entries req to: id={}: {:?}", target, rpc);
+        debug!(
+            "send_append_entries target: {}, rpc: {}",
+            target,
+            rpc.summary()
+        );
 
         let (mut client, endpoint) = self.make_client(&target).await?;
 
@@ -145,13 +149,17 @@ impl RaftNetwork<LogEntry> for Network {
         Ok(resp)
     }
 
-    #[tracing::instrument(level = "debug", skip(self), fields(id=self.sto.id, rpc=%rpc.summary()))]
+    #[tracing::instrument(level = "debug", skip_all, fields(id=self.sto.id, target=target))]
     async fn send_install_snapshot(
         &self,
         target: NodeId,
         rpc: InstallSnapshotRequest,
     ) -> anyhow::Result<InstallSnapshotResponse> {
-        info!("install_snapshot req to: id={}", target);
+        info!(
+            "send_install_snapshot target: {}, rpc: {}",
+            target,
+            rpc.summary()
+        );
 
         let start = Instant::now();
         let (mut client, endpoint) = self.make_client(&target).await?;
@@ -181,9 +189,9 @@ impl RaftNetwork<LogEntry> for Network {
         Ok(resp)
     }
 
-    #[tracing::instrument(level = "debug", skip(self), fields(id=self.sto.id))]
+    #[tracing::instrument(level = "debug", skip_all, fields(id=self.sto.id, target=target))]
     async fn send_vote(&self, target: NodeId, rpc: VoteRequest) -> anyhow::Result<VoteResponse> {
-        info!("vote: req to: target={} {:?}", target, rpc);
+        info!("send_vote: target: {} rpc: {}", target, rpc.summary());
 
         let (mut client, endpoint) = self.make_client(&target).await?;
         let req = common_tracing::inject_span_to_tonic_request(rpc);

--- a/src/meta/sled-store/Cargo.toml
+++ b/src/meta/sled-store/Cargo.toml
@@ -17,7 +17,7 @@ io-uring = ["sled/io_uring"]
 [dependencies]
 common-meta-types = { path = "../types" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.1" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", rev = "v0.7.2-alpha.1" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyhow = "1.0.58"

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -15,7 +15,7 @@ common-datavalues = { path = "../../common/datavalues" }
 common-exception = { path = "../../common/exception" }
 common-storage = { path = "../../common/storage" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", rev = "v0.7.1" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", rev = "v0.7.2-alpha.1" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyerror = "0.1.6"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta): reduce long span info

Remove long info out of span.

Update openraft to 0.7.2-alpha.1, with normalized logging.

## Changelog







## Related Issues