### PR TITLE
fix: prefer schema of datablock while writing resultset

### DIFF
--- a/src/common/planners/src/plan_user_stage_describe.rs
+++ b/src/common/planners/src/plan_user_stage_describe.rs
@@ -25,6 +25,7 @@ impl DescribeUserStagePlan {
             DataField::new("stage_type", Vu8::to_data_type()),
             DataField::new("stage_params", Vu8::to_data_type()),
             DataField::new("copy_options", Vu8::to_data_type()),
+            DataField::new("number_of_files", u64::to_data_type()),
             DataField::new("file_format_options", Vu8::to_data_type()),
             DataField::new("comment", Vu8::to_data_type()),
         ])

--- a/src/common/planners/src/plan_user_stage_describe.rs
+++ b/src/common/planners/src/plan_user_stage_describe.rs
@@ -25,8 +25,9 @@ impl DescribeUserStagePlan {
             DataField::new("stage_type", Vu8::to_data_type()),
             DataField::new("stage_params", Vu8::to_data_type()),
             DataField::new("copy_options", Vu8::to_data_type()),
-            DataField::new("number_of_files", u64::to_data_type()),
             DataField::new("file_format_options", Vu8::to_data_type()),
+            DataField::new("number_of_files", u64::to_data_type()),
+            DataField::new("creator", Vu8::to_data_type()),
             DataField::new("comment", Vu8::to_data_type()),
         ])
     }

--- a/src/query/service/src/servers/mysql/writers/query_result_writer.rs
+++ b/src/query/service/src/servers/mysql/writers/query_result_writer.rs
@@ -167,7 +167,6 @@ impl<'a, W: AsyncWrite + Send + Unpin> DFQueryResultWriter<'a, W> {
             query_result.schema.as_ref()
         };
 
-        // match convert_schema(&query_result.schema) {
         match convert_schema(result_schema) {
             Err(error) => Self::err(&error, dataset_writer).await,
             Ok(columns) => {

--- a/tests/logictest/suites/base/05_ddl/05_0016_ddl_stage
+++ b/tests/logictest/suites/base/05_ddl/05_0016_ddl_stage
@@ -13,8 +13,11 @@ CREATE STAGE test_stage_internal file_format=(type=csv compression=AUTO record_d
 statement ok
 LIST @test_stage_internal;
 
-statement ok
+statement query TTTTTITT
 desc stage test_stage_internal;
+
+----
+test_stage_internal Internal StageParams { storage: Fs(StorageFsConfig { root: "_data" }) } CopyOptions { on_error: None, size_limit: 0 } FileFormatOptions { format: Csv, skip_header: 0, field_delimiter: "", record_delimiter: "NONE", compression: Auto } 0 'root'@'127.0.0.1'
 
 statement query TTITT
 SHOW STAGES;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- While streaming back the resultset in MySQL handler, prefer the schema carried by data block (if any) to `QueryResult::schema`, since the schema of `QueryResult` obtained from `Interpreter::schema`,  might be empty(the default implementation)

- tweak logictest 
  check resultset of `desc stage ..`

- fix incorrect schema of plan `DescribeUserStagePlan`

Fixes #7200
