### PR TITLE
refactor(meta-service): RaftClient manages active peers metric

### DIFF
--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -573,7 +573,7 @@ impl MetaNode {
         let advertise_endpoint = conf.raft_api_advertise_host_endpoint();
         #[allow(clippy::never_loop)]
         for addr in addrs {
-            let timeout = Some(Duration::from_millis(1_000));
+            let timeout = Some(Duration::from_millis(3_000));
             info!(
                 "try to join cluster via {}, timeout: {:?}...",
                 addr, timeout

--- a/src/meta/types/src/endpoint.rs
+++ b/src/meta/types/src/endpoint.rs
@@ -28,9 +28,3 @@ impl fmt::Display for Endpoint {
         write!(f, "{}:{}", self.addr, self.port)
     }
 }
-
-impl From<Endpoint> for String {
-    fn from(endpoint: Endpoint) -> Self {
-        format!("{}:{}", endpoint.addr, endpoint.port)
-    }
-}


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta-service): RaftClient manages active peers metric

RaftClient is a wrapper of grpc client: RaftServiceClient and auto
increase the metric active-peer and also decrease the value when client
is dropped.

- Fix: #7207

## Changelog







## Related Issues