### PR TITLE
feat(metrics): Add metrics about IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,6 +1759,7 @@ dependencies = [
  "common-streams",
  "futures",
  "futures-util",
+ "metrics 0.19.0",
  "opendal",
  "serde",
  "serde_json",

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -38,6 +38,8 @@ chrono = "0.4.19"
 futures = "0.3.21"
 futures-util = "0.3.21"
 opendal = { version = "0.13.1", features = ["layers-retry"] }
+metrics = "0.19.0"
+opendal = { version = "0.13.0", features = ["layers-retry"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 tracing = "0.1.35"

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -35,6 +35,8 @@ use common_meta_app::schema::TableStatistics;
 use common_meta_app::schema::UpdateTableMetaReply;
 use common_meta_app::schema::UpdateTableMetaReq;
 use common_meta_types::MatchSeq;
+use common_storages_util::metrics::METRIC_BYTES_WRITE_COUNT;
+use common_storages_util::metrics::METRIC_ROWS_WRITE_COUNT;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
@@ -171,6 +173,8 @@ impl FuseTable {
             rows: summary.row_count as usize,
             bytes: summary.uncompressed_byte_size as usize,
         };
+        metrics::counter!(METRIC_BYTES_WRITE_COUNT, summary.row_count);
+        metrics::counter!(METRIC_ROWS_WRITE_COUNT, summary.uncompressed_byte_size);
         ctx.get_write_progress().incr(&progress_values);
 
         let segments = segments

--- a/src/query/storages/fuse/src/operations/read.rs
+++ b/src/query/storages/fuse/src/operations/read.rs
@@ -31,6 +31,8 @@ use common_planners::Extras;
 use common_planners::PartInfoPtr;
 use common_planners::Projection;
 use common_planners::ReadDataSourcePlan;
+use common_storages_util::metrics::METRIC_BYTES_SCANNED_COUNT;
+use common_storages_util::metrics::METRIC_ROWS_SCANNED_COUNT;
 
 use crate::io::BlockReader;
 use crate::operations::read::State::Generated;
@@ -187,6 +189,8 @@ impl Processor for FuseTableSource {
                     rows: data_block.num_rows(),
                     bytes: data_block.memory_size(),
                 };
+                metrics::counter!(METRIC_BYTES_SCANNED_COUNT, progress_values.rows as u64);
+                metrics::counter!(METRIC_ROWS_SCANNED_COUNT, progress_values.bytes as u64);
                 self.scan_progress.incr(&progress_values);
 
                 self.state = match partitions.is_empty() {

--- a/src/query/storages/util/src/metrics.rs
+++ b/src/query/storages/util/src/metrics.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(unused_crate_dependencies)]
+pub const METRIC_ROWS_SCANNED_COUNT: &str = "io.metric_rows_scanned_count";
+pub const METRIC_ROWS_WRITE_COUNT: &str = "io.metric_rows_write_count";
 
-pub mod metrics;
-pub mod retry;
-pub mod storage_context;
-pub mod table_option_keys;
+pub const METRIC_BYTES_SCANNED_COUNT: &str = "io.metric_bytes_scanned_count";
+pub const METRIC_BYTES_WRITE_COUNT: &str = "io.metric_bytes_write_count";


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Add metrics for rows scanned/write.
- Add metrics for bytes scanned/write.
- Add metrics for s3 bytes recv/send.

Fixes #6458
