### PR TITLE
refactor(fuse): split DataBlock into multiple pages if necessary during writing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,6 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.12.0"
-source = "git+https://github.com/datafuse-extras/arrow2?rev=2b427cf#2b427cf4f49cde6623db391d39f32363bfe441d0"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.12.0"
+source = "git+https://github.com/datafuse-extras/arrow2?rev=ada1bf9#ada1bf9966e6fc4426fe10c3b00c7389a34ef54e"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.12.0"
-source = "git+https://github.com/datafuse-extras/arrow2?rev=4cdf6ff2#4cdf6ff2a90de01f501266b43955e04ad00dd816"
+source = "git+https://github.com/datafuse-extras/arrow2?rev=2b427cf#2b427cf4f49cde6623db391d39f32363bfe441d0"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/src/common/arrow/Cargo.toml
+++ b/src/common/arrow/Cargo.toml
@@ -38,7 +38,7 @@ simd = ["arrow/simd"]
 arrow = { package = "arrow2", git = "https://github.com/datafuse-extras/arrow2", default-features = false, features = [
     "io_parquet",
     "io_parquet_compression",
-], rev = "4cdf6ff2" }
+], rev = "2b427cf" }
 
 # Crates.io dependencies
 arrow-format = { version = "0.7.0", features = ["flight-data", "flight-service", "ipc"] }

--- a/src/common/arrow/Cargo.toml
+++ b/src/common/arrow/Cargo.toml
@@ -38,7 +38,8 @@ simd = ["arrow/simd"]
 arrow = { package = "arrow2", git = "https://github.com/datafuse-extras/arrow2", default-features = false, features = [
     "io_parquet",
     "io_parquet_compression",
-], rev = "2b427cf" }
+], rev = "ada1bf9" }
+
 
 # Crates.io dependencies
 arrow-format = { version = "0.7.0", features = ["flight-data", "flight-service", "ipc"] }

--- a/src/common/arrow/Cargo.toml
+++ b/src/common/arrow/Cargo.toml
@@ -40,7 +40,6 @@ arrow = { package = "arrow2", git = "https://github.com/datafuse-extras/arrow2",
     "io_parquet_compression",
 ], rev = "ada1bf9" }
 
-
 # Crates.io dependencies
 arrow-format = { version = "0.7.0", features = ["flight-data", "flight-service", "ipc"] }
 futures = "0.3.21"

--- a/src/common/io/src/format_settings.rs
+++ b/src/common/io/src/format_settings.rs
@@ -39,6 +39,8 @@ pub struct FormatSettings {
     pub tsv_null_bytes: Vec<u8>,
     pub json_quote_denormals: bool,
     pub json_escape_forward_slashes: bool,
+    /// parquet page size limit (in bytes, before compressed)
+    pub parquet_output_page_size: usize,
 
     pub input_buffer_size: usize,
     pub decompress_buffer_size: usize,
@@ -64,6 +66,7 @@ impl Default for FormatSettings {
             tsv_null_bytes: vec![b'\\', b'N'],
             json_quote_denormals: false,
             json_escape_forward_slashes: true,
+            parquet_output_page_size: 1024 * 1024,
             input_buffer_size: 1024 * 1024,
             decompress_buffer_size: 1024 * 1024,
             ident_case_sensitive: false,

--- a/src/query/datablocks/src/kernels/data_block_slice.rs
+++ b/src/query/datablocks/src/kernels/data_block_slice.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_datavalues::prelude::ceil;
+use common_exception::ErrorCode;
 use common_exception::Result;
 
 use crate::DataBlock;
@@ -20,6 +21,13 @@ use crate::DataBlock;
 impl DataBlock {
     pub fn split_block_by_size(block: &DataBlock, max_block_size: usize) -> Result<Vec<DataBlock>> {
         let size = block.num_rows();
+        if max_block_size == 0 {
+            return if size != 0 {
+                Err(ErrorCode::LogicalError("illegal max_block_size."))
+            } else {
+                Ok(vec![])
+            };
+        }
         let mut blocks = Vec::with_capacity(ceil(size, max_block_size));
 
         let mut offset = 0;

--- a/src/query/datablocks/src/utils.rs
+++ b/src/query/datablocks/src/utils.rs
@@ -32,7 +32,7 @@ pub fn serialize_data_blocks_with_compression(
     blocks: Vec<DataBlock>,
     schema: impl AsRef<DataSchema>,
     buf: &mut Vec<u8>,
-    chunk_size: usize,
+    data_page_size_limit: usize,
     compression: CompressionOptions,
 ) -> Result<(u64, ThriftFileMetaData)> {
     let arrow_schema = schema.as_ref().to_arrow();
@@ -41,7 +41,7 @@ pub fn serialize_data_blocks_with_compression(
         write_statistics: false,
         compression,
         version: Version::V2,
-        data_page_size_limit: chunk_size,
+        data_page_size_limit,
     };
     let batches = blocks
         .into_iter()
@@ -81,14 +81,14 @@ pub fn serialize_data_blocks_with_compression(
 pub fn serialize_data_blocks(
     blocks: Vec<DataBlock>,
     schema: impl AsRef<DataSchema>,
-    chunk_size: usize,
+    page_size_limit: usize,
     buf: &mut Vec<u8>,
 ) -> Result<(u64, ThriftFileMetaData)> {
     serialize_data_blocks_with_compression(
         blocks,
         schema,
         buf,
-        chunk_size,
+        page_size_limit,
         CompressionOptions::Lz4Raw,
     )
 }

--- a/src/query/datablocks/src/utils.rs
+++ b/src/query/datablocks/src/utils.rs
@@ -32,6 +32,7 @@ pub fn serialize_data_blocks_with_compression(
     blocks: Vec<DataBlock>,
     schema: impl AsRef<DataSchema>,
     buf: &mut Vec<u8>,
+    chunk_size: usize,
     compression: CompressionOptions,
 ) -> Result<(u64, ThriftFileMetaData)> {
     let arrow_schema = schema.as_ref().to_arrow();
@@ -40,6 +41,7 @@ pub fn serialize_data_blocks_with_compression(
         write_statistics: false,
         compression,
         version: Version::V2,
+        data_page_size_limit: chunk_size,
     };
     let batches = blocks
         .into_iter()
@@ -79,9 +81,16 @@ pub fn serialize_data_blocks_with_compression(
 pub fn serialize_data_blocks(
     blocks: Vec<DataBlock>,
     schema: impl AsRef<DataSchema>,
+    chunk_size: usize,
     buf: &mut Vec<u8>,
 ) -> Result<(u64, ThriftFileMetaData)> {
-    serialize_data_blocks_with_compression(blocks, schema, buf, CompressionOptions::Lz4Raw)
+    serialize_data_blocks_with_compression(
+        blocks,
+        schema,
+        buf,
+        chunk_size,
+        CompressionOptions::Lz4Raw,
+    )
 }
 
 fn col_encoding(_data_type: &ArrowDataType) -> Encoding {

--- a/src/query/formats/src/output_format_parquet.rs
+++ b/src/query/formats/src/output_format_parquet.rs
@@ -24,13 +24,15 @@ use crate::output_format::OutputFormat;
 pub struct ParquetOutputFormat {
     schema: DataSchemaRef,
     data_blocks: Vec<DataBlock>,
+    page_size_limit: usize,
 }
 
 impl ParquetOutputFormat {
-    pub fn create(schema: DataSchemaRef, _format_setting: FormatSettings) -> Self {
+    pub fn create(schema: DataSchemaRef, format_setting: FormatSettings) -> Self {
         Self {
             schema,
             data_blocks: vec![],
+            page_size_limit: format_setting.parquet_output_page_size,
         }
     }
 }
@@ -46,7 +48,7 @@ impl OutputFormat for ParquetOutputFormat {
         let _ = serialize_data_blocks(
             self.data_blocks.clone(),
             &self.schema,
-            1024 * 1024, // TODO
+            self.page_size_limit,
             &mut buf,
         )?;
 

--- a/src/query/formats/src/output_format_parquet.rs
+++ b/src/query/formats/src/output_format_parquet.rs
@@ -44,7 +44,7 @@ impl OutputFormat for ParquetOutputFormat {
     }
 
     fn finalize(&mut self) -> Result<Vec<u8>> {
-        let mut buf = Vec::with_capacity(100 * 1024 * 1024); // todo adjust this
+        let mut buf = Vec::with_capacity(10 * 1024 * 1024);
         let _ = serialize_data_blocks(
             self.data_blocks.clone(),
             &self.schema,

--- a/src/query/formats/src/output_format_parquet.rs
+++ b/src/query/formats/src/output_format_parquet.rs
@@ -42,8 +42,13 @@ impl OutputFormat for ParquetOutputFormat {
     }
 
     fn finalize(&mut self) -> Result<Vec<u8>> {
-        let mut buf = Vec::with_capacity(100 * 1024 * 1024);
-        let _ = serialize_data_blocks(self.data_blocks.clone(), &self.schema, &mut buf)?;
+        let mut buf = Vec::with_capacity(100 * 1024 * 1024); // todo adjust this
+        let _ = serialize_data_blocks(
+            self.data_blocks.clone(),
+            &self.schema,
+            1024 * 1024, // TODO
+            &mut buf,
+        )?;
 
         Ok(buf)
     }

--- a/src/query/service/src/storages/result/result_table.rs
+++ b/src/query/service/src/storages/result/result_table.rs
@@ -41,7 +41,7 @@ use crate::storages::result::result_locations::ResultLocations;
 use crate::storages::result::result_table_source::ResultTableSource;
 use crate::storages::Table;
 
-pub const DEFAULT_DATA_PAGE_SIZE_LIMIT: usize = 1024 * 1024;
+pub const DEFAULT_RESULT_TABLE_DATA_PAGE_SIZE_LIMIT: usize = 1024 * 1024;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "t", content = "c")]

--- a/src/query/service/src/storages/result/result_table.rs
+++ b/src/query/service/src/storages/result/result_table.rs
@@ -41,6 +41,8 @@ use crate::storages::result::result_locations::ResultLocations;
 use crate::storages::result::result_table_source::ResultTableSource;
 use crate::storages::Table;
 
+pub const DEFAULT_DATA_PAGE_SIZE_LIMIT: usize = 1024 * 1024;
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "t", content = "c")]
 pub enum ResultStorageInfo {

--- a/src/query/service/src/storages/result/result_table_sink.rs
+++ b/src/query/service/src/storages/result/result_table_sink.rs
@@ -41,6 +41,7 @@ use crate::storages::result::block_buffer::BlockInfo;
 use crate::storages::result::result_locations::ResultLocations;
 use crate::storages::result::result_table::ResultStorageInfo;
 use crate::storages::result::result_table::ResultTableMeta;
+use crate::storages::result::result_table::DEFAULT_DATA_PAGE_SIZE_LIMIT;
 use crate::storages::result::ResultQueryInfo;
 
 enum State {
@@ -177,7 +178,7 @@ impl Processor for ResultTableSink {
                 let location = self.locations.gen_block_location();
                 let block_statistics = BlockStatistics::from(&block, location.clone(), None)?;
 
-                let mut data = Vec::with_capacity(100 * 1024 * 1024);
+                let mut data = Vec::with_capacity(DEFAULT_DATA_PAGE_SIZE_LIMIT);
                 let schema = block.schema().clone();
                 let (size, meta_data) =
                     serialize_data_blocks(vec![block.clone()], &schema, 1024 * 1024, &mut data)?;

--- a/src/query/service/src/storages/result/result_table_sink.rs
+++ b/src/query/service/src/storages/result/result_table_sink.rs
@@ -41,7 +41,7 @@ use crate::storages::result::block_buffer::BlockInfo;
 use crate::storages::result::result_locations::ResultLocations;
 use crate::storages::result::result_table::ResultStorageInfo;
 use crate::storages::result::result_table::ResultTableMeta;
-use crate::storages::result::result_table::DEFAULT_DATA_PAGE_SIZE_LIMIT;
+use crate::storages::result::result_table::DEFAULT_RESULT_TABLE_DATA_PAGE_SIZE_LIMIT;
 use crate::storages::result::ResultQueryInfo;
 
 enum State {
@@ -178,10 +178,14 @@ impl Processor for ResultTableSink {
                 let location = self.locations.gen_block_location();
                 let block_statistics = BlockStatistics::from(&block, location.clone(), None)?;
 
-                let mut data = Vec::with_capacity(DEFAULT_DATA_PAGE_SIZE_LIMIT);
+                let mut data = Vec::with_capacity(10 * 1024 * 1024);
                 let schema = block.schema().clone();
-                let (size, meta_data) =
-                    serialize_data_blocks(vec![block.clone()], &schema, 1024 * 1024, &mut data)?;
+                let (size, meta_data) = serialize_data_blocks(
+                    vec![block.clone()],
+                    &schema,
+                    DEFAULT_RESULT_TABLE_DATA_PAGE_SIZE_LIMIT,
+                    &mut data,
+                )?;
 
                 let bloom_index_location = None;
                 let bloom_index_size = 0_u64;

--- a/src/query/service/src/storages/result/result_table_sink.rs
+++ b/src/query/service/src/storages/result/result_table_sink.rs
@@ -180,7 +180,7 @@ impl Processor for ResultTableSink {
                 let mut data = Vec::with_capacity(100 * 1024 * 1024);
                 let schema = block.schema().clone();
                 let (size, meta_data) =
-                    serialize_data_blocks(vec![block.clone()], &schema, &mut data)?;
+                    serialize_data_blocks(vec![block.clone()], &schema, 1024 * 1024, &mut data)?;
 
                 let bloom_index_location = None;
                 let bloom_index_size = 0_u64;

--- a/src/query/service/src/storages/result/writer.rs
+++ b/src/query/service/src/storages/result/writer.rs
@@ -100,7 +100,8 @@ impl ResultTableWriter {
         let mut data = Vec::with_capacity(100 * 1024 * 1024);
         let block_statistics = BlockStatistics::from(&block, location.clone(), None)?;
         let schema = block.schema().clone();
-        let (size, meta_data) = serialize_data_blocks(vec![block], &schema, &mut data)?;
+        let (size, meta_data) =
+            serialize_data_blocks(vec![block], &schema, 1024 * 1024, &mut data)?;
         self.data_accessor
             .object(&location)
             .write(data)

--- a/src/query/service/src/storages/result/writer.rs
+++ b/src/query/service/src/storages/result/writer.rs
@@ -32,6 +32,7 @@ use crate::storages::fuse::FuseTable;
 use crate::storages::result::result_locations::ResultLocations;
 use crate::storages::result::result_table::ResultStorageInfo;
 use crate::storages::result::result_table::ResultTableMeta;
+use crate::storages::result::result_table::DEFAULT_RESULT_TABLE_DATA_PAGE_SIZE_LIMIT;
 use crate::storages::result::ResultQueryInfo;
 
 pub struct ResultTableWriter {
@@ -100,8 +101,12 @@ impl ResultTableWriter {
         let mut data = Vec::with_capacity(100 * 1024 * 1024);
         let block_statistics = BlockStatistics::from(&block, location.clone(), None)?;
         let schema = block.schema().clone();
-        let (size, meta_data) =
-            serialize_data_blocks(vec![block], &schema, 1024 * 1024, &mut data)?;
+        let (size, meta_data) = serialize_data_blocks(
+            vec![block],
+            &schema,
+            DEFAULT_RESULT_TABLE_DATA_PAGE_SIZE_LIMIT,
+            &mut data,
+        )?;
         self.data_accessor
             .object(&location)
             .write(data)

--- a/src/query/service/tests/it/storages/fuse/io.rs
+++ b/src/query/service/tests/it/storages/fuse/io.rs
@@ -157,7 +157,7 @@ async fn test_block_writer_retry() -> Result<()> {
     let mock = Arc::new(Mock::with_exception(errors));
     let op = Operator::new(mock.clone());
     let block = DataBlock::empty();
-    let r = write_block(block, &op, "loc").await;
+    let r = write_block(block, &op, "loc", 0).await;
     assert!(r.is_err());
     let e = r.unwrap_err();
     assert_eq!(ErrorCode::storage_other_code(), e.code());

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/deletion_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/deletion_mutator.rs
@@ -93,11 +93,14 @@ async fn test_deletion_mutator_multiple_empty_segments() -> Result<()> {
     );
 
     let table_ctx: Arc<dyn TableContext> = ctx as Arc<dyn TableContext>;
+    // we do not care about chunk size in this test case, choose it arbitrarily
+    let chunk_size = 10;
     let mut mutator = DeletionMutator::try_create(
         table_ctx,
         location_generator,
         Arc::new(base_snapshot),
         ClusterStatsGenerator::default(),
+        chunk_size,
     )?;
 
     // clear half of the segments

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/deletion_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/deletion_mutator.rs
@@ -93,14 +93,14 @@ async fn test_deletion_mutator_multiple_empty_segments() -> Result<()> {
     );
 
     let table_ctx: Arc<dyn TableContext> = ctx as Arc<dyn TableContext>;
-    // we do not care about chunk size in this test case, choose it arbitrarily
-    let chunk_size = 10;
+    // we do not care about page size in this test case, choose it arbitrarily
+    let test_page_size_limit = 1024 * 1024;
     let mut mutator = DeletionMutator::try_create(
         table_ctx,
         location_generator,
         Arc::new(base_snapshot),
         ClusterStatsGenerator::default(),
-        chunk_size,
+        test_page_size_limit,
     )?;
 
     // clear half of the segments

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -155,7 +155,8 @@ async fn test_accumulator() -> common_exception::Result<()> {
         let block = item?;
         let block_statistics = BlockStatistics::from(&block, "does_not_matter".to_owned(), None)?;
         let block_writer = BlockWriter::new(&table_ctx, &operator, &loc_generator);
-        let block_meta = block_writer.write(block, None).await?;
+        let chunk_size = block.num_rows();
+        let block_meta = block_writer.write(block, None, chunk_size).await?;
         stats_acc.add_with_block_meta(block_meta, block_statistics)?;
     }
 

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -151,12 +151,12 @@ async fn test_accumulator() -> common_exception::Result<()> {
     let table_ctx: Arc<dyn TableContext> = ctx;
     let loc_generator = TableMetaLocationGenerator::with_prefix("/".to_owned());
 
+    let page_size_limit = 1024 * 1024;
     for item in blocks {
         let block = item?;
         let block_statistics = BlockStatistics::from(&block, "does_not_matter".to_owned(), None)?;
-        let block_writer = BlockWriter::new(&table_ctx, &operator, &loc_generator);
-        let chunk_size = block.num_rows();
-        let block_meta = block_writer.write(block, None, chunk_size).await?;
+        let block_writer = BlockWriter::new(&table_ctx, &operator, &loc_generator, page_size_limit);
+        let block_meta = block_writer.write(block, None).await?;
         stats_acc.add_with_block_meta(block_meta, block_statistics)?;
     }
 

--- a/src/query/storages/fuse/src/constants.rs
+++ b/src/query/storages/fuse/src/constants.rs
@@ -26,5 +26,5 @@ pub const FUSE_TBL_SNAPSHOT_PREFIX: &str = "_ss";
 pub const DEFAULT_BLOCK_PER_SEGMENT: usize = 1000;
 pub const DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD: usize = 100 * 1024 * 1024;
 pub const DEFAULT_ROW_PER_BLOCK: usize = 1000 * 1000;
-pub const DEFAULT_PAGE_SIZE_LIMIT: usize = 10000;
+pub const DEFAULT_PAGE_SIZE_LIMIT: usize = 1024 * 1024;
 pub const DEFAULT_AVG_DEPTH_THRESHOLD: f64 = 0.01;

--- a/src/query/storages/fuse/src/constants.rs
+++ b/src/query/storages/fuse/src/constants.rs
@@ -16,7 +16,7 @@ pub const FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD: &str = "block_size_threshold
 pub const FUSE_OPT_KEY_BLOCK_PER_SEGMENT: &str = "block_per_segment";
 pub const FUSE_OPT_KEY_ROW_PER_BLOCK: &str = "row_per_block";
 pub const FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD: &str = "row_avg_depth_threshold";
-pub const FUSE_OPT_KEY_CHUNK_SIZE: &str = "row_per_chunk";
+pub const FUSE_OPT_KEY_PAGE_SIZE_LIMIT: &str = "page_size_limit";
 
 pub const FUSE_TBL_BLOCK_PREFIX: &str = "_b";
 pub const FUSE_TBL_BLOCK_INDEX_PREFIX: &str = "_i";
@@ -26,5 +26,5 @@ pub const FUSE_TBL_SNAPSHOT_PREFIX: &str = "_ss";
 pub const DEFAULT_BLOCK_PER_SEGMENT: usize = 1000;
 pub const DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD: usize = 100 * 1024 * 1024;
 pub const DEFAULT_ROW_PER_BLOCK: usize = 1000 * 1000;
-pub const DEFAULT_CHUNK_SIZE: usize = 10000;
+pub const DEFAULT_PAGE_SIZE_LIMIT: usize = 10000;
 pub const DEFAULT_AVG_DEPTH_THRESHOLD: f64 = 0.01;

--- a/src/query/storages/fuse/src/constants.rs
+++ b/src/query/storages/fuse/src/constants.rs
@@ -16,6 +16,7 @@ pub const FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD: &str = "block_size_threshold
 pub const FUSE_OPT_KEY_BLOCK_PER_SEGMENT: &str = "block_per_segment";
 pub const FUSE_OPT_KEY_ROW_PER_BLOCK: &str = "row_per_block";
 pub const FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD: &str = "row_avg_depth_threshold";
+pub const FUSE_OPT_KEY_CHUNK_SIZE: &str = "row_per_chunk";
 
 pub const FUSE_TBL_BLOCK_PREFIX: &str = "_b";
 pub const FUSE_TBL_BLOCK_INDEX_PREFIX: &str = "_i";
@@ -25,4 +26,5 @@ pub const FUSE_TBL_SNAPSHOT_PREFIX: &str = "_ss";
 pub const DEFAULT_BLOCK_PER_SEGMENT: usize = 1000;
 pub const DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD: usize = 100 * 1024 * 1024;
 pub const DEFAULT_ROW_PER_BLOCK: usize = 1000 * 1000;
+pub const DEFAULT_CHUNK_SIZE: usize = 10000;
 pub const DEFAULT_AVG_DEPTH_THRESHOLD: f64 = 0.01;

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -53,10 +53,10 @@ use crate::NavigationPoint;
 use crate::Table;
 use crate::TableStatistics;
 use crate::DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD;
-use crate::DEFAULT_CHUNK_SIZE;
+use crate::DEFAULT_PAGE_SIZE_LIMIT;
 use crate::DEFAULT_ROW_PER_BLOCK;
 use crate::FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD;
-use crate::FUSE_OPT_KEY_CHUNK_SIZE;
+use crate::FUSE_OPT_KEY_PAGE_SIZE_LIMIT;
 use crate::FUSE_OPT_KEY_ROW_PER_BLOCK;
 use crate::OPT_KEY_DATABASE_ID;
 use crate::OPT_KEY_LEGACY_SNAPSHOT_LOC;
@@ -237,8 +237,8 @@ impl FuseTable {
         BlockCompactor::new(max_rows_per_block, min_rows_per_block, max_bytes_per_block)
     }
 
-    pub(crate) fn get_chunk_size(&self) -> usize {
-        self.get_option(FUSE_OPT_KEY_CHUNK_SIZE, DEFAULT_CHUNK_SIZE)
+    pub(crate) fn get_page_size_limit(&self) -> usize {
+        self.get_option(FUSE_OPT_KEY_PAGE_SIZE_LIMIT, DEFAULT_PAGE_SIZE_LIMIT)
     }
 }
 

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -53,8 +53,10 @@ use crate::NavigationPoint;
 use crate::Table;
 use crate::TableStatistics;
 use crate::DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD;
+use crate::DEFAULT_CHUNK_SIZE;
 use crate::DEFAULT_ROW_PER_BLOCK;
 use crate::FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD;
+use crate::FUSE_OPT_KEY_CHUNK_SIZE;
 use crate::FUSE_OPT_KEY_ROW_PER_BLOCK;
 use crate::OPT_KEY_DATABASE_ID;
 use crate::OPT_KEY_LEGACY_SNAPSHOT_LOC;
@@ -233,6 +235,10 @@ impl FuseTable {
             DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD,
         );
         BlockCompactor::new(max_rows_per_block, min_rows_per_block, max_bytes_per_block)
+    }
+
+    pub(crate) fn get_chunk_size(&self) -> usize {
+        self.get_option(FUSE_OPT_KEY_CHUNK_SIZE, DEFAULT_CHUNK_SIZE)
     }
 }
 

--- a/src/query/storages/fuse/src/io/read/block_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block_reader.rs
@@ -25,7 +25,6 @@ use common_arrow::arrow::io::parquet::write::to_parquet_schema;
 use common_arrow::parquet::compression::Compression as ParquetCompression;
 use common_arrow::parquet::metadata::ColumnDescriptor;
 use common_arrow::parquet::metadata::SchemaDescriptor;
-// use common_arrow::parquet::read::BasicDecompressor;
 use common_arrow::parquet::read::Decompressor;
 use common_arrow::parquet::read::PageMetaData;
 use common_arrow::parquet::read::PageReader;
@@ -112,7 +111,6 @@ impl BlockReader {
                     Arc::new(|_, _| true),
                     vec![],
                 );
-                // BasicDecompressor::new(pages, vec![])
                 Decompressor::new(pages, vec![])
             })
             .collect::<Vec<_>>();

--- a/src/query/storages/fuse/src/io/read/block_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block_reader.rs
@@ -25,7 +25,8 @@ use common_arrow::arrow::io::parquet::write::to_parquet_schema;
 use common_arrow::parquet::compression::Compression as ParquetCompression;
 use common_arrow::parquet::metadata::ColumnDescriptor;
 use common_arrow::parquet::metadata::SchemaDescriptor;
-use common_arrow::parquet::read::BasicDecompressor;
+// use common_arrow::parquet::read::BasicDecompressor;
+use common_arrow::parquet::read::Decompressor;
 use common_arrow::parquet::read::PageMetaData;
 use common_arrow::parquet::read::PageReader;
 use common_datablocks::DataBlock;
@@ -111,7 +112,8 @@ impl BlockReader {
                     Arc::new(|_, _| true),
                     vec![],
                 );
-                BasicDecompressor::new(pages, vec![])
+                // BasicDecompressor::new(pages, vec![])
+                Decompressor::new(pages, vec![])
             })
             .collect::<Vec<_>>();
 

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -33,9 +33,9 @@ use crate::operations::FuseTableSink;
 use crate::statistics::ClusterStatsGenerator;
 use crate::FuseTable;
 use crate::DEFAULT_BLOCK_PER_SEGMENT;
-use crate::DEFAULT_CHUNK_SIZE;
+use crate::DEFAULT_PAGE_SIZE_LIMIT;
 use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
-use crate::FUSE_OPT_KEY_CHUNK_SIZE;
+use crate::FUSE_OPT_KEY_PAGE_SIZE_LIMIT;
 
 impl FuseTable {
     pub fn do_append2(&self, ctx: Arc<dyn TableContext>, pipeline: &mut Pipeline) -> Result<()> {
@@ -77,7 +77,7 @@ impl FuseTable {
 
         let da = ctx.get_storage_operator()?;
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
-        let chunk_size = self.get_option(FUSE_OPT_KEY_CHUNK_SIZE, DEFAULT_CHUNK_SIZE);
+        let chunk_size = self.get_option(FUSE_OPT_KEY_PAGE_SIZE_LIMIT, DEFAULT_PAGE_SIZE_LIMIT);
         for _ in 0..pipeline.output_len() {
             let input_port = InputPort::create();
             sink_pipeline_builder.add_sink(

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -33,7 +33,9 @@ use crate::operations::FuseTableSink;
 use crate::statistics::ClusterStatsGenerator;
 use crate::FuseTable;
 use crate::DEFAULT_BLOCK_PER_SEGMENT;
+use crate::DEFAULT_CHUNK_SIZE;
 use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
+use crate::FUSE_OPT_KEY_CHUNK_SIZE;
 
 impl FuseTable {
     pub fn do_append2(&self, ctx: Arc<dyn TableContext>, pipeline: &mut Pipeline) -> Result<()> {
@@ -75,6 +77,7 @@ impl FuseTable {
 
         let da = ctx.get_storage_operator()?;
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
+        let chunk_size = self.get_option(FUSE_OPT_KEY_CHUNK_SIZE, DEFAULT_CHUNK_SIZE);
         for _ in 0..pipeline.output_len() {
             let input_port = InputPort::create();
             sink_pipeline_builder.add_sink(
@@ -86,6 +89,7 @@ impl FuseTable {
                     da.clone(),
                     self.meta_location_generator().clone(),
                     cluster_stats_gen.clone(),
+                    chunk_size,
                 )?,
             );
         }

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -100,7 +100,7 @@ impl FuseTable {
         })?;
 
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
-        let chunk_size = self.get_chunk_size();
+        let page_size_limit = self.get_page_size_limit();
         for _ in 0..pipeline.output_len() {
             let input_port = InputPort::create();
             sink_pipeline_builder.add_sink(
@@ -112,7 +112,7 @@ impl FuseTable {
                     mutator.get_storage_operator(),
                     self.meta_location_generator().clone(),
                     ClusterStatsGenerator::default(),
-                    chunk_size,
+                    page_size_limit,
                 )?,
             );
         }

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -100,6 +100,7 @@ impl FuseTable {
         })?;
 
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
+        let chunk_size = self.get_chunk_size();
         for _ in 0..pipeline.output_len() {
             let input_port = InputPort::create();
             sink_pipeline_builder.add_sink(
@@ -111,6 +112,7 @@ impl FuseTable {
                     mutator.get_storage_operator(),
                     self.meta_location_generator().clone(),
                     ClusterStatsGenerator::default(),
+                    chunk_size,
                 )?,
             );
         }

--- a/src/query/storages/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/src/operations/delete.rs
@@ -72,11 +72,13 @@ impl FuseTable {
         plan: &DeletePlan,
     ) -> Result<()> {
         let cluster_stats_gen = self.cluster_stats_gen(ctx.clone())?;
+        let chunk_size = self.get_chunk_size();
         let mut deletion_collector = DeletionMutator::try_create(
             ctx.clone(),
             self.meta_location_generator.clone(),
             snapshot.clone(),
             cluster_stats_gen,
+            chunk_size,
         )?;
         let schema = self.table_info.schema();
         // TODO refine pruner

--- a/src/query/storages/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/src/operations/delete.rs
@@ -72,13 +72,13 @@ impl FuseTable {
         plan: &DeletePlan,
     ) -> Result<()> {
         let cluster_stats_gen = self.cluster_stats_gen(ctx.clone())?;
-        let chunk_size = self.get_chunk_size();
+        let page_size_limit = self.get_page_size_limit();
         let mut deletion_collector = DeletionMutator::try_create(
             ctx.clone(),
             self.meta_location_generator.clone(),
             snapshot.clone(),
             cluster_stats_gen,
-            chunk_size,
+            page_size_limit,
         )?;
         let schema = self.table_info.schema();
         // TODO refine pruner

--- a/src/query/storages/fuse/src/operations/fuse_sink.rs
+++ b/src/query/storages/fuse/src/operations/fuse_sink.rs
@@ -75,7 +75,7 @@ pub struct FuseTableSink {
     meta_locations: TableMetaLocationGenerator,
     accumulator: StatisticsAccumulator,
     cluster_stats_gen: ClusterStatsGenerator,
-    chunk_size: usize,
+    page_size_limit: usize,
 }
 
 impl FuseTableSink {
@@ -86,7 +86,7 @@ impl FuseTableSink {
         data_accessor: Operator,
         meta_locations: TableMetaLocationGenerator,
         cluster_stats_gen: ClusterStatsGenerator,
-        chunk_size: usize,
+        page_size_limit: usize,
     ) -> Result<ProcessorPtr> {
         Ok(ProcessorPtr::create(Box::new(FuseTableSink {
             ctx,
@@ -97,7 +97,7 @@ impl FuseTableSink {
             accumulator: Default::default(),
             num_block_threshold: num_block_threshold as u64,
             cluster_stats_gen,
-            chunk_size,
+            page_size_limit,
         })))
     }
 }
@@ -181,7 +181,7 @@ impl Processor for FuseTableSink {
                 let mut data = Vec::with_capacity(100 * 1024 * 1024);
                 let schema = block.schema().clone();
                 let (size, meta_data) =
-                    serialize_data_blocks(vec![block], &schema, self.chunk_size, &mut data)?;
+                    serialize_data_blocks(vec![block], &schema, self.page_size_limit, &mut data)?;
 
                 self.state = State::Serialized {
                     data,

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -180,7 +180,7 @@ impl FuseTable {
 
         let da = ctx.get_storage_operator()?;
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
-        let chunk_size = self.get_chunk_size();
+        let page_size_limit = self.get_page_size_limit();
         for _ in 0..pipeline.output_len() {
             let input_port = InputPort::create();
             sink_pipeline_builder.add_sink(
@@ -192,7 +192,7 @@ impl FuseTable {
                     da.clone(),
                     self.meta_location_generator().clone(),
                     cluster_stats_gen.clone(),
-                    chunk_size,
+                    page_size_limit,
                 )?,
             );
         }

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -180,6 +180,7 @@ impl FuseTable {
 
         let da = ctx.get_storage_operator()?;
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
+        let chunk_size = self.get_chunk_size();
         for _ in 0..pipeline.output_len() {
             let input_port = InputPort::create();
             sink_pipeline_builder.add_sink(
@@ -191,6 +192,7 @@ impl FuseTable {
                     da.clone(),
                     self.meta_location_generator().clone(),
                     cluster_stats_gen.clone(),
+                    chunk_size,
                 )?,
             );
         }

--- a/src/query/storages/preludes/src/system/configs_table.rs
+++ b/src/query/storages/preludes/src/system/configs_table.rs
@@ -101,6 +101,8 @@ impl SyncSystemTable for ConfigsTable {
             storage_config_value,
         );
 
+        // jemalloc config/opts
+
         let names: Vec<&str> = names.iter().map(|x| x.as_str()).collect();
         let values: Vec<&str> = values.iter().map(|x| x.as_str()).collect();
         let groups: Vec<&str> = groups.iter().map(|x| x.as_str()).collect();

--- a/src/query/storages/preludes/src/system/configs_table.rs
+++ b/src/query/storages/preludes/src/system/configs_table.rs
@@ -101,8 +101,6 @@ impl SyncSystemTable for ConfigsTable {
             storage_config_value,
         );
 
-        // jemalloc config/opts
-
         let names: Vec<&str> = names.iter().map(|x| x.as_str()).collect();
         let values: Vec<&str> = values.iter().map(|x| x.as_str()).collect();
         let groups: Vec<&str> = groups.iter().map(|x| x.as_str()).collect();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- During writing `DataBlock` to object storage, split `DataBlock` into multiple pages if row numbers of the data block exceed the given threshold.
  so that
  - data could be deserialized into smaller chunks and passed to computing components early
  - peak memory usage is likely to be lesser



A simple test with local fs backend verified the above assumptions:

 TODO: desc of test scenario

<del>
- multi pages (oversize_threshold:0, max row per page, 10_000 rows)

  ~~~
  Time (mean ± σ):     849.3 ms ±  26.0 ms    [User: 2.2 ms, System: 1.3 ms]
  Range (min … max):   795.2 ms … 927.4 ms    100 runs
  ~~~

- single page(oversize_threshold:0)

  ~~~
   Time (mean ± σ):      1.160 s ±  0.131 s    [User: 0.003 s, System: 0.001 s]
   Range (min … max):    0.908 s …  1.342 s    100 runs
  ~~~
</del>

NOTE: 
- Reading of column pages is still in one-go （to better utilize the high bandwidth of object storage service)
- need further perf (with s3 backend and other test data set)

Fixes #issue
