### PR TITLE
fix(planner): Validate duplicated column name when creating table

### DIFF
--- a/tests/logictest/suites/base/05_ddl/05_0000_ddl_create_tables
+++ b/tests/logictest/suites/base/05_ddl/05_0000_ddl_create_tables
@@ -218,3 +218,17 @@ DROP DATABASE db2;
 statement error 1002
 CREATE TABLE system.test(a INT);
 
+statement ok
+drop table if exists t;
+
+statement error Duplicated column name
+create table t(a int, a int);
+
+statement error Duplicated column name
+create table t(a int, A int);
+
+statement error Duplicated column name
+create table t("A" int, "A" int);
+
+statement error Duplicated column name
+create table t as select number, number from numbers(1);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fixes #7247 