### PR TITLE
refactor(parser): improve parsing speed

### DIFF
--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -196,23 +196,6 @@ pub enum Expr<'a> {
         unit: IntervalKind,
         date: Box<Expr<'a>>,
     },
-    /// NULLIF(<expr>, <expr>)
-    NullIf {
-        span: &'a [Token<'a>],
-        expr1: Box<Expr<'a>>,
-        expr2: Box<Expr<'a>>,
-    },
-    // Coalesce(<expr>, <expr>, ...)
-    Coalesce {
-        span: &'a [Token<'a>],
-        exprs: Vec<Expr<'a>>,
-    },
-    /// IFNULL(<expr>, <expr>)
-    IfNull {
-        span: &'a [Token<'a>],
-        expr1: Box<Expr<'a>>,
-        expr2: Box<Expr<'a>>,
-    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -377,10 +360,7 @@ impl<'a> Expr<'a> {
             | Expr::Interval { span, .. }
             | Expr::DateAdd { span, .. }
             | Expr::DateSub { span, .. }
-            | Expr::DateTrunc { span, .. }
-            | Expr::NullIf { span, .. }
-            | Expr::Coalesce { span, .. }
-            | Expr::IfNull { span, .. } => span,
+            | Expr::DateTrunc { span, .. } => span,
         }
     }
 }
@@ -867,17 +847,6 @@ impl<'a> Display for Expr<'a> {
             }
             Expr::DateTrunc { unit, date, .. } => {
                 write!(f, "DATE_TRUNC({unit}, {date})")?;
-            }
-            Expr::NullIf { expr1, expr2, .. } => {
-                write!(f, "NULLIF({expr1}, {expr2})")?;
-            }
-            Expr::Coalesce { exprs, .. } => {
-                write!(f, "COALESCE(")?;
-                write_comma_separated_list(f, exprs)?;
-                write!(f, ")")?;
-            }
-            Expr::IfNull { expr1, expr2, .. } => {
-                write!(f, "IFNULL({expr1}, {expr2})")?;
             }
         }
 

--- a/src/query/ast/src/ast/format/ast_format.rs
+++ b/src/query/ast/src/ast/format/ast_format.rs
@@ -662,52 +662,6 @@ impl<'ast> Visitor<'ast> for AstFormatVisitor {
         self.children.push(node);
     }
 
-    fn visit_nullif(
-        &mut self,
-        _span: &'ast [Token<'ast>],
-        expr1: &'ast Expr<'ast>,
-        expr2: &'ast Expr<'ast>,
-    ) {
-        self.visit_expr(expr1);
-        let expr_child1 = self.children.pop().unwrap();
-        self.visit_expr(expr2);
-        let expr_child2 = self.children.pop().unwrap();
-
-        let name = "Function NullIf".to_string();
-        let format_ctx = AstFormatContext::with_children(name, 2);
-        let node = FormatTreeNode::with_children(format_ctx, vec![expr_child1, expr_child2]);
-        self.children.push(node);
-    }
-
-    fn visit_coalesce(&mut self, _span: &'ast [Token<'ast>], exprs: &'ast [Expr<'ast>]) {
-        let mut children = Vec::with_capacity(exprs.len());
-        for expr in exprs.iter() {
-            self.visit_expr(expr);
-            children.push(self.children.pop().unwrap());
-        }
-        let name = "Function Coalesce".to_string();
-        let format_ctx = AstFormatContext::with_children(name, children.len());
-        let node = FormatTreeNode::with_children(format_ctx, children);
-        self.children.push(node);
-    }
-
-    fn visit_ifnull(
-        &mut self,
-        _span: &'ast [Token<'ast>],
-        expr1: &'ast Expr<'ast>,
-        expr2: &'ast Expr<'ast>,
-    ) {
-        self.visit_expr(expr1);
-        let expr_child1 = self.children.pop().unwrap();
-        self.visit_expr(expr2);
-        let expr_child2 = self.children.pop().unwrap();
-
-        let name = "Function IfNull".to_string();
-        let format_ctx = AstFormatContext::with_children(name, 2);
-        let node = FormatTreeNode::with_children(format_ctx, vec![expr_child1, expr_child2]);
-        self.children.push(node);
-    }
-
     fn visit_query(&mut self, query: &'ast Query<'ast>) {
         let mut children = Vec::new();
         if let Some(with) = &query.with {

--- a/src/query/ast/src/ast/format/syntax/expr.rs
+++ b/src/query/ast/src/ast/format/syntax/expr.rs
@@ -353,20 +353,5 @@ pub(crate) fn pretty_expr(expr: Expr) -> RcDoc {
             .append(RcDoc::space())
             .append(pretty_expr(*date))
             .append(RcDoc::text(")")),
-        Expr::NullIf { expr1, expr2, .. } => RcDoc::text("NULLIF(")
-            .append(pretty_expr(*expr1))
-            .append(RcDoc::text(","))
-            .append(RcDoc::space())
-            .append(pretty_expr(*expr2))
-            .append(RcDoc::text(")")),
-        Expr::Coalesce { exprs, .. } => RcDoc::text("COALESCE(")
-            .append(inline_comma(exprs.into_iter().map(pretty_expr)))
-            .append(RcDoc::text(")")),
-        Expr::IfNull { expr1, expr2, .. } => RcDoc::text("IFNULL(")
-            .append(pretty_expr(*expr1))
-            .append(RcDoc::text(","))
-            .append(RcDoc::space())
-            .append(pretty_expr(*expr2))
-            .append(RcDoc::text(")")),
     }
 }

--- a/src/query/ast/src/ast/mod.rs
+++ b/src/query/ast/src/ast/mod.rs
@@ -36,7 +36,7 @@ pub struct Identifier<'a> {
 }
 
 impl<'a> Identifier<'a> {
-    pub fn quoted(&self) -> bool {
+    pub fn is_quoted(&self) -> bool {
         self.quote.is_some()
     }
 }

--- a/src/query/ast/src/ast/query.rs
+++ b/src/query/ast/src/ast/query.rs
@@ -154,17 +154,17 @@ pub enum TableReference<'a> {
         alias: Option<TableAlias<'a>>,
         travel_point: Option<TimeTravelPoint<'a>>,
     },
-    // Derived table, which can be a subquery or joined tables or combination of them
-    Subquery {
-        span: &'a [Token<'a>],
-        subquery: Box<Query<'a>>,
-        alias: Option<TableAlias<'a>>,
-    },
     // `TABLE(expr)[ AS alias ]`
     TableFunction {
         span: &'a [Token<'a>],
         name: Identifier<'a>,
         params: Vec<Expr<'a>>,
+        alias: Option<TableAlias<'a>>,
+    },
+    // Derived table, which can be a subquery or joined tables or combination of them
+    Subquery {
+        span: &'a [Token<'a>],
+        subquery: Box<Query<'a>>,
         alias: Option<TableAlias<'a>>,
     },
     Join {
@@ -267,16 +267,6 @@ impl<'a> Display for TableReference<'a> {
                     write!(f, " AS {alias}")?;
                 }
             }
-            TableReference::Subquery {
-                span: _,
-                subquery,
-                alias,
-            } => {
-                write!(f, "({subquery})")?;
-                if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
-                }
-            }
             TableReference::TableFunction {
                 span: _,
                 name,
@@ -286,6 +276,16 @@ impl<'a> Display for TableReference<'a> {
                 write!(f, "{name}(")?;
                 write_comma_separated_list(f, params)?;
                 write!(f, ")")?;
+                if let Some(alias) = alias {
+                    write!(f, " AS {alias}")?;
+                }
+            }
+            TableReference::Subquery {
+                span: _,
+                subquery,
+                alias,
+            } => {
+                write!(f, "({subquery})")?;
                 if let Some(alias) = alias {
                     write!(f, " AS {alias}")?;
                 }

--- a/src/query/ast/src/error.rs
+++ b/src/query/ast/src/error.rs
@@ -20,8 +20,6 @@ use std::num::ParseIntError;
 
 use itertools::Itertools;
 use logos::Span;
-use pratt::NoError;
-use pratt::PrattError;
 
 use crate::input::Input;
 use crate::parser::token::*;
@@ -316,25 +314,4 @@ fn pretty_print_error(source: &str, lables: Vec<(Span, String)>) -> String {
     std::str::from_utf8(&writer.into_inner())
         .unwrap()
         .to_string()
-}
-
-impl<T: std::fmt::Debug> From<PrattError<T, pratt::NoError>> for ErrorKind {
-    fn from(err: PrattError<T, NoError>) -> Self {
-        match err {
-            PrattError::EmptyInput => ErrorKind::Other("expected more tokens for expression"),
-            PrattError::UnexpectedNilfix(_) => {
-                ErrorKind::Other("unable to parse the expression value")
-            }
-            PrattError::UnexpectedPrefix(_) => {
-                ErrorKind::Other("unable to parse the prefix operator")
-            }
-            PrattError::UnexpectedInfix(_) => {
-                ErrorKind::Other("unable to parse the binary operator")
-            }
-            PrattError::UnexpectedPostfix(_) => {
-                ErrorKind::Other("unable to parse the postfix operator")
-            }
-            PrattError::UserError(_) => unreachable!(),
-        }
-    }
 }

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -810,7 +810,7 @@ impl TokenKind {
             | TokenKind::CASE
             | TokenKind::CAST
             // | TokenKind::CHECK
-            | TokenKind::COALESCE
+            // | TokenKind::COALESCE
             // | TokenKind::COLLATE
             // | TokenKind::COLUMN
             // | TokenKind::CONSTRAINT
@@ -836,7 +836,7 @@ impl TokenKind {
             // | TokenKind::FOREIGN
             // | TokenKind::GREATEST
             // | TokenKind::GROUPING
-            | TokenKind::IFNULL
+            // | TokenKind::IFNULL
             | TokenKind::IN
             // | TokenKind::INITIALLY
             // | TokenKind::INOUT
@@ -854,7 +854,7 @@ impl TokenKind {
             // | TokenKind::NORMALIZE
             | TokenKind::NOT
             | TokenKind::NULL
-            | TokenKind::NULLIF
+            // | TokenKind::NULLIF
             // | TokenKind::NUMERIC
             // | TokenKind::ONLY
             | TokenKind::OR

--- a/src/query/ast/src/visitors/visitor.rs
+++ b/src/query/ast/src/visitors/visitor.rs
@@ -336,32 +336,6 @@ pub trait Visitor<'ast>: Sized {
         walk_expr(self, date);
     }
 
-    fn visit_nullif(
-        &mut self,
-        _span: &'ast [Token<'ast>],
-        expr1: &'ast Expr<'ast>,
-        expr2: &'ast Expr<'ast>,
-    ) {
-        walk_expr(self, expr1);
-        walk_expr(self, expr2);
-    }
-
-    fn visit_coalesce(&mut self, _span: &'ast [Token<'ast>], exprs: &'ast [Expr<'ast>]) {
-        for expr in exprs {
-            walk_expr(self, expr);
-        }
-    }
-
-    fn visit_ifnull(
-        &mut self,
-        _span: &'ast [Token<'ast>],
-        expr1: &'ast Expr<'ast>,
-        expr2: &'ast Expr<'ast>,
-    ) {
-        walk_expr(self, expr1);
-        walk_expr(self, expr2);
-    }
-
     fn visit_statement(&mut self, statement: &'ast Statement<'ast>) {
         walk_statement(self, statement);
     }

--- a/src/query/ast/src/visitors/visitor_mut.rs
+++ b/src/query/ast/src/visitors/visitor_mut.rs
@@ -340,32 +340,6 @@ pub trait VisitorMut: Sized {
         walk_expr_mut(self, date);
     }
 
-    fn visit_nullif(
-        &mut self,
-        _span: &mut &[Token<'_>],
-        expr1: &mut Expr<'_>,
-        expr2: &mut Expr<'_>,
-    ) {
-        walk_expr_mut(self, expr1);
-        walk_expr_mut(self, expr2);
-    }
-
-    fn visit_coalesce(&mut self, _span: &mut &[Token<'_>], exprs: &mut [Expr<'_>]) {
-        for expr in exprs.iter_mut() {
-            walk_expr_mut(self, expr);
-        }
-    }
-
-    fn visit_ifnull(
-        &mut self,
-        _span: &mut &[Token<'_>],
-        expr1: &mut Expr<'_>,
-        expr2: &mut Expr<'_>,
-    ) {
-        walk_expr_mut(self, expr1);
-        walk_expr_mut(self, expr2);
-    }
-
     fn visit_statement(&mut self, statement: &mut Statement<'_>) {
         walk_statement_mut(self, statement);
     }

--- a/src/query/ast/src/visitors/walk.rs
+++ b/src/query/ast/src/visitors/walk.rs
@@ -131,9 +131,6 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expr: &'a Expr<'a>) {
             unit,
         } => visitor.visit_date_sub(span, unit, interval, date),
         Expr::DateTrunc { span, unit, date } => visitor.visit_date_trunc(span, unit, date),
-        Expr::NullIf { span, expr1, expr2 } => visitor.visit_nullif(span, expr1, expr2),
-        Expr::Coalesce { span, exprs } => visitor.visit_coalesce(span, exprs),
-        Expr::IfNull { span, expr1, expr2 } => visitor.visit_ifnull(span, expr1, expr2),
     }
 }
 

--- a/src/query/ast/src/visitors/walk_mut.rs
+++ b/src/query/ast/src/visitors/walk_mut.rs
@@ -131,9 +131,6 @@ pub fn walk_expr_mut<'a, V: VisitorMut>(visitor: &mut V, expr: &mut Expr<'a>) {
             unit,
         } => visitor.visit_date_sub(span, unit, interval, date),
         Expr::DateTrunc { span, unit, date } => visitor.visit_date_trunc(span, unit, date),
-        Expr::IfNull { span, expr1, expr2 } => visitor.visit_ifnull(span, expr1, expr2),
-        Expr::NullIf { span, expr1, expr2 } => visitor.visit_nullif(span, expr1, expr2),
-        Expr::Coalesce { span, exprs } => visitor.visit_coalesce(span, exprs),
     }
 }
 

--- a/src/query/ast/tests/it/testdata/expr-error.txt
+++ b/src/query/ast/tests/it/testdata/expr-error.txt
@@ -2,12 +2,12 @@
 5 * (a and ) 1
 ---------- Output ---------
 error: 
-  --> SQL:1:12
+  --> SQL:1:8
   |
 1 | 5 * (a and ) 1
-  | -   -      ^ expected more tokens for expression
-  | |   |       
-  | |   while parsing `(<expr> [,] [...])`
+  | -   -  ^^^ expecting more subsequent tokens
+  | |   |   
+  | |   while parsing `(<expr> [, ...])`
   | while parsing expression
 
 
@@ -15,10 +15,10 @@ error:
 a + +
 ---------- Output ---------
 error: 
-  --> SQL:1:6
+  --> SQL:1:5
   |
 1 | a + +
-  | -    ^ expected more tokens for expression
+  | -   ^ expecting more subsequent tokens
   | |    
   | while parsing expression
 
@@ -55,7 +55,7 @@ error:
   --> SQL:1:10
   |
 1 | CAST(col1)
-  | ----     ^ expected `AS`, `,`, `(`, `.`, `IS`, `NOT`, or 57 more ...
+  | ----     ^ expected `AS`, `,`, `(`, `.`, `IS`, `NOT`, or 54 more ...
   | |         
   | while parsing `CAST(... AS ...)`
   | while parsing expression

--- a/src/query/ast/tests/it/testdata/expr.txt
+++ b/src/query/ast/tests/it/testdata/expr.txt
@@ -2615,9 +2615,9 @@ BinaryOp {
 ---------- Input ----------
 nullif(1, 1)
 ---------- Output ---------
-NULLIF(1, 1)
+nullif(1, 1)
 ---------- AST ------------
-NullIf {
+FunctionCall {
     span: [
         NULLIF(0..6),
         LParen(6..7),
@@ -2626,31 +2626,40 @@ NullIf {
         LiteralInteger(10..11),
         RParen(11..12),
     ],
-    expr1: Literal {
-        span: [
-            LiteralInteger(7..8),
-        ],
-        lit: Integer(
-            1,
-        ),
+    distinct: false,
+    name: Identifier {
+        name: "nullif",
+        quote: None,
+        span: NULLIF(0..6),
     },
-    expr2: Literal {
-        span: [
-            LiteralInteger(10..11),
-        ],
-        lit: Integer(
-            1,
-        ),
-    },
+    args: [
+        Literal {
+            span: [
+                LiteralInteger(7..8),
+            ],
+            lit: Integer(
+                1,
+            ),
+        },
+        Literal {
+            span: [
+                LiteralInteger(10..11),
+            ],
+            lit: Integer(
+                1,
+            ),
+        },
+    ],
+    params: [],
 }
 
 
 ---------- Input ----------
 nullif(a, b)
 ---------- Output ---------
-NULLIF(a, b)
+nullif(a, b)
 ---------- AST ------------
-NullIf {
+FunctionCall {
     span: [
         NULLIF(0..6),
         LParen(6..7),
@@ -2659,39 +2668,48 @@ NullIf {
         Ident(10..11),
         RParen(11..12),
     ],
-    expr1: ColumnRef {
-        span: [
-            Ident(7..8),
-        ],
-        database: None,
-        table: None,
-        column: Identifier {
-            name: "a",
-            quote: None,
-            span: Ident(7..8),
-        },
+    distinct: false,
+    name: Identifier {
+        name: "nullif",
+        quote: None,
+        span: NULLIF(0..6),
     },
-    expr2: ColumnRef {
-        span: [
-            Ident(10..11),
-        ],
-        database: None,
-        table: None,
-        column: Identifier {
-            name: "b",
-            quote: None,
-            span: Ident(10..11),
+    args: [
+        ColumnRef {
+            span: [
+                Ident(7..8),
+            ],
+            database: None,
+            table: None,
+            column: Identifier {
+                name: "a",
+                quote: None,
+                span: Ident(7..8),
+            },
         },
-    },
+        ColumnRef {
+            span: [
+                Ident(10..11),
+            ],
+            database: None,
+            table: None,
+            column: Identifier {
+                name: "b",
+                quote: None,
+                span: Ident(10..11),
+            },
+        },
+    ],
+    params: [],
 }
 
 
 ---------- Input ----------
 coalesce(1, 2, 3)
 ---------- Output ---------
-COALESCE(1, 2, 3)
+coalesce(1, 2, 3)
 ---------- AST ------------
-Coalesce {
+FunctionCall {
     span: [
         COALESCE(0..8),
         LParen(8..9),
@@ -2702,7 +2720,13 @@ Coalesce {
         LiteralInteger(15..16),
         RParen(16..17),
     ],
-    exprs: [
+    distinct: false,
+    name: Identifier {
+        name: "coalesce",
+        quote: None,
+        span: COALESCE(0..8),
+    },
+    args: [
         Literal {
             span: [
                 LiteralInteger(9..10),
@@ -2728,15 +2752,16 @@ Coalesce {
             ),
         },
     ],
+    params: [],
 }
 
 
 ---------- Input ----------
 coalesce(a, b, c)
 ---------- Output ---------
-COALESCE(a, b, c)
+coalesce(a, b, c)
 ---------- AST ------------
-Coalesce {
+FunctionCall {
     span: [
         COALESCE(0..8),
         LParen(8..9),
@@ -2747,7 +2772,13 @@ Coalesce {
         Ident(15..16),
         RParen(16..17),
     ],
-    exprs: [
+    distinct: false,
+    name: Identifier {
+        name: "coalesce",
+        quote: None,
+        span: COALESCE(0..8),
+    },
+    args: [
         ColumnRef {
             span: [
                 Ident(9..10),
@@ -2785,15 +2816,16 @@ Coalesce {
             },
         },
     ],
+    params: [],
 }
 
 
 ---------- Input ----------
 ifnull(1, 1)
 ---------- Output ---------
-IFNULL(1, 1)
+ifnull(1, 1)
 ---------- AST ------------
-IfNull {
+FunctionCall {
     span: [
         IFNULL(0..6),
         LParen(6..7),
@@ -2802,31 +2834,40 @@ IfNull {
         LiteralInteger(10..11),
         RParen(11..12),
     ],
-    expr1: Literal {
-        span: [
-            LiteralInteger(7..8),
-        ],
-        lit: Integer(
-            1,
-        ),
+    distinct: false,
+    name: Identifier {
+        name: "ifnull",
+        quote: None,
+        span: IFNULL(0..6),
     },
-    expr2: Literal {
-        span: [
-            LiteralInteger(10..11),
-        ],
-        lit: Integer(
-            1,
-        ),
-    },
+    args: [
+        Literal {
+            span: [
+                LiteralInteger(7..8),
+            ],
+            lit: Integer(
+                1,
+            ),
+        },
+        Literal {
+            span: [
+                LiteralInteger(10..11),
+            ],
+            lit: Integer(
+                1,
+            ),
+        },
+    ],
+    params: [],
 }
 
 
 ---------- Input ----------
 ifnull(a, b)
 ---------- Output ---------
-IFNULL(a, b)
+ifnull(a, b)
 ---------- AST ------------
-IfNull {
+FunctionCall {
     span: [
         IFNULL(0..6),
         LParen(6..7),
@@ -2835,30 +2876,39 @@ IfNull {
         Ident(10..11),
         RParen(11..12),
     ],
-    expr1: ColumnRef {
-        span: [
-            Ident(7..8),
-        ],
-        database: None,
-        table: None,
-        column: Identifier {
-            name: "a",
-            quote: None,
-            span: Ident(7..8),
-        },
+    distinct: false,
+    name: Identifier {
+        name: "ifnull",
+        quote: None,
+        span: IFNULL(0..6),
     },
-    expr2: ColumnRef {
-        span: [
-            Ident(10..11),
-        ],
-        database: None,
-        table: None,
-        column: Identifier {
-            name: "b",
-            quote: None,
-            span: Ident(10..11),
+    args: [
+        ColumnRef {
+            span: [
+                Ident(7..8),
+            ],
+            database: None,
+            table: None,
+            column: Identifier {
+                name: "a",
+                quote: None,
+                span: Ident(7..8),
+            },
         },
-    },
+        ColumnRef {
+            span: [
+                Ident(10..11),
+            ],
+            database: None,
+            table: None,
+            column: Identifier {
+                name: "b",
+                quote: None,
+                span: Ident(10..11),
+            },
+        },
+    ],
+    params: [],
 }
 
 

--- a/src/query/ast/tests/it/testdata/query-error.txt
+++ b/src/query/ast/tests/it/testdata/query-error.txt
@@ -2,10 +2,12 @@
 select * from customer join where a = b
 ---------- Output ---------
 error: 
-  --> SQL:1:29
+  --> SQL:1:24
   |
 1 | select * from customer join where a = b
-  |                             ^^^^^ expected `(`, `WITH`, `UNION`, `EXCEPT`, `INTERSECT`, `SELECT`, or 2 more ...
+  | ------                 ^^^^ expecting more subsequent tokens
+  | |                       
+  | while parsing `SELECT ...`
 
 
 ---------- Input ----------
@@ -15,7 +17,7 @@ error:
   --> SQL:1:15
   |
 1 | select * from join customer
-  | ------        ^^^^ expected `(`, `UNION`, `EXCEPT`, `INTERSECT`, `SELECT`, <Ident>, or 2 more ...
+  | ------        ^^^^ missing lhs or rhs for the binary operator
   | |              
   | while parsing `SELECT ...`
 
@@ -27,7 +29,9 @@ error:
   --> SQL:1:50
   |
 1 | select * from customer natural inner join orders on a = b
-  |                                                  ^^ expected `(`, `.`, `AT`, <Ident>, <QuotedString>, `AS`, or 19 more ...
+  | ------                                           ^^ join condition conflicting with NATURAL
+  | |                                                 
+  | while parsing `SELECT ...`
 
 
 ---------- Input ----------

--- a/src/query/ast/tests/it/testdata/query.txt
+++ b/src/query/ast/tests/it/testdata/query.txt
@@ -119,10 +119,8 @@ Query {
             from: [
                 Join {
                     span: [
-                        Ident(14..22),
                         INNER(23..28),
                         JOIN(29..33),
-                        Ident(34..40),
                     ],
                     join: Join {
                         op: Inner,
@@ -208,10 +206,8 @@ Query {
             from: [
                 Join {
                     span: [
-                        Ident(14..22),
                         CROSS(23..28),
                         JOIN(29..33),
-                        Ident(34..40),
                     ],
                     join: Join {
                         op: CrossJoin,
@@ -307,14 +303,8 @@ Query {
             from: [
                 Join {
                     span: [
-                        Ident(14..22),
                         INNER(23..28),
                         JOIN(29..33),
-                        Ident(34..40),
-                        ON(41..43),
-                        Ident(44..45),
-                        Eq(46..47),
-                        Ident(48..49),
                     ],
                     join: Join {
                         op: Inner,
@@ -452,14 +442,8 @@ Query {
             from: [
                 Join {
                     span: [
-                        Ident(14..22),
                         INNER(23..28),
                         JOIN(29..33),
-                        Ident(34..40),
-                        ON(41..43),
-                        Ident(44..45),
-                        Eq(46..47),
-                        Ident(48..49),
                     ],
                     join: Join {
                         op: Inner,
@@ -596,11 +580,9 @@ Query {
             from: [
                 Join {
                     span: [
-                        Ident(14..22),
                         NATURAL(23..30),
                         FULL(31..35),
                         JOIN(36..40),
-                        Ident(41..47),
                     ],
                     join: Join {
                         op: FullOuter,
@@ -702,18 +684,9 @@ Query {
             from: [
                 Join {
                     span: [
-                        Ident(14..22),
-                        NATURAL(23..30),
-                        JOIN(31..35),
-                        Ident(36..42),
                         LEFT(43..47),
                         OUTER(48..53),
                         JOIN(54..58),
-                        Ident(59..65),
-                        USING(66..71),
-                        LParen(72..73),
-                        Ident(73..75),
-                        RParen(75..76),
                     ],
                     join: Join {
                         op: LeftOuter,
@@ -728,18 +701,8 @@ Query {
                         ),
                         left: Join {
                             span: [
-                                Ident(14..22),
                                 NATURAL(23..30),
                                 JOIN(31..35),
-                                Ident(36..42),
-                                LEFT(43..47),
-                                OUTER(48..53),
-                                JOIN(54..58),
-                                Ident(59..65),
-                                USING(66..71),
-                                LParen(72..73),
-                                Ident(73..75),
-                                RParen(75..76),
                             ],
                             join: Join {
                                 op: Inner,
@@ -2554,20 +2517,9 @@ Query {
                                 from: [
                                     Join {
                                         span: [
-                                            Ident(280..288),
                                             LEFT(289..293),
                                             OUTER(294..299),
                                             JOIN(300..304),
-                                            Ident(305..311),
-                                            ON(312..314),
-                                            Ident(343..352),
-                                            Eq(353..354),
-                                            Ident(355..364),
-                                            AND(393..396),
-                                            Ident(397..406),
-                                            NOT(407..410),
-                                            LIKE(411..415),
-                                            QuotedString(416..425),
                                         ],
                                         join: Join {
                                             op: LeftOuter,

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -2225,17 +2225,7 @@ Query(
                 from: [
                     Join {
                         span: [
-                            Ident(14..15),
                             JOIN(16..20),
-                            Ident(21..22),
-                            ON(23..25),
-                            Ident(26..27),
-                            Period(27..28),
-                            Ident(28..29),
-                            Eq(30..31),
-                            Ident(32..33),
-                            Period(33..34),
-                            Ident(34..35),
                         ],
                         join: Join {
                             op: Inner,
@@ -2388,19 +2378,9 @@ Query(
                 from: [
                     Join {
                         span: [
-                            Ident(14..15),
                             LEFT(16..20),
                             OUTER(21..26),
                             JOIN(27..31),
-                            Ident(32..33),
-                            ON(34..36),
-                            Ident(37..38),
-                            Period(38..39),
-                            Ident(39..40),
-                            Eq(41..42),
-                            Ident(43..44),
-                            Period(44..45),
-                            Ident(45..46),
                         ],
                         join: Join {
                             op: LeftOuter,
@@ -2553,19 +2533,9 @@ Query(
                 from: [
                     Join {
                         span: [
-                            Ident(14..15),
                             RIGHT(16..21),
                             OUTER(22..27),
                             JOIN(28..32),
-                            Ident(33..34),
-                            ON(35..37),
-                            Ident(38..39),
-                            Period(39..40),
-                            Ident(40..41),
-                            Eq(42..43),
-                            Ident(44..45),
-                            Period(45..46),
-                            Ident(46..47),
                         ],
                         join: Join {
                             op: RightOuter,
@@ -2718,19 +2688,9 @@ Query(
                 from: [
                     Join {
                         span: [
-                            Ident(14..15),
                             FULL(16..20),
                             OUTER(21..26),
                             JOIN(27..31),
-                            Ident(32..33),
-                            ON(34..36),
-                            Ident(37..38),
-                            Period(38..39),
-                            Ident(39..40),
-                            Eq(41..42),
-                            Ident(43..44),
-                            Period(44..45),
-                            Ident(45..46),
                         ],
                         join: Join {
                             op: FullOuter,
@@ -2881,18 +2841,8 @@ Query(
                 from: [
                     Join {
                         span: [
-                            Ident(14..15),
                             INNER(16..21),
                             JOIN(22..26),
-                            Ident(27..28),
-                            ON(29..31),
-                            Ident(32..33),
-                            Period(33..34),
-                            Ident(34..35),
-                            Eq(36..37),
-                            Ident(38..39),
-                            Period(39..40),
-                            Ident(40..41),
                         ],
                         join: Join {
                             op: Inner,
@@ -3037,15 +2987,9 @@ Query(
                 from: [
                     Join {
                         span: [
-                            Ident(14..15),
                             LEFT(16..20),
                             OUTER(21..26),
                             JOIN(27..31),
-                            Ident(32..33),
-                            USING(34..39),
-                            LParen(39..40),
-                            Ident(40..41),
-                            RParen(41..42),
                         ],
                         join: Join {
                             op: LeftOuter,
@@ -3151,15 +3095,9 @@ Query(
                 from: [
                     Join {
                         span: [
-                            Ident(14..15),
                             RIGHT(16..21),
                             OUTER(22..27),
                             JOIN(28..32),
-                            Ident(33..34),
-                            USING(35..40),
-                            LParen(40..41),
-                            Ident(41..42),
-                            RParen(42..43),
                         ],
                         join: Join {
                             op: RightOuter,
@@ -3265,15 +3203,9 @@ Query(
                 from: [
                     Join {
                         span: [
-                            Ident(14..15),
                             FULL(16..20),
                             OUTER(21..26),
                             JOIN(27..31),
-                            Ident(32..33),
-                            USING(34..39),
-                            LParen(39..40),
-                            Ident(40..41),
-                            RParen(41..42),
                         ],
                         join: Join {
                             op: FullOuter,
@@ -3377,14 +3309,8 @@ Query(
                 from: [
                     Join {
                         span: [
-                            Ident(14..15),
                             INNER(16..21),
                             JOIN(22..26),
-                            Ident(27..28),
-                            USING(29..34),
-                            LParen(34..35),
-                            Ident(35..36),
-                            RParen(36..37),
                         ],
                         join: Join {
                             op: Inner,

--- a/src/query/service/src/sql/optimizer/heuristic/subquery_rewriter.rs
+++ b/src/query/service/src/sql/optimizer/heuristic/subquery_rewriter.rs
@@ -321,10 +321,10 @@ impl SubqueryRewriter {
                 });
 
                 let scalar = if flatten_info.from_count_func {
-                    // convert count aggregate function to multi_if function, if count() is null, then 0 else count()
+                    // convert count aggregate function to multi_if function, if count() is not null, then count() else 0
                     let is_null = Scalar::FunctionCall(FunctionCall {
                         arguments: vec![column_ref.clone()],
-                        func_name: "is_null".to_string(),
+                        func_name: "is_not_null".to_string(),
                         arg_types: vec![column_ref.data_type()],
                         return_type: Box::new(BooleanType::new_impl()),
                     });
@@ -334,7 +334,7 @@ impl SubqueryRewriter {
                     });
                     Scalar::CastExpr(CastExpr {
                         argument: Box::new(Scalar::FunctionCall(FunctionCall {
-                            arguments: vec![is_null, zero, column_ref.clone()],
+                            arguments: vec![is_null, column_ref.clone(), zero],
                             func_name: "if".to_string(),
                             arg_types: vec![
                                 BooleanType::new_impl(),

--- a/src/query/service/src/sql/planner/semantic/name_resolution.rs
+++ b/src/query/service/src/sql/planner/semantic/name_resolution.rs
@@ -50,8 +50,8 @@ pub fn normalize_identifier<'a>(
     ident: &Identifier<'a>,
     context: &NameResolutionContext,
 ) -> Identifier<'a> {
-    if (ident.quoted() && context.quoted_ident_case_sensitive)
-        || (!ident.quoted() && context.unquoted_ident_case_sensitive)
+    if (ident.is_quoted() && context.quoted_ident_case_sensitive)
+        || (!ident.is_quoted() && context.unquoted_ident_case_sensitive)
     {
         ident.clone()
     } else {

--- a/tests/logictest/suites/mode/standalone/explain/limit.test
+++ b/tests/logictest/suites/mode/standalone/explain/limit.test
@@ -56,14 +56,6 @@ statement query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = (select count(*) from numbers(1) as t2, numbers(1) as t3 where t.number = t2.number) group by t.number order by t.number desc limit 3;
 
 ----
-<<<<<<< HEAD
-Limit: [3], Offset: [0]
-└── Sort: [number (#0) DESC], limit: [3]
-    └── Aggregate(Final): group items: [t.number (#0)], aggregate functions: []
-        └── Aggregate(Partial): group items: [t.number (#0)], aggregate functions: []
-            └── Filter: [t.number (#0) = CAST(if(is_not_null(scalar_subquery_4 (#4)), scalar_subquery_4 (#4), 0) AS BIGINT UNSIGNED)]
-                └── HashJoin: SINGLE, build keys: [subquery_6 (#6)], probe keys: [subquery_0 (#0)], join filters: []
-=======
 Limit
 ├── limit: [3]
 ├── offset: [0]
@@ -77,12 +69,11 @@ Limit
             ├── group items: [t.number (#0)]
             ├── aggregate functions: []
             └── Filter
-                ├── filters: [t.number (#0) = CAST(if(is_null(scalar_subquery_4 (#4)), 0, scalar_subquery_4 (#4)) AS BIGINT UNSIGNED)]
+                ├── filters: [t.number (#0) = CAST(if(is_not_null(scalar_subquery_4 (#4)), scalar_subquery_4 (#4), 0) AS BIGINT UNSIGNED)]
                 └── HashJoin: SINGLE
                     ├── build keys: [subquery_6 (#6)]
                     ├── probe keys: [subquery_0 (#0)]
                     ├── other filters: []
->>>>>>> a19ff7335 (refine explain format)
                     ├── CrossJoin
                     │   ├── build keys: []
                     │   ├── probe keys: []

--- a/tests/logictest/suites/mode/standalone/explain/limit.test
+++ b/tests/logictest/suites/mode/standalone/explain/limit.test
@@ -56,6 +56,14 @@ statement query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = (select count(*) from numbers(1) as t2, numbers(1) as t3 where t.number = t2.number) group by t.number order by t.number desc limit 3;
 
 ----
+<<<<<<< HEAD
+Limit: [3], Offset: [0]
+└── Sort: [number (#0) DESC], limit: [3]
+    └── Aggregate(Final): group items: [t.number (#0)], aggregate functions: []
+        └── Aggregate(Partial): group items: [t.number (#0)], aggregate functions: []
+            └── Filter: [t.number (#0) = CAST(if(is_not_null(scalar_subquery_4 (#4)), scalar_subquery_4 (#4), 0) AS BIGINT UNSIGNED)]
+                └── HashJoin: SINGLE, build keys: [subquery_6 (#6)], probe keys: [subquery_0 (#0)], join filters: []
+=======
 Limit
 ├── limit: [3]
 ├── offset: [0]
@@ -74,6 +82,7 @@ Limit
                     ├── build keys: [subquery_6 (#6)]
                     ├── probe keys: [subquery_0 (#0)]
                     ├── other filters: []
+>>>>>>> a19ff7335 (refine explain format)
                     ├── CrossJoin
                     │   ├── build keys: []
                     │   ├── probe keys: []

--- a/tests/logictest/suites/mode/standalone/explain/subquery.test
+++ b/tests/logictest/suites/mode/standalone/explain/subquery.test
@@ -5,7 +5,7 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = 
 Project
 ├── projections: [number (#0)]
 └── Filter
-    ├── filters: [t.number (#0) = CAST(if(is_null(scalar_subquery_4 (#4)), 0, scalar_subquery_4 (#4)) AS BIGINT UNSIGNED)]
+    ├── filters: [t.number (#0) = CAST(if(is_not_null(scalar_subquery_4 (#4)), scalar_subquery_4 (#4), 0) AS BIGINT UNSIGNED)]
     └── HashJoin: SINGLE
         ├── build keys: [subquery_6 (#6)]
         ├── probe keys: [subquery_0 (#0)]
@@ -301,7 +301,7 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where (select cou
 Project
 ├── projections: [number (#0)]
 └── Filter
-    ├── filters: [CAST(if(is_null(scalar_subquery_3 (#3)), 0, scalar_subquery_3 (#3)) AS BIGINT UNSIGNED)]
+    ├── filters: [CAST(if(is_not_null(scalar_subquery_3 (#3)), scalar_subquery_3 (#3), 0) AS BIGINT UNSIGNED)]
     └── HashJoin: SINGLE
         ├── build keys: [subquery_5 (#5)]
         ├── probe keys: [subquery_0 (#0)]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- improve parsing speed for large query test case from 3ms to 700us
- remove unnecessary `NULLIF `, `IFNULL`, and `COALESCE` parser
- desugar functional calls like`is_null`, `database`, `current_user`, etc

Fixes https://github.com/datafuselabs/databend/issues/7225
