### PR TITLE
chore(planner): Add statistics info in explain result

### DIFF
--- a/src/query/ast/src/ast/format/mod.rs
+++ b/src/query/ast/src/ast/format/mod.rs
@@ -26,8 +26,8 @@ pub use syntax::pretty_statement;
 
 #[derive(Clone)]
 pub struct FormatTreeNode<T: Display + Clone> {
-    payload: T,
-    children: Vec<Self>,
+    pub payload: T,
+    pub children: Vec<Self>,
 }
 
 impl<T> FormatTreeNode<T>

--- a/src/query/service/src/interpreters/fragments/v2/plan_fragment.rs
+++ b/src/query/service/src/interpreters/fragments/v2/plan_fragment.rs
@@ -205,6 +205,7 @@ impl PhysicalPlanReplacer for ReplaceReadSource {
         Ok(PhysicalPlan::TableScan(TableScan {
             source: Box::new(self.source.clone()),
             name_mapping: plan.name_mapping.clone(),
+            table_index: plan.table_index,
         }))
     }
 }

--- a/src/query/service/src/sql/executor/format.rs
+++ b/src/query/service/src/sql/executor/format.rs
@@ -16,6 +16,7 @@ use common_ast::ast::FormatTreeNode;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_planners::StageKind;
+use itertools::Itertools;
 
 use super::AggregateFinal;
 use super::AggregatePartial;
@@ -125,9 +126,10 @@ fn project_to_format_tree(
     metadata: &MetadataRef,
 ) -> Result<FormatTreeNode<String>> {
     let columns = plan
-        .projections
+        .columns
         .iter()
-        .map(|column| column.to_string())
+        .sorted()
+        .map(|column| format!("{} (#{})", metadata.read().column(*column).name, column))
         .collect::<Vec<_>>()
         .join(", ");
     Ok(FormatTreeNode::with_children("Project".to_string(), vec![

--- a/src/query/service/src/sql/executor/format.rs
+++ b/src/query/service/src/sql/executor/format.rs
@@ -1,0 +1,326 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_ast::ast::FormatTreeNode;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_planners::StageKind;
+
+use super::AggregateFinal;
+use super::AggregatePartial;
+use super::EvalScalar;
+use super::Exchange;
+use super::Filter;
+use super::HashJoin;
+use super::Limit;
+use super::PhysicalPlan;
+use super::Project;
+use super::Sort;
+use super::TableScan;
+use super::UnionAll;
+use crate::sql::IndexType;
+use crate::sql::MetadataRef;
+
+impl PhysicalPlan {
+    pub fn format(&self, metadata: MetadataRef) -> Result<String> {
+        to_format_tree(self, &metadata)?.format_pretty()
+    }
+}
+
+fn to_format_tree(plan: &PhysicalPlan, metadata: &MetadataRef) -> Result<FormatTreeNode<String>> {
+    match plan {
+        PhysicalPlan::TableScan(plan) => table_scan_to_format_tree(plan, metadata),
+        PhysicalPlan::Filter(plan) => filter_to_format_tree(plan, metadata),
+        PhysicalPlan::Project(plan) => project_to_format_tree(plan, metadata),
+        PhysicalPlan::EvalScalar(plan) => eval_scalar_to_format_tree(plan, metadata),
+        PhysicalPlan::AggregatePartial(plan) => aggregate_partial_to_format_tree(plan, metadata),
+        PhysicalPlan::AggregateFinal(plan) => aggregate_final_to_format_tree(plan, metadata),
+        PhysicalPlan::Sort(plan) => sort_to_format_tree(plan, metadata),
+        PhysicalPlan::Limit(plan) => limit_to_format_tree(plan, metadata),
+        PhysicalPlan::HashJoin(plan) => hash_join_to_format_tree(plan, metadata),
+        PhysicalPlan::Exchange(plan) => exchange_to_format_tree(plan, metadata),
+        PhysicalPlan::UnionAll(plan) => union_all_to_format_tree(plan, metadata),
+        PhysicalPlan::ExchangeSource(_) | PhysicalPlan::ExchangeSink(_) => {
+            Err(ErrorCode::LogicalError("Invalid physical plan"))
+        }
+    }
+}
+
+fn table_scan_to_format_tree(
+    plan: &TableScan,
+    metadata: &MetadataRef,
+) -> Result<FormatTreeNode<String>> {
+    let table = metadata.read().table(plan.table_index).clone();
+    let table_name = format!("{}.{}.{}", table.catalog, table.database, table.name);
+    let filters = plan
+        .source
+        .push_downs
+        .as_ref()
+        .map_or("".to_string(), |extras| {
+            extras
+                .filters
+                .iter()
+                .map(|f| f.column_name())
+                .collect::<Vec<_>>()
+                .join(", ")
+        });
+
+    let limit = plan
+        .source
+        .push_downs
+        .as_ref()
+        .map_or("NONE".to_string(), |extras| {
+            extras
+                .limit
+                .map_or("NONE".to_string(), |limit| limit.to_string())
+        });
+
+    Ok(FormatTreeNode::with_children(
+        "TableScan".to_string(),
+        vec![
+            FormatTreeNode::new(format!("table: {table_name}")),
+            FormatTreeNode::new(format!("read rows: {}", plan.source.statistics.read_rows)),
+            FormatTreeNode::new(format!("read bytes: {}", plan.source.statistics.read_bytes)),
+            FormatTreeNode::new(format!(
+                "partitions total: {}",
+                plan.source.statistics.partitions_total
+            )),
+            FormatTreeNode::new(format!(
+                "partitions scanned: {}",
+                plan.source.statistics.partitions_scanned
+            )),
+            FormatTreeNode::new(format!(
+                "push downs: [filters: [{filters}], limit: {limit}]"
+            )),
+        ],
+    ))
+}
+
+fn filter_to_format_tree(plan: &Filter, metadata: &MetadataRef) -> Result<FormatTreeNode<String>> {
+    let filter = plan
+        .predicates
+        .iter()
+        .map(|scalar| scalar.pretty_display(metadata))
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+    Ok(FormatTreeNode::with_children("Filter".to_string(), vec![
+        FormatTreeNode::new(format!("filters: [{filter}]")),
+        to_format_tree(&plan.input, metadata)?,
+    ]))
+}
+
+fn project_to_format_tree(
+    plan: &Project,
+    metadata: &MetadataRef,
+) -> Result<FormatTreeNode<String>> {
+    let columns = plan
+        .projections
+        .iter()
+        .map(|column| column.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Ok(FormatTreeNode::with_children("Project".to_string(), vec![
+        FormatTreeNode::new(format!("columns: [{columns}]")),
+        to_format_tree(&plan.input, metadata)?,
+    ]))
+}
+
+fn eval_scalar_to_format_tree(
+    plan: &EvalScalar,
+    metadata: &MetadataRef,
+) -> Result<FormatTreeNode<String>> {
+    let scalars = plan
+        .scalars
+        .iter()
+        .map(|(scalar, _)| scalar.pretty_display(metadata))
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+    Ok(FormatTreeNode::with_children(
+        "EvalScalar".to_string(),
+        vec![
+            FormatTreeNode::new(format!("expressions: [{scalars}]")),
+            to_format_tree(&plan.input, metadata)?,
+        ],
+    ))
+}
+
+fn aggregate_partial_to_format_tree(
+    plan: &AggregatePartial,
+    metadata: &MetadataRef,
+) -> Result<FormatTreeNode<String>> {
+    let group_by = plan
+        .group_by
+        .iter()
+        .map(|column| {
+            let index = column.parse::<IndexType>()?;
+            let column = metadata.read().column(index).clone();
+            Ok(column.name)
+        })
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+
+    let agg_funcs = plan
+        .agg_funcs
+        .iter()
+        .map(|agg| agg.pretty_display(metadata))
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+    Ok(FormatTreeNode::with_children(
+        "AggregatePartial".to_string(),
+        vec![
+            FormatTreeNode::new(format!("group by: [{group_by}]")),
+            FormatTreeNode::new(format!("aggregate functions: [{agg_funcs}]")),
+            to_format_tree(&plan.input, metadata)?,
+        ],
+    ))
+}
+
+fn aggregate_final_to_format_tree(
+    plan: &AggregateFinal,
+    metadata: &MetadataRef,
+) -> Result<FormatTreeNode<String>> {
+    let group_by = plan
+        .group_by
+        .iter()
+        .map(|column| {
+            let index = column.parse::<IndexType>()?;
+            let column = metadata.read().column(index).clone();
+            Ok(column.name)
+        })
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+
+    let agg_funcs = plan
+        .agg_funcs
+        .iter()
+        .map(|agg| agg.pretty_display(metadata))
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+    Ok(FormatTreeNode::with_children(
+        "AggregateFinal".to_string(),
+        vec![
+            FormatTreeNode::new(format!("group by: [{group_by}]")),
+            FormatTreeNode::new(format!("aggregate functions: [{agg_funcs}]")),
+            to_format_tree(&plan.input, metadata)?,
+        ],
+    ))
+}
+
+fn sort_to_format_tree(plan: &Sort, metadata: &MetadataRef) -> Result<FormatTreeNode<String>> {
+    let sort_keys = plan
+        .order_by
+        .iter()
+        .map(|sort_key| {
+            let index = sort_key.order_by.parse::<IndexType>()?;
+            let column = metadata.read().column(index).clone();
+            Ok(format!(
+                "{} {} {}",
+                column.name,
+                if sort_key.asc { "ASC" } else { "DESC" },
+                if sort_key.nulls_first {
+                    "NULLS FIRST"
+                } else {
+                    "NULLS LAST"
+                }
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+    Ok(FormatTreeNode::with_children("Sort".to_string(), vec![
+        FormatTreeNode::new(format!("sort keys: [{sort_keys}]")),
+        to_format_tree(&plan.input, metadata)?,
+    ]))
+}
+
+fn limit_to_format_tree(plan: &Limit, metadata: &MetadataRef) -> Result<FormatTreeNode<String>> {
+    Ok(FormatTreeNode::with_children("Limit".to_string(), vec![
+        FormatTreeNode::new(format!(
+            "limit: {}",
+            plan.limit
+                .map_or("NONE".to_string(), |limit| limit.to_string())
+        )),
+        FormatTreeNode::new(format!("offset: {}", plan.offset)),
+        to_format_tree(&plan.input, metadata)?,
+    ]))
+}
+
+fn hash_join_to_format_tree(
+    plan: &HashJoin,
+    metadata: &MetadataRef,
+) -> Result<FormatTreeNode<String>> {
+    let build_keys = plan
+        .build_keys
+        .iter()
+        .map(|scalar| scalar.pretty_display(metadata))
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+    let probe_keys = plan
+        .probe_keys
+        .iter()
+        .map(|scalar| scalar.pretty_display(metadata))
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+    let filters = plan
+        .other_conditions
+        .iter()
+        .map(|filter| filter.pretty_display(metadata))
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+
+    let mut build_child = to_format_tree(&plan.build, metadata)?;
+    let mut probe_child = to_format_tree(&plan.probe, metadata)?;
+
+    build_child.payload = format!("{}(Build)", build_child.payload);
+    probe_child.payload = format!("{}(Probe)", probe_child.payload);
+
+    Ok(FormatTreeNode::with_children("HashJoin".to_string(), vec![
+        FormatTreeNode::new(format!("join type: {}", plan.join_type)),
+        FormatTreeNode::new(format!("build keys: [{build_keys}]")),
+        FormatTreeNode::new(format!("probe keys: [{probe_keys}]")),
+        FormatTreeNode::new(format!("filters: [{filters}]")),
+        build_child,
+        probe_child,
+    ]))
+}
+
+fn exchange_to_format_tree(
+    plan: &Exchange,
+    metadata: &MetadataRef,
+) -> Result<FormatTreeNode<String>> {
+    Ok(FormatTreeNode::with_children("Exchange".to_string(), vec![
+        FormatTreeNode::new(format!("exchange type: {}", match plan.kind {
+            StageKind::Normal => format!(
+                "Hash({})",
+                plan.keys
+                    .iter()
+                    .map(|scalar| { scalar.pretty_display(metadata) })
+                    .collect::<Result<Vec<_>>>()?
+                    .join(", ")
+            ),
+            StageKind::Expansive => "Broadcast".to_string(),
+            StageKind::Merge => "Merge".to_string(),
+        })),
+        to_format_tree(&plan.input, metadata)?,
+    ]))
+}
+
+fn union_all_to_format_tree(
+    plan: &UnionAll,
+    metadata: &MetadataRef,
+) -> Result<FormatTreeNode<String>> {
+    Ok(FormatTreeNode::with_children("UnionAll".to_string(), vec![
+        to_format_tree(&plan.left, metadata)?,
+        to_format_tree(&plan.right, metadata)?,
+    ]))
+}

--- a/src/query/service/src/sql/executor/mod.rs
+++ b/src/query/service/src/sql/executor/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod expression_builder;
+mod format;
 mod physical_plan;
 mod physical_plan_builder;
 mod physical_plan_display;

--- a/src/query/service/src/sql/executor/physical_plan.rs
+++ b/src/query/service/src/sql/executor/physical_plan.rs
@@ -30,6 +30,7 @@ use common_planners::StageKind;
 use super::physical_scalar::PhysicalScalar;
 use super::AggregateFunctionDesc;
 use super::SortDesc;
+use crate::sql::optimizer::ColumnSet;
 use crate::sql::plans::JoinType;
 use crate::sql::IndexType;
 
@@ -72,6 +73,9 @@ impl Filter {
 pub struct Project {
     pub input: Box<PhysicalPlan>,
     pub projections: Vec<usize>,
+
+    /// Only used for display
+    pub columns: ColumnSet,
 }
 
 impl Project {

--- a/src/query/service/src/sql/executor/physical_plan.rs
+++ b/src/query/service/src/sql/executor/physical_plan.rs
@@ -39,6 +39,9 @@ pub type ColumnID = String;
 pub struct TableScan {
     pub name_mapping: BTreeMap<String, ColumnID>,
     pub source: Box<ReadDataSourcePlan>,
+
+    /// Only used for display
+    pub table_index: IndexType,
 }
 
 impl TableScan {

--- a/src/query/service/src/sql/executor/physical_plan_builder.rs
+++ b/src/query/service/src/sql/executor/physical_plan_builder.rs
@@ -278,6 +278,8 @@ impl PhysicalPlanBuilder {
                         .sorted()
                         .map(|index| input_schema.index_of(index.to_string().as_str()))
                         .collect::<Result<_>>()?,
+
+                    columns: project.columns.clone(),
                 }))
             }
             RelOperator::EvalScalar(eval_scalar) => Ok(PhysicalPlan::EvalScalar(EvalScalar {

--- a/src/query/service/src/sql/executor/physical_plan_builder.rs
+++ b/src/query/service/src/sql/executor/physical_plan_builder.rs
@@ -229,6 +229,7 @@ impl PhysicalPlanBuilder {
                 Ok(PhysicalPlan::TableScan(TableScan {
                     name_mapping,
                     source: Box::new(source),
+                    table_index: scan.table_index,
                 }))
             }
             RelOperator::PhysicalHashJoin(join) => {

--- a/src/query/service/src/sql/executor/physical_plan_visitor.rs
+++ b/src/query/service/src/sql/executor/physical_plan_visitor.rs
@@ -67,6 +67,7 @@ pub trait PhysicalPlanReplacer {
         Ok(PhysicalPlan::Project(Project {
             input: Box::new(input),
             projections: plan.projections.clone(),
+            columns: plan.columns.clone(),
         }))
     }
 

--- a/src/query/service/src/sql/executor/physical_scalar.rs
+++ b/src/query/service/src/sql/executor/physical_scalar.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_datavalues::format_data_type_sql;
 use common_datavalues::DataTypeImpl;
 use common_datavalues::DataValue;
+use common_exception::Result;
 
 use super::ColumnID;
+use crate::sql::IndexType;
+use crate::sql::MetadataRef;
 
 /// Serializable and desugared representation of `Scalar`.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -48,6 +52,37 @@ impl PhysicalScalar {
             PhysicalScalar::Cast { target, .. } => target.clone(),
         }
     }
+
+    /// Display with readable variable name.
+    pub fn pretty_display(&self, metadata: &MetadataRef) -> Result<String> {
+        match self {
+            PhysicalScalar::Variable { column_id, .. } => {
+                let index = column_id.parse::<IndexType>()?;
+                let column = metadata.read().column(index).clone();
+                let table_name = match column.table_index {
+                    Some(table_index) => {
+                        format!("{}.", metadata.read().table(table_index).name.clone())
+                    }
+                    None => "".to_string(),
+                };
+                Ok(format!("{}{} (#{})", table_name, column.name, index))
+            }
+            PhysicalScalar::Constant { value, .. } => Ok(value.to_string()),
+            PhysicalScalar::Function { name, args, .. } => {
+                let args = args
+                    .iter()
+                    .map(|(arg, _)| arg.pretty_display(metadata))
+                    .collect::<Result<Vec<_>>>()?
+                    .join(", ");
+                Ok(format!("{}({})", name, args))
+            }
+            PhysicalScalar::Cast { input, target } => Ok(format!(
+                "CAST({} AS {})",
+                input.pretty_display(metadata)?,
+                format_data_type_sql(target)
+            )),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -55,6 +90,24 @@ pub struct AggregateFunctionDesc {
     pub sig: AggregateFunctionSignature,
     pub column_id: ColumnID,
     pub args: Vec<ColumnID>,
+}
+
+impl AggregateFunctionDesc {
+    pub fn pretty_display(&self, metadata: &MetadataRef) -> Result<String> {
+        Ok(format!(
+            "{}({})",
+            self.sig.name,
+            self.args
+                .iter()
+                .map(|arg| {
+                    let index = arg.parse::<IndexType>()?;
+                    let column = metadata.read().column(index).clone();
+                    Ok(column.name)
+                })
+                .collect::<Result<Vec<_>>>()?
+                .join(", ")
+        ))
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/tests/logictest/suites/mode/cluster/04_0002_explain_v2
+++ b/tests/logictest/suites/mode/cluster/04_0002_explain_v2
@@ -17,7 +17,7 @@ explain select t1.a from t1 where a > 0;
 Exchange
 ├── exchange type: Merge
 └── Project
-    ├── columns: [0]
+    ├── columns: [a (#0)]
     └── Filter
         ├── filters: [>(t1.a (#0), 0)]
         └── TableScan

--- a/tests/logictest/suites/mode/cluster/04_0002_explain_v2
+++ b/tests/logictest/suites/mode/cluster/04_0002_explain_v2
@@ -14,66 +14,81 @@ statement query T
 explain select t1.a from t1 where a > 0;
 
 ----
-Exchange(Merge)
+Exchange
+├── exchange type: Merge
 └── Project
-    ├── projections: [a (#0)]
+    ├── columns: [0]
     └── Filter
-        ├── filters: [t1.a (#0) > 0]
-        └── PhysicalScan
+        ├── filters: [>(t1.a (#0), 0)]
+        └── TableScan
             ├── table: default.default.t1
-            ├── filters: [t1.a (#0) > 0]
-            ├── order by: []
-            └── limit: NONE
+            ├── read rows: 0
+            ├── read bytes: 0
+            ├── partitions total: 0
+            ├── partitions scanned: 0
+            └── push downs: [filters: [(a > 0)], limit: NONE]
 
 statement query T
 explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a and t2.a > 5 and t1.a > 1);
 
 ----
-Exchange(Merge)
+Exchange
+├── exchange type: Merge
 └── Filter
-    ├── filters: [(t1.a (#0) > 3) OR ((t2.a (#2) > 5) AND (t1.a (#0) > 1))]
-    └── HashJoin: INNER
+    ├── filters: [or(>(t1.a (#0), 3), and(>(t2.a (#2), 5), >(t1.a (#0), 1)))]
+    └── HashJoin
+        ├── join type: INNER
         ├── build keys: [t2.a (#2)]
         ├── probe keys: [t1.a (#0)]
-        ├── other filters: []
-        ├── Exchange(Hash)
-        │   ├── Exchange(Hash): keys: [t1.a (#0)]
-        │   └── PhysicalScan
-        │       ├── table: default.default.t1
-        │       ├── filters: []
-        │       ├── order by: []
-        │       └── limit: NONE
-        └── Exchange(Hash)
-            ├── Exchange(Hash): keys: [t2.a (#2)]
-            └── PhysicalScan
-                ├── table: default.default.t2
-                ├── filters: []
-                ├── order by: []
-                └── limit: NONE
+        ├── filters: []
+        ├── Exchange(Build)
+        │   ├── exchange type: Hash(t2.a (#2))
+        │   └── TableScan
+        │       ├── table: default.default.t2
+        │       ├── read rows: 0
+        │       ├── read bytes: 0
+        │       ├── partitions total: 0
+        │       ├── partitions scanned: 0
+        │       └── push downs: [filters: [], limit: NONE]
+        └── Exchange(Probe)
+            ├── exchange type: Hash(t1.a (#0))
+            └── TableScan
+                ├── table: default.default.t1
+                ├── read rows: 0
+                ├── read bytes: 0
+                ├── partitions total: 0
+                ├── partitions scanned: 0
+                └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a);
 
 ----
-Exchange(Merge)
-└── HashJoin: INNER
+Exchange
+├── exchange type: Merge
+└── HashJoin
+    ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
-    ├── other filters: []
-    ├── Exchange(Hash)
-    │   ├── Exchange(Hash): keys: [t1.a (#0)]
-    │   └── PhysicalScan
-    │       ├── table: default.default.t1
-    │       ├── filters: []
-    │       ├── order by: []
-    │       └── limit: NONE
-    └── Exchange(Hash)
-        ├── Exchange(Hash): keys: [t2.a (#2)]
-        └── PhysicalScan
-            ├── table: default.default.t2
-            ├── filters: []
-            ├── order by: []
-            └── limit: NONE
+    ├── filters: []
+    ├── Exchange(Build)
+    │   ├── exchange type: Hash(t2.a (#2))
+    │   └── TableScan
+    │       ├── table: default.default.t2
+    │       ├── read rows: 0
+    │       ├── read bytes: 0
+    │       ├── partitions total: 0
+    │       ├── partitions scanned: 0
+    │       └── push downs: [filters: [], limit: NONE]
+    └── Exchange(Probe)
+        ├── exchange type: Hash(t1.a (#0))
+        └── TableScan
+            ├── table: default.default.t1
+            ├── read rows: 0
+            ├── read bytes: 0
+            ├── partitions total: 0
+            ├── partitions scanned: 0
+            └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain raw select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a);

--- a/tests/logictest/suites/mode/cluster/exchange.test
+++ b/tests/logictest/suites/mode/cluster/exchange.test
@@ -143,7 +143,7 @@ Exchange
     └── Exchange(Probe)
         ├── exchange type: Hash(number (#1))
         └── Project
-            ├── columns: [2]
+            ├── columns: [number (#1)]
             └── EvalScalar
                 ├── expressions: [sum(number) (#3)]
                 └── AggregateFinal

--- a/tests/logictest/suites/mode/cluster/exchange.test
+++ b/tests/logictest/suites/mode/cluster/exchange.test
@@ -2,133 +2,163 @@ statement query T
 explain select * from numbers(1) t, numbers(2) t1 where t.number = t1.number;
 
 ----
-Exchange(Merge)
-└── HashJoin: INNER
-    ├── build keys: [t1.number (#1)]
-    ├── probe keys: [t.number (#0)]
-    ├── other filters: []
-    ├── Exchange(Hash)
-    │   ├── Exchange(Hash): keys: [t.number (#0)]
-    │   └── PhysicalScan
+Exchange
+├── exchange type: Merge
+└── HashJoin
+    ├── join type: INNER
+    ├── build keys: [numbers.number (#1)]
+    ├── probe keys: [numbers.number (#0)]
+    ├── filters: []
+    ├── Exchange(Build)
+    │   ├── exchange type: Hash(numbers.number (#1))
+    │   └── TableScan
     │       ├── table: default.system.numbers
-    │       ├── filters: []
-    │       ├── order by: []
-    │       └── limit: NONE
-    └── Exchange(Hash)
-        ├── Exchange(Hash): keys: [t1.number (#1)]
-        └── PhysicalScan
+    │       ├── read rows: 2
+    │       ├── read bytes: 16
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       └── push downs: [filters: [], limit: NONE]
+    └── Exchange(Probe)
+        ├── exchange type: Hash(numbers.number (#0))
+        └── TableScan
             ├── table: default.system.numbers
-            ├── filters: []
-            ├── order by: []
-            └── limit: NONE
+            ├── read rows: 1
+            ├── read bytes: 8
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from numbers(1) t, numbers(2) t1, numbers(3) t2 where t.number = t1.number and t.number = t2.number;
 
 ----
-Exchange(Merge)
-└── HashJoin: INNER
-    ├── build keys: [t2.number (#2)]
-    ├── probe keys: [t.number (#0)]
-    ├── other filters: []
-    ├── HashJoin: INNER
-    │   ├── build keys: [t1.number (#1)]
-    │   ├── probe keys: [t.number (#0)]
-    │   ├── other filters: []
-    │   ├── Exchange(Hash)
-    │   │   ├── Exchange(Hash): keys: [t.number (#0)]
-    │   │   └── PhysicalScan
-    │   │       ├── table: default.system.numbers
-    │   │       ├── filters: []
-    │   │       ├── order by: []
-    │   │       └── limit: NONE
-    │   └── Exchange(Hash)
-    │       ├── Exchange(Hash): keys: [t1.number (#1)]
-    │       └── PhysicalScan
-    │           ├── table: default.system.numbers
-    │           ├── filters: []
-    │           ├── order by: []
-    │           └── limit: NONE
-    └── Exchange(Hash)
-        ├── Exchange(Hash): keys: [t2.number (#2)]
-        └── PhysicalScan
-            ├── table: default.system.numbers
-            ├── filters: []
-            ├── order by: []
-            └── limit: NONE
+Exchange
+├── exchange type: Merge
+└── HashJoin
+    ├── join type: INNER
+    ├── build keys: [numbers.number (#2)]
+    ├── probe keys: [numbers.number (#0)]
+    ├── filters: []
+    ├── Exchange(Build)
+    │   ├── exchange type: Hash(numbers.number (#2))
+    │   └── TableScan
+    │       ├── table: default.system.numbers
+    │       ├── read rows: 3
+    │       ├── read bytes: 24
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       └── push downs: [filters: [], limit: NONE]
+    └── HashJoin(Probe)
+        ├── join type: INNER
+        ├── build keys: [numbers.number (#1)]
+        ├── probe keys: [numbers.number (#0)]
+        ├── filters: []
+        ├── Exchange(Build)
+        │   ├── exchange type: Hash(numbers.number (#1))
+        │   └── TableScan
+        │       ├── table: default.system.numbers
+        │       ├── read rows: 2
+        │       ├── read bytes: 16
+        │       ├── partitions total: 1
+        │       ├── partitions scanned: 1
+        │       └── push downs: [filters: [], limit: NONE]
+        └── Exchange(Probe)
+            ├── exchange type: Hash(numbers.number (#0))
+            └── TableScan
+                ├── table: default.system.numbers
+                ├── read rows: 1
+                ├── read bytes: 8
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from (select number as a, number+1 as b from numbers(1)) t, numbers(2) t1, numbers(3) t2 where a = t1.number and b = t2.number;
 
 ----
-Exchange(Merge)
-└── HashJoin: INNER
-    ├── build keys: [t2.number (#4)]
-    ├── probe keys: [t.b (#1)]
-    ├── other filters: []
-    ├── Exchange(Hash)
-    │   ├── Exchange(Hash): keys: [t.b (#1)]
-    │   └── HashJoin: INNER
-    │       ├── build keys: [t1.number (#3)]
-    │       ├── probe keys: [t.a (#0)]
-    │       ├── other filters: []
-    │       ├── Exchange(Hash)
-    │       │   ├── Exchange(Hash): keys: [t.a (#0)]
-    │       │   └── EvalScalar
-    │       │       ├── scalars: [+(numbers.number (#0), 1)]
-    │       │       └── PhysicalScan
-    │       │           ├── table: default.system.numbers
-    │       │           ├── filters: []
-    │       │           ├── order by: []
-    │       │           └── limit: NONE
-    │       └── Exchange(Hash)
-    │           ├── Exchange(Hash): keys: [t1.number (#3)]
-    │           └── PhysicalScan
-    │               ├── table: default.system.numbers
-    │               ├── filters: []
-    │               ├── order by: []
-    │               └── limit: NONE
-    └── Exchange(Hash)
-        ├── Exchange(Hash): keys: [t2.number (#4)]
-        └── PhysicalScan
-            ├── table: default.system.numbers
+Exchange
+├── exchange type: Merge
+└── HashJoin
+    ├── join type: INNER
+    ├── build keys: [numbers.number (#4)]
+    ├── probe keys: [b (#1)]
+    ├── filters: []
+    ├── Exchange(Build)
+    │   ├── exchange type: Hash(numbers.number (#4))
+    │   └── TableScan
+    │       ├── table: default.system.numbers
+    │       ├── read rows: 3
+    │       ├── read bytes: 24
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       └── push downs: [filters: [], limit: NONE]
+    └── Exchange(Probe)
+        ├── exchange type: Hash(b (#1))
+        └── HashJoin
+            ├── join type: INNER
+            ├── build keys: [numbers.number (#3)]
+            ├── probe keys: [numbers.number (#0)]
             ├── filters: []
-            ├── order by: []
-            └── limit: NONE
+            ├── Exchange(Build)
+            │   ├── exchange type: Hash(numbers.number (#3))
+            │   └── TableScan
+            │       ├── table: default.system.numbers
+            │       ├── read rows: 2
+            │       ├── read bytes: 16
+            │       ├── partitions total: 1
+            │       ├── partitions scanned: 1
+            │       └── push downs: [filters: [], limit: NONE]
+            └── Exchange(Probe)
+                ├── exchange type: Hash(numbers.number (#0))
+                └── EvalScalar
+                    ├── expressions: [+(numbers.number (#0), 1)]
+                    └── TableScan
+                        ├── table: default.system.numbers
+                        ├── read rows: 1
+                        ├── read bytes: 8
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from (select sum(number) as number from numbers(1) group by number) t, numbers(2) t1 where t.number = t1.number;
 
 ----
-Exchange(Merge)
-└── HashJoin: INNER
-    ├── build keys: [t1.number (#4)]
-    ├── probe keys: [t.number (#1)]
-    ├── other filters: []
-    ├── Exchange(Hash)
-    │   ├── Exchange(Hash): keys: [t.number (#1)]
-    │   └── Project
-    │       ├── projections: [number (#1)]
-    │       └── EvalScalar
-    │           ├── scalars: [sum(number) (#3)]
-    │           └── Aggregate(Final)
-    │               ├── group items: [numbers.number (#0)]
-    │               ├── aggregate functions: [sum(number)]
-    │               └── Aggregate(Partial)
-    │                   ├── group items: [numbers.number (#0)]
-    │                   ├── aggregate functions: [sum(number)]
-    │                   └── Exchange(Hash)
-    │                       ├── Exchange(Hash): keys: [numbers.number (#0)]
-    │                       └── PhysicalScan
-    │                           ├── table: default.system.numbers
-    │                           ├── filters: []
-    │                           ├── order by: []
-    │                           └── limit: NONE
-    └── Exchange(Hash)
-        ├── Exchange(Hash): keys: [t1.number (#4)]
-        └── PhysicalScan
-            ├── table: default.system.numbers
-            ├── filters: []
-            ├── order by: []
-            └── limit: NONE
+Exchange
+├── exchange type: Merge
+└── HashJoin
+    ├── join type: INNER
+    ├── build keys: [numbers.number (#4)]
+    ├── probe keys: [number (#1)]
+    ├── filters: []
+    ├── Exchange(Build)
+    │   ├── exchange type: Hash(numbers.number (#4))
+    │   └── TableScan
+    │       ├── table: default.system.numbers
+    │       ├── read rows: 2
+    │       ├── read bytes: 16
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       └── push downs: [filters: [], limit: NONE]
+    └── Exchange(Probe)
+        ├── exchange type: Hash(number (#1))
+        └── Project
+            ├── columns: [2]
+            └── EvalScalar
+                ├── expressions: [sum(number) (#3)]
+                └── AggregateFinal
+                    ├── group by: [number]
+                    ├── aggregate functions: [sum(number)]
+                    └── AggregatePartial
+                        ├── group by: [number]
+                        ├── aggregate functions: [sum(number)]
+                        └── Exchange
+                            ├── exchange type: Hash(numbers.number (#0))
+                            └── TableScan
+                                ├── table: default.system.numbers
+                                ├── read rows: 1
+                                ├── read bytes: 8
+                                ├── partitions total: 1
+                                ├── partitions scanned: 1
+                                └── push downs: [filters: [], limit: NONE]
 

--- a/tests/logictest/suites/mode/standalone/explain/explain.test
+++ b/tests/logictest/suites/mode/standalone/explain/explain.test
@@ -15,7 +15,7 @@ explain select t1.a from t1 where a > 0;
 
 ----
 Project
-├── columns: [0]
+├── columns: [a (#0)]
 └── Filter
     ├── filters: [>(t1.a (#0), 0)]
     └── TableScan

--- a/tests/logictest/suites/mode/standalone/explain/explain.test
+++ b/tests/logictest/suites/mode/standalone/explain/explain.test
@@ -15,54 +15,66 @@ explain select t1.a from t1 where a > 0;
 
 ----
 Project
-├── projections: [a (#0)]
+├── columns: [0]
 └── Filter
-    ├── filters: [t1.a (#0) > 0]
-    └── PhysicalScan
+    ├── filters: [>(t1.a (#0), 0)]
+    └── TableScan
         ├── table: default.default.t1
-        ├── filters: [t1.a (#0) > 0]
-        ├── order by: []
-        └── limit: NONE
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        └── push downs: [filters: [(a > 0)], limit: NONE]
 
 statement query T
 explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a and t2.a > 5 and t1.a > 1);
 
 ----
 Filter
-├── filters: [(t1.a (#0) > 3) OR ((t2.a (#2) > 5) AND (t1.a (#0) > 1))]
-└── HashJoin: INNER
+├── filters: [or(>(t1.a (#0), 3), and(>(t2.a (#2), 5), >(t1.a (#0), 1)))]
+└── HashJoin
+    ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
-    ├── other filters: []
-    ├── PhysicalScan
-    │   ├── table: default.default.t1
-    │   ├── filters: []
-    │   ├── order by: []
-    │   └── limit: NONE
-    └── PhysicalScan
-        ├── table: default.default.t2
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.default.t2
+    │   ├── read rows: 0
+    │   ├── read bytes: 0
+    │   ├── partitions total: 0
+    │   ├── partitions scanned: 0
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.default.t1
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a);
 
 ----
-HashJoin: INNER
+HashJoin
+├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── other filters: []
-├── PhysicalScan
-│   ├── table: default.default.t1
-│   ├── filters: []
-│   ├── order by: []
-│   └── limit: NONE
-└── PhysicalScan
-    ├── table: default.default.t2
-    ├── filters: []
-    ├── order by: []
-    └── limit: NONE
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.default.t2
+│   ├── read rows: 0
+│   ├── read bytes: 0
+│   ├── partitions total: 0
+│   ├── partitions scanned: 0
+│   └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.default.t1
+    ├── read rows: 0
+    ├── read bytes: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain raw select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a);
@@ -220,7 +232,6 @@ AS
     WHERE
         number > 10
 
-onlyif mysql
 statement query T
 explain ast select 1, 'ab', [1,2,3] as a, (1, 'a') as t;
 
@@ -243,9 +254,8 @@ Query (children 1)
                     ├── Literal Integer(1)
                     └── Literal String("a")
 
-onlyif mysql
 statement query T
-explain ast select case when a > 1 then 'x' when a < 10 then 'y' else 'z' end from t1
+explain ast select case when a > 1 then 'x' when a < 10 then 'y' else 'z' end from t1;
 
 ----
 Query (children 1)
@@ -269,7 +279,6 @@ Query (children 1)
         └── TableList (children 1)
             └── TableIdentifier t1
 
-onlyif mysql
 statement query T
 explain ast select a, sum(b) as sum from t1 where a in (1, 2) and b > 0 and b < 100 group by a order by a limit 3;
 
@@ -307,8 +316,6 @@ Query (children 3)
 └── LimitList (children 1)
     └── Literal Integer(3)
 
-
-onlyif mysql
 statement query T
 explain ast select * from t1 inner join t2 on t1.a = t2.a and t1.b = t2.b and t1.a > 2;
 
@@ -336,7 +343,6 @@ Query (children 1)
                                 ├── ColumnIdentifier t1.a
                                 └── Literal Integer(2)
 
-onlyif mysql
 statement query T
 explain ast with cte (a, b) as (select 1, 2 union all select 3, 4) select a, b from cte;
 
@@ -371,7 +377,6 @@ Query (children 2)
         └── TableList (children 1)
             └── TableIdentifier cte
 
-onlyif mysql
 statement query T
 explain ast insert into t1 (a, b) values (1, 2),(3, 4);
 
@@ -384,7 +389,6 @@ Insert (children 3)
 └── Source (children 1)
     └── ValueSouce
 
-onlyif mysql
 statement query T
 explain ast delete from t1 where a > 100 and b > 1 and b < 10;
 
@@ -403,7 +407,6 @@ Delete (children 2)
         ├── ColumnIdentifier b
         └── Literal Integer(10)
 
-onlyif mysql
 statement query T
 explain ast copy into t1 from 's3://mybucket/data.csv' file_format = ( type = 'CSV' field_delimiter = ',' record_delimiter = '\n' skip_header = 1) size_limit=10;
 
@@ -420,16 +423,14 @@ Copy (children 4)
 │   └── FileFormat type = "CSV"
 └── SizeLimit 10
 
-onlyif mysql
 statement query T
-explain ast create database db1 engine=default
+explain ast create database db1 engine=default;
 
 ----
 CreateDatabase (children 2)
 ├── DatabaseIdentifier db1
 └── DatabaseEngine DEFAULT
 
-onlyif mysql
 statement query T
 explain ast create table t3(a int64, b uint64, c float64, d string, e array(int32), f tuple(f1 bool, f2 string)) engine=fuse cluster by (a, b, c) comment='test' compression='LZ4';
 
@@ -458,7 +459,6 @@ CreateTable (children 5)
     ├── TableOption comment = "test"
     └── TableOption compression = "LZ4"
 
-onlyif mysql
 statement query T
 explain ast create view v as select number % 3 as a from numbers(100) where number > 10;
 
@@ -481,7 +481,6 @@ CreateView (children 2)
                     ├── ColumnIdentifier number
                     └── Literal Integer(10)
 
-onlyif mysql
 statement query T
 explain ast show create table t1;
 
@@ -489,7 +488,6 @@ explain ast show create table t1;
 ShowCreateTable (children 1)
 └── TableIdentifier t1
 
-onlyif mysql
 statement query T
 explain ast create user 'test'@'localhost' identified with sha256_password by 'new_password';
 

--- a/tests/logictest/suites/mode/standalone/explain/join.test
+++ b/tests/logictest/suites/mode/standalone/explain/join.test
@@ -3,141 +3,174 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = 
 
 ----
 Project
-├── projections: [number (#0)]
-└── HashJoin: INNER
-    ├── build keys: [t1.number (#1)]
-    ├── probe keys: [t.number (#0)]
-    ├── other filters: []
-    ├── PhysicalScan
+├── columns: [0]
+└── HashJoin
+    ├── join type: INNER
+    ├── build keys: [numbers.number (#1)]
+    ├── probe keys: [numbers.number (#0)]
+    ├── filters: []
+    ├── TableScan(Build)
     │   ├── table: default.system.numbers
-    │   ├── filters: []
-    │   ├── order by: []
-    │   └── limit: NONE
-    └── PhysicalScan
+    │   ├── read rows: 1
+    │   ├── read bytes: 8
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
         ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+        ├── read rows: 1
+        ├── read bytes: 8
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = t1.number and t.number = t1.number + 1;
 
 ----
 Project
-├── projections: [number (#0)]
-└── HashJoin: INNER
-    ├── build keys: [t1.number (#1), +(t1.number (#1), 1)]
-    ├── probe keys: [t.number (#0), t.number (#0)]
-    ├── other filters: []
-    ├── PhysicalScan
+├── columns: [0]
+└── HashJoin
+    ├── join type: INNER
+    ├── build keys: [numbers.number (#1), +(numbers.number (#1), 1)]
+    ├── probe keys: [numbers.number (#0), numbers.number (#0)]
+    ├── filters: []
+    ├── TableScan(Build)
     │   ├── table: default.system.numbers
-    │   ├── filters: []
-    │   ├── order by: []
-    │   └── limit: NONE
-    └── PhysicalScan
+    │   ├── read rows: 1
+    │   ├── read bytes: 8
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
         ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+        ├── read rows: 1
+        ├── read bytes: 8
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number > 1 and 1 < t1.number;
 
 ----
 Project
-├── projections: [number (#0)]
-└── CrossJoin
+├── columns: [0]
+└── HashJoin
+    ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── other filters: []
-    ├── Filter
-    │   ├── filters: [t.number (#0) > 1]
-    │   └── PhysicalScan
+    ├── filters: []
+    ├── Filter(Build)
+    │   ├── filters: [<(1, numbers.number (#1))]
+    │   └── TableScan
     │       ├── table: default.system.numbers
-    │       ├── filters: [t.number (#0) > 1]
-    │       ├── order by: []
-    │       └── limit: NONE
-    └── Filter
-        ├── filters: [1 < t1.number (#1)]
-        └── PhysicalScan
+    │       ├── read rows: 1
+    │       ├── read bytes: 8
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       └── push downs: [filters: [(1 < number)], limit: NONE]
+    └── Filter(Probe)
+        ├── filters: [>(numbers.number (#0), 1)]
+        └── TableScan
             ├── table: default.system.numbers
-            ├── filters: [1 < t1.number (#1)]
-            ├── order by: []
-            └── limit: NONE
+            ├── read rows: 1
+            ├── read bytes: 8
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            └── push downs: [filters: [(number > 1)], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number + t1.number = 1;
 
 ----
 Project
-├── projections: [number (#0)]
+├── columns: [0]
 └── Filter
-    ├── filters: [+(t.number (#0), t1.number (#1)) = 1]
-    └── CrossJoin
+    ├── filters: [=(+(numbers.number (#0), numbers.number (#1)), 1)]
+    └── HashJoin
+        ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
-        ├── other filters: []
-        ├── PhysicalScan
+        ├── filters: []
+        ├── TableScan(Build)
         │   ├── table: default.system.numbers
-        │   ├── filters: []
-        │   ├── order by: []
-        │   └── limit: NONE
-        └── PhysicalScan
+        │   ├── read rows: 1
+        │   ├── read bytes: 8
+        │   ├── partitions total: 1
+        │   ├── partitions scanned: 1
+        │   └── push downs: [filters: [], limit: NONE]
+        └── TableScan(Probe)
             ├── table: default.system.numbers
-            ├── filters: []
-            ├── order by: []
-            └── limit: NONE
+            ├── read rows: 1
+            ├── read bytes: 8
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = cast(t1.number as string);
 
 ----
 Project
-├── projections: [number (#0)]
-└── HashJoin: INNER
-    ├── build keys: [CAST(CAST(t1.number (#1) AS VARCHAR) AS DOUBLE)]
-    ├── probe keys: [CAST(t.number (#0) AS DOUBLE)]
-    ├── other filters: []
-    ├── PhysicalScan
+├── columns: [0]
+└── HashJoin
+    ├── join type: INNER
+    ├── build keys: [CAST(CAST(numbers.number (#1) AS VARCHAR) AS DOUBLE)]
+    ├── probe keys: [CAST(numbers.number (#0) AS DOUBLE)]
+    ├── filters: []
+    ├── TableScan(Build)
     │   ├── table: default.system.numbers
-    │   ├── filters: []
-    │   ├── order by: []
-    │   └── limit: NONE
-    └── PhysicalScan
+    │   ├── read rows: 1
+    │   ├── read bytes: 8
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
         ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+        ├── read rows: 1
+        ├── read bytes: 8
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t, numbers(1) as t1, numbers(1) as t2 where t1.number = t2.number and t.number = 1;
 
 ----
 Project
-├── projections: [number (#0)]
-└── HashJoin: INNER
-    ├── build keys: [t2.number (#2)]
-    ├── probe keys: [t1.number (#1)]
-    ├── other filters: []
-    ├── CrossJoin
-    │   ├── build keys: []
-    │   ├── probe keys: []
-    │   ├── other filters: []
-    │   ├── Filter
-    │   │   ├── filters: [t.number (#0) = 1]
-    │   │   └── PhysicalScan
-    │   │       ├── table: default.system.numbers
-    │   │       ├── filters: [t.number (#0) = 1]
-    │   │       ├── order by: []
-    │   │       └── limit: NONE
-    │   └── PhysicalScan
-    │       ├── table: default.system.numbers
-    │       ├── filters: []
-    │       ├── order by: []
-    │       └── limit: NONE
-    └── PhysicalScan
-        ├── table: default.system.numbers
+├── columns: [0]
+└── HashJoin
+    ├── join type: INNER
+    ├── build keys: [numbers.number (#2)]
+    ├── probe keys: [numbers.number (#1)]
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.system.numbers
+    │   ├── read rows: 1
+    │   ├── read bytes: 8
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── HashJoin(Probe)
+        ├── join type: CROSS
+        ├── build keys: []
+        ├── probe keys: []
         ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+        ├── TableScan(Build)
+        │   ├── table: default.system.numbers
+        │   ├── read rows: 1
+        │   ├── read bytes: 8
+        │   ├── partitions total: 1
+        │   ├── partitions scanned: 1
+        │   └── push downs: [filters: [], limit: NONE]
+        └── Filter(Probe)
+            ├── filters: [=(numbers.number (#0), 1)]
+            └── TableScan
+                ├── table: default.system.numbers
+                ├── read rows: 1
+                ├── read bytes: 8
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                └── push downs: [filters: [(number = 1)], limit: NONE]
 

--- a/tests/logictest/suites/mode/standalone/explain/join.test
+++ b/tests/logictest/suites/mode/standalone/explain/join.test
@@ -3,7 +3,7 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = 
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [numbers.number (#1)]
@@ -29,7 +29,7 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = 
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [numbers.number (#1), +(numbers.number (#1), 1)]
@@ -55,7 +55,7 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number > 
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: CROSS
     ├── build keys: []
@@ -85,7 +85,7 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number + 
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── Filter
     ├── filters: [=(+(numbers.number (#0), numbers.number (#1)), 1)]
     └── HashJoin
@@ -113,7 +113,7 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = 
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [CAST(CAST(numbers.number (#1) AS VARCHAR) AS DOUBLE)]
@@ -139,7 +139,7 @@ explain select t.number from numbers(1) as t, numbers(1) as t1, numbers(1) as t2
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [numbers.number (#2)]

--- a/tests/logictest/suites/mode/standalone/explain/limit.test
+++ b/tests/logictest/suites/mode/standalone/explain/limit.test
@@ -3,167 +3,186 @@ explain select * from (select t.number from numbers(10) as t limit 8) limit 9;
 
 ----
 Limit
-├── limit: [9]
-├── offset: [0]
+├── limit: 9
+├── offset: 0
 └── Limit
-    ├── limit: [8]
-    ├── offset: [0]
-    └── PhysicalScan
+    ├── limit: 8
+    ├── offset: 0
+    └── TableScan
         ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: []
-        └── limit: 8
+        ├── read rows: 8
+        ├── read bytes: 64
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: 8]
 
 statement query T
 explain select * from (select t.number from numbers(10) as t order by number desc) order by number asc;
 
 ----
 Sort
-├── sort keys: [number (#0) ASC]
-├── limit: [NONE]
+├── sort keys: [number ASC NULLS LAST]
 └── Sort
-    ├── sort keys: [number (#0) DESC]
-    ├── limit: [NONE]
-    └── PhysicalScan
+    ├── sort keys: [number DESC NULLS LAST]
+    └── TableScan
         ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: [number (#0) DESC]
-        └── limit: NONE
+        ├── read rows: 10
+        ├── read bytes: 80
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select number from (select t.number from numbers(10) as t order by number desc limit 8) order by number asc limit 9;
 
 ----
 Limit
-├── limit: [9]
-├── offset: [0]
+├── limit: 9
+├── offset: 0
 └── Sort
-    ├── sort keys: [number (#0) ASC]
-    ├── limit: [9]
+    ├── sort keys: [number ASC NULLS LAST]
     └── Limit
-        ├── limit: [8]
-        ├── offset: [0]
+        ├── limit: 8
+        ├── offset: 0
         └── Sort
-            ├── sort keys: [number (#0) DESC]
-            ├── limit: [8]
-            └── PhysicalScan
+            ├── sort keys: [number DESC NULLS LAST]
+            └── TableScan
                 ├── table: default.system.numbers
-                ├── filters: []
-                ├── order by: [number (#0) DESC]
-                └── limit: 8
+                ├── read rows: 10
+                ├── read bytes: 80
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                └── push downs: [filters: [], limit: 8]
 
 statement query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = (select count(*) from numbers(1) as t2, numbers(1) as t3 where t.number = t2.number) group by t.number order by t.number desc limit 3;
 
 ----
 Limit
-├── limit: [3]
-├── offset: [0]
+├── limit: 3
+├── offset: 0
 └── Sort
-    ├── sort keys: [number (#0) DESC]
-    ├── limit: [3]
-    └── Aggregate(Final)
-        ├── group items: [t.number (#0)]
+    ├── sort keys: [number DESC NULLS LAST]
+    └── AggregateFinal
+        ├── group by: [number]
         ├── aggregate functions: []
-        └── Aggregate(Partial)
-            ├── group items: [t.number (#0)]
+        └── AggregatePartial
+            ├── group by: [number]
             ├── aggregate functions: []
             └── Filter
-                ├── filters: [t.number (#0) = CAST(if(is_not_null(scalar_subquery_4 (#4)), scalar_subquery_4 (#4), 0) AS BIGINT UNSIGNED)]
-                └── HashJoin: SINGLE
-                    ├── build keys: [subquery_6 (#6)]
-                    ├── probe keys: [subquery_0 (#0)]
-                    ├── other filters: []
-                    ├── CrossJoin
-                    │   ├── build keys: []
-                    │   ├── probe keys: []
-                    │   ├── other filters: []
-                    │   ├── PhysicalScan
-                    │   │   ├── table: default.system.numbers
-                    │   │   ├── filters: []
-                    │   │   ├── order by: []
-                    │   │   └── limit: NONE
-                    │   └── PhysicalScan
-                    │       ├── table: default.system.numbers
-                    │       ├── filters: []
-                    │       ├── order by: []
-                    │       └── limit: NONE
-                    └── Project
-                        ├── projections: [COUNT(*) (#4),number (#6)]
-                        └── EvalScalar
-                            ├── scalars: [COUNT(*) (#5)]
-                            └── Aggregate(Final)
-                                ├── group items: [subquery_6 (#6)]
-                                ├── aggregate functions: [COUNT(*)]
-                                └── Aggregate(Partial)
-                                    ├── group items: [subquery_6 (#6)]
-                                    ├── aggregate functions: [COUNT(*)]
-                                    └── HashJoin: INNER
-                                        ├── build keys: [t2.number (#2)]
-                                        ├── probe keys: [subquery_6 (#6)]
-                                        ├── other filters: []
-                                        ├── PhysicalScan
-                                        │   ├── table: default.system.numbers
-                                        │   ├── filters: []
-                                        │   ├── order by: []
-                                        │   └── limit: NONE
-                                        └── CrossJoin
-                                            ├── build keys: []
-                                            ├── probe keys: []
-                                            ├── other filters: []
-                                            ├── PhysicalScan
-                                            │   ├── table: default.system.numbers
-                                            │   ├── filters: []
-                                            │   ├── order by: []
-                                            │   └── limit: NONE
-                                            └── PhysicalScan
-                                                ├── table: default.system.numbers
-                                                ├── filters: []
-                                                ├── order by: []
-                                                └── limit: NONE
+                ├── filters: [=(numbers.number (#0), CAST(if(is_not_null(COUNT(*) (#4)), COUNT(*) (#4), 0) AS BIGINT UNSIGNED))]
+                └── HashJoin
+                    ├── join type: SINGLE
+                    ├── build keys: [number (#6)]
+                    ├── probe keys: [numbers.number (#0)]
+                    ├── filters: []
+                    ├── Project(Build)
+                    │   ├── columns: [2, 1]
+                    │   └── EvalScalar
+                    │       ├── expressions: [COUNT(*) (#5)]
+                    │       └── AggregateFinal
+                    │           ├── group by: [number]
+                    │           ├── aggregate functions: [count()]
+                    │           └── AggregatePartial
+                    │               ├── group by: [number]
+                    │               ├── aggregate functions: [count()]
+                    │               └── HashJoin
+                    │                   ├── join type: INNER
+                    │                   ├── build keys: [numbers.number (#2)]
+                    │                   ├── probe keys: [number (#6)]
+                    │                   ├── filters: []
+                    │                   ├── HashJoin(Build)
+                    │                   │   ├── join type: CROSS
+                    │                   │   ├── build keys: []
+                    │                   │   ├── probe keys: []
+                    │                   │   ├── filters: []
+                    │                   │   ├── TableScan(Build)
+                    │                   │   │   ├── table: default.system.numbers
+                    │                   │   │   ├── read rows: 1
+                    │                   │   │   ├── read bytes: 8
+                    │                   │   │   ├── partitions total: 1
+                    │                   │   │   ├── partitions scanned: 1
+                    │                   │   │   └── push downs: [filters: [], limit: NONE]
+                    │                   │   └── TableScan(Probe)
+                    │                   │       ├── table: default.system.numbers
+                    │                   │       ├── read rows: 1
+                    │                   │       ├── read bytes: 8
+                    │                   │       ├── partitions total: 1
+                    │                   │       ├── partitions scanned: 1
+                    │                   │       └── push downs: [filters: [], limit: NONE]
+                    │                   └── TableScan(Probe)
+                    │                       ├── table: default.system.numbers
+                    │                       ├── read rows: 1
+                    │                       ├── read bytes: 8
+                    │                       ├── partitions total: 1
+                    │                       ├── partitions scanned: 1
+                    │                       └── push downs: [filters: [], limit: NONE]
+                    └── HashJoin(Probe)
+                        ├── join type: CROSS
+                        ├── build keys: []
+                        ├── probe keys: []
+                        ├── filters: []
+                        ├── TableScan(Build)
+                        │   ├── table: default.system.numbers
+                        │   ├── read rows: 1
+                        │   ├── read bytes: 8
+                        │   ├── partitions total: 1
+                        │   ├── partitions scanned: 1
+                        │   └── push downs: [filters: [], limit: NONE]
+                        └── TableScan(Probe)
+                            ├── table: default.system.numbers
+                            ├── read rows: 1
+                            ├── read bytes: 8
+                            ├── partitions total: 1
+                            ├── partitions scanned: 1
+                            └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from (select count(t1.number) as c1 from numbers(1) as t1 group by number) as t3 left join (select count(t.number) as c from numbers(2) as t group by number) as t4 on t3.c1=t4.c order by t3.c1 limit 1;
 
 ----
 Limit
-├── limit: [1]
-├── offset: [0]
+├── limit: 1
+├── offset: 0
 └── Sort
-    ├── sort keys: [c1 (#1) ASC]
-    ├── limit: [1]
-    └── HashJoin: LEFT OUTER
-        ├── build keys: [t4.c (#5)]
-        ├── probe keys: [CAST(t3.c1 (#1) AS BIGINT UNSIGNED NULL)]
-        ├── other filters: []
-        ├── Project
-        │   ├── projections: [c1 (#1)]
+    ├── sort keys: [c1 ASC NULLS LAST]
+    └── HashJoin
+        ├── join type: LEFT OUTER
+        ├── build keys: [c (#5)]
+        ├── probe keys: [CAST(c1 (#1) AS BIGINT UNSIGNED NULL)]
+        ├── filters: []
+        ├── Project(Build)
+        │   ├── columns: [2]
         │   └── EvalScalar
-        │       ├── scalars: [count(t1.number) (#3)]
-        │       └── Aggregate(Final)
-        │           ├── group items: [t1.number (#0)]
-        │           ├── aggregate functions: [count(t1.number)]
-        │           └── Aggregate(Partial)
-        │               ├── group items: [t1.number (#0)]
-        │               ├── aggregate functions: [count(t1.number)]
-        │               └── PhysicalScan
+        │       ├── expressions: [count(t.number) (#7)]
+        │       └── AggregateFinal
+        │           ├── group by: [number]
+        │           ├── aggregate functions: [count(number)]
+        │           └── AggregatePartial
+        │               ├── group by: [number]
+        │               ├── aggregate functions: [count(number)]
+        │               └── TableScan
         │                   ├── table: default.system.numbers
-        │                   ├── filters: []
-        │                   ├── order by: []
-        │                   └── limit: NONE
-        └── Project
-            ├── projections: [c (#5)]
+        │                   ├── read rows: 2
+        │                   ├── read bytes: 16
+        │                   ├── partitions total: 1
+        │                   ├── partitions scanned: 1
+        │                   └── push downs: [filters: [], limit: NONE]
+        └── Project(Probe)
+            ├── columns: [2]
             └── EvalScalar
-                ├── scalars: [count(t.number) (#7)]
-                └── Aggregate(Final)
-                    ├── group items: [t.number (#4)]
-                    ├── aggregate functions: [count(t.number)]
-                    └── Aggregate(Partial)
-                        ├── group items: [t.number (#4)]
-                        ├── aggregate functions: [count(t.number)]
-                        └── PhysicalScan
+                ├── expressions: [count(t1.number) (#3)]
+                └── AggregateFinal
+                    ├── group by: [number]
+                    ├── aggregate functions: [count(number)]
+                    └── AggregatePartial
+                        ├── group by: [number]
+                        ├── aggregate functions: [count(number)]
+                        └── TableScan
                             ├── table: default.system.numbers
-                            ├── filters: []
-                            ├── order by: []
-                            └── limit: NONE
+                            ├── read rows: 1
+                            ├── read bytes: 8
+                            ├── partitions total: 1
+                            ├── partitions scanned: 1
+                            └── push downs: [filters: [], limit: NONE]
 

--- a/tests/logictest/suites/mode/standalone/explain/limit.test
+++ b/tests/logictest/suites/mode/standalone/explain/limit.test
@@ -77,7 +77,7 @@ Limit
                     ├── probe keys: [numbers.number (#0)]
                     ├── filters: []
                     ├── Project(Build)
-                    │   ├── columns: [2, 1]
+                    │   ├── columns: [COUNT(*) (#4), number (#6)]
                     │   └── EvalScalar
                     │       ├── expressions: [COUNT(*) (#5)]
                     │       └── AggregateFinal
@@ -152,7 +152,7 @@ Limit
         ├── probe keys: [CAST(c1 (#1) AS BIGINT UNSIGNED NULL)]
         ├── filters: []
         ├── Project(Build)
-        │   ├── columns: [2]
+        │   ├── columns: [c (#5)]
         │   └── EvalScalar
         │       ├── expressions: [count(t.number) (#7)]
         │       └── AggregateFinal
@@ -169,7 +169,7 @@ Limit
         │                   ├── partitions scanned: 1
         │                   └── push downs: [filters: [], limit: NONE]
         └── Project(Probe)
-            ├── columns: [2]
+            ├── columns: [c1 (#1)]
             └── EvalScalar
                 ├── expressions: [count(t1.number) (#3)]
                 └── AggregateFinal

--- a/tests/logictest/suites/mode/standalone/explain/prune_column.test
+++ b/tests/logictest/suites/mode/standalone/explain/prune_column.test
@@ -3,7 +3,7 @@ explain select * from (select a from (select number as a, number + 1 as b from n
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── TableScan
     ├── table: default.system.numbers
     ├── read rows: 1
@@ -17,7 +17,7 @@ explain select a from (select number as a, count(*) as b from numbers(1) group b
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── AggregateFinal
     ├── group by: [number]
     ├── aggregate functions: []
@@ -37,14 +37,14 @@ explain select a from (select number as a, number b, sum(number) as c, number as
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── Limit
     ├── limit: 1
     ├── offset: 0
     └── Sort
         ├── sort keys: [number ASC NULLS LAST]
         └── Project
-            ├── columns: [0]
+            ├── columns: [number (#0)]
             └── Filter
                 ├── filters: [>(numbers.number (#0), 1)]
                 └── AggregateFinal
@@ -66,14 +66,14 @@ explain select * from (select t1.a from (select number + 1 as a, number + 1 as b
 
 ----
 Project
-├── columns: [0]
+├── columns: [a (#1)]
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [b (#11)]
     ├── probe keys: [b (#2)]
     ├── filters: []
     ├── Project(Build)
-    │   ├── columns: [1]
+    │   ├── columns: [b (#11)]
     │   └── EvalScalar
     │       ├── expressions: [+(numbers.number (#9), 1)]
     │       └── TableScan
@@ -84,7 +84,7 @@ Project
     │           ├── partitions scanned: 1
     │           └── push downs: [filters: [], limit: NONE]
     └── Project(Probe)
-        ├── columns: [3, 2]
+        ├── columns: [a (#1), b (#2)]
         └── Filter
             ├── filters: [=(c (#3), 1)]
             └── EvalScalar
@@ -102,7 +102,7 @@ explain select t1.a from (select number + 1 as a, number + 1 as b from numbers(1
 
 ----
 Project
-├── columns: [0]
+├── columns: [a (#1)]
 └── Filter
     ├── filters: [=(a (#1), COUNT(*) (#21))]
     └── HashJoin
@@ -111,7 +111,7 @@ Project
         ├── probe keys: []
         ├── filters: []
         ├── Project(Build)
-        │   ├── columns: [1]
+        │   ├── columns: [COUNT(*) (#21)]
         │   └── EvalScalar
         │       ├── expressions: [COUNT(*) (#22)]
         │       └── AggregateFinal
@@ -121,14 +121,14 @@ Project
         │               ├── group by: []
         │               ├── aggregate functions: [count()]
         │               └── Project
-        │                   ├── columns: [0]
+        │                   ├── columns: [a (#6)]
         │                   └── HashJoin
         │                       ├── join type: INNER
         │                       ├── build keys: [b (#16)]
         │                       ├── probe keys: [b (#7)]
         │                       ├── filters: []
         │                       ├── Project(Build)
-        │                       │   ├── columns: [1]
+        │                       │   ├── columns: [b (#16)]
         │                       │   └── EvalScalar
         │                       │       ├── expressions: [+(numbers.number (#14), 1)]
         │                       │       └── TableScan
@@ -139,7 +139,7 @@ Project
         │                       │           ├── partitions scanned: 1
         │                       │           └── push downs: [filters: [], limit: NONE]
         │                       └── Project(Probe)
-        │                           ├── columns: [1, 3]
+        │                           ├── columns: [a (#6), b (#7)]
         │                           └── Filter
         │                               ├── filters: [=(c (#8), 1)]
         │                               └── EvalScalar
@@ -152,7 +152,7 @@ Project
         │                                       ├── partitions scanned: 1
         │                                       └── push downs: [filters: [], limit: NONE]
         └── Project(Probe)
-            ├── columns: [1]
+            ├── columns: [a (#1)]
             └── EvalScalar
                 ├── expressions: [+(numbers.number (#0), 1)]
                 └── TableScan
@@ -168,7 +168,7 @@ explain select name from system.functions order by example;
 
 ----
 Project
-├── columns: [1]
+├── columns: [name (#0)]
 └── Sort
     ├── sort keys: [example ASC NULLS LAST]
     └── TableScan
@@ -184,7 +184,7 @@ explain select t.number from numbers(10) t where exists(select * from numbers(10
 
 ----
 Project
-├── columns: [1]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: CROSS
     ├── build keys: []
@@ -198,7 +198,7 @@ Project
     │   ├── partitions scanned: 1
     │   └── push downs: [filters: [], limit: NONE]
     └── Project(Probe)
-        ├── columns: [1]
+        ├── columns: [subquery (#3)]
         └── Filter
             ├── filters: [subquery (#3)]
             └── EvalScalar

--- a/tests/logictest/suites/mode/standalone/explain/prune_column.test
+++ b/tests/logictest/suites/mode/standalone/explain/prune_column.test
@@ -3,196 +3,220 @@ explain select * from (select a from (select number as a, number + 1 as b from n
 
 ----
 Project
-├── projections: [number (#0)]
-└── PhysicalScan
+├── columns: [0]
+└── TableScan
     ├── table: default.system.numbers
-    ├── filters: []
-    ├── order by: []
-    └── limit: NONE
+    ├── read rows: 1
+    ├── read bytes: 8
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select a from (select number as a, count(*) as b from numbers(1) group by a);
 
 ----
 Project
-├── projections: [number (#0)]
-└── Aggregate(Final)
-    ├── group items: [numbers.number (#0)]
+├── columns: [0]
+└── AggregateFinal
+    ├── group by: [number]
     ├── aggregate functions: []
-    └── Aggregate(Partial)
-        ├── group items: [numbers.number (#0)]
+    └── AggregatePartial
+        ├── group by: [number]
         ├── aggregate functions: []
-        └── PhysicalScan
+        └── TableScan
             ├── table: default.system.numbers
-            ├── filters: []
-            ├── order by: []
-            └── limit: NONE
+            ├── read rows: 1
+            ├── read bytes: 8
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select a from (select number as a, number b, sum(number) as c, number as d, number as e from numbers(1) group by a, b, d, e) where b > 1 order by d limit 1;
 
 ----
 Project
-├── projections: [number (#0)]
+├── columns: [0]
 └── Limit
-    ├── limit: [1]
-    ├── offset: [0]
+    ├── limit: 1
+    ├── offset: 0
     └── Sort
-        ├── sort keys: [number (#0) ASC]
-        ├── limit: [1]
+        ├── sort keys: [number ASC NULLS LAST]
         └── Project
-            ├── projections: [number (#0)]
+            ├── columns: [0]
             └── Filter
-                ├── filters: [numbers.b (#0) > 1]
-                └── Aggregate(Final)
-                    ├── group items: [numbers.number (#0), numbers.number (#0), numbers.number (#0), numbers.number (#0)]
+                ├── filters: [>(numbers.number (#0), 1)]
+                └── AggregateFinal
+                    ├── group by: [number, number, number, number]
                     ├── aggregate functions: []
-                    └── Aggregate(Partial)
-                        ├── group items: [numbers.number (#0), numbers.number (#0), numbers.number (#0), numbers.number (#0)]
+                    └── AggregatePartial
+                        ├── group by: [number, number, number, number]
                         ├── aggregate functions: []
-                        └── PhysicalScan
+                        └── TableScan
                             ├── table: default.system.numbers
-                            ├── filters: []
-                            ├── order by: []
-                            └── limit: NONE
+                            ├── read rows: 1
+                            ├── read bytes: 8
+                            ├── partitions total: 1
+                            ├── partitions scanned: 1
+                            └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from (select t1.a from (select number + 1 as a, number + 1 as b, number + 1 as c, number + 1 as d from numbers(1)) as t1, (select number + 1 as a, number + 1 as b, number + 1 as c from numbers(1)) as t2 where t1.b = t2.b and t1.c = 1);
 
 ----
 Project
-├── projections: [a (#1)]
-└── HashJoin: INNER
-    ├── build keys: [t2.b (#11)]
-    ├── probe keys: [t1.b (#2)]
-    ├── other filters: []
-    ├── Project
-    │   ├── projections: [a (#1),b (#2)]
-    │   └── Filter
-    │       ├── filters: [t1.c (#3) = 1]
-    │       └── EvalScalar
-    │           ├── scalars: [+(numbers.number (#0), 1), +(numbers.number (#0), 1), +(numbers.number (#0), 1)]
-    │           └── PhysicalScan
-    │               ├── table: default.system.numbers
-    │               ├── filters: []
-    │               ├── order by: []
-    │               └── limit: NONE
-    └── Project
-        ├── projections: [b (#11)]
-        └── EvalScalar
-            ├── scalars: [+(numbers.number (#9), 1)]
-            └── PhysicalScan
-                ├── table: default.system.numbers
-                ├── filters: []
-                ├── order by: []
-                └── limit: NONE
+├── columns: [0]
+└── HashJoin
+    ├── join type: INNER
+    ├── build keys: [b (#11)]
+    ├── probe keys: [b (#2)]
+    ├── filters: []
+    ├── Project(Build)
+    │   ├── columns: [1]
+    │   └── EvalScalar
+    │       ├── expressions: [+(numbers.number (#9), 1)]
+    │       └── TableScan
+    │           ├── table: default.system.numbers
+    │           ├── read rows: 1
+    │           ├── read bytes: 8
+    │           ├── partitions total: 1
+    │           ├── partitions scanned: 1
+    │           └── push downs: [filters: [], limit: NONE]
+    └── Project(Probe)
+        ├── columns: [3, 2]
+        └── Filter
+            ├── filters: [=(c (#3), 1)]
+            └── EvalScalar
+                ├── expressions: [+(numbers.number (#0), 1), +(numbers.number (#0), 1), +(numbers.number (#0), 1)]
+                └── TableScan
+                    ├── table: default.system.numbers
+                    ├── read rows: 1
+                    ├── read bytes: 8
+                    ├── partitions total: 1
+                    ├── partitions scanned: 1
+                    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t1.a from (select number + 1 as a, number + 1 as b from numbers(1)) as t1 where t1.a = (select count(*) from (select t2.a, t3.a from (select number + 1 as a, number + 1 as b, number + 1 as c, number + 1 as d from numbers(1)) as t2, (select number + 1 as a, number + 1 as b, number + 1 as c from numbers(1)) as t3 where t2.b = t3.b and t2.c = 1));
 
 ----
 Project
-├── projections: [a (#1)]
+├── columns: [0]
 └── Filter
-    ├── filters: [t1.a (#1) = scalar_subquery_21 (#21)]
-    └── HashJoin: SINGLE
+    ├── filters: [=(a (#1), COUNT(*) (#21))]
+    └── HashJoin
+        ├── join type: SINGLE
         ├── build keys: []
         ├── probe keys: []
-        ├── other filters: []
-        ├── Project
-        │   ├── projections: [a (#1)]
+        ├── filters: []
+        ├── Project(Build)
+        │   ├── columns: [1]
         │   └── EvalScalar
-        │       ├── scalars: [+(numbers.number (#0), 1)]
-        │       └── PhysicalScan
-        │           ├── table: default.system.numbers
-        │           ├── filters: []
-        │           ├── order by: []
-        │           └── limit: NONE
-        └── Project
-            ├── projections: [COUNT(*) (#21)]
+        │       ├── expressions: [COUNT(*) (#22)]
+        │       └── AggregateFinal
+        │           ├── group by: []
+        │           ├── aggregate functions: [count()]
+        │           └── AggregatePartial
+        │               ├── group by: []
+        │               ├── aggregate functions: [count()]
+        │               └── Project
+        │                   ├── columns: [0]
+        │                   └── HashJoin
+        │                       ├── join type: INNER
+        │                       ├── build keys: [b (#16)]
+        │                       ├── probe keys: [b (#7)]
+        │                       ├── filters: []
+        │                       ├── Project(Build)
+        │                       │   ├── columns: [1]
+        │                       │   └── EvalScalar
+        │                       │       ├── expressions: [+(numbers.number (#14), 1)]
+        │                       │       └── TableScan
+        │                       │           ├── table: default.system.numbers
+        │                       │           ├── read rows: 1
+        │                       │           ├── read bytes: 8
+        │                       │           ├── partitions total: 1
+        │                       │           ├── partitions scanned: 1
+        │                       │           └── push downs: [filters: [], limit: NONE]
+        │                       └── Project(Probe)
+        │                           ├── columns: [1, 3]
+        │                           └── Filter
+        │                               ├── filters: [=(c (#8), 1)]
+        │                               └── EvalScalar
+        │                                   ├── expressions: [+(numbers.number (#5), 1), +(numbers.number (#5), 1), +(numbers.number (#5), 1)]
+        │                                   └── TableScan
+        │                                       ├── table: default.system.numbers
+        │                                       ├── read rows: 1
+        │                                       ├── read bytes: 8
+        │                                       ├── partitions total: 1
+        │                                       ├── partitions scanned: 1
+        │                                       └── push downs: [filters: [], limit: NONE]
+        └── Project(Probe)
+            ├── columns: [1]
             └── EvalScalar
-                ├── scalars: [COUNT(*) (#22)]
-                └── Aggregate(Final)
-                    ├── group items: []
-                    ├── aggregate functions: [COUNT(*)]
-                    └── Aggregate(Partial)
-                        ├── group items: []
-                        ├── aggregate functions: [COUNT(*)]
-                        └── Project
-                            ├── projections: [a (#6)]
-                            └── HashJoin: INNER
-                                ├── build keys: [t3.b (#16)]
-                                ├── probe keys: [t2.b (#7)]
-                                ├── other filters: []
-                                ├── Project
-                                │   ├── projections: [a (#6),b (#7)]
-                                │   └── Filter
-                                │       ├── filters: [t2.c (#8) = 1]
-                                │       └── EvalScalar
-                                │           ├── scalars: [+(numbers.number (#5), 1), +(numbers.number (#5), 1), +(numbers.number (#5), 1)]
-                                │           └── PhysicalScan
-                                │               ├── table: default.system.numbers
-                                │               ├── filters: []
-                                │               ├── order by: []
-                                │               └── limit: NONE
-                                └── Project
-                                    ├── projections: [b (#16)]
-                                    └── EvalScalar
-                                        ├── scalars: [+(numbers.number (#14), 1)]
-                                        └── PhysicalScan
-                                            ├── table: default.system.numbers
-                                            ├── filters: []
-                                            ├── order by: []
-                                            └── limit: NONE
+                ├── expressions: [+(numbers.number (#0), 1)]
+                └── TableScan
+                    ├── table: default.system.numbers
+                    ├── read rows: 1
+                    ├── read bytes: 8
+                    ├── partitions total: 1
+                    ├── partitions scanned: 1
+                    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select name from system.functions order by example;
 
 ----
 Project
-├── projections: [name (#0)]
+├── columns: [1]
 └── Sort
-    ├── sort keys: [example (#7) ASC]
-    ├── limit: [NONE]
-    └── PhysicalScan
+    ├── sort keys: [example ASC NULLS LAST]
+    └── TableScan
         ├── table: default.system.functions
-        ├── filters: []
-        ├── order by: [example (#7) ASC]
-        └── limit: NONE
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(10) t where exists(select * from numbers(10));
 
 ----
 Project
-├── projections: [number (#0)]
-└── CrossJoin
+├── columns: [1]
+└── HashJoin
+    ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── other filters: []
-    ├── Project
-    │   ├── projections: [subquery (#3)]
-    │   └── Filter
-    │       ├── filters: [subquery_3 (#3)]
-    │       └── EvalScalar
-    │           ├── scalars: [count(*) (#2) = 1]
-    │           └── Aggregate(Final)
-    │               ├── group items: []
-    │               ├── aggregate functions: [count(*)]
-    │               └── Aggregate(Partial)
-    │                   ├── group items: []
-    │                   ├── aggregate functions: [count(*)]
-    │                   └── Limit
-    │                       ├── limit: [1]
-    │                       ├── offset: [0]
-    │                       └── PhysicalScan
-    │                           ├── table: default.system.numbers
-    │                           ├── filters: []
-    │                           ├── order by: []
-    │                           └── limit: 1
-    └── PhysicalScan
-        ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.system.numbers
+    │   ├── read rows: 10
+    │   ├── read bytes: 80
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── Project(Probe)
+        ├── columns: [1]
+        └── Filter
+            ├── filters: [subquery (#3)]
+            └── EvalScalar
+                ├── expressions: [=(count(*) (#2), 1)]
+                └── AggregateFinal
+                    ├── group by: []
+                    ├── aggregate functions: [count()]
+                    └── AggregatePartial
+                        ├── group by: []
+                        ├── aggregate functions: [count()]
+                        └── Limit
+                            ├── limit: 1
+                            ├── offset: 0
+                            └── TableScan
+                                ├── table: default.system.numbers
+                                ├── read rows: 1
+                                ├── read bytes: 8
+                                ├── partitions total: 1
+                                ├── partitions scanned: 1
+                                └── push downs: [filters: [], limit: 1]
 

--- a/tests/logictest/suites/mode/standalone/explain/select.test
+++ b/tests/logictest/suites/mode/standalone/explain/select.test
@@ -141,7 +141,7 @@ explain select a from (select number as a, number+1 as b from numbers(1));
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── TableScan
     ├── table: default.system.numbers
     ├── read rows: 1

--- a/tests/logictest/suites/mode/standalone/explain/select.test
+++ b/tests/logictest/suites/mode/standalone/explain/select.test
@@ -2,73 +2,85 @@ statement query T
 explain select * from numbers(1);
 
 ----
-PhysicalScan
+TableScan
 ├── table: default.system.numbers
-├── filters: []
-├── order by: []
-└── limit: NONE
+├── read rows: 1
+├── read bytes: 8
+├── partitions total: 1
+├── partitions scanned: 1
+└── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from (select * from numbers(1)) as t1 where number = 1;
 
 ----
 Filter
-├── filters: [t1.number (#0) = 1]
-└── PhysicalScan
+├── filters: [=(numbers.number (#0), 1)]
+└── TableScan
     ├── table: default.system.numbers
-    ├── filters: [t1.number (#0) = 1]
-    ├── order by: []
-    └── limit: NONE
+    ├── read rows: 1
+    ├── read bytes: 8
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [(number = 1)], limit: NONE]
 
 statement query T
 explain select * from (select number as a, number + 1 as b from numbers(1)) as t1 where a = 1 and b = 1;
 
 ----
 Filter
-├── filters: [t1.a (#0) = 1, t1.b (#1) = 1]
+├── filters: [=(numbers.number (#0), 1), =(b (#1), 1)]
 └── EvalScalar
-    ├── scalars: [+(numbers.number (#0), 1)]
-    └── PhysicalScan
+    ├── expressions: [+(numbers.number (#0), 1)]
+    └── TableScan
         ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+        ├── read rows: 1
+        ├── read bytes: 8
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from (select number as a, number + 1 as b from numbers(1)) as t1 where a = 1;
 
 ----
 EvalScalar
-├── scalars: [+(numbers.number (#0), 1)]
+├── expressions: [+(numbers.number (#0), 1)]
 └── Filter
-    ├── filters: [t1.a (#0) = 1]
-    └── PhysicalScan
+    ├── filters: [=(numbers.number (#0), 1)]
+    └── TableScan
         ├── table: default.system.numbers
-        ├── filters: [t1.a (#0) = 1]
-        ├── order by: []
-        └── limit: NONE
+        ├── read rows: 1
+        ├── read bytes: 8
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [(number = 1)], limit: NONE]
 
 statement query T
 explain select * from numbers(1) where number = pow(1, 1 + 1);
 
 ----
 Filter
-├── filters: [numbers.number (#0) = 1]
-└── PhysicalScan
+├── filters: [=(numbers.number (#0), 1)]
+└── TableScan
     ├── table: default.system.numbers
-    ├── filters: [numbers.number (#0) = 1]
-    ├── order by: []
-    └── limit: NONE
+    ├── read rows: 1
+    ├── read bytes: 8
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [(number = '1.0')], limit: NONE]
 
 statement query T
 explain select * from numbers(1) where TRUE and 1 = 1;
 
 ----
-PhysicalScan
+TableScan
 ├── table: default.system.numbers
-├── filters: []
-├── order by: []
-└── limit: NONE
+├── read rows: 1
+├── read bytes: 8
+├── partitions total: 1
+├── partitions scanned: 1
+└── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from numbers(1) where number = 0 and false;
@@ -76,11 +88,13 @@ explain select * from numbers(1) where number = 0 and false;
 ----
 Filter
 ├── filters: [false]
-└── PhysicalScan
+└── TableScan
     ├── table: default.system.numbers
-    ├── filters: [false]
-    ├── order by: []
-    └── limit: NONE
+    ├── read rows: 1
+    ├── read bytes: 8
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [false], limit: NONE]
 
 statement query T
 explain select * from numbers(1) where number = 0 and null;
@@ -88,11 +102,13 @@ explain select * from numbers(1) where number = 0 and null;
 ----
 Filter
 ├── filters: [false]
-└── PhysicalScan
+└── TableScan
     ├── table: default.system.numbers
-    ├── filters: [false]
-    ├── order by: []
-    └── limit: NONE
+    ├── read rows: 1
+    ├── read bytes: 8
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [false], limit: NONE]
 
 statement query T
 explain select * from numbers(1) where null;
@@ -100,31 +116,37 @@ explain select * from numbers(1) where null;
 ----
 Filter
 ├── filters: [NULL]
-└── PhysicalScan
+└── TableScan
     ├── table: default.system.numbers
-    ├── filters: [NULL]
-    ├── order by: []
-    └── limit: NONE
+    ├── read rows: 1
+    ├── read bytes: 8
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [NULL], limit: NONE]
 
 statement query T
 explain select a from (select number as a, number as b from numbers(1));
 
 ----
-PhysicalScan
+TableScan
 ├── table: default.system.numbers
-├── filters: []
-├── order by: []
-└── limit: NONE
+├── read rows: 1
+├── read bytes: 8
+├── partitions total: 1
+├── partitions scanned: 1
+└── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select a from (select number as a, number+1 as b from numbers(1));
 
 ----
 Project
-├── projections: [number (#0)]
-└── PhysicalScan
+├── columns: [0]
+└── TableScan
     ├── table: default.system.numbers
-    ├── filters: []
-    ├── order by: []
-    └── limit: NONE
+    ├── read rows: 1
+    ├── read bytes: 8
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
 

--- a/tests/logictest/suites/mode/standalone/explain/select_limit_offset.test
+++ b/tests/logictest/suites/mode/standalone/explain/select_limit_offset.test
@@ -137,28 +137,33 @@ explain select * from t left join t1 on t.a = t1.a limit 1,2;
 
 ----
 Limit
-├── limit: [2]
-├── offset: [1]
-└── HashJoin: LEFT OUTER
+├── limit: 2
+├── offset: 1
+└── HashJoin
+    ├── join type: LEFT OUTER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [CAST(t.a (#0) AS INT NULL)]
-    ├── other filters: []
-    ├── Limit
-    │   ├── limit: [2]
-    │   ├── offset: [1]
-    │   └── PhysicalScan
-    │       ├── table: default.default.t
-    │       ├── filters: []
-    │       ├── order by: []
-    │       └── limit: 3
-    └── Limit
-        ├── limit: [2]
-        ├── offset: [1]
-        └── PhysicalScan
-            ├── table: default.default.t1
-            ├── filters: []
-            ├── order by: []
-            └── limit: 3
+    ├── filters: []
+    ├── Limit(Build)
+    │   ├── limit: 2
+    │   ├── offset: 1
+    │   └── TableScan
+    │       ├── table: default.default.t1
+    │       ├── read rows: 2
+    │       ├── read bytes: 31
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       └── push downs: [filters: [], limit: 3]
+    └── Limit(Probe)
+        ├── limit: 2
+        ├── offset: 1
+        └── TableScan
+            ├── table: default.default.t
+            ├── read rows: 1
+            ├── read bytes: 27
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            └── push downs: [filters: [], limit: 3]
 
 statement query II
 select * from t left join t1 on t.a = t1.a limit 1;
@@ -171,3 +176,4 @@ drop table if exists t;
 
 statement ok
 drop table if exists t1;
+

--- a/tests/logictest/suites/mode/standalone/explain/subquery.test
+++ b/tests/logictest/suites/mode/standalone/explain/subquery.test
@@ -3,7 +3,7 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = 
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── Filter
     ├── filters: [=(numbers.number (#0), CAST(if(is_not_null(COUNT(*) (#4)), COUNT(*) (#4), 0) AS BIGINT UNSIGNED))]
     └── HashJoin
@@ -12,7 +12,7 @@ Project
         ├── probe keys: [numbers.number (#0)]
         ├── filters: []
         ├── Project(Build)
-        │   ├── columns: [2, 1]
+        │   ├── columns: [COUNT(*) (#4), number (#6)]
         │   └── EvalScalar
         │       ├── expressions: [COUNT(*) (#5)]
         │       └── AggregateFinal
@@ -77,7 +77,7 @@ explain select t.number from numbers(1) as t where exists (select t1.number from
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── Filter
     ├── filters: [or(marker (#3), >(numbers.number (#0), 1))]
     └── HashJoin
@@ -117,7 +117,7 @@ explain select t.number from numbers(1) as t where exists (select * from numbers
 
 ----
 Project
-├── columns: [1]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: CROSS
     ├── build keys: []
@@ -131,7 +131,7 @@ Project
     │   ├── partitions scanned: 1
     │   └── push downs: [filters: [], limit: NONE]
     └── Project(Probe)
-        ├── columns: [1]
+        ├── columns: [subquery (#3)]
         └── Filter
             ├── filters: [subquery (#3)]
             └── EvalScalar
@@ -160,7 +160,7 @@ explain select t.number from numbers(1) as t where number = (select * from numbe
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── Filter
     ├── filters: [=(numbers.number (#0), numbers.number (#1))]
     └── HashJoin
@@ -190,7 +190,7 @@ explain select t.number from numbers(1) as t where exists (select * from numbers
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: SEMI
     ├── build keys: [numbers.number (#1)]
@@ -216,7 +216,7 @@ explain select t.number from numbers(1) as t where not exists (select * from num
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── Filter
     ├── filters: [not(marker (#3))]
     └── HashJoin
@@ -256,7 +256,7 @@ explain select * from numbers(1) as t where exists (select number as a from numb
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: SEMI
     ├── build keys: [numbers.number (#1)]
@@ -282,7 +282,7 @@ explain select t.number from numbers(1) as t where exists (select * from numbers
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: SEMI
     ├── build keys: [numbers.number (#1)]
@@ -312,7 +312,7 @@ explain select t.number from numbers(1) as t where exists (select * from numbers
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: SEMI
     ├── build keys: [numbers.number (#1)]
@@ -338,7 +338,7 @@ explain select t.number from numbers(1) as t where exists (select number as a, n
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── HashJoin
     ├── join type: SEMI
     ├── build keys: [numbers.number (#1)]
@@ -364,7 +364,7 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where (select cou
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── Filter
     ├── filters: [CAST(if(is_not_null(COUNT(*) = 1 (#3)), COUNT(*) = 1 (#3), 0) AS BIGINT UNSIGNED)]
     └── HashJoin
@@ -373,7 +373,7 @@ Project
         ├── probe keys: [numbers.number (#0)]
         ├── filters: []
         ├── Project(Build)
-        │   ├── columns: [2, 1]
+        │   ├── columns: [COUNT(*) = 1 (#3), number (#5)]
         │   └── EvalScalar
         │       ├── expressions: [=(COUNT(*) (#4), 1)]
         │       └── AggregateFinal
@@ -426,7 +426,7 @@ explain select t.number from numbers(1) as t where exists(select * from numbers(
 
 ----
 Project
-├── columns: [0]
+├── columns: [number (#0)]
 └── Filter
     ├── filters: [not(marker (#4))]
     └── HashJoin

--- a/tests/logictest/suites/mode/standalone/explain/subquery.test
+++ b/tests/logictest/suites/mode/standalone/explain/subquery.test
@@ -3,388 +3,475 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = 
 
 ----
 Project
-├── projections: [number (#0)]
+├── columns: [0]
 └── Filter
-    ├── filters: [t.number (#0) = CAST(if(is_not_null(scalar_subquery_4 (#4)), scalar_subquery_4 (#4), 0) AS BIGINT UNSIGNED)]
-    └── HashJoin: SINGLE
-        ├── build keys: [subquery_6 (#6)]
-        ├── probe keys: [subquery_0 (#0)]
-        ├── other filters: []
-        ├── CrossJoin
-        │   ├── build keys: []
-        │   ├── probe keys: []
-        │   ├── other filters: []
-        │   ├── PhysicalScan
-        │   │   ├── table: default.system.numbers
-        │   │   ├── filters: []
-        │   │   ├── order by: []
-        │   │   └── limit: NONE
-        │   └── PhysicalScan
-        │       ├── table: default.system.numbers
-        │       ├── filters: []
-        │       ├── order by: []
-        │       └── limit: NONE
-        └── Project
-            ├── projections: [COUNT(*) (#4),number (#6)]
-            └── EvalScalar
-                ├── scalars: [COUNT(*) (#5)]
-                └── Aggregate(Final)
-                    ├── group items: [subquery_6 (#6)]
-                    ├── aggregate functions: [COUNT(*)]
-                    └── Aggregate(Partial)
-                        ├── group items: [subquery_6 (#6)]
-                        ├── aggregate functions: [COUNT(*)]
-                        └── HashJoin: INNER
-                            ├── build keys: [t2.number (#2)]
-                            ├── probe keys: [subquery_6 (#6)]
-                            ├── other filters: []
-                            ├── PhysicalScan
-                            │   ├── table: default.system.numbers
-                            │   ├── filters: []
-                            │   ├── order by: []
-                            │   └── limit: NONE
-                            └── CrossJoin
-                                ├── build keys: []
-                                ├── probe keys: []
-                                ├── other filters: []
-                                ├── PhysicalScan
-                                │   ├── table: default.system.numbers
-                                │   ├── filters: []
-                                │   ├── order by: []
-                                │   └── limit: NONE
-                                └── PhysicalScan
-                                    ├── table: default.system.numbers
-                                    ├── filters: []
-                                    ├── order by: []
-                                    └── limit: NONE
+    ├── filters: [=(numbers.number (#0), CAST(if(is_not_null(COUNT(*) (#4)), COUNT(*) (#4), 0) AS BIGINT UNSIGNED))]
+    └── HashJoin
+        ├── join type: SINGLE
+        ├── build keys: [number (#6)]
+        ├── probe keys: [numbers.number (#0)]
+        ├── filters: []
+        ├── Project(Build)
+        │   ├── columns: [2, 1]
+        │   └── EvalScalar
+        │       ├── expressions: [COUNT(*) (#5)]
+        │       └── AggregateFinal
+        │           ├── group by: [number]
+        │           ├── aggregate functions: [count()]
+        │           └── AggregatePartial
+        │               ├── group by: [number]
+        │               ├── aggregate functions: [count()]
+        │               └── HashJoin
+        │                   ├── join type: INNER
+        │                   ├── build keys: [numbers.number (#2)]
+        │                   ├── probe keys: [number (#6)]
+        │                   ├── filters: []
+        │                   ├── HashJoin(Build)
+        │                   │   ├── join type: CROSS
+        │                   │   ├── build keys: []
+        │                   │   ├── probe keys: []
+        │                   │   ├── filters: []
+        │                   │   ├── TableScan(Build)
+        │                   │   │   ├── table: default.system.numbers
+        │                   │   │   ├── read rows: 1
+        │                   │   │   ├── read bytes: 8
+        │                   │   │   ├── partitions total: 1
+        │                   │   │   ├── partitions scanned: 1
+        │                   │   │   └── push downs: [filters: [], limit: NONE]
+        │                   │   └── TableScan(Probe)
+        │                   │       ├── table: default.system.numbers
+        │                   │       ├── read rows: 1
+        │                   │       ├── read bytes: 8
+        │                   │       ├── partitions total: 1
+        │                   │       ├── partitions scanned: 1
+        │                   │       └── push downs: [filters: [], limit: NONE]
+        │                   └── TableScan(Probe)
+        │                       ├── table: default.system.numbers
+        │                       ├── read rows: 1
+        │                       ├── read bytes: 8
+        │                       ├── partitions total: 1
+        │                       ├── partitions scanned: 1
+        │                       └── push downs: [filters: [], limit: NONE]
+        └── HashJoin(Probe)
+            ├── join type: CROSS
+            ├── build keys: []
+            ├── probe keys: []
+            ├── filters: []
+            ├── TableScan(Build)
+            │   ├── table: default.system.numbers
+            │   ├── read rows: 1
+            │   ├── read bytes: 8
+            │   ├── partitions total: 1
+            │   ├── partitions scanned: 1
+            │   └── push downs: [filters: [], limit: NONE]
+            └── TableScan(Probe)
+                ├── table: default.system.numbers
+                ├── read rows: 1
+                ├── read bytes: 8
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t where exists (select t1.number from numbers(1) as t1 where t.number = t1.number) or t.number > 1;
 
 ----
 Project
-├── projections: [number (#0)]
+├── columns: [0]
 └── Filter
-    ├── filters: [(3 (#3)) OR (t.number (#0) > 1)]
-    └── HashJoin: MARK
-        ├── build keys: [subquery_0 (#0)]
-        ├── probe keys: [subquery_2 (#2)]
-        ├── other filters: []
-        ├── HashJoin: INNER
-        │   ├── build keys: [t1.number (#1)]
-        │   ├── probe keys: [subquery_2 (#2)]
-        │   ├── other filters: []
-        │   ├── PhysicalScan
-        │   │   ├── table: default.system.numbers
-        │   │   ├── filters: []
-        │   │   ├── order by: []
-        │   │   └── limit: NONE
-        │   └── PhysicalScan
-        │       ├── table: default.system.numbers
-        │       ├── filters: []
-        │       ├── order by: []
-        │       └── limit: NONE
-        └── PhysicalScan
-            ├── table: default.system.numbers
+    ├── filters: [or(marker (#3), >(numbers.number (#0), 1))]
+    └── HashJoin
+        ├── join type: MARK
+        ├── build keys: [numbers.number (#0)]
+        ├── probe keys: [number (#2)]
+        ├── filters: []
+        ├── TableScan(Build)
+        │   ├── table: default.system.numbers
+        │   ├── read rows: 1
+        │   ├── read bytes: 8
+        │   ├── partitions total: 1
+        │   ├── partitions scanned: 1
+        │   └── push downs: [filters: [], limit: NONE]
+        └── HashJoin(Probe)
+            ├── join type: INNER
+            ├── build keys: [numbers.number (#1)]
+            ├── probe keys: [number (#2)]
             ├── filters: []
-            ├── order by: []
-            └── limit: NONE
+            ├── TableScan(Build)
+            │   ├── table: default.system.numbers
+            │   ├── read rows: 1
+            │   ├── read bytes: 8
+            │   ├── partitions total: 1
+            │   ├── partitions scanned: 1
+            │   └── push downs: [filters: [], limit: NONE]
+            └── TableScan(Probe)
+                ├── table: default.system.numbers
+                ├── read rows: 1
+                ├── read bytes: 8
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t where exists (select * from numbers(1) where number = 0);
 
 ----
 Project
-├── projections: [number (#0)]
-└── CrossJoin
+├── columns: [1]
+└── HashJoin
+    ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── other filters: []
-    ├── Project
-    │   ├── projections: [subquery (#3)]
-    │   └── Filter
-    │       ├── filters: [subquery_3 (#3)]
-    │       └── EvalScalar
-    │           ├── scalars: [count(*) (#2) = 1]
-    │           └── Aggregate(Final)
-    │               ├── group items: []
-    │               ├── aggregate functions: [count(*)]
-    │               └── Aggregate(Partial)
-    │                   ├── group items: []
-    │                   ├── aggregate functions: [count(*)]
-    │                   └── Limit
-    │                       ├── limit: [1]
-    │                       ├── offset: [0]
-    │                       └── Filter
-    │                           ├── filters: [numbers.number (#1) = 0]
-    │                           └── PhysicalScan
-    │                               ├── table: default.system.numbers
-    │                               ├── filters: [numbers.number (#1) = 0]
-    │                               ├── order by: []
-    │                               └── limit: NONE
-    └── PhysicalScan
-        ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.system.numbers
+    │   ├── read rows: 1
+    │   ├── read bytes: 8
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── Project(Probe)
+        ├── columns: [1]
+        └── Filter
+            ├── filters: [subquery (#3)]
+            └── EvalScalar
+                ├── expressions: [=(count(*) (#2), 1)]
+                └── AggregateFinal
+                    ├── group by: []
+                    ├── aggregate functions: [count()]
+                    └── AggregatePartial
+                        ├── group by: []
+                        ├── aggregate functions: [count()]
+                        └── Limit
+                            ├── limit: 1
+                            ├── offset: 0
+                            └── Filter
+                                ├── filters: [=(numbers.number (#1), 0)]
+                                └── TableScan
+                                    ├── table: default.system.numbers
+                                    ├── read rows: 1
+                                    ├── read bytes: 8
+                                    ├── partitions total: 1
+                                    ├── partitions scanned: 1
+                                    └── push downs: [filters: [(number = 0)], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t where number = (select * from numbers(1) where number = 0);
 
 ----
 Project
-├── projections: [number (#0)]
+├── columns: [0]
 └── Filter
-    ├── filters: [t.number (#0) = scalar_subquery_1 (#1)]
-    └── HashJoin: SINGLE
+    ├── filters: [=(numbers.number (#0), numbers.number (#1))]
+    └── HashJoin
+        ├── join type: SINGLE
         ├── build keys: []
         ├── probe keys: []
-        ├── other filters: []
-        ├── PhysicalScan
-        │   ├── table: default.system.numbers
-        │   ├── filters: []
-        │   ├── order by: []
-        │   └── limit: NONE
-        └── Filter
-            ├── filters: [numbers.number (#1) = 0]
-            └── PhysicalScan
-                ├── table: default.system.numbers
-                ├── filters: [numbers.number (#1) = 0]
-                ├── order by: []
-                └── limit: NONE
+        ├── filters: []
+        ├── Filter(Build)
+        │   ├── filters: [=(numbers.number (#1), 0)]
+        │   └── TableScan
+        │       ├── table: default.system.numbers
+        │       ├── read rows: 1
+        │       ├── read bytes: 8
+        │       ├── partitions total: 1
+        │       ├── partitions scanned: 1
+        │       └── push downs: [filters: [(number = 0)], limit: NONE]
+        └── TableScan(Probe)
+            ├── table: default.system.numbers
+            ├── read rows: 1
+            ├── read bytes: 8
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t where exists (select * from numbers(1) where number = t.number);
 
 ----
 Project
-├── projections: [number (#0)]
-└── HashJoin: SEMI
+├── columns: [0]
+└── HashJoin
+    ├── join type: SEMI
     ├── build keys: [numbers.number (#1)]
-    ├── probe keys: [t.number (#0)]
-    ├── other filters: []
-    ├── PhysicalScan
+    ├── probe keys: [numbers.number (#0)]
+    ├── filters: []
+    ├── TableScan(Build)
     │   ├── table: default.system.numbers
-    │   ├── filters: []
-    │   ├── order by: []
-    │   └── limit: NONE
-    └── PhysicalScan
+    │   ├── read rows: 1
+    │   ├── read bytes: 8
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
         ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+        ├── read rows: 1
+        ├── read bytes: 8
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t where not exists (select * from numbers(1) where number = t.number);
 
 ----
 Project
-├── projections: [number (#0)]
+├── columns: [0]
 └── Filter
-    ├── filters: [not(3 (#3))]
-    └── HashJoin: MARK
-        ├── build keys: [subquery_0 (#0)]
-        ├── probe keys: [subquery_2 (#2)]
-        ├── other filters: []
-        ├── HashJoin: INNER
-        │   ├── build keys: [numbers.number (#1)]
-        │   ├── probe keys: [subquery_2 (#2)]
-        │   ├── other filters: []
-        │   ├── PhysicalScan
-        │   │   ├── table: default.system.numbers
-        │   │   ├── filters: []
-        │   │   ├── order by: []
-        │   │   └── limit: NONE
-        │   └── PhysicalScan
-        │       ├── table: default.system.numbers
-        │       ├── filters: []
-        │       ├── order by: []
-        │       └── limit: NONE
-        └── PhysicalScan
-            ├── table: default.system.numbers
+    ├── filters: [not(marker (#3))]
+    └── HashJoin
+        ├── join type: MARK
+        ├── build keys: [numbers.number (#0)]
+        ├── probe keys: [number (#2)]
+        ├── filters: []
+        ├── TableScan(Build)
+        │   ├── table: default.system.numbers
+        │   ├── read rows: 1
+        │   ├── read bytes: 8
+        │   ├── partitions total: 1
+        │   ├── partitions scanned: 1
+        │   └── push downs: [filters: [], limit: NONE]
+        └── HashJoin(Probe)
+            ├── join type: INNER
+            ├── build keys: [numbers.number (#1)]
+            ├── probe keys: [number (#2)]
             ├── filters: []
-            ├── order by: []
-            └── limit: NONE
+            ├── TableScan(Build)
+            │   ├── table: default.system.numbers
+            │   ├── read rows: 1
+            │   ├── read bytes: 8
+            │   ├── partitions total: 1
+            │   ├── partitions scanned: 1
+            │   └── push downs: [filters: [], limit: NONE]
+            └── TableScan(Probe)
+                ├── table: default.system.numbers
+                ├── read rows: 1
+                ├── read bytes: 8
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from numbers(1) as t where exists (select number as a from numbers(1) where number = t.number);
 
 ----
 Project
-├── projections: [number (#0)]
-└── HashJoin: SEMI
+├── columns: [0]
+└── HashJoin
+    ├── join type: SEMI
     ├── build keys: [numbers.number (#1)]
-    ├── probe keys: [t.number (#0)]
-    ├── other filters: []
-    ├── PhysicalScan
+    ├── probe keys: [numbers.number (#0)]
+    ├── filters: []
+    ├── TableScan(Build)
     │   ├── table: default.system.numbers
-    │   ├── filters: []
-    │   ├── order by: []
-    │   └── limit: NONE
-    └── PhysicalScan
+    │   ├── read rows: 1
+    │   ├── read bytes: 8
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
         ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+        ├── read rows: 1
+        ├── read bytes: 8
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t where exists (select * from numbers(1) where number = t.number and number = 0 and t.number < 10);
 
 ----
 Project
-├── projections: [number (#0)]
-└── HashJoin: SEMI
+├── columns: [0]
+└── HashJoin
+    ├── join type: SEMI
     ├── build keys: [numbers.number (#1)]
-    ├── probe keys: [t.number (#0)]
-    ├── other filters: []
-    ├── Filter
-    │   ├── filters: [t.number (#0) < 10]
-    │   └── PhysicalScan
+    ├── probe keys: [numbers.number (#0)]
+    ├── filters: []
+    ├── Filter(Build)
+    │   ├── filters: [=(numbers.number (#1), 0)]
+    │   └── TableScan
     │       ├── table: default.system.numbers
-    │       ├── filters: [t.number (#0) < 10]
-    │       ├── order by: []
-    │       └── limit: NONE
-    └── Filter
-        ├── filters: [numbers.number (#1) = 0]
-        └── PhysicalScan
+    │       ├── read rows: 1
+    │       ├── read bytes: 8
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       └── push downs: [filters: [(number = 0)], limit: NONE]
+    └── Filter(Probe)
+        ├── filters: [<(numbers.number (#0), 10)]
+        └── TableScan
             ├── table: default.system.numbers
-            ├── filters: [numbers.number (#1) = 0]
-            ├── order by: []
-            └── limit: NONE
+            ├── read rows: 1
+            ├── read bytes: 8
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            └── push downs: [filters: [(number < 10)], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t where exists (select * from numbers(1) where number = t.number and t.number < number);
 
 ----
 Project
-├── projections: [number (#0)]
-└── HashJoin: SEMI
+├── columns: [0]
+└── HashJoin
+    ├── join type: SEMI
     ├── build keys: [numbers.number (#1)]
-    ├── probe keys: [t.number (#0)]
-    ├── other filters: [t.number (#0) < numbers.number (#1)]
-    ├── PhysicalScan
+    ├── probe keys: [numbers.number (#0)]
+    ├── filters: [<(numbers.number (#0), numbers.number (#1))]
+    ├── TableScan(Build)
     │   ├── table: default.system.numbers
-    │   ├── filters: []
-    │   ├── order by: []
-    │   └── limit: NONE
-    └── PhysicalScan
+    │   ├── read rows: 1
+    │   ├── read bytes: 8
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
         ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+        ├── read rows: 1
+        ├── read bytes: 8
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t where exists (select number as a, number as b, number as c from numbers(1) where number = t.number);
 
 ----
 Project
-├── projections: [number (#0)]
-└── HashJoin: SEMI
+├── columns: [0]
+└── HashJoin
+    ├── join type: SEMI
     ├── build keys: [numbers.number (#1)]
-    ├── probe keys: [t.number (#0)]
-    ├── other filters: []
-    ├── PhysicalScan
+    ├── probe keys: [numbers.number (#0)]
+    ├── filters: []
+    ├── TableScan(Build)
     │   ├── table: default.system.numbers
-    │   ├── filters: []
-    │   ├── order by: []
-    │   └── limit: NONE
-    └── PhysicalScan
+    │   ├── read rows: 1
+    │   ├── read bytes: 8
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
         ├── table: default.system.numbers
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+        ├── read rows: 1
+        ├── read bytes: 8
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where (select count(*) = 1 from numbers(1) where t.number = number) and t.number = t1.number;
 
 ----
 Project
-├── projections: [number (#0)]
+├── columns: [0]
 └── Filter
-    ├── filters: [CAST(if(is_not_null(scalar_subquery_3 (#3)), scalar_subquery_3 (#3), 0) AS BIGINT UNSIGNED)]
-    └── HashJoin: SINGLE
-        ├── build keys: [subquery_5 (#5)]
-        ├── probe keys: [subquery_0 (#0)]
-        ├── other filters: []
-        ├── HashJoin: INNER
-        │   ├── build keys: [t1.number (#1)]
-        │   ├── probe keys: [t.number (#0)]
-        │   ├── other filters: []
-        │   ├── PhysicalScan
-        │   │   ├── table: default.system.numbers
-        │   │   ├── filters: []
-        │   │   ├── order by: []
-        │   │   └── limit: NONE
-        │   └── PhysicalScan
-        │       ├── table: default.system.numbers
-        │       ├── filters: []
-        │       ├── order by: []
-        │       └── limit: NONE
-        └── Project
-            ├── projections: [COUNT(*) = 1 (#3),number (#5)]
-            └── EvalScalar
-                ├── scalars: [COUNT(*) (#4) = 1]
-                └── Aggregate(Final)
-                    ├── group items: [subquery_5 (#5)]
-                    ├── aggregate functions: [COUNT(*)]
-                    └── Aggregate(Partial)
-                        ├── group items: [subquery_5 (#5)]
-                        ├── aggregate functions: [COUNT(*)]
-                        └── HashJoin: INNER
-                            ├── build keys: [numbers.number (#2)]
-                            ├── probe keys: [subquery_5 (#5)]
-                            ├── other filters: []
-                            ├── PhysicalScan
-                            │   ├── table: default.system.numbers
-                            │   ├── filters: []
-                            │   ├── order by: []
-                            │   └── limit: NONE
-                            └── PhysicalScan
-                                ├── table: default.system.numbers
-                                ├── filters: []
-                                ├── order by: []
-                                └── limit: NONE
+    ├── filters: [CAST(if(is_not_null(COUNT(*) = 1 (#3)), COUNT(*) = 1 (#3), 0) AS BIGINT UNSIGNED)]
+    └── HashJoin
+        ├── join type: SINGLE
+        ├── build keys: [number (#5)]
+        ├── probe keys: [numbers.number (#0)]
+        ├── filters: []
+        ├── Project(Build)
+        │   ├── columns: [2, 1]
+        │   └── EvalScalar
+        │       ├── expressions: [=(COUNT(*) (#4), 1)]
+        │       └── AggregateFinal
+        │           ├── group by: [number]
+        │           ├── aggregate functions: [count()]
+        │           └── AggregatePartial
+        │               ├── group by: [number]
+        │               ├── aggregate functions: [count()]
+        │               └── HashJoin
+        │                   ├── join type: INNER
+        │                   ├── build keys: [numbers.number (#2)]
+        │                   ├── probe keys: [number (#5)]
+        │                   ├── filters: []
+        │                   ├── TableScan(Build)
+        │                   │   ├── table: default.system.numbers
+        │                   │   ├── read rows: 1
+        │                   │   ├── read bytes: 8
+        │                   │   ├── partitions total: 1
+        │                   │   ├── partitions scanned: 1
+        │                   │   └── push downs: [filters: [], limit: NONE]
+        │                   └── TableScan(Probe)
+        │                       ├── table: default.system.numbers
+        │                       ├── read rows: 1
+        │                       ├── read bytes: 8
+        │                       ├── partitions total: 1
+        │                       ├── partitions scanned: 1
+        │                       └── push downs: [filters: [], limit: NONE]
+        └── HashJoin(Probe)
+            ├── join type: INNER
+            ├── build keys: [numbers.number (#1)]
+            ├── probe keys: [numbers.number (#0)]
+            ├── filters: []
+            ├── TableScan(Build)
+            │   ├── table: default.system.numbers
+            │   ├── read rows: 1
+            │   ├── read bytes: 8
+            │   ├── partitions total: 1
+            │   ├── partitions scanned: 1
+            │   └── push downs: [filters: [], limit: NONE]
+            └── TableScan(Probe)
+                ├── table: default.system.numbers
+                ├── read rows: 1
+                ├── read bytes: 8
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t where exists(select * from numbers(1) as t1 where t.number > t1.number) and not exists(select * from numbers(1) as t1 where t.number < t1.number);
 
 ----
 Project
-├── projections: [number (#0)]
+├── columns: [0]
 └── Filter
-    ├── filters: [not(4 (#4))]
-    └── HashJoin: MARK
-        ├── build keys: [subquery_0 (#0)]
-        ├── probe keys: [subquery_3 (#3)]
-        ├── other filters: []
-        ├── Filter
-        │   ├── filters: [subquery_3 (#3) < t1.number (#2)]
-        │   └── CrossJoin
-        │       ├── build keys: []
-        │       ├── probe keys: []
-        │       ├── other filters: []
-        │       ├── PhysicalScan
-        │       │   ├── table: default.system.numbers
-        │       │   ├── filters: []
-        │       │   ├── order by: []
-        │       │   └── limit: NONE
-        │       └── PhysicalScan
-        │           ├── table: default.system.numbers
-        │           ├── filters: []
-        │           ├── order by: []
-        │           └── limit: NONE
-        └── HashJoin: SEMI
-            ├── build keys: []
-            ├── probe keys: []
-            ├── other filters: [t.number (#0) > t1.number (#1)]
-            ├── PhysicalScan
-            │   ├── table: default.system.numbers
-            │   ├── filters: []
-            │   ├── order by: []
-            │   └── limit: NONE
-            └── PhysicalScan
-                ├── table: default.system.numbers
+    ├── filters: [not(marker (#4))]
+    └── HashJoin
+        ├── join type: MARK
+        ├── build keys: [numbers.number (#0)]
+        ├── probe keys: [number (#3)]
+        ├── filters: []
+        ├── HashJoin(Build)
+        │   ├── join type: SEMI
+        │   ├── build keys: []
+        │   ├── probe keys: []
+        │   ├── filters: [>(numbers.number (#0), numbers.number (#1))]
+        │   ├── TableScan(Build)
+        │   │   ├── table: default.system.numbers
+        │   │   ├── read rows: 1
+        │   │   ├── read bytes: 8
+        │   │   ├── partitions total: 1
+        │   │   ├── partitions scanned: 1
+        │   │   └── push downs: [filters: [], limit: NONE]
+        │   └── TableScan(Probe)
+        │       ├── table: default.system.numbers
+        │       ├── read rows: 1
+        │       ├── read bytes: 8
+        │       ├── partitions total: 1
+        │       ├── partitions scanned: 1
+        │       └── push downs: [filters: [], limit: NONE]
+        └── Filter(Probe)
+            ├── filters: [<(number (#3), numbers.number (#2))]
+            └── HashJoin
+                ├── join type: CROSS
+                ├── build keys: []
+                ├── probe keys: []
                 ├── filters: []
-                ├── order by: []
-                └── limit: NONE
+                ├── TableScan(Build)
+                │   ├── table: default.system.numbers
+                │   ├── read rows: 1
+                │   ├── read bytes: 8
+                │   ├── partitions total: 1
+                │   ├── partitions scanned: 1
+                │   └── push downs: [filters: [], limit: NONE]
+                └── TableScan(Probe)
+                    ├── table: default.system.numbers
+                    ├── read rows: 1
+                    ├── read bytes: 8
+                    ├── partitions total: 1
+                    ├── partitions scanned: 1
+                    └── push downs: [filters: [], limit: NONE]
 

--- a/tests/logictest/suites/mode/standalone/explain/where_optimizaiton.test
+++ b/tests/logictest/suites/mode/standalone/explain/where_optimizaiton.test
@@ -9,7 +9,7 @@ explain select a from t_where_optimizer where a = 1;
 
 ----
 Project
-├── columns: [0]
+├── columns: [a (#0)]
 └── Filter
     ├── filters: [=(t_where_optimizer.a (#0), 1)]
     └── TableScan
@@ -77,7 +77,7 @@ explain select a from t_where_optimizer where b = 1;
 
 ----
 Project
-├── columns: [0]
+├── columns: [a (#0)]
 └── TableScan
     ├── table: default.default.t_where_optimizer
     ├── read rows: 0
@@ -97,7 +97,7 @@ explain select * from t_where_optimizer where s:a > 0;
 
 ----
 Project
-├── columns: [0, 1]
+├── columns: [id (#0), s (#1)]
 └── TableScan
     ├── table: default.default.t_where_optimizer
     ├── read rows: 0

--- a/tests/logictest/suites/mode/standalone/explain/where_optimizaiton.test
+++ b/tests/logictest/suites/mode/standalone/explain/where_optimizaiton.test
@@ -4,84 +4,90 @@ drop table if exists t_where_optimizer;
 statement ok
 create table if not exists t_where_optimizer (a int, b int);
 
--- SQLs that prewhere optimization will not be applied.
-
 statement query T
 explain select a from t_where_optimizer where a = 1;
 
 ----
 Project
-├── projections: [a (#0)]
+├── columns: [0]
 └── Filter
-    ├── filters: [t_where_optimizer.a (#0) = 1]
-    └── PhysicalScan
+    ├── filters: [=(t_where_optimizer.a (#0), 1)]
+    └── TableScan
         ├── table: default.default.t_where_optimizer
-        ├── filters: [t_where_optimizer.a (#0) = 1]
-        ├── order by: []
-        └── limit: NONE
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        └── push downs: [filters: [(a = 1)], limit: NONE]
 
 statement query T
 explain select * from t_where_optimizer where a = b;
 
 ----
 Filter
-    ├── filters: [t_where_optimizer.a (#0) = t_where_optimizer.b (#1)]
-    └── PhysicalScan
-        ├── table: default.default.t_where_optimizer
-        ├── filters: [t_where_optimizer.a (#0) = t_where_optimizer.b (#1)]
-        ├── order by: []
-        └── limit: NONE
+├── filters: [=(t_where_optimizer.a (#0), t_where_optimizer.b (#1))]
+└── TableScan
+    ├── table: default.default.t_where_optimizer
+    ├── read rows: 0
+    ├── read bytes: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    └── push downs: [filters: [(a = b)], limit: NONE]
 
 statement query T
 explain select * from t_where_optimizer where a = 1 or b > 2;
 
 ----
 Filter
-    ├── filters: [(t_where_optimizer.a (#0) = 1) OR (t_where_optimizer.b (#1) > 2)]
-    └── PhysicalScan
-        ├── table: default.default.t_where_optimizer
-        ├── filters: [(t_where_optimizer.a (#0) = 1) OR (t_where_optimizer.b (#1) > 2)]
-        ├── order by: []
-        └── limit: NONE
-
--- SQLs that prewhere optimization will be applied.
+├── filters: [or(=(t_where_optimizer.a (#0), 1), >(t_where_optimizer.b (#1), 2))]
+└── TableScan
+    ├── table: default.default.t_where_optimizer
+    ├── read rows: 0
+    ├── read bytes: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    └── push downs: [filters: [((a = 1) or (b > 2))], limit: NONE]
 
 statement query T
 explain select * from t_where_optimizer where a = 1 and b > 2;
 
 ----
-PhysicalScan
-        ├── table: default.default.t_where_optimizer
-        ├── filters: [t_where_optimizer.a (#0) = 1, t_where_optimizer.b (#1) > 2]
-        ├── order by: []
-        └── limit: NONE
+TableScan
+├── table: default.default.t_where_optimizer
+├── read rows: 0
+├── read bytes: 0
+├── partitions total: 0
+├── partitions scanned: 0
+└── push downs: [filters: [(a = 1), (b > 2)], limit: NONE]
 
 statement query T
 explain select * from t_where_optimizer where b = 1;
 
 ----
-PhysicalScan
-        ├── table: default.default.t_where_optimizer
-        ├── filters: [t_where_optimizer.b (#1) = 1]
-        ├── order by: []
-        └── limit: NONE
+TableScan
+├── table: default.default.t_where_optimizer
+├── read rows: 0
+├── read bytes: 0
+├── partitions total: 0
+├── partitions scanned: 0
+└── push downs: [filters: [(b = 1)], limit: NONE]
 
 statement query T
 explain select a from t_where_optimizer where b = 1;
 
 ----
 Project
-├── projections: [a (#0)]
-└── PhysicalScan
+├── columns: [0]
+└── TableScan
     ├── table: default.default.t_where_optimizer
-    ├── filters: [t_where_optimizer.b (#1) = 1]
-    ├── order by: []
-    └── limit: NONE
+    ├── read rows: 0
+    ├── read bytes: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    └── push downs: [filters: [(b = 1)], limit: NONE]
 
 statement ok
 drop table t_where_optimizer;
-
--- Tuple (inner column) type test
 
 statement ok
 create table t_where_optimizer(id int, s tuple(a int, b int));
@@ -91,12 +97,15 @@ explain select * from t_where_optimizer where s:a > 0;
 
 ----
 Project
-├── projections: [id (#0),s (#1)] 
-└── PhysicalScan
+├── columns: [0, 1]
+└── TableScan
     ├── table: default.default.t_where_optimizer
-    ├── filters: [t_where_optimizer.s:a (#2) > 0]
-    ├── order by: []
-    └── limit: NONE
+    ├── read rows: 0
+    ├── read bytes: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    └── push downs: [filters: [(s:a > 0)], limit: NONE]
 
 statement ok
 drop table t_where_optimizer;
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Example:
```sql
mysql> explain select number+1 from numbers(10);
+----------------------------------------------------------+
| explain                                                  |
+----------------------------------------------------------+
| Project                                                  |
| ├── columns: [1]                                         |
| └── EvalScalar                                           |
|     ├── expressions: [+(numbers.number, 1)]              |
|     └── TableScan                                        |
|         ├── table: default.system.numbers                |
|         ├── read rows: 10                                |
|         ├── read bytes: 80                               |
|         ├── partitions total: 1                          |
|         ├── partitions scanned: 1                        |
|         └── push downs: [filters: [], limit: NONE]       |
+----------------------------------------------------------+
11 rows in set (0.02 sec)
Read 0 rows, 0.00 B in 0.005 sec., 0 rows/sec., 0.00 B/sec.
```

Close #7350 