### PR TITLE
feat(http_handler): the first request no longer wait for query to start

### DIFF
--- a/src/query/functions/src/scalars/others/sleep.rs
+++ b/src/query/functions/src/scalars/others/sleep.rs
@@ -83,9 +83,9 @@ impl Function for SleepFunction {
             value.as_u64().map(Duration::from_secs).map_err(|_| err())?
         };
 
-        if duration.ge(&Duration::from_secs(3)) {
+        if duration.gt(&Duration::from_secs(30)) {
             return Err(ErrorCode::BadArguments(format!(
-                "The maximum sleep time is 3 seconds. Requested: {:?}",
+                "The maximum sleep time is 30 seconds. Requested: {:?}",
                 duration
             )));
         };

--- a/src/query/service/src/servers/http/v1/query/http_query_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_manager.rs
@@ -112,7 +112,7 @@ impl HttpQueryManager {
         let q = queries.remove(query_id);
         if let Some(q) = queries.remove(query_id) {
             if q.is_async() {
-                q.update_expire_time().await;
+                q.update_expire_time(false).await;
             }
         }
         q

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -647,7 +647,7 @@ async fn test_query_log() -> Result<()> {
             .as_str()
             .unwrap()
             .to_lowercase()
-            .contains("aborted"),
+            .contains("killed"),
         "{:?}",
         result
     );


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. [feat(http_handler): the first request no longer wait for query to start.](https://github.com/datafuselabs/databend/commit/eace65b7f664af3f3bb970831694e44677fdd0ad) 
    1. start query in the runtime of query context, and then polling for page just like the following request.   the starting of query may involve read and prune( with bloom filter) partitions
    2. add a state of STARTING, only internal for now
2. [never clear expire time.](https://github.com/datafuselabs/databend/commit/26448b5a5abcc13370151be2f4c8c01745630076) 
    1. because the handler future may be dropped without notice. https://github.com/hyperium/hyper/issues/707
    2. base on the previous commit: all request (including the first) should return in more than wait_time_secs


Fixes https://github.com/datafuselabs/databend-perf/issues/106
