### PR TITLE
feat(meta-service): add metrics `last_seq`

### DIFF
--- a/src/meta/service/src/metrics/mod.rs
+++ b/src/meta/service/src/metrics/mod.rs
@@ -44,5 +44,6 @@ pub use meta_metrics::set_meta_metrics_current_leader;
 pub use meta_metrics::set_meta_metrics_current_term;
 pub use meta_metrics::set_meta_metrics_is_leader;
 pub use meta_metrics::set_meta_metrics_last_log_index;
+pub use meta_metrics::set_meta_metrics_last_seq;
 pub use meta_metrics::set_meta_metrics_node_is_health;
 pub use meta_metrics::set_meta_metrics_proposals_applied;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feat(meta-service): add metrics `last_seq`

Other changes:

- Refactor: subscribe_metrics() does not need to watch another Receiver:
  `MetaNode.running_rx` for shutting down event.
  When MetaNode is shutting down, `metrics_rx.changed()` returns an
  error indicating Raft is shutting down.

- Refactor: reduce indent `:()`

- Fix: #7395

## Changelog







## Related Issues