### PR TITLE
ci(meta-service): extend timeout for join-cluster; fix path for artifact uploading

### DIFF
--- a/.github/actions/artifact_failure/action.yml
+++ b/.github/actions/artifact_failure/action.yml
@@ -21,3 +21,14 @@ runs:
           query*.log
           metasrv.log
           nohup.out
+          meta/types/.databend
+          meta/protos/.databend
+          meta/app/.databend
+          meta/grpc/.databend
+          meta/sled-store/.databend
+          meta/raft-store/.databend
+          meta/api/.databend
+          meta/proto-conv/.databend
+          meta/service/.databend
+          meta/embedded/.databend
+          meta/store/.databend

--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -569,7 +569,7 @@ impl MetaNode {
         let advertise_endpoint = conf.raft_api_advertise_host_endpoint();
         #[allow(clippy::never_loop)]
         for addr in addrs {
-            let timeout = Some(Duration::from_millis(3_000));
+            let timeout = Some(Duration::from_millis(10_000));
             info!(
                 "try to join cluster via {}, timeout: {:?}...",
                 addr, timeout


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### ci(meta-service): extend timeout for join-cluster; fix path for artifact uploading

## Changelog







## Related Issues