### PR TITLE
chore(meta): update and lock deps: thiserror and openraft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5055,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.7.2"
-source = "git+https://github.com/drmingdrmer/openraft?rev=v0.7.2-alpha.2#42f6ff09f7adf179388d536257f1ee0bab7afbbc"
+source = "git+https://github.com/drmingdrmer/openraft?rev=v0.7.2-alpha.4#d4922c2572d0b44753bafcb5ec804a179b425f67"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -7376,18 +7376,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -57,7 +57,7 @@ tonic = "0.7.2"
 tracing = "0.1.35"
 url = "2.2.2"
 
-openraft = { git = "https://github.com/drmingdrmer/openraft", rev = "v0.7.2-alpha.2" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", rev = "v0.7.2-alpha.4" }
 
 [[bin]]
 name = "databend-meta"

--- a/src/common/exception/Cargo.toml
+++ b/src/common/exception/Cargo.toml
@@ -20,7 +20,7 @@ paste = "1.0.7"
 prost = "0.10.4"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-thiserror = "1.0.31"
+thiserror = "=1.0.31"
 time = "0.3.10"
 tonic = "0.7.2"
 

--- a/src/common/grpc/Cargo.toml
+++ b/src/common/grpc/Cargo.toml
@@ -18,12 +18,12 @@ common-exception = { path = "../exception" }
 # Github dependencies
 
 # Crates.io dependencies
-anyerror = "0.1.6"
+anyerror = "=0.1.6"
 hyper = "0.14.19"
 jwt-simple = "0.11.0"
 once_cell = "1.12.0"
 serde = { version = "1.0.137", features = ["derive"] }
-thiserror = "1.0.31"
+thiserror = "=1.0.31"
 tonic = { version = "0.7.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
 tracing = "0.1.35"
 trust-dns-resolver = { version = "0.21.2", features = ["system-config"] }

--- a/src/meta/api/Cargo.toml
+++ b/src/meta/api/Cargo.toml
@@ -22,12 +22,12 @@ common-proto-conv = { path = "../proto-conv" }
 common-protos = { path = "../protos" }
 common-tracing = { path = "../../common/tracing" }
 
-anyerror = "0.1.6"
+anyerror = "=0.1.6"
 anyhow = "1.0.58"
 async-trait = "0.1.56"
 enumflags2 = { version = "0.7.5", features = ["serde"] }
 maplit = "1.0.2"
 serde_json = "1.0.81"
-thiserror = "1.0.31"
+thiserror = "=1.0.31"
 tonic = { version = "0.7.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
 tracing = "0.1.35"

--- a/src/meta/grpc/Cargo.toml
+++ b/src/meta/grpc/Cargo.toml
@@ -35,7 +35,7 @@ rand = "0.8.5"
 semver = "1.0.10"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-thiserror = "1.0.31"
+thiserror = "=1.0.31"
 tonic = { version = "0.7.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
 tracing = "0.1.35"
 

--- a/src/meta/proto-conv/Cargo.toml
+++ b/src/meta/proto-conv/Cargo.toml
@@ -18,7 +18,7 @@ common-protos = { path = "../protos" }
 common-storage = { path = "../../common/storage" }
 
 num = "0.4.0"
-thiserror = "1.0.31"
+thiserror = "=1.0.31"
 
 enumflags2 = { version = "0.7.5", features = ["serde"] }
 serde_json = "1.0.81"

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -40,7 +40,7 @@ common-tracing = { path = "../../common/tracing" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 # Crates.io dependencies
-anyerror = "0.1.6"
+anyerror = "=0.1.6"
 anyhow = "1.0.58"
 async-trait = "0.1.56"
 clap = { version = "3.2.5", features = ["derive", "env"] }

--- a/src/meta/sled-store/Cargo.toml
+++ b/src/meta/sled-store/Cargo.toml
@@ -17,7 +17,7 @@ io-uring = ["sled/io_uring"]
 [dependencies]
 common-meta-types = { path = "../types" }
 
-openraft = { git = "https://github.com/drmingdrmer/openraft", rev = "v0.7.2-alpha.2" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", rev = "v0.7.2-alpha.4" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyhow = "1.0.58"

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -15,10 +15,10 @@ common-datavalues = { path = "../../query/datavalues" }
 common-exception = { path = "../../common/exception" }
 common-storage = { path = "../../common/storage" }
 
-openraft = { git = "https://github.com/drmingdrmer/openraft", rev = "v0.7.2-alpha.2" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", rev = "v0.7.2-alpha.4" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
-anyerror = "0.1.6"
+anyerror = "=0.1.6"
 derive_more = "0.99.17"
 enumflags2 = { version = "0.7.5", features = ["serde"] }
 hex = "0.4.3"
@@ -31,7 +31,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 sha1 = "0.10.1"
 sha2 = "0.10.2"
-thiserror = "1.0.31"
+thiserror = "=1.0.31"
 tonic = { version = "0.7.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
 
 [build-dependencies]

--- a/src/query/ast/Cargo.toml
+++ b/src/query/ast/Cargo.toml
@@ -31,7 +31,7 @@ nom = "7.1.1"
 nom-rule = "0.3.0"
 pratt = "0.3.0"
 pretty = "0.11.3"
-thiserror = "1.0.31"
+thiserror = "=1.0.31"
 url = "2.2.2"
 
 [dev-dependencies]

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -137,7 +137,7 @@ snailquote = "0.3.1"
 strum = "0.24.1"
 strum_macros = "0.24.0"
 tempfile = { version = "3.3.0", optional = true }
-thiserror = "1.0.31"
+thiserror = "=1.0.31"
 threadpool = "1.8.1"
 thrift = { version = "0.15.0", optional = true }
 time = "0.3.10"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### dep(meta): update and lock deps: thiserror and openraft

- Lock thiserror to 1.0.31; The latest version 1.0.33 has been using
  different std error API provided by latest nightly rust.

- Upgrade openraft to add feature to remove a learner.

## Changelog







## Related Issues