### PR TITLE
docs: sum only supports numeric expressions

### DIFF
--- a/docs/doc/30-reference/20-functions/10-aggregate-functions/aggregate-sum.md
+++ b/docs/doc/30-reference/20-functions/10-aggregate-functions/aggregate-sum.md
@@ -20,7 +20,7 @@ SUM(expression)
 
 | Arguments   | Description |
 | ----------- | ----------- |
-| expression  | Any expression |
+| expression  | Any numerical expression |
 
 ## Return Type
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```sql
MySQL [databend4]> select sum('sdf') from t1;
ERROR 1105 (HY000): Code: 1065, displayText = error:
  --> SQL:1:8
  |
1 | select sum('sdf') from t1
  |        ^^^^^^^^^^ AggregateSumFunction does not support type 'String(String)'

.
```
