### PR TITLE
chore: switch to upstream parquet2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5337,8 +5337,9 @@ dependencies = [
 
 [[package]]
 name = "parquet2"
-version = "0.14.1"
-source = "git+https://github.com/datafuse-extras/parquet2?rev=3a468fc3c4#3a468fc3c43154b11c22800aff0b83cd22fd4d3c"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3eb21c37048a08693214d1f0d34eea97a8d90322e15c4a5e2017d56420e1195"
 dependencies = [
  "async-stream",
  "bitpacking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,3 @@ gimli = { opt-level = 3 }
 miniz_oxide = { opt-level = 3 }
 object = { opt-level = 3 }
 rustc-demangle = { opt-level = 3 }
-
-#[patch.crates-io]
-#parquet2 = { version = "0.14.1", optional = true, git = "https://github.com/datafuse-extras/parquet2", rev = "3a468fc3c4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,5 +106,5 @@ miniz_oxide = { opt-level = 3 }
 object = { opt-level = 3 }
 rustc-demangle = { opt-level = 3 }
 
-[patch.crates-io]
-parquet2 = { version = "0.14.1", optional = true, git = "https://github.com/datafuse-extras/parquet2", rev = "3a468fc3c4" }
+#[patch.crates-io]
+#parquet2 = { version = "0.14.1", optional = true, git = "https://github.com/datafuse-extras/parquet2", rev = "3a468fc3c4" }

--- a/src/common/arrow/Cargo.toml
+++ b/src/common/arrow/Cargo.toml
@@ -22,7 +22,6 @@ arrow-default = [
 ]
 default = ["arrow-default", "parquet-default"]
 parquet-default = [
-    "parquet2/non_standard_legacy_lz4",
     "parquet2/lz4",
     "parquet2/zstd",
     "parquet2/snappy",

--- a/src/query/storages/fuse/src/io/read/block_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block_reader.rs
@@ -383,11 +383,11 @@ impl BlockReader {
             Compression::Lz4 => {
                 let err_msg = r#"Deprecated compression algorithm [Lz4] detected.
                 
-                                        Legacy compression algorithm [Lz4] no longer supported.
+                                        The Legacy compression algorithm [Lz4] is no longer supported.
                                         To migrate data from old format, please consider re-create the table, 
-                                        by using an old compatiable version [v0.8.25-nightly … v0.7.12-nightly].
+                                        by using an old compatible version [v0.8.25-nightly … v0.7.12-nightly].
                                         
-                                        - Bring up the compatiable version of databend-query
+                                        - Bring up the compatible version of databend-query
                                         - re-create the table
                                            Suppose the name of table is T
                                             ~~~

--- a/src/query/storages/index/src/bloom_filter.rs
+++ b/src/query/storages/index/src/bloom_filter.rs
@@ -24,7 +24,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_pipeline_transforms::processors::transforms::transform_expression_executor::ExpressionExecutor;
 use common_planners::Expression;
-use tracing::info;
+use tracing::debug;
 
 use crate::IndexSchemaVersion;
 use crate::SupportedType;
@@ -390,7 +390,7 @@ impl BloomFilter {
         let power_of_ln2 = core::f32::consts::LN_2 as f64 * core::f32::consts::LN_2 as f64;
         let m = -(num_items as f64 * false_positive_rate.ln()) / power_of_ln2;
         let num_bits = m.ceil() as usize;
-        info!(
+        debug!(
             "Bloom filter calculate optimal bits, num_bits: {}, num_items: {}, false_positive_rate: {}",
             num_bits, num_items, false_positive_rate
         );
@@ -406,7 +406,7 @@ impl BloomFilter {
     pub fn optimal_num_hashes(num_items: u64, num_bits: u64) -> usize {
         let k = num_bits as f64 / num_items as f64 * core::f32::consts::LN_2 as f64;
         let num_hashes = std::cmp::max(2, k.ceil() as usize); // at least two hashes
-        info!(
+        debug!(
             "Bloom filter calculate optimal hashes, num_hashes: {}",
             num_hashes
         );


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- deprecate legacy compression algo `lz4`
  use `Lz4Raw` instead.
- use upstream parquet2 (instead patched version of our own)


**About backward compatibility:**

After this PR is merged, users who have legacy data that used legacy `Lz4`, will encounter runtime exceptions like this:

            Deprecated compression algorithm [Lz4] detected.
    
            The legacy compression algorithm [Lz4] is no longer supported.
            To migrate data from the old format, please consider re-create the table, 
            by using an old compatible version [v0.8.25-nightly … v0.7.12-nightly].
            
            - Bring up the compatiable version of databend-query
            - re-create the table
               Suppose the name of the table is T
                ~~~
                create table tmp_t as select * from T;
                drop table T all;
                alter table tmp_t rename to T;
                ~~~
            Please note that the history of table T WILL BE LOST.
                                 
To the best of my knowledge, there are no serious datasets that uses legacy `Lz4`



Fixes #6064
