### PR TITLE
feat(hive): try to use the file size returned by list()

### DIFF
--- a/src/query/storages/hive/src/hive_table.rs
+++ b/src/query/storages/hive/src/hive_table.rs
@@ -549,7 +549,7 @@ async fn do_list_files_from_dir(
                 let filename = path.to_string();
                 let length = match de.content_length() {
                     Some(len) => len,
-                    None => get_file_length(operator.clone(), &path).await?,
+                    None => get_file_length(operator.clone(), path).await?,
                 };
                 all_files.push(HiveFileInfo::create(filename, length));
             }

--- a/src/query/storages/hive/src/hive_table.rs
+++ b/src/query/storages/hive/src/hive_table.rs
@@ -546,9 +546,11 @@ async fn do_list_files_from_dir(
         }
         match de.mode() {
             ObjectMode::FILE => {
-                // todo, support in opendal#list
                 let filename = path.to_string();
-                let length = get_file_length(operator.clone(), path).await?;
+                let length = match de.content_length() {
+                    Some(len) => len,
+                    None => get_file_length(operator.clone(), &path).await?,
+                };
                 all_files.push(HiveFileInfo::create(filename, length));
             }
             ObjectMode::DIR => {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
after https://github.com/datafuselabs/opendal/pull/577,  we could use the file size from list() , avoid to fetch the meta from seperated files.  cc @Xuanwo 
