### PR TITLE
refactor(meta-error): cleanup abuse of MetaError:

### DIFF
--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -169,6 +169,8 @@ build_exceptions! {
     InvalidConfig(2002),
     MetaStorageError(2003),
     InvalidArgument(2004),
+    // Meta service replied with invalid data
+    InvalidReply(2005),
 
     TableVersionMismatched(2009),
     OCCRetryFailure(2011),

--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -156,6 +156,7 @@ pub use raft_types::LogIndex;
 pub use raft_types::NodeId;
 pub use raft_types::Term;
 pub use role_info::RoleInfo;
+pub use role_info::RoleInfoSerdeError;
 pub use seq_num::SeqNum;
 pub use seq_value::IntoSeqV;
 pub use seq_value::KVMeta;

--- a/src/meta/types/src/meta_errors.rs
+++ b/src/meta/types/src/meta_errors.rs
@@ -51,13 +51,7 @@ pub enum MetaError {
     StartMetaServiceError(String),
 
     #[error("{0}")]
-    ConcurrentSnapshotInstall(String),
-
-    #[error("{0}")]
     MetaServiceError(String),
-
-    #[error("{0}")]
-    IllegalRoleInfoFormat(String),
 
     #[error("{0}")]
     IllegalUserInfoFormat(String),

--- a/src/meta/types/src/meta_errors_into.rs
+++ b/src/meta/types/src/meta_errors_into.rs
@@ -48,9 +48,7 @@ impl From<MetaError> for ErrorCode {
             }
             MetaError::MetaStoreNotFound => ErrorCode::MetaServiceError("MetaStoreNotFound"),
             MetaError::StartMetaServiceError(err_str) => ErrorCode::MetaServiceError(err_str),
-            MetaError::ConcurrentSnapshotInstall(err_str) => ErrorCode::MetaServiceError(err_str),
             MetaError::MetaServiceError(err_str) => ErrorCode::MetaServiceError(err_str),
-            MetaError::IllegalRoleInfoFormat(err_str) => ErrorCode::MetaServiceError(err_str),
             MetaError::IllegalUserInfoFormat(err_str) => ErrorCode::MetaServiceError(err_str),
             MetaError::SerdeError(ae) => {
                 ErrorCode::MetaServiceError(ae.to_string()).set_backtrace(ae.backtrace())

--- a/src/meta/types/src/meta_raft_errors.rs
+++ b/src/meta/types/src/meta_raft_errors.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 
 pub type ForwardToLeader = openraft::error::ForwardToLeader;
 
-// represent raft related errors
+/// Raft protocol related errors
 #[derive(Error, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum MetaRaftError {
     #[error(transparent)]
@@ -33,7 +33,7 @@ pub enum MetaRaftError {
     #[error("{0}")]
     ConsistentReadError(String),
 
-    #[error("{0}")]
+    #[error(transparent)]
     RaftFatal(#[from] Fatal),
 
     #[error("{0}")]


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta-error): cleanup abuse of MetaError:

- Remove unused `MetaError::ConcurrentSnapshotInstall`

- `RoleInfo` should have a type specific error, instead of using `MetaError`. `MetaError` is too big for `<RoleInfo as TryFrom>::Error`.

## Changelog







## Related Issues