### PR TITLE
refactor(meta-service): cleanup MetaError

### DIFF
--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -728,15 +728,11 @@ impl MetaNode {
         }
     }
 
-    pub async fn get_status(&self) -> MetaResult<MetaNodeStatus> {
+    pub async fn get_status(&self) -> Result<MetaNodeStatus, MetaError> {
         let voters = self.get_voters().await?;
         let non_voters = self.get_non_voters().await?;
 
-        let endpoint = self
-            .sto
-            .get_node_endpoint(&self.sto.id)
-            .await
-            .map_err(|e| MetaError::MetaServiceError(format!("get self endpoint failed: {}", e)))?;
+        let endpoint = self.sto.get_node_endpoint(&self.sto.id).await?;
 
         let db_size = self
             .sto

--- a/src/meta/types/src/cluster.rs
+++ b/src/meta/types/src/cluster.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::TryFrom;
 use std::fmt;
 use std::net::SocketAddr;
 use std::str::FromStr;
@@ -23,8 +22,6 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::Endpoint;
-use crate::MetaError;
-use crate::MetaResult;
 
 /// A slot is a virtual and intermediate allocation unit in a distributed storage.
 /// The key of an object is mapped to a slot by some hashing algo.
@@ -64,20 +61,6 @@ pub struct NodeInfo {
     pub cpu_nums: u64,
     pub version: u32,
     pub flight_address: String,
-}
-
-impl TryFrom<Vec<u8>> for NodeInfo {
-    type Error = MetaError;
-
-    fn try_from(value: Vec<u8>) -> MetaResult<Self> {
-        match serde_json::from_slice(&value) {
-            Ok(user_info) => Ok(user_info),
-            Err(serialize_error) => Err(MetaError::IllegalUserInfoFormat(format!(
-                "Cannot deserialize cluster id from bytes. cause {}",
-                serialize_error
-            ))),
-        }
-    }
 }
 
 impl NodeInfo {

--- a/src/meta/types/src/meta_errors.rs
+++ b/src/meta/types/src/meta_errors.rs
@@ -48,13 +48,7 @@ pub enum MetaError {
     MetaStoreNotFound,
 
     #[error("{0}")]
-    StartMetaServiceError(String),
-
-    #[error("{0}")]
     MetaServiceError(String),
-
-    #[error("{0}")]
-    IllegalUserInfoFormat(String),
 
     /// type to represent serialize/deserialize errors
     #[error(transparent)]
@@ -74,7 +68,3 @@ pub enum MetaError {
 }
 
 pub type MetaResult<T> = Result<T, MetaError>;
-
-#[derive(Error, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[error("InvalidMembership")]
-pub struct InvalidMembership {}

--- a/src/meta/types/src/meta_errors_into.rs
+++ b/src/meta/types/src/meta_errors_into.rs
@@ -47,9 +47,7 @@ impl From<MetaError> for ErrorCode {
                 ErrorCode::MetaServiceError(format!("meta store already exists: {}", node_id))
             }
             MetaError::MetaStoreNotFound => ErrorCode::MetaServiceError("MetaStoreNotFound"),
-            MetaError::StartMetaServiceError(err_str) => ErrorCode::MetaServiceError(err_str),
             MetaError::MetaServiceError(err_str) => ErrorCode::MetaServiceError(err_str),
-            MetaError::IllegalUserInfoFormat(err_str) => ErrorCode::MetaServiceError(err_str),
             MetaError::SerdeError(ae) => {
                 ErrorCode::MetaServiceError(ae.to_string()).set_backtrace(ae.backtrace())
             }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta-service): cleanup MetaError

- Remove unused error MetaError::IllegalUserInfoFormat

- Do not return error but just panic instead. Because if meta-service
  fails to start up, nothing else can be done.
  Similarly, just panic when failing to shut down.

- Cleanup some unnecessary error mappings.

## Changelog







## Related Issues