### PR TITLE
feat(planner): Implement join reordering

### DIFF
--- a/src/query/service/src/sql/optimizer/cascades/explore_rules.rs
+++ b/src/query/service/src/sql/optimizer/cascades/explore_rules.rs
@@ -16,7 +16,12 @@ use crate::sql::optimizer::RuleID;
 use crate::sql::optimizer::RuleSet;
 
 pub fn get_explore_rule_set() -> RuleSet {
-    RuleSet::create_with_ids(vec![RuleID::CommuteJoin]).unwrap()
+    RuleSet::create_with_ids(vec![
+        RuleID::CommuteJoin,
+        RuleID::LeftAssociateJoin,
+        RuleID::RightAssociateJoin,
+    ])
+    .unwrap()
 }
 
 #[cfg(test)]

--- a/src/query/service/src/sql/optimizer/cascades/mod.rs
+++ b/src/query/service/src/sql/optimizer/cascades/mod.rs
@@ -170,7 +170,7 @@ impl CascadesOptimizer {
             .map(|index| self.find_optimal_plan(*index))
             .collect::<Result<Vec<_>>>()?;
 
-        let result = SExpr::create(m_expr.plan.clone(), children, None);
+        let result = SExpr::create(m_expr.plan.clone(), children, None, None);
 
         Ok(result)
     }

--- a/src/query/service/src/sql/optimizer/heuristic/decorrelate.rs
+++ b/src/query/service/src/sql/optimizer/heuristic/decorrelate.rs
@@ -22,7 +22,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 
 use crate::sql::binder::wrap_cast_if_needed;
-use crate::sql::binder::JoinCondition;
+use crate::sql::binder::JoinPredicate;
 use crate::sql::binder::Visibility;
 use crate::sql::optimizer::heuristic::subquery_rewriter::FlattenInfo;
 use crate::sql::optimizer::heuristic::subquery_rewriter::SubqueryRewriter;
@@ -158,20 +158,20 @@ impl SubqueryRewriter {
         let mut left_filters = vec![];
         let mut right_filters = vec![];
         for pred in filter.predicates.iter() {
-            let join_condition = JoinCondition::new(pred, &input_prop, &filter_prop);
+            let join_condition = JoinPredicate::new(pred, &input_prop, &filter_prop);
             match join_condition {
-                JoinCondition::Left(filter) => {
+                JoinPredicate::Left(filter) => {
                     left_filters.push(filter.clone());
                 }
-                JoinCondition::Right(filter) => {
+                JoinPredicate::Right(filter) => {
                     right_filters.push(filter.clone());
                 }
 
-                JoinCondition::Other(pred) => {
+                JoinPredicate::Other(pred) => {
                     other_conditions.push(pred.clone());
                 }
 
-                JoinCondition::Both { left, right } => {
+                JoinPredicate::Both { left, right } => {
                     let join_type = compare_coercion(&left.data_type(), &right.data_type())?;
                     let left = wrap_cast_if_needed(left.clone(), &join_type);
                     let right = wrap_cast_if_needed(right.clone(), &join_type);

--- a/src/query/service/src/sql/optimizer/heuristic/mod.rs
+++ b/src/query/service/src/sql/optimizer/heuristic/mod.rs
@@ -128,7 +128,8 @@ impl HeuristicOptimizer {
         for expr in s_expr.children() {
             implemented_children.push(self.implement_expression(expr)?);
         }
-        let implemented_expr = SExpr::create(s_expr.plan().clone(), implemented_children, None);
+        let implemented_expr =
+            SExpr::create(s_expr.plan().clone(), implemented_children, None, None);
         // Implement expression with Implementor
         let mut state = TransformState::new();
         self.implementor.implement(&implemented_expr, &mut state)?;

--- a/src/query/service/src/sql/optimizer/heuristic/prune_columns.rs
+++ b/src/query/service/src/sql/optimizer/heuristic/prune_columns.rs
@@ -63,7 +63,7 @@ impl ColumnPruner {
                     .iter()
                     .map(|expr| self.prune_columns(expr, require_columns.clone()))
                     .collect::<Result<Vec<_>>>()?;
-                Ok(SExpr::create(p.clone(), children, None))
+                Ok(SExpr::create(p.clone(), children, None, None))
             }
         }
     }

--- a/src/query/service/src/sql/optimizer/heuristic/where_optimizer.rs
+++ b/src/query/service/src/sql/optimizer/heuristic/where_optimizer.rs
@@ -151,7 +151,7 @@ impl WhereOptimizer {
                 .iter()
                 .map(|expr| self.where_optimize(expr.clone()))
                 .collect::<Result<Vec<_>>>()?;
-            Ok(SExpr::create(rel_op.clone(), children, None))
+            Ok(SExpr::create(rel_op.clone(), children, None, None))
         }
     }
 }

--- a/src/query/service/src/sql/optimizer/property/builder.rs
+++ b/src/query/service/src/sql/optimizer/property/builder.rs
@@ -41,7 +41,12 @@ impl<'a> RelExpr<'a> {
 
     pub fn derive_relational_prop(&self) -> Result<RelationalProperty> {
         let plan = match self {
-            RelExpr::SExpr { expr } => expr.plan(),
+            RelExpr::SExpr { expr } => {
+                if let Some(rel_prop) = &expr.rel_prop {
+                    return Ok(*rel_prop.clone());
+                }
+                expr.plan()
+            }
             RelExpr::MExpr { expr, .. } => &expr.plan,
         };
 

--- a/src/query/service/src/sql/optimizer/property/enforcer.rs
+++ b/src/query/service/src/sql/optimizer/property/enforcer.rs
@@ -28,7 +28,7 @@ pub fn require_property(required: &RequiredProperty, s_expr: &SExpr) -> Result<S
         .iter()
         .map(|child| require_property(required, child))
         .collect::<Result<Vec<SExpr>>>()?;
-    let optimized_expr = SExpr::create(s_expr.plan().clone(), optimized_children, None);
+    let optimized_expr = SExpr::create(s_expr.plan().clone(), optimized_children, None, None);
 
     let rel_expr = RelExpr::with_s_expr(&optimized_expr);
     let mut children = Vec::with_capacity(s_expr.arity());
@@ -45,7 +45,12 @@ pub fn require_property(required: &RequiredProperty, s_expr: &SExpr) -> Result<S
         children.push(enforced_child);
     }
 
-    Ok(SExpr::create(optimized_expr.plan().clone(), children, None))
+    Ok(SExpr::create(
+        optimized_expr.plan().clone(),
+        children,
+        None,
+        None,
+    ))
 }
 
 /// Try to enforce physical property from a physical `SExpr`

--- a/src/query/service/src/sql/optimizer/property/mod.rs
+++ b/src/query/service/src/sql/optimizer/property/mod.rs
@@ -37,7 +37,7 @@ impl RequiredProperty {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct RelationalProperty {
     pub output_columns: ColumnSet,
     pub outer_columns: ColumnSet,

--- a/src/query/service/src/sql/optimizer/rule/factory.rs
+++ b/src/query/service/src/sql/optimizer/rule/factory.rs
@@ -22,6 +22,8 @@ use super::rewrite::RulePushDownFilterEvalScalar;
 use super::rewrite::RulePushDownFilterJoin;
 use super::rewrite::RulePushDownFilterProject;
 use super::transform::RuleCommuteJoin;
+use super::transform::RuleLeftAssociateJoin;
+use super::transform::RuleRightAssociateJoin;
 use crate::sql::optimizer::rule::rewrite::RuleEliminateFilter;
 use crate::sql::optimizer::rule::rewrite::RuleEliminateProject;
 use crate::sql::optimizer::rule::rewrite::RuleMergeEvalScalar;
@@ -72,6 +74,8 @@ impl RuleFactory {
                 Ok(Box::new(RuleNormalizeDisjunctiveFilter::new()))
             }
             RuleID::CommuteJoin => Ok(Box::new(RuleCommuteJoin::new())),
+            RuleID::LeftAssociateJoin => Ok(Box::new(RuleLeftAssociateJoin::new())),
+            RuleID::RightAssociateJoin => Ok(Box::new(RuleRightAssociateJoin::new())),
         }
     }
 }

--- a/src/query/service/src/sql/optimizer/rule/mod.rs
+++ b/src/query/service/src/sql/optimizer/rule/mod.rs
@@ -67,6 +67,8 @@ pub enum RuleID {
 
     // Exploration rules
     CommuteJoin,
+    LeftAssociateJoin,
+    RightAssociateJoin,
 
     // Implementation rules
     ImplementGet,
@@ -97,6 +99,8 @@ impl Display for RuleID {
             RuleID::FoldCountAggregate => write!(f, "FoldCountAggregate"),
 
             RuleID::CommuteJoin => write!(f, "CommuteJoin"),
+            RuleID::LeftAssociateJoin => write!(f, "LeftAssociateJoin"),
+            RuleID::RightAssociateJoin => write!(f, "RightAssociateJoin"),
 
             RuleID::ImplementGet => write!(f, "ImplementGet"),
             RuleID::ImplementHashJoin => write!(f, "ImplementHashJoin"),

--- a/src/query/service/src/sql/optimizer/rule/rewrite/rule_push_down_filter_join.rs
+++ b/src/query/service/src/sql/optimizer/rule/rewrite/rule_push_down_filter_join.rs
@@ -16,7 +16,7 @@ use common_datavalues::type_coercion::compare_coercion;
 use common_exception::Result;
 
 use crate::sql::binder::wrap_cast_if_needed;
-use crate::sql::binder::JoinCondition;
+use crate::sql::binder::JoinPredicate;
 use crate::sql::optimizer::rule::Rule;
 use crate::sql::optimizer::rule::TransformState;
 use crate::sql::optimizer::RelExpr;
@@ -93,19 +93,19 @@ impl Rule for RulePushDownFilterJoin {
         let mut need_push = false;
 
         for predicate in filter.predicates.into_iter() {
-            let pred = JoinCondition::new(&predicate, &left_prop, &right_prop);
+            let pred = JoinPredicate::new(&predicate, &left_prop, &right_prop);
             match pred {
-                JoinCondition::Left(_) => {
+                JoinPredicate::Left(_) => {
                     need_push = true;
                     left_push_down.push(predicate);
                 }
-                JoinCondition::Right(_) => {
+                JoinPredicate::Right(_) => {
                     need_push = true;
                     right_push_down.push(predicate);
                 }
-                JoinCondition::Other(_) => original_predicates.push(predicate),
+                JoinPredicate::Other(_) => original_predicates.push(predicate),
 
-                JoinCondition::Both { left, right } => {
+                JoinPredicate::Both { left, right } => {
                     let left_type = left.data_type();
                     let right_type = right.data_type();
                     let join_key_type = compare_coercion(&left_type, &right_type);

--- a/src/query/service/src/sql/optimizer/rule/rule_implement_hash_join.rs
+++ b/src/query/service/src/sql/optimizer/rule/rule_implement_hash_join.rs
@@ -75,6 +75,7 @@ impl Rule for RuleImplementHashJoin {
             .into(),
             s_expr.children().to_vec(),
             None,
+            None,
         );
         state.add_result(result);
 

--- a/src/query/service/src/sql/optimizer/rule/transform/mod.rs
+++ b/src/query/service/src/sql/optimizer/rule/transform/mod.rs
@@ -13,5 +13,10 @@
 // limitations under the License.
 
 mod rule_commute_join;
+mod rule_left_associate_join;
+mod rule_right_associate_join;
+mod util;
 
 pub use rule_commute_join::RuleCommuteJoin;
+pub use rule_left_associate_join::RuleLeftAssociateJoin;
+pub use rule_right_associate_join::RuleRightAssociateJoin;

--- a/src/query/service/src/sql/optimizer/rule/transform/rule_left_associate_join.rs
+++ b/src/query/service/src/sql/optimizer/rule/transform/rule_left_associate_join.rs
@@ -116,7 +116,7 @@ impl Rule for RuleLeftAssociateJoin {
         let contains_cross_join =
             join1.join_type == JoinType::Cross || join2.join_type == JoinType::Cross;
 
-        let predicates = vec![get_join_predicates(&join1), get_join_predicates(&join2)].concat();
+        let predicates = vec![get_join_predicates(&join1)?, get_join_predicates(&join2)?].concat();
 
         let mut join_3 = LogicalInnerJoin::default();
         let mut join_4 = LogicalInnerJoin::default();

--- a/src/query/service/src/sql/optimizer/rule/transform/rule_left_associate_join.rs
+++ b/src/query/service/src/sql/optimizer/rule/transform/rule_left_associate_join.rs
@@ -1,0 +1,204 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::vec;
+
+use common_exception::Result;
+
+use super::util::get_join_predicates;
+use crate::sql::binder::JoinPredicate;
+use crate::sql::optimizer::rule::Rule;
+use crate::sql::optimizer::rule::TransformState;
+use crate::sql::optimizer::RelExpr;
+use crate::sql::optimizer::RuleID;
+use crate::sql::optimizer::SExpr;
+use crate::sql::plans::JoinType;
+use crate::sql::plans::LogicalInnerJoin;
+use crate::sql::plans::PatternPlan;
+use crate::sql::plans::RelOp;
+
+/// Rule to apply associativity of join.
+/// The left associativity of join can be denoted as `(A ⋈ B) ⋈ C = A ⋈ (B ⋈ C)`.
+///
+/// If we have a join tree like:
+///    join
+///    /  \
+///  join  t3
+///  /  \
+///  t1  t2
+///
+/// We can represent it as `(t1 ⋈ t2) ⋈ t3`. With this rule, we can transform
+/// it to `t1 ⋈ (t2 ⋈ t3)`, which looks like:
+///    join
+///    /  \
+///   t1  join
+///       /  \
+///      t2  t3
+pub struct RuleLeftAssociateJoin {
+    id: RuleID,
+    pattern: SExpr,
+}
+
+impl RuleLeftAssociateJoin {
+    pub fn new() -> Self {
+        Self {
+            id: RuleID::LeftAssociateJoin,
+
+            // LogicalJoin
+            // | \
+            // |  *
+            // LogicalJoin
+            // | \
+            // |  *
+            // *
+            pattern: SExpr::create_binary(
+                PatternPlan {
+                    plan_type: RelOp::LogicalInnerJoin,
+                }
+                .into(),
+                SExpr::create_binary(
+                    PatternPlan {
+                        plan_type: RelOp::LogicalInnerJoin,
+                    }
+                    .into(),
+                    SExpr::create_pattern_leaf(),
+                    SExpr::create_pattern_leaf(),
+                ),
+                SExpr::create_pattern_leaf(),
+            ),
+        }
+    }
+}
+
+impl Rule for RuleLeftAssociateJoin {
+    fn id(&self) -> RuleID {
+        self.id
+    }
+
+    fn apply(&self, s_expr: &SExpr, state: &mut TransformState) -> Result<()> {
+        // We denote the join tree with:
+        //    join1
+        //    /  \
+        //  join2 t3
+        //  /  \
+        // t1  t2
+        //
+        // After applying the transform, we will get:
+        //   join3
+        //   /  \
+        //  t1  join4
+        //      /  \
+        //     t2  t3
+        let join1: LogicalInnerJoin = s_expr.plan.clone().try_into()?;
+        let join2: LogicalInnerJoin = s_expr.child(0)?.plan.clone().try_into()?;
+        let t1 = s_expr.child(0)?.child(0)?;
+        let t2 = s_expr.child(0)?.child(1)?;
+        let t3 = s_expr.child(1)?;
+
+        // Ensure inner joins
+        if join1.join_type != JoinType::Inner || join2.join_type != JoinType::Inner {
+            return Ok(());
+        }
+
+        // Check if original sexpr contains cross join.
+        // We will reject the results contain cross join if there is no cross join in original sexpr.
+        let contains_cross_join =
+            join1.join_type == JoinType::Cross || join2.join_type == JoinType::Cross;
+
+        let predicates = vec![get_join_predicates(&join1), get_join_predicates(&join2)].concat();
+
+        let mut join_3 = LogicalInnerJoin::default();
+        let mut join_4 = LogicalInnerJoin::default();
+
+        let t1_prop = RelExpr::with_s_expr(t1).derive_relational_prop()?;
+        let t2_prop = RelExpr::with_s_expr(t2).derive_relational_prop()?;
+        let t3_prop = RelExpr::with_s_expr(t3).derive_relational_prop()?;
+        let join4_prop = RelExpr::with_s_expr(&SExpr::create_binary(
+            join_4.clone().into(),
+            t2.clone(),
+            t3.clone(),
+        ))
+        .derive_relational_prop()?;
+
+        let mut join_4_preds = vec![];
+
+        // Resolve predicates for join3
+        for predicate in predicates.iter() {
+            let join_pred = JoinPredicate::new(predicate, &t1_prop, &join4_prop);
+            match join_pred {
+                JoinPredicate::Left(pred) => {
+                    // TODO(leiysky): push down the predicate
+                    join_3.other_conditions.push(pred.clone());
+                }
+                JoinPredicate::Right(pred) => {
+                    join_4_preds.push(pred.clone());
+                }
+                JoinPredicate::Both { left, right } => {
+                    join_3.left_conditions.push(left.clone());
+                    join_3.right_conditions.push(right.clone());
+                }
+                JoinPredicate::Other(pred) => {
+                    join_3.other_conditions.push(pred.clone());
+                }
+            }
+        }
+
+        if !join_3.left_conditions.is_empty() && !join_3.right_conditions.is_empty() {
+            join_3.join_type = JoinType::Inner;
+        }
+
+        // Resolve predicates for join4
+        for predicate in join_4_preds.iter() {
+            let join_pred = JoinPredicate::new(predicate, &t2_prop, &t3_prop);
+            match join_pred {
+                JoinPredicate::Left(_) | JoinPredicate::Right(_) | JoinPredicate::Other(_) => {
+                    // TODO(leiysky): push down the predicate
+                    join_4.other_conditions.push(predicate.clone());
+                }
+                JoinPredicate::Both { left, right } => {
+                    join_4.left_conditions.push(left.clone());
+                    join_4.right_conditions.push(right.clone());
+                }
+            }
+        }
+
+        if !join_4.left_conditions.is_empty() && !join_4.right_conditions.is_empty() {
+            join_4.join_type = JoinType::Inner;
+        }
+
+        // Reject inefficient cross join
+        if !contains_cross_join
+            && (join_3.join_type == JoinType::Cross || join_4.join_type == JoinType::Cross)
+        {
+            return Ok(());
+        }
+
+        let result = SExpr::create(
+            join_3.into(),
+            vec![
+                t1.clone(),
+                SExpr::create_binary(join_4.into(), t2.clone(), t3.clone()),
+            ],
+            s_expr.original_group,
+        );
+
+        state.add_result(result);
+
+        Ok(())
+    }
+
+    fn pattern(&self) -> &SExpr {
+        &self.pattern
+    }
+}

--- a/src/query/service/src/sql/optimizer/rule/transform/rule_left_associate_join.rs
+++ b/src/query/service/src/sql/optimizer/rule/transform/rule_left_associate_join.rs
@@ -191,6 +191,7 @@ impl Rule for RuleLeftAssociateJoin {
                 SExpr::create_binary(join_4.into(), t2.clone(), t3.clone()),
             ],
             s_expr.original_group,
+            None,
         );
 
         state.add_result(result);

--- a/src/query/service/src/sql/optimizer/rule/transform/rule_right_associate_join.rs
+++ b/src/query/service/src/sql/optimizer/rule/transform/rule_right_associate_join.rs
@@ -1,0 +1,200 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::Result;
+
+use super::util::get_join_predicates;
+use crate::sql::binder::JoinPredicate;
+use crate::sql::optimizer::rule::Rule;
+use crate::sql::optimizer::rule::TransformState;
+use crate::sql::optimizer::RelExpr;
+use crate::sql::optimizer::RuleID;
+use crate::sql::optimizer::SExpr;
+use crate::sql::plans::JoinType;
+use crate::sql::plans::LogicalInnerJoin;
+use crate::sql::plans::PatternPlan;
+use crate::sql::plans::RelOp;
+
+/// Rule to apply associativity of join.
+/// The right associativity of join can be denoted as `A ⋈ (B ⋈ C) = (A ⋈ B) ⋈ C`.
+///
+/// If we have a join tree like:
+///    join
+///    /  \
+///   t1  join
+///       /  \
+///      t2  t3
+///
+/// We can represent it as `t1 ⋈ (t2 ⋈ t3)`. With this rule, we can transform
+/// it to `(t1 ⋈ t2) ⋈ t3`, which looks like:
+///    join
+///    /  \
+///  join  t3
+///  /  \
+///  t1  t2
+pub struct RuleRightAssociateJoin {
+    id: RuleID,
+    pattern: SExpr,
+}
+
+impl RuleRightAssociateJoin {
+    pub fn new() -> Self {
+        Self {
+            id: RuleID::RightAssociateJoin,
+
+            // LogicalJoin
+            // | \
+            // *  LogicalJoin
+            //    | \
+            //    *  *
+            pattern: SExpr::create_binary(
+                PatternPlan {
+                    plan_type: RelOp::LogicalInnerJoin,
+                }
+                .into(),
+                SExpr::create_pattern_leaf(),
+                SExpr::create_binary(
+                    PatternPlan {
+                        plan_type: RelOp::LogicalInnerJoin,
+                    }
+                    .into(),
+                    SExpr::create_pattern_leaf(),
+                    SExpr::create_pattern_leaf(),
+                ),
+            ),
+        }
+    }
+}
+
+impl Rule for RuleRightAssociateJoin {
+    fn id(&self) -> RuleID {
+        self.id
+    }
+
+    fn apply(&self, s_expr: &SExpr, state: &mut TransformState) -> Result<()> {
+        // We denote the join tree with:
+        //    join1
+        //    /  \
+        //   t1  join2
+        //      /  \
+        //     t2  t3
+        //
+        // After applying the transform, we will get:
+        //    join3
+        //    /  \
+        //  join4 t3
+        //  /  \
+        // t1  t2
+        let join1: LogicalInnerJoin = s_expr.plan.clone().try_into()?;
+        let join2: LogicalInnerJoin = s_expr.child(1)?.plan.clone().try_into()?;
+        let t1 = s_expr.child(0)?;
+        let t2 = s_expr.child(1)?.child(0)?;
+        let t3 = s_expr.child(1)?.child(1)?;
+
+        // Ensure inner joins
+        if join1.join_type != JoinType::Inner || join2.join_type != JoinType::Inner {
+            return Ok(());
+        }
+
+        // Check if original sexpr contains cross join.
+        // We will reject the results contain cross join if there is no cross join in original sexpr.
+        let contains_cross_join =
+            join1.join_type == JoinType::Cross || join2.join_type == JoinType::Cross;
+
+        let predicates = vec![get_join_predicates(&join1), get_join_predicates(&join2)].concat();
+
+        let mut join_3 = LogicalInnerJoin::default();
+        let mut join_4 = LogicalInnerJoin::default();
+
+        let t1_prop = RelExpr::with_s_expr(t1).derive_relational_prop()?;
+        let t2_prop = RelExpr::with_s_expr(t2).derive_relational_prop()?;
+        let t3_prop = RelExpr::with_s_expr(t3).derive_relational_prop()?;
+        let join4_prop = RelExpr::with_s_expr(&SExpr::create_binary(
+            join_4.clone().into(),
+            t1.clone(),
+            t2.clone(),
+        ))
+        .derive_relational_prop()?;
+
+        let mut join_4_preds = vec![];
+
+        // Resolve predicates for join3
+        for predicate in predicates.iter() {
+            let join_pred = JoinPredicate::new(predicate, &join4_prop, &t3_prop);
+            match join_pred {
+                JoinPredicate::Right(pred) => {
+                    // TODO(leiysky): push down the predicate
+                    join_3.other_conditions.push(pred.clone());
+                }
+                JoinPredicate::Left(pred) => {
+                    join_4_preds.push(pred.clone());
+                }
+                JoinPredicate::Both { left, right } => {
+                    join_3.left_conditions.push(left.clone());
+                    join_3.right_conditions.push(right.clone());
+                }
+                JoinPredicate::Other(pred) => {
+                    join_3.other_conditions.push(pred.clone());
+                }
+            }
+        }
+
+        if !join_3.left_conditions.is_empty() && !join_3.right_conditions.is_empty() {
+            join_3.join_type = JoinType::Inner;
+        }
+
+        // Resolve predicates for join4
+        for predicate in join_4_preds.iter() {
+            let join_pred = JoinPredicate::new(predicate, &t1_prop, &t2_prop);
+            match join_pred {
+                JoinPredicate::Left(_) | JoinPredicate::Right(_) | JoinPredicate::Other(_) => {
+                    // TODO(leiysky): push down the predicate
+                    join_4.other_conditions.push(predicate.clone());
+                }
+                JoinPredicate::Both { left, right } => {
+                    join_4.left_conditions.push(left.clone());
+                    join_4.right_conditions.push(right.clone());
+                }
+            }
+        }
+
+        if !join_4.left_conditions.is_empty() && !join_4.right_conditions.is_empty() {
+            join_4.join_type = JoinType::Inner;
+        }
+
+        // Reject inefficient cross join
+        if !contains_cross_join
+            && (join_3.join_type == JoinType::Cross || join_4.join_type == JoinType::Cross)
+        {
+            return Ok(());
+        }
+
+        let result = SExpr::create(
+            join_3.into(),
+            vec![
+                SExpr::create_binary(join_4.into(), t1.clone(), t2.clone()),
+                t3.clone(),
+            ],
+            s_expr.original_group,
+        );
+
+        state.add_result(result);
+
+        Ok(())
+    }
+
+    fn pattern(&self) -> &SExpr {
+        &self.pattern
+    }
+}

--- a/src/query/service/src/sql/optimizer/rule/transform/rule_right_associate_join.rs
+++ b/src/query/service/src/sql/optimizer/rule/transform/rule_right_associate_join.rs
@@ -187,6 +187,7 @@ impl Rule for RuleRightAssociateJoin {
                 t3.clone(),
             ],
             s_expr.original_group,
+            None,
         );
 
         state.add_result(result);

--- a/src/query/service/src/sql/optimizer/rule/transform/rule_right_associate_join.rs
+++ b/src/query/service/src/sql/optimizer/rule/transform/rule_right_associate_join.rs
@@ -112,7 +112,7 @@ impl Rule for RuleRightAssociateJoin {
         let contains_cross_join =
             join1.join_type == JoinType::Cross || join2.join_type == JoinType::Cross;
 
-        let predicates = vec![get_join_predicates(&join1), get_join_predicates(&join2)].concat();
+        let predicates = vec![get_join_predicates(&join1)?, get_join_predicates(&join2)?].concat();
 
         let mut join_3 = LogicalInnerJoin::default();
         let mut join_4 = LogicalInnerJoin::default();

--- a/src/query/service/src/sql/optimizer/rule/transform/util.rs
+++ b/src/query/service/src/sql/optimizer/rule/transform/util.rs
@@ -1,0 +1,36 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_datavalues::BooleanType;
+
+use crate::sql::plans::ComparisonExpr;
+use crate::sql::plans::ComparisonOp;
+use crate::sql::plans::LogicalInnerJoin;
+use crate::sql::plans::Scalar;
+
+pub fn get_join_predicates(join: &LogicalInnerJoin) -> Vec<Scalar> {
+    join.left_conditions
+        .iter()
+        .zip(join.right_conditions.iter())
+        .map(|(left_cond, right_cond)| {
+            Scalar::ComparisonExpr(ComparisonExpr {
+                left: Box::new(left_cond.clone()),
+                right: Box::new(right_cond.clone()),
+                op: ComparisonOp::Equal,
+                return_type: Box::new(BooleanType::new_impl()),
+            })
+        })
+        .chain(join.other_conditions.clone().into_iter())
+        .collect()
+}

--- a/src/query/service/src/sql/planner/binder/scalar_common.rs
+++ b/src/query/service/src/sql/planner/binder/scalar_common.rs
@@ -110,14 +110,14 @@ pub fn satisfied_by(scalar: &Scalar, prop: &RelationalProperty) -> bool {
 /// - Both: `a = b`
 /// - Other: `a+b = 1`
 #[derive(Clone, Debug)]
-pub enum JoinCondition<'a> {
+pub enum JoinPredicate<'a> {
     Left(&'a Scalar),
     Right(&'a Scalar),
     Both { left: &'a Scalar, right: &'a Scalar },
     Other(&'a Scalar),
 }
 
-impl<'a> JoinCondition<'a> {
+impl<'a> JoinPredicate<'a> {
     pub fn new(
         scalar: &'a Scalar,
         left_prop: &RelationalProperty,

--- a/src/query/service/src/sql/planner/plans/logical_join.rs
+++ b/src/query/service/src/sql/planner/plans/logical_join.rs
@@ -87,6 +87,19 @@ pub struct LogicalInnerJoin {
     pub from_correlated_subquery: bool,
 }
 
+impl Default for LogicalInnerJoin {
+    fn default() -> Self {
+        Self {
+            left_conditions: Default::default(),
+            right_conditions: Default::default(),
+            other_conditions: Default::default(),
+            join_type: JoinType::Cross,
+            marker_index: Default::default(),
+            from_correlated_subquery: Default::default(),
+        }
+    }
+}
+
 impl Operator for LogicalInnerJoin {
     fn rel_op(&self) -> RelOp {
         RelOp::LogicalInnerJoin

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/chain.test
@@ -1,0 +1,234 @@
+statement ok
+create database join_reorder;
+
+statement ok
+use join_reorder;
+
+statement ok
+create table t as select number as a from numbers(1);
+
+statement ok
+create table t1 as select number as a from numbers(10);
+
+statement ok
+create table t2 as select number as a from numbers(100);
+
+statement query T
+explain select * from t, t1, t2 where t.a = t1.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t1.a (#1)]
+├── probe keys: [t2.a (#2)]
+├── filters: []
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#0)]
+│   ├── probe keys: [t1.a (#1)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 31
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 68
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 431
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t1.a (#2), t1.a (#2)]
+├── probe keys: [t.a (#0), t2.a (#1)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t1
+│   ├── read rows: 10
+│   ├── read bytes: 68
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: CROSS
+    ├── build keys: []
+    ├── probe keys: []
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t
+    │   ├── read rows: 1
+    │   ├── read bytes: 31
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t1, t, t2 where t.a = t1.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t1.a (#0)]
+├── probe keys: [t2.a (#2)]
+├── filters: []
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#1)]
+│   ├── probe keys: [t1.a (#0)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 31
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 68
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 431
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t1, t2, t where t.a = t1.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t.a (#2)]
+├── probe keys: [t1.a (#0)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t
+│   ├── read rows: 1
+│   ├── read bytes: 31
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: INNER
+    ├── build keys: [t1.a (#0)]
+    ├── probe keys: [t2.a (#1)]
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t1
+    │   ├── read rows: 10
+    │   ├── read bytes: 68
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t.a (#2)]
+├── probe keys: [t1.a (#1)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t
+│   ├── read rows: 1
+│   ├── read bytes: 31
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: INNER
+    ├── build keys: [t1.a (#1)]
+    ├── probe keys: [t2.a (#0)]
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t1
+    │   ├── read rows: 10
+    │   ├── read bytes: 68
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t2, t, t1 where t.a = t1.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t1.a (#2), t1.a (#2)]
+├── probe keys: [t.a (#1), t2.a (#0)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t1
+│   ├── read rows: 10
+│   ├── read bytes: 68
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: CROSS
+    ├── build keys: []
+    ├── probe keys: []
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t
+    │   ├── read rows: 1
+    │   ├── read bytes: 31
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement ok
+drop database join_reorder;
+

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/cycles.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/cycles.test
@@ -1,0 +1,234 @@
+statement ok
+create database join_reorder;
+
+statement ok
+use join_reorder;
+
+statement ok
+create table t as select number as a from numbers(1);
+
+statement ok
+create table t1 as select number as a from numbers(10);
+
+statement ok
+create table t2 as select number as a from numbers(100);
+
+statement query T
+explain select * from t, t1, t2 where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t1.a (#1), t.a (#0)]
+├── probe keys: [t2.a (#2), t2.a (#2)]
+├── filters: []
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#0)]
+│   ├── probe keys: [t1.a (#1)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 31
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 68
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 431
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t1.a (#2), t1.a (#2)]
+├── probe keys: [t.a (#0), t2.a (#1)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t1
+│   ├── read rows: 10
+│   ├── read bytes: 68
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: INNER
+    ├── build keys: [t.a (#0)]
+    ├── probe keys: [t2.a (#1)]
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t
+    │   ├── read rows: 1
+    │   ├── read bytes: 31
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t1, t, t2 where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t1.a (#0), t.a (#1)]
+├── probe keys: [t2.a (#2), t2.a (#2)]
+├── filters: []
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#1)]
+│   ├── probe keys: [t1.a (#0)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 31
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 68
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 431
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t1, t2, t where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t.a (#2), t.a (#2)]
+├── probe keys: [t1.a (#0), t2.a (#1)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t
+│   ├── read rows: 1
+│   ├── read bytes: 31
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: INNER
+    ├── build keys: [t1.a (#0)]
+    ├── probe keys: [t2.a (#1)]
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t1
+    │   ├── read rows: 10
+    │   ├── read bytes: 68
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t.a (#2), t.a (#2)]
+├── probe keys: [t1.a (#1), t2.a (#0)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t
+│   ├── read rows: 1
+│   ├── read bytes: 31
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: INNER
+    ├── build keys: [t1.a (#1)]
+    ├── probe keys: [t2.a (#0)]
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t1
+    │   ├── read rows: 10
+    │   ├── read bytes: 68
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t2, t, t1 where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t1.a (#2), t1.a (#2)]
+├── probe keys: [t.a (#1), t2.a (#0)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t1
+│   ├── read rows: 10
+│   ├── read bytes: 68
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: INNER
+    ├── build keys: [t.a (#1)]
+    ├── probe keys: [t2.a (#0)]
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t
+    │   ├── read rows: 1
+    │   ├── read bytes: 31
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement ok
+drop database join_reorder;
+

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/star.test
@@ -1,0 +1,234 @@
+statement ok
+create database join_reorder;
+
+statement ok
+use join_reorder;
+
+statement ok
+create table t as select number as a from numbers(1);
+
+statement ok
+create table t1 as select number as a from numbers(10);
+
+statement ok
+create table t2 as select number as a from numbers(100);
+
+statement query T
+explain select * from t, t1, t2 where t.a = t2.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t.a (#0), t1.a (#1)]
+├── probe keys: [t2.a (#2), t2.a (#2)]
+├── filters: []
+├── HashJoin(Build)
+│   ├── join type: CROSS
+│   ├── build keys: []
+│   ├── probe keys: []
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 31
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 68
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 431
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t, t2, t1 where t.a = t2.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t1.a (#2)]
+├── probe keys: [t2.a (#1)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t1
+│   ├── read rows: 10
+│   ├── read bytes: 68
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: INNER
+    ├── build keys: [t.a (#0)]
+    ├── probe keys: [t2.a (#1)]
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t
+    │   ├── read rows: 1
+    │   ├── read bytes: 31
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t1, t, t2 where t.a = t2.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t.a (#1), t1.a (#0)]
+├── probe keys: [t2.a (#2), t2.a (#2)]
+├── filters: []
+├── HashJoin(Build)
+│   ├── join type: CROSS
+│   ├── build keys: []
+│   ├── probe keys: []
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 31
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 68
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 431
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t1, t2, t where t.a = t2.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t.a (#2)]
+├── probe keys: [t2.a (#1)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t
+│   ├── read rows: 1
+│   ├── read bytes: 31
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: INNER
+    ├── build keys: [t1.a (#0)]
+    ├── probe keys: [t2.a (#1)]
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t1
+    │   ├── read rows: 10
+    │   ├── read bytes: 68
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t2, t1, t where t.a = t2.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t.a (#2)]
+├── probe keys: [t2.a (#0)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t
+│   ├── read rows: 1
+│   ├── read bytes: 31
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: INNER
+    ├── build keys: [t1.a (#1)]
+    ├── probe keys: [t2.a (#0)]
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t1
+    │   ├── read rows: 10
+    │   ├── read bytes: 68
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select * from t2, t, t1 where t.a = t2.a and t1.a = t2.a;
+
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t1.a (#2)]
+├── probe keys: [t2.a (#0)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.join_reorder.t1
+│   ├── read rows: 10
+│   ├── read bytes: 68
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [], limit: NONE]
+└── HashJoin(Probe)
+    ├── join type: INNER
+    ├── build keys: [t.a (#1)]
+    ├── probe keys: [t2.a (#0)]
+    ├── filters: []
+    ├── TableScan(Build)
+    │   ├── table: default.join_reorder.t
+    │   ├── read rows: 1
+    │   ├── read bytes: 31
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.join_reorder.t2
+        ├── read rows: 100
+        ├── read bytes: 431
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
+
+statement ok
+drop database join_reorder;
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Introduce two exploration rules `LeftAssociateJoin` and `RightAssociateJoin` to enumerate join trees.

With the rules, we can exploit the associativity of join operator $\(A\bowtie B\) \bowtie C = A\bowtie \(B \bowtie C\)$.

In the current implementation, we only care about the reordering of inner joins and cross joins, which is the most common case.

Close #7440 
