### PR TITLE
fix: fix ceil return type

### DIFF
--- a/src/query/functions-v2/src/scalars/math.rs
+++ b/src/query/functions-v2/src/scalars/math.rs
@@ -176,11 +176,11 @@ pub fn register(registry: &mut FunctionRegistry) {
     for left in ALL_INTEGER_TYPES {
         with_number_mapped_type!(L, match left {
             DataType::L => {
-                registry.register_1_arg::<NumberType<L>, NumberType<f64>, _, _>(
+                registry.register_1_arg::<NumberType<L>, NumberType<L>, _, _>(
                     "ceil",
                     FunctionProperty::default(),
                     |_| None,
-                    |val| val as f64,
+                    |val| val,
                 );
             }
             _ => unreachable!(),

--- a/src/query/functions-v2/tests/it/scalars/math.rs
+++ b/src/query/functions-v2/tests/it/scalars/math.rs
@@ -29,6 +29,7 @@ fn test_math() {
     test_abs(file);
     test_sign(file);
     test_trigonometric(file);
+    test_ceil(file);
     test_exp(file);
     test_round(file);
     test_sqrt(file);
@@ -71,6 +72,16 @@ fn test_trigonometric(file: &mut impl Write) {
         "a",
         DataType::Int64,
         Column::from_data(vec![1i64, -1, 1024]),
+    )]);
+}
+
+fn test_ceil(file: &mut impl Write) {
+    run_ast(file, "ceil(5)", &[]);
+    run_ast(file, "ceil(5.6)", &[]);
+    run_ast(file, "ceil(a)", &[(
+        "a",
+        DataType::Float64,
+        Column::from_data(vec![1.23f64, -1.23]),
     )]);
 }
 

--- a/src/query/functions-v2/tests/it/scalars/testdata/math.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/math.txt
@@ -191,6 +191,45 @@ evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 
 
+ast            : ceil(5)
+raw expr       : ceil(5_u8)
+checked expr   : ceil<UInt8>(5_u8)
+optimized expr : 5_u8
+output type    : UInt8
+output domain  : Unknown
+output         : 5
+
+
+ast            : ceil(5.6)
+raw expr       : ceil(5.6_f64)
+checked expr   : ceil<Float64>(5.6_f64)
+optimized expr : 6.0_f64
+output type    : Float64
+output domain  : Unknown
+output         : 6.0
+
+
+ast            : ceil(a)
+raw expr       : ceil(ColumnRef(0)::Float64)
+checked expr   : ceil<Float64>(ColumnRef(0))
+evaluation:
++--------+----------------+---------+
+|        | a              | Output  |
++--------+----------------+---------+
+| Type   | Float64        | Float64 |
+| Domain | {-1.23..=1.23} | Unknown |
+| Row 0  | 1.23           | 2.0     |
+| Row 1  | -1.23          | -1.0    |
++--------+----------------+---------+
+evaluation (internal):
++--------+------------------------+
+| Column | Data                   |
++--------+------------------------+
+| a      | Float64([1.23, -1.23]) |
+| Output | Float64([2.0, -1.0])   |
++--------+------------------------+
+
+
 ast            : exp(2)
 raw expr       : exp(2_u8)
 checked expr   : exp<UInt8>(2_u8)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix `ceil` return type when arg is an integer.

Fixes #issue
