### PR TITLE
ci(proto): add compat test for CopyOptions::purge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,7 @@ dependencies = [
  "enumflags2",
  "maplit",
  "num",
+ "pretty_assertions",
  "serde_json",
  "thiserror",
 ]

--- a/src/meta/proto-conv/Cargo.toml
+++ b/src/meta/proto-conv/Cargo.toml
@@ -28,3 +28,4 @@ serde_json = "1.0.81"
 [dev-dependencies]
 anyhow = "1.0.58"
 maplit = "1.0.2"
+pretty_assertions = "1.2.1"

--- a/src/meta/proto-conv/src/lib.rs
+++ b/src/meta/proto-conv/src/lib.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// For use of const fn: `Option::<T>::unwrap` at compile time.
+#![feature(const_option)]
+
 //! Provides conversion from and to protobuf defined meta data, which is used for transport.
 //!
 //! Thus protobuf messages has the maximized compatibility.

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -14,7 +14,33 @@
 
 use crate::Incompatible;
 
-pub const VER: u64 = 5;
+/// Describes metadata changes.
+///
+/// This is a list of every `VER` and the corresponding change it introduces.
+///
+/// ## For developers
+///
+/// Every time fields are added/removed into/from data types in this crate:
+/// - Add a new line to this list to describe what changed.
+/// - Add a test case to ensure protobuf message serialized by this this version can be loaded,
+///   similar to: test_user_stage_fs_v6() in tests/it/user_stage.rs;
+///
+/// `VER` is the current metadata version and is automatically set to the last version.
+/// `MIN_COMPATIBLE_VER` is the oldest compatible version.
+const META_CHANGE_LOG: &[(u64, &str)] = &[
+    //
+    (1, "----------: Initial"),
+    (2, "2022-07-13: Add: share.proto"),
+    (3, "2022-07-29: Add: user.proto/UserOption::default_role"),
+    (4, "2022-08-22: Add: config.proto/GcsStorageConfig"),
+    (
+        5,
+        "2022-08-25: Add: ShareMeta::share_from_db_ids; DatabaseMeta::from_share",
+    ),
+    (6, "2022-09-08: Add: users.proto/CopyOptions::purge"),
+];
+
+pub const VER: u64 = META_CHANGE_LOG.last().unwrap().0;
 pub const MIN_COMPATIBLE_VER: u64 = 1;
 
 pub fn check_ver(msg_ver: u64, msg_min_compatible: u64) -> Result<(), Incompatible> {

--- a/src/meta/proto-conv/tests/it/common.rs
+++ b/src/meta/proto-conv/tests/it/common.rs
@@ -1,0 +1,72 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Debug;
+use std::fmt::Display;
+
+use common_proto_conv::FromToProto;
+use common_proto_conv::VER;
+use pretty_assertions::assert_eq;
+
+/// Tests converting rust types from/to protobuf defined types.
+/// It also print out encoded protobuf message as data for backward compatibility test.
+pub(crate) fn test_pb_from_to<MT>(name: impl Display, m: MT) -> anyhow::Result<()>
+where
+    MT: FromToProto + PartialEq + Debug,
+    MT::PB: common_protos::prost::Message,
+{
+    let p = m.to_pb()?;
+
+    let mut buf = vec![];
+    common_protos::prost::Message::encode(&p, &mut buf)?;
+    // The encoded data should be saved for compatability test.
+    println!("// Encoded data of version {} of {}:", VER, name);
+    println!("// It is generated with common::test_pb_from_to.");
+    println!("let {}_v{} = vec!{:?};", name, VER, buf);
+
+    let got = MT::from_pb(p)?;
+    assert_eq!(m, got, "convert from/to protobuf: {}", name);
+    Ok(())
+}
+
+/// Tests loading old version data.
+pub(crate) fn test_load_old<MT>(name: impl Display, buf: &[u8], want: MT) -> anyhow::Result<()>
+where
+    MT: FromToProto + PartialEq + Debug,
+    MT::PB: common_protos::prost::Message + Default,
+{
+    let p: MT::PB = common_protos::prost::Message::decode(buf).map_err(print_err)?;
+    let got = MT::from_pb(p).map_err(print_err)?;
+
+    assert_eq!(want, got, "loading {} with version {} program", name, VER);
+    Ok(())
+}
+
+pub(crate) fn print_err<T: Debug>(e: T) -> T {
+    eprintln!("Error: {:?}", e);
+    e
+}
+
+macro_rules! func_name {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        let n = &name[..name.len() - 3];
+        let nn = n.replace("::{{closure}}", "");
+        nn
+    }};
+}

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -11,5 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#[macro_use]
+pub(crate) mod common;
 mod proto_conv;
 mod user_proto_conv;
+mod user_stage;

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -28,6 +28,8 @@ use common_proto_conv::VER;
 use common_protos::pb;
 use maplit::btreemap;
 
+use crate::common::print_err;
+
 fn s(ss: impl ToString) -> String {
     ss.to_string()
 }
@@ -240,7 +242,11 @@ fn test_incompatible() -> anyhow::Result<()> {
     let res = mt::DatabaseMeta::from_pb(p);
     assert_eq!(
         Incompatible {
-            reason: s("executable ver=6 is smaller than the message min compatible ver: 7")
+            reason: format!(
+                "executable ver={} is smaller than the message min compatible ver: {}",
+                VER,
+                VER + 1
+            )
         },
         res.unwrap_err()
     );
@@ -487,9 +493,4 @@ fn test_load_old() -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-fn print_err<T: Debug>(e: T) -> T {
-    eprintln!("Error: {:?}", e);
-    e
 }

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -14,7 +14,6 @@
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::fmt::Debug;
 use std::sync::Arc;
 
 use common_datavalues as dv;

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -24,6 +24,7 @@ use common_meta_app::schema as mt;
 use common_meta_app::share;
 use common_proto_conv::FromToProto;
 use common_proto_conv::Incompatible;
+use common_proto_conv::VER;
 use common_protos::pb;
 use maplit::btreemap;
 
@@ -233,13 +234,13 @@ fn test_pb_from_to() -> anyhow::Result<()> {
 fn test_incompatible() -> anyhow::Result<()> {
     let db_meta = new_db_meta();
     let mut p = db_meta.to_pb()?;
-    p.ver = 6;
-    p.min_compatible = 6;
+    p.ver = VER + 1;
+    p.min_compatible = VER + 1;
 
     let res = mt::DatabaseMeta::from_pb(p);
     assert_eq!(
         Incompatible {
-            reason: s("executable ver=5 is smaller than the message min compatible ver: 6")
+            reason: s("executable ver=6 is smaller than the message min compatible ver: 7")
         },
         res.unwrap_err()
     );

--- a/src/meta/proto-conv/tests/it/user_proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/user_proto_conv.rs
@@ -30,10 +30,6 @@ use pretty_assertions::assert_eq;
 
 use crate::common::print_err;
 
-fn s(ss: impl ToString) -> String {
-    ss.to_string()
-}
-
 fn test_user_info() -> UserInfo {
     let option = mt::UserOption::default()
         .with_set_flag(mt::UserOptionFlag::TenantSetting)
@@ -173,7 +169,11 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let res = mt::UserInfo::from_pb(p);
         assert_eq!(
             Incompatible {
-                reason: s("executable ver=6 is smaller than the message min compatible ver: 7")
+                reason: format!(
+                    "executable ver={} is smaller than the message min compatible ver: {}",
+                    VER,
+                    VER + 1
+                )
             },
             res.unwrap_err()
         );
@@ -188,7 +188,11 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let res = mt::UserStageInfo::from_pb(p);
         assert_eq!(
             Incompatible {
-                reason: s("executable ver=6 is smaller than the message min compatible ver: 7")
+                reason: format!(
+                    "executable ver={} is smaller than the message min compatible ver: {}",
+                    VER,
+                    VER + 1
+                )
             },
             res.unwrap_err()
         )
@@ -203,7 +207,11 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let res = mt::UserStageInfo::from_pb(p);
         assert_eq!(
             Incompatible {
-                reason: s("executable ver=6 is smaller than the message min compatible ver: 7")
+                reason: format!(
+                    "executable ver={} is smaller than the message min compatible ver: {}",
+                    VER,
+                    VER + 1
+                )
             },
             res.unwrap_err()
         );
@@ -218,7 +226,11 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let res = mt::UserStageInfo::from_pb(p);
         assert_eq!(
             Incompatible {
-                reason: s("executable ver=6 is smaller than the message min compatible ver: 7")
+                reason: format!(
+                    "executable ver={} is smaller than the message min compatible ver: {}",
+                    VER,
+                    VER + 1
+                )
             },
             res.unwrap_err()
         );

--- a/src/meta/proto-conv/tests/it/user_stage.rs
+++ b/src/meta/proto-conv/tests/it/user_stage.rs
@@ -1,0 +1,361 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test UserStageInfo
+
+use common_meta_types as mt;
+use common_storage::StorageFsConfig;
+use common_storage::StorageGcsConfig;
+use common_storage::StorageParams;
+use common_storage::StorageS3Config;
+
+use crate::common;
+use crate::user_proto_conv::test_fs_stage_info;
+use crate::user_proto_conv::test_gcs_stage_info;
+use crate::user_proto_conv::test_s3_stage_info;
+
+#[test]
+fn test_user_stage_fs_latest() -> anyhow::Result<()> {
+    common::test_pb_from_to("user_stage_fs", test_fs_stage_info())?;
+    Ok(())
+}
+
+#[test]
+fn test_user_stage_s3_latest() -> anyhow::Result<()> {
+    common::test_pb_from_to("user_stage_s3", test_s3_stage_info())?;
+    Ok(())
+}
+
+#[test]
+fn test_user_stage_gcs_latest() -> anyhow::Result<()> {
+    common::test_pb_from_to("user_stage_gcs", test_gcs_stage_info())?;
+    Ok(())
+}
+
+#[test]
+fn test_user_stage_fs_v6() -> anyhow::Result<()> {
+    // Encoded data of version 6 of user_stage_fs:
+    // It is generated with common::test_pb_from_to.
+    let user_stage_fs_v6 = vec![
+        10, 17, 102, 115, 58, 47, 47, 100, 105, 114, 47, 116, 111, 47, 102, 105, 108, 101, 115, 26,
+        25, 10, 23, 18, 21, 10, 13, 47, 100, 105, 114, 47, 116, 111, 47, 102, 105, 108, 101, 115,
+        160, 6, 6, 168, 6, 1, 34, 20, 8, 1, 16, 128, 8, 26, 1, 124, 34, 2, 47, 47, 40, 2, 160, 6,
+        6, 168, 6, 1, 42, 10, 10, 3, 32, 154, 5, 16, 142, 8, 24, 1, 50, 4, 116, 101, 115, 116, 160,
+        6, 6, 168, 6, 1,
+    ];
+
+    let want = mt::UserStageInfo {
+        stage_name: "fs://dir/to/files".to_string(),
+        stage_type: mt::StageType::Internal,
+        stage_params: mt::StageParams {
+            storage: StorageParams::Fs(StorageFsConfig {
+                root: "/dir/to/files".to_string(),
+            }),
+        },
+        file_format_options: mt::FileFormatOptions {
+            format: mt::StageFileFormatType::Json,
+            skip_header: 1024,
+            field_delimiter: "|".to_string(),
+            record_delimiter: "//".to_string(),
+            compression: mt::StageFileCompression::Bz2,
+        },
+        copy_options: mt::CopyOptions {
+            on_error: mt::OnErrorMode::SkipFileNum(666),
+            size_limit: 1038,
+            purge: true,
+        },
+        comment: "test".to_string(),
+        ..Default::default()
+    };
+
+    common::test_load_old(func_name!(), user_stage_fs_v6.as_slice(), want)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_user_stage_s3_v6() -> anyhow::Result<()> {
+    // Encoded data of version 6 of user_stage_s3:
+    // It is generated with common::test_pb_from_to.
+    let user_stage_s3_v6 = vec![
+        10, 24, 115, 51, 58, 47, 47, 109, 121, 98, 117, 99, 107, 101, 116, 47, 100, 97, 116, 97,
+        47, 102, 105, 108, 101, 115, 16, 1, 26, 100, 10, 98, 10, 96, 18, 24, 104, 116, 116, 112,
+        115, 58, 47, 47, 115, 51, 46, 97, 109, 97, 122, 111, 110, 97, 119, 115, 46, 99, 111, 109,
+        26, 9, 109, 121, 95, 107, 101, 121, 95, 105, 100, 34, 13, 109, 121, 95, 115, 101, 99, 114,
+        101, 116, 95, 107, 101, 121, 42, 8, 109, 121, 98, 117, 99, 107, 101, 116, 50, 11, 47, 100,
+        97, 116, 97, 47, 102, 105, 108, 101, 115, 58, 13, 109, 121, 95, 109, 97, 115, 116, 101,
+        114, 95, 107, 101, 121, 160, 6, 6, 168, 6, 1, 34, 20, 8, 1, 16, 128, 8, 26, 1, 124, 34, 2,
+        47, 47, 40, 2, 160, 6, 6, 168, 6, 1, 42, 10, 10, 3, 32, 154, 5, 16, 142, 8, 24, 1, 50, 4,
+        116, 101, 115, 116, 160, 6, 6, 168, 6, 1,
+    ];
+
+    let want = mt::UserStageInfo {
+        stage_name: "s3://mybucket/data/files".to_string(),
+        stage_type: mt::StageType::External,
+        stage_params: mt::StageParams {
+            storage: StorageParams::S3(StorageS3Config {
+                bucket: "mybucket".to_string(),
+                root: "/data/files".to_string(),
+                access_key_id: "my_key_id".to_string(),
+                secret_access_key: "my_secret_key".to_string(),
+                master_key: "my_master_key".to_string(),
+                ..Default::default()
+            }),
+        },
+        file_format_options: mt::FileFormatOptions {
+            format: mt::StageFileFormatType::Json,
+            skip_header: 1024,
+            field_delimiter: "|".to_string(),
+            record_delimiter: "//".to_string(),
+            compression: mt::StageFileCompression::Bz2,
+        },
+        copy_options: mt::CopyOptions {
+            on_error: mt::OnErrorMode::SkipFileNum(666),
+            size_limit: 1038,
+            purge: true,
+        },
+        comment: "test".to_string(),
+        ..Default::default()
+    };
+
+    common::test_load_old(func_name!(), user_stage_s3_v6.as_slice(), want)?;
+    Ok(())
+}
+
+#[test]
+fn test_user_stage_gcs_v6() -> anyhow::Result<()> {
+    // Encoded data of version 6 of user_stage_gcs:
+    // It is generated with common::test_pb_from_to.
+    let user_stage_gcs_v6 = vec![
+        10, 26, 103, 99, 115, 58, 47, 47, 109, 121, 95, 98, 117, 99, 107, 101, 116, 47, 100, 97,
+        116, 97, 47, 102, 105, 108, 101, 115, 16, 1, 26, 81, 10, 79, 26, 77, 10, 30, 104, 116, 116,
+        112, 115, 58, 47, 47, 115, 116, 111, 114, 97, 103, 101, 46, 103, 111, 111, 103, 108, 101,
+        97, 112, 105, 115, 46, 99, 111, 109, 18, 9, 109, 121, 95, 98, 117, 99, 107, 101, 116, 26,
+        11, 47, 100, 97, 116, 97, 47, 102, 105, 108, 101, 115, 34, 13, 109, 121, 95, 99, 114, 101,
+        100, 101, 110, 116, 105, 97, 108, 160, 6, 6, 168, 6, 1, 34, 20, 8, 1, 16, 128, 8, 26, 1,
+        124, 34, 2, 47, 47, 40, 2, 160, 6, 6, 168, 6, 1, 42, 10, 10, 3, 32, 154, 5, 16, 142, 8, 24,
+        1, 50, 4, 116, 101, 115, 116, 160, 6, 6, 168, 6, 1,
+    ];
+    //
+    let want = mt::UserStageInfo {
+        stage_name: "gcs://my_bucket/data/files".to_string(),
+        stage_type: mt::StageType::External,
+        stage_params: mt::StageParams {
+            storage: StorageParams::Gcs(StorageGcsConfig {
+                endpoint_url: "https://storage.googleapis.com".to_string(),
+                bucket: "my_bucket".to_string(),
+                root: "/data/files".to_string(),
+                credential: "my_credential".to_string(),
+            }),
+        },
+        file_format_options: mt::FileFormatOptions {
+            format: mt::StageFileFormatType::Json,
+            skip_header: 1024,
+            field_delimiter: "|".to_string(),
+            record_delimiter: "//".to_string(),
+            compression: mt::StageFileCompression::Bz2,
+        },
+        copy_options: mt::CopyOptions {
+            on_error: mt::OnErrorMode::SkipFileNum(666),
+            size_limit: 1038,
+            purge: true,
+        },
+        comment: "test".to_string(),
+        ..Default::default()
+    };
+    common::test_load_old(func_name!(), user_stage_gcs_v6.as_slice(), want)?;
+    Ok(())
+}
+
+#[test]
+fn test_user_stage_fs_v4() -> anyhow::Result<()> {
+    // Encoded data of version 4 of user_stage_fs:
+    // It is generated with common::test_pb_from_to.
+    let user_stage_fs_v4 = vec![
+        10, 17, 102, 115, 58, 47, 47, 100, 105, 114, 47, 116, 111, 47, 102, 105, 108, 101, 115, 26,
+        25, 10, 23, 18, 21, 10, 13, 47, 100, 105, 114, 47, 116, 111, 47, 102, 105, 108, 101, 115,
+        160, 6, 4, 168, 6, 1, 34, 20, 8, 1, 16, 128, 8, 26, 1, 124, 34, 2, 47, 47, 40, 2, 160, 6,
+        4, 168, 6, 1, 42, 8, 10, 3, 32, 154, 5, 16, 142, 8, 50, 4, 116, 101, 115, 116, 160, 6, 4,
+        168, 6, 1,
+    ];
+
+    let want = mt::UserStageInfo {
+        stage_name: "fs://dir/to/files".to_string(),
+        stage_type: mt::StageType::Internal,
+        stage_params: mt::StageParams {
+            storage: StorageParams::Fs(StorageFsConfig {
+                root: "/dir/to/files".to_string(),
+            }),
+        },
+        file_format_options: mt::FileFormatOptions {
+            format: mt::StageFileFormatType::Json,
+            skip_header: 1024,
+            field_delimiter: "|".to_string(),
+            record_delimiter: "//".to_string(),
+            compression: mt::StageFileCompression::Bz2,
+        },
+        copy_options: mt::CopyOptions {
+            on_error: mt::OnErrorMode::SkipFileNum(666),
+            size_limit: 1038,
+            purge: false,
+        },
+        comment: "test".to_string(),
+        ..Default::default()
+    };
+
+    common::test_load_old(func_name!(), user_stage_fs_v4.as_slice(), want)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_user_stage_s3_v4() -> anyhow::Result<()> {
+    // Encoded data of version 4 of user_stage_s3:
+    // It is generated with common::test_pb_from_to.
+    let user_stage_s3_v4 = vec![
+        10, 24, 115, 51, 58, 47, 47, 109, 121, 98, 117, 99, 107, 101, 116, 47, 100, 97, 116, 97,
+        47, 102, 105, 108, 101, 115, 16, 1, 26, 100, 10, 98, 10, 96, 18, 24, 104, 116, 116, 112,
+        115, 58, 47, 47, 115, 51, 46, 97, 109, 97, 122, 111, 110, 97, 119, 115, 46, 99, 111, 109,
+        26, 9, 109, 121, 95, 107, 101, 121, 95, 105, 100, 34, 13, 109, 121, 95, 115, 101, 99, 114,
+        101, 116, 95, 107, 101, 121, 42, 8, 109, 121, 98, 117, 99, 107, 101, 116, 50, 11, 47, 100,
+        97, 116, 97, 47, 102, 105, 108, 101, 115, 58, 13, 109, 121, 95, 109, 97, 115, 116, 101,
+        114, 95, 107, 101, 121, 160, 6, 4, 168, 6, 1, 34, 20, 8, 1, 16, 128, 8, 26, 1, 124, 34, 2,
+        47, 47, 40, 2, 160, 6, 4, 168, 6, 1, 42, 8, 10, 3, 32, 154, 5, 16, 142, 8, 50, 4, 116, 101,
+        115, 116, 160, 6, 4, 168, 6, 1,
+    ];
+
+    let want = mt::UserStageInfo {
+        stage_name: "s3://mybucket/data/files".to_string(),
+        stage_type: mt::StageType::External,
+        stage_params: mt::StageParams {
+            storage: StorageParams::S3(StorageS3Config {
+                bucket: "mybucket".to_string(),
+                root: "/data/files".to_string(),
+                access_key_id: "my_key_id".to_string(),
+                secret_access_key: "my_secret_key".to_string(),
+                master_key: "my_master_key".to_string(),
+                ..Default::default()
+            }),
+        },
+        file_format_options: mt::FileFormatOptions {
+            format: mt::StageFileFormatType::Json,
+            skip_header: 1024,
+            field_delimiter: "|".to_string(),
+            record_delimiter: "//".to_string(),
+            compression: mt::StageFileCompression::Bz2,
+        },
+        copy_options: mt::CopyOptions {
+            on_error: mt::OnErrorMode::SkipFileNum(666),
+            size_limit: 1038,
+            purge: false,
+        },
+        comment: "test".to_string(),
+        ..Default::default()
+    };
+
+    common::test_load_old(func_name!(), user_stage_s3_v4.as_slice(), want)?;
+    Ok(())
+}
+
+#[test]
+fn test_user_stage_gcs_v4() -> anyhow::Result<()> {
+    // Encoded data of version 4 of user_stage_gcs:
+    // It is generated with common::test_pb_from_to.
+    let user_stage_gcs_v4 = vec![
+        10, 26, 103, 99, 115, 58, 47, 47, 109, 121, 95, 98, 117, 99, 107, 101, 116, 47, 100, 97,
+        116, 97, 47, 102, 105, 108, 101, 115, 16, 1, 26, 81, 10, 79, 26, 77, 10, 30, 104, 116, 116,
+        112, 115, 58, 47, 47, 115, 116, 111, 114, 97, 103, 101, 46, 103, 111, 111, 103, 108, 101,
+        97, 112, 105, 115, 46, 99, 111, 109, 18, 9, 109, 121, 95, 98, 117, 99, 107, 101, 116, 26,
+        11, 47, 100, 97, 116, 97, 47, 102, 105, 108, 101, 115, 34, 13, 109, 121, 95, 99, 114, 101,
+        100, 101, 110, 116, 105, 97, 108, 160, 6, 4, 168, 6, 1, 34, 20, 8, 1, 16, 128, 8, 26, 1,
+        124, 34, 2, 47, 47, 40, 2, 160, 6, 4, 168, 6, 1, 42, 8, 10, 3, 32, 154, 5, 16, 142, 8, 50,
+        4, 116, 101, 115, 116, 160, 6, 4, 168, 6, 1,
+    ];
+    let want = mt::UserStageInfo {
+        stage_name: "gcs://my_bucket/data/files".to_string(),
+        stage_type: mt::StageType::External,
+        stage_params: mt::StageParams {
+            storage: StorageParams::Gcs(StorageGcsConfig {
+                endpoint_url: "https://storage.googleapis.com".to_string(),
+                bucket: "my_bucket".to_string(),
+                root: "/data/files".to_string(),
+                credential: "my_credential".to_string(),
+            }),
+        },
+        file_format_options: mt::FileFormatOptions {
+            format: mt::StageFileFormatType::Json,
+            skip_header: 1024,
+            field_delimiter: "|".to_string(),
+            record_delimiter: "//".to_string(),
+            compression: mt::StageFileCompression::Bz2,
+        },
+        copy_options: mt::CopyOptions {
+            on_error: mt::OnErrorMode::SkipFileNum(666),
+            size_limit: 1038,
+            purge: false,
+        },
+        comment: "test".to_string(),
+        ..Default::default()
+    };
+    common::test_load_old(func_name!(), user_stage_gcs_v4.as_slice(), want)?;
+    Ok(())
+}
+
+#[test]
+fn test_user_stage_s3_v1() -> anyhow::Result<()> {
+    // Encoded data of version 1 of user_stage_s3:
+    // It is generated with common::test_pb_from_to.
+    let user_stage_s3_v1 = vec![
+        10, 24, 115, 51, 58, 47, 47, 109, 121, 98, 117, 99, 107, 101, 116, 47, 100, 97, 116, 97,
+        47, 102, 105, 108, 101, 115, 16, 1, 26, 97, 10, 95, 10, 93, 18, 24, 104, 116, 116, 112,
+        115, 58, 47, 47, 115, 51, 46, 97, 109, 97, 122, 111, 110, 97, 119, 115, 46, 99, 111, 109,
+        26, 9, 109, 121, 95, 107, 101, 121, 95, 105, 100, 34, 13, 109, 121, 95, 115, 101, 99, 114,
+        101, 116, 95, 107, 101, 121, 42, 8, 109, 121, 98, 117, 99, 107, 101, 116, 50, 11, 47, 100,
+        97, 116, 97, 47, 102, 105, 108, 101, 115, 58, 13, 109, 121, 95, 109, 97, 115, 116, 101,
+        114, 95, 107, 101, 121, 160, 6, 1, 34, 17, 8, 1, 16, 128, 8, 26, 1, 124, 34, 2, 47, 47, 40,
+        2, 160, 6, 1, 42, 8, 10, 3, 32, 154, 5, 16, 142, 8, 50, 4, 116, 101, 115, 116, 160, 6, 1,
+    ];
+
+    let want = mt::UserStageInfo {
+        stage_name: "s3://mybucket/data/files".to_string(),
+        stage_type: mt::StageType::External,
+        stage_params: mt::StageParams {
+            storage: StorageParams::S3(StorageS3Config {
+                bucket: "mybucket".to_string(),
+                root: "/data/files".to_string(),
+                access_key_id: "my_key_id".to_string(),
+                secret_access_key: "my_secret_key".to_string(),
+                master_key: "my_master_key".to_string(),
+                ..Default::default()
+            }),
+        },
+        file_format_options: mt::FileFormatOptions {
+            format: mt::StageFileFormatType::Json,
+            skip_header: 1024,
+            field_delimiter: "|".to_string(),
+            record_delimiter: "//".to_string(),
+            compression: mt::StageFileCompression::Bz2,
+        },
+        copy_options: mt::CopyOptions {
+            on_error: mt::OnErrorMode::SkipFileNum(666),
+            size_limit: 1038,
+            purge: false,
+        },
+        comment: "test".to_string(),
+        ..Default::default()
+    };
+
+    common::test_load_old(func_name!(), user_stage_s3_v1.as_slice(), want)?;
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### test(proto): add compat test for CopyOptions::purge

- Move the UserStageInfo test into separate files.

  A backward compatibility test should not compare the decoded data with a
  dedicated sample, but not with the data of the latest version.

- Doc: explain how to maintain `VER` and add a simple change-log for
  `VER`, to make it clear when to remove a no longer supported feature
  in the future.

- This is a supplementary PR for #7518, to complete metadata version management and provide test for the new feature introduced.

## Changelog







## Related Issues