### PR TITLE
feat(meta-service): new RPC to echo client ip

### DIFF
--- a/src/meta/grpc/src/grpc_action.rs
+++ b/src/meta/grpc/src/grpc_action.rs
@@ -16,6 +16,7 @@ use std::convert::TryInto;
 use std::fmt::Debug;
 
 use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
+use common_meta_types::protobuf::ClientInfo;
 use common_meta_types::protobuf::RaftRequest;
 use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::protobuf::WatchResponse;
@@ -35,6 +36,7 @@ use tonic::Request;
 
 use crate::grpc_client::AuthInterceptor;
 use crate::message::ExportReq;
+use crate::message::GetClientInfo;
 use crate::message::GetEndpoints;
 use crate::message::MakeClient;
 
@@ -160,4 +162,8 @@ impl RequestFor for GetEndpoints {
 
 impl RequestFor for TxnRequest {
     type Reply = TxnReply;
+}
+
+impl RequestFor for GetClientInfo {
+    type Reply = ClientInfo;
 }

--- a/src/meta/grpc/src/message.rs
+++ b/src/meta/grpc/src/message.rs
@@ -14,6 +14,7 @@
 
 use common_base::base::tokio::sync::oneshot::Sender;
 use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
+use common_meta_types::protobuf::ClientInfo;
 use common_meta_types::protobuf::ExportedChunk;
 use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::protobuf::WatchResponse;
@@ -72,6 +73,9 @@ pub enum Request {
 
     /// Get endpoints, for test
     GetEndpoints(GetEndpoints),
+
+    /// Get info about the client
+    GetClientInfo(GetClientInfo),
 }
 
 /// Meta-client worker-to-handle response body
@@ -86,6 +90,7 @@ pub enum Response {
     Export(tonic::codec::Streaming<ExportedChunk>),
     MakeClient(MetaServiceClient<InterceptedService<Channel, AuthInterceptor>>),
     GetEndpoints(Vec<String>),
+    GetClientInfo(ClientInfo),
 }
 
 /// Export all data stored in metasrv
@@ -101,3 +106,7 @@ pub struct MakeClient {}
 /// Get all meta server endpoints
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct GetEndpoints {}
+
+/// Get info about client
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct GetClientInfo {}

--- a/src/meta/grpc/tests/it/grpc_server.rs
+++ b/src/meta/grpc/tests/it/grpc_server.rs
@@ -19,6 +19,8 @@ use std::time::Duration;
 use common_base::base::tokio;
 use common_meta_types::protobuf::meta_service_server::MetaService;
 use common_meta_types::protobuf::meta_service_server::MetaServiceServer;
+use common_meta_types::protobuf::ClientInfo;
+use common_meta_types::protobuf::Empty;
 use common_meta_types::protobuf::ExportedChunk;
 use common_meta_types::protobuf::HandshakeResponse;
 use common_meta_types::protobuf::MemberListReply;
@@ -100,6 +102,13 @@ impl MetaService for GrpcServiceForTestImpl {
         &self,
         _request: Request<MemberListRequest>,
     ) -> Result<Response<MemberListReply>, Status> {
+        todo!()
+    }
+
+    async fn get_client_info(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<ClientInfo>, Status> {
         todo!()
     }
 }

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -24,6 +24,8 @@ use common_grpc::GrpcToken;
 use common_meta_grpc::MetaGrpcReadReq;
 use common_meta_grpc::MetaGrpcWriteReq;
 use common_meta_types::protobuf::meta_service_server::MetaService;
+use common_meta_types::protobuf::ClientInfo;
+use common_meta_types::protobuf::Empty;
 use common_meta_types::protobuf::ExportedChunk;
 use common_meta_types::protobuf::HandshakeRequest;
 use common_meta_types::protobuf::HandshakeResponse;
@@ -263,6 +265,20 @@ impl MetaService for MetaServiceImpl {
         incr_meta_metrics_meta_sent_bytes(resp.encoded_len() as u64);
 
         Ok(Response::new(resp))
+    }
+
+    async fn get_client_info(
+        &self,
+        request: Request<Empty>,
+    ) -> Result<Response<ClientInfo>, Status> {
+        let r = request.remote_addr();
+        if let Some(addr) = r {
+            let resp = ClientInfo {
+                client_addr: addr.to_string(),
+            };
+            return Ok(Response::new(resp));
+        }
+        Err(Status::unavailable("can not get client ip address"))
     }
 }
 

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_get_client_info.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_get_client_info.rs
@@ -1,0 +1,51 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use common_base::base::tokio;
+use common_meta_grpc::MetaGrpcClient;
+use pretty_assertions::assert_eq;
+use regex::Regex;
+
+use crate::init_meta_ut;
+
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
+async fn test_get_client_info() -> anyhow::Result<()> {
+    // - Start a metasrv server.
+    // - Get client ip
+
+    let (_tc, addr) = crate::tests::start_metasrv().await?;
+
+    let client = MetaGrpcClient::try_create(
+        vec![addr],
+        "root",
+        "xxx",
+        None,
+        Some(Duration::from_secs(10)),
+        None,
+    )?;
+
+    let resp = client.get_client_info().await?;
+
+    let client_addr = resp.client_addr;
+
+    let masked_addr = Regex::new(r"\d+")
+        .unwrap()
+        .replace_all(&client_addr, "1")
+        .to_string();
+
+    assert_eq!("1.1.1.1:1", masked_addr);
+    Ok(())
+}

--- a/src/meta/service/tests/it/grpc/mod.rs
+++ b/src/meta/service/tests/it/grpc/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod metasrv_grpc_api;
 mod metasrv_grpc_export;
+pub mod metasrv_grpc_get_client_info;
 pub mod metasrv_grpc_handshake;
 pub mod metasrv_grpc_kv_api;
 pub mod metasrv_grpc_kv_api_restart_cluster;

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -143,6 +143,11 @@ message TxnReply {
   string error = 3;
 }
 
+message ClientInfo {
+  // The address of the connected in form of "<ip>:<port>"
+  string client_addr = 10;
+}
+
 service RaftService {
 
   rpc Write(RaftRequest) returns (RaftReply) {}
@@ -181,4 +186,7 @@ service MetaService {
 
   // Get MetaSrv member list endpoints
   rpc MemberList(MemberListRequest) returns (MemberListReply);
+
+  // Respond with the information about the client.
+  rpc GetClientInfo(Empty) returns (ClientInfo);
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feat(meta-service): new RPC to echo client ip

For a query node to find out its ip address without manually
maintaining it in config file.

- Related PR: #7510

## Changelog







## Related Issues