### PR TITLE
refactor: Make planner depends on TableContext trait

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -111,5 +111,7 @@ pub trait TableContext: Send + Sync {
     // Get user manager api.
     fn get_user_manager(&self) -> Arc<UserApiProvider>;
     fn get_cluster(&self) -> Arc<Cluster>;
+    async fn get_table(&self, catalog: &str, database: &str, table: &str)
+    -> Result<Arc<dyn Table>>;
     async fn get_processes_info(&self) -> Vec<ProcessInfo>;
 }

--- a/src/query/service/src/api/http/v1/logs.rs
+++ b/src/query/service/src/api/http/v1/logs.rs
@@ -25,6 +25,7 @@ use tokio_stream::StreamExt;
 use crate::sessions::QueryContext;
 use crate::sessions::SessionManager;
 use crate::sessions::SessionType;
+use crate::sessions::TableContext;
 use crate::storages::TableStreamReadWrap;
 use crate::storages::ToReadDataSourcePlan;
 

--- a/src/query/service/src/interpreters/interpreter_table_describe.rs
+++ b/src/query/service/src/interpreters/interpreter_table_describe.rs
@@ -24,6 +24,7 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::sessions::QueryContext;
+use crate::sessions::TableContext;
 use crate::sql::executor::PhysicalScalar;
 use crate::sql::PlanParser;
 use crate::storages::view::view_table::QUERY;

--- a/src/query/service/src/interpreters/interpreter_table_exists.rs
+++ b/src/query/service/src/interpreters/interpreter_table_exists.rs
@@ -24,6 +24,7 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::sessions::QueryContext;
+use crate::sessions::TableContext;
 
 pub struct ExistsTableInterpreter {
     ctx: Arc<QueryContext>,

--- a/src/query/service/src/interpreters/interpreter_table_truncate.rs
+++ b/src/query/service/src/interpreters/interpreter_table_truncate.rs
@@ -23,6 +23,7 @@ use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::Interpreter;
 use crate::sessions::QueryContext;
+use crate::sessions::TableContext;
 
 pub struct TruncateTableInterpreter {
     ctx: Arc<QueryContext>,

--- a/src/query/service/src/optimizers/optimizer_statistics_exact.rs
+++ b/src/query/service/src/optimizers/optimizer_statistics_exact.rs
@@ -27,6 +27,7 @@ use common_legacy_planners::PlanRewriter;
 
 use crate::optimizers::Optimizer;
 use crate::sessions::QueryContext;
+use crate::sessions::TableContext;
 use crate::storages::ToReadDataSourcePlan;
 
 struct StatisticsExactImpl<'a> {

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -125,22 +125,6 @@ impl QueryContext {
         StageTable::try_create(table_info.clone())
     }
 
-    /// Fetch a Table by db and table name.
-    ///
-    /// It guaranteed to return a consistent result for multiple calls, in a same query.
-    /// E.g.:
-    /// ```sql
-    /// SELECT * FROM (SELECT * FROM db.table_name) as subquery_1, (SELECT * FROM db.table_name) AS subquery_2
-    /// ```
-    pub async fn get_table(
-        &self,
-        catalog: &str,
-        database: &str,
-        table: &str,
-    ) -> Result<Arc<dyn Table>> {
-        self.shared.get_table(catalog, database, table).await
-    }
-
     pub async fn set_current_database(&self, new_database_name: String) -> Result<()> {
         let tenant_id = self.get_tenant();
         let catalog = self.get_catalog(self.get_current_catalog().as_str())?;
@@ -416,6 +400,22 @@ impl TableContext for QueryContext {
 
     fn get_cluster(&self) -> Arc<Cluster> {
         self.shared.get_cluster()
+    }
+
+    /// Fetch a Table by db and table name.
+    ///
+    /// It guaranteed to return a consistent result for multiple calls, in a same query.
+    /// E.g.:
+    /// ```sql
+    /// SELECT * FROM (SELECT * FROM db.table_name) as subquery_1, (SELECT * FROM db.table_name) AS subquery_2
+    /// ```
+    async fn get_table(
+        &self,
+        catalog: &str,
+        database: &str,
+        table: &str,
+    ) -> Result<Arc<dyn Table>> {
+        self.shared.get_table(catalog, database, table).await
     }
 
     // Get all the processes list info.

--- a/src/query/service/src/sql/optimizer/heuristic/mod.rs
+++ b/src/query/service/src/sql/optimizer/heuristic/mod.rs
@@ -26,7 +26,7 @@ use once_cell::sync::Lazy;
 
 use super::rule::RuleID;
 use super::ColumnSet;
-use crate::sessions::QueryContext;
+use crate::sessions::TableContext;
 use crate::sql::optimizer::heuristic::decorrelate::decorrelate_subquery;
 use crate::sql::optimizer::heuristic::implement::HeuristicImplementor;
 pub use crate::sql::optimizer::heuristic::rule_list::RuleList;
@@ -65,14 +65,14 @@ pub struct HeuristicOptimizer {
     rules: RuleList,
     implementor: HeuristicImplementor,
 
-    _ctx: Arc<QueryContext>,
+    _ctx: Arc<dyn TableContext>,
     bind_context: Box<BindContext>,
     metadata: MetadataRef,
 }
 
 impl HeuristicOptimizer {
     pub fn new(
-        ctx: Arc<QueryContext>,
+        ctx: Arc<dyn TableContext>,
         bind_context: Box<BindContext>,
         metadata: MetadataRef,
         rules: RuleList,

--- a/src/query/service/src/sql/optimizer/mod.rs
+++ b/src/query/service/src/sql/optimizer/mod.rs
@@ -50,7 +50,7 @@ use self::util::contains_local_table_scan;
 use self::util::validate_distributed_query;
 use super::plans::Plan;
 use super::BindContext;
-use crate::sessions::QueryContext;
+use crate::sessions::TableContext;
 pub use crate::sql::optimizer::heuristic::RuleList;
 pub use crate::sql::optimizer::rule::RuleID;
 use crate::sql::optimizer::rule::RuleSet;
@@ -74,7 +74,7 @@ impl OptimizerContext {
 }
 
 pub fn optimize(
-    ctx: Arc<QueryContext>,
+    ctx: Arc<dyn TableContext>,
     opt_ctx: Arc<OptimizerContext>,
     plan: Plan,
 ) -> Result<Plan> {
@@ -130,7 +130,7 @@ pub fn optimize(
 }
 
 pub fn optimize_query(
-    ctx: Arc<QueryContext>,
+    ctx: Arc<dyn TableContext>,
     opt_ctx: Arc<OptimizerContext>,
     metadata: MetadataRef,
     bind_context: Box<BindContext>,

--- a/src/query/service/src/sql/planner/binder/copy.rs
+++ b/src/query/service/src/sql/planner/binder/copy.rs
@@ -31,7 +31,6 @@ use common_meta_types::UserStageInfo;
 use common_storage::parse_uri_location;
 use common_storage::UriLocation;
 
-use crate::sessions::TableContext;
 use crate::sql::binder::Binder;
 use crate::sql::normalize_identifier;
 use crate::sql::plans::CopyPlanV2;

--- a/src/query/service/src/sql/planner/binder/ddl/account.rs
+++ b/src/query/service/src/sql/planner/binder/ddl/account.rs
@@ -30,7 +30,6 @@ use common_meta_types::GrantObject;
 use common_meta_types::UserOption;
 use common_meta_types::UserPrivilegeSet;
 
-use crate::sessions::TableContext;
 use crate::sql::plans::Plan;
 use crate::sql::Binder;
 

--- a/src/query/service/src/sql/planner/binder/ddl/database.rs
+++ b/src/query/service/src/sql/planner/binder/ddl/database.rs
@@ -39,7 +39,6 @@ use common_legacy_planners::UndropDatabasePlan;
 use common_meta_app::schema::DatabaseMeta;
 use common_meta_app::share::ShareNameIdent;
 
-use crate::sessions::TableContext;
 use crate::sql::binder::Binder;
 use crate::sql::planner::semantic::normalize_identifier;
 use crate::sql::plans::Plan;

--- a/src/query/service/src/sql/planner/binder/ddl/share.rs
+++ b/src/query/service/src/sql/planner/binder/ddl/share.rs
@@ -16,7 +16,6 @@ use common_ast::ast::*;
 use common_exception::Result;
 use itertools::Itertools;
 
-use crate::sessions::TableContext;
 use crate::sql::binder::Binder;
 use crate::sql::normalize_identifier;
 use crate::sql::plans::AlterShareTenantsPlan;

--- a/src/query/service/src/sql/planner/binder/ddl/stage.rs
+++ b/src/query/service/src/sql/planner/binder/ddl/stage.rs
@@ -26,7 +26,6 @@ use common_meta_types::UserStageInfo;
 use common_storage::parse_uri_location;
 use common_storage::UriLocation;
 
-use crate::sessions::TableContext;
 use crate::sql::binder::Binder;
 use crate::sql::plans::Plan;
 use crate::sql::statements::parse_copy_file_format_options;

--- a/src/query/service/src/sql/planner/binder/ddl/table.rs
+++ b/src/query/service/src/sql/planner/binder/ddl/table.rs
@@ -39,7 +39,6 @@ use common_meta_app::schema::TableMeta;
 use tracing::debug;
 
 use crate::catalogs::DatabaseCatalog;
-use crate::sessions::TableContext;
 use crate::sql::binder::scalar::ScalarBinder;
 use crate::sql::binder::Binder;
 use crate::sql::binder::Visibility;

--- a/src/query/service/src/sql/planner/binder/ddl/view.rs
+++ b/src/query/service/src/sql/planner/binder/ddl/view.rs
@@ -20,7 +20,6 @@ use common_legacy_planners::AlterViewPlan;
 use common_legacy_planners::CreateViewPlan;
 use common_legacy_planners::DropViewPlan;
 
-use crate::sessions::TableContext;
 use crate::sql::binder::Binder;
 use crate::sql::planner::semantic::normalize_identifier;
 use crate::sql::plans::Plan;

--- a/src/query/service/src/sql/planner/binder/delete.rs
+++ b/src/query/service/src/sql/planner/binder/delete.rs
@@ -22,7 +22,6 @@ use common_legacy_planners::DeletePlan;
 use common_legacy_planners::Expression;
 use common_legacy_planners::Projection;
 
-use crate::sessions::TableContext;
 use crate::sql::binder::Binder;
 use crate::sql::binder::ScalarBinder;
 use crate::sql::executor::ExpressionBuilderWithoutRenaming;

--- a/src/query/service/src/sql/planner/binder/insert.rs
+++ b/src/query/service/src/sql/planner/binder/insert.rs
@@ -42,7 +42,6 @@ use tracing::debug;
 use crate::evaluator::EvalNode;
 use crate::evaluator::Evaluator;
 use crate::pipelines::processors::transforms::ExpressionTransformV2;
-use crate::sessions::QueryContext;
 use crate::sessions::TableContext;
 use crate::sql::binder::Binder;
 use crate::sql::binder::ScalarBinder;
@@ -196,7 +195,7 @@ impl<'a> Binder {
 }
 
 pub struct ValueSourceV2<'a> {
-    ctx: Arc<QueryContext>,
+    ctx: Arc<dyn TableContext>,
     name_resolution_ctx: &'a NameResolutionContext,
     bind_context: &'a BindContext,
     schema: DataSchemaRef,
@@ -205,7 +204,7 @@ pub struct ValueSourceV2<'a> {
 
 impl<'a> ValueSourceV2<'a> {
     pub fn new(
-        ctx: Arc<QueryContext>,
+        ctx: Arc<dyn TableContext>,
         name_resolution_ctx: &'a NameResolutionContext,
         bind_context: &'a BindContext,
         schema: DataSchemaRef,
@@ -444,7 +443,7 @@ fn fill_default_value(
 async fn exprs_to_datavalue<'a>(
     exprs: Vec<Expr<'a>>,
     schema: &DataSchemaRef,
-    ctx: Arc<QueryContext>,
+    ctx: Arc<dyn TableContext>,
     name_resolution_ctx: &NameResolutionContext,
     bind_context: &BindContext,
     metadata: MetadataRef,

--- a/src/query/service/src/sql/planner/binder/join.rs
+++ b/src/query/service/src/sql/planner/binder/join.rs
@@ -24,7 +24,7 @@ use common_datavalues::wrap_nullable;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
-use crate::sessions::QueryContext;
+use crate::sessions::TableContext;
 use crate::sql::binder::scalar_common::split_conjunctions;
 use crate::sql::binder::scalar_common::split_equivalent_predicate;
 use crate::sql::binder::scalar_common::wrap_cast_if_needed;
@@ -235,7 +235,7 @@ pub fn check_duplicate_join_tables(
 }
 
 struct JoinConditionResolver<'a> {
-    ctx: Arc<QueryContext>,
+    ctx: Arc<dyn TableContext>,
     name_resolution_ctx: &'a NameResolutionContext,
     metadata: MetadataRef,
 
@@ -247,7 +247,7 @@ struct JoinConditionResolver<'a> {
 
 impl<'a> JoinConditionResolver<'a> {
     pub fn new(
-        ctx: Arc<QueryContext>,
+        ctx: Arc<dyn TableContext>,
         name_resolution_ctx: &'a NameResolutionContext,
         metadata: MetadataRef,
         left_context: &'a BindContext,

--- a/src/query/service/src/sql/planner/binder/mod.rs
+++ b/src/query/service/src/sql/planner/binder/mod.rs
@@ -42,7 +42,7 @@ use super::plans::Plan;
 use super::plans::RewriteKind;
 use super::semantic::NameResolutionContext;
 use crate::catalogs::CatalogManager;
-use crate::sessions::QueryContext;
+use crate::sessions::TableContext;
 use crate::sql::planner::metadata::MetadataRef;
 
 mod aggregate;
@@ -75,7 +75,7 @@ mod table;
 /// - Validate expressions
 /// - Build `Metadata`
 pub struct Binder {
-    ctx: Arc<QueryContext>,
+    ctx: Arc<dyn TableContext>,
     catalogs: Arc<CatalogManager>,
     name_resolution_ctx: NameResolutionContext,
     metadata: MetadataRef,
@@ -83,7 +83,7 @@ pub struct Binder {
 
 impl<'a> Binder {
     pub fn new(
-        ctx: Arc<QueryContext>,
+        ctx: Arc<dyn TableContext>,
         catalogs: Arc<CatalogManager>,
         name_resolution_ctx: NameResolutionContext,
         metadata: MetadataRef,

--- a/src/query/service/src/sql/planner/binder/scalar.rs
+++ b/src/query/service/src/sql/planner/binder/scalar.rs
@@ -18,7 +18,7 @@ use common_ast::ast::Expr;
 use common_datavalues::DataTypeImpl;
 use common_exception::Result;
 
-use crate::sessions::QueryContext;
+use crate::sessions::TableContext;
 use crate::sql::planner::binder::BindContext;
 use crate::sql::planner::metadata::MetadataRef;
 use crate::sql::planner::semantic::NameResolutionContext;
@@ -28,7 +28,7 @@ use crate::sql::plans::Scalar;
 /// Helper for binding scalar expression with `BindContext`.
 pub struct ScalarBinder<'a> {
     bind_context: &'a BindContext,
-    ctx: Arc<QueryContext>,
+    ctx: Arc<dyn TableContext>,
     name_resolution_ctx: &'a NameResolutionContext,
     metadata: MetadataRef,
     aliases: &'a [(String, Scalar)],
@@ -37,7 +37,7 @@ pub struct ScalarBinder<'a> {
 impl<'a> ScalarBinder<'a> {
     pub fn new(
         bind_context: &'a BindContext,
-        ctx: Arc<QueryContext>,
+        ctx: Arc<dyn TableContext>,
         name_resolution_ctx: &'a NameResolutionContext,
         metadata: MetadataRef,
         aliases: &'a [(String, Scalar)],

--- a/src/query/service/src/sql/planner/binder/sort.rs
+++ b/src/query/service/src/sql/planner/binder/sort.rs
@@ -23,7 +23,6 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 
 use super::bind_context::NameResolutionResult;
-use crate::sessions::TableContext;
 use crate::sql::binder::scalar::ScalarBinder;
 use crate::sql::binder::select::SelectList;
 use crate::sql::binder::Binder;

--- a/src/query/service/src/sql/planner/binder/table.rs
+++ b/src/query/service/src/sql/planner/binder/table.rs
@@ -32,7 +32,6 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_legacy_planners::Expression;
 
-use crate::sessions::TableContext;
 use crate::sql::binder::scalar::ScalarBinder;
 use crate::sql::binder::Binder;
 use crate::sql::binder::ColumnBinding;

--- a/src/query/service/src/sql/planner/mod.rs
+++ b/src/query/service/src/sql/planner/mod.rs
@@ -24,7 +24,6 @@ use parking_lot::RwLock;
 pub use plans::ScalarExpr;
 
 use crate::clusters::ClusterHelper;
-use crate::sessions::QueryContext;
 use crate::sql::optimizer::optimize;
 pub use crate::sql::planner::binder::BindContext;
 
@@ -56,11 +55,11 @@ const PROBE_INSERT_INITIAL_TOKENS: usize = 128;
 const PROBE_INSERT_MAX_TOKENS: usize = 128 * 8;
 
 pub struct Planner {
-    ctx: Arc<QueryContext>,
+    ctx: Arc<dyn TableContext>,
 }
 
 impl Planner {
-    pub fn new(ctx: Arc<QueryContext>) -> Self {
+    pub fn new(ctx: Arc<dyn TableContext>) -> Self {
         Planner { ctx }
     }
 

--- a/src/query/service/src/sql/planner/semantic/type_check.rs
+++ b/src/query/service/src/sql/planner/semantic/type_check.rs
@@ -56,7 +56,6 @@ use common_legacy_planners::validate_function_arg;
 use super::name_resolution::NameResolutionContext;
 use super::normalize_identifier;
 use crate::evaluator::Evaluator;
-use crate::sessions::QueryContext;
 use crate::sessions::TableContext;
 use crate::sql::binder::wrap_cast_if_needed;
 use crate::sql::binder::Binder;
@@ -90,7 +89,7 @@ use crate::sql::ScalarExpr;
 /// argument types of expressions, or unresolvable columns.
 pub struct TypeChecker<'a> {
     bind_context: &'a BindContext,
-    ctx: Arc<QueryContext>,
+    ctx: Arc<dyn TableContext>,
     name_resolution_ctx: &'a NameResolutionContext,
     metadata: MetadataRef,
 
@@ -104,7 +103,7 @@ pub struct TypeChecker<'a> {
 impl<'a> TypeChecker<'a> {
     pub fn new(
         bind_context: &'a BindContext,
-        ctx: Arc<QueryContext>,
+        ctx: Arc<dyn TableContext>,
         name_resolution_ctx: &'a NameResolutionContext,
         metadata: MetadataRef,
         aliases: &'a [(String, Scalar)],

--- a/src/query/service/src/sql/statements/statement_common.rs
+++ b/src/query/service/src/sql/statements/statement_common.rs
@@ -53,7 +53,7 @@ use crate::sessions::TableContext;
 ///
 /// - @internal/abc => (internal, "/stage/internal/abc")
 pub async fn parse_stage_location(
-    ctx: &Arc<QueryContext>,
+    ctx: &Arc<dyn TableContext>,
     location: &str,
 ) -> Result<(UserStageInfo, String)> {
     let mgr = ctx.get_user_manager();
@@ -75,7 +75,7 @@ pub async fn parse_stage_location(
 ///
 /// Difference is input location has already been parsed by parser.
 pub async fn parse_stage_location_v2(
-    ctx: &Arc<QueryContext>,
+    ctx: &Arc<dyn TableContext>,
     name: &str,
     path: &str,
 ) -> Result<(UserStageInfo, String)> {

--- a/src/query/service/tests/it/sql/statements/statement_common.rs
+++ b/src/query/service/tests/it/sql/statements/statement_common.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_base::base::tokio;
 use common_exception::Result;
 use common_meta_types::StageType;
@@ -50,7 +52,8 @@ async fn test_parse_stage_location_internal() -> Result<()> {
     ];
 
     for (name, input, expected) in cases {
-        let (stage, path) = parse_stage_location(&ctx, input).await?;
+        let table_context: Arc<dyn TableContext> = ctx.clone();
+        let (stage, path) = parse_stage_location(&table_context, input).await?;
 
         assert_eq!(stage, stage_info, "{}", name);
         assert_eq!(path, expected, "{}", name);
@@ -83,7 +86,8 @@ async fn test_parse_stage_location_external() -> Result<()> {
     ];
 
     for (name, input, expected) in cases {
-        let (stage, path) = parse_stage_location(&ctx, input).await?;
+        let table_context: Arc<dyn TableContext> = ctx.clone();
+        let (stage, path) = parse_stage_location(&table_context, input).await?;
 
         assert_eq!(stage, stage_info, "{}", name);
         assert_eq!(path, expected, "{}", name);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR depends on https://github.com/datafuselabs/databend/pull/7597. Please review after #7597 is merged.

---

This PR makes the planner depends on the `TableContext` trait instead of the `QueryContext` struct.

Make space for the future refactor.