### PR TITLE
ci: find binary path in two places for meta-query compatability test

### DIFF
--- a/.github/actions/test_sqllogic_standalone_linux/action.yml
+++ b/.github/actions/test_sqllogic_standalone_linux/action.yml
@@ -23,7 +23,7 @@ runs:
         sha: ${{ github.sha }}
         target: ${{ inputs.target }}
 
-    - name: Run sqllogic Tests with Standalone mode with embedded meta-store
+    - name: Run sqllogic Tests with Standalone mode
       shell: bash
       run: |
         docker run --rm --tty --net=host \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,6 +1438,7 @@ dependencies = [
  "common-io",
  "common-meta-api",
  "common-meta-embedded",
+ "common-meta-store",
  "common-meta-types",
  "common-proto-conv",
  "common-protos",

--- a/scripts/ci/ci-run-sqllogic-tests.sh
+++ b/scripts/ci/ci-run-sqllogic-tests.sh
@@ -4,7 +4,7 @@
 set -e
 
 echo "Starting standalone DatabendQuery and DatabendMeta"
-./scripts/ci/deploy/databend-query-standalone-embedded-meta.sh
+./scripts/ci/deploy/databend-query-standalone.sh
 
 SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 cd "$SCRIPT_PATH/../../tests/logictest" || exit

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -41,8 +41,8 @@ pub static METACLI_COMMIT_SEMVER: Lazy<Version> = Lazy::new(|| {
 /// Oldest compatible nightly metasrv version
 pub static MIN_METASRV_SEMVER: Version = Version {
     major: 0,
-    minor: 7,
-    patch: 63,
+    minor: 8,
+    patch: 30,
     pre: Prerelease::EMPTY,
     build: BuildMetadata::EMPTY,
 };

--- a/src/meta/store/src/lib.rs
+++ b/src/meta/store/src/lib.rs
@@ -55,6 +55,16 @@ impl MetaStore {
             MetaStore::R(_) => false,
         }
     }
+
+    pub async fn get_local_addr(&self) -> std::result::Result<Option<String>, MetaError> {
+        match self {
+            MetaStore::L(_) => Ok(None),
+            MetaStore::R(grpc_client) => {
+                let client_info = grpc_client.get_client_info().await?;
+                Ok(Some(client_info.client_addr))
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/query/management/Cargo.toml
+++ b/src/query/management/Cargo.toml
@@ -22,6 +22,7 @@ common-meta-api = { path = "../../meta/api" }
 common-meta-types = { path = "../../meta/types" }
 common-proto-conv = { path = "../../meta/proto-conv" }
 common-protos = { path = "../../meta/protos" }
+common-meta-store = { path = "../../meta/store" }
 
 async-trait = "0.1.56"
 serde_json = "1.0.81"

--- a/src/query/management/Cargo.toml
+++ b/src/query/management/Cargo.toml
@@ -19,10 +19,10 @@ common-exception = { path = "../../common/exception" }
 common-functions = { path = "../functions" }
 common-io = { path = "../../common/io" }
 common-meta-api = { path = "../../meta/api" }
+common-meta-store = { path = "../../meta/store" }
 common-meta-types = { path = "../../meta/types" }
 common-proto-conv = { path = "../../meta/proto-conv" }
 common-protos = { path = "../../meta/protos" }
-common-meta-store = { path = "../../meta/store" }
 
 async-trait = "0.1.56"
 serde_json = "1.0.81"

--- a/src/query/management/src/cluster/cluster_api.rs
+++ b/src/query/management/src/cluster/cluster_api.rs
@@ -28,4 +28,6 @@ pub trait ClusterApi: Sync + Send {
 
     // Keep the tenant's cluster node alive.
     async fn heartbeat(&self, node: &NodeInfo, seq: Option<u64>) -> Result<u64>;
+
+    async fn get_local_addr(&self) -> Result<Option<String>>;
 }

--- a/src/query/management/tests/it/cluster.rs
+++ b/src/query/management/tests/it/cluster.rs
@@ -21,6 +21,7 @@ use common_exception::Result;
 use common_management::*;
 use common_meta_api::KVApi;
 use common_meta_embedded::MetaEmbedded;
+use common_meta_store::MetaStore;
 use common_meta_types::NodeInfo;
 use common_meta_types::SeqV;
 
@@ -153,8 +154,8 @@ fn create_test_node_info() -> NodeInfo {
     }
 }
 
-async fn new_cluster_api() -> Result<(Arc<MetaEmbedded>, ClusterMgr)> {
-    let test_api = Arc::new(MetaEmbedded::new_temp().await?);
+async fn new_cluster_api() -> Result<(MetaStore, ClusterMgr)> {
+    let test_api = MetaStore::L(Arc::new(MetaEmbedded::new_temp().await?));
     let cluster_manager = ClusterMgr::create(
         test_api.clone(),
         "test-tenant-id",

--- a/src/query/service/tests/it/clusters.rs
+++ b/src/query/service/tests/it/clusters.rs
@@ -44,9 +44,9 @@ async fn test_remove_invalid_nodes() -> Result<()> {
         .query_flight_address("invalid_address_2")
         .build();
 
-    let meta_client = ClusterDiscovery::create_meta_client(&config_1).await?;
-    let cluster_discovery_1 = ClusterDiscovery::try_create(&config_1, meta_client.clone()).await?;
-    let cluster_discovery_2 = ClusterDiscovery::try_create(&config_2, meta_client.clone()).await?;
+    let metastore = ClusterDiscovery::create_meta_client(&config_1).await?;
+    let cluster_discovery_1 = ClusterDiscovery::try_create(&config_1, metastore.clone()).await?;
+    let cluster_discovery_2 = ClusterDiscovery::try_create(&config_2, metastore.clone()).await?;
 
     cluster_discovery_1.register_to_metastore(&config_1).await?;
     cluster_discovery_2.register_to_metastore(&config_2).await?;

--- a/tests/compat/test-compat.sh
+++ b/tests/compat/test-compat.sh
@@ -134,6 +134,24 @@ kill_proc() {
     echo " === Done kill $name"
 }
 
+# Find path in old and new location.
+# Databend release once changed binary path from `./` to `./bin`.
+find_binary_path()
+{
+    local base="$1"
+    local binary_name="$2"
+
+    if [ -f "$base/$binary_name" ]; then
+        echo "$base/$binary_name"
+    elif [ -f "$base/bin/$binary_name" ]; then
+        echo "$base/bin/$binary_name"
+    else
+        echo " === Can not find binary path for $binary_name in $base/ or $base/bin" >&2
+        exit 1
+    fi
+
+}
+
 # Test specified version of query and meta
 run_test() {
     local query_ver="$1"
@@ -141,8 +159,8 @@ run_test() {
 
     echo " === Test with query-$query_ver and metasrv-$metasrv_ver"
 
-    local query="./bins/$query_ver/databend-query"
-    local metasrv="./bins/$metasrv_ver/databend-meta"
+    local query="$(find_binary_path "./bins/$query_ver" "databend-query")"
+    local metasrv="$(find_binary_path "./bins/$metasrv_ver" "databend-meta")"
 
     # "$metasrv" --single --cmd ver
 

--- a/tests/logictest/suites/base/20+_others/20_0009_auto_disvover_ip
+++ b/tests/logictest/suites/base/20+_others/20_0009_auto_disvover_ip
@@ -1,0 +1,4 @@
+statement query I
+select * from system.clusters where host = '0.0.0.0' or host = '::';
+
+----


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### CI: find binary path in two places for meta-query compatability test


##### feat(cluster): upgrade MIN_METASRV_SEMVER


##### feat(cluster): Use external meta service for logica testing


##### feat(cluster): auto discover ip when ip is unspecified or loop back

## Changelog







## Related Issues