### PR TITLE
docs: Fix edit url link for blog

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -44,7 +44,7 @@ const config = {
                 blog: {
                     showReadingTime: true,
                     editUrl:
-                        'https://github.com/datafuselabs/databend/edit/main/databend/blog',
+                        'https://github.com/datafuselabs/databend/edit/main/website',
                 },
                 theme: {
                     customCss: require.resolve('./src/css/custom.scss'),


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

docs: Fix edit url link for blog

Fix https://github.com/datafuselabs/databend/issues/7619
