### PR TITLE
fix: Update k8s images to latest tag

### DIFF
--- a/scripts/kubernetes/meta-standalone.yaml
+++ b/scripts/kubernetes/meta-standalone.yaml
@@ -36,7 +36,7 @@ spec:
           - "meta-service.databend-system.svc.cluster.local"
       containers:
         - name: databend-meta
-          image: datafuselabs/databend-meta:v0.6.100-nightly
+          image: datafuselabs/databend-meta:latest
           command:
             - /databend-meta
           args:

--- a/scripts/kubernetes/query-cluster.yaml
+++ b/scripts/kubernetes/query-cluster.yaml
@@ -164,7 +164,7 @@ spec:
           envFrom:
             - secretRef:
                 name: query-secrets
-          image: datafuselabs/databend-query:v0.6.100-nightly
+          image: datafuselabs/databend-query:latest
           name: query
           ports:
             - name: http


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Use latest docker image tags

Fixes #7649 
