### PR TITLE
ci: Fix test_sqllogic_base_cluster_linux not checked by mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,6 +15,7 @@ queue_rules:
       - check-success=test_stateful_standalone_linux
       - check-success=test_sqllogic_base_standalone_linux
       - check-success=test_sqllogic_ydb_standalone_linux
+      - check-success=test_sqllogic_base_cluster_linux
 
   - name: docs_queue
     conditions:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Fix test_sqllogic_base_cluster_linux not checked by mergify
