### PR TITLE
chore(query): change InterpreterFactoryV2.get to async

### DIFF
--- a/src/query/service/src/interpreters/access/accessor.rs
+++ b/src/query/service/src/interpreters/access/accessor.rs
@@ -22,13 +22,14 @@ use crate::interpreters::ManagementModeAccess;
 use crate::sessions::QueryContext;
 use crate::sql::plans::Plan;
 
+#[async_trait::async_trait]
 pub trait AccessChecker: Sync + Send {
     // Check the access permission for the old plan.
     // TODO(bohu): Remove after new plan done.
     fn check(&self, plan: &PlanNode) -> Result<()>;
 
     // Check the access permission for the old plan.
-    fn check_new(&self, _plan: &Plan) -> Result<()>;
+    async fn check_new(&self, _plan: &Plan) -> Result<()>;
 }
 
 pub struct Accessor {
@@ -49,9 +50,9 @@ impl Accessor {
         Ok(())
     }
 
-    pub fn check_new(&self, plan: &Plan) -> Result<()> {
+    pub async fn check_new(&self, plan: &Plan) -> Result<()> {
         for accessor in self.accessors.values() {
-            accessor.check_new(plan)?;
+            accessor.check_new(plan).await?;
         }
         Ok(())
     }

--- a/src/query/service/src/interpreters/access/accessor.rs
+++ b/src/query/service/src/interpreters/access/accessor.rs
@@ -26,7 +26,7 @@ use crate::sql::plans::Plan;
 pub trait AccessChecker: Sync + Send {
     // Check the access permission for the old plan.
     // TODO(bohu): Remove after new plan done.
-    fn check(&self, plan: &PlanNode) -> Result<()>;
+    async fn check(&self, plan: &PlanNode) -> Result<()>;
 
     // Check the access permission for the old plan.
     async fn check_new(&self, _plan: &Plan) -> Result<()>;
@@ -43,9 +43,9 @@ impl Accessor {
         Accessor { accessors }
     }
 
-    pub fn check(&self, plan: &PlanNode) -> Result<()> {
+    pub async fn check(&self, plan: &PlanNode) -> Result<()> {
         for accessor in self.accessors.values() {
-            accessor.check(plan)?;
+            accessor.check(plan).await?;
         }
         Ok(())
     }

--- a/src/query/service/src/interpreters/access/management_mode_access.rs
+++ b/src/query/service/src/interpreters/access/management_mode_access.rs
@@ -33,6 +33,7 @@ impl ManagementModeAccess {
     }
 }
 
+#[async_trait::async_trait]
 impl AccessChecker for ManagementModeAccess {
     // Check what we can do if in management mode.
     fn check(&self, plan: &PlanNode) -> Result<()> {
@@ -50,7 +51,7 @@ impl AccessChecker for ManagementModeAccess {
     }
 
     // Check what we can do if in management mode.
-    fn check_new(&self, plan: &Plan) -> Result<()> {
+    async fn check_new(&self, plan: &Plan) -> Result<()> {
         // Allows for management-mode.
         if self.ctx.get_config().query.management_mode {
             let ok = match plan {

--- a/src/query/service/src/interpreters/access/management_mode_access.rs
+++ b/src/query/service/src/interpreters/access/management_mode_access.rs
@@ -36,7 +36,7 @@ impl ManagementModeAccess {
 #[async_trait::async_trait]
 impl AccessChecker for ManagementModeAccess {
     // Check what we can do if in management mode.
-    fn check(&self, plan: &PlanNode) -> Result<()> {
+    async fn check(&self, plan: &PlanNode) -> Result<()> {
         // Allows for management-mode.
         if self.ctx.get_config().query.management_mode {
             return match plan {

--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -36,11 +36,12 @@ pub struct InterpreterFactory;
 /// InterpreterFactory provides `get` method which transforms the PlanNode into the corresponding interpreter.
 /// Such as: SelectPlan -> SelectInterpreter, ExplainPlan -> ExplainInterpreter, ...
 impl InterpreterFactory {
-    pub fn get(ctx: Arc<QueryContext>, plan: PlanNode) -> Result<Arc<dyn Interpreter>> {
+    pub async fn get(ctx: Arc<QueryContext>, plan: PlanNode) -> Result<Arc<dyn Interpreter>> {
         // Check the access permission.
         let access_checker = Accessor::create(ctx.clone());
         access_checker
             .check(&plan)
+            .await
             .map(|e| error!("Access.denied(v1): {:?}", e))?;
 
         let inner = Self::create_interpreter(ctx.clone(), &plan)?;

--- a/src/query/service/src/interpreters/interpreter_factory_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_factory_v2.rs
@@ -43,11 +43,12 @@ impl InterpreterFactoryV2 {
         matches!(stmt, DfStatement::SeeYouAgain)
     }
 
-    pub fn get(ctx: Arc<QueryContext>, plan: &Plan) -> Result<InterpreterPtr> {
+    pub async fn get(ctx: Arc<QueryContext>, plan: &Plan) -> Result<InterpreterPtr> {
         // Check the access permission.
         let access_checker = Accessor::create(ctx.clone());
         access_checker
             .check_new(plan)
+            .await
             .map(|e| error!("Access.denied(v2): {:?}", e))?;
 
         let inner = InterpreterFactoryV2::create_interpreter(ctx.clone(), plan)?;

--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -221,7 +221,9 @@ pub async fn clickhouse_handler_get(
         let format = get_format_from_plan(&plan, format)?;
 
         context.attach_query_str(&sql);
-        let interpreter = InterpreterFactoryV2::get(context.clone(), &plan).map_err(BadRequest)?;
+        let interpreter = InterpreterFactoryV2::get(context.clone(), &plan)
+            .await
+            .map_err(BadRequest)?;
         execute(context, interpreter, plan.schema(), format, None, params)
             .await
             .map_err(InternalServerError)
@@ -293,7 +295,9 @@ pub async fn clickhouse_handler_post(
         let format = get_format_with_default(fmt, default_format)?;
         let format = get_format_from_plan(&plan, format)?;
         ctx.attach_query_str(&sql);
-        let interpreter = InterpreterFactoryV2::get(ctx.clone(), &plan).map_err(BadRequest)?;
+        let interpreter = InterpreterFactoryV2::get(ctx.clone(), &plan)
+            .await
+            .map_err(BadRequest)?;
 
         execute(ctx, interpreter, plan.schema(), format, None, params)
             .await

--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -235,7 +235,9 @@ pub async fn clickhouse_handler_get(
         context.attach_query_str(&sql);
         let format = get_format_with_default(format, default_format)?;
         let schema = plan.schema();
-        let interpreter = InterpreterFactory::get(context.clone(), plan).map_err(BadRequest)?;
+        let interpreter = InterpreterFactory::get(context.clone(), plan)
+            .await
+            .map_err(BadRequest)?;
         execute(context, interpreter, schema, format, None, params)
             .await
             .map_err(InternalServerError)
@@ -312,7 +314,9 @@ pub async fn clickhouse_handler_post(
         let format = get_format_with_default(format, default_format)?;
 
         let schema = plan.schema();
-        let interpreter = InterpreterFactory::get(ctx.clone(), plan).map_err(BadRequest)?;
+        let interpreter = InterpreterFactory::get(ctx.clone(), plan)
+            .await
+            .map_err(BadRequest)?;
         execute(ctx, interpreter, schema, format, None, params)
             .await
             .map_err(InternalServerError)

--- a/src/query/service/src/servers/http/v1/load.rs
+++ b/src/query/service/src/servers/http/v1/load.rs
@@ -72,7 +72,7 @@ fn execute_query(
     source_builder: SourcePipeBuilder,
 ) -> impl Future<Output = Result<()>> {
     async move {
-        let interpreter = InterpreterFactory::get(context.clone(), node)?;
+        let interpreter = InterpreterFactory::get(context.clone(), node).await?;
 
         if let Err(cause) = interpreter.start().await {
             error!("interpreter.start error: {:?}", cause);
@@ -202,8 +202,9 @@ pub async fn streaming_load(
             StatusCode::BAD_REQUEST,
         )),
     }?;
-    let interpreter =
-        InterpreterFactory::get(context.clone(), plan.clone()).map_err(InternalServerError)?;
+    let interpreter = InterpreterFactory::get(context.clone(), plan.clone())
+        .await
+        .map_err(InternalServerError)?;
     let _ = interpreter
         .set_source_pipe_builder(Some(source_pipe_builder))
         .map_err(|e| error!("interpreter.set_source_pipe_builder.error: {:?}", e));

--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -245,7 +245,7 @@ impl ExecuteState {
             let mut planner = Planner::new(ctx.clone());
             let (plan, _, _) = planner.plan_sql(sql).await?;
             is_select = matches!(&plan, Plan::Query { .. });
-            InterpreterFactoryV2::get(ctx.clone(), &plan)
+            InterpreterFactoryV2::get(ctx.clone(), &plan).await
         } else {
             let plan = match PlanParser::parse(ctx.clone(), sql).await {
                 Ok(p) => p,

--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -256,7 +256,7 @@ impl ExecuteState {
             };
 
             is_select = matches!(&plan, PlanNode::Select(_));
-            InterpreterFactory::get(ctx.clone(), plan)
+            InterpreterFactory::get(ctx.clone(), plan).await
         }?;
 
         if is_v2 && is_select {

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -347,10 +347,9 @@ impl<W: AsyncWrite + Send + Unpin> InteractiveWorkerBase<W> {
                 let mut has_result_set = true;
                 let interpreter = if settings.get_enable_planner_v2()? != 0 {
                     let mut planner = Planner::new(context.clone());
-                    planner.plan_sql(query).await.and_then(|v| async move {
-                        has_result_set = has_result_set_by_plan(&v.0);
-                        InterpreterFactoryV2::get(context.clone(), &v.0).await
-                    })
+                    let plan_res = planner.plan_sql(query).await?;
+                    has_result_set = has_result_set_by_plan(&plan_res.0);
+                    InterpreterFactoryV2::get(context.clone(), &plan_res.0).await
                 } else {
                     let (plan, _) = PlanParser::parse_with_hint(query, context.clone()).await;
                     plan.and_then(|v| {

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -347,9 +347,9 @@ impl<W: AsyncWrite + Send + Unpin> InteractiveWorkerBase<W> {
                 let mut has_result_set = true;
                 let interpreter = if settings.get_enable_planner_v2()? != 0 {
                     let mut planner = Planner::new(context.clone());
-                    planner.plan_sql(query).await.and_then(|v| {
+                    planner.plan_sql(query).await.and_then(|v| async move {
                         has_result_set = has_result_set_by_plan(&v.0);
-                        InterpreterFactoryV2::get(context.clone(), &v.0)
+                        InterpreterFactoryV2::get(context.clone(), &v.0).await
                     })
                 } else {
                     let (plan, _) = PlanParser::parse_with_hint(query, context.clone()).await;

--- a/src/query/service/tests/it/api/http/status.rs
+++ b/src/query/service/tests/it/api/http/status.rs
@@ -62,7 +62,7 @@ async fn run_query(query_ctx: &Arc<QueryContext>) -> Result<Arc<dyn Interpreter>
         .await?;
     query_ctx.set_current_user(user);
     let plan = PlanParser::parse(query_ctx.clone(), sql).await?;
-    InterpreterFactory::get(query_ctx.clone(), plan)
+    InterpreterFactory::get(query_ctx.clone(), plan).await
 }
 
 #[tokio::test]

--- a/src/query/service/tests/it/interpreters/access/management_mode_access.rs
+++ b/src/query/service/tests/it/interpreters/access/management_mode_access.rs
@@ -159,7 +159,7 @@ async fn test_management_mode_access() -> Result<()> {
         for test in group.tests {
             let (plan, _, _) = planner.plan_sql(test.query).await?;
             if test.is_err {
-                let res = InterpreterFactoryV2::get(ctx.clone(), &plan);
+                let res = InterpreterFactoryV2::get(ctx.clone(), &plan).await;
                 assert_eq!(
                     test.is_err,
                     res.is_err(),
@@ -167,7 +167,7 @@ async fn test_management_mode_access() -> Result<()> {
                     (group.name, test.name)
                 );
             } else {
-                let interpreter = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+                let interpreter = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
                 interpreter.execute(ctx.clone()).await?;
             }
         }

--- a/src/query/service/tests/it/interpreters/async_insert_queue.rs
+++ b/src/query/service/tests/it/interpreters/async_insert_queue.rs
@@ -134,7 +134,7 @@ async fn test_async_insert_queue() -> Result<()> {
     {
         let query = "select * from default.test";
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan.clone()).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![
@@ -390,7 +390,7 @@ async fn test_async_insert_queue_no_wait() -> Result<()> {
     {
         let query = "select * from default.test";
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan.clone()).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![

--- a/src/query/service/tests/it/interpreters/async_insert_queue.rs
+++ b/src/query/service/tests/it/interpreters/async_insert_queue.rs
@@ -51,7 +51,7 @@ async fn test_async_insert_queue() -> Result<()> {
     {
         let query = "create table default.test(a int, b String) Engine = Memory;";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -170,7 +170,7 @@ async fn test_async_insert_queue_max_data_size() -> Result<()> {
     {
         let query = "create table default.test(a int, b String) Engine = Memory;";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -220,7 +220,7 @@ async fn test_async_insert_queue_busy_timeout() -> Result<()> {
     {
         let query = "create table default.test(a int, b String) Engine = Memory;";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -271,7 +271,7 @@ async fn test_async_insert_queue_stale_timeout() -> Result<()> {
     {
         let query = "create table default.test(a int, b String) Engine = Memory;";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -321,7 +321,7 @@ async fn test_async_insert_queue_wait_timeout() -> Result<()> {
     {
         let query = "create table default.test(a int, b String) Engine = Memory;";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -364,7 +364,7 @@ async fn test_async_insert_queue_no_wait() -> Result<()> {
     {
         let query = "create table default.test(a int, b String) Engine = Memory;";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 

--- a/src/query/service/tests/it/interpreters/interpreter_call.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_call.rs
@@ -33,7 +33,7 @@ async fn test_call_interpreter() -> Result<()> {
 
     let query = "call system$test()";
     let (plan, _, _) = planner.plan_sql(query).await?;
-    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
     assert_eq!(executor.name(), "CallInterpreter");
     let res = executor.execute(ctx.clone()).await;
     assert_eq!(res.is_err(), true);
@@ -53,7 +53,7 @@ async fn test_call_fuse_snapshot_interpreter() -> Result<()> {
     {
         let query = "call system$fuse_snapshot()";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CallInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert_eq!(res.is_err(), true);
@@ -65,7 +65,7 @@ async fn test_call_fuse_snapshot_interpreter() -> Result<()> {
     {
         let query = "call system$fuse_snapshot(default, test)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CallInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert_eq!(res.is_err(), true);
@@ -79,7 +79,7 @@ async fn test_call_fuse_snapshot_interpreter() -> Result<()> {
     {
         let query = "call system$fuse_snapshot(system, tables)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CallInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert_eq!(res.is_err(), true);
@@ -95,7 +95,7 @@ async fn test_call_fuse_snapshot_interpreter() -> Result<()> {
         ";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -103,7 +103,7 @@ async fn test_call_fuse_snapshot_interpreter() -> Result<()> {
     {
         let query = "call system$fuse_snapshot(default, a)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -119,7 +119,7 @@ async fn test_call_fuse_block_interpreter() -> Result<()> {
     {
         let query = "call system$fuse_block()";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CallInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert_eq!(res.is_err(), true);
@@ -131,7 +131,7 @@ async fn test_call_fuse_block_interpreter() -> Result<()> {
     {
         let query = "call system$fuse_block(default, test)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CallInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert_eq!(res.is_err(), true);
@@ -145,7 +145,7 @@ async fn test_call_fuse_block_interpreter() -> Result<()> {
     {
         let query = "call system$fuse_block(system, tables)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CallInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert_eq!(res.is_err(), true);
@@ -161,7 +161,7 @@ async fn test_call_fuse_block_interpreter() -> Result<()> {
         ";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -169,7 +169,7 @@ async fn test_call_fuse_block_interpreter() -> Result<()> {
     {
         let query = "call system$fuse_block(default, a)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -185,7 +185,7 @@ async fn test_call_clustering_information_interpreter() -> Result<()> {
     {
         let query = "call system$clustering_information()";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CallInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert_eq!(res.is_err(), true);
@@ -197,7 +197,7 @@ async fn test_call_clustering_information_interpreter() -> Result<()> {
     {
         let query = "call system$clustering_information(default, test)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CallInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert_eq!(res.is_err(), true);
@@ -211,7 +211,7 @@ async fn test_call_clustering_information_interpreter() -> Result<()> {
     {
         let query = "call system$clustering_information(system, tables)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CallInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert_eq!(res.is_err(), true);
@@ -227,7 +227,7 @@ async fn test_call_clustering_information_interpreter() -> Result<()> {
         ";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -235,7 +235,7 @@ async fn test_call_clustering_information_interpreter() -> Result<()> {
     {
         let query = "call system$clustering_information(default, a)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let res = executor.execute(ctx.clone()).await;
         assert_eq!(res.is_err(), true);
         let expect =
@@ -250,7 +250,7 @@ async fn test_call_clustering_information_interpreter() -> Result<()> {
     ";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -258,7 +258,7 @@ async fn test_call_clustering_information_interpreter() -> Result<()> {
     {
         let query = "call system$clustering_information(default, b)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -294,7 +294,7 @@ async fn test_call_tenant_quota_interpreter() -> Result<()> {
     {
         let query = "call admin$tenant_quota()";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![
@@ -311,7 +311,7 @@ async fn test_call_tenant_quota_interpreter() -> Result<()> {
     {
         let query = "call admin$tenant_quota(tenant1)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![
@@ -328,7 +328,7 @@ async fn test_call_tenant_quota_interpreter() -> Result<()> {
     {
         let query = "call admin$tenant_quota(tenant1, 7, 5, 3, 3)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![
@@ -344,7 +344,7 @@ async fn test_call_tenant_quota_interpreter() -> Result<()> {
     {
         let query = "call admin$tenant_quota(tenant1, 8)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![
@@ -360,7 +360,7 @@ async fn test_call_tenant_quota_interpreter() -> Result<()> {
     {
         let query = "call admin$tenant_quota(tenant1)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![
@@ -377,7 +377,7 @@ async fn test_call_tenant_quota_interpreter() -> Result<()> {
     {
         let query = "call admin$tenant_quota()";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![
@@ -402,7 +402,7 @@ async fn test_call_tenant_quote_without_management_mode() -> Result<()> {
     {
         let query = "call admin$tenant_quota(tenant1)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let res = executor.execute(ctx.clone()).await;
         assert_eq!(res.is_err(), true);
         let expect =

--- a/src/query/service/tests/it/interpreters/interpreter_cluster_key_alter.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_cluster_key_alter.rs
@@ -33,7 +33,7 @@ async fn test_alter_table_cluster_key_interpreter() -> Result<()> {
         ";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -41,7 +41,7 @@ async fn test_alter_table_cluster_key_interpreter() -> Result<()> {
     {
         let query = "Alter TABLE a CLUSTER BY(a, b)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "AlterTableClusterKeyInterpreter");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/src/query/service/tests/it/interpreters/interpreter_cluster_key_drop.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_cluster_key_drop.rs
@@ -33,7 +33,7 @@ async fn test_drop_table_cluster_key_interpreter() -> Result<()> {
         ";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -41,7 +41,7 @@ async fn test_drop_table_cluster_key_interpreter() -> Result<()> {
     {
         let query = "ALTER TABLE a DROP CLUSTER KEY";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropTableClusterKeyInterpreter");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/src/query/service/tests/it/interpreters/interpreter_database_create.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_database_create.rs
@@ -26,7 +26,7 @@ async fn test_create_database_interpreter() -> Result<()> {
 
     let query = "create database db1";
     let (plan, _, _) = planner.plan_sql(query).await?;
-    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
     assert_eq!(executor.name(), "CreateDatabaseInterpreter");
     let mut stream = executor.execute(ctx.clone()).await?;
     while let Some(_block) = stream.next().await {}

--- a/src/query/service/tests/it/interpreters/interpreter_database_drop.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_database_drop.rs
@@ -26,7 +26,7 @@ async fn test_drop_database_interpreter() -> Result<()> {
 
     let query = "drop database default";
     let (plan, _, _) = planner.plan_sql(query).await?;
-    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
     assert_eq!(executor.name(), "DropDatabaseInterpreter");
     let stream = executor.execute(ctx.clone()).await?;
     let result = stream.try_collect::<Vec<_>>().await?;

--- a/src/query/service/tests/it/interpreters/interpreter_database_rename.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_database_rename.rs
@@ -29,7 +29,7 @@ async fn test_rename_database_interpreter() -> Result<()> {
         let query = "create database test1";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -38,7 +38,7 @@ async fn test_rename_database_interpreter() -> Result<()> {
         let query = "alter database test1 rename to test2";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "RenameDatabaseInterpreter");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -50,7 +50,7 @@ async fn test_rename_database_interpreter() -> Result<()> {
     {
         let query = "drop database test2";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropDatabaseInterpreter");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/src/query/service/tests/it/interpreters/interpreter_database_show_create.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_database_show_create.rs
@@ -28,7 +28,7 @@ async fn test_show_create_database_interpreter() -> Result<()> {
     {
         let query = "show create database default";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "ShowCreateDatabaseInterpreter");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -46,7 +46,7 @@ async fn test_show_create_database_interpreter() -> Result<()> {
     {
         let query = "show create database system";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "ShowCreateDatabaseInterpreter");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/src/query/service/tests/it/interpreters/interpreter_empty.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_empty.rs
@@ -27,7 +27,7 @@ async fn test_empty_interpreter() -> Result<()> {
     {
         let query = "/*!40101*/select number from numbers_mt(1)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
 
         let stream = executor.execute(ctx.clone()).await?;

--- a/src/query/service/tests/it/interpreters/interpreter_explain.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_explain.rs
@@ -29,7 +29,7 @@ async fn test_explain_interpreter() -> Result<()> {
     ";
 
     let plan = PlanParser::parse(ctx.clone(), query).await?;
-    let executor = InterpreterFactory::get(ctx.clone(), plan)?;
+    let executor = InterpreterFactory::get(ctx.clone(), plan).await?;
     assert_eq!(executor.name(), "ExplainInterpreter");
 
     let stream = executor.execute(ctx).await?;

--- a/src/query/service/tests/it/interpreters/interpreter_factory_interceptor.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_factory_interceptor.rs
@@ -85,7 +85,7 @@ async fn test_interpreter_interceptor_for_insert() -> Result<()> {
     {
         let query = "create table t as select number from numbers_mt(1)";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let interpreter = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let interpreter = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         interpreter.start().await?;
         let stream = interpreter.execute(ctx.clone()).await?;
         stream.try_collect::<Vec<_>>().await?;

--- a/src/query/service/tests/it/interpreters/interpreter_factory_interceptor.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_factory_interceptor.rs
@@ -27,7 +27,7 @@ async fn test_interpreter_interceptor() -> Result<()> {
         let query = "select number from numbers_mt(100) where number > 90";
         ctx.attach_query_str(query);
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
+        let interpreter = InterpreterFactory::get(ctx.clone(), plan).await?;
         interpreter.start().await?;
         let stream = interpreter.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -57,7 +57,7 @@ async fn test_interpreter_interceptor() -> Result<()> {
     {
         let query = "select log_type, handler_type, cpu_usage, scan_rows, scan_bytes, scan_partitions, written_rows, written_bytes, result_rows, result_bytes, query_kind, query_text, sql_user, sql_user_quota from system.query_log";
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
+        let interpreter = InterpreterFactory::get(ctx.clone(), plan).await?;
 
         let stream = interpreter.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -96,7 +96,7 @@ async fn test_interpreter_interceptor_for_insert() -> Result<()> {
     {
         let query = "select log_type, handler_type, cpu_usage, scan_rows, scan_bytes, scan_partitions, written_rows, written_bytes, result_rows, result_bytes, query_kind, query_text, sql_user, sql_user_quota from system.query_log";
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
+        let interpreter = InterpreterFactory::get(ctx.clone(), plan).await?;
 
         let stream = interpreter.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/src/query/service/tests/it/interpreters/interpreter_insert.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_insert.rs
@@ -27,7 +27,7 @@ async fn test_insert_into_interpreter() -> Result<()> {
     {
         let query = "create table default.default_value_table(a String, b String DEFAULT 'b') Engine = Memory";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -35,7 +35,7 @@ async fn test_insert_into_interpreter() -> Result<()> {
     {
         let query = "create table default.input_table(a String, b String, c String, d String, e String) Engine = Memory";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -43,7 +43,7 @@ async fn test_insert_into_interpreter() -> Result<()> {
     {
         let query = "create table default.output_table(a UInt8, b Int8, c UInt16, d Int16, e String) Engine = Memory";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -69,7 +69,7 @@ async fn test_insert_into_interpreter() -> Result<()> {
         {
             let query = "select * from default.default_value_table";
             let (plan, _, _) = planner.plan_sql(query).await?;
-            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
             let stream = executor.execute(ctx.clone()).await?;
             let result = stream.try_collect::<Vec<_>>().await?;
             let expected = vec![
@@ -105,7 +105,7 @@ async fn test_insert_into_interpreter() -> Result<()> {
     {
         let query = "select * from default.output_table";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![

--- a/src/query/service/tests/it/interpreters/interpreter_insert.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_insert.rs
@@ -53,7 +53,7 @@ async fn test_insert_into_interpreter() -> Result<()> {
         {
             let query = "insert into default.default_value_table(a) values('a')";
             let plan = PlanParser::parse(ctx.clone(), query).await?;
-            let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+            let executor = InterpreterFactory::get(ctx.clone(), plan.clone()).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
 
@@ -61,7 +61,7 @@ async fn test_insert_into_interpreter() -> Result<()> {
         {
             let query = "insert into default.default_value_table(a) select a from default.default_value_table";
             let plan = PlanParser::parse(ctx.clone(), query).await?;
-            let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+            let executor = InterpreterFactory::get(ctx.clone(), plan.clone()).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
 
@@ -88,7 +88,7 @@ async fn test_insert_into_interpreter() -> Result<()> {
     {
         let query = "insert into default.input_table values(1,1,1,1,1), (2,2,2,2,2)";
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan.clone()).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -97,7 +97,7 @@ async fn test_insert_into_interpreter() -> Result<()> {
         let query = "insert into default.output_table select * from default.input_table";
 
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan.clone()).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 

--- a/src/query/service/tests/it/interpreters/interpreter_privilege_grant.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_privilege_grant.rs
@@ -79,7 +79,7 @@ async fn test_grant_privilege_interpreter() -> Result<()> {
 
     for tt in tests {
         let (plan, _, _) = planner.plan_sql(&tt.query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "GrantPrivilegeInterpreter");
         let r = match executor.execute(ctx.clone()).await {
             Err(err) => Err(err),

--- a/src/query/service/tests/it/interpreters/interpreter_privilege_revoke.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_privilege_revoke.rs
@@ -48,7 +48,7 @@ async fn test_revoke_privilege_interpreter() -> Result<()> {
     user_mgr.add_user(&tenant, user_info.clone(), false).await?;
     let query = format!("REVOKE ALL ON *.* FROM '{}'@'{}'", name, hostname);
     let (plan, _, _) = planner.plan_sql(&query).await?;
-    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
     assert_eq!(executor.name(), "RevokePrivilegeInterpreter");
     let mut stream = executor.execute(ctx.clone()).await?;
     while let Some(_block) = stream.next().await {}
@@ -78,7 +78,7 @@ async fn test_revoke_privilege_interpreter_on_role() -> Result<()> {
 
     let query = "REVOKE ALL ON *.* FROM ROLE 'role1'";
     let (plan, _, _) = planner.plan_sql(query).await?;
-    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
     assert_eq!(executor.name(), "RevokePrivilegeInterpreter");
     let mut stream = executor.execute(ctx.clone()).await?;
     while let Some(_block) = stream.next().await {}

--- a/src/query/service/tests/it/interpreters/interpreter_role_grant.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_role_grant.rs
@@ -33,7 +33,7 @@ async fn test_grant_role_interpreter() -> Result<()> {
     {
         let query = "GRANT ROLE 'test' TO 'test_user'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "GrantRoleInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert!(res.is_err());
@@ -48,7 +48,7 @@ async fn test_grant_role_interpreter() -> Result<()> {
     {
         let query = "GRANT ROLE 'test' TO 'test_user'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "GrantRoleInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert!(res.is_err());
@@ -64,7 +64,7 @@ async fn test_grant_role_interpreter() -> Result<()> {
 
         let query = "GRANT ROLE 'test' TO 'test_user'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
 
         let user_info = user_mgr.get_user(&tenant, user_info.identity()).await?;
@@ -77,7 +77,7 @@ async fn test_grant_role_interpreter() -> Result<()> {
     {
         let query = "GRANT ROLE 'test' TO ROLE 'test_role'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "GrantRoleInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert!(res.is_err());
@@ -96,7 +96,7 @@ async fn test_grant_role_interpreter() -> Result<()> {
 
         let query = "GRANT ROLE 'test' TO ROLE 'test_role'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
 
         let role_info = user_mgr

--- a/src/query/service/tests/it/interpreters/interpreter_role_revoke.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_role_revoke.rs
@@ -35,7 +35,7 @@ async fn test_revoke_role_interpreter() -> Result<()> {
     {
         let query = "REVOKE ROLE 'test' FROM 'test_user'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "RevokeRoleInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert!(res.is_err());
@@ -52,7 +52,7 @@ async fn test_revoke_role_interpreter() -> Result<()> {
 
         let query = "REVOKE ROLE 'test' FROM 'test_user'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
 
         let user_info = user_mgr.get_user(&tenant, test_user.identity()).await?;
@@ -64,7 +64,7 @@ async fn test_revoke_role_interpreter() -> Result<()> {
     {
         let query = "REVOKE ROLE 'test' FROM 'test_user'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
 
         let user_info = user_mgr
@@ -78,7 +78,7 @@ async fn test_revoke_role_interpreter() -> Result<()> {
     {
         let query = "REVOKE ROLE 'test' FROM ROLE 'test_role'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "RevokeRoleInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert!(res.is_err());
@@ -97,7 +97,7 @@ async fn test_revoke_role_interpreter() -> Result<()> {
     {
         let query = "REVOKE ROLE 'test' FROM ROLE 'test_role'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
 
         let role_info = user_mgr
@@ -111,7 +111,7 @@ async fn test_revoke_role_interpreter() -> Result<()> {
     {
         let query = "REVOKE ROLE 'test' FROM ROLE 'test_role'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
 
         let role_info = user_mgr

--- a/src/query/service/tests/it/interpreters/interpreter_select.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_select.rs
@@ -26,7 +26,7 @@ async fn test_select_interpreter() -> Result<()> {
     {
         let query = "select number from numbers_mt(10)";
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let executor = InterpreterFactory::get(ctx.clone(), plan)?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan).await?;
         assert_eq!(executor.name(), "SelectInterpreter");
 
         let stream = executor.execute(ctx.clone()).await?;
@@ -56,7 +56,7 @@ async fn test_select_interpreter() -> Result<()> {
     {
         let query = "select 1 + 1, 2 + 2, 3 * 3, 4 * 4";
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let executor = InterpreterFactory::get(ctx.clone(), plan)?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan).await?;
         assert_eq!(executor.name(), "SelectInterpreter");
 
         let stream = executor.execute(ctx.clone()).await?;

--- a/src/query/service/tests/it/interpreters/interpreter_setting.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_setting.rs
@@ -42,7 +42,7 @@ async fn test_setting_interpreter_error() -> Result<()> {
 
     let query = "SET max_block_size=1";
     let (plan, _, _) = planner.plan_sql(query).await?;
-    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
     if let Err(e) = executor.execute(ctx.clone()).await {
         let expect = "Code: 1020, displayText = Unknown variable: \"xx\".";
         assert_eq!(expect, e.to_string());

--- a/src/query/service/tests/it/interpreters/interpreter_setting.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_setting.rs
@@ -26,7 +26,7 @@ async fn test_setting_interpreter() -> Result<()> {
 
     let query = "SET max_block_size=1";
     let (plan, _, _) = planner.plan_sql(query).await?;
-    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
     assert_eq!(executor.name(), "SettingInterpreter");
 
     let mut stream = executor.execute(ctx.clone()).await?;

--- a/src/query/service/tests/it/interpreters/interpreter_share_desc.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_share_desc.rs
@@ -28,7 +28,7 @@ async fn test_desc_share_interpreter() -> Result<()> {
     {
         let query = "create share t";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let _ = stream.try_collect::<Vec<_>>().await?;
     }
@@ -37,7 +37,7 @@ async fn test_desc_share_interpreter() -> Result<()> {
     {
         let query = "desc share t";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DescShareInterpreter");
         assert!(executor.execute(ctx.clone()).await.is_ok());
     }

--- a/src/query/service/tests/it/interpreters/interpreter_show_databases.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_databases.rs
@@ -28,7 +28,7 @@ async fn test_show_databases_interpreter() -> Result<()> {
     {
         let query = "show databases";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -48,7 +48,7 @@ async fn test_show_databases_interpreter() -> Result<()> {
     {
         let query = "show databases like '%tem%'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![

--- a/src/query/service/tests/it/interpreters/interpreter_show_engines.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_engines.rs
@@ -28,7 +28,7 @@ async fn test_show_engines_interpreter() -> Result<()> {
     {
         let query = "show engines";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/src/query/service/tests/it/interpreters/interpreter_show_functions.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_functions.rs
@@ -26,7 +26,7 @@ async fn test_show_functions_interpreter() -> Result<()> {
     {
         let query = "show functions";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let _ = executor.execute(ctx.clone()).await?;
     }

--- a/src/query/service/tests/it/interpreters/interpreter_show_grant.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_grant.rs
@@ -46,7 +46,7 @@ async fn test_show_grant_interpreter() -> Result<()> {
     {
         let query = "SHOW GRANTS FOR 'test'@'localhost'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "ShowGrantsInterpreter");
 
         let stream = executor.execute(ctx.clone()).await?;
@@ -58,7 +58,7 @@ async fn test_show_grant_interpreter() -> Result<()> {
     {
         let query = "SHOW GRANTS FOR ROLE 'role1'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "ShowGrantsInterpreter");
 
         let stream = executor.execute(ctx.clone()).await?;
@@ -80,7 +80,7 @@ async fn test_show_grant_interpreter() -> Result<()> {
     {
         let query = "SHOW GRANTS FOR ROLE 'role2'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
 
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -106,7 +106,7 @@ async fn test_show_grant_interpreter() -> Result<()> {
     {
         let query = "SHOW GRANTS FOR 'test'@'localhost'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
 
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -134,7 +134,7 @@ async fn test_show_grant_interpreter() -> Result<()> {
     {
         let query = "SHOW GRANTS FOR 'test'@'localhost'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
 
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -155,7 +155,7 @@ async fn test_show_grant_interpreter() -> Result<()> {
     {
         let query = "SHOW GRANTS FOR ROLE 'role1'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
 
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -180,7 +180,7 @@ async fn test_show_grant_interpreter() -> Result<()> {
     {
         let query = "SHOW GRANTS FOR ROLE 'role1'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
 
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/src/query/service/tests/it/interpreters/interpreter_show_metrics.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_metrics.rs
@@ -28,7 +28,7 @@ async fn test_show_metrics_interpreter() -> Result<()> {
     {
         let query = "show metrics";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let _ = executor.execute(ctx.clone()).await?;
     }

--- a/src/query/service/tests/it/interpreters/interpreter_show_processlist.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_processlist.rs
@@ -26,7 +26,7 @@ async fn test_show_processlist_interpreter() -> Result<()> {
     {
         let query = "show processlist";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let _ = executor.execute(ctx.clone()).await?;
     }

--- a/src/query/service/tests/it/interpreters/interpreter_show_roles.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_roles.rs
@@ -26,7 +26,7 @@ async fn test_show_roles_interpreter() -> Result<()> {
     {
         let query = "CREATE ROLE 'test'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -34,7 +34,7 @@ async fn test_show_roles_interpreter() -> Result<()> {
     {
         let query = "show roles";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
 
         let stream = executor.execute(ctx.clone()).await?;

--- a/src/query/service/tests/it/interpreters/interpreter_show_settings.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_settings.rs
@@ -27,7 +27,7 @@ async fn test_show_settings_interpreter() -> Result<()> {
     {
         let query = "show settings";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
 
         let stream = executor.execute(ctx.clone()).await?;

--- a/src/query/service/tests/it/interpreters/interpreter_show_stages.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_stages.rs
@@ -27,7 +27,7 @@ async fn test_show_stages_interpreter() -> Result<()> {
     {
         let query = "CREATE STAGE test url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z')";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CreateUserStageInterpreter");
         let mut stream = executor.execute(ctx.clone()).await?;
         while let Some(_block) = stream.next().await {}
@@ -36,7 +36,7 @@ async fn test_show_stages_interpreter() -> Result<()> {
     // show stages.
     {
         let (plan, _, _) = planner.plan_sql("show stages").await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         // Show stage will be rewritten into query.
         assert_eq!(executor.name(), "SelectInterpreterV2");
 

--- a/src/query/service/tests/it/interpreters/interpreter_show_tab_stat.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_tab_stat.rs
@@ -30,7 +30,7 @@ async fn test_show_tab_stat_interpreter() -> Result<()> {
         {
             let query = "create database db1";
             let (plan, _, _) = planner.plan_sql(query).await?;
-            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
 
@@ -38,7 +38,7 @@ async fn test_show_tab_stat_interpreter() -> Result<()> {
         {
             let query = "use db1";
             let (plan, _, _) = planner.plan_sql(query).await?;
-            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
 
@@ -46,13 +46,13 @@ async fn test_show_tab_stat_interpreter() -> Result<()> {
         {
             let query = "create table data(a Int)";
             let (plan, _, _) = planner.plan_sql(query).await?;
-            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
         {
             let query = "create table bend(a Int)";
             let (plan, _, _) = planner.plan_sql(query).await?;
-            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
     }
@@ -61,7 +61,7 @@ async fn test_show_tab_stat_interpreter() -> Result<()> {
     {
         let query = "show table status like '%da%'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -79,7 +79,7 @@ async fn test_show_tab_stat_interpreter() -> Result<()> {
     {
         let query = "show table status where Name != 'data'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -97,7 +97,7 @@ async fn test_show_tab_stat_interpreter() -> Result<()> {
     {
         let query = "show table status from db1";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -116,7 +116,7 @@ async fn test_show_tab_stat_interpreter() -> Result<()> {
     {
         let query = "drop database db1";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 

--- a/src/query/service/tests/it/interpreters/interpreter_show_tables.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_tables.rs
@@ -30,7 +30,7 @@ async fn test_show_tables_interpreter() -> Result<()> {
         {
             let query = "create database db1";
             let (plan, _, _) = planner.plan_sql(query).await?;
-            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
 
@@ -38,7 +38,7 @@ async fn test_show_tables_interpreter() -> Result<()> {
         {
             let query = "use db1";
             let (plan, _, _) = planner.plan_sql(query).await?;
-            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
 
@@ -46,13 +46,13 @@ async fn test_show_tables_interpreter() -> Result<()> {
         {
             let query = "create table data(a Int)";
             let (plan, _, _) = planner.plan_sql(query).await?;
-            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
         {
             let query = "create table bend(a Int)";
             let (plan, _, _) = planner.plan_sql(query).await?;
-            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
     }
@@ -61,7 +61,7 @@ async fn test_show_tables_interpreter() -> Result<()> {
     {
         let query = "show tables";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -80,7 +80,7 @@ async fn test_show_tables_interpreter() -> Result<()> {
     {
         let query = "show tables like '%da%'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -98,7 +98,7 @@ async fn test_show_tables_interpreter() -> Result<()> {
     {
         let query = "show tables where name != 'data'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -116,7 +116,7 @@ async fn test_show_tables_interpreter() -> Result<()> {
     {
         let query = "show tables from db1";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -135,7 +135,7 @@ async fn test_show_tables_interpreter() -> Result<()> {
     {
         let query = "drop database db1";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 

--- a/src/query/service/tests/it/interpreters/interpreter_show_users.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_show_users.rs
@@ -26,7 +26,7 @@ async fn test_show_users_interpreter() -> Result<()> {
     {
         let query = "CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -34,7 +34,7 @@ async fn test_show_users_interpreter() -> Result<()> {
     {
         let query = "show users";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "SelectInterpreterV2");
 
         let stream = executor.execute(ctx.clone()).await?;

--- a/src/query/service/tests/it/interpreters/interpreter_table_create.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_table_create.rs
@@ -31,7 +31,7 @@ async fn test_create_table_interpreter() -> Result<()> {
         ";
 
         let (plan, _, _) = planner.plan_sql(TEST_CREATE_QUERY).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -40,7 +40,7 @@ async fn test_create_table_interpreter() -> Result<()> {
             "CREATE TABLE default.test_b(a varchar, x int) as select b, a from default.test_a";
 
         let (plan, _, _) = planner.plan_sql(TEST_CREATE_QUERY_SELECT).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let mut stream = executor.execute(ctx.clone()).await?;
         while let Some(_block) = stream.next().await {}
 
@@ -73,7 +73,7 @@ async fn test_create_table_interpreter() -> Result<()> {
             c varchar(255) comment 'c', d smallint comment 'd', e Date comment 'e')\
             Engine = Null COMMENT = 'test create'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
 
         assert!(executor.execute(ctx.clone()).await.is_ok());
     }

--- a/src/query/service/tests/it/interpreters/interpreter_table_describe.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_table_describe.rs
@@ -33,7 +33,7 @@ async fn interpreter_describe_table_test() -> Result<()> {
         ";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -41,7 +41,7 @@ async fn interpreter_describe_table_test() -> Result<()> {
     {
         let query = "DESCRIBE a";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DescribeTableInterpreter");
 
         let stream = executor.execute(ctx.clone()).await?;
@@ -64,7 +64,7 @@ async fn interpreter_describe_table_test() -> Result<()> {
     {
         let query = "show fields from a";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DescribeTableInterpreter");
 
         let stream = executor.execute(ctx.clone()).await?;

--- a/src/query/service/tests/it/interpreters/interpreter_table_drop.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_table_drop.rs
@@ -33,7 +33,7 @@ async fn test_drop_table_interpreter() -> Result<()> {
         ";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -41,7 +41,7 @@ async fn test_drop_table_interpreter() -> Result<()> {
     {
         let query = "DROP TABLE a";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropTableInterpreter");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/src/query/service/tests/it/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_table_recluster.rs
@@ -28,7 +28,7 @@ async fn test_alter_recluster_interpreter() -> Result<()> {
         let query = "CREATE TABLE default.t(a bigint, b int) Engine = Fuse cluster by(a+1)";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -60,7 +60,7 @@ async fn test_alter_recluster_interpreter() -> Result<()> {
     {
         let query = "select * from clustering_information('default', 't')";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![
@@ -77,7 +77,7 @@ async fn test_alter_recluster_interpreter() -> Result<()> {
     {
         let query = "ALTER TABLE default.t RECLUSTER FINAL where a != 4";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -85,7 +85,7 @@ async fn test_alter_recluster_interpreter() -> Result<()> {
     {
         let query = "select * from clustering_information('default', 't')";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![
@@ -102,7 +102,7 @@ async fn test_alter_recluster_interpreter() -> Result<()> {
     {
         let query = "select count(*) from fuse_snapshot('default', 't')";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![
@@ -119,7 +119,7 @@ async fn test_alter_recluster_interpreter() -> Result<()> {
     {
         let query = "select count(*) from system.clustering_history";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![

--- a/src/query/service/tests/it/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_table_recluster.rs
@@ -36,7 +36,7 @@ async fn test_alter_recluster_interpreter() -> Result<()> {
     {
         let query = "insert into default.t values(1,1),(3,3)";
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan.clone()).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -44,7 +44,7 @@ async fn test_alter_recluster_interpreter() -> Result<()> {
     {
         let query = "insert into default.t values(2,2),(5,5)";
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan.clone()).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -52,7 +52,7 @@ async fn test_alter_recluster_interpreter() -> Result<()> {
     {
         let query = "insert into default.t values(4,4)";
         let plan = PlanParser::parse(ctx.clone(), query).await?;
-        let executor = InterpreterFactory::get(ctx.clone(), plan.clone())?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan.clone()).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 

--- a/src/query/service/tests/it/interpreters/interpreter_table_rename.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_table_rename.rs
@@ -33,7 +33,7 @@ async fn test_rename_table_interpreter() -> Result<()> {
         ";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -41,7 +41,7 @@ async fn test_rename_table_interpreter() -> Result<()> {
     {
         let query = "RENAME TABLE a TO b";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "RenameTableInterpreter");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
@@ -53,7 +53,7 @@ async fn test_rename_table_interpreter() -> Result<()> {
     {
         let query = "DROP TABLE b";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropTableInterpreter");
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;

--- a/src/query/service/tests/it/interpreters/interpreter_table_show_create.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_table_show_create.rs
@@ -156,11 +156,11 @@ async fn interpreter_show_create_table_with_comments_test() -> Result<()> {
         for stmt in case.create_stmt {
             // create table in the new planner to support column comment.
             let (plan, _, _) = planner.plan_sql(stmt).await?;
-            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
         let (plan, _, _) = planner.plan_sql(case.show_stmt).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "ShowCreateTableInterpreter");
         let result = executor
             .execute(ctx.clone())

--- a/src/query/service/tests/it/interpreters/interpreter_table_show_create.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_table_show_create.rs
@@ -76,11 +76,11 @@ async fn interpreter_show_create_table_test() -> Result<()> {
     for case in cases {
         for stmt in case.create_stmt {
             let (plan, _, _) = planner.plan_sql(stmt).await?;
-            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+            let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
             let _ = executor.execute(ctx.clone()).await?;
         }
         let (plan, _, _) = planner.plan_sql(case.show_stmt).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "ShowCreateTableInterpreter");
         let result = executor
             .execute(ctx.clone())

--- a/src/query/service/tests/it/interpreters/interpreter_table_truncate.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_table_truncate.rs
@@ -33,7 +33,7 @@ async fn test_truncate_table_interpreter() -> Result<()> {
         ";
 
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -41,7 +41,7 @@ async fn test_truncate_table_interpreter() -> Result<()> {
     {
         let query = "INSERT INTO default.a VALUES('1,1', '2,2')";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let _ = executor.execute(ctx.clone()).await?;
     }
 
@@ -49,7 +49,7 @@ async fn test_truncate_table_interpreter() -> Result<()> {
     {
         let query = "SELECT * FROM default.a";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec![
@@ -66,7 +66,7 @@ async fn test_truncate_table_interpreter() -> Result<()> {
     {
         let query = "TRUNCATE TABLE default.a";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "TruncateTableInterpreter");
 
         let stream = executor.execute(ctx.clone()).await?;
@@ -79,7 +79,7 @@ async fn test_truncate_table_interpreter() -> Result<()> {
     {
         let query = "SELECT * FROM default.a";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let expected = vec!["++", "++"];

--- a/src/query/service/tests/it/interpreters/interpreter_use_database.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_use_database.rs
@@ -26,7 +26,7 @@ async fn test_use_interpreter() -> Result<()> {
 
     let query = "USE default";
     let (plan, _, _) = planner.plan_sql(query).await?;
-    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
     assert_eq!(executor.name(), "UseDatabaseInterpreter");
 
     let mut stream = executor.execute(ctx.clone()).await?;

--- a/src/query/service/tests/it/interpreters/interpreter_use_database.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_use_database.rs
@@ -42,7 +42,7 @@ async fn test_use_database_interpreter_error() -> Result<()> {
 
     let query = "USE xx";
     let (plan, _, _) = planner.plan_sql(query).await?;
-    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
 
     if let Err(e) = executor.execute(ctx.clone()).await {
         let expect = "Code: 1003, displayText = Cannot USE 'xx', because the 'xx' doesn't exist.";

--- a/src/query/service/tests/it/interpreters/interpreter_user_alter.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_user_alter.rs
@@ -56,7 +56,7 @@ async fn test_alter_user_interpreter() -> Result<()> {
         );
 
         let (plan, _, _) = planner.plan_sql(&test_query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "AlterUserInterpreter");
         let mut stream = executor.execute(ctx.clone()).await?;
         while let Some(_block) = stream.next().await {}
@@ -71,7 +71,7 @@ async fn test_alter_user_interpreter() -> Result<()> {
         let test_query = format!("ALTER USER '{}'@'{}' WITH TENANTSETTING", name, hostname);
 
         let (plan, _, _) = planner.plan_sql(&test_query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "AlterUserInterpreter");
         let mut stream = executor.execute(ctx.clone()).await?;
         while let Some(_block) = stream.next().await {}
@@ -90,7 +90,7 @@ async fn test_alter_user_interpreter() -> Result<()> {
         );
 
         let (plan, _, _) = planner.plan_sql(&test_query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "AlterUserInterpreter");
         let mut stream = executor.execute(ctx.clone()).await?;
         while let Some(_block) = stream.next().await {}

--- a/src/query/service/tests/it/interpreters/interpreter_user_create.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_user_create.rs
@@ -26,7 +26,7 @@ async fn test_create_user_interpreter() -> Result<()> {
 
     let query = "CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'";
     let (plan, _, _) = planner.plan_sql(query).await?;
-    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
     assert_eq!(executor.name(), "CreateUserInterpreter");
     let mut stream = executor.execute(ctx.clone()).await?;
     while let Some(_block) = stream.next().await {}

--- a/src/query/service/tests/it/interpreters/interpreter_user_drop.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_user_drop.rs
@@ -33,7 +33,7 @@ async fn test_drop_user_interpreter() -> Result<()> {
     {
         let query = "DROP USER 'test'@'localhost'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropUserInterpreter");
         let ret = executor.execute(ctx.clone()).await;
         assert!(ret.is_err())
@@ -42,7 +42,7 @@ async fn test_drop_user_interpreter() -> Result<()> {
     {
         let query = "DROP USER IF EXISTS 'test'@'localhost'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropUserInterpreter");
         let ret = executor.execute(ctx.clone()).await;
         assert!(ret.is_ok())
@@ -69,7 +69,7 @@ async fn test_drop_user_interpreter() -> Result<()> {
 
         let query = "DROP USER 'test'@'localhost'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropUserInterpreter");
         executor.execute(ctx.clone()).await?;
     }

--- a/src/query/service/tests/it/interpreters/interpreter_user_stage.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_user_stage.rs
@@ -31,7 +31,7 @@ async fn test_user_stage_interpreter() -> Result<()> {
     {
         let query = "CREATE STAGE test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z')";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CreateUserStageInterpreter");
         let mut stream = executor.execute(ctx.clone()).await?;
         while let Some(_block) = stream.next().await {}
@@ -41,7 +41,7 @@ async fn test_user_stage_interpreter() -> Result<()> {
     {
         let query = "DESC STAGE test_stage";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let mut stream = executor.execute(ctx.clone()).await?;
         let mut blocks = vec![];
 
@@ -76,7 +76,7 @@ async fn test_user_stage_interpreter() -> Result<()> {
         quota_api.set_quota(&quota, None).await?;
         let query = "CREATE STAGE test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z')";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CreateUserStageInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert!(res.is_err());
@@ -90,7 +90,7 @@ async fn test_user_stage_interpreter() -> Result<()> {
     {
         let query = "DROP STAGE if exists test_stage";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropUserStageInterpreter");
 
         let mut stream = executor.execute(ctx.clone()).await?;

--- a/src/query/service/tests/it/interpreters/interpreter_user_udf_alter.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_user_udf_alter.rs
@@ -30,7 +30,7 @@ async fn test_alter_udf_interpreter() -> Result<()> {
     {
         let query = "CREATE FUNCTION IF NOT EXISTS isnotempty AS (p) -> not(is_null(p)) DESC = 'This is a description'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CreateUserUDFInterpreter");
         let mut stream = executor.execute(ctx.clone()).await?;
         while let Some(_block) = stream.next().await {}
@@ -47,7 +47,7 @@ async fn test_alter_udf_interpreter() -> Result<()> {
     {
         let query = "ALTER FUNCTION isnotempty AS (d) -> not(is_not_null(d)) DESC = 'This is a new description'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "AlterUserUDFInterpreter");
 
         let mut stream = executor.execute(ctx.clone()).await?;

--- a/src/query/service/tests/it/interpreters/interpreter_user_udf_create.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_user_udf_create.rs
@@ -31,7 +31,7 @@ async fn test_create_udf_interpreter() -> Result<()> {
     {
         let query = "CREATE FUNCTION IF NOT EXISTS isnotempty AS (p) -> not(is_null(p)) DESC = 'This is a description'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CreateUserUDFInterpreter");
         let mut stream = executor.execute(ctx.clone()).await?;
         while let Some(_block) = stream.next().await {}
@@ -49,7 +49,7 @@ async fn test_create_udf_interpreter() -> Result<()> {
     {
         let query = "CREATE FUNCTION IF NOT EXISTS isnotempty AS (p) -> not(is_null(p)) DESC = 'This is a description'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         executor.execute(ctx.clone()).await?;
 
         let udf = UserApiProvider::instance()
@@ -66,7 +66,7 @@ async fn test_create_udf_interpreter() -> Result<()> {
         let query =
             "CREATE FUNCTION isnotempty AS (p) -> not(is_null(p)) DESC = 'This is a description'";
         let (plan, _, _) = planner.plan_sql(query).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let r = executor.execute(ctx.clone()).await;
         assert!(r.is_err());
         let e = r.err();

--- a/src/query/service/tests/it/interpreters/interpreter_user_udf_drop.rs
+++ b/src/query/service/tests/it/interpreters/interpreter_user_udf_drop.rs
@@ -34,7 +34,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
 
     {
         let (plan, _, _) = planner.plan_sql(CREATE_UDF).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         let mut stream = executor.execute(ctx.clone()).await?;
         while let Some(_block) = stream.next().await {}
         let udf = UserApiProvider::instance()
@@ -49,7 +49,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
 
     {
         let (plan, _, _) = planner.plan_sql(DROP_UDF).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropUserUDFInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert!(res.is_ok());
@@ -57,7 +57,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
 
     {
         let (plan, _, _) = planner.plan_sql(DROP_UDF_IF_EXISTS).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropUserUDFInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert!(res.is_ok());
@@ -65,7 +65,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
 
     {
         let (plan, _, _) = planner.plan_sql(DROP_UDF).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropUserUDFInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert!(res.is_err());
@@ -73,7 +73,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
 
     {
         let (plan, _, _) = planner.plan_sql(CREATE_UDF).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "CreateUserUDFInterpreter");
         let mut stream = executor.execute(ctx.clone()).await?;
         while let Some(_block) = stream.next().await {}
@@ -89,7 +89,7 @@ async fn test_drop_udf_interpreter() -> Result<()> {
 
     {
         let (plan, _, _) = planner.plan_sql(DROP_UDF_IF_EXISTS).await?;
-        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+        let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
         assert_eq!(executor.name(), "DropUserUDFInterpreter");
         let res = executor.execute(ctx.clone()).await;
         assert!(res.is_ok());

--- a/src/query/service/tests/it/storages/fuse/table.rs
+++ b/src/query/service/tests/it/storages/fuse/table.rs
@@ -273,7 +273,7 @@ async fn test_fuse_table_optimize() -> Result<()> {
     let query = format!("optimize table {}.{} compact", db_name, tbl_name);
 
     let (plan, _, _) = planner.plan_sql(&query).await?;
-    let interpreter = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let interpreter = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
 
     // `PipelineBuilder` will parallelize the table reading according to value of setting `max_threads`,
     // and `Table::read` will also try to de-queue read jobs preemptively. thus, the number of blocks

--- a/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
+++ b/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
@@ -410,7 +410,7 @@ pub async fn expects_ok(
 pub async fn execute_query(ctx: Arc<QueryContext>, query: &str) -> Result<SendableDataBlockStream> {
     let mut planner = Planner::new(ctx.clone());
     let (plan, _, _) = planner.plan_sql(query).await?;
-    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan)?;
+    let executor = InterpreterFactoryV2::get(ctx.clone(), &plan).await?;
     executor.execute(ctx.clone()).await
 }
 

--- a/src/query/service/tests/it/table_functions/numbers_table.rs
+++ b/src/query/service/tests/it/table_functions/numbers_table.rs
@@ -120,7 +120,7 @@ async fn test_limit_push_down() -> Result<()> {
         let actual = format!("{:?}", plan);
         assert_eq!(test.expect, actual, "{:#?}", test.name);
 
-        let executor = InterpreterFactory::get(ctx.clone(), plan)?;
+        let executor = InterpreterFactory::get(ctx.clone(), plan).await?;
 
         let stream = executor.execute(ctx.clone()).await?;
         let result = stream.try_collect::<Vec<_>>().await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

*  InterpreterFactoryV2.get to sync
*  InterpreterFactory.get to sync

Fixes #7702
