### PR TITLE
ci: Add fuse_compat into mergify check list

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,6 +10,8 @@ queue_rules:
       - check-success~=^build_(aarch64|x86_64)_musl$
       - check-success=test_unit
       - check-success=test_metactl
+      - check-success=fuse_compat
+      - check-success=test_compat
       # state tests
       - check-success~=^test_(stateless|stateful)_(standalone|cluster)_linux$
       # sqllogic tests


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Add fuse_compat into mergify check list