### PR TITLE
chore(query): Move privilege check to access check

### DIFF
--- a/src/query/service/src/interpreters/access/accessor.rs
+++ b/src/query/service/src/interpreters/access/accessor.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_legacy_planners::PlanNode;
 
+use crate::interpreters::access::PrivilegeAccess;
 use crate::interpreters::ManagementModeAccess;
 use crate::sessions::QueryContext;
 use crate::sql::plans::Plan;
@@ -39,7 +40,11 @@ pub struct Accessor {
 impl Accessor {
     pub fn create(ctx: Arc<QueryContext>) -> Self {
         let mut accessors: HashMap<String, Box<dyn AccessChecker>> = Default::default();
-        accessors.insert("management".to_string(), ManagementModeAccess::create(ctx));
+        accessors.insert(
+            "management".to_string(),
+            ManagementModeAccess::create(ctx.clone()),
+        );
+        accessors.insert("privilege".to_string(), PrivilegeAccess::create(ctx));
         Accessor { accessors }
     }
 

--- a/src/query/service/src/interpreters/access/mod.rs
+++ b/src/query/service/src/interpreters/access/mod.rs
@@ -14,7 +14,9 @@
 
 mod accessor;
 mod management_mode_access;
+mod privilege_access;
 
 pub use accessor::AccessChecker;
 pub use accessor::Accessor;
 pub use management_mode_access::ManagementModeAccess;
+pub use privilege_access::PrivilegeAccess;

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -1,0 +1,135 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_exception::Result;
+use common_legacy_planners::PlanNode;
+use common_meta_types::GrantObject;
+use common_meta_types::UserPrivilegeType;
+
+use crate::interpreters::access::AccessChecker;
+use crate::sessions::QueryContext;
+use crate::sql::plans::Plan;
+
+pub struct PrivilegeAccess {
+    ctx: Arc<QueryContext>,
+}
+
+impl PrivilegeAccess {
+    pub fn create(ctx: Arc<QueryContext>) -> Box<dyn AccessChecker> {
+        Box::new(PrivilegeAccess { ctx })
+    }
+}
+
+#[async_trait::async_trait]
+impl AccessChecker for PrivilegeAccess {
+    async fn check(&self, plan: &PlanNode) -> Result<()> {
+        match plan {
+            PlanNode::Empty(_) => {}
+            PlanNode::Stage(_) => {}
+            PlanNode::Broadcast(_) => {}
+            PlanNode::Remote(_) => {}
+            PlanNode::Projection(_) => {}
+            PlanNode::Expression(_) => {}
+            PlanNode::AggregatorPartial(_) => {}
+            PlanNode::AggregatorFinal(_) => {}
+            PlanNode::Filter(_) => {}
+            PlanNode::Having(_) => {}
+            PlanNode::WindowFunc(_) => {}
+            PlanNode::Sort(_) => {}
+            PlanNode::Limit(_) => {}
+            PlanNode::LimitBy(_) => {}
+            PlanNode::ReadSource(_) => {}
+            PlanNode::SubQueryExpression(_) => {}
+            PlanNode::Sink(_) => {}
+            PlanNode::Explain(_) => {}
+            PlanNode::Select(_) => {}
+            PlanNode::Insert(_) => {}
+            PlanNode::Delete(_) => {}
+        }
+        Ok(())
+    }
+
+    async fn check_new(&self, plan: &Plan) -> Result<()> {
+        match plan {
+            Plan::Query { .. } => {}
+            Plan::Explain { .. } => {}
+            Plan::Copy(_) => {}
+            Plan::Call(_) => {}
+            Plan::ShowCreateDatabase(_) => {}
+            Plan::CreateDatabase(_) => {}
+            Plan::DropDatabase(_) => {}
+            Plan::UndropDatabase(_) => {}
+            Plan::RenameDatabase(_) => {}
+            Plan::UseDatabase(_) => {}
+            Plan::ShowCreateTable(_) => {}
+            Plan::DescribeTable(_) => {}
+            Plan::CreateTable(_) => {}
+            Plan::DropTable(_) => {}
+            Plan::UndropTable(_) => {}
+            Plan::RenameTable(_) => {}
+            Plan::AlterTableClusterKey(_) => {}
+            Plan::DropTableClusterKey(_) => {}
+            Plan::ReclusterTable(_) => {}
+            Plan::TruncateTable(_) => {}
+            Plan::OptimizeTable(_) => {}
+            Plan::ExistsTable(_) => {}
+            Plan::Insert(_) => {}
+            Plan::Delete(_) => {}
+            Plan::CreateView(_) => {}
+            Plan::AlterView(_) => {}
+            Plan::DropView(plan) => {
+                self.ctx
+                    .get_current_session()
+                    .validate_privilege(
+                        &GrantObject::Database(plan.catalog.clone(), plan.database.clone()),
+                        UserPrivilegeType::Drop,
+                    )
+                    .await?;
+            }
+            Plan::AlterUser(_) => {}
+            Plan::CreateUser(_) => {}
+            Plan::DropUser(_) => {}
+            Plan::CreateUDF(_) => {}
+            Plan::AlterUDF(_) => {}
+            Plan::DropUDF(_) => {}
+            Plan::CreateRole(_) => {}
+            Plan::DropRole(_) => {}
+            Plan::GrantRole(_) => {}
+            Plan::GrantPriv(_) => {}
+            Plan::ShowGrants(_) => {}
+            Plan::RevokePriv(_) => {}
+            Plan::RevokeRole(_) => {}
+            Plan::ListStage(_) => {}
+            Plan::CreateStage(_) => {}
+            Plan::DropStage(_) => {}
+            Plan::RemoveStage(_) => {}
+            Plan::Presign(_) => {}
+            Plan::SetVariable(_) => {}
+            Plan::Kill(_) => {}
+            Plan::CreateShare(_) => {}
+            Plan::DropShare(_) => {}
+            Plan::GrantShareObject(_) => {}
+            Plan::RevokeShareObject(_) => {}
+            Plan::AlterShareTenants(_) => {}
+            Plan::DescShare(_) => {}
+            Plan::ShowShares(_) => {}
+            Plan::ShowObjectGrantPrivileges(_) => {}
+            Plan::ShowGrantTenantsOfShare(_) => {}
+        }
+
+        Ok(())
+    }
+}

--- a/src/query/service/src/interpreters/interpreter_cluster_key_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_cluster_key_alter.rs
@@ -16,8 +16,6 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_legacy_planners::AlterTableClusterKeyPlan;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 
 use super::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -43,18 +41,6 @@ impl Interpreter for AlterTableClusterKeyInterpreter {
 
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let plan = &self.plan;
-        self.ctx
-            .get_current_session()
-            .validate_privilege(
-                &GrantObject::Table(
-                    plan.catalog.clone(),
-                    plan.database.clone(),
-                    plan.table.clone(),
-                ),
-                UserPrivilegeType::Alter,
-            )
-            .await?;
-
         let tenant = self.ctx.get_tenant();
         let catalog = self.ctx.get_catalog(&plan.catalog)?;
 

--- a/src/query/service/src/interpreters/interpreter_cluster_key_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_cluster_key_drop.rs
@@ -16,8 +16,6 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_legacy_planners::DropTableClusterKeyPlan;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 
 use super::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -43,18 +41,6 @@ impl Interpreter for DropTableClusterKeyInterpreter {
 
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let plan = &self.plan;
-        self.ctx
-            .get_current_session()
-            .validate_privilege(
-                &GrantObject::Table(
-                    plan.catalog.clone(),
-                    plan.database.clone(),
-                    plan.table.clone(),
-                ),
-                UserPrivilegeType::Alter,
-            )
-            .await?;
-
         let tenant = self.ctx.get_tenant();
         let catalog = self.ctx.get_catalog(&plan.catalog)?;
 

--- a/src/query/service/src/interpreters/interpreter_database_create.rs
+++ b/src/query/service/src/interpreters/interpreter_database_create.rs
@@ -17,8 +17,6 @@ use std::sync::Arc;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_legacy_planners::CreateDatabasePlan;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 use common_users::UserApiProvider;
 
 use crate::interpreters::Interpreter;
@@ -46,11 +44,6 @@ impl Interpreter for CreateDatabaseInterpreter {
 
     #[tracing::instrument(level = "debug", skip(self), fields(ctx.id = self.ctx.get_id().as_str()))]
     async fn execute2(&self) -> Result<PipelineBuildResult> {
-        self.ctx
-            .get_current_session()
-            .validate_privilege(&GrantObject::Global, UserPrivilegeType::Create)
-            .await?;
-
         let tenant = self.plan.tenant.clone();
         let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
         let quota = quota_api.get_quota(None).await?.data;

--- a/src/query/service/src/interpreters/interpreter_database_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_database_drop.rs
@@ -16,8 +16,6 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_legacy_planners::DropDatabasePlan;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -42,11 +40,6 @@ impl Interpreter for DropDatabaseInterpreter {
     }
 
     async fn execute2(&self) -> Result<PipelineBuildResult> {
-        self.ctx
-            .get_current_session()
-            .validate_privilege(&GrantObject::Global, UserPrivilegeType::Drop)
-            .await?;
-
         let catalog = self.ctx.get_catalog(&self.plan.catalog)?;
         catalog.drop_database(self.plan.clone().into()).await?;
 

--- a/src/query/service/src/interpreters/interpreter_database_undrop.rs
+++ b/src/query/service/src/interpreters/interpreter_database_undrop.rs
@@ -16,8 +16,6 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_legacy_planners::UndropDatabasePlan;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -43,16 +41,6 @@ impl Interpreter for UndropDatabaseInterpreter {
 
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let catalog_name = self.plan.catalog.as_str();
-        let db_name = self.plan.database.as_str();
-
-        self.ctx
-            .get_current_session()
-            .validate_privilege(
-                &GrantObject::Database(catalog_name.into(), db_name.into()),
-                UserPrivilegeType::Drop,
-            )
-            .await?;
-
         let catalog = self.ctx.get_catalog(catalog_name)?;
         catalog.undrop_database(self.plan.clone().into()).await?;
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_kill.rs
+++ b/src/query/service/src/interpreters/interpreter_kill.rs
@@ -17,8 +17,6 @@ use std::sync::Arc;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_legacy_planners::KillPlan;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -61,11 +59,6 @@ impl Interpreter for KillInterpreter {
     }
 
     async fn execute2(&self) -> Result<PipelineBuildResult> {
-        self.ctx
-            .get_current_session()
-            .validate_privilege(&GrantObject::Global, UserPrivilegeType::Super)
-            .await?;
-
         let id = &self.plan.id;
         // If press Ctrl + C, MySQL Client will create a new session and send query
         // `kill query mysql_connection_id` to server.

--- a/src/query/service/src/interpreters/interpreter_table_create_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create_v2.rs
@@ -18,8 +18,6 @@ use common_datavalues::DataField;
 use common_datavalues::DataSchemaRefExt;
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 use common_users::UserApiProvider;
 
 use crate::interpreters::InsertInterpreterV2;
@@ -51,14 +49,6 @@ impl Interpreter for CreateTableInterpreterV2 {
     }
 
     async fn execute2(&self) -> Result<PipelineBuildResult> {
-        self.ctx
-            .get_current_session()
-            .validate_privilege(
-                &GrantObject::Database(self.plan.catalog.clone(), self.plan.database.clone()),
-                UserPrivilegeType::Create,
-            )
-            .await?;
-
         let tenant = self.plan.tenant.clone();
         let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
         let quota = quota_api.get_quota(None).await?.data;

--- a/src/query/service/src/interpreters/interpreter_table_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_table_drop.rs
@@ -18,8 +18,6 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_legacy_planners::DropTablePlan;
 use common_legacy_planners::TruncateTablePlan;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -53,14 +51,6 @@ impl Interpreter for DropTableInterpreter {
             .get_table(catalog_name, db_name, tbl_name)
             .await
             .ok();
-
-        self.ctx
-            .get_current_session()
-            .validate_privilege(
-                &GrantObject::Database(catalog_name.into(), db_name.into()),
-                UserPrivilegeType::Drop,
-            )
-            .await?;
 
         if let Some(table) = &tbl {
             if table.get_table_info().engine() == VIEW_ENGINE {

--- a/src/query/service/src/interpreters/interpreter_table_truncate.rs
+++ b/src/query/service/src/interpreters/interpreter_table_truncate.rs
@@ -16,8 +16,6 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_legacy_planners::TruncateTablePlan;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -45,14 +43,6 @@ impl Interpreter for TruncateTableInterpreter {
         let catalog_name = self.plan.catalog.as_str();
         let db_name = self.plan.database.as_str();
         let tbl_name = self.plan.table.as_str();
-
-        self.ctx
-            .get_current_session()
-            .validate_privilege(
-                &GrantObject::Table(catalog_name.into(), db_name.into(), tbl_name.into()),
-                UserPrivilegeType::Delete,
-            )
-            .await?;
 
         let tbl = self.ctx.get_table(catalog_name, db_name, tbl_name).await?;
         tbl.truncate(self.ctx.clone(), self.plan.clone()).await?;

--- a/src/query/service/src/interpreters/interpreter_table_undrop.rs
+++ b/src/query/service/src/interpreters/interpreter_table_undrop.rs
@@ -16,8 +16,6 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_legacy_planners::UndropTablePlan;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -43,17 +41,6 @@ impl Interpreter for UndropTableInterpreter {
 
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let catalog_name = self.plan.catalog.as_str();
-        let db_name = self.plan.database.as_str();
-
-        // shall we add UserPrivilege::Type::Undrop ?
-        self.ctx
-            .get_current_session()
-            .validate_privilege(
-                &GrantObject::Database(catalog_name.into(), db_name.into()),
-                UserPrivilegeType::Drop,
-            )
-            .await?;
-
         let catalog = self.ctx.get_catalog(catalog_name)?;
         catalog.undrop_table(self.plan.clone().into()).await?;
 

--- a/src/query/service/src/interpreters/interpreter_view_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_view_alter.rs
@@ -22,8 +22,6 @@ use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::DropTableReq;
 use common_meta_app::schema::TableMeta;
 use common_meta_app::schema::TableNameIdent;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -49,15 +47,6 @@ impl Interpreter for AlterViewInterpreter {
     }
 
     async fn execute2(&self) -> Result<PipelineBuildResult> {
-        // check privilige
-        self.ctx
-            .get_current_session()
-            .validate_privilege(
-                &GrantObject::Database(self.plan.catalog.clone(), self.plan.database.clone()),
-                UserPrivilegeType::Create,
-            )
-            .await?;
-
         // check whether view has exists
         if !self
             .ctx

--- a/src/query/service/src/interpreters/interpreter_view_create.rs
+++ b/src/query/service/src/interpreters/interpreter_view_create.rs
@@ -21,8 +21,6 @@ use common_legacy_planners::CreateViewPlan;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::TableMeta;
 use common_meta_app::schema::TableNameIdent;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -48,15 +46,6 @@ impl Interpreter for CreateViewInterpreter {
     }
 
     async fn execute2(&self) -> Result<PipelineBuildResult> {
-        // check privilige
-        self.ctx
-            .get_current_session()
-            .validate_privilege(
-                &GrantObject::Database(self.plan.catalog.clone(), self.plan.database.clone()),
-                UserPrivilegeType::Create,
-            )
-            .await?;
-
         // check whether view has exists
         if self
             .ctx

--- a/src/query/service/src/interpreters/interpreter_view_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_view_drop.rs
@@ -19,8 +19,6 @@ use common_exception::Result;
 use common_legacy_planners::DropViewPlan;
 use common_meta_app::schema::DropTableReq;
 use common_meta_app::schema::TableNameIdent;
-use common_meta_types::GrantObject;
-use common_meta_types::UserPrivilegeType;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -54,14 +52,6 @@ impl Interpreter for DropViewInterpreter {
             .get_table(&catalog_name, &db_name, &viewname)
             .await
             .ok();
-
-        self.ctx
-            .get_current_session()
-            .validate_privilege(
-                &GrantObject::Database(catalog_name.clone(), db_name.clone()),
-                UserPrivilegeType::Drop,
-            )
-            .await?;
 
         if let Some(table) = &tbl {
             if table.get_table_info().engine() != VIEW_ENGINE {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Move privilege checks from runtime `execute2` to access check.
`access/accessor` is a factory for all the checks now:
* management mode check
* privileges check
* shared table check?

It needs to bind the meta information in the binder.

Fixes #7697
