### PR TITLE
fix(planner): Fix `EXPLAIN AST` for invalid query

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -212,6 +212,8 @@ impl AccessChecker for PrivilegeAccess {
             Plan::ShowShares(_) => {}
             Plan::ShowObjectGrantPrivileges(_) => {}
             Plan::ShowGrantTenantsOfShare(_) => {}
+            Plan::ExplainAst { .. } => {}
+            Plan::ExplainSyntax { .. } => {}
         }
 
         Ok(())

--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -39,10 +39,10 @@ impl InterpreterFactory {
     pub async fn get(ctx: Arc<QueryContext>, plan: PlanNode) -> Result<Arc<dyn Interpreter>> {
         // Check the access permission.
         let access_checker = Accessor::create(ctx.clone());
-        access_checker
-            .check(&plan)
-            .await
-            .map(|e| error!("Access.denied(v1): {:?}", e))?;
+        access_checker.check(&plan).await.map_err(|e| {
+            error!("Access.denied(v1): {:?}", e);
+            e
+        })?;
 
         let inner = Self::create_interpreter(ctx.clone(), &plan)?;
         let query_kind = plan.name().to_string();

--- a/src/query/service/src/sql/planner/format/display_plan.rs
+++ b/src/query/service/src/sql/planner/format/display_plan.rs
@@ -26,6 +26,8 @@ impl Plan {
                 let result = plan.format_indent()?;
                 Ok(format!("{:?}:\n{}", kind, result))
             }
+            Plan::ExplainAst { .. } => Ok("ExplainAst".to_string()),
+            Plan::ExplainSyntax { .. } => Ok("ExplainSyntax".to_string()),
 
             Plan::Copy(plan) => Ok(format!("{:?}", plan)),
 

--- a/tests/logictest/suites/mode/standalone/explain/explain.test
+++ b/tests/logictest/suites/mode/standalone/explain/explain.test
@@ -498,6 +498,21 @@ CreateUser (children 3)
 ├── AuthType sha256_password
 └── Password "new_password"
 
+statement query T
+explain ast select unknown_table.a + 1 from unknown_table1;
+
+----
+Query (children 1)
+└── QueryBody (children 1)
+    └── SelectQuery (children 2)
+        ├── SelectList (children 1)
+        │   └── Target (children 1)
+        │       └── Function + (children 2)
+        │           ├── ColumnIdentifier unknown_table.a
+        │           └── Literal Integer(1)
+        └── TableList (children 1)
+            └── TableIdentifier unknown_table1
+
 statement ok
 drop table t1;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

For the invalid queries like `select * from table_not_exists`, we should allow displaying the parsing results of the queries with `EXPLAIN AST` instead of raising an error.
