### PR TITLE
chore: bump deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,12 +96,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
-
-[[package]]
 name = "array-init-cursor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,7 +362,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "bitflags",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-util",
  "http",
  "http-body",
@@ -380,8 +374,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde",
- "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
@@ -397,7 +389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f0c0a60006f2a293d82d571f635042a72edf927539b7685bd62d361963839b"
 dependencies = [
  "async-trait",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-util",
  "http",
  "http-body",
@@ -704,9 +696,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "bzip2"
@@ -1170,7 +1162,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "common-arrow",
- "octocrab",
  "paste",
  "prost 0.10.4",
  "serde",
@@ -1229,7 +1220,7 @@ dependencies = [
  "blake3",
  "bstr",
  "bumpalo",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "chrono-tz",
  "common-arrow",
  "common-datablocks",
@@ -1275,7 +1266,7 @@ dependencies = [
  "base64 0.13.0",
  "bstr",
  "bumpalo",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "comfy-table",
  "common-arrow",
  "common-ast",
@@ -1371,7 +1362,7 @@ name = "common-io"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "chrono",
  "chrono-tz",
  "common-exception",
@@ -1542,7 +1533,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "common-base",
  "common-exception",
  "common-grpc",
@@ -1981,7 +1972,6 @@ dependencies = [
  "common-datavalues",
  "common-exception",
  "common-io",
- "csv-async",
  "futures",
  "opendal",
  "parking_lot 0.12.1",
@@ -2034,10 +2024,6 @@ dependencies = [
 [[package]]
 name = "common-workspace-hack"
 version = "0.1.0"
-dependencies = [
- "axum",
- "openssl-src",
-]
 
 [[package]]
 name = "concurrent-queue"
@@ -2357,21 +2343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv-async"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19b33b32fd48f83388821bd8f534b59e1b1ffd5c6c83771d1b23abd3dac2685"
-dependencies = [
- "bstr",
- "cfg-if",
- "csv-core",
- "futures",
- "itoa 1.0.3",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "csv-core"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,7 +2483,7 @@ dependencies = [
  "bit-vec",
  "bumpalo",
  "byteorder",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "chrono",
  "chrono-tz",
  "clap 3.2.22",
@@ -2583,7 +2554,6 @@ dependencies = [
  "nom",
  "num",
  "num_cpus",
- "octocrab",
  "once_cell",
  "opendal",
  "opensrv-mysql",
@@ -2763,12 +2733,6 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "downcast"
@@ -3118,11 +3082,10 @@ checksum = "ee1b05cbd864bcaecbd3455d6d967862d446e4ebfc3c2e5e5b9841e53cba6673"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -3526,7 +3489,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -3648,7 +3611,7 @@ checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.0",
  "bitflags",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "headers-core",
  "http",
  "httpdate",
@@ -3767,7 +3730,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "fnv",
  "itoa 1.0.3",
 ]
@@ -3778,7 +3741,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "http",
  "pin-project-lite",
 ]
@@ -3833,7 +3796,7 @@ version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -3882,27 +3845,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "hyper",
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "hyperx"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5617e92fc2f2501c3e2bc6ce547cad841adba2bae5b921c7e52510beca6d084c"
-dependencies = [
- "base64 0.13.0",
- "bytes 1.1.0",
- "http",
- "httpdate",
- "language-tags",
- "mime",
- "percent-encoding",
- "unicase",
 ]
 
 [[package]]
@@ -3926,6 +3873,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -4043,9 +4000,9 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -4157,12 +4114,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,9 +4203,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "libgit2-sys"
@@ -4632,7 +4583,7 @@ version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a30ba6d97eb198c5e8a35d67d5779d6680cca35652a60ee90fc23dc431d4fde8"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "encoding_rs",
  "futures-util",
  "http",
@@ -4677,7 +4628,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456207bb9636a0fdade67a64cea7bdebe6730c3c16ee5e34f2c481838ee5a39e"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "crossbeam",
  "flate2",
  "futures-core",
@@ -4715,7 +4666,7 @@ dependencies = [
  "bitflags",
  "bitvec",
  "byteorder",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "cc",
  "chrono",
  "cmake",
@@ -4978,33 +4929,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "octocrab"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3731cf8af31e9df81c7f529d3907f8a01c6ffea0cb8a989a637f66a9201a23"
-dependencies = [
- "arc-swap",
- "async-trait",
- "base64 0.13.0",
- "bytes 1.1.0",
- "chrono",
- "hyperx",
- "jsonwebtoken",
- "once_cell",
- "reqwest",
- "secrecy",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "snafu",
- "url",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "oorandom"
@@ -5030,7 +4958,7 @@ dependencies = [
  "async-trait",
  "backon 0.2.0",
  "base64 0.13.0",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "flagset",
  "futures",
  "hdrs",
@@ -5063,7 +4991,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "byte-unit",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "clap 3.2.22",
  "derive_more",
  "futures",
@@ -5411,9 +5339,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
@@ -5582,7 +5510,7 @@ checksum = "c4216504241ea26ae80929e341c5b1b6641c324a3ba99c22ea8f4b961a789e04"
 dependencies = [
  "async-compression",
  "async-trait",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-util",
  "headers",
  "http",
@@ -5841,7 +5769,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "prost-derive 0.10.1",
 ]
 
@@ -5851,7 +5779,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "prost-derive 0.11.0",
 ]
 
@@ -5861,7 +5789,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "cfg-if",
  "cmake",
  "heck",
@@ -5909,7 +5837,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "prost 0.10.4",
 ]
 
@@ -5919,7 +5847,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "prost 0.11.0",
 ]
 
@@ -6192,7 +6120,7 @@ dependencies = [
  "anyhow",
  "backon 0.1.0",
  "base64 0.13.0",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "dirs",
  "form_urlencoded",
  "hex",
@@ -6214,12 +6142,12 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64 0.13.0",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -6231,11 +6159,11 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "mime_guess",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -6556,15 +6484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secrecy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6754,15 +6673,6 @@ dependencies = [
  "indexmap",
  "itoa 1.0.3",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_path_to_error"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d"
-dependencies = [
  "serde",
 ]
 
@@ -7004,29 +6914,6 @@ name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
-
-[[package]]
-name = "snafu"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2"
-dependencies = [
- "backtrace",
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "snailquote"
@@ -7489,7 +7376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
 dependencies = [
  "autocfg 1.1.0",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "libc",
  "memchr",
  "mio",
@@ -7563,7 +7450,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -7590,7 +7477,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.13.0",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-core",
  "futures-util",
  "h2",
@@ -7625,7 +7512,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.13.0",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-core",
  "futures-util",
  "h2",
@@ -7666,7 +7553,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1d786fcf313b48f1aac280142eae249f3c03495355c7906aa49872a41955015"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "prost 0.10.4",
  "prost-types 0.10.1",
  "tokio",
@@ -7702,7 +7589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
 dependencies = [
  "bitflags",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-core",
  "futures-util",
  "http",
@@ -7854,7 +7741,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna",
+ "idna 0.2.3",
  "ipnet",
  "lazy_static",
  "log",
@@ -7899,7 +7786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -8062,12 +7949,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.3.0",
  "percent-encoding",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,7 +3755,8 @@ checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 [[package]]
 name = "http-types"
 version = "2.12.0"
-source = "git+https://github.com/Xuanwo/http-types?rev=106fc6d#106fc6d57c339334d864ac4378678fc351abb852"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ object = { opt-level = 3 }
 rustc-demangle = { opt-level = 3 }
 
 [patch.crates-io]
-# http-types doesn't play well with the new errors api.
-# This fork address this problem, and should be removed once we upgrade to
-# new toolchain.
-http-types = { git = "https://github.com/Xuanwo/http-types", rev = "106fc6d" }
+# If there are dependencies that need patching, they can be listed below.
+# For example:
+# http-types = { git = "https://github.com/Xuanwo/http-types", rev = "106fc6d" }

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -47,16 +47,16 @@ databend-meta = { path = "../meta/service" }
 databend-query = { path = "../query/service" }
 
 # Crates.io dependencies
-anyhow = "1.0.64"
-clap = { version = "3.2.5", features = ["derive", "env"] }
+anyhow = "1.0.65"
+clap = { version = "3.2.22", features = ["derive", "env"] }
 openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.2" }
 sentry = "0.27.0"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
-tokio-stream = "0.1.9"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
+tokio-stream = "0.1.10"
 tonic = "0.7.2"
-tracing = "0.1.35"
-url = "2.2.2"
+tracing = "0.1.36"
+url = "2.3.1"
 
 [[bin]]
 name = "databend-meta"

--- a/src/common/arrow/Cargo.toml
+++ b/src/common/arrow/Cargo.toml
@@ -39,7 +39,7 @@ arrow = { package = "arrow2", version = "0.14.0", default-features = false, feat
     "io_parquet_compression",
 ] }
 arrow-format = { version = "0.7.0", features = ["flight-data", "flight-service", "ipc"] }
-futures = "0.3.21"
+futures = "0.3.24"
 parquet2 = { version = "0.16.3", default_features = false }
 
 [dev-dependencies]

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -26,24 +26,24 @@ common-exception = { path = "../exception" }
 # Github dependencies
 
 # Crates.io dependencies
-async-trait = "0.1.56"
-ctrlc = { version = "3.2.2", features = ["termination"] }
-futures = "0.3.21"
-libc = "0.2.126"
+async-trait = "0.1.57"
+ctrlc = { version = "3.2.3", features = ["termination"] }
+futures = "0.3.24"
+libc = "0.2.133"
 num_cpus = "1.13.1"
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 parking_lot = "0.12.1"
-pprof = { version = "0.10.0", features = [
+pprof = { version = "0.10.1", features = [
     "flamegraph",
     "protobuf-codec",
     "protobuf",
 ] }
-serde = { version = "1.0.137", features = ["derive"] }
+serde = { version = "1.0.144", features = ["derive"] }
 tikv-jemalloc-ctl = { version = "0.4.2", optional = true }
 tikv-jemalloc-sys = "0.4.3"
-tokio = { version = "1.19.2", features = ["full"] }
-tracing = "0.1.35"
+tokio = { version = "1.21.1", features = ["full"] }
+tracing = "0.1.36"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 
 [dev-dependencies]
-anyhow = "1.0.64"
+anyhow = "1.0.65"

--- a/src/common/building/Cargo.toml
+++ b/src/common/building/Cargo.toml
@@ -11,9 +11,9 @@ doctest = false
 test = false
 
 [dependencies]
-anyhow = "1.0.64"
+anyhow = "1.0.65"
 cargo-license = "0.5.1"
 cargo_metadata = "0.15.0"
 git2 = { version = "0.14.4", default-features = false }
-tracing = "0.1.35"
-vergen = "7.2.1"
+tracing = "0.1.36"
+vergen = "7.4.2"

--- a/src/common/cache/Cargo.toml
+++ b/src/common/cache/Cargo.toml
@@ -21,9 +21,9 @@ common-exception = { path = "../exception" }
 # Github dependencies
 
 # Crates.io dependencies
-filetime = "0.2.16"
+filetime = "0.2.17"
 ritelinked = { version = "0.3.2", default-features = false, features = ["ahash", "inline-more"] }
-tracing = "0.1.35"
+tracing = "0.1.36"
 walkdir = "2.3.2"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]

--- a/src/common/contexts/Cargo.toml
+++ b/src/common/contexts/Cargo.toml
@@ -11,5 +11,5 @@ test = false
 [dependencies]
 common-base = { path = "../base" }
 
-async-trait = "0.1.56"
+async-trait = "0.1.57"
 opendal = { version = "0.17.1", features = ["layers-retry"] }

--- a/src/common/exception/Cargo.toml
+++ b/src/common/exception/Cargo.toml
@@ -13,15 +13,14 @@ test = false
 [dependencies] # In alphabetical order
 common-arrow = { path = "../arrow" }
 
-anyhow = "1.0.64"
+anyhow = "1.0.65"
 bincode = { version = "2.0.0-rc.1", features = ["serde", "std", "alloc"] }
-octocrab = "0.16.0"
-paste = "1.0.7"
+paste = "1.0.9"
 prost = "0.10.4"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 thiserror = "1"
-time = "0.3.10"
+time = "0.3.14"
 tonic = "0.7.2"
 
 # Github dependencies

--- a/src/common/exception/src/exception_into.rs
+++ b/src/common/exception/src/exception_into.rs
@@ -179,13 +179,6 @@ impl From<prost::EncodeError> for ErrorCode {
     }
 }
 
-// ===  octocrab error ===
-impl From<octocrab::Error> for ErrorCode {
-    fn from(error: octocrab::Error) -> Self {
-        ErrorCode::NetworkRequestError(format!("octocrab error, cause: {}", error))
-    }
-}
-
 // ===  ser/de to/from tonic::Status ===
 #[derive(thiserror::Error, serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SerializedError {

--- a/src/common/grpc/Cargo.toml
+++ b/src/common/grpc/Cargo.toml
@@ -19,13 +19,13 @@ common-exception = { path = "../exception" }
 
 # Crates.io dependencies
 anyerror = "=0.1.7"
-hyper = "0.14.19"
+hyper = "0.14.20"
 jwt-simple = "0.11.0"
-once_cell = "1.12.0"
-serde = { version = "1.0.137", features = ["derive"] }
+once_cell = "1.15.0"
+serde = { version = "1.0.144", features = ["derive"] }
 thiserror = "1"
 tonic = { version = "0.7.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
-tracing = "0.1.35"
+tracing = "0.1.36"
 trust-dns-resolver = { version = "0.21.2", features = ["system-config"] }
 
 [build-dependencies]

--- a/src/common/http/Cargo.toml
+++ b/src/common/http/Cargo.toml
@@ -23,11 +23,11 @@ common-exception = { path = "../exception" }
 # Github dependencies
 
 # Crates.io dependencies
-futures = "0.3.21"
-poem = { version = "1.3.31", features = ["rustls"] }
-serde = { version = "1.0.137", features = ["derive"] }
+futures = "0.3.24"
+poem = { version = "1.3.42", features = ["rustls"] }
+serde = { version = "1.0.144", features = ["derive"] }
 tempfile = { version = "3.3.0", optional = true }
-tracing = "0.1.35"
+tracing = "0.1.36"
 
 [dev-dependencies]
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.3.0"

--- a/src/common/io/Cargo.toml
+++ b/src/common/io/Cargo.toml
@@ -18,14 +18,14 @@ common-exception = { path = "../exception" }
 
 # Crates.io dependencies
 bincode = { version = "2.0.0-rc.1", features = ["serde", "std"] }
-bytes = "1.1.0"
-chrono = "0.4.20"
-chrono-tz = "0.6.1"
-futures = "0.3.21"
+bytes = "1.2.1"
+chrono = "0.4.22"
+chrono-tz = "0.6.3"
+futures = "0.3.24"
 lexical-core = "0.8.5"
 micromarshal = "0.1.0"
-serde = { version = "1.0.137", features = ["derive"] }
-time = "0.3.10"
+serde = { version = "1.0.144", features = ["derive"] }
+time = "0.3.14"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/src/common/macros/Cargo.toml
+++ b/src/common/macros/Cargo.toml
@@ -11,6 +11,6 @@ doctest = false
 test = false
 
 [dependencies]
-proc-macro2 = "1.0.40"
-quote = "1.0.20"
-syn = { version = "1.0.98", features = ["full"] }
+proc-macro2 = "1.0.43"
+quote = "1.0.21"
+syn = { version = "1.0.100", features = ["full"] }

--- a/src/common/metrics/Cargo.toml
+++ b/src/common/metrics/Cargo.toml
@@ -17,16 +17,16 @@ common-exception = { path = "../exception" }
 # Crates.io dependencies
 metrics = "0.19.0"
 metrics-exporter-prometheus = { version = "0.10.0", default-features = false }
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 parking_lot = "0.12.1"
 prometheus-parse = "0.2.3"
-serde = { version = "1.0.137", features = ["derive"] }
-tracing = "0.1.35"
+serde = { version = "1.0.144", features = ["derive"] }
+tracing = "0.1.36"
 
 [dev-dependencies]
-anyhow = "1.0.64"
+anyhow = "1.0.65"
 
 [dev-dependencies.tokio]
 default-features = false
 features = ["io-util", "net", "sync", "rt-multi-thread", "macros"]
-version = "1.19.2"
+version = "1.21.1"

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -14,15 +14,15 @@ common-base = { path = "../base" }
 common-contexts = { path = "../contexts" }
 common-exception = { path = "../exception" }
 
-anyhow = "1.0.64"
+anyhow = "1.0.65"
 backon = "0.1.0"
 globiter = "0.1.0"
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 opendal = { version = "0.17.1", features = [
     "layers-retry",
     "layers-tracing",
     "layers-metrics",
     "compress",
 ] }
-percent-encoding = "2.1.0"
-serde = { version = "1.0.137", features = ["derive"] }
+percent-encoding = "2.2.0"
+serde = { version = "1.0.144", features = ["derive"] }

--- a/src/common/tracing/Cargo.toml
+++ b/src/common/tracing/Cargo.toml
@@ -19,16 +19,16 @@ common-base = { path = "../base" }
 common-exception = { path = "../exception" }
 
 # Crates.io dependencies
-console-subscriber = { version = "0.1.6", optional = true }
-once_cell = "1.12.0"
+console-subscriber = { version = "0.1.8", optional = true }
+once_cell = "1.15.0"
 opentelemetry = { version = "0.17.0", default-features = false, features = ["trace", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio"] }
 sentry-tracing = "0.27.0"
-serde = { version = "1.0.140", features = ["derive"] }
+serde = { version = "1.0.144", features = ["derive"] }
 tonic = "0.7.2"
-tracing = "0.1.35"
+tracing = "0.1.36"
 tracing-appender = "0.2.2"
-tracing-bunyan-formatter = "0.3.2"
+tracing-bunyan-formatter = "0.3.3"
 tracing-log = "0.1.3"
-tracing-opentelemetry = "0.17.3"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter", "ansi"] }
+tracing-opentelemetry = "0.17.4"
+tracing-subscriber = { version = "0.3.15", features = ["env-filter", "ansi"] }

--- a/src/meta/api/Cargo.toml
+++ b/src/meta/api/Cargo.toml
@@ -22,11 +22,11 @@ common-proto-conv = { path = "../proto-conv" }
 common-protos = { path = "../protos" }
 common-tracing = { path = "../../common/tracing" }
 
-anyhow = "1.0.64"
-async-trait = "0.1.56"
+anyhow = "1.0.65"
+async-trait = "0.1.57"
 enumflags2 = { version = "0.7.5", features = ["serde"] }
 maplit = "1.0.2"
-serde_json = "1.0.81"
+serde_json = "1.0.85"
 thiserror = "1"
 tonic = { version = "0.7.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
-tracing = "0.1.35"
+tracing = "0.1.36"

--- a/src/meta/app/Cargo.toml
+++ b/src/meta/app/Cargo.toml
@@ -18,7 +18,7 @@ enumflags2 = { version = "0.7.5", features = ["serde"] }
 maplit = "1.0.2"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
-serde = { version = "1.0.137", features = ["derive", "rc"] }
+serde = { version = "1.0.144", features = ["derive", "rc"] }
 
 [build-dependencies]
 common-building = { path = "../../common/building" }

--- a/src/meta/client/Cargo.toml
+++ b/src/meta/client/Cargo.toml
@@ -27,17 +27,17 @@ common-protos = { path = "../protos" }
 common-tracing = { path = "../../common/tracing" }
 
 derive_more = "0.99.17"
-futures = "0.3.21"
-once_cell = "1.12.0"
+futures = "0.3.24"
+once_cell = "1.15.0"
 parking_lot = "0.12.1"
 prost = "0.10.4"
 rand = "0.8.5"
-semver = "1.0.10"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
+semver = "1.0.14"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 thiserror = "1"
 tonic = { version = "0.7.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
-tracing = "0.1.35"
+tracing = "0.1.36"
 
 [dev-dependencies]
 

--- a/src/meta/embedded/Cargo.toml
+++ b/src/meta/embedded/Cargo.toml
@@ -25,10 +25,10 @@ common-meta-types = { path = "../types" }
 common-tracing = { path = "../../common/tracing" }
 
 # Crates.io dependencies
-async-trait = "0.1.56"
-once_cell = "1.12.0"
+async-trait = "0.1.57"
+once_cell = "1.15.0"
 tempfile = "3.3.0"
-tracing = "0.1.35"
+tracing = "0.1.36"
 
 [dev-dependencies]
-anyhow = "1.0.64"
+anyhow = "1.0.65"

--- a/src/meta/proto-conv/Cargo.toml
+++ b/src/meta/proto-conv/Cargo.toml
@@ -21,11 +21,11 @@ num = "0.4.0"
 thiserror = "1"
 
 enumflags2 = { version = "0.7.5", features = ["serde"] }
-serde_json = "1.0.81"
+serde_json = "1.0.85"
 
 [build-dependencies]
 
 [dev-dependencies]
-anyhow = "1.0.64"
+anyhow = "1.0.65"
 maplit = "1.0.2"
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.3.0"

--- a/src/meta/raft-store/Cargo.toml
+++ b/src/meta/raft-store/Cargo.toml
@@ -24,20 +24,20 @@ common-meta-types = { path = "../types" }
 common-tracing = { path = "../../common/tracing" }
 
 # crates.io deps
-anyhow = "1.0.64"
-async-trait = "0.1.56"
-bytes = "1.1.0"
+anyhow = "1.0.65"
+async-trait = "0.1.57"
+bytes = "1.2.1"
 derive_more = "0.99.17"
 hostname = "0.3.1"
 maplit = "1.0.2"
 num = "0.4.0"
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 rand = "0.8.5"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
-tracing = "0.1.35"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
+tracing = "0.1.36"
 
 [dev-dependencies]
 common-base = { path = "../../common/base" }
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.3.0"
 tempfile = "3.3.0"

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -42,35 +42,35 @@ sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafus
 
 # Crates.io dependencies
 anyerror = "=0.1.7"
-anyhow = "1.0.64"
-async-trait = "0.1.56"
-clap = { version = "3.2.5", features = ["derive", "env"] }
-futures = "0.3.21"
+anyhow = "1.0.65"
+async-trait = "0.1.57"
+clap = { version = "3.2.22", features = ["derive", "env"] }
+futures = "0.3.24"
 num = "0.4.0"
-once_cell = "1.12.0"
-poem = { version = "1.3.31", features = ["rustls"] }
-prometheus = { version = "0.13.1", features = ["process"] }
+once_cell = "1.15.0"
+poem = { version = "1.3.42", features = ["rustls"] }
+prometheus = { version = "0.13.2", features = ["process"] }
 prost = "0.10.4"
-semver = "1.0.10"
-serde = { version = "1.0.137", features = ["derive"] }
+semver = "1.0.14"
+serde = { version = "1.0.144", features = ["derive"] }
 serde-bridge = "0.0.3"
-serde_json = "1.0.81"
+serde_json = "1.0.85"
 serfig = "0.0.2"
 tempfile = "3.3.0"
-tokio-stream = "0.1.9"
+tokio-stream = "0.1.10"
 tonic = { version = "0.7.2", features = ["tls"] }
 tonic-reflection = "0.4.0"
-tracing = "0.1.35"
+tracing = "0.1.36"
 tracing-appender = "0.2.2"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter", "ansi"] }
+tracing-subscriber = { version = "0.3.15", features = ["env-filter", "ansi"] }
 
 [dev-dependencies]
 async-entry = "0.3.1"
-env_logger = "0.9.0"
+env_logger = "0.9.1"
 maplit = "1.0.2"
-pretty_assertions = "1.2.1"
-regex = "1.5.6"
-reqwest = { version = "0.11.11", features = ["json"] }
+pretty_assertions = "1.3.0"
+regex = "1.6.0"
+reqwest = { version = "0.11.12", features = ["json"] }
 temp-env = "0.2.0"
 
 [build-dependencies]

--- a/src/meta/sled-store/Cargo.toml
+++ b/src/meta/sled-store/Cargo.toml
@@ -20,13 +20,13 @@ common-meta-types = { path = "../types" }
 openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.2" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
-anyhow = "1.0.64"
+anyhow = "1.0.65"
 byteorder = "1.4.3"
-once_cell = "1.12.0"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
+once_cell = "1.15.0"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 tempfile = "3.3.0"
-tracing = "0.1.35"
+tracing = "0.1.36"
 
 [dev-dependencies]
 common-base = { path = "../../common/base" }

--- a/src/meta/store/Cargo.toml
+++ b/src/meta/store/Cargo.toml
@@ -23,5 +23,5 @@ common-meta-embedded = { path = "../embedded" }
 common-meta-types = { path = "../types" }
 
 # Crates.io dependencies
-async-trait = "0.1.56"
-tracing = "0.1.35"
+async-trait = "0.1.57"
+tracing = "0.1.36"

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -18,19 +18,19 @@ openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.2" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyerror = "=0.1.7"
-chrono = "0.4.20"
+chrono = "0.4.22"
 derive_more = "0.99.17"
 enumflags2 = { version = "0.7.5", features = ["serde"] }
 hex = "0.4.3"
 maplit = "1.0.2"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 prost = "0.10.4"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
-sha1 = "0.10.1"
-sha2 = "0.10.2"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
+sha1 = "0.10.5"
+sha2 = "0.10.6"
 thiserror = "1"
 tonic = { version = "0.7.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
 
@@ -40,5 +40,5 @@ prost-build = "0.10.4"
 tonic-build = "0.7.2"
 
 [dev-dependencies]
-anyhow = "1.0.64"
-regex = "1.5.6"
+anyhow = "1.0.65"
+regex = "1.6.0"

--- a/src/query/ast/Cargo.toml
+++ b/src/query/ast/Cargo.toml
@@ -23,23 +23,23 @@ common-meta-types = { path = "../../meta/types" }
 codespan-reporting = { git = "https://github.com/brendanzab/codespan", rev = "c84116f5" }
 
 # Crates.io dependencies
-async-trait = "0.1.56"
+async-trait = "0.1.57"
 fast-float = "0.2.0"
-itertools = "0.10.3"
+itertools = "0.10.5"
 logos = "0.12.1"
 nom = "7.1.1"
 nom-rule = "0.3.0"
 pratt = "0.3.0"
 pretty = "0.11.3"
 thiserror = "1"
-url = "2.2.2"
+url = "2.3.1"
 
 [dev-dependencies]
 common-base = { path = "../../common/base" }
 criterion = "0.3"
 goldenfile = "1.4"
-pretty_assertions = "1.2.1"
-regex = "1.5.6"
+pretty_assertions = "1.3.0"
+regex = "1.6.0"
 
 [[bench]]
 name = "bench"

--- a/src/query/catalog/Cargo.toml
+++ b/src/query/catalog/Cargo.toml
@@ -24,7 +24,7 @@ common-pipeline-core = { path = "../pipeline/core" }
 common-settings = { path = "../settings" }
 common-users = { path = "../users" }
 
-async-trait = "0.1.56"
-dyn-clone = "1.0.6"
+async-trait = "0.1.57"
+dyn-clone = "1.0.9"
 opendal = { version = "0.17.1", features = ["layers-retry"] }
 parking_lot = "0.12.1"

--- a/src/query/codegen/Cargo.toml
+++ b/src/query/codegen/Cargo.toml
@@ -22,5 +22,5 @@ common-expression = { path = "../expression" }
 # https://github.com/reem/rust-ordered-float/pull/110 is released.
 itertools = "0.10"
 ordered-float = { version = "3.1.0", features = ["serde"] }
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"

--- a/src/query/config/Cargo.toml
+++ b/src/query/config/Cargo.toml
@@ -18,12 +18,12 @@ common-storage = { path = "../../common/storage" }
 common-tracing = { path = "../../common/tracing" }
 common-users = { path = "../users" }
 
-clap = { version = "3.2.5", features = ["derive", "env"] }
+clap = { version = "3.2.22", features = ["derive", "env"] }
 hex = "0.4.3"
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 opendal = { version = "0.17.1", features = ["layers-retry", "compress"], optional = true }
-semver = "1.0.10"
-serde = { version = "1.0.137", features = ["derive"] }
+semver = "1.0.14"
+serde = { version = "1.0.144", features = ["derive"] }
 serfig = "0.0.2"
 thrift = { version = "0.15.0", optional = true }
 

--- a/src/query/datablocks/Cargo.toml
+++ b/src/query/datablocks/Cargo.toml
@@ -21,12 +21,12 @@ common-io = { path = "../../common/io" }
 
 # Crates.io dependencies
 ahash = "0.7.6"
-comfy-table = "6.0.0"
+comfy-table = "6.1.0"
 parking_lot = "0.12.1"
 primitive-types = "0.11.1"
-regex = "1.5.6"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
+regex = "1.6.0"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 
 [dev-dependencies]
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.3.0"

--- a/src/query/datavalues/Cargo.toml
+++ b/src/query/datavalues/Cargo.toml
@@ -20,25 +20,25 @@ primitive-types = "0.11.1"
 # Github dependencies
 
 # Crates.io dependencies
-chrono = "0.4.20"
-chrono-tz = "0.6.1"
-dyn-clone = "1.0.6"
+chrono = "0.4.22"
+chrono-tz = "0.6.3"
+dyn-clone = "1.0.9"
 enum_dispatch = "0.3.8"
-itertools = "0.10.3"
+itertools = "0.10.5"
 lexical-core = "0.8.5"
 micromarshal = "0.1.0"
 num = "0.4.0"
-once_cell = "1.12.0"
-ordered-float = "3.0.0"
-paste = "1.0.7"
+once_cell = "1.15.0"
+ordered-float = "3.1.0"
+paste = "1.0.9"
 rand = { version = "0.8.5", features = ["small_rng"] }
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
-smallvec = { version = "1.8.0", features = ["write"] }
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
+smallvec = { version = "1.9.0", features = ["write"] }
 
 [dev-dependencies]
 criterion = "0.3"
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.3.0"
 rand = "0.8.5"
 
 [[bench]]

--- a/src/query/expression/Cargo.toml
+++ b/src/query/expression/Cargo.toml
@@ -18,7 +18,7 @@ common-exception = { path = "../../common/exception" }
 
 # Crates.io dependencies
 chrono = "0.4"
-chrono-tz = "0.6.1"
+chrono-tz = "0.6.3"
 comfy-table = "6"
 common-jsonb = { path = "../../common/jsonb" }
 educe = "0.4"

--- a/src/query/formats/Cargo.toml
+++ b/src/query/formats/Cargo.toml
@@ -19,11 +19,11 @@ common-exception = { path = "../../common/exception" }
 common-io = { path = "../../common/io" }
 
 # Crates.io dependencies
-once_cell = "1.12.0"
-serde_json = "1.0.81"
-similar-asserts = "1.2.0"
+once_cell = "1.15.0"
+serde_json = "1.0.85"
+similar-asserts = "1.4.2"
 strum = "0.24.1"
-strum_macros = "0.24.0"
+strum_macros = "0.24.3"
 
 [dev-dependencies]
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.3.0"

--- a/src/query/functions-v2/Cargo.toml
+++ b/src/query/functions-v2/Cargo.toml
@@ -20,24 +20,24 @@ common-io = { path = "../../common/io" }
 # Crates.io dependencies
 base64 = "0.13.0"
 bstr = "0.2.17"
-bumpalo = "3.10.0"
-bytes = "1.1.0"
+bumpalo = "3.11.0"
+bytes = "1.2.1"
 crc32fast = "1.3.2"
 hex = "0.4.3"
-itertools = "0.10.3"
+itertools = "0.10.5"
 match-template = "0.0.1"
 num-traits = "0.2.15"
 # TODO(andylokandy): Use the version from crates.io once
 # https://github.com/reem/rust-ordered-float/pull/110 is released.
 common-jsonb = { path = "../../common/jsonb" }
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 ordered-float = { version = "3.1.0", features = [
     "serde",
     "rand",
 ] }
 rand = { version = "0.8.5", features = ["small_rng"] }
-regex = "1.5.6"
-serde = { version = "1.0.137", features = ["derive"] }
+regex = "1.6.0"
+serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0"
 simdutf8 = "0.1.4"
 strength_reduce = "0.2.3"

--- a/src/query/functions/Cargo.toml
+++ b/src/query/functions/Cargo.toml
@@ -22,31 +22,31 @@ common-io = { path = "../../common/io" }
 base64 = "0.13.0"
 blake3 = "1.3.1"
 bstr = "0.2.17"
-bumpalo = "3.10.0"
-bytes = "1.1.0"
-chrono-tz = "0.6.1"
+bumpalo = "3.11.0"
+bytes = "1.2.1"
+chrono-tz = "0.6.3"
 crc32fast = "1.3.2"
-dyn-clone = "1.0.6"
-geo-types = "0.7.6"
+dyn-clone = "1.0.9"
+geo-types = "0.7.7"
 h3ron = "0.14.0"
 hex = "0.4.3"
-itertools = "0.10.3"
+itertools = "0.10.5"
 md5 = "0.7.0"
 memchr = "2.5.0"
 naive-cityhash = "0.2.0"
 num = "0.4.0"
 num-format = "0.4.0"
 num-traits = "0.2.15"
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 ordered-float = { version = "3.1.0", features = ["serde"] }
-pulldown-cmark = { version = "0.9.1", default-features = false }
+pulldown-cmark = { version = "0.9.2", default-features = false }
 rand = { version = "0.8.5", features = ["small_rng"] }
-regex = "1.5.6"
-rust-embed = { version = "6.4.0", features = ["debug-embed"] }
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
-sha1 = "0.10.1"
-sha2 = "0.10.2"
+regex = "1.6.0"
+rust-embed = { version = "6.4.1", features = ["debug-embed"] }
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
+sha1 = "0.10.5"
+sha2 = "0.10.6"
 simdutf8 = "0.1.4"
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "7f246e3" }
 strength_reduce = "0.2.3"
@@ -54,6 +54,6 @@ twox-hash = "1.6.3"
 uuid = { version = "1.1.2", features = ["v4"] }
 
 [dev-dependencies]
-bumpalo = "3.10.0"
+bumpalo = "3.11.0"
 float-cmp = "0.9.0"
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.3.0"

--- a/src/query/legacy-parser/Cargo.toml
+++ b/src/query/legacy-parser/Cargo.toml
@@ -14,5 +14,5 @@ common-exception = { path = "../../common/exception" }
 common-functions = { path = "../functions" }
 common-legacy-planners = { path = "../legacy-planners" }
 
-async-trait = "0.1.56"
+async-trait = "0.1.57"
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "7f246e3" }

--- a/src/query/legacy-planners/Cargo.toml
+++ b/src/query/legacy-planners/Cargo.toml
@@ -23,10 +23,10 @@ common-meta-types = { path = "../../meta/types" }
 
 # Crates.io dependencies
 bitflags = "1.3.2"
-once_cell = "1.12.0"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
+once_cell = "1.15.0"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 typetag = "0.1.8"
 
 [dev-dependencies]
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.3.0"

--- a/src/query/management/Cargo.toml
+++ b/src/query/management/Cargo.toml
@@ -24,10 +24,10 @@ common-meta-types = { path = "../../meta/types" }
 common-proto-conv = { path = "../../meta/proto-conv" }
 common-protos = { path = "../../meta/protos" }
 
-async-trait = "0.1.56"
-serde_json = "1.0.81"
+async-trait = "0.1.57"
+serde_json = "1.0.85"
 
 [dev-dependencies]
 common-meta-embedded = { path = "../../meta/embedded" }
 common-storage = { path = "../../common/storage" }
-mockall = "0.11.1"
+mockall = "0.11.2"

--- a/src/query/pipeline/core/Cargo.toml
+++ b/src/query/pipeline/core/Cargo.toml
@@ -17,16 +17,16 @@ common-datavalues = { path = "../../datavalues" }
 common-exception = { path = "../../../common/exception" }
 common-io = { path = "../../../common/io" }
 
-async-trait = "0.1.56"
-futures = "0.3.21"
-futures-util = "0.3.21"
-itertools = "0.10.3"
+async-trait = "0.1.57"
+futures = "0.3.24"
+futures-util = "0.3.24"
+itertools = "0.10.5"
 num_cpus = "1.13.1"
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 parking_lot = "0.12.1"
 petgraph = "0.6.2"
-serde = { version = "1.0.137", features = ["derive"] }
-time = "0.3.10"
+serde = { version = "1.0.144", features = ["derive"] }
+time = "0.3.14"
 
 [dev-dependencies]
-tokio = { version = "1.19.2", features = ["full"] }
+tokio = { version = "1.21.1", features = ["full"] }

--- a/src/query/pipeline/sinks/Cargo.toml
+++ b/src/query/pipeline/sinks/Cargo.toml
@@ -17,4 +17,4 @@ common-exception = { path = "../../../common/exception" }
 common-pipeline-core = { path = "../core" }
 
 async-channel = "1.7.1"
-async-trait = { version = "0.1.0", package = "async-trait-fn" }
+async-trait = { version = "0.1.57", package = "async-trait-fn" }

--- a/src/query/pipeline/sources/Cargo.toml
+++ b/src/query/pipeline/sources/Cargo.toml
@@ -24,14 +24,14 @@ common-settings = { path = "../../settings" }
 common-storage = { path = "../../../common/storage" }
 common-streams = { path = "../../streams" }
 
-async-trait = { version = "0.1.0", package = "async-trait-fn" }
+async-trait = { version = "0.1.57", package = "async-trait-fn" }
 bstr = "0.2.17"
 crossbeam-channel = "0.5.6"
 csv-core = "0.1.10"
-futures = "0.3.21"
-futures-util = "0.3.21"
+futures = "0.3.24"
+futures-util = "0.3.24"
 opendal = { version = "0.17.1", features = ["layers-retry", "compress"] }
 parking_lot = "0.12.1"
-serde_json = "1.0.81"
-similar-asserts = "1.2.0"
-tracing = "0.1.35"
+serde_json = "1.0.85"
+similar-asserts = "1.4.2"
+tracing = "0.1.36"

--- a/src/query/pipeline/transforms/Cargo.toml
+++ b/src/query/pipeline/transforms/Cargo.toml
@@ -16,5 +16,5 @@ common-exception = { path = "../../../common/exception" }
 common-legacy-planners = { path = "../../legacy-planners" }
 common-pipeline-core = { path = "../core" }
 
-async-trait = { version = "0.1.0", package = "async-trait-fn" }
-tracing = "0.1.35"
+async-trait = { version = "0.1.57", package = "async-trait-fn" }
+tracing = "0.1.36"

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -79,72 +79,71 @@ sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "7f
 
 # Crates.io dependencies
 ahash = "0.7.6"
-async-channel = "1.6.1"
+async-channel = "1.7.1"
 async-compat = "0.2.1"
 async-recursion = "1.0.0"
 async-stream = "0.3.3"
-async-trait = { version = "0.1.0", package = "async-trait-fn" }
+async-trait = { version = "0.1.57", package = "async-trait-fn" }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 backon = "0.1.0"
 base64 = "0.13.0"
 bincode = "2.0.0-rc.1"
 bit-vec = { version = "0.6.3", features = ["serde_std"] }
-bumpalo = "3.10.0"
+bumpalo = "3.11.0"
 byteorder = "1.4.3"
-bytes = "1.1.0"
-chrono = "0.4.20"
-chrono-tz = "0.6.1"
-clap = { version = "3.2.5", features = ["derive", "env"] }
-dyn-clone = "1.0.6"
+bytes = "1.2.1"
+chrono = "0.4.22"
+chrono-tz = "0.6.3"
+clap = { version = "3.2.22", features = ["derive", "env"] }
+dyn-clone = "1.0.9"
 enum_dispatch = "0.3.8"
-futures = "0.3.21"
-futures-util = "0.3.21"
-headers = "0.3.7"
+futures = "0.3.24"
+futures-util = "0.3.24"
+headers = "0.3.8"
 http = "0.2.8"
-itertools = "0.10.3"
-jwtk = "0.2.3"
-lz4 = "1.23.3"
+itertools = "0.10.5"
+jwtk = "0.2.4"
+lz4 = "1.24.0"
 metrics = "0.19.0"
 naive-cityhash = "0.2.0"
 nom = "7.1.1"
 num = "0.4.0"
 num_cpus = "1.13.1"
-octocrab = "0.16.0"
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 opendal = { version = "0.17.1", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
 opensrv-mysql = "0.2.0"
-openssl = { version = "0.10.40", features = ["vendored"] }
+openssl = { version = "0.10.41", features = ["vendored"] }
 parking_lot = "0.12.1"
-paste = "1.0.7"
+paste = "1.0.9"
 petgraph = "0.6.2"
-poem = { version = "1.3.31", features = ["rustls", "multipart", "compression"] }
+poem = { version = "1.3.42", features = ["rustls", "multipart", "compression"] }
 primitive-types = "0.11.1"
 prost = "0.10.4"
 rand = "0.8.5"
-regex = "1.5.6"
-reqwest = "0.11.11"
+regex = "1.6.0"
+reqwest = "0.11.12"
 rsa = "0.5.0"
-semver = "1.0.10"
-serde = { version = "1.0.137", features = ["derive"] }
+semver = "1.0.14"
+serde = { version = "1.0.144", features = ["derive"] }
 serde-bridge = "0.0.3"
-serde_json = "1.0.81"
-serde_repr = "0.1.8"
+serde_json = "1.0.85"
+serde_repr = "0.1.9"
 serfig = "0.0.2"
-sha1 = "0.10.1"
-sha2 = "0.10.2"
-smallvec = { version = "1.8.0", features = ["write"] }
+sha1 = "0.10.5"
+sha2 = "0.10.6"
+smallvec = { version = "1.9.0", features = ["write"] }
 snailquote = "0.3.1"
 strum = "0.24.1"
-strum_macros = "0.24.0"
+strum_macros = "0.24.3"
 tempfile = { version = "3.3.0", optional = true }
 thiserror = "1"
 threadpool = "1.8.1"
 thrift = { version = "0.15.0", optional = true }
-time = "0.3.10"
+time = "0.3.14"
 tokio-rustls = "0.23.4"
-tokio-stream = { version = "0.1.9", features = ["net"] }
+tokio-stream = { version = "0.1.10", features = ["net"] }
 tonic = "0.7.2"
-tracing = "0.1.35"
+tracing = "0.1.36"
 tracing-appender = "0.2.2"
 twox-hash = "1.6.3"
 typetag = "0.1.8"
@@ -158,13 +157,13 @@ hex = "0.4.3"
 jwt-simple = "0.11.0"
 maplit = "1.0.2"
 mysql_async = "0.30.0"
-pretty_assertions = "1.2.1"
-reqwest = { version = "0.11.11", features = ["json", "native-tls"] }
+pretty_assertions = "1.3.0"
+reqwest = { version = "0.11.12", features = ["json", "native-tls"] }
 temp-env = "0.2.0"
 tempfile = "3.3.0"
 toml = { version = "0.5.9", default-features = false }
-url = "2.2.2"
-wiremock = "0.5.13"
+url = "2.3.1"
+wiremock = "0.5.14"
 
 [build-dependencies]
 common-building = { path = "../../common/building" }

--- a/src/query/settings/Cargo.toml
+++ b/src/query/settings/Cargo.toml
@@ -16,7 +16,7 @@ common-exception = { path = "../../common/exception" }
 common-meta-types = { path = "../../meta/types" }
 common-users = { path = "../users" }
 
-futures = "0.3.21"
-itertools = "0.10.3"
+futures = "0.3.24"
+itertools = "0.10.5"
 num_cpus = "1.13.1"
 parking_lot = "0.12.1"

--- a/src/query/storages/fuse-meta/Cargo.toml
+++ b/src/query/storages/fuse-meta/Cargo.toml
@@ -18,5 +18,5 @@ common-datavalues = { path = "../../datavalues" }
 common-exception = { path = "../../../common/exception" }
 common-metrics = { path = "../../../common/metrics" }
 
-once_cell = "1.12.0"
-serde = { version = "1.0.137", features = ["derive"] }
+once_cell = "1.15.0"
+serde = { version = "1.0.144", features = ["derive"] }

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -32,14 +32,14 @@ common-storages-index = { path = "../index" }
 common-storages-util = { path = "../util" }
 common-streams = { path = "../../streams" }
 
-async-trait = { version = "0.1.0", package = "async-trait-fn" }
+async-trait = { version = "0.1.57", package = "async-trait-fn" }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
-chrono = "0.4.19"
-futures = "0.3.21"
-futures-util = "0.3.21"
+chrono = "0.4.22"
+futures = "0.3.24"
+futures-util = "0.3.24"
 opendal = { version = "0.17.1", features = ["layers-retry"] }
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
-tracing = "0.1.35"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
+tracing = "0.1.36"
 typetag = "0.1.8"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }

--- a/src/query/storages/hive-meta-store/Cargo.toml
+++ b/src/query/storages/hive-meta-store/Cargo.toml
@@ -27,4 +27,4 @@ hive-it = []
 thrift = "0.15.0"
 
 [build-dependencies]
-which = "4.2.5"
+which = "4.3.0"

--- a/src/query/storages/hive/Cargo.toml
+++ b/src/query/storages/hive/Cargo.toml
@@ -29,10 +29,10 @@ common-storages-index = { path = "../index" }
 common-storages-util = { path = "../util" }
 
 async-recursion = "1.0.0"
-async-trait = "0.1.56"
-futures = "0.3.21"
+async-trait = "0.1.57"
+futures = "0.3.24"
 opendal = { version = "0.17.1", features = ["layers-retry"] }
-serde = { version = "1.0.137", features = ["derive"] }
+serde = { version = "1.0.144", features = ["derive"] }
 thrift = "0.15.0"
-tracing = "0.1.35"
+tracing = "0.1.36"
 typetag = "0.1.8"

--- a/src/query/storages/index/Cargo.toml
+++ b/src/query/storages/index/Cargo.toml
@@ -24,5 +24,5 @@ common-pipeline-transforms = { path = "../../pipeline/transforms" }
 bincode = { version = "2.0.0-rc.1", features = ["serde", "std", "alloc"] }
 bit-vec = { version = "0.6.3", features = ["serde_std"] }
 rand = "0.8.5"
-serde = { version = "1.0.137", features = ["derive"] }
-tracing = "0.1.35"
+serde = { version = "1.0.144", features = ["derive"] }
+tracing = "0.1.36"

--- a/src/query/storages/preludes/Cargo.toml
+++ b/src/query/storages/preludes/Cargo.toml
@@ -37,26 +37,26 @@ common-tracing = { path = "../../../common/tracing" }
 common-users = { path = "../../users" }
 
 async-stream = "0.3.3"
-async-trait = { version = "0.1.0", package = "async-trait-fn" }
+async-trait = { version = "0.1.57", package = "async-trait-fn" }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
-chrono = "0.4.19"
-clap = { version = "3.2.5", features = ["derive", "env"] }
-futures = "0.3.21"
-futures-util = "0.3.21"
-itertools = "0.10.3"
+chrono = "0.4.22"
+clap = { version = "3.2.22", features = ["derive", "env"] }
+futures = "0.3.24"
+futures-util = "0.3.24"
+itertools = "0.10.5"
 num_cpus = "1.13.1"
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 opendal = { version = "0.17.1", features = ["layers-retry"] }
 parking_lot = "0.12.1"
-reqwest = "0.11.11"
-semver = "1.0.10"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
+reqwest = "0.11.12"
+semver = "1.0.14"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 serfig = "0.0.2"
 snailquote = "0.3.1"
 thrift = "0.15.0"
-time = "0.3.10"
-tracing = "0.1.35"
+time = "0.3.14"
+tracing = "0.1.36"
 typetag = "0.1.8"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 walkdir = "2.3.2"

--- a/src/query/storages/share/Cargo.toml
+++ b/src/query/storages/share/Cargo.toml
@@ -17,8 +17,8 @@ common-meta-app = { path = "../../../meta/app" }
 common-storages-util = { path = "../util" }
 
 opendal = { version = "0.17.1", features = ["layers-retry"] }
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 
 [dev-dependencies]
 goldenfile = "1.4"

--- a/src/query/storages/util/Cargo.toml
+++ b/src/query/storages/util/Cargo.toml
@@ -21,9 +21,9 @@ common-exception = { path = "../../../common/exception" }
 common-fuse-meta = { path = "../fuse-meta" }
 common-meta-api = { path = "../../../meta/api" }
 
-async-trait = { version = "0.1.0", package = "async-trait-fn" }
+async-trait = { version = "0.1.57", package = "async-trait-fn" }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
-futures-util = "0.3.21"
-once_cell = "1.12.0"
+futures-util = "0.3.24"
+once_cell = "1.15.0"
 parking_lot = "0.12.1"
-tracing = "0.1.35"
+tracing = "0.1.36"

--- a/src/query/streams/Cargo.toml
+++ b/src/query/streams/Cargo.toml
@@ -23,12 +23,12 @@ common-io = { path = "../../common/io" }
 
 # Crates.io dependencies
 async-stream = "0.3.3"
-async-trait = "0.1.56"
-chrono-tz = "0.6.1"
-futures = "0.3.21"
+async-trait = "0.1.57"
+chrono-tz = "0.6.3"
+futures = "0.3.24"
 parking_lot = "0.12.1"
 pin-project-lite = "0.2.9"
-serde_json = { version = "1.0.81", default-features = false, features = ["preserve_order"] }
+serde_json = { version = "1.0.85", default-features = false, features = ["preserve_order"] }
 tempfile = "3.3.0"
 
 [dev-dependencies]

--- a/src/query/users/Cargo.toml
+++ b/src/query/users/Cargo.toml
@@ -27,11 +27,11 @@ common-tracing = { path = "../../common/tracing" }
 # Github dependencies
 
 # Crates.io dependencies
-jwtk = "0.2.3"
-once_cell = "1.12.0"
+jwtk = "0.2.4"
+once_cell = "1.15.0"
 parking_lot = "0.12.1"
-serde = { version = "1.0.137", features = ["derive"] }
-tracing = "0.1.35"
+serde = { version = "1.0.144", features = ["derive"] }
+tracing = "0.1.36"
 
 [dev-dependencies]
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.3.0"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -4,11 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["openssl-src", "axum"]
 
 [dependencies]
-openssl-src = { version = "111.22" }
-# axum has yanked the latest version, we can remove this after
-# new version released.
-# ref: https://github.com/datafuselabs/databend/issues/6996
-axum = "=0.5.13"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Just a normal maintenance. 

The octocrab has been removed here because we no longer have a GitHub engine.

The workspace-hack will be retained and will allow us to introduce other tool hacks later.

Fixes #issue
