### PR TITLE
refactor: Delay physical scalar build to interpreter

### DIFF
--- a/src/query/ast/src/ast/statements/table.rs
+++ b/src/query/ast/src/ast/statements/table.rs
@@ -421,7 +421,7 @@ impl Display for ExistsTableStmt<'_> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Engine {
     Null,
     Memory,

--- a/src/query/service/src/interpreters/interpreter_table_create_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create_v2.rs
@@ -165,7 +165,7 @@ impl CreateTableInterpreterV2 {
     fn build_request(&self) -> Result<CreateTableReq> {
         let mut fields = Vec::with_capacity(self.plan.schema.num_fields());
         for (idx, field) in self.plan.schema.fields().clone().into_iter().enumerate() {
-            let field = if let Some(scalar) = &self.plan.field_default_exprs[idx] {
+            let field = if let Some(Some(scalar)) = &self.plan.field_default_exprs.get(idx) {
                 let mut builder = PhysicalScalarBuilder;
                 let physical_scaler = builder.build(scalar)?;
                 field.with_default_expr(Some(serde_json::to_string(&physical_scaler)?))

--- a/src/query/service/src/interpreters/interpreter_table_create_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create_v2.rs
@@ -18,6 +18,9 @@ use common_datavalues::DataField;
 use common_datavalues::DataSchemaRefExt;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_app::schema::CreateTableReq;
+use common_meta_app::schema::TableMeta;
+use common_meta_app::schema::TableNameIdent;
 use common_users::UserApiProvider;
 
 use crate::interpreters::InsertInterpreterV2;
@@ -25,6 +28,7 @@ use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
 use crate::sessions::QueryContext;
 use crate::sessions::TableContext;
+use crate::sql::executor::PhysicalScalarBuilder;
 use crate::sql::plans::create_table_v2::CreateTablePlanV2;
 use crate::sql::plans::insert::Insert;
 use crate::sql::plans::insert::InsertInputSource;
@@ -52,7 +56,7 @@ impl Interpreter for CreateTableInterpreterV2 {
         let tenant = self.plan.tenant.clone();
         let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
         let quota = quota_api.get_quota(None).await?.data;
-        let engine = self.plan.engine();
+        let engine = self.plan.engine;
         let catalog = self.ctx.get_catalog(self.plan.catalog.as_str())?;
         let tables = catalog
             .list_tables(&self.plan.tenant, &self.plan.database)
@@ -79,7 +83,7 @@ impl Interpreter for CreateTableInterpreterV2 {
 
         match engine_desc {
             Some(engine) => {
-                if !self.plan.cluster_keys.is_empty() && !engine.support_cluster_key {
+                if self.plan.cluster_key.is_some() && !engine.support_cluster_key {
                     return Err(ErrorCode::UnsupportedEngineParams(format!(
                         "Unsupported cluster key for engine: {}",
                         engine.engine_name
@@ -109,7 +113,7 @@ impl CreateTableInterpreterV2 {
         let catalog = self.ctx.get_catalog(&self.plan.catalog)?;
 
         // TODO: maybe the table creation and insertion should be a transaction, but it may require create_table support 2pc.
-        catalog.create_table(self.plan.clone().into()).await?;
+        catalog.create_table(self.build_request()?).await?;
         let table = catalog
             .get_table(tenant.as_str(), &self.plan.database, &self.plan.table)
             .await?;
@@ -149,8 +153,53 @@ impl CreateTableInterpreterV2 {
 
     async fn create_table(&self) -> Result<PipelineBuildResult> {
         let catalog = self.ctx.get_catalog(self.plan.catalog.as_str())?;
-        catalog.create_table(self.plan.clone().into()).await?;
+        catalog.create_table(self.build_request()?).await?;
 
         Ok(PipelineBuildResult::create())
+    }
+
+    /// Build CreateTableReq from CreateTablePlanV2.
+    ///
+    /// - Rebuild `DataSchema` with default exprs.
+    /// - Update cluster key of table meta.
+    fn build_request(&self) -> Result<CreateTableReq> {
+        let mut fields = Vec::with_capacity(self.plan.schema.num_fields());
+        for (idx, field) in self.plan.schema.fields().clone().into_iter().enumerate() {
+            let field = if let Some(scalar) = &self.plan.field_default_exprs[idx] {
+                let mut builder = PhysicalScalarBuilder;
+                let physical_scaler = builder.build(scalar)?;
+                field.with_default_expr(Some(serde_json::to_string(&physical_scaler)?))
+            } else {
+                field
+            };
+            fields.push(field)
+        }
+        let schema = DataSchemaRefExt::create(fields);
+
+        let mut table_meta = TableMeta {
+            schema,
+            engine: self.plan.engine.to_string(),
+            options: self.plan.options.clone(),
+            default_cluster_key: None,
+            field_comments: self.plan.field_comments.clone(),
+            drop_on: None,
+            statistics: Default::default(),
+            ..Default::default()
+        };
+        if let Some(cluster_key) = &self.plan.cluster_key {
+            table_meta = table_meta.push_cluster_key(cluster_key.clone());
+        }
+
+        let req = CreateTableReq {
+            if_not_exists: self.plan.if_not_exists,
+            name_ident: TableNameIdent {
+                tenant: self.plan.tenant.to_string(),
+                db_name: self.plan.database.to_string(),
+                table_name: self.plan.table.to_string(),
+            },
+            table_meta,
+        };
+
+        Ok(req)
     }
 }

--- a/src/query/service/src/sql/planner/binder/ddl/table.rs
+++ b/src/query/service/src/sql/planner/binder/ddl/table.rs
@@ -390,9 +390,8 @@ impl<'a> Binder {
                     })
                     .collect();
                 let schema = DataSchemaRefExt::create(fields);
-                let num_fields = schema.num_fields();
                 Self::validate_create_table_schema(&schema)?;
-                (schema, vec![None; num_fields], vec![])
+                (schema, vec![], vec![])
             }
             (Some(source), Some(query)) => {
                 // e.g. `CREATE TABLE t (i INT) AS SELECT * from old_t` with columns speicified
@@ -863,11 +862,7 @@ impl<'a> Binder {
                 );
                 let table_name = normalize_identifier(table, &self.name_resolution_ctx).name;
                 let table = self.ctx.get_table(&catalog, &database, &table_name).await?;
-                Ok((
-                    table.schema(),
-                    vec![None; table.schema().num_fields()],
-                    table.field_comments().clone(),
-                ))
+                Ok((table.schema(), vec![], table.field_comments().clone()))
             }
         }
     }

--- a/src/query/service/src/sql/planner/plans/create_table_v2.rs
+++ b/src/query/service/src/sql/planner/plans/create_table_v2.rs
@@ -23,8 +23,7 @@ use crate::sql::plans::Plan;
 
 pub type TableOptions = BTreeMap<String, String>;
 
-// Replace `PlanNode` with `Plan`
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(Clone)]
 pub struct CreateTablePlanV2 {
     pub if_not_exists: bool,
     pub tenant: String,
@@ -37,7 +36,6 @@ pub struct CreateTablePlanV2 {
     pub table_meta: TableMeta,
 
     pub cluster_keys: Vec<String>,
-    #[serde(skip)]
     pub as_select: Option<Box<Plan>>,
 }
 

--- a/src/query/service/src/sql/planner/plans/create_table_v2.rs
+++ b/src/query/service/src/sql/planner/plans/create_table_v2.rs
@@ -14,72 +14,33 @@
 
 use std::collections::BTreeMap;
 
+use common_ast::ast::Engine;
 use common_datavalues::DataSchemaRef;
-use common_meta_app::schema::CreateTableReq;
-use common_meta_app::schema::TableMeta;
-use common_meta_app::schema::TableNameIdent;
 
 use crate::sql::plans::Plan;
+use crate::sql::plans::Scalar;
 
 pub type TableOptions = BTreeMap<String, String>;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CreateTablePlanV2 {
     pub if_not_exists: bool,
     pub tenant: String,
-    /// The catalog name
     pub catalog: String,
     pub database: String,
-    /// The table name
     pub table: String,
 
-    pub table_meta: TableMeta,
-
-    pub cluster_keys: Vec<String>,
+    pub schema: DataSchemaRef,
+    pub engine: Engine,
+    pub options: TableOptions,
+    pub field_default_exprs: Vec<Option<Scalar>>,
+    pub field_comments: Vec<String>,
+    pub cluster_key: Option<String>,
     pub as_select: Option<Box<Plan>>,
-}
-
-impl From<CreateTablePlanV2> for CreateTableReq {
-    fn from(p: CreateTablePlanV2) -> Self {
-        CreateTableReq {
-            if_not_exists: p.if_not_exists,
-            name_ident: TableNameIdent {
-                tenant: p.tenant,
-                db_name: p.database,
-                table_name: p.table,
-            },
-            table_meta: p.table_meta,
-        }
-    }
 }
 
 impl CreateTablePlanV2 {
     pub fn schema(&self) -> DataSchemaRef {
-        self.table_meta.schema.clone()
-    }
-
-    pub fn options(&self) -> &BTreeMap<String, String> {
-        &self.table_meta.options
-    }
-
-    pub fn engine(&self) -> &str {
-        &self.table_meta.engine
-    }
-
-    pub fn as_select(&self) -> &Option<Box<Plan>> {
-        &self.as_select
-    }
-}
-
-impl std::fmt::Debug for CreateTablePlanV2 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CreateTablePlanV2")
-            .field("if_not_exists", &self.if_not_exists)
-            .field("tenant", &self.tenant)
-            .field("catalog", &self.catalog)
-            .field("database", &self.database)
-            .field("table", &self.table)
-            .field("cluster_keys", &self.cluster_keys)
-            .finish()
+        self.schema.clone()
     }
 }

--- a/src/query/service/tests/it/storages/fuse/pruning.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_ast::ast::Engine;
 use common_base::base::tokio;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -26,7 +27,6 @@ use common_legacy_planners::lit;
 use common_legacy_planners::sub;
 use common_legacy_planners::Expression;
 use common_legacy_planners::Extras;
-use common_meta_app::schema::TableMeta;
 use databend_query::interpreters::CreateTableInterpreterV2;
 use databend_query::interpreters::Interpreter;
 use databend_query::sessions::QueryContext;
@@ -76,19 +76,18 @@ async fn test_block_pruner() -> Result<()> {
         tenant: fixture.default_tenant(),
         database: fixture.default_db_name(),
         table: test_tbl_name.to_string(),
-        table_meta: TableMeta {
-            schema: test_schema.clone(),
-            engine: "FUSE".to_string(),
-            options: [
-                (FUSE_OPT_KEY_ROW_PER_BLOCK.to_owned(), num_blocks_opt),
-                (FUSE_OPT_KEY_BLOCK_PER_SEGMENT.to_owned(), "1".to_owned()),
-                (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
-            ]
-            .into(),
-            ..Default::default()
-        },
+        schema: test_schema.clone(),
+        engine: Engine::Fuse,
+        options: [
+            (FUSE_OPT_KEY_ROW_PER_BLOCK.to_owned(), num_blocks_opt),
+            (FUSE_OPT_KEY_BLOCK_PER_SEGMENT.to_owned(), "1".to_owned()),
+            (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
+        ]
+        .into(),
+        field_default_exprs: vec![None; test_schema.num_fields()],
+        field_comments: vec![],
         as_select: None,
-        cluster_keys: vec![],
+        cluster_key: None,
     };
 
     let interpreter = CreateTableInterpreterV2::try_create(ctx.clone(), create_table_plan)?;
@@ -222,21 +221,20 @@ async fn test_block_pruner_monotonic() -> Result<()> {
         tenant: fixture.default_tenant(),
         database: fixture.default_db_name(),
         table: test_tbl_name.to_string(),
-        table_meta: TableMeta {
-            schema: test_schema.clone(),
-            engine: "FUSE".to_string(),
-            options: [
-                (FUSE_OPT_KEY_ROW_PER_BLOCK.to_owned(), num_blocks_opt),
-                // for the convenience of testing, let one seegment contains one block
-                (FUSE_OPT_KEY_BLOCK_PER_SEGMENT.to_owned(), "1".to_owned()),
-                // database id is required for FUSE
-                (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
-            ]
-            .into(),
-            ..Default::default()
-        },
+        schema: test_schema.clone(),
+        engine: Engine::Fuse,
+        options: [
+            (FUSE_OPT_KEY_ROW_PER_BLOCK.to_owned(), num_blocks_opt),
+            // for the convenience of testing, let one seegment contains one block
+            (FUSE_OPT_KEY_BLOCK_PER_SEGMENT.to_owned(), "1".to_owned()),
+            // database id is required for FUSE
+            (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
+        ]
+        .into(),
+        field_default_exprs: vec![None; test_schema.num_fields()],
+        field_comments: vec![],
         as_select: None,
-        cluster_keys: vec![],
+        cluster_key: None,
     };
 
     let catalog = ctx.get_catalog("default")?;

--- a/src/query/service/tests/it/storages/fuse/pruning.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning.rs
@@ -84,7 +84,7 @@ async fn test_block_pruner() -> Result<()> {
             (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
         ]
         .into(),
-        field_default_exprs: vec![None; test_schema.num_fields()],
+        field_default_exprs: vec![],
         field_comments: vec![],
         as_select: None,
         cluster_key: None,
@@ -231,7 +231,7 @@ async fn test_block_pruner_monotonic() -> Result<()> {
             (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
         ]
         .into(),
-        field_default_exprs: vec![None; test_schema.num_fields()],
+        field_default_exprs: vec![],
         field_comments: vec![],
         as_select: None,
         cluster_key: None,

--- a/src/query/service/tests/it/storages/fuse/table.rs
+++ b/src/query/service/tests/it/storages/fuse/table.rs
@@ -309,7 +309,7 @@ async fn test_fuse_alter_table_cluster_key() -> Result<()> {
             (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
         ]
         .into(),
-        field_default_exprs: vec![None; TestFixture::default_schema().num_fields()],
+        field_default_exprs: vec![],
         field_comments: vec![],
         as_select: None,
         cluster_key: None,

--- a/src/query/service/tests/it/storages/fuse/table.rs
+++ b/src/query/service/tests/it/storages/fuse/table.rs
@@ -14,12 +14,12 @@
 
 use std::default::Default;
 
+use common_ast::ast::Engine;
 use common_base::base::tokio;
 use common_exception::Result;
 use common_legacy_planners::ReadDataSourcePlan;
 use common_legacy_planners::SourceInfo;
 use common_meta_app::schema::TableInfo;
-use common_meta_app::schema::TableMeta;
 use common_planner::plans::AlterTableClusterKeyPlan;
 use common_planner::plans::DropTableClusterKeyPlan;
 use databend_query::interpreters::AlterTableClusterKeyInterpreter;
@@ -302,20 +302,17 @@ async fn test_fuse_alter_table_cluster_key() -> Result<()> {
         catalog: fixture.default_catalog_name(),
         database: fixture.default_db_name(),
         table: fixture.default_table_name(),
-        table_meta: TableMeta {
-            schema: TestFixture::default_schema(),
-            engine: "FUSE".to_string(),
-            options: [
-                // database id is required for FUSE
-                (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
-            ]
-            .into(),
-            cluster_keys: vec![],
-            default_cluster_key_id: None,
-            ..Default::default()
-        },
+        schema: TestFixture::default_schema(),
+        engine: Engine::Fuse,
+        options: [
+            // database id is required for FUSE
+            (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
+        ]
+        .into(),
+        field_default_exprs: vec![None; TestFixture::default_schema().num_fields()],
+        field_comments: vec![],
         as_select: None,
-        cluster_keys: vec![],
+        cluster_key: None,
     };
 
     // create test table

--- a/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
+++ b/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
@@ -155,7 +155,7 @@ impl TestFixture {
                 (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
             ]
             .into(),
-            field_default_exprs: vec![None; TestFixture::default_schema().num_fields()],
+            field_default_exprs: vec![],
             field_comments: vec![],
             as_select: None,
             cluster_key: Some("(id)".to_string()),
@@ -177,7 +177,7 @@ impl TestFixture {
                 (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
             ]
             .into(),
-            field_default_exprs: vec![None; TestFixture::default_schema().num_fields()],
+            field_default_exprs: vec![],
             field_comments: vec![],
             as_select: None,
             cluster_key: None,

--- a/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
+++ b/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
@@ -15,6 +15,7 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
 
+use common_ast::ast::Engine;
 use common_catalog::catalog::CATALOG_DEFAULT;
 use common_datablocks::assert_blocks_sorted_eq_with_name;
 use common_datablocks::DataBlock;
@@ -23,7 +24,6 @@ use common_exception::Result;
 use common_legacy_planners::Expression;
 use common_legacy_planners::Extras;
 use common_meta_app::schema::DatabaseMeta;
-use common_meta_app::schema::TableMeta;
 use common_pipeline_core::processors::port::OutputPort;
 use common_pipeline_core::SourcePipeBuilder;
 use common_planner::plans::CreateDatabasePlan;
@@ -148,21 +148,17 @@ impl TestFixture {
             catalog: self.default_catalog_name(),
             database: self.default_db_name(),
             table: self.default_table_name(),
-            table_meta: TableMeta {
-                schema: TestFixture::default_schema(),
-                engine: "FUSE".to_string(),
-                options: [
-                    // database id is required for FUSE
-                    (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
-                ]
-                .into(),
-                default_cluster_key: Some("(id)".to_string()),
-                cluster_keys: vec!["(id)".to_string()],
-                default_cluster_key_id: Some(0),
-                ..Default::default()
-            },
-            cluster_keys: vec!["id".to_string()],
+            schema: TestFixture::default_schema(),
+            engine: Engine::Fuse,
+            options: [
+                // database id is required for FUSE
+                (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
+            ]
+            .into(),
+            field_default_exprs: vec![None; TestFixture::default_schema().num_fields()],
+            field_comments: vec![],
             as_select: None,
+            cluster_key: Some("(id)".to_string()),
         }
     }
 
@@ -174,18 +170,17 @@ impl TestFixture {
             catalog: self.default_catalog_name(),
             database: self.default_db_name(),
             table: self.default_table_name(),
-            table_meta: TableMeta {
-                schema: TestFixture::default_schema(),
-                engine: "FUSE".to_string(),
-                options: [
-                    // database id is required for FUSE
-                    (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
-                ]
-                .into(),
-                ..Default::default()
-            },
+            schema: TestFixture::default_schema(),
+            engine: Engine::Fuse,
+            options: [
+                // database id is required for FUSE
+                (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
+            ]
+            .into(),
+            field_default_exprs: vec![None; TestFixture::default_schema().num_fields()],
+            field_comments: vec![],
             as_select: None,
-            cluster_keys: vec![],
+            cluster_key: None,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR is another try after https://github.com/datafuselabs/databend/pull/7800

By moving physical scalar build to interpreter, `Planner` don't need to depend on `PhysicalScalarBuilder` anymore.