### PR TITLE
chore: use cargo workspace inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
+[workspace.package]
+version = "0.1.0"
+authors = ["Databend Authors <opensource@datafuselabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
 [workspace]
 members = [
     # Binaries

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "databend-binaries"
-version = "0.1.0"
 description = "databend command line tools"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [features]
 default = ["simd"]

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-base"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/common/building/Cargo.toml
+++ b/src/common/building/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-building"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/common/cache/Cargo.toml
+++ b/src/common/cache/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-cache"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/common/exception/Cargo.toml
+++ b/src/common/exception/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-exception"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/common/grpc/Cargo.toml
+++ b/src/common/grpc/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-grpc"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/common/hashtable/Cargo.toml
+++ b/src/common/hashtable/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-hashtable"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/common/http/Cargo.toml
+++ b/src/common/http/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-http"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/common/io/Cargo.toml
+++ b/src/common/io/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-io"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/common/jsonb/Cargo.toml
+++ b/src/common/jsonb/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-jsonb"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 byteorder = "1.4.3"

--- a/src/common/metrics/Cargo.toml
+++ b/src/common/metrics/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-metrics"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-storage"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [features]
 storage-hdfs = ["opendal/services-hdfs"]

--- a/src/common/tracing/Cargo.toml
+++ b/src/common/tracing/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-tracing"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/meta/api/Cargo.toml
+++ b/src/meta/api/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-meta-api"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/meta/app/Cargo.toml
+++ b/src/meta/app/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-meta-app"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/meta/client/Cargo.toml
+++ b/src/meta/client/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "common-meta-client"
-version = "0.1.0"
 description = "common meta grpc"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/meta/embedded/Cargo.toml
+++ b/src/meta/embedded/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "common-meta-embedded"
-version = "0.1.0"
 description = "distributed meta data service"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/meta/proto-conv/Cargo.toml
+++ b/src/meta/proto-conv/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-proto-conv"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/meta/protos/Cargo.toml
+++ b/src/meta/protos/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-protos"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/meta/raft-store/Cargo.toml
+++ b/src/meta/raft-store/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "common-meta-raft-store"
-version = "0.1.0"
 description = "Raft state machine"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "databend-meta"
-version = "0.1.0"
 description = "distributed meta data service"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/meta/sled-store/Cargo.toml
+++ b/src/meta/sled-store/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "common-meta-sled-store"
-version = "0.1.0"
 description = "Sled store backend for raft state machine"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/meta/store/Cargo.toml
+++ b/src/meta/store/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "common-meta-store"
-version = "0.1.0"
 description = "MetaStore is impl with either a local embedded meta store, or a grpc-client of metasrv"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-meta-types"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/ast/Cargo.toml
+++ b/src/query/ast/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-ast"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/codegen/Cargo.toml
+++ b/src/query/codegen/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "codegen"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/datablocks/Cargo.toml
+++ b/src/query/datablocks/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-datablocks"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/datavalues/Cargo.toml
+++ b/src/query/datavalues/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-datavalues"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/expression/Cargo.toml
+++ b/src/query/expression/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-expression"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 test = false

--- a/src/query/formats/Cargo.toml
+++ b/src/query/formats/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-formats"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/functions-v2/Cargo.toml
+++ b/src/query/functions-v2/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-functions-v2"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/functions/Cargo.toml
+++ b/src/query/functions/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-functions"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/legacy-expression/Cargo.toml
+++ b/src/query/legacy-expression/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-legacy-expression"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/legacy-planners/Cargo.toml
+++ b/src/query/legacy-planners/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-legacy-planners"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/management/Cargo.toml
+++ b/src/query/management/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-management"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/query/pipeline/core/Cargo.toml
+++ b/src/query/pipeline/core/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-pipeline-core"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/src/query/planner/Cargo.toml
+++ b/src/query/planner/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-planner"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 common-catalog = { path = "../catalog" }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "databend-query"
-version = "0.1.0"
 description = "A real-time Cloud Distributed Query Engine"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/storages/fuse-meta/Cargo.toml
+++ b/src/query/storages/fuse-meta/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-fuse-meta"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [features]
 

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-storages-fuse"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/src/query/storages/hive-meta-store/Cargo.toml
+++ b/src/query/storages/hive-meta-store/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-hive-meta-store"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false

--- a/src/query/storages/share/Cargo.toml
+++ b/src/query/storages/share/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-storages-share"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/src/query/users/Cargo.toml
+++ b/src/query/users/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "common-users"
-version = "0.1.0"
-authors = ["Databend Authors <opensource@datafuselabs.com>"]
-license = "Apache-2.0"
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

A new cargo feature stabilized in Rust 1.64, see https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace

It works well on the recent toolchain and have nice editor support on VSCode.
