### PR TITLE
refactor(meta): Remove not used conv for TableInfo

### DIFF
--- a/src/meta/proto-conv/src/table_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/table_from_to_protobuf_impl.rs
@@ -78,43 +78,6 @@ impl FromToProto for mt::TableCopiedFileLock {
     }
 }
 
-impl FromToProto for mt::TableInfo {
-    type PB = pb::TableInfo;
-    fn from_pb(p: pb::TableInfo) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
-
-        let ident = match p.ident {
-            None => {
-                return Err(Incompatible {
-                    reason: "TableInfo.ident can not be None".to_string(),
-                });
-            }
-            Some(x) => x,
-        };
-        let v = Self {
-            ident: mt::TableIdent::from_pb(ident)?,
-            desc: p.desc,
-            name: p.name,
-            meta: mt::TableMeta::from_pb(p.meta.ok_or_else(|| Incompatible {
-                reason: "TableInfo.meta can not be None".to_string(),
-            })?)?,
-        };
-        Ok(v)
-    }
-
-    fn to_pb(&self) -> Result<pb::TableInfo, Incompatible> {
-        let p = pb::TableInfo {
-            ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
-            ident: Some(self.ident.to_pb()?),
-            desc: self.desc.clone(),
-            name: self.name.clone(),
-            meta: Some(self.meta.to_pb()?),
-        };
-        Ok(p)
-    }
-}
-
 impl FromToProto for mt::TableNameIdent {
     type PB = pb::TableNameIdent;
     fn from_pb(p: pb::TableNameIdent) -> Result<Self, Incompatible> {

--- a/src/meta/protos/proto/table.proto
+++ b/src/meta/protos/proto/table.proto
@@ -26,30 +26,6 @@ message DbIdTableName {
   string table_name = 2;
 }
 
-// Complete table info.
-message TableInfo {
-  uint64 ver = 100;
-  uint64 min_compatible = 101;
-
-  TableIdent ident = 1;
-
-  /// For a table it is `db_name.table_name`.
-  /// For a table function, it is `table_name(args)`
-  string desc = 2;
-
-  /// `name` is meant to be used with table-function.
-  /// Table-function is identified by `name`.
-  /// A table in the contrast, can only be identified by table-id.
-  string name = 3;
-
-  /// The essential information about a table definition.
-  ///
-  /// It is about what a table actually is.
-  /// `name`, `id` or `version` is not included in the table structure
-  /// definition.
-  TableMeta meta = 4;
-}
-
 // The identifier of a table by name. Names can be changed.
 // There is no guarantee that two get-table request by name will return the same
 // instance.


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor(meta): Remove not used conv for TableInfo
