### PR TITLE
refactor(meta/service): upgrade openraft v0.7.2..v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5003,8 +5003,8 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.7.2"
-source = "git+https://github.com/datafuselabs/openraft?tag=v0.7.2#6057abbf355993a81537c3d28d914adad10b90ae"
+version = "0.7.3"
+source = "git+https://github.com/datafuselabs/openraft?tag=v0.7.3#2c06dc4d1e2973e4a91a9fb4a3345d1ce9055fc2"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -49,7 +49,7 @@ databend-query = { path = "../query/service" }
 # Crates.io dependencies
 anyhow = "1.0.65"
 clap = { version = "3.2.22", features = ["derive", "env"] }
-openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.2" }
+openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.3" }
 sentry = "0.27.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"

--- a/src/binaries/meta/main.rs
+++ b/src/binaries/meta/main.rs
@@ -24,6 +24,7 @@ use common_macros::databend_main;
 use common_meta_sled_store::init_sled_db;
 use common_meta_store::MetaStoreProvider;
 use common_tracing::init_logging;
+use common_tracing::set_panic_hook;
 use databend_meta::api::GrpcServer;
 use databend_meta::api::HttpService;
 use databend_meta::configs::Config;
@@ -62,6 +63,8 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
             ..Default::default()
         })));
     }
+
+    set_panic_hook();
 
     let _guards = init_logging("databend-meta", &conf.log);
 

--- a/src/meta/sled-store/Cargo.toml
+++ b/src/meta/sled-store/Cargo.toml
@@ -17,7 +17,7 @@ io-uring = ["sled/io_uring"]
 [dependencies]
 common-meta-types = { path = "../types" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.2" }
+openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.3" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyhow = "1.0.65"

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -14,7 +14,7 @@ test = false
 common-exception = { path = "../../common/exception" }
 common-storage = { path = "../../common/storage" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.2" }
+openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.3" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyerror = "=0.1.7"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/service): upgrade openraft v0.7.2..v0.7.3

Openraft v0.7.3

Changed:

-   Changed: [25e94c36](https://github.com/datafuselabs/openraft/commit/25e94c36e5c8ae640044196070f9a067d5f105a3) InstallSnapshotResponse: replies the last applied log id; Do not install a smaller snapshot; by 张炎泼; 2022-09-22

    A snapshot may not be installed by a follower if it already has a higher
    `last_applied` log id locally.
    In such a case, it just ignores the snapshot and respond with its local
    `last_applied` log id.

    This way the applied state(i.e., `last_applied`) will never revert back.

Fixed:

-   Fixed: [21684bbd](https://github.com/datafuselabs/openraft/commit/21684bbdfdc54b18daa68f623afc2b0be6718c72) potential inconsistency when installing snapshot; by 张炎泼; 2022-09-22

    The conflicting logs that are before `snapshot_meta.last_log_id` should
    be deleted before installing a snapshot.

    Otherwise there is chance the snapshot is installed but conflicting logs
    are left in the store, when a node crashes.


##### chore(meta/bin): record panic in log

## Changelog







## Related Issues