### PR TITLE
chore(meta-grpc-client): add metric label about request name

### DIFF
--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -97,6 +97,7 @@ const META_GRPC_CLIENT_REQUEST_SUCCESS: &str = "meta_grpc_client_request_success
 const META_GRPC_CLIENT_REQUEST_FAILED: &str = "meta_grpc_client_request_fail";
 const META_GRPC_MAKE_CLIENT_FAILED: &str = "meta_grpc_make_client_fail";
 const LABEL_ENDPOINT: &str = "endpoint";
+const LABEL_REQUEST: &str = "request";
 const LABEL_ERROR: &str = "error";
 
 #[derive(Debug)]
@@ -345,6 +346,7 @@ impl MetaGrpcClient {
 
             let resp_tx = req.resp_tx;
             let req = req.req;
+            let req_name = req.name();
 
             let resp = match req {
                 message::Request::Get(r) => {
@@ -402,7 +404,10 @@ impl MetaGrpcClient {
             if let Some(current_endpoint) = current_endpoint {
                 label_histogram_with_val(
                     META_GRPC_CLIENT_REQUEST_DURATION_MS,
-                    vec![(LABEL_ENDPOINT, current_endpoint.to_string())],
+                    vec![
+                        (LABEL_ENDPOINT, current_endpoint.to_string()),
+                        (LABEL_REQUEST, req_name.to_string()),
+                    ],
                     start.elapsed().as_millis() as f64,
                 );
 
@@ -412,6 +417,7 @@ impl MetaGrpcClient {
                         vec![
                             (LABEL_ENDPOINT, current_endpoint.to_string()),
                             (LABEL_ERROR, err.to_string()),
+                            (LABEL_REQUEST, req_name.to_string()),
                         ],
                         1,
                     );
@@ -419,7 +425,10 @@ impl MetaGrpcClient {
                 } else {
                     label_counter_with_val_and_labels(
                         META_GRPC_CLIENT_REQUEST_SUCCESS,
-                        vec![(LABEL_ENDPOINT, current_endpoint.to_string())],
+                        vec![
+                            (LABEL_ENDPOINT, current_endpoint.to_string()),
+                            (LABEL_REQUEST, req_name.to_string()),
+                        ],
                         1,
                     );
                 }

--- a/src/meta/client/src/message.rs
+++ b/src/meta/client/src/message.rs
@@ -80,6 +80,23 @@ pub enum Request {
     GetClientInfo(GetClientInfo),
 }
 
+impl Request {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Request::Get(_) => "Get",
+            Request::MGet(_) => "MGet",
+            Request::PrefixList(_) => "PrefixList",
+            Request::Upsert(_) => "Upsert",
+            Request::Txn(_) => "Txn",
+            Request::Watch(_) => "Watch",
+            Request::Export(_) => "Export",
+            Request::MakeClient(_) => "MakeClient",
+            Request::GetEndpoints(_) => "GetEndpoints",
+            Request::GetClientInfo(_) => "GetClientInfo",
+        }
+    }
+}
+
 /// Meta-client worker-to-handle response body
 #[derive(Debug, derive_more::TryInto)]
 pub enum Response {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently we have the metrics about grpc client for metasrv, however the current metrics did not include the name of request for metasrv, it makes hard to diagnose the latency percentiles, especially with some long calls like `WATCH` 

This PR adds an extra `request` label to the metrics, so we can get the different latencies of different requests.
