### PR TITLE
fix(storage): fix bloom filter index always missing

### DIFF
--- a/src/query/storages/fuse-meta/src/caches/cache.rs
+++ b/src/query/storages/fuse-meta/src/caches/cache.rs
@@ -69,9 +69,9 @@ impl CacheManager {
         } else {
             let table_snapshot_cache = Self::new_item_cache(config.table_cache_snapshot_count);
             let segment_info_cache = Self::new_item_cache(config.table_cache_segment_count);
-            let bloom_index_cache = Self::new_bytes_cache(DEFAULT_BLOOM_INDEX_META_CACHE_ITEMS);
+            let bloom_index_cache = Self::new_bytes_cache(DEFAULT_BLOOM_INDEX_COLUMN_CACHE_SIZE);
             let bloom_index_meta_cache =
-                Self::new_item_cache(DEFAULT_BLOOM_INDEX_COLUMN_CACHE_SIZE);
+                Self::new_item_cache(DEFAULT_BLOOM_INDEX_META_CACHE_ITEMS);
 
             let file_meta_data_cache = Self::new_item_cache(DEFAULT_FILE_META_DATA_CACHE_ITEMS);
 

--- a/src/query/storages/fuse-meta/src/caches/cache.rs
+++ b/src/query/storages/fuse-meta/src/caches/cache.rs
@@ -70,8 +70,7 @@ impl CacheManager {
             let table_snapshot_cache = Self::new_item_cache(config.table_cache_snapshot_count);
             let segment_info_cache = Self::new_item_cache(config.table_cache_segment_count);
             let bloom_index_cache = Self::new_bytes_cache(DEFAULT_BLOOM_INDEX_COLUMN_CACHE_SIZE);
-            let bloom_index_meta_cache =
-                Self::new_item_cache(DEFAULT_BLOOM_INDEX_META_CACHE_ITEMS);
+            let bloom_index_meta_cache = Self::new_item_cache(DEFAULT_BLOOM_INDEX_META_CACHE_ITEMS);
 
             let file_meta_data_cache = Self::new_item_cache(DEFAULT_FILE_META_DATA_CACHE_ITEMS);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(storage): fix bloom filter index always missing

Fixes #issue
