### PR TITLE
feat: add XOR bloom filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44124848854b941eafdb34f05b3bcf59472f643c7e151eba7c2b69daa469ed5"
+
+[[package]]
 name = "array-init-cursor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +782,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbordata"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d1b01dea75baf7521dfb06c2462d8339d71f4320a2244d1f8f6b94265ded858"
+dependencies = [
+ "cbordata-derive",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "cbordata-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9fd16dfe515476789addde9311da025a1f0c45ddd81b7b0315c9d426577dcb"
+dependencies = [
+ "heck 0.3.3",
+ "lazy_static",
+ "proc-macro-error 0.4.12",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,8 +923,8 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck",
- "proc-macro-error",
+ "heck 0.4.0",
+ "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
  "syn",
@@ -1862,6 +1893,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "bit-vec",
+ "cbordata",
  "common-catalog",
  "common-datablocks",
  "common-datavalues",
@@ -1873,6 +1905,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "tracing",
+ "xorfilter-rs",
 ]
 
 [[package]]
@@ -2832,7 +2865,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3406,7 +3439,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
  "syn",
@@ -3653,6 +3686,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -4750,7 +4792,7 @@ checksum = "ea8dd3c6d80d1e61031aecc5fdfaf4b7d2324dbd94d575ac12f94e5d6856c2d4"
 dependencies = [
  "nom",
  "pratt",
- "proc-macro-error",
+ "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
  "syn",
@@ -4791,6 +4833,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
+ "arbitrary",
  "autocfg 1.1.0",
  "num-integer",
  "num-traits",
@@ -5672,14 +5715,40 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr 0.4.12",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "proc-macro-error-attr",
+ "proc-macro-error-attr 1.0.4",
  "proc-macro2",
  "quote",
  "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "syn-mid",
  "version_check",
 ]
 
@@ -5780,7 +5849,7 @@ dependencies = [
  "bytes 1.2.1",
  "cfg-if",
  "cmake",
- "heck",
+ "heck 0.4.0",
  "itertools",
  "lazy_static",
  "log",
@@ -7038,7 +7107,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -7127,6 +7196,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -8289,6 +8369,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xorfilter-rs"
+version = "0.5.1"
+source = "git+https://github.com/bnclabs/xorfilter#a0f07b6e056cbdadd586c62d0ca234a3f50ed7d0"
+dependencies = [
+ "cbordata",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8374,7 +8374,7 @@ dependencies = [
 [[package]]
 name = "xorfilter-rs"
 version = "0.5.1"
-source = "git+https://github.com/bnclabs/xorfilter#a0f07b6e056cbdadd586c62d0ca234a3f50ed7d0"
+source = "git+https://github.com/datafuse-extras/xorfilter#a0f07b6e056cbdadd586c62d0ca234a3f50ed7d0"
 dependencies = [
  "cbordata",
 ]

--- a/src/query/storages/index/Cargo.toml
+++ b/src/query/storages/index/Cargo.toml
@@ -23,6 +23,8 @@ common-pipeline-transforms = { path = "../../pipeline/transforms" }
 
 bincode = { version = "2.0.0-rc.1", features = ["serde", "std", "alloc"] }
 bit-vec = { version = "0.6.3", features = ["serde_std"] }
+cbordata = { version = "0.6.0" }
 rand = "0.8.5"
 serde = { version = "1.0.144", features = ["derive"] }
 tracing = "0.1.36"
+xorfilter-rs = { git = "https://github.com/bnclabs/xorfilter", features = ["cbordata"] }

--- a/src/query/storages/index/Cargo.toml
+++ b/src/query/storages/index/Cargo.toml
@@ -27,4 +27,4 @@ cbordata = { version = "0.6.0" }
 rand = "0.8.5"
 serde = { version = "1.0.144", features = ["derive"] }
 tracing = "0.1.36"
-xorfilter-rs = { git = "https://github.com/bnclabs/xorfilter", features = ["cbordata"] }
+xorfilter-rs = { git = "https://github.com/datafuse-extras/xorfilter", features = ["cbordata"] }

--- a/src/query/storages/index/src/bloom/bloom.rs
+++ b/src/query/storages/index/src/bloom/bloom.rs
@@ -17,8 +17,10 @@ use std::hash::Hash;
 use common_exception::Result;
 
 pub trait Bloom: Sized {
-    // Length of the bitmap index.
+    // The number of keys added/built into the bitmap index.
     fn len(&self) -> Result<usize>;
+
+    fn is_empty(&self) -> bool;
 
     /// Add key into the bitmap index.
     fn add_key<K: ?Sized + Hash>(&mut self, key: &K);

--- a/src/query/storages/index/src/bloom/bloom.rs
+++ b/src/query/storages/index/src/bloom/bloom.rs
@@ -1,0 +1,40 @@
+//  Copyright 2022 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::hash::Hash;
+
+use common_exception::Result;
+
+pub trait Bloom: Sized {
+    // Length of the bitmap index.
+    fn len(&self) -> Result<usize>;
+
+    /// Add key into the bitmap index.
+    fn add_key<K: ?Sized + Hash>(&mut self, key: &K);
+
+    /// Add several keys into the bitmap index.
+    fn add_keys<K: Hash>(&mut self, keys: &[K]);
+
+    /// Build the bitmap index.
+    fn build(&mut self) -> Result<()>;
+
+    /// Check the key is in the bitmap index.
+    fn contains<K: ?Sized + Hash>(&self, key: &K) -> bool;
+
+    /// Serialize the bitmap index to binary array.
+    fn to_bytes(&self) -> Result<Vec<u8>>;
+
+    /// Deserialize the binary array to bitmap index.
+    fn from_bytes(buf: &[u8]) -> Result<(Self, usize)>;
+}

--- a/src/query/storages/index/src/bloom/mod.rs
+++ b/src/query/storages/index/src/bloom/mod.rs
@@ -17,3 +17,4 @@ mod bloom;
 mod xor8;
 
 pub use bloom::Bloom;
+pub use xor8::XorBloom;

--- a/src/query/storages/index/src/bloom/mod.rs
+++ b/src/query/storages/index/src/bloom/mod.rs
@@ -1,0 +1,19 @@
+//  Copyright 2022 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#[allow(clippy::module_inception)]
+mod bloom;
+mod xor8;
+
+pub use bloom::Bloom;

--- a/src/query/storages/index/src/bloom/xor8.rs
+++ b/src/query/storages/index/src/bloom/xor8.rs
@@ -1,0 +1,80 @@
+//  Copyright 2022 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::hash::BuildHasher;
+use std::hash::Hash;
+
+use cbordata::Cbor;
+use cbordata::FromCbor;
+use cbordata::IntoCbor;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use xorfilter::Xor8;
+
+use crate::bloom::Bloom;
+
+impl<H> Bloom for Xor8<H>
+where H: Clone + BuildHasher + Into<Vec<u8>> + From<Vec<u8>>
+{
+    fn len(&self) -> Result<usize> {
+        match self.len() {
+            Some(n) => Ok(n),
+            None => Err(ErrorCode::UnImplement("Xor8 does not implement len()")),
+        }
+    }
+
+    #[inline]
+    fn add_key<K: ?Sized + Hash>(&mut self, key: &K) {
+        self.insert(key)
+    }
+
+    #[inline]
+    fn add_keys<K: Hash>(&mut self, _keys: &[K]) {
+        todo!()
+    }
+
+    #[inline]
+    fn build(&mut self) -> Result<()> {
+        self.build()
+            .map_err(|e| ErrorCode::UnexpectedError(format!("Xor8.build error:{:?}", e)))
+    }
+
+    #[inline]
+    fn contains<K: ?Sized + Hash>(&self, key: &K) -> bool {
+        self.contains(key)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>> {
+        let mut buf: Vec<u8> = vec![];
+
+        let cbor_val = self
+            .clone()
+            .into_cbor()
+            .map_err(|e| ErrorCode::UnexpectedError(format!("Xor8.into_cbor error:{:}", e)))?;
+        cbor_val
+            .encode(&mut buf)
+            .map_err(|e| ErrorCode::UnexpectedError(format!("Xor8.encode error:{:}", e)))?;
+
+        Ok(buf)
+    }
+
+    fn from_bytes(mut buf: &[u8]) -> Result<(Self, usize)> {
+        let (cbor_val, n) = Cbor::decode(&mut buf)
+            .map_err(|e| ErrorCode::UnexpectedError(format!("Xor8.cbor.decode error:{:}", e)))?;
+
+        let xor_value = Xor8::<H>::from_cbor(cbor_val)
+            .map_err(|e| ErrorCode::UnexpectedError(format!("Xor8.from_cborerror:{:}", e)))?;
+        Ok((xor_value, n))
+    }
+}

--- a/src/query/storages/index/src/bloom/xor8.rs
+++ b/src/query/storages/index/src/bloom/xor8.rs
@@ -47,8 +47,8 @@ where H: Clone + BuildHasher + Into<Vec<u8>> + From<Vec<u8>>
     }
 
     #[inline]
-    fn add_keys<K: Hash>(&mut self, _keys: &[K]) {
-        todo!()
+    fn add_keys<K: Hash>(&mut self, keys: &[K]) {
+        self.populate(keys)
     }
 
     #[inline]

--- a/src/query/storages/index/src/bloom/xor8.rs
+++ b/src/query/storages/index/src/bloom/xor8.rs
@@ -34,6 +34,13 @@ where H: Clone + BuildHasher + Into<Vec<u8>> + From<Vec<u8>>
         }
     }
 
+    fn is_empty(&self) -> bool {
+        match self.len() {
+            Some(n) => n == 0,
+            None => true,
+        }
+    }
+
     #[inline]
     fn add_key<K: ?Sized + Hash>(&mut self, key: &K) {
         self.insert(key)

--- a/src/query/storages/index/src/bloom/xor8.rs
+++ b/src/query/storages/index/src/bloom/xor8.rs
@@ -19,7 +19,6 @@ use cbordata::FromCbor;
 use cbordata::IntoCbor;
 use common_exception::ErrorCode;
 use common_exception::Result;
-use xorfilter::BuildHasherDefault;
 use xorfilter::Xor8;
 
 use crate::bloom::Bloom;
@@ -31,7 +30,7 @@ pub struct XorBloom {
 impl XorBloom {
     pub fn create() -> Self {
         XorBloom {
-            filter: Default::default(),
+            filter: Xor8::default(),
         }
     }
 }
@@ -87,7 +86,7 @@ impl Bloom for XorBloom {
         let (cbor_val, n) = Cbor::decode(&mut buf)
             .map_err(|e| ErrorCode::UnexpectedError(format!("Xor8.cbor.decode error:{:}", e)))?;
 
-        let xor_value = Xor8::<BuildHasherDefault>::from_cbor(cbor_val)
+        let xor_value = Xor8::from_cbor(cbor_val)
             .map_err(|e| ErrorCode::UnexpectedError(format!("Xor8.from_cborerror:{:}", e)))?;
         Ok((Self { filter: xor_value }, n))
     }

--- a/src/query/storages/index/src/lib.rs
+++ b/src/query/storages/index/src/lib.rs
@@ -19,7 +19,7 @@ use common_datavalues::DataType;
 use common_datavalues::DataTypeImpl;
 use common_datavalues::NullableType;
 
-mod bloom;
+pub mod bloom;
 pub mod bloom_filter;
 pub mod index_min_max;
 pub mod range_filter;

--- a/src/query/storages/index/src/lib.rs
+++ b/src/query/storages/index/src/lib.rs
@@ -19,6 +19,7 @@ use common_datavalues::DataType;
 use common_datavalues::DataTypeImpl;
 use common_datavalues::NullableType;
 
+mod bloom;
 pub mod bloom_filter;
 pub mod index_min_max;
 pub mod range_filter;

--- a/src/query/storages/index/tests/it/bloom/mod.rs
+++ b/src/query/storages/index/tests/it/bloom/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod xor;

--- a/src/query/storages/index/tests/it/bloom/xor.rs
+++ b/src/query/storages/index/tests/it/bloom/xor.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_datablocks::DataBlock;
+use common_datavalues::prelude::*;
+use common_datavalues::DataField;
+use common_datavalues::DataSchemaRefExt;
+use common_datavalues::Series;
+use common_datavalues::SeriesFrom;
 use common_exception::Result;
 use common_storages_index::bloom::Bloom;
 use common_storages_index::bloom::XorBloom;
@@ -159,6 +165,42 @@ fn test_xor_bitmap_duplicate_string() -> Result<()> {
     // string enc:61, raw:3000000, ratio:0.000020333333
     println!(
         "string enc:{}, raw:{}, ratio:{}",
+        val.len(),
+        size,
+        val.len() as f32 / size as f32
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_xor_bitmap_data_block() -> Result<()> {
+    let seed: u64 = random();
+    let numbers = 1_000_000;
+
+    let size = 8 * numbers;
+    let mut rng = StdRng::seed_from_u64(seed);
+    let keys: Vec<i64> = (0..numbers).map(|_| rng.gen::<i64>()).collect();
+
+    let schema = DataSchemaRefExt::create(vec![DataField::new("a", i64::to_data_type())]);
+    let block = DataBlock::create(schema, vec![Series::from_data(keys)]);
+    let column = block.try_column_by_name("a")?;
+
+    let mut filter = XorBloom::create();
+    filter.add_keys(&column.to_values());
+    filter.build()?;
+
+    for key in column.to_values() {
+        assert!(filter.contains(&key), "key {} not present", key);
+    }
+
+    let val = filter.to_bytes()?;
+    let (_, n) = XorBloom::from_bytes(&val)?;
+    assert_eq!(n, val.len(), "{} {}", n, val.len());
+
+    // data block enc:1230069, raw:8000000, ratio:0.15375863
+    println!(
+        "data block enc:{}, raw:{}, ratio:{}",
         val.len(),
         size,
         val.len() as f32 / size as f32

--- a/src/query/storages/index/tests/it/bloom/xor.rs
+++ b/src/query/storages/index/tests/it/bloom/xor.rs
@@ -1,0 +1,137 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_storages_index::bloom::Bloom;
+use rand::prelude::random;
+use rand::rngs::StdRng;
+use rand::Rng;
+use rand::SeedableRng;
+use xorfilter::BuildHasherDefault;
+use xorfilter::Xor8;
+
+#[test]
+fn test_xor_bitmap_u64() {
+    let seed: u64 = random();
+    let numbers = 1_000_000;
+
+    let size = 8 * numbers;
+    let mut rng = StdRng::seed_from_u64(seed);
+    let keys: Vec<u64> = (0..numbers).map(|_| rng.gen::<u64>()).collect();
+
+    let mut filter = Xor8::<BuildHasherDefault>::new();
+    for key in keys.clone().into_iter() {
+        filter.add_key(&key);
+    }
+    filter.build().unwrap();
+
+    for key in keys.iter() {
+        assert!(filter.contains(key), "key {} not present", key);
+    }
+
+    {
+        let val = <Xor8 as Bloom>::to_bytes(&filter).unwrap();
+        let (_, n) = <Xor8<BuildHasherDefault> as Bloom>::from_bytes(&val).unwrap();
+        assert_eq!(n, val.len(), "{} {}", n, val.len());
+
+        // u64 bitmap enc:1230069, raw:8000000, ratio:0.15375863
+        println!(
+            "u64 bitmap enc:{}, raw:{}, ratio:{}",
+            val.len(),
+            size,
+            val.len() as f32 / size as f32
+        );
+    }
+}
+
+#[test]
+fn test_xor_bitmap_bool() {
+    let seed: u64 = random();
+    let numbers = 1_000_000;
+
+    let size = numbers;
+    let mut rng = StdRng::seed_from_u64(seed);
+    let keys: Vec<bool> = (0..numbers).map(|_| rng.gen::<u64>() % 2 == 0).collect();
+
+    let mut filter = Xor8::<BuildHasherDefault>::new();
+    for key in keys.clone().into_iter() {
+        filter.add_key(&key);
+    }
+    filter.build().unwrap();
+
+    for key in keys.iter() {
+        assert!(filter.contains(key), "key {} not present", key);
+    }
+
+    {
+        let val = <Xor8 as Bloom>::to_bytes(&filter).unwrap();
+        let (_, n) = <Xor8<BuildHasherDefault> as Bloom>::from_bytes(&val).unwrap();
+        assert_eq!(n, val.len(), "{} {}", n, val.len());
+
+        // bool bitmap enc:61, raw:1000000, ratio:0.000061
+        println!(
+            "bool bitmap enc:{}, raw:{}, ratio:{}",
+            val.len(),
+            size,
+            val.len() as f32 / size as f32
+        );
+    }
+}
+
+#[test]
+fn test_xor_bitmap_string() {
+    let seed: u64 = random();
+    let numbers = 100_000;
+
+    let len = 30;
+    let size = 30 * numbers;
+    let mut rng = StdRng::seed_from_u64(seed);
+    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+                            abcdefghijklmnopqrstuvwxyz\
+                            0123456789)(*&^%$#@!~";
+
+    let keys: Vec<String> = (0..numbers)
+        .map(|_| {
+            (0..len)
+                .map(|_| {
+                    let idx = rng.gen_range(0..CHARSET.len());
+                    CHARSET[idx] as char
+                })
+                .collect()
+        })
+        .collect();
+
+    let mut filter = Xor8::<BuildHasherDefault>::new();
+    for key in keys.clone().into_iter() {
+        filter.add_key(&key);
+    }
+    filter.build().unwrap();
+
+    for key in keys.iter() {
+        assert!(filter.contains(key), "key {} not present", key);
+    }
+
+    {
+        let val = <Xor8 as Bloom>::to_bytes(&filter).unwrap();
+        let (_, n) = <Xor8<BuildHasherDefault> as Bloom>::from_bytes(&val).unwrap();
+        assert_eq!(n, val.len(), "{} {}", n, val.len());
+
+        // string enc:123067, raw:3000000, ratio:0.041022334
+        println!(
+            "string enc:{}, raw:{}, ratio:{}",
+            val.len(),
+            size,
+            val.len() as f32 / size as f32
+        );
+    }
+}

--- a/src/query/storages/index/tests/it/bloom/xor.rs
+++ b/src/query/storages/index/tests/it/bloom/xor.rs
@@ -30,9 +30,7 @@ fn test_xor_bitmap_u64() {
     let keys: Vec<u64> = (0..numbers).map(|_| rng.gen::<u64>()).collect();
 
     let mut filter = Xor8::<BuildHasherDefault>::new();
-    for key in keys.clone().into_iter() {
-        filter.add_key(&key);
-    }
+    filter.add_keys(&keys);
     filter.build().unwrap();
 
     for key in keys.iter() {
@@ -112,9 +110,7 @@ fn test_xor_bitmap_string() {
         .collect();
 
     let mut filter = Xor8::<BuildHasherDefault>::new();
-    for key in keys.clone().into_iter() {
-        filter.add_key(&key);
-    }
+    filter.add_keys(&keys);
     filter.build().unwrap();
 
     for key in keys.iter() {

--- a/src/query/storages/index/tests/it/bloom/xor.rs
+++ b/src/query/storages/index/tests/it/bloom/xor.rs
@@ -47,6 +47,9 @@ fn test_xor_bitmap_u64() -> Result<()> {
     let (_, n) = XorBloom::from_bytes(&val)?;
     assert_eq!(n, val.len(), "{} {}", n, val.len());
 
+    // Lock the size.
+    assert_eq!(n, 1230069);
+
     // u64 bitmap enc:1230069, raw:8000000, ratio:0.15375863
     println!(
         "u64 bitmap enc:{}, raw:{}, ratio:{}",
@@ -80,6 +83,9 @@ fn test_xor_bitmap_bool() -> Result<()> {
     let val = filter.to_bytes()?;
     let (_, n) = XorBloom::from_bytes(&val)?;
     assert_eq!(n, val.len(), "{} {}", n, val.len());
+
+    // Lock the size.
+    assert_eq!(n, 61);
 
     // bool bitmap enc:61, raw:1000000, ratio:0.000061
     println!(
@@ -127,6 +133,9 @@ fn test_xor_bitmap_string() -> Result<()> {
     let (_, n) = XorBloom::from_bytes(&val)?;
     assert_eq!(n, val.len(), "{} {}", n, val.len());
 
+    // Lock the size.
+    assert_eq!(n, 123067);
+
     // string enc:123067, raw:3000000, ratio:0.041022334
     println!(
         "string enc:{}, raw:{}, ratio:{}",
@@ -154,13 +163,14 @@ fn test_xor_bitmap_duplicate_string() -> Result<()> {
     }
     filter.build()?;
 
-    for key in keys.iter() {
-        assert!(filter.contains(key), "key {} not present", key);
-    }
+    assert!(filter.contains(&keys[0]), "key {} not present", key);
 
     let val = filter.to_bytes()?;
     let (_, n) = XorBloom::from_bytes(&val)?;
     assert_eq!(n, val.len(), "{} {}", n, val.len());
+
+    // Lock the size.
+    assert_eq!(n, 61);
 
     // string enc:61, raw:3000000, ratio:0.000020333333
     println!(

--- a/src/query/storages/index/tests/it/bloom/xor.rs
+++ b/src/query/storages/index/tests/it/bloom/xor.rs
@@ -199,8 +199,10 @@ fn test_xor_bitmap_data_block() -> Result<()> {
     assert_eq!(n, val.len(), "{} {}", n, val.len());
 
     // data block enc:1230069, raw:8000000, ratio:0.15375863
+    // Actually, it not related to datablock, it related to the type of the column
+    // Here it same as u64.
     println!(
-        "data block enc:{}, raw:{}, ratio:{}",
+        "data block(i64) enc:{}, raw:{}, ratio:{}",
         val.len(),
         size,
         val.len() as f32 / size as f32

--- a/src/query/storages/index/tests/it/main.rs
+++ b/src/query/storages/index/tests/it/main.rs
@@ -1,0 +1,15 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod bloom;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Introduce a new bloom trait
* Use XOR instead of bloom filter

Test result(bitmap encode size / raw data size):
```
u64: 
bitmap enc:1230069, raw:8000000, ratio:0.15375863

bool:
bitmap enc:61, raw:1000000, ratio:0.000061

string:
string enc:123067, raw:3000000, ratio:0.041022334

100000 records of the same key:
string enc:61, raw:3000000, ratio:0.000020333333
```


Part of #7748
