### PR TITLE
fix: disable bloom filter index in write path

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/optimize.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/optimize.rs
@@ -46,7 +46,7 @@ async fn do_purge_test(case_name: &str, operation: &str) -> Result<()> {
     let tbl = fixture.default_table_name();
     let qry = format!("optimize table {}.{} {}", db, tbl, operation);
 
-    // insert, and then insert overwrite (1 snapshot, 1 segment, 1 data block, 1 index block for each insertion);
+    // insert, and then insert overwrite (1 snapshot, 1 segment, 1 data block, for each insertion);
     do_insertions(&fixture).await?;
 
     // execute the query
@@ -54,7 +54,7 @@ async fn do_purge_test(case_name: &str, operation: &str) -> Result<()> {
     execute_command(ctx, &qry).await?;
 
     // there should be only 1 snapshot, 1 segment, 1 block left, and 0 index left
-    check_data_dir(&fixture, case_name, 1, 1, 1, 1).await;
+    check_data_dir(&fixture, case_name, 1, 1, 1, 0).await;
     history_should_have_only_one_item(&fixture, case_name).await
 }
 

--- a/src/query/service/tests/it/storages/fuse/operations/purge_truncate.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/purge_truncate.rs
@@ -32,7 +32,7 @@ async fn test_fuse_truncate_purge_stmt() -> Result<()> {
     append_sample_data(1, &fixture).await?;
     append_sample_data(1, &fixture).await?;
 
-    let expected_index_count = 2;
+    let expected_index_count = 0;
     // there should be some data there: 2 snapshot, 2 segment, 2 block
     check_data_dir(&fixture, "truncate_purge", 2, 2, 2, expected_index_count).await;
 

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -160,7 +160,7 @@ async fn test_accumulator() -> common_exception::Result<()> {
     }
 
     assert_eq!(10, stats_acc.blocks_statistics.len());
-    assert!(stats_acc.index_size > 0);
+    assert_eq!(stats_acc.index_size, 0);
     Ok(())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

hot fix, should have disabled bloom index in write path as well.


Fixes #7780
