### PR TITLE
chore(sqllogic): add SHOW SETTINGS test

### DIFF
--- a/tests/logictest/suites/base/06_show/06_0003_show_settings
+++ b/tests/logictest/suites/base/06_show/06_0003_show_settings
@@ -1,0 +1,13 @@
+statement ok
+SET max_threads=11;
+
+statement error 2801
+SET unknown_settings=11; 
+
+statement ok
+SHOW SETTINGS;
+
+onlyif mysql
+statement ok
+SHOW SETTINGS LIKE 'enable%';
+


### PR DESCRIPTION
Signed-off-by: Yisong Han <yisong8686@gmail.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

I think a simple test of show settings still needs to be added in case there is a functional failure.
eg. [show tables](https://github.com/datafuselabs/databend/blob/main/tests/logictest/suites/base/06_show/06_0004_show_tables#L85)

Fixes #7184 
