### PR TITLE
fix: use shortcut path if filter vector is empty during pruning

### DIFF
--- a/src/query/storages/fuse/src/pruning/pruning_executor.rs
+++ b/src/query/storages/fuse/src/pruning/pruning_executor.rs
@@ -68,8 +68,13 @@ impl BlockPruner {
 
         let filter_expressions = push_down.as_ref().map(|extra| extra.filters.as_slice());
 
+        let is_filter_empty = match filter_expressions {
+            None => true,
+            Some(filters) => filters.is_empty(),
+        };
+
         // shortcut, just returns all the blocks
-        if limit.is_none() && filter_expressions.is_none() {
+        if limit.is_none() && is_filter_empty {
             return Self::all_the_blocks(segment_locs, ctx.as_ref()).await;
         }
 

--- a/src/query/storages/fuse/src/pruning/pruning_executor.rs
+++ b/src/query/storages/fuse/src/pruning/pruning_executor.rs
@@ -73,8 +73,9 @@ impl BlockPruner {
             Some(filters) => filters.is_empty(),
         };
 
-        // shortcut, just returns all the blocks
-        if limit.is_none() && is_filter_empty {
+        // shortcut, just returns all the blocks.
+        // we use the original limit (from push_down) here, since order_by alone, can use shortcut
+        if push_down.as_ref().and_then(|p| p.limit).is_none() && is_filter_empty {
             return Self::all_the_blocks(segment_locs, ctx.as_ref()).await;
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Minor fix:

During pruning, use the shortcut path if the filter vector is empty.

For queries like "select * from t", which has no filter conditions, an `Some<V>` where `V:Vec<LegacyExpression>` is passed in, if the vectory `V` is empty, we should use the "shortcut", i.e. just return all the blocks locations as the targets of scan.

Fixes #issue
