### PR TITLE
chore: Bump OpenDAL version to 0.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5077,9 +5077,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendal"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d30fcce5168e0634891b2734b820e81fd00bba1a0623d001a97fde6512f195"
+checksum = "fa33a6658bab80917bae47cb2eab9f11dd0d3327e223ab5d03188634a8f83426"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/src/common/contexts/Cargo.toml
+++ b/src/common/contexts/Cargo.toml
@@ -12,4 +12,4 @@ test = false
 common-base = { path = "../base" }
 
 async-trait = "0.1.57"
-opendal = { version = "0.17.1", features = ["layers-retry"] }
+opendal = { version = "0.17.2", features = ["layers-retry"] }

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.65"
 backon = "0.2.0"
 globiter = "0.1.0"
 once_cell = "1.15.0"
-opendal = { version = "0.17.1", features = [
+opendal = { version = "0.17.2", features = [
     "layers-retry",
     "layers-tracing",
     "layers-metrics",

--- a/src/query/catalog/Cargo.toml
+++ b/src/query/catalog/Cargo.toml
@@ -26,4 +26,4 @@ common-settings = { path = "../settings" }
 
 async-trait = "0.1.57"
 dyn-clone = "1.0.9"
-opendal = { version = "0.17.1", features = ["layers-retry"] }
+opendal = { version = "0.17.2", features = ["layers-retry"] }

--- a/src/query/config/Cargo.toml
+++ b/src/query/config/Cargo.toml
@@ -21,7 +21,7 @@ common-users = { path = "../users" }
 clap = { version = "3.2.22", features = ["derive", "env"] }
 hex = "0.4.3"
 once_cell = "1.15.0"
-opendal = { version = "0.17.1", features = ["layers-retry", "compress"], optional = true }
+opendal = { version = "0.17.2", features = ["layers-retry", "compress"], optional = true }
 semver = "1.0.14"
 serde = { version = "1.0.145", features = ["derive"] }
 serfig = "0.0.2"

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -111,7 +111,7 @@ nom = "7.1.1"
 num = "0.4.0"
 num_cpus = "1.13.1"
 once_cell = "1.15.0"
-opendal = { version = "0.17.1", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.17.2", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
 opensrv-mysql = "0.2.0"
 openssl = { version = "0.10.41", features = ["vendored"] }
 parking_lot = "0.12.1"

--- a/src/query/streams/Cargo.toml
+++ b/src/query/streams/Cargo.toml
@@ -32,4 +32,4 @@ serde_json = { version = "1.0.85", default-features = false, features = ["preser
 tempfile = "3.3.0"
 
 [dev-dependencies]
-opendal = { version = "0.17.1", features = ["layers-retry", "compress"] }
+opendal = { version = "0.17.2", features = ["layers-retry", "compress"] }


### PR DESCRIPTION
Signed-off-by: ClSlaid <cailue@bupt.edu.cn>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR bumps the OpenDAL dependency version to 0.17.2

Fixes #7896 
