### PR TITLE
feat(intpu_format): check memory_size() for building data block.

### DIFF
--- a/src/query/datavalues/src/columns/array/mutable.rs
+++ b/src/query/datavalues/src/columns/array/mutable.rs
@@ -142,6 +142,10 @@ impl MutableColumn for MutableArrayColumn {
             )),
         }
     }
+
+    fn memory_size(&self) -> usize {
+        self.inner_column.memory_size() + self.offsets.len() * std::mem::size_of::<i64>()
+    }
 }
 
 impl ScalarColumnBuilder for MutableArrayColumn {

--- a/src/query/datavalues/src/columns/boolean/mutable.rs
+++ b/src/query/datavalues/src/columns/boolean/mutable.rs
@@ -71,6 +71,10 @@ impl MutableColumn for MutableBooleanColumn {
             ErrorCode::BadDataArrayLength("Bool column is empty when pop data value")
         })
     }
+
+    fn memory_size(&self) -> usize {
+        self.values.as_slice().len()
+    }
 }
 
 impl Default for MutableBooleanColumn {

--- a/src/query/datavalues/src/columns/mutable.rs
+++ b/src/query/datavalues/src/columns/mutable.rs
@@ -38,4 +38,6 @@ pub trait MutableColumn: Send + Sync {
     }
 
     fn shrink_to_fit(&mut self);
+
+    fn memory_size(&self) -> usize;
 }

--- a/src/query/datavalues/src/columns/null/mutable.rs
+++ b/src/query/datavalues/src/columns/null/mutable.rs
@@ -80,4 +80,8 @@ impl MutableColumn for MutableNullColumn {
                 ErrorCode::BadDataArrayLength("Null column is empty when pop data value")
             })
     }
+
+    fn memory_size(&self) -> usize {
+        std::mem::size_of::<usize>()
+    }
 }

--- a/src/query/datavalues/src/columns/nullable/mutable.rs
+++ b/src/query/datavalues/src/columns/nullable/mutable.rs
@@ -77,6 +77,10 @@ impl MutableColumn for MutableNullableColumn {
                 if v { value } else { Ok(DataValue::Null) }
             })
     }
+
+    fn memory_size(&self) -> usize {
+        self.inner.memory_size() + self.values.as_slice().len()
+    }
 }
 
 impl MutableNullableColumn {

--- a/src/query/datavalues/src/columns/object/mutable.rs
+++ b/src/query/datavalues/src/columns/object/mutable.rs
@@ -80,6 +80,10 @@ where T: ObjectType
         let data_value = DataValue::try_from(t)?;
         Ok(data_value)
     }
+
+    fn memory_size(&self) -> usize {
+        self.values.iter().map(|v| v.memory_size()).sum()
+    }
 }
 
 impl<T> Default for MutableObjectColumn<T>

--- a/src/query/datavalues/src/columns/primitive/mutable.rs
+++ b/src/query/datavalues/src/columns/primitive/mutable.rs
@@ -82,6 +82,10 @@ where T: PrimitiveType
         let data_value = DataValue::try_from(t)?;
         Ok(data_value)
     }
+
+    fn memory_size(&self) -> usize {
+        self.values.len() * std::mem::size_of::<T>()
+    }
 }
 
 impl<T> Default for MutablePrimitiveColumn<T>

--- a/src/query/datavalues/src/columns/string/mutable.rs
+++ b/src/query/datavalues/src/columns/string/mutable.rs
@@ -151,6 +151,10 @@ impl MutableColumn for MutableStringColumn {
             ErrorCode::BadDataArrayLength("String column array is empty when pop data value")
         })
     }
+
+    fn memory_size(&self) -> usize {
+        self.values.len() + self.offsets.len() * std::mem::size_of::<i64>()
+    }
 }
 
 impl ScalarColumnBuilder for MutableStringColumn {

--- a/src/query/datavalues/src/columns/struct_/mutable.rs
+++ b/src/query/datavalues/src/columns/struct_/mutable.rs
@@ -136,6 +136,10 @@ impl MutableColumn for MutableStructColumn {
         }
         Ok(DataValue::Struct(values))
     }
+
+    fn memory_size(&self) -> usize {
+        self.inner_columns.iter().map(|v| v.memory_size()).sum()
+    }
 }
 
 impl ScalarColumnBuilder for MutableStructColumn {

--- a/src/query/datavalues/src/types/deserializations/array.rs
+++ b/src/query/datavalues/src/types/deserializations/array.rs
@@ -24,6 +24,10 @@ pub struct ArrayDeserializer {
 }
 
 impl TypeDeserializer for ArrayDeserializer {
+    fn memory_size(&self) -> usize {
+        self.builder.memory_size()
+    }
+
     #[allow(clippy::uninit_vec)]
     fn de_binary(&mut self, reader: &mut &[u8], _format: &FormatSettings) -> Result<()> {
         let size = reader.read_uvarint()?;

--- a/src/query/datavalues/src/types/deserializations/boolean.rs
+++ b/src/query/datavalues/src/types/deserializations/boolean.rs
@@ -23,6 +23,10 @@ pub struct BooleanDeserializer {
 }
 
 impl TypeDeserializer for BooleanDeserializer {
+    fn memory_size(&self) -> usize {
+        self.builder.memory_size()
+    }
+
     fn de_binary(&mut self, reader: &mut &[u8], _format: &FormatSettings) -> Result<()> {
         let value: bool = reader.read_scalar()?;
         self.builder.append_value(value);

--- a/src/query/datavalues/src/types/deserializations/date.rs
+++ b/src/query/datavalues/src/types/deserializations/date.rs
@@ -34,6 +34,10 @@ where
     T: PrimitiveType,
     T: Unmarshal<T> + StatBuffer + FromLexical,
 {
+    fn memory_size(&self) -> usize {
+        self.builder.memory_size()
+    }
+
     fn de_binary(&mut self, reader: &mut &[u8], _format: &FormatSettings) -> Result<()> {
         let value: T = reader.read_scalar()?;
         check_date(value.as_i32())?;

--- a/src/query/datavalues/src/types/deserializations/mod.rs
+++ b/src/query/datavalues/src/types/deserializations/mod.rs
@@ -43,6 +43,8 @@ pub use variant::*;
 
 #[enum_dispatch]
 pub trait TypeDeserializer: Send + Sync {
+    fn memory_size(&self) -> usize;
+
     fn de_binary(&mut self, reader: &mut &[u8], format: &FormatSettings) -> Result<()>;
 
     fn de_default(&mut self, format: &FormatSettings);

--- a/src/query/datavalues/src/types/deserializations/null.rs
+++ b/src/query/datavalues/src/types/deserializations/null.rs
@@ -27,6 +27,10 @@ pub struct NullDeserializer {
 }
 
 impl TypeDeserializer for NullDeserializer {
+    fn memory_size(&self) -> usize {
+        self.builder.memory_size()
+    }
+
     fn de_binary(&mut self, _reader: &mut &[u8], _format: &FormatSettings) -> Result<()> {
         self.builder.append_default();
         Ok(())

--- a/src/query/datavalues/src/types/deserializations/nullable.rs
+++ b/src/query/datavalues/src/types/deserializations/nullable.rs
@@ -29,6 +29,10 @@ pub struct NullableDeserializer {
 }
 
 impl TypeDeserializer for NullableDeserializer {
+    fn memory_size(&self) -> usize {
+        self.inner.memory_size() + self.bitmap.as_slice().len()
+    }
+
     fn de_binary(&mut self, reader: &mut &[u8], format: &FormatSettings) -> Result<()> {
         let valid: bool = reader.read_scalar()?;
         if valid {

--- a/src/query/datavalues/src/types/deserializations/number.rs
+++ b/src/query/datavalues/src/types/deserializations/number.rs
@@ -29,6 +29,10 @@ where
     T: PrimitiveType,
     T: Unmarshal<T> + StatBuffer + FromLexical,
 {
+    fn memory_size(&self) -> usize {
+        self.builder.memory_size()
+    }
+
     fn de_binary(&mut self, reader: &mut &[u8], _format: &FormatSettings) -> Result<()> {
         let value: T = reader.read_scalar()?;
         self.builder.append_value(value);

--- a/src/query/datavalues/src/types/deserializations/string.rs
+++ b/src/query/datavalues/src/types/deserializations/string.rs
@@ -35,6 +35,10 @@ impl StringDeserializer {
 }
 
 impl TypeDeserializer for StringDeserializer {
+    fn memory_size(&self) -> usize {
+        self.builder.memory_size()
+    }
+
     // See GroupHash.rs for StringColumn
     #[allow(clippy::uninit_vec)]
     fn de_binary(&mut self, reader: &mut &[u8], _format: &FormatSettings) -> Result<()> {

--- a/src/query/datavalues/src/types/deserializations/struct_.rs
+++ b/src/query/datavalues/src/types/deserializations/struct_.rs
@@ -24,6 +24,10 @@ pub struct StructDeserializer {
 }
 
 impl TypeDeserializer for StructDeserializer {
+    fn memory_size(&self) -> usize {
+        self.builder.memory_size()
+    }
+
     #[allow(clippy::uninit_vec)]
     fn de_binary(&mut self, reader: &mut &[u8], format: &FormatSettings) -> Result<()> {
         let mut values = Vec::with_capacity(self.inners.len());

--- a/src/query/datavalues/src/types/deserializations/timestamp.rs
+++ b/src/query/datavalues/src/types/deserializations/timestamp.rs
@@ -25,6 +25,10 @@ pub struct TimestampDeserializer {
 }
 
 impl TypeDeserializer for TimestampDeserializer {
+    fn memory_size(&self) -> usize {
+        self.builder.memory_size()
+    }
+
     fn de_binary(&mut self, reader: &mut &[u8], _format: &FormatSettings) -> Result<()> {
         let value: i64 = reader.read_scalar()?;
         check_timestamp(value)?;

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_csv.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_csv.rs
@@ -15,6 +15,7 @@
 use std::mem;
 use std::sync::Arc;
 
+use common_datavalues::DataSchemaRef;
 use common_datavalues::TypeDeserializer;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -40,6 +41,7 @@ impl InputFormatCSV {
     fn read_row(
         buf: &[u8],
         deserializers: &mut [common_datavalues::TypeDeserializerImpl],
+        schema: &DataSchemaRef,
         field_ends: &[usize],
         format_settings: &FormatSettings,
         path: &str,
@@ -56,12 +58,12 @@ impl InputFormatCSV {
             } else {
                 // todo(youngsofun): do not need escape, already done in csv-core
                 if let Err(e) = deserializer.de_text(&mut reader, format_settings) {
-                    let err_msg = format_column_error(c, col_data, &e.message());
+                    let err_msg = format_column_error(schema, c, col_data, &e.message());
                     return Err(csv_error(&err_msg, path, row_index));
                 };
                 reader.ignore_white_spaces().expect("must success");
                 if reader.must_eof().is_err() {
-                    let err_msg = format_column_error(c, col_data, "bad field end");
+                    let err_msg = format_column_error(schema, c, col_data, "bad field end");
                     return Err(csv_error(&err_msg, path, row_index));
                 }
             }
@@ -110,6 +112,7 @@ impl InputFormatTextBase for InputFormatCSV {
             Self::read_row(
                 buf,
                 columns,
+                &builder.ctx.schema,
                 &batch.field_ends[field_end_idx..field_end_idx + n_column],
                 &builder.ctx.format_settings,
                 &batch.path,

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_tsv.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_tsv.rs
@@ -34,6 +34,7 @@ use crate::processors::sources::input_formats::input_format_text::RowBatch;
 pub struct InputFormatTSV {}
 
 impl InputFormatTSV {
+    #[allow(clippy::too_many_arguments)]
     fn read_row(
         buf: &[u8],
         deserializers: &mut Vec<common_datavalues::TypeDeserializerImpl>,

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/input_context.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/input_context.rs
@@ -43,6 +43,7 @@ use crate::processors::sources::input_formats::input_split::SplitInfo;
 use crate::processors::sources::input_formats::InputFormat;
 
 const MIN_ROW_PER_BLOCK: usize = 800 * 1000;
+const DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD: usize = 100 * 1024 * 1024;
 
 #[derive(Debug)]
 pub enum InputPlan {
@@ -120,6 +121,7 @@ pub struct InputContext {
 
     pub read_batch_size: usize,
     pub rows_per_block: usize,
+    pub block_memory_size_threshold: usize,
 
     pub scan_progress: Arc<Progress>,
 }
@@ -205,6 +207,7 @@ impl InputContext {
             scan_progress,
             source: InputSource::Operator(operator),
             plan: InputPlan::CopyInto(plan),
+            block_memory_size_threshold: DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD,
         })
     }
 
@@ -259,6 +262,7 @@ impl InputContext {
             source: InputSource::Stream(Mutex::new(Some(stream_receiver))),
             plan: InputPlan::StreamingLoad(plan),
             splits: vec![],
+            block_memory_size_threshold: DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD,
         })
     }
 

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/input_pipeline.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/input_pipeline.rs
@@ -277,6 +277,7 @@ pub trait InputFormatPipe: Sized + Send + 'static {
                 tracing::debug!("read {} bytes", n);
                 if let Err(e) = batch_tx.send(Ok(batch.into())).await {
                     tracing::warn!("fail to send ReadBatch: {}", e);
+                    break;
                 }
             }
         }

--- a/src/query/service/src/pipelines/executor/executor_graph.rs
+++ b/src/query/service/src/pipelines/executor/executor_graph.rs
@@ -241,15 +241,7 @@ impl ExecutingGraph {
                 if state_guard_cache.is_none() {
                     state_guard_cache = Some(node.state.lock().unwrap());
                 }
-                let event = node.processor.event()?;
-                tracing::debug!(
-                    "node id:{:?}, name:{:?}, event: {:?}",
-                    node.processor.id(),
-                    node.processor.name(),
-                    event
-                );
-
-                let processor_state = match event {
+                let processor_state = match node.processor.event()? {
                     Event::Finished => State::Finished,
                     Event::NeedData | Event::NeedConsume => State::Idle,
                     Event::Sync => {

--- a/tests/suites/0_stateless/14_clickhouse_http_handler/14_0007_http_clickhouse_input_format_diagnostic.sh
+++ b/tests/suites/0_stateless/14_clickhouse_http_handler/14_0007_http_clickhouse_input_format_diagnostic.sh
@@ -35,8 +35,8 @@ curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT
 echo -e '\ntsv 1'
 cat << EOF > /tmp/databend_test_tsv_error1.txt
 insert into a(a,b,c) format TSV
-"2023-04-08 01:01:01"	"Hello"	12345678
-1989-023-03 15:23:23	"World"	123456
+2023-04-08 01:01:01	Hello	12345678
+1989-023-03 15:23:23	World	123456
 EOF
 curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" --data-binary @/tmp/databend_test_tsv_error1.txt | grep -c "Date"
 
@@ -44,8 +44,8 @@ curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT
 echo -e '\ntsv 2'
 cat << EOF > /tmp/databend_test_tsv_error2.txt
 insert into a(a,b,c) format TSV
-2023-04-08 01:01:01	"Hello"	12345678
-1989-02-03 15:23:23	"World"	123456 1
+2023-04-08 01:01:01	Hello	12345678
+1989-02-03 15:23:23	World	123456 1
 EOF
 curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" --data-binary @/tmp/databend_test_tsv_error2.txt | grep -c "column 2 (c int32): bad field end"
 

--- a/tests/suites/0_stateless/14_clickhouse_http_handler/14_0007_http_clickhouse_input_format_diagnostic.sh
+++ b/tests/suites/0_stateless/14_clickhouse_http_handler/14_0007_http_clickhouse_input_format_diagnostic.sh
@@ -29,7 +29,7 @@ cat << EOF > /tmp/databend_test_csv_error3.txt
 insert into a(a,b,c) format CSV "2023-04-08 01:01:01",,123Hello
 
 EOF
-curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" --data-binary @/tmp/databend_test_csv_error3.txt | grep -c "column 2: bad field end"
+curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" --data-binary @/tmp/databend_test_csv_error3.txt | grep -c "column 2 (c int32): bad field end"
 
 # 1 bad date
 echo -e '\ntsv 1'
@@ -47,7 +47,7 @@ insert into a(a,b,c) format TSV
 2023-04-08 01:01:01	"Hello"	12345678
 1989-02-03 15:23:23	"World"	123456 1
 EOF
-curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" --data-binary @/tmp/databend_test_tsv_error2.txt | grep -c "column 2: bad field end"
+curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" --data-binary @/tmp/databend_test_tsv_error2.txt | grep -c "column 2 (c int32): bad field end"
 
 echo -e '\ntsv 3'
 # 3 bad number
@@ -55,7 +55,7 @@ cat << EOF > /tmp/databend_test_tsv_error3.txt
 insert into a(a,b,c) format TSV
 2023-04-08 01:01:01		123Hello
 EOF
-curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" --data-binary @/tmp/databend_test_tsv_error3.txt | grep -c "column 2: bad field end"
+curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" --data-binary @/tmp/databend_test_tsv_error3.txt | grep -c "column 2 (c int32): bad field end"
 
 # cleanup
 curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" -d "drop table a"

--- a/tests/suites/0_stateless/14_clickhouse_http_handler/14_0007_http_clickhouse_input_format_diagnostic.sh
+++ b/tests/suites/0_stateless/14_clickhouse_http_handler/14_0007_http_clickhouse_input_format_diagnostic.sh
@@ -18,7 +18,7 @@ curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT
 # 2 one more column
 echo -e '\ncsv 2'
 cat << EOF > /tmp/databend_test_csv_error2.txt
-insert into a(a,b,c) format CSV "2023-04-08 01:01:01", "Hello",12345678,1
+insert into a(a,b,c) format CSV "2023-04-08 01:01:01","Hello",12345678,1
 
 EOF
 curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" --data-binary @/tmp/databend_test_csv_error2.txt | grep -c "allow ending"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

since estimating the size of the variant column is very expensive.
we use the size of bytes before json decode.


Fixes https://github.com/datafuselabs/databend/issues/7923

related to https://github.com/datafuselabs/databend/issues/7760