### PR TITLE
refactor(query): upgrade thrift runtime 0.16..0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,7 +1519,7 @@ dependencies = [
 name = "common-hive-meta-store"
 version = "0.1.0"
 dependencies = [
- "thrift 0.16.0",
+ "thrift 0.17.0",
  "which",
 ]
 
@@ -2041,7 +2041,7 @@ dependencies = [
  "futures",
  "opendal",
  "serde",
- "thrift 0.16.0",
+ "thrift 0.17.0",
  "tracing",
  "typetag",
 ]
@@ -2111,7 +2111,7 @@ dependencies = [
  "serde_repr",
  "serfig",
  "snailquote",
- "thrift 0.16.0",
+ "thrift 0.17.0",
  "time 0.3.14",
  "tracing",
  "typetag",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,7 +1275,7 @@ dependencies = [
  "semver 1.0.14",
  "serde",
  "serfig",
- "thrift",
+ "thrift 0.17.0",
 ]
 
 [[package]]
@@ -1519,7 +1519,7 @@ dependencies = [
 name = "common-hive-meta-store"
 version = "0.1.0"
 dependencies = [
- "thrift",
+ "thrift 0.16.0",
  "which",
 ]
 
@@ -2041,7 +2041,7 @@ dependencies = [
  "futures",
  "opendal",
  "serde",
- "thrift",
+ "thrift 0.16.0",
  "tracing",
  "typetag",
 ]
@@ -2111,7 +2111,7 @@ dependencies = [
  "serde_repr",
  "serfig",
  "snailquote",
- "thrift",
+ "thrift 0.16.0",
  "time 0.3.14",
  "tracing",
  "typetag",
@@ -2815,7 +2815,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "threadpool",
- "thrift",
+ "thrift 0.17.0",
  "time 0.3.14",
  "tokio-rustls",
  "tokio-stream",
@@ -5379,7 +5379,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",
  "thiserror",
- "thrift",
+ "thrift 0.16.0",
  "tokio",
 ]
 
@@ -5435,6 +5435,15 @@ name = "ordered-float"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
  "num-traits",
 ]
@@ -7578,6 +7587,18 @@ dependencies = [
  "integer-encoding",
  "log",
  "ordered-float 1.1.1",
+ "threadpool",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "git+https://github.com/datafuse-extras/thrift?tag=v0.17.0#4d493e867b349f3475203ef9848353b315203c51"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "log",
+ "ordered-float 2.10.0",
  "threadpool",
 ]
 

--- a/src/query/config/Cargo.toml
+++ b/src/query/config/Cargo.toml
@@ -28,7 +28,6 @@ semver = "1.0.14"
 serde = { version = "1.0.145", features = ["derive"] }
 serfig = "0.0.2"
 
-
 [features]
 default = []
 storage-hdfs = ["opendal/services-hdfs", "common-storage/storage-hdfs"]

--- a/src/query/config/Cargo.toml
+++ b/src/query/config/Cargo.toml
@@ -18,6 +18,8 @@ common-storage = { path = "../../common/storage" }
 common-tracing = { path = "../../common/tracing" }
 common-users = { path = "../users" }
 
+thrift = { git = "https://github.com/datafuse-extras/thrift", tag = "v0.17.0", optional = true }
+
 clap = { version = "3.2.22", features = ["derive", "env"] }
 hex = "0.4.3"
 once_cell = "1.15.0"
@@ -25,7 +27,7 @@ opendal = { version = "0.17", features = ["layers-retry", "compress"], optional 
 semver = "1.0.14"
 serde = { version = "1.0.145", features = ["derive"] }
 serfig = "0.0.2"
-thrift = { version = "0.16.0", optional = true }
+
 
 [features]
 default = []

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -77,6 +77,7 @@ common-users = { path = "../users" }
 
 # Github dependencies
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "7f246e3" }
+thrift = { git = "https://github.com/datafuse-extras/thrift", tag = "v0.17.0", optional = true }
 
 # Crates.io dependencies
 ahash = "0.8.0"
@@ -138,7 +139,6 @@ strum_macros = "0.24.3"
 tempfile = { version = "3.3.0", optional = true }
 thiserror = "1"
 threadpool = "1.8.1"
-thrift = { version = "0.16.0", optional = true }
 time = "0.3.14"
 tokio-rustls = "0.23.4"
 tokio-stream = { version = "0.1.10", features = ["net"] }

--- a/src/query/storages/hive-meta-store/Cargo.toml
+++ b/src/query/storages/hive-meta-store/Cargo.toml
@@ -22,9 +22,9 @@ hive-it = []
 # Workspace dependencies
 
 # Github dependencies
+thrift = { git = "https://github.com/datafuse-extras/thrift", tag = "v0.17.0" }
 
 # Crates.io dependencies
-thrift = "0.16.0"
 
 [build-dependencies]
 which = "4.3.0"

--- a/src/query/storages/hive/Cargo.toml
+++ b/src/query/storages/hive/Cargo.toml
@@ -29,11 +29,12 @@ common-pipeline-sources = { path = "../../pipeline/sources" }
 common-storages-index = { path = "../index" }
 common-storages-util = { path = "../util" }
 
+thrift = { git = "https://github.com/datafuse-extras/thrift", tag = "v0.17.0" }
+
 async-recursion = "1.0.0"
 async-trait = "0.1.57"
 futures = "0.3.24"
 opendal = { version = "0.17", features = ["layers-retry"] }
 serde = { version = "1.0.145", features = ["derive"] }
-thrift = "0.16.0"
 tracing = "0.1.36"
 typetag = "0.2.3"

--- a/src/query/storages/preludes/Cargo.toml
+++ b/src/query/storages/preludes/Cargo.toml
@@ -36,6 +36,8 @@ common-streams = { path = "../../streams" }
 common-tracing = { path = "../../../common/tracing" }
 common-users = { path = "../../users" }
 
+thrift = { git = "https://github.com/datafuse-extras/thrift", tag = "v0.17.0" }
+
 async-stream = "0.3.3"
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
 chrono = "0.4.22"
@@ -54,7 +56,6 @@ serde_json = "1.0.85"
 serde_repr = "0.1.9"
 serfig = "0.0.2"
 snailquote = "0.3.1"
-thrift = "0.16.0"
 time = "0.3.14"
 tracing = "0.1.36"
 typetag = "0.2.3"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(query): upgrade thrift runtime 0.16..0.17

Thrift 0.17 introduces new trait `TSerialize`.

## Changelog







## Related Issues