### PR TITLE
chore(planner): Improve explain pipeline

### DIFF
--- a/src/query/pipeline/core/src/pipeline_display.rs
+++ b/src/query/pipeline/core/src/pipeline_display.rs
@@ -29,7 +29,7 @@ struct PipelineIndentDisplayWrapper<'a> {
 }
 
 impl<'a> PipelineIndentDisplayWrapper<'a> {
-    fn pipe_name(pipe: &Pipe) -> &'static str {
+    fn pipe_name(pipe: &Pipe) -> String {
         unsafe {
             match pipe {
                 Pipe::SimplePipe { processors, .. } => processors[0].name(),

--- a/src/query/pipeline/core/src/processors/processor.rs
+++ b/src/query/pipeline/core/src/processors/processor.rs
@@ -35,7 +35,7 @@ pub enum Event {
 // The design is inspired by ClickHouse processors
 #[async_trait::async_trait]
 pub trait Processor: Send {
-    fn name(&self) -> &'static str;
+    fn name(&self) -> String;
 
     /// Reference used for downcast.
     fn as_any(&mut self) -> &mut dyn Any;
@@ -87,7 +87,7 @@ impl ProcessorPtr {
     }
 
     /// # Safety
-    pub unsafe fn name(&self) -> &'static str {
+    pub unsafe fn name(&self) -> String {
         (*self.inner.get()).name()
     }
 

--- a/src/query/pipeline/core/src/processors/resize_processor.rs
+++ b/src/query/pipeline/core/src/processors/resize_processor.rs
@@ -141,8 +141,8 @@ impl ResizeProcessor {
 
 #[async_trait::async_trait]
 impl Processor for ResizeProcessor {
-    fn name(&self) -> &'static str {
-        "Resize"
+    fn name(&self) -> String {
+        "Resize".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/pipeline/sinks/src/processors/sinks/async_sink.rs
+++ b/src/query/pipeline/sinks/src/processors/sinks/async_sink.rs
@@ -62,8 +62,8 @@ impl<T: AsyncSink + 'static> AsyncSinker<T> {
 
 #[async_trait::async_trait]
 impl<T: AsyncSink + 'static> Processor for AsyncSinker<T> {
-    fn name(&self) -> &'static str {
-        T::NAME
+    fn name(&self) -> String {
+        T::NAME.to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/pipeline/sinks/src/processors/sinks/sync_sink.rs
+++ b/src/query/pipeline/sinks/src/processors/sinks/sync_sink.rs
@@ -58,8 +58,8 @@ impl<T: Sink + 'static> Sinker<T> {
 
 #[async_trait::async_trait]
 impl<T: Sink + 'static> Processor for Sinker<T> {
-    fn name(&self) -> &'static str {
-        T::NAME
+    fn name(&self) -> String {
+        T::NAME.to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/pipeline/sources/src/processors/sources/async_source.rs
+++ b/src/query/pipeline/sources/src/processors/sources/async_source.rs
@@ -65,8 +65,8 @@ impl<T: 'static + AsyncSource> AsyncSourcer<T> {
 
 #[async_trait::async_trait]
 impl<T: 'static + AsyncSource> Processor for AsyncSourcer<T> {
-    fn name(&self) -> &'static str {
-        T::NAME
+    fn name(&self) -> String {
+        T::NAME.to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/pipeline/sources/src/processors/sources/empty_source.rs
+++ b/src/query/pipeline/sources/src/processors/sources/empty_source.rs
@@ -32,8 +32,8 @@ impl EmptySource {
 }
 
 impl Processor for EmptySource {
-    fn name(&self) -> &'static str {
-        "EmptySource"
+    fn name(&self) -> String {
+        "EmptySource".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/source_aligner.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/source_aligner.rs
@@ -74,8 +74,8 @@ impl<I: InputFormatPipe> Aligner<I> {
 
 #[async_trait::async_trait]
 impl<I: InputFormatPipe> Processor for Aligner<I> {
-    fn name(&self) -> &'static str {
-        "Aligner"
+    fn name(&self) -> String {
+        "Aligner".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/source_deserializer.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/source_deserializer.rs
@@ -58,8 +58,8 @@ impl<I: InputFormatPipe> DeserializeSource<I> {
 
 #[async_trait::async_trait]
 impl<I: InputFormatPipe> Processor for DeserializeSource<I> {
-    fn name(&self) -> &'static str {
-        "Deserializer"
+    fn name(&self) -> String {
+        "Deserializer".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/transform_deserializer.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/transform_deserializer.rs
@@ -83,8 +83,8 @@ impl<I: InputFormatPipe> DeserializeTransformer<I> {
 
 #[async_trait::async_trait]
 impl<I: InputFormatPipe> Processor for DeserializeTransformer<I> {
-    fn name(&self) -> &'static str {
-        "DeserializeTransformer"
+    fn name(&self) -> String {
+        "DeserializeTransformer".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/pipeline/sources/src/processors/sources/one_block_source.rs
+++ b/src/query/pipeline/sources/src/processors/sources/one_block_source.rs
@@ -38,8 +38,8 @@ impl OneBlockSource {
 
 #[async_trait::async_trait]
 impl Processor for OneBlockSource {
-    fn name(&self) -> &'static str {
-        "BlockSource"
+    fn name(&self) -> String {
+        "BlockSource".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/pipeline/sources/src/processors/sources/sync_source.rs
+++ b/src/query/pipeline/sources/src/processors/sources/sync_source.rs
@@ -63,8 +63,8 @@ impl<T: 'static + SyncSource> SyncSourcer<T> {
 
 #[async_trait::async_trait]
 impl<T: 'static + SyncSource> Processor for SyncSourcer<T> {
-    fn name(&self) -> &'static str {
-        T::NAME
+    fn name(&self) -> String {
+        T::NAME.to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/pipeline/transforms/src/processors/transforms/transform.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform.rs
@@ -29,6 +29,10 @@ pub trait Transform: Send {
     const SKIP_EMPTY_DATA_BLOCK: bool = false;
 
     fn transform(&mut self, data: DataBlock) -> Result<DataBlock>;
+
+    fn name(&self) -> String {
+        Self::NAME.to_string()
+    }
 }
 
 pub struct Transformer<T: Transform + 'static> {
@@ -54,8 +58,8 @@ impl<T: Transform + 'static> Transformer<T> {
 
 #[async_trait::async_trait]
 impl<T: Transform + 'static> Processor for Transformer<T> {
-    fn name(&self) -> &'static str {
-        T::NAME
+    fn name(&self) -> String {
+        Transform::name(&self.transform)
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact.rs
@@ -115,8 +115,8 @@ impl<T: Compactor + Send + 'static> TransformCompact<T> {
 
 #[async_trait::async_trait]
 impl<T: Compactor + Send + 'static> Processor for TransformCompact<T> {
-    fn name(&self) -> &'static str {
-        T::name()
+    fn name(&self) -> String {
+        T::name().to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/api/rpc/exchange/exchange_sink_merge.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_sink_merge.rs
@@ -63,8 +63,8 @@ impl ExchangeMergeSink {
 
 #[async_trait::async_trait]
 impl Processor for ExchangeMergeSink {
-    fn name(&self) -> &'static str {
-        "ExchangeMergeSink"
+    fn name(&self) -> String {
+        "ExchangeMergeSink".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/api/rpc/exchange/exchange_sink_shuffle.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_sink_shuffle.rs
@@ -70,8 +70,8 @@ impl ExchangePublisherSink {
 
 #[async_trait::async_trait]
 impl Processor for ExchangePublisherSink {
-    fn name(&self) -> &'static str {
-        "ExchangeShuffleSink"
+    fn name(&self) -> String {
+        "ExchangeShuffleSink".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/api/rpc/exchange/exchange_transform.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_transform.rs
@@ -135,8 +135,8 @@ impl ExchangeTransform {
 
 #[async_trait::async_trait]
 impl Processor for ExchangeTransform {
-    fn name(&self) -> &'static str {
-        "ExchangeTransform"
+    fn name(&self) -> String {
+        "ExchangeTransform".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/api/rpc/exchange/exchange_transform_source.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_transform_source.rs
@@ -69,8 +69,8 @@ impl ExchangeSourceTransform {
 
 #[async_trait::async_trait]
 impl Processor for ExchangeSourceTransform {
-    fn name(&self) -> &'static str {
-        "ExchangeSourceTransform"
+    fn name(&self) -> String {
+        "ExchangeSourceTransform".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/pipelines/processors/transforms/chunk_operator.rs
+++ b/src/query/service/src/pipelines/processors/transforms/chunk_operator.rs
@@ -124,4 +124,24 @@ impl Transform for CompoundChunkOperator {
             .iter()
             .try_fold(data, |input, op| op.execute(&self.ctx, input))
     }
+
+    fn name(&self) -> String {
+        format!(
+            "{}({})",
+            Self::NAME,
+            self.operators
+                .iter()
+                .map(|op| {
+                    match op {
+                        ChunkOperator::Map { .. } => "Map",
+                        ChunkOperator::Filter { .. } => "Filter",
+                        ChunkOperator::Project { .. } => "Project",
+                        ChunkOperator::Rename { .. } => "Rename",
+                    }
+                    .to_string()
+                })
+                .collect::<Vec<String>>()
+                .join("->")
+        )
+    }
 }

--- a/src/query/service/src/pipelines/processors/transforms/transform_aggregator.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_aggregator.rs
@@ -288,8 +288,8 @@ impl<TAggregator: Aggregator + 'static> AggregatorTransform<TAggregator> {
 }
 
 impl<TAggregator: Aggregator + 'static> Processor for AggregatorTransform<TAggregator> {
-    fn name(&self) -> &'static str {
-        TAggregator::NAME
+    fn name(&self) -> String {
+        TAggregator::NAME.to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/pipelines/processors/transforms/transform_create_sets.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_create_sets.rs
@@ -79,8 +79,8 @@ impl TransformCreateSets {
 
 #[async_trait::async_trait]
 impl Processor for TransformCreateSets {
-    fn name(&self) -> &'static str {
-        "TransformCreateSets"
+    fn name(&self) -> String {
+        "TransformCreateSets".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/pipelines/processors/transforms/transform_hash_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_hash_join.rs
@@ -100,8 +100,8 @@ impl TransformHashJoinProbe {
 
 #[async_trait::async_trait]
 impl Processor for TransformHashJoinProbe {
-    fn name(&self) -> &'static str {
-        "HashJoin"
+    fn name(&self) -> String {
+        "HashJoin".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/pipelines/processors/transforms/transform_limit.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_limit.rs
@@ -120,13 +120,14 @@ impl<const MODE: usize> TransformLimitImpl<MODE> {
 
 #[async_trait::async_trait]
 impl<const MODE: usize> Processor for TransformLimitImpl<MODE> {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> String {
         match MODE {
             ONLY_LIMIT => "LimitTransform",
             ONLY_OFFSET => "OffsetTransform",
             OFFSET_AND_LIMIT => "OffsetAndLimitTransform",
             _ => unreachable!(),
         }
+        .to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/pipelines/processors/transforms/transform_merge_block.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_merge_block.rs
@@ -78,8 +78,8 @@ impl TransformMergeBlock {
 
 #[async_trait::async_trait]
 impl Processor for TransformMergeBlock {
-    fn name(&self) -> &'static str {
-        "TransformMergeBlock"
+    fn name(&self) -> String {
+        "TransformMergeBlock".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/storages/result/result_table_sink.rs
+++ b/src/query/service/src/storages/result/result_table_sink.rs
@@ -143,8 +143,8 @@ impl ResultTableSink {
 
 #[async_trait]
 impl Processor for ResultTableSink {
-    fn name(&self) -> &'static str {
-        "ResultTableSink"
+    fn name(&self) -> String {
+        "ResultTableSink".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/storages/result/result_table_source.rs
+++ b/src/query/service/src/storages/result/result_table_source.rs
@@ -74,8 +74,8 @@ impl ResultTableSource {
 
 #[async_trait::async_trait]
 impl Processor for ResultTableSource {
-    fn name(&self) -> &'static str {
-        "ResultTableSource"
+    fn name(&self) -> String {
+        "ResultTableSource".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/storages/stage/stage_table_sink.rs
+++ b/src/query/service/src/storages/stage/stage_table_sink.rs
@@ -150,8 +150,8 @@ impl StageTableSink {
 
 #[async_trait]
 impl Processor for StageTableSink {
-    fn name(&self) -> &'static str {
-        "StageSink"
+    fn name(&self) -> String {
+        "StageSink".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/storages/fuse/src/operations/fuse_sink.rs
+++ b/src/query/storages/fuse/src/operations/fuse_sink.rs
@@ -113,8 +113,8 @@ impl FuseTableSink {
 
 #[async_trait]
 impl Processor for FuseTableSink {
-    fn name(&self) -> &'static str {
-        "FuseSink"
+    fn name(&self) -> String {
+        "FuseSink".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/storages/fuse/src/operations/read.rs
+++ b/src/query/storages/fuse/src/operations/read.rs
@@ -235,8 +235,8 @@ impl FuseTableSource {
 
 #[async_trait::async_trait]
 impl Processor for FuseTableSource {
-    fn name(&self) -> &'static str {
-        "FuseEngineSource"
+    fn name(&self) -> String {
+        "FuseEngineSource".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/storages/hive/src/hive_table_source.rs
+++ b/src/query/storages/hive/src/hive_table_source.rs
@@ -106,8 +106,8 @@ impl HiveTableSource {
 
 #[async_trait::async_trait]
 impl Processor for HiveTableSource {
-    fn name(&self) -> &'static str {
-        "HiveEngineSource"
+    fn name(&self) -> String {
+        "HiveEngineSource".to_string()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Improve format of explain pipeline:
```sql
mysql> explain pipeline select number+1 from numbers(10) where number < 5;
+-----------------------------------------------------+
| explain                                             |
+-----------------------------------------------------+
| CompoundChunkOperator(Map) × 1 processor            |
|   CompoundChunkOperator(Filter) × 1 processor       |
|     CompoundChunkOperator(Rename) × 1 processor     |
|       CompoundChunkOperator(Project) × 1 processor  |
|         NumbersSourceTransform × 1 processor        |
+-----------------------------------------------------+
5 rows in set (0.11 sec)
Read 0 rows, 0.00 B in 0.003 sec., 0 rows/sec., 0.00 B/sec.
```
