### PR TITLE
feat(query): migrate variant func to func-v2

### DIFF
--- a/src/common/jsonb/src/error.rs
+++ b/src/common/jsonb/src/error.rs
@@ -72,6 +72,7 @@ impl Display for ParseErrorCode {
 pub enum Error {
     InvalidUtf8,
     InvalidEOF,
+    InvalidToken,
 
     InvalidJsonb,
     InvalidJsonbHeader,
@@ -91,6 +92,12 @@ impl Display for Error {
 
 impl From<std::io::Error> for Error {
     fn from(_error: std::io::Error) -> Self {
+        Error::InvalidUtf8
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(_error: std::str::Utf8Error) -> Self {
         Error::InvalidUtf8
     }
 }

--- a/src/common/jsonb/src/from.rs
+++ b/src/common/jsonb/src/from.rs
@@ -15,6 +15,8 @@
 use core::iter::FromIterator;
 use std::borrow::Cow;
 
+use ordered_float::OrderedFloat;
+
 use super::number::Number;
 use super::value::Object;
 use super::value::Value;
@@ -65,6 +67,18 @@ from_unsigned_integer! {
 
 from_float! {
     f32 f64
+}
+
+impl<'a> From<OrderedFloat<f32>> for Value<'a> {
+    fn from(f: OrderedFloat<f32>) -> Self {
+        Value::Number(Number::Float64(f.0 as f64))
+    }
+}
+
+impl<'a> From<OrderedFloat<f64>> for Value<'a> {
+    fn from(f: OrderedFloat<f64>) -> Self {
+        Value::Number(Number::Float64(f.0))
+    }
 }
 
 impl<'a> From<bool> for Value<'a> {

--- a/src/common/jsonb/src/functions.rs
+++ b/src/common/jsonb/src/functions.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::convert::TryInto;
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::VecDeque;
 
@@ -20,11 +21,12 @@ use super::constants::*;
 use super::error::*;
 use super::jentry::JEntry;
 use super::number::Number;
+use super::value::JsonPath;
 
 // builtin functions for `JSONB` bytes without decode all Values
 
-// build `JSONB` array from items
-// Assuming that the input values is valid JSONB data
+/// Build `JSONB` array from items.
+/// Assuming that the input values is valid JSONB data.
 pub fn build_array<'a>(
     items: impl IntoIterator<Item = &'a [u8]>,
     buf: &mut Vec<u8>,
@@ -60,8 +62,8 @@ pub fn build_array<'a>(
     Ok(())
 }
 
-// build `JSONB` object from items
-// Assuming that the input values is valid JSONB data
+/// Build `JSONB` object from items.
+/// Assuming that the input values is valid JSONB data.
 pub fn build_object<'a, K: AsRef<str>>(
     items: impl IntoIterator<Item = (K, &'a [u8])>,
     buf: &mut Vec<u8>,
@@ -111,12 +113,224 @@ pub fn build_object<'a, K: AsRef<str>>(
     Ok(())
 }
 
-// `JSONB` values supports partial decode for comparison,
-// if the values are found to be unequal,
-// the result will be returned immediately
-//
-// in first level header, values compare as the following order
-// Scalar Null > Array > Object > Other Scalars(String > Number > Boolean)
+/// Get the length of `JSONB` array.
+pub fn array_length(value: &[u8]) -> Option<usize> {
+    let header = read_u32(value, 0).unwrap();
+    match header & CONTAINER_HEADER_TYPE_MASK {
+        ARRAY_CONTAINER_TAG => {
+            let length = (header & CONTAINER_HEADER_LEN_MASK) as usize;
+            Some(length)
+        }
+        _ => None,
+    }
+}
+
+/// Get the inner value by ignoring case name of `JSONB` object.
+pub fn get_by_name_ignore_case(value: &[u8], name: &str) -> Option<Vec<u8>> {
+    let header = read_u32(value, 0).unwrap();
+    match header & CONTAINER_HEADER_TYPE_MASK {
+        OBJECT_CONTAINER_TAG => {
+            let length = (header & CONTAINER_HEADER_LEN_MASK) as usize;
+            let mut jentry_offset = 4;
+            let mut val_offset = 8 * length + 4;
+
+            let mut key_jentries: VecDeque<JEntry> = VecDeque::with_capacity(length);
+            for _ in 0..length {
+                let encoded = read_u32(value, jentry_offset).unwrap();
+                let key_jentry = JEntry::decode_jentry(encoded);
+
+                jentry_offset += 4;
+                val_offset += key_jentry.length as usize;
+                key_jentries.push_back(key_jentry);
+            }
+
+            let mut offsets = None;
+            let mut key_offset = 8 * length + 4;
+            while let Some(key_jentry) = key_jentries.pop_front() {
+                let prev_key_offset = key_offset;
+                key_offset += key_jentry.length as usize;
+                let key =
+                    unsafe { std::str::from_utf8_unchecked(&value[prev_key_offset..key_offset]) };
+                // first match the value with the same name, if not found,
+                // then match the value with the ignoring case name.
+                if name.eq(key) {
+                    offsets = Some((jentry_offset, val_offset));
+                    break;
+                } else if name.eq_ignore_ascii_case(key) && offsets.is_none() {
+                    offsets = Some((jentry_offset, val_offset));
+                }
+                let val_encoded = read_u32(value, jentry_offset).unwrap();
+                let val_jentry = JEntry::decode_jentry(val_encoded);
+                jentry_offset += 4;
+                val_offset += val_jentry.length as usize;
+            }
+            if let Some((jentry_offset, mut val_offset)) = offsets {
+                let mut buf: Vec<u8> = Vec::new();
+                let encoded = read_u32(value, jentry_offset).unwrap();
+                let jentry = JEntry::decode_jentry(encoded);
+                let prev_val_offset = val_offset;
+                val_offset += jentry.length as usize;
+                match jentry.type_code {
+                    CONTAINER_TAG => buf.extend_from_slice(&value[prev_val_offset..val_offset]),
+                    _ => {
+                        let scalar_header = SCALAR_CONTAINER_TAG;
+                        buf.extend_from_slice(&scalar_header.to_be_bytes());
+                        buf.extend_from_slice(&encoded.to_be_bytes());
+                        if val_offset > prev_val_offset {
+                            buf.extend_from_slice(&value[prev_val_offset..val_offset]);
+                        }
+                    }
+                }
+                return Some(buf);
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Get the inner value by JSON path of `JSONB` object.
+/// JSON path can be a nested index or name,
+/// used to get inner value of array and object respectively.
+pub fn get_by_path<'a>(value: &'a [u8], paths: Vec<JsonPath<'a>>) -> Option<Vec<u8>> {
+    let mut offset = 0;
+    let mut buf: Vec<u8> = Vec::new();
+
+    for i in 0..paths.len() {
+        let path = paths.get(i).unwrap();
+        let header = read_u32(value, offset).unwrap();
+        let (jentry_offset, val_offset) = match path {
+            JsonPath::String(name) => {
+                if header & CONTAINER_HEADER_TYPE_MASK != OBJECT_CONTAINER_TAG {
+                    return None;
+                }
+                let length = (header & CONTAINER_HEADER_LEN_MASK) as usize;
+                let mut jentry_offset = offset + 4;
+                let mut val_offset = offset + 8 * length + 4;
+
+                let mut key_jentries: VecDeque<JEntry> = VecDeque::with_capacity(length);
+                for _ in 0..length {
+                    let encoded = read_u32(value, jentry_offset).unwrap();
+                    let key_jentry = JEntry::decode_jentry(encoded);
+
+                    jentry_offset += 4;
+                    val_offset += key_jentry.length as usize;
+                    key_jentries.push_back(key_jentry);
+                }
+
+                let mut found = false;
+                let mut key_offset = offset + 8 * length + 4;
+                while let Some(key_jentry) = key_jentries.pop_front() {
+                    let prev_key_offset = key_offset;
+                    key_offset += key_jentry.length as usize;
+                    let key = unsafe {
+                        std::str::from_utf8_unchecked(&value[prev_key_offset..key_offset])
+                    };
+                    if name.eq(key) {
+                        found = true;
+                        break;
+                    }
+                    let val_encoded = read_u32(value, jentry_offset).unwrap();
+                    let val_jentry = JEntry::decode_jentry(val_encoded);
+                    jentry_offset += 4;
+                    val_offset += val_jentry.length as usize;
+                }
+                if !found {
+                    return None;
+                }
+                (jentry_offset, val_offset)
+            }
+            JsonPath::UInt64(index) => {
+                if header & CONTAINER_HEADER_TYPE_MASK != ARRAY_CONTAINER_TAG {
+                    return None;
+                }
+                let length = (header & CONTAINER_HEADER_LEN_MASK) as usize;
+                if *index as usize >= length {
+                    return None;
+                }
+                let mut jentry_offset = offset + 4;
+                let mut val_offset = offset + 4 * length + 4;
+
+                for _ in 0..*index {
+                    let encoded = read_u32(value, jentry_offset).unwrap();
+                    let jentry = JEntry::decode_jentry(encoded);
+
+                    jentry_offset += 4;
+                    val_offset += jentry.length as usize;
+                }
+                (jentry_offset, val_offset)
+            }
+        };
+        let encoded = read_u32(value, jentry_offset).unwrap();
+        let jentry = JEntry::decode_jentry(encoded);
+        // if the last JSON path, return the value
+        // if the value is a container value, then continue get for next JSON path.
+        match jentry.type_code {
+            CONTAINER_TAG => {
+                if i == paths.len() - 1 {
+                    buf.extend_from_slice(&value[val_offset..val_offset + jentry.length as usize]);
+                } else {
+                    offset = val_offset;
+                }
+            }
+            _ => {
+                if i == paths.len() - 1 {
+                    let scalar_header = SCALAR_CONTAINER_TAG;
+                    buf.extend_from_slice(&scalar_header.to_be_bytes());
+                    buf.extend_from_slice(&encoded.to_be_bytes());
+                    if jentry.length > 0 {
+                        buf.extend_from_slice(
+                            &value[val_offset..val_offset + jentry.length as usize],
+                        );
+                    }
+                } else {
+                    return None;
+                }
+            }
+        }
+    }
+    Some(buf)
+}
+
+/// Get the keys of a `JSONB` object.
+pub fn object_keys(value: &[u8]) -> Option<Vec<u8>> {
+    let header = read_u32(value, 0).unwrap();
+    match header & CONTAINER_HEADER_TYPE_MASK {
+        OBJECT_CONTAINER_TAG => {
+            let mut buf: Vec<u8> = Vec::new();
+            let length = (header & CONTAINER_HEADER_LEN_MASK) as usize;
+            let key_header = ARRAY_CONTAINER_TAG | length as u32;
+            buf.extend_from_slice(&key_header.to_be_bytes());
+
+            let mut jentry_offset = 4;
+            let mut key_offset = 8 * length + 4;
+            let mut key_offsets = Vec::with_capacity(length);
+            for _ in 0..length {
+                let key_encoded = read_u32(value, jentry_offset).unwrap();
+                let key_jentry = JEntry::decode_jentry(key_encoded);
+                buf.extend_from_slice(&key_encoded.to_be_bytes());
+
+                jentry_offset += 4;
+                key_offset += key_jentry.length as usize;
+                key_offsets.push(key_offset);
+            }
+            let mut prev_key_offset = 8 * length + 4;
+            for key_offset in key_offsets {
+                if key_offset > prev_key_offset {
+                    buf.extend_from_slice(&value[prev_key_offset..key_offset]);
+                }
+                prev_key_offset = key_offset;
+            }
+            Some(buf)
+        }
+        _ => None,
+    }
+}
+
+/// `JSONB` values supports partial decode for comparison,
+/// if the values are found to be unequal, the result will be returned immediately.
+/// In first level header, values compare as the following order:
+/// Scalar Null > Array > Object > Other Scalars(String > Number > Boolean).
 pub fn compare(left: &[u8], right: &[u8]) -> Result<Ordering, Error> {
     let left_header = read_u32(left, 0)?;
     let right_header = read_u32(right, 0)?;
@@ -192,9 +406,9 @@ fn compare_scalar(
         (CONTAINER_TAG, CONTAINER_TAG) => compare_container(left, right),
         (STRING_TAG, STRING_TAG) => {
             let left_offset = left_jentry.length as usize;
-            let left_str = std::str::from_utf8(&left[..left_offset]).unwrap();
+            let left_str = unsafe { std::str::from_utf8_unchecked(&left[..left_offset]) };
             let right_offset = right_jentry.length as usize;
-            let right_str = std::str::from_utf8(&right[..right_offset]).unwrap();
+            let right_str = unsafe { std::str::from_utf8_unchecked(&right[..right_offset]) };
             Ok(left_str.cmp(right_str))
         }
         (NUMBER_TAG, NUMBER_TAG) => {
@@ -357,6 +571,235 @@ fn compare_object(
     }
 
     Ok(left_length.cmp(&right_length))
+}
+
+/// Returns true if the `JSONB` is a Null.
+pub fn is_null(value: &[u8]) -> bool {
+    as_null(value).is_some()
+}
+
+/// If the `JSONB` is a Null, returns (). Returns None otherwise.
+pub fn as_null(value: &[u8]) -> Option<()> {
+    let header = read_u32(value, 0).unwrap();
+    match header & CONTAINER_HEADER_TYPE_MASK {
+        SCALAR_CONTAINER_TAG => {
+            let jentry = read_u32(value, 4).unwrap();
+            match jentry {
+                NULL_TAG => Some(()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Returns true if the `JSONB` is a Boolean. Returns false otherwise.
+pub fn is_boolean(value: &[u8]) -> bool {
+    as_bool(value).is_some()
+}
+
+/// If the `JSONB` is a Boolean, returns the associated bool. Returns None otherwise.
+pub fn as_bool(value: &[u8]) -> Option<bool> {
+    let header = read_u32(value, 0).unwrap();
+    match header & CONTAINER_HEADER_TYPE_MASK {
+        SCALAR_CONTAINER_TAG => {
+            let jentry = read_u32(value, 4).unwrap();
+            match jentry {
+                FALSE_TAG => Some(false),
+                TRUE_TAG => Some(true),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Returns true if the `JSONB` is a Number. Returns false otherwise.
+pub fn is_number(value: &[u8]) -> bool {
+    as_number(value).is_some()
+}
+
+/// If the `JSONB` is a Number, returns the Number. Returns None otherwise.
+pub fn as_number(value: &[u8]) -> Option<Number> {
+    let header = read_u32(value, 0).unwrap();
+    match header & CONTAINER_HEADER_TYPE_MASK {
+        SCALAR_CONTAINER_TAG => {
+            let jentry_encoded = read_u32(value, 4).unwrap();
+            let jentry = JEntry::decode_jentry(jentry_encoded);
+            match jentry.type_code {
+                NUMBER_TAG => {
+                    let length = jentry.length as usize;
+                    let num = Number::decode(&value[8..8 + length]);
+                    Some(num)
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Returns true if the `JSONB` is a i64 Number. Returns false otherwise.
+pub fn is_i64(value: &[u8]) -> bool {
+    as_i64(value).is_some()
+}
+
+/// If the `JSONB` is a Number, represent it as i64 if possible. Returns None otherwise.
+pub fn as_i64(value: &[u8]) -> Option<i64> {
+    match as_number(value) {
+        Some(num) => num.as_i64(),
+        None => None,
+    }
+}
+
+/// Returns true if the `JSONB` is a u64 Number. Returns false otherwise.
+pub fn is_u64(value: &[u8]) -> bool {
+    as_u64(value).is_some()
+}
+
+/// If the `JSONB` is a Number, represent it as u64 if possible. Returns None otherwise.
+pub fn as_u64(value: &[u8]) -> Option<u64> {
+    match as_number(value) {
+        Some(num) => num.as_u64(),
+        None => None,
+    }
+}
+
+/// Returns true if the `JSONB` is a f64 Number. Returns false otherwise.
+pub fn is_f64(value: &[u8]) -> bool {
+    as_f64(value).is_some()
+}
+
+/// If the `JSONB` is a Number, represent it as f64 if possible. Returns None otherwise.
+pub fn as_f64(value: &[u8]) -> Option<f64> {
+    match as_number(value) {
+        Some(num) => num.as_f64(),
+        None => None,
+    }
+}
+
+/// Returns true if the `JSONB` is a String. Returns false otherwise.
+pub fn is_string(value: &[u8]) -> bool {
+    as_str(value).is_some()
+}
+
+/// If the `JSONB` is a String, returns the String. Returns None otherwise.
+pub fn as_str(value: &[u8]) -> Option<Cow<'_, str>> {
+    let header = read_u32(value, 0).unwrap();
+    match header & CONTAINER_HEADER_TYPE_MASK {
+        SCALAR_CONTAINER_TAG => {
+            let jentry_encoded = read_u32(value, 4).unwrap();
+            let jentry = JEntry::decode_jentry(jentry_encoded);
+            match jentry.type_code {
+                STRING_TAG => {
+                    let length = jentry.length as usize;
+                    let s = unsafe { std::str::from_utf8_unchecked(&value[8..8 + length]) };
+                    Some(Cow::Borrowed(s))
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Returns true if the `JSONB` is An Array. Returns false otherwise.
+pub fn is_array(value: &[u8]) -> bool {
+    let header = read_u32(value, 0).unwrap();
+    matches!(header & CONTAINER_HEADER_TYPE_MASK, ARRAY_CONTAINER_TAG)
+}
+
+/// Returns true if the `JSONB` is An Object. Returns false otherwise.
+pub fn is_object(value: &[u8]) -> bool {
+    let header = read_u32(value, 0).unwrap();
+    matches!(header & CONTAINER_HEADER_TYPE_MASK, OBJECT_CONTAINER_TAG)
+}
+
+/// Parse path string to Json path.
+/// Support `["<name>"]`, `[<index>]`, `:name` and `.name`.
+pub fn parse_json_path(path: &[u8]) -> Result<Vec<JsonPath>, Error> {
+    let mut idx = 0;
+    let mut prev_idx = 0;
+    let mut json_paths = Vec::new();
+    while idx < path.len() {
+        let c = read_char(path, &mut idx)?;
+        if c == b'[' {
+            let c = read_char(path, &mut idx)?;
+            if c == b'"' {
+                prev_idx = idx;
+                loop {
+                    let c = read_char(path, &mut idx)?;
+                    if c == b'\\' {
+                        idx += 1;
+                    } else if c == b'"' {
+                        let c = read_char(path, &mut idx)?;
+                        if c != b']' {
+                            return Err(Error::InvalidToken);
+                        }
+                        break;
+                    }
+                }
+                if prev_idx == idx - 2 {
+                    return Err(Error::InvalidToken);
+                }
+                let s = std::str::from_utf8(&path[prev_idx..idx - 2])?;
+                let json_path = JsonPath::String(Cow::Borrowed(s));
+                json_paths.push(json_path);
+            } else {
+                prev_idx = idx - 1;
+                loop {
+                    let c = read_char(path, &mut idx)?;
+                    if c == b']' {
+                        break;
+                    }
+                }
+                if prev_idx == idx - 1 {
+                    return Err(Error::InvalidToken);
+                }
+                let s = std::str::from_utf8(&path[prev_idx..idx - 1])?;
+                if let Ok(v) = s.parse::<u64>() {
+                    let json_path = JsonPath::UInt64(v);
+                    json_paths.push(json_path);
+                } else {
+                    return Err(Error::InvalidToken);
+                }
+            }
+        } else {
+            if c == b':' || c == b'.' {
+                if idx == 1 {
+                    return Err(Error::InvalidToken);
+                } else {
+                    prev_idx = idx;
+                }
+            }
+            while idx < path.len() {
+                let c = read_char(path, &mut idx)?;
+                if c == b':' || c == b'.' || c == b'[' {
+                    idx -= 1;
+                    break;
+                } else if c == b'\\' {
+                    idx += 1;
+                }
+            }
+            if prev_idx == idx {
+                return Err(Error::InvalidToken);
+            }
+            let s = std::str::from_utf8(&path[prev_idx..idx])?;
+            let json_path = JsonPath::String(Cow::Borrowed(s));
+            json_paths.push(json_path);
+        }
+    }
+    Ok(json_paths)
+}
+
+fn read_char(buf: &[u8], idx: &mut usize) -> Result<u8, Error> {
+    match buf.get(*idx) {
+        Some(v) => {
+            *idx += 1;
+            Ok(*v)
+        }
+        None => Err(Error::InvalidEOF),
+    }
 }
 
 fn read_u32(buf: &[u8], idx: usize) -> Result<u32, Error> {

--- a/src/common/jsonb/src/parser.rs
+++ b/src/common/jsonb/src/parser.rs
@@ -229,7 +229,7 @@ impl<'a> Parser<'a> {
                 return Err(self.error(ParseErrorCode::InvalidNumberValue));
             }
         }
-        let s = std::str::from_utf8(&self.buf[start_idx..self.idx]).unwrap();
+        let s = unsafe { std::str::from_utf8_unchecked(&self.buf[start_idx..self.idx]) };
 
         if !has_fraction && !has_exponent {
             if !negative {

--- a/src/query/functions-v2/src/scalars/string.rs
+++ b/src/query/functions-v2/src/scalars/string.rs
@@ -37,7 +37,6 @@ use itertools::izip;
 pub fn register(registry: &mut FunctionRegistry) {
     registry.register_aliases("upper", &["ucase"]);
     registry.register_aliases("lower", &["lcase"]);
-    registry.register_aliases("octet_length", &["length"]);
     registry.register_aliases("char_length", &["character_length"]);
     registry.register_aliases("substr", &["substring", "mid"]);
 
@@ -100,6 +99,13 @@ pub fn register(registry: &mut FunctionRegistry) {
 
     registry.register_1_arg::<StringType, NumberType<u64>, _, _>(
         "octet_length",
+        FunctionProperty::default(),
+        |_| None,
+        |val, _| val.len() as u64,
+    );
+
+    registry.register_1_arg::<StringType, NumberType<u64>, _, _>(
+        "length",
         FunctionProperty::default(),
         |_| None,
         |val, _| val.len() as u64,

--- a/src/query/functions-v2/src/scalars/string_multi_args.rs
+++ b/src/query/functions-v2/src/scalars/string_multi_args.rs
@@ -689,7 +689,7 @@ fn regexp_instr_fn(
 
             regexp::validate_regexp_arguments("regexp_instr", pos, occur, ro)?;
             if source.is_empty() || pat.is_empty() {
-                builder.push(NumberScalar::UInt64(0u64));
+                builder.push_default();
                 continue;
             }
             key.push(pat.to_vec());
@@ -937,19 +937,16 @@ fn regexp_substr_fn(
             }));
             Ok(Value::Column(col))
         }
-        _ => {
-            let is_not_null = validity.pop();
-            match is_not_null {
-                Some(is_not_null) => {
-                    if is_not_null {
-                        Ok(Value::Column(Column::String(builder.build())))
-                    } else {
-                        Ok(Value::Scalar(Scalar::Null))
-                    }
+        _ => match validity.pop() {
+            Some(is_not_null) => {
+                if is_not_null {
+                    Ok(Value::Scalar(Scalar::String(builder.build_scalar())))
+                } else {
+                    Ok(Value::Scalar(Scalar::Null))
                 }
-                None => Ok(Value::Scalar(Scalar::Null)),
             }
-        }
+            None => Ok(Value::Scalar(Scalar::Null)),
+        },
     }
 }
 

--- a/src/query/functions-v2/src/scalars/variant.rs
+++ b/src/query/functions-v2/src/scalars/variant.rs
@@ -12,13 +12,53 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+use std::sync::Arc;
+
 use bstr::ByteSlice;
+use common_arrow::arrow::bitmap::MutableBitmap;
+use common_expression::types::nullable::NullableColumn;
+use common_expression::types::number::Float64Type;
+use common_expression::types::number::Int64Type;
+use common_expression::types::number::Number;
+use common_expression::types::number::NumberColumnBuilder;
+use common_expression::types::number::NumberScalar;
+use common_expression::types::number::UInt32Type;
+use common_expression::types::number::UInt64Type;
+use common_expression::types::number::F64;
+use common_expression::types::string::StringColumnBuilder;
 use common_expression::types::variant::JSONB_NULL;
+use common_expression::types::AnyType;
+use common_expression::types::BooleanType;
+use common_expression::types::DataType;
+use common_expression::types::NullableType;
+use common_expression::types::NumberDataType;
 use common_expression::types::StringType;
 use common_expression::types::VariantType;
 use common_expression::vectorize_with_builder_1_arg;
+use common_expression::wrap_nullable;
+use common_expression::Column;
+use common_expression::Function;
+use common_expression::FunctionContext;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
+use common_expression::FunctionSignature;
+use common_expression::Scalar;
+use common_expression::Value;
+use common_expression::ValueRef;
+use common_jsonb::array_length;
+use common_jsonb::as_bool;
+use common_jsonb::as_f64;
+use common_jsonb::as_i64;
+use common_jsonb::as_str;
+use common_jsonb::get_by_name_ignore_case;
+use common_jsonb::get_by_path;
+use common_jsonb::is_array;
+use common_jsonb::is_object;
+use common_jsonb::object_keys;
+use common_jsonb::parse_json_path;
+use common_jsonb::parse_value;
+use common_jsonb::JsonPath;
 
 pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, VariantType, _, _>(
@@ -40,4 +80,1280 @@ pub fn register(registry: &mut FunctionRegistry) {
             Ok(())
         }),
     );
+
+    registry.register_1_arg_core::<StringType, NullableType<VariantType>, _, _>(
+        "try_parse_json",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(column) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for v in column.iter() {
+                    if v.trim().is_empty() {
+                        bitmap.push(true);
+                        builder.put_slice(JSONB_NULL);
+                        builder.commit_row();
+                        continue;
+                    }
+                    match parse_value(v) {
+                        Ok(value) => {
+                            value.to_vec(&mut builder.data);
+                            bitmap.push(true);
+                        }
+                        Err(_) => bitmap.push(false),
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(s) => {
+                let val = if s.trim().is_empty() {
+                    Value::Scalar(Some(JSONB_NULL.to_vec()))
+                } else {
+                    match parse_value(s) {
+                        Ok(val) => {
+                            let mut buf = Vec::new();
+                            val.to_vec(&mut buf);
+                            Value::Scalar(Some(buf))
+                        }
+                        Err(_) => Value::Scalar(None),
+                    }
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<NullableType<StringType>, NullableType<VariantType>, _, _>(
+        "try_parse_json",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(NullableColumn { validity, column }) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for (valid, v) in validity.iter().zip(column.iter()) {
+                    if !valid {
+                        bitmap.push(false);
+                        builder.commit_row();
+                        continue;
+                    }
+                    if v.trim().is_empty() {
+                        bitmap.push(true);
+                        builder.put_slice(JSONB_NULL);
+                        builder.commit_row();
+                        continue;
+                    }
+                    match parse_value(v) {
+                        Ok(value) => {
+                            value.to_vec(&mut builder.data);
+                            bitmap.push(true);
+                        }
+                        Err(_) => {
+                            bitmap.push(false);
+                        }
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(None) => Ok(Value::Scalar(None)),
+            ValueRef::Scalar(Some(s)) => {
+                let val = if s.trim().is_empty() {
+                    Value::Scalar(Some(JSONB_NULL.to_vec()))
+                } else {
+                    match parse_value(s) {
+                        Ok(val) => {
+                            let mut buf = Vec::new();
+                            val.to_vec(&mut buf);
+                            Value::Scalar(Some(buf))
+                        }
+                        Err(_) => Value::Scalar(None),
+                    }
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<StringType, NullableType<StringType>, _, _>(
+        "check_json",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(column) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for v in column.iter() {
+                    if v.trim().is_empty() {
+                        bitmap.push(false);
+                        builder.commit_row();
+                        continue;
+                    }
+                    match parse_value(v) {
+                        Ok(_) => bitmap.push(false),
+                        Err(e) => {
+                            bitmap.push(true);
+                            builder.put_slice(e.to_string().as_bytes());
+                        }
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(s) => {
+                let val = if s.trim().is_empty() {
+                    Value::Scalar(None)
+                } else {
+                    match parse_value(s) {
+                        Ok(_) => Value::Scalar(None),
+                        Err(e) => Value::Scalar(Some(e.to_string().as_bytes().to_vec())),
+                    }
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<NullableType<StringType>, NullableType<StringType>, _, _>(
+        "check_json",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(NullableColumn { validity, column }) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for (valid, v) in validity.iter().zip(column.iter()) {
+                    if !valid {
+                        bitmap.push(false);
+                        builder.commit_row();
+                        continue;
+                    }
+                    if v.trim().is_empty() {
+                        bitmap.push(false);
+                        builder.commit_row();
+                        continue;
+                    }
+                    match parse_value(v) {
+                        Ok(_) => bitmap.push(false),
+                        Err(e) => {
+                            bitmap.push(true);
+                            builder.put_slice(e.to_string().as_bytes());
+                        }
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(None) => Ok(Value::Scalar(None)),
+            ValueRef::Scalar(Some(s)) => {
+                let val = if s.trim().is_empty() {
+                    Value::Scalar(None)
+                } else {
+                    match parse_value(s) {
+                        Ok(_) => Value::Scalar(None),
+                        Err(e) => Value::Scalar(Some(e.to_string().as_bytes().to_vec())),
+                    }
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<VariantType, NullableType<UInt32Type>, _, _>(
+        "length",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(column) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = NumberColumnBuilder::with_capacity(&NumberDataType::UInt32, size);
+                for v in column.iter() {
+                    match array_length(v) {
+                        Some(len) => {
+                            bitmap.push(true);
+                            builder.push(NumberScalar::UInt32(len as u32));
+                        }
+                        None => {
+                            bitmap.push(false);
+                            builder.push_default();
+                        }
+                    }
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: u32::try_downcast_column(&builder.build()).unwrap(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(v) => {
+                let val = match array_length(v) {
+                    Some(len) => Value::Scalar(Some(len as u32)),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<NullableType<VariantType>, NullableType<UInt32Type>, _, _>(
+        "length",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(NullableColumn { validity, column }) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = NumberColumnBuilder::with_capacity(&NumberDataType::UInt32, size);
+                for (valid, v) in validity.iter().zip(column.iter()) {
+                    if !valid {
+                        bitmap.push(false);
+                        builder.push_default();
+                        continue;
+                    }
+                    match array_length(v) {
+                        Some(len) => {
+                            bitmap.push(true);
+                            builder.push(NumberScalar::UInt32(len as u32));
+                        }
+                        None => {
+                            bitmap.push(false);
+                            builder.push_default();
+                        }
+                    }
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: u32::try_downcast_column(&builder.build()).unwrap(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(None) => Ok(Value::Scalar(None)),
+            ValueRef::Scalar(Some(v)) => {
+                let val = match array_length(v) {
+                    Some(len) => Value::Scalar(Some(len as u32)),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<VariantType, NullableType<VariantType>, _, _>(
+        "object_keys",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(column) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for v in column.iter() {
+                    match object_keys(v) {
+                        Some(keys) => {
+                            bitmap.push(true);
+                            builder.put_slice(&keys);
+                        }
+                        None => {
+                            bitmap.push(false);
+                        }
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(v) => {
+                let val = match object_keys(v) {
+                    Some(keys) => Value::Scalar(Some(keys)),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<NullableType<VariantType>, NullableType<VariantType>, _, _>(
+        "object_keys",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(NullableColumn { validity, column }) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for (valid, v) in validity.iter().zip(column.iter()) {
+                    if !valid {
+                        bitmap.push(false);
+                        builder.commit_row();
+                        continue;
+                    }
+                    match object_keys(v) {
+                        Some(keys) => {
+                            bitmap.push(true);
+                            builder.put_slice(&keys);
+                        }
+                        None => {
+                            bitmap.push(false);
+                        }
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(None) => Ok(Value::Scalar(None)),
+            ValueRef::Scalar(Some(v)) => {
+                let val = match object_keys(v) {
+                    Some(keys) => Value::Scalar(Some(keys)),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_function_factory("get", |_, _| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "get",
+                args_type: vec![DataType::Variant, DataType::Number(NumberDataType::UInt64)],
+                return_type: DataType::Nullable(Box::new(DataType::Variant)),
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| None),
+            eval: Box::new(get_by_index_fn),
+        }))
+    });
+
+    registry.register_function_factory("get", |_, _| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "get",
+                args_type: vec![
+                    DataType::Nullable(Box::new(DataType::Variant)),
+                    DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt64))),
+                ],
+                return_type: DataType::Nullable(Box::new(DataType::Variant)),
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| None),
+            eval: Box::new(wrap_nullable(get_by_index_fn)),
+        }))
+    });
+
+    registry.register_function_factory("get", |_, _| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "get",
+                args_type: vec![DataType::Variant, DataType::String],
+                return_type: DataType::Nullable(Box::new(DataType::Variant)),
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| None),
+            eval: Box::new(get_by_name_fn),
+        }))
+    });
+
+    registry.register_function_factory("get", |_, _| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "get",
+                args_type: vec![
+                    DataType::Nullable(Box::new(DataType::Variant)),
+                    DataType::Nullable(Box::new(DataType::String)),
+                ],
+                return_type: DataType::Nullable(Box::new(DataType::Variant)),
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| None),
+            eval: Box::new(wrap_nullable(get_by_name_fn)),
+        }))
+    });
+
+    registry.register_function_factory("get_ignore_case", |_, _| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "get_ignore_case",
+                args_type: vec![DataType::Variant, DataType::String],
+                return_type: DataType::Nullable(Box::new(DataType::Variant)),
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| None),
+            eval: Box::new(get_ignore_case_fn),
+        }))
+    });
+
+    registry.register_function_factory("get_ignore_case", |_, _| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "get_ignore_case",
+                args_type: vec![
+                    DataType::Nullable(Box::new(DataType::Variant)),
+                    DataType::Nullable(Box::new(DataType::String)),
+                ],
+                return_type: DataType::Nullable(Box::new(DataType::Variant)),
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| None),
+            eval: Box::new(wrap_nullable(get_ignore_case_fn)),
+        }))
+    });
+
+    registry.register_function_factory("get_path", |_, _| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "get_path",
+                args_type: vec![DataType::Variant, DataType::String],
+                return_type: DataType::Nullable(Box::new(DataType::Variant)),
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| None),
+            eval: Box::new(get_path_fn),
+        }))
+    });
+
+    registry.register_function_factory("get_path", |_, _| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "get_path",
+                args_type: vec![
+                    DataType::Nullable(Box::new(DataType::Variant)),
+                    DataType::Nullable(Box::new(DataType::String)),
+                ],
+                return_type: DataType::Nullable(Box::new(DataType::Variant)),
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| None),
+            eval: Box::new(wrap_nullable(get_path_fn)),
+        }))
+    });
+
+    registry.register_function_factory("json_extract_path_text", |_, _| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "json_extract_path_text",
+                args_type: vec![DataType::String, DataType::String],
+                return_type: DataType::Nullable(Box::new(DataType::String)),
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| None),
+            eval: Box::new(json_extract_path_text_fn),
+        }))
+    });
+
+    registry.register_function_factory("json_extract_path_text", |_, _| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "json_extract_path_text",
+                args_type: vec![
+                    DataType::Nullable(Box::new(DataType::String)),
+                    DataType::Nullable(Box::new(DataType::String)),
+                ],
+                return_type: DataType::Nullable(Box::new(DataType::String)),
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| None),
+            eval: Box::new(wrap_nullable(json_extract_path_text_fn)),
+        }))
+    });
+
+    registry.register_1_arg_core::<VariantType, NullableType<BooleanType>, _, _>(
+        "as_boolean",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(column) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = MutableBitmap::with_capacity(size);
+                for v in column.iter() {
+                    match as_bool(v) {
+                        Some(val) => {
+                            bitmap.push(true);
+                            builder.push(val);
+                        }
+                        None => {
+                            bitmap.push(false);
+                            builder.push(false);
+                        }
+                    }
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.into(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(v) => {
+                let val = match as_bool(v) {
+                    Some(val) => Value::Scalar(Some(val)),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<NullableType<VariantType>, NullableType<BooleanType>, _, _>(
+        "as_boolean",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(NullableColumn { validity, column }) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = MutableBitmap::with_capacity(size);
+                for (valid, v) in validity.iter().zip(column.iter()) {
+                    if !valid {
+                        bitmap.push(false);
+                        builder.push(false);
+                        continue;
+                    }
+                    match as_bool(v) {
+                        Some(val) => {
+                            bitmap.push(true);
+                            builder.push(val);
+                        }
+                        None => {
+                            bitmap.push(false);
+                            builder.push(false);
+                        }
+                    }
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.into(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(None) => Ok(Value::Scalar(None)),
+            ValueRef::Scalar(Some(v)) => {
+                let val = match as_bool(v) {
+                    Some(val) => Value::Scalar(Some(val)),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<VariantType, NullableType<Int64Type>, _, _>(
+        "as_integer",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(column) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = NumberColumnBuilder::with_capacity(&NumberDataType::Int64, size);
+                for v in column.iter() {
+                    match as_i64(v) {
+                        Some(val) => {
+                            bitmap.push(true);
+                            builder.push(NumberScalar::Int64(val));
+                        }
+                        None => {
+                            bitmap.push(false);
+                            builder.push_default();
+                        }
+                    }
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: i64::try_downcast_column(&builder.build()).unwrap(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(v) => {
+                let val = match as_i64(v) {
+                    Some(val) => Value::Scalar(Some(val)),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<NullableType<VariantType>, NullableType<Int64Type>, _, _>(
+        "as_integer",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(NullableColumn { validity, column }) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = NumberColumnBuilder::with_capacity(&NumberDataType::Int64, size);
+                for (valid, v) in validity.iter().zip(column.iter()) {
+                    if !valid {
+                        bitmap.push(false);
+                        builder.push_default();
+                        continue;
+                    }
+                    match as_i64(v) {
+                        Some(val) => {
+                            bitmap.push(true);
+                            builder.push(NumberScalar::Int64(val));
+                        }
+                        None => {
+                            bitmap.push(false);
+                            builder.push_default();
+                        }
+                    }
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: i64::try_downcast_column(&builder.build()).unwrap(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(None) => Ok(Value::Scalar(None)),
+            ValueRef::Scalar(Some(v)) => {
+                let val = match as_i64(v) {
+                    Some(val) => Value::Scalar(Some(val)),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<VariantType, NullableType<Float64Type>, _, _>(
+        "as_float",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(column) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder =
+                    NumberColumnBuilder::with_capacity(&NumberDataType::Float64, size);
+                for v in column.iter() {
+                    match as_f64(v) {
+                        Some(val) => {
+                            bitmap.push(true);
+                            builder.push(NumberScalar::Float64(val.into()));
+                        }
+                        None => {
+                            bitmap.push(false);
+                            builder.push_default();
+                        }
+                    }
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: F64::try_downcast_column(&builder.build()).unwrap(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(v) => {
+                let val = match as_f64(v) {
+                    Some(val) => Value::Scalar(Some(val.into())),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<NullableType<VariantType>, NullableType<Float64Type>, _, _>(
+        "as_float",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(NullableColumn { validity, column }) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder =
+                    NumberColumnBuilder::with_capacity(&NumberDataType::Float64, size);
+                for (valid, v) in validity.iter().zip(column.iter()) {
+                    if !valid {
+                        bitmap.push(false);
+                        builder.push_default();
+                        continue;
+                    }
+                    match as_f64(v) {
+                        Some(val) => {
+                            bitmap.push(true);
+                            builder.push(NumberScalar::Float64(val.into()));
+                        }
+                        None => {
+                            bitmap.push(false);
+                            builder.push_default();
+                        }
+                    }
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: F64::try_downcast_column(&builder.build()).unwrap(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(None) => Ok(Value::Scalar(None)),
+            ValueRef::Scalar(Some(v)) => {
+                let val = match as_f64(v) {
+                    Some(val) => Value::Scalar(Some(val.into())),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<VariantType, NullableType<StringType>, _, _>(
+        "as_string",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(column) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for v in column.iter() {
+                    match as_str(v) {
+                        Some(val) => {
+                            bitmap.push(true);
+                            builder.put_slice(val.as_bytes());
+                        }
+                        None => {
+                            bitmap.push(false);
+                        }
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(v) => {
+                let val = match as_str(v) {
+                    Some(val) => Value::Scalar(Some(val.as_bytes().to_vec())),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<NullableType<VariantType>, NullableType<StringType>, _, _>(
+        "as_string",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(NullableColumn { validity, column }) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for (valid, v) in validity.iter().zip(column.iter()) {
+                    if !valid {
+                        bitmap.push(false);
+                        builder.commit_row();
+                        continue;
+                    }
+                    match as_str(v) {
+                        Some(val) => {
+                            bitmap.push(true);
+                            builder.put_slice(val.as_bytes());
+                        }
+                        None => {
+                            bitmap.push(false);
+                        }
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(None) => Ok(Value::Scalar(None)),
+            ValueRef::Scalar(Some(v)) => {
+                let val = match as_str(v) {
+                    Some(val) => Value::Scalar(Some(val.as_bytes().to_vec())),
+                    None => Value::Scalar(None),
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<VariantType, NullableType<VariantType>, _, _>(
+        "as_array",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(column) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for v in column.iter() {
+                    if is_array(v) {
+                        bitmap.push(true);
+                        builder.put_slice(v.as_bytes());
+                    } else {
+                        bitmap.push(false);
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(v) => {
+                let val = if is_array(v) {
+                    Value::Scalar(Some(v.as_bytes().to_vec()))
+                } else {
+                    Value::Scalar(None)
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<NullableType<VariantType>, NullableType<VariantType>, _, _>(
+        "as_array",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(NullableColumn { validity, column }) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for (valid, v) in validity.iter().zip(column.iter()) {
+                    if !valid {
+                        bitmap.push(false);
+                        builder.commit_row();
+                        continue;
+                    }
+                    if is_array(v) {
+                        bitmap.push(true);
+                        builder.put_slice(v.as_bytes());
+                    } else {
+                        bitmap.push(false);
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(None) => Ok(Value::Scalar(None)),
+            ValueRef::Scalar(Some(v)) => {
+                let val = if is_array(v) {
+                    Value::Scalar(Some(v.as_bytes().to_vec()))
+                } else {
+                    Value::Scalar(None)
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<VariantType, NullableType<VariantType>, _, _>(
+        "as_object",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(column) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for v in column.iter() {
+                    if is_object(v) {
+                        bitmap.push(true);
+                        builder.put_slice(v.as_bytes());
+                    } else {
+                        bitmap.push(false);
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(v) => {
+                let val = if is_object(v) {
+                    Value::Scalar(Some(v.as_bytes().to_vec()))
+                } else {
+                    Value::Scalar(None)
+                };
+                Ok(val)
+            }
+        },
+    );
+
+    registry.register_1_arg_core::<NullableType<VariantType>, NullableType<VariantType>, _, _>(
+        "as_object",
+        FunctionProperty::default(),
+        |_| None,
+        |arg, _| match &arg {
+            ValueRef::Column(NullableColumn { validity, column }) => {
+                let size = column.len();
+                let mut bitmap = MutableBitmap::with_capacity(size);
+                let mut builder = StringColumnBuilder::with_capacity(size, 0);
+                for (valid, v) in validity.iter().zip(column.iter()) {
+                    if !valid {
+                        bitmap.push(false);
+                        builder.commit_row();
+                        continue;
+                    }
+                    if is_object(v) {
+                        bitmap.push(true);
+                        builder.put_slice(v.as_bytes());
+                    } else {
+                        bitmap.push(false);
+                    }
+                    builder.commit_row();
+                }
+                let col = NullableColumn {
+                    validity: bitmap.into(),
+                    column: builder.build(),
+                };
+                Ok(Value::Column(col))
+            }
+            ValueRef::Scalar(None) => Ok(Value::Scalar(None)),
+            ValueRef::Scalar(Some(v)) => {
+                let val = if is_object(v) {
+                    Value::Scalar(Some(v.as_bytes().to_vec()))
+                } else {
+                    Value::Scalar(None)
+                };
+                Ok(val)
+            }
+        },
+    );
+}
+
+fn get_by_index_fn(
+    args: &[ValueRef<AnyType>],
+    _: FunctionContext,
+) -> Result<Value<AnyType>, String> {
+    let len = args.iter().find_map(|arg| match arg {
+        ValueRef::Column(col) => Some(col.len()),
+        _ => None,
+    });
+
+    let source_arg = args[0].try_downcast::<VariantType>().unwrap();
+    let index_arg = args[1].try_downcast::<UInt64Type>().unwrap();
+    let size = len.unwrap_or(1);
+    let mut bitmap = MutableBitmap::with_capacity(size);
+    let mut builder = StringColumnBuilder::with_capacity(size, 0);
+    for idx in 0..size {
+        let s = unsafe { source_arg.index_unchecked(idx) };
+        if s.is_empty() {
+            bitmap.push(false);
+            builder.commit_row();
+            continue;
+        }
+        let index = unsafe { index_arg.index_unchecked(idx) };
+        let json_path = JsonPath::UInt64(index);
+        match get_by_path(s, vec![json_path]) {
+            Some(val) => {
+                builder.put_slice(val.as_slice());
+                bitmap.push(true);
+            }
+            None => bitmap.push(false),
+        }
+        builder.commit_row();
+    }
+    match len {
+        Some(_) => {
+            let col = Column::Nullable(Box::new(NullableColumn {
+                validity: bitmap.into(),
+                column: Column::Variant(builder.build()),
+            }));
+            Ok(Value::Column(col))
+        }
+        _ => match bitmap.pop() {
+            Some(is_not_null) => {
+                if is_not_null {
+                    Ok(Value::Scalar(Scalar::Variant(builder.build_scalar())))
+                } else {
+                    Ok(Value::Scalar(Scalar::Null))
+                }
+            }
+            None => Ok(Value::Scalar(Scalar::Null)),
+        },
+    }
+}
+
+fn get_by_name_fn(
+    args: &[ValueRef<AnyType>],
+    _: FunctionContext,
+) -> Result<Value<AnyType>, String> {
+    let len = args.iter().find_map(|arg| match arg {
+        ValueRef::Column(col) => Some(col.len()),
+        _ => None,
+    });
+
+    let source_arg = args[0].try_downcast::<VariantType>().unwrap();
+    let name_arg = args[1].try_downcast::<StringType>().unwrap();
+    let size = len.unwrap_or(1);
+    let mut bitmap = MutableBitmap::with_capacity(size);
+    let mut builder = StringColumnBuilder::with_capacity(size, 0);
+    for idx in 0..size {
+        let s = unsafe { source_arg.index_unchecked(idx) };
+        let name = unsafe { name_arg.index_unchecked(idx) };
+        if s.is_empty() || name.is_empty() {
+            bitmap.push(false);
+            builder.commit_row();
+            continue;
+        }
+        let name = String::from_utf8(name.to_vec()).map_err(|err| {
+            format!(
+                "Unable convert name '{}' to string: {}",
+                &String::from_utf8_lossy(name),
+                err
+            )
+        })?;
+
+        let json_path = JsonPath::String(Cow::Borrowed(&name));
+        match get_by_path(s, vec![json_path]) {
+            Some(val) => {
+                builder.put_slice(val.as_slice());
+                bitmap.push(true);
+            }
+            None => bitmap.push(false),
+        }
+        builder.commit_row();
+    }
+    match len {
+        Some(_) => {
+            let col = Column::Nullable(Box::new(NullableColumn {
+                validity: bitmap.into(),
+                column: Column::Variant(builder.build()),
+            }));
+            Ok(Value::Column(col))
+        }
+        _ => match bitmap.pop() {
+            Some(is_not_null) => {
+                if is_not_null {
+                    Ok(Value::Scalar(Scalar::Variant(builder.build_scalar())))
+                } else {
+                    Ok(Value::Scalar(Scalar::Null))
+                }
+            }
+            None => Ok(Value::Scalar(Scalar::Null)),
+        },
+    }
+}
+
+fn get_ignore_case_fn(
+    args: &[ValueRef<AnyType>],
+    _: FunctionContext,
+) -> Result<Value<AnyType>, String> {
+    let len = args.iter().find_map(|arg| match arg {
+        ValueRef::Column(col) => Some(col.len()),
+        _ => None,
+    });
+
+    let source_arg = args[0].try_downcast::<VariantType>().unwrap();
+    let name_arg = args[1].try_downcast::<StringType>().unwrap();
+    let size = len.unwrap_or(1);
+    let mut bitmap = MutableBitmap::with_capacity(size);
+    let mut builder = StringColumnBuilder::with_capacity(size, 0);
+    for idx in 0..size {
+        let s = unsafe { source_arg.index_unchecked(idx) };
+        let name = unsafe { name_arg.index_unchecked(idx) };
+        if s.is_empty() || name.is_empty() {
+            bitmap.push(false);
+            builder.commit_row();
+            continue;
+        }
+        let name = String::from_utf8(name.to_vec()).map_err(|err| {
+            format!(
+                "Unable convert name '{}' to string: {}",
+                &String::from_utf8_lossy(name),
+                err
+            )
+        })?;
+
+        match get_by_name_ignore_case(s, &name) {
+            Some(val) => {
+                builder.put_slice(val.as_slice());
+                bitmap.push(true);
+            }
+            None => bitmap.push(false),
+        }
+        builder.commit_row();
+    }
+    match len {
+        Some(_) => {
+            let col = Column::Nullable(Box::new(NullableColumn {
+                validity: bitmap.into(),
+                column: Column::Variant(builder.build()),
+            }));
+            Ok(Value::Column(col))
+        }
+        _ => match bitmap.pop() {
+            Some(is_not_null) => {
+                if is_not_null {
+                    Ok(Value::Scalar(Scalar::Variant(builder.build_scalar())))
+                } else {
+                    Ok(Value::Scalar(Scalar::Null))
+                }
+            }
+            None => Ok(Value::Scalar(Scalar::Null)),
+        },
+    }
+}
+
+fn get_path_fn(args: &[ValueRef<AnyType>], _: FunctionContext) -> Result<Value<AnyType>, String> {
+    let len = args.iter().find_map(|arg| match arg {
+        ValueRef::Column(col) => Some(col.len()),
+        _ => None,
+    });
+
+    let source_arg = args[0].try_downcast::<VariantType>().unwrap();
+    let path_arg = args[1].try_downcast::<StringType>().unwrap();
+    let size = len.unwrap_or(1);
+    let mut bitmap = MutableBitmap::with_capacity(size);
+    let mut builder = StringColumnBuilder::with_capacity(size, 0);
+    for idx in 0..size {
+        let s = unsafe { source_arg.index_unchecked(idx) };
+        let path = unsafe { path_arg.index_unchecked(idx) };
+        if s.is_empty() || path.is_empty() {
+            bitmap.push(false);
+            builder.commit_row();
+            continue;
+        }
+        let json_paths = parse_json_path(path).map_err(|err| {
+            format!(
+                "Invalid extraction path '{}': {}",
+                &String::from_utf8_lossy(path),
+                err
+            )
+        })?;
+        match get_by_path(s, json_paths) {
+            Some(val) => {
+                builder.put_slice(val.as_slice());
+                bitmap.push(true);
+            }
+            None => bitmap.push(false),
+        }
+        builder.commit_row();
+    }
+    match len {
+        Some(_) => {
+            let col = Column::Nullable(Box::new(NullableColumn {
+                validity: bitmap.into(),
+                column: Column::Variant(builder.build()),
+            }));
+            Ok(Value::Column(col))
+        }
+        _ => match bitmap.pop() {
+            Some(is_not_null) => {
+                if is_not_null {
+                    Ok(Value::Scalar(Scalar::Variant(builder.build_scalar())))
+                } else {
+                    Ok(Value::Scalar(Scalar::Null))
+                }
+            }
+            None => Ok(Value::Scalar(Scalar::Null)),
+        },
+    }
+}
+
+fn json_extract_path_text_fn(
+    args: &[ValueRef<AnyType>],
+    _: FunctionContext,
+) -> Result<Value<AnyType>, String> {
+    let len = args.iter().find_map(|arg| match arg {
+        ValueRef::Column(col) => Some(col.len()),
+        _ => None,
+    });
+
+    let source_arg = args[0].try_downcast::<StringType>().unwrap();
+    let path_arg = args[1].try_downcast::<StringType>().unwrap();
+    let size = len.unwrap_or(1);
+    let mut bitmap = MutableBitmap::with_capacity(size);
+    let mut builder = StringColumnBuilder::with_capacity(size, 0);
+    for idx in 0..size {
+        let s = unsafe { source_arg.index_unchecked(idx) };
+        if s.trim().is_empty() {
+            bitmap.push(false);
+            builder.commit_row();
+            continue;
+        }
+        let value = common_jsonb::parse_value(s)
+            .map_err(|err| format!("unable to parse '{}': {}", &String::from_utf8_lossy(s), err))?;
+        let path = unsafe { path_arg.index_unchecked(idx) };
+        if path.is_empty() {
+            bitmap.push(false);
+            builder.commit_row();
+            continue;
+        }
+        let json_paths = parse_json_path(path).map_err(|err| {
+            format!(
+                "Invalid extraction path '{}': {}",
+                &String::from_utf8_lossy(path),
+                err
+            )
+        })?;
+        match value.get_by_path(&json_paths) {
+            Some(val) => {
+                let json_val = format!("{val}");
+                builder.put_str(&json_val);
+                bitmap.push(true);
+            }
+            None => bitmap.push(false),
+        }
+        builder.commit_row();
+    }
+    match len {
+        Some(_) => {
+            let col = Column::Nullable(Box::new(NullableColumn {
+                validity: bitmap.into(),
+                column: Column::Variant(builder.build()),
+            }));
+            Ok(Value::Column(col))
+        }
+        _ => match bitmap.pop() {
+            Some(is_not_null) => {
+                if is_not_null {
+                    Ok(Value::Scalar(Scalar::Variant(builder.build_scalar())))
+                } else {
+                    Ok(Value::Scalar(Scalar::Null))
+                }
+            }
+            None => Ok(Value::Scalar(Scalar::Null)),
+        },
+    }
 }

--- a/src/query/functions-v2/tests/it/scalars/testdata/string.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/string.txt
@@ -174,7 +174,7 @@ output         : NULL
 
 ast            : length(a)
 raw expr       : length(ColumnRef(0)::String)
-checked expr   : octet_length<String>(ColumnRef(0))
+checked expr   : length<String>(ColumnRef(0))
 evaluation:
 +--------+-----------------------------------+---------+
 |        | a                                 | Output  |

--- a/src/query/functions-v2/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/variant.txt
@@ -116,3 +116,1234 @@ evaluation (internal):
 +--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
+ast            : parse_json(s)
+raw expr       : parse_json(ColumnRef(0)::String NULL)
+checked expr   : parse_json<String NULL>(ColumnRef(0))
+evaluation:
++--------+------------------------+--------------+
+|        | s                      | Output       |
++--------+------------------------+--------------+
+| Type   | String NULL            | Variant NULL |
+| Domain | {""..="true"} ∪ {NULL} | Unknown      |
+| Row 0  | "true"                 | true         |
+| Row 1  | "false"                | false        |
+| Row 2  | NULL                   | NULL         |
+| Row 3  | "1234"                 | 1234         |
++--------+------------------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                            |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x7472756566616c736531323334, offsets: [0, 4, 9, 9, 13] }, validity: [0b____1011] }                                               |
+| Output | NullableColumn { column: StringColumn { data: 0x20000000400000002000000030000000200000000000000020000000200000035004d2, offsets: [0, 8, 16, 24, 35] }, validity: [0b____1011] } |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : try_parse_json(NULL)
+raw expr       : try_parse_json(NULL)
+checked expr   : try_parse_json<String NULL>(CAST(NULL AS String NULL))
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : try_parse_json('nuLL')
+raw expr       : try_parse_json("nuLL")
+checked expr   : try_parse_json<String>("nuLL")
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : try_parse_json('null')
+raw expr       : try_parse_json("null")
+checked expr   : try_parse_json<String>("null")
+optimized expr : 0x2000000000000000
+output type    : Variant NULL
+output domain  : Unknown
+output         : null
+
+
+ast            : try_parse_json('true')
+raw expr       : try_parse_json("true")
+checked expr   : try_parse_json<String>("true")
+optimized expr : 0x2000000040000000
+output type    : Variant NULL
+output domain  : Unknown
+output         : true
+
+
+ast            : try_parse_json('false')
+raw expr       : try_parse_json("false")
+checked expr   : try_parse_json<String>("false")
+optimized expr : 0x2000000030000000
+output type    : Variant NULL
+output domain  : Unknown
+output         : false
+
+
+ast            : try_parse_json('"测试"')
+raw expr       : try_parse_json("\"测试\"")
+checked expr   : try_parse_json<String>("\"测试\"")
+optimized expr : 0x2000000010000006e6b58be8af95
+output type    : Variant NULL
+output domain  : Unknown
+output         : "测试"
+
+
+ast            : try_parse_json('1234')
+raw expr       : try_parse_json("1234")
+checked expr   : try_parse_json<String>("1234")
+optimized expr : 0x20000000200000035004d2
+output type    : Variant NULL
+output domain  : Unknown
+output         : 1234
+
+
+ast            : try_parse_json('[1,2,3,4]')
+raw expr       : try_parse_json("[1,2,3,4]")
+checked expr   : try_parse_json<String>("[1,2,3,4]")
+optimized expr : 0x80000004200000022000000220000002200000025001500250035004
+output type    : Variant NULL
+output domain  : Unknown
+output         : [1,2,3,4]
+
+
+ast            : try_parse_json('{"a":"b","c":"d"}')
+raw expr       : try_parse_json("{\"a\":\"b\",\"c\":\"d\"}")
+checked expr   : try_parse_json<String>("{\"a\":\"b\",\"c\":\"d\"}")
+optimized expr : 0x400000021000000110000001100000011000000161636264
+output type    : Variant NULL
+output domain  : Unknown
+output         : {"a":"b","c":"d"}
+
+
+ast            : try_parse_json(s)
+raw expr       : try_parse_json(ColumnRef(0)::String)
+checked expr   : try_parse_json<String>(ColumnRef(0))
+evaluation:
++--------+-----------------------------------------------------------+-----------------------+
+|        | s                                                         | Output                |
++--------+-----------------------------------------------------------+-----------------------+
+| Type   | String                                                    | Variant NULL          |
+| Domain | {"\"\\\\\\\"abc\\\\\\\"\""..="{\"k\":\"v\",\"a\":\"b\"}"} | Unknown               |
+| Row 0  | "null"                                                    | null                  |
+| Row 1  | "true"                                                    | true                  |
+| Row 2  | "9223372036854775807"                                     | 9223372036854775807   |
+| Row 3  | "-32768"                                                  | -32768                |
+| Row 4  | "1234.5678"                                               | 1234.5678             |
+| Row 5  | "1.912e2"                                                 | 191.2                 |
+| Row 6  | "\"\\\\\\\"abc\\\\\\\"\""                                 | "\\\"abc\\\""         |
+| Row 7  | "\"databend\""                                            | "databend"            |
+| Row 8  | "{\"k\":\"v\",\"a\":\"b\"}"                               | {"a":"b","k":"v"}     |
+| Row 9  | "[1,2,3,[\"a\",\"b\",\"c\"]]"                             | [1,2,3,["a","b","c"]] |
++--------+-----------------------------------------------------------+-----------------------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x6e756c6c74727565393232333337323033363835343737353830372d3332373638313233342e35363738312e3931326532225c5c5c226162635c5c5c2222226461746162656e64227b226b223a2276222c2261223a2262227d5b312c322c332c5b2261222c2262222c2263225d5d, offsets: [0, 4, 8, 27, 33, 42, 49, 62, 72, 89, 110] }                                                                                                                                                                                                           |
+| Output | NullableColumn { column: StringColumn { data: 0x200000000000000020000000400000002000000020000009507fffffffffffffff200000002000000340800020000000200000096040934a456d5cfaad2000000020000009604067e6666666666620000000100000075c226162635c2220000000100000086461746162656e644000000210000001100000011000000110000001616b6276800000042000000220000002200000025000001350015002500380000003100000011000000110000001616263, offsets: [0, 8, 16, 33, 44, 61, 78, 93, 109, 133, 178] }, validity: [0b11111111, 0b______11] } |
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : try_parse_json(s)
+raw expr       : try_parse_json(ColumnRef(0)::String NULL)
+checked expr   : try_parse_json<String NULL>(ColumnRef(0))
+evaluation:
++--------+-----------------------+--------------+
+|        | s                     | Output       |
++--------+-----------------------+--------------+
+| Type   | String NULL           | Variant NULL |
+| Domain | {""..="ttt"} ∪ {NULL} | Unknown      |
+| Row 0  | "true"                | true         |
+| Row 1  | "ttt"                 | NULL         |
+| Row 2  | NULL                  | NULL         |
+| Row 3  | "1234"                | 1234         |
++--------+-----------------------+--------------+
+evaluation (internal):
++--------+-----------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                          |
++--------+-----------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x7472756574747431323334, offsets: [0, 4, 7, 7, 11] }, validity: [0b____1011] }                 |
+| Output | NullableColumn { column: StringColumn { data: 0x200000004000000020000000200000035004d2, offsets: [0, 8, 8, 8, 19] }, validity: [0b____1001] } |
++--------+-----------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : check_json(NULL)
+raw expr       : check_json(NULL)
+checked expr   : check_json<String NULL>(CAST(NULL AS String NULL))
+optimized expr : NULL
+output type    : String NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : check_json('true')
+raw expr       : check_json("true")
+checked expr   : check_json<String>("true")
+optimized expr : NULL
+output type    : String NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : check_json('nuLL')
+raw expr       : check_json("nuLL")
+checked expr   : check_json<String>("nuLL")
+optimized expr : "expected ident, pos 3"
+output type    : String NULL
+output domain  : Unknown
+output         : "expected ident, pos 3"
+
+
+ast            : check_json(s)
+raw expr       : check_json(ColumnRef(0)::String)
+checked expr   : check_json<String>(ColumnRef(0))
+evaluation:
++--------+------------------+-------------------------+
+|        | s                | Output                  |
++--------+------------------+-------------------------+
+| Type   | String           | String NULL             |
+| Domain | {"abc"..="true"} | Unknown                 |
+| Row 0  | "null"           | NULL                    |
+| Row 1  | "abc"            | "expected value, pos 1" |
+| Row 2  | "true"           | NULL                    |
++--------+------------------+-------------------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                            |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x6e756c6c61626374727565, offsets: [0, 4, 7, 11] }                                                                         |
+| Output | NullableColumn { column: StringColumn { data: 0x65787065637465642076616c75652c20706f732031, offsets: [0, 0, 21, 21] }, validity: [0b_____010] } |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : check_json(s)
+raw expr       : check_json(ColumnRef(0)::String NULL)
+checked expr   : check_json<String NULL>(ColumnRef(0))
+evaluation:
++--------+-----------------------+-------------------------+
+|        | s                     | Output                  |
++--------+-----------------------+-------------------------+
+| Type   | String NULL           | String NULL             |
+| Domain | {""..="ttt"} ∪ {NULL} | Unknown                 |
+| Row 0  | "true"                | NULL                    |
+| Row 1  | "ttt"                 | "expected ident, pos 2" |
+| Row 2  | NULL                  | NULL                    |
+| Row 3  | "1234"                | NULL                    |
++--------+-----------------------+-------------------------+
+evaluation (internal):
++--------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                |
++--------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x7472756574747431323334, offsets: [0, 4, 7, 7, 11] }, validity: [0b____1011] }                       |
+| Output | NullableColumn { column: StringColumn { data: 0x6578706563746564206964656e742c20706f732032, offsets: [0, 0, 21, 21, 21] }, validity: [0b____0010] } |
++--------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : length(parse_json('1234'))
+raw expr       : length(parse_json("1234"))
+checked expr   : length<Variant>(parse_json<String>("1234"))
+optimized expr : NULL
+output type    : UInt32 NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : length(parse_json('[1,2,3,4]'))
+raw expr       : length(parse_json("[1,2,3,4]"))
+checked expr   : length<Variant>(parse_json<String>("[1,2,3,4]"))
+optimized expr : 4_u32
+output type    : UInt32 NULL
+output domain  : Unknown
+output         : 4
+
+
+ast            : length(parse_json('{"k":"v"}'))
+raw expr       : length(parse_json("{\"k\":\"v\"}"))
+checked expr   : length<Variant>(parse_json<String>("{\"k\":\"v\"}"))
+optimized expr : NULL
+output type    : UInt32 NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : length(parse_json(s))
+raw expr       : length(parse_json(ColumnRef(0)::String))
+checked expr   : length<Variant>(parse_json<String>(ColumnRef(0)))
+evaluation:
++--------+----------------------------------+-------------+
+|        | s                                | Output      |
++--------+----------------------------------+-------------+
+| Type   | String                           | UInt32 NULL |
+| Domain | {"[\"a\",\"b\",\"c\"]"..="true"} | Unknown     |
+| Row 0  | "true"                           | NULL        |
+| Row 1  | "[1,2,3,4]"                      | 4           |
+| Row 2  | "[\"a\",\"b\",\"c\"]"            | 3           |
++--------+----------------------------------+-------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                   |
++--------+--------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x747275655b312c322c332c345d5b2261222c2262222c2263225d, offsets: [0, 4, 13, 26] } |
+| Output | NullableColumn { column: UInt32([0, 4, 3]), validity: [0b_____110] }                                   |
++--------+--------------------------------------------------------------------------------------------------------+
+
+
+ast            : length(parse_json(s))
+raw expr       : length(parse_json(ColumnRef(0)::String NULL))
+checked expr   : length<Variant>(CAST(parse_json<String NULL>(ColumnRef(0)) AS Variant))
+evaluation:
++--------+------------------------+-------------+
+|        | s                      | Output      |
++--------+------------------------+-------------+
+| Type   | String NULL            | UInt32 NULL |
+| Domain | {""..="true"} ∪ {NULL} | Unknown     |
+| Row 0  | "true"                 | NULL        |
+| Row 1  | "[1,2,3,4]"            | 4           |
+| Row 2  | NULL                   | NULL        |
+| Row 3  | "[\"a\",\"b\",\"c\"]"  | 3           |
++--------+------------------------+-------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                          |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275655b312c322c332c345d5b2261222c2262222c2263225d, offsets: [0, 4, 13, 13, 26] }, validity: [0b____1011] } |
+| Output | NullableColumn { column: UInt32([0, 4, 0, 3]), validity: [0b____1010] }                                                                                       |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : object_keys(parse_json('[1,2,3,4]'))
+raw expr       : object_keys(parse_json("[1,2,3,4]"))
+checked expr   : object_keys<Variant>(parse_json<String>("[1,2,3,4]"))
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : object_keys(parse_json('{"k1":"v1","k2":"v2"}'))
+raw expr       : object_keys(parse_json("{\"k1\":\"v1\",\"k2\":\"v2\"}"))
+checked expr   : object_keys<Variant>(parse_json<String>("{\"k1\":\"v1\",\"k2\":\"v2\"}"))
+optimized expr : 0x8000000210000002100000026b316b32
+output type    : Variant NULL
+output domain  : Unknown
+output         : ["k1","k2"]
+
+
+ast            : object_keys(parse_json(s))
+raw expr       : object_keys(parse_json(ColumnRef(0)::String))
+checked expr   : object_keys<Variant>(parse_json<String>(ColumnRef(0)))
+evaluation:
++--------+-------------------------------------------------+--------------+
+|        | s                                               | Output       |
++--------+-------------------------------------------------+--------------+
+| Type   | String                                          | Variant NULL |
+| Domain | {"[1,2,3,4]"..="{\"k1\":\"v1\",\"k2\":\"v2\"}"} | Unknown      |
+| Row 0  | "[1,2,3,4]"                                     | NULL         |
+| Row 1  | "{\"a\":\"b\",\"c\":\"d\"}"                     | ["a","c"]    |
+| Row 2  | "{\"k1\":\"v1\",\"k2\":\"v2\"}"                 | ["k1","k2"]  |
++--------+-------------------------------------------------+--------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                              |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x5b312c322c332c345d7b2261223a2262222c2263223a2264227d7b226b31223a227631222c226b32223a227632227d, offsets: [0, 9, 26, 47] }                  |
+| Output | NullableColumn { column: StringColumn { data: 0x80000002100000011000000161638000000210000002100000026b316b32, offsets: [0, 0, 14, 30] }, validity: [0b_____110] } |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : object_keys(parse_json(s))
+raw expr       : object_keys(parse_json(ColumnRef(0)::String NULL))
+checked expr   : object_keys<Variant>(CAST(parse_json<String NULL>(ColumnRef(0)) AS Variant))
+evaluation:
++--------+-------------------------------------------------+--------------+
+|        | s                                               | Output       |
++--------+-------------------------------------------------+--------------+
+| Type   | String NULL                                     | Variant NULL |
+| Domain | {""..="{\"k1\":\"v1\",\"k2\":\"v2\"}"} ∪ {NULL} | Unknown      |
+| Row 0  | "[1,2,3,4]"                                     | NULL         |
+| Row 1  | "{\"a\":\"b\",\"c\":\"d\"}"                     | ["a","c"]    |
+| Row 2  | NULL                                            | NULL         |
+| Row 3  | "{\"k1\":\"v1\",\"k2\":\"v2\"}"                 | ["k1","k2"]  |
++--------+-------------------------------------------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                    |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x5b312c322c332c345d7b2261223a2262222c2263223a2264227d7b226b31223a227631222c226b32223a227632227d, offsets: [0, 9, 26, 26, 47] }, validity: [0b____1011] } |
+| Output | NullableColumn { column: StringColumn { data: 0x80000002100000011000000161638000000210000002100000026b316b32, offsets: [0, 0, 14, 14, 30] }, validity: [0b____1010] }                                   |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : get(parse_json('null'), 1)
+raw expr       : get(parse_json("null"), 1_u8)
+checked expr   : get<Variant, UInt64>(parse_json<String>("null"), CAST(1_u8 AS UInt64))
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : get(parse_json('null'), 'k')
+raw expr       : get(parse_json("null"), "k")
+checked expr   : get<Variant, String>(parse_json<String>("null"), "k")
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : get(parse_json('[1,2,3,4]'), 1)
+raw expr       : get(parse_json("[1,2,3,4]"), 1_u8)
+checked expr   : get<Variant, UInt64>(parse_json<String>("[1,2,3,4]"), CAST(1_u8 AS UInt64))
+optimized expr : 0x20000000200000025002
+output type    : Variant NULL
+output domain  : Unknown
+output         : 2
+
+
+ast            : get(parse_json('[1,2,3,4]'), 5)
+raw expr       : get(parse_json("[1,2,3,4]"), 5_u8)
+checked expr   : get<Variant, UInt64>(parse_json<String>("[1,2,3,4]"), CAST(5_u8 AS UInt64))
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : get(parse_json('{"k":"v"}'), 'k')
+raw expr       : get(parse_json("{\"k\":\"v\"}"), "k")
+checked expr   : get<Variant, String>(parse_json<String>("{\"k\":\"v\"}"), "k")
+optimized expr : 0x200000001000000176
+output type    : Variant NULL
+output domain  : Unknown
+output         : "v"
+
+
+ast            : get(parse_json('{"k":"v"}'), 'x')
+raw expr       : get(parse_json("{\"k\":\"v\"}"), "x")
+checked expr   : get<Variant, String>(parse_json<String>("{\"k\":\"v\"}"), "x")
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : get(parse_json(s), i)
+raw expr       : get(parse_json(ColumnRef(0)::String), ColumnRef(1)::UInt64)
+checked expr   : get<Variant, UInt64>(parse_json<String>(ColumnRef(0)), ColumnRef(1))
+evaluation:
++--------+----------------------------------+---------+--------------+
+|        | s                                | i       | Output       |
++--------+----------------------------------+---------+--------------+
+| Type   | String                           | UInt64  | Variant NULL |
+| Domain | {"[\"a\",\"b\",\"c\"]"..="true"} | {0..=1} | Unknown      |
+| Row 0  | "true"                           | 0       | NULL         |
+| Row 1  | "[1,2,3,4]"                      | 0       | 1            |
+| Row 2  | "[\"a\",\"b\",\"c\"]"            | 1       | "b"          |
++--------+----------------------------------+---------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                        |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x747275655b312c322c332c345d5b2261222c2262222c2263225d, offsets: [0, 4, 13, 26] }                                      |
+| i      | UInt64([0, 0, 1])                                                                                                                           |
+| Output | NullableColumn { column: StringColumn { data: 0x20000000200000025001200000001000000162, offsets: [0, 0, 10, 19] }, validity: [0b_____110] } |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : get(parse_json(s), i)
+raw expr       : get(parse_json(ColumnRef(0)::String NULL), ColumnRef(1)::UInt64 NULL)
+checked expr   : get<Variant NULL, UInt64 NULL>(parse_json<String NULL>(ColumnRef(0)), ColumnRef(1))
+evaluation:
++--------+------------------------+------------------+--------------+
+|        | s                      | i                | Output       |
++--------+------------------------+------------------+--------------+
+| Type   | String NULL            | UInt64 NULL      | Variant NULL |
+| Domain | {""..="true"} ∪ {NULL} | {0..=2} ∪ {NULL} | Unknown      |
+| Row 0  | "true"                 | NULL             | NULL         |
+| Row 1  | "[1,2,3,4]"            | 2                | 3            |
+| Row 2  | NULL                   | NULL             | NULL         |
+| Row 3  | "[\"a\",\"b\",\"c\"]"  | 1                | "b"          |
++--------+------------------------+------------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                          |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275655b312c322c332c345d5b2261222c2262222c2263225d, offsets: [0, 4, 13, 13, 26] }, validity: [0b____1011] } |
+| i      | NullableColumn { column: UInt64([0, 2, 0, 1]), validity: [0b____1010] }                                                                                       |
+| Output | NullableColumn { column: StringColumn { data: 0x20000000200000025003200000001000000162, offsets: [0, 0, 10, 10, 19] }, validity: [0b____1010] }               |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : get(parse_json(s), k)
+raw expr       : get(parse_json(ColumnRef(0)::String), ColumnRef(1)::String)
+checked expr   : get<Variant, String>(parse_json<String>(ColumnRef(0)), ColumnRef(1))
+evaluation:
++--------+------------------------+-------------+--------------+
+|        | s                      | k           | Output       |
++--------+------------------------+-------------+--------------+
+| Type   | String                 | String      | Variant NULL |
+| Domain | {"true"..="{\"k\":1}"} | {"k"..="x"} | Unknown      |
+| Row 0  | "true"                 | "k"         | NULL         |
+| Row 1  | "{\"k\":1}"            | "k"         | 1            |
+| Row 2  | "{\"a\":\"b\"}"        | "x"         | NULL         |
++--------+------------------------+-------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                      |
++--------+---------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x747275657b226b223a317d7b2261223a2262227d, offsets: [0, 4, 11, 20] }                                |
+| k      | StringColumn { data: 0x6b6b78, offsets: [0, 1, 2, 3] }                                                                    |
+| Output | NullableColumn { column: StringColumn { data: 0x20000000200000025001, offsets: [0, 0, 10, 10] }, validity: [0b_____010] } |
++--------+---------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : get(parse_json(s), k)
+raw expr       : get(parse_json(ColumnRef(0)::String NULL), ColumnRef(1)::String)
+checked expr   : get<Variant, String>(CAST(parse_json<String NULL>(ColumnRef(0)) AS Variant), ColumnRef(1))
+evaluation:
++--------+-----------------------------+------------+--------------+
+|        | s                           | k          | Output       |
++--------+-----------------------------+------------+--------------+
+| Type   | String NULL                 | String     | Variant NULL |
+| Domain | {""..="{\"k\":1}"} ∪ {NULL} | {""..="k"} | Unknown      |
+| Row 0  | "true"                      | ""         | NULL         |
+| Row 1  | "{\"k\":1}"                 | "k"        | 1            |
+| Row 2  | NULL                        | ""         | NULL         |
+| Row 3  | "{\"a\":\"b\"}"             | "a"        | "b"          |
++--------+-----------------------------+------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                              |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275657b226b223a317d7b2261223a2262227d, offsets: [0, 4, 11, 11, 20] }, validity: [0b____1011] } |
+| k      | StringColumn { data: 0x6b61, offsets: [0, 0, 1, 1, 2] }                                                                                           |
+| Output | NullableColumn { column: StringColumn { data: 0x20000000200000025001200000001000000162, offsets: [0, 0, 10, 10, 19] }, validity: [0b____1010] }   |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : get_ignore_case(parse_json('{"Aa":1, "aA":2, "aa":3}'), 'AA')
+raw expr       : get_ignore_case(parse_json("{\"Aa\":1, \"aA\":2, \"aa\":3}"), "AA")
+checked expr   : get_ignore_case<Variant, String>(parse_json<String>("{\"Aa\":1, \"aA\":2, \"aa\":3}"), "AA")
+optimized expr : 0x20000000200000025001
+output type    : Variant NULL
+output domain  : Unknown
+output         : 1
+
+
+ast            : get_ignore_case(parse_json('{"Aa":1, "aA":2, "aa":3}'), 'aa')
+raw expr       : get_ignore_case(parse_json("{\"Aa\":1, \"aA\":2, \"aa\":3}"), "aa")
+checked expr   : get_ignore_case<Variant, String>(parse_json<String>("{\"Aa\":1, \"aA\":2, \"aa\":3}"), "aa")
+optimized expr : 0x20000000200000025003
+output type    : Variant NULL
+output domain  : Unknown
+output         : 3
+
+
+ast            : get_ignore_case(parse_json('{"Aa":1, "aA":2, "aa":3}'), 'bb')
+raw expr       : get_ignore_case(parse_json("{\"Aa\":1, \"aA\":2, \"aa\":3}"), "bb")
+checked expr   : get_ignore_case<Variant, String>(parse_json<String>("{\"Aa\":1, \"aA\":2, \"aa\":3}"), "bb")
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : get_ignore_case(parse_json(s), k)
+raw expr       : get_ignore_case(parse_json(ColumnRef(0)::String), ColumnRef(1)::String)
+checked expr   : get_ignore_case<Variant, String>(parse_json<String>(ColumnRef(0)), ColumnRef(1))
+evaluation:
++--------+------------------------+-------------+--------------+
+|        | s                      | k           | Output       |
++--------+------------------------+-------------+--------------+
+| Type   | String                 | String      | Variant NULL |
+| Domain | {"true"..="{\"k\":1}"} | {"A"..="k"} | Unknown      |
+| Row 0  | "true"                 | "k"         | NULL         |
+| Row 1  | "{\"k\":1}"            | "K"         | 1            |
+| Row 2  | "{\"a\":\"b\"}"        | "A"         | "b"          |
++--------+------------------------+-------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                        |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x747275657b226b223a317d7b2261223a2262227d, offsets: [0, 4, 11, 20] }                                                  |
+| k      | StringColumn { data: 0x6b4b41, offsets: [0, 1, 2, 3] }                                                                                      |
+| Output | NullableColumn { column: StringColumn { data: 0x20000000200000025001200000001000000162, offsets: [0, 0, 10, 19] }, validity: [0b_____110] } |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : get_ignore_case(parse_json(s), k)
+raw expr       : get_ignore_case(parse_json(ColumnRef(0)::String NULL), ColumnRef(1)::String)
+checked expr   : get_ignore_case<Variant, String>(CAST(parse_json<String NULL>(ColumnRef(0)) AS Variant), ColumnRef(1))
+evaluation:
++--------+-----------------------------+------------+--------------+
+|        | s                           | k          | Output       |
++--------+-----------------------------+------------+--------------+
+| Type   | String NULL                 | String     | Variant NULL |
+| Domain | {""..="{\"k\":1}"} ∪ {NULL} | {""..="K"} | Unknown      |
+| Row 0  | "true"                      | ""         | NULL         |
+| Row 1  | "{\"k\":1}"                 | "K"        | 1            |
+| Row 2  | NULL                        | ""         | NULL         |
+| Row 3  | "{\"a\":\"b\"}"             | "A"        | "b"          |
++--------+-----------------------------+------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                              |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275657b226b223a317d7b2261223a2262227d, offsets: [0, 4, 11, 11, 20] }, validity: [0b____1011] } |
+| k      | StringColumn { data: 0x4b41, offsets: [0, 0, 1, 1, 2] }                                                                                           |
+| Output | NullableColumn { column: StringColumn { data: 0x20000000200000025001200000001000000162, offsets: [0, 0, 10, 10, 19] }, validity: [0b____1010] }   |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : get_path(parse_json('[[1,2],3]'), '[0]')
+raw expr       : get_path(parse_json("[[1,2],3]"), "[0]")
+checked expr   : get_path<Variant, String>(parse_json<String>("[[1,2],3]"), "[0]")
+optimized expr : 0x80000002200000022000000250015002
+output type    : Variant NULL
+output domain  : Unknown
+output         : [1,2]
+
+
+ast            : get_path(parse_json('[[1,2],3]'), '[0][1]')
+raw expr       : get_path(parse_json("[[1,2],3]"), "[0][1]")
+checked expr   : get_path<Variant, String>(parse_json<String>("[[1,2],3]"), "[0][1]")
+optimized expr : 0x20000000200000025002
+output type    : Variant NULL
+output domain  : Unknown
+output         : 2
+
+
+ast            : get_path(parse_json('[1,2,3]'), '[0]')
+raw expr       : get_path(parse_json("[1,2,3]"), "[0]")
+checked expr   : get_path<Variant, String>(parse_json<String>("[1,2,3]"), "[0]")
+optimized expr : 0x20000000200000025001
+output type    : Variant NULL
+output domain  : Unknown
+output         : 1
+
+
+ast            : get_path(parse_json('[1,2,3]'), 'k2:k3')
+raw expr       : get_path(parse_json("[1,2,3]"), "k2:k3")
+checked expr   : get_path<Variant, String>(parse_json<String>("[1,2,3]"), "k2:k3")
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : get_path(parse_json('{"a":{"b":2}}'), '["a"]["b"]')
+raw expr       : get_path(parse_json("{\"a\":{\"b\":2}}"), "[\"a\"][\"b\"]")
+checked expr   : get_path<Variant, String>(parse_json<String>("{\"a\":{\"b\":2}}"), "[\"a\"][\"b\"]")
+optimized expr : 0x20000000200000025002
+output type    : Variant NULL
+output domain  : Unknown
+output         : 2
+
+
+ast            : get_path(parse_json('{"a":{"b":2}}'), 'a:b')
+raw expr       : get_path(parse_json("{\"a\":{\"b\":2}}"), "a:b")
+checked expr   : get_path<Variant, String>(parse_json<String>("{\"a\":{\"b\":2}}"), "a:b")
+optimized expr : 0x20000000200000025002
+output type    : Variant NULL
+output domain  : Unknown
+output         : 2
+
+
+ast            : get_path(parse_json('{"a":{"b":2}}'), '["a"]')
+raw expr       : get_path(parse_json("{\"a\":{\"b\":2}}"), "[\"a\"]")
+checked expr   : get_path<Variant, String>(parse_json<String>("{\"a\":{\"b\":2}}"), "[\"a\"]")
+optimized expr : 0x400000011000000120000002625002
+output type    : Variant NULL
+output domain  : Unknown
+output         : {"b":2}
+
+
+ast            : get_path(parse_json('{"a":{"b":2}}'), 'a')
+raw expr       : get_path(parse_json("{\"a\":{\"b\":2}}"), "a")
+checked expr   : get_path<Variant, String>(parse_json<String>("{\"a\":{\"b\":2}}"), "a")
+optimized expr : 0x400000011000000120000002625002
+output type    : Variant NULL
+output domain  : Unknown
+output         : {"b":2}
+
+
+ast            : get_path(parse_json(s), k)
+raw expr       : get_path(parse_json(ColumnRef(0)::String), ColumnRef(1)::String)
+checked expr   : get_path<Variant, String>(parse_json<String>(ColumnRef(0)), ColumnRef(1))
+evaluation:
++--------+---------------------------------+-------------------+--------------+
+|        | s                               | k                 | Output       |
++--------+---------------------------------+-------------------+--------------+
+| Type   | String                          | String            | Variant NULL |
+| Domain | {"[\"a\",\"b\"]"..="{\"k\":1}"} | {"[\"a\"]"..="k"} | Unknown      |
+| Row 0  | "true"                          | "k"               | NULL         |
+| Row 1  | "{\"k\":1}"                     | "[\"k\"]"         | 1            |
+| Row 2  | "[\"a\",\"b\"]"                 | "[\"a\"]"         | NULL         |
++--------+---------------------------------+-------------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                      |
++--------+---------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x747275657b226b223a317d5b2261222c2262225d, offsets: [0, 4, 11, 20] }                                |
+| k      | StringColumn { data: 0x6b5b226b225d5b2261225d, offsets: [0, 1, 6, 11] }                                                   |
+| Output | NullableColumn { column: StringColumn { data: 0x20000000200000025001, offsets: [0, 0, 10, 10] }, validity: [0b_____010] } |
++--------+---------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : get_path(parse_json(s), k)
+raw expr       : get_path(parse_json(ColumnRef(0)::String NULL), ColumnRef(1)::String)
+checked expr   : get_path<Variant, String>(CAST(parse_json<String NULL>(ColumnRef(0)) AS Variant), ColumnRef(1))
+evaluation:
++--------+-----------------------------+--------------+--------------+
+|        | s                           | k            | Output       |
++--------+-----------------------------+--------------+--------------+
+| Type   | String NULL                 | String       | Variant NULL |
+| Domain | {""..="{\"k\":1}"} ∪ {NULL} | {""..="[0]"} | Unknown      |
+| Row 0  | "true"                      | "[0]"        | NULL         |
+| Row 1  | "{\"k\":1}"                 | "[\"k\"]"    | 1            |
+| Row 2  | NULL                        | ""           | NULL         |
+| Row 3  | "[\"a\",\"b\"]"             | "[0]"        | "a"          |
++--------+-----------------------------+--------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                              |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275657b226b223a317d5b2261222c2262225d, offsets: [0, 4, 11, 11, 20] }, validity: [0b____1011] } |
+| k      | StringColumn { data: 0x5b305d5b226b225d5b305d, offsets: [0, 3, 8, 8, 11] }                                                                        |
+| Output | NullableColumn { column: StringColumn { data: 0x20000000200000025001200000001000000161, offsets: [0, 0, 10, 10, 19] }, validity: [0b____1010] }   |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : json_extract_path_text('[[1,2],3]', '[0]')
+raw expr       : json_extract_path_text("[[1,2],3]", "[0]")
+checked expr   : json_extract_path_text<String, String>("[[1,2],3]", "[0]")
+optimized expr : 0x5b312c325d
+output type    : String NULL
+output domain  : Unknown
+output         : [1,2]
+
+
+ast            : json_extract_path_text('[[1,2],3]', '[0][1]')
+raw expr       : json_extract_path_text("[[1,2],3]", "[0][1]")
+checked expr   : json_extract_path_text<String, String>("[[1,2],3]", "[0][1]")
+optimized expr : 0x32
+output type    : String NULL
+output domain  : Unknown
+output         : 2
+
+
+ast            : json_extract_path_text('[1,2,3]', '[0]')
+raw expr       : json_extract_path_text("[1,2,3]", "[0]")
+checked expr   : json_extract_path_text<String, String>("[1,2,3]", "[0]")
+optimized expr : 0x31
+output type    : String NULL
+output domain  : Unknown
+output         : 1
+
+
+ast            : json_extract_path_text('[1,2,3]', 'k2:k3')
+raw expr       : json_extract_path_text("[1,2,3]", "k2:k3")
+checked expr   : json_extract_path_text<String, String>("[1,2,3]", "k2:k3")
+optimized expr : NULL
+output type    : String NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : json_extract_path_text('{"a":{"b":2}}', '["a"]["b"]')
+raw expr       : json_extract_path_text("{\"a\":{\"b\":2}}", "[\"a\"][\"b\"]")
+checked expr   : json_extract_path_text<String, String>("{\"a\":{\"b\":2}}", "[\"a\"][\"b\"]")
+optimized expr : 0x32
+output type    : String NULL
+output domain  : Unknown
+output         : 2
+
+
+ast            : json_extract_path_text('{"a":{"b":2}}', 'a:b')
+raw expr       : json_extract_path_text("{\"a\":{\"b\":2}}", "a:b")
+checked expr   : json_extract_path_text<String, String>("{\"a\":{\"b\":2}}", "a:b")
+optimized expr : 0x32
+output type    : String NULL
+output domain  : Unknown
+output         : 2
+
+
+ast            : json_extract_path_text('{"a":{"b":2}}', '["a"]')
+raw expr       : json_extract_path_text("{\"a\":{\"b\":2}}", "[\"a\"]")
+checked expr   : json_extract_path_text<String, String>("{\"a\":{\"b\":2}}", "[\"a\"]")
+optimized expr : 0x7b2262223a327d
+output type    : String NULL
+output domain  : Unknown
+output         : {"b":2}
+
+
+ast            : json_extract_path_text('{"a":{"b":2}}', 'a')
+raw expr       : json_extract_path_text("{\"a\":{\"b\":2}}", "a")
+checked expr   : json_extract_path_text<String, String>("{\"a\":{\"b\":2}}", "a")
+optimized expr : 0x7b2262223a327d
+output type    : String NULL
+output domain  : Unknown
+output         : {"b":2}
+
+
+ast            : json_extract_path_text(s, k)
+raw expr       : json_extract_path_text(ColumnRef(0)::String, ColumnRef(1)::String)
+checked expr   : json_extract_path_text<String, String>(ColumnRef(0), ColumnRef(1))
+evaluation:
++--------+---------------------------------+-------------------+-------------+
+|        | s                               | k                 | Output      |
++--------+---------------------------------+-------------------+-------------+
+| Type   | String                          | String            | String NULL |
+| Domain | {"[\"a\",\"b\"]"..="{\"k\":1}"} | {"[\"a\"]"..="k"} | Unknown     |
+| Row 0  | "true"                          | "k"               | NULL        |
+| Row 1  | "{\"k\":1}"                     | "[\"k\"]"         | 1           |
+| Row 2  | "[\"a\",\"b\"]"                 | "[\"a\"]"         | NULL        |
++--------+---------------------------------+-------------------+-------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                  |
++--------+-------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x747275657b226b223a317d5b2261222c2262225d, offsets: [0, 4, 11, 20] }            |
+| k      | StringColumn { data: 0x6b5b226b225d5b2261225d, offsets: [0, 1, 6, 11] }                               |
+| Output | NullableColumn { column: StringColumn { data: 0x31, offsets: [0, 0, 1, 1] }, validity: [0b_____010] } |
++--------+-------------------------------------------------------------------------------------------------------+
+
+
+ast            : json_extract_path_text(s, k)
+raw expr       : json_extract_path_text(ColumnRef(0)::String NULL, ColumnRef(1)::String)
+checked expr   : json_extract_path_text<String NULL, String NULL>(ColumnRef(0), CAST(ColumnRef(1) AS String NULL))
+evaluation:
++--------+-----------------------------+--------------+-------------+
+|        | s                           | k            | Output      |
++--------+-----------------------------+--------------+-------------+
+| Type   | String NULL                 | String       | String NULL |
+| Domain | {""..="{\"k\":1}"} ∪ {NULL} | {""..="[0]"} | Unknown     |
+| Row 0  | "true"                      | "[0]"        | NULL        |
+| Row 1  | "{\"k\":1}"                 | "[\"k\"]"    | 1           |
+| Row 2  | NULL                        | ""           | NULL        |
+| Row 3  | "[\"a\",\"b\"]"             | "[0]"        | "a"         |
++--------+-----------------------------+--------------+-------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                              |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275657b226b223a317d5b2261222c2262225d, offsets: [0, 4, 11, 11, 20] }, validity: [0b____1011] } |
+| k      | StringColumn { data: 0x5b305d5b226b225d5b305d, offsets: [0, 3, 8, 8, 11] }                                                                        |
+| Output | NullableColumn { column: StringColumn { data: 0x31226122, offsets: [0, 0, 1, 1, 4] }, validity: [0b____1010] }                                    |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_boolean(parse_json('true'))
+raw expr       : as_boolean(parse_json("true"))
+checked expr   : as_boolean<Variant>(parse_json<String>("true"))
+optimized expr : true
+output type    : Boolean NULL
+output domain  : Unknown
+output         : true
+
+
+ast            : as_boolean(parse_json('123'))
+raw expr       : as_boolean(parse_json("123"))
+checked expr   : as_boolean<Variant>(parse_json<String>("123"))
+optimized expr : NULL
+output type    : Boolean NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : as_integer(parse_json('true'))
+raw expr       : as_integer(parse_json("true"))
+checked expr   : as_integer<Variant>(parse_json<String>("true"))
+optimized expr : NULL
+output type    : Int64 NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : as_integer(parse_json('123'))
+raw expr       : as_integer(parse_json("123"))
+checked expr   : as_integer<Variant>(parse_json<String>("123"))
+optimized expr : 123_i64
+output type    : Int64 NULL
+output domain  : Unknown
+output         : 123
+
+
+ast            : as_float(parse_json('"ab"'))
+raw expr       : as_float(parse_json("\"ab\""))
+checked expr   : as_float<Variant>(parse_json<String>("\"ab\""))
+optimized expr : NULL
+output type    : Float64 NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : as_float(parse_json('12.34'))
+raw expr       : as_float(parse_json("12.34"))
+checked expr   : as_float<Variant>(parse_json<String>("12.34"))
+optimized expr : 12.34_f64
+output type    : Float64 NULL
+output domain  : Unknown
+output         : 12.34
+
+
+ast            : as_string(parse_json('"ab"'))
+raw expr       : as_string(parse_json("\"ab\""))
+checked expr   : as_string<Variant>(parse_json<String>("\"ab\""))
+optimized expr : "ab"
+output type    : String NULL
+output domain  : Unknown
+output         : "ab"
+
+
+ast            : as_string(parse_json('12.34'))
+raw expr       : as_string(parse_json("12.34"))
+checked expr   : as_string<Variant>(parse_json<String>("12.34"))
+optimized expr : NULL
+output type    : String NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : as_array(parse_json('[1,2,3]'))
+raw expr       : as_array(parse_json("[1,2,3]"))
+checked expr   : as_array<Variant>(parse_json<String>("[1,2,3]"))
+optimized expr : 0x80000003200000022000000220000002500150025003
+output type    : Variant NULL
+output domain  : Unknown
+output         : [1,2,3]
+
+
+ast            : as_array(parse_json('{"a":"b"}'))
+raw expr       : as_array(parse_json("{\"a\":\"b\"}"))
+checked expr   : as_array<Variant>(parse_json<String>("{\"a\":\"b\"}"))
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : as_object(parse_json('[1,2,3]'))
+raw expr       : as_object(parse_json("[1,2,3]"))
+checked expr   : as_object<Variant>(parse_json<String>("[1,2,3]"))
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : Unknown
+output         : NULL
+
+
+ast            : as_object(parse_json('{"a":"b"}'))
+raw expr       : as_object(parse_json("{\"a\":\"b\"}"))
+checked expr   : as_object<Variant>(parse_json<String>("{\"a\":\"b\"}"))
+optimized expr : 0x4000000110000001100000016162
+output type    : Variant NULL
+output domain  : Unknown
+output         : {"a":"b"}
+
+
+ast            : as_boolean(parse_json(s))
+raw expr       : as_boolean(parse_json(ColumnRef(0)::String))
+checked expr   : as_boolean<Variant>(parse_json<String>(ColumnRef(0)))
+evaluation:
++--------+------------------------------+--------------+
+|        | s                            | Output       |
++--------+------------------------------+--------------+
+| Type   | String                       | Boolean NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
+| Row 0  | "true"                       | true         |
+| Row 1  | "123"                        | NULL         |
+| Row 2  | "12.34"                      | NULL         |
+| Row 3  | "\"ab\""                     | NULL         |
+| Row 4  | "[1,2,3]"                    | NULL         |
+| Row 5  | "{\"a\":\"b\"}"              | NULL         |
++--------+------------------------------+--------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                          |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] } |
+| Output | NullableColumn { column: Boolean([0b__000001]), validity: [0b__000001] }                                                      |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_boolean(try_parse_json(s))
+raw expr       : as_boolean(try_parse_json(ColumnRef(0)::String))
+checked expr   : as_boolean<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
+evaluation:
++--------+------------------------------+--------------+
+|        | s                            | Output       |
++--------+------------------------------+--------------+
+| Type   | String                       | Boolean NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
+| Row 0  | "true"                       | true         |
+| Row 1  | "123"                        | NULL         |
+| Row 2  | "12.34"                      | NULL         |
+| Row 3  | "\"ab\""                     | NULL         |
+| Row 4  | "[1,2,3]"                    | NULL         |
+| Row 5  | "{\"a\":\"b\"}"              | NULL         |
++--------+------------------------------+--------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                          |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] } |
+| Output | NullableColumn { column: Boolean([0b__000001]), validity: [0b__000001] }                                                      |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_integer(parse_json(s))
+raw expr       : as_integer(parse_json(ColumnRef(0)::String))
+checked expr   : as_integer<Variant>(parse_json<String>(ColumnRef(0)))
+evaluation:
++--------+------------------------------+------------+
+|        | s                            | Output     |
++--------+------------------------------+------------+
+| Type   | String                       | Int64 NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown    |
+| Row 0  | "true"                       | NULL       |
+| Row 1  | "123"                        | 123        |
+| Row 2  | "12.34"                      | NULL       |
+| Row 3  | "\"ab\""                     | NULL       |
+| Row 4  | "[1,2,3]"                    | NULL       |
+| Row 5  | "{\"a\":\"b\"}"              | NULL       |
++--------+------------------------------+------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                          |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] } |
+| Output | NullableColumn { column: Int64([0, 123, 0, 0, 0, 0]), validity: [0b__000010] }                                                |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_integer(try_parse_json(s))
+raw expr       : as_integer(try_parse_json(ColumnRef(0)::String))
+checked expr   : as_integer<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
+evaluation:
++--------+------------------------------+------------+
+|        | s                            | Output     |
++--------+------------------------------+------------+
+| Type   | String                       | Int64 NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown    |
+| Row 0  | "true"                       | NULL       |
+| Row 1  | "123"                        | 123        |
+| Row 2  | "12.34"                      | NULL       |
+| Row 3  | "\"ab\""                     | NULL       |
+| Row 4  | "[1,2,3]"                    | NULL       |
+| Row 5  | "{\"a\":\"b\"}"              | NULL       |
++--------+------------------------------+------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                          |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] } |
+| Output | NullableColumn { column: Int64([0, 123, 0, 0, 0, 0]), validity: [0b__000010] }                                                |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_float(parse_json(s))
+raw expr       : as_float(parse_json(ColumnRef(0)::String))
+checked expr   : as_float<Variant>(parse_json<String>(ColumnRef(0)))
+evaluation:
++--------+------------------------------+--------------+
+|        | s                            | Output       |
++--------+------------------------------+--------------+
+| Type   | String                       | Float64 NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
+| Row 0  | "true"                       | NULL         |
+| Row 1  | "123"                        | 123          |
+| Row 2  | "12.34"                      | 12.34        |
+| Row 3  | "\"ab\""                     | NULL         |
+| Row 4  | "[1,2,3]"                    | NULL         |
+| Row 5  | "{\"a\":\"b\"}"              | NULL         |
++--------+------------------------------+--------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                          |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] } |
+| Output | NullableColumn { column: Float64([0, 123, 12.34, 0, 0, 0]), validity: [0b__000110] }                                          |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_float(try_parse_json(s))
+raw expr       : as_float(try_parse_json(ColumnRef(0)::String))
+checked expr   : as_float<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
+evaluation:
++--------+------------------------------+--------------+
+|        | s                            | Output       |
++--------+------------------------------+--------------+
+| Type   | String                       | Float64 NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
+| Row 0  | "true"                       | NULL         |
+| Row 1  | "123"                        | 123          |
+| Row 2  | "12.34"                      | 12.34        |
+| Row 3  | "\"ab\""                     | NULL         |
+| Row 4  | "[1,2,3]"                    | NULL         |
+| Row 5  | "{\"a\":\"b\"}"              | NULL         |
++--------+------------------------------+--------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                          |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] } |
+| Output | NullableColumn { column: Float64([0, 123, 12.34, 0, 0, 0]), validity: [0b__000110] }                                          |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_string(parse_json(s))
+raw expr       : as_string(parse_json(ColumnRef(0)::String))
+checked expr   : as_string<Variant>(parse_json<String>(ColumnRef(0)))
+evaluation:
++--------+------------------------------+-------------+
+|        | s                            | Output      |
++--------+------------------------------+-------------+
+| Type   | String                       | String NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown     |
+| Row 0  | "true"                       | NULL        |
+| Row 1  | "123"                        | NULL        |
+| Row 2  | "12.34"                      | NULL        |
+| Row 3  | "\"ab\""                     | "ab"        |
+| Row 4  | "[1,2,3]"                    | NULL        |
+| Row 5  | "{\"a\":\"b\"}"              | NULL        |
++--------+------------------------------+-------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                          |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] } |
+| Output | NullableColumn { column: StringColumn { data: 0x6162, offsets: [0, 0, 0, 0, 2, 2, 2] }, validity: [0b__001000] }              |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_string(try_parse_json(s))
+raw expr       : as_string(try_parse_json(ColumnRef(0)::String))
+checked expr   : as_string<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
+evaluation:
++--------+------------------------------+-------------+
+|        | s                            | Output      |
++--------+------------------------------+-------------+
+| Type   | String                       | String NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown     |
+| Row 0  | "true"                       | NULL        |
+| Row 1  | "123"                        | NULL        |
+| Row 2  | "12.34"                      | NULL        |
+| Row 3  | "\"ab\""                     | "ab"        |
+| Row 4  | "[1,2,3]"                    | NULL        |
+| Row 5  | "{\"a\":\"b\"}"              | NULL        |
++--------+------------------------------+-------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                          |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] } |
+| Output | NullableColumn { column: StringColumn { data: 0x6162, offsets: [0, 0, 0, 0, 2, 2, 2] }, validity: [0b__001000] }              |
++--------+-------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_array(parse_json(s))
+raw expr       : as_array(parse_json(ColumnRef(0)::String))
+checked expr   : as_array<Variant>(parse_json<String>(ColumnRef(0)))
+evaluation:
++--------+------------------------------+--------------+
+|        | s                            | Output       |
++--------+------------------------------+--------------+
+| Type   | String                       | Variant NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
+| Row 0  | "true"                       | NULL         |
+| Row 1  | "123"                        | NULL         |
+| Row 2  | "12.34"                      | NULL         |
+| Row 3  | "\"ab\""                     | NULL         |
+| Row 4  | "[1,2,3]"                    | [1,2,3]      |
+| Row 5  | "{\"a\":\"b\"}"              | NULL         |
++--------+------------------------------+--------------+
+evaluation (internal):
++--------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                       |
++--------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] }                              |
+| Output | NullableColumn { column: StringColumn { data: 0x80000003200000022000000220000002500150025003, offsets: [0, 0, 0, 0, 0, 22, 22] }, validity: [0b__010000] } |
++--------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_array(try_parse_json(s))
+raw expr       : as_array(try_parse_json(ColumnRef(0)::String))
+checked expr   : as_array<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
+evaluation:
++--------+------------------------------+--------------+
+|        | s                            | Output       |
++--------+------------------------------+--------------+
+| Type   | String                       | Variant NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
+| Row 0  | "true"                       | NULL         |
+| Row 1  | "123"                        | NULL         |
+| Row 2  | "12.34"                      | NULL         |
+| Row 3  | "\"ab\""                     | NULL         |
+| Row 4  | "[1,2,3]"                    | [1,2,3]      |
+| Row 5  | "{\"a\":\"b\"}"              | NULL         |
++--------+------------------------------+--------------+
+evaluation (internal):
++--------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                       |
++--------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] }                              |
+| Output | NullableColumn { column: StringColumn { data: 0x80000003200000022000000220000002500150025003, offsets: [0, 0, 0, 0, 0, 22, 22] }, validity: [0b__010000] } |
++--------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_object(parse_json(s))
+raw expr       : as_object(parse_json(ColumnRef(0)::String))
+checked expr   : as_object<Variant>(parse_json<String>(ColumnRef(0)))
+evaluation:
++--------+------------------------------+--------------+
+|        | s                            | Output       |
++--------+------------------------------+--------------+
+| Type   | String                       | Variant NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
+| Row 0  | "true"                       | NULL         |
+| Row 1  | "123"                        | NULL         |
+| Row 2  | "12.34"                      | NULL         |
+| Row 3  | "\"ab\""                     | NULL         |
+| Row 4  | "[1,2,3]"                    | NULL         |
+| Row 5  | "{\"a\":\"b\"}"              | {"a":"b"}    |
++--------+------------------------------+--------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                      |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] }             |
+| Output | NullableColumn { column: StringColumn { data: 0x4000000110000001100000016162, offsets: [0, 0, 0, 0, 0, 0, 14] }, validity: [0b__100000] } |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : as_object(try_parse_json(s))
+raw expr       : as_object(try_parse_json(ColumnRef(0)::String))
+checked expr   : as_object<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
+evaluation:
++--------+------------------------------+--------------+
+|        | s                            | Output       |
++--------+------------------------------+--------------+
+| Type   | String                       | Variant NULL |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
+| Row 0  | "true"                       | NULL         |
+| Row 1  | "123"                        | NULL         |
+| Row 2  | "12.34"                      | NULL         |
+| Row 3  | "\"ab\""                     | NULL         |
+| Row 4  | "[1,2,3]"                    | NULL         |
+| Row 5  | "{\"a\":\"b\"}"              | {"a":"b"}    |
++--------+------------------------------+--------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                      |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] }             |
+| Output | NullableColumn { column: StringColumn { data: 0x4000000110000001100000016162, offsets: [0, 0, 0, 0, 0, 0, 14] }, validity: [0b__100000] } |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------+
+
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

migrate variant functions to functions-v2

```
parse_json
try_parse_json
check_json
length
object_keys
get
```

part of #7717
