### PR TITLE
feat(clusters): add binary commit version to system.clusters

### DIFF
--- a/src/meta/types/src/cluster.rs
+++ b/src/meta/types/src/cluster.rs
@@ -61,15 +61,22 @@ pub struct NodeInfo {
     pub cpu_nums: u64,
     pub version: u32,
     pub flight_address: String,
+    pub binary_version: String,
 }
 
 impl NodeInfo {
-    pub fn create(id: String, cpu_nums: u64, flight_address: String) -> NodeInfo {
+    pub fn create(
+        id: String,
+        cpu_nums: u64,
+        flight_address: String,
+        binary_version: String,
+    ) -> NodeInfo {
         NodeInfo {
             id,
             cpu_nums,
             version: 0,
             flight_address,
+            binary_version,
         }
     }
 

--- a/src/meta/types/tests/it/cluster.rs
+++ b/src/meta/types/tests/it/cluster.rs
@@ -22,11 +22,13 @@ fn test_node_info_ip_port() -> Result<()> {
         cpu_nums: 1,
         version: 1,
         flight_address: "1.2.3.4:123".to_string(),
+        binary_version: "v0.8-binary-version".to_string(),
     };
 
     let (ip, port) = n.ip_port()?;
     assert_eq!("1.2.3.4".to_string(), ip);
     assert_eq!(123, port);
+    assert_eq!("v0.8-binary-version".to_string(), n.binary_version);
 
     Ok(())
 }

--- a/src/query/management/tests/it/cluster.rs
+++ b/src/query/management/tests/it/cluster.rs
@@ -151,6 +151,7 @@ fn create_test_node_info() -> NodeInfo {
         cpu_nums: 0,
         version: 0,
         flight_address: String::from("ip:port"),
+        binary_version: "binary_version".to_string(),
     }
 }
 

--- a/src/query/service/src/clusters/cluster.rs
+++ b/src/query/service/src/clusters/cluster.rs
@@ -375,7 +375,12 @@ impl ClusterDiscovery {
             }
         }
 
-        let node_info = NodeInfo::create(self.local_id.clone(), cpus, address);
+        let node_info = NodeInfo::create(
+            self.local_id.clone(),
+            cpus,
+            address,
+            crate::version::DATABEND_COMMIT_VERSION.to_string(),
+        );
 
         self.drop_invalid_nodes(&node_info).await?;
         match self.api_provider.add_node(node_info.clone()).await {

--- a/src/query/service/src/storages/system/clusters_table.rs
+++ b/src/query/service/src/storages/system/clusters_table.rs
@@ -44,6 +44,7 @@ impl SyncSystemTable for ClustersTable {
         let mut names = MutableStringColumn::with_capacity(cluster_nodes.len());
         let mut addresses = MutableStringColumn::with_capacity(cluster_nodes.len());
         let mut addresses_port = MutablePrimitiveColumn::<u16>::with_capacity(cluster_nodes.len());
+        let mut versions = MutableStringColumn::with_capacity(cluster_nodes.len());
 
         for cluster_node in &cluster_nodes {
             let (ip, port) = cluster_node.ip_port()?;
@@ -51,12 +52,14 @@ impl SyncSystemTable for ClustersTable {
             names.append_value(cluster_node.id.as_bytes());
             addresses.append_value(ip.as_bytes());
             addresses_port.append_value(port);
+            versions.append_value(cluster_node.binary_version.as_bytes());
         }
 
         Ok(DataBlock::create(self.table_info.schema(), vec![
             names.finish().arc(),
             addresses.finish().arc(),
             addresses_port.finish().arc(),
+            versions.finish().arc(),
         ]))
     }
 }
@@ -67,6 +70,7 @@ impl ClustersTable {
             DataField::new("name", Vu8::to_data_type()),
             DataField::new("host", Vu8::to_data_type()),
             DataField::new("port", u16::to_data_type()),
+            DataField::new("version", Vu8::to_data_type()),
         ]);
 
         let table_info = TableInfo {

--- a/src/query/service/tests/it/storages/system/clusters_table.rs
+++ b/src/query/service/tests/it/storages/system/clusters_table.rs
@@ -29,7 +29,7 @@ async fn test_clusters_table() -> Result<()> {
     let stream = table.read(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
-    assert_eq!(block.num_columns(), 3);
+    assert_eq!(block.num_columns(), 4);
 
     Ok(())
 }

--- a/src/query/service/tests/it/tests/context.rs
+++ b/src/query/service/tests/it/tests/context.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_config::DATABEND_COMMIT_VERSION;
 use common_exception::Result;
 use common_meta_embedded::MetaEmbedded;
 use common_meta_types::AuthInfo;
@@ -126,7 +127,12 @@ impl ClusterDescriptor {
 
     pub fn with_node(self, id: impl Into<String>, addr: impl Into<String>) -> ClusterDescriptor {
         let mut new_nodes = self.cluster_nodes_list.clone();
-        new_nodes.push(Arc::new(NodeInfo::create(id.into(), 0, addr.into())));
+        new_nodes.push(Arc::new(NodeInfo::create(
+            id.into(),
+            0,
+            addr.into(),
+            DATABEND_COMMIT_VERSION.to_string(),
+        )));
         ClusterDescriptor {
             cluster_nodes_list: new_nodes,
             local_node_id: self.local_node_id,

--- a/tests/logictest/suites/base/01_system/01_0008_system_clusters
+++ b/tests/logictest/suites/base/01_system/01_0008_system_clusters
@@ -1,6 +1,6 @@
 onlyif mysql
 statement query BB
-SELECT length(name)>0, length(version) FROM system.clusters LIMIT 1;
+SELECT length(name)>0, length(version)>0 FROM system.clusters LIMIT 1;
 
 ----
 1 1

--- a/tests/logictest/suites/base/01_system/01_0008_system_clusters
+++ b/tests/logictest/suites/base/01_system/01_0008_system_clusters
@@ -1,0 +1,6 @@
+onlyif mysql
+statement query BB
+SELECT length(name)>0, length(version) FROM system.clusters LIMIT 1;
+
+----
+1 1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Add binary commit version to system.clusters
```
mysql> select * from system.clusters;
+------------------------+-----------+------+------------------------------------------------------------------------------+
| name                   | host      | port | version                                                                      |
+------------------------+-----------+------+------------------------------------------------------------------------------+
| kOSA7yj0ULTreyQfmwoIH7 | 127.0.0.1 | 9090 | v0.8.54-nightly-fd32998-simd(rust-1.66.0-nightly-2022-09-30T00:39:13.36732Z) |
+------------------------+-----------+------+------------------------------------------------------------------------------+
```

Fixes #7968
