### PR TITLE
feat(meta/service): add histogram metrics for rpc delay: metasrv_meta_network_rpc_delay_seconds

### DIFF
--- a/docs/doc/50-manage/00-metasrv/50-metasrv-metrics.md
+++ b/docs/doc/50-manage/00-metasrv/50-metasrv-metrics.md
@@ -18,10 +18,10 @@ All the metrics is under `metasrv` prefix.
 These metrics describe the status of the `metasrv`. All these metrics are prefixed with `metasrv_server_`.
 
 | Name              | Description                                       | Type    |
-| ----------------- | ------------------------------------------------- | ------- |
-| current_leader_id | Current leader id of cluster, 0 means no leader.  | IntGauge   |
+|-------------------|---------------------------------------------------|---------|
+| current_leader_id | Current leader id of cluster, 0 means no leader.  | Gauge   |
 | is_leader         | Whether or not this node is current leader.       | Gauge   |
-| node_is_health    | Whether or not this node is health.               | IntGauge |
+| node_is_health    | Whether or not this node is health.               | Gauge   |
 | leader_changes    | Number of leader changes seen.                    | Counter |
 | applying_snapshot | Whether or not statemachine is applying snapshot. | Gauge   |
 | proposals_applied | Total number of consensus proposals applied.      | Gauge   |
@@ -51,21 +51,21 @@ If and only if the node state is `Follower` or `Leader` , `node_is_health` is 1,
 
 These metrics describe the network status of raft nodes in the `metasrv`. All these metrics are prefixed with `metasrv_raft_network_`.
 
-| Name                    | Description                                       | Labels                            | Type          |
-| ----------------------- | ------------------------------------------------- | --------------------------------- | ------------- |
-| active_peers            | Current number of active connections to peers.    | id(node id),address(peer address) | GaugeVec      |
-| fail_connect_to_peer    | Total number of fail connections to peers.        | id(node id),address(peer address) | CounterVec    |
-| sent_bytes              | Total number of sent bytes to peers.              | to(node id)                       | CounterVec    |
-| recv_bytes              | Total number of received bytes from peers.        | from(remote address)              | CounterVec    |
-| sent_failures           | Total number of send failures to peers.           | to(node id)                       | CounterVec    |
-| snapshot_send_success   | Total number of successful snapshot sends.        | to(node id)                       | IntCounterVec |
-| snapshot_send_failures  | Total number of snapshot send failures.           | to(node id)                       | IntCounterVec |
-| snapshot_send_inflights | Total number of inflight snapshot sends.          | to(node id)                       | IntGaugeVec   |
-| snapshot_sent_seconds   | Total latency distributions of snapshot sends.    | to(node id)                       | HistogramVec  |
-| snapshot_recv_success   | Total number of successful receive snapshot.      | from(remote address)              | IntCounterVec |
-| snapshot_recv_failures  | Total number of snapshot receive failures.        | from(remote address)              | IntCounterVec |
-| snapshot_recv_inflights | Total number of inflight snapshot receives.       | from(remote address)              | IntGaugeVec   |
-| snapshot_recv_seconds   | Total latency distributions of snapshot receives. | from(remote address)              | HistogramVec  |
+| Name                    | Description                                       | Labels                            | Type      |
+|-------------------------|---------------------------------------------------|-----------------------------------|-----------|
+| active_peers            | Current number of active connections to peers.    | id(node id),address(peer address) | Gauge     |
+| fail_connect_to_peer    | Total number of fail connections to peers.        | id(node id),address(peer address) | Counter   |
+| sent_bytes              | Total number of sent bytes to peers.              | to(node id)                       | Counter   |
+| recv_bytes              | Total number of received bytes from peers.        | from(remote address)              | Counter   |
+| sent_failures           | Total number of send failures to peers.           | to(node id)                       | Counter   |
+| snapshot_send_success   | Total number of successful snapshot sends.        | to(node id)                       | Counter   |
+| snapshot_send_failures  | Total number of snapshot send failures.           | to(node id)                       | Counter   |
+| snapshot_send_inflights | Total number of inflight snapshot sends.          | to(node id)                       | Gauge     |
+| snapshot_sent_seconds   | Total latency distributions of snapshot sends.    | to(node id)                       | Histogram |
+| snapshot_recv_success   | Total number of successful receive snapshot.      | from(remote address)              | Counter   |
+| snapshot_recv_failures  | Total number of snapshot receive failures.        | from(remote address)              | Counter   |
+| snapshot_recv_inflights | Total number of inflight snapshot receives.       | from(remote address)              | Gauge     |
+| snapshot_recv_seconds   | Total latency distributions of snapshot receives. | from(remote address)              | Histogram |
 
 `active_peers` indicates how many active connection between cluster members, `fail_connect_to_peer` indicates the number of fail connections to peers. Each has the labels: id(node id) and address (peer address).
 
@@ -83,10 +83,10 @@ These metrics describe the network status of raft nodes in the `metasrv`. All th
 
 These metrics describe the storage status of raft nodes in the `metasrv`. All these metrics are prefixed with `metasrv_raft_storage_`.
 
-| Name                    | Description                                       | Labels                            | Type          |
-| ----------------------- | ------------------------------------------------- | --------------------------------- | ------------- |
-| raft_store_write_failed            | Total number of raft store write failures.    | func(function name) | CounterVec      |
-| raft_store_read_failed            | Total number of raft store read failures.    | func(function name) | CounterVec      |
+| Name                    | Description                                | Labels              | Type    |
+|-------------------------|--------------------------------------------|---------------------|---------|
+| raft_store_write_failed | Total number of raft store write failures. | func(function name) | Counter |
+| raft_store_read_failed  | Total number of raft store read failures.  | func(function name) | Counter |
 
 `raft_store_write_failed` and `raft_store_read_failed` indicate the total number of raft store write and read failures.
 
@@ -94,10 +94,11 @@ These metrics describe the storage status of raft nodes in the `metasrv`. All th
 
 These metrics describe the network status of meta service in the `metasrv`. All these metrics are prefixed with `metasrv_meta_network_`.
 
-| Name             | Description                                            | Type       |
-| ---------------- | ------------------------------------------------------ | ---------- |
-| meta_sent_bytes  | Total number of sent bytes to meta grpc client.        | IntCounter |
-| meta_recv_bytes  | Total number of recv bytes from meta grpc client.      | IntCounter |
-| meta_inflights   | Total number of inflight meta grpc requests.           | IntGauge   |
-| meta_req_success | Total number of success request from meta grpc client. | IntCounter |
-| meta_req_failed  | Total number of fail request from meta grpc client.    | IntCounter |
+| Name              | Description                                            | Type      |
+|-------------------|--------------------------------------------------------|-----------|
+| sent_bytes        | Total number of sent bytes to meta grpc client.        | Counter   |
+| recv_bytes        | Total number of recv bytes from meta grpc client.      | Counter   |
+| inflights         | Total number of inflight meta grpc requests.           | Gauge     |
+| req_success       | Total number of success request from meta grpc client. | Counter   |
+| req_failed        | Total number of fail request from meta grpc client.    | Counter   |
+| rpc_delay_seconds | Latency distribution of meta-service API in second.    | Histogram |

--- a/src/common/metrics/src/counter.rs
+++ b/src/common/metrics/src/counter.rs
@@ -38,6 +38,12 @@ use std::ops::DerefMut;
 /// Defines how to report counter metrics.
 pub trait Count {
     fn incr_count(&mut self, n: i64);
+
+    /// Create a guard instance that increases the counter when created, and decreases the counter when dropped.
+    fn guard() -> WithCount<Self, ()>
+    where Self: Default + Sized {
+        WithCount::new((), Self::default())
+    }
 }
 
 /// Binds a counter to a `T`.

--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -24,7 +24,7 @@ use common_meta_types::Node;
 use common_meta_types::RaftChangeMembershipError;
 use common_meta_types::RaftWriteError;
 use common_meta_types::SeqV;
-use common_metrics::counter::WithCount;
+use common_metrics::counter::Count;
 use tracing::debug;
 use tracing::info;
 
@@ -182,7 +182,7 @@ impl<'a> MetaLeader<'a> {
         entry.time_ms = Some(SeqV::<()>::now_ms());
 
         // report metrics
-        let _guard = WithCount::new((), ProposalPending);
+        let _guard = ProposalPending::guard();
 
         info!("write LogEntry: {}", entry);
         let write_res = self.meta_node.raft.client_write(entry).await;

--- a/src/meta/service/tests/it/api/http/metrics.rs
+++ b/src/meta/service/tests/it/api/http/metrics.rs
@@ -56,6 +56,14 @@ async fn test_metrics() -> anyhow::Result<()> {
 
     // Sample output:
     // metasrv_server_leader_changes 3
+    // metasrv_meta_network_rpc_delay_seconds_sum 0.015056999000000001
+    // metasrv_meta_network_rpc_delay_seconds{quantile="0"} 0.003751958
+    // metasrv_meta_network_rpc_delay_seconds{quantile="0.5"} 0.005509397423424308
+    // metasrv_meta_network_rpc_delay_seconds{quantile="0.9"} 0.005509397423424308
+    // metasrv_meta_network_rpc_delay_seconds{quantile="0.95"} 0.005509397423424308
+    // metasrv_meta_network_rpc_delay_seconds{quantile="0.99"} 0.005509397423424308
+    // metasrv_meta_network_rpc_delay_seconds{quantile="0.999"} 0.005509397423424308
+    // metasrv_meta_network_rpc_delay_seconds{quantile="1"} 0.005795875
     // metasrv_raft_network_recv_bytes{from="127.0.0.1:62268"} 1752
     // metasrv_raft_network_recv_bytes{from="127.0.0.1:62270"} 1535
     // metasrv_raft_network_sent_bytes{to="1"} 1752
@@ -91,6 +99,16 @@ async fn test_metrics() -> anyhow::Result<()> {
             let key = segments.next().unwrap();
             metric_keys.insert(key);
             info!("found response metric key: {:?}", key);
+
+            // strip labels `foo{label=1, label=2}`
+            let mut key_and_labels = key.split('{');
+            if let Some(striped) = key_and_labels.next() {
+                metric_keys.insert(striped);
+                info!(
+                    "found response metric key with label striped: {:?}",
+                    striped
+                );
+            }
         }
         metric_keys
     };
@@ -100,6 +118,8 @@ async fn test_metrics() -> anyhow::Result<()> {
     assert!(metric_keys.contains("metasrv_server_leader_changes"));
     assert!(metric_keys.contains("metasrv_server_last_log_index"));
     assert!(metric_keys.contains("metasrv_server_proposals_pending"));
+    assert!(metric_keys.contains("metasrv_raft_network_active_peers"));
+    assert!(metric_keys.contains("metasrv_raft_network_recv_bytes"));
     assert!(metric_keys.contains("metasrv_server_is_leader"));
     assert!(metric_keys.contains("metasrv_server_node_is_health"));
     assert!(metric_keys.contains("metasrv_server_last_seq"));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feature(meta/service): add histogram metrics for rpc delay: metasrv_meta_network_rpc_delay_seconds

```
metasrv_meta_network_rpc_delay_seconds_sum 0.015056999000000001
metasrv_meta_network_rpc_delay_seconds{quantile="0"} 0.003751958
metasrv_meta_network_rpc_delay_seconds{quantile="0.5"} 0.005509397423424308
metasrv_meta_network_rpc_delay_seconds{quantile="0.9"} 0.005509397423424308
metasrv_meta_network_rpc_delay_seconds{quantile="0.95"} 0.005509397423424308
metasrv_meta_network_rpc_delay_seconds{quantile="0.99"} 0.005509397423424308
metasrv_meta_network_rpc_delay_seconds{quantile="0.999"} 0.005509397423424308
metasrv_meta_network_rpc_delay_seconds{quantile="1"} 0.005795875
```


## Changelog







## Related Issues