### PR TITLE
chore(meta): upgrade openraft 0.7.3..0.7.4-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5262,7 +5262,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.7.3"
-source = "git+https://github.com/datafuselabs/openraft?tag=v0.7.3#2c06dc4d1e2973e4a91a9fb4a3345d1ce9055fc2"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.7.4-alpha.1#1bd22edc0a8dc7a9c314341370b3dfeb357411b5"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -49,7 +49,7 @@ databend-query = { path = "../query/service" }
 # Crates.io dependencies
 anyhow = "1.0.65"
 clap = { version = "3.2.22", features = ["derive", "env"] }
-openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.3" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.7.4-alpha.1" }
 sentry = "0.27.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"

--- a/src/meta/sled-store/Cargo.toml
+++ b/src/meta/sled-store/Cargo.toml
@@ -17,7 +17,7 @@ io-uring = ["sled/io_uring"]
 [dependencies]
 common-meta-types = { path = "../types" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.3" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.7.4-alpha.1" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyhow = "1.0.65"

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -14,7 +14,7 @@ test = false
 common-exception = { path = "../../common/exception" }
 common-storage = { path = "../../common/storage" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.3" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.7.4-alpha.1" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyerror = "=0.1.7"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore(meta): upgrade openraft 0.7.3..0.7.4-alpha.1

Remove unused error AddLearnerError::Exists

## Changelog







## Related Issues