### PR TITLE
chore(meta): upgrade openraft 0.7.3..0.7.4-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5262,7 +5262,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.7.3"
-source = "git+https://github.com/datafuselabs/openraft?tag=v0.7.3#2c06dc4d1e2973e4a91a9fb4a3345d1ce9055fc2"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.7.4-alpha.2#2896b98e34825a8623ec4650da405c79827ecbee"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -49,7 +49,7 @@ databend-query = { path = "../query/service" }
 # Crates.io dependencies
 anyhow = "1.0.65"
 clap = { version = "3.2.22", features = ["derive", "env"] }
-openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.3" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.7.4-alpha.2" }
 sentry = "0.27.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"

--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -31,6 +31,7 @@ use common_meta_raft_store::config::RaftConfig;
 use common_meta_raft_store::sled_key_spaces::GenericKV;
 use common_meta_raft_store::state_machine::StateMachine;
 use common_meta_sled_store::openraft;
+use common_meta_sled_store::openraft::error::AddLearnerError;
 use common_meta_sled_store::openraft::DefensiveCheck;
 use common_meta_sled_store::openraft::StoreExt;
 use common_meta_sled_store::SledKeySpace;
@@ -49,6 +50,7 @@ use common_meta_types::InvalidReply;
 use common_meta_types::LeaveRequest;
 use common_meta_types::LogEntry;
 use common_meta_types::MetaAPIError;
+use common_meta_types::MetaDataError;
 use common_meta_types::MetaError;
 use common_meta_types::MetaManagementError;
 use common_meta_types::MetaNetworkError;
@@ -423,11 +425,8 @@ impl MetaNode {
         Ok(joined)
     }
 
-    // spawn a monitor to watch raft state changes such as leader changes,
-    // and manually add non-voter to cluster so that non-voter receives raft logs.
+    /// Spawn a monitor to watch raft state changes and report metrics changes.
     pub async fn subscribe_metrics(mn: Arc<Self>, mut metrics_rx: watch::Receiver<RaftMetrics>) {
-        // TODO(luhuanbing): every state change triggers add_non_voter is not very reasonable
-
         let meta_node = mn.clone();
 
         let fut = async move {
@@ -444,20 +443,7 @@ impl MetaNode {
 
                 let mm = metrics_rx.borrow().clone();
 
-                if let Some(cur) = mm.current_leader {
-                    if cur == meta_node.sto.id {
-                        let res = meta_node.add_configured_non_voters().await;
-
-                        if let Err(err) = res {
-                            warn!(
-                                "fail to add non-voter: my id={}, err:{:?}",
-                                meta_node.sto.id, err
-                            );
-                        }
-                    }
-                }
-
-                // metrics about server state and role.
+                // Report metrics about server state and role.
 
                 server_metrics::set_node_is_health(
                     mm.state == State::Follower || mm.state == State::Leader,
@@ -711,25 +697,6 @@ impl MetaNode {
         Ok(())
     }
 
-    /// When a leader is established, it is the leader's responsibility to setup replication from itself to non-voters, AKA learners.
-    /// openraft does not persist the node set of non-voters, thus we need to do it manually.
-    /// This fn should be called once a node found it becomes leader.
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn add_configured_non_voters(&self) -> MetaResult<()> {
-        let node_ids = self.sto.list_non_voters().await;
-        for i in node_ids.iter() {
-            let x = self.raft.add_learner(*i, true).await;
-
-            info!("add_non_voter result: {:?}", x);
-            if x.is_ok() {
-                info!("non-voter is added: {}", i);
-            } else {
-                info!("non-voter already exist: {}", i);
-            }
-        }
-        Ok(())
-    }
-
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn get_node(&self, node_id: &NodeId) -> MetaResult<Option<Node>> {
         // inconsistent get: from local state machine
@@ -948,6 +915,13 @@ impl MetaNode {
                 cmd: Cmd::AddNode { node_id, node },
             })
             .await?;
+        self.raft
+            .add_learner(node_id, false)
+            .await
+            .map_err(|e| match e {
+                AddLearnerError::ForwardToLeader(e) => MetaAPIError::ForwardToLeader(e),
+                AddLearnerError::Fatal(e) => MetaAPIError::DataError(MetaDataError::WriteError(e)),
+            })?;
         Ok(resp)
     }
 

--- a/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
@@ -375,6 +375,7 @@ async fn test_meta_node_restart() -> anyhow::Result<()> {
         .wait(timeout())
         .state(State::Learner, "learner restart")
         .await?;
+    mn0.raft.add_learner(1, false).await?;
     mn1.raft
         .wait(timeout())
         .current_leader(0, "node-1 has leader")

--- a/src/meta/sled-store/Cargo.toml
+++ b/src/meta/sled-store/Cargo.toml
@@ -17,7 +17,7 @@ io-uring = ["sled/io_uring"]
 [dependencies]
 common-meta-types = { path = "../types" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.3" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.7.4-alpha.2" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyhow = "1.0.65"

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -14,7 +14,7 @@ test = false
 common-exception = { path = "../../common/exception" }
 common-storage = { path = "../../common/storage" }
 
-openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.3" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.7.4-alpha.2" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 anyerror = "=0.1.7"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore(meta): upgrade openraft 0.7.3..0.7.4-alpha.2

https://github.com/drmingdrmer/openraft/tree/v0.7.4-alpha.2

Openraft changes:

- Fix: changing membership should not remove replication to all learners
  When changing membership, replications to the learners(non-voters) that
  are not added as voter should be kept.

  E.g.: with a cluster of voters `{0}` and learners `{1, 2, 3}`, changing
  membership to `{0, 1, 2}` should not remove replication to node `3`.

  Only replications to removed members should be removed.

- Change: remove AddLearnerError::Exists, which is not actually used

Other changes:

- Remove adding learner when leader established

- Fix: #7895

## Changelog







## Related Issues