### PR TITLE
refactor(meta/service): use MetaStorageError if possible

### DIFF
--- a/src/meta/raft-store/src/state_machine/sm.rs
+++ b/src/meta/raft-store/src/state_machine/sm.rs
@@ -923,18 +923,12 @@ impl StateMachine {
 
     pub fn get_node(&self, node_id: &NodeId) -> Result<Option<Node>, MetaStorageError> {
         let sm_nodes = self.nodes();
-        match sm_nodes.get(node_id) {
-            Ok(e) => Ok(e),
-            Err(e) => Err(e.into()),
-        }
+        sm_nodes.get(node_id)
     }
 
     pub fn get_nodes(&self) -> Result<Vec<Node>, MetaStorageError> {
         let sm_nodes = self.nodes();
-        match sm_nodes.range_values(..) {
-            Ok(e) => Ok(e),
-            Err(e) => Err(e.into()),
-        }
+        sm_nodes.range_values(..)
     }
 
     pub fn unexpired_opt<V: Debug>(

--- a/src/meta/raft-store/src/state_machine/sm.rs
+++ b/src/meta/raft-store/src/state_machine/sm.rs
@@ -42,9 +42,7 @@ use common_meta_types::KVMeta;
 use common_meta_types::LogEntry;
 use common_meta_types::LogId;
 use common_meta_types::MatchSeqExt;
-use common_meta_types::MetaResult;
 use common_meta_types::MetaStorageError;
-use common_meta_types::MetaStorageResult;
 use common_meta_types::Node;
 use common_meta_types::NodeId;
 use common_meta_types::Operation;
@@ -354,7 +352,7 @@ impl StateMachine {
         &self,
         key: &str,
         txn_tree: &TransactionSledTree,
-    ) -> MetaStorageResult<AppliedState> {
+    ) -> Result<AppliedState, MetaStorageError> {
         let r = self.txn_incr_seq(key, txn_tree)?;
 
         Ok(r.into())
@@ -366,7 +364,7 @@ impl StateMachine {
         node_id: &u64,
         node: &Node,
         txn_tree: &TransactionSledTree,
-    ) -> MetaStorageResult<AppliedState> {
+    ) -> Result<AppliedState, MetaStorageError> {
         let sm_nodes = txn_tree.key_space::<Nodes>();
 
         let prev = sm_nodes.get(node_id)?;
@@ -385,7 +383,7 @@ impl StateMachine {
         &self,
         node_id: &u64,
         txn_tree: &TransactionSledTree,
-    ) -> MetaStorageResult<AppliedState> {
+    ) -> Result<AppliedState, MetaStorageError> {
         let sm_nodes = txn_tree.key_space::<Nodes>();
 
         let prev = sm_nodes.get(node_id)?;
@@ -403,7 +401,7 @@ impl StateMachine {
         upsert_kv: &UpsertKV,
         txn_tree: &TransactionSledTree,
         log_time_ms: u64,
-    ) -> MetaStorageResult<AppliedState> {
+    ) -> Result<AppliedState, MetaStorageError> {
         debug!(upsert_kv = debug(upsert_kv), "apply_update_kv_cmd");
 
         let sub_tree = txn_tree.key_space::<GenericKV>();
@@ -457,7 +455,7 @@ impl StateMachine {
         &self,
         txn_tree: &TransactionSledTree,
         cond: &TxnCondition,
-    ) -> MetaStorageResult<bool> {
+    ) -> Result<bool, MetaStorageError> {
         debug!(cond = display(cond), "txn_execute_one_condition");
 
         let key = cond.key.clone();
@@ -499,7 +497,7 @@ impl StateMachine {
         &self,
         txn_tree: &TransactionSledTree,
         condition: &Vec<TxnCondition>,
-    ) -> MetaStorageResult<bool> {
+    ) -> Result<bool, MetaStorageError> {
         for cond in condition {
             debug!(condition = display(cond), "txn_execute_condition");
 
@@ -516,7 +514,7 @@ impl StateMachine {
         txn_tree: &TransactionSledTree,
         get: &TxnGetRequest,
         resp: &mut TxnReply,
-    ) -> MetaStorageResult<()> {
+    ) -> Result<(), MetaStorageError> {
         let sub_tree = txn_tree.key_space::<GenericKV>();
         let sv = sub_tree.get(&get.key)?;
         let value = sv.map(PbSeqV::from);
@@ -539,7 +537,7 @@ impl StateMachine {
         resp: &mut TxnReply,
         events: &mut Option<Vec<NotifyKVEvent>>,
         log_time_ms: u64,
-    ) -> MetaStorageResult<()> {
+    ) -> Result<(), MetaStorageError> {
         let sub_tree = txn_tree.key_space::<GenericKV>();
 
         let (prev, result) = match put.expire_at {
@@ -584,7 +582,7 @@ impl StateMachine {
         resp: &mut TxnReply,
         events: &mut Option<Vec<NotifyKVEvent>>,
         log_time_ms: u64,
-    ) -> MetaStorageResult<()> {
+    ) -> Result<(), MetaStorageError> {
         let sub_tree = txn_tree.key_space::<GenericKV>();
 
         let (prev, result) =
@@ -619,7 +617,7 @@ impl StateMachine {
         resp: &mut TxnReply,
         events: &mut Option<Vec<NotifyKVEvent>>,
         log_time_ms: u64,
-    ) -> MetaStorageResult<()> {
+    ) -> Result<(), MetaStorageError> {
         let mut count: u32 = 0;
         if let Some(kv_pairs) = kv_pairs {
             if let Some(kv_pairs) = kv_pairs.get(delete_by_prefix) {
@@ -660,7 +658,7 @@ impl StateMachine {
         resp: &mut TxnReply,
         events: &mut Option<Vec<NotifyKVEvent>>,
         log_time_ms: u64,
-    ) -> MetaStorageResult<()> {
+    ) -> Result<(), MetaStorageError> {
         debug!(op = display(op), "txn execute TxnOp");
         match &op.request {
             Some(txn_op::Request::Get(get)) => {
@@ -695,7 +693,7 @@ impl StateMachine {
         txn_tree: &TransactionSledTree,
         kv_pairs: Option<&(DeleteByPrefixKeyMap, DeleteByPrefixKeyMap)>,
         log_time_ms: u64,
-    ) -> MetaStorageResult<AppliedState> {
+    ) -> Result<AppliedState, MetaStorageError> {
         debug!(txn = display(req), "apply txn cmd");
 
         let condition = &req.condition;
@@ -793,7 +791,11 @@ impl StateMachine {
         res
     }
 
-    fn txn_incr_seq(&self, key: &str, txn_tree: &TransactionSledTree) -> MetaStorageResult<u64> {
+    fn txn_incr_seq(
+        &self,
+        key: &str,
+        txn_tree: &TransactionSledTree,
+    ) -> Result<u64, MetaStorageError> {
         let seq_sub_tree = txn_tree.key_space::<Sequences>();
 
         let key = key.to_string();
@@ -811,7 +813,7 @@ impl StateMachine {
         sub_tree: &AsTxnKeySpace<'s, KS>,
         upsert_kv: &UpsertKV,
         log_time_ms: u64,
-    ) -> MetaStorageResult<(Option<SeqV>, Option<SeqV>)>
+    ) -> Result<(Option<SeqV>, Option<SeqV>), MetaStorageError>
     where
         KS: SledKeySpace<K = String, V = SeqV>,
     {
@@ -850,7 +852,7 @@ impl StateMachine {
         key: &str,
         value: (u64, AppliedState),
         txn_tree: &TransactionSledTree,
-    ) -> MetaStorageResult<AppliedState> {
+    ) -> Result<AppliedState, MetaStorageError> {
         let v = ClientLastRespValue {
             req_serial_num: value.0,
             res: value.1.clone(),
@@ -861,7 +863,7 @@ impl StateMachine {
         Ok(value.1)
     }
 
-    pub fn get_membership(&self) -> MetaStorageResult<Option<EffectiveMembership>> {
+    pub fn get_membership(&self) -> Result<Option<EffectiveMembership>, MetaStorageError> {
         let sm_meta = self.sm_meta();
         let mem = sm_meta
             .get(&StateMachineMetaKey::LastMembership)?
@@ -870,7 +872,7 @@ impl StateMachine {
         Ok(mem)
     }
 
-    pub fn get_last_applied(&self) -> MetaStorageResult<Option<LogId>> {
+    pub fn get_last_applied(&self) -> Result<Option<LogId>, MetaStorageError> {
         let sm_meta = self.sm_meta();
         let last_applied = sm_meta
             .get(&LastApplied)?
@@ -879,13 +881,16 @@ impl StateMachine {
         Ok(last_applied)
     }
 
-    pub async fn add_node(&self, node_id: u64, node: &Node) -> MetaStorageResult<()> {
+    pub async fn add_node(&self, node_id: u64, node: &Node) -> Result<(), MetaStorageError> {
         let sm_nodes = self.nodes();
         sm_nodes.insert(&node_id, node).await?;
         Ok(())
     }
 
-    pub fn get_client_last_resp(&self, key: &str) -> MetaResult<Option<(u64, AppliedState)>> {
+    pub fn get_client_last_resp(
+        &self,
+        key: &str,
+    ) -> Result<Option<(u64, AppliedState)>, MetaStorageError> {
         let client_last_resps = self.client_last_resps();
         let v: Option<ClientLastRespValue> = client_last_resps.get(&key.to_string())?;
 
@@ -900,7 +905,7 @@ impl StateMachine {
         &self,
         key: &str,
         txn_tree: &TransactionSledTree,
-    ) -> MetaStorageResult<(u64, AppliedState)> {
+    ) -> Result<(u64, AppliedState), MetaStorageError> {
         let client_last_resps = txn_tree.key_space::<ClientLastResps>();
         let v = client_last_resps.get(&key.to_string())?;
 
@@ -916,7 +921,7 @@ impl StateMachine {
         sm_nodes.range_keys(..).expect("fail to list nodes")
     }
 
-    pub fn get_node(&self, node_id: &NodeId) -> MetaResult<Option<Node>> {
+    pub fn get_node(&self, node_id: &NodeId) -> Result<Option<Node>, MetaStorageError> {
         let sm_nodes = self.nodes();
         match sm_nodes.get(node_id) {
             Ok(e) => Ok(e),
@@ -924,7 +929,7 @@ impl StateMachine {
         }
     }
 
-    pub fn get_nodes(&self) -> MetaResult<Vec<Node>> {
+    pub fn get_nodes(&self) -> Result<Vec<Node>, MetaStorageError> {
         let sm_nodes = self.nodes();
         match sm_nodes.range_values(..) {
             Ok(e) => Ok(e),

--- a/src/meta/sled-store/src/sled_tree.rs
+++ b/src/meta/sled-store/src/sled_tree.rs
@@ -55,6 +55,7 @@ pub struct SledTree {
     pub tree: sled::Tree,
 }
 
+#[allow(clippy::type_complexity)]
 impl SledTree {
     /// Open SledTree
     pub fn open<N: AsRef<[u8]> + Display>(
@@ -624,6 +625,7 @@ impl<'a, KV: SledKeySpace> Deref for AsTxnKeySpace<'a, KV> {
     }
 }
 
+#[allow(clippy::type_complexity)]
 impl<'a, KV: SledKeySpace> AsKeySpace<'a, KV> {
     pub fn contains_key(&self, key: &KV::K) -> Result<bool, MetaStorageError> {
         self.inner.contains_key::<KV>(key)


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/service): use MetaStorageError if possible

Most methods in `RaftStoreBare` do not need to return `MetaError`, but just
`MetaStorageError`.

Other changes:

- Provides a method `get_nodes()` to simplify getting voter/non-voter
  nodes.

## Changelog







## Related Issues