### PR TITLE
fix: union needs more than one coercion type

### DIFF
--- a/tests/logictest/suites/base/15_query/union.test
+++ b/tests/logictest/suites/base/15_query/union.test
@@ -106,3 +106,11 @@ SELECT 'Кирилл' as a, 'Müller' as b, '我是谁' as c, 'ASCII' as d, 2 as
 ----
 NULL NULL NULL NULL 1
 Кирилл Müller 我是谁 ASCII 2
+
+statement query TTFI
+SELECT 'Кирилл' as a, 'Müller' as b, 1.0 as c, 2 as id UNION SELECT NULL as a, NULL as b, 1 as c,  1 as id order by id;
+
+----
+NULL NULL 1.0 1
+Кирилл Müller 1.0 2
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The ticket processes the case that union needs more than one different coercion type.

For the case

```sql
SELECT 'Кирилл' as a, 'Müller' as b, 1.0 as c, 2 as id UNION SELECT NULL as a, NULL as b, 1 as c,  1 as id order by id;
```
coercion types contain two different types: `nullable` and `double`.

Fixes #issue
