### PR TITLE
fix: Use unicode_segmentation to truncate INSERT statement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "common-functions",
  "common-legacy-expression",
  "sqlparser",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/src/query/legacy-parser/Cargo.toml
+++ b/src/query/legacy-parser/Cargo.toml
@@ -16,3 +16,4 @@ common-legacy-expression = { path = "../legacy-expression" }
 
 async-trait = "0.1.57"
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "7f246e3" }
+unicode-segmentation = "^1.2"

--- a/src/query/legacy-parser/src/sql_common.rs
+++ b/src/query/legacy-parser/src/sql_common.rs
@@ -161,25 +161,12 @@ mod test {
 
     #[test]
     fn test_short_sql_truncation_on_unicode() {
-        assert_eq!(
-            SQLCommon::short_sql("CREATE TABLE `test` (.....)"),
-            "CREATE TABLE `test` (.....)"
-        );
         // short insert into statements are not truncated
         assert_eq!(
             SQLCommon::short_sql("INSERT INTO `test` VALUES('abcd', 'def');"),
             "INSERT INTO `test` VALUES('abcd', 'def');"
         );
-        // long one are at 64th char
-        let long_without_unicode =
-            "INSERT INTO `test` VALUES ('abcd', 'def'),('abcd', 'def'),('abcd', 'def');";
-        let shortned = SQLCommon::short_sql(long_without_unicode);
-        assert_eq!(shortned.len(), 67); // 64 chars + ...
-        assert_eq!(
-            shortned,
-            "INSERT INTO `test` VALUES ('abcd', 'def'),('abcd', 'def'),('abcd..."
-        );
-
+        // long one are at 64th char...
         let shortned = SQLCommon::short_sql(LONG_INSERT_WITH_UNICODE_AT_TRUNCATION_POINT);
         assert_eq!(shortned.len(), 68); // 64 chars with a multibyte one (é) + ...
         assert_eq!(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Use unicode_segmentation crate to extract graphemes to truncate big `INSERT` statements instead of directly indexing first 64 bytes of the statement, which is unsafe: it panics if a multibyte unicode character is spread between the 63th & 64th byte of the string. 

Fixes #8010
