### PR TITLE
refactor: Checking StorageParams correctness when create table with external location.

### DIFF
--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -274,20 +274,26 @@ impl StorageOperator {
     }
 
     pub async fn try_create(conf: &StorageConfig) -> common_exception::Result<StorageOperator> {
-        let operator = init_operator(&conf.params)?;
+        Self::try_create_with_storage_params(&conf.params).await
+    }
+
+    pub async fn try_create_with_storage_params(
+        sp: &StorageParams,
+    ) -> common_exception::Result<StorageOperator> {
+        let operator = init_operator(sp)?;
 
         // OpenDAL will send a real request to underlying storage to check whether it works or not.
         // If this check failed, it's highly possible that the users have configured it wrongly.
         if let Err(cause) = operator.check().await {
             return Err(ErrorCode::StorageUnavailable(format!(
                 "current configured storage is not available: config: {:?}, cause: {cause}",
-                conf
+                sp
             )));
         }
 
         Ok(StorageOperator {
             operator,
-            params: conf.params.clone(),
+            params: sp.clone(),
         })
     }
 

--- a/src/query/service/src/sql/planner/binder/ddl/table.rs
+++ b/src/query/service/src/sql/planner/binder/ddl/table.rs
@@ -46,6 +46,7 @@ use common_planner::plans::ShowCreateTablePlan;
 use common_planner::plans::TruncateTablePlan;
 use common_planner::plans::UndropTablePlan;
 use common_storage::parse_uri_location;
+use common_storage::StorageOperator;
 use common_storage::UriLocation;
 use tracing::debug;
 
@@ -375,6 +376,10 @@ impl<'a> Binder {
                     connection: uri.connection.clone(),
                 };
                 let (sp, _) = parse_uri_location(&uri)?;
+
+                // create a temporary op to check if params is correct
+                StorageOperator::try_create_with_storage_params(&sp).await?;
+
                 Some(sp)
             }
             None => None,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Checking `StorageParams`(aka: storage connection params) correctness when create table with external location.
ref: #8022 

Fixes #issue
