### PR TITLE
refactor(mark join): no need to init_markers in RightMark.

### DIFF
--- a/tests/logictest/suites/crdb/join
+++ b/tests/logictest/suites/crdb/join
@@ -1154,49 +1154,49 @@ statement query T
 explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where b.x > 42;
 
 ----
-HashJoin                                                       
-├── join type: INNER                                           
-├── build keys: [b.x (#1)]                                     
-├── probe keys: [a.x (#0)]                                     
-├── filters: []                                                
-├── TableScan(Build)                                           
-│   ├── table: default.default.twocolumn                       
-│   ├── read rows: 4                                           
-│   ├── read bytes: 79                                         
-│   ├── partitions total: 1                                    
-│   ├── partitions scanned: 1                                  
-│   └── push downs: [filters: [(x > 42)], limit: NONE]         
-└── TableScan(Probe)                                           
-    ├── table: default.default.onecolumn                       
-    ├── read rows: 4                                           
-    ├── read bytes: 62                                         
-    ├── partitions total: 2                                    
-    ├── partitions scanned: 2                                  
-    └── push downs: [filters: [], limit: NONE]                 
+HashJoin
+├── join type: INNER
+├── build keys: [b.x (#1)]
+├── probe keys: [a.x (#0)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.default.twocolumn
+│   ├── read rows: 4
+│   ├── read bytes: 309
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [(x > 42)], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.default.onecolumn
+    ├── read rows: 4
+    ├── read bytes: 376
+    ├── partitions total: 2
+    ├── partitions scanned: 2
+    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where b.x > 44 or b.x < 43;
 
 ----
-HashJoin                                                                     
-├── join type: INNER                                                         
-├── build keys: [b.x (#1)]                                                   
-├── probe keys: [a.x (#0)]                                                   
-├── filters: []                                                              
-├── TableScan(Build)                                                         
-│   ├── table: default.default.twocolumn                                     
-│   ├── read rows: 4                                                         
-│   ├── read bytes: 79                                                       
-│   ├── partitions total: 1                                                  
-│   ├── partitions scanned: 1                                                
-│   └── push downs: [filters: [((x > 44) or (x < 43))], limit: NONE]         
-└── TableScan(Probe)                                                         
-    ├── table: default.default.onecolumn                                     
-    ├── read rows: 4                                                         
-    ├── read bytes: 62                                                       
-    ├── partitions total: 2                                                  
-    ├── partitions scanned: 2                                                
-    └── push downs: [filters: [], limit: NONE]                               
+HashJoin
+├── join type: INNER
+├── build keys: [b.x (#1)]
+├── probe keys: [a.x (#0)]
+├── filters: []
+├── TableScan(Build)
+│   ├── table: default.default.twocolumn
+│   ├── read rows: 4
+│   ├── read bytes: 309
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   └── push downs: [filters: [((x > 44) or (x < 43))], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.default.onecolumn
+    ├── read rows: 4
+    ├── read bytes: 376
+    ├── partitions total: 2
+    ├── partitions scanned: 2
+    └── push downs: [filters: [], limit: NONE]
 
 
 statement query T
@@ -1211,14 +1211,14 @@ HashJoin
 ├── TableScan(Build)                                                     
 │   ├── table: default.default.twocolumn                                 
 │   ├── read rows: 4                                                     
-│   ├── read bytes: 79                                                   
+│   ├── read bytes: 309
 │   ├── partitions total: 1                                              
 │   ├── partitions scanned: 1                                            
 │   └── push downs: [filters: [(x > 42), (x < 45)], limit: NONE]         
 └── TableScan(Probe)                                                     
     ├── table: default.default.onecolumn                                 
     ├── read rows: 4                                                     
-    ├── read bytes: 62                                                   
+    ├── read bytes: 376                                                   
     ├── partitions total: 2                                              
     ├── partitions scanned: 2                                            
     └── push downs: [filters: [], limit: NONE]                           
@@ -1239,14 +1239,14 @@ Filter
     ├── TableScan(Build)                                   
     │   ├── table: default.default.twocolumn               
     │   ├── read rows: 4                                   
-    │   ├── read bytes: 79                                 
+    │   ├── read bytes: 309
     │   ├── partitions total: 1                            
     │   ├── partitions scanned: 1                          
     │   └── push downs: [filters: [], limit: NONE]         
     └── TableScan(Probe)                                   
         ├── table: default.default.onecolumn               
         ├── read rows: 4                                   
-        ├── read bytes: 62                                 
+        ├── read bytes: 376                                 
         ├── partitions total: 2                            
         ├── partitions scanned: 2                          
         └── push downs: [filters: [], limit: NONE]         
@@ -1263,14 +1263,14 @@ HashJoin
 ├── TableScan(Build)                                                     
 │   ├── table: default.default.twocolumn                                 
 │   ├── read rows: 4                                                     
-│   ├── read bytes: 79                                                   
+│   ├── read bytes: 309
 │   ├── partitions total: 1                                              
 │   ├── partitions scanned: 1                                            
 │   └── push downs: [filters: [(x > 42), (x < 45)], limit: NONE]         
 └── TableScan(Probe)                                                     
     ├── table: default.default.onecolumn                                 
     ├── read rows: 4                                                     
-    ├── read bytes: 62                                                   
+    ├── read bytes: 376                                                   
     ├── partitions total: 2                                              
     ├── partitions scanned: 2                                            
     └── push downs: [filters: [], limit: NONE]                           


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

not a bug, but useless.
refactor with `match` to make code more readable

Fixes #issue
