### PR TITLE
feat(http_handler): return query id and state headers .

### DIFF
--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -193,7 +193,7 @@ async fn query_cancel_handler(
 async fn query_state_handler(
     _ctx: &HttpQueryContext,
     Path(query_id): Path<String>,
-) -> PoemResult<Json<QueryResponse>> {
+) -> PoemResult<impl IntoResponse> {
     let http_query_manager = HttpQueryManager::instance();
     match http_query_manager.get_query(&query_id).await {
         Some(query) => {
@@ -208,7 +208,7 @@ async fn query_state_handler(
 async fn query_page_handler(
     _ctx: &HttpQueryContext,
     Path((query_id, page_no)): Path<(String, usize)>,
-) -> PoemResult<Json<QueryResponse>> {
+) -> PoemResult<impl IntoResponse> {
     let http_query_manager = HttpQueryManager::instance();
     match http_query_manager.get_query(&query_id).await {
         Some(query) => {
@@ -228,7 +228,7 @@ async fn query_page_handler(
 pub(crate) async fn query_handler(
     ctx: &HttpQueryContext,
     Json(req): Json<HttpQueryRequest>,
-) -> PoemResult<Json<QueryResponse>> {
+) -> PoemResult<impl IntoResponse> {
     info!("receive http query: {:?}", req);
     let http_query_manager = HttpQueryManager::instance();
     let sql = req.sql.clone();

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -49,6 +49,9 @@ use crate::sessions::QueryAffect;
 use crate::sessions::SessionType;
 use crate::storages::result::ResultTable;
 
+const HEADER_QUERY_ID: &str = "X-DATABEND-QUERY-ID";
+const HEADER_QUERY_STATE: &str = "X-DATABEND-QUERY-STATE";
+
 pub fn make_page_uri(query_id: &str, page_no: usize) -> String {
     format!("/v1/query/{}/page/{}", query_id, page_no)
 }
@@ -136,6 +139,8 @@ impl QueryResponse {
             kill_uri: Some(make_kill_uri(&id)),
             error: r.state.error.as_ref().map(QueryError::from_error_code),
         })
+        .with_header(HEADER_QUERY_ID, id.clone())
+        .with_header(HEADER_QUERY_STATE, state.state.to_string())
     }
 
     pub(crate) fn fail_to_start_sql(err: &ErrorCode) -> impl IntoResponse {

--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -63,6 +63,12 @@ pub enum ExecuteStateKind {
     Succeeded,
 }
 
+impl std::fmt::Display for ExecuteStateKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Default, Debug)]
 pub struct Progresses {
     pub scan_progress: ProgressValues,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR


```
 curl  --header 'Content-Type: application/json'  --request POST '127.0.0.1:8001/v1/query/'  --data-raw '{"sql": "select 1"}' -u root:
```
result like

``` 
...
x-databend-query-id: c169d93c-babc-46a0-9d93-c9d218cd9025
x-databend-query-state: Succeeded
...
```

fixes https://github.com/datafuselabs/databend/issues/7992
