### PR TITLE
fix: `only_null` for nullable column should return false when column is empty

### DIFF
--- a/src/query/datavalues/src/columns/nullable/mod.rs
+++ b/src/query/datavalues/src/columns/nullable/mod.rs
@@ -116,6 +116,9 @@ impl Column for NullableColumn {
     }
 
     fn only_null(&self) -> bool {
+        if self.len() == 0 {
+            return false;
+        }
         self.validity.unset_bits() == self.validity.len()
     }
 

--- a/src/query/datavalues/src/columns/nullable/mod.rs
+++ b/src/query/datavalues/src/columns/nullable/mod.rs
@@ -116,7 +116,7 @@ impl Column for NullableColumn {
     }
 
     fn only_null(&self) -> bool {
-        if self.len() == 0 {
+        if self.is_empty() {
             return false;
         }
         self.validity.unset_bits() == self.validity.len()

--- a/src/query/datavalues/src/scalars/viewer.rs
+++ b/src/query/datavalues/src/scalars/viewer.rs
@@ -393,7 +393,7 @@ impl<'a> ScalarViewer<'a> for StructViewer<'a> {
 #[inline]
 fn try_extract_inner(column: &ColumnRef) -> Result<(&ColumnRef, Bitmap)> {
     let (all_is_null, validity) = column.validity();
-    let first_flag = if all_is_null {
+    let first_flag = if all_is_null || column.is_empty() {
         false
     } else {
         validity.map_or(true, |c| c.get_bit(0))

--- a/tests/logictest/suites/base/15_query/functions/cast.test
+++ b/tests/logictest/suites/base/15_query/functions/cast.test
@@ -26,6 +26,12 @@ statement error
 select int_nullable::int from cast_test;
 
 statement ok
+drop table if exists t0
+
+statement ok
+drop table if exists t1
+
+statement ok
 CREATE TABLE t0(c0BOOLEAN BOOL NULL DEFAULT(false));
 
 statement ok

--- a/tests/logictest/suites/base/15_query/functions/cast.test
+++ b/tests/logictest/suites/base/15_query/functions/cast.test
@@ -1,5 +1,3 @@
-
-
 statement ok
 drop table if exists cast_test;
 
@@ -26,3 +24,21 @@ select try_cast(int_not_nullable as int) from cast_test;
 
 statement error
 select int_nullable::int from cast_test;
+
+statement ok
+CREATE TABLE t0(c0BOOLEAN BOOL NULL DEFAULT(false));
+
+statement ok
+CREATE TABLE t1(c0VARCHAR VARCHAR NULL, c1BOOLEAN BOOLEAN NULL DEFAULT(false));
+
+statement ok
+INSERT INTO t1(c1boolean, c0varchar) VALUES (true, '0');
+
+statement ok
+SELECT (false and NULL NOT IN (0.1, 0.2, 0.3,0.4)) ::BIGINT FROM t1,t0;
+
+statement ok
+drop table t0;
+
+statement ok
+drop table t1;

--- a/tests/logictest/suites/base/15_query/select.test
+++ b/tests/logictest/suites/base/15_query/select.test
@@ -1,5 +1,3 @@
-
-
 statement query T
 select 'Hello, world!';
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Fixes https://github.com/datafuselabs/databend/issues/8000
