### PR TITLE
feat: Bump OpenDAL to 0.19 for new features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f609ceb2c41b0d0277314a789ef0e7eb14593d5485f7c67320bed3924ebb1b33"
+checksum = "7bb50c5a2ef4b9b1e7ae73e3a73b52ea24b20312d629f9c4df28260b7ad2c3c4"
 dependencies = [
  "bincode_derive",
  "serde",
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "bincode_derive"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913287a8f3e00db4c7ae1b87e9b9b8cebd6b89217eaadfc281fa5c897da35dc3"
+checksum = "0a45a23389446d2dd25dc8e73a7a3b3c43522b630cac068927f0649d43d719d2"
 dependencies = [
  "virtue",
 ]
@@ -5279,9 +5279,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendal"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0afeab09d50984cc6b89281271548fa008f7224410c392ea441186708bbd930"
+checksum = "a14cec5f8274036de7b3a7a727a647322a30d05dfef2dbb2c2f95bda81a5e39d"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -5289,6 +5289,7 @@ dependencies = [
  "async-trait",
  "backon",
  "base64",
+ "bincode",
  "bytes",
  "flagset",
  "futures",
@@ -6446,9 +6447,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c338306df4ba0010b78f1c4469bf034313ad46b2c43020ec448432e5e07fab26"
+checksum = "a082aef1e547f31ddde9db1eb92e983ed92dbd521678709ba2574cf768c919ef"
 dependencies = [
  "anyhow",
  "backon",
@@ -7718,6 +7719,7 @@ dependencies = [
  "itoa 1.0.3",
  "libc",
  "num_threads",
+ "serde",
  "time-macros",
 ]
 
@@ -8143,7 +8145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -8373,9 +8375,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "virtue"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757cfbfe0d17ee6f22fe97e536d463047d451b47cf9d11e2b7d1398b0ef274dd"
+checksum = "7b60dcd6a64dd45abf9bd426970c9843726da7fc08f44cd6fcebf68c21220a63"
 
 [[package]]
 name = "void"

--- a/src/common/contexts/Cargo.toml
+++ b/src/common/contexts/Cargo.toml
@@ -12,4 +12,4 @@ test = false
 common-base = { path = "../base" }
 
 async-trait = "0.1.57"
-opendal = { version = "0.18", features = ["layers-retry"] }
+opendal = { version = "0.19", features = ["layers-retry"] }

--- a/src/common/contexts/src/dal/dal_context.rs
+++ b/src/common/contexts/src/dal/dal_context.rs
@@ -31,9 +31,9 @@ use opendal::ops::PresignedRequest;
 use opendal::Accessor;
 use opendal::AccessorMetadata;
 use opendal::BytesReader;
-use opendal::DirStreamer;
 use opendal::Layer;
 use opendal::ObjectMetadata;
+use opendal::ObjectStreamer;
 
 use crate::DalMetrics;
 
@@ -146,7 +146,7 @@ impl Accessor for DalContext {
         self.get_inner()?.delete(path, args).await
     }
 
-    async fn list(&self, path: &str, args: OpList) -> Result<DirStreamer> {
+    async fn list(&self, path: &str, args: OpList) -> Result<ObjectStreamer> {
         self.get_inner()?.list(path, args).await
     }
 

--- a/src/common/contexts/src/dal/dal_runtime.rs
+++ b/src/common/contexts/src/dal/dal_runtime.rs
@@ -29,9 +29,9 @@ use opendal::ops::PresignedRequest;
 use opendal::Accessor;
 use opendal::AccessorMetadata;
 use opendal::BytesReader;
-use opendal::DirStreamer;
 use opendal::Layer;
 use opendal::ObjectMetadata;
+use opendal::ObjectStreamer;
 
 /// # TODO
 ///
@@ -128,7 +128,7 @@ impl Accessor for DalRuntime {
             .expect("join must success")
     }
 
-    async fn list(&self, path: &str, args: OpList) -> Result<DirStreamer> {
+    async fn list(&self, path: &str, args: OpList) -> Result<ObjectStreamer> {
         let op = self.get_inner()?;
         let path = path.to_string();
         self.runtime

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.65"
 backon = "0.2.0"
 globiter = "0.1.0"
 once_cell = "1.15.0"
-opendal = { version = "0.18", features = [
+opendal = { version = "0.19", features = [
     "layers-retry",
     "layers-tracing",
     "layers-metrics",

--- a/src/query/catalog/Cargo.toml
+++ b/src/query/catalog/Cargo.toml
@@ -27,4 +27,4 @@ common-storage = { path = "../../common/storage" }
 
 async-trait = "0.1.57"
 dyn-clone = "1.0.9"
-opendal = { version = "0.18", features = ["layers-retry"] }
+opendal = { version = "0.19", features = ["layers-retry"] }

--- a/src/query/config/Cargo.toml
+++ b/src/query/config/Cargo.toml
@@ -23,7 +23,7 @@ thrift = { git = "https://github.com/datafuse-extras/thrift", tag = "v0.17.0", o
 clap = { version = "3.2.22", features = ["derive", "env"] }
 hex = "0.4.3"
 once_cell = "1.15.0"
-opendal = { version = "0.18", features = ["layers-retry", "compress"], optional = true }
+opendal = { version = "0.19", features = ["layers-retry", "compress"], optional = true }
 semver = "1.0.14"
 serde = { version = "1.0.145", features = ["derive"] }
 serfig = "0.0.2"

--- a/src/query/pipeline/sources/Cargo.toml
+++ b/src/query/pipeline/sources/Cargo.toml
@@ -30,7 +30,7 @@ crossbeam-channel = "0.5.6"
 csv-core = "0.1.10"
 futures = "0.3.24"
 futures-util = "0.3.24"
-opendal = { version = "0.18", features = ["layers-retry", "compress"] }
+opendal = { version = "0.19", features = ["layers-retry", "compress"] }
 parking_lot = "0.12.1"
 serde_json = "1.0.85"
 similar-asserts = "1.4.2"

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -111,7 +111,7 @@ nom = "7.1.1"
 num = "0.4.0"
 num_cpus = "1.13.1"
 once_cell = "1.15.0"
-opendal = { version = "0.18", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.19", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
 opensrv-mysql = "0.2.0"
 openssl = { version = "0.10.41", features = ["vendored"] }
 parking_lot = "0.12.1"

--- a/src/query/sharing/Cargo.toml
+++ b/src/query/sharing/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 futures = "0.3"
 http = "0.2"
 moka = "0.9"
-opendal = "0.18"
+opendal = "0.19"
 reqwest = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -39,7 +39,7 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 chrono = "0.4.22"
 futures = "0.3.24"
 futures-util = "0.3.24"
-opendal = { version = "0.18", features = ["layers-retry"] }
+opendal = { version = "0.19", features = ["layers-retry"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
 tracing = "0.1.36"

--- a/src/query/storages/hive/Cargo.toml
+++ b/src/query/storages/hive/Cargo.toml
@@ -34,7 +34,7 @@ thrift = { git = "https://github.com/datafuse-extras/thrift", tag = "v0.17.0" }
 async-recursion = "1.0.0"
 async-trait = "0.1.57"
 futures = "0.3.24"
-opendal = { version = "0.18", features = ["layers-retry"] }
+opendal = { version = "0.19", features = ["layers-retry"] }
 serde = { version = "1.0.145", features = ["derive"] }
 tracing = "0.1.36"
 typetag = "0.2.3"

--- a/src/query/storages/preludes/Cargo.toml
+++ b/src/query/storages/preludes/Cargo.toml
@@ -47,7 +47,7 @@ futures-util = "0.3.24"
 itertools = "0.10.5"
 num_cpus = "1.13.1"
 once_cell = "1.15.0"
-opendal = { version = "0.18", features = ["layers-retry"] }
+opendal = { version = "0.19", features = ["layers-retry"] }
 parking_lot = "0.12.1"
 reqwest = "0.11.12"
 semver = "1.0.14"

--- a/src/query/storages/share/Cargo.toml
+++ b/src/query/storages/share/Cargo.toml
@@ -16,7 +16,7 @@ common-exception = { path = "../../../common/exception" }
 common-meta-app = { path = "../../../meta/app" }
 common-storages-util = { path = "../util" }
 
-opendal = { version = "0.18", features = ["layers-retry"] }
+opendal = { version = "0.19", features = ["layers-retry"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
 

--- a/src/query/streams/Cargo.toml
+++ b/src/query/streams/Cargo.toml
@@ -32,4 +32,4 @@ serde_json = { version = "1.0.85", default-features = false, features = ["preser
 tempfile = "3.3.0"
 
 [dev-dependencies]
-opendal = { version = "0.18", features = ["layers-retry", "compress"] }
+opendal = { version = "0.19", features = ["layers-retry", "compress"] }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: Bump OpenDAL to 0.19 for new features

We can implement the backend on oss and redis now!

- https://github.com/datafuselabs/opendal/discussions/823
