### PR TITLE
chore: tidy up method names of table trait

### DIFF
--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -127,7 +127,7 @@ pub trait Table: Sync + Send {
         None
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -142,7 +142,7 @@ pub trait Table: Sync + Send {
         )))
     }
 
-    fn append2(
+    fn append(
         &self,
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -112,22 +112,26 @@ pub trait Table: Sync + Send {
         )))
     }
 
-    // defaults to generate one single part and empty statistics
+    /// Gather partitions to be scanned according to the push_downs
     async fn read_partitions(
         &self,
         ctx: Arc<dyn TableContext>,
         push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
         let (_, _) = (ctx, push_downs);
-
-        unimplemented!()
+        Err(ErrorCode::UnImplement(format!(
+            "read_partitions operation for table {} is not implemented. table engine : {}",
+            self.name(),
+            self.get_table_info().meta.engine
+        )))
     }
 
     fn table_args(&self) -> Option<Vec<LegacyExpression>> {
         None
     }
 
-    fn read(
+    /// Assembly the pipeline of reading data from storage, according to the plan
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,
@@ -136,13 +140,14 @@ pub trait Table: Sync + Send {
         let (_, _, _) = (ctx, plan, pipeline);
 
         Err(ErrorCode::UnImplement(format!(
-            "read2 operation for table {} is not implemented, table engine is {}",
+            "read_data operation for table {} is not implemented. table engine : {}",
             self.name(),
             self.get_table_info().meta.engine
         )))
     }
 
-    fn append(
+    /// Assembly the pipeline of appending data to storage
+    fn append_data(
         &self,
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
@@ -151,7 +156,7 @@ pub trait Table: Sync + Send {
         let (_, _, _) = (ctx, pipeline, need_output);
 
         Err(ErrorCode::UnImplement(format!(
-            "append2 operation for table {} is not implemented, table engine is {}",
+            "append_data operation for table {} is not implemented. table engine : {}",
             self.name(),
             self.get_table_info().meta.engine
         )))

--- a/src/query/service/src/api/http/v1/logs.rs
+++ b/src/query/service/src/api/http/v1/logs.rs
@@ -73,5 +73,7 @@ async fn execute_query(ctx: Arc<QueryContext>) -> Result<SendableDataBlockStream
     let tracing_table = ctx.get_table("default", "system", "tracing").await?;
     let tracing_table_read_plan = tracing_table.read_plan(ctx.clone(), None).await?;
 
-    tracing_table.read(ctx, &tracing_table_read_plan).await
+    tracing_table
+        .read_data_block_stream(ctx, &tracing_table_read_plan)
+        .await
 }

--- a/src/query/service/src/interpreters/interpreter_common.rs
+++ b/src/query/service/src/interpreters/interpreter_common.rs
@@ -73,7 +73,7 @@ pub fn append2table(
         &mut build_res.main_pipeline,
     )?;
 
-    table.append2(ctx.clone(), &mut build_res.main_pipeline, false)?;
+    table.append(ctx.clone(), &mut build_res.main_pipeline, false)?;
 
     if need_commit {
         build_res.main_pipeline.set_on_finished(move |may_error| {

--- a/src/query/service/src/interpreters/interpreter_common.rs
+++ b/src/query/service/src/interpreters/interpreter_common.rs
@@ -73,7 +73,7 @@ pub fn append2table(
         &mut build_res.main_pipeline,
     )?;
 
-    table.append(ctx.clone(), &mut build_res.main_pipeline, false)?;
+    table.append_data(ctx.clone(), &mut build_res.main_pipeline, false)?;
 
     if need_commit {
         build_res.main_pipeline.set_on_finished(move |may_error| {

--- a/src/query/service/src/interpreters/interpreter_copy_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_v2.rs
@@ -209,7 +209,7 @@ impl CopyInterpreterV2 {
 
         let from_table = self.ctx.build_table_from_source_plan(&read_source_plan)?;
         from_table.read_partitions(self.ctx.clone(), None).await?;
-        from_table.read2(
+        from_table.read(
             self.ctx.clone(),
             &read_source_plan,
             &mut build_res.main_pipeline,

--- a/src/query/service/src/interpreters/interpreter_copy_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_v2.rs
@@ -217,7 +217,7 @@ impl CopyInterpreterV2 {
 
         let to_table = self.ctx.get_table(catalog_name, db_name, tbl_name).await?;
 
-        to_table.append2(self.ctx.clone(), &mut build_res.main_pipeline, false)?;
+        to_table.append(self.ctx.clone(), &mut build_res.main_pipeline, false)?;
 
         let ctx = self.ctx.clone();
         let files = files.clone();

--- a/src/query/service/src/interpreters/interpreter_copy_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_v2.rs
@@ -209,7 +209,7 @@ impl CopyInterpreterV2 {
 
         let from_table = self.ctx.build_table_from_source_plan(&read_source_plan)?;
         from_table.read_partitions(self.ctx.clone(), None).await?;
-        from_table.read(
+        from_table.read_data(
             self.ctx.clone(),
             &read_source_plan,
             &mut build_res.main_pipeline,
@@ -217,7 +217,7 @@ impl CopyInterpreterV2 {
 
         let to_table = self.ctx.get_table(catalog_name, db_name, tbl_name).await?;
 
-        to_table.append(self.ctx.clone(), &mut build_res.main_pipeline, false)?;
+        to_table.append_data(self.ctx.clone(), &mut build_res.main_pipeline, false)?;
 
         let ctx = self.ctx.clone();
         let files = files.clone();

--- a/src/query/service/src/sql/executor/pipeline_builder.rs
+++ b/src/query/service/src/sql/executor/pipeline_builder.rs
@@ -230,7 +230,7 @@ impl PipelineBuilder {
     fn build_table_scan(&mut self, scan: &TableScan) -> Result<()> {
         let table = self.ctx.build_table_from_source_plan(&scan.source)?;
         self.ctx.try_set_partitions(scan.source.parts.clone())?;
-        table.read(self.ctx.clone(), &scan.source, &mut self.main_pipeline)?;
+        table.read_data(self.ctx.clone(), &scan.source, &mut self.main_pipeline)?;
         let schema = scan.source.schema();
         let projections = scan
             .name_mapping
@@ -652,7 +652,7 @@ impl PipelineBuilder {
             &mut self.main_pipeline,
         )?;
 
-        table.append(self.ctx.clone(), &mut self.main_pipeline, true)?;
+        table.append_data(self.ctx.clone(), &mut self.main_pipeline, true)?;
 
         Ok(())
     }

--- a/src/query/service/src/sql/executor/pipeline_builder.rs
+++ b/src/query/service/src/sql/executor/pipeline_builder.rs
@@ -230,7 +230,7 @@ impl PipelineBuilder {
     fn build_table_scan(&mut self, scan: &TableScan) -> Result<()> {
         let table = self.ctx.build_table_from_source_plan(&scan.source)?;
         self.ctx.try_set_partitions(scan.source.parts.clone())?;
-        table.read2(self.ctx.clone(), &scan.source, &mut self.main_pipeline)?;
+        table.read(self.ctx.clone(), &scan.source, &mut self.main_pipeline)?;
         let schema = scan.source.schema();
         let projections = scan
             .name_mapping

--- a/src/query/service/src/sql/executor/pipeline_builder.rs
+++ b/src/query/service/src/sql/executor/pipeline_builder.rs
@@ -652,7 +652,7 @@ impl PipelineBuilder {
             &mut self.main_pipeline,
         )?;
 
-        table.append2(self.ctx.clone(), &mut self.main_pipeline, true)?;
+        table.append(self.ctx.clone(), &mut self.main_pipeline, true)?;
 
         Ok(())
     }

--- a/src/query/service/src/storages/result/download.rs
+++ b/src/query/service/src/storages/result/download.rs
@@ -51,7 +51,7 @@ impl ResultTable {
             .await?;
         ctx.try_set_partitions(parts)?;
         let mut block_stream = self
-            .read(ctx.clone(), &ReadDataSourcePlan {
+            .read_data_block_stream(ctx.clone(), &ReadDataSourcePlan {
                 catalog: "".to_string(),
                 source_info: SourceInfo::TableSource(Default::default()),
                 scan_fields: None,

--- a/src/query/service/src/storages/result/result_table.rs
+++ b/src/query/service/src/storages/result/result_table.rs
@@ -158,7 +158,7 @@ impl Table for ResultTable {
         }
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/service/src/storages/result/result_table.rs
+++ b/src/query/service/src/storages/result/result_table.rs
@@ -158,7 +158,7 @@ impl Table for ResultTable {
         }
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/service/src/storages/stage/stage_table.rs
+++ b/src/query/service/src/storages/stage/stage_table.rs
@@ -114,7 +114,7 @@ impl Table for StageTable {
         Ok((Statistics::default(), vec![]))
     }
 
-    fn read(
+    fn read_data(
         &self,
         _ctx: Arc<dyn TableContext>,
         _plan: &ReadDataSourcePlan,
@@ -138,7 +138,12 @@ impl Table for StageTable {
         Ok(())
     }
 
-    fn append(&self, ctx: Arc<dyn TableContext>, pipeline: &mut Pipeline, _: bool) -> Result<()> {
+    fn append_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        pipeline: &mut Pipeline,
+        _: bool,
+    ) -> Result<()> {
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
         let single = self.table_info.stage_info.copy_options.single;
         let op = StageTable::get_op(&ctx, &self.table_info.stage_info)?;

--- a/src/query/service/src/storages/stage/stage_table.rs
+++ b/src/query/service/src/storages/stage/stage_table.rs
@@ -138,7 +138,7 @@ impl Table for StageTable {
         Ok(())
     }
 
-    fn append2(&self, ctx: Arc<dyn TableContext>, pipeline: &mut Pipeline, _: bool) -> Result<()> {
+    fn append(&self, ctx: Arc<dyn TableContext>, pipeline: &mut Pipeline, _: bool) -> Result<()> {
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
         let single = self.table_info.stage_info.copy_options.single;
         let op = StageTable::get_op(&ctx, &self.table_info.stage_info)?;

--- a/src/query/service/src/storages/stage/stage_table.rs
+++ b/src/query/service/src/storages/stage/stage_table.rs
@@ -114,7 +114,7 @@ impl Table for StageTable {
         Ok((Statistics::default(), vec![]))
     }
 
-    fn read2(
+    fn read(
         &self,
         _ctx: Arc<dyn TableContext>,
         _plan: &ReadDataSourcePlan,

--- a/src/query/service/src/storages/storage_table_read_wrap.rs
+++ b/src/query/service/src/storages/storage_table_read_wrap.rs
@@ -43,7 +43,7 @@ impl<T: Table> TableStreamReadWrap for T {
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let mut pipeline = Pipeline::create();
-        self.read(ctx.clone(), plan, &mut pipeline)?;
+        self.read_data(ctx.clone(), plan, &mut pipeline)?;
 
         let settings = ctx.get_settings();
         pipeline.set_max_threads(settings.get_max_threads()? as usize);
@@ -63,7 +63,7 @@ impl TableStreamReadWrap for dyn Table {
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let mut pipeline = Pipeline::create();
-        self.read(ctx.clone(), plan, &mut pipeline)?;
+        self.read_data(ctx.clone(), plan, &mut pipeline)?;
 
         let settings = ctx.get_settings();
         pipeline.set_max_threads(settings.get_max_threads()? as usize);

--- a/src/query/service/src/storages/storage_table_read_wrap.rs
+++ b/src/query/service/src/storages/storage_table_read_wrap.rs
@@ -28,7 +28,7 @@ use crate::storages::Table;
 
 #[async_trait::async_trait]
 pub trait TableStreamReadWrap: Send + Sync {
-    async fn read(
+    async fn read_data_block_stream(
         &self,
         _ctx: Arc<QueryContext>,
         _plan: &ReadDataSourcePlan,
@@ -37,13 +37,13 @@ pub trait TableStreamReadWrap: Send + Sync {
 
 #[async_trait::async_trait]
 impl<T: Table> TableStreamReadWrap for T {
-    async fn read(
+    async fn read_data_block_stream(
         &self,
         ctx: Arc<QueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let mut pipeline = Pipeline::create();
-        self.read2(ctx.clone(), plan, &mut pipeline)?;
+        self.read(ctx.clone(), plan, &mut pipeline)?;
 
         let settings = ctx.get_settings();
         pipeline.set_max_threads(settings.get_max_threads()? as usize);
@@ -57,13 +57,13 @@ impl<T: Table> TableStreamReadWrap for T {
 
 #[async_trait::async_trait]
 impl TableStreamReadWrap for dyn Table {
-    async fn read(
+    async fn read_data_block_stream(
         &self,
         ctx: Arc<QueryContext>,
         plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let mut pipeline = Pipeline::create();
-        self.read2(ctx.clone(), plan, &mut pipeline)?;
+        self.read(ctx.clone(), plan, &mut pipeline)?;
 
         let settings = ctx.get_settings();
         pipeline.set_max_threads(settings.get_max_threads()? as usize);

--- a/src/query/service/src/table_functions/async_crash_me.rs
+++ b/src/query/service/src/table_functions/async_crash_me.rs
@@ -116,7 +116,7 @@ impl Table for AsyncCrashMeTable {
         Some(vec![LegacyExpression::create_literal(DataValue::UInt64(0))])
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         _plan: &ReadDataSourcePlan,

--- a/src/query/service/src/table_functions/async_crash_me.rs
+++ b/src/query/service/src/table_functions/async_crash_me.rs
@@ -116,7 +116,7 @@ impl Table for AsyncCrashMeTable {
         Some(vec![LegacyExpression::create_literal(DataValue::UInt64(0))])
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         _plan: &ReadDataSourcePlan,

--- a/src/query/service/src/table_functions/numbers_table.rs
+++ b/src/query/service/src/table_functions/numbers_table.rs
@@ -177,7 +177,7 @@ impl Table for NumbersTable {
         ))])
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/service/src/table_functions/numbers_table.rs
+++ b/src/query/service/src/table_functions/numbers_table.rs
@@ -177,7 +177,7 @@ impl Table for NumbersTable {
         ))])
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/service/src/table_functions/sync_crash_me.rs
+++ b/src/query/service/src/table_functions/sync_crash_me.rs
@@ -116,7 +116,7 @@ impl Table for SyncCrashMeTable {
         Some(vec![LegacyExpression::create_literal(DataValue::UInt64(0))])
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         _plan: &ReadDataSourcePlan,

--- a/src/query/service/src/table_functions/sync_crash_me.rs
+++ b/src/query/service/src/table_functions/sync_crash_me.rs
@@ -116,7 +116,7 @@ impl Table for SyncCrashMeTable {
         Some(vec![LegacyExpression::create_literal(DataValue::UInt64(0))])
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         _plan: &ReadDataSourcePlan,

--- a/src/query/service/tests/it/storages/fuse/operations/navigate.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/navigate.rs
@@ -157,7 +157,7 @@ async fn test_fuse_historical_table_is_read_only() -> Result<()> {
         .await?;
 
     // check append2
-    let res = tbl.append2(ctx.clone(), &mut Pipeline::create(), false);
+    let res = tbl.append(ctx.clone(), &mut Pipeline::create(), false);
     assert_not_writable(res, "append2");
 
     // check append_data

--- a/src/query/service/tests/it/storages/fuse/operations/navigate.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/navigate.rs
@@ -157,7 +157,7 @@ async fn test_fuse_historical_table_is_read_only() -> Result<()> {
         .await?;
 
     // check append2
-    let res = tbl.append(ctx.clone(), &mut Pipeline::create(), false);
+    let res = tbl.append_data(ctx.clone(), &mut Pipeline::create(), false);
     assert_not_writable(res, "append2");
 
     // check append_data

--- a/src/query/service/tests/it/storages/fuse/table.rs
+++ b/src/query/service/tests/it/storages/fuse/table.rs
@@ -74,7 +74,7 @@ async fn test_fuse_table_normal_case() -> Result<()> {
 
         ctx.try_set_partitions(parts.clone())?;
         let stream = table
-            .read(ctx.clone(), &ReadDataSourcePlan {
+            .read_data_block_stream(ctx.clone(), &ReadDataSourcePlan {
                 catalog: "default".to_owned(),
                 source_info: SourceInfo::TableSource(Default::default()),
                 scan_fields: None,
@@ -134,7 +134,7 @@ async fn test_fuse_table_normal_case() -> Result<()> {
         ctx.try_set_partitions(parts.clone())?;
 
         let stream = table
-            .read(ctx.clone(), &ReadDataSourcePlan {
+            .read_data_block_stream(ctx.clone(), &ReadDataSourcePlan {
                 catalog: "default".to_owned(),
                 source_info: SourceInfo::TableSource(Default::default()),
                 scan_fields: None,

--- a/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
+++ b/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
@@ -350,7 +350,9 @@ pub async fn test_drive_with_args_and_ctx(
         .read_plan(ctx.clone(), Some(Extras::default()))
         .await?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
-    func.as_table().read(ctx, &source_plan).await
+    func.as_table()
+        .read_data_block_stream(ctx, &source_plan)
+        .await
 }
 
 pub async fn test_drive_clustering_information(
@@ -364,7 +366,9 @@ pub async fn test_drive_clustering_information(
         .read_plan(ctx.clone(), Some(Extras::default()))
         .await?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
-    func.as_table().read(ctx, &source_plan).await
+    func.as_table()
+        .read_data_block_stream(ctx, &source_plan)
+        .await
 }
 
 pub fn expects_err<T>(case_name: &str, err_code: u16, res: Result<T>) {

--- a/src/query/service/tests/it/storages/memory.rs
+++ b/src/query/service/tests/it/storages/memory.rs
@@ -130,7 +130,9 @@ async fn test_memorytable() -> Result<()> {
             assert_eq!(table.engine(), "Memory");
             assert!(table.benefit_column_prune());
 
-            let stream = table.read(ctx.clone(), &source_plan).await?;
+            let stream = table
+                .read_data_block_stream(ctx.clone(), &source_plan)
+                .await?;
             let result = stream.try_collect::<Vec<_>>().await?;
             assert_blocks_sorted_eq(expected_datablocks, &result);
 
@@ -164,7 +166,9 @@ async fn test_memorytable() -> Result<()> {
         ctx.try_set_partitions(source_plan.parts.clone())?;
         assert_eq!(table.engine(), "Memory");
 
-        let stream = table.read(ctx.clone(), &source_plan).await?;
+        let stream = table
+            .read_data_block_stream(ctx.clone(), &source_plan)
+            .await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         assert_blocks_sorted_eq(
             vec![
@@ -186,7 +190,7 @@ async fn test_memorytable() -> Result<()> {
         table.truncate(ctx.clone(), false).await?;
 
         let source_plan = table.read_plan(ctx.clone(), None).await?;
-        let stream = table.read(ctx, &source_plan).await?;
+        let stream = table.read_data_block_stream(ctx, &source_plan).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         assert_blocks_sorted_eq(vec!["++", "++"], &result);
     }

--- a/src/query/service/tests/it/storages/null.rs
+++ b/src/query/service/tests/it/storages/null.rs
@@ -45,7 +45,9 @@ async fn test_null_table() -> Result<()> {
         let source_plan = table.read_plan(ctx.clone(), None).await?;
         assert_eq!(table.engine(), "Null");
 
-        let stream = table.read(ctx.clone(), &source_plan).await?;
+        let stream = table
+            .read_data_block_stream(ctx.clone(), &source_plan)
+            .await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let block = &result[0];
         assert_eq!(block.num_columns(), 1);

--- a/src/query/service/tests/it/storages/result/result_table.rs
+++ b/src/query/service/tests/it/storages/result/result_table.rs
@@ -74,7 +74,7 @@ async fn test_result_table() -> Result<()> {
         assert_eq!(stats.read_rows, 3);
         ctx.try_set_partitions(parts)?;
         let stream = table
-            .read(ctx.clone(), &ReadDataSourcePlan {
+            .read_data_block_stream(ctx.clone(), &ReadDataSourcePlan {
                 catalog: "".to_string(),
                 source_info: SourceInfo::TableSource(Default::default()),
                 scan_fields: None,

--- a/src/query/service/tests/it/storages/system.rs
+++ b/src/query/service/tests/it/storages/system.rs
@@ -91,7 +91,7 @@ async fn run_table_tests(
     writeln!(file, "{table_info}").unwrap();
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 
-    let stream = table.read(ctx, &source_plan).await?;
+    let stream = table.read_data_block_stream(ctx, &source_plan).await?;
     let blocks = stream.try_collect::<Vec<_>>().await?;
     let formatted = pretty_format_blocks(&blocks).unwrap();
     let mut actual_lines: Vec<&str> = formatted.trim().lines().collect();
@@ -115,7 +115,7 @@ async fn test_clusters_table() -> Result<()> {
 
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 
-    let stream = table.read(ctx, &source_plan).await?;
+    let stream = table.read_data_block_stream(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 4);
@@ -168,7 +168,7 @@ async fn test_configs_table(file: &mut impl Write) -> Result<()> {
         let table = ConfigsTable::create(1);
         let source_plan = table.read_plan(ctx.clone(), None).await?;
 
-        let stream = table.read(ctx, &source_plan).await?;
+        let stream = table.read_data_block_stream(ctx, &source_plan).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let block = &result[0];
         assert_eq!(block.num_columns(), 4);
@@ -184,7 +184,7 @@ async fn test_contributors_table() -> Result<()> {
     let table = ContributorsTable::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 
-    let stream = table.read(ctx, &source_plan).await?;
+    let stream = table.read_data_block_stream(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 1);
@@ -196,7 +196,7 @@ async fn test_credits_table() -> Result<()> {
     let table = CreditsTable::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 
-    let stream = table.read(ctx, &source_plan).await?;
+    let stream = table.read_data_block_stream(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 3);
@@ -224,7 +224,7 @@ async fn test_functions_table() -> Result<()> {
     let table = FunctionsTable::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 
-    let stream = table.read(ctx, &source_plan).await?;
+    let stream = table.read_data_block_stream(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 8);
@@ -240,7 +240,7 @@ async fn test_metrics_table() -> Result<()> {
     metrics::counter!("test.test_metrics_table_count", 1);
     metrics::histogram!("test.test_metrics_table_histogram", 1.0);
 
-    let stream = table.read(ctx, &source_plan).await?;
+    let stream = table.read_data_block_stream(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 4);
@@ -293,7 +293,7 @@ async fn test_tables_table() -> Result<()> {
     let table = TablesTableWithoutHistory::create(1);
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 
-    let stream = table.read(ctx, &source_plan).await?;
+    let stream = table.read_data_block_stream(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 10);
@@ -357,7 +357,7 @@ async fn test_tracing_table() -> Result<()> {
     let table: Arc<dyn Table> = Arc::new(TracingTable::create(1));
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 
-    let stream = table.read(ctx, &source_plan).await?;
+    let stream = table.read_data_block_stream(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 7);

--- a/src/query/service/tests/it/table_functions/numbers_table.rs
+++ b/src/query/service/tests/it/table_functions/numbers_table.rs
@@ -44,7 +44,10 @@ async fn test_number_table() -> Result<()> {
         .await?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
 
-    let stream = table.as_table().read(ctx, &source_plan).await?;
+    let stream = table
+        .as_table()
+        .read_data_block_stream(ctx, &source_plan)
+        .await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 1);

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -324,7 +324,7 @@ impl Table for FuseTable {
     }
 
     #[tracing::instrument(level = "debug", name = "fuse_table_read2", skip(self, ctx, pipeline), fields(ctx.id = ctx.get_id().as_str()))]
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,
@@ -333,7 +333,7 @@ impl Table for FuseTable {
         self.do_read2(ctx, plan, pipeline)
     }
 
-    fn append(
+    fn append_data(
         &self,
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -333,7 +333,7 @@ impl Table for FuseTable {
         self.do_read2(ctx, plan, pipeline)
     }
 
-    fn append2(
+    fn append(
         &self,
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -324,7 +324,7 @@ impl Table for FuseTable {
     }
 
     #[tracing::instrument(level = "debug", name = "fuse_table_read2", skip(self, ctx, pipeline), fields(ctx.id = ctx.get_id().as_str()))]
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/storages/fuse/src/table_functions/clustering_informations/clustering_information_table.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_informations/clustering_information_table.rs
@@ -109,7 +109,7 @@ impl Table for ClusteringInformationTable {
         ])
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/fuse/src/table_functions/clustering_informations/clustering_information_table.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_informations/clustering_information_table.rs
@@ -109,7 +109,7 @@ impl Table for ClusteringInformationTable {
         ])
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
@@ -113,7 +113,7 @@ impl Table for FuseBlockTable {
         Some(args)
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
@@ -113,7 +113,7 @@ impl Table for FuseBlockTable {
         Some(args)
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment_table.rs
@@ -109,7 +109,7 @@ impl Table for FuseSegmentTable {
         ])
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment_table.rs
@@ -109,7 +109,7 @@ impl Table for FuseSegmentTable {
         ])
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot_table.rs
@@ -105,7 +105,7 @@ impl Table for FuseSnapshotTable {
         ])
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot_table.rs
@@ -105,7 +105,7 @@ impl Table for FuseSnapshotTable {
         ])
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/storages/hive/src/hive_table.rs
+++ b/src/query/storages/hive/src/hive_table.rs
@@ -383,7 +383,7 @@ impl Table for HiveTable {
         None
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/storages/hive/src/hive_table.rs
+++ b/src/query/storages/hive/src/hive_table.rs
@@ -383,7 +383,7 @@ impl Table for HiveTable {
         None
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/storages/preludes/src/memory/memory_table.rs
+++ b/src/query/storages/preludes/src/memory/memory_table.rs
@@ -187,7 +187,7 @@ impl Table for MemoryTable {
         Ok((statistics, parts))
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,
@@ -214,7 +214,12 @@ impl Table for MemoryTable {
         Ok(())
     }
 
-    fn append(&self, ctx: Arc<dyn TableContext>, pipeline: &mut Pipeline, _: bool) -> Result<()> {
+    fn append_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        pipeline: &mut Pipeline,
+        _: bool,
+    ) -> Result<()> {
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
         for _ in 0..pipeline.output_len() {
             let input_port = InputPort::create();

--- a/src/query/storages/preludes/src/memory/memory_table.rs
+++ b/src/query/storages/preludes/src/memory/memory_table.rs
@@ -214,7 +214,7 @@ impl Table for MemoryTable {
         Ok(())
     }
 
-    fn append2(&self, ctx: Arc<dyn TableContext>, pipeline: &mut Pipeline, _: bool) -> Result<()> {
+    fn append(&self, ctx: Arc<dyn TableContext>, pipeline: &mut Pipeline, _: bool) -> Result<()> {
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
         for _ in 0..pipeline.output_len() {
             let input_port = InputPort::create();

--- a/src/query/storages/preludes/src/memory/memory_table.rs
+++ b/src/query/storages/preludes/src/memory/memory_table.rs
@@ -187,7 +187,7 @@ impl Table for MemoryTable {
         Ok((statistics, parts))
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/storages/preludes/src/null/null_table.rs
+++ b/src/query/storages/preludes/src/null/null_table.rs
@@ -91,7 +91,7 @@ impl Table for NullTable {
         Ok(())
     }
 
-    fn append2(&self, _: Arc<dyn TableContext>, pipeline: &mut Pipeline, _: bool) -> Result<()> {
+    fn append(&self, _: Arc<dyn TableContext>, pipeline: &mut Pipeline, _: bool) -> Result<()> {
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
         for _ in 0..pipeline.output_len() {
             let input_port = InputPort::create();

--- a/src/query/storages/preludes/src/null/null_table.rs
+++ b/src/query/storages/preludes/src/null/null_table.rs
@@ -74,7 +74,7 @@ impl Table for NullTable {
         Ok((Statistics::default(), vec![]))
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/preludes/src/null/null_table.rs
+++ b/src/query/storages/preludes/src/null/null_table.rs
@@ -74,7 +74,7 @@ impl Table for NullTable {
         Ok((Statistics::default(), vec![]))
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,
@@ -91,7 +91,12 @@ impl Table for NullTable {
         Ok(())
     }
 
-    fn append(&self, _: Arc<dyn TableContext>, pipeline: &mut Pipeline, _: bool) -> Result<()> {
+    fn append_data(
+        &self,
+        _: Arc<dyn TableContext>,
+        pipeline: &mut Pipeline,
+        _: bool,
+    ) -> Result<()> {
         let mut sink_pipeline_builder = SinkPipeBuilder::create();
         for _ in 0..pipeline.output_len() {
             let input_port = InputPort::create();

--- a/src/query/storages/preludes/src/random/random_table.rs
+++ b/src/query/storages/preludes/src/random/random_table.rs
@@ -143,7 +143,7 @@ impl Table for RandomTable {
         true
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/storages/preludes/src/random/random_table.rs
+++ b/src/query/storages/preludes/src/random/random_table.rs
@@ -143,7 +143,7 @@ impl Table for RandomTable {
         true
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,

--- a/src/query/storages/preludes/src/system/log_queue.rs
+++ b/src/query/storages/preludes/src/system/log_queue.rs
@@ -163,7 +163,7 @@ impl<Event: SystemLogElement + 'static> Table for SystemLogTable<Event> {
         Ok((Statistics::default(), vec![]))
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/preludes/src/system/log_queue.rs
+++ b/src/query/storages/preludes/src/system/log_queue.rs
@@ -163,7 +163,7 @@ impl<Event: SystemLogElement + 'static> Table for SystemLogTable<Event> {
         Ok((Statistics::default(), vec![]))
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/preludes/src/system/table.rs
+++ b/src/query/storages/preludes/src/system/table.rs
@@ -102,7 +102,7 @@ impl<TTable: 'static + SyncSystemTable> Table for SyncOneBlockSystemTable<TTable
         self.inner_table.get_partitions(ctx, push_downs)
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,
@@ -221,7 +221,7 @@ impl<TTable: 'static + AsyncSystemTable> Table for AsyncOneBlockSystemTable<TTab
         self.inner_table.get_partitions(ctx, push_downs).await
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/preludes/src/system/table.rs
+++ b/src/query/storages/preludes/src/system/table.rs
@@ -102,7 +102,7 @@ impl<TTable: 'static + SyncSystemTable> Table for SyncOneBlockSystemTable<TTable
         self.inner_table.get_partitions(ctx, push_downs)
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,
@@ -221,7 +221,7 @@ impl<TTable: 'static + AsyncSystemTable> Table for AsyncOneBlockSystemTable<TTab
         self.inner_table.get_partitions(ctx, push_downs).await
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/preludes/src/system/tracing_table.rs
+++ b/src/query/storages/preludes/src/system/tracing_table.rs
@@ -109,7 +109,7 @@ impl Table for TracingTable {
         Ok((Statistics::default(), vec![]))
     }
 
-    fn read2(
+    fn read(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,

--- a/src/query/storages/preludes/src/system/tracing_table.rs
+++ b/src/query/storages/preludes/src/system/tracing_table.rs
@@ -109,7 +109,7 @@ impl Table for TracingTable {
         Ok((Statistics::default(), vec![]))
     }
 
-    fn read(
+    fn read_data(
         &self,
         ctx: Arc<dyn TableContext>,
         _: &ReadDataSourcePlan,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

renaming of the following method names of trait Table

- `read2` to `read_data`
- `append2` to `append_data`
- minor doc tweaks

Fixes #issue
