### PR TITLE
feat: support COPY INTO from oss backend

### DIFF
--- a/src/common/storage/src/config.rs
+++ b/src/common/storage/src/config.rs
@@ -44,6 +44,7 @@ pub enum StorageParams {
     Ipfs(StorageIpfsConfig),
     Memory,
     Obs(StorageObsConfig),
+    Oss(StorageOssConfig),
     S3(StorageS3Config),
 }
 
@@ -87,6 +88,11 @@ impl Display for StorageParams {
                 "obs://bucket={},root={},endpoint={}",
                 v.bucket, v.root, v.endpoint_url
             ),
+            StorageParams::Oss(v) => write!(
+                f,
+                "oss://bucket={},root={},endpoint={}",
+                v.bucket, v.root, v.endpoint_url
+            ),
             StorageParams::S3(v) => {
                 write!(
                     f,
@@ -113,6 +119,7 @@ impl StorageParams {
             StorageParams::Ipfs(c) => c.endpoint_url.starts_with("https://"),
             StorageParams::Memory => false,
             StorageParams::Obs(v) => v.endpoint_url.starts_with("https://"),
+            StorageParams::Oss(v) => v.endpoint_url.starts_with("https://"),
             StorageParams::S3(v) => v.endpoint_url.starts_with("https://"),
             StorageParams::Gcs(v) => v.endpoint_url.starts_with("https://"),
         }
@@ -335,6 +342,34 @@ impl Debug for StorageObsConfig {
                 "secret_access_key",
                 &mask_string(&self.secret_access_key, 3),
             )
+            .finish()
+    }
+}
+/// config for Aliyun Object Storage Service
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageOssConfig {
+    pub endpoint_url: String,
+    pub bucket: String,
+    pub access_key_id: String,
+    pub access_key_secret: String,
+    pub oidc_token: String,
+    pub role_arn: String,
+    pub root: String,
+}
+
+impl Debug for StorageOssConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StorageOssConfig")
+            .field("endpoint_url", &self.endpoint_url)
+            .field("bucket", &self.bucket)
+            .field("root", &self.root)
+            .field("access_key_id", &mask_string(&self.access_key_id, 3))
+            .field(
+                "access_key_secret",
+                &mask_string(&self.access_key_secret, 3),
+            )
+            .field("oidc_token", &mask_string(&self.oidc_token, 3))
+            .field("role_arn", &mask_string(&self.role_arn, 3))
             .finish()
     }
 }

--- a/src/common/storage/src/lib.rs
+++ b/src/common/storage/src/lib.rs
@@ -26,6 +26,7 @@ pub use config::StorageHdfsConfig;
 pub use config::StorageHttpConfig;
 pub use config::StorageIpfsConfig;
 pub use config::StorageObsConfig;
+pub use config::StorageOssConfig;
 pub use config::StorageParams;
 pub use config::StorageS3Config;
 pub use config::STORAGE_FTP_DEFAULT_ENDPOINT;

--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -34,6 +34,7 @@ use opendal::services::gcs;
 use opendal::services::http;
 use opendal::services::memory;
 use opendal::services::obs;
+use opendal::services::oss;
 use opendal::services::s3;
 use opendal::Operator;
 
@@ -45,6 +46,7 @@ use crate::config::StorageGcsConfig;
 use crate::config::StorageHttpConfig;
 use crate::config::StorageObsConfig;
 use crate::StorageConfig;
+use crate::StorageOssConfig;
 
 /// init_operator will init an opendal operator based on storage config.
 pub fn init_operator(cfg: &StorageParams) -> Result<Operator> {
@@ -60,6 +62,7 @@ pub fn init_operator(cfg: &StorageParams) -> Result<Operator> {
         StorageParams::Memory => init_memory_operator()?,
         StorageParams::Obs(cfg) => init_obs_operator(cfg)?,
         StorageParams::S3(cfg) => init_s3_operator(cfg)?,
+        StorageParams::Oss(cfg) => init_oss_operator(cfg)?,
     };
 
     let op = op
@@ -307,4 +310,22 @@ impl StorageOperator {
     pub fn get_storage_params(&self) -> StorageParams {
         self.params.clone()
     }
+}
+
+/// init_oss_operator will init an opendal OSS operator with input oss config.
+fn init_oss_operator(cfg: &StorageOssConfig) -> Result<Operator> {
+    let mut builder = oss::Builder::default();
+
+    // endpoint
+    let backend = builder
+        .endpoint(&cfg.endpoint_url)
+        .access_key_id(&cfg.access_key_id)
+        .access_key_secret(&cfg.access_key_secret)
+        .oidc_token(&cfg.oidc_token)
+        .role_arn(&cfg.role_arn)
+        .bucket(&cfg.bucket)
+        .root(&cfg.root)
+        .build()?;
+
+    Ok(Operator::new(backend))
 }

--- a/src/common/storage/tests/location.rs
+++ b/src/common/storage/tests/location.rs
@@ -20,6 +20,7 @@ use common_storage::StorageFtpConfig;
 use common_storage::StorageGcsConfig;
 use common_storage::StorageHttpConfig;
 use common_storage::StorageIpfsConfig;
+use common_storage::StorageOssConfig;
 use common_storage::StorageParams;
 use common_storage::StorageS3Config;
 use common_storage::UriLocation;
@@ -45,6 +46,36 @@ fn test_parse_uri_location() -> Result<()> {
                 StorageParams::Ipfs(StorageIpfsConfig {
                     endpoint_url: "https://ipfs.filebase.io".to_string(),
                     root: "/ipfs/too-naive".to_string(),
+                }),
+                "/".to_string(),
+            ),
+        ),
+        (
+            "oss location",
+            UriLocation {
+                protocol: "oss".to_string(),
+                name: "zhen".to_string(),
+                path: "/highest/".to_string(),
+                connection: vec![
+                    ("endpoint_url", "https://oss-cn-litang.example.com"),
+                    ("access_key_id", "dzin"),
+                    ("access_key_secret", "p=ear1"),
+                    ("oidc_token", "ric-kV--"),
+                    ("role_arn", "tester"),
+                ]
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect::<BTreeMap<String, String>>(),
+            },
+            (
+                StorageParams::Oss(StorageOssConfig {
+                    endpoint_url: "https://oss-cn-litang.example.com".to_string(),
+                    root: "/highest/".to_string(),
+                    bucket: "zhen".to_string(),
+                    access_key_id: "dzin".to_string(),
+                    access_key_secret: "p=ear1".to_string(),
+                    oidc_token: "ric-kV--".to_string(),
+                    role_arn: "tester".to_string(),
                 }),
                 "/".to_string(),
             ),


### PR DESCRIPTION
Signed-off-by: ClSlaid <cailue@bupt.edu.cn>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR allows you to copy from Aliyun OSS with its native API, for example:

```mysql
COPY INTO ontime FROM 'oss://example-bucket/ontime.csv' CONNECTION=( ENDPOINT_URL='https://oss-cn-litang.example.com' ACCESS_KEY_ID='<access_key_id>' ACCESS_KEY_SECRET='<access_key_secret>' OIDC_TOKEN='<oidc-token>' ROLE_ARN='<ROLE-ARN>' ) FILE_FORMAT=( TYPE = 'CSV' );
```

Fixes #8068
