### PR TITLE
fix: S3 operator's security_token is not set

### DIFF
--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -213,6 +213,7 @@ fn init_s3_operator(cfg: &StorageS3Config) -> Result<Operator> {
     // Credential.
     builder.access_key_id(&cfg.access_key_id);
     builder.secret_access_key(&cfg.secret_access_key);
+    builder.security_token(&cfg.security_token);
 
     // Bucket.
     builder.bucket(&cfg.bucket);


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fixes https://github.com/datafuselabs/databend/issues/8069
