### PR TITLE
docs: fix typo in token docs

### DIFF
--- a/docs/doc/21-load-data/01-s3.md
+++ b/docs/doc/21-load-data/01-s3.md
@@ -17,6 +17,7 @@ Databend [COPY](../30-reference/30-sql/10-dml/dml-copy-into-table.md) command ca
 ### Step 1. Data Files for Loading
 
 Download the sample data file(Choose CSV or Parquet), the file contains two records:
+
 ```text
 Transaction Processing,Jim Gray,1992
 Readings in Database Systems,Michael Stonebraker,2004
@@ -40,7 +41,6 @@ Download [books.parquet](https://datafuse-1253727613.cos.ap-hongkong.myqcloud.co
 </TabItem>
 
 </Tabs>
-
 
 ### Step 2. Creating an Amazon S3 Bucket
 
@@ -78,6 +78,7 @@ CREATE TABLE books
 Now that the database and table have been created.
 In Step 3 of this Quickstart, you uploaded the `books.csv` or `books.parquet` file to your bucket.
 To use the COPY data loading, you will need the following information:
+
 * The name of the S3 URI(*s3://bucket/to/path/*), such as: *s3://databend-bohu/data/*
 * Your AWS account’s access keys, such as:
   * Access Key ID: *your-access-key-id*
@@ -95,11 +96,10 @@ Using this URI and keys, execute the following statement, replacing the placehol
 ```sql
 COPY INTO books
   FROM 's3://databend-bohu/data/'
-  credentials=(aws_key_id='<your-access-key-id>' aws_secret_key='<your-secret-access-key>' [aws-token='<your-aws-temporary-access-token>'])
+  credentials=(aws_key_id='<your-access-key-id>' aws_secret_key='<your-secret-access-key>' [aws_token='<your-aws-temporary-access-token>'])
   pattern ='.*[.]csv'
   file_format = (type = 'CSV' field_delimiter = ','  record_delimiter = '\n' skip_header = 0);
 ```
-
 
 </TabItem>
 
@@ -117,7 +117,6 @@ COPY INTO books
 
 </Tabs>
 
-
 :::tip
 
 If the file(s) is large and we want to check the file format is ok to parse, we can use the `SIZE_LIMIT`:
@@ -130,6 +129,7 @@ COPY INTO books
   file_format = (type = 'CSV' field_delimiter = ','  record_delimiter = '\n' skip_header = 0)
   size_limit = 1; -- only load 1 rows
 ```
+
 :::
 
 ### Step 6. Verify the Loaded Data
@@ -146,6 +146,6 @@ SELECT * FROM books;
 +------------------------------+----------------------+-------+
 ```
 
-### Step 7. Congratulations!
+### Step 7. Congratulations
 
 You have successfully completed the tutorial.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Tiny tipy fix in docs

