### PR TITLE
feat: try get segments parallel

### DIFF
--- a/src/query/service/tests/it/storages/testdata/system-tables.txt
+++ b/src/query/service/tests/it/storages/testdata/system-tables.txt
@@ -305,8 +305,8 @@ DB.Table: 'system'.'settings', Table: settings-table_id:1, ver:0, Engine: System
 | group_by_two_level_threshold   | 10000      | 10000      | SESSION | The threshold of keys to open two-level aggregation, default value: 10000.                          | UInt64 |
 | input_read_buffer_size         | 1048576    | 1048576    | SESSION | The size of buffer in bytes for input with format. By default, it is 1MB.                           | UInt64 |
 | max_block_size                 | 10000      | 10000      | SESSION | Maximum block size for reading, default value: 10000.                                               | UInt64 |
-| max_storage_io_requests        | 1000       | 1000       | SESSION | The maximum number of concurrent IO requests. By default, it is 1000.                               | UInt64 |
 | max_execute_time               | 0          | 0          | SESSION | The maximum query execution time. it means no limit if the value is zero. default value: 0.         | UInt64 |
+| max_storage_io_requests        | 1000       | 1000       | SESSION | The maximum number of concurrent IO requests. By default, it is 1000.                               | UInt64 |
 | max_threads                    | 2          | 16         | SESSION | The maximum number of threads to execute the request. By default, it is determined automatically.   | UInt64 |
 | quoted_ident_case_sensitive    | 1          | 1          | SESSION | Case sensitivity of quoted identifiers, default value: 1 (aka case-sensitive).                      | UInt64 |
 | sql_dialect                    | PostgreSQL | PostgreSQL | SESSION | SQL dialect, support "PostgreSQL" and "MySQL", default value: "PostgreSQL".                         | String |

--- a/src/query/service/tests/it/storages/testdata/system-tables.txt
+++ b/src/query/service/tests/it/storages/testdata/system-tables.txt
@@ -305,7 +305,7 @@ DB.Table: 'system'.'settings', Table: settings-table_id:1, ver:0, Engine: System
 | group_by_two_level_threshold   | 10000      | 10000      | SESSION | The threshold of keys to open two-level aggregation, default value: 10000.                          | UInt64 |
 | input_read_buffer_size         | 1048576    | 1048576    | SESSION | The size of buffer in bytes for input with format. By default, it is 1MB.                           | UInt64 |
 | max_block_size                 | 10000      | 10000      | SESSION | Maximum block size for reading, default value: 10000.                                               | UInt64 |
-| max_concurrent_prune           | 1000       | 1000       | SESSION | The maximum number of concurrent pruning. By default, it is 1000.                                   | UInt64 |
+| max_storage_io_requests        | 1000       | 1000       | SESSION | The maximum number of concurrent IO requests. By default, it is 1000.                               | UInt64 |
 | max_execute_time               | 0          | 0          | SESSION | The maximum query execution time. it means no limit if the value is zero. default value: 0.         | UInt64 |
 | max_threads                    | 2          | 16         | SESSION | The maximum number of threads to execute the request. By default, it is determined automatically.   | UInt64 |
 | quoted_ident_case_sensitive    | 1          | 1          | SESSION | Case sensitivity of quoted identifiers, default value: 1 (aka case-sensitive).                      | UInt64 |

--- a/src/query/settings/src/lib.rs
+++ b/src/query/settings/src/lib.rs
@@ -130,15 +130,15 @@ impl Settings {
                 desc: "The maximum number of threads to execute the request. By default, it is determined automatically.",
                 possible_values: None,
             },
-            // max_concurrent_prune
+            // max_storage_io_requests
             SettingValue {
                 default_value: UserSettingValue::UInt64(1000),
                 user_setting: UserSetting::create(
-                    "max_concurrent_prune",
+                    "max_storage_io_requests",
                     UserSettingValue::UInt64(1000),
                 ),
                 level: ScopeLevel::Session,
-                desc: "The maximum number of concurrent pruning. By default, it is 1000.",
+                desc: "The maximum number of concurrent IO requests. By default, it is 1000.",
                 possible_values: None,
             },
             // flight_client_timeout
@@ -395,13 +395,13 @@ impl Settings {
         self.try_set_u64(key, val, false)
     }
 
-    pub fn get_max_concurrent_prune(&self) -> Result<u64> {
-        let key = "max_concurrent_prune";
+    pub fn get_max_storage_io_requests(&self) -> Result<u64> {
+        let key = "max_storage_io_requests";
         self.try_get_u64(key)
     }
 
-    pub fn set_max_concurrent_prune(&self, val: u64) -> Result<()> {
-        let key = "max_concurrent_prune";
+    pub fn set_max_storage_io_requests(&self, val: u64) -> Result<()> {
+        let key = "max_storage_io_requests";
         self.try_set_u64(key, val, false)
     }
 

--- a/src/query/storages/fuse/src/fuse_segment.rs
+++ b/src/query/storages/fuse/src/fuse_segment.rs
@@ -1,0 +1,73 @@
+//  Copyright 2022 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::sync::Arc;
+
+use common_base::base::tokio::sync::Semaphore;
+use common_base::base::Runtime;
+use common_catalog::table_context::TableContext;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_fuse_meta::meta::Location;
+use common_fuse_meta::meta::SegmentInfo;
+use common_fuse_meta::meta::TableSnapshot;
+use futures_util::future;
+
+use crate::io::MetaReaders;
+
+// Read one segment file by location.
+async fn read_segment(ctx: Arc<dyn TableContext>, loc: Location) -> Result<Arc<SegmentInfo>> {
+    let (path, ver) = loc;
+    let reader = MetaReaders::segment_info_reader(ctx.as_ref());
+    reader.read(path, None, ver).await
+}
+
+// Read a snapshot's all segments in concurrency.
+pub async fn read_segments(
+    ctx: Arc<dyn TableContext>,
+    snapshot: Arc<TableSnapshot>,
+) -> Result<Vec<Result<Arc<SegmentInfo>>>> {
+    let max_runtime_threads = ctx.get_settings().get_max_threads()? as usize;
+    let max_io_concurrency = ctx.get_settings().get_max_concurrent_prune()? as usize;
+
+    // 1.1 combine all the tasks.
+    let mut iter = snapshot.segments.iter();
+    let tasks = std::iter::from_fn(move || {
+        if let Some(location) = iter.next() {
+            let ctx = ctx.clone();
+            let location = location.clone();
+            Some(async move { read_segment(ctx, location).await })
+        } else {
+            None
+        }
+    });
+
+    // 1.2 build the runtime.
+    let semaphore = Arc::new(Semaphore::new(max_io_concurrency));
+    let segments_runtime = Arc::new(Runtime::with_worker_threads(
+        max_runtime_threads,
+        Some("fuse-req-segments-worker".to_owned()),
+    )?);
+
+    // 1.3 spawn all the tasks to the runtime.
+    let join_handlers = segments_runtime
+        .try_spawn_batch(semaphore.clone(), tasks)
+        .await?;
+
+    // 1.4 get all the result.
+    let joint: Vec<Result<Arc<SegmentInfo>>> = future::try_join_all(join_handlers)
+        .await
+        .map_err(|e| ErrorCode::StorageOther(format!("request segments failure, {}", e)))?;
+    Ok(joint)
+}

--- a/src/query/storages/fuse/src/fuse_segment.rs
+++ b/src/query/storages/fuse/src/fuse_segment.rs
@@ -39,7 +39,7 @@ pub async fn read_segments(
     snapshot: Arc<TableSnapshot>,
 ) -> Result<Vec<Result<Arc<SegmentInfo>>>> {
     let max_runtime_threads = ctx.get_settings().get_max_threads()? as usize;
-    let max_io_concurrency = ctx.get_settings().get_max_concurrent_prune()? as usize;
+    let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
 
     // 1.1 combine all the tasks.
     let mut iter = snapshot.segments.iter();
@@ -54,7 +54,7 @@ pub async fn read_segments(
     });
 
     // 1.2 build the runtime.
-    let semaphore = Arc::new(Semaphore::new(max_io_concurrency));
+    let semaphore = Arc::new(Semaphore::new(max_io_requests));
     let segments_runtime = Arc::new(Runtime::with_worker_threads(
         max_runtime_threads,
         Some("fuse-req-segments-worker".to_owned()),

--- a/src/query/storages/fuse/src/lib.rs
+++ b/src/query/storages/fuse/src/lib.rs
@@ -19,6 +19,7 @@
 mod constants;
 mod fuse_lazy_part;
 mod fuse_part;
+mod fuse_segment;
 mod fuse_table;
 pub mod io;
 pub mod operations;

--- a/src/query/storages/fuse/src/pruning/pruning_executor.rs
+++ b/src/query/storages/fuse/src/pruning/pruning_executor.rs
@@ -88,19 +88,18 @@ impl BlockPruner {
         // 2. setup concurrency controls
         let max_threads = ctx.get_settings().get_max_threads()? as usize;
         let max_concurrency = {
-            let max_concurrent_prune_setting =
-                ctx.get_settings().get_max_concurrent_prune()? as usize;
-            // Prevent us from miss-configured max_concurrent_prune setting, e.g. 0
+            let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
+            // Prevent us from miss-configured max_storage_io_requests setting, e.g. 0
             //
             // note that inside the segment pruning, the SAME Semaphore is used to
             // control the concurrency of block pruning, to prevent us from waiting for
             // a permit while hold the last permit, at least 2 permits should be
             // given to this semaphore.
-            let v = std::cmp::max(max_concurrent_prune_setting, 10);
-            if v > max_concurrent_prune_setting {
+            let v = std::cmp::max(max_io_requests, 10);
+            if v > max_io_requests {
                 warn!(
-                    "max_concurrent_prune setting is too low {}, increased to {}",
-                    max_concurrent_prune_setting, v
+                    "max_storage_io_requests setting is too low {}, increased to {}",
+                    max_io_requests, v
                 )
             }
             v

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
@@ -14,10 +14,16 @@
 
 use std::sync::Arc;
 
+use common_base::base::tokio::sync::Semaphore;
+use common_base::base::Runtime;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
+use common_exception::ErrorCode;
 use common_exception::Result;
+use common_fuse_meta::meta::Location;
+use common_fuse_meta::meta::SegmentInfo;
 use common_fuse_meta::meta::TableSnapshot;
+use futures_util::future;
 use futures_util::TryStreamExt;
 
 use crate::io::MetaReaders;
@@ -75,6 +81,12 @@ impl<'a> FuseBlock<'a> {
         Ok(DataBlock::empty_with_schema(Self::schema()))
     }
 
+    async fn get_segment(ctx: Arc<dyn TableContext>, loc: Location) -> Result<Arc<SegmentInfo>> {
+        let (path, ver) = loc;
+        let reader = MetaReaders::segment_info_reader(ctx.as_ref());
+        reader.read(path, None, ver).await
+    }
+
     async fn to_block(&self, snapshot: Arc<TableSnapshot>) -> Result<DataBlock> {
         let len = snapshot.summary.block_count as usize;
         let snapshot_id = vec![snapshot.snapshot_id.simple().to_string().into_bytes()];
@@ -84,9 +96,35 @@ impl<'a> FuseBlock<'a> {
         let mut bloom_filter_location: Vec<Option<Vec<u8>>> = Vec::with_capacity(len);
         let mut bloom_filter_size: Vec<u64> = Vec::with_capacity(len);
 
-        let reader = MetaReaders::segment_info_reader(self.ctx.as_ref());
-        for (x, ver) in &snapshot.segments {
-            let segment = reader.read(x, None, *ver).await?;
+        // 1.1 combine all the tasks.
+        let tasks = std::iter::from_fn(|| {
+            let ctx = self.ctx.clone();
+            let segments = snapshot.segments.clone();
+            if let Some(location) = segments.into_iter().next() {
+                return Some(async move { Self::get_segment(ctx, location.clone()).await });
+            }
+            None
+        });
+
+        // 1.2 build the runtime.
+        let max_threads = self.ctx.get_settings().get_max_threads()? as usize;
+        let segments_runtime = Arc::new(Runtime::with_worker_threads(
+            max_threads,
+            Some("fuse-block-worker".to_owned()),
+        )?);
+        let semaphore = Arc::new(Semaphore::new(100));
+
+        // 1.3 spawn all the tasks to the runtime.
+        let join_handlers = segments_runtime
+            .try_spawn_batch(semaphore.clone(), tasks)
+            .await?;
+
+        // 1.4 get all the result.
+        let joint: Vec<Result<Arc<SegmentInfo>>> = future::try_join_all(join_handlers)
+            .await
+            .map_err(|e| ErrorCode::StorageOther(format!("get segments failure, {}", e)))?;
+        for segment in joint {
+            let segment = segment?;
             segment.blocks.clone().into_iter().for_each(|block| {
                 block_location.push(block.location.0.into_bytes());
                 block_size.push(block.block_size);

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
@@ -85,7 +85,7 @@ impl<'a> FuseBlock<'a> {
         let mut bloom_filter_location: Vec<Option<Vec<u8>>> = Vec::with_capacity(len);
         let mut bloom_filter_size: Vec<u64> = Vec::with_capacity(len);
 
-        let segments = read_segments(self.ctx.clone(), snapshot.clone()).await?;
+        let segments = read_segments(self.ctx.clone(), &snapshot.segments).await?;
         for segment in segments {
             let segment = segment?;
             segment.blocks.clone().into_iter().for_each(|block| {

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
@@ -108,11 +108,13 @@ impl<'a> FuseBlock<'a> {
 
         // 1.2 build the runtime.
         let max_threads = self.ctx.get_settings().get_max_threads()? as usize;
+        let max_concurrent_prune_setting =
+            self.ctx.get_settings().get_max_concurrent_prune()? as usize;
+        let semaphore = Arc::new(Semaphore::new(max_concurrent_prune_setting));
         let segments_runtime = Arc::new(Runtime::with_worker_threads(
             max_threads,
-            Some("fuse-block-worker".to_owned()),
+            Some("fuse-block-segments-worker".to_owned()),
         )?);
-        let semaphore = Arc::new(Semaphore::new(100));
 
         // 1.3 spawn all the tasks to the runtime.
         let join_handlers = segments_runtime

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
@@ -97,14 +97,13 @@ impl<'a> FuseBlock<'a> {
         let mut bloom_filter_size: Vec<u64> = Vec::with_capacity(len);
 
         // 1.1 combine all the tasks.
-        let tasks = std::iter::from_fn(|| {
+
+        let mut tasks = Vec::with_capacity(snapshot.segments.len());
+        for segment in &snapshot.segments {
             let ctx = self.ctx.clone();
-            let segments = snapshot.segments.clone();
-            if let Some(location) = segments.into_iter().next() {
-                return Some(async move { Self::get_segment(ctx, location.clone()).await });
-            }
-            None
-        });
+            let seg = segment.clone();
+            tasks.push(async move { Self::get_segment(ctx, seg).await });
+        }
 
         // 1.2 build the runtime.
         let max_threads = self.ctx.get_settings().get_max_threads()? as usize;

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
@@ -20,6 +20,7 @@ use common_exception::Result;
 use common_fuse_meta::meta::Location;
 use futures_util::TryStreamExt;
 
+use crate::fuse_segment::read_segments;
 use crate::io::MetaReaders;
 use crate::io::SnapshotHistoryReader;
 use crate::sessions::TableContext;
@@ -59,7 +60,7 @@ impl<'a> FuseSegment<'a> {
             // find the element by snapshot_id in stream
             while let Some(snapshot) = snapshot_stream.try_next().await? {
                 if snapshot.snapshot_id.simple().to_string() == self.snapshot_id {
-                    return self.segments_to_block(&snapshot.segments).await;
+                    return self.to_block(&snapshot.segments).await;
                 }
             }
         }
@@ -67,8 +68,8 @@ impl<'a> FuseSegment<'a> {
         Ok(DataBlock::empty_with_schema(Self::schema()))
     }
 
-    async fn segments_to_block(&self, segments: &[Location]) -> Result<DataBlock> {
-        let len = segments.len();
+    async fn to_block(&self, locations: &[Location]) -> Result<DataBlock> {
+        let len = locations.len();
         let mut format_versions: Vec<u64> = Vec::with_capacity(len);
         let mut block_count: Vec<u64> = Vec::with_capacity(len);
         let mut row_count: Vec<u64> = Vec::with_capacity(len);
@@ -76,17 +77,15 @@ impl<'a> FuseSegment<'a> {
         let mut uncompressed: Vec<u64> = Vec::with_capacity(len);
         let mut file_location: Vec<Vec<u8>> = Vec::with_capacity(len);
 
-        for segment_location in segments {
-            let (location, version) = (segment_location.0.clone(), segment_location.1);
-            let reader = MetaReaders::segment_info_reader(self.ctx.as_ref());
-            let segment_info = reader.read(&location, None, version).await?;
-
-            format_versions.push(version);
-            block_count.push(segment_info.summary.block_count);
-            row_count.push(segment_info.summary.row_count);
-            compressed.push(segment_info.summary.compressed_byte_size);
-            uncompressed.push(segment_info.summary.uncompressed_byte_size);
-            file_location.push(location.into_bytes());
+        let segments = read_segments(self.ctx.clone(), locations).await?;
+        for (idx, segment) in segments.iter().enumerate() {
+            let segment = segment.clone()?;
+            format_versions.push(locations[idx].1);
+            block_count.push(segment.summary.block_count);
+            row_count.push(segment.summary.row_count);
+            compressed.push(segment.summary.compressed_byte_size);
+            uncompressed.push(segment.summary.uncompressed_byte_size);
+            file_location.push(locations[idx].0.clone().into_bytes());
         }
 
         Ok(DataBlock::create(FuseSegment::schema(), vec![


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Add `read_segments` for read all segments in concurrency, used in `fuse_segment` and `fuse_block`
* Rename `max_concurrent_prune` to `max_storage_io_requests`

Fixes #issue
