### PR TITLE
chore: brew install coreutils to get sha256sum command

### DIFF
--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -98,6 +98,8 @@ jobs:
       - name: Rust setup
         run: |
           bash ./scripts/setup/dev_setup.sh -yb
+      - name: Install coreutils for macOS sha256sum
+        run: brew install coreutils
       - name: Cross setup
         if: matrix.arch == 'aarch64'
         run: |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

for macos release, `sha256sum: command not found`

Fixes https://github.com/datafuselabs/databend/actions/runs/3214730421
