### PR TITLE
chore: try to fast the compact&purge

### DIFF
--- a/src/query/storages/fuse/src/operations/mutation/compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact_mutator.rs
@@ -93,13 +93,13 @@ impl CompactMutator {
 impl TableMutator for CompactMutator {
     async fn blocks_select(&mut self) -> Result<bool> {
         let snapshot = self.base_snapshot.clone();
-        let locations = &snapshot.segments;
+        let segment_locations = &snapshot.segments;
         // Blocks that need to be reorganized into new segments.
         let mut remain_blocks = Vec::new();
         let mut summarys = Vec::new();
 
         // Read all segments information in parallel.
-        let segments = read_segments(self.ctx.clone(), locations).await?;
+        let segments = read_segments(self.ctx.clone(), segment_locations).await?;
         for (idx, segment) in segments.iter().enumerate() {
             let mut need_merge = false;
             let mut remains = Vec::new();
@@ -121,7 +121,7 @@ impl TableMutator for CompactMutator {
             // If the number of blocks of segment meets block_per_seg, and the blocks in segments donot need to be compacted,
             // then record the segment information.
             if !need_merge && segment.blocks.len() == self.block_per_seg {
-                let location = locations[idx].clone();
+                let location = segment_locations[idx].clone();
                 self.segments.push(location);
                 summarys.push(segment.summary.clone());
                 continue;

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
@@ -68,8 +68,8 @@ impl<'a> FuseSegment<'a> {
         Ok(DataBlock::empty_with_schema(Self::schema()))
     }
 
-    async fn to_block(&self, locations: &[Location]) -> Result<DataBlock> {
-        let len = locations.len();
+    async fn to_block(&self, segment_locations: &[Location]) -> Result<DataBlock> {
+        let len = segment_locations.len();
         let mut format_versions: Vec<u64> = Vec::with_capacity(len);
         let mut block_count: Vec<u64> = Vec::with_capacity(len);
         let mut row_count: Vec<u64> = Vec::with_capacity(len);
@@ -77,15 +77,15 @@ impl<'a> FuseSegment<'a> {
         let mut uncompressed: Vec<u64> = Vec::with_capacity(len);
         let mut file_location: Vec<Vec<u8>> = Vec::with_capacity(len);
 
-        let segments = read_segments(self.ctx.clone(), locations).await?;
+        let segments = read_segments(self.ctx.clone(), segment_locations).await?;
         for (idx, segment) in segments.iter().enumerate() {
             let segment = segment.clone()?;
-            format_versions.push(locations[idx].1);
+            format_versions.push(segment_locations[idx].1);
             block_count.push(segment.summary.block_count);
             row_count.push(segment.summary.row_count);
             compressed.push(segment.summary.compressed_byte_size);
             uncompressed.push(segment.summary.uncompressed_byte_size);
-            file_location.push(locations[idx].0.clone().into_bytes());
+            file_location.push(segment_locations[idx].0.clone().into_bytes());
         }
 
         Ok(DataBlock::create(FuseSegment::schema(), vec![


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* `optimize table xx compact` is faster now by using `read_segments`
* `optimize table xx purge` is slowed by all the snapshot reads (a chain we can not parallel). I will try it in another PR
* Rename some gc.rs function names.

Fixes #7914
