### PR TITLE
feat(rbac): Add builtin PUBLIC role

### DIFF
--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -23,6 +23,9 @@ use common_meta_types::UserPrivilegeSet;
 use crate::role_util::find_all_related_roles;
 use crate::UserApiProvider;
 
+pub const BUILTIN_ROLE_ACCOUNT_ADMIN: &str = "account_admin";
+pub const BUILTIN_ROLE_PUBLIC: &str = "public";
+
 impl UserApiProvider {
     // Get one role from by tenant.
     pub async fn get_role(&self, tenant: &str, role: String) -> Result<RoleInfo> {
@@ -70,17 +73,19 @@ impl UserApiProvider {
         }
     }
 
-    // Ensure the builtin roles inside a tenant. Currently we have two builtin roles
-    // 1. ACCOUNT_ADMIN, which has the equivalent privileges of `GRANT ALL ON *.* TO ROLE account_admin`.
-    // 2. PUBLIC, which have no other privilege, also every role contains the PUBLIC role.
+    // Ensure the builtin roles inside a tenant. Currently we have two builtin roles:
+    // 1. ACCOUNT_ADMIN, which has the equivalent privileges of `GRANT ALL ON *.* TO ROLE account_admin`,
+    //    it also contains all roles. ACCOUNT_ADMIN can access the data objects which owned by any role.
+    // 2. PUBLIC, which have no any privilege by default, but every role contains the PUBLIC role.
+    //    The data objects which owned by PUBLIC can be accessed by any role.
     pub async fn ensure_builtin_roles(&self, tenant: &str) -> Result<u64> {
-        let mut role_info = RoleInfo::new("account_admin");
+        let mut role_info = RoleInfo::new(BUILTIN_ROLE_ACCOUNT_ADMIN);
         role_info.grants.grant_privileges(
             &GrantObject::Global,
             UserPrivilegeSet::available_privileges_on_global(),
         );
-        self.add_role(tenant, role_info, true).await;
-        let role_info = RoleInfo::new("public");
+        self.add_role(tenant, role_info, true).await?;
+        let role_info = RoleInfo::new(BUILTIN_ROLE_PUBLIC);
         self.add_role(tenant, role_info, true).await
     }
 
@@ -166,6 +171,8 @@ impl UserApiProvider {
         }
     }
 
+    // Find all related roles by role names. Every role have a PUBLIC role, and ACCOUNT_ADMIN
+    // default contains every role.
     async fn find_related_roles(
         &self,
         tenant: &str,

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -70,14 +70,17 @@ impl UserApiProvider {
         }
     }
 
-    // Ensure the builtin roles inside a tenant. Currently the only builtin role is account_admin,
-    // which has the equivalent privileges of `GRANT ALL ON *.* TO ROLE account_admin`.
+    // Ensure the builtin roles inside a tenant. Currently we have two builtin roles
+    // 1. ACCOUNT_ADMIN, which has the equivalent privileges of `GRANT ALL ON *.* TO ROLE account_admin`.
+    // 2. PUBLIC, which have no other privilege, also every role contains the PUBLIC role.
     pub async fn ensure_builtin_roles(&self, tenant: &str) -> Result<u64> {
         let mut role_info = RoleInfo::new("account_admin");
         role_info.grants.grant_privileges(
             &GrantObject::Global,
             UserPrivilegeSet::available_privileges_on_global(),
         );
+        self.add_role(tenant, role_info, true).await;
+        let role_info = RoleInfo::new("public");
         self.add_role(tenant, role_info, true).await
     }
 

--- a/src/query/users/src/role_util.rs
+++ b/src/query/users/src/role_util.rs
@@ -18,11 +18,22 @@ use std::collections::VecDeque;
 
 use common_meta_types::RoleInfo;
 
+use crate::role_mgr::BUILTIN_ROLE_ACCOUNT_ADMIN;
+use crate::role_mgr::BUILTIN_ROLE_PUBLIC;
+
 // An role can be granted with multiple roles, find all the related roles in a DFS manner
 pub fn find_all_related_roles(
     cache: &HashMap<String, RoleInfo>,
     role_identities: &[String],
 ) -> Vec<RoleInfo> {
+    // if it's ACCOUNT_ADMIN, return all roles.
+    if role_identities.contains(&BUILTIN_ROLE_ACCOUNT_ADMIN.to_string()) {
+        return cache.iter().map(|(_, v)| v.clone()).collect();
+    }
+    // append PUBLIC role, since it's every role's child by default.
+    let mut role_identities = role_identities.to_vec();
+    role_identities.push(BUILTIN_ROLE_PUBLIC.to_string());
+    // find all related roles by role_identities in a BFS manner.
     let mut visited: HashSet<String> = HashSet::new();
     let mut result: Vec<RoleInfo> = vec![];
     let mut q: VecDeque<String> = role_identities.iter().cloned().collect();

--- a/tests/logictest/suites/base/06_show/06_0007_show_roles
+++ b/tests/logictest/suites/base/06_show/06_0007_show_roles
@@ -6,6 +6,7 @@ SHOW ROLES;
 
 ----
 account_admin 0
+public 0
 test 0
 
 statement ok

--- a/tests/logictest/suites/base/06_show/06_0007_show_roles_v2
+++ b/tests/logictest/suites/base/06_show/06_0007_show_roles_v2
@@ -8,6 +8,7 @@ SHOW ROLES;
 
 ----
 account_admin 0
+public 0
 test 0
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR adds another builtin role PUBLIC, which plays as the builtin role with the lowest privileges.

It's also a special role, which is the child by every other role by default. Thus every other role can access the data objects owned by PUBLIC role, any role can switch to PUBLIC role.

The opposite side is the ACCOUNT_ADMIN role, which plays as the highest builtin role. ACCOUNT_ADMIN can access every data objects owned by any role, and can be switched to any role.

Fixes #6827
