### PR TITLE
feat(log): Add query_start_time and query_duration to query log

### DIFF
--- a/src/query/service/src/interpreters/interpreter_query_log.rs
+++ b/src/query/service/src/interpreters/interpreter_query_log.rs
@@ -94,9 +94,9 @@ impl InterpreterQueryLog {
         let current_database = ctx.get_current_database();
 
         // Stats.
-        let event_time = convert_log_timestamp(now);
+        let event_time = convert_query_log_timestamp(now);
         let event_date = (event_time / (24 * 3_600_000_000)) as i32;
-        let query_start_time = convert_log_timestamp(ctx.get_created_time());
+        let query_start_time = convert_query_log_timestamp(ctx.get_created_time());
 
         let written_rows = 0u64;
         let written_bytes = 0u64;
@@ -197,9 +197,9 @@ impl InterpreterQueryLog {
         let query_text = ctx.get_query_str();
 
         // Stats.
-        let event_time = convert_log_timestamp(now);
+        let event_time = convert_query_log_timestamp(now);
         let event_date = (event_time / (24 * 3_600_000_000)) as i32;
-        let query_start_time = convert_log_timestamp(ctx.get_created_time());
+        let query_start_time = convert_query_log_timestamp(ctx.get_created_time());
         let query_duration_ms = (event_time - query_start_time) / 1_000;
         let dal_metrics = ctx.get_dal_metrics();
 
@@ -294,7 +294,7 @@ impl InterpreterQueryLog {
     }
 }
 
-fn convert_log_timestamp(time: SystemTime) -> i64 {
+fn convert_query_log_timestamp(time: SystemTime) -> i64 {
     time.duration_since(UNIX_EPOCH)
         .unwrap_or(Duration::new(0, 0))
         .as_micros() as i64

--- a/src/query/service/src/interpreters/interpreter_query_log.rs
+++ b/src/query/service/src/interpreters/interpreter_query_log.rs
@@ -149,6 +149,7 @@ impl InterpreterQueryLog {
             event_date,
             event_time,
             query_start_time,
+            query_duration_ms: 0,
             current_database,
             databases: "".to_string(),
             tables: "".to_string(),
@@ -199,6 +200,7 @@ impl InterpreterQueryLog {
         let event_time = convert_log_timestamp(now);
         let event_date = (event_time / (24 * 3_600_000_000)) as i32;
         let query_start_time = convert_log_timestamp(ctx.get_created_time());
+        let query_duration_ms = (event_time - query_start_time) / 1_000;
         let dal_metrics = ctx.get_dal_metrics();
 
         let written_rows = ctx.get_write_progress_value().rows as u64;
@@ -259,6 +261,7 @@ impl InterpreterQueryLog {
             event_date,
             event_time,
             query_start_time,
+            query_duration_ms,
             databases: "".to_string(),
             tables: "".to_string(),
             columns: "".to_string(),

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Weak;
+use std::time::SystemTime;
 
 use chrono_tz::Tz;
 use common_base::base::tokio::task::JoinHandle;
@@ -69,6 +70,7 @@ pub struct QueryContext {
     partition_queue: Arc<RwLock<VecDeque<PartInfoPtr>>>,
     shared: Arc<QueryContextShared>,
     fragment_id: Arc<AtomicUsize>,
+    created_time: SystemTime,
 }
 
 impl QueryContext {
@@ -84,6 +86,7 @@ impl QueryContext {
             version: format!("DatabendQuery {}", *crate::version::DATABEND_COMMIT_VERSION),
             shared,
             fragment_id: Arc::new(AtomicUsize::new(0)),
+            created_time: SystemTime::now(),
         })
     }
 
@@ -186,6 +189,10 @@ impl QueryContext {
 
     pub fn set_executor(&self, weak_ptr: Weak<PipelineExecutor>) {
         self.shared.set_executor(weak_ptr)
+    }
+
+    pub fn get_created_time(&self) -> SystemTime {
+        self.created_time
     }
 }
 

--- a/src/query/service/tests/it/storages/testdata/system-tables.txt
+++ b/src/query/service/tests/it/storages/testdata/system-tables.txt
@@ -101,8 +101,10 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | pid                      | system   | tracing             | BIGINT            |              |                    | false       |         |
 | port                     | system   | clusters            | SMALLINT UNSIGNED |              |                    | false       |         |
 | projections              | system   | query_log           | VARCHAR           |              |                    | false       |         |
+| query_duration_ms        | system   | query_log           | BIGINT            |              |                    | false       |         |
 | query_id                 | system   | query_log           | VARCHAR           |              |                    | false       |         |
 | query_kind               | system   | query_log           | VARCHAR           |              |                    | false       |         |
+| query_start_time         | system   | query_log           | TIMESTAMP(3)      |              |                    | false       |         |
 | query_text               | system   | query_log           | VARCHAR           |              |                    | false       |         |
 | reclustered_bytes        | system   | clustering_history  | BIGINT UNSIGNED   |              |                    | false       |         |
 | reclustered_rows         | system   | clustering_history  | BIGINT UNSIGNED   |              |                    | false       |         |

--- a/src/query/storages/preludes/src/system/query_log_table.rs
+++ b/src/query/storages/preludes/src/system/query_log_table.rs
@@ -140,6 +140,8 @@ impl SystemLogElement for QueryLogElement {
             DataField::new("query_text", Vu8::to_data_type()),
             DataField::new("event_date", DateType::new_impl()),
             DataField::new("event_time", TimestampType::new_impl(3)),
+            DataField::new("query_start_time", TimestampType::new_impl(3)),
+            DataField::new("query_duration_ms", i64::to_data_type()),
             // Schema.
             DataField::new("current_database", Vu8::to_data_type()),
             DataField::new("databases", Vu8::to_data_type()),
@@ -232,6 +234,14 @@ impl SystemLogElement for QueryLogElement {
             .next()
             .unwrap()
             .append_data_value(DataValue::Int64(self.event_time))?;
+        columns
+            .next()
+            .unwrap()
+            .append_data_value(DataValue::Int64(self.query_start_time))?;
+        columns
+            .next()
+            .unwrap()
+            .append_data_value(DataValue::Int64(self.query_duration_ms))?;
         // Schema.
         columns
             .next()

--- a/src/query/storages/preludes/src/system/query_log_table.rs
+++ b/src/query/storages/preludes/src/system/query_log_table.rs
@@ -73,6 +73,8 @@ pub struct QueryLogElement {
     pub event_date: i32,
     #[serde(serialize_with = "datetime_str")]
     pub event_time: i64,
+    #[serde(serialize_with = "datetime_str")]
+    pub query_start_time: i64,
 
     // Schema.
     pub current_database: String,

--- a/src/query/storages/preludes/src/system/query_log_table.rs
+++ b/src/query/storages/preludes/src/system/query_log_table.rs
@@ -75,6 +75,7 @@ pub struct QueryLogElement {
     pub event_time: i64,
     #[serde(serialize_with = "datetime_str")]
     pub query_start_time: i64,
+    pub query_duration_ms: i64,
 
     // Schema.
     pub current_database: String,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently it's hard to calculate the query duration in the query log without aggregation by query id.

This PR adds a query_start_time and query_duration field to the query log, may make analyze query duration easier.

Fixes #issue
