### PR TITLE
chore: add part of duckdb join logictest suites 

### DIFF
--- a/tests/logictest/suites/duckdb/sql/join/inner/equality_join_limits.test
+++ b/tests/logictest/suites/duckdb/sql/join/inner/equality_join_limits.test
@@ -1,0 +1,224 @@
+# name: test/sql/join/inner/equality_join_limits.test
+# description: Test equality joins on numeric limits
+# group: [inner]
+# from: https://github.com/duckdb/duckdb/blob/master/test/sql/join/inner/equality_join_limits.test
+
+statement ok
+drop table if exists t;
+
+statement ok
+drop table if exists u;
+
+# TINYINT limits
+statement ok
+CREATE TABLE t(t_k0 TINYINT);
+
+statement ok
+INSERT INTO t VALUES (-128), (127);
+
+statement ok
+CREATE TABLE u(u_k0 TINYINT);
+
+statement ok
+INSERT INTO u VALUES (-128), (127);
+
+statement query II
+SELECT t_k0, u_k0 FROM   t, u   WHERE t_k0 = u_k0;
+
+----
+-128	 -128
+127	127
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP TABLE u;
+
+# SMALLINT limits
+statement ok
+CREATE TABLE t(t_k0 SMALLINT);
+
+statement ok
+INSERT INTO t VALUES (-32768), (32767);
+
+statement ok
+CREATE TABLE u(u_k0 SMALLINT);
+
+statement ok
+INSERT INTO u VALUES (-32768), (32767);
+
+statement query II
+SELECT t_k0, u_k0 FROM   t, u   WHERE t_k0 = u_k0;
+
+----
+-32768	 -32768
+32767	32767
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP TABLE u;
+
+# INTEGER limits
+statement ok
+CREATE TABLE t(t_k0 INTEGER);
+
+statement ok
+INSERT INTO t VALUES (-2147483648), (2147483647);
+
+statement ok
+CREATE TABLE u(u_k0 INTEGER);
+
+statement ok
+INSERT INTO u VALUES (-2147483648), (2147483647);
+
+statement query II
+SELECT t_k0, u_k0 FROM   t, u   WHERE t_k0 = u_k0;
+
+----
+-2147483648	 -2147483648
+2147483647	2147483647
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP TABLE u;
+
+# BIGINT limits
+statement ok
+CREATE TABLE t(t_k0 BIGINT);
+
+statement ok
+INSERT INTO t VALUES (-9223372036854775808), (9223372036854775807);
+
+statement ok
+CREATE TABLE u(u_k0 BIGINT);
+
+statement ok
+INSERT INTO u VALUES (-9223372036854775808), (9223372036854775807);
+
+statement query II
+SELECT t_k0, u_k0 FROM   t, u   WHERE t_k0 = u_k0;
+
+----
+-9223372036854775808	 -9223372036854775808
+9223372036854775807	9223372036854775807
+
+statement ok
+DROP TABLE if exists t;
+
+statement ok
+DROP TABLE if exists u;
+
+statement ok
+DROP TABLE if exists t;
+
+statement ok
+DROP TABLE if exists u;
+
+# UTINYINT limits
+statement ok
+CREATE TABLE t(t_k0 TINYINT UNSIGNED);
+
+statement ok
+INSERT INTO t VALUES (0), (255);
+
+statement ok
+CREATE TABLE u(u_k0 TINYINT UNSIGNED);
+
+statement ok
+INSERT INTO u VALUES (0), (255);
+
+statement query II
+SELECT t_k0, u_k0 FROM   t, u   WHERE t_k0 = u_k0;
+
+----
+0	 0
+255	255
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP TABLE u;
+
+# USMALLINT limits
+statement ok
+CREATE TABLE t(t_k0 SMALLINT UNSIGNED);
+
+statement ok
+INSERT INTO t VALUES (0), (65535);
+
+statement ok
+CREATE TABLE u(u_k0 SMALLINT UNSIGNED);
+
+statement ok
+INSERT INTO u VALUES (0), (65535);
+
+statement query II
+SELECT t_k0, u_k0 FROM   t, u   WHERE t_k0 = u_k0;
+
+----
+0	 0
+65535	65535
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP TABLE u;
+
+# UINTEGER limits
+statement ok
+CREATE TABLE t(t_k0 INTEGER UNSIGNED);
+
+statement ok
+INSERT INTO t VALUES (0), (4294967295);
+
+statement ok
+CREATE TABLE u(u_k0 INTEGER UNSIGNED);
+
+statement ok
+INSERT INTO u VALUES (0), (4294967295);
+
+statement query II
+SELECT t_k0, u_k0 FROM   t, u   WHERE t_k0 = u_k0;
+
+----
+0	 0
+4294967295	4294967295
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP TABLE u;
+
+# UBIGINT limits
+statement ok
+CREATE TABLE t(t_k0 BIGINT UNSIGNED);
+
+statement ok
+INSERT INTO t VALUES (0), (18446744073709551615);
+
+statement ok
+CREATE TABLE u(u_k0 BIGINT UNSIGNED);
+
+statement ok
+INSERT INTO u VALUES (0), (18446744073709551615);
+
+statement query II
+SELECT t_k0, u_k0 FROM   t, u   WHERE t_k0 = u_k0;
+
+----
+0	 0
+18446744073709551615	18446744073709551615
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP TABLE u;

--- a/tests/logictest/suites/duckdb/sql/join/inner/test_join.test
+++ b/tests/logictest/suites/duckdb/sql/join/inner/test_join.test
@@ -1,0 +1,99 @@
+# name: test/sql/join/inner/test_join.test
+# description: Test basic joins of tables
+# group: [inner]
+# from https://github.com/duckdb/duckdb/blob/master/test/sql/join/inner/test_join.test
+
+statement ok
+drop table if exists test
+
+statement ok
+CREATE TABLE test (a INTEGER, b INTEGER);
+
+statement ok
+INSERT INTO test VALUES (11, 1), (12, 2), (13, 3)
+
+statement ok
+drop table if exists test2
+
+statement ok
+CREATE TABLE test2 (b INTEGER, c INTEGER);
+
+statement ok
+INSERT INTO test2 VALUES (1, 10), (1, 20), (2, 30)
+
+# simple cross product + join condition
+statement query III
+SELECT a, test.b, c FROM test, test2 WHERE test.b = test2.b ORDER BY c;
+
+----
+11	1	10
+11	1	20
+12	2	30
+
+# ambiguous reference to column
+statement statement error
+SELECT b FROM test, test2 WHERE test.b > test2.b;
+
+# simple cross product + multiple join conditions
+statement query III
+SELECT a, test.b, c FROM test, test2 WHERE test.b=test2.b AND test.a-1=test2.c
+
+----
+11	1	10
+
+# use join columns in subquery
+#statement query III
+#SELECT a, (SELECT test.a), c FROM test, test2 WHERE test.b = test2.b ORDER BY c;
+
+#----
+#11	11	10
+#11	11	20
+#12	12	30
+
+# explicit join
+statement query III
+SELECT a, test.b, c FROM test INNER JOIN test2 ON test.b = test2.b ORDER BY c;
+
+----
+11	1	10
+11	1	20
+12	2	30
+
+# explicit join with condition the wrong way around
+statement query III
+SELECT a, test.b, c FROM test INNER JOIN test2 ON test2.b = test.b ORDER BY c;
+
+----
+11	1	10
+11	1	20
+12	2	30
+
+# explicit join with additional condition that is no left-right comparision
+statement query III
+SELECT a, test.b, c FROM test INNER JOIN test2 ON test2.b = test.b and test.b = 2;
+
+----
+12	2	30
+
+# explicit join with additional condition that is constant
+statement query III
+SELECT a, test.b, c FROM test INNER JOIN test2 ON test2.b = test.b and 2 = 2 ORDER BY c;
+
+----
+11	1	10
+11	1	20
+12	2	30
+
+# explicit join with only condition that is no left-right comparision
+statement query III
+SELECT a, test.b, c FROM test INNER JOIN test2 ON test.b = 2 ORDER BY c;
+
+----
+12	2	10
+12	2	20
+12	2	30
+
+# explicit join with only condition that is constant
+statement ok
+SELECT a, test.b, c FROM test INNER JOIN test2 ON NULL = 2;
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

It seems that databend does not support subquery？

[line 44](https://github.com/datafuselabs/databend/pull/8123/files#diff-c8c5d3ed8bbbe64989721909639b35b8c2504e8f6796306318d3602c89f994d3R44)
```
statement query III
SELECT a, (SELECT test.a), c FROM test, test2 WHERE test.b = test2.b ORDER BY c;

----
11	11	10
11	11	20
12	12	30
```
Actual：
```sql
MySQL [(none)]> select (select a) from test;
ERROR 1105 (HY000): Code: 1058, displayText = downcast column error, column type: "Primitive", expected column: "common_datavalues::columns::nullable::NullableColumn".
```
