### PR TITLE
chore(ci): set `GITHUB_TOKEN` for release

### DIFF
--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -364,6 +364,8 @@ jobs:
       - name: Get release
         id: get_release
         uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: download sha256sums
         uses: actions/download-artifact@v2
         with:
@@ -376,6 +378,8 @@ jobs:
           done
       - name: upload checksums
         uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: sha256sums.txt


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

https://github.com/bruceadams/get-release

> This Action requires that the environment variable GITHUB_TOKEN be set correctly.

Fixes #issue
