### PR TITLE
chore: try to reduce the snapshot read memory

### DIFF
--- a/src/query/storages/fuse-meta/src/meta/v1/snapshot.rs
+++ b/src/query/storages/fuse-meta/src/meta/v1/snapshot.rs
@@ -129,23 +129,16 @@ impl From<v0::TableSnapshot> for TableSnapshot {
 // This *ONLY* used for some optimize operation, like PURGE/FUSE_SNAPSHOT function to avoid OOM.
 #[derive(Clone, Debug)]
 pub struct TableSnapshotLite {
-    /// format version of snapshot
     pub format_version: FormatVersion,
-
-    /// id of snapshot
     pub snapshot_id: SnapshotId,
-
-    /// timestamp of this snapshot
-    //  for backward compatibility, `Option` is used
     pub timestamp: Option<DateTime<Utc>>,
-
-    /// previous snapshot
     pub prev_snapshot_id: Option<(SnapshotId, FormatVersion)>,
-
-    /// Summary Statistics
-    pub summary: Statistics,
-
-    pub segment_count: usize,
+    pub row_count: u32,
+    pub block_count: u32,
+    pub index_size: u32,
+    pub uncompressed_byte_size: u32,
+    pub compressed_byte_size: u32,
+    pub segment_count: u32,
 }
 
 impl From<&TableSnapshot> for TableSnapshotLite {
@@ -155,8 +148,12 @@ impl From<&TableSnapshot> for TableSnapshotLite {
             snapshot_id: value.snapshot_id,
             timestamp: value.timestamp,
             prev_snapshot_id: value.prev_snapshot_id,
-            summary: value.summary.clone(),
-            segment_count: value.segments.len(),
+            row_count: value.summary.row_count as u32,
+            block_count: value.summary.block_count as u32,
+            index_size: value.summary.index_size as u32,
+            uncompressed_byte_size: value.summary.uncompressed_byte_size as u32,
+            segment_count: value.segments.len() as u32,
+            compressed_byte_size: value.summary.compressed_byte_size as u32,
         }
     }
 }

--- a/src/query/storages/fuse/src/fuse_snapshot.rs
+++ b/src/query/storages/fuse/src/fuse_snapshot.rs
@@ -140,7 +140,7 @@ pub async fn read_snapshots_by_root_file(
     // 1. Get all the snapshot by chunks.
     let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
     let mut snapshot_map = HashMap::with_capacity(snapshot_files.len());
-    for chunks in snapshot_files.chunks(max_io_requests * 5) {
+    for chunks in snapshot_files.chunks(max_io_requests) {
         let results =
             read_snapshots(ctx.clone(), chunks, format_version, data_accessor.clone()).await?;
         for snapshot in results.into_iter().flatten() {

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
@@ -19,7 +19,7 @@ use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_fuse_meta::meta::TableSnapshotLite;
 
-use crate::fuse_snapshot::read_snapshot_lites_by_root_file;
+use crate::fuse_snapshot::read_snapshots_by_root_file;
 use crate::io::TableMetaLocationGenerator;
 use crate::sessions::TableContext;
 use crate::FuseTable;
@@ -39,7 +39,7 @@ impl<'a> FuseSnapshot<'a> {
         let snapshot_location = self.table.snapshot_loc();
         if let Some(snapshot_location) = snapshot_location {
             let snapshot_version = self.table.snapshot_format_version();
-            let snapshots = read_snapshot_lites_by_root_file(
+            let snapshots = read_snapshots_by_root_file(
                 self.ctx.clone(),
                 snapshot_location,
                 snapshot_version,

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
@@ -62,12 +62,12 @@ impl<'a> FuseSnapshot<'a> {
         let mut snapshot_locations: Vec<Vec<u8>> = Vec::with_capacity(len);
         let mut prev_snapshot_ids: Vec<Option<Vec<u8>>> = Vec::with_capacity(len);
         let mut format_versions: Vec<u64> = Vec::with_capacity(len);
-        let mut segment_count: Vec<u64> = Vec::with_capacity(len);
-        let mut block_count: Vec<u64> = Vec::with_capacity(len);
-        let mut row_count: Vec<u64> = Vec::with_capacity(len);
-        let mut compressed: Vec<u64> = Vec::with_capacity(len);
-        let mut uncompressed: Vec<u64> = Vec::with_capacity(len);
-        let mut index_size: Vec<u64> = Vec::with_capacity(len);
+        let mut segment_count: Vec<u32> = Vec::with_capacity(len);
+        let mut block_count: Vec<u32> = Vec::with_capacity(len);
+        let mut row_count: Vec<u32> = Vec::with_capacity(len);
+        let mut compressed: Vec<u32> = Vec::with_capacity(len);
+        let mut uncompressed: Vec<u32> = Vec::with_capacity(len);
+        let mut index_size: Vec<u32> = Vec::with_capacity(len);
         let mut timestamps: Vec<Option<i64>> = Vec::with_capacity(len);
         let mut current_snapshot_version = latest_snapshot_version;
         for s in snapshots {
@@ -83,12 +83,12 @@ impl<'a> FuseSnapshot<'a> {
             };
             prev_snapshot_ids.push(id);
             format_versions.push(s.format_version);
-            segment_count.push(s.segment_count as u64);
-            block_count.push(s.summary.block_count);
-            row_count.push(s.summary.row_count);
-            compressed.push(s.summary.compressed_byte_size);
-            uncompressed.push(s.summary.uncompressed_byte_size);
-            index_size.push(s.summary.index_size);
+            segment_count.push(s.segment_count);
+            block_count.push(s.block_count);
+            row_count.push(s.row_count);
+            compressed.push(s.compressed_byte_size);
+            uncompressed.push(s.uncompressed_byte_size);
+            index_size.push(s.index_size);
             timestamps.push(s.timestamp.map(|dt| (dt.timestamp_micros()) as i64));
             current_snapshot_version = ver;
         }
@@ -114,12 +114,12 @@ impl<'a> FuseSnapshot<'a> {
             DataField::new("snapshot_location", Vu8::to_data_type()),
             DataField::new("format_version", u64::to_data_type()),
             DataField::new_nullable("previous_snapshot_id", Vu8::to_data_type()),
-            DataField::new("segment_count", u64::to_data_type()),
-            DataField::new("block_count", u64::to_data_type()),
-            DataField::new("row_count", u64::to_data_type()),
-            DataField::new("bytes_uncompressed", u64::to_data_type()),
-            DataField::new("bytes_compressed", u64::to_data_type()),
-            DataField::new("index_size", u64::to_data_type()),
+            DataField::new("segment_count", u32::to_data_type()),
+            DataField::new("block_count", u32::to_data_type()),
+            DataField::new("row_count", u32::to_data_type()),
+            DataField::new("bytes_uncompressed", u32::to_data_type()),
+            DataField::new("bytes_compressed", u32::to_data_type()),
+            DataField::new("index_size", u32::to_data_type()),
             DataField::new_nullable("timestamp", TimestampType::new_impl(6)),
         ])
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

**Make the TableSnapshotLite use less memory**

Fixes #issue
