### PR TITLE
fix: undrop not working as expected if table is dropped by using "drop table t all"

### DIFF
--- a/src/query/service/tests/it/storages/fuse/table.rs
+++ b/src/query/service/tests/it/storages/fuse/table.rs
@@ -212,7 +212,8 @@ async fn test_fuse_table_truncate() -> Result<()> {
     assert_eq!(stats.read_rows, (num_blocks * rows_per_block) as usize);
 
     // truncate
-    let r = table.truncate(ctx.clone(), false).await;
+    let purge = false;
+    let r = table.truncate(ctx.clone(), purge).await;
     assert!(r.is_ok());
 
     // get the latest tbl

--- a/src/query/service/tests/it/storages/memory.rs
+++ b/src/query/service/tests/it/storages/memory.rs
@@ -187,7 +187,8 @@ async fn test_memorytable() -> Result<()> {
 
     // truncate.
     {
-        table.truncate(ctx.clone(), false).await?;
+        let purge = false;
+        table.truncate(ctx.clone(), purge).await?;
 
         let source_plan = table.read_plan(ctx.clone(), None).await?;
         let stream = table.read_data_block_stream(ctx, &source_plan).await?;

--- a/src/query/service/tests/it/storages/null.rs
+++ b/src/query/service/tests/it/storages/null.rs
@@ -55,7 +55,8 @@ async fn test_null_table() -> Result<()> {
 
     // truncate.
     {
-        table.truncate(ctx, false).await?;
+        let purge = false;
+        table.truncate(ctx, purge).await?;
     }
 
     Ok(())

--- a/src/query/storages/preludes/src/null/null_table.rs
+++ b/src/query/storages/preludes/src/null/null_table.rs
@@ -105,10 +105,6 @@ impl Table for NullTable {
         pipeline.add_pipe(sink_pipeline_builder.finalize());
         Ok(())
     }
-
-    async fn truncate(&self, _ctx: Arc<dyn TableContext>, _: bool) -> Result<()> {
-        Ok(())
-    }
 }
 
 struct NullSource {

--- a/tests/logictest/suites/base/12_time_travel/12_0003_time_travel_undrop
+++ b/tests/logictest/suites/base/12_time_travel/12_0003_time_travel_undrop
@@ -107,6 +107,8 @@ SELECT count(1) FROM t;
 ----
 2
 
+statement ok
+DROP TABLE t;
 
 statement ok
 CREATE TABLE t(c int);

--- a/tests/logictest/suites/base/12_time_travel/12_0003_time_travel_undrop
+++ b/tests/logictest/suites/base/12_time_travel/12_0003_time_travel_undrop
@@ -107,5 +107,24 @@ SELECT count(1) FROM t;
 ----
 2
 
+
+statement ok
+CREATE TABLE t(c int);
+
+statement ok
+INSERT INTO t values(1);
+
+statement ok
+DROP TABLE t ALL;
+
+statement ok
+UNDROP TABLE t;
+
+statement query I
+SELECT count(*) FROM t;
+
+----
+0
+
 statement ok
 DROP database db_12_0003;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

during the execution of "drop table all", the table should refresh itself before truncating 

Fixes #8174
