### PR TITLE
feat: add limit push down to fuse_snapshot

### DIFF
--- a/src/query/service/src/procedures/systems/fuse_snapshot.rs
+++ b/src/query/service/src/procedures/systems/fuse_snapshot.rs
@@ -60,7 +60,7 @@ impl OneBlockProcedure for FuseSnapshotProcedure {
 
         let tbl = FuseTable::try_from_table(tbl.as_ref())?;
 
-        Ok(FuseSnapshot::new(ctx, tbl).get_snapshots().await?)
+        Ok(FuseSnapshot::new(ctx, tbl).get_snapshots(None).await?)
     }
 
     fn schema(&self) -> Arc<DataSchema> {

--- a/src/query/service/tests/it/storages/fuse/operations/purge_drop.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/purge_drop.rs
@@ -54,9 +54,9 @@ async fn test_fuse_snapshot_truncate_in_drop_all_stmt() -> Result<()> {
         &fixture,
         "drop table: there should be 1 snapshot, 0 segment/block",
         1, // 1 snapshot
-        1, // 0 segments
-        1, // 0 blocks
-        1, // 0 index
+        0, // 0 segments
+        0, // 0 blocks
+        0, // 0 index
     )
     .await;
     Ok(())

--- a/src/query/service/tests/it/storages/fuse/operations/purge_truncate.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/purge_truncate.rs
@@ -52,9 +52,9 @@ async fn test_fuse_truncate_purge_stmt() -> Result<()> {
         &fixture,
         "truncate_after_purge_check_file_items",
         1,
-        1,
-        1,
-        1,
+        0,
+        0,
+        0,
     )
     .await;
     Ok(())

--- a/src/query/storages/fuse/src/fuse_file.rs
+++ b/src/query/storages/fuse/src/fuse_file.rs
@@ -57,13 +57,13 @@ impl FuseFile {
 
         // 1.2 build the runtime.
         let semaphore = Arc::new(Semaphore::new(max_io_requests));
-        let segments_runtime = Arc::new(Runtime::with_worker_threads(
+        let file_runtime = Arc::new(Runtime::with_worker_threads(
             max_runtime_threads,
             Some("fuse-req-remove-files-worker".to_owned()),
         )?);
 
         // 1.3 spawn all the tasks to the runtime.
-        let join_handlers = segments_runtime
+        let join_handlers = file_runtime
             .try_spawn_batch(semaphore.clone(), tasks)
             .await?;
 

--- a/src/query/storages/fuse/src/fuse_snapshot.rs
+++ b/src/query/storages/fuse/src/fuse_snapshot.rs
@@ -92,13 +92,13 @@ impl FuseSnapshotIO {
 
         // 1.2 build the runtime.
         let semaphore = Arc::new(Semaphore::new(max_io_requests));
-        let segments_runtime = Arc::new(Runtime::with_worker_threads(
+        let snapshot_runtime = Arc::new(Runtime::with_worker_threads(
             max_runtime_threads,
             Some("fuse-req-snapshots-worker".to_owned()),
         )?);
 
         // 1.3 spawn all the tasks to the runtime.
-        let join_handlers = segments_runtime
+        let join_handlers = snapshot_runtime
             .try_spawn_batch(semaphore.clone(), tasks)
             .await?;
 
@@ -108,52 +108,23 @@ impl FuseSnapshotIO {
             .map_err(|e| ErrorCode::StorageOther(format!("read snapshots failure, {}", e)))
     }
 
-    // Read all the snapshots by the root file:
-    // 1. Get the prefix:'/db/table/_ss/' from the root_snapshot_file('/db/table/_ss/xx.json')
-    // 2. List all the files in the prefix
-    // 3. Try to read all the snapshot files in parallel.
+    // Read all the snapshots by the root file.
+    // limit: read how many snapshot files
+    // with_segment_locations: if true will get the segments of the snapshot
     pub async fn read_snapshot_lites(
         &self,
         root_snapshot_file: String,
+        limit: Option<usize>,
         with_segment_locations: bool, // Return segment location or not
     ) -> Result<(Vec<TableSnapshotLite>, HashSet<Location>)> {
         let ctx = self.ctx.clone();
         let data_accessor = self.operator.clone();
 
-        let mut segment_locations = HashSet::new();
+        // Get all file list.
         let mut snapshot_files = vec![];
-        if let Some(path) = Path::new(&root_snapshot_file).parent() {
-            let mut snapshot_prefix = path.to_str().unwrap_or("").to_string();
-
-            // Check if the prefix:db/table/_ss is reasonable.
-            if !snapshot_prefix.contains('/') {
-                return Ok((vec![], segment_locations));
-            }
-
-            // Append '/' to the end if need.
-            if !snapshot_prefix.ends_with('/') {
-                snapshot_prefix += "/";
-            }
-
-            // List the prefix path to get all the snapshot files list.
-            let mut ds = data_accessor.object(&snapshot_prefix).list().await?;
-            while let Some(de) = ds.try_next().await? {
-                match de.mode() {
-                    ObjectMode::FILE => {
-                        let location = de.path().to_string();
-                        if location != root_snapshot_file {
-                            snapshot_files.push(de.path().to_string());
-                        }
-                    }
-                    _ => {
-                        warn!(
-                            "Found not snapshot file in {:}, found: {:?}",
-                            snapshot_prefix, de
-                        );
-                        continue;
-                    }
-                }
-            }
+        let mut segment_locations = HashSet::new();
+        if let Some(prefix) = Self::get_s3_prefix_from_file(&root_snapshot_file) {
+            snapshot_files = self.get_files(&prefix, limit).await?;
         }
 
         // 1. Get all the snapshot by chunks.
@@ -181,8 +152,8 @@ impl FuseSnapshotIO {
         }
 
         let mut snapshot_chain = vec![];
-        // 1.1 Get the root snapshot.
         {
+            // 1 Get the root snapshot.
             let root_snapshot = Self::read_snapshot(
                 ctx.clone(),
                 root_snapshot_file.clone(),
@@ -215,5 +186,58 @@ impl FuseSnapshotIO {
         }
 
         Ok((snapshot_chain, segment_locations))
+    }
+
+    async fn get_files(&self, prefix: &str, limit: Option<usize>) -> Result<Vec<String>> {
+        let data_accessor = self.operator.clone();
+
+        let mut file_list = vec![];
+        let mut ds = data_accessor.object(prefix).list().await?;
+        while let Some(de) = ds.try_next().await? {
+            match de.mode() {
+                ObjectMode::FILE => {
+                    let location = de.path().to_string();
+                    let modified = de.last_modified().await;
+                    file_list.push((location, modified));
+                }
+                _ => {
+                    warn!("found not snapshot file in {:}, found: {:?}", prefix, de);
+                    continue;
+                }
+            }
+        }
+
+        // let mut vector: Vec<(i32, Option<i32>)> = vec![(1, Some(1)), (2, None), (3, Some(3)), (4, None)];
+        // vector.sort_by(|(_, k1), (_, k2)| k2.cmp(k1));
+        // Result:
+        // [(3, Some(3)), (1, Some(1)), (2, None),(4, None)]
+        file_list.sort_by(|(_, m1), (_, m2)| m2.cmp(m1));
+
+        Ok(match limit {
+            None => file_list.into_iter().map(|v| v.0).collect::<Vec<String>>(),
+            Some(v) => file_list
+                .into_iter()
+                .take(v as usize)
+                .map(|v| v.0)
+                .collect::<Vec<String>>(),
+        })
+    }
+
+    // _ss/xx/yy.json -> _ss/xx/
+    fn get_s3_prefix_from_file(file_path: &str) -> Option<String> {
+        if let Some(path) = Path::new(&file_path).parent() {
+            let mut prefix = path.to_str().unwrap_or("").to_string();
+
+            if !prefix.contains('/') {
+                return None;
+            }
+
+            // Append '/' to the end if need.
+            if !prefix.ends_with('/') {
+                prefix += "/";
+            }
+            return Some(prefix);
+        }
+        None
     }
 }

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -73,7 +73,7 @@ impl FuseTable {
                 self.snapshot_format_version(),
             );
             (all_snapshot_lites, all_segment_locations) = fuse_snapshot_io
-                .read_snapshot_lites(root_snapshot_location, true)
+                .read_snapshot_lites(root_snapshot_location, None, true)
                 .await?;
         }
 

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
@@ -34,7 +34,7 @@ impl<'a> FuseSnapshot<'a> {
         Self { ctx, table }
     }
 
-    pub async fn get_snapshots(self) -> Result<DataBlock> {
+    pub async fn get_snapshots(self, limit: Option<usize>) -> Result<DataBlock> {
         let meta_location_generator = self.table.meta_location_generator.clone();
         let snapshot_location = self.table.snapshot_loc();
         if let Some(snapshot_location) = snapshot_location {
@@ -45,7 +45,7 @@ impl<'a> FuseSnapshot<'a> {
                 snapshot_version,
             );
             let (snapshots, _) = fuse_snapshot_io
-                .read_snapshot_lites(snapshot_location, false)
+                .read_snapshot_lites(snapshot_location, limit, false)
                 .await?;
             return self.to_block(&meta_location_generator, &snapshots, snapshot_version);
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

**Push down the limit to fuse_snapshot to fast `select * from fuse_snapshot(db, table) limit 1`**

Fixes #8189 
Fixes #8181
