### PR TITLE
refactor(meta/sled): simplify SledTree APIs

### DIFF
--- a/src/meta/service/src/store/store_bare.rs
+++ b/src/meta/service/src/store/store_bare.rs
@@ -669,13 +669,15 @@ impl RaftStoreBare {
             None => return Ok(vec![]),
         };
 
-        let nodes = sm.nodes().range_kvs(..)?;
+        let nodes = sm.nodes().range(..)?;
+        let mut ns = vec![];
 
-        let ns = nodes
-            .into_iter()
-            .filter(|(node_id, _)| predicate(&membership, node_id))
-            .map(|(_, node)| node)
-            .collect();
+        for x in nodes {
+            let item = x?;
+            if predicate(&membership, &item.key()?) {
+                ns.push(item.value()?);
+            }
+        }
 
         Ok(ns)
     }

--- a/src/meta/sled-store/src/lib.rs
+++ b/src/meta/sled-store/src/lib.rs
@@ -28,6 +28,7 @@ pub use sled_serde::SledSerde;
 pub use sled_tree::AsKeySpace;
 pub use sled_tree::AsTxnKeySpace;
 pub use sled_tree::SledAsRef;
+pub use sled_tree::SledItem;
 pub use sled_tree::SledTree;
 pub use sled_tree::TransactionSledTree;
 pub use store::Store;

--- a/src/meta/sled-store/tests/it/sled_tree.rs
+++ b/src/meta/sled-store/tests/it/sled_tree.rs
@@ -29,7 +29,6 @@ use crate::testing;
 use crate::testing::fake_key_spaces::Files;
 use crate::testing::fake_key_spaces::GenericKV;
 use crate::testing::fake_key_spaces::Logs;
-use crate::testing::fake_key_spaces::Nodes;
 use crate::testing::fake_key_spaces::StateMachineMeta;
 use crate::testing::fake_state_machine_meta::StateMachineMetaKey::Initialized;
 use crate::testing::fake_state_machine_meta::StateMachineMetaKey::LastApplied;
@@ -48,225 +47,7 @@ async fn test_sled_tree_open() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_append() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-
-    let logs: Vec<(LogIndex, Entry<LogEntry>)> = vec![
-        (8, Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        }),
-        (5, Entry {
-            log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(LogEntry {
-                txid: None,
-                time_ms: None,
-                cmd: Cmd::IncrSeq {
-                    key: "foo".to_string(),
-                },
-            }),
-        }),
-    ];
-
-    tree.append::<Logs, _>(&logs).await?;
-
-    let want: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(LogEntry {
-                txid: None,
-                time_ms: None,
-                cmd: Cmd::IncrSeq {
-                    key: "foo".to_string(),
-                },
-            }),
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-    ];
-
-    let got = tree.range_values::<Logs, _>(0..)?;
-    assert_eq!(want, got);
-
-    let got = tree.range_values::<Logs, _>(0..=5)?;
-    assert_eq!(want[0..1], got);
-
-    let got = tree.range_values::<Logs, _>(6..9)?;
-    assert_eq!(want[1..], got);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_append_and_range_get() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-
-    let logs: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(LogEntry {
-                txid: None,
-                time_ms: None,
-
-                cmd: Cmd::IncrSeq {
-                    key: "foo".to_string(),
-                },
-            }),
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 9 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 10 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId {
-                term: 1,
-                index: 256,
-            },
-            payload: EntryPayload::Blank,
-        },
-    ];
-
-    tree.append::<Logs, _>(&logs).await?;
-
-    let got = tree.range_values::<Logs, _>(0..)?;
-    assert_eq!(logs, got);
-
-    let got = tree.range_values::<Logs, _>(0..=2)?;
-    assert_eq!(logs[0..1], got);
-
-    let got = tree.range_values::<Logs, _>(0..3)?;
-    assert_eq!(logs[0..1], got);
-
-    let got = tree.range_values::<Logs, _>(0..5)?;
-    assert_eq!(logs[0..2], got);
-
-    let got = tree.range_values::<Logs, _>(0..10)?;
-    assert_eq!(logs[0..3], got);
-
-    let got = tree.range_values::<Logs, _>(0..11)?;
-    assert_eq!(logs[0..4], got);
-
-    let got = tree.range_values::<Logs, _>(9..11)?;
-    assert_eq!(logs[2..4], got);
-
-    let got = tree.range_values::<Logs, _>(10..256)?;
-    assert_eq!(logs[3..4], got);
-
-    let got = tree.range_values::<Logs, _>(10..257)?;
-    assert_eq!(logs[3..5], got);
-
-    let got = tree.range_values::<Logs, _>(257..)?;
-    assert_eq!(logs[5..], got);
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_range_keys() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-
-    let logs: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 9 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 10 },
-            payload: EntryPayload::Blank,
-        },
-    ];
-
-    tree.append::<Logs, _>(&logs).await?;
-
-    let got = tree.range_keys::<Logs, _>(0..)?;
-    assert_eq!(vec![2, 9, 10], got);
-
-    let got = tree.range_keys::<Logs, _>(0..=2)?;
-    assert_eq!(vec![2], got);
-
-    let got = tree.range_keys::<Logs, _>(0..3)?;
-    assert_eq!(vec![2], got);
-
-    let got = tree.range_keys::<Logs, _>(0..10)?;
-    assert_eq!(vec![2, 9], got);
-
-    let got = tree.range_keys::<Logs, _>(0..11)?;
-    assert_eq!(vec![2, 9, 10], got);
-
-    let got = tree.range_keys::<Logs, _>(9..11)?;
-    assert_eq!(vec![9, 10], got);
-
-    let got = tree.range_keys::<Logs, _>(10..256)?;
-    assert_eq!(vec![10], got);
-
-    let got = tree.range_keys::<Logs, _>(11..)?;
-    assert_eq!(Vec::<LogIndex>::new(), got);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_range_kvs() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-
-    let logs: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 9 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 10 },
-            payload: EntryPayload::Blank,
-        },
-    ];
-
-    tree.append::<Logs, _>(&logs).await?;
-
-    let got = tree.range_kvs::<Logs, _>(9..11)?;
-    assert_eq!(vec![(9, logs[1].clone()), (10, logs[2].clone())], got);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_range() -> anyhow::Result<()> {
+async fn test_as_range() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_sled_ut!();
     let _ent = ut_span.enter();
 
@@ -277,6 +58,8 @@ async fn test_sled_tree_range() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledTree::open(db, tc.tree_name, true)?;
+    let log_tree = tree.key_space::<Logs>();
+    let meta_tree = tree.key_space::<StateMachineMeta>();
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -296,7 +79,7 @@ async fn test_sled_tree_range() -> anyhow::Result<()> {
         },
     ];
 
-    tree.append::<Logs, _>(&logs).await?;
+    log_tree.append(&logs).await?;
 
     let metas = vec![
         (
@@ -306,193 +89,40 @@ async fn test_sled_tree_range() -> anyhow::Result<()> {
         (Initialized, StateMachineMetaValue::Bool(true)),
     ];
 
-    tree.append::<StateMachineMeta, _>(metas.as_slice()).await?;
+    meta_tree.append(metas.as_slice()).await?;
 
-    let log_tree = tree.key_space::<Logs>();
-    let meta_tree = tree.key_space::<StateMachineMeta>();
-
-    // key sapce Logs
-
-    let mut it = tree.range::<Logs, _>(..)?;
-    assert_eq!((2, logs[0].clone()), it.next().unwrap()?);
-    assert_eq!((4, logs[1].clone()), it.next().unwrap()?);
-    assert!(it.next().is_none());
+    // key space Logs
 
     let mut it = log_tree.range(..)?;
-    assert_eq!((2, logs[0].clone()), it.next().unwrap()?);
-    assert_eq!((4, logs[1].clone()), it.next().unwrap()?);
+    assert_eq!((2, logs[0].clone()), it.next().unwrap()?.kv()?);
+    assert_eq!((4, logs[1].clone()), it.next().unwrap()?.kv()?);
     assert!(it.next().is_none());
 
-    // key sapce Logs reversed
-
-    let mut it = tree.range::<Logs, _>(..)?.rev();
-    assert_eq!((4, logs[1].clone()), it.next().unwrap()?);
-    assert_eq!((2, logs[0].clone()), it.next().unwrap()?);
-    assert!(it.next().is_none());
+    // key space Logs reversed
 
     let mut it = log_tree.range(..)?.rev();
-    assert_eq!((4, logs[1].clone()), it.next().unwrap()?);
-    assert_eq!((2, logs[0].clone()), it.next().unwrap()?);
+    assert_eq!((4, logs[1].clone()), it.next().unwrap()?.kv()?);
+    assert_eq!((2, logs[0].clone()), it.next().unwrap()?.kv()?);
     assert!(it.next().is_none());
 
     // key space StateMachineMeta
 
-    let mut it = tree.range::<StateMachineMeta, _>(..)?;
-    assert_eq!(metas[0], it.next().unwrap()?);
-    assert_eq!(metas[1], it.next().unwrap()?);
-    assert!(it.next().is_none());
-
     let mut it = meta_tree.range(..)?;
-    assert_eq!(metas[0], it.next().unwrap()?);
-    assert_eq!(metas[1], it.next().unwrap()?);
+    assert_eq!(metas[0], it.next().unwrap()?.kv()?);
+    assert_eq!(metas[1], it.next().unwrap()?.kv()?);
     assert!(it.next().is_none());
 
     // key space StateMachineMeta reversed
 
-    let mut it = tree.range::<StateMachineMeta, _>(..)?.rev();
-    assert_eq!(metas[1], it.next().unwrap()?);
-    assert_eq!(metas[0], it.next().unwrap()?);
-    assert!(it.next().is_none());
-
     let mut it = meta_tree.range(..)?.rev();
-    assert_eq!(metas[1], it.next().unwrap()?);
-    assert_eq!(metas[0], it.next().unwrap()?);
+    assert_eq!(metas[1], it.next().unwrap()?.kv()?);
+    assert_eq!(metas[0], it.next().unwrap()?.kv()?);
     assert!(it.next().is_none());
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_scan_prefix() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-
-    let files: Vec<(String, String)> = vec![
-        ("a".to_string(), "x".to_string()),
-        ("ab".to_string(), "xy".to_string()),
-        ("abc".to_string(), "xyz".to_string()),
-        ("abd".to_string(), "xyZ".to_string()),
-        ("b".to_string(), "y".to_string()),
-    ];
-
-    tree.append::<Files, _>(&files).await?;
-
-    let got = tree.scan_prefix::<Files>(&"ab".to_string())?;
-    assert_eq!(files[1..4], got);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_insert() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-
-    assert!(tree.get::<Logs>(&5)?.is_none());
-
-    let logs: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(LogEntry {
-                txid: None,
-                time_ms: None,
-
-                cmd: Cmd::IncrSeq {
-                    key: "foo".to_string(),
-                },
-            }),
-        },
-    ];
-
-    for log in logs.iter() {
-        tree.insert::<Logs>(&log.log_id.index, log).await?;
-    }
-
-    assert_eq!(logs, tree.range_values::<Logs, _>(..)?);
-
-    // insert and override
-
-    let override_2 = Entry {
-        log_id: LogId { term: 10, index: 2 },
-        payload: EntryPayload::Blank,
-    };
-
-    let prev = tree
-        .insert::<Logs>(&override_2.log_id.index, &override_2)
-        .await?;
-    assert_eq!(Some(logs[0].clone()), prev);
-
-    // insert and override nothing
-
-    let override_nothing = Entry {
-        log_id: LogId {
-            term: 10,
-            index: 100,
-        },
-        payload: EntryPayload::Blank,
-    };
-
-    let prev = tree
-        .insert::<Logs>(&override_nothing.log_id.index, &override_nothing)
-        .await?;
-    assert_eq!(None, prev);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_get() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-
-    assert!(tree.get::<Logs>(&5)?.is_none());
-
-    let logs: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(LogEntry {
-                txid: None,
-                time_ms: None,
-
-                cmd: Cmd::IncrSeq {
-                    key: "foo".to_string(),
-                },
-            }),
-        },
-    ];
-
-    tree.append::<Logs, _>(&logs).await?;
-
-    assert_eq!(None, tree.get::<Logs>(&1)?);
-    assert_eq!(Some(logs[0].clone()), tree.get::<Logs>(&2)?);
-    assert_eq!(None, tree.get::<Logs>(&3)?);
-    assert_eq!(Some(logs[1].clone()), tree.get::<Logs>(&4)?);
-    assert_eq!(None, tree.get::<Logs>(&5)?);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_last() -> anyhow::Result<()> {
+async fn test_key_space_last() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_sled_ut!();
     let _ent = ut_span.enter();
 
@@ -503,8 +133,9 @@ async fn test_sled_tree_last() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledTree::open(db, tc.tree_name, true)?;
+    let log_tree = tree.key_space::<Logs>();
 
-    assert!(tree.last::<Logs>()?.is_none());
+    assert_eq!(None, log_tree.last()?);
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -524,8 +155,9 @@ async fn test_sled_tree_last() -> anyhow::Result<()> {
         },
     ];
 
-    tree.append::<Logs, _>(&logs).await?;
-    assert_eq!(None, tree.last::<StateMachineMeta>()?);
+    log_tree.append(&logs).await?;
+    assert_eq!(Some((4, logs[1].clone())), log_tree.last()?);
+    assert_eq!(None, tree.key_space::<StateMachineMeta>().last()?);
 
     let metas = vec![
         (
@@ -535,188 +167,21 @@ async fn test_sled_tree_last() -> anyhow::Result<()> {
         (Initialized, StateMachineMetaValue::Bool(true)),
     ];
 
-    tree.append::<StateMachineMeta, _>(metas.as_slice()).await?;
+    tree.key_space::<StateMachineMeta>()
+        .append(metas.as_slice())
+        .await?;
 
-    assert_eq!(Some((4, logs[1].clone())), tree.last::<Logs>()?);
+    assert_eq!(Some((4, logs[1].clone())), log_tree.last()?);
     assert_eq!(
         Some((Initialized, StateMachineMetaValue::Bool(true))),
-        tree.last::<StateMachineMeta>()?
+        tree.key_space::<StateMachineMeta>().last()?
     );
 
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_remove() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-
-    let logs: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 9 },
-            payload: EntryPayload::Blank,
-        },
-    ];
-
-    tree.append::<Logs, _>(&logs).await?;
-
-    let removed = tree.remove::<Logs>(&0, false).await?;
-    assert_eq!(None, removed);
-    assert_eq!(logs[..], tree.range_values::<Logs, _>(0..)?);
-
-    // remove other key space
-    let removed = tree.remove::<Nodes>(&0, false).await?;
-    assert_eq!(None, removed);
-    assert_eq!(logs[..], tree.range_values::<Logs, _>(0..)?);
-
-    let removed = tree.remove::<Logs>(&2, false).await?;
-    assert_eq!(Some(logs[0].clone()), removed);
-    assert_eq!(logs[1..], tree.range_values::<Logs, _>(0..)?);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_range_remove() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-
-    let logs: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(LogEntry {
-                txid: None,
-                time_ms: None,
-
-                cmd: Cmd::IncrSeq {
-                    key: "foo".to_string(),
-                },
-            }),
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 9 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 10 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId {
-                term: 1,
-                index: 256,
-            },
-            payload: EntryPayload::Blank,
-        },
-    ];
-
-    tree.append::<Logs, _>(&logs).await?;
-    tree.range_remove::<Logs, _>(0.., false).await?;
-    assert_eq!(logs[5..], tree.range_values::<Logs, _>(0..)?);
-
-    tree.append::<Logs, _>(&logs).await?;
-    tree.range_remove::<Logs, _>(1.., false).await?;
-    assert_eq!(logs[5..], tree.range_values::<Logs, _>(0..)?);
-
-    tree.append::<Logs, _>(&logs).await?;
-    tree.range_remove::<Logs, _>(3.., true).await?;
-    assert_eq!(logs[0..1], tree.range_values::<Logs, _>(0..)?);
-
-    tree.append::<Logs, _>(&logs).await?;
-    tree.range_remove::<Logs, _>(3..10, true).await?;
-    assert_eq!(logs[0..1], tree.range_values::<Logs, _>(0..5)?);
-    assert_eq!(logs[3..], tree.range_values::<Logs, _>(5..)?);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_sled_tree_multi_types() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-
-    let logs: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(LogEntry {
-                txid: None,
-                time_ms: None,
-
-                cmd: Cmd::IncrSeq {
-                    key: "foo".to_string(),
-                },
-            }),
-        },
-    ];
-
-    tree.append::<Logs, _>(&logs).await?;
-
-    let metas = vec![
-        (
-            LastApplied,
-            StateMachineMetaValue::LogId(LogId { term: 1, index: 2 }),
-        ),
-        (Initialized, StateMachineMetaValue::Bool(true)),
-    ];
-    tree.append::<StateMachineMeta, _>(&metas).await?;
-
-    // range get/keys are limited to its own namespace.
-    {
-        let got = tree.range_values::<Logs, _>(..)?;
-        assert_eq!(logs, got);
-
-        let got = tree.range_values::<StateMachineMeta, _>(..=LastApplied)?;
-        assert_eq!(
-            vec![StateMachineMetaValue::LogId(LogId { term: 1, index: 2 })],
-            got
-        );
-
-        let got = tree.range_values::<StateMachineMeta, _>(Initialized..)?;
-        assert_eq!(vec![StateMachineMetaValue::Bool(true)], got);
-
-        let got = tree.range_keys::<StateMachineMeta, _>(Initialized..)?;
-        assert_eq!(vec![Initialized], got);
-    }
-
-    // range remove are limited to its own namespace.
-    {
-        tree.range_remove::<StateMachineMeta, _>(.., false).await?;
-
-        let got = tree.range_values::<Logs, _>(..)?;
-        assert_eq!(logs, got);
-    }
-
-    Ok(())
-}
-
-// --- key space test ---
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_as_append() -> anyhow::Result<()> {
+async fn test_key_space_append() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_sled_ut!();
     let _ent = ut_span.enter();
 
@@ -776,7 +241,7 @@ async fn test_as_append() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_as_append_and_range_get() -> anyhow::Result<()> {
+async fn test_key_space_append_and_range_get() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_sled_ut!();
     let _ent = ut_span.enter();
 
@@ -853,7 +318,7 @@ async fn test_as_append_and_range_get() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_as_range_keys() -> anyhow::Result<()> {
+async fn test_key_space_range_kvs() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_sled_ut!();
     let _ent = ut_span.enter();
 
@@ -879,68 +344,18 @@ async fn test_as_range_keys() -> anyhow::Result<()> {
 
     log_tree.append(&logs).await?;
 
-    let got = log_tree.range_keys(0..)?;
-    assert_eq!(vec![2, 9, 10], got);
+    let got = log_tree
+        .range(9..)?
+        .map(|x| x.unwrap().kv().unwrap())
+        .collect::<Vec<_>>();
 
-    let got = log_tree.range_keys(0..=2)?;
-    assert_eq!(vec![2], got);
-
-    let got = log_tree.range_keys(0..3)?;
-    assert_eq!(vec![2], got);
-
-    let got = log_tree.range_keys(0..10)?;
-    assert_eq!(vec![2, 9], got);
-
-    let got = log_tree.range_keys(0..11)?;
-    assert_eq!(vec![2, 9, 10], got);
-
-    let got = log_tree.range_keys(9..11)?;
-    assert_eq!(vec![9, 10], got);
-
-    let got = log_tree.range_keys(10..256)?;
-    assert_eq!(vec![10], got);
-
-    let got = log_tree.range_keys(11..)?;
-    assert_eq!(Vec::<LogIndex>::new(), got);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_as_range_kvs() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-    let log_tree = tree.key_space::<Logs>();
-
-    let logs: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 9 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 10 },
-            payload: EntryPayload::Blank,
-        },
-    ];
-
-    log_tree.append(&logs).await?;
-
-    let got = log_tree.range_kvs(9..)?;
     assert_eq!(vec![(9, logs[1].clone()), (10, logs[2].clone()),], got);
 
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_as_scan_prefix() -> anyhow::Result<()> {
+async fn test_key_space_scan_prefix() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_sled_ut!();
     let _ent = ut_span.enter();
 
@@ -984,7 +399,7 @@ async fn test_as_scan_prefix() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_as_insert() -> anyhow::Result<()> {
+async fn test_key_space_insert() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_sled_ut!();
     let _ent = ut_span.enter();
 
@@ -1013,9 +428,7 @@ async fn test_as_insert() -> anyhow::Result<()> {
         },
     ];
 
-    for log in logs.iter() {
-        log_tree.insert(&log.log_id.index, log).await?;
-    }
+    log_tree.append(&logs).await?;
 
     assert_eq!(logs, log_tree.range_values(..)?);
 
@@ -1050,7 +463,7 @@ async fn test_as_insert() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_as_get() -> anyhow::Result<()> {
+async fn test_key_space_get() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_sled_ut!();
     let _ent = ut_span.enter();
 
@@ -1091,77 +504,7 @@ async fn test_as_get() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_as_last() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-    let log_tree = tree.key_space::<Logs>();
-
-    assert_eq!(None, log_tree.last()?);
-
-    let logs: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 3, index: 4 },
-            payload: EntryPayload::Normal(LogEntry {
-                txid: None,
-                time_ms: None,
-
-                cmd: Cmd::IncrSeq {
-                    key: "foo".to_string(),
-                },
-            }),
-        },
-    ];
-
-    log_tree.append(&logs).await?;
-    assert_eq!(Some((4, logs[1].clone())), log_tree.last()?);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_as_remove() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_sled_ut!();
-    let _ent = ut_span.enter();
-
-    let tc = new_sled_test_context();
-    let db = &tc.db;
-    let tree = SledTree::open(db, tc.tree_name, true)?;
-    let log_tree = tree.key_space::<Logs>();
-
-    let logs: Vec<Entry<LogEntry>> = vec![
-        Entry {
-            log_id: LogId { term: 1, index: 2 },
-            payload: EntryPayload::Blank,
-        },
-        Entry {
-            log_id: LogId { term: 1, index: 9 },
-            payload: EntryPayload::Blank,
-        },
-    ];
-
-    log_tree.append(&logs).await?;
-
-    let removed = log_tree.remove(&0, false).await?;
-    assert_eq!(None, removed);
-    assert_eq!(logs[..], log_tree.range_values(0..)?);
-
-    let removed = log_tree.remove(&2, false).await?;
-    assert_eq!(Some(logs[0].clone()), removed);
-    assert_eq!(logs[1..], log_tree.range_values(0..)?);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_as_range_remove() -> anyhow::Result<()> {
+async fn test_key_space_range_remove() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_sled_ut!();
     let _ent = ut_span.enter();
 
@@ -1224,7 +567,7 @@ async fn test_as_range_remove() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_as_multi_types() -> anyhow::Result<()> {
+async fn test_key_space_multi_types() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_sled_ut!();
     let _ent = ut_span.enter();
 
@@ -1277,7 +620,10 @@ async fn test_as_multi_types() -> anyhow::Result<()> {
         let got = sm_meta.range_values(Initialized..)?;
         assert_eq!(vec![StateMachineMetaValue::Bool(true)], got);
 
-        let got = sm_meta.range_keys(Initialized..)?;
+        let got = sm_meta
+            .range(Initialized..)?
+            .map(|x| x.unwrap().key().unwrap())
+            .collect::<Vec<_>>();
         assert_eq!(vec![Initialized], got);
     }
 

--- a/src/meta/sled-store/tests/it/sled_txn_tree.rs
+++ b/src/meta/sled-store/tests/it/sled_txn_tree.rs
@@ -229,7 +229,7 @@ async fn test_sled_txn_tree_key_space_update_and_fetch() -> anyhow::Result<()> {
         Ok(())
     })?;
 
-    let got = tree.get::<Nodes>(&100)?.unwrap();
+    let got = tree.key_space::<Nodes>().get(&100)?.unwrap();
     assert_eq!(
         "aa".to_string(),
         got.name,
@@ -245,7 +245,7 @@ async fn test_sled_txn_tree_key_space_update_and_fetch() -> anyhow::Result<()> {
         Ok(())
     })?;
 
-    let got = tree.get::<Nodes>(&100)?;
+    let got = tree.key_space::<Nodes>().get(&100)?;
     assert!(got.is_none(), "delete by return None");
     Ok(())
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/sled): simplify SledTree APIs

Remove unused API from `SledTree`, and merge APIs with similar
functions, such as `range_keys()`, `range_values()` and `range_kvs()`
and be replaced with a simple `range()`; `insert()` can be replaced with
`append()`.

Make `SledTree` APIs crate-public. Only leave key-space based API public.

## Changelog







## Related Issues