### PR TITLE
feat(planner): optimize right join

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::Ordering;
-
 use common_arrow::arrow::bitmap::Bitmap;
 use common_arrow::arrow::bitmap::MutableBitmap;
 use common_catalog::table_context::TableContext;
@@ -203,7 +201,7 @@ impl JoinHashTable {
 
     pub(crate) fn find_unmatched_build_indexes(
         &self,
-        row_state: &Vec<Vec<usize>>,
+        row_state: &[Vec<usize>],
     ) -> Result<Vec<RowPtr>> {
         // For right/full join, build side will appear at least once in the joined table
         // Find the unmatched rows in build side
@@ -263,7 +261,7 @@ impl JoinHashTable {
         let mut row_state = Vec::with_capacity(chunks.len());
         for chunk in chunks.iter() {
             let mut rows = Vec::with_capacity(chunk.num_rows());
-            for row_index in 0..chunk.num_rows() {
+            for _row_index in 0..chunk.num_rows() {
                 rows.push(0);
             }
             row_state.push(rows);

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/desc.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/desc.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
 use common_catalog::table_context::TableContext;

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/desc.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/desc.rs
@@ -46,8 +46,6 @@ pub struct RightJoinDesc {
     /// Record rows in build side that are matched with rows in probe side.
     /// It's order-sensitive, aligned with the order of rows in merged block.
     pub(crate) build_indexes: RwLock<Vec<RowPtr>>,
-    /// Record row in build side that is matched how many rows in probe side.
-    pub(crate) row_state: RwLock<HashMap<RowPtr, Arc<AtomicUsize>>>,
 }
 
 impl RightJoinDesc {
@@ -55,7 +53,6 @@ impl RightJoinDesc {
         let max_block_size = ctx.get_settings().get_max_block_size()? as usize;
         Ok(RightJoinDesc {
             build_indexes: RwLock::new(Vec::with_capacity(max_block_size)),
-            row_state: RwLock::new(HashMap::with_capacity(max_block_size)),
         })
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_join.rs
@@ -95,11 +95,11 @@ impl JoinHashTable {
                         let mut build_indexes =
                             self.hash_join_desc.right_join_desc.build_indexes.write();
                         // dummy row ptr
-                        // here assume there is no RowPtr, which chunk_index is u32::MAX and row_index is u32::MAX
+                        // here assume there is no RowPtr, which chunk_index is usize::MAX and row_index is usize::MAX
                         build_indexes.push(RowPtr {
                             chunk_index: usize::MAX,
                             row_index: usize::MAX,
-                            marker: None,
+                            marker: Some(MarkerKind::False),
                         });
                     }
                     // dummy row ptr

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_join.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::iter::TrustedLen;
-use std::sync::atomic::Ordering;
 
 use common_arrow::arrow::bitmap::Bitmap;
 use common_arrow::arrow::bitmap::MutableBitmap;

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_join.rs
@@ -75,7 +75,10 @@ impl JoinHashTable {
                             self.hash_join_desc.right_join_desc.build_indexes.write();
                         build_indexes.extend(probe_result_ptrs);
                         for row_ptr in probe_result_ptrs.iter() {
-                            full_row_state.get(row_ptr).unwrap().fetch_add(1, Ordering::Relaxed);
+                            full_row_state
+                                .get(row_ptr)
+                                .unwrap()
+                                .fetch_add(1, Ordering::Relaxed);
                         }
                     }
 
@@ -216,7 +219,10 @@ impl JoinHashTable {
             let build_indexes = self.hash_join_desc.right_join_desc.build_indexes.read();
             for (idx, build_index) in build_indexes.iter().enumerate() {
                 if !bm.get(idx) {
-                    full_row_state.get(build_index).unwrap().store(0, Ordering::Relaxed);
+                    full_row_state
+                        .get(build_index)
+                        .unwrap()
+                        .store(0, Ordering::Relaxed);
                 }
             }
         }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
@@ -44,19 +44,12 @@ impl JoinHashTable {
         let valids = &probe_state.valids;
         let mut validity = MutableBitmap::with_capacity(input.num_rows());
         let mut build_indexes = self.hash_join_desc.right_join_desc.build_indexes.write();
-        let row_state = self.hash_join_desc.right_join_desc.row_state.read();
         let build_indexes_len = build_indexes.len();
         for (i, key) in keys_iter.enumerate() {
             let probe_result_ptr = self.probe_key(hash_table, key, valids, i);
             if let Some(v) = probe_result_ptr {
                 let probe_result_ptrs = v.get_value();
                 build_indexes.extend(probe_result_ptrs);
-                for row_ptr in probe_result_ptrs.iter() {
-                    row_state
-                        .get(row_ptr)
-                        .unwrap()
-                        .fetch_add(1, Ordering::Relaxed);
-                }
                 probe_indexes.extend(std::iter::repeat(i as u32).take(probe_result_ptrs.len()));
                 validity.extend_constant(probe_result_ptrs.len(), true);
             }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::iter::TrustedLen;
-use std::sync::atomic::Ordering;
 
 use common_arrow::arrow::bitmap::Bitmap;
 use common_arrow::arrow::bitmap::MutableBitmap;

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
@@ -52,7 +52,10 @@ impl JoinHashTable {
                 let probe_result_ptrs = v.get_value();
                 build_indexes.extend(probe_result_ptrs);
                 for row_ptr in probe_result_ptrs.iter() {
-                    row_state.get(row_ptr).unwrap().fetch_add(1, Ordering::Relaxed);
+                    row_state
+                        .get(row_ptr)
+                        .unwrap()
+                        .fetch_add(1, Ordering::Relaxed);
                 }
                 probe_indexes.extend(std::iter::repeat(i as u32).take(probe_result_ptrs.len()));
                 validity.extend_constant(probe_result_ptrs.len(), true);

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::iter::TrustedLen;
+use std::sync::atomic::Ordering;
 
 use common_arrow::arrow::bitmap::Bitmap;
 use common_arrow::arrow::bitmap::MutableBitmap;
@@ -39,32 +40,26 @@ impl JoinHashTable {
         Key: HashTableKeyable + Clone + 'static,
         IT: Iterator<Item = Key> + TrustedLen,
     {
-        let local_build_indexes = &mut probe_state.build_indexs;
         let probe_indexes = &mut probe_state.probe_indexs;
         let valids = &probe_state.valids;
-        let mut validity = MutableBitmap::new();
+        let mut validity = MutableBitmap::with_capacity(input.num_rows());
         let mut build_indexes = self.hash_join_desc.right_join_desc.build_indexes.write();
+        let row_state = self.hash_join_desc.right_join_desc.row_state.read();
+        let build_indexes_len = build_indexes.len();
         for (i, key) in keys_iter.enumerate() {
             let probe_result_ptr = self.probe_key(hash_table, key, valids, i);
             if let Some(v) = probe_result_ptr {
                 let probe_result_ptrs = v.get_value();
                 build_indexes.extend(probe_result_ptrs);
-                local_build_indexes.extend_from_slice(probe_result_ptrs);
                 for row_ptr in probe_result_ptrs.iter() {
-                    {
-                        let mut row_state = self.hash_join_desc.right_join_desc.row_state.write();
-                        row_state
-                            .entry(*row_ptr)
-                            .and_modify(|e| *e += 1)
-                            .or_insert(1_usize);
-                    }
+                    row_state.get(row_ptr).unwrap().fetch_add(1, Ordering::Relaxed);
                 }
                 probe_indexes.extend(std::iter::repeat(i as u32).take(probe_result_ptrs.len()));
                 validity.extend_constant(probe_result_ptrs.len(), true);
             }
         }
 
-        let build_block = self.row_space.gather(local_build_indexes)?;
+        let build_block = self.row_space.gather(&build_indexes[build_indexes_len..])?;
         let mut probe_block = DataBlock::block_take_by_indices(input, probe_indexes)?;
 
         // If join type is right join, need to wrap nullable for probe side

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/row.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/row.rs
@@ -40,9 +40,19 @@ impl Chunk {
 
 #[derive(Clone, Copy, Debug)]
 pub struct RowPtr {
-    pub chunk_index: u32,
-    pub row_index: u32,
+    pub chunk_index: usize,
+    pub row_index: usize,
     pub marker: Option<MarkerKind>,
+}
+
+impl RowPtr {
+    pub fn new(chunk_index: usize, row_index: usize) -> Self {
+        RowPtr {
+            chunk_index,
+            row_index,
+            marker: None,
+        }
+    }
 }
 
 pub struct RowSpace {

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/row.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/row.rs
@@ -93,11 +93,6 @@ impl RowSpace {
         chunks.iter().map(|c| c.data_block.clone()).collect()
     }
 
-    pub fn rows_number(&self) -> usize {
-        let chunks = self.chunks.read().unwrap();
-        chunks.iter().map(|c| c.num_rows()).sum()
-    }
-
     pub fn gather(&self, row_ptrs: &[RowPtr]) -> Result<DataBlock> {
         let data_blocks = self.datablocks();
         let num_rows = data_blocks

--- a/src/query/service/src/sql/executor/pipeline_builder.rs
+++ b/src/query/service/src/sql/executor/pipeline_builder.rs
@@ -148,7 +148,7 @@ impl PipelineBuilder {
             &join.build_keys,
             join.build.output_schema()?,
             join.probe.output_schema()?,
-            HashJoinDesc::create(join)?,
+            HashJoinDesc::create(self.ctx.clone(), join)?,
         )
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The ticket aims to optimize right join based tpch 13.

```sql
select
    c_count,
    count(*) as custdist
from
    (
        select
            c_custkey,
            count(o_orderkey) as c_count
        from
            customer
                left outer join
            orders
            on c_custkey = o_custkey
                and o_comment not like '%pending%deposits%'
        group by
            c_custkey
    )
        c_orders
group by
    c_count
order by
    custdist desc,
    c_count desc;
```

Before:

<img width="1919" alt="image" src="https://user-images.githubusercontent.com/41979257/195756530-65453ed1-fd07-4125-b2e1-69156c5ee0e3.png">

Now:

<img width="1919" alt="image" src="https://user-images.githubusercontent.com/41979257/195756559-1ec92b42-8fa0-4dba-bd5b-3bf2de7bad71.png">

After the ticket, tpch13 will speed up 2x and performance bottleneck will become https://github.com/datafuselabs/databend/issues/8118 (@TCeason is working on it).

Part of https://github.com/datafuselabs/databend/issues/8073
