### PR TITLE
chore: change log level to warn for io retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4666,12 +4666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/transform_deserializer.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/transform_deserializer.rs
@@ -101,7 +101,7 @@ impl<I: InputFormatPipe> Processor for DeserializeTransformer<I> {
         } else {
             match self.processor.output_buffer.pop_front() {
                 Some(data_block) => {
-                    tracing::info!("DeserializeTransformer push rows {}", data_block.num_rows());
+                    tracing::trace!("DeserializeTransformer push rows {}", data_block.num_rows());
                     self.output.push_data(Ok(data_block));
                     Ok(Event::NeedConsume)
                 }

--- a/src/query/service/src/storages/result/writer.rs
+++ b/src/query/service/src/storages/result/writer.rs
@@ -26,7 +26,7 @@ use common_legacy_planners::PartInfoPtr;
 use common_streams::SendableDataBlockStream;
 use futures::StreamExt;
 use opendal::Operator;
-use tracing::debug;
+use tracing::warn;
 
 use crate::sessions::QueryContext;
 use crate::sessions::TableContext;
@@ -111,7 +111,7 @@ impl ResultTableWriter {
             .retry(ExponentialBackoff::default())
             .when(|err| err.kind() == ErrorKind::Interrupted)
             .notify(|err, dur| {
-                debug!(
+                warn!(
                     "append block write retry after {}s for error {:?}",
                     dur.as_secs(),
                     err

--- a/src/query/service/src/storages/stage/stage_table_sink.rs
+++ b/src/query/service/src/storages/stage/stage_table_sink.rs
@@ -32,7 +32,7 @@ use common_pipeline_core::processors::processor::Event;
 use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_core::processors::Processor;
 use opendal::Operator;
-use tracing::debug;
+use tracing::warn;
 
 use crate::sessions::TableContext;
 
@@ -277,7 +277,7 @@ impl Processor for StageTableSink {
                     .retry(ExponentialBackoff::default())
                     .when(|err| err.kind() == ErrorKind::Interrupted)
                     .notify(|err, dur| {
-                        debug!(
+                        warn!(
                             "stage table sink write retry after {}s for error {:?}",
                             dur.as_secs(),
                             err

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -26,7 +26,7 @@ use common_fuse_meta::meta::BlockMeta;
 use common_fuse_meta::meta::ClusterStatistics;
 use common_fuse_meta::meta::Location;
 use opendal::Operator;
-use tracing::debug;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::index::BlockFilter;
@@ -136,7 +136,7 @@ pub async fn write_data(data: &[u8], data_accessor: &Operator, location: &str) -
         .retry(ExponentialBackoff::default())
         .when(|err| err.kind() == ErrorKind::Interrupted)
         .notify(|err, dur| {
-            debug!(
+            warn!(
                 "fuse table block writer write_data retry after {}s for error {:?}",
                 dur.as_secs(),
                 err

--- a/src/query/storages/fuse/src/io/write/meta_writer.rs
+++ b/src/query/storages/fuse/src/io/write/meta_writer.rs
@@ -20,7 +20,7 @@ use backon::Retryable;
 use common_exception::Result;
 use opendal::Operator;
 use serde::Serialize;
-use tracing::debug;
+use tracing::warn;
 
 pub async fn write_meta<T>(data_accessor: &Operator, location: &str, meta: T) -> Result<()>
 where T: Serialize {
@@ -30,7 +30,7 @@ where T: Serialize {
         .retry(ExponentialBackoff::default())
         .when(|err| err.kind() == ErrorKind::Interrupted)
         .notify(|err, dur| {
-            debug!(
+            warn!(
                 "stage table sink write retry after {}s for error {:?}",
                 dur.as_secs(),
                 err

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -382,7 +382,7 @@ impl FuseTable {
             .retry(backon::ExponentialBackoff::default())
             .when(|err| err.kind() == ErrorKind::Interrupted)
             .notify(|err, dur| {
-                debug!(
+                warn!(
                     "fuse table write_last_snapshot_hint retry after {}s for error {:?}",
                     dur.as_secs(),
                     err


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Change io retry from `debug` to `warn`
* Change `info` to `trace` for `transform_deserializer.rs` to less log

Fixes #issue
