### PR TITLE
feat(meta/schema_api): add API list_all_tables

### DIFF
--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -35,6 +35,7 @@ use common_meta_app::schema::RenameDatabaseReply;
 use common_meta_app::schema::RenameDatabaseReq;
 use common_meta_app::schema::RenameTableReply;
 use common_meta_app::schema::RenameTableReq;
+use common_meta_app::schema::TableId;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
@@ -92,6 +93,14 @@ pub trait SchemaApi: Send + Sync {
     // table
 
     async fn create_table(&self, req: CreateTableReq) -> Result<CreateTableReply, KVAppError>;
+
+    /// List all tables belonging to every db and every tenant.
+    ///
+    /// I.e.: all tables found in key-space: `__fd_table_by_id/`.
+    /// Notice that this key space includes both deleted and non-deleted table-metas. `TableMeta.drop_on.is_some()` indicates it's a deleted(but not yet gargbage collected) one.
+    ///
+    /// It returns a list of (table-id, table-meta-seq, table-meta).
+    async fn list_all_tables(&self) -> Result<Vec<(TableId, u64, TableMeta)>, KVAppError>;
 
     async fn drop_table(&self, req: DropTableReq) -> Result<DropTableReply, KVAppError>;
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feat(meta/schema_api): add API list_all_tables

`list_all_tables()` returns a list of every table that stored in
the meta-store.

It is meant for interanl usages such cleaning up garbage data(e.g.
cleaning up unreferenced object in s3).

## Changelog







## Related Issues