### PR TITLE
feat: optimize subquery by deleting redundancy join

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4666,12 +4666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/query/service/src/sql/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/service/src/sql/planner/optimizer/heuristic/decorrelate.rs
@@ -39,6 +39,7 @@ use crate::sql::plans::AndExpr;
 use crate::sql::plans::BoundColumnRef;
 use crate::sql::plans::CastExpr;
 use crate::sql::plans::ComparisonExpr;
+use crate::sql::plans::ComparisonOp;
 use crate::sql::plans::EvalScalar;
 use crate::sql::plans::Filter;
 use crate::sql::plans::FunctionCall;
@@ -238,7 +239,7 @@ impl SubqueryRewriter {
             SubqueryType::Scalar => {
                 let correlated_columns = subquery.outer_columns.clone();
                 let flatten_plan =
-                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info)?;
+                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info, true)?;
                 // Construct single join
                 let mut left_conditions = Vec::with_capacity(correlated_columns.len());
                 let mut right_conditions = Vec::with_capacity(correlated_columns.len());
@@ -266,7 +267,7 @@ impl SubqueryRewriter {
                 }
                 let correlated_columns = subquery.outer_columns.clone();
                 let flatten_plan =
-                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info)?;
+                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info, true)?;
                 // Construct mark join
                 let mut left_conditions = Vec::with_capacity(correlated_columns.len());
                 let mut right_conditions = Vec::with_capacity(correlated_columns.len());
@@ -299,7 +300,7 @@ impl SubqueryRewriter {
             SubqueryType::Any => {
                 let correlated_columns = subquery.outer_columns.clone();
                 let flatten_plan =
-                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info)?;
+                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info, true)?;
                 let mut left_conditions = Vec::with_capacity(correlated_columns.len());
                 let mut right_conditions = Vec::with_capacity(correlated_columns.len());
                 self.add_equi_conditions(
@@ -362,10 +363,14 @@ impl SubqueryRewriter {
         plan: &SExpr,
         correlated_columns: &ColumnSet,
         flatten_info: &mut FlattenInfo,
+        need_cross_join: bool,
     ) -> Result<SExpr> {
         let rel_expr = RelExpr::with_s_expr(plan);
         let prop = rel_expr.derive_relational_prop()?;
         if prop.outer_columns.is_empty() {
+            if !need_cross_join {
+                return Ok(plan.clone());
+            }
             // Construct a LogicalGet plan by correlated columns.
             // Finally generate a cross join, so we finish flattening the subquery.
             let mut metadata = self.metadata.write();
@@ -420,7 +425,7 @@ impl SubqueryRewriter {
         match plan.plan() {
             RelOperator::EvalScalar(eval_scalar) => {
                 let flatten_plan =
-                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
+                    self.flatten(plan.child(0)?, correlated_columns, flatten_info, true)?;
                 let mut items = Vec::with_capacity(eval_scalar.items.len());
                 for item in eval_scalar.items.iter() {
                     let new_item = ScalarItem {
@@ -453,14 +458,69 @@ impl SubqueryRewriter {
                 ))
             }
             RelOperator::Filter(filter) => {
-                let flatten_plan =
-                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
+                let mut need_cross_join = true;
+                let mut predicates_set: HashSet<Scalar> =
+                    HashSet::from_iter(filter.predicates.iter().cloned());
                 let mut predicates = Vec::with_capacity(filter.predicates.len());
+                if filter.predicates.iter().all(|predicate| {
+                    if predicate.used_columns().iter().all(|column| {
+                        if correlated_columns.contains(column) {
+                            if let Scalar::ComparisonExpr(ComparisonExpr {
+                                left, right, op, ..
+                            }) = predicate
+                            {
+                                if op == &ComparisonOp::Equal {
+                                    if let Scalar::BoundColumnRef(BoundColumnRef {
+                                        column: left_column,
+                                    }) = &**left
+                                    {
+                                        if let Scalar::BoundColumnRef(BoundColumnRef {
+                                            column: right_column,
+                                        }) = &**right
+                                        {
+                                            if correlated_columns.contains(&left_column.index)
+                                                && !correlated_columns.contains(&right_column.index)
+                                            {
+                                            }
+                                            if !correlated_columns.contains(&left_column.index)
+                                                && correlated_columns.contains(&right_column.index)
+                                            {
+                                                self.derived_columns
+                                                    .insert(right_column.index, left_column.index);
+                                            }
+                                            predicates_set.remove(predicate);
+                                            return true;
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            return true;
+                        }
+                        false
+                    }) {
+                        return true;
+                    }
+                    false
+                }) {
+                    need_cross_join = false;
+                }
+                let flatten_plan = self.flatten(
+                    plan.child(0)?,
+                    correlated_columns,
+                    flatten_info,
+                    need_cross_join,
+                )?;
+
                 for predicate in filter.predicates.iter() {
                     predicates.push(self.flatten_scalar(predicate, correlated_columns)?);
                 }
                 let filter_plan = Filter {
-                    predicates,
+                    predicates: if !need_cross_join {
+                        predicates_set.into_iter().collect()
+                    } else {
+                        predicates
+                    },
                     is_having: filter.is_having,
                 }
                 .into();
@@ -469,9 +529,9 @@ impl SubqueryRewriter {
             RelOperator::LogicalInnerJoin(join) => {
                 // Currently, we don't support join conditions contain subquery
                 let left_flatten_plan =
-                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
+                    self.flatten(plan.child(0)?, correlated_columns, flatten_info, true)?;
                 let right_flatten_plan =
-                    self.flatten(plan.child(1)?, correlated_columns, flatten_info)?;
+                    self.flatten(plan.child(1)?, correlated_columns, flatten_info, true)?;
                 Ok(SExpr::create_binary(
                     LogicalInnerJoin {
                         left_conditions: join.left_conditions.clone(),
@@ -488,7 +548,7 @@ impl SubqueryRewriter {
             }
             RelOperator::Aggregate(aggregate) => {
                 let flatten_plan =
-                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
+                    self.flatten(plan.child(0)?, correlated_columns, flatten_info, true)?;
                 let mut group_items = Vec::with_capacity(aggregate.group_items.len());
                 for item in aggregate.group_items.iter() {
                     let scalar = self.flatten_scalar(&item.scalar, correlated_columns)?;
@@ -546,15 +606,15 @@ impl SubqueryRewriter {
             RelOperator::Sort(_) | RelOperator::Limit(_) => {
                 // Currently, we don't support sort and limit contain subquery.
                 let flatten_plan =
-                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
+                    self.flatten(plan.child(0)?, correlated_columns, flatten_info, true)?;
                 Ok(SExpr::create_unary(plan.plan().clone(), flatten_plan))
             }
 
             RelOperator::UnionAll(op) => {
                 let left_flatten_plan =
-                    self.flatten(plan.child(0)?, correlated_columns, flatten_info)?;
+                    self.flatten(plan.child(0)?, correlated_columns, flatten_info, true)?;
                 let right_flatten_plan =
-                    self.flatten(plan.child(1)?, correlated_columns, flatten_info)?;
+                    self.flatten(plan.child(1)?, correlated_columns, flatten_info, true)?;
                 Ok(SExpr::create_binary(
                     op.clone().into(),
                     left_flatten_plan,

--- a/src/query/service/src/sql/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/service/src/sql/planner/optimizer/heuristic/decorrelate.rs
@@ -481,6 +481,8 @@ impl SubqueryRewriter {
                                             if correlated_columns.contains(&left_column.index)
                                                 && !correlated_columns.contains(&right_column.index)
                                             {
+                                                self.derived_columns
+                                                    .insert(left_column.index, right_column.index);
                                             }
                                             if !correlated_columns.contains(&left_column.index)
                                                 && correlated_columns.contains(&right_column.index)

--- a/src/query/service/src/sql/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/service/src/sql/planner/optimizer/heuristic/decorrelate.rs
@@ -46,6 +46,7 @@ use crate::sql::plans::FunctionCall;
 use crate::sql::plans::JoinType;
 use crate::sql::plans::LogicalGet;
 use crate::sql::plans::LogicalInnerJoin;
+use crate::sql::plans::LogicalOperator;
 use crate::sql::plans::OrExpr;
 use crate::sql::plans::PatternPlan;
 use crate::sql::plans::RelOp;
@@ -239,7 +240,7 @@ impl SubqueryRewriter {
             SubqueryType::Scalar => {
                 let correlated_columns = subquery.outer_columns.clone();
                 let flatten_plan =
-                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info, true)?;
+                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info, false)?;
                 // Construct single join
                 let mut left_conditions = Vec::with_capacity(correlated_columns.len());
                 let mut right_conditions = Vec::with_capacity(correlated_columns.len());
@@ -267,7 +268,7 @@ impl SubqueryRewriter {
                 }
                 let correlated_columns = subquery.outer_columns.clone();
                 let flatten_plan =
-                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info, true)?;
+                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info, false)?;
                 // Construct mark join
                 let mut left_conditions = Vec::with_capacity(correlated_columns.len());
                 let mut right_conditions = Vec::with_capacity(correlated_columns.len());
@@ -300,7 +301,7 @@ impl SubqueryRewriter {
             SubqueryType::Any => {
                 let correlated_columns = subquery.outer_columns.clone();
                 let flatten_plan =
-                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info, true)?;
+                    self.flatten(&subquery.subquery, &correlated_columns, flatten_info, false)?;
                 let mut left_conditions = Vec::with_capacity(correlated_columns.len());
                 let mut right_conditions = Vec::with_capacity(correlated_columns.len());
                 self.add_equi_conditions(
@@ -363,7 +364,7 @@ impl SubqueryRewriter {
         plan: &SExpr,
         correlated_columns: &ColumnSet,
         flatten_info: &mut FlattenInfo,
-        need_cross_join: bool,
+        mut need_cross_join: bool,
     ) -> Result<SExpr> {
         let rel_expr = RelExpr::with_s_expr(plan);
         let prop = rel_expr.derive_relational_prop()?;
@@ -424,8 +425,19 @@ impl SubqueryRewriter {
 
         match plan.plan() {
             RelOperator::EvalScalar(eval_scalar) => {
-                let flatten_plan =
-                    self.flatten(plan.child(0)?, correlated_columns, flatten_info, true)?;
+                if eval_scalar
+                    .used_columns()?
+                    .iter()
+                    .any(|index| correlated_columns.contains(index))
+                {
+                    need_cross_join = true;
+                }
+                let flatten_plan = self.flatten(
+                    plan.child(0)?,
+                    correlated_columns,
+                    flatten_info,
+                    need_cross_join,
+                )?;
                 let mut items = Vec::with_capacity(eval_scalar.items.len());
                 for item in eval_scalar.items.iter() {
                     let new_item = ScalarItem {
@@ -458,25 +470,21 @@ impl SubqueryRewriter {
                 ))
             }
             RelOperator::Filter(filter) => {
-                let mut predicates_set: HashSet<Scalar> =
-                    HashSet::from_iter(filter.predicates.iter().cloned());
                 let mut predicates = Vec::with_capacity(filter.predicates.len());
-                let need_cross_join =
-                    self.join_outer_inner_table(filter, &mut predicates_set, correlated_columns)?;
+                if !need_cross_join {
+                    need_cross_join = self.join_outer_inner_table(filter, correlated_columns)?;
+                    if need_cross_join {
+                        self.derived_columns.clear();
+                    }
+                }
                 let flatten_plan = self.flatten(
                     plan.child(0)?,
                     correlated_columns,
                     flatten_info,
                     need_cross_join,
                 )?;
-                if need_cross_join {
-                    for predicate in filter.predicates.iter() {
-                        predicates.push(self.flatten_scalar(predicate, correlated_columns)?);
-                    }
-                } else {
-                    for predicate in predicates_set.iter() {
-                        predicates.push(self.flatten_scalar(predicate, correlated_columns)?);
-                    }
+                for predicate in filter.predicates.iter() {
+                    predicates.push(self.flatten_scalar(predicate, correlated_columns)?);
                 }
 
                 let filter_plan = Filter {
@@ -488,10 +496,25 @@ impl SubqueryRewriter {
             }
             RelOperator::LogicalInnerJoin(join) => {
                 // Currently, we don't support join conditions contain subquery
-                let left_flatten_plan =
-                    self.flatten(plan.child(0)?, correlated_columns, flatten_info, true)?;
-                let right_flatten_plan =
-                    self.flatten(plan.child(1)?, correlated_columns, flatten_info, true)?;
+                if join
+                    .used_columns()?
+                    .iter()
+                    .any(|index| correlated_columns.contains(index))
+                {
+                    need_cross_join = true;
+                }
+                let left_flatten_plan = self.flatten(
+                    plan.child(0)?,
+                    correlated_columns,
+                    flatten_info,
+                    need_cross_join,
+                )?;
+                let right_flatten_plan = self.flatten(
+                    plan.child(1)?,
+                    correlated_columns,
+                    flatten_info,
+                    need_cross_join,
+                )?;
                 Ok(SExpr::create_binary(
                     LogicalInnerJoin {
                         left_conditions: join.left_conditions.clone(),
@@ -507,8 +530,19 @@ impl SubqueryRewriter {
                 ))
             }
             RelOperator::Aggregate(aggregate) => {
-                let flatten_plan =
-                    self.flatten(plan.child(0)?, correlated_columns, flatten_info, true)?;
+                if aggregate
+                    .used_columns()?
+                    .iter()
+                    .any(|index| correlated_columns.contains(index))
+                {
+                    need_cross_join = true;
+                }
+                let flatten_plan = self.flatten(
+                    plan.child(0)?,
+                    correlated_columns,
+                    flatten_info,
+                    need_cross_join,
+                )?;
                 let mut group_items = Vec::with_capacity(aggregate.group_items.len());
                 for item in aggregate.group_items.iter() {
                     let scalar = self.flatten_scalar(&item.scalar, correlated_columns)?;
@@ -563,18 +597,62 @@ impl SubqueryRewriter {
                     flatten_plan,
                 ))
             }
-            RelOperator::Sort(_) | RelOperator::Limit(_) => {
-                // Currently, we don't support sort and limit contain subquery.
-                let flatten_plan =
-                    self.flatten(plan.child(0)?, correlated_columns, flatten_info, true)?;
+            RelOperator::Sort(op) => {
+                // Currently, we don't support sort contain subquery.
+                if op
+                    .used_columns()?
+                    .iter()
+                    .any(|index| correlated_columns.contains(index))
+                {
+                    need_cross_join = true;
+                }
+                let flatten_plan = self.flatten(
+                    plan.child(0)?,
+                    correlated_columns,
+                    flatten_info,
+                    need_cross_join,
+                )?;
+                Ok(SExpr::create_unary(plan.plan().clone(), flatten_plan))
+            }
+
+            RelOperator::Limit(op) => {
+                // Currently, we don't support limit contain subquery.
+                if op
+                    .used_columns()?
+                    .iter()
+                    .any(|index| correlated_columns.contains(index))
+                {
+                    need_cross_join = true;
+                }
+                let flatten_plan = self.flatten(
+                    plan.child(0)?,
+                    correlated_columns,
+                    flatten_info,
+                    need_cross_join,
+                )?;
                 Ok(SExpr::create_unary(plan.plan().clone(), flatten_plan))
             }
 
             RelOperator::UnionAll(op) => {
-                let left_flatten_plan =
-                    self.flatten(plan.child(0)?, correlated_columns, flatten_info, true)?;
-                let right_flatten_plan =
-                    self.flatten(plan.child(1)?, correlated_columns, flatten_info, true)?;
+                if op
+                    .used_columns()?
+                    .iter()
+                    .any(|index| correlated_columns.contains(index))
+                {
+                    need_cross_join = true;
+                }
+                let left_flatten_plan = self.flatten(
+                    plan.child(0)?,
+                    correlated_columns,
+                    flatten_info,
+                    need_cross_join,
+                )?;
+                let right_flatten_plan = self.flatten(
+                    plan.child(1)?,
+                    correlated_columns,
+                    flatten_info,
+                    need_cross_join,
+                )?;
                 Ok(SExpr::create_binary(
                     op.clone().into(),
                     left_flatten_plan,
@@ -730,7 +808,6 @@ impl SubqueryRewriter {
     fn join_outer_inner_table(
         &mut self,
         filter: &Filter,
-        predicates_set: &mut HashSet<Scalar>,
         correlated_columns: &ColumnSet,
     ) -> Result<bool> {
         Ok(!filter.predicates.iter().all(|predicate| {
@@ -764,7 +841,6 @@ impl SubqueryRewriter {
                                     self.derived_columns
                                         .insert(right_column.index, left_column.index);
                                 }
-                                predicates_set.remove(predicate);
                                 return true;
                             }
                         }

--- a/src/query/service/src/sql/planner/plans/aggregate.rs
+++ b/src/query/service/src/sql/planner/plans/aggregate.rs
@@ -25,6 +25,7 @@ use crate::sql::plans::Operator;
 use crate::sql::plans::PhysicalOperator;
 use crate::sql::plans::RelOp;
 use crate::sql::plans::ScalarItem;
+use crate::sql::ScalarExpr;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)]
 pub enum AggregateMode {
@@ -159,5 +160,18 @@ impl LogicalOperator for Aggregate {
 
             column_stats: Default::default(),
         })
+    }
+
+    fn used_columns<'a>(&self) -> Result<ColumnSet> {
+        let mut used_columns = ColumnSet::new();
+        for group_item in self.group_items.iter() {
+            used_columns.insert(group_item.index);
+            used_columns.extend(group_item.scalar.used_columns())
+        }
+        for agg in self.aggregate_functions.iter() {
+            used_columns.insert(agg.index);
+            used_columns.extend(agg.scalar.used_columns())
+        }
+        Ok(used_columns)
     }
 }

--- a/src/query/service/src/sql/planner/plans/dummy_table_scan.rs
+++ b/src/query/service/src/sql/planner/plans/dummy_table_scan.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_exception::Result;
+
 use super::LogicalOperator;
 use super::Operator;
 use super::PhysicalOperator;
@@ -48,7 +50,7 @@ impl LogicalOperator for DummyTableScan {
     fn derive_relational_prop<'a>(
         &self,
         _rel_expr: &crate::sql::optimizer::RelExpr<'a>,
-    ) -> common_exception::Result<crate::sql::optimizer::RelationalProperty> {
+    ) -> Result<RelationalProperty> {
         Ok(RelationalProperty {
             output_columns: ColumnSet::new(),
             outer_columns: ColumnSet::new(),
@@ -58,13 +60,17 @@ impl LogicalOperator for DummyTableScan {
             column_stats: Default::default(),
         })
     }
+
+    fn used_columns<'a>(&self) -> Result<ColumnSet> {
+        Ok(ColumnSet::new())
+    }
 }
 
 impl PhysicalOperator for DummyTableScan {
     fn derive_physical_prop<'a>(
         &self,
         _rel_expr: &crate::sql::optimizer::RelExpr<'a>,
-    ) -> common_exception::Result<crate::sql::optimizer::PhysicalProperty> {
+    ) -> Result<PhysicalProperty> {
         Ok(PhysicalProperty {
             distribution: crate::sql::optimizer::Distribution::Serial,
         })
@@ -75,7 +81,7 @@ impl PhysicalOperator for DummyTableScan {
         _rel_expr: &crate::sql::optimizer::RelExpr<'a>,
         _child_index: usize,
         required: &crate::sql::optimizer::RequiredProperty,
-    ) -> common_exception::Result<crate::sql::optimizer::RequiredProperty> {
+    ) -> Result<crate::sql::optimizer::RequiredProperty> {
         Ok(required.clone())
     }
 }

--- a/src/query/service/src/sql/planner/plans/eval_scalar.rs
+++ b/src/query/service/src/sql/planner/plans/eval_scalar.rs
@@ -111,4 +111,13 @@ impl LogicalOperator for EvalScalar {
             column_stats: Default::default(),
         })
     }
+
+    fn used_columns<'a>(&self) -> Result<ColumnSet> {
+        let mut used_columns = ColumnSet::new();
+        for item in self.items.iter() {
+            used_columns.insert(item.index);
+            used_columns.extend(item.scalar.used_columns());
+        }
+        Ok(used_columns)
+    }
 }

--- a/src/query/service/src/sql/planner/plans/filter.rs
+++ b/src/query/service/src/sql/planner/plans/filter.rs
@@ -102,4 +102,12 @@ impl LogicalOperator for Filter {
             column_stats: Default::default(),
         })
     }
+
+    fn used_columns<'a>(&self) -> Result<ColumnSet> {
+        Ok(self
+            .predicates
+            .iter()
+            .map(|scalar| scalar.used_columns())
+            .fold(ColumnSet::new(), |acc, x| acc.union(&x).cloned().collect()))
+    }
 }

--- a/src/query/service/src/sql/planner/plans/limit.rs
+++ b/src/query/service/src/sql/planner/plans/limit.rs
@@ -14,6 +14,7 @@
 
 use common_exception::Result;
 
+use crate::sql::optimizer::ColumnSet;
 use crate::sql::optimizer::Distribution;
 use crate::sql::optimizer::PhysicalProperty;
 use crate::sql::optimizer::RelExpr;
@@ -84,5 +85,9 @@ impl LogicalOperator for Limit {
 
             column_stats: Default::default(),
         })
+    }
+
+    fn used_columns<'a>(&self) -> Result<ColumnSet> {
+        Ok(ColumnSet::new())
     }
 }

--- a/src/query/service/src/sql/planner/plans/logical_get.rs
+++ b/src/query/service/src/sql/planner/plans/logical_get.rs
@@ -106,4 +106,8 @@ impl LogicalOperator for LogicalGet {
             column_stats: Default::default(),
         })
     }
+
+    fn used_columns<'a>(&self) -> Result<ColumnSet> {
+        Ok(self.columns.clone())
+    }
 }

--- a/src/query/service/src/sql/planner/plans/logical_join.rs
+++ b/src/query/service/src/sql/planner/plans/logical_join.rs
@@ -19,6 +19,7 @@ use common_exception::Result;
 use common_planner::IndexType;
 
 use super::ScalarExpr;
+use crate::sql::optimizer::ColumnSet;
 use crate::sql::optimizer::RelExpr;
 use crate::sql::optimizer::RelationalProperty;
 use crate::sql::plans::LogicalOperator;
@@ -218,5 +219,18 @@ impl LogicalOperator for LogicalInnerJoin {
 
             column_stats: Default::default(),
         })
+    }
+
+    fn used_columns<'a>(&self) -> Result<ColumnSet> {
+        let mut used_columns = ColumnSet::new();
+        for cond in self
+            .left_conditions
+            .iter()
+            .chain(self.right_conditions.iter())
+            .chain(self.other_conditions.iter())
+        {
+            used_columns = used_columns.union(&cond.used_columns()).cloned().collect();
+        }
+        Ok(used_columns)
     }
 }

--- a/src/query/service/src/sql/planner/plans/operator.rs
+++ b/src/query/service/src/sql/planner/plans/operator.rs
@@ -27,6 +27,7 @@ use super::pattern::PatternPlan;
 use super::physical_scan::PhysicalScan;
 use super::sort::Sort;
 use super::union_all::UnionAll;
+use crate::sql::optimizer::ColumnSet;
 use crate::sql::optimizer::PhysicalProperty;
 use crate::sql::optimizer::RelExpr;
 use crate::sql::optimizer::RelationalProperty;
@@ -51,6 +52,7 @@ pub trait Operator {
 
 pub trait LogicalOperator {
     fn derive_relational_prop<'a>(&self, rel_expr: &RelExpr<'a>) -> Result<RelationalProperty>;
+    fn used_columns(&self) -> Result<ColumnSet>;
 }
 
 pub trait PhysicalOperator {

--- a/src/query/service/src/sql/planner/plans/sort.rs
+++ b/src/query/service/src/sql/planner/plans/sort.rs
@@ -15,6 +15,7 @@
 use common_exception::Result;
 use common_planner::IndexType;
 
+use crate::sql::optimizer::ColumnSet;
 use crate::sql::optimizer::Distribution;
 use crate::sql::optimizer::PhysicalProperty;
 use crate::sql::optimizer::RelExpr;
@@ -80,5 +81,13 @@ impl PhysicalOperator for Sort {
 impl LogicalOperator for Sort {
     fn derive_relational_prop<'a>(&self, rel_expr: &RelExpr<'a>) -> Result<RelationalProperty> {
         rel_expr.derive_relational_prop_child(0)
+    }
+
+    fn used_columns<'a>(&self) -> Result<ColumnSet> {
+        let mut used_columns = ColumnSet::new();
+        for item in &self.items {
+            used_columns.insert(item.index);
+        }
+        Ok(used_columns)
     }
 }

--- a/src/query/service/src/sql/planner/plans/union_all.rs
+++ b/src/query/service/src/sql/planner/plans/union_all.rs
@@ -15,6 +15,7 @@
 use common_exception::Result;
 use common_planner::IndexType;
 
+use crate::sql::optimizer::ColumnSet;
 use crate::sql::optimizer::Distribution;
 use crate::sql::optimizer::PhysicalProperty;
 use crate::sql::optimizer::RelExpr;
@@ -88,6 +89,15 @@ impl LogicalOperator for UnionAll {
 
             column_stats: Default::default(),
         })
+    }
+
+    fn used_columns<'a>(&self) -> Result<ColumnSet> {
+        let mut used_columns = ColumnSet::new();
+        for (left, right) in &self.pairs {
+            used_columns.insert(*left);
+            used_columns.insert(*right);
+        }
+        Ok(used_columns)
     }
 }
 

--- a/tests/logictest/suites/duckdb/sql/aggregate/having/test_having.test
+++ b/tests/logictest/suites/duckdb/sql/aggregate/having/test_having.test
@@ -54,6 +54,7 @@ SELECT test.b, SUM(a) FROM test GROUP BY test.b HAVING SUM(a)=(SELECT SUM(a) FRO
 
 ----
 21 12
+22 24
 
 statement query II
 SELECT test.b, SUM(a) FROM test GROUP BY test.b HAVING SUM(a)*2=(SELECT SUM(a)+SUM(t.a) FROM test t WHERE test.b=t.b) ORDER BY test.b;

--- a/tests/logictest/suites/duckdb/sql/aggregate/having/test_having.test
+++ b/tests/logictest/suites/duckdb/sql/aggregate/having/test_having.test
@@ -61,6 +61,7 @@ SELECT test.b, SUM(a) FROM test GROUP BY test.b HAVING SUM(a)*2=(SELECT SUM(a)+S
 
 ----
 21 12
+22 24
 
 -- statement query II
 -- SELECT test.b, SUM(a) FROM test GROUP BY test.b HAVING SUM(a)*2+2=(SELECT SUM(a)+SUM(t.a)+COUNT(t.a) FROM test t WHERE test.b=t.b) ORDER BY test.b;

--- a/tests/logictest/suites/mode/standalone/explain/limit.test
+++ b/tests/logictest/suites/mode/standalone/explain/limit.test
@@ -96,13 +96,15 @@ Limit
                     │               │   ├── partitions total: 1
                     │               │   ├── partitions scanned: 1
                     │               │   └── push downs: [filters: [], limit: NONE]
-                    │               └── TableScan(Probe)
-                    │                   ├── table: default.system.numbers
-                    │                   ├── read rows: 1
-                    │                   ├── read bytes: 8
-                    │                   ├── partitions total: 1
-                    │                   ├── partitions scanned: 1
-                    │                   └── push downs: [filters: [], limit: NONE]
+                    │               └── Filter(Probe)
+                    │                   ├── filters: [=(subquery_2 (#2), t2.number (#2))]
+                    │                   └── TableScan
+                    │                       ├── table: default.system.numbers
+                    │                       ├── read rows: 1
+                    │                       ├── read bytes: 8
+                    │                       ├── partitions total: 1
+                    │                       ├── partitions scanned: 1
+                    │                       └── push downs: [filters: [(number = number)], limit: NONE]
                     └── HashJoin(Probe)
                         ├── join type: CROSS
                         ├── build keys: []

--- a/tests/logictest/suites/mode/standalone/explain/limit.test
+++ b/tests/logictest/suites/mode/standalone/explain/limit.test
@@ -73,7 +73,7 @@ Limit
                 ├── filters: [=(t.number (#0), CAST(if(is_not_null(scalar_subquery_4 (#4)), scalar_subquery_4 (#4), 0) AS BIGINT UNSIGNED))]
                 └── HashJoin
                     ├── join type: SINGLE
-                    ├── build keys: [subquery_6 (#6)]
+                    ├── build keys: [subquery_2 (#2)]
                     ├── probe keys: [subquery_0 (#0)]
                     ├── filters: []
                     ├── EvalScalar(Build)
@@ -85,9 +85,9 @@ Limit
                     │           ├── group by: [number]
                     │           ├── aggregate functions: [count()]
                     │           └── HashJoin
-                    │               ├── join type: INNER
-                    │               ├── build keys: [subquery_6 (#6)]
-                    │               ├── probe keys: [t2.number (#2)]
+                    │               ├── join type: CROSS
+                    │               ├── build keys: []
+                    │               ├── probe keys: []
                     │               ├── filters: []
                     │               ├── TableScan(Build)
                     │               │   ├── table: default.system.numbers
@@ -96,25 +96,13 @@ Limit
                     │               │   ├── partitions total: 1
                     │               │   ├── partitions scanned: 1
                     │               │   └── push downs: [filters: [], limit: NONE]
-                    │               └── HashJoin(Probe)
-                    │                   ├── join type: CROSS
-                    │                   ├── build keys: []
-                    │                   ├── probe keys: []
-                    │                   ├── filters: []
-                    │                   ├── TableScan(Build)
-                    │                   │   ├── table: default.system.numbers
-                    │                   │   ├── read rows: 1
-                    │                   │   ├── read bytes: 8
-                    │                   │   ├── partitions total: 1
-                    │                   │   ├── partitions scanned: 1
-                    │                   │   └── push downs: [filters: [], limit: NONE]
-                    │                   └── TableScan(Probe)
-                    │                       ├── table: default.system.numbers
-                    │                       ├── read rows: 1
-                    │                       ├── read bytes: 8
-                    │                       ├── partitions total: 1
-                    │                       ├── partitions scanned: 1
-                    │                       └── push downs: [filters: [], limit: NONE]
+                    │               └── TableScan(Probe)
+                    │                   ├── table: default.system.numbers
+                    │                   ├── read rows: 1
+                    │                   ├── read bytes: 8
+                    │                   ├── partitions total: 1
+                    │                   ├── partitions scanned: 1
+                    │                   └── push downs: [filters: [], limit: NONE]
                     └── HashJoin(Probe)
                         ├── join type: CROSS
                         ├── build keys: []

--- a/tests/logictest/suites/mode/standalone/explain/subquery.test
+++ b/tests/logictest/suites/mode/standalone/explain/subquery.test
@@ -6,7 +6,7 @@ Filter
 ├── filters: [=(t.number (#0), CAST(if(is_not_null(scalar_subquery_4 (#4)), scalar_subquery_4 (#4), 0) AS BIGINT UNSIGNED))]
 └── HashJoin
     ├── join type: SINGLE
-    ├── build keys: [subquery_6 (#6)]
+    ├── build keys: [subquery_2 (#2)]
     ├── probe keys: [subquery_0 (#0)]
     ├── filters: []
     ├── EvalScalar(Build)
@@ -18,9 +18,9 @@ Filter
     │           ├── group by: [number]
     │           ├── aggregate functions: [count()]
     │           └── HashJoin
-    │               ├── join type: INNER
-    │               ├── build keys: [subquery_6 (#6)]
-    │               ├── probe keys: [t2.number (#2)]
+    │               ├── join type: CROSS
+    │               ├── build keys: []
+    │               ├── probe keys: []
     │               ├── filters: []
     │               ├── TableScan(Build)
     │               │   ├── table: default.system.numbers
@@ -29,25 +29,13 @@ Filter
     │               │   ├── partitions total: 1
     │               │   ├── partitions scanned: 1
     │               │   └── push downs: [filters: [], limit: NONE]
-    │               └── HashJoin(Probe)
-    │                   ├── join type: CROSS
-    │                   ├── build keys: []
-    │                   ├── probe keys: []
-    │                   ├── filters: []
-    │                   ├── TableScan(Build)
-    │                   │   ├── table: default.system.numbers
-    │                   │   ├── read rows: 1
-    │                   │   ├── read bytes: 8
-    │                   │   ├── partitions total: 1
-    │                   │   ├── partitions scanned: 1
-    │                   │   └── push downs: [filters: [], limit: NONE]
-    │                   └── TableScan(Probe)
-    │                       ├── table: default.system.numbers
-    │                       ├── read rows: 1
-    │                       ├── read bytes: 8
-    │                       ├── partitions total: 1
-    │                       ├── partitions scanned: 1
-    │                       └── push downs: [filters: [], limit: NONE]
+    │               └── TableScan(Probe)
+    │                   ├── table: default.system.numbers
+    │                   ├── read rows: 1
+    │                   ├── read bytes: 8
+    │                   ├── partitions total: 1
+    │                   ├── partitions scanned: 1
+    │                   └── push downs: [filters: [], limit: NONE]
     └── HashJoin(Probe)
         ├── join type: CROSS
         ├── build keys: []
@@ -73,31 +61,19 @@ explain select t.number from numbers(1) as t where exists (select t1.number from
 
 ----
 Filter
-├── filters: [or(3 (#3), >(t.number (#0), 1))]
+├── filters: [or(2 (#2), >(t.number (#0), 1))]
 └── HashJoin
-    ├── join type: RIGHT MARK
-    ├── build keys: [subquery_2 (#2)]
-    ├── probe keys: [subquery_0 (#0)]
+    ├── join type: LEFT MARK
+    ├── build keys: [subquery_0 (#0)]
+    ├── probe keys: [subquery_1 (#1)]
     ├── filters: []
-    ├── HashJoin(Build)
-    │   ├── join type: INNER
-    │   ├── build keys: [subquery_2 (#2)]
-    │   ├── probe keys: [t1.number (#1)]
-    │   ├── filters: []
-    │   ├── TableScan(Build)
-    │   │   ├── table: default.system.numbers
-    │   │   ├── read rows: 1
-    │   │   ├── read bytes: 8
-    │   │   ├── partitions total: 1
-    │   │   ├── partitions scanned: 1
-    │   │   └── push downs: [filters: [], limit: NONE]
-    │   └── TableScan(Probe)
-    │       ├── table: default.system.numbers
-    │       ├── read rows: 1
-    │       ├── read bytes: 8
-    │       ├── partitions total: 1
-    │       ├── partitions scanned: 1
-    │       └── push downs: [filters: [], limit: NONE]
+    ├── TableScan(Build)
+    │   ├── table: default.system.numbers
+    │   ├── read rows: 1
+    │   ├── read bytes: 8
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   └── push downs: [filters: [], limit: NONE]
     └── TableScan(Probe)
         ├── table: default.system.numbers
         ├── read rows: 1
@@ -327,7 +303,7 @@ Filter
 ├── filters: [CAST(if(is_not_null(scalar_subquery_3 (#3)), scalar_subquery_3 (#3), 0) AS BIGINT UNSIGNED)]
 └── HashJoin
     ├── join type: SINGLE
-    ├── build keys: [subquery_5 (#5)]
+    ├── build keys: [subquery_2 (#2)]
     ├── probe keys: [subquery_0 (#0)]
     ├── filters: []
     ├── EvalScalar(Build)
@@ -338,25 +314,13 @@ Filter
     │       └── AggregatePartial
     │           ├── group by: [number]
     │           ├── aggregate functions: [count()]
-    │           └── HashJoin
-    │               ├── join type: INNER
-    │               ├── build keys: [subquery_5 (#5)]
-    │               ├── probe keys: [numbers.number (#2)]
-    │               ├── filters: []
-    │               ├── TableScan(Build)
-    │               │   ├── table: default.system.numbers
-    │               │   ├── read rows: 1
-    │               │   ├── read bytes: 8
-    │               │   ├── partitions total: 1
-    │               │   ├── partitions scanned: 1
-    │               │   └── push downs: [filters: [], limit: NONE]
-    │               └── TableScan(Probe)
-    │                   ├── table: default.system.numbers
-    │                   ├── read rows: 1
-    │                   ├── read bytes: 8
-    │                   ├── partitions total: 1
-    │                   ├── partitions scanned: 1
-    │                   └── push downs: [filters: [], limit: NONE]
+    │           └── TableScan
+    │               ├── table: default.system.numbers
+    │               ├── read rows: 1
+    │               ├── read bytes: 8
+    │               ├── partitions total: 1
+    │               ├── partitions scanned: 1
+    │               └── push downs: [filters: [], limit: NONE]
     └── HashJoin(Probe)
         ├── join type: INNER
         ├── build keys: [t1.number (#1)]

--- a/tests/logictest/suites/mode/standalone/explain/subquery.test
+++ b/tests/logictest/suites/mode/standalone/explain/subquery.test
@@ -29,13 +29,15 @@ Filter
     │               │   ├── partitions total: 1
     │               │   ├── partitions scanned: 1
     │               │   └── push downs: [filters: [], limit: NONE]
-    │               └── TableScan(Probe)
-    │                   ├── table: default.system.numbers
-    │                   ├── read rows: 1
-    │                   ├── read bytes: 8
-    │                   ├── partitions total: 1
-    │                   ├── partitions scanned: 1
-    │                   └── push downs: [filters: [], limit: NONE]
+    │               └── Filter(Probe)
+    │                   ├── filters: [=(subquery_2 (#2), t2.number (#2))]
+    │                   └── TableScan
+    │                       ├── table: default.system.numbers
+    │                       ├── read rows: 1
+    │                       ├── read bytes: 8
+    │                       ├── partitions total: 1
+    │                       ├── partitions scanned: 1
+    │                       └── push downs: [filters: [(number = number)], limit: NONE]
     └── HashJoin(Probe)
         ├── join type: CROSS
         ├── build keys: []
@@ -74,13 +76,15 @@ Filter
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   └── push downs: [filters: [], limit: NONE]
-    └── TableScan(Probe)
-        ├── table: default.system.numbers
-        ├── read rows: 1
-        ├── read bytes: 8
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+    └── Filter(Probe)
+        ├── filters: [=(subquery_1 (#1), t1.number (#1))]
+        └── TableScan
+            ├── table: default.system.numbers
+            ├── read rows: 1
+            ├── read bytes: 8
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            └── push downs: [filters: [(number = number)], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t where exists (select * from numbers(1) where number = 0);
@@ -314,13 +318,15 @@ Filter
     │       └── AggregatePartial
     │           ├── group by: [number]
     │           ├── aggregate functions: [count()]
-    │           └── TableScan
-    │               ├── table: default.system.numbers
-    │               ├── read rows: 1
-    │               ├── read bytes: 8
-    │               ├── partitions total: 1
-    │               ├── partitions scanned: 1
-    │               └── push downs: [filters: [], limit: NONE]
+    │           └── Filter
+    │               ├── filters: [=(subquery_2 (#2), numbers.number (#2))]
+    │               └── TableScan
+    │                   ├── table: default.system.numbers
+    │                   ├── read rows: 1
+    │                   ├── read bytes: 8
+    │                   ├── partitions total: 1
+    │                   ├── partitions scanned: 1
+    │                   └── push downs: [filters: [(number = number)], limit: NONE]
     └── HashJoin(Probe)
         ├── join type: INNER
         ├── build keys: [t1.number (#1)]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Optimize subquery by deleting redundancy join.

After the ticket, tpch q20 won't oom.

Fixes https://github.com/datafuselabs/databend/issues/8077
