### PR TITLE
feat(query): migrate datetime rounder functions to v2.

### DIFF
--- a/docs/doc/30-reference/20-functions/30-datetime-functions/tomonday.md
+++ b/docs/doc/30-reference/20-functions/30-datetime-functions/tomonday.md
@@ -19,19 +19,12 @@ to_monday( <expr> )
 
 ## Return Type
 
-`UInt16` datatype.
+Datetime object, returns date in “YYYY-MM-DD” format.
 
 ## Examples
 
 ```sql
 SELECT to_monday(now());
-+------------------+
-| to_monday(now()) |
-+------------------+
-|            19079 |
-+------------------+
-
-SELECT to_date(to_monday(now()));
 +---------------------------+
 | to_date(to_monday(now())) |
 +---------------------------+
@@ -42,6 +35,6 @@ SELECT to_monday(to_timestamp(1630812366));
 +-------------------------------------+
 | to_monday(to_timestamp(1630812366)) |
 +-------------------------------------+
-|                               18869 |
+| 2021-08-30                          |
 +-------------------------------------+
 ```

--- a/docs/doc/30-reference/20-functions/30-datetime-functions/tostartofweek.md
+++ b/docs/doc/30-reference/20-functions/30-datetime-functions/tostartofweek.md
@@ -2,7 +2,8 @@
 title: TO_START_OF_WEEK
 ---
 
-Returns the first day of the year for a date or a date with time (timestamp/datetime).
+Returns the first day of the week for a date or a date with time (timestamp/datetime).
+The first day of a week can be Sunday or Monday, which is specified by the argument `mode`.
 
 ## Syntax
 
@@ -15,6 +16,7 @@ to_start_of_week(expr)
 | Arguments   | Description |
 | ----------- | ----------- |
 | expr | date/timestamp |
+| mode | Optional. If it is 0, the result is Sunday, otherwise, the result is Monday. The default value is 0 |
 
 ## Return Type
 

--- a/src/query/functions-v2/tests/it/scalars/datetime.rs
+++ b/src/query/functions-v2/tests/it/scalars/datetime.rs
@@ -39,6 +39,7 @@ fn test_datetime() {
     test_date_arith(file);
     test_timestamp_arith(file);
     test_to_number(file);
+    test_rounder_functions(file);
 }
 
 fn test_to_timestamp(file: &mut impl Write) {
@@ -1012,4 +1013,35 @@ fn test_to_number(file: &mut impl Write) {
         DataType::Timestamp,
         from_timestamp_data(vec![-100, 0, 100]),
     )]);
+}
+
+fn test_rounder_functions(file: &mut impl Write) {
+    run_ast(file, "to_start_of_second(to_timestamp(1630812366))", &[]);
+    run_ast(file, "to_start_of_minute(to_timestamp(1630812366))", &[]);
+    run_ast(
+        file,
+        "to_start_of_five_minutes(to_timestamp(1630812366))",
+        &[],
+    );
+    run_ast(
+        file,
+        "to_start_of_ten_minutes(to_timestamp(1630812366))",
+        &[],
+    );
+    run_ast(
+        file,
+        "to_start_of_fifteen_minutes(to_timestamp(1630812366))",
+        &[],
+    );
+    run_ast(file, "to_start_of_hour(to_timestamp(1630812366))", &[]);
+    run_ast(file, "to_start_of_day(to_timestamp(1630812366))", &[]);
+    run_ast(file, "time_slot(to_timestamp(1630812366))", &[]);
+    run_ast(file, "to_monday(to_timestamp(1630812366))", &[]);
+    run_ast(file, "to_start_of_week(to_timestamp(1630812366))", &[]);
+    run_ast(file, "to_start_of_week(to_timestamp(1630812366))", &[]);
+    run_ast(file, "to_start_of_week(to_timestamp(1630812366), 1)", &[]);
+    run_ast(file, "to_start_of_month(to_timestamp(1630812366))", &[]);
+    run_ast(file, "to_start_of_quarter(to_timestamp(1630812366))", &[]);
+    run_ast(file, "to_start_of_year(to_timestamp(1630812366))", &[]);
+    run_ast(file, "to_start_of_iso_year(to_timestamp(1630812366))", &[]);
 }

--- a/src/query/functions-v2/tests/it/scalars/datetime.rs
+++ b/src/query/functions-v2/tests/it/scalars/datetime.rs
@@ -1044,4 +1044,12 @@ fn test_rounder_functions(file: &mut impl Write) {
     run_ast(file, "to_start_of_quarter(to_timestamp(1630812366))", &[]);
     run_ast(file, "to_start_of_year(to_timestamp(1630812366))", &[]);
     run_ast(file, "to_start_of_iso_year(to_timestamp(1630812366))", &[]);
+
+    run_ast(file, "date_trunc(year, to_timestamp(1630812366))", &[]);
+    run_ast(file, "date_trunc(quarter, to_timestamp(1630812366))", &[]);
+    run_ast(file, "date_trunc(month, to_timestamp(1630812366))", &[]);
+    run_ast(file, "date_trunc(day, to_timestamp(1630812366))", &[]);
+    run_ast(file, "date_trunc(hour, to_timestamp(1630812366))", &[]);
+    run_ast(file, "date_trunc(minute, to_timestamp(1630812366))", &[]);
+    run_ast(file, "date_trunc(second, to_timestamp(1630812366))", &[]);
 }

--- a/src/query/functions-v2/tests/it/scalars/parser.rs
+++ b/src/query/functions-v2/tests/it/scalars/parser.rs
@@ -39,8 +39,8 @@ macro_rules! with_interval_mapped_name {
     (| $t:tt | $($tail:tt)*) => {
         match_template::match_template! {
             $t = [
-              Year => "years", Quarter => "quarters", Month => "months", Day => "days",
-              Hour => "hours", Minute => "minutes", Second => "seconds",
+              Year => "year", Quarter => "quarter", Month => "month", Day => "day",
+              Hour => "hour", Minute => "minute", Second => "second",
             ],
             $($tail)*
         }
@@ -53,7 +53,7 @@ macro_rules! transform_interval_add_sub {
             with_interval_mapped_name!(|INTERVAL| match $unit {
                 IntervalKind::INTERVAL => RawExpr::FunctionCall {
                     span: transform_span($span),
-                    name: concat!("add_", INTERVAL).to_string(),
+                    name: concat!("add_", INTERVAL, "s").to_string(),
                     params: vec![],
                     args: vec![
                         transform_expr(*$date, $columns),
@@ -68,7 +68,7 @@ macro_rules! transform_interval_add_sub {
             with_interval_mapped_name!(|INTERVAL| match $unit {
                 IntervalKind::INTERVAL => RawExpr::FunctionCall {
                     span: transform_span($span),
-                    name: concat!("subtract_", INTERVAL).to_string(),
+                    name: concat!("subtract_", INTERVAL, "s").to_string(),
                     params: vec![],
                     args: vec![
                         transform_expr(*$date, $columns),
@@ -362,7 +362,7 @@ pub fn transform_expr(ast: common_ast::ast::Expr, columns: &[(&str, DataType)]) 
             with_interval_mapped_name!(|INTERVAL| match unit {
                 IntervalKind::INTERVAL => RawExpr::FunctionCall {
                     span: transform_span(span),
-                    name: concat!("add_", INTERVAL).to_string(),
+                    name: concat!("add_", INTERVAL, "s").to_string(),
                     params: vec![],
                     args: vec![
                         transform_expr(*date, columns),
@@ -383,12 +383,25 @@ pub fn transform_expr(ast: common_ast::ast::Expr, columns: &[(&str, DataType)]) 
             with_interval_mapped_name!(|INTERVAL| match unit {
                 IntervalKind::INTERVAL => RawExpr::FunctionCall {
                     span: transform_span(span),
-                    name: concat!("subtract_", INTERVAL).to_string(),
+                    name: concat!("subtract_", INTERVAL, "s").to_string(),
                     params: vec![],
                     args: vec![
                         transform_expr(*date, columns),
                         transform_expr(*interval, columns),
                     ],
+                },
+                kind => {
+                    unimplemented!("{kind:?} is not supported")
+                }
+            })
+        }
+        common_ast::ast::Expr::DateTrunc { span, unit, date } => {
+            with_interval_mapped_name!(|INTERVAL| match unit {
+                IntervalKind::INTERVAL => RawExpr::FunctionCall {
+                    span: transform_span(span),
+                    name: concat!("to_start_of_", INTERVAL).to_string(),
+                    params: vec![],
+                    args: vec![transform_expr(*date, columns),],
                 },
                 kind => {
                     unimplemented!("{kind:?} is not supported")

--- a/src/query/functions-v2/tests/it/scalars/testdata/datetime.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/datetime.txt
@@ -3060,3 +3060,147 @@ evaluation (internal):
 +--------+-------------------+
 
 
+ast            : to_start_of_second(to_timestamp(1630812366))
+raw expr       : to_start_of_second(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_second<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630812366000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 03:26:06.000000
+
+
+ast            : to_start_of_minute(to_timestamp(1630812366))
+raw expr       : to_start_of_minute(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_minute<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630812360000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 03:26:00.000000
+
+
+ast            : to_start_of_five_minutes(to_timestamp(1630812366))
+raw expr       : to_start_of_five_minutes(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_five_minutes<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630812300000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 03:25:00.000000
+
+
+ast            : to_start_of_ten_minutes(to_timestamp(1630812366))
+raw expr       : to_start_of_ten_minutes(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_ten_minutes<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630812000000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 03:20:00.000000
+
+
+ast            : to_start_of_fifteen_minutes(to_timestamp(1630812366))
+raw expr       : to_start_of_fifteen_minutes(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_fifteen_minutes<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630811700000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 03:15:00.000000
+
+
+ast            : to_start_of_hour(to_timestamp(1630812366))
+raw expr       : to_start_of_hour(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_hour<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630810800000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 03:00:00.000000
+
+
+ast            : to_start_of_day(to_timestamp(1630812366))
+raw expr       : to_start_of_day(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_day<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630800000000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 00:00:00.000000
+
+
+ast            : time_slot(to_timestamp(1630812366))
+raw expr       : time_slot(to_timestamp(1630812366_u32))
+checked expr   : time_slot<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630810800000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 03:00:00.000000
+
+
+ast            : to_monday(to_timestamp(1630812366))
+raw expr       : to_monday(to_timestamp(1630812366_u32))
+checked expr   : to_monday<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 18869
+output type    : Date
+output domain  : Unknown
+output         : 2021-08-30
+
+
+ast            : to_start_of_week(to_timestamp(1630812366))
+raw expr       : to_start_of_week(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_week<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 18875
+output type    : Date
+output domain  : Unknown
+output         : 2021-09-05
+
+
+ast            : to_start_of_week(to_timestamp(1630812366))
+raw expr       : to_start_of_week(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_week<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 18875
+output type    : Date
+output domain  : Unknown
+output         : 2021-09-05
+
+
+ast            : to_start_of_week(to_timestamp(1630812366), 1)
+raw expr       : to_start_of_week(to_timestamp(1630812366_u32), 1_u8)
+checked expr   : to_start_of_week<Timestamp, Int64>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)), CAST(1_u8 AS Int64))
+optimized expr : 18869
+output type    : Date
+output domain  : Unknown
+output         : 2021-08-30
+
+
+ast            : to_start_of_month(to_timestamp(1630812366))
+raw expr       : to_start_of_month(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_month<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 18871
+output type    : Date
+output domain  : Unknown
+output         : 2021-09-01
+
+
+ast            : to_start_of_quarter(to_timestamp(1630812366))
+raw expr       : to_start_of_quarter(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_quarter<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 18809
+output type    : Date
+output domain  : Unknown
+output         : 2021-07-01
+
+
+ast            : to_start_of_year(to_timestamp(1630812366))
+raw expr       : to_start_of_year(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_year<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 18628
+output type    : Date
+output domain  : Unknown
+output         : 2021-01-01
+
+
+ast            : to_start_of_iso_year(to_timestamp(1630812366))
+raw expr       : to_start_of_iso_year(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_iso_year<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 18631
+output type    : Date
+output domain  : Unknown
+output         : 2021-01-04
+
+

--- a/src/query/functions-v2/tests/it/scalars/testdata/datetime.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/datetime.txt
@@ -3204,3 +3204,66 @@ output domain  : Unknown
 output         : 2021-01-04
 
 
+ast            : date_trunc(year, to_timestamp(1630812366))
+raw expr       : to_start_of_year(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_year<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 18628
+output type    : Date
+output domain  : Unknown
+output         : 2021-01-01
+
+
+ast            : date_trunc(quarter, to_timestamp(1630812366))
+raw expr       : to_start_of_quarter(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_quarter<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 18809
+output type    : Date
+output domain  : Unknown
+output         : 2021-07-01
+
+
+ast            : date_trunc(month, to_timestamp(1630812366))
+raw expr       : to_start_of_month(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_month<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 18871
+output type    : Date
+output domain  : Unknown
+output         : 2021-09-01
+
+
+ast            : date_trunc(day, to_timestamp(1630812366))
+raw expr       : to_start_of_day(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_day<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630800000000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 00:00:00.000000
+
+
+ast            : date_trunc(hour, to_timestamp(1630812366))
+raw expr       : to_start_of_hour(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_hour<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630810800000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 03:00:00.000000
+
+
+ast            : date_trunc(minute, to_timestamp(1630812366))
+raw expr       : to_start_of_minute(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_minute<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630812360000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 03:26:00.000000
+
+
+ast            : date_trunc(second, to_timestamp(1630812366))
+raw expr       : to_start_of_second(to_timestamp(1630812366_u32))
+checked expr   : to_start_of_second<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
+optimized expr : 1630812366000000
+output type    : Timestamp
+output domain  : Unknown
+output         : 2021-09-05 03:26:06.000000
+
+

--- a/src/query/functions/src/scalars/dates/date.rs
+++ b/src/query/functions/src/scalars/dates/date.rs
@@ -86,10 +86,10 @@ impl DateFunction {
         factory.register("to_hour", ToHourFunction::desc());
         factory.register("to_minute", ToMinuteFunction::desc());
         factory.register("to_second", ToSecondFunction::desc());
-        factory.register("to_monday", ToMondayFunction::desc());
         factory.register("to_year", ToYearFunction::desc());
 
         // rounders
+        factory.register("to_monday", ToMondayFunction::desc());
         factory.register(
             "to_start_of_second",
             Self::round_function_creator(Round::Second),

--- a/src/query/functions/src/scalars/dates/number_function.rs
+++ b/src/query/functions/src/scalars/dates/number_function.rs
@@ -301,12 +301,16 @@ impl NumberOperator<u8> for ToSecond {
 #[derive(Clone)]
 pub struct ToMonday;
 
-impl NumberOperator<u16> for ToMonday {
+impl NumberOperator<i32> for ToMonday {
     const IS_DETERMINISTIC: bool = true;
 
-    fn to_number(value: DateTime<Tz>, tz: &Tz) -> u16 {
+    fn to_number(value: DateTime<Tz>, tz: &Tz) -> i32 {
         let weekday = value.weekday();
-        (get_day(value, tz) as u32 - weekday.num_days_from_monday()) as u16
+        (get_day(value, tz) as u32 - weekday.num_days_from_monday()) as i32
+    }
+
+    fn return_type() -> Option<DataTypeImpl> {
+        Some(DateType::new_impl())
     }
 }
 
@@ -478,6 +482,6 @@ pub type ToHourFunction = NumberFunction<ToHour, u8>;
 pub type ToMinuteFunction = NumberFunction<ToMinute, u8>;
 pub type ToSecondFunction = NumberFunction<ToSecond, u8>;
 
-pub type ToMondayFunction = NumberFunction<ToMonday, u16>;
+pub type ToMondayFunction = NumberFunction<ToMonday, i32>;
 
 pub type ToYearFunction = NumberFunction<ToYear, u16>;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

return timestamp:

-  to_start_of_second
- to_start_of_minute
- to_start_of_five_minutes
- to_start_of_ten_minutes
- to_start_of_fifteen_minutes
- to_start_of_hour
- to_start_of_day
- time_slot

return date:

- to_monday
- to_start_of_week
- to_start_of_month
- to_start_of_quarter
- to_start_of_year
- to_start_of_iso_year

return timestamp or date:

- date_trunc

Part of #8048
