### PR TITLE
chore: output block file size

### DIFF
--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
@@ -82,6 +82,7 @@ impl<'a> FuseBlock<'a> {
         let timestamp = vec![snapshot.timestamp.map(|dt| (dt.timestamp_micros()) as i64)];
         let mut block_location: Vec<Vec<u8>> = Vec::with_capacity(len);
         let mut block_size: Vec<u64> = Vec::with_capacity(len);
+        let mut file_size: Vec<u64> = Vec::with_capacity(len);
         let mut bloom_filter_location: Vec<Option<Vec<u8>>> = Vec::with_capacity(len);
         let mut bloom_filter_size: Vec<u64> = Vec::with_capacity(len);
 
@@ -92,6 +93,7 @@ impl<'a> FuseBlock<'a> {
             segment.blocks.clone().into_iter().for_each(|block| {
                 block_location.push(block.location.0.into_bytes());
                 block_size.push(block.block_size);
+                file_size.push(block.file_size);
                 bloom_filter_location.push(
                     block
                         .bloom_filter_index_location
@@ -106,6 +108,7 @@ impl<'a> FuseBlock<'a> {
             Arc::new(ConstColumn::new(Series::from_data(timestamp), len)),
             Series::from_data(block_location),
             Series::from_data(block_size),
+            Series::from_data(file_size),
             Series::from_data(bloom_filter_location),
             Series::from_data(bloom_filter_size),
         ]))
@@ -117,6 +120,7 @@ impl<'a> FuseBlock<'a> {
             DataField::new_nullable("timestamp", TimestampType::new_impl()),
             DataField::new("block_location", Vu8::to_data_type()),
             DataField::new("block_size", u64::to_data_type()),
+            DataField::new("file_size", u64::to_data_type()),
             DataField::new_nullable("bloom_filter_location", Vu8::to_data_type()),
             DataField::new("bloom_filter_size", u64::to_data_type()),
         ])


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add fuse_block() output block file size

Fixes https://github.com/datafuselabs/databend/issues/8285
