### PR TITLE
fix(meta): import: AsKeySpace::clear() should not entire sled tree

### DIFF
--- a/.github/actions/test_metactl/action.yml
+++ b/.github/actions/test_metactl/action.yml
@@ -23,3 +23,8 @@ runs:
       shell: bash
       run: |
         bash ./tests/metactl/test-metactl.sh
+
+    - name: Test metactl restore new cluster
+      shell: bash
+      run: |
+        bash ./tests/metactl/test-metactl-restore-new-cluster.sh

--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -152,12 +152,12 @@ async fn init_new_cluster(
     max_log_id: Option<LogId>,
     id: u64,
 ) -> anyhow::Result<()> {
-    println!("init-cluster: {:?}", initial_cluster);
+    eprintln!("init-cluster: {:?}", initial_cluster);
 
     let mut node_ids = BTreeSet::new();
     let mut nodes = BTreeMap::new();
     for peer in initial_cluster {
-        println!("peer:{}", peer);
+        eprintln!("peer:{}", peer);
         let node_info: Vec<&str> = peer.split('=').collect();
         if node_info.len() != 2 {
             return Err(anyhow::anyhow!("invalid peer str: {}", peer));
@@ -182,7 +182,7 @@ async fn init_new_cluster(
             endpoint: endpoint.clone(),
             grpc_api_addr: Some(addrs[1].to_string()),
         };
-        println!("new cluster node:{}", node);
+        eprintln!("new cluster node:{}", node);
         nodes.insert(id, node);
     }
 
@@ -224,7 +224,7 @@ async fn init_new_cluster(
     // construct AddNode log entries
     {
         // first clear all the nodes info
-        sm.nodes().clear()?;
+        sm.nodes().range_remove(.., true).await?;
 
         for node in nodes {
             sm.add_node(node.0, &node.1).await?;

--- a/src/meta/sled-store/src/sled_tree.rs
+++ b/src/meta/sled-store/src/sled_tree.rs
@@ -508,14 +508,6 @@ impl<'a, KV: SledKeySpace> AsKeySpace<'a, KV> {
         self.inner.range_remove::<KV, R>(range, flush).await
     }
 
-    pub fn clear(&self) -> Result<(), MetaStorageError> {
-        let err = self.inner.tree.clear();
-        match err {
-            Err(err) => Err(MetaStorageError::SledError(AnyError::new(&err))),
-            Ok(()) => Ok(()),
-        }
-    }
-
     pub fn range<R>(
         &self,
         range: R,

--- a/tests/metactl/test-metactl-restore-new-cluster.sh
+++ b/tests/metactl/test-metactl-restore-new-cluster.sh
@@ -35,6 +35,14 @@ echo "import old meta node data to new cluster"
 ./target/debug/databend-metactl --import --raft-dir ./.databend/new_meta2 --id=5 --db meta.db --initial-cluster 4=localhost:29103,0.0.0.0:19191 5=localhost:29203,0.0.0.0:29191 6=localhost:29303,0.0.0.0:39191
 ./target/debug/databend-metactl --import --raft-dir ./.databend/new_meta3 --id=6 --db meta.db --initial-cluster 4=localhost:29103,0.0.0.0:19191 5=localhost:29203,0.0.0.0:29191 6=localhost:29303,0.0.0.0:39191
 
+echo " === check if state machine is complete by checking key 'LastMembership'"
+if ./target/debug/databend-metactl --export --raft-dir ./.databend/new_meta1 | grep LastMembership; then
+    echo "=== 'LastMembership' is found"
+else
+    echo "=== 'LastMembership' not found"
+    exit 1;
+fi
+
 echo "start 3 new meta node cluster"
 nohup ./target/debug/databend-meta --config-file=./tests/metactl/config/new-databend-meta-node-1.toml &
 python3 scripts/ci/wait_tcp.py --timeout 5 --port 19191


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

### fix(metactl): AsKeySpace::clear() should not clear the whole tree

### fix(meta): test metactl restore-cluster mode

### chore(meta): test imported meta data by checking a key in the state machine

## Changelog







## Related Issues