### PR TITLE
refactor(query): improve comparison number with string

### DIFF
--- a/src/query/functions/src/scalars/comparisons/comparison.rs
+++ b/src/query/functions/src/scalars/comparisons/comparison.rs
@@ -173,7 +173,9 @@ impl<T: ComparisonImpl> ComparisonFunctionCreator<T> {
         }
 
         let mut least_supertype = compare_coercion(args[0], args[1])?;
-        if display_name == "=" && (lhs_id.is_string() && rhs_id.is_numeric())  || (rhs_id.is_string() && lhs_id.is_numeric()){
+        if display_name == "=" && (lhs_id.is_string() && rhs_id.is_numeric())
+            || (rhs_id.is_string() && lhs_id.is_numeric())
+        {
             least_supertype = Vu8::to_data_type();
         }
 

--- a/src/query/functions/src/scalars/comparisons/comparison.rs
+++ b/src/query/functions/src/scalars/comparisons/comparison.rs
@@ -172,7 +172,11 @@ impl<T: ComparisonImpl> ComparisonFunctionCreator<T> {
             });
         }
 
-        let least_supertype = compare_coercion(args[0], args[1])?;
+        let mut least_supertype = compare_coercion(args[0], args[1])?;
+        if display_name == "=" && (lhs_id.is_string() && rhs_id.is_numeric())  || (rhs_id.is_string() && lhs_id.is_numeric()){
+            least_supertype = Vu8::to_data_type();
+        }
+
         with_match_physical_primitive_type!(least_supertype.data_type_id().to_physical_type(), |$T| {
             let func = Arc::new(ComparisonPrimitiveImpl::<$T, _>::new(least_supertype, true, T::eval_simd::<$T>));
             ComparisonFunction::try_create_func(display_name, func)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Fixes #issue

```
MySQL [(none)]> select count() from numbers(1000000000) where to_string(number) =  10;
+---------+
| count() |
+---------+
|       1 |
+---------+
1 row in set (1.780 sec)

MySQL [(none)]> select count() from numbers(1000000000) where to_string(number) =  10;
ERROR 2013 (HY000): Lost connection to server during query
MySQL [(none)]> select count() from numbers(1000000000) where to_string(number) =  10;
ERROR 2006 (HY000): Server has gone away
No connection. Trying to reconnect...
Connection id:    9
Current database: *** NONE ***

+---------+
| count() |
+---------+
|       1 |
+---------+
1 row in set (0.775 sec)
```
