### PR TITLE
fix: failed to release the permits on time in the block pruner

### DIFF
--- a/src/query/storages/fuse/src/pruning/pruning_executor.rs
+++ b/src/query/storages/fuse/src/pruning/pruning_executor.rs
@@ -238,8 +238,9 @@ impl BlockPruner {
                     let filter_pruner = filter_pruner.clone();
                     let index_location = block_meta.bloom_filter_index_location.clone();
                     let index_size = block_meta.bloom_filter_index_size;
-                    let v: BlockPruningFuture = Box::new(move |_: OwnedSemaphorePermit| {
+                    let v: BlockPruningFuture = Box::new(move |permit: OwnedSemaphorePermit| {
                         Box::pin(async move {
+                            let _permit = permit;
                             let keep = filter_pruner.should_keep(&index_location, index_size).await
                                 && ctx.limiter.within_limit(row_count);
                             (block_idx, keep)
@@ -247,8 +248,11 @@ impl BlockPruner {
                     });
                     v
                 } else {
-                    let v: BlockPruningFuture = Box::new(move |_: OwnedSemaphorePermit| {
-                        Box::pin(async move { (block_idx, false) })
+                    let v: BlockPruningFuture = Box::new(move |permit: OwnedSemaphorePermit| {
+                        Box::pin(async move {
+                            let _permit = permit;
+                            (block_idx, false)
+                        })
                     });
                     v
                 }

--- a/tests/logictest/http_connector.py
+++ b/tests/logictest/http_connector.py
@@ -76,7 +76,8 @@ def get_error(response):
         return None
 
     # Wrap errno into msg, for result check
-    return Error(msg=response['error']['message'], errno=response['error']['code'])
+    return Error(msg=response['error']['message'],
+                 errno=response['error']['code'])
 
 
 class HttpConnector(object):

--- a/tests/logictest/logictest.py
+++ b/tests/logictest/logictest.py
@@ -163,9 +163,9 @@ class Statement:
 
 
 class ParsedStatement(
-    collections.namedtuple(
-        'ParsedStatement',
-        ["at_line", "s_type", "suite_name", "text", "results", "runs_on"])):
+        collections.namedtuple(
+            'ParsedStatement',
+            ["at_line", "s_type", "suite_name", "text", "results", "runs_on"])):
 
     def get_fields(self):
         return self._fields
@@ -284,7 +284,7 @@ class SuiteRunner(object):
                     continue
 
                 if self.args.skip and any(
-                        [re.search(r, base_name) for r in skips]):
+                    [re.search(r, base_name) for r in skips]):
                     log.info(f"Skip test file {filename}")
                     continue
 
@@ -296,7 +296,7 @@ class SuiteRunner(object):
                     continue
 
                 if not self.args.pattern or any(
-                        [re.search(r, base_name) for r in self.args.pattern]):
+                    [re.search(r, base_name) for r in self.args.pattern]):
                     self.statement_files.append(
                         (filename, os.path.relpath(filename, suite_path)))
 
@@ -356,7 +356,8 @@ class SuiteRunner(object):
     # expect the query just return ok
     def assert_execute_ok(self, statement):
         try:
-            error = safe_execute(lambda: self.execute_ok(statement.text), statement)
+            error = safe_execute(lambda: self.execute_ok(statement.text),
+                                 statement)
         except Exception as err:
             raise LogicError(runner=self.kind,
                              message=str(err),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

failed to release the permits on time in the block pruner, which may lead to OOM, even if `max_storage_io_requests` is set to a small number,  if the number of blocks is large

Fixes #issue
