### PR TITLE
refactor(meta/service): enable tracing log for databend-meta

### DIFF
--- a/src/binaries/meta/main.rs
+++ b/src/binaries/meta/main.rs
@@ -66,7 +66,7 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
 
     set_panic_hook();
 
-    let _guards = init_logging("databend-meta", &conf.log);
+    let _guards = init_logging("databend-meta", &conf.log, true);
 
     info!("Databend Meta version: {}", METASRV_COMMIT_VERSION.as_str());
     info!(

--- a/src/binaries/metactl/main.rs
+++ b/src/binaries/metactl/main.rs
@@ -189,7 +189,7 @@ impl Default for RaftConfig {
 async fn main() -> anyhow::Result<()> {
     let config = Config::parse();
 
-    let _guards = init_logging("metactl", &LogConfig::default());
+    let _guards = init_logging("metactl", &LogConfig::default(), true);
 
     eprintln!();
     eprintln!("███╗   ███╗███████╗████████╗ █████╗        ██████╗████████╗██╗     ");

--- a/src/meta/raft-store/tests/it/testing.rs
+++ b/src/meta/raft-store/tests/it/testing.rs
@@ -45,10 +45,14 @@ macro_rules! init_raft_store_ut {
         let t = tempfile::tempdir().expect("create temp dir to sled db");
         common_meta_sled_store::init_temp_sled_db(t);
 
-        common_tracing::init_logging("meta_unittests", &common_tracing::Config::new_testing());
+        let guards = common_tracing::init_logging(
+            "meta_unittests",
+            &common_tracing::Config::new_testing(),
+            true,
+        );
 
         let name = common_tracing::func_name!();
         let span = tracing::debug_span!("ut", "{}", name.split("::").last().unwrap());
-        ((), span)
+        (guards, span)
     }};
 }

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -60,6 +60,8 @@ tokio-stream = "0.1.10"
 tonic = { version = "0.8.1", features = ["tls"] }
 tonic-reflection = "0.5.0"
 tracing = "0.1.36"
+tracing-appender = "0.2.2"
+tracing-subscriber = { version = "0.3.15", features = ["env-filter", "ansi"] }
 
 [dev-dependencies]
 async-entry = "0.3.1"
@@ -70,8 +72,6 @@ regex = "1.6.0"
 reqwest = { version = "0.11.12", features = ["json"] }
 temp-env = "0.3.0"
 tempfile = "3.3.0"
-tracing-appender = "0.2.2"
-tracing-subscriber = { version = "0.3.15", features = ["env-filter", "ansi"] }
 
 [build-dependencies]
 common-building = { path = "../../common/building" }

--- a/src/meta/service/src/lib.rs
+++ b/src/meta/service/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod api;
 pub mod configs;
 pub mod export;
+pub mod logging;
 pub mod meta_service;
 pub mod metrics;
 pub mod network;

--- a/src/meta/service/src/logging.rs
+++ b/src/meta/service/src/logging.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2022 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 use std::env;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -37,8 +36,30 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Registry;
 
-static META_UT_LOG_GUARD: Lazy<Arc<Mutex<Option<Vec<WorkerGuard>>>>> =
+struct MetaLogGuard {
+    #[allow(dead_code)]
+    log_guards: Vec<WorkerGuard>,
+}
+
+static META_LOG_GUARD: Lazy<Arc<Mutex<Option<MetaLogGuard>>>> =
     Lazy::new(|| Arc::new(Mutex::new(None)));
+
+/// 1. Open a temp sled::Db for all tests.
+/// 2. Initialize a global tracing.
+/// 3. Create a span for a test case. One needs to enter it by `span.enter()` and keeps the guard held.
+#[macro_export]
+macro_rules! init_meta_ut {
+    () => {{
+        let t = tempfile::tempdir().expect("create temp dir to sled db");
+        common_meta_sled_store::init_temp_sled_db(t);
+
+        let guards = $crate::logging::init_meta_ut_tracing();
+
+        let name = common_tracing::func_name!();
+        let span = tracing::debug_span!("ut", "{}", name.split("::").last().unwrap());
+        (guards, span)
+    }};
+}
 
 /// Format tracing events with span-id support.
 pub struct EventFormatter {}
@@ -98,20 +119,21 @@ pub fn init_meta_ut_tracing() {
     static START: Once = Once::new();
 
     START.call_once(|| {
-        let mut g = META_UT_LOG_GUARD.as_ref().lock().unwrap();
-        *g = Some(do_init_meta_ut_tracing(
-            "meta_unittests",
-            &Config::new_testing(),
-        ));
+        let guards = do_init_meta_ut_tracing("meta_unittests", &Config::new_testing());
+
+        let mut g = META_LOG_GUARD.as_ref().lock().unwrap();
+        *g = Some(MetaLogGuard { log_guards: guards });
     });
 }
 
-pub fn do_init_meta_ut_tracing(app_name: &str, config: &Config) -> Vec<WorkerGuard> {
+pub fn do_init_meta_ut_tracing(name: &str, config: &Config) -> Vec<WorkerGuard> {
     let mut guards = vec![];
 
-    let span_rolling_appender =
-        RollingFileAppender::new(Rotation::HOURLY, &config.file.dir, app_name);
+    let span_rolling_appender = RollingFileAppender::new(Rotation::HOURLY, &config.file.dir, name);
     let (writer, writer_guard) = tracing_appender::non_blocking(span_rolling_appender);
+
+    let directives =
+        env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_x| config.file.level.to_string());
 
     let f_layer = fmt::Layer::new()
         .with_span_events(fmt::format::FmtSpan::FULL)
@@ -119,17 +141,14 @@ pub fn do_init_meta_ut_tracing(app_name: &str, config: &Config) -> Vec<WorkerGua
         .with_ansi(false)
         .event_format(EventFormatter {});
 
+    let env_filter = EnvFilter::new(directives);
+
     guards.push(writer_guard);
 
-    // Use env RUST_LOG to initialize log if present.
-    // Otherwise use the specified level.
-    let directives =
-        env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_x| config.file.level.to_string());
-    let env_filter = EnvFilter::new(directives);
     let subscriber = Registry::default().with(env_filter).with(f_layer);
 
-    tracing::subscriber::set_global_default(subscriber)
-        .expect("error setting global tracing subscriber");
+    let _ = tracing::subscriber::set_global_default(subscriber);
+    tracing::error!("start");
 
     guards
 }

--- a/src/meta/service/tests/it/api/http/cluster_state_test.rs
+++ b/src/meta/service/tests/it/api/http/cluster_state_test.rs
@@ -22,6 +22,7 @@ use common_meta_types::Node;
 use databend_meta::api::http::v1::cluster_state::nodes_handler;
 use databend_meta::api::http::v1::cluster_state::status_handler;
 use databend_meta::api::HttpService;
+use databend_meta::init_meta_ut;
 use databend_meta::meta_service::MetaNode;
 use poem::get;
 use poem::http::Method;
@@ -33,7 +34,6 @@ use poem::Request;
 use poem::Route;
 use pretty_assertions::assert_eq;
 
-use crate::init_meta_ut;
 use crate::tests::service::MetaSrvTestContext;
 use crate::tests::tls_constants::TEST_CA_CERT;
 use crate::tests::tls_constants::TEST_CN_NAME;

--- a/src/meta/service/tests/it/api/http/metrics.rs
+++ b/src/meta/service/tests/it/api/http/metrics.rs
@@ -15,6 +15,7 @@
 use common_base::base::tokio;
 use common_metrics::init_default_metrics_recorder;
 use databend_meta::api::http::v1::metrics::metrics_handler;
+use databend_meta::init_meta_ut;
 use maplit::btreeset;
 use poem::get;
 use poem::http::Method;
@@ -27,7 +28,6 @@ use poem::Route;
 use pretty_assertions::assert_eq;
 use tracing::info;
 
-use crate::init_meta_ut;
 use crate::tests::meta_node::start_meta_node_cluster;
 
 #[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]

--- a/src/meta/service/tests/it/api/http_service.rs
+++ b/src/meta/service/tests/it/api/http_service.rs
@@ -20,9 +20,9 @@ use common_base::base::Stoppable;
 use common_exception::Result;
 use databend_meta::api::HttpService;
 use databend_meta::configs::Config;
+use databend_meta::init_meta_ut;
 use databend_meta::meta_service::MetaNode;
 
-use crate::init_meta_ut;
 use crate::tests::service::MetaSrvTestContext;
 use crate::tests::tls_constants::TEST_CA_CERT;
 use crate::tests::tls_constants::TEST_CN_NAME;

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
@@ -26,12 +26,12 @@ use common_meta_types::Operation;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKVReply;
 use common_meta_types::UpsertKVReq;
+use databend_meta::init_meta_ut;
 use pretty_assertions::assert_eq;
 use tokio::time::Duration;
 use tracing::debug;
 use tracing::info;
 
-use crate::init_meta_ut;
 use crate::tests::service::MetaSrvTestContext;
 use crate::tests::start_metasrv_with_context;
 

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_export.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_export.rs
@@ -21,12 +21,11 @@ use common_meta_types::protobuf::Empty;
 use common_meta_types::MatchSeq;
 use common_meta_types::Operation;
 use common_meta_types::UpsertKVReq;
+use databend_meta::init_meta_ut;
 use pretty_assertions::assert_eq;
 use regex::Regex;
 use tokio_stream::StreamExt;
 use tracing::info;
-
-use crate::init_meta_ut;
 
 #[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_export() -> anyhow::Result<()> {

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_get_client_info.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_get_client_info.rs
@@ -16,10 +16,9 @@ use std::time::Duration;
 
 use common_base::base::tokio;
 use common_meta_client::MetaGrpcClient;
+use databend_meta::init_meta_ut;
 use pretty_assertions::assert_eq;
 use regex::Regex;
-
-use crate::init_meta_ut;
 
 #[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_get_client_info() -> anyhow::Result<()> {

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_handshake.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_handshake.rs
@@ -26,12 +26,12 @@ use common_meta_client::MetaGrpcClient;
 use common_meta_client::METACLI_COMMIT_SEMVER;
 use common_meta_client::MIN_METASRV_SEMVER;
 use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
+use databend_meta::init_meta_ut;
 use databend_meta::version::MIN_METACLI_SEMVER;
 use semver::Version;
 use tracing::debug;
 use tracing::info;
 
-use crate::init_meta_ut;
 use crate::tests::start_metasrv;
 
 /// - Test client version < serverside min-compatible-client-ver.

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api.rs
@@ -17,8 +17,8 @@ use std::sync::Mutex;
 
 use common_base::base::tokio;
 use common_meta_api::KVApiTestSuite;
+use databend_meta::init_meta_ut;
 
-use crate::init_meta_ut;
 use crate::tests::service::MetaSrvBuilder;
 
 #[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -25,9 +25,9 @@ use common_meta_client::MetaGrpcClient;
 use common_meta_types::MatchSeq;
 use common_meta_types::Operation;
 use common_meta_types::UpsertKVReq;
+use databend_meta::init_meta_ut;
 use tracing::info;
 
-use crate::init_meta_ut;
 use crate::tests::service::start_metasrv_cluster;
 use crate::tests::service::MetaSrvTestContext;
 use crate::tests::start_metasrv_with_context;

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_schema_api.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_schema_api.rs
@@ -20,8 +20,8 @@ use std::sync::Mutex;
 use common_base::base::tokio;
 use common_meta_api::SchemaApiTestSuite;
 use common_meta_api::ShareApiTestSuite;
+use databend_meta::init_meta_ut;
 
-use crate::init_meta_ut;
 use crate::tests::service::MetaSrvBuilder;
 
 #[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_schema_api_follower_follower.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_schema_api_follower_follower.rs
@@ -16,8 +16,8 @@
 
 use common_base::base::tokio;
 use common_meta_api::SchemaApiTestSuite;
+use databend_meta::init_meta_ut;
 
-use crate::init_meta_ut;
 use crate::tests::service::start_metasrv_cluster;
 
 #[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_schema_api_leader_follower.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_schema_api_leader_follower.rs
@@ -15,8 +15,8 @@
 //! Test metasrv SchemaApi by writing to leader and then reading from a follower.
 use common_base::base::tokio;
 use common_meta_api::SchemaApiTestSuite;
+use databend_meta::init_meta_ut;
 
-use crate::init_meta_ut;
 use crate::tests::service::start_metasrv_cluster;
 
 #[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_tls.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_tls.rs
@@ -20,9 +20,9 @@ use common_grpc::RpcClientTlsConfig;
 use common_meta_api::KVApi;
 use common_meta_api::SchemaApi;
 use common_meta_client::MetaGrpcClient;
+use databend_meta::init_meta_ut;
 use pretty_assertions::assert_eq;
 
-use crate::init_meta_ut;
 use crate::tests::service::MetaSrvTestContext;
 use crate::tests::start_metasrv_with_context;
 use crate::tests::tls_constants::TEST_CA_CERT;

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
@@ -35,8 +35,7 @@ use common_meta_types::TxnDeleteRequest;
 use common_meta_types::TxnOp;
 use common_meta_types::TxnPutRequest;
 use common_meta_types::UpsertKVReq;
-
-use crate::init_meta_ut;
+use databend_meta::init_meta_ut;
 
 async fn upsert_kv_client_main(addr: String, updates: Vec<UpsertKVReq>) -> anyhow::Result<()> {
     let client = MetaGrpcClient::try_create(

--- a/src/meta/service/tests/it/meta_node/meta_node_kv_api.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_kv_api.rs
@@ -19,10 +19,10 @@ use async_trait::async_trait;
 use common_base::base::tokio;
 use common_meta_api::ApiBuilder;
 use common_meta_api::KVApiTestSuite;
+use databend_meta::init_meta_ut;
 use databend_meta::meta_service::MetaNode;
 use maplit::btreeset;
 
-use crate::init_meta_ut;
 use crate::tests::meta_node::start_meta_node_cluster;
 use crate::tests::meta_node::start_meta_node_leader;
 use crate::tests::service::MetaSrvTestContext;

--- a/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
@@ -24,9 +24,9 @@ use common_meta_types::MatchSeq;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKV;
+use databend_meta::init_meta_ut;
 use tracing::info;
 
-use crate::init_meta_ut;
 use crate::tests::meta_node::start_meta_node_leader;
 use crate::tests::meta_node::start_meta_node_non_voter;
 

--- a/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
@@ -25,6 +25,7 @@ use common_meta_types::LogEntry;
 use common_meta_types::NodeId;
 use common_meta_types::UpsertKV;
 use databend_meta::configs;
+use databend_meta::init_meta_ut;
 use databend_meta::meta_service::ForwardRequest;
 use databend_meta::meta_service::ForwardRequestBody;
 use databend_meta::meta_service::JoinRequest;
@@ -34,7 +35,6 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 use tracing::info;
 
-use crate::init_meta_ut;
 use crate::tests::meta_node::start_meta_node_cluster;
 use crate::tests::meta_node::start_meta_node_leader;
 use crate::tests::meta_node::start_meta_node_non_voter;

--- a/src/meta/service/tests/it/meta_node/meta_node_replication.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_replication.rs
@@ -20,10 +20,10 @@ use common_meta_types::Cmd;
 use common_meta_types::LogEntry;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKV;
+use databend_meta::init_meta_ut;
 use databend_meta::meta_service::MetaNode;
 use tracing::info;
 
-use crate::init_meta_ut;
 use crate::tests::meta_node::start_meta_node_non_voter;
 use crate::tests::meta_node::timeout;
 use crate::tests::service::MetaSrvTestContext;

--- a/src/meta/service/tests/it/meta_node/meta_node_request_forwarding.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_request_forwarding.rs
@@ -20,11 +20,11 @@ use common_meta_types::ForwardToLeader;
 use common_meta_types::LogEntry;
 use common_meta_types::RaftWriteError;
 use common_meta_types::UpsertKV;
+use databend_meta::init_meta_ut;
 use databend_meta::meta_service::meta_leader::MetaLeader;
 use databend_meta::meta_service::MetaNode;
 use maplit::btreeset;
 
-use crate::init_meta_ut;
 use crate::tests::meta_node::start_meta_node_cluster;
 use crate::tests::service::MetaSrvTestContext;
 

--- a/src/meta/service/tests/it/meta_node/meta_node_seq_api.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_seq_api.rs
@@ -21,9 +21,9 @@ use common_meta_types::AppliedState;
 use common_meta_types::Cmd;
 use common_meta_types::LogEntry;
 use common_meta_types::RetryableError;
+use databend_meta::init_meta_ut;
 use databend_meta::meta_service::MetaNode;
 
-use crate::init_meta_ut;
 use crate::tests::service::MetaSrvTestContext;
 
 #[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]

--- a/src/meta/service/tests/it/store.rs
+++ b/src/meta/service/tests/it/store.rs
@@ -31,13 +31,13 @@ use common_meta_sled_store::openraft::RaftStorage;
 use common_meta_sled_store::openraft::StorageHelper;
 use common_meta_types::AppliedState;
 use common_meta_types::LogEntry;
+use databend_meta::init_meta_ut;
 use databend_meta::store::RaftStoreBare;
 use databend_meta::Opened;
 use maplit::btreeset;
 use tracing::debug;
 use tracing::info;
 
-use crate::init_meta_ut;
 use crate::tests::service::MetaSrvTestContext;
 
 struct MetaStoreBuilder {

--- a/src/meta/service/tests/it/tests/mod.rs
+++ b/src/meta/service/tests/it/tests/mod.rs
@@ -14,11 +14,9 @@
 
 //! Supporting mod for tests
 
-pub mod logging;
 pub mod meta_node;
 pub mod service;
 pub mod tls_constants;
 
-pub use service::next_port;
 pub use service::start_metasrv;
 pub use service::start_metasrv_with_context;

--- a/src/meta/service/tests/it/tests/service.rs
+++ b/src/meta/service/tests/it/tests/service.rs
@@ -199,23 +199,6 @@ impl MetaSrvTestContext {
     }
 }
 
-/// 1. Open a temp sled::Db for all tests.
-/// 2. Initialize a global tracing.
-/// 3. Create a span for a test case. One needs to enter it by `span.enter()` and keeps the guard held.
-#[macro_export]
-macro_rules! init_meta_ut {
-    () => {{
-        let t = tempfile::tempdir().expect("create temp dir to sled db");
-        common_meta_sled_store::init_temp_sled_db(t);
-
-        $crate::tests::logging::init_meta_ut_tracing();
-
-        let name = common_tracing::func_name!();
-        let span = tracing::debug_span!("ut", "{}", name.split("::").last().unwrap());
-        ((), span)
-    }};
-}
-
 /// Build metasrv or metasrv cluster, returns the clients
 #[derive(Clone)]
 pub struct MetaSrvBuilder {

--- a/src/meta/sled-store/tests/it/testing/mod.rs
+++ b/src/meta/sled-store/tests/it/testing/mod.rs
@@ -27,11 +27,15 @@ macro_rules! init_sled_ut {
         let t = tempfile::tempdir().expect("create temp dir to sled db");
 
         common_meta_sled_store::init_temp_sled_db(t);
-        common_tracing::init_logging("sled_unittests", &common_tracing::Config::new_testing());
+        let guards = common_tracing::init_logging(
+            "sled_unittests",
+            &common_tracing::Config::new_testing(),
+            true,
+        );
 
         let name = common_tracing::func_name!();
         let span = tracing::debug_span!("ut", "{}", name.split("::").last().unwrap());
-        ((), span)
+        (guards, span)
     }};
 }
 

--- a/tests/metactl/test-metactl-restore-new-cluster.sh
+++ b/tests/metactl/test-metactl-restore-new-cluster.sh
@@ -6,7 +6,7 @@ SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 
 rm -fr .databend/
 
-echo "start 3 meta node cluster"
+echo " === start 3 meta node cluster"
 
 nohup ./target/debug/databend-meta --config-file=./tests/metactl/config/databend-meta-node-1.toml &
 python3 scripts/ci/wait_tcp.py --timeout 5 --port 9191
@@ -19,18 +19,18 @@ python3 scripts/ci/wait_tcp.py --timeout 5 --port 28302
 
 curl -sL http://127.0.0.1:28101/v1/cluster/status
 
-echo "stop 3 meta node cluster"
+echo " === stop 3 meta node cluster"
 killall databend-meta
 sleep 2
 
-echo "export meta node data"
+echo " === export meta node data"
 
 ./target/debug/databend-metactl --export --raft-dir ./.databend/meta1 --db meta.db
 
 
 rm -fr .databend/
 
-echo "import old meta node data to new cluster"
+echo " === import old meta node data to new cluster"
 ./target/debug/databend-metactl --import --raft-dir ./.databend/new_meta1 --id=4 --db meta.db --initial-cluster 4=localhost:29103,0.0.0.0:19191 5=localhost:29203,0.0.0.0:29191 6=localhost:29303,0.0.0.0:39191
 ./target/debug/databend-metactl --import --raft-dir ./.databend/new_meta2 --id=5 --db meta.db --initial-cluster 4=localhost:29103,0.0.0.0:19191 5=localhost:29203,0.0.0.0:29191 6=localhost:29303,0.0.0.0:39191
 ./target/debug/databend-metactl --import --raft-dir ./.databend/new_meta3 --id=6 --db meta.db --initial-cluster 4=localhost:29103,0.0.0.0:19191 5=localhost:29203,0.0.0.0:29191 6=localhost:29303,0.0.0.0:39191
@@ -39,11 +39,11 @@ echo " === check if state machine is complete by checking key 'LastMembership'"
 if ./target/debug/databend-metactl --export --raft-dir ./.databend/new_meta1 | grep LastMembership; then
     echo "=== 'LastMembership' is found"
 else
-    echo "=== 'LastMembership' not found"
+    echo "=== 'LastMembership' is not found"
     exit 1;
 fi
 
-echo "start 3 new meta node cluster"
+echo " === start 3 new meta node cluster"
 nohup ./target/debug/databend-meta --config-file=./tests/metactl/config/new-databend-meta-node-1.toml &
 python3 scripts/ci/wait_tcp.py --timeout 5 --port 19191
 
@@ -53,7 +53,14 @@ python3 scripts/ci/wait_tcp.py --timeout 5 --port 29191
 nohup ./target/debug/databend-meta --config-file=./tests/metactl/config/new-databend-meta-node-3.toml &
 python3 scripts/ci/wait_tcp.py --timeout 5 --port 39191
 
-echo "check new cluster state"
-curl -sL http://127.0.0.1:28101/v1/cluster/status | grep "\"voters\":\[{\"name\":\"4\",\"endpoint\":{\"addr\":\"localhost\",\"port\":29103},\"grpc_api_addr\":\"0.0.0.0:19191\"},{\"name\":\"5\",\"endpoint\":{\"addr\":\"localhost\",\"port\":29203},\"grpc_api_addr\":\"0.0.0.0:29191\"},{\"name\":\"6\",\"endpoint\":{\"addr\":\"localhost\",\"port\":29303},\"grpc_api_addr\":\"0.0.0.0:39191\"}\]"
+echo " === sleep 3 sec to wait for membership to commit"
+time sleep 3
+
+echo " === dump new cluster state:"
+curl -sL http://127.0.0.1:28101/v1/cluster/status
+
+echo " === check new cluster state has the voters 4, 5, 6"
+curl -sL http://127.0.0.1:28101/v1/cluster/status \
+    | grep '"voters":\[{"name":"4","endpoint":{"addr":"localhost","port":29103},"grpc_api_addr":"0.0.0.0:19191"},{"name":"5","endpoint":{"addr":"localhost","port":29203},"grpc_api_addr":"0.0.0.0:29191"},{"name":"6","endpoint":{"addr":"localhost","port":29303},"grpc_api_addr":"0.0.0.0:39191"}\]'
 
 killall databend-meta


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/service): enable tracing log for databend-meta

The default `BunyanFormattingLayer` logging does not include complete
tracing information. Databend-meta output to another log file
`databend-meta-tracing` which includes complete span info and tracing
event field.

## Changelog







## Related Issues