### PR TITLE
refactor(meta/service): try best to leave a cluster

### DIFF
--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -143,8 +143,9 @@ impl<'a> MetaLeader<'a> {
 
     /// A node leave the cluster.
     ///
-    /// - Remove the node from cluster.
     /// - Remove the node from membership.
+    /// - Stop replication.
+    /// - Remove the node from cluster.
     ///
     /// If the node is not in cluster membership, it still returns Ok.
     #[tracing::instrument(level = "debug", skip(self))]
@@ -153,33 +154,23 @@ impl<'a> MetaLeader<'a> {
         let metrics = self.meta_node.raft.metrics().borrow().clone();
         let membership = metrics.membership_config.membership.clone();
 
-        if !membership.contains(&node_id) {
-            return Ok(());
-        }
-
         // safe unwrap: if the first config is None, panic is the expected behavior here.
         let mut membership = membership.get_ith_config(0).unwrap().clone();
-        membership.remove(&node_id);
 
-        self.meta_node
-            .raft
-            .change_membership(membership, true)
-            .await?;
+        // 1. Remove it from membership if needed.
+        if membership.contains(&node_id) {
+            membership.remove(&node_id);
 
-        let ent = LogEntry {
-            txid: None,
-            time_ms: None,
-            cmd: Cmd::RemoveNode { node_id },
-        };
-        self.write(ent).await?;
+            self.meta_node
+                .raft
+                .change_membership(membership, true)
+                .await?;
+        }
 
-        // When write(RemoveNode{}) returns, the replication to that node should be dropped.
-        // But there is chance `add_configured_non_voters()` adds it back because it runs in another task.
-        // Thus we need to ensure the replication is removed here.
+        // 2. Stop replication
         let res = self.meta_node.raft.remove_learner(node_id).await;
-
         if let Err(e) = res {
-            return match e {
+            let res = match e {
                 RemoveLearnerError::ForwardToLeader(e) => {
                     Err(RaftChangeMembershipError::ForwardToLeader(e))
                 }
@@ -193,7 +184,16 @@ impl<'a> MetaLeader<'a> {
                 }
                 RemoveLearnerError::Fatal(e) => Err(RaftChangeMembershipError::Fatal(e)),
             };
+            res?;
         }
+
+        // 3. Remove node info
+        let ent = LogEntry {
+            txid: None,
+            time_ms: None,
+            cmd: Cmd::RemoveNode { node_id },
+        };
+        self.write(ent).await?;
 
         Ok(())
     }

--- a/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
@@ -193,10 +193,11 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
 #[async_entry::test(worker_threads = 5, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_node_leave() -> anyhow::Result<()> {
     // - Bring up a cluster
-    // - Leave a node by sending a Leave request to a non-voter.
+    // - Leave a     voter node by sending a Leave request to a non-voter.
+    // - Leave a non-voter node by sending a Leave request to a non-voter.
     // - Restart all nodes and check if states are restored.
 
-    let (mut _nlog, tcs) = start_meta_node_cluster(btreeset![0, 1, 2], btreeset![3]).await?;
+    let (mut log_index, tcs) = start_meta_node_cluster(btreeset![0, 1, 2], btreeset![3]).await?;
     let mut all = test_context_nodes(&tcs);
 
     let leader_id = 0;
@@ -204,26 +205,75 @@ async fn test_meta_node_leave() -> anyhow::Result<()> {
 
     let leader = all[leader_id as usize].clone();
 
-    // leave a node
-    let req = ForwardRequest {
-        forward_to_leader: 0,
-        body: ForwardRequestBody::Leave(LeaveRequest {
-            node_id: leave_node_id,
-        }),
-    };
+    info!("--- leave voter node-1");
+    {
+        let req = ForwardRequest {
+            forward_to_leader: 0,
+            body: ForwardRequestBody::Leave(LeaveRequest {
+                node_id: leave_node_id,
+            }),
+        };
 
-    leader.handle_forwardable_request(req).await?;
+        leader.handle_forwardable_request(req).await?;
+        // Change membership
+        log_index += 2;
+        // Remove node
+        log_index += 1;
 
-    leader
-        .raft
-        .wait(timeout())
-        .members(btreeset! {0,2}, "node-1 left the cluster")
-        .await?;
+        leader
+            .raft
+            .wait(timeout())
+            .log(Some(log_index), "commit leave-request logs for node-1")
+            .await?;
+
+        leader
+            .raft
+            .wait(timeout())
+            .members(btreeset! {0,2}, "node-1 left the cluster")
+            .await?;
+    }
+
+    info!("--- check nodes list: node-1 is removed");
+    {
+        let nodes = leader.get_nodes().await?;
+        assert_eq!(
+            vec!["0", "2", "3"],
+            nodes.iter().map(|x| x.name.clone()).collect::<Vec<_>>()
+        );
+    }
+
+    info!("--- leave non-voter node-3");
+    {
+        let req = ForwardRequest {
+            forward_to_leader: 0,
+            body: ForwardRequestBody::Leave(LeaveRequest { node_id: 3 }),
+        };
+
+        leader.handle_forwardable_request(req).await?;
+        // Remove node, no membership change
+        log_index += 1;
+
+        leader
+            .raft
+            .wait(timeout())
+            .log(Some(log_index), "commit leave-request logs for node-3")
+            .await?;
+    }
+
+    info!("--- check nodes list: node-3 is removed");
+    {
+        let nodes = leader.get_nodes().await?;
+        assert_eq!(
+            vec!["0", "2"],
+            nodes.iter().map(|x| x.name.clone()).collect::<Vec<_>>()
+        );
+    }
 
     info!("--- stop all meta node");
-
-    for mn in all.drain(..) {
-        mn.stop().await?;
+    {
+        for mn in all.drain(..) {
+            mn.stop().await?;
+        }
     }
 
     // restart the cluster and check membership


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/service): try best to leave a cluster

When leaving a node from a meta-service cluster, no matter the node is a
voter and non-voter(learner), it should try the best removing it with
the following step:

- Remove it from membership list.
- Stop replication to it.
- Remove its node info record from meta store.

Before this commit, if the node is not in membership list it won't do
anything, hense there is no way to clean up a dirty state, e.g., to
remove a non-voter(learner).

## Changelog







## Related Issues