### PR TITLE
feat(http handler): no longer need to call `final_uri` explicitly.

### DIFF
--- a/docs/doc/30-reference/00-api/00-rest.md
+++ b/docs/doc/30-reference/00-api/00-rest.md
@@ -20,9 +20,8 @@ This handler return results in `pages` with long-polling.
    of type `QueryResponse`.
 2. Use fields of `QueryResponse` for further processing:
     1. A `GET` to the `next_uri` returns the next `page` of query results. It returns `QueryResponse` too, processing it
-       the same way recursively until `next_uri` is nil.
-    2. A `GET` to the `final_uri` finally after all results is fetched (`next_uri = nil`) or the remaining is not
-       needed. Return empty body.
+       the same way until `next_uri` is null.
+    2. (optional) A `GET` to the `kill_uri` to kill the query. Return empty body.
     3. (optional) A `GET` to the `stats_uri` to get stats only at once (without long-polling), return `QueryResponse`
        with empty `data` field.
 
@@ -81,16 +80,10 @@ you are expected to get JSON like this (formatted):
     "running_time_ms": 466.85395800000003
   },
   "stats_uri": "/v1/query/3cd25ab7-c3a4-42ce-9e02-e1b354d91f06",
-  "final_uri": "/v1/query/3cd25ab7-c3a4-42ce-9e02-e1b354d91f06/kill?delete=true",
   "next_uri": null
   "affect": null
 }
 ```
-
-Note:
-
-1. next_uri is null because all data is returned.
-1. client should call final_uri to tell the server the client has received the results and server can delete them.
 
 
 ## Query Request

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -110,14 +110,40 @@ pub struct QueryResponse {
 }
 
 impl QueryResponse {
-    pub(crate) fn from_internal(id: String, r: HttpQueryResponseInternal) -> impl IntoResponse {
+    pub(crate) fn from_internal(
+        id: String,
+        r: HttpQueryResponseInternal,
+        is_final: bool,
+    ) -> impl IntoResponse {
         let state = r.state.clone();
-        let (data, next_url) = match (state.state, r.data) {
-            (ExecuteStateKind::Succeeded | ExecuteStateKind::Running, Some(d)) => {
-                (d.page.data, d.next_page_no.map(|n| make_page_uri(&id, n)))
+        let (data, next_uri) = if is_final {
+            (JsonBlock::empty(), None)
+        } else {
+            match state.state {
+                ExecuteStateKind::Running => match r.data {
+                    None => (JsonBlock::empty(), Some(make_state_uri(&id))),
+                    Some(d) => {
+                        let uri = match d.next_page_no {
+                            Some(n) => Some(make_page_uri(&id, n)),
+                            None => Some(make_state_uri(&id)),
+                        };
+                        (d.page.data, uri)
+                    }
+                },
+                ExecuteStateKind::Failed => (JsonBlock::empty(), Some(make_final_uri(&id))),
+                ExecuteStateKind::Succeeded => match r.data {
+                    None => (JsonBlock::empty(), Some(make_final_uri(&id))),
+                    Some(d) => {
+                        let uri = match d.next_page_no {
+                            Some(n) => Some(make_page_uri(&id, n)),
+                            None => Some(make_final_uri(&id)),
+                        };
+                        (d.page.data, uri)
+                    }
+                },
             }
-            _ => (JsonBlock::empty(), None),
         };
+
         let schema = data.schema().clone();
         let session_id = r.session_id.clone();
         let stats = QueryStats {
@@ -133,7 +159,7 @@ impl QueryResponse {
             stats,
             affect: state.affect,
             id: id.clone(),
-            next_uri: next_url,
+            next_uri,
             stats_uri: Some(make_state_uri(&id)),
             final_uri: Some(make_final_uri(&id)),
             kill_uri: Some(make_kill_uri(&id)),
@@ -163,17 +189,23 @@ impl QueryResponse {
 }
 
 #[poem::handler]
-async fn query_detach_handler(
+async fn query_final_handler(
     _ctx: &HttpQueryContext,
     Path(query_id): Path<String>,
-) -> impl IntoResponse {
+) -> PoemResult<impl IntoResponse> {
     let http_query_manager = HttpQueryManager::instance();
     match http_query_manager.remove_query(&query_id).await {
         Some(query) => {
-            query.detach().await;
-            StatusCode::OK
+            let mut response = query.get_response_state_only().await;
+            if response.state.state == ExecuteStateKind::Running {
+                return Err(PoemError::from_string(
+                    format!("query {} is still running, can not final it", query_id),
+                    StatusCode::BAD_REQUEST,
+                ));
+            }
+            Ok(QueryResponse::from_internal(query_id, response, true))
         }
-        None => StatusCode::NOT_FOUND,
+        None => Err(query_id_not_found(query_id)),
     }
 }
 
@@ -203,7 +235,7 @@ async fn query_state_handler(
     match http_query_manager.get_query(&query_id).await {
         Some(query) => {
             let response = query.get_response_state_only().await;
-            Ok(QueryResponse::from_internal(query_id, response))
+            Ok(QueryResponse::from_internal(query_id, response, false))
         }
         None => Err(query_id_not_found(query_id)),
     }
@@ -223,7 +255,7 @@ async fn query_page_handler(
                 .await
                 .map_err(|err| poem::Error::from_string(err.message(), StatusCode::NOT_FOUND))?;
             query.update_expire_time(false).await;
-            Ok(QueryResponse::from_internal(query_id, resp))
+            Ok(QueryResponse::from_internal(query_id, resp, false))
         }
         None => Err(query_id_not_found(query_id)),
     }
@@ -255,7 +287,7 @@ pub(crate) async fn query_handler(
                 &query.id, &resp.state, rows, next_page, sql
             );
             query.update_expire_time(false).await;
-            Ok(QueryResponse::from_internal(query.id.to_string(), resp).into_response())
+            Ok(QueryResponse::from_internal(query.id.to_string(), resp, false).into_response())
         }
         Err(e) => {
             error!("Fail to start sql, Error: {:?}", e);
@@ -277,7 +309,7 @@ pub fn query_route() -> Route {
         )
         .at(
             "/:id/final",
-            get(query_detach_handler).post(query_detach_handler),
+            get(query_final_handler).post(query_final_handler),
         )
 }
 

--- a/tests/logictest/http_runner.py
+++ b/tests/logictest/http_runner.py
@@ -2,7 +2,7 @@ from abc import ABC
 
 import logictest
 import http_connector
-
+from mysql.connector.errors import Error
 
 class TestHttp(logictest.SuiteRunner, ABC):
 
@@ -25,12 +25,16 @@ class TestHttp(logictest.SuiteRunner, ABC):
         self.reset_connection()
 
     def execute_ok(self, statement):
-        resp = self.get_connection().query_with_session(statement)
-        return http_connector.get_error(resp[0])
+        try:
+            self.get_connection().query_with_session(statement)
+        except Error as e:
+            return e
 
     def execute_error(self, statement):
-        resp = self.get_connection().query_with_session(statement)
-        return http_connector.get_error(resp[0])
+        try:
+            self.get_connection().query_with_session(statement)
+        except Error as e:
+            return e
 
     def execute_query(self, statement):
         results = self.get_connection().fetch_all(statement.text)

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/chain.test
@@ -1,4 +1,7 @@
 statement ok
+drop database if exists join_reorder;
+
+statement ok
 create database join_reorder;
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

step 1 of https://github.com/datafuselabs/databend/issues/8271


a bug of  HTTP logic test is fixed：
  `statement query `(compare results)  show `not equal` even if the SQL failed.
