### PR TITLE
feat: add_source and add_sink to pipeline to simple the usage

### DIFF
--- a/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
+++ b/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
@@ -24,8 +24,6 @@ use common_exception::Result;
 use common_legacy_expression::LegacyExpression;
 use common_legacy_planners::Extras;
 use common_meta_app::schema::DatabaseMeta;
-use common_pipeline_core::processors::port::OutputPort;
-use common_pipeline_core::SourcePipeBuilder;
 use common_planner::plans::CreateDatabasePlan;
 use common_storage::StorageFsConfig;
 use common_storage::StorageParams;
@@ -284,15 +282,12 @@ impl TestFixture {
             .map(|b| b.schema().clone())
             .unwrap_or_else(|| table.schema());
         let mut build_res = PipelineBuildResult::create();
-        let mut builder = SourcePipeBuilder::create();
 
         let blocks = Arc::new(Mutex::new(VecDeque::from_iter(blocks)));
-        let output = OutputPort::create();
-        builder.add_source(
-            output.clone(),
-            BlocksSource::create(self.ctx.clone(), output, blocks)?,
-        );
-        build_res.main_pipeline.add_pipe(builder.finalize());
+        build_res.main_pipeline.add_source(
+            |output| BlocksSource::create(self.ctx.clone(), output, blocks.clone()),
+            1,
+        )?;
 
         append2table(
             self.ctx.clone(),

--- a/src/query/storages/preludes/src/null/null_table.rs
+++ b/src/query/storages/preludes/src/null/null_table.rs
@@ -24,7 +24,6 @@ use common_legacy_planners::ReadDataSourcePlan;
 use common_legacy_planners::Statistics;
 use common_meta_app::schema::TableInfo;
 
-use crate::pipelines::processors::port::InputPort;
 use crate::pipelines::processors::port::OutputPort;
 use crate::pipelines::processors::processor::ProcessorPtr;
 use crate::pipelines::processors::EmptySink;
@@ -32,7 +31,6 @@ use crate::pipelines::processors::SyncSource;
 use crate::pipelines::processors::SyncSourcer;
 use crate::pipelines::Pipe;
 use crate::pipelines::Pipeline;
-use crate::pipelines::SinkPipeBuilder;
 use crate::sessions::TableContext;
 use crate::storages::StorageContext;
 use crate::storages::StorageDescription;
@@ -97,12 +95,7 @@ impl Table for NullTable {
         pipeline: &mut Pipeline,
         _: bool,
     ) -> Result<()> {
-        let mut sink_pipeline_builder = SinkPipeBuilder::create();
-        for _ in 0..pipeline.output_len() {
-            let input_port = InputPort::create();
-            sink_pipeline_builder.add_sink(input_port.clone(), EmptySink::create(input_port));
-        }
-        pipeline.add_pipe(sink_pipeline_builder.finalize());
+        pipeline.add_sink(|input| Ok(EmptySink::create(input)))?;
         Ok(())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

There are many places to use `Source` or `Sink` builder like this:
```
        let mut sink_pipeline_builder = SinkPipeBuilder::create();
        for _ in 0..pipeline.output_len() {
            let input_port = InputPort::create();
            sink_pipeline_builder.add_sink(input_port.clone(), EmptySink::create(input_port));
        }
        pipeline.add_pipe(sink_pipeline_builder.finalize());
```

This PR adds the `add_source` and `add_sink` functions to simplify the usage.
```
pipeline.add_sink(|input| Ok(EmptySink::create(input)))?;
```

If these two functions are OK, I will move them all to the new in another PR.

Fixes #issue
