### PR TITLE
fix(planner): Fix aggregation in cluster mode

### DIFF
--- a/src/query/service/src/sql/planner/optimizer/property/property.rs
+++ b/src/query/service/src/sql/planner/optimizer/property/property.rs
@@ -78,9 +78,12 @@ impl Distribution {
             | (Distribution::Random, _)
             | (Distribution::Serial, Distribution::Serial)
             | (Distribution::Broadcast, Distribution::Broadcast) => true,
-            (Distribution::Hash(ref keys), Distribution::Hash(ref other_keys)) => keys
-                .iter()
-                .all(|key| other_keys.iter().any(|other_key| key == other_key)),
+
+            // TODO(leiysky): this is actually broken by https://github.com/datafuselabs/databend/pull/7451
+            // , would be fixed later.
+            // (Distribution::Hash(ref keys), Distribution::Hash(ref other_keys)) => keys
+            //     .iter()
+            //     .all(|key| other_keys.iter().any(|other_key| key == other_key)),
             _ => false,
         }
     }

--- a/src/query/service/src/sql/planner/plans/aggregate.rs
+++ b/src/query/service/src/sql/planner/plans/aggregate.rs
@@ -105,9 +105,8 @@ impl PhysicalOperator for Aggregate {
                     // Scalar aggregation
                     required.distribution = Distribution::Serial;
                 } else {
-                    // Group aggregation, enforce `Hash` distribution
-                    required.distribution =
-                        Distribution::Hash(vec![self.group_items[0].scalar.clone()]);
+                    // The distribution should have been derived by partial aggregation
+                    required.distribution = Distribution::Any;
                 }
             }
 

--- a/tests/logictest/suites/base/15_query/aggregate.test
+++ b/tests/logictest/suites/base/15_query/aggregate.test
@@ -25,3 +25,22 @@ select (count(1) > 1)::int from numbers(10);
 
 ----
 1
+
+statement ok
+drop table if exists t;
+
+statement ok
+create table t(a int, b int);
+
+statement ok
+insert into t values(1, 1), (1, 2), (2, 1), (2, 2);
+
+statement query II
+select a, sum(sum) as sum from (select a, sum(a) as sum from t group by a, b) as t group by a order by a;
+
+----
+1	2
+2	4
+
+statement ok
+drop table t;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

We derived the wrong data distribution of aggregation if there is more than one group key since we will actually use an internal column `_group_by_key` as the distribute key which cannot be recognized during planning for now.

This can be improved in the future.

Close #8290 
Close #8292
