### PR TITLE
bugfix(planner): Fix join associate rules

### DIFF
--- a/src/query/service/src/sql/planner/optimizer/rule/transform/rule_left_associate_join.rs
+++ b/src/query/service/src/sql/planner/optimizer/rule/transform/rule_left_associate_join.rs
@@ -66,12 +66,12 @@ impl RuleLeftAssociateJoin {
                 PatternPlan {
                     plan_type: RelOp::LogicalInnerJoin,
                 }
-                    .into(),
+                .into(),
                 SExpr::create_binary(
                     PatternPlan {
                         plan_type: RelOp::LogicalInnerJoin,
                     }
-                        .into(),
+                    .into(),
                     SExpr::create_pattern_leaf(),
                     SExpr::create_pattern_leaf(),
                 ),
@@ -129,7 +129,7 @@ impl Rule for RuleLeftAssociateJoin {
             t2.clone(),
             t3.clone(),
         ))
-            .derive_relational_prop()?;
+        .derive_relational_prop()?;
 
         let mut join_4_preds = vec![];
 

--- a/src/query/service/src/sql/planner/optimizer/rule/transform/rule_left_associate_join.rs
+++ b/src/query/service/src/sql/planner/optimizer/rule/transform/rule_left_associate_join.rs
@@ -66,12 +66,12 @@ impl RuleLeftAssociateJoin {
                 PatternPlan {
                     plan_type: RelOp::LogicalInnerJoin,
                 }
-                .into(),
+                    .into(),
                 SExpr::create_binary(
                     PatternPlan {
                         plan_type: RelOp::LogicalInnerJoin,
                     }
-                    .into(),
+                        .into(),
                     SExpr::create_pattern_leaf(),
                     SExpr::create_pattern_leaf(),
                 ),
@@ -129,7 +129,7 @@ impl Rule for RuleLeftAssociateJoin {
             t2.clone(),
             t3.clone(),
         ))
-        .derive_relational_prop()?;
+            .derive_relational_prop()?;
 
         let mut join_4_preds = vec![];
 
@@ -190,7 +190,7 @@ impl Rule for RuleLeftAssociateJoin {
                 t1.clone(),
                 SExpr::create_binary(join_4.into(), t2.clone(), t3.clone()),
             ],
-            s_expr.original_group,
+            None,
             None,
         );
 

--- a/src/query/service/src/sql/planner/optimizer/rule/transform/rule_right_associate_join.rs
+++ b/src/query/service/src/sql/planner/optimizer/rule/transform/rule_right_associate_join.rs
@@ -62,13 +62,13 @@ impl RuleRightAssociateJoin {
                 PatternPlan {
                     plan_type: RelOp::LogicalInnerJoin,
                 }
-                    .into(),
+                .into(),
                 SExpr::create_pattern_leaf(),
                 SExpr::create_binary(
                     PatternPlan {
                         plan_type: RelOp::LogicalInnerJoin,
                     }
-                        .into(),
+                    .into(),
                     SExpr::create_pattern_leaf(),
                     SExpr::create_pattern_leaf(),
                 ),
@@ -125,7 +125,7 @@ impl Rule for RuleRightAssociateJoin {
             t1.clone(),
             t2.clone(),
         ))
-            .derive_relational_prop()?;
+        .derive_relational_prop()?;
 
         let mut join_4_preds = vec![];
 

--- a/src/query/service/src/sql/planner/optimizer/rule/transform/rule_right_associate_join.rs
+++ b/src/query/service/src/sql/planner/optimizer/rule/transform/rule_right_associate_join.rs
@@ -62,13 +62,13 @@ impl RuleRightAssociateJoin {
                 PatternPlan {
                     plan_type: RelOp::LogicalInnerJoin,
                 }
-                .into(),
+                    .into(),
                 SExpr::create_pattern_leaf(),
                 SExpr::create_binary(
                     PatternPlan {
                         plan_type: RelOp::LogicalInnerJoin,
                     }
-                    .into(),
+                        .into(),
                     SExpr::create_pattern_leaf(),
                     SExpr::create_pattern_leaf(),
                 ),
@@ -125,7 +125,7 @@ impl Rule for RuleRightAssociateJoin {
             t1.clone(),
             t2.clone(),
         ))
-        .derive_relational_prop()?;
+            .derive_relational_prop()?;
 
         let mut join_4_preds = vec![];
 
@@ -186,7 +186,7 @@ impl Rule for RuleRightAssociateJoin {
                 SExpr::create_binary(join_4.into(), t1.clone(), t2.clone()),
                 t3.clone(),
             ],
-            s_expr.original_group,
+            None,
             None,
         );
 

--- a/tests/logictest/suites/mode/standalone/explain/explain_memo.test
+++ b/tests/logictest/suites/mode/standalone/explain/explain_memo.test
@@ -19,3 +19,49 @@ Group #2
 ├── PhysicalHashJoin [#0, #1]
 └── PhysicalHashJoin [#1, #0]
 
+statement query T
+explain memo select * from
+    numbers(1) as t,
+    numbers(10) as t1,
+    numbers(100) as t2
+    where t.number = t1.number and t1.number = t2.number;
+
+----
+Group #0
+├── best cost: [#1] 1
+├── LogicalGet []
+└── PhysicalScan []
+
+Group #1
+├── best cost: [#1] 10
+├── LogicalGet []
+└── PhysicalScan []
+
+Group #2
+├── best cost: [#3] 31
+├── LogicalInnerJoin [#0, #1]
+├── LogicalInnerJoin [#1, #0]
+├── PhysicalHashJoin [#0, #1]
+└── PhysicalHashJoin [#1, #0]
+
+Group #3
+├── best cost: [#1] 100
+├── LogicalGet []
+└── PhysicalScan []
+
+Group #4
+├── best cost: [#3] 331
+├── LogicalInnerJoin [#2, #3]
+├── LogicalInnerJoin [#0, #5]
+├── LogicalInnerJoin [#3, #2]
+├── PhysicalHashJoin [#3, #2]
+├── PhysicalHashJoin [#0, #5]
+└── PhysicalHashJoin [#2, #3]
+
+Group #5
+├── best cost: [#3] 310
+├── LogicalInnerJoin [#1, #3]
+├── LogicalInnerJoin [#3, #1]
+├── PhysicalHashJoin [#1, #3]
+└── PhysicalHashJoin [#3, #1]
+

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/chain.test
@@ -127,35 +127,35 @@ explain select * from t1, t2, t where t.a = t1.a and t1.a = t2.a;
 ----
 HashJoin
 ├── join type: INNER
-├── build keys: [t.a (#2)]
-├── probe keys: [t1.a (#0)]
+├── build keys: [t1.a (#0)]
+├── probe keys: [t2.a (#1)]
 ├── filters: []
-├── TableScan(Build)
-│   ├── table: default.join_reorder.t
-│   ├── read rows: 1
-│   ├── read bytes: 197
-│   ├── partitions total: 1
-│   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
-└── HashJoin(Probe)
-    ├── join type: INNER
-    ├── build keys: [t1.a (#0)]
-    ├── probe keys: [t2.a (#1)]
-    ├── filters: []
-    ├── TableScan(Build)
-    │   ├── table: default.join_reorder.t1
-    │   ├── read rows: 10
-    │   ├── read bytes: 243
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
-    └── TableScan(Probe)
-        ├── table: default.join_reorder.t2
-        ├── read rows: 100
-        ├── read bytes: 610
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#2)]
+│   ├── probe keys: [t1.a (#0)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 197
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 243
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 610
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a;
@@ -163,35 +163,35 @@ explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a;
 ----
 HashJoin
 ├── join type: INNER
-├── build keys: [t.a (#2)]
-├── probe keys: [t1.a (#1)]
+├── build keys: [t1.a (#1)]
+├── probe keys: [t2.a (#0)]
 ├── filters: []
-├── TableScan(Build)
-│   ├── table: default.join_reorder.t
-│   ├── read rows: 1
-│   ├── read bytes: 197
-│   ├── partitions total: 1
-│   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
-└── HashJoin(Probe)
-    ├── join type: INNER
-    ├── build keys: [t1.a (#1)]
-    ├── probe keys: [t2.a (#0)]
-    ├── filters: []
-    ├── TableScan(Build)
-    │   ├── table: default.join_reorder.t1
-    │   ├── read rows: 10
-    │   ├── read bytes: 243
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
-    └── TableScan(Probe)
-        ├── table: default.join_reorder.t2
-        ├── read rows: 100
-        ├── read bytes: 610
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#2)]
+│   ├── probe keys: [t1.a (#1)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 197
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 243
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 610
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from t2, t, t1 where t.a = t1.a and t1.a = t2.a;
@@ -375,3 +375,4 @@ HashJoin
 
 statement ok
 drop database join_reorder;
+

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/cycles.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/cycles.test
@@ -55,35 +55,35 @@ explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
 ----
 HashJoin
 ├── join type: INNER
-├── build keys: [t1.a (#2), t1.a (#2)]
-├── probe keys: [t.a (#0), t2.a (#1)]
+├── build keys: [t1.a (#2), t.a (#0)]
+├── probe keys: [t2.a (#1), t2.a (#1)]
 ├── filters: []
-├── TableScan(Build)
-│   ├── table: default.join_reorder.t1
-│   ├── read rows: 10
-│   ├── read bytes: 243
-│   ├── partitions total: 1
-│   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
-└── HashJoin(Probe)
-    ├── join type: INNER
-    ├── build keys: [t.a (#0)]
-    ├── probe keys: [t2.a (#1)]
-    ├── filters: []
-    ├── TableScan(Build)
-    │   ├── table: default.join_reorder.t
-    │   ├── read rows: 1
-    │   ├── read bytes: 197
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
-    └── TableScan(Probe)
-        ├── table: default.join_reorder.t2
-        ├── read rows: 100
-        ├── read bytes: 610
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#0)]
+│   ├── probe keys: [t1.a (#2)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 197
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 243
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 610
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from t1, t, t2 where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
@@ -127,35 +127,35 @@ explain select * from t1, t2, t where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
 ----
 HashJoin
 ├── join type: INNER
-├── build keys: [t.a (#2), t.a (#2)]
-├── probe keys: [t1.a (#0), t2.a (#1)]
+├── build keys: [t.a (#2), t1.a (#0)]
+├── probe keys: [t2.a (#1), t2.a (#1)]
 ├── filters: []
-├── TableScan(Build)
-│   ├── table: default.join_reorder.t
-│   ├── read rows: 1
-│   ├── read bytes: 197
-│   ├── partitions total: 1
-│   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
-└── HashJoin(Probe)
-    ├── join type: INNER
-    ├── build keys: [t1.a (#0)]
-    ├── probe keys: [t2.a (#1)]
-    ├── filters: []
-    ├── TableScan(Build)
-    │   ├── table: default.join_reorder.t1
-    │   ├── read rows: 10
-    │   ├── read bytes: 243
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
-    └── TableScan(Probe)
-        ├── table: default.join_reorder.t2
-        ├── read rows: 100
-        ├── read bytes: 610
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#2)]
+│   ├── probe keys: [t1.a (#0)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 197
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 243
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 610
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
@@ -163,35 +163,35 @@ explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
 ----
 HashJoin
 ├── join type: INNER
-├── build keys: [t.a (#2), t.a (#2)]
-├── probe keys: [t1.a (#1), t2.a (#0)]
+├── build keys: [t.a (#2), t1.a (#1)]
+├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
-├── TableScan(Build)
-│   ├── table: default.join_reorder.t
-│   ├── read rows: 1
-│   ├── read bytes: 197
-│   ├── partitions total: 1
-│   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
-└── HashJoin(Probe)
-    ├── join type: INNER
-    ├── build keys: [t1.a (#1)]
-    ├── probe keys: [t2.a (#0)]
-    ├── filters: []
-    ├── TableScan(Build)
-    │   ├── table: default.join_reorder.t1
-    │   ├── read rows: 10
-    │   ├── read bytes: 243
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
-    └── TableScan(Probe)
-        ├── table: default.join_reorder.t2
-        ├── read rows: 100
-        ├── read bytes: 610
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#2)]
+│   ├── probe keys: [t1.a (#1)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 197
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 243
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 610
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from t2, t, t1 where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
@@ -199,35 +199,35 @@ explain select * from t2, t, t1 where t.a = t1.a and t1.a = t2.a and t2.a = t.a;
 ----
 HashJoin
 ├── join type: INNER
-├── build keys: [t1.a (#2), t1.a (#2)]
-├── probe keys: [t.a (#1), t2.a (#0)]
+├── build keys: [t1.a (#2), t.a (#1)]
+├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
-├── TableScan(Build)
-│   ├── table: default.join_reorder.t1
-│   ├── read rows: 10
-│   ├── read bytes: 243
-│   ├── partitions total: 1
-│   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
-└── HashJoin(Probe)
-    ├── join type: INNER
-    ├── build keys: [t.a (#1)]
-    ├── probe keys: [t2.a (#0)]
-    ├── filters: []
-    ├── TableScan(Build)
-    │   ├── table: default.join_reorder.t
-    │   ├── read rows: 1
-    │   ├── read bytes: 197
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
-    └── TableScan(Probe)
-        ├── table: default.join_reorder.t2
-        ├── read rows: 100
-        ├── read bytes: 610
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#1)]
+│   ├── probe keys: [t1.a (#2)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 197
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── read rows: 10
+│       ├── read bytes: 243
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── read rows: 100
+    ├── read bytes: 610
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
 
 statement ok
 drop database join_reorder;

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/mark.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/mark.test
@@ -45,3 +45,4 @@ HashJoin
     ├── partitions total: 2
     ├── partitions scanned: 2
     └── push downs: [filters: [], limit: NONE]
+

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/star.test
@@ -127,35 +127,35 @@ explain select * from t1, t2, t where t.a = t2.a and t1.a = t2.a;
 ----
 HashJoin
 ├── join type: INNER
-├── build keys: [t.a (#2)]
-├── probe keys: [t2.a (#1)]
+├── build keys: [t2.a (#1)]
+├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── TableScan(Build)
-│   ├── table: default.join_reorder.t
-│   ├── read rows: 1
-│   ├── read bytes: 197
-│   ├── partitions total: 1
-│   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
-└── HashJoin(Probe)
-    ├── join type: INNER
-    ├── build keys: [t1.a (#0)]
-    ├── probe keys: [t2.a (#1)]
-    ├── filters: []
-    ├── TableScan(Build)
-    │   ├── table: default.join_reorder.t1
-    │   ├── read rows: 10
-    │   ├── read bytes: 243
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
-    └── TableScan(Probe)
-        ├── table: default.join_reorder.t2
-        ├── read rows: 100
-        ├── read bytes: 610
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#2)]
+│   ├── probe keys: [t2.a (#1)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 197
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t2
+│       ├── read rows: 100
+│       ├── read bytes: 610
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t1
+    ├── read rows: 10
+    ├── read bytes: 243
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from t2, t1, t where t.a = t2.a and t1.a = t2.a;
@@ -163,35 +163,35 @@ explain select * from t2, t1, t where t.a = t2.a and t1.a = t2.a;
 ----
 HashJoin
 ├── join type: INNER
-├── build keys: [t.a (#2)]
-├── probe keys: [t2.a (#0)]
+├── build keys: [t2.a (#0)]
+├── probe keys: [t1.a (#1)]
 ├── filters: []
-├── TableScan(Build)
-│   ├── table: default.join_reorder.t
-│   ├── read rows: 1
-│   ├── read bytes: 197
-│   ├── partitions total: 1
-│   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
-└── HashJoin(Probe)
-    ├── join type: INNER
-    ├── build keys: [t1.a (#1)]
-    ├── probe keys: [t2.a (#0)]
-    ├── filters: []
-    ├── TableScan(Build)
-    │   ├── table: default.join_reorder.t1
-    │   ├── read rows: 10
-    │   ├── read bytes: 243
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
-    └── TableScan(Probe)
-        ├── table: default.join_reorder.t2
-        ├── read rows: 100
-        ├── read bytes: 610
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+├── HashJoin(Build)
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#2)]
+│   ├── probe keys: [t2.a (#0)]
+│   ├── filters: []
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── read rows: 1
+│   │   ├── read bytes: 197
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   └── push downs: [filters: [], limit: NONE]
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t2
+│       ├── read rows: 100
+│       ├── read bytes: 610
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       └── push downs: [filters: [], limit: NONE]
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t1
+    ├── read rows: 10
+    ├── read bytes: 243
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select * from t2, t, t1 where t.a = t2.a and t1.a = t2.a;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Sometimes the substitutions generated by join associate rules won't be inserted into the memo, which causes orphan groups.

Close #8304
