### PR TITLE
fix: "optimize purge" may incorrectly delete data of pending txs

### DIFF
--- a/src/query/service/tests/it/storages/fuse/table_functions/fuse_snapshot_table.rs
+++ b/src/query/service/tests/it/storages/fuse/table_functions/fuse_snapshot_table.rs
@@ -147,6 +147,7 @@ async fn test_fuse_snapshot_table_read() -> Result<()> {
     }
 
     {
+        // previously, inserted 5 blocks, 3 rows per block
         // another 5 blocks, 15 rows here
         append_sample_data(5, &fixture).await?;
         let expected = vec![

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
@@ -45,7 +45,7 @@ impl<'a> FuseSnapshot<'a> {
                 snapshot_version,
             );
             let (snapshots, _) = snapshots_io
-                .read_snapshot_lites(snapshot_location, limit, false)
+                .read_snapshot_lites(snapshot_location, limit, false, None)
                 .await?;
             return self.to_block(&meta_location_generator, &snapshots, snapshot_version);
         }

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
@@ -37,6 +37,7 @@ impl<'a> FuseSnapshot<'a> {
     pub async fn get_snapshots(self, limit: Option<usize>) -> Result<DataBlock> {
         let meta_location_generator = self.table.meta_location_generator.clone();
         let snapshot_location = self.table.snapshot_loc().await?;
+        let snapshot = self.table.read_table_snapshot(self.ctx.clone()).await?;
         if let Some(snapshot_location) = snapshot_location {
             let snapshot_version = self.table.snapshot_format_version().await?;
             let snapshots_io = SnapshotsIO::create(
@@ -45,7 +46,12 @@ impl<'a> FuseSnapshot<'a> {
                 snapshot_version,
             );
             let (snapshots, _) = snapshots_io
-                .read_snapshot_lites(snapshot_location, limit, false, None)
+                .read_snapshot_lites(
+                    snapshot_location,
+                    limit,
+                    false,
+                    snapshot.and_then(|s| s.timestamp),
+                )
                 .await?;
             return self.to_block(&meta_location_generator, &snapshots, snapshot_version);
         }

--- a/tests/logictest/http_connector.py
+++ b/tests/logictest/http_connector.py
@@ -160,8 +160,7 @@ class HttpConnector(object):
         while response['next_uri'] is not None:
             resp = self.next_page(response['next_uri'])
             response = json.loads(resp.content)
-            log.debug(
-                f"Sql in progress, fetch next_uri content: {response}")
+            log.debug(f"Sql in progress, fetch next_uri content: {response}")
             check_error(response)
             session = response['session']
             if session:

--- a/tests/logictest/http_runner.py
+++ b/tests/logictest/http_runner.py
@@ -4,6 +4,7 @@ import logictest
 import http_connector
 from mysql.connector.errors import Error
 
+
 class TestHttp(logictest.SuiteRunner, ABC):
 
     def __init__(self, kind, args):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The "optimize table t purge" statement may incorrectly delete data of pending transactions.

While collecting snapshots from storage, snapshots that have bigger timestamps than  GC root's, should be excluded. 



Fixes #issue
