### PR TITLE
fix: add a threshold for compact block

### DIFF
--- a/src/query/ast/src/ast/format/ast_format.rs
+++ b/src/query/ast/src/ast/format/ast_format.rs
@@ -1349,7 +1349,7 @@ impl<'ast> Visitor<'ast> for AstFormatVisitor {
         let mut children = Vec::new();
         self.visit_table_ref(&stmt.catalog, &stmt.database, &stmt.table);
         children.push(self.children.pop().unwrap());
-        if let Some(action) = stmt.action {
+        if let Some(action) = &stmt.action {
             let action_name = format!("Action {}", action);
             let action_format_ctx = AstFormatContext::new(action_name);
             children.push(FormatTreeNode::new(action_format_ctx));

--- a/src/query/ast/src/ast/statements/table.rs
+++ b/src/query/ast/src/ast/statements/table.rs
@@ -382,7 +382,7 @@ pub struct OptimizeTableStmt<'a> {
     pub catalog: Option<Identifier<'a>>,
     pub database: Option<Identifier<'a>>,
     pub table: Identifier<'a>,
-    pub action: Option<OptimizeTableAction>,
+    pub action: Option<OptimizeTableAction<'a>>,
 }
 
 impl Display for OptimizeTableStmt<'_> {
@@ -444,32 +444,41 @@ impl Display for Engine {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CompactTarget {
     Block,
     Segment,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OptimizeTableAction {
+#[derive(Debug, Clone, PartialEq)]
+pub enum OptimizeTableAction<'a> {
     All,
     Purge,
-    Compact(CompactTarget),
+    Compact {
+        target: CompactTarget,
+        limit: Option<Expr<'a>>,
+    },
 }
 
-impl Display for OptimizeTableAction {
+impl<'a> Display for OptimizeTableAction<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             OptimizeTableAction::All => write!(f, "ALL"),
             OptimizeTableAction::Purge => write!(f, "PURGE"),
-            OptimizeTableAction::Compact(action) => match action {
-                CompactTarget::Block => {
-                    write!(f, "COMPACT BLOCK")
+            OptimizeTableAction::Compact { target, limit } => {
+                match target {
+                    CompactTarget::Block => {
+                        write!(f, "COMPACT BLOCK")?;
+                    }
+                    CompactTarget::Segment => {
+                        write!(f, "COMPACT SEGMENT")?;
+                    }
                 }
-                CompactTarget::Segment => {
-                    write!(f, "COMPACT SEGMENT")
+                if let Some(limit) = limit {
+                    write!(f, " LIMIT {limit}")?;
                 }
-            },
+                Ok(())
+            }
         }
     }
 }

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -1344,13 +1344,12 @@ pub fn optimize_table_action(i: Input) -> IResult<OptimizeTableAction> {
     alt((
         value(OptimizeTableAction::All, rule! { ALL }),
         value(OptimizeTableAction::Purge, rule! { PURGE }),
-        value(
-            OptimizeTableAction::Compact(CompactTarget::Segment),
-            rule! { COMPACT ~ SEGMENT},
-        ),
-        value(
-            OptimizeTableAction::Compact(CompactTarget::Block),
-            rule! { COMPACT},
+        map(
+            rule! { COMPACT ~ (SEGMENT)? ~ ( LIMIT ~ ^#expr )?},
+            |(_, opt_segment, opt_limit)| OptimizeTableAction::Compact {
+                target: opt_segment.map_or(CompactTarget::Block, |_| CompactTarget::Segment),
+                limit: opt_limit.map(|(_, limit)| limit),
+            },
         ),
     ))(i)
 }

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -233,9 +233,10 @@ pub trait Table: Sync + Send {
         &self,
         ctx: Arc<dyn TableContext>,
         target: CompactTarget,
+        limit: Option<usize>,
         pipeline: &mut Pipeline,
     ) -> Result<Option<Box<dyn TableMutator>>> {
-        let (_, _, _) = (ctx, target, pipeline);
+        let (_, _, _, _) = (ctx, target, limit, pipeline);
 
         Err(ErrorCode::UnImplement(format!(
             "table {},  of engine type {}, does not support compact",

--- a/src/query/planner/src/plans/optimize_table.rs
+++ b/src/query/planner/src/plans/optimize_table.rs
@@ -34,6 +34,6 @@ impl OptimizeTablePlan {
 pub enum OptimizeTableAction {
     All,
     Purge,
-    CompactBlocks,
-    CompactSegments,
+    CompactBlocks(Option<usize>),
+    CompactSegments(Option<usize>),
 }

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/full_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/full_compact_mutator.rs
@@ -176,7 +176,7 @@ async fn build_mutator(
     settings.set_max_threads(1)?;
     let mut pipeline = common_pipeline_core::Pipeline::create();
     let mutator = fuse_table
-        .compact(ctx.clone(), CompactTarget::Blocks, &mut pipeline)
+        .compact(ctx.clone(), CompactTarget::Blocks, None, &mut pipeline)
         .await?;
     assert!(mutator.is_some());
     let mutator = mutator.unwrap();

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -57,7 +57,7 @@ async fn test_compact_segment_normal_case() -> Result<()> {
     let fuse_table = FuseTable::try_from_table(table.as_ref())?;
     let mut pipeline = common_pipeline_core::Pipeline::create();
     let mutator = fuse_table
-        .compact(ctx.clone(), CompactTarget::Segments, &mut pipeline)
+        .compact(ctx.clone(), CompactTarget::Segments, None, &mut pipeline)
         .await?;
     assert!(mutator.is_some());
     let mutator = mutator.unwrap();
@@ -102,7 +102,7 @@ async fn test_compact_segment_resolvable_conflict() -> Result<()> {
     let fuse_table = FuseTable::try_from_table(table.as_ref())?;
     let mut pipeline = common_pipeline_core::Pipeline::create();
     let mutator = fuse_table
-        .compact(ctx.clone(), CompactTarget::Segments, &mut pipeline)
+        .compact(ctx.clone(), CompactTarget::Segments, None, &mut pipeline)
         .await?;
     assert!(mutator.is_some());
     let mutator = mutator.unwrap();
@@ -165,7 +165,7 @@ async fn test_compact_segment_unresolvable_conflict() -> Result<()> {
     let fuse_table = FuseTable::try_from_table(table.as_ref())?;
     let mut pipeline = common_pipeline_core::Pipeline::create();
     let mutator = fuse_table
-        .compact(ctx.clone(), CompactTarget::Segments, &mut pipeline)
+        .compact(ctx.clone(), CompactTarget::Segments, None, &mut pipeline)
         .await?;
     assert!(mutator.is_some());
     let mutator = mutator.unwrap();
@@ -200,7 +200,7 @@ async fn compact_segment(ctx: Arc<QueryContext>, table: &Arc<dyn Table>) -> Resu
     let fuse_table = FuseTable::try_from_table(table.as_ref())?;
     let mut pipeline = common_pipeline_core::Pipeline::create();
     let mutator = fuse_table
-        .compact(ctx, CompactTarget::Segments, &mut pipeline)
+        .compact(ctx, CompactTarget::Segments, None, &mut pipeline)
         .await?
         .unwrap();
     mutator.try_commit(table.clone()).await

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -778,16 +778,30 @@ impl<'a> Binder {
             .map(|ident| normalize_identifier(ident, &self.name_resolution_ctx).name)
             .unwrap_or_else(|| self.ctx.get_current_database());
         let table = normalize_identifier(table, &self.name_resolution_ctx).name;
-        let action = action
-            .clone()
-            .map_or(OptimizeTableAction::Purge, |v| match v {
+        let action = if let Some(ast_action) = action {
+            match ast_action {
                 AstOptimizeTableAction::All => OptimizeTableAction::All,
                 AstOptimizeTableAction::Purge => OptimizeTableAction::Purge,
-                AstOptimizeTableAction::Compact { target, .. } => match target {
-                    CompactTarget::Block => OptimizeTableAction::CompactBlocks,
-                    CompactTarget::Segment => OptimizeTableAction::CompactSegments,
-                },
-            });
+                AstOptimizeTableAction::Compact { target, limit } => {
+                    let limit_cnt = match limit {
+                        Some(Expr::Literal {
+                            lit: Literal::Integer(uint),
+                            ..
+                        }) => Some(*uint as usize),
+                        Some(_) => {
+                            return Err(ErrorCode::IllegalDataType("Unsupported limit type"));
+                        }
+                        _ => None,
+                    };
+                    match target {
+                        CompactTarget::Block => OptimizeTableAction::CompactBlocks(limit_cnt),
+                        CompactTarget::Segment => OptimizeTableAction::CompactSegments(limit_cnt),
+                    }
+                }
+            }
+        } else {
+            OptimizeTableAction::Purge
+        };
 
         Ok(Plan::OptimizeTable(Box::new(OptimizeTablePlan {
             catalog,

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -778,14 +778,16 @@ impl<'a> Binder {
             .map(|ident| normalize_identifier(ident, &self.name_resolution_ctx).name)
             .unwrap_or_else(|| self.ctx.get_current_database());
         let table = normalize_identifier(table, &self.name_resolution_ctx).name;
-        let action = action.map_or(OptimizeTableAction::Purge, |v| match v {
-            AstOptimizeTableAction::All => OptimizeTableAction::All,
-            AstOptimizeTableAction::Purge => OptimizeTableAction::Purge,
-            AstOptimizeTableAction::Compact(target) => match target {
-                CompactTarget::Block => OptimizeTableAction::CompactBlocks,
-                CompactTarget::Segment => OptimizeTableAction::CompactSegments,
-            },
-        });
+        let action = action
+            .clone()
+            .map_or(OptimizeTableAction::Purge, |v| match v {
+                AstOptimizeTableAction::All => OptimizeTableAction::All,
+                AstOptimizeTableAction::Purge => OptimizeTableAction::Purge,
+                AstOptimizeTableAction::Compact { target, .. } => match target {
+                    CompactTarget::Block => OptimizeTableAction::CompactBlocks,
+                    CompactTarget::Segment => OptimizeTableAction::CompactSegments,
+                },
+            });
 
         Ok(Plan::OptimizeTable(Box::new(OptimizeTablePlan {
             catalog,

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -456,9 +456,10 @@ impl Table for FuseTable {
         &self,
         ctx: Arc<dyn TableContext>,
         target: CompactTarget,
+        limit: Option<usize>,
         pipeline: &mut Pipeline,
     ) -> Result<Option<Box<dyn TableMutator>>> {
-        self.do_compact(ctx, target, pipeline).await
+        self.do_compact(ctx, target, limit, pipeline).await
     }
 
     async fn recluster(

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -115,11 +115,6 @@ impl FuseTable {
             return Ok(None);
         }
 
-        let max_threads = ctx.get_settings().get_max_threads()? as usize;
-        if mutator.selected_blocks().len() < max_threads * 2 {
-            return Ok(None);
-        }
-
         let partitions_total = mutator.partitions_total();
         let (statistics, parts) = Self::read_partitions_with_metas(
             ctx.clone(),

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -33,9 +33,10 @@ use crate::TableMutator;
 use crate::DEFAULT_BLOCK_PER_SEGMENT;
 use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 
-struct CompactOptions {
-    base_snapshot: Arc<TableSnapshot>,
-    block_per_seg: usize,
+pub struct CompactOptions {
+    pub base_snapshot: Arc<TableSnapshot>,
+    pub block_per_seg: usize,
+    pub limit: Option<usize>,
 }
 
 impl FuseTable {
@@ -43,6 +44,7 @@ impl FuseTable {
         &self,
         ctx: Arc<dyn TableContext>,
         target: CompactTarget,
+        limit: Option<usize>,
         pipeline: &mut Pipeline,
     ) -> Result<Option<Box<dyn TableMutator>>> {
         let snapshot_opt = self.read_table_snapshot(ctx.clone()).await?;
@@ -63,6 +65,7 @@ impl FuseTable {
         let compact_params = CompactOptions {
             base_snapshot,
             block_per_seg,
+            limit,
         };
 
         match target {
@@ -103,10 +106,9 @@ impl FuseTable {
         let block_per_seg = options.block_per_seg;
         let mut mutator = FullCompactMutator::try_create(
             ctx.clone(),
-            options.base_snapshot,
+            options,
             block_compactor.clone(),
             self.meta_location_generator().clone(),
-            block_per_seg,
             self.cluster_key_meta.is_some(),
             self.operator.clone(),
         )?;

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -115,6 +115,11 @@ impl FuseTable {
             return Ok(None);
         }
 
+        let max_threads = ctx.get_settings().get_max_threads()? as usize;
+        if mutator.selected_blocks().len() < max_threads * 2 {
+            return Ok(None);
+        }
+
         let partitions_total = mutator.partitions_total();
         let (statistics, parts) = Self::read_partitions_with_metas(
             ctx.clone(),

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -34,6 +34,7 @@ use crate::DEFAULT_BLOCK_PER_SEGMENT;
 use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 
 pub struct CompactOptions {
+    // the snapshot that compactor working on, it never changed during phases compaction.
     pub base_snapshot: Arc<TableSnapshot>,
     pub block_per_seg: usize,
     pub limit: Option<usize>,
@@ -82,9 +83,8 @@ impl FuseTable {
     ) -> Result<Option<Box<dyn TableMutator>>> {
         let mut segment_mutator = SegmentCompactMutator::try_create(
             ctx.clone(),
-            options.base_snapshot,
+            options,
             self.meta_location_generator().clone(),
-            options.block_per_seg,
             self.operator.clone(),
         )?;
 

--- a/src/query/storages/fuse/src/operations/mod.rs
+++ b/src/query/storages/fuse/src/operations/mod.rs
@@ -28,6 +28,7 @@ mod truncate;
 
 pub mod util;
 
+pub(crate) use compact::CompactOptions;
 pub use fuse_sink::FuseTableSink;
 pub use mutation::delete_from_block;
 pub use mutation::DeletionMutator;

--- a/src/query/storages/fuse/src/operations/mutation/abort_operation.rs
+++ b/src/query/storages/fuse/src/operations/mutation/abort_operation.rs
@@ -21,7 +21,7 @@ use opendal::Operator;
 
 use crate::io::Files;
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default)]
 pub struct AbortOperation {
     pub segments: Vec<String>,
     pub blocks: Vec<String>,

--- a/tests/logictest/suites/base/09_fuse_engine/09_0008_fuse_optimize_table
+++ b/tests/logictest/suites/base/09_fuse_engine/09_0008_fuse_optimize_table
@@ -27,6 +27,23 @@ select * from t order by a;
 6
 7
 
+
+
+statement ok
+set max_threads=2;
+
+statement ok
+optimize table t compact;
+
+statement query II
+select * from fuse_snapshot('db_09_0008', 't') limit 1;
+
+----
+1 3
+
+statement ok
+set max_threads=1;
+
 statement ok
 optimize table t compact;
 
@@ -38,11 +55,11 @@ select * from t order by a;
 6
 7
 
-statement query B
-select count(*)=4 from fuse_snapshot('db_09_0008', 't');
+statement query II
+select * from fuse_snapshot('db_09_0008', 't') limit 1;
 
 ----
-1
+1 1
 
 
 

--- a/tests/logictest/suites/base/09_fuse_engine/09_0008_fuse_optimize_table
+++ b/tests/logictest/suites/base/09_fuse_engine/09_0008_fuse_optimize_table
@@ -36,7 +36,7 @@ statement ok
 optimize table t compact;
 
 statement query II
-select * from fuse_snapshot('db_09_0008', 't') limit 1;
+select segment_count,block_count from fuse_snapshot('db_09_0008', 't') order by to_uint64(timestamp) desc limit 1;
 
 ----
 1 3
@@ -56,7 +56,7 @@ select * from t order by a;
 7
 
 statement query II
-select * from fuse_snapshot('db_09_0008', 't') limit 1;
+select segment_count,block_count from fuse_snapshot('db_09_0008', 't') order by to_uint64(timestamp) desc limit 1;
 
 ----
 1 1

--- a/tests/logictest/suites/base/09_fuse_engine/09_0008_fuse_optimize_table
+++ b/tests/logictest/suites/base/09_fuse_engine/09_0008_fuse_optimize_table
@@ -27,8 +27,6 @@ select * from t order by a;
 6
 7
 
-
-
 statement ok
 set max_threads=2;
 
@@ -205,6 +203,51 @@ select segment_count, block_count from fuse_snapshot('db_09_0008', 't1') limit 1
 ----
 1 3
 
+
+statement ok
+create table t2(a uint64);
+
+statement ok
+insert into t2 values (5);
+
+statement ok
+insert into t2 values (6);
+
+statement ok
+insert into t2 values (7);
+
+statement query II
+select segment_count, block_count from fuse_snapshot('db_09_0008', 't2') limit 1;
+
+----
+3 3
+
+statement ok
+set max_threads=1;
+
+statement ok
+optimize table t2 compact limit 2;
+
+statement query II
+select segment_count, block_count from fuse_snapshot('db_09_0008', 't2') limit 1;
+
+----
+2 2
+
+statement ok
+insert into t2 values (8);
+
+statement ok
+optimize table t2 compact segment limit 2;
+
+statement query II
+select segment_count, block_count from fuse_snapshot('db_09_0008', 't2') limit 1;
+
+----
+2 3
+
+
+
 statement ok
 DROP TABLE m;
 
@@ -213,6 +256,9 @@ DROP TABLE t;
 
 statement ok
 DROP TABLE t1;
+
+statement ok
+DROP TABLE t2;
 
 statement ok
 DROP DATABASE db_09_0008;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add a threshold 2 for compact blocks, if the selected blocks are less than 2*max_threads, compact is skipped.

 Add a limit to batch compaction.
```
optimize table [database.]table_name compact [segment] [limit segment_count];
```

Fixes #8316 
Fixes #8241 