### PR TITLE
feat(parser): Relax the order requirement about the COPY options

### DIFF
--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -45,6 +45,23 @@ pub struct CopyStmt<'a> {
     pub force: bool,
 }
 
+impl<'a> CopyStmt<'a> {
+    pub fn apply_option(&mut self, opt: CopyOption) {
+        match opt {
+            CopyOption::Files(v) => self.files = v,
+            CopyOption::Pattern(v) => self.pattern = v,
+            CopyOption::FileFormat(v) => self.file_format = v,
+            CopyOption::ValidationMode(v) => self.validation_mode = v,
+            CopyOption::SizeLimit(v) => self.size_limit = v,
+            CopyOption::MaxFileSize(v) => self.max_file_size = v,
+            CopyOption::SplitSize(v) => self.split_size = v,
+            CopyOption::Single(v) => self.single = v,
+            CopyOption::Purge(v) => self.purge = v,
+            CopyOption::Force(v) => self.force = v,
+        }
+    }
+}
+
 impl Display for CopyStmt<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "COPY")?;
@@ -201,21 +218,4 @@ pub enum CopyOption {
     Single(bool),
     Purge(bool),
     Force(bool),
-}
-
-impl CopyOption {
-    pub fn apply(&self, stmt: &mut CopyStmt<'_>) {
-        match self {
-            CopyOption::Files(v) => stmt.files = v.clone(),
-            CopyOption::Pattern(v) => stmt.pattern = v.clone(),
-            CopyOption::FileFormat(v) => stmt.file_format = v.clone(),
-            CopyOption::ValidationMode(v) => stmt.validation_mode = v.clone(),
-            CopyOption::SizeLimit(v) => stmt.size_limit = *v,
-            CopyOption::MaxFileSize(v) => stmt.max_file_size = *v,
-            CopyOption::SplitSize(v) => stmt.split_size = *v,
-            CopyOption::Single(v) => stmt.single = *v,
-            CopyOption::Purge(v) => stmt.purge = *v,
-            CopyOption::Force(v) => stmt.force = *v,
-        }
-    }
 }

--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -190,9 +190,7 @@ impl Display for UriLocation {
     }
 }
 
-pub enum CopyOptionItem<'a> {
-    Dst(CopyUnit<'a>),
-    Src(CopyUnit<'a>),
+pub enum CopyOptionItem {
     Files(Vec<String>),
     Pattern(String),
     FileFormat(BTreeMap<String, String>),
@@ -203,4 +201,21 @@ pub enum CopyOptionItem<'a> {
     Single(bool),
     Purge(bool),
     Force(bool),
+}
+
+impl CopyOptionItem {
+    pub fn apply(&self, stmt: &mut CopyStmt<'_>) {
+        match self {
+            CopyOptionItem::Files(v) => stmt.files = v.clone(),
+            CopyOptionItem::Pattern(v) => stmt.pattern = v.clone(),
+            CopyOptionItem::FileFormat(v) => stmt.file_format = v.clone(),
+            CopyOptionItem::ValidationMode(v) => stmt.validation_mode = v.clone(),
+            CopyOptionItem::SizeLimit(v) => stmt.size_limit = *v,
+            CopyOptionItem::MaxFileSize(v) => stmt.max_file_size = *v,
+            CopyOptionItem::SplitSize(v) => stmt.split_size = *v,
+            CopyOptionItem::Single(v) => stmt.single = *v,
+            CopyOptionItem::Purge(v) => stmt.purge = *v,
+            CopyOptionItem::Force(v) => stmt.force = *v,
+        }
+    }
 }

--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -189,3 +189,18 @@ impl Display for UriLocation {
         Ok(())
     }
 }
+
+pub enum CopyOptionItem<'a> {
+    Dst(CopyUnit<'a>),
+    Src(CopyUnit<'a>),
+    Files(Vec<String>),
+    Pattern(String),
+    FileFormat(BTreeMap<String, String>),
+    ValidationMode(String),
+    SizeLimit(usize),
+    MaxFileSize(usize),
+    SplitSize(usize),
+    Single(bool),
+    Purge(bool),
+    Force(bool),
+}

--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -190,7 +190,7 @@ impl Display for UriLocation {
     }
 }
 
-pub enum CopyOptionItem {
+pub enum CopyOption {
     Files(Vec<String>),
     Pattern(String),
     FileFormat(BTreeMap<String, String>),
@@ -203,19 +203,19 @@ pub enum CopyOptionItem {
     Force(bool),
 }
 
-impl CopyOptionItem {
+impl CopyOption {
     pub fn apply(&self, stmt: &mut CopyStmt<'_>) {
         match self {
-            CopyOptionItem::Files(v) => stmt.files = v.clone(),
-            CopyOptionItem::Pattern(v) => stmt.pattern = v.clone(),
-            CopyOptionItem::FileFormat(v) => stmt.file_format = v.clone(),
-            CopyOptionItem::ValidationMode(v) => stmt.validation_mode = v.clone(),
-            CopyOptionItem::SizeLimit(v) => stmt.size_limit = *v,
-            CopyOptionItem::MaxFileSize(v) => stmt.max_file_size = *v,
-            CopyOptionItem::SplitSize(v) => stmt.split_size = *v,
-            CopyOptionItem::Single(v) => stmt.single = *v,
-            CopyOptionItem::Purge(v) => stmt.purge = *v,
-            CopyOptionItem::Force(v) => stmt.force = *v,
+            CopyOption::Files(v) => stmt.files = v.clone(),
+            CopyOption::Pattern(v) => stmt.pattern = v.clone(),
+            CopyOption::FileFormat(v) => stmt.file_format = v.clone(),
+            CopyOption::ValidationMode(v) => stmt.validation_mode = v.clone(),
+            CopyOption::SizeLimit(v) => stmt.size_limit = *v,
+            CopyOption::MaxFileSize(v) => stmt.max_file_size = *v,
+            CopyOption::SplitSize(v) => stmt.split_size = *v,
+            CopyOption::Single(v) => stmt.single = *v,
+            CopyOption::Purge(v) => stmt.purge = *v,
+            CopyOption::Force(v) => stmt.force = *v,
         }
     }
 }

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -756,7 +756,7 @@ pub fn statement(i: Input) -> IResult<StatementMsg> {
             COPY
             ~ INTO ~ #copy_unit
             ~ FROM ~ #copy_unit
-            ~ ( #copy_option_item )*
+            ~ ( #copy_option )*
         },
         |(_, _, dst, _, src, opts)| {
             let mut copy_stmt = CopyStmt {
@@ -1592,43 +1592,43 @@ pub fn auth_type(i: Input) -> IResult<AuthType> {
     ))(i)
 }
 
-pub fn copy_option_item(i: Input) -> IResult<CopyOptionItem> {
+pub fn copy_option(i: Input) -> IResult<CopyOption> {
     alt((
         map(
             rule! { FILES ~ "=" ~ "(" ~ #comma_separated_list0(literal_string) ~ ")" },
-            |(_, _, _, files, _)| CopyOptionItem::Files(files),
+            |(_, _, _, files, _)| CopyOption::Files(files),
         ),
         map(
             rule! { PATTERN ~ "=" ~ #literal_string },
-            |(_, _, pattern)| CopyOptionItem::Pattern(pattern),
+            |(_, _, pattern)| CopyOption::Pattern(pattern),
         ),
         map(rule! { FILE_FORMAT ~ "=" ~ #options }, |(_, _, options)| {
-            CopyOptionItem::FileFormat(options)
+            CopyOption::FileFormat(options)
         }),
         map(
             rule! { VALIDATION_MODE ~ "=" ~ #literal_string },
-            |(_, _, validation_mode)| CopyOptionItem::ValidationMode(validation_mode),
+            |(_, _, validation_mode)| CopyOption::ValidationMode(validation_mode),
         ),
         map(
             rule! { SIZE_LIMIT ~ "=" ~ #literal_u64 },
-            |(_, _, size_limit)| CopyOptionItem::SizeLimit(size_limit as usize),
+            |(_, _, size_limit)| CopyOption::SizeLimit(size_limit as usize),
         ),
         map(
             rule! { MAX_FILE_SIZE ~ "=" ~ #literal_u64 },
-            |(_, _, max_file_size)| CopyOptionItem::MaxFileSize(max_file_size as usize),
+            |(_, _, max_file_size)| CopyOption::MaxFileSize(max_file_size as usize),
         ),
         map(
             rule! { SPLIT_SIZE ~ "=" ~ #literal_u64 },
-            |(_, _, split_size)| CopyOptionItem::SplitSize(split_size as usize),
+            |(_, _, split_size)| CopyOption::SplitSize(split_size as usize),
         ),
         map(rule! { SINGLE ~ "=" ~ #literal_bool }, |(_, _, single)| {
-            CopyOptionItem::Single(single)
+            CopyOption::Single(single)
         }),
         map(rule! { PURGE ~ "=" ~ #literal_bool }, |(_, _, purge)| {
-            CopyOptionItem::Purge(purge)
+            CopyOption::Purge(purge)
         }),
         map(rule! { FORCE ~ "=" ~ #literal_bool }, |(_, _, force)| {
-            CopyOptionItem::Force(force)
+            CopyOption::Force(force)
         }),
     ))(i)
 }

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -750,6 +750,7 @@ pub fn statement(i: Input) -> IResult<StatementMsg> {
             stage_name: stage_name.to_string(),
         },
     );
+
     let copy_into = map(
         rule! {
             COPY
@@ -1609,6 +1610,47 @@ pub fn auth_type(i: Input) -> IResult<AuthType> {
         value(AuthType::Sha256Password, rule! { SHA256_PASSWORD }),
         value(AuthType::DoubleSha1Password, rule! { DOUBLE_SHA1_PASSWORD }),
         value(AuthType::JWT, rule! { JWT }),
+    ))(i)
+}
+
+pub fn copy_option_item(i: Input) -> IResult<CopyOptionItem> {
+    alt((
+        map(
+            rule! { FILES ~ "=" ~ "(" ~ #comma_separated_list0(literal_string) ~ ")" },
+            |(_, _, _, files, _)| CopyOptionItem::Files(files),
+        ),
+        map(
+            rule! { PATTERN ~ "=" ~ #literal_string },
+            |(_, _, pattern)| CopyOptionItem::Pattern(pattern),
+        ),
+        map(rule! { FILE_FORMAT ~ "=" ~ #options }, |(_, _, options)| {
+            CopyOptionItem::FileFormat(options)
+        }),
+        map(
+            rule! { VALIDATION_MODE ~ "=" ~ #literal_string },
+            |(_, _, validation_mode)| CopyOptionItem::ValidationMode(validation_mode),
+        ),
+        map(
+            rule! { SIZE_LIMIT ~ "=" ~ #literal_u64 },
+            |(_, _, size_limit)| CopyOptionItem::SizeLimit(size_limit as usize),
+        ),
+        map(
+            rule! { MAX_FILE_SIZE ~ "=" ~ #literal_u64 },
+            |(_, _, max_file_size)| CopyOptionItem::MaxFileSize(max_file_size as usize),
+        ),
+        map(
+            rule! { SPLIT_SIZE ~ "=" ~ #literal_u64 },
+            |(_, _, split_size)| CopyOptionItem::SplitSize(split_size as usize),
+        ),
+        map(rule! { SINGLE ~ "=" ~ #literal_bool }, |(_, _, single)| {
+            CopyOptionItem::Single(single)
+        }),
+        map(rule! { PURGE ~ "=" ~ #literal_bool }, |(_, _, purge)| {
+            CopyOptionItem::Purge(purge)
+        }),
+        map(rule! { FORCE ~ "=" ~ #literal_bool }, |(_, _, force)| {
+            CopyOptionItem::Force(force)
+        }),
     ))(i)
 }
 

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -756,48 +756,27 @@ pub fn statement(i: Input) -> IResult<StatementMsg> {
             COPY
             ~ INTO ~ #copy_unit
             ~ FROM ~ #copy_unit
-            ~ ( FILES ~ "=" ~ "(" ~ #comma_separated_list0(literal_string) ~ ")")?
-            ~ ( PATTERN ~ "=" ~ #literal_string)?
-            ~ ( FILE_FORMAT ~ "=" ~ #options)?
-            ~ ( VALIDATION_MODE ~ "=" ~ #literal_string)?
-            ~ ( SIZE_LIMIT ~ "=" ~ #literal_u64)?
-            ~ ( MAX_FILE_SIZE ~ "=" ~ #literal_u64)?
-            ~ ( SPLIT_SIZE ~ "=" ~ #literal_u64)?
-            ~ ( SINGLE ~ "=" ~ #literal_bool)?
-            ~ ( PURGE ~ "=" ~ #literal_bool)?
-            ~ ( FORCE ~ "=" ~ #literal_bool)?
+            ~ ( #copy_option_item )*
         },
-        |(
-            _,
-            _,
-            dst,
-            _,
-            src,
-            files,
-            pattern,
-            file_format,
-            validation_mode,
-            size_limit,
-            max_file_size,
-            split_size,
-            single,
-            purge,
-            force,
-        )| {
-            Statement::Copy(CopyStmt {
+        |(_, _, dst, _, src, opts)| {
+            let mut copy_stmt = CopyStmt {
                 src,
                 dst,
-                files: files.map(|v| v.3).unwrap_or_default(),
-                pattern: pattern.map(|v| v.2).unwrap_or_default(),
-                file_format: file_format.map(|v| v.2).unwrap_or_default(),
-                validation_mode: validation_mode.map(|v| v.2).unwrap_or_default(),
-                size_limit: size_limit.map(|v| v.2).unwrap_or_default() as usize,
-                max_file_size: max_file_size.map(|v| v.2).unwrap_or_default() as usize,
-                split_size: split_size.map(|v| v.2).unwrap_or_default() as usize,
-                single: single.map(|v| v.2).unwrap_or_default(),
-                purge: purge.map(|v| v.2).unwrap_or_default(),
-                force: force.map(|v| v.2).unwrap_or_default(),
-            })
+                files: Default::default(),
+                pattern: Default::default(),
+                file_format: Default::default(),
+                validation_mode: Default::default(),
+                size_limit: Default::default(),
+                max_file_size: Default::default(),
+                split_size: Default::default(),
+                single: Default::default(),
+                purge: Default::default(),
+                force: Default::default(),
+            };
+            for opt in opts {
+                opt.apply(&mut copy_stmt);
+            }
+            Statement::Copy(copy_stmt)
         },
     );
 

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -774,7 +774,7 @@ pub fn statement(i: Input) -> IResult<StatementMsg> {
                 force: Default::default(),
             };
             for opt in opts {
-                opt.apply(&mut copy_stmt);
+                copy_stmt.apply_option(opt);
             }
             Statement::Copy(copy_stmt)
         },

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -198,6 +198,18 @@ fn test_statement() {
                 )
                 size_limit=10;"#,
         r#"COPY INTO mytable
+                FROM 's3://mybucket/data.csv'
+                CONNECTION = (
+                    ENDPOINT_URL = 'http://127.0.0.1:9900'
+                )
+                size_limit=10
+                FILE_FORMAT = (
+                    type = 'CSV'
+                    field_delimiter = ','
+                    record_delimiter = '\n'
+                    skip_header = 1
+                );"#,
+        r#"COPY INTO mytable
                 FROM 'https://127.0.0.1:9900';"#,
         r#"COPY INTO mytable
                 FROM 'https://127.0.0.1:';"#,

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -6595,6 +6595,63 @@ Copy(
 
 ---------- Input ----------
 COPY INTO mytable
+                FROM 's3://mybucket/data.csv'
+                CONNECTION = (
+                    ENDPOINT_URL = 'http://127.0.0.1:9900'
+                )
+                size_limit=10
+                FILE_FORMAT = (
+                    type = 'CSV'
+                    field_delimiter = ','
+                    record_delimiter = '\n'
+                    skip_header = 1
+                );
+---------- Output ---------
+COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( endpoint_url='http://127.0.0.1:9900' ) FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+---------- AST ------------
+Copy(
+    CopyStmt {
+        src: UriLocation(
+            UriLocation {
+                protocol: "s3",
+                name: "mybucket",
+                path: "/data.csv",
+                connection: {
+                    "endpoint_url": "http://127.0.0.1:9900",
+                },
+            },
+        ),
+        dst: Table {
+            catalog: None,
+            database: None,
+            table: Identifier {
+                name: "mytable",
+                quote: None,
+                span: Ident(10..17),
+            },
+        },
+        files: [],
+        pattern: "",
+        file_format: {
+            "field_delimiter": ",",
+            "record_delimiter": "\n",
+            "skip_header": "1",
+            "type": "CSV",
+        },
+        validation_mode: "",
+        size_limit: 10,
+        max_file_size: 0,
+        split_size: 0,
+        single: false,
+        purge: false,
+        force: false,
+    },
+)
+
+
+---------- Input ----------
+COPY INTO mytable
                 FROM 'https://127.0.0.1:9900';
 ---------- Output ---------
 COPY INTO mytable FROM 'https://127.0.0.1:9900/' SINGLE = false PURGE = false FORCE = false


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently the options to the COPY statement requires order as:

```
            ~ ( FILES ~ "=" ~ "(" ~ #comma_separated_list0(literal_string) ~ ")")?
            ~ ( PATTERN ~ "=" ~ #literal_string)?
            ~ ( FILE_FORMAT ~ "=" ~ #options)?
            ~ ( VALIDATION_MODE ~ "=" ~ #literal_string)?
            ~ ( SIZE_LIMIT ~ "=" ~ #literal_u64)?
            ~ ( MAX_FILE_SIZE ~ "=" ~ #literal_u64)?
            ~ ( SPLIT_SIZE ~ "=" ~ #literal_u64)?
            ~ ( SINGLE ~ "=" ~ #literal_bool)?
            ~ ( PURGE ~ "=" ~ #literal_bool)?
            ~ ( FORCE ~ "=" ~ #literal_bool)?
```

If we put FORCE option in front of PURGE, we'll get a syntax error. The args order is hard to memorize, makes it hard for users to use the COPY statment.

This PR relax the order requirement about the COPY options, so we can put PURGE option in front of the SINGLE option in our SQL.