### PR TITLE
feat: config options for bloom filter cache

### DIFF
--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -134,14 +134,10 @@ pub struct QueryConfig {
     pub table_cache_snapshot_count: u64,
     /// Max number of cached table segment
     pub table_cache_segment_count: u64,
-    /// Max number of cached table block meta
-    pub table_cache_block_meta_count: u64,
-    /// Table memory cache size (mb)
-    pub table_memory_cache_mb_size: u64,
-    /// Table disk cache folder root
-    pub table_disk_cache_root: String,
-    /// Table disk cache size (mb)
-    pub table_disk_cache_mb_size: u64,
+    /// Max number of cached bloom index meta objects
+    pub table_cache_bloom_index_meta_count: u64,
+    /// Max bytes of cached bloom index
+    pub table_cache_bloom_index_data_bytes: u64,
     /// If in management mode, only can do some meta level operations(database/table/user/stage etc.) with metasrv.
     pub management_mode: bool,
     pub jwt_key_file: String,
@@ -185,10 +181,8 @@ impl Default for QueryConfig {
             table_cache_enabled: false,
             table_cache_snapshot_count: 256,
             table_cache_segment_count: 10240,
-            table_cache_block_meta_count: 102400,
-            table_memory_cache_mb_size: 256,
-            table_disk_cache_root: "_cache".to_string(),
-            table_disk_cache_mb_size: 1024,
+            table_cache_bloom_index_meta_count: 3000,
+            table_cache_bloom_index_data_bytes: 1024 * 1024 * 1024,
             management_mode: false,
             jwt_key_file: "".to_string(),
             async_insert_max_data_size: 10000,

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -130,6 +130,14 @@ pub struct QueryConfig {
     pub max_query_log_size: usize,
     /// Table Cached enabled
     pub table_cache_enabled: bool,
+    /// Max number of cached table block meta
+    pub table_cache_block_meta_count: u64,
+    /// Table memory cache size (mb)
+    pub table_memory_cache_mb_size: u64,
+    /// Table disk cache folder root
+    pub table_disk_cache_root: String,
+    /// Table disk cache size (mb)
+    pub table_disk_cache_mb_size: u64,
     /// Max number of cached table snapshot
     pub table_cache_snapshot_count: u64,
     /// Max number of cached table segment
@@ -179,6 +187,10 @@ impl Default for QueryConfig {
             wait_timeout_mills: 5000,
             max_query_log_size: 10000,
             table_cache_enabled: false,
+            table_cache_block_meta_count: 102400,
+            table_memory_cache_mb_size: 256,
+            table_disk_cache_root: "_cache".to_string(),
+            table_disk_cache_mb_size: 1024,
             table_cache_snapshot_count: 256,
             table_cache_segment_count: 10240,
             table_cache_bloom_index_meta_count: 3000,

--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -898,8 +898,8 @@ pub struct QueryConfig {
     #[clap(long, default_value = "3000")]
     pub table_cache_bloom_index_meta_count: u64,
 
-    /// Max bytes of cached bloom index
-    #[clap(long, default_value = "1024 * 1024 * 1024")]
+    /// Max bytes of cached bloom index, default value is 1GB
+    #[clap(long, default_value = "1073741824")]
     pub table_cache_bloom_index_data_bytes: u64,
 
     /// If in management mode, only can do some meta level operations(database/table/user/stage etc.) with metasrv.

--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -886,6 +886,22 @@ pub struct QueryConfig {
     #[clap(long)]
     pub table_cache_enabled: bool,
 
+    /// Max number of cached table block meta
+    #[clap(long, default_value = "102400")]
+    pub table_cache_block_meta_count: u64,
+
+    /// Table memory cache size (mb)
+    #[clap(long, default_value = "256")]
+    pub table_memory_cache_mb_size: u64,
+
+    /// Table disk cache folder root
+    #[clap(long, default_value = "_cache")]
+    pub table_disk_cache_root: String,
+
+    /// Table disk cache size (mb)
+    #[clap(long, default_value = "1024")]
+    pub table_disk_cache_mb_size: u64,
+
     /// Max number of cached table snapshot
     #[clap(long, default_value = "256")]
     pub table_cache_snapshot_count: u64,
@@ -967,6 +983,10 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
             wait_timeout_mills: self.wait_timeout_mills,
             max_query_log_size: self.max_query_log_size,
             table_cache_enabled: self.table_cache_enabled,
+            table_cache_block_meta_count: self.table_cache_block_meta_count,
+            table_memory_cache_mb_size: self.table_memory_cache_mb_size,
+            table_disk_cache_root: self.table_disk_cache_root,
+            table_disk_cache_mb_size: self.table_disk_cache_mb_size,
             table_cache_snapshot_count: self.table_cache_snapshot_count,
             table_cache_segment_count: self.table_cache_segment_count,
             table_cache_bloom_index_meta_count: self.table_cache_bloom_index_meta_count,
@@ -1022,6 +1042,10 @@ impl From<InnerQueryConfig> for QueryConfig {
             wait_timeout_mills: inner.wait_timeout_mills,
             max_query_log_size: inner.max_query_log_size,
             table_cache_enabled: inner.table_cache_enabled,
+            table_cache_block_meta_count: inner.table_cache_block_meta_count,
+            table_memory_cache_mb_size: inner.table_memory_cache_mb_size,
+            table_disk_cache_root: inner.table_disk_cache_root,
+            table_disk_cache_mb_size: inner.table_disk_cache_mb_size,
             table_cache_snapshot_count: inner.table_cache_snapshot_count,
             table_cache_segment_count: inner.table_cache_segment_count,
             table_cache_bloom_index_meta_count: inner.table_cache_bloom_index_meta_count,

--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -894,21 +894,13 @@ pub struct QueryConfig {
     #[clap(long, default_value = "10240")]
     pub table_cache_segment_count: u64,
 
-    /// Max number of cached table block meta
-    #[clap(long, default_value = "102400")]
-    pub table_cache_block_meta_count: u64,
+    /// Max number of cached bloom index meta objects
+    #[clap(long, default_value = "3000")]
+    pub table_cache_bloom_index_meta_count: u64,
 
-    /// Table memory cache size (mb)
-    #[clap(long, default_value = "256")]
-    pub table_memory_cache_mb_size: u64,
-
-    /// Table disk cache folder root
-    #[clap(long, default_value = "_cache")]
-    pub table_disk_cache_root: String,
-
-    /// Table disk cache size (mb)
-    #[clap(long, default_value = "1024")]
-    pub table_disk_cache_mb_size: u64,
+    /// Max bytes of cached bloom index
+    #[clap(long, default_value = "1024 * 1024 * 1024")]
+    pub table_cache_bloom_index_data_bytes: u64,
 
     /// If in management mode, only can do some meta level operations(database/table/user/stage etc.) with metasrv.
     #[clap(long)]
@@ -977,10 +969,8 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
             table_cache_enabled: self.table_cache_enabled,
             table_cache_snapshot_count: self.table_cache_snapshot_count,
             table_cache_segment_count: self.table_cache_segment_count,
-            table_cache_block_meta_count: self.table_cache_block_meta_count,
-            table_memory_cache_mb_size: self.table_memory_cache_mb_size,
-            table_disk_cache_root: self.table_disk_cache_root,
-            table_disk_cache_mb_size: self.table_disk_cache_mb_size,
+            table_cache_bloom_index_meta_count: self.table_cache_bloom_index_meta_count,
+            table_cache_bloom_index_data_bytes: self.table_cache_bloom_index_data_bytes,
             management_mode: self.management_mode,
             jwt_key_file: self.jwt_key_file,
             async_insert_max_data_size: self.async_insert_max_data_size,
@@ -1034,10 +1024,8 @@ impl From<InnerQueryConfig> for QueryConfig {
             table_cache_enabled: inner.table_cache_enabled,
             table_cache_snapshot_count: inner.table_cache_snapshot_count,
             table_cache_segment_count: inner.table_cache_segment_count,
-            table_cache_block_meta_count: inner.table_cache_block_meta_count,
-            table_memory_cache_mb_size: inner.table_memory_cache_mb_size,
-            table_disk_cache_root: inner.table_disk_cache_root,
-            table_disk_cache_mb_size: inner.table_disk_cache_mb_size,
+            table_cache_bloom_index_meta_count: inner.table_cache_bloom_index_meta_count,
+            table_cache_bloom_index_data_bytes: inner.table_cache_bloom_index_data_bytes,
             management_mode: inner.management_mode,
             jwt_key_file: inner.jwt_key_file,
             async_insert_max_data_size: inner.async_insert_max_data_size,

--- a/src/query/service/tests/it/configs.rs
+++ b/src/query/service/tests/it/configs.rs
@@ -62,10 +62,8 @@ max_query_log_size = 10000
 table_cache_enabled = false
 table_cache_snapshot_count = 256
 table_cache_segment_count = 10240
-table_cache_block_meta_count = 102400
-table_memory_cache_mb_size = 256
-table_disk_cache_root = "_cache"
-table_disk_cache_mb_size = 1024
+table_cache_bloom_index_meta_count = 3000
+table_cache_bloom_index_data_bytes = 1073741824
 management_mode = false
 jwt_key_file = ""
 async_insert_max_data_size = 10000
@@ -182,9 +180,13 @@ fn test_env_config_s3() -> Result<()> {
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
             ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
-            ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
-            ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
-            ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
+            ("QUERY_TABLE_CACHE_SNAPSHOT_COUNT", Some("256")),
+            ("QUERY_TABLE_CACHE_SEGMENT_COUNT", Some("10240")),
+            ("TABLE_CACHE_BLOOM_INDEX_META_COUNT", Some("3000")),
+            (
+                "TABLE_CACHE_BLOOM_INDEX_DATA_BYTES",
+                Some(format!("{}", 1024 * 1024 * 1024).as_str()),
+            ),
             ("STORAGE_TYPE", Some("s3")),
             ("STORAGE_NUM_CPUS", Some("16")),
             ("STORAGE_FS_DATA_PATH", Some("/tmp/test")),
@@ -254,9 +256,13 @@ fn test_env_config_s3() -> Result<()> {
             assert!(configured.query.table_engine_memory_enabled);
 
             assert!(configured.query.table_cache_enabled);
-            assert_eq!(512, configured.query.table_memory_cache_mb_size);
-            assert_eq!("_cache_env", configured.query.table_disk_cache_root);
-            assert_eq!(512, configured.query.table_disk_cache_mb_size);
+            assert_eq!(10240, configured.query.table_cache_segment_count);
+            assert_eq!(256, configured.query.table_cache_snapshot_count);
+            assert_eq!(3000, configured.query.table_cache_bloom_index_meta_count);
+            assert_eq!(
+                1024 * 1024 * 1024,
+                configured.query.table_cache_bloom_index_data_bytes
+            );
         },
     );
 
@@ -284,9 +290,13 @@ fn test_env_config_fs() -> Result<()> {
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
             ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
-            ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
-            ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
-            ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
+            ("QUERY_TABLE_CACHE_SNAPSHOT_COUNT", Some("256")),
+            ("QUERY_TABLE_CACHE_SEGMENT_COUNT", Some("10240")),
+            ("TABLE_CACHE_BLOOM_INDEX_META_COUNT", Some("3000")),
+            (
+                "TABLE_CACHE_BLOOM_INDEX_DATA_BYTES",
+                Some(format!("{}", 1024 * 1024 * 1024).as_str()),
+            ),
             ("STORAGE_TYPE", Some("fs")),
             ("STORAGE_NUM_CPUS", Some("16")),
             ("STORAGE_FS_DATA_PATH", Some("/tmp/test")),
@@ -356,9 +366,13 @@ fn test_env_config_fs() -> Result<()> {
             assert!(configured.query.table_engine_memory_enabled);
 
             assert!(configured.query.table_cache_enabled);
-            assert_eq!(512, configured.query.table_memory_cache_mb_size);
-            assert_eq!("_cache_env", configured.query.table_disk_cache_root);
-            assert_eq!(512, configured.query.table_disk_cache_mb_size);
+            assert_eq!(10240, configured.query.table_cache_segment_count);
+            assert_eq!(256, configured.query.table_cache_snapshot_count);
+            assert_eq!(3000, configured.query.table_cache_bloom_index_meta_count);
+            assert_eq!(
+                1024 * 1024 * 1024,
+                configured.query.table_cache_bloom_index_data_bytes
+            );
         },
     );
 
@@ -385,9 +399,13 @@ fn test_env_config_gcs() -> Result<()> {
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
             ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
-            ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
-            ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
-            ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
+            ("QUERY_TABLE_CACHE_SNAPSHOT_COUNT", Some("256")),
+            ("QUERY_TABLE_CACHE_SEGMENT_COUNT", Some("10240")),
+            ("TABLE_CACHE_BLOOM_INDEX_META_COUNT", Some("3000")),
+            (
+                "TABLE_CACHE_BLOOM_INDEX_DATA_BYTES",
+                Some(format!("{}", 1024 * 1024 * 1024).as_str()),
+            ),
             ("STORAGE_TYPE", Some("gcs")),
             ("STORAGE_NUM_CPUS", Some("16")),
             ("STORAGE_FS_DATA_PATH", Some("/tmp/test")),
@@ -464,9 +482,13 @@ fn test_env_config_gcs() -> Result<()> {
             assert!(configured.query.table_engine_memory_enabled);
 
             assert!(configured.query.table_cache_enabled);
-            assert_eq!(512, configured.query.table_memory_cache_mb_size);
-            assert_eq!("_cache_env", configured.query.table_disk_cache_root);
-            assert_eq!(512, configured.query.table_disk_cache_mb_size);
+            assert_eq!(10240, configured.query.table_cache_segment_count);
+            assert_eq!(256, configured.query.table_cache_snapshot_count);
+            assert_eq!(3000, configured.query.table_cache_bloom_index_meta_count);
+            assert_eq!(
+                1024 * 1024 * 1024,
+                configured.query.table_cache_bloom_index_data_bytes
+            );
         },
     );
 
@@ -493,9 +515,13 @@ fn test_env_config_oss() -> Result<()> {
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
             ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
-            ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
-            ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
-            ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
+            ("QUERY_TABLE_CACHE_SNAPSHOT_COUNT", Some("256")),
+            ("QUERY_TABLE_CACHE_SEGMENT_COUNT", Some("10240")),
+            ("TABLE_CACHE_BLOOM_INDEX_META_COUNT", Some("3000")),
+            (
+                "TABLE_CACHE_BLOOM_INDEX_DATA_BYTES",
+                Some(format!("{}", 1024 * 1024 * 1024).as_str()),
+            ),
             ("STORAGE_TYPE", Some("oss")),
             ("STORAGE_NUM_CPUS", Some("16")),
             ("STORAGE_FS_DATA_PATH", Some("/tmp/test")),
@@ -579,9 +605,13 @@ fn test_env_config_oss() -> Result<()> {
             assert!(configured.query.table_engine_memory_enabled);
 
             assert!(configured.query.table_cache_enabled);
-            assert_eq!(512, configured.query.table_memory_cache_mb_size);
-            assert_eq!("_cache_env", configured.query.table_disk_cache_root);
-            assert_eq!(512, configured.query.table_disk_cache_mb_size);
+            assert_eq!(10240, configured.query.table_cache_segment_count);
+            assert_eq!(256, configured.query.table_cache_snapshot_count);
+            assert_eq!(3000, configured.query.table_cache_bloom_index_meta_count);
+            assert_eq!(
+                1024 * 1024 * 1024,
+                configured.query.table_cache_bloom_index_data_bytes
+            );
         },
     );
     Ok(())
@@ -630,10 +660,8 @@ max_query_log_size = 10000
 table_cache_enabled = false
 table_cache_snapshot_count = 256
 table_cache_segment_count = 10240
-table_cache_block_meta_count = 102400
-table_memory_cache_mb_size = 256
-table_disk_cache_root = "_cache"
-table_disk_cache_mb_size = 1024
+table_cache_bloom_index_meta_count = 3000
+table_cache_bloom_index_data_bytes = 1073741824
 management_mode = false
 jwt_key_file = ""
 async_insert_max_data_size = 10000

--- a/src/query/service/tests/it/configs.rs
+++ b/src/query/service/tests/it/configs.rs
@@ -60,6 +60,10 @@ database_engine_github_enabled = true
 wait_timeout_mills = 5000
 max_query_log_size = 10000
 table_cache_enabled = false
+table_cache_block_meta_count = 102400
+table_memory_cache_mb_size = 256
+table_disk_cache_root = "_cache"
+table_disk_cache_mb_size = 1024
 table_cache_snapshot_count = 256
 table_cache_segment_count = 10240
 table_cache_bloom_index_meta_count = 3000
@@ -180,6 +184,9 @@ fn test_env_config_s3() -> Result<()> {
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
             ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
+            ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
+            ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
+            ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
             ("QUERY_TABLE_CACHE_SNAPSHOT_COUNT", Some("256")),
             ("QUERY_TABLE_CACHE_SEGMENT_COUNT", Some("10240")),
             ("TABLE_CACHE_BLOOM_INDEX_META_COUNT", Some("3000")),
@@ -290,7 +297,10 @@ fn test_env_config_fs() -> Result<()> {
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
             ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
-            ("QUERY_TABLE_CACHE_SNAPSHOT_COUNT", Some("256")),
+            ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
+            ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
+            ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
+            ("QU-ERY_TABLE_CACHE_SNAPSHOT_COUNT", Some("256")),
             ("QUERY_TABLE_CACHE_SEGMENT_COUNT", Some("10240")),
             ("TABLE_CACHE_BLOOM_INDEX_META_COUNT", Some("3000")),
             (
@@ -366,6 +376,9 @@ fn test_env_config_fs() -> Result<()> {
             assert!(configured.query.table_engine_memory_enabled);
 
             assert!(configured.query.table_cache_enabled);
+            assert_eq!(512, configured.query.table_memory_cache_mb_size);
+            assert_eq!("_cache_env", configured.query.table_disk_cache_root);
+            assert_eq!(512, configured.query.table_disk_cache_mb_size);
             assert_eq!(10240, configured.query.table_cache_segment_count);
             assert_eq!(256, configured.query.table_cache_snapshot_count);
             assert_eq!(3000, configured.query.table_cache_bloom_index_meta_count);
@@ -399,6 +412,9 @@ fn test_env_config_gcs() -> Result<()> {
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
             ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
+            ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
+            ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
+            ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
             ("QUERY_TABLE_CACHE_SNAPSHOT_COUNT", Some("256")),
             ("QUERY_TABLE_CACHE_SEGMENT_COUNT", Some("10240")),
             ("TABLE_CACHE_BLOOM_INDEX_META_COUNT", Some("3000")),
@@ -482,6 +498,9 @@ fn test_env_config_gcs() -> Result<()> {
             assert!(configured.query.table_engine_memory_enabled);
 
             assert!(configured.query.table_cache_enabled);
+            assert_eq!(512, configured.query.table_memory_cache_mb_size);
+            assert_eq!("_cache_env", configured.query.table_disk_cache_root);
+            assert_eq!(512, configured.query.table_disk_cache_mb_size);
             assert_eq!(10240, configured.query.table_cache_segment_count);
             assert_eq!(256, configured.query.table_cache_snapshot_count);
             assert_eq!(3000, configured.query.table_cache_bloom_index_meta_count);
@@ -515,6 +534,9 @@ fn test_env_config_oss() -> Result<()> {
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
             ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
+            ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
+            ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
+            ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
             ("QUERY_TABLE_CACHE_SNAPSHOT_COUNT", Some("256")),
             ("QUERY_TABLE_CACHE_SEGMENT_COUNT", Some("10240")),
             ("TABLE_CACHE_BLOOM_INDEX_META_COUNT", Some("3000")),
@@ -605,6 +627,9 @@ fn test_env_config_oss() -> Result<()> {
             assert!(configured.query.table_engine_memory_enabled);
 
             assert!(configured.query.table_cache_enabled);
+            assert_eq!(512, configured.query.table_memory_cache_mb_size);
+            assert_eq!("_cache_env", configured.query.table_disk_cache_root);
+            assert_eq!(512, configured.query.table_disk_cache_mb_size);
             assert_eq!(10240, configured.query.table_cache_segment_count);
             assert_eq!(256, configured.query.table_cache_snapshot_count);
             assert_eq!(3000, configured.query.table_cache_bloom_index_meta_count);
@@ -660,6 +685,10 @@ max_query_log_size = 10000
 table_cache_enabled = false
 table_cache_snapshot_count = 256
 table_cache_segment_count = 10240
+table_cache_block_meta_count = 102400
+table_memory_cache_mb_size = 256
+table_disk_cache_root = "_cache"
+table_disk_cache_mb_size = 1024
 table_cache_bloom_index_meta_count = 3000
 table_cache_bloom_index_data_bytes = 1073741824
 management_mode = false

--- a/src/query/service/tests/it/storages/testdata/system-tables.txt
+++ b/src/query/service/tests/it/storages/testdata/system-tables.txt
@@ -208,14 +208,12 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | query   | rpc_tls_server_cert                  |                                |             |
 | query   | rpc_tls_server_key                   |                                |             |
 | query   | share_endpoint_address               |                                |             |
-| query   | table_cache_block_meta_count         | 102400                         |             |
+| query   | table_cache_bloom_index_data_bytes   | 1073741824                     |             |
+| query   | table_cache_bloom_index_meta_count   | 3000                           |             |
 | query   | table_cache_enabled                  | false                          |             |
 | query   | table_cache_segment_count            | 10240                          |             |
 | query   | table_cache_snapshot_count           | 256                            |             |
-| query   | table_disk_cache_mb_size             | 1024                           |             |
-| query   | table_disk_cache_root                | _cache                         |             |
 | query   | table_engine_memory_enabled          | true                           |             |
-| query   | table_memory_cache_mb_size           | 256                            |             |
 | query   | tenant_id                            | test                           |             |
 | query   | users                                |                                |             |
 | query   | wait_timeout_mills                   | 5000                           |             |

--- a/src/query/service/tests/it/storages/testdata/system-tables.txt
+++ b/src/query/service/tests/it/storages/testdata/system-tables.txt
@@ -208,12 +208,16 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | query   | rpc_tls_server_cert                  |                                |             |
 | query   | rpc_tls_server_key                   |                                |             |
 | query   | share_endpoint_address               |                                |             |
+| query   | table_cache_block_meta_count         | 102400                         |             |
 | query   | table_cache_bloom_index_data_bytes   | 1073741824                     |             |
 | query   | table_cache_bloom_index_meta_count   | 3000                           |             |
 | query   | table_cache_enabled                  | false                          |             |
 | query   | table_cache_segment_count            | 10240                          |             |
 | query   | table_cache_snapshot_count           | 256                            |             |
+| query   | table_disk_cache_mb_size             | 1024                           |             |
+| query   | table_disk_cache_root                | _cache                         |             |
 | query   | table_engine_memory_enabled          | true                           |             |
+| query   | table_memory_cache_mb_size           | 256                            |             |
 | query   | tenant_id                            | test                           |             |
 | query   | users                                |                                |             |
 | query   | wait_timeout_mills                   | 5000                           |             |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

config options for bloom filter cache

- new config options for bloom index cache 
~~~
    /// Max number of cached bloom index meta objects
    #[clap(long, default_value = "3000")]
    pub table_cache_bloom_index_meta_count: u64,

    /// Max bytes of cached bloom index, default value is 1GB
    #[clap(long, default_value = "1073741824")]
    pub table_cache_bloom_index_data_bytes: u64,
~~~
- remove unused config options
 ~~~
    /// Max number of cached table block meta
    pub table_cache_block_meta_count: u64,
    /// Table memory cache size (mb)
    pub table_memory_cache_mb_size: u64,
    /// Table disk cache folder root
    pub table_disk_cache_root: String,
    /// Table disk cache size (mb)
    pub table_disk_cache_mb_size: u64,
 ~~~

Fixes #8279
