### PR TITLE
fix(query): StringSearchLike vector_vector can not match '\n'

### DIFF
--- a/src/query/functions-v2/src/scalars/comparison.rs
+++ b/src/query/functions-v2/src/scalars/comparison.rs
@@ -328,8 +328,8 @@ fn like_pattern_to_regex(pattern: &str) -> String {
                 regex.push('\\');
                 regex.push(c);
             }
-            '%' => regex.push_str(".*"),
-            '_' => regex.push('.'),
+            '%' => regex.push_str("(?s:.)*"),
+            '_' => regex.push_str("(?s:.)"),
             '\\' => match chars.peek().cloned() {
                 Some('%') => {
                     regex.push('%');

--- a/src/query/functions-v2/tests/it/scalars/comparison.rs
+++ b/src/query/functions-v2/tests/it/scalars/comparison.rs
@@ -362,6 +362,8 @@ fn test_gte(file: &mut impl Write) {
 
 fn test_like(file: &mut impl Write, columns: &[(&str, DataType, Column)]) {
     run_ast(file, "'1' like '2'", &[]);
+    run_ast(file, "'hello\n' like 'h%'", &[]);
+    run_ast(file, "'h\n' like 'h_'", &[]);
 
     let like_columns = [(
         "lhs",

--- a/src/query/functions-v2/tests/it/scalars/testdata/comparison.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/comparison.txt
@@ -830,6 +830,26 @@ output domain  : Unknown
 output         : false
 
 
+ast            : 'hello
+' like 'h%'
+raw expr       : like("hello\n", "h%")
+checked expr   : like<String, String>("hello\n", "h%")
+optimized expr : true
+output type    : Boolean
+output domain  : Unknown
+output         : true
+
+
+ast            : 'h
+' like 'h_'
+raw expr       : like("h\n", "h_")
+checked expr   : like<String, String>("h\n", "h_")
+optimized expr : true
+output type    : Boolean
+output domain  : Unknown
+output         : true
+
+
 ast            : lhs like 'a%'
 raw expr       : like(ColumnRef(0)::String, "a%")
 checked expr   : like<String, String>(ColumnRef(0), "a%")

--- a/src/query/functions/src/scalars/comparisons/comparison_like.rs
+++ b/src/query/functions/src/scalars/comparisons/comparison_like.rs
@@ -194,8 +194,8 @@ pub fn like_pattern_to_regex(pattern: &str) -> String {
                 regex.push('\\');
                 regex.push(c);
             }
-            '%' => regex.push_str(".*"),
-            '_' => regex.push('.'),
+            '%' => regex.push_str("(?s:.)*"),
+            '_' => regex.push_str("(?s:.)"),
             '\\' => match chars.peek().cloned() {
                 Some('%') => {
                     regex.push('%');

--- a/tests/logictest/suites/base/02_function/02_0005_function_compare
+++ b/tests/logictest/suites/base/02_function/02_0005_function_compare
@@ -52,6 +52,18 @@ select '%' like '\%';
 ----
 1
 
+statement query B
+select 'h\n' like 'h_';
+
+----
+1
+
+statement query B
+select 'hello\n' like 'h%';
+
+----
+1
+
 
 statement query B
 select '%' like '\\%';


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Before this pr

query "select 'hello\n' like 'h%'; " will return false.

Because rust regexp lib : `. will match any valid UTF-8 encoded Unicode scalar value except for \n. (To also match \n, enable the s flag, e.g., (?s:.).)`

More description in #8354 

Fixes #8354
