### PR TITLE
refactor(meta/binary): record every error when joining/leaving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,6 +2837,7 @@ dependencies = [
  "common-tracing",
  "env_logger",
  "futures",
+ "itertools",
  "maplit",
  "metrics",
  "once_cell",

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -48,6 +48,7 @@ async-trait = "0.1.57"
 backon = "0.2.0"
 clap = { workspace = true }
 futures = "0.3.24"
+itertools = "0.10.5"
 metrics = "0.20.1"
 once_cell = "1.15.0"
 poem = { version = "1", features = ["rustls"] }

--- a/src/meta/service/src/meta_service/meta_service_impl.rs
+++ b/src/meta/service/src/meta_service/meta_service_impl.rs
@@ -104,7 +104,7 @@ impl RaftService for RaftServiceImpl {
         return Ok(tonic::Response::new(raft_reply));
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn forward(
         &self,
         request: tonic::Request<RaftRequest>,

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
@@ -15,13 +15,11 @@
 //! Test arrow-grpc API of metasrv
 use std::collections::HashSet;
 
-use anyerror::AnyError;
 use common_base::base::tokio;
 use common_base::base::Stoppable;
 use common_meta_api::KVApi;
 use common_meta_client::MetaGrpcClient;
 use common_meta_types::MatchSeq;
-use common_meta_types::MetaManagementError;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKVReply;
@@ -158,15 +156,15 @@ async fn test_retry_join() -> anyhow::Result<()> {
 
         tc1.config.raft_config.join = vec![bad_addr.clone()];
         let ret = start_metasrv_with_context(&mut tc1).await;
-        let expect = MetaManagementError::Join(AnyError::error(format!(
+        let expect = format!(
             "fail to join {} cluster via {:?}",
             1, tc1.config.raft_config.join
-        )));
+        );
 
         match ret {
             Ok(_) => panic!("must return JoinClusterFail"),
             Err(e) => {
-                assert_eq!(e.to_string(), expect.to_string());
+                assert!(e.to_string().starts_with(&expect));
             }
         }
     }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/binary): record every error when joining/leaving

- Part of #8369


##### chore(meta): remove unexpected span info

## Changelog







## Related Issues