### PR TITLE
fix: should ignore `StorageNotFound` errors in concurrent GC

### DIFF
--- a/src/query/storages/fuse/src/io/snapshots.rs
+++ b/src/query/storages/fuse/src/io/snapshots.rs
@@ -140,7 +140,7 @@ impl SnapshotsIO {
             let results = self.read_snapshots(chunks).await?;
             info!("Finish to read_snapshots, chunk:[{}]", idx);
 
-            for snapshot in results.into_iter().collect::<Result<Vec<_>>>()? {
+            for snapshot in results.into_iter().flatten() {
                 if snapshot.timestamp > min_snapshot_timestamp {
                     continue;
                 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

should ignore `StorageNotFound` errors in concurrent GC as long as we follow the order of cleaning data, things will be ok

Fixes #issue
