### PR TITLE
feat(query): get the system open file limits and set

### DIFF
--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -49,10 +49,12 @@ databend-query = { path = "../query/service" }
 # Crates.io dependencies
 anyhow = { workspace = true }
 clap = { workspace = true }
+limits-rs = "0.1.0"
 openraft = { workspace = true }
 sentry = "0.27.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
+sysinfo = "0.26.5"
 tokio-stream = "0.1.10"
 tonic = "0.8.1"
 tracing = "0.1.36"

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -54,7 +54,6 @@ openraft = { workspace = true }
 sentry = "0.27.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
-sysinfo = "0.26.5"
 tokio-stream = "0.1.10"
 tonic = "0.8.1"
 tracing = "0.1.36"

--- a/src/binaries/query/main.rs
+++ b/src/binaries/query/main.rs
@@ -264,15 +264,7 @@ fn try_set_max_open_files() {
     let max_open_files_limit = limits.max_open_files.soft;
     if let Some(max_open_files) = max_open_files_limit {
         if max_open_files < 65535 {
-            let set = sysinfo::set_open_files_limit(max_open_files.try_into().unwrap());
-            match set {
-                true => {
-                    warn!("Open files limit has been set to {}", max_open_files);
-                }
-                false => {
-                    warn!("Open files limit set to {} failed", max_open_files);
-                }
-            }
+            warn!("The open file limit is too low for the databend-query. Please consider increase it by running `ulimit -n 65535`");
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

If the open file limit is less than 65535, set it to 65535.

Fixes #8387 
