### PR TITLE
refactor: decouple meta readers from TableContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,6 @@ dependencies = [
  "async-trait-fn",
  "common-arrow",
  "common-cache",
- "common-catalog",
  "common-exception",
  "common-fuse-meta",
  "opendal",

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -194,29 +194,16 @@ pub trait Table: Sync + Send {
         Ok(())
     }
 
-    async fn table_statistics(
-        &self,
-        ctx: Arc<dyn TableContext>,
-    ) -> Result<Option<TableStatistics>> {
-        let _ = ctx;
-
+    async fn table_statistics(&self) -> Result<Option<TableStatistics>> {
         Ok(None)
     }
 
-    async fn column_statistics_provider(
-        &self,
-        ctx: Arc<dyn TableContext>,
-    ) -> Result<Box<dyn ColumnStatisticsProvider>> {
-        let _ = ctx;
+    async fn column_statistics_provider(&self) -> Result<Box<dyn ColumnStatisticsProvider>> {
         Ok(Box::new(DummyColumnStatisticsProvider))
     }
 
-    async fn navigate_to(
-        &self,
-        ctx: Arc<dyn TableContext>,
-        instant: &NavigationPoint,
-    ) -> Result<Arc<dyn Table>> {
-        let (_, _) = (ctx, instant);
+    async fn navigate_to(&self, instant: &NavigationPoint) -> Result<Arc<dyn Table>> {
+        let _ = instant;
 
         Err(ErrorCode::UnImplement(format!(
             "table {},  of engine type {}, does not support time travel",

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -194,7 +194,7 @@ pub trait Table: Sync + Send {
         Ok(())
     }
 
-    async fn table_statistics(&self) -> Result<Option<TableStatistics>> {
+    fn table_statistics(&self) -> Result<Option<TableStatistics>> {
         Ok(None)
     }
 

--- a/src/query/service/src/table_functions/numbers_table.rs
+++ b/src/query/service/src/table_functions/numbers_table.rs
@@ -216,7 +216,7 @@ impl Table for NumbersTable {
         Ok(())
     }
 
-    async fn table_statistics(&self) -> Result<Option<TableStatistics>> {
+    fn table_statistics(&self) -> Result<Option<TableStatistics>> {
         Ok(Some(TableStatistics {
             num_rows: Some(self.total),
             data_size: Some(self.total * 8),

--- a/src/query/service/src/table_functions/numbers_table.rs
+++ b/src/query/service/src/table_functions/numbers_table.rs
@@ -216,10 +216,7 @@ impl Table for NumbersTable {
         Ok(())
     }
 
-    async fn table_statistics(
-        &self,
-        _ctx: Arc<dyn TableContext>,
-    ) -> Result<Option<TableStatistics>> {
+    async fn table_statistics(&self) -> Result<Option<TableStatistics>> {
         Ok(Some(TableStatistics {
             num_rows: Some(self.total),
             data_size: Some(self.total * 8),

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -129,7 +129,7 @@ async fn test_compact_segment_resolvable_conflict() -> Result<()> {
 
     let latest = table.refresh(ctx.as_ref()).await?;
     let latest_fuse_table = FuseTable::try_from_table(latest.as_ref())?;
-    let table_statistics = latest_fuse_table.table_statistics().await?.unwrap();
+    let table_statistics = latest_fuse_table.table_statistics()?.unwrap();
 
     assert_eq!(table_statistics.num_rows.unwrap() as usize, num_inserts * 2);
 

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -129,10 +129,7 @@ async fn test_compact_segment_resolvable_conflict() -> Result<()> {
 
     let latest = table.refresh(ctx.as_ref()).await?;
     let latest_fuse_table = FuseTable::try_from_table(latest.as_ref())?;
-    let table_statistics = latest_fuse_table
-        .table_statistics(ctx.clone())
-        .await?
-        .unwrap();
+    let table_statistics = latest_fuse_table.table_statistics().await?.unwrap();
 
     assert_eq!(table_statistics.num_rows.unwrap() as usize, num_inserts * 2);
 

--- a/src/query/service/tests/it/storages/fuse/pruning.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning.rs
@@ -148,7 +148,7 @@ async fn test_block_pruner() -> Result<()> {
         .get(OPT_KEY_SNAPSHOT_LOCATION)
         .unwrap();
 
-    let reader = MetaReaders::table_snapshot_reader(ctx.clone(), fuse_table.get_operator());
+    let reader = MetaReaders::table_snapshot_reader(fuse_table.get_operator());
     let snapshot = reader.read(snapshot_loc.as_str(), None, 1).await?;
 
     // nothing is pruned
@@ -293,7 +293,7 @@ async fn test_block_pruner_monotonic() -> Result<()> {
         .options()
         .get(OPT_KEY_SNAPSHOT_LOCATION)
         .unwrap();
-    let reader = MetaReaders::table_snapshot_reader(ctx.clone(), fuse_table.get_operator());
+    let reader = MetaReaders::table_snapshot_reader(fuse_table.get_operator());
     let snapshot = reader.read(snapshot_loc.as_str(), None, 1).await?;
 
     // a + b > 20; some blocks pruned

--- a/src/query/service/tests/it/storages/fuse/table.rs
+++ b/src/query/service/tests/it/storages/fuse/table.rs
@@ -332,7 +332,7 @@ async fn test_fuse_alter_table_cluster_key() -> Result<()> {
         .options()
         .get(OPT_KEY_SNAPSHOT_LOCATION)
         .unwrap();
-    let reader = MetaReaders::table_snapshot_reader(ctx.clone(), fuse_table.get_operator());
+    let reader = MetaReaders::table_snapshot_reader(fuse_table.get_operator());
     let snapshot = reader.read(snapshot_loc.as_str(), None, 1).await?;
     let expected = Some((0, "(id)".to_string()));
     assert_eq!(snapshot.cluster_key_meta, expected);
@@ -359,7 +359,7 @@ async fn test_fuse_alter_table_cluster_key() -> Result<()> {
         .options()
         .get(OPT_KEY_SNAPSHOT_LOCATION)
         .unwrap();
-    let reader = MetaReaders::table_snapshot_reader(ctx, fuse_table.get_operator());
+    let reader = MetaReaders::table_snapshot_reader(fuse_table.get_operator());
     let snapshot = reader.read(snapshot_loc.as_str(), None, 1).await?;
     let expected = None;
     assert_eq!(snapshot.cluster_key_meta, expected);

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -306,7 +306,7 @@ impl<'a> Binder {
             };
             bind_context.add_column_binding(column_binding);
         }
-        let stat = table.table().table_statistics(self.ctx.clone()).await?;
+        let stat = table.table().table_statistics().await?;
         Ok((
             SExpr::create_leaf(
                 LogicalGet {
@@ -337,7 +337,7 @@ impl<'a> Binder {
         let mut table_meta = catalog.get_table(tenant, database_name, table_name).await?;
 
         if let Some(tp) = travel_point {
-            table_meta = table_meta.navigate_to(self.ctx.clone(), tp).await?;
+            table_meta = table_meta.navigate_to(tp).await?;
         }
         Ok(table_meta)
     }

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -80,7 +80,6 @@ impl<'a> Binder {
         );
 
         self.bind_base_table(bind_context, database, table_index)
-            .await
     }
 
     pub(super) async fn bind_table_reference(
@@ -155,9 +154,8 @@ impl<'a> Binder {
                                 .write()
                                 .add_table(catalog, database.clone(), table_meta);
 
-                        let (s_expr, mut bind_context) = self
-                            .bind_base_table(bind_context, database.as_str(), table_index)
-                            .await?;
+                        let (s_expr, mut bind_context) =
+                            self.bind_base_table(bind_context, database.as_str(), table_index)?;
                         if let Some(alias) = alias {
                             bind_context.apply_table_alias(alias, &self.name_resolution_ctx)?;
                         }
@@ -218,9 +216,8 @@ impl<'a> Binder {
                     table.clone(),
                 );
 
-                let (s_expr, mut bind_context) = self
-                    .bind_base_table(bind_context, "system", table_index)
-                    .await?;
+                let (s_expr, mut bind_context) =
+                    self.bind_base_table(bind_context, "system", table_index)?;
                 if let Some(alias) = alias {
                     bind_context.apply_table_alias(alias, &self.name_resolution_ctx)?;
                 }
@@ -282,7 +279,7 @@ impl<'a> Binder {
         Ok((cte_info.s_expr.clone(), new_bind_context))
     }
 
-    async fn bind_base_table(
+    fn bind_base_table(
         &mut self,
         bind_context: &BindContext,
         database_name: &str,
@@ -306,7 +303,7 @@ impl<'a> Binder {
             };
             bind_context.add_column_binding(column_binding);
         }
-        let stat = table.table().table_statistics().await?;
+        let stat = table.table().table_statistics()?;
         Ok((
             SExpr::create_leaf(
                 LogicalGet {

--- a/src/query/storages/cache/Cargo.toml
+++ b/src/query/storages/cache/Cargo.toml
@@ -14,7 +14,6 @@ test = false
 [dependencies]
 common-arrow = { path = "../../../common/arrow" }
 common-cache = { path = "../../../common/cache" }
-common-catalog = { path = "../../../common/../query/catalog" }
 common-exception = { path = "../../../common/exception" }
 common-fuse-meta = { path = "../fuse-meta" }
 

--- a/src/query/storages/fuse-meta/src/caches/cache.rs
+++ b/src/query/storages/fuse-meta/src/caches/cache.rs
@@ -20,7 +20,7 @@ use common_exception::Result;
 use once_cell::sync::OnceCell;
 
 use crate::caches::memory_cache::new_bytes_cache;
-use crate::caches::memory_cache::new_item_cache_new;
+use crate::caches::memory_cache::new_item_cache;
 use crate::caches::memory_cache::BloomIndexCache;
 use crate::caches::memory_cache::BloomIndexMetaCache;
 use crate::caches::memory_cache::BytesCache;
@@ -28,6 +28,7 @@ use crate::caches::memory_cache::FileMetaDataCache;
 use crate::caches::memory_cache::LabeledItemCache;
 use crate::caches::SegmentInfoCache;
 use crate::caches::TableSnapshotCache;
+use crate::caches::TenantLabel;
 
 static DEFAULT_FILE_META_DATA_CACHE_ITEMS: u64 = 3000;
 
@@ -62,28 +63,23 @@ impl CacheManager {
 
             CACHE_MANAGER.set(v).ok();
         } else {
-            let tenant_id = config.tenant_id.clone();
-            let cluster_id = config.cluster_id.clone();
-            let table_snapshot_cache = Self::new_item_cache(
-                config.table_cache_snapshot_count,
-                tenant_id.clone(),
-                cluster_id.clone(),
-            );
-            let segment_info_cache = Self::new_item_cache(
-                config.table_cache_segment_count,
-                tenant_id.clone(),
-                cluster_id.clone(),
-            );
+            let tenant_label = TenantLabel {
+                tenant_id: config.tenant_id.clone(),
+                cluster_id: config.cluster_id.clone(),
+            };
+            let table_snapshot_cache =
+                Self::new_item_cache(config.table_cache_snapshot_count, tenant_label.clone());
+            let segment_info_cache =
+                Self::new_item_cache(config.table_cache_segment_count, tenant_label.clone());
             let bloom_index_data_cache =
                 Self::new_bytes_cache(config.table_cache_bloom_index_data_bytes);
             let bloom_index_meta_cache = Self::new_item_cache(
                 config.table_cache_bloom_index_meta_count,
-                tenant_id.clone(),
-                cluster_id.clone(),
+                tenant_label.clone(),
             );
 
             let file_meta_data_cache =
-                Self::new_item_cache(DEFAULT_FILE_META_DATA_CACHE_ITEMS, tenant_id, cluster_id);
+                Self::new_item_cache(DEFAULT_FILE_META_DATA_CACHE_ITEMS, tenant_label);
 
             v.init(Arc::new(Self {
                 table_snapshot_cache,
@@ -136,13 +132,9 @@ impl CacheManager {
         self.cluster_id.as_str()
     }
 
-    fn new_item_cache<T>(
-        capacity: u64,
-        tenant_id: String,
-        cluster_id: String,
-    ) -> Option<LabeledItemCache<T>> {
+    fn new_item_cache<T>(capacity: u64, tenant_label: TenantLabel) -> Option<LabeledItemCache<T>> {
         if capacity > 0 {
-            Some(new_item_cache_new(capacity, tenant_id, cluster_id))
+            Some(new_item_cache(capacity, tenant_label))
         } else {
             None
         }

--- a/src/query/storages/fuse-meta/src/caches/cache.rs
+++ b/src/query/storages/fuse-meta/src/caches/cache.rs
@@ -23,8 +23,8 @@ use crate::caches::memory_cache::new_bytes_cache;
 use crate::caches::memory_cache::new_item_cache;
 use crate::caches::memory_cache::BloomIndexCache;
 use crate::caches::memory_cache::BloomIndexMetaCache;
-use crate::caches::memory_cache::BytesCache;
 use crate::caches::memory_cache::FileMetaDataCache;
+use crate::caches::memory_cache::LabeledBytesCache;
 use crate::caches::memory_cache::LabeledItemCache;
 use crate::caches::SegmentInfoCache;
 use crate::caches::TableSnapshotCache;
@@ -71,8 +71,10 @@ impl CacheManager {
                 Self::new_item_cache(config.table_cache_snapshot_count, tenant_label.clone());
             let segment_info_cache =
                 Self::new_item_cache(config.table_cache_segment_count, tenant_label.clone());
-            let bloom_index_data_cache =
-                Self::new_bytes_cache(config.table_cache_bloom_index_data_bytes);
+            let bloom_index_data_cache = Self::new_bytes_cache(
+                config.table_cache_bloom_index_data_bytes,
+                tenant_label.clone(),
+            );
             let bloom_index_meta_cache = Self::new_item_cache(
                 config.table_cache_bloom_index_meta_count,
                 tenant_label.clone(),
@@ -140,9 +142,9 @@ impl CacheManager {
         }
     }
 
-    fn new_bytes_cache(capacity: u64) -> Option<BytesCache> {
+    fn new_bytes_cache(capacity: u64, tenant_label: TenantLabel) -> Option<LabeledBytesCache> {
         if capacity > 0 {
-            Some(new_bytes_cache(capacity))
+            Some(new_bytes_cache(capacity, tenant_label))
         } else {
             None
         }

--- a/src/query/storages/fuse-meta/src/caches/metrics.rs
+++ b/src/query/storages/fuse-meta/src/caches/metrics.rs
@@ -20,20 +20,21 @@ const CACHE_READ_BYTES_FROM_LOCAL: &str = "cache_read_bytes_from_local";
 const CACHE_ACCESS_COUNT: &str = "cache_access_count";
 const CACHE_ACCESS_HIT_COUNT: &str = "cache_access_hit_count";
 
+#[derive(Clone)]
 pub struct TenantLabel {
     pub tenant_id: String,
     pub cluster_id: String,
 }
 
-pub struct CacheDeferMetrics {
-    pub tenant_label: TenantLabel,
+pub struct CacheDeferMetrics<'a> {
+    pub tenant_label: &'a TenantLabel,
     pub cache_hit: bool,
     pub read_bytes: u64,
 }
 
-impl Drop for CacheDeferMetrics {
+impl Drop for CacheDeferMetrics<'_> {
     fn drop(&mut self) {
-        let label = &self.tenant_label;
+        let label = self.tenant_label;
         let tenant_id = &label.tenant_id;
         let cluster_id = &label.cluster_id;
 

--- a/src/query/storages/fuse-meta/src/caches/mod.rs
+++ b/src/query/storages/fuse-meta/src/caches/mod.rs
@@ -19,6 +19,7 @@ mod metrics;
 pub use cache::CacheManager;
 pub use memory_cache::new_item_cache;
 pub use memory_cache::ItemCache;
+pub use memory_cache::LabeledItemCache;
 pub use memory_cache::SegmentInfoCache;
 pub use memory_cache::TableSnapshotCache;
 

--- a/src/query/storages/fuse-meta/src/caches/mod.rs
+++ b/src/query/storages/fuse-meta/src/caches/mod.rs
@@ -17,7 +17,6 @@ mod memory_cache;
 mod metrics;
 
 pub use cache::CacheManager;
-pub use memory_cache::new_item_cache;
 pub use memory_cache::ItemCache;
 pub use memory_cache::LabeledItemCache;
 pub use memory_cache::SegmentInfoCache;

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -420,7 +420,7 @@ impl Table for FuseTable {
         self.do_gc(&ctx, keep_last_snapshot).await
     }
 
-    async fn table_statistics(&self) -> Result<Option<TableStatistics>> {
+    fn table_statistics(&self) -> Result<Option<TableStatistics>> {
         let s = &self.table_info.meta.statistics;
         Ok(Some(TableStatistics {
             num_rows: Some(s.number_of_rows),

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -87,14 +87,8 @@ impl FuseTable {
         Ok(r)
     }
 
-    pub fn do_create(table_info: TableInfo, read_only: bool) -> Result<Box<FuseTable>> {
-        let storage_prefix = Self::parse_storage_prefix(&table_info)?;
-        let cluster_key_meta = table_info.meta.cluster_key();
-        let mut cluster_keys = Vec::new();
-        if let Some((_, order)) = &cluster_key_meta {
-            cluster_keys = ExpressionParser::parse_exprs(order)?;
-        }
-        let mut operator = match table_info.from_share {
+    fn init_operator(table_info: &TableInfo) -> Result<Operator> {
+        let operator = match table_info.from_share {
             Some(ref from_share) => create_share_table_operator(
                 ShareTableConfig::share_endpoint_address(),
                 &table_info.tenant,
@@ -113,9 +107,27 @@ impl FuseTable {
                 }
             }
         };
-        let data_metrics = Arc::new(StorageMetrics::default());
-        operator = operator.layer(StorageMetricsLayer::new(data_metrics.clone()));
+        Ok(operator)
+    }
 
+    pub fn do_create(table_info: TableInfo, read_only: bool) -> Result<Box<FuseTable>> {
+        let operator = Self::init_operator(&table_info)?;
+        Self::do_create_with_operator(table_info, operator, read_only)
+    }
+
+    pub fn do_create_with_operator(
+        table_info: TableInfo,
+        operator: Operator,
+        read_only: bool,
+    ) -> Result<Box<FuseTable>> {
+        let storage_prefix = Self::parse_storage_prefix(&table_info)?;
+        let cluster_key_meta = table_info.meta.cluster_key();
+        let mut cluster_keys = Vec::new();
+        if let Some((_, order)) = &cluster_key_meta {
+            cluster_keys = ExpressionParser::parse_exprs(order)?;
+        }
+        let data_metrics = Arc::new(StorageMetrics::default());
+        let operator = operator.layer(StorageMetricsLayer::new(data_metrics.clone()));
         Ok(Box::new(FuseTable {
             table_info,
             cluster_keys,
@@ -153,13 +165,10 @@ impl FuseTable {
         Ok(table_storage_prefix(db_id, table_id))
     }
 
-    #[tracing::instrument(level = "debug", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    pub(crate) async fn read_table_snapshot(
-        &self,
-        ctx: Arc<dyn TableContext>,
-    ) -> Result<Option<Arc<TableSnapshot>>> {
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) async fn read_table_snapshot(&self) -> Result<Option<Arc<TableSnapshot>>> {
         if let Some(loc) = self.snapshot_loc().await? {
-            let reader = MetaReaders::table_snapshot_reader(ctx, self.get_operator());
+            let reader = MetaReaders::table_snapshot_reader(self.get_operator());
             let ver = self.snapshot_format_version().await?;
             Ok(Some(reader.read(loc.as_str(), None, ver).await?))
         } else {
@@ -277,7 +286,7 @@ impl Table for FuseTable {
         let cluster_key_meta = new_table_meta.cluster_key();
         let schema = self.schema().as_ref().clone();
 
-        let prev = self.read_table_snapshot(ctx.clone()).await?;
+        let prev = self.read_table_snapshot().await?;
         let prev_version = self.snapshot_format_version().await?;
         let prev_timestamp = prev.as_ref().and_then(|v| v.timestamp);
         let prev_snapshot_id = prev.as_ref().map(|v| (v.snapshot_id, prev_version));
@@ -321,7 +330,7 @@ impl Table for FuseTable {
 
         let schema = self.schema().as_ref().clone();
 
-        let prev = self.read_table_snapshot(ctx.clone()).await?;
+        let prev = self.read_table_snapshot().await?;
         let prev_version = self.snapshot_format_version().await?;
         let prev_timestamp = prev.as_ref().and_then(|v| v.timestamp);
         let prev_snapshot_id = prev.as_ref().map(|v| (v.snapshot_id, prev_version));
@@ -411,10 +420,7 @@ impl Table for FuseTable {
         self.do_gc(&ctx, keep_last_snapshot).await
     }
 
-    async fn table_statistics(
-        &self,
-        _ctx: Arc<dyn TableContext>,
-    ) -> Result<Option<TableStatistics>> {
+    async fn table_statistics(&self) -> Result<Option<TableStatistics>> {
         let s = &self.table_info.meta.statistics;
         Ok(Some(TableStatistics {
             num_rows: Some(s.number_of_rows),
@@ -424,11 +430,8 @@ impl Table for FuseTable {
         }))
     }
 
-    async fn column_statistics_provider(
-        &self,
-        ctx: Arc<dyn TableContext>,
-    ) -> Result<Box<dyn ColumnStatisticsProvider>> {
-        let provider = if let Some(snapshot) = self.read_table_snapshot(ctx).await? {
+    async fn column_statistics_provider(&self) -> Result<Box<dyn ColumnStatisticsProvider>> {
+        let provider = if let Some(snapshot) = self.read_table_snapshot().await? {
             let stats = &snapshot.summary.col_stats;
             FakedColumnStatisticsProvider {
                 column_stats: stats.clone(),
@@ -440,18 +443,14 @@ impl Table for FuseTable {
         Ok(Box::new(provider))
     }
 
-    #[tracing::instrument(level = "debug", name = "fuse_table_navigate_to", skip(self, ctx), fields(ctx.id = ctx.get_id().as_str()))]
-    async fn navigate_to(
-        &self,
-        ctx: Arc<dyn TableContext>,
-        point: &NavigationPoint,
-    ) -> Result<Arc<dyn Table>> {
+    #[tracing::instrument(level = "debug", name = "fuse_table_navigate_to", skip_all)]
+    async fn navigate_to(&self, point: &NavigationPoint) -> Result<Arc<dyn Table>> {
         match point {
             NavigationPoint::SnapshotID(snapshot_id) => {
-                Ok(self.navigate_to_snapshot(ctx, snapshot_id.as_str()).await?)
+                Ok(self.navigate_to_snapshot(snapshot_id.as_str()).await?)
             }
             NavigationPoint::TimePoint(time_point) => {
-                Ok(self.navigate_to_time_point(ctx, *time_point).await?)
+                Ok(self.navigate_to_time_point(*time_point).await?)
             }
         }
     }

--- a/src/query/storages/fuse/src/io/read/bloom_index_reader.rs
+++ b/src/query/storages/fuse/src/io/read/bloom_index_reader.rs
@@ -77,6 +77,7 @@ mod util_v1 {
     use common_base::base::GlobalIORuntime;
     use common_base::base::Runtime;
     use common_base::base::TrySpawn;
+    use common_fuse_meta::caches::CacheDeferMetrics;
     use common_fuse_meta::caches::CacheManager;
 
     use super::*;
@@ -211,7 +212,15 @@ mod util_v1 {
                     // get by cache
                     let mut bloom_index_cache_guard = bloom_index_cache.write();
 
+                    let mut metrics = CacheDeferMetrics {
+                        tenant_label: bloom_index_cache.label(),
+                        cache_hit: false,
+                        read_bytes: 0,
+                    };
+
                     if let Some(bytes) = bloom_index_cache_guard.get(&cache_key) {
+                        metrics.cache_hit = true;
+                        metrics.read_bytes = bytes.len() as u64;
                         return Ok((bytes.clone(), idx));
                     }
                 }

--- a/src/query/storages/fuse/src/io/read/bloom_index_reader.rs
+++ b/src/query/storages/fuse/src/io/read/bloom_index_reader.rs
@@ -91,7 +91,7 @@ mod util_v1 {
         path: &str,
         length: u64,
     ) -> Result<DataBlock> {
-        let file_meta = load_index_meta(dal.clone(), &ctx, path, length).await?;
+        let file_meta = load_index_meta(dal.clone(), path, length).await?;
         if file_meta.row_groups.len() != 1 {
             return Err(ErrorCode::StorageOther(format!(
                 "invalid v1 bloom index filter index, number of row group should be 1, but found {} row groups",
@@ -253,17 +253,11 @@ mod util_v1 {
     /// Loads index meta data
     /// read data from cache, or populate cache items if possible
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn load_index_meta(
-        dal: Operator,
-        ctx: &Arc<dyn TableContext>,
-        path: &str,
-        length: u64,
-    ) -> Result<Arc<FileMetaData>> {
+    async fn load_index_meta(dal: Operator, path: &str, length: u64) -> Result<Arc<FileMetaData>> {
         let storage_runtime = GlobalIORuntime::instance();
-        let ctx_cloned = ctx.clone();
         let path_owned = path.to_owned();
         async move {
-            let reader = MetaReaders::file_meta_data_reader(ctx_cloned, dal);
+            let reader = MetaReaders::file_meta_data_reader(dal);
             // Format of FileMetaData is not versioned, version argument is ignored by the underlying reader,
             // so we just pass a zero to reader
             let version = 0;

--- a/src/query/storages/fuse/src/io/read/meta_readers.rs
+++ b/src/query/storages/fuse/src/io/read/meta_readers.rs
@@ -12,57 +12,46 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use common_arrow::parquet::metadata::FileMetaData;
-use common_catalog::table_context::TableContext;
 use common_exception::Result;
 use common_fuse_meta::caches::CacheManager;
-use common_fuse_meta::caches::TenantLabel;
 use common_fuse_meta::meta::SegmentInfo;
 use common_fuse_meta::meta::SegmentInfoVersion;
 use common_fuse_meta::meta::SnapshotVersion;
 use common_fuse_meta::meta::TableSnapshot;
 use common_storages_cache::CachedReader;
-use common_storages_cache::HasTenantLabel;
 use common_storages_cache::Loader;
 use opendal::BytesReader;
 use opendal::Operator;
 
 use super::versioned_reader::VersionedReader;
 
-pub type SegmentInfoReader<'a> = CachedReader<SegmentInfo, LoaderWrapper<&'a dyn TableContext>>;
-pub type TableSnapshotReader = CachedReader<TableSnapshot, LoaderWrapper<Arc<dyn TableContext>>>;
-pub type BloomIndexFileMetaDataReader = CachedReader<FileMetaData, Arc<dyn TableContext>>;
+pub type SegmentInfoReader = CachedReader<SegmentInfo, LoaderWrapper<Operator>>;
+pub type TableSnapshotReader = CachedReader<TableSnapshot, LoaderWrapper<Operator>>;
+pub type BloomIndexFileMetaDataReader = CachedReader<FileMetaData, Operator>;
 
 pub struct MetaReaders;
 
 impl MetaReaders {
-    pub fn segment_info_reader(ctx: &dyn TableContext, dal: Operator) -> SegmentInfoReader {
+    pub fn segment_info_reader(dal: Operator) -> SegmentInfoReader {
         SegmentInfoReader::new(
             CacheManager::instance().get_table_segment_cache(),
-            LoaderWrapper(ctx),
             "SEGMENT_INFO_CACHE".to_owned(),
-            dal,
+            LoaderWrapper(dal),
         )
     }
 
-    pub fn table_snapshot_reader(ctx: Arc<dyn TableContext>, dal: Operator) -> TableSnapshotReader {
+    pub fn table_snapshot_reader(dal: Operator) -> TableSnapshotReader {
         TableSnapshotReader::new(
             CacheManager::instance().get_table_snapshot_cache(),
-            LoaderWrapper(ctx),
             "SNAPSHOT_CACHE".to_owned(),
-            dal,
+            LoaderWrapper(dal),
         )
     }
 
-    pub fn file_meta_data_reader(
-        ctx: Arc<dyn TableContext>,
-        dal: Operator,
-    ) -> BloomIndexFileMetaDataReader {
+    pub fn file_meta_data_reader(dal: Operator) -> BloomIndexFileMetaDataReader {
         BloomIndexFileMetaDataReader::new(
             CacheManager::instance().get_bloom_index_meta_cache(),
-            ctx,
             "BLOOM_INDEX_FILE_META_DATA_CACHE".to_owned(),
             dal,
         )
@@ -74,40 +63,29 @@ impl MetaReaders {
 pub struct LoaderWrapper<T>(T);
 
 #[async_trait::async_trait]
-impl<T> Loader<TableSnapshot> for LoaderWrapper<T>
-where T: Sync + Send
-{
+impl Loader<TableSnapshot> for LoaderWrapper<Operator> {
     async fn load(
         &self,
-        op: Operator,
         key: &str,
         length_hint: Option<u64>,
         version: u64,
     ) -> Result<TableSnapshot> {
         let version = SnapshotVersion::try_from(version)?;
-        let reader = bytes_reader(op, key, length_hint).await?;
+        let reader = bytes_reader(&self.0, key, length_hint).await?;
         version.read(reader).await
     }
 }
 
 #[async_trait::async_trait]
-impl<T> Loader<SegmentInfo> for LoaderWrapper<T>
-where T: Sync + Send
-{
-    async fn load(
-        &self,
-        op: Operator,
-        key: &str,
-        length_hint: Option<u64>,
-        version: u64,
-    ) -> Result<SegmentInfo> {
+impl Loader<SegmentInfo> for LoaderWrapper<Operator> {
+    async fn load(&self, key: &str, length_hint: Option<u64>, version: u64) -> Result<SegmentInfo> {
         let version = SegmentInfoVersion::try_from(version)?;
-        let reader = bytes_reader(op, key, length_hint).await?;
+        let reader = bytes_reader(&self.0, key, length_hint).await?;
         version.read(reader).await
     }
 }
 
-async fn bytes_reader(op: Operator, path: &str, len: Option<u64>) -> Result<BytesReader> {
+async fn bytes_reader(op: &Operator, path: &str, len: Option<u64>) -> Result<BytesReader> {
     let object = op.object(path);
 
     let len = match len {
@@ -121,12 +99,4 @@ async fn bytes_reader(op: Operator, path: &str, len: Option<u64>) -> Result<Byte
 
     let reader = object.range_reader(..len).await?;
     Ok(Box::new(reader))
-}
-
-impl<T> HasTenantLabel for LoaderWrapper<T>
-where T: HasTenantLabel
-{
-    fn tenant_label(&self) -> TenantLabel {
-        self.0.tenant_label()
-    }
 }

--- a/src/query/storages/fuse/src/io/segments.rs
+++ b/src/query/storages/fuse/src/io/segments.rs
@@ -39,13 +39,9 @@ impl SegmentsIO {
     }
 
     // Read one segment file by location.
-    async fn read_segment(
-        dal: Operator,
-        ctx: Arc<dyn TableContext>,
-        segment_location: Location,
-    ) -> Result<Arc<SegmentInfo>> {
+    async fn read_segment(dal: Operator, segment_location: Location) -> Result<Arc<SegmentInfo>> {
         let (path, ver) = segment_location;
-        let reader = MetaReaders::segment_info_reader(ctx.as_ref(), dal);
+        let reader = MetaReaders::segment_info_reader(dal);
         reader.read(path, None, ver).await
     }
 
@@ -67,10 +63,9 @@ impl SegmentsIO {
         let mut iter = segment_locations.iter();
         let tasks = std::iter::from_fn(move || {
             if let Some(location) = iter.next() {
-                let ctx = ctx.clone();
                 let location = location.clone();
                 Some(
-                    Self::read_segment(self.operator.clone(), ctx, location)
+                    Self::read_segment(self.operator.clone(), location)
                         .instrument(tracing::debug_span!("read_segment")),
                 )
             } else {

--- a/src/query/storages/fuse/src/io/write/segment_writer.rs
+++ b/src/query/storages/fuse/src/io/write/segment_writer.rs
@@ -50,7 +50,7 @@ impl<'a> SegmentWriter<'a> {
 
         let segment = Arc::new(segment);
         if let Some(ref cache) = self.cache {
-            let cache = &mut cache.item.write();
+            let cache = &mut cache.write();
             cache.put(segment_location.0.clone(), segment);
         }
         Ok(segment_location)

--- a/src/query/storages/fuse/src/io/write/segment_writer.rs
+++ b/src/query/storages/fuse/src/io/write/segment_writer.rs
@@ -50,7 +50,7 @@ impl<'a> SegmentWriter<'a> {
 
         let segment = Arc::new(segment);
         if let Some(ref cache) = self.cache {
-            let cache = &mut cache.write();
+            let cache = &mut cache.item.write();
             cache.put(segment_location.0.clone(), segment);
         }
         Ok(segment_location)

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -313,7 +313,7 @@ impl FuseTable {
         match reply {
             Ok(_) => {
                 if let Some(snapshot_cache) = CacheManager::instance().get_table_snapshot_cache() {
-                    let cache = &mut snapshot_cache.item.write();
+                    let cache = &mut snapshot_cache.write();
                     cache.put(snapshot_location.clone(), Arc::new(snapshot));
                 }
                 // try keep a hit file of last snapshot

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -313,7 +313,7 @@ impl FuseTable {
         match reply {
             Ok(_) => {
                 if let Some(snapshot_cache) = CacheManager::instance().get_table_snapshot_cache() {
-                    let cache = &mut snapshot_cache.write();
+                    let cache = &mut snapshot_cache.item.write();
                     cache.put(snapshot_location.clone(), Arc::new(snapshot));
                 }
                 // try keep a hit file of last snapshot

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -45,7 +45,7 @@ impl FuseTable {
         target: CompactTarget,
         pipeline: &mut Pipeline,
     ) -> Result<Option<Box<dyn TableMutator>>> {
-        let snapshot_opt = self.read_table_snapshot(ctx.clone()).await?;
+        let snapshot_opt = self.read_table_snapshot().await?;
         let base_snapshot = if let Some(val) = snapshot_opt {
             val
         } else {

--- a/src/query/storages/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/src/operations/delete.rs
@@ -35,7 +35,7 @@ use crate::FuseTable;
 
 impl FuseTable {
     pub async fn do_delete(&self, ctx: Arc<dyn TableContext>, plan: &DeletePlan) -> Result<()> {
-        let snapshot_opt = self.read_table_snapshot(ctx.clone()).await?;
+        let snapshot_opt = self.read_table_snapshot().await?;
 
         // check if table is empty
         let snapshot = if let Some(val) = snapshot_opt {

--- a/src/query/storages/fuse/src/operations/fuse_sink.rs
+++ b/src/query/storages/fuse/src/operations/fuse_sink.rs
@@ -221,7 +221,7 @@ impl Processor for FuseTableSink {
             }
             State::PreCommitSegment { location, segment } => {
                 if let Some(segment_cache) = CacheManager::instance().get_table_segment_cache() {
-                    let cache = &mut segment_cache.item.write();
+                    let cache = &mut segment_cache.write();
                     cache.put(location.clone(), segment.clone());
                 }
 

--- a/src/query/storages/fuse/src/operations/fuse_sink.rs
+++ b/src/query/storages/fuse/src/operations/fuse_sink.rs
@@ -221,7 +221,7 @@ impl Processor for FuseTableSink {
             }
             State::PreCommitSegment { location, segment } => {
                 if let Some(segment_cache) = CacheManager::instance().get_table_segment_cache() {
-                    let cache = &mut segment_cache.write();
+                    let cache = &mut segment_cache.item.write();
                     cache.put(location.clone(), segment.clone());
                 }
 

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -32,7 +32,7 @@ use crate::FuseTable;
 
 impl FuseTable {
     pub async fn do_gc(&self, ctx: &Arc<dyn TableContext>, keep_last_snapshot: bool) -> Result<()> {
-        let r = self.read_table_snapshot(ctx.clone()).await;
+        let r = self.read_table_snapshot().await;
         let snapshot_opt = match r {
             Err(e) if e.code() == ErrorCode::storage_not_found_code() => {
                 // concurrent gc: someone else has already collected this snapshot, ignore it

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -265,7 +265,7 @@ impl FuseTable {
 
     fn clean_cache(&self, locs: &[String]) {
         if let Some(c) = CacheManager::instance().get_table_segment_cache() {
-            let cache = &mut *c.item.write();
+            let cache = &mut *c.write();
             for loc in locs {
                 cache.pop(loc);
             }

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -265,7 +265,7 @@ impl FuseTable {
 
     fn clean_cache(&self, locs: &[String]) {
         if let Some(c) = CacheManager::instance().get_table_segment_cache() {
-            let cache = &mut *c.write();
+            let cache = &mut *c.item.write();
             for loc in locs {
                 cache.pop(loc);
             }

--- a/src/query/storages/fuse/src/operations/mutation/base_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/base_mutator.rs
@@ -88,8 +88,7 @@ impl BaseMutator {
         let mut segments_editor =
             HashMap::<_, _, RandomState>::from_iter(segments.clone().into_iter().enumerate());
 
-        let segment_reader =
-            MetaReaders::segment_info_reader(self.ctx.as_ref(), self.data_accessor.clone());
+        let segment_reader = MetaReaders::segment_info_reader(self.data_accessor.clone());
 
         let segment_info_cache = CacheManager::instance().get_table_segment_cache();
         let seg_writer = SegmentWriter::new(

--- a/src/query/storages/fuse/src/operations/navigate.rs
+++ b/src/query/storages/fuse/src/operations/navigate.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use chrono::Utc;
-use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_fuse_meta::meta::TableSnapshot;
@@ -31,10 +30,9 @@ use crate::OPT_KEY_SNAPSHOT_LOCATION;
 impl FuseTable {
     pub async fn navigate_to_time_point(
         &self,
-        ctx: Arc<dyn TableContext>,
         time_point: DateTime<Utc>,
     ) -> Result<Arc<FuseTable>> {
-        self.find(ctx, |snapshot| {
+        self.find(|snapshot| {
             if let Some(ts) = snapshot.timestamp {
                 ts <= time_point
             } else {
@@ -43,12 +41,8 @@ impl FuseTable {
         })
         .await
     }
-    pub async fn navigate_to_snapshot(
-        &self,
-        ctx: Arc<dyn TableContext>,
-        snapshot_id: &str,
-    ) -> Result<Arc<FuseTable>> {
-        self.find(ctx, |snapshot| {
+    pub async fn navigate_to_snapshot(&self, snapshot_id: &str) -> Result<Arc<FuseTable>> {
+        self.find(|snapshot| {
             snapshot
                 .snapshot_id
                 .simple()
@@ -59,7 +53,7 @@ impl FuseTable {
         .await
     }
 
-    pub async fn find<P>(&self, ctx: Arc<dyn TableContext>, mut pred: P) -> Result<Arc<FuseTable>>
+    pub async fn find<P>(&self, mut pred: P) -> Result<Arc<FuseTable>>
     where P: FnMut(&TableSnapshot) -> bool {
         let snapshot_location = if let Some(loc) = self.snapshot_loc().await? {
             loc
@@ -71,7 +65,7 @@ impl FuseTable {
         };
 
         let snapshot_version = self.snapshot_format_version().await?;
-        let reader = MetaReaders::table_snapshot_reader(ctx, self.get_operator());
+        let reader = MetaReaders::table_snapshot_reader(self.get_operator());
 
         // grab the table history
         // snapshots are order by timestamp DESC.

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -48,7 +48,7 @@ impl FuseTable {
     ) -> Result<(Statistics, Partitions)> {
         debug!("fuse table do read partitions, push downs:{:?}", push_downs);
 
-        let snapshot = self.read_table_snapshot(ctx.clone()).await?;
+        let snapshot = self.read_table_snapshot().await?;
         match snapshot {
             Some(snapshot) => {
                 if let Some(result) = self.check_quick_path(&snapshot, &push_downs) {

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -50,7 +50,7 @@ impl FuseTable {
             return Ok(None);
         }
 
-        let snapshot_opt = self.read_table_snapshot(ctx.clone()).await?;
+        let snapshot_opt = self.read_table_snapshot().await?;
         let snapshot = if let Some(val) = snapshot_opt {
             val
         } else {

--- a/src/query/storages/fuse/src/operations/truncate.rs
+++ b/src/query/storages/fuse/src/operations/truncate.rs
@@ -30,7 +30,7 @@ use crate::OPT_KEY_SNAPSHOT_LOCATION;
 impl FuseTable {
     #[inline]
     pub async fn do_truncate(&self, ctx: Arc<dyn TableContext>, purge: bool) -> Result<()> {
-        if let Some(prev_snapshot) = self.read_table_snapshot(ctx.clone()).await? {
+        if let Some(prev_snapshot) = self.read_table_snapshot().await? {
             let prev_id = prev_snapshot.snapshot_id;
 
             let new_snapshot = TableSnapshot::new(

--- a/src/query/storages/fuse/src/pruning/pruning_executor.rs
+++ b/src/query/storages/fuse/src/pruning/pruning_executor.rs
@@ -46,7 +46,6 @@ type SegmentIndex = usize;
 type SegmentPruningJoinHandles = Vec<JoinHandle<Result<Vec<(SegmentIndex, BlockMeta)>>>>;
 
 struct PruningContext {
-    ctx: Arc<dyn TableContext>,
     limiter: LimiterPruner,
     range_pruner: Arc<dyn RangePruner + Send + Sync>,
     filter_pruner: Option<Arc<dyn Pruner + Send + Sync>>,
@@ -115,7 +114,6 @@ impl BlockPruner {
 
         // 3. setup pruning context
         let pruning_ctx = Arc::new(PruningContext {
-            ctx: ctx.clone(),
             limiter: limiter.clone(),
             range_pruner: range_pruner.clone(),
             filter_pruner,
@@ -175,8 +173,7 @@ impl BlockPruner {
         segment_idx: SegmentIndex,
         segment_location: Location,
     ) -> Result<Vec<(SegmentIndex, BlockMeta)>> {
-        let segment_reader =
-            MetaReaders::segment_info_reader(pruning_ctx.ctx.as_ref(), dal.clone());
+        let segment_reader = MetaReaders::segment_info_reader(dal.clone());
 
         let (path, ver) = segment_location;
         let segment_info = segment_reader.read(path, None, ver).await?;

--- a/src/query/storages/fuse/src/table_functions/clustering_informations/clustering_information.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_informations/clustering_information.rs
@@ -58,12 +58,11 @@ impl<'a> ClusteringInformation<'a> {
     }
 
     pub async fn get_clustering_info(&self) -> Result<DataBlock> {
-        let snapshot = self.table.read_table_snapshot(self.ctx.clone()).await?;
+        let snapshot = self.table.read_table_snapshot().await?;
 
         let mut blocks = Vec::new();
         if let Some(snapshot) = snapshot {
-            let reader =
-                MetaReaders::segment_info_reader(self.ctx.as_ref(), self.table.get_operator());
+            let reader = MetaReaders::segment_info_reader(self.table.get_operator());
             for (x, ver) in &snapshot.segments {
                 let res = reader.read(x, None, *ver).await?;
                 let mut block = res.blocks.clone();

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
@@ -47,7 +47,7 @@ impl<'a> FuseBlock<'a> {
 
     pub async fn get_blocks(&self) -> Result<DataBlock> {
         let tbl = self.table;
-        let maybe_snapshot = tbl.read_table_snapshot(self.ctx.clone()).await?;
+        let maybe_snapshot = tbl.read_table_snapshot().await?;
         if let Some(snapshot) = maybe_snapshot {
             if self.snapshot_id.is_none() {
                 return self.to_block(snapshot).await;
@@ -58,7 +58,7 @@ impl<'a> FuseBlock<'a> {
             let snapshot_location = tbl
                 .meta_location_generator
                 .snapshot_location_from_uuid(&snapshot.snapshot_id, snapshot_version)?;
-            let reader = MetaReaders::table_snapshot_reader(self.ctx.clone(), tbl.get_operator());
+            let reader = MetaReaders::table_snapshot_reader(tbl.get_operator());
             let mut snapshot_stream = reader.snapshot_history(
                 snapshot_location,
                 snapshot_version,

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
@@ -43,14 +43,14 @@ impl<'a> FuseSegment<'a> {
 
     pub async fn get_segments(&self) -> Result<DataBlock> {
         let tbl = self.table;
-        let maybe_snapshot = tbl.read_table_snapshot(self.ctx.clone()).await?;
+        let maybe_snapshot = tbl.read_table_snapshot().await?;
         if let Some(snapshot) = maybe_snapshot {
             // prepare the stream of snapshot
             let snapshot_version = tbl.snapshot_format_version().await?;
             let snapshot_location = tbl
                 .meta_location_generator
                 .snapshot_location_from_uuid(&snapshot.snapshot_id, snapshot_version)?;
-            let reader = MetaReaders::table_snapshot_reader(self.ctx.clone(), tbl.get_operator());
+            let reader = MetaReaders::table_snapshot_reader(tbl.get_operator());
             let mut snapshot_stream = reader.snapshot_history(
                 snapshot_location,
                 snapshot_version,

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
@@ -37,7 +37,7 @@ impl<'a> FuseSnapshot<'a> {
     pub async fn get_snapshots(self, limit: Option<usize>) -> Result<DataBlock> {
         let meta_location_generator = self.table.meta_location_generator.clone();
         let snapshot_location = self.table.snapshot_loc().await?;
-        let snapshot = self.table.read_table_snapshot(self.ctx.clone()).await?;
+        let snapshot = self.table.read_table_snapshot().await?;
         if let Some(snapshot_location) = snapshot_location {
             let snapshot_version = self.table.snapshot_format_version().await?;
             let snapshots_io = SnapshotsIO::create(

--- a/src/query/storages/hive/src/hive_parquet_block_reader.rs
+++ b/src/query/storages/hive/src/hive_parquet_block_reader.rs
@@ -25,7 +25,6 @@ use common_arrow::parquet::metadata::RowGroupMetaData;
 use common_arrow::parquet::read::BasicDecompressor;
 use common_arrow::parquet::read::PageReader;
 use common_base::base::tokio::sync::Semaphore;
-use common_catalog::table_context::TableContext;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
@@ -200,13 +199,8 @@ impl HiveParquetBlockReader {
         }
     }
 
-    pub async fn read_meta_data(
-        &self,
-        ctx: Arc<dyn TableContext>,
-        dal: Operator,
-        filename: &str,
-    ) -> Result<Arc<FileMetaData>> {
-        let reader = FileMetaDataReader::new_reader(ctx, dal);
+    pub async fn read_meta_data(&self, dal: Operator, filename: &str) -> Result<Arc<FileMetaData>> {
+        let reader = FileMetaDataReader::new_reader(dal);
         reader.read(filename, None, 0).await
     }
 

--- a/src/query/storages/hive/src/hive_table.rs
+++ b/src/query/storages/hive/src/hive_table.rs
@@ -462,7 +462,7 @@ impl Table for HiveTable {
         Ok(())
     }
 
-    async fn table_statistics(&self) -> Result<Option<TableStatistics>> {
+    fn table_statistics(&self) -> Result<Option<TableStatistics>> {
         Ok(None)
     }
 }

--- a/src/query/storages/hive/src/hive_table.rs
+++ b/src/query/storages/hive/src/hive_table.rs
@@ -462,10 +462,7 @@ impl Table for HiveTable {
         Ok(())
     }
 
-    async fn table_statistics(
-        &self,
-        _ctx: Arc<dyn TableContext>,
-    ) -> Result<Option<TableStatistics>> {
+    async fn table_statistics(&self) -> Result<Option<TableStatistics>> {
         Ok(None)
     }
 }

--- a/src/query/storages/hive/src/hive_table_source.rs
+++ b/src/query/storages/hive/src/hive_table_source.rs
@@ -194,7 +194,7 @@ impl Processor for HiveTableSource {
                 let part = HivePartInfo::from_part(&part)?;
                 let file_meta = self
                     .block_reader
-                    .read_meta_data(self.ctx.clone(), self.dal.clone(), &part.filename)
+                    .read_meta_data(self.dal.clone(), &part.filename)
                     .await?;
                 let mut hive_blocks = HiveBlocks::create(file_meta, part.clone());
                 match hive_blocks.prune() {

--- a/src/query/storages/preludes/src/system/tables_table.rs
+++ b/src/query/storages/preludes/src/system/tables_table.rs
@@ -99,7 +99,7 @@ where TablesTable<T>: HistoryAware
         let mut index_size: Vec<Option<u64>> = Vec::new();
 
         for (_, tbl) in &database_tables {
-            let stats = tbl.table_statistics(ctx.clone()).await?;
+            let stats = tbl.table_statistics().await?;
             num_rows.push(stats.as_ref().and_then(|v| v.num_rows));
             data_size.push(stats.as_ref().and_then(|v| v.data_size));
             data_compressed_size.push(stats.as_ref().and_then(|v| v.data_size_compressed));

--- a/src/query/storages/preludes/src/system/tables_table.rs
+++ b/src/query/storages/preludes/src/system/tables_table.rs
@@ -99,7 +99,7 @@ where TablesTable<T>: HistoryAware
         let mut index_size: Vec<Option<u64>> = Vec::new();
 
         for (_, tbl) in &database_tables {
-            let stats = tbl.table_statistics().await?;
+            let stats = tbl.table_statistics()?;
             num_rows.push(stats.as_ref().and_then(|v| v.num_rows));
             data_size.push(stats.as_ref().and_then(|v| v.data_size));
             data_compressed_size.push(stats.as_ref().and_then(|v| v.data_size_compressed));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- pure refactors
  - decouple meta readers from TableContext
  - change method  `Table::table_statistics` to sync fn
- add cache metrics to bloom index reader

Fixes #issue
