### PR TITLE
docs(meta/management): explain when to join a cluster

### DIFF
--- a/docs/doc/50-manage/00-metasrv/20-metasrv-add-remove-node.md
+++ b/docs/doc/50-manage/00-metasrv/20-metasrv-add-remove-node.md
@@ -1,7 +1,7 @@
 ---
 title: Manage a Databend Meta Service Cluster
 sidebar_label: Manage a Meta Service Cluster
-description: 
+description:
   How to add/remove nodes from the Databend Meta Service cluster
 ---
 
@@ -36,6 +36,28 @@ join                = ["localhost:28103"]
 
 The arg `join` specifies a list of raft addresses(`<raft_advertise_host>:<raft_api_port>`) of nodes in the existing cluster it wants to
 be joined to.
+
+Databend-meta will skip `join` argument if it's already joined to a cluster.
+It check whether the **committed** membership contains its id to decide if to
+join. The explanation of this policy:(but you do not really have to read it:)
+
+> - It can not rely on if there are logs.
+>   It's possible the leader has setup a replication to this new
+>   node but not yet added it as a **voter**. In such a case, this node will
+>   never be added into the cluster automatically.
+>
+> - It must detect if there is a committed **membership** config
+>   that includes this node. Thus only when a node has already joined to a
+>   cluster(leader committed the membership and has replicated it to this node),
+>   it skips the join process.
+>
+> #### Why skip checking membership in raft logs:
+>
+> A leader may have replicated **non-committed** membership to this node and the crashed.
+> Then the next leader does not know about this new node.
+>
+> Only when the membership is committed, this node can be sure it is in a cluster.
+
 
 ### 1.2 Start the new node
 

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -47,6 +47,7 @@ use tonic::Request;
 use tonic::Response;
 use tonic::Status;
 use tonic::Streaming;
+use tracing::debug;
 use tracing::info;
 
 use crate::meta_service::meta_service_impl::GrpcStream;
@@ -121,6 +122,8 @@ impl MetaService for MetaServiceImpl {
             payload,
         } = req;
 
+        debug!("handle handshake request, client ver: {}", protocol_version);
+
         let min_compatible = to_digit_ver(&MIN_METACLI_SEMVER);
 
         // backward compatibility: no version in handshake.
@@ -149,6 +152,8 @@ impl MetaService for MetaServiceImpl {
                 payload: token.into_bytes(),
             };
             let output = futures::stream::once(async { Ok(resp) });
+
+            debug!("handshake OK");
             Ok(Response::new(Box::pin(output)))
         } else {
             Err(Status::unauthenticated(format!(

--- a/tests/metactl/config/new-databend-meta-node-2.toml
+++ b/tests/metactl/config/new-databend-meta-node-2.toml
@@ -16,4 +16,4 @@ raft_listen_host = "127.0.0.1"
 raft_advertise_host = "localhost"
 
 # Start up mode: join a cluster
-join          = ["127.0.0.1:28103"]
+join          = ["127.0.0.1:29103"]

--- a/tests/metactl/config/new-databend-meta-node-3.toml
+++ b/tests/metactl/config/new-databend-meta-node-3.toml
@@ -16,4 +16,4 @@ raft_listen_host = "127.0.0.1"
 raft_advertise_host = "localhost"
 
 # Start up mode: join a cluster
-join          = ["127.0.0.1:28103"]
+join          = ["127.0.0.1:29103"]

--- a/tests/metactl/test-metactl-restore-new-cluster.sh
+++ b/tests/metactl/test-metactl-restore-new-cluster.sh
@@ -58,9 +58,11 @@ time sleep 3
 
 echo " === dump new cluster state:"
 curl -sL http://127.0.0.1:28101/v1/cluster/status
+echo ""
 
 echo " === check new cluster state has the voters 4, 5, 6"
 curl -sL http://127.0.0.1:28101/v1/cluster/status \
     | grep '"voters":\[{"name":"4","endpoint":{"addr":"localhost","port":29103},"grpc_api_addr":"0.0.0.0:19191"},{"name":"5","endpoint":{"addr":"localhost","port":29203},"grpc_api_addr":"0.0.0.0:29191"},{"name":"6","endpoint":{"addr":"localhost","port":29303},"grpc_api_addr":"0.0.0.0:39191"}\]'
+echo ""
 
 killall databend-meta


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### docs(meta/management): explain when to join a cluster

##### refactor(meta/management): when joining a node, detect membership instead of log

A databend-meta node may always be started with `--join` arg.
With this arg, meta node should decide whether to execute the
**join-to-a-cluster** process.

Before this commit it detect if there are logs. This way is not very
relliable: it's possible the leader has setup a replication to this new
node but not yet added it as a **voter**. In such a case, this node will
never be added into the cluster automatically.

In stead, in this commit it detect if there is a **membership** config
that includes this node to decide if to join a cluster. Thus only when a
node has already joined to a cluster(leader committed the membership and
has replicated it to this node), it skips the join process.


##### chore(meta): add log of handshake

- Part of #8383

## Changelog







## Related Issues