### PR TITLE
refactor(meta/management): non blocking join

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5460,7 +5460,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.7.3"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.7.4-alpha.2#2896b98e34825a8623ec4650da405c79827ecbee"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.7.4-alpha.3#c6fe29d4a53b47f6c43d83a24e1610788a4c0166"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ members = [
 
 [workspace.dependencies]
 # databend maintains:
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.7.4-alpha.2" }
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.7.4-alpha.3" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 # error

--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -136,7 +136,7 @@ impl<'a> MetaLeader<'a> {
 
         self.meta_node
             .raft
-            .change_membership(membership, true)
+            .change_membership(membership, false)
             .await?;
         Ok(())
     }

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
@@ -376,7 +376,8 @@ async fn test_auto_sync_addr() -> anyhow::Result<()> {
         // wait for leader observed
         // if tc0 is old leader, then we need to check both current_leader is some and current_term > old_term
         // if tc0 isn't old leader, then we need do nothing.
-        if meta_node.get_leader().await == 0 {
+        let leader_id = meta_node.get_leader().await?;
+        if leader_id == Some(0) {
             let metrics = meta_node
                 .raft
                 .wait(Some(Duration::from_millis(30_000)))

--- a/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
@@ -107,7 +107,7 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
 
     info!("--- join non-voter 2 to cluster by leader");
 
-    let leader_id = all[0].get_leader().await;
+    let leader_id = all[0].get_leader().await?.unwrap();
     let leader = all[leader_id as usize].clone();
 
     let admin_req = join_req(
@@ -318,7 +318,7 @@ async fn test_meta_node_join_rejoin() -> anyhow::Result<()> {
 
     info!("--- join non-voter 1 to cluster");
 
-    let leader_id = all[0].get_leader().await;
+    let leader_id = all[0].get_leader().await?.unwrap();
     let leader = all[leader_id as usize].clone();
     let req = join_req(
         node_id,
@@ -544,7 +544,7 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
         let leader = tc.meta_node();
 
         leader
-            .as_leader()
+            .assume_leader()
             .await?
             .write(LogEntry {
                 txid: None,
@@ -628,14 +628,14 @@ fn join_req(
 /// Write one log on leader, check all nodes replicated the log.
 /// Returns the number log committed.
 async fn assert_upsert_kv_synced(meta_nodes: Vec<Arc<MetaNode>>, key: &str) -> anyhow::Result<u64> {
-    let leader_id = meta_nodes[0].get_leader().await;
+    let leader_id = meta_nodes[0].get_leader().await?.unwrap();
     let leader = meta_nodes[leader_id as usize].clone();
 
     let last_applied = leader.raft.metrics().borrow().last_applied;
     info!("leader: last_applied={:?}", last_applied);
     {
         leader
-            .as_leader()
+            .assume_leader()
             .await?
             .write(LogEntry {
                 txid: None,

--- a/src/meta/types/src/errors/meta_raft_errors.rs
+++ b/src/meta/types/src/errors/meta_raft_errors.rs
@@ -19,8 +19,6 @@ pub use openraft::error::Fatal;
 pub use openraft::error::ForwardToLeader;
 pub use openraft::error::InProgress;
 pub use openraft::error::InitializeError;
-pub use openraft::error::LearnerIsLagging;
-pub use openraft::error::LearnerNotFound;
 use openraft::NodeId;
 use serde::Deserialize;
 use serde::Serialize;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/management): non blocking join

- Upgrade openraft v0.7.4-alpha.2..v0.7.4-alpha.3:
  Change-membership does not return error when replication lags.

  If `blocking` is `true`, `Raft::change_membership(..., blocking)` will
  block until repliication to new nodes become upto date.
  But it won't return an error when proposing change-membership log.

- Join a node to cluster in non-blocking mode: the leader does not wait
  replication to the new node to become up to date. In case there are a
  logs to sync.

- `MetaNode::get_leader()` should have a max timeout. Otherwise it may
  block for ever.

- Fix: #8386

## Changelog







## Related Issues