### PR TITLE
fix: read segments in the order of locations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,6 +2181,7 @@ dependencies = [
  "common-storages-index",
  "futures",
  "futures-util",
+ "itertools",
  "metrics",
  "opendal",
  "serde",

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -41,6 +41,7 @@ backon = "0.2"
 chrono = "0.4.22"
 futures = "0.3.24"
 futures-util = "0.3.24"
+itertools = "0.10.5"
 metrics = "0.20.1"
 opendal = { version = "0.19", features = ["layers-retry"] }
 serde = { workspace = true }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Read segments in the order of locations.

Fixes #issue
