### PR TITLE
refactor(planner): use right mark join as subquery's default join type

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
@@ -143,7 +143,6 @@ impl JoinHashTable {
                 }
             }
         }
-        dbg!(markers.clone());
         markers
     }
 

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
@@ -143,6 +143,7 @@ impl JoinHashTable {
                 }
             }
         }
+        dbg!(markers.clone());
         markers
     }
 

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_state_impl.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_state_impl.rs
@@ -137,7 +137,7 @@ impl HashJoinState for JoinHashTable {
                     .map(|x| Some(*x))
                     .collect(),
                 JoinType::RightMark => {
-                    if !has_null {
+                    if !has_null && !chunk.cols.is_empty() {
                         if let Some(validity) = chunk.cols[0].validity().1 {
                             if validity.unset_bits() > 0 {
                                 has_null = true;

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/join_hash_table.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/join_hash_table.rs
@@ -251,6 +251,10 @@ impl JoinHashTable {
             .iter()
             .map(|expr| Ok(expr.eval(&func_ctx, input)?.vector().clone()))
             .collect::<Result<Vec<ColumnRef>>>()?;
+
+        if self.hash_join_desc.join_type == JoinType::RightMark {
+            probe_state.markers = Some(Self::init_markers(&probe_keys, input.num_rows()));
+        }
         let probe_keys = probe_keys.iter().collect::<Vec<&ColumnRef>>();
 
         if probe_keys.iter().any(|c| c.is_nullable() || c.is_null()) {

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_mark.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_mark.rs
@@ -44,8 +44,7 @@ impl JoinHashTable {
     {
         let valids = &probe_state.valids;
         let has_null = *self.hash_join_desc.marker_join_desc.has_null.read();
-        let mut markers = Self::init_markers(input.columns(), input.num_rows());
-
+        let markers = probe_state.markers.as_mut().unwrap();
         for (i, key) in keys_iter.enumerate() {
             let probe_result_ptr = match self.hash_join_desc.from_correlated_subquery {
                 true => hash_table.find_key(&key),
@@ -58,7 +57,7 @@ impl JoinHashTable {
         }
 
         Ok(vec![self.merge_eq_block(
-            &self.create_marker_block(has_null, markers)?,
+            &self.create_marker_block(has_null, markers.clone())?,
             input,
         )?])
     }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
@@ -15,6 +15,7 @@
 use common_arrow::arrow::bitmap::Bitmap;
 
 use super::row::RowPtr;
+use crate::pipelines::processors::transforms::hash_join::desc::MarkerKind;
 
 /// ProbeState used for probe phase of hash join.
 /// We may need some reuseable state for probe phase.
@@ -27,6 +28,7 @@ pub struct ProbeState {
     // probe_indexs: the result index to the probe block row -> [0, 1, 2, 2, 3]
     // row_state:  the state (counter) of the probe block row -> [1, 1, 2, 1]
     pub(crate) row_state: Vec<u32>,
+    pub(crate) markers: Option<Vec<MarkerKind>>,
 }
 
 impl ProbeState {
@@ -43,6 +45,7 @@ impl ProbeState {
             build_indexs: Vec::with_capacity(capacity),
             row_state: Vec::with_capacity(capacity),
             valids: None,
+            markers: None,
         }
     }
 }

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -288,14 +288,14 @@ impl SubqueryRewriter {
                     )
                 };
                 let join_plan = LogicalInnerJoin {
-                    left_conditions,
-                    right_conditions,
+                    left_conditions: right_conditions,
+                    right_conditions: left_conditions,
                     non_equi_conditions: vec![],
-                    join_type: JoinType::LeftMark,
+                    join_type: JoinType::RightMark,
                     marker_index: Some(marker_index),
                     from_correlated_subquery: true,
                 };
-                let s_expr = SExpr::create_binary(join_plan.into(), flatten_plan, left.clone());
+                let s_expr = SExpr::create_binary(join_plan.into(), left.clone(), flatten_plan);
                 Ok((s_expr, UnnestResult::MarkJoin { marker_index }))
             }
             SubqueryType::Any => {
@@ -342,16 +342,16 @@ impl SubqueryRewriter {
                     )
                 };
                 let mark_join = LogicalInnerJoin {
-                    left_conditions,
-                    right_conditions,
+                    left_conditions: right_conditions,
+                    right_conditions: left_conditions,
                     non_equi_conditions,
-                    join_type: JoinType::LeftMark,
+                    join_type: JoinType::RightMark,
                     marker_index: Some(marker_index),
                     from_correlated_subquery: true,
                 }
                 .into();
                 Ok((
-                    SExpr::create_binary(mark_join, flatten_plan, left.clone()),
+                    SExpr::create_binary(mark_join, left.clone(), flatten_plan),
                     UnnestResult::MarkJoin { marker_index },
                 ))
             }

--- a/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
@@ -517,11 +517,9 @@ impl SubqueryRewriter {
                     from_correlated_subquery: false,
                 }
                 .into();
-                let s_expr = SExpr::create_binary(mark_join, left.clone(), *subquery.subquery.clone());
-                Ok((
-                    s_expr,
-                    UnnestResult::MarkJoin { marker_index },
-                ))
+                let s_expr =
+                    SExpr::create_binary(mark_join, left.clone(), *subquery.subquery.clone());
+                Ok((s_expr, UnnestResult::MarkJoin { marker_index }))
             }
             _ => unreachable!(),
         }

--- a/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
@@ -506,19 +506,20 @@ impl SubqueryRewriter {
                     )
                 };
                 // Consider the sql: select * from t1 where t1.a = any(select t2.a from t2);
-                // Will be transferred to:select t1.a, t2.a, marker_index from t2, t1 where t2.a = t1.a;
-                // Note that subquery is the left table, and it'll be the probe side.
+                // Will be transferred to:select t1.a, t2.a, marker_index from t1, t2 where t2.a = t1.a;
+                // Note that subquery is the right table, and it'll be the build side.
                 let mark_join = LogicalInnerJoin {
-                    left_conditions,
-                    right_conditions,
+                    left_conditions: right_conditions,
+                    right_conditions: left_conditions,
                     non_equi_conditions,
-                    join_type: JoinType::LeftMark,
+                    join_type: JoinType::RightMark,
                     marker_index: Some(marker_index),
                     from_correlated_subquery: false,
                 }
                 .into();
+                let s_expr = SExpr::create_binary(mark_join, left.clone(), *subquery.subquery.clone());
                 Ok((
-                    SExpr::create_binary(mark_join, *subquery.subquery.clone(), left.clone()),
+                    s_expr,
                     UnnestResult::MarkJoin { marker_index },
                 ))
             }

--- a/src/query/sql/src/planner/plans/logical_join.rs
+++ b/src/query/sql/src/planner/plans/logical_join.rs
@@ -40,9 +40,9 @@ pub enum JoinType {
     RightAnti,
     Cross,
     /// Mark Join is a special case of join that is used to process Any subquery and correlated Exists subquery.
-    /// Left Mark Join use subquery as probe side.
+    /// Left Mark Join use subquery as probe side, it's blocked at `mark_join_blocks`
     LeftMark,
-    /// Right Mark Join use subquery as build side.
+    /// Right Mark Join use subquery as build side, it's executed by streaming.
     RightMark,
     /// Single Join is a special kind of join that is used to process correlated scalar subquery.
     Single,

--- a/tests/logictest/suites/mode/standalone/explain/subquery.test
+++ b/tests/logictest/suites/mode/standalone/explain/subquery.test
@@ -65,26 +65,26 @@ explain select t.number from numbers(1) as t where exists (select t1.number from
 Filter
 ├── filters: [or(2 (#2), >(t.number (#0), 1))]
 └── HashJoin
-    ├── join type: LEFT MARK
-    ├── build keys: [subquery_0 (#0)]
-    ├── probe keys: [subquery_1 (#1)]
+    ├── join type: RIGHT MARK
+    ├── build keys: [subquery_1 (#1)]
+    ├── probe keys: [subquery_0 (#0)]
     ├── filters: []
-    ├── TableScan(Build)
-    │   ├── table: default.system.numbers
-    │   ├── read rows: 1
-    │   ├── read bytes: 8
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
-    └── Filter(Probe)
-        ├── filters: [=(subquery_1 (#1), t1.number (#1))]
-        └── TableScan
-            ├── table: default.system.numbers
-            ├── read rows: 1
-            ├── read bytes: 8
-            ├── partitions total: 1
-            ├── partitions scanned: 1
-            └── push downs: [filters: [(number = number)], limit: NONE]
+    ├── Filter(Build)
+    │   ├── filters: [=(subquery_1 (#1), t1.number (#1))]
+    │   └── TableScan
+    │       ├── table: default.system.numbers
+    │       ├── read rows: 1
+    │       ├── read bytes: 8
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       └── push downs: [filters: [(number = number)], limit: NONE]
+    └── TableScan(Probe)
+        ├── table: default.system.numbers
+        ├── read rows: 1
+        ├── read bytes: 8
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        └── push downs: [filters: [], limit: NONE]
 
 statement query T
 explain select t.number from numbers(1) as t where exists (select * from numbers(1) where number = 0);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The ticket contains two things:

- Right mark join is executed by streaming, there is no blocking pipeline operator. So use right mark join as default correlated subquery join type.
- Fix some bugs in right mark join

Fixes #issue
