### PR TITLE
feat(meta): add key space `Expire`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,6 +1729,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "byteorder",
+ "chrono",
  "common-base",
  "common-exception",
  "common-grpc",

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -252,6 +252,7 @@ pub fn txn_op_put(key: &impl KVApiKey, value: Vec<u8>) -> TxnOp {
     }
 }
 
+// TODO: replace it with common_meta_types::with::With
 pub fn txn_op_put_with_expire(key: &impl KVApiKey, value: Vec<u8>, expire_at: u64) -> TxnOp {
     TxnOp {
         request: Some(Request::Put(TxnPutRequest {

--- a/src/meta/raft-store/Cargo.toml
+++ b/src/meta/raft-store/Cargo.toml
@@ -26,6 +26,8 @@ common-tracing = { path = "../../common/tracing" }
 # crates.io deps
 anyhow = { workspace = true }
 async-trait = "0.1.57"
+byteorder = "1.4.3"
+chrono = "0.4.22"
 derive_more = "0.99.17"
 hostname = "0.3.1"
 maplit = "1.0.2"

--- a/src/meta/raft-store/src/sled_key_spaces.rs
+++ b/src/meta/raft-store/src/sled_key_spaces.rs
@@ -27,6 +27,8 @@ use serde::Serialize;
 use crate::state::RaftStateKey;
 use crate::state::RaftStateValue;
 use crate::state_machine::ClientLastRespValue;
+use crate::state_machine::ExpireKey;
+use crate::state_machine::ExpireValue;
 use crate::state_machine::LogMetaKey;
 use crate::state_machine::LogMetaValue;
 use crate::state_machine::StateMachineMetaKey;
@@ -81,7 +83,16 @@ impl SledKeySpace for RaftStateKV {
     type V = RaftStateValue;
 }
 
-// preserved PREFIX = 5
+/// Stores a index for kv records with expire time.
+///
+/// It stores them in expire time order.
+pub struct Expire {}
+impl SledKeySpace for Expire {
+    const PREFIX: u8 = 5;
+    const NAME: &'static str = "expire";
+    type K = ExpireKey;
+    type V = ExpireValue;
+}
 
 /// Key-Value Types for storing general purpose kv in sled::Tree:
 pub struct GenericKV {}

--- a/src/meta/raft-store/src/state_machine/expire.rs
+++ b/src/meta/raft-store/src/state_machine/expire.rs
@@ -1,0 +1,119 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This mod defines a key space in state machine to store the index of keys with an expiration time.
+//!
+//! This secondary index is `(expire_time, seq) -> key`, as the key-value's primary index is `key -> (seq, expire_time, value)`.
+//! Because `seq` in meta-store is globally unique, it may be used to identify every update to every key.
+
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::mem::size_of_val;
+use std::time::Duration;
+use std::time::UNIX_EPOCH;
+
+use byteorder::BigEndian;
+use byteorder::ByteOrder;
+use chrono::DateTime;
+use chrono::Utc;
+use common_meta_sled_store::sled::IVec;
+use common_meta_sled_store::SledBytesError;
+use common_meta_sled_store::SledOrderedSerde;
+
+/// The identifier of the index for kv with expiration.
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ExpireKey {
+    /// The time in millisecond when a key will be expired.
+    pub time_ms: u64,
+
+    /// The `seq` of the value when the key is written.
+    ///
+    /// The `seq` of value is globally unique in meta-store.
+    pub seq: u64,
+}
+
+/// The value of an expiration index is the record key.
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ExpireValue {
+    key: String,
+}
+
+impl SledOrderedSerde for ExpireKey {
+    fn ser(&self) -> Result<IVec, SledBytesError> {
+        let size = size_of_val(self);
+        let mut buf = vec![0; size];
+
+        BigEndian::write_u64(&mut buf, self.time_ms);
+        BigEndian::write_u64(&mut buf[size_of_val(&self.time_ms)..], self.seq);
+        Ok(buf.into())
+    }
+
+    fn de<V: AsRef<[u8]>>(v: V) -> Result<Self, SledBytesError>
+    where Self: Sized {
+        let b = v.as_ref();
+
+        let time_ms = BigEndian::read_u64(b);
+        let seq = BigEndian::read_u64(&b[size_of_val(&time_ms)..]);
+
+        Ok(Self { time_ms, seq })
+    }
+}
+
+impl Display for ExpireKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let t = UNIX_EPOCH + Duration::from_millis(self.time_ms);
+        let datetime: DateTime<Utc> = t.into();
+        write!(f, "{}={}", datetime.format("%Y-%m-%d-%H-%M-%S"), self.seq)
+    }
+}
+
+impl ExpireKey {
+    pub fn new(time_ms: u64, seq: u64) -> Self {
+        Self { time_ms, seq }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common_meta_sled_store::SledOrderedSerde;
+
+    use crate::state_machine::ExpireKey;
+
+    #[test]
+    fn test_expire_key_serde() -> anyhow::Result<()> {
+        let k = ExpireKey::new(0x01020304, 0x04030201);
+        let enc = <ExpireKey as SledOrderedSerde>::ser(&k)?;
+        assert_eq!(
+            vec![
+                0u8, 0, 0, 0, 1, 2, 3, 4, //
+                0u8, 0, 0, 0, 4, 3, 2, 1,
+            ],
+            enc.as_ref()
+        );
+
+        let got_dec = <ExpireKey as SledOrderedSerde>::de(enc)?;
+        assert_eq!(k, got_dec);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expire_key_display() -> anyhow::Result<()> {
+        let ms = 1666670258202;
+        let k = ExpireKey::new(ms, 1000);
+        assert_eq!("2022-10-25-03-57-38=1000", format!("{}", k));
+
+        Ok(())
+    }
+}

--- a/src/meta/raft-store/src/state_machine/mod.rs
+++ b/src/meta/raft-store/src/state_machine/mod.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 pub use client_last_resp::ClientLastRespValue;
+pub use expire::ExpireKey;
+pub use expire::ExpireValue;
 pub use log_meta::LogMetaKey;
 pub use log_meta::LogMetaValue;
 pub use sm::SerializableSnapshot;
@@ -25,6 +27,7 @@ pub use state_machine_meta::StateMachineMetaKey;
 pub use state_machine_meta::StateMachineMetaValue;
 
 pub mod client_last_resp;
+mod expire;
 pub mod log_meta;
 pub mod sm;
 mod sm_kv_api_impl;

--- a/src/meta/raft-store/src/state_machine/sm.rs
+++ b/src/meta/raft-store/src/state_machine/sm.rs
@@ -26,11 +26,11 @@ use common_meta_sled_store::openraft;
 use common_meta_sled_store::openraft::EffectiveMembership;
 use common_meta_sled_store::openraft::MessageSummary;
 use common_meta_sled_store::AsKeySpace;
-use common_meta_sled_store::AsTxnKeySpace;
 use common_meta_sled_store::SledKeySpace;
 use common_meta_sled_store::SledTree;
 use common_meta_sled_store::Store;
 use common_meta_sled_store::TransactionSledTree;
+use common_meta_sled_store::TxnKeySpace;
 use common_meta_stoerr::MetaStorageError;
 use common_meta_types::txn_condition;
 use common_meta_types::txn_op;
@@ -537,20 +537,13 @@ impl StateMachine {
     ) -> Result<(), MetaStorageError> {
         let sub_tree = txn_tree.key_space::<GenericKV>();
 
-        let (prev, result) = match put.expire_at {
-            None => self.txn_sub_tree_upsert(
-                &sub_tree,
-                &UpsertKV::update(&put.key, &put.value),
-                log_time_ms,
-            )?,
-            Some(expire_at) => self.txn_sub_tree_upsert(
-                &sub_tree,
-                &UpsertKV::update(&put.key, &put.value).with(KVMeta {
-                    expire_at: Some(expire_at),
-                }),
-                log_time_ms,
-            )?,
-        };
+        let (prev, result) = self.txn_sub_tree_upsert(
+            &sub_tree,
+            &UpsertKV::update(&put.key, &put.value).with(KVMeta {
+                expire_at: put.expire_at,
+            }),
+            log_time_ms,
+        )?;
 
         if let Some(events) = events {
             events.push((put.key.to_string(), prev.clone(), result));
@@ -807,7 +800,7 @@ impl StateMachine {
     #[allow(clippy::type_complexity)]
     fn txn_sub_tree_upsert<'s, KS>(
         &'s self,
-        sub_tree: &AsTxnKeySpace<'s, KS>,
+        sub_tree: &TxnKeySpace<'s, KS>,
         upsert_kv: &UpsertKV,
         log_time_ms: u64,
     ) -> Result<(Option<SeqV>, Option<SeqV>), MetaStorageError>

--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -995,19 +995,6 @@ impl MetaNode {
         Ok(resp)
     }
 
-    /// Remove a node from this cluster.
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn remove_node(&self, node_id: NodeId) -> Result<AppliedState, MetaError> {
-        let resp = self
-            .write(LogEntry {
-                txid: None,
-                time_ms: None,
-                cmd: Cmd::RemoveNode { node_id },
-            })
-            .await?;
-        Ok(resp)
-    }
-
     pub async fn get_state_machine(&self) -> RwLockReadGuard<'_, StateMachine> {
         self.sto.state_machine.read().await
     }

--- a/src/meta/sled-store/src/lib.rs
+++ b/src/meta/sled-store/src/lib.rs
@@ -26,11 +26,11 @@ pub use sled_serde::SledOrderedSerde;
 pub use sled_serde::SledRangeSerde;
 pub use sled_serde::SledSerde;
 pub use sled_tree::AsKeySpace;
-pub use sled_tree::AsTxnKeySpace;
 pub use sled_tree::SledAsRef;
 pub use sled_tree::SledItem;
 pub use sled_tree::SledTree;
 pub use sled_tree::TransactionSledTree;
+pub use sled_tree::TxnKeySpace;
 pub use store::Store;
 
 mod bytes_error;

--- a/src/meta/sled-store/src/sled_tree.rs
+++ b/src/meta/sled-store/src/sled_tree.rs
@@ -389,8 +389,8 @@ pub struct TransactionSledTree<'a> {
 }
 
 impl TransactionSledTree<'_> {
-    pub fn key_space<KV: SledKeySpace>(&self) -> AsTxnKeySpace<KV> {
-        AsTxnKeySpace::<KV> {
+    pub fn key_space<KV: SledKeySpace>(&self) -> TxnKeySpace<KV> {
+        TxnKeySpace::<KV> {
             inner: self,
             phantom: PhantomData,
         }
@@ -403,12 +403,12 @@ pub struct AsKeySpace<'a, KV: SledKeySpace> {
     phantom: PhantomData<KV>,
 }
 
-pub struct AsTxnKeySpace<'a, KV: SledKeySpace> {
+pub struct TxnKeySpace<'a, KV: SledKeySpace> {
     inner: &'a TransactionSledTree<'a>,
     phantom: PhantomData<KV>,
 }
 
-impl<'a, KV: SledKeySpace> Store<KV> for AsTxnKeySpace<'a, KV> {
+impl<'a, KV: SledKeySpace> Store<KV> for TxnKeySpace<'a, KV> {
     type Error = MetaStorageError;
 
     fn insert(&self, key: &KV::K, value: &KV::V) -> Result<Option<KV::V>, Self::Error> {
@@ -477,7 +477,7 @@ impl<'a, KV: SledKeySpace> Store<KV> for AsTxnKeySpace<'a, KV> {
 ///     sub_tree.insert(key, &seq_kv_value);
 /// }
 /// ```
-impl<'a, KV: SledKeySpace> Deref for AsTxnKeySpace<'a, KV> {
+impl<'a, KV: SledKeySpace> Deref for TxnKeySpace<'a, KV> {
     type Target = &'a TransactionSledTree<'a>;
 
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feat(meta): add key space `Expire`

Introduce another key space to meta-store: `Expire` to store the
secondary index `(expire_time, seq) -> key`, as the key-value's primary
index is `key -> (seq, expire_time, value)`.

Because `seq` in the meta-store is globally unique, it may be used to
identify every update to every key.

With this index, cleaning up expired keys can be done in `O(1)` time.

Minor refinements:

- Simplify updating expire time when upsert kv
- Rename `AsTxnKeySpace` to `TxnKeySpace`

- Fix: #8440

## Changelog







## Related Issues