### PR TITLE
feat: reduce the memory usage when compact

### DIFF
--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -379,7 +379,8 @@ impl Table for FuseTable {
         plan: &ReadDataSourcePlan,
         pipeline: &mut Pipeline,
     ) -> Result<()> {
-        self.do_read_data(ctx, plan, pipeline)
+        let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
+        self.do_read_data(ctx, plan, pipeline, max_io_requests)
     }
 
     fn append_data(

--- a/src/query/storages/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/src/io/mod.rs
@@ -16,6 +16,7 @@ mod files;
 mod locations;
 mod read;
 mod segments;
+mod segments_lite;
 mod snapshots;
 mod write;
 

--- a/src/query/storages/fuse/src/io/segments_lite.rs
+++ b/src/query/storages/fuse/src/io/segments_lite.rs
@@ -1,0 +1,65 @@
+//  Copyright 2022 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::sync::Arc;
+
+use common_exception::Result;
+use common_fuse_meta::meta::BlockMeta;
+use common_fuse_meta::meta::Location;
+use common_fuse_meta::meta::SegmentInfo;
+
+use crate::io::SegmentsIO;
+
+impl SegmentsIO {
+    // Read SegmentLite with chunks for memory usage.
+    // Used for optimize table compact etc.
+    pub async fn read_segment_lites(
+        &self,
+        segment_locations: &[Location],
+    ) -> Result<Vec<Arc<SegmentInfo>>> {
+        let chunk_size = 100;
+        let mut lites = vec![];
+
+        for chunk in segment_locations.chunks(chunk_size) {
+            let results = self.read_segments(chunk).await?;
+            for res in results.into_iter().flatten() {
+                lites.push(Self::segment_lite(&res));
+            }
+        }
+        Ok(lites)
+    }
+
+    // Trim the col_stats to default to reduce the memory usage.
+    fn segment_lite(segment: &Arc<SegmentInfo>) -> Arc<SegmentInfo> {
+        let blocks = segment
+            .blocks
+            .iter()
+            .map(|v| {
+                BlockMeta::new(
+                    v.row_count,
+                    v.block_size,
+                    v.file_size,
+                    Default::default(),
+                    v.col_metas.clone(),
+                    v.cluster_stats.clone(),
+                    v.location.clone(),
+                    v.bloom_filter_index_location.clone(),
+                    v.bloom_filter_index_size,
+                )
+            })
+            .collect();
+
+        Arc::new(SegmentInfo::new(blocks, segment.summary.clone()))
+    }
+}

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -139,9 +139,11 @@ impl FuseTable {
         };
 
         ctx.try_set_partitions(plan.parts.clone())?;
-        self.do_read_data(ctx.clone(), &plan, pipeline)?;
 
         let max_threads = ctx.get_settings().get_max_threads()? as usize;
+        self.do_read_data(ctx.clone(), &plan, pipeline, max_threads)?;
+
+        // Resize.
         pipeline.resize(max_threads)?;
 
         pipeline.add_transform(|transform_input_port, transform_output_port| {

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -130,6 +130,7 @@ impl FuseTable {
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,
         pipeline: &mut Pipeline,
+        max_io_requests: usize,
     ) -> Result<()> {
         let mut lazy_init_segments = Vec::with_capacity(plan.parts.len());
 
@@ -181,7 +182,6 @@ impl FuseTable {
         let prewhere_filter = self.build_prewhere_filter_executor(ctx.clone(), plan)?;
         let remain_reader = self.build_remain_reader(plan)?;
 
-        let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
         info!("read block data adjust max io requests:{}", max_io_requests);
 
         // Add source pipe.

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -132,7 +132,9 @@ impl FuseTable {
         };
 
         ctx.try_set_partitions(plan.parts.clone())?;
-        self.do_read_data(ctx.clone(), &plan, pipeline)?;
+
+        let max_threads = ctx.get_settings().get_max_threads()? as usize;
+        self.do_read_data(ctx.clone(), &plan, pipeline, max_threads)?;
 
         let cluster_stats_gen = self.get_cluster_stats_gen(
             ctx.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Reduce the memory usage for `optimize table xx compact limit 100`, trim the col_stats:

Before: `fuse_compact_segments_memory_usage 1735155007 bytes`
This PR:`fuse_compact_segments_memory_usage 317131997 bytes`

Fixes #issue
