### PR TITLE
fix: avoid oom when compact&recluster

### DIFF
--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -379,7 +379,8 @@ impl Table for FuseTable {
         plan: &ReadDataSourcePlan,
         pipeline: &mut Pipeline,
     ) -> Result<()> {
-        self.do_read_data(ctx, plan, pipeline)
+        let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
+        self.do_read_data(ctx, plan, pipeline, max_io_requests)
     }
 
     fn append_data(

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -139,10 +139,10 @@ impl FuseTable {
         };
 
         ctx.try_set_partitions(plan.parts.clone())?;
-        self.do_read_data(ctx.clone(), &plan, pipeline)?;
 
+        // It's easy to OOM if we set the max_io_request more than the max threads.
         let max_threads = ctx.get_settings().get_max_threads()? as usize;
-        pipeline.resize(max_threads)?;
+        self.do_read_data(ctx.clone(), &plan, pipeline, max_threads)?;
 
         pipeline.add_transform(|transform_input_port, transform_output_port| {
             TransformCompact::try_create(

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -130,6 +130,7 @@ impl FuseTable {
         ctx: Arc<dyn TableContext>,
         plan: &ReadDataSourcePlan,
         pipeline: &mut Pipeline,
+        max_io_requests: usize,
     ) -> Result<()> {
         let mut lazy_init_segments = Vec::with_capacity(plan.parts.len());
 
@@ -181,7 +182,6 @@ impl FuseTable {
         let prewhere_filter = self.build_prewhere_filter_executor(ctx.clone(), plan)?;
         let remain_reader = self.build_remain_reader(plan)?;
 
-        let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
         info!("read block data adjust max io requests:{}", max_io_requests);
 
         // Add source pipe.

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -132,7 +132,10 @@ impl FuseTable {
         };
 
         ctx.try_set_partitions(plan.parts.clone())?;
-        self.do_read_data(ctx.clone(), &plan, pipeline)?;
+
+        // It's easy to OOM if we set the max_io_request more than the max threads.
+        let max_threads = ctx.get_settings().get_max_threads()? as usize;
+        self.do_read_data(ctx.clone(), &plan, pipeline, max_threads)?;
 
         let cluster_stats_gen = self.get_cluster_stats_gen(
             ctx.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Set the max io requests to max threads when compact&recluster to avoid OOM.

Fixes #issue
