### PR TITLE
feat(hive): add filesize to avoid stat operate in opendal

### DIFF
--- a/src/query/storages/hive/src/hive_file_splitter.rs
+++ b/src/query/storages/hive/src/hive_file_splitter.rs
@@ -59,6 +59,7 @@ impl HiveFileSplitter {
                     hive_file_info.filename.clone(),
                     hive_file_info.partition.clone(),
                     r,
+                    hive_file_info.length,
                 )
             })
             .collect()

--- a/src/query/storages/hive/src/hive_parquet_block_reader.rs
+++ b/src/query/storages/hive/src/hive_parquet_block_reader.rs
@@ -199,9 +199,14 @@ impl HiveParquetBlockReader {
         }
     }
 
-    pub async fn read_meta_data(&self, dal: Operator, filename: &str) -> Result<Arc<FileMetaData>> {
+    pub async fn read_meta_data(
+        &self,
+        dal: Operator,
+        filename: &str,
+        filesize: u64,
+    ) -> Result<Arc<FileMetaData>> {
         let reader = FileMetaDataReader::new_reader(dal);
-        reader.read(filename, None, 0).await
+        reader.read(filename, Some(filesize), 0).await
     }
 
     pub async fn read_columns_data(

--- a/src/query/storages/hive/src/hive_partition.rs
+++ b/src/query/storages/hive/src/hive_partition.rs
@@ -30,6 +30,8 @@ pub struct HivePartInfo {
     pub partitions: Option<String>,
     // only the data in ranges belong to this partition
     pub range: Range<u64>,
+    // file size
+    pub filesize: u64,
 }
 
 #[typetag::serde(name = "hive")]
@@ -51,11 +53,13 @@ impl HivePartInfo {
         filename: String,
         partitions: Option<String>,
         range: Range<u64>,
+        filesize: u64,
     ) -> Arc<Box<dyn PartInfo>> {
         Arc::new(Box::new(HivePartInfo {
             filename,
             partitions,
             range,
+            filesize,
         }))
     }
 

--- a/src/query/storages/hive/src/hive_table_source.rs
+++ b/src/query/storages/hive/src/hive_table_source.rs
@@ -194,7 +194,7 @@ impl Processor for HiveTableSource {
                 let part = HivePartInfo::from_part(&part)?;
                 let file_meta = self
                     .block_reader
-                    .read_meta_data(self.dal.clone(), &part.filename)
+                    .read_meta_data(self.dal.clone(), &part.filename, part.filesize)
                     .await?;
                 let mut hive_blocks = HiveBlocks::create(file_meta, part.clone());
                 match hive_blocks.prune() {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
if not passing filesize to parquet reader, opendal will do stat() to get it

original committed by  lizhenwei