### PR TITLE
fix(storage): compact limit

### DIFF
--- a/src/query/storages/fuse/src/operations/mutation/compact_mutator/full_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact_mutator/full_compact_mutator.rs
@@ -139,6 +139,9 @@ impl TableMutator for FullCompactMutator {
                     }
                 });
 
+                // todo: add real metrics
+                metrics_set_selected_blocks_memory_usage(0.0);
+
                 // If the number of blocks of segment meets block_per_seg, and the blocks in segments donot need to be compacted,
                 // then record the segment information.
                 if !need_merge && segments[i].blocks.len() == self.compact_params.block_per_seg {

--- a/src/query/storages/fuse/src/operations/mutation/compact_mutator/full_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact_mutator/full_compact_mutator.rs
@@ -98,8 +98,6 @@ impl TableMutator for FullCompactMutator {
         let snapshot = self.compact_params.base_snapshot.clone();
         let segment_locations = &snapshot.segments;
 
-        // Blocks that need to be reorganized into new segments.
-        let mut remain_blocks = Vec::new();
         // Read all segments information in parallel.
         let segments_io = SegmentsIO::create(self.ctx.clone(), self.data_accessor.clone());
         let segments = segments_io
@@ -112,61 +110,69 @@ impl TableMutator for FullCompactMutator {
         metrics_set_segments_memory_usage(0.0);
 
         let limit = self.compact_params.limit.unwrap_or(segments.len());
-        if limit < segments.len() {
-            for i in limit..segments.len() {
-                self.merged_segments_locations
-                    .push(segment_locations[i].clone());
-                self.merged_segment_statistics =
-                    merge_statistics(&self.merged_segment_statistics, &segments[i].summary)?;
-            }
-        }
-
-        for (idx, segment) in segments.iter().take(limit).enumerate() {
-            let mut need_merge = false;
-            let mut remains = Vec::new();
-
-            segment.blocks.iter().for_each(|b| {
-                if self.is_cluster
-                    || self
-                        .block_compactor
-                        .check_perfect_block(b.row_count as usize, b.block_size as usize)
-                {
-                    remains.push(b.clone());
-                } else {
-                    self.selected_blocks.push(b.clone());
-                    need_merge = true;
-                }
-            });
-
-            // todo: add real metrics
-            metrics_set_selected_blocks_memory_usage(0.0);
-
-            // If the number of blocks of segment meets block_per_seg, and the blocks in segments donot need to be compacted,
-            // then record the segment information.
-            if !need_merge && segment.blocks.len() == self.compact_params.block_per_seg {
-                self.merged_segments_locations
-                    .push(segment_locations[idx].clone());
-                self.merged_segment_statistics =
-                    merge_statistics(&self.merged_segment_statistics, &segment.summary)?;
-                continue;
-            }
-
-            remain_blocks.append(&mut remains);
-        }
 
         let max_threads = self.ctx.get_settings().get_max_threads()? as usize;
-        // Because the pipeline is used, a threshold for the number of blocks is added to resolve
-        // https://github.com/datafuselabs/databend/issues/8316
-        if self.selected_blocks.len() < max_threads * 2 {
-            remain_blocks.append(&mut self.selected_blocks);
-            self.selected_blocks.clear();
-        }
 
-        if self.selected_blocks.is_empty()
-            && (remain_blocks.is_empty()
-                || snapshot.segments.len() - self.merged_segments_locations.len() <= 1)
-        {
-            return Ok(false);
+        let mut unchanged_segment_locations = Vec::with_capacity(limit / 2);
+
+        let mut unchanged_segment_statistics = Statistics::default();
+
+        let mut start = 0;
+        // Blocks that need to be reorganized into new segments.
+        let mut remain_blocks = Vec::new();
+        loop {
+            let end = std::cmp::min(start + limit, segments.len());
+            for i in start..end {
+                let mut need_merge = false;
+                let mut remains = Vec::new();
+
+                segments[i].blocks.iter().for_each(|b| {
+                    if self.is_cluster
+                        || self
+                            .block_compactor
+                            .check_perfect_block(b.row_count as usize, b.block_size as usize)
+                    {
+                        remains.push(b.clone());
+                    } else {
+                        self.selected_blocks.push(b.clone());
+                        need_merge = true;
+                    }
+                });
+
+                // If the number of blocks of segment meets block_per_seg, and the blocks in segments donot need to be compacted,
+                // then record the segment information.
+                if !need_merge && segments[i].blocks.len() == self.compact_params.block_per_seg {
+                    unchanged_segment_locations.push(segment_locations[i].clone());
+                    unchanged_segment_statistics =
+                        merge_statistics(&unchanged_segment_statistics, &segments[i].summary)?;
+                    continue;
+                }
+
+                remain_blocks.append(&mut remains);
+            }
+
+            // Because the pipeline is used, a threshold for the number of blocks is added to resolve
+            // https://github.com/datafuselabs/databend/issues/8316
+            if self.selected_blocks.len() >= max_threads * 2 {
+                if end < segments.len() {
+                    self.merged_segments_locations = segment_locations[end..].to_vec();
+                    for segment in &segments[end..] {
+                        unchanged_segment_statistics =
+                            merge_statistics(&unchanged_segment_statistics, &segment.summary)?;
+                    }
+                }
+
+                self.merged_segments_locations
+                    .extend(unchanged_segment_locations.into_iter());
+                self.merged_segment_statistics = unchanged_segment_statistics;
+                break;
+            }
+
+            if end == segments.len() {
+                self.selected_blocks.clear();
+                return Ok(false);
+            }
+            start = end;
         }
 
         // Create new segments.

--- a/src/query/storages/fuse/src/operations/mutation/compact_mutator/segment_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact_mutator/segment_compact_mutator.rs
@@ -118,41 +118,57 @@ impl TableMutator for SegmentCompactMutator {
             .await?
             .into_iter()
             .collect::<Result<Vec<_>>>()?;
+        let number_segments = base_segments.len();
 
         let blocks_per_segment_threshold = self.compact_params.block_per_seg;
 
-        let mut segments_tobe_compacted = Vec::with_capacity(base_segments.len() / 2);
+        let mut segments_tobe_compacted = Vec::with_capacity(number_segments / 2);
 
-        let mut unchanged_segment_locations = Vec::with_capacity(base_segments.len() / 2);
+        let mut unchanged_segment_locations = Vec::with_capacity(number_segments / 2);
 
         let mut unchanged_segment_statistics = Statistics::default();
 
-        let limit = self.compact_params.limit.unwrap_or(base_segments.len());
-        if limit < base_segments.len() {
-            for i in limit..base_segments.len() {
-                unchanged_segment_locations.push(base_segment_locations[i].clone());
-                unchanged_segment_statistics =
-                    merge_statistics(&unchanged_segment_statistics, &base_segments[i].summary)?;
-            }
-        }
+        let mut start = 0;
+        let limit = self.compact_params.limit.unwrap_or(number_segments);
+        loop {
+            let end = std::cmp::min(start + limit, number_segments);
 
-        for (idx, segment) in base_segments.iter().take(limit).enumerate() {
-            let number_blocks = segment.blocks.len();
-            if number_blocks >= blocks_per_segment_threshold {
-                // skip if current segment is large enough, mark it as unchanged
-                unchanged_segment_locations.push(base_segment_locations[idx].clone());
-                unchanged_segment_statistics =
-                    merge_statistics(&unchanged_segment_statistics, &segment.summary)?;
-                continue;
-            } else {
-                // if number of blocks meets the threshold, mark them down
-                segments_tobe_compacted.push(segment)
+            for idx in start..end {
+                let number_blocks = base_segments[idx].blocks.len();
+                if number_blocks >= blocks_per_segment_threshold {
+                    // skip if current segment is large enough, mark it as unchanged
+                    unchanged_segment_locations.push(base_segment_locations[idx].clone());
+                    unchanged_segment_statistics = merge_statistics(
+                        &unchanged_segment_statistics,
+                        &base_segments[idx].summary,
+                    )?;
+                    continue;
+                } else {
+                    // if number of blocks meets the threshold, mark them down
+                    segments_tobe_compacted.push(&base_segments[idx])
+                }
             }
-        }
 
-        // check if necessary to compact the segment meta: at least two segments were marked as segments_tobe_compacted
-        if segments_tobe_compacted.len() <= 1 {
-            return Ok(false);
+            // check if necessary to compact the segment meta: at least two segments were marked as segments_tobe_compacted
+            if segments_tobe_compacted.len() > 1 {
+                if end < number_segments {
+                    unchanged_segment_locations = base_segment_locations[end..]
+                        .iter()
+                        .chain(unchanged_segment_locations.iter())
+                        .cloned()
+                        .collect();
+                    for segment in &base_segments[end..] {
+                        unchanged_segment_statistics =
+                            merge_statistics(&unchanged_segment_statistics, &segment.summary)?;
+                    }
+                }
+                break;
+            }
+
+            if end == number_segments {
+                return Ok(false);
+            }
+            start = end;
         }
 
         // flatten the block metas of segments being compacted
@@ -169,7 +185,7 @@ impl TableMutator for SegmentCompactMutator {
         // note that the newly segments will be persistent into storage, such that if retry
         // happens during the later `try_commit` phase, they do not need to be written again.
         let mut compacted_segment_statistics = Statistics::default();
-        let mut compacted_segment_locations = Vec::with_capacity(base_segments.len() / 2);
+        let mut compacted_segment_locations = Vec::with_capacity(number_segments / 2);
         let segment_info_cache = CacheManager::instance().get_table_segment_cache();
         let segment_writer = SegmentWriter::new(
             &self.data_accessor,

--- a/tests/logictest/suites/base/09_fuse_engine/09_0008_fuse_optimize_table
+++ b/tests/logictest/suites/base/09_fuse_engine/09_0008_fuse_optimize_table
@@ -34,10 +34,10 @@ statement ok
 optimize table t compact;
 
 statement query II
-select segment_count,block_count from fuse_snapshot('db_09_0008', 't') order by to_uint64(timestamp) desc limit 1;
+select segment_count,block_count from fuse_snapshot('db_09_0008', 't') limit 1;
 
 ----
-1 3
+3 3
 
 statement ok
 set max_threads=1;
@@ -54,7 +54,7 @@ select * from t order by a;
 7
 
 statement query II
-select segment_count,block_count from fuse_snapshot('db_09_0008', 't') order by to_uint64(timestamp) desc limit 1;
+select segment_count,block_count from fuse_snapshot('db_09_0008', 't') limit 1;
 
 ----
 1 1
@@ -216,14 +216,17 @@ insert into t2 values (6);
 statement ok
 insert into t2 values (7);
 
+statement ok
+insert into t2 values (8);
+
 statement query II
 select segment_count, block_count from fuse_snapshot('db_09_0008', 't2') limit 1;
 
 ----
-3 3
+4 4
 
 statement ok
-set max_threads=1;
+set max_threads=2;
 
 statement ok
 optimize table t2 compact limit 2;
@@ -235,7 +238,7 @@ select segment_count, block_count from fuse_snapshot('db_09_0008', 't2') limit 1
 2 2
 
 statement ok
-insert into t2 values (8);
+insert into t2 values (9);
 
 statement ok
 optimize table t2 compact segment limit 2;

--- a/tests/logictest/suites/base/09_fuse_engine/09_0008_fuse_optimize_table
+++ b/tests/logictest/suites/base/09_fuse_engine/09_0008_fuse_optimize_table
@@ -205,7 +205,7 @@ select segment_count, block_count from fuse_snapshot('db_09_0008', 't1') limit 1
 
 
 statement ok
-create table t2(a uint64);
+create table t2(a uint64) block_per_segment=2;
 
 statement ok
 insert into t2 values (5);
@@ -241,13 +241,25 @@ statement ok
 insert into t2 values (9);
 
 statement ok
+insert into t2 values (10);
+
+statement ok
 optimize table t2 compact segment limit 2;
 
 statement query II
 select segment_count, block_count from fuse_snapshot('db_09_0008', 't2') limit 1;
 
 ----
-2 3
+3 4
+
+statement ok
+optimize table t2 compact segment limit 2;
+
+statement query II
+select segment_count, block_count from fuse_snapshot('db_09_0008', 't2') limit 1;
+
+----
+2 4
 
 
 

--- a/tests/logictest/suites/base/09_fuse_engine/09_0018_issues
+++ b/tests/logictest/suites/base/09_fuse_engine/09_0018_issues
@@ -17,7 +17,7 @@ statement ok
 INSERT INTO t_issue_8130 VALUES(2);
 
 statement ok
-optimize table t_issue_8130 compact;
+optimize table t_issue_8130 compact segment;
 
 statement query II
 select segment_count, block_count from fuse_snapshot('issues', 't_issue_8130') order by timestamp desc limit 1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

For example
```
optimize table t compact limit 100;
```
When the first 100 segments do not need to be optimized, continue to the next 100 segments. This allows all segments to be optimized.

Fixes #8474
