### PR TITLE
chore(meta): expire_seq_v() returns two value.

### DIFF
--- a/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
+++ b/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
@@ -92,7 +92,7 @@ impl KVApi for StateMachine {
 
         for x in keys.iter() {
             let v = kvs.get(x)?;
-            let v = Self::unexpired_opt(v, local_now_ms);
+            let (_, v) = Self::expire_seq_v(v, local_now_ms);
             res.push(v)
         }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore(meta): expire_seq_v() returns two value.

In order to clean up expired kv record, the already expired value should
also be returned and kept until it is cleaned.

`expire_seq_v()` expires an `SeqV` and returns:

- `(Some, None)` if it expires.
- `(None, Some)` if it does not.
- `(None, None)` if the input is None.

- Part of #8425

## Changelog







## Related Issues