### PR TITLE
chore(meta/test): fix test-metactl failure: "already undergoing a configuration change"

### DIFF
--- a/tests/metactl/test-metactl-restore-new-cluster.sh
+++ b/tests/metactl/test-metactl-restore-new-cluster.sh
@@ -11,11 +11,17 @@ echo " === start 3 meta node cluster"
 nohup ./target/debug/databend-meta --config-file=./tests/metactl/config/databend-meta-node-1.toml &
 python3 scripts/ci/wait_tcp.py --timeout 5 --port 9191
 
+sleep 1
+
 nohup ./target/debug/databend-meta --config-file=./tests/metactl/config/databend-meta-node-2.toml &
 python3 scripts/ci/wait_tcp.py --timeout 5 --port 28202
 
+sleep 1
+
 nohup ./target/debug/databend-meta --config-file=./tests/metactl/config/databend-meta-node-3.toml &
 python3 scripts/ci/wait_tcp.py --timeout 5 --port 28302
+
+sleep 1
 
 curl -sL http://127.0.0.1:28101/v1/cluster/status
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore(meta/test): fix test-metactl failure: "already undergoing a configuration change"

Problem:

When a databend-meta node starts in **background** with `nohup
databend-meta &`, it does not block until a databend-meta process being
fully ready.

Thus actually all 3 nodes somehow start up simultaneously when bringing
up a testing cluster. Thus node-3 may try to join before the leader
commit the membership change log for node-2. So there is an error:

```
common_meta_types::errors::meta_api_errors::MetaAPIError: the cluster is already undergoing a configuration change at log 1-6 while: join via: 127.0.0.1:28103.
```

Which caused the flaky failure in:
https://github.com/datafuselabs/databend/actions/runs/3336536017/jobs/5521979303

To fix it, sleep a second before starting the next node.

## Changelog







## Related Issues