### PR TITLE
fix(planner): view alias

### DIFF
--- a/tests/logictest/suites/base/01_system/01_0003_information_schema
+++ b/tests/logictest/suites/base/01_system/01_0003_information_schema
@@ -30,3 +30,13 @@ select count(1) > 1 from information_Schema.Columns;
 
 ----
 1
+
+statement query T
+SELECT t.table_catalog FROM information_schema.TABLES t WHERE t.TABLE_SCHEMA = 'INFORMATION_SCHEMA';
+
+----
+INFORMATION_SCHEMA
+INFORMATION_SCHEMA
+INFORMATION_SCHEMA
+INFORMATION_SCHEMA
+INFORMATION_SCHEMA


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

sql: select v1.c1 from view as v1 where v1.c1=1 

will not return err: column c1 not exists.

Fixes #8510
