### PR TITLE
feat(meta): auto-clean expired keys

### DIFF
--- a/src/meta/raft-store/src/state_machine/sm.rs
+++ b/src/meta/raft-store/src/state_machine/sm.rs
@@ -73,11 +73,14 @@ use tracing::info;
 
 use crate::config::RaftConfig;
 use crate::sled_key_spaces::ClientLastResps;
+use crate::sled_key_spaces::Expire;
 use crate::sled_key_spaces::GenericKV;
 use crate::sled_key_spaces::Nodes;
 use crate::sled_key_spaces::Sequences;
 use crate::sled_key_spaces::StateMachineMeta;
 use crate::state_machine::ClientLastRespValue;
+use crate::state_machine::ExpireKey;
+use crate::state_machine::ExpireValue;
 use crate::state_machine::MetaSnapshotId;
 use crate::state_machine::StateMachineMetaKey;
 use crate::state_machine::StateMachineMetaKey::Initialized;
@@ -259,18 +262,21 @@ impl StateMachine {
     #[tracing::instrument(level = "debug", skip(self, entry), fields(log_id=%entry.log_id))]
     pub async fn apply(&self, entry: &Entry<LogEntry>) -> Result<AppliedState, MetaStorageError> {
         info!("apply: summary: {}", entry.summary(),);
-
-        let log_id = &entry.log_id;
-
         debug!("sled tx start: {:?}", entry);
 
+        let log_id = &entry.log_id;
         let log_time_ms = Self::get_log_time(entry);
+
+        let expired = self.list_expired_kvs(log_time_ms)?;
+        debug!("expired keys: {:?}", expired);
 
         let kv_pairs = self.scan_prefix_if_needed(entry)?;
 
         let result = self.sm_tree.txn(true, move |txn_tree| {
             let txn_sm_meta = txn_tree.key_space::<StateMachineMeta>();
             txn_sm_meta.insert(&LastApplied, &StateMachineMetaValue::LogId(*log_id))?;
+
+            self.clean_expired_kvs(&txn_tree, &expired)?;
 
             match entry.payload {
                 EntryPayload::Blank => {
@@ -367,7 +373,7 @@ impl StateMachine {
         key: &str,
         txn_tree: &TransactionSledTree,
     ) -> Result<AppliedState, MetaStorageError> {
-        let r = self.txn_incr_seq(key, txn_tree)?;
+        let r = Self::txn_incr_seq(key, txn_tree)?;
 
         Ok(r.into())
     }
@@ -418,12 +424,17 @@ impl StateMachine {
     ) -> Result<AppliedState, MetaStorageError> {
         debug!(upsert_kv = debug(upsert_kv), "apply_update_kv_cmd");
 
-        let (prev, result) = self.txn_upsert_kv(txn_tree, upsert_kv, log_time_ms)?;
+        let (expired, prev, result) = Self::txn_upsert_kv(txn_tree, upsert_kv, log_time_ms)?;
 
         debug!("applied UpsertKV: {:?} {:?}", upsert_kv, result);
 
         if let Some(subscriber) = &self.subscriber {
-            subscriber.kv_changed(&upsert_kv.key, prev.clone(), result.clone());
+            if expired.is_some() {
+                subscriber.kv_changed(&upsert_kv.key, expired, None);
+            }
+            if prev != result {
+                subscriber.kv_changed(&upsert_kv.key, prev.clone(), result.clone());
+            }
         }
 
         Ok(Change::new(prev, result).into())
@@ -551,7 +562,7 @@ impl StateMachine {
         events: &mut Option<Vec<NotifyKVEvent>>,
         log_time_ms: u64,
     ) -> Result<(), MetaStorageError> {
-        let (prev, result) = self.txn_upsert_kv(
+        let (expired, prev, result) = Self::txn_upsert_kv(
             txn_tree,
             &UpsertKV::update(&put.key, &put.value).with(KVMeta {
                 expire_at: put.expire_at,
@@ -560,7 +571,12 @@ impl StateMachine {
         )?;
 
         if let Some(events) = events {
-            events.push((put.key.to_string(), prev.clone(), result));
+            if expired.is_some() {
+                events.push((put.key.to_string(), expired, None));
+            }
+            if prev != result {
+                events.push((put.key.to_string(), prev.clone(), result));
+            }
         }
 
         let put_resp = TxnPutResponse {
@@ -587,11 +603,16 @@ impl StateMachine {
         events: &mut Option<Vec<NotifyKVEvent>>,
         log_time_ms: u64,
     ) -> Result<(), MetaStorageError> {
-        let (prev, result) =
-            self.txn_upsert_kv(txn_tree, &UpsertKV::delete(&delete.key), log_time_ms)?;
+        let (expired, prev, result) =
+            Self::txn_upsert_kv(txn_tree, &UpsertKV::delete(&delete.key), log_time_ms)?;
 
         if let Some(events) = events {
-            events.push((delete.key.to_string(), prev.clone(), result));
+            if expired.is_some() {
+                events.push((delete.key.to_string(), expired, None));
+            }
+            if prev != result {
+                events.push((delete.key.to_string(), prev.clone(), result));
+            }
         }
 
         let del_resp = TxnDeleteResponse {
@@ -624,13 +645,18 @@ impl StateMachine {
         if let Some(kv_pairs) = kv_pairs {
             if let Some(kv_pairs) = kv_pairs.get(delete_by_prefix) {
                 for (key, _seq) in kv_pairs.iter() {
-                    let ret = self.txn_upsert_kv(txn_tree, &UpsertKV::delete(key), log_time_ms);
+                    let ret = Self::txn_upsert_kv(txn_tree, &UpsertKV::delete(key), log_time_ms);
 
                     if let Ok(ret) = ret {
                         count += 1;
 
                         if let Some(events) = events {
-                            events.push((key.to_string(), ret.0.clone(), ret.1));
+                            if ret.0.is_some() {
+                                events.push((key.to_string(), ret.0.clone(), None));
+                            }
+                            if ret.1 != ret.2 {
+                                events.push((key.to_string(), ret.1.clone(), ret.2));
+                            }
                         }
                     }
                 }
@@ -791,11 +817,76 @@ impl StateMachine {
         res
     }
 
-    fn txn_incr_seq(
+    /// Before applying, list expired keys to clean.
+    ///
+    /// Apply is done in a sled-txn tree, which does not provide listing function.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub fn list_expired_kvs(
         &self,
-        key: &str,
+        log_time_ms: u64,
+    ) -> Result<Vec<(String, ExpireKey)>, MetaStorageError> {
+        if log_time_ms == 0 {
+            return Ok(vec![]);
+        }
+
+        let at_most = 32;
+        let mut to_clean = Vec::with_capacity(at_most);
+
+        info!("list_expired_kv, log_time_ts: {}", log_time_ms);
+
+        let expires = self.sm_tree.key_space::<Expire>();
+
+        let it = expires.range(..)?.take(at_most);
+        for item_res in it {
+            let item = item_res?;
+            let k: ExpireKey = item.key()?;
+            if log_time_ms > k.time_ms {
+                let v: ExpireValue = item.value()?;
+                to_clean.push((v.key, k))
+            }
+        }
+
+        Ok(to_clean)
+    }
+
+    /// Remove expired key-values, and corresponding secondary expiration index record.
+    ///
+    /// This should be done inside a sled-transaction.
+    #[tracing::instrument(level = "debug", skip_all)]
+    fn clean_expired_kvs(
+        &self,
         txn_tree: &TransactionSledTree,
-    ) -> Result<u64, MetaStorageError> {
+        expired: &[(String, ExpireKey)],
+    ) -> Result<(), MetaStorageError> {
+        let kvs = txn_tree.key_space::<GenericKV>();
+        let expires = txn_tree.key_space::<Expire>();
+
+        for (key, expire_key) in expired.iter() {
+            let sv = kvs.get(key)?;
+
+            if let Some(seq_v) = &sv {
+                if expire_key.seq == seq_v.seq {
+                    info!("clean expired: {}, {}", key, expire_key);
+
+                    kvs.remove(key)?;
+                    expires.remove(expire_key)?;
+
+                    if let Some(subscriber) = &self.subscriber {
+                        subscriber.kv_changed(key, sv, None);
+                    }
+                    continue;
+                }
+            }
+
+            unreachable!(
+                "trying to remove un-cleanable: {}, {}, kv-record: {:?}",
+                key, expire_key, sv
+            );
+        }
+        Ok(())
+    }
+
+    fn txn_incr_seq(key: &str, txn_tree: &TransactionSledTree) -> Result<u64, MetaStorageError> {
         let seqs = txn_tree.key_space::<Sequences>();
 
         let key = key.to_string();
@@ -809,43 +900,109 @@ impl StateMachine {
         Ok(new_value.0)
     }
 
+    /// Execute an upsert-kv operation on a transactional sled tree.
+    ///
+    /// KV has two indexes:
+    /// - The primary index: `key -> (seq, meta(expire_time), value)`,
+    /// - and a secondary expiration index: `(expire_time, seq) -> key`.
+    ///
+    /// Thus upsert a kv record is done in two steps:
+    /// update the primary index and optionally update the secondary index.
+    ///
+    /// It returns 3 SeqV:
+    /// - `(None, None, x)`: upsert nonexistent key;
+    /// - `(None, Some, x)`: upsert existent and non-expired key;
+    /// - `(Some, None, x)`: upsert existent but expired key;
     #[allow(clippy::type_complexity)]
     fn txn_upsert_kv(
-        &self,
         txn_tree: &TransactionSledTree,
         upsert_kv: &UpsertKV,
         log_time_ms: u64,
-    ) -> Result<(Option<SeqV>, Option<SeqV>), MetaStorageError> {
+    ) -> Result<(Option<SeqV>, Option<SeqV>, Option<SeqV>), MetaStorageError> {
+        let (expired, prev, res) =
+            Self::txn_upsert_kv_primary_index(txn_tree, upsert_kv, log_time_ms)?;
+
+        let expires = txn_tree.key_space::<Expire>();
+
+        if let Some(sv) = &expired {
+            if let Some(m) = &sv.meta {
+                if let Some(exp) = m.expire_at {
+                    expires.remove(&ExpireKey::new(exp * 1000, sv.seq))?;
+                }
+            }
+        }
+
+        // No change, no need to update expiration index
+        if prev == res {
+            return Ok((expired, prev, res));
+        }
+
+        // Remove previous expiration index, add a new one.
+
+        if let Some(sv) = &prev {
+            if let Some(m) = &sv.meta {
+                if let Some(exp) = m.expire_at {
+                    expires.remove(&ExpireKey::new(exp * 1000, sv.seq))?;
+                }
+            }
+        }
+
+        if let Some(sv) = &res {
+            if let Some(m) = &sv.meta {
+                if let Some(exp) = m.expire_at {
+                    let k = ExpireKey::new(exp * 1000, sv.seq);
+                    let v = ExpireValue {
+                        key: upsert_kv.key.clone(),
+                    };
+                    expires.insert(&k, &v)?;
+                }
+            }
+        }
+
+        Ok((expired, prev, res))
+    }
+
+    /// It returns 3 SeqV:
+    /// - The first one is `Some` if an existent record expired.
+    /// - The second and the third represent the change that is made by the upsert operation.
+    ///
+    /// Only one of the first and second can be `Some`.
+    #[allow(clippy::type_complexity)]
+    fn txn_upsert_kv_primary_index(
+        txn_tree: &TransactionSledTree,
+        upsert_kv: &UpsertKV,
+        log_time_ms: u64,
+    ) -> Result<(Option<SeqV>, Option<SeqV>, Option<SeqV>), MetaStorageError> {
         let kvs = txn_tree.key_space::<GenericKV>();
 
         let prev = kvs.get(&upsert_kv.key)?;
 
-        // If prev is timed out, treat it as a None.
-        let (_original, prev) = Self::expire_seq_v(prev, log_time_ms);
+        // If prev is timed out, treat it as a None. But still keep the original value for cleaning up it.
+        let (expired, prev) = Self::expire_seq_v(prev, log_time_ms);
 
         if upsert_kv.seq.match_seq(&prev).is_err() {
-            return Ok((prev.clone(), prev));
+            return Ok((expired, prev.clone(), prev));
         }
 
         let mut new_seq_v = match &upsert_kv.value {
             Operation::Update(v) => SeqV::with_meta(0, upsert_kv.value_meta.clone(), v.clone()),
             Operation::Delete => {
                 kvs.remove(&upsert_kv.key)?;
-                return Ok((prev, None));
+                return Ok((expired, prev, None));
             }
             Operation::AsIs => match prev {
-                None => return Ok((prev, None)),
+                None => return Ok((expired, prev, None)),
                 Some(ref prev_kv_value) => {
                     prev_kv_value.clone().set_meta(upsert_kv.value_meta.clone())
                 }
             },
         };
 
-        new_seq_v.seq = self.txn_incr_seq(GenericKV::NAME, txn_tree)?;
+        new_seq_v.seq = Self::txn_incr_seq(GenericKV::NAME, txn_tree)?;
         kvs.insert(&upsert_kv.key, &new_seq_v)?;
 
         debug!("applied upsert: {:?} res: {:?}", upsert_kv, new_seq_v);
-        Ok((prev, Some(new_seq_v)))
+        Ok((expired, prev, Some(new_seq_v)))
     }
 
     fn txn_client_last_resp_update(

--- a/src/meta/raft-store/tests/it/state_machine/expire.rs
+++ b/src/meta/raft-store/tests/it/state_machine/expire.rs
@@ -1,0 +1,168 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use common_base::base::tokio;
+use common_meta_raft_store::sled_key_spaces::Expire;
+use common_meta_raft_store::sled_key_spaces::GenericKV;
+use common_meta_raft_store::state_machine::ExpireKey;
+use common_meta_raft_store::state_machine::StateMachine;
+use common_meta_sled_store::openraft::Entry;
+use common_meta_sled_store::openraft::EntryPayload;
+use common_meta_sled_store::openraft::LogId;
+use common_meta_sled_store::AsKeySpace;
+use common_meta_types::Cmd;
+use common_meta_types::KVMeta;
+use common_meta_types::LogEntry;
+use common_meta_types::UpsertKV;
+use common_meta_types::With;
+
+use crate::init_raft_store_ut;
+use crate::testing::new_raft_test_context;
+
+#[async_entry::test(
+    worker_threads = 3,
+    init = "init_raft_store_ut!()",
+    tracing_span = "debug"
+)]
+async fn test_state_machine_update_expiration_index() -> anyhow::Result<()> {
+    // - Update expiration index when upsert.
+    // - Remove from expiration index when overriding
+    // - Remove from expiration index when log-time is provided.
+
+    let tc = new_raft_test_context();
+    let sm = StateMachine::open(&tc.raft_config, 0).await?;
+    let expires = sm.sm_tree.key_space::<Expire>();
+
+    let ls_expire = |expire_key_space: &AsKeySpace<Expire>| {
+        expire_key_space
+            .range(..)
+            .unwrap()
+            .map(|item_res| {
+                let item = item_res.unwrap();
+                (item.key().unwrap(), item.value().unwrap().key)
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let s = |x: &str| x.to_string();
+
+    let now = now();
+
+    sm.apply(&ent(3, "a", Some(now - 1), None)).await?;
+    assert_eq!(
+        vec![(ExpireKey::new((now - 1) * 1000, 1), s("a"))],
+        ls_expire(&expires)
+    );
+
+    // override
+    sm.apply(&ent(4, "a", Some(now - 2), None)).await?;
+    assert_eq!(
+        vec![(ExpireKey::new((now - 2) * 1000, 2), s("a"))],
+        ls_expire(&expires)
+    );
+
+    // Add another expiration index
+    sm.apply(&ent(5, "b", Some(now - 2), None)).await?;
+    assert_eq!(
+        vec![
+            //
+            (ExpireKey::new((now - 2) * 1000, 2), s("a")),
+            (ExpireKey::new((now - 2) * 1000, 3), s("b")),
+        ],
+        ls_expire(&expires)
+    );
+
+    // Clean expired
+    sm.apply(&ent(6, "a", Some(now + 1), Some(now * 1000)))
+        .await?;
+    assert_eq!(
+        vec![
+            //
+            (ExpireKey::new((now + 1) * 1000, 4), s("a")),
+        ],
+        ls_expire(&expires)
+    );
+    let kvs = sm.sm_tree.key_space::<GenericKV>();
+    assert!(kvs.get(&s("b"))?.is_none());
+
+    Ok(())
+}
+
+#[async_entry::test(
+    worker_threads = 3,
+    init = "init_raft_store_ut!()",
+    tracing_span = "debug"
+)]
+async fn test_state_machine_list_expired() -> anyhow::Result<()> {
+    // - Feed logs into state machine.
+    // - List expired keys
+
+    let tc = new_raft_test_context();
+    let sm = StateMachine::open(&tc.raft_config, 0).await?;
+
+    let now = now();
+
+    let logs = vec![
+        ent(3, "a", Some(now - 1), None), //
+        ent(4, "b", Some(now - 2), None),
+        ent(5, "c", Some(now + 20), None),
+        ent(6, "d", Some(now - 3), None),
+    ];
+
+    for l in logs.iter() {
+        sm.apply(l).await?;
+    }
+
+    let ls = sm.list_expired_kvs(now * 1000)?;
+
+    assert_eq!(
+        vec![
+            expired_item("d", now - 3, 4), //
+            expired_item("b", now - 2, 2),
+            expired_item("a", now - 1, 1),
+        ],
+        ls
+    );
+
+    Ok(())
+}
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+/// Build an item returned by `list_expired_kvs()`.
+fn expired_item(key: &str, time_sec: u64, seq: u64) -> (String, ExpireKey) {
+    (key.to_string(), ExpireKey::new(time_sec * 1000, seq))
+}
+
+/// Build a raft log entry with expire time
+fn ent(index: u64, key: &str, expire: Option<u64>, time_ms: Option<u64>) -> Entry<LogEntry> {
+    Entry {
+        log_id: LogId { term: 1, index },
+        payload: EntryPayload::Normal(LogEntry {
+            txid: None,
+            time_ms,
+            cmd: Cmd::UpsertKV(
+                UpsertKV::update(key, key.as_bytes()).with(KVMeta { expire_at: expire }),
+            ),
+        }),
+    }
+}

--- a/src/meta/raft-store/tests/it/state_machine/mod.rs
+++ b/src/meta/raft-store/tests/it/state_machine/mod.rs
@@ -38,6 +38,7 @@ use tracing::info;
 use crate::init_raft_store_ut;
 use crate::testing::new_raft_test_context;
 
+mod expire;
 mod schema_api_impl;
 mod snapshot;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feat(meta): auto-clean expired keys

- Clean up to 32 expired keys before applying a raft-log.

- When modifying(insert/update/delete) a kv record, it emits at most two events:
  - If the existent key expires, emit a `delete` event because an
    expired key is seen and removed.
  - Then, the event of the update follows.

- Fix: #8489
- Fix: #8490
- Fix: #8540



## Changelog







## Related Issues