### PR TITLE
fix(planner): select view column not exists

### DIFF
--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -139,12 +139,21 @@ impl<'a> Binder {
                         let tokens = tokenize_sql(query.as_str())?;
                         let backtrace = Backtrace::new();
                         let (stmt, _) = parse_sql(&tokens, Dialect::PostgreSQL, &backtrace)?;
+
                         if let Statement::Query(query) = &stmt {
-                            // view maybe has alias, e.g. select v1.col1 from v as v1;
                             let (s_expr, mut bind_context) =
                                 self.bind_query(bind_context, query).await?;
                             if let Some(alias) = alias {
+                                // view maybe has alias, e.g. select v1.col1 from v as v1;
                                 bind_context.apply_table_alias(alias, &self.name_resolution_ctx)?;
+                            } else {
+                                // e.g. select v0.c0 from v0;
+                                for column in bind_context.columns.iter_mut() {
+                                    column.database_name = None;
+                                    column.table_name = Some(
+                                        normalize_identifier(table, &self.name_resolution_ctx).name,
+                                    );
+                                }
                             }
                             Ok((s_expr, bind_context))
                         } else {

--- a/tests/logictest/suites/base/05_ddl/05_0019_ddl_create_view
+++ b/tests/logictest/suites/base/05_ddl/05_0019_ddl_create_view
@@ -19,3 +19,53 @@ DROP VIEW IF EXISTS tmp_view;
 statement ok
 DROP VIEW IF EXISTS tmp_view2;
 
+statement ok
+drop database if exists test_view;
+
+statement ok
+drop view if exists default.v0;
+
+statement ok
+create database test_view;
+
+statement ok
+create table test_view.t0(id int);
+
+statement ok
+create table test_view.t1(id int);
+
+statement ok
+insert into test_view.t0 values(1);
+
+statement ok
+insert into test_view.t0 values(2);
+
+statement ok
+create view default.v0 as select * from test_view.t0 union select * from test_view.t1;
+
+statement query T
+select * from default.v0;
+
+----
+1
+2
+
+statement query T
+select v0.id from default.v0;
+
+----
+1
+2
+
+statement query T
+select v1.id from default.v0 as v1;
+
+----
+1
+2
+
+statement ok
+drop view default.v0;
+
+statement ok
+drop database test_view;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix this:

select v0.c0 from v0;

befor this pr, will return err `column not exists.`

Detials in #8542 
Fixes #8542
