### PR TITLE
fix(session): CURRENT ROLE behavior with AUTH ROLE is set

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -79,7 +79,6 @@ pub trait TableContext: Send + Sync {
     fn get_current_database(&self) -> String;
     fn get_config(&self) -> Config;
     fn get_current_user(&self) -> Result<UserInfo>;
-    fn set_current_user(&self, user: UserInfo);
     fn get_current_role(&self) -> Option<RoleInfo>;
     fn get_fuse_version(&self) -> String;
     fn get_changed_settings(&self) -> Arc<Settings>;

--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -99,8 +99,7 @@ impl AuthMgr {
                 }?
             }
         };
-        session.set_current_user(user_info);
-        session.refresh_current_role().await?;
+        session.set_authed_user(user_info).await?;
         Ok(())
     }
 

--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -50,7 +50,7 @@ impl AuthMgr {
     }
 
     pub async fn auth(&self, session: Arc<Session>, credential: &Credential) -> Result<()> {
-        let user_info = match credential {
+        match credential {
             Credential::Jwt {
                 token: t,
                 hostname: h,
@@ -60,16 +60,17 @@ impl AuthMgr {
                     .as_ref()
                     .ok_or_else(|| ErrorCode::AuthenticateFailure("jwt auth not configured."))?;
                 let parsed_jwt = jwt_auth.parse_jwt(t.as_str()).await?;
-                let (tenant, user_name) = self
+                let (tenant, user_name, auth_role) = self
                     .process_jwt_claims(&session, parsed_jwt.claims())
                     .await?;
-                UserApiProvider::instance()
+                let user_info = UserApiProvider::instance()
                     .get_user_with_client_ip(
                         &tenant,
                         &user_name,
                         h.as_ref().unwrap_or(&"%".to_string()),
                     )
-                    .await?
+                    .await?;
+                session.set_authed_user(user_info, auth_role).await?;
             }
             Credential::Password {
                 name: n,
@@ -80,26 +81,26 @@ impl AuthMgr {
                 let user = UserApiProvider::instance()
                     .get_user_with_client_ip(&tenant, n, h.as_ref().unwrap_or(&"%".to_string()))
                     .await?;
-                match &user.auth_info {
-                    AuthInfo::None => Ok(user),
+                let user = match &user.auth_info {
+                    AuthInfo::None => user,
                     AuthInfo::Password {
                         hash_value: h,
                         hash_method: t,
                     } => match p {
-                        None => Err(ErrorCode::AuthenticateFailure("password required")),
+                        None => return Err(ErrorCode::AuthenticateFailure("password required")),
                         Some(p) => {
                             if *h == t.hash(p) {
-                                Ok(user)
+                                user
                             } else {
-                                Err(ErrorCode::AuthenticateFailure("wrong password"))
+                                return Err(ErrorCode::AuthenticateFailure("wrong password"));
                             }
                         }
                     },
-                    _ => Err(ErrorCode::AuthenticateFailure("wrong auth type")),
-                }?
+                    _ => return Err(ErrorCode::AuthenticateFailure("wrong auth type")),
+                };
+                session.set_authed_user(user, None).await?;
             }
         };
-        session.set_authed_user(user_info).await?;
         Ok(())
     }
 
@@ -107,7 +108,7 @@ impl AuthMgr {
         &self,
         session: &Arc<Session>,
         claims: &Claims<CustomClaims>,
-    ) -> Result<(String, String)> {
+    ) -> Result<(String, String, Option<String>)> {
         // setup tenant if the JWT claims contain extra.tenant_id
         if let Some(ref tenant) = claims.extra.tenant_id {
             session.set_current_tenant(tenant.clone());
@@ -121,9 +122,7 @@ impl AuthMgr {
             .ok_or_else(|| ErrorCode::AuthenticateFailure("sub not found in claims"))?;
 
         // set user auth_role if claims contain extra.role
-        if let Some(ref auth_role) = claims.extra.role {
-            session.set_auth_role(auth_role.clone());
-        }
+        let auth_role = claims.extra.role.clone();
 
         // create user if not exists when the JWT claims contains ensure_user
         if let Some(ref ensure_user) = claims.extra.ensure_user {
@@ -140,6 +139,6 @@ impl AuthMgr {
                 .add_user(&tenant, user_info.clone(), true)
                 .await?;
         }
-        Ok((tenant, user_name))
+        Ok((tenant, user_name, auth_role))
     }
 }

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -270,7 +270,7 @@ impl<W: AsyncWrite + Send + Unpin> InteractiveWorkerBase<W> {
 
         let authed = user_info.auth_info.auth_mysql(&info.user_password, salt)?;
         if authed {
-            self.session.set_authed_user(user_info).await?;
+            self.session.set_authed_user(user_info, None).await?;
         }
         Ok(authed)
     }

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -270,8 +270,7 @@ impl<W: AsyncWrite + Send + Unpin> InteractiveWorkerBase<W> {
 
         let authed = user_info.auth_info.auth_mysql(&info.user_password, salt)?;
         if authed {
-            self.session.set_current_user(user_info);
-            self.session.refresh_current_role().await?;
+            self.session.set_authed_user(user_info).await?;
         }
         Ok(authed)
     }

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -281,9 +281,6 @@ impl TableContext for QueryContext {
     fn get_current_user(&self) -> Result<UserInfo> {
         self.shared.get_current_user()
     }
-    fn set_current_user(&self, user: UserInfo) {
-        self.shared.set_current_user(user)
-    }
     fn get_current_role(&self) -> Option<RoleInfo> {
         self.shared.get_current_role()
     }

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -154,10 +154,6 @@ impl QueryContextShared {
         self.session.get_current_user()
     }
 
-    pub fn set_current_user(&self, user: UserInfo) {
-        self.session.set_current_user(user);
-    }
-
     pub fn get_current_role(&self) -> Option<RoleInfo> {
         self.session.get_current_role()
     }

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -207,10 +207,16 @@ impl Session {
     }
 
     // set_authed_user() is called after authentication is passed in various protocol handlers, like
-    // HTTP handler, clickhouse query handler, mysql query handler.
-    // TODO(liyz): add current_role: Option<String> to the parameter to handle X-DATABEND-ROLE
-    pub async fn set_authed_user(self: &Arc<Self>, user: UserInfo) -> Result<()> {
+    // HTTP handler, clickhouse query handler, mysql query handler. auth_role represents the role
+    // granted by external authenticator, it will over write the current user's granted roles, and
+    // becomes the CURRENT ROLE if not set X-DATABEND-ROLE.
+    pub async fn set_authed_user(
+        self: &Arc<Self>,
+        user: UserInfo,
+        auth_role: Option<String>,
+    ) -> Result<()> {
         self.session_ctx.set_current_user(user);
+        self.session_ctx.set_auth_role(auth_role);
         self.ensure_current_role().await?;
         Ok(())
     }
@@ -266,10 +272,6 @@ impl Session {
 
     pub fn get_current_role(self: &Arc<Self>) -> Option<RoleInfo> {
         self.session_ctx.get_current_role()
-    }
-
-    pub fn set_auth_role(self: &Arc<Self>, role: String) {
-        self.session_ctx.set_auth_role(role);
     }
 
     // Returns all the roles the current session has. If the user have been granted auth_role,

--- a/src/query/service/src/sessions/session_ctx.rs
+++ b/src/query/service/src/sessions/session_ctx.rs
@@ -163,9 +163,9 @@ impl SessionContext {
         lock.clone()
     }
 
-    pub fn set_auth_role(&self, role: String) {
+    pub fn set_auth_role(&self, role: Option<String>) {
         let mut lock = self.auth_role.write();
-        *lock = Some(role);
+        *lock = role;
     }
 
     pub fn get_client_host(&self) -> Option<SocketAddr> {

--- a/src/query/service/tests/it/api/http/status.rs
+++ b/src/query/service/tests/it/api/http/status.rs
@@ -60,7 +60,10 @@ async fn run_query(query_ctx: &Arc<QueryContext>) -> Result<Arc<dyn Interpreter>
     let user = UserApiProvider::instance()
         .get_user("test", UserIdentity::new("root", "localhost"))
         .await?;
-    query_ctx.set_current_user(user);
+    query_ctx
+        .get_current_session()
+        .set_authed_user(user)
+        .await?;
     let mut planner = Planner::new(query_ctx.clone());
     let (plan, _, _) = planner.plan_sql(sql).await?;
     query_ctx.attach_query_str(plan.to_string(), sql);

--- a/src/query/service/tests/it/api/http/status.rs
+++ b/src/query/service/tests/it/api/http/status.rs
@@ -62,7 +62,7 @@ async fn run_query(query_ctx: &Arc<QueryContext>) -> Result<Arc<dyn Interpreter>
         .await?;
     query_ctx
         .get_current_session()
-        .set_authed_user(user)
+        .set_authed_user(user, None)
         .await?;
     let mut planner = Planner::new(query_ctx.clone());
     let (plan, _, _) = planner.plan_sql(sql).await?;

--- a/src/query/service/tests/it/context_function.rs
+++ b/src/query/service/tests/it/context_function.rs
@@ -36,7 +36,7 @@ async fn test_context_function_build_arg_from_ctx() -> Result<()> {
     // Ok.
     {
         let args = ContextFunction::build_args_from_ctx(ctx.clone(), "current_role")?;
-        assert_eq!("", format!("{:?}", args[0]));
+        assert_eq!("public", format!("{:?}", args[0]));
     }
 
     // Ok.

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -815,11 +815,11 @@ async fn test_auth_jwt() -> Result<()> {
     let token = key_pair.sign(claims)?;
     let bear = headers::Authorization::bearer(&token).unwrap();
     // root user can only login in localhost
-    test_auth_post(&ep, user_name, bear, "127.0.0.1").await?;
+    assert_auth_current_user(&ep, user_name, bear, "127.0.0.1").await?;
     Ok(())
 }
 
-async fn test_auth_post(
+async fn assert_auth_current_user(
     ep: &EndpointType,
     user_name: &str,
     header: impl Header,
@@ -854,6 +854,40 @@ async fn test_auth_post(
         v[0][0],
         serde_json::Value::String(format!("'{}'@'{}'", user_name, host))
     );
+    Ok(())
+}
+
+async fn assert_auth_current_role(
+    ep: &EndpointType,
+    role_name: &str,
+    header: impl Header,
+) -> Result<()> {
+    let sql = "select current_role()";
+
+    let json = serde_json::json!({"sql": sql.to_string()});
+
+    let path = "/v1/query";
+    let uri = format!("{}?wait_time_secs={}", path, 3);
+    let content_type = "application/json";
+    let body = serde_json::to_vec(&json)?;
+
+    let response = ep
+        .call(
+            Request::builder()
+                .uri(uri.parse().unwrap())
+                .method(Method::POST)
+                .header(header::CONTENT_TYPE, content_type)
+                .typed_header(header)
+                .body(body),
+        )
+        .await
+        .unwrap();
+
+    let (_, resp) = check_response(response).await?;
+    let v = resp.data;
+    assert_eq!(v.len(), 1);
+    assert_eq!(v[0].len(), 1);
+    assert_eq!(v[0][0], serde_json::Value::String(role_name.to_string()));
     Ok(())
 }
 
@@ -905,14 +939,15 @@ async fn test_auth_jwt_with_create_user() -> Result<()> {
         nonce: None,
         custom: CustomClaims {
             tenant_id: None,
-            role: None,
+            role: Some("account_admin".to_string()),
             ensure_user: Some(EnsureUser::default()),
         },
     };
 
     let token = key_pair.sign(claims)?;
-    let bear = headers::Authorization::bearer(&token).unwrap();
-    test_auth_post(&ep, user_name, bear, "%").await?;
+    let bearer = headers::Authorization::bearer(&token).unwrap();
+    assert_auth_current_user(&ep, user_name, bearer.clone(), "%").await?;
+    assert_auth_current_role(&ep, "account_admin", bearer).await?;
     Ok(())
 }
 
@@ -1429,6 +1464,6 @@ async fn test_auth_configured_user() -> Result<()> {
 
     let basic = headers::Authorization::basic(user_name, pass_word);
     // root user can only login in localhost
-    test_auth_post(&ep, user_name, basic, "%").await?;
+    assert_auth_current_user(&ep, user_name, basic, "%").await?;
     Ok(())
 }

--- a/src/query/service/tests/it/tests/context.rs
+++ b/src/query/service/tests/it/tests/context.rs
@@ -61,7 +61,7 @@ async fn create_query_context_with_session(
         UserPrivilegeSet::available_privileges_on_global(),
     );
 
-    dummy_session.set_current_user(user_info);
+    dummy_session.set_authed_user(user_info).await?;
 
     let dummy_query_context = dummy_session.create_query_context().await?;
     dummy_query_context.get_settings().set_max_threads(8)?;
@@ -92,7 +92,9 @@ pub async fn create_query_context_with_config(
         current_user = Some(user_info);
     }
 
-    dummy_session.set_current_user(current_user.unwrap());
+    dummy_session
+        .set_authed_user(current_user.unwrap())
+        .await?;
     let dummy_query_context = dummy_session.create_query_context().await?;
 
     dummy_query_context.get_settings().set_max_threads(8)?;

--- a/src/query/service/tests/it/tests/context.rs
+++ b/src/query/service/tests/it/tests/context.rs
@@ -61,7 +61,7 @@ async fn create_query_context_with_session(
         UserPrivilegeSet::available_privileges_on_global(),
     );
 
-    dummy_session.set_authed_user(user_info).await?;
+    dummy_session.set_authed_user(user_info, None).await?;
 
     let dummy_query_context = dummy_session.create_query_context().await?;
     dummy_query_context.get_settings().set_max_threads(8)?;
@@ -93,7 +93,7 @@ pub async fn create_query_context_with_config(
     }
 
     dummy_session
-        .set_authed_user(current_user.unwrap())
+        .set_authed_user(current_user.unwrap(), None)
         .await?;
     let dummy_query_context = dummy_session.create_query_context().await?;
 

--- a/src/query/users/src/role_cache_mgr.rs
+++ b/src/query/users/src/role_cache_mgr.rs
@@ -146,9 +146,12 @@ impl RoleCacheManager {
             match cached.get(tenant) {
                 None => true,
                 Some(cached_roles) => {
-                    // if the cache is too old, force reload the data (the background polling task
-                    // may got some network errors, leaves the cache outdated)
+                    // force reload the data when:
+                    // - if the cache is too old (the background polling task
+                    //   may got some network errors, leaves the cache outdated)
+                    // - if the cache is empty
                     cached_roles.cached_at.elapsed() >= self.polling_interval * 2
+                        || cached_roles.roles.is_empty()
                 }
             }
         };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The behaviour about CURRENT ROLE with auth_role is broken, as the auth_role is set as "account_admin", but `SELECT current_role()` still gets "public".

The expected behaviour is that when the AUTH ROLE is set, it defaults as the CURRENT ROLE, except when X-DATABEND-ROLE is set (which must be one of the AUTH ROLE's children roles).

This PR also made a minor refactor: replace session.set_current_user to session.set_authed_user which plays as an unified entrypoint on authentication success. So instead of manage logics in different handlers, we can collect the works on authenticated success into this method.