### PR TITLE
refactor: make block meta easier to be cloned

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/mutation/deletion_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/deletion_mutator.rs
@@ -58,7 +58,7 @@ async fn test_deletion_mutator_multiple_empty_segments() -> Result<()> {
         // structures are filled with arbitrary values, no effects for this test case
         let block_id = Uuid::new_v4().simple().to_string();
         let location = (block_id, DataBlock::VERSION);
-        let test_block_meta = BlockMeta::new(
+        let test_block_meta = Arc::new(BlockMeta::new(
             1,
             1,
             1,
@@ -68,7 +68,7 @@ async fn test_deletion_mutator_multiple_empty_segments() -> Result<()> {
             location.clone(),
             None,
             0,
-        );
+        ));
         let segment = SegmentInfo::new(vec![test_block_meta], Statistics::default());
         Ok::<_, ErrorCode>((seg_writer.write_segment(segment).await?, location))
     };

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -54,7 +54,7 @@ async fn test_recluster_mutator_block_select() -> Result<()> {
     let gen_test_seg = |cluster_stats: Option<ClusterStatistics>| async {
         let block_id = Uuid::new_v4().simple().to_string();
         let location = (block_id, DataBlock::VERSION);
-        let test_block_meta = BlockMeta::new(
+        let test_block_meta = Arc::new(BlockMeta::new(
             1,
             1,
             1,
@@ -64,7 +64,7 @@ async fn test_recluster_mutator_block_select() -> Result<()> {
             location.clone(),
             None,
             0,
-        );
+        ));
         let segment = SegmentInfo::new(vec![test_block_meta], Statistics::default());
         Ok::<_, ErrorCode>((seg_writer.write_segment(segment).await?, location))
     };

--- a/src/query/service/tests/it/storages/fuse/operations/read_plan.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/read_plan.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::iter::Iterator;
+use std::sync::Arc;
 
 use common_arrow::arrow::datatypes::DataType as ArrowType;
 use common_arrow::arrow::datatypes::Field as ArrowField;
@@ -78,7 +79,7 @@ fn test_to_partitions() -> Result<()> {
 
     let bloom_filter_location = None;
     let bloom_filter_size = 0;
-    let block_meta = BlockMeta::new(
+    let block_meta = Arc::new(BlockMeta::new(
         0,
         block_size,
         0,
@@ -88,7 +89,7 @@ fn test_to_partitions() -> Result<()> {
         location,
         bloom_filter_location,
         bloom_filter_size,
-    );
+    ));
 
     let blocks_metas = (0..num_of_block)
         .into_iter()

--- a/src/query/service/tests/it/storages/fuse/pruning.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning.rs
@@ -49,7 +49,7 @@ async fn apply_block_pruning(
     push_down: &Option<Extras>,
     ctx: Arc<QueryContext>,
     op: Operator,
-) -> Result<Vec<BlockMeta>> {
+) -> Result<Vec<Arc<BlockMeta>>> {
     let ctx: Arc<dyn TableContext> = ctx;
     let segment_locs = table_snapshot.segments.clone();
     BlockPruner::prune(&ctx, op, schema, push_down, segment_locs)

--- a/src/query/storages/fuse-meta/src/meta/v1/segment.rs
+++ b/src/query/storages/fuse-meta/src/meta/v1/segment.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_datablocks::DataBlock;
 use serde::Deserialize;
@@ -34,7 +35,7 @@ pub struct SegmentInfo {
     /// format version
     format_version: FormatVersion,
     /// blocks belong to this segment
-    pub blocks: Vec<BlockMeta>,
+    pub blocks: Vec<Arc<BlockMeta>>,
     /// summary statistics
     pub summary: Statistics,
 }
@@ -99,7 +100,7 @@ impl BlockMeta {
 }
 
 impl SegmentInfo {
-    pub fn new(blocks: Vec<BlockMeta>, summary: Statistics) -> Self {
+    pub fn new(blocks: Vec<Arc<BlockMeta>>, summary: Statistics) -> Self {
         Self {
             format_version: SegmentInfo::VERSION,
             blocks,
@@ -118,7 +119,11 @@ impl From<v0::SegmentInfo> for SegmentInfo {
     fn from(s: v0::SegmentInfo) -> Self {
         Self {
             format_version: SegmentInfo::VERSION,
-            blocks: s.blocks.into_iter().map(|b| b.into()).collect::<_>(),
+            blocks: s
+                .blocks
+                .into_iter()
+                .map(|b| Arc::new(b.into()))
+                .collect::<_>(),
             summary: s.summary,
         }
     }

--- a/src/query/storages/fuse/src/operations/mutation/base_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/base_mutator.rs
@@ -133,7 +133,7 @@ impl BaseMutator {
                     })?;
                 if let Some(block_meta) = replacement.new_block_meta {
                     abort_operation = abort_operation.add_block(&block_meta);
-                    block_editor.insert(*position, block_meta);
+                    block_editor.insert(*position, Arc::new(block_meta));
                 } else {
                     block_editor.remove(position);
                 }

--- a/src/query/storages/fuse/src/operations/mutation/compact_mutator/full_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact_mutator/full_compact_mutator.rs
@@ -45,7 +45,7 @@ pub struct FullCompactMutator {
     data_accessor: Operator,
     block_compactor: BlockCompactor,
     location_generator: TableMetaLocationGenerator,
-    selected_blocks: Vec<BlockMeta>,
+    selected_blocks: Vec<Arc<BlockMeta>>,
     // summarised statistics of all the accumulated segments(segment compacted, and unchanged)
     merged_segment_statistics: Statistics,
     // locations all the accumulated segments(segment compacted, and unchanged)
@@ -83,7 +83,7 @@ impl FullCompactMutator {
         self.compact_params.base_snapshot.summary.block_count as usize
     }
 
-    pub fn selected_blocks(&self) -> Vec<BlockMeta> {
+    pub fn selected_blocks(&self) -> Vec<Arc<BlockMeta>> {
         self.selected_blocks.clone()
     }
 

--- a/src/query/storages/fuse/src/operations/mutation/compact_mutator/segment_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact_mutator/segment_compact_mutator.rs
@@ -31,7 +31,7 @@ use crate::io::TableMetaLocationGenerator;
 use crate::operations::mutation::AbortOperation;
 use crate::operations::CompactOptions;
 use crate::statistics::merge_statistics;
-use crate::statistics::reducers::reduce_block_metas_new;
+use crate::statistics::reducers::reduce_block_metas;
 use crate::FuseTable;
 use crate::TableContext;
 use crate::TableMutator;
@@ -172,12 +172,11 @@ impl TableMutator for SegmentCompactMutator {
         }
 
         // flatten the block metas of segments being compacted
-        let mut blocks_of_new_segments: Vec<&Arc<BlockMeta>> = vec![];
-        for segment in segments_tobe_compacted {
-            for x in &segment.blocks {
-                blocks_of_new_segments.push(x);
-            }
-        }
+        let blocks_of_new_segments: Vec<Arc<BlockMeta>> = segments_tobe_compacted
+            .iter()
+            .flat_map(|v| v.blocks.iter())
+            .cloned()
+            .collect();
 
         // split the block metas into chunks of blocks, with chunk size set to block_per_seg
         let chunk_of_blocks = blocks_of_new_segments.chunks(blocks_per_segment_threshold);
@@ -193,11 +192,9 @@ impl TableMutator for SegmentCompactMutator {
             &segment_info_cache,
         );
         for chunk in chunk_of_blocks {
-            let stats = reduce_block_metas_new(chunk)?;
+            let stats = reduce_block_metas(chunk)?;
             compacted_segment_statistics = merge_statistics(&compacted_segment_statistics, &stats)?;
-            let blocks: Vec<Arc<BlockMeta>> =
-                chunk.iter().map(|block| Clone::clone(*block)).collect();
-            let new_segment = SegmentInfo::new(blocks, stats);
+            let new_segment = SegmentInfo::new(chunk.to_vec(), stats);
             let location = segment_writer.write_segment(new_segment).await?;
             compacted_segment_locations.push(location);
         }

--- a/src/query/storages/fuse/src/operations/mutation/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/recluster_mutator.rs
@@ -41,8 +41,8 @@ static MAX_BLOCK_COUNT: usize = 50;
 #[derive(Clone)]
 pub struct ReclusterMutator {
     base_mutator: BaseMutator,
-    blocks_map: BTreeMap<i32, Vec<(usize, BlockMeta)>>,
-    selected_blocks: Vec<BlockMeta>,
+    blocks_map: BTreeMap<i32, Vec<(usize, Arc<BlockMeta>)>>,
+    selected_blocks: Vec<Arc<BlockMeta>>,
     level: i32,
     block_compactor: BlockCompactor,
     threshold: f64,
@@ -55,7 +55,7 @@ impl ReclusterMutator {
         base_snapshot: Arc<TableSnapshot>,
         threshold: f64,
         block_compactor: BlockCompactor,
-        blocks_map: BTreeMap<i32, Vec<(usize, BlockMeta)>>,
+        blocks_map: BTreeMap<i32, Vec<(usize, Arc<BlockMeta>)>>,
         data_accessor: Operator,
     ) -> Result<Self> {
         let base_mutator =
@@ -74,7 +74,7 @@ impl ReclusterMutator {
         self.base_mutator.base_snapshot.summary.block_count as usize
     }
 
-    pub fn selected_blocks(&self) -> Vec<BlockMeta> {
+    pub fn selected_blocks(&self) -> Vec<Arc<BlockMeta>> {
         self.selected_blocks.clone()
     }
 

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -134,7 +134,7 @@ impl FuseTable {
         _: Arc<dyn TableContext>,
         schema: DataSchemaRef,
         push_downs: Option<Extras>,
-        block_metas: Vec<BlockMeta>,
+        block_metas: Vec<Arc<BlockMeta>>,
         partitions_total: usize,
     ) -> Result<(Statistics, Partitions)> {
         let arrow_schema = schema.to_arrow();
@@ -158,7 +158,7 @@ impl FuseTable {
     }
 
     pub fn to_partitions(
-        blocks_metas: &[BlockMeta],
+        blocks_metas: &[Arc<BlockMeta>],
         column_leaves: &ColumnLeaves,
         push_down: Option<Extras>,
     ) -> (Statistics, Partitions) {
@@ -189,7 +189,10 @@ impl FuseTable {
         }
     }
 
-    pub fn all_columns_partitions(metas: &[BlockMeta], limit: usize) -> (Statistics, Partitions) {
+    pub fn all_columns_partitions(
+        metas: &[Arc<BlockMeta>],
+        limit: usize,
+    ) -> (Statistics, Partitions) {
         let mut statistics = Statistics::default_exact();
         let mut partitions = Partitions::default();
 
@@ -220,7 +223,7 @@ impl FuseTable {
     }
 
     fn projection_partitions(
-        metas: &[BlockMeta],
+        metas: &[Arc<BlockMeta>],
         column_leaves: &ColumnLeaves,
         projection: &Projection,
         limit: usize,

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -70,7 +70,7 @@ impl FuseTable {
         .await?;
 
         let default_cluster_key_id = self.cluster_key_meta.clone().unwrap().0;
-        let mut blocks_map: BTreeMap<i32, Vec<(usize, BlockMeta)>> = BTreeMap::new();
+        let mut blocks_map: BTreeMap<i32, Vec<(usize, Arc<BlockMeta>)>> = BTreeMap::new();
         block_metas.iter().for_each(|(idx, b)| {
             if let Some(stats) = &b.cluster_stats {
                 if stats.cluster_key_id == default_cluster_key_id && stats.level >= 0 {

--- a/src/query/storages/fuse/src/pruning/topn_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/topn_pruner.rs
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use std::sync::Arc;
+
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -40,7 +42,10 @@ impl TopNPrunner {
 }
 
 impl TopNPrunner {
-    pub(crate) fn prune(&self, metas: Vec<(usize, BlockMeta)>) -> Result<Vec<(usize, BlockMeta)>> {
+    pub(crate) fn prune(
+        &self,
+        metas: Vec<(usize, Arc<BlockMeta>)>,
+    ) -> Result<Vec<(usize, Arc<BlockMeta>)>> {
         if self.sort.len() != 1 {
             return Ok(metas);
         }
@@ -78,7 +83,7 @@ impl TopNPrunner {
                 })?;
                 Ok((*id, stat.clone(), meta.clone()))
             })
-            .collect::<Result<Vec<(usize, ColumnStatistics, BlockMeta)>>>()?;
+            .collect::<Result<Vec<(usize, ColumnStatistics, Arc<BlockMeta>)>>>()?;
 
         id_stats.sort_by(|a, b| {
             if a.1.null_count + b.1.null_count != 0 && *nulls_first {

--- a/src/query/storages/fuse/src/statistics/accumulator.rs
+++ b/src/query/storages/fuse/src/statistics/accumulator.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_arrow::parquet::metadata::ThriftFileMetaData;
 use common_datablocks::DataBlock;
@@ -28,7 +29,7 @@ use crate::statistics::block_statistics::BlockStatistics;
 
 #[derive(Default)]
 pub struct StatisticsAccumulator {
-    pub blocks_metas: Vec<BlockMeta>,
+    pub blocks_metas: Vec<Arc<BlockMeta>>,
     pub blocks_statistics: Vec<StatisticsOfColumns>,
     pub summary_row_count: u64,
     pub summary_block_count: u64,
@@ -105,7 +106,7 @@ impl StatisticsAccumulator {
         let data_location = (block_statistics.block_file_location, DataBlock::VERSION);
         let cluster_stats = block_statistics.block_cluster_statistics;
 
-        self.blocks_metas.push(BlockMeta::new(
+        self.blocks_metas.push(Arc::new(BlockMeta::new(
             row_count,
             block_size,
             file_size,
@@ -115,7 +116,7 @@ impl StatisticsAccumulator {
             data_location,
             bloom_filter_index_location,
             bloom_filter_index_size,
-        ));
+        )));
 
         Ok(())
     }

--- a/src/query/storages/fuse/src/statistics/reducers.rs
+++ b/src/query/storages/fuse/src/statistics/reducers.rs
@@ -14,7 +14,6 @@
 
 use std::borrow::Borrow;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use common_datavalues::DataValue;
 use common_exception::Result;
@@ -140,34 +139,6 @@ pub fn reduce_block_metas<T: Borrow<BlockMeta>>(block_metas: &[T]) -> Result<Sta
         .iter()
         .map(|v| &v.borrow().col_stats)
         .collect::<Vec<_>>();
-    let merged_col_stats = reduce_block_statistics(&stats)?;
-
-    Ok(Statistics {
-        row_count,
-        block_count,
-        uncompressed_byte_size,
-        compressed_byte_size,
-        index_size,
-        col_stats: merged_col_stats,
-    })
-}
-
-pub fn reduce_block_metas_new(block_metas: &[&Arc<BlockMeta>]) -> Result<Statistics> {
-    let mut row_count: u64 = 0;
-    let mut block_count: u64 = 0;
-    let mut uncompressed_byte_size: u64 = 0;
-    let mut compressed_byte_size: u64 = 0;
-    let mut index_size: u64 = 0;
-
-    block_metas.iter().for_each(|b| {
-        row_count += b.row_count;
-        block_count += 1;
-        uncompressed_byte_size += b.block_size;
-        compressed_byte_size += b.file_size;
-        index_size += b.bloom_filter_index_size;
-    });
-
-    let stats = block_metas.iter().map(|v| &v.col_stats).collect::<Vec<_>>();
     let merged_col_stats = reduce_block_statistics(&stats)?;
 
     Ok(Statistics {

--- a/src/query/storages/fuse/src/statistics/reducers.rs
+++ b/src/query/storages/fuse/src/statistics/reducers.rs
@@ -14,6 +14,7 @@
 
 use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_datavalues::DataValue;
 use common_exception::Result;
@@ -61,9 +62,6 @@ pub fn reduce_block_statistics<T: Borrow<StatisticsOfColumns>>(
 
             // TODO:
 
-            // for some data types, we shall balance the accuracy and the length
-            // e.g. for a string col, which max value is "abcdef....", we record the max as something like "b"
-
             // In accumulator.rs, we use aggregation functions to get the min/max of `DataValue`s,
             // like this:
             //   `let maxs = eval_aggr("max", vec![], &[column_field], rows)?`
@@ -104,6 +102,16 @@ pub fn merge_statistics(l: &Statistics, r: &Statistics) -> Result<Statistics> {
     Ok(s)
 }
 
+pub fn merge_statistics_mut(l: &mut Statistics, r: &Statistics) -> Result<()> {
+    l.row_count += r.row_count;
+    l.block_count += r.block_count;
+    l.uncompressed_byte_size += r.uncompressed_byte_size;
+    l.compressed_byte_size += r.compressed_byte_size;
+    l.index_size += r.index_size;
+    l.col_stats = reduce_block_statistics(&[&l.col_stats, &r.col_stats])?;
+    Ok(())
+}
+
 pub fn reduce_statistics<T: Borrow<Statistics>>(stats: &[T]) -> Result<Statistics> {
     let mut statistics = Statistics::default();
     for item in stats {
@@ -132,6 +140,34 @@ pub fn reduce_block_metas<T: Borrow<BlockMeta>>(block_metas: &[T]) -> Result<Sta
         .iter()
         .map(|v| &v.borrow().col_stats)
         .collect::<Vec<_>>();
+    let merged_col_stats = reduce_block_statistics(&stats)?;
+
+    Ok(Statistics {
+        row_count,
+        block_count,
+        uncompressed_byte_size,
+        compressed_byte_size,
+        index_size,
+        col_stats: merged_col_stats,
+    })
+}
+
+pub fn reduce_block_metas_new(block_metas: &[&Arc<BlockMeta>]) -> Result<Statistics> {
+    let mut row_count: u64 = 0;
+    let mut block_count: u64 = 0;
+    let mut uncompressed_byte_size: u64 = 0;
+    let mut compressed_byte_size: u64 = 0;
+    let mut index_size: u64 = 0;
+
+    block_metas.iter().for_each(|b| {
+        row_count += b.row_count;
+        block_count += 1;
+        uncompressed_byte_size += b.block_size;
+        compressed_byte_size += b.file_size;
+        index_size += b.bloom_filter_index_size;
+    });
+
+    let stats = block_metas.iter().map(|v| &v.col_stats).collect::<Vec<_>>();
     let merged_col_stats = reduce_block_statistics(&stats)?;
 
     Ok(Statistics {

--- a/src/query/storages/fuse/src/table_functions/clustering_informations/clustering_information.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_informations/clustering_information.rs
@@ -70,6 +70,7 @@ impl<'a> ClusteringInformation<'a> {
             }
         };
 
+        // TODO iterator of blocks
         let info = self.get_clustering_stats(blocks)?;
 
         let names = self
@@ -106,7 +107,7 @@ impl<'a> ClusteringInformation<'a> {
         Ok((cluster_stats.min, cluster_stats.max))
     }
 
-    fn get_clustering_stats(&self, blocks: Vec<BlockMeta>) -> Result<ClusteringStatistics> {
+    fn get_clustering_stats(&self, blocks: Vec<Arc<BlockMeta>>) -> Result<ClusteringStatistics> {
         if blocks.is_empty() {
             return Ok(ClusteringStatistics {
                 total_block_count: 0,

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
@@ -91,15 +91,17 @@ impl<'a> FuseBlock<'a> {
         let segments = segments_io.read_segments(&snapshot.segments).await?;
         for segment in segments {
             let segment = segment?;
-            segment.blocks.clone().into_iter().for_each(|block| {
-                block_location.push(block.location.0.into_bytes());
+            segment.blocks.iter().for_each(|block| {
+                let block = block.as_ref();
+                block_location.push(block.location.0.clone().into_bytes());
                 block_size.push(block.block_size);
                 file_size.push(block.file_size);
                 row_count.push(block.row_count);
                 bloom_filter_location.push(
                     block
                         .bloom_filter_index_location
-                        .map(|(s, _)| s.into_bytes()),
+                        .as_ref()
+                        .map(|(s, _)| s.to_owned().into_bytes()),
                 );
                 bloom_filter_size.push(block.bloom_filter_index_size);
             });


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

After reading `SegmentInfo` from storage,  block meta is owned by an `Arc<SegmentInfo>` (which may be cached). 
For situations that need block metas only, like pruning, we have no choice but to clone the block meta, which hurts the performance.

In this PR, changes SegmentInfo from

~~~
pub struct SegmentInfo {
   ....
    pub blocks: Vec<BlockMeta>,
   ....
}
~~~

to

~~~
pub struct SegmentInfo {
   ....
    pub blocks: Vec<Arc<BlockMeta>>,
   ....
}
~~~

and refactor related components accordingly.



Fixes #issue
