### PR TITLE
fix: Fix downloading the default version

### DIFF
--- a/website/src/pages/download/index.tsx
+++ b/website/src/pages/download/index.tsx
@@ -22,7 +22,7 @@ const MAC_X86 = 'macOS (x86, 64-bit)';
 const MAC_ARM = 'macOS (ARM, 64-bit)';
 const Releases: FC = (): ReactElement=> {
   const [cacheTagName] = useLocalStorageState<string>('global-cache-tag-name');
-  const tagName = cacheTagName as string || 'v0.8.25';
+  const tagName = cacheTagName as string || 'v0.8.96-nightly';
   const DOWNLOAD_LINK = 'https://repo.databend.rs/databend/';
   const [releaseData, setReleaseData] = useState<IRow[]>([
     { 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fixed default versions, There was an '-nightly' missing
