### PR TITLE
refactor(meta): return InvalidReply if fail to decode a message

### DIFF
--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -640,30 +640,19 @@ impl MetaNode {
                 Ok(r) => {
                     let reply = r.into_inner();
 
-                    if reply.error.is_empty() {
-                        // No error. It does not have to decode an error from an old databend-meta
-
-                        let res: Result<ForwardResponse, MetaAPIError> = reply.into();
-                        match res {
-                            Ok(v) => {
-                                info!("join cluster via {} success: {:?}", addr, v);
-                                return Ok(Ok(()));
-                            }
-                            Err(e) => {
-                                error!("join cluster via {} fail: {}", addr, e.to_string());
-                                errors.push(
-                                    AnyError::new(&e)
-                                        .add_context(|| format!("join via: {}", addr.clone())),
-                                );
-                            }
+                    let res: Result<ForwardResponse, MetaAPIError> = reply.into();
+                    match res {
+                        Ok(v) => {
+                            info!("join cluster via {} success: {:?}", addr, v);
+                            return Ok(Ok(()));
                         }
-                    } else {
-                        // TODO: workaround: error type changed. new version of databend-meta does not understand old databend-meta error.
-                        error!("join cluster via {} fail: {}", addr, &reply.error);
-                        errors.push(
-                            AnyError::error(&reply.error)
-                                .add_context(|| format!("join via: {}", addr.clone())),
-                        );
+                        Err(e) => {
+                            error!("join cluster via {} fail: {}", addr, e.to_string());
+                            errors.push(
+                                AnyError::new(&e)
+                                    .add_context(|| format!("join via: {}", addr.clone())),
+                            );
+                        }
                     }
                 }
                 Err(s) => {

--- a/src/meta/service/tests/it/meta_node/meta_node_seq_api.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_seq_api.rs
@@ -20,7 +20,7 @@ use common_meta_types::protobuf::raft_service_client::RaftServiceClient;
 use common_meta_types::AppliedState;
 use common_meta_types::Cmd;
 use common_meta_types::LogEntry;
-use common_meta_types::RetryableError;
+use common_meta_types::MetaError;
 use databend_meta::init_meta_ut;
 use databend_meta::meta_service::MetaNode;
 
@@ -46,7 +46,7 @@ async fn test_meta_node_incr_seq() -> anyhow::Result<()> {
         };
         let raft_reply = client.write(req).await?.into_inner();
 
-        let res: Result<AppliedState, RetryableError> = raft_reply.into();
+        let res: Result<AppliedState, MetaError> = raft_reply.into();
         let resp: AppliedState = res?;
         match resp {
             AppliedState::Seq { seq } => {

--- a/src/meta/types/src/errors/kv_app_errors.rs
+++ b/src/meta/types/src/errors/kv_app_errors.rs
@@ -17,6 +17,7 @@ use common_meta_stoerr::MetaStorageError;
 use tonic::Status;
 
 use crate::AppError;
+use crate::InvalidReply;
 use crate::MetaAPIError;
 use crate::MetaClientError;
 use crate::MetaError;
@@ -86,6 +87,13 @@ impl From<MetaNetworkError> for KVAppError {
 
 impl From<MetaAPIError> for KVAppError {
     fn from(e: MetaAPIError) -> Self {
+        let meta_err = MetaError::from(e);
+        Self::MetaError(meta_err)
+    }
+}
+
+impl From<InvalidReply> for KVAppError {
+    fn from(e: InvalidReply) -> Self {
         let meta_err = MetaError::from(e);
         Self::MetaError(meta_err)
     }

--- a/src/meta/types/src/errors/meta_api_errors.rs
+++ b/src/meta/types/src/errors/meta_api_errors.rs
@@ -20,6 +20,7 @@ use openraft::error::ChangeMembershipError;
 use openraft::error::Fatal;
 use openraft::error::ForwardToLeader;
 
+use crate::InvalidReply;
 use crate::MetaNetworkError;
 
 /// Errors raised when meta-service handling a request.
@@ -123,5 +124,12 @@ impl From<MetaDataReadError> for MetaOperationError {
     fn from(e: MetaDataReadError) -> Self {
         let de = MetaDataError::from(e);
         MetaOperationError::from(de)
+    }
+}
+
+impl From<InvalidReply> for MetaAPIError {
+    fn from(e: InvalidReply) -> Self {
+        let net_err = MetaNetworkError::from(e);
+        Self::NetworkError(net_err)
     }
 }

--- a/src/meta/types/src/errors/meta_errors.rs
+++ b/src/meta/types/src/errors/meta_errors.rs
@@ -18,6 +18,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 
+use crate::InvalidReply;
 use crate::MetaAPIError;
 use crate::MetaClientError;
 use crate::MetaNetworkError;
@@ -56,5 +57,12 @@ impl From<tonic::Status> for MetaError {
     fn from(status: tonic::Status) -> Self {
         let net_err = MetaNetworkError::from(status);
         MetaError::NetworkError(net_err)
+    }
+}
+
+impl From<InvalidReply> for MetaError {
+    fn from(e: InvalidReply) -> Self {
+        let api_err = MetaAPIError::from(e);
+        Self::APIError(api_err)
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta): return InvalidReply if fail to decode a message

During upgrading, different version of databend-query/meta run in a same
cluster. If a message that can not be decoded received, return an
`InvalidReply` error instead of just panicking the program.

Returning such an error might make the cluster unable to operate while
upgrading, but data durability and consistency won't be compromised.

## Changelog







## Related Issues