### PR TITLE
chore(query): increase max_block_size default value to 65536

### DIFF
--- a/docs/doc/30-reference/30-sql/40-show/show-settings.md
+++ b/docs/doc/30-reference/30-sql/40-show/show-settings.md
@@ -32,7 +32,7 @@ SHOW SETTINGS;
 | format_skip_header             | 0          | 0          | SESSION | Whether to skip the input header, default value: 0                                                 | UInt64 |
 | group_by_two_level_threshold   | 10000      | 10000      | SESSION | The threshold of keys to open two-level aggregation, default value: 10000                          | UInt64 |
 | input_read_buffer_size         | 1048576    | 1048576    | SESSION | The size of buffer in bytes for input with format. By default, it is 1MB.                          | UInt64 |
-| max_block_size                 | 10000      | 10000      | SESSION | Maximum block size for reading                                                                     | UInt64 |
+| max_block_size                 | 65536      | 65536      | SESSION | Maximum block size for reading                                                                     | UInt64 |
 | max_execute_time               | 0          | 0          | SESSION | The maximum query execution time. it means no limit if the value is zero. default value: 0         | UInt64 |
 | max_threads                    | 10         | 16         | SESSION | The maximum number of threads to execute the request. By default, it is determined automatically.  | UInt64 |
 | quoted_ident_case_sensitive    | 1          | 1          | SESSION | Case sensitivity of quoted identifiers, default value: 1 (aka case-sensitive)                      | UInt64 |

--- a/docs/doc/30-reference/30-sql/70-system-tables/system-settings.md
+++ b/docs/doc/30-reference/30-sql/70-system-tables/system-settings.md
@@ -81,12 +81,12 @@ set group_by_two_level_threshold = 10000;
 
 ## max_block_size
 
-Maximum block size for reading, default value: 10000.
+Maximum block size for reading, default value: 65536.
 
 Examples:
 
 ```sql
-set max_block_size = 10000;
+set max_block_size = 65536;
 ```
 
 ## max_threads

--- a/src/query/service/tests/it/storages/testdata/system-tables.txt
+++ b/src/query/service/tests/it/storages/testdata/system-tables.txt
@@ -329,7 +329,7 @@ DB.Table: 'system'.'settings', Table: settings-table_id:1, ver:0, Engine: System
 | format_skip_header             | 0          | 0          | SESSION | Whether to skip the input header, default value: 0.                                                 | UInt64 |
 | group_by_two_level_threshold   | 10000      | 10000      | SESSION | The threshold of keys to open two-level aggregation, default value: 10000.                          | UInt64 |
 | input_read_buffer_size         | 1048576    | 1048576    | SESSION | The size of buffer in bytes for input with format. By default, it is 1MB.                           | UInt64 |
-| max_block_size                 | 10000      | 10000      | SESSION | Maximum block size for reading, default value: 10000.                                               | UInt64 |
+| max_block_size                 | 65536      | 65536      | SESSION | Maximum block size for reading, default value: 65536.                                               | UInt64 |
 | max_execute_time               | 0          | 0          | SESSION | The maximum query execution time. it means no limit if the value is zero. default value: 0.         | UInt64 |
 | max_storage_io_requests        | 1000       | 1000       | SESSION | The maximum number of concurrent IO requests. By default, it is 1000.                               | UInt64 |
 | max_threads                    | 2          | 16         | SESSION | The maximum number of threads to execute the request. By default, it is determined automatically.   | UInt64 |

--- a/src/query/settings/src/lib.rs
+++ b/src/query/settings/src/lib.rs
@@ -122,13 +122,13 @@ impl Settings {
         let values = vec![
             // max_block_size
             SettingValue {
-                default_value: UserSettingValue::UInt64(10000),
+                default_value: UserSettingValue::UInt64(65536),
                 user_setting: UserSetting::create(
                     "max_block_size",
-                    UserSettingValue::UInt64(10000),
+                    UserSettingValue::UInt64(65536),
                 ),
                 level: ScopeLevel::Session,
-                desc: "Maximum block size for reading, default value: 10000.",
+                desc: "Maximum block size for reading, default value: 65536.",
                 possible_values: None,
             },
             // max_threads

--- a/tests/fuse-compat/compat-logictest/fuse_compat_write
+++ b/tests/fuse-compat/compat-logictest/fuse_compat_write
@@ -2,7 +2,7 @@ statement ok
 set global timezone = 'UTC';
 
 statement ok
-set global max_block_size = 10000;
+set global max_block_size = 65536;
 
 statement ok
 DROP TABLE IF EXISTS fuse_compat_table;

--- a/tests/logictest/suites/base/20+_others/20_0007_random_engine
+++ b/tests/logictest/suites/base/20+_others/20_0007_random_engine
@@ -31,11 +31,15 @@ SELECT COUNT(*) FROM (SELECT * FROM random_table LIMIT 8765);
 ----
 8765
 
+
+statement ok
+set max_block_size = 100;
+
 statement query I
-SELECT COUNT(*) FROM random_table;
+SELECT COUNT(*) FROM random_table ;
 
 ----
-10000
+100
 
 statement ok
 DROP TABLE random_table;

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/mark.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/mark.test
@@ -18,8 +18,8 @@ HashJoin
     ├── table: default.system.numbers
     ├── read rows: 10000
     ├── read bytes: 80000
-    ├── partitions total: 2
-    ├── partitions scanned: 2
+    ├── partitions total: 1
+    ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
 
 statement query T
@@ -42,7 +42,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── read rows: 10000
     ├── read bytes: 80000
-    ├── partitions total: 2
-    ├── partitions scanned: 2
+    ├── partitions total: 1
+    ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Smaller block size gives better cache locality, but it causes much more overhead to schedule the query.

Now the new pipeline engine works better using larger value in memory table tests.


```
MySQL [(none)]> select sum(number) , avg(number)  from numbers_mt(1000000000);
+--------------------+-------------+
| sum(number)        | avg(number) |
+--------------------+-------------+
| 499999999500000000 | 499999999.5 |
+--------------------+-------------+
1 row in set (0.074 sec)

MySQL [(none)]> set  max_block_size = 65536;
Query OK, 0 rows affected (0.003 sec)

MySQL [(none)]> select sum(number) , avg(number)  from numbers_mt(1000000000);
+--------------------+-------------+
| sum(number)        | avg(number) |
+--------------------+-------------+
| 499999999500000000 | 499999999.5 |
+--------------------+-------------+
1 row in set (0.053 sec)
```

Closes #issue
