### PR TITLE
ci: Upgrade rust toolchain to 1.67-nightly

### DIFF
--- a/scripts/setup/rust-toolchain.toml
+++ b/scripts/setup/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-09-18"
+channel = "nightly-2022-11-02"
 components = ["rustfmt", "clippy", "rust-src"]

--- a/scripts/setup/rust-tools.txt
+++ b/scripts/setup/rust-tools.txt
@@ -1,3 +1,3 @@
-cargo-audit@0.17.0
+cargo-audit@0.17.3
 cargo-machete@0.4.0
-taplo-cli@0.7.0
+taplo-cli@0.8.0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Upgrade rust toolchain to 1.67-nightly