### PR TITLE
feat(compact): optimize compact for data load.

### DIFF
--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use chrono::Utc;
+use common_datablocks::BlockCompactThresholds;
 use common_datablocks::DataBlock;
 use common_datavalues::chrono;
 use common_datavalues::DataSchemaRef;
@@ -220,6 +221,14 @@ pub trait Table: Sync + Send {
             self.name(),
             self.get_table_info().engine(),
         )))
+    }
+
+    fn get_block_compact_thresholds(&self) -> BlockCompactThresholds {
+        BlockCompactThresholds {
+            max_rows_per_block: 1000 * 1000,
+            min_rows_per_block: 800 * 1000,
+            max_bytes_per_block: 100 * 1024 * 1024,
+        }
     }
 
     async fn compact(

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -162,10 +162,10 @@ pub trait Table: Sync + Send {
         &self,
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
+        append_mode: AppendMode,
         need_output: bool,
-        _is_ingest: bool,
     ) -> Result<()> {
-        let (_, _, _) = (ctx, pipeline, need_output);
+        let (_, _, _, _) = (ctx, pipeline, append_mode, need_output);
 
         Err(ErrorCode::Unimplemented(format!(
             "append_data operation for table {} is not implemented. table engine : {}",
@@ -315,6 +315,13 @@ pub struct ColumnStatistics {
 pub enum CompactTarget {
     Blocks,
     Segments,
+}
+
+pub enum AppendMode {
+    // From INSERT and RECUSTER operation
+    Normal,
+    // From COPY, Streaming load peration
+    Copy,
 }
 
 pub trait ColumnStatisticsProvider {

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -231,6 +231,10 @@ pub trait Table: Sync + Send {
         }
     }
 
+    fn set_block_compact_thresholds(&self, _thresholds: BlockCompactThresholds) {
+        unimplemented!()
+    }
+
     async fn compact(
         &self,
         ctx: Arc<dyn TableContext>,

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -163,6 +163,7 @@ pub trait Table: Sync + Send {
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
         need_output: bool,
+        _is_ingest: bool,
     ) -> Result<()> {
         let (_, _, _) = (ctx, pipeline, need_output);
 

--- a/src/query/datablocks/src/block_compact_thresholds.rs
+++ b/src/query/datablocks/src/block_compact_thresholds.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_pipeline_transforms::processors::transforms::BlockCompactor as Compactor;
-
-#[derive(Clone, Default)]
+#[derive(Clone, Copy, Default)]
 pub struct BlockCompactThresholds {
-    max_rows_per_block: usize,
-    min_rows_per_block: usize,
-    max_bytes_per_block: usize,
+    pub max_rows_per_block: usize,
+    pub min_rows_per_block: usize,
+    pub max_bytes_per_block: usize,
 }
 
 impl BlockCompactThresholds {
@@ -48,14 +46,5 @@ impl BlockCompactThresholds {
             return true;
         }
         false
-    }
-
-    pub fn to_compactor(&self, is_recluster: bool) -> Compactor {
-        Compactor::new(
-            self.max_rows_per_block,
-            self.min_rows_per_block,
-            self.max_bytes_per_block,
-            is_recluster,
-        )
     }
 }

--- a/src/query/datablocks/src/block_compact_thresholds.rs
+++ b/src/query/datablocks/src/block_compact_thresholds.rs
@@ -32,13 +32,14 @@ impl BlockCompactThresholds {
         }
     }
 
+    #[inline]
     pub fn check_perfect_block(&self, row_count: usize, block_size: usize) -> bool {
-        if row_count <= self.max_rows_per_block
-            && (row_count >= self.min_rows_per_block || block_size >= self.max_bytes_per_block)
-        {
-            return true;
-        }
-        false
+        row_count <= self.max_rows_per_block && self.check_large_enough(row_count, block_size)
+    }
+
+    #[inline]
+    pub fn check_large_enough(&self, row_count: usize, block_size: usize) -> bool {
+        row_count >= self.min_rows_per_block || block_size >= self.max_bytes_per_block
     }
 
     pub fn check_for_recluster(&self, total_rows: usize, total_bytes: usize) -> bool {

--- a/src/query/datablocks/src/block_compact_thresholds.rs
+++ b/src/query/datablocks/src/block_compact_thresholds.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Debug)]
 pub struct BlockCompactThresholds {
     pub max_rows_per_block: usize,
     pub min_rows_per_block: usize,

--- a/src/query/datablocks/src/lib.rs
+++ b/src/query/datablocks/src/lib.rs
@@ -15,6 +15,7 @@
 #![feature(hash_raw_entry)]
 #![feature(trusted_len)]
 
+mod block_compact_thresholds;
 mod data_block;
 mod data_block_debug;
 mod kernels;
@@ -22,6 +23,7 @@ mod memory;
 mod meta_info;
 mod utils;
 
+pub use block_compact_thresholds::BlockCompactThresholds;
 pub use data_block::DataBlock;
 pub use data_block_debug::*;
 pub use kernels::*;

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/input_context.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/input_context.rs
@@ -21,6 +21,7 @@ use std::sync::Mutex;
 
 use common_base::base::tokio::sync::mpsc::Receiver;
 use common_base::base::Progress;
+use common_datablocks::BlockCompactThresholds;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -44,9 +45,6 @@ use crate::processors::sources::input_formats::input_format_text::InputFormatTex
 use crate::processors::sources::input_formats::input_pipeline::StreamingReadBatch;
 use crate::processors::sources::input_formats::input_split::SplitInfo;
 use crate::processors::sources::input_formats::InputFormat;
-
-const MIN_ROW_PER_BLOCK: usize = 800 * 1000;
-const DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD: usize = 100 * 1024 * 1024;
 
 #[derive(Debug)]
 pub enum InputPlan {
@@ -123,8 +121,7 @@ pub struct InputContext {
     pub format_settings: FormatSettings,
 
     pub read_batch_size: usize,
-    pub rows_per_block: usize,
-    pub block_memory_size_threshold: usize,
+    pub block_compact_thresholds: BlockCompactThresholds,
 
     pub scan_progress: Arc<Progress>,
 }
@@ -137,7 +134,7 @@ impl Debug for InputContext {
             .field("field_delimiter", &self.field_delimiter)
             .field("record_delimiter", &self.record_delimiter)
             .field("format_settings", &self.format_settings)
-            .field("rows_per_block", &self.rows_per_block)
+            .field("block_compact_thresholds", &self.block_compact_thresholds)
             .field("read_batch_size", &self.read_batch_size)
             .field("num_splits", &self.splits.len())
             .finish()
@@ -168,6 +165,7 @@ impl InputContext {
         stage_info: UserStageInfo,
         files: Vec<String>,
         scan_progress: Arc<Progress>,
+        block_compact_thresholds: BlockCompactThresholds,
     ) -> Result<Self> {
         if files.is_empty() {
             return Err(ErrorCode::BadArguments("no file to copy"));
@@ -184,7 +182,6 @@ impl InputContext {
         let splits = format
             .get_splits(&plan, &operator, &settings, &schema)
             .await?;
-        let rows_per_block = MIN_ROW_PER_BLOCK;
         let record_delimiter = {
             if file_format_options.stage.record_delimiter.is_empty() {
                 format.default_record_delimiter()
@@ -211,14 +208,13 @@ impl InputContext {
             settings,
             format_settings,
             record_delimiter,
-            rows_per_block,
             read_batch_size,
             rows_to_skip,
             field_delimiter,
             scan_progress,
             source: InputSource::Operator(operator),
             plan: InputPlan::CopyInto(plan),
-            block_memory_size_threshold: DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD,
+            block_compact_thresholds,
         })
     }
 
@@ -229,6 +225,7 @@ impl InputContext {
         schema: DataSchemaRef,
         scan_progress: Arc<Progress>,
         is_multi_part: bool,
+        block_compact_thresholds: BlockCompactThresholds,
     ) -> Result<Self> {
         let (format_name, rows_to_skip) = remove_clickhouse_format_suffix(format_name);
         let rows_to_skip = std::cmp::max(settings.get_format_skip_header()? as usize, rows_to_skip);
@@ -249,7 +246,6 @@ impl InputContext {
         let format = Self::get_input_format(&format_type)?;
         let format_settings = format_type.get_format_settings(&file_format_options, &settings)?;
         let read_batch_size = settings.get_input_read_buffer_size()? as usize;
-        let rows_per_block = MIN_ROW_PER_BLOCK;
         let field_delimiter = file_format_options.stage.field_delimiter;
         let field_delimiter = {
             if field_delimiter.is_empty() {
@@ -277,7 +273,6 @@ impl InputContext {
             settings,
             format_settings,
             record_delimiter,
-            rows_per_block,
             read_batch_size,
             field_delimiter,
             rows_to_skip,
@@ -285,7 +280,7 @@ impl InputContext {
             source: InputSource::Stream(Mutex::new(Some(stream_receiver))),
             plan: InputPlan::StreamingLoad(plan),
             splits: vec![],
-            block_memory_size_threshold: DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD,
+            block_compact_thresholds,
         })
     }
 

--- a/src/query/pipeline/transforms/src/processors/transforms/mod.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod transform;
 pub mod transform_block_compact;
+pub mod transform_block_compact_no_split;
 pub mod transform_compact;
 pub mod transform_limit;
 pub mod transform_multi_sort_merge;

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_block_compact.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_block_compact.rs
@@ -55,7 +55,7 @@ impl Compactor for BlockCompactor {
         self.aborting.store(true, Ordering::Release);
     }
 
-    fn compact_partial(&self, blocks: &mut Vec<DataBlock>) -> Result<Vec<DataBlock>> {
+    fn compact_partial(&mut self, blocks: &mut Vec<DataBlock>) -> Result<Vec<DataBlock>> {
         if blocks.is_empty() {
             return Ok(vec![]);
         }

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_block_compact.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_block_compact.rs
@@ -16,6 +16,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use common_datablocks::BlockCompactThresholds;
 use common_datablocks::DataBlock;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -24,9 +25,7 @@ use super::Compactor;
 use super::TransformCompact;
 
 pub struct BlockCompactor {
-    max_rows_per_block: usize,
-    min_rows_per_block: usize,
-    max_bytes_per_block: usize,
+    thresholds: BlockCompactThresholds,
     // A flag denoting whether it is a recluster operation.
     // Will be removed later.
     is_recluster: bool,
@@ -34,16 +33,9 @@ pub struct BlockCompactor {
 }
 
 impl BlockCompactor {
-    pub fn new(
-        max_rows_per_block: usize,
-        min_rows_per_block: usize,
-        max_bytes_per_block: usize,
-        is_recluster: bool,
-    ) -> Self {
+    pub fn new(thresholds: BlockCompactThresholds, is_recluster: bool) -> Self {
         BlockCompactor {
-            max_rows_per_block,
-            min_rows_per_block,
-            max_bytes_per_block,
+            thresholds,
             is_recluster,
             aborting: Arc::new(AtomicBool::new(false)),
         }
@@ -73,9 +65,9 @@ impl Compactor for BlockCompactor {
         let block = blocks[size - 1].clone();
 
         // perfect block
-        if block.num_rows() <= self.max_rows_per_block
-            && (block.num_rows() >= self.min_rows_per_block
-                || block.memory_size() >= self.max_bytes_per_block)
+        if self
+            .thresholds
+            .check_perfect_block(block.num_rows(), block.memory_size())
         {
             res.push(block);
             blocks.remove(size - 1);
@@ -86,16 +78,16 @@ impl Compactor for BlockCompactor {
             let merged = DataBlock::concat_blocks(blocks)?;
             blocks.clear();
 
-            if accumulated_rows >= self.max_rows_per_block {
+            if accumulated_rows >= self.thresholds.max_rows_per_block {
                 // Used for recluster opreation, will be removed later.
                 if self.is_recluster {
                     let mut offset = 0;
                     let mut remain_rows = accumulated_rows;
-                    while remain_rows >= self.max_rows_per_block {
-                        let cut = merged.slice(offset, self.max_rows_per_block);
+                    while remain_rows >= self.thresholds.max_rows_per_block {
+                        let cut = merged.slice(offset, self.thresholds.max_rows_per_block);
                         res.push(cut);
-                        offset += self.max_rows_per_block;
-                        remain_rows -= self.max_rows_per_block;
+                        offset += self.thresholds.max_rows_per_block;
+                        remain_rows -= self.thresholds.max_rows_per_block;
                     }
 
                     if remain_rows > 0 {
@@ -105,7 +97,7 @@ impl Compactor for BlockCompactor {
                     // we can't use slice here, it did not deallocate memory
                     res.push(merged);
                 }
-            } else if accumulated_bytes >= self.max_bytes_per_block {
+            } else if accumulated_bytes >= self.thresholds.max_bytes_per_block {
                 // too large for merged block, flush to results
                 res.push(merged);
             } else {
@@ -130,18 +122,18 @@ impl Compactor for BlockCompactor {
             }
 
             // Perfect block, no need to compact
-            if block.num_rows() <= self.max_rows_per_block
-                && (block.num_rows() >= self.min_rows_per_block
-                    || block.memory_size() >= self.max_bytes_per_block)
+            if self
+                .thresholds
+                .check_perfect_block(block.num_rows(), block.memory_size())
             {
                 res.push(block.clone());
             } else {
-                let block = if block.num_rows() > self.max_rows_per_block {
-                    let b = block.slice(0, self.max_rows_per_block);
+                let block = if block.num_rows() > self.thresholds.max_rows_per_block {
+                    let b = block.slice(0, self.thresholds.max_rows_per_block);
                     res.push(b);
                     block.slice(
-                        self.max_rows_per_block,
-                        block.num_rows() - self.max_rows_per_block,
+                        self.thresholds.max_rows_per_block,
+                        block.num_rows() - self.thresholds.max_rows_per_block,
                     )
                 } else {
                     block.clone()
@@ -150,7 +142,7 @@ impl Compactor for BlockCompactor {
                 accumulated_rows += block.num_rows();
                 temp_blocks.push(block);
 
-                while accumulated_rows >= self.max_rows_per_block {
+                while accumulated_rows >= self.thresholds.max_rows_per_block {
                     if self.aborting.load(Ordering::Relaxed) {
                         return Err(ErrorCode::AbortedQuery(
                             "Aborted query, because the server is shutting down or the query was killed.",
@@ -158,14 +150,14 @@ impl Compactor for BlockCompactor {
                     }
 
                     let block = DataBlock::concat_blocks(&temp_blocks)?;
-                    res.push(block.slice(0, self.max_rows_per_block));
-                    accumulated_rows -= self.max_rows_per_block;
+                    res.push(block.slice(0, self.thresholds.max_rows_per_block));
+                    accumulated_rows -= self.thresholds.max_rows_per_block;
 
                     temp_blocks.clear();
                     if accumulated_rows != 0 {
                         temp_blocks.push(block.slice(
-                            self.max_rows_per_block,
-                            block.num_rows() - self.max_rows_per_block,
+                            self.thresholds.max_rows_per_block,
+                            block.num_rows() - self.thresholds.max_rows_per_block,
                         ));
                     }
                 }

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_block_compact_no_split.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_block_compact_no_split.rs
@@ -1,0 +1,116 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use common_datablocks::BlockCompactThresholds;
+use common_datablocks::DataBlock;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use super::Compactor;
+use super::TransformCompact;
+
+pub struct BlockCompactorNoSplit {
+    thresholds: BlockCompactThresholds,
+    aborting: Arc<AtomicBool>,
+    // call block.memory_size() only once.
+    // we may no longer need it if we start using jsonb, otherwise it should be put in CompactorState
+    accumulated_rows: usize,
+    accumulated_bytes: usize,
+}
+
+impl BlockCompactorNoSplit {
+    pub fn new(thresholds: BlockCompactThresholds) -> Self {
+        BlockCompactorNoSplit {
+            thresholds,
+            accumulated_rows: 0,
+            accumulated_bytes: 0,
+            aborting: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl Compactor for BlockCompactorNoSplit {
+    fn name() -> &'static str {
+        "BlockCompactTransform"
+    }
+
+    fn use_partial_compact() -> bool {
+        true
+    }
+
+    fn interrupt(&self) {
+        self.aborting.store(true, Ordering::Release);
+    }
+
+    fn compact_partial(&mut self, blocks: &mut Vec<DataBlock>) -> Result<Vec<DataBlock>> {
+        if blocks.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let size = blocks.len();
+        let mut res = Vec::with_capacity(size);
+        let block = blocks[size - 1].clone();
+
+        let num_rows = block.num_rows();
+        let num_bytes = block.memory_size();
+
+        if self.thresholds.check_large_enough(num_rows, num_bytes) {
+            // pass through the new data block just arrived
+            res.push(block);
+            blocks.remove(size - 1);
+        } else {
+            let accumulated_rows_new = self.accumulated_rows + num_rows;
+            let accumulated_bytes_new = self.accumulated_bytes + num_rows;
+
+            if self
+                .thresholds
+                .check_large_enough(accumulated_rows_new, accumulated_bytes_new)
+            {
+                // avoid call concat_blocks for each new block
+                let merged = DataBlock::concat_blocks(blocks)?;
+                blocks.clear();
+                self.accumulated_rows = 0;
+                self.accumulated_bytes = 0;
+                res.push(merged);
+            } else {
+                self.accumulated_rows = accumulated_rows_new;
+                self.accumulated_bytes = accumulated_bytes_new;
+            }
+        }
+
+        Ok(res)
+    }
+
+    fn compact_final(&self, blocks: &[DataBlock]) -> Result<Vec<DataBlock>> {
+        let mut res = vec![];
+        if self.accumulated_rows != 0 {
+            if self.aborting.load(Ordering::Relaxed) {
+                return Err(ErrorCode::AbortedQuery(
+                    "Aborted query, because the server is shutting down or the query was killed.",
+                ));
+            }
+
+            let block = DataBlock::concat_blocks(blocks)?;
+            res.push(block);
+        }
+
+        Ok(res)
+    }
+}
+
+pub type TransformBlockCompact = TransformCompact<BlockCompactorNoSplit>;

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact.rs
@@ -44,7 +44,7 @@ pub trait Compactor {
     fn interrupt(&self) {}
 
     /// `compact_partial` is called when a new block is pushed and `use_partial_compact` is enabled
-    fn compact_partial(&self, _blocks: &mut Vec<DataBlock>) -> Result<Vec<DataBlock>> {
+    fn compact_partial(&mut self, _blocks: &mut Vec<DataBlock>) -> Result<Vec<DataBlock>> {
         Ok(vec![])
     }
 

--- a/src/query/service/src/interpreters/common/table.rs
+++ b/src/query/service/src/interpreters/common/table.rs
@@ -61,7 +61,7 @@ pub fn append2table(
         &mut build_res.main_pipeline,
     )?;
 
-    table.append_data(ctx.clone(), &mut build_res.main_pipeline, false)?;
+    table.append_data(ctx.clone(), &mut build_res.main_pipeline, false, false)?;
 
     if need_commit {
         build_res.main_pipeline.set_on_finished(move |may_error| {

--- a/src/query/service/src/interpreters/common/table.rs
+++ b/src/query/service/src/interpreters/common/table.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use common_base::base::GlobalIORuntime;
+use common_catalog::table::AppendMode;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_datavalues::DataSchemaRef;
@@ -61,7 +62,12 @@ pub fn append2table(
         &mut build_res.main_pipeline,
     )?;
 
-    table.append_data(ctx.clone(), &mut build_res.main_pipeline, false, false)?;
+    table.append_data(
+        ctx.clone(),
+        &mut build_res.main_pipeline,
+        AppendMode::Normal,
+        false,
+    )?;
 
     if need_commit {
         build_res.main_pipeline.set_on_finished(move |may_error| {

--- a/src/query/service/src/interpreters/common/table.rs
+++ b/src/query/service/src/interpreters/common/table.rs
@@ -54,6 +54,7 @@ pub fn append2table(
     build_res: &mut PipelineBuildResult,
     overwrite: bool,
     need_commit: bool,
+    append_mode: AppendMode,
 ) -> Result<()> {
     fill_missing_columns(
         ctx.clone(),
@@ -65,7 +66,7 @@ pub fn append2table(
     table.append_data(
         ctx.clone(),
         &mut build_res.main_pipeline,
-        AppendMode::Normal,
+        append_mode,
         false,
     )?;
 

--- a/src/query/service/src/interpreters/interpreter_copy_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_v2.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use common_base::base::GlobalIORuntime;
+use common_catalog::table::AppendMode;
 use common_datavalues::chrono::Utc;
 use common_datavalues::prelude::*;
 use common_exception::ErrorCode;
@@ -304,7 +305,12 @@ impl CopyInterpreterV2 {
             &mut build_res.main_pipeline,
         )?;
 
-        to_table.append_data(self.ctx.clone(), &mut build_res.main_pipeline, false, true)?;
+        to_table.append_data(
+            self.ctx.clone(),
+            &mut build_res.main_pipeline,
+            AppendMode::Copy,
+            false,
+        )?;
 
         let ctx = self.ctx.clone();
         let files = files.clone();

--- a/src/query/service/src/interpreters/interpreter_copy_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_v2.rs
@@ -413,6 +413,7 @@ impl CopyInterpreterV2 {
             &mut build_res,
             false,
             true,
+            AppendMode::Normal,
         )?;
         Ok(build_res)
     }

--- a/src/query/service/src/interpreters/interpreter_copy_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_v2.rs
@@ -294,14 +294,15 @@ impl CopyInterpreterV2 {
         tracing::debug!("copy_files_to_table from source: {:?}", read_source_plan);
 
         let from_table = self.ctx.build_table_from_source_plan(&read_source_plan)?;
+        let to_table = self.ctx.get_table(catalog_name, db_name, tbl_name).await?;
+        from_table.set_block_compact_thresholds(to_table.get_block_compact_thresholds());
+
         from_table.read_partitions(self.ctx.clone(), None).await?;
         from_table.read_data(
             self.ctx.clone(),
             &read_source_plan,
             &mut build_res.main_pipeline,
         )?;
-
-        let to_table = self.ctx.get_table(catalog_name, db_name, tbl_name).await?;
 
         to_table.append_data(self.ctx.clone(), &mut build_res.main_pipeline, false)?;
 

--- a/src/query/service/src/interpreters/interpreter_copy_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_v2.rs
@@ -304,7 +304,7 @@ impl CopyInterpreterV2 {
             &mut build_res.main_pipeline,
         )?;
 
-        to_table.append_data(self.ctx.clone(), &mut build_res.main_pipeline, false)?;
+        to_table.append_data(self.ctx.clone(), &mut build_res.main_pipeline, false, true)?;
 
         let ctx = self.ctx.clone();
         let files = files.clone();

--- a/src/query/service/src/interpreters/interpreter_insert_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_insert_v2.rs
@@ -21,6 +21,7 @@ use common_ast::parser::parse_comma_separated_exprs;
 use common_ast::parser::tokenize_sql;
 use common_ast::Backtrace;
 use common_base::base::GlobalIORuntime;
+use common_catalog::table::AppendMode;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::ErrorCode;
@@ -232,6 +233,11 @@ impl Interpreter for InsertInterpreterV2 {
             };
         }
 
+        let append_mode = match &self.plan.source {
+            InsertInputSource::StreamingWithFormat(_, _, _) => AppendMode::Copy,
+            _ => AppendMode::Normal,
+        };
+
         append2table(
             self.ctx.clone(),
             table.clone(),
@@ -239,6 +245,7 @@ impl Interpreter for InsertInterpreterV2 {
             &mut build_res,
             self.plan.overwrite,
             true,
+            append_mode,
         )?;
 
         Ok(build_res)

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -659,7 +659,7 @@ impl PipelineBuilder {
                 )?;
             }
         }
-        table.append_data(self.ctx.clone(), &mut self.main_pipeline, true)?;
+        table.append_data(self.ctx.clone(), &mut self.main_pipeline, true, false)?;
 
         Ok(())
     }

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use async_channel::Receiver;
+use common_catalog::table::AppendMode;
 use common_datablocks::DataBlock;
 use common_datablocks::SortColumnDescription;
 use common_datavalues::DataField;
@@ -659,7 +660,12 @@ impl PipelineBuilder {
                 )?;
             }
         }
-        table.append_data(self.ctx.clone(), &mut self.main_pipeline, true, false)?;
+        table.append_data(
+            self.ctx.clone(),
+            &mut self.main_pipeline,
+            AppendMode::Normal,
+            true,
+        )?;
 
         Ok(())
     }

--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -264,6 +264,11 @@ pub async fn clickhouse_handler_post(
             &mut insert.source
         {
             let (tx, rx) = tokio::sync::mpsc::channel(2);
+            let to_table = ctx
+                .get_table(&insert.catalog, &insert.database, &insert.table)
+                .await
+                .map_err(InternalServerError)?;
+
             let input_context = Arc::new(
                 InputContext::try_create_from_insert(
                     format.as_str(),
@@ -272,6 +277,7 @@ pub async fn clickhouse_handler_post(
                     schema,
                     ctx.get_scan_progress(),
                     false,
+                    to_table.get_block_compact_thresholds(),
                 )
                 .await
                 .map_err(InternalServerError)?,

--- a/src/query/service/src/servers/http/v1/load.rs
+++ b/src/query/service/src/servers/http/v1/load.rs
@@ -128,6 +128,10 @@ pub async fn streaming_load(
                         StatusCode::BAD_REQUEST,
                     ));
                 };
+                let to_table = context
+                    .get_table(&insert.catalog, &insert.database, &insert.table)
+                    .await
+                    .map_err(InternalServerError)?;
                 let (tx, rx) = tokio::sync::mpsc::channel(2);
                 let input_context = Arc::new(
                     InputContext::try_create_from_insert(
@@ -137,6 +141,7 @@ pub async fn streaming_load(
                         schema,
                         context.get_scan_progress(),
                         true,
+                        to_table.get_block_compact_thresholds(),
                     )
                     .await
                     .map_err(InternalServerError)?,

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -32,7 +32,7 @@ use common_storages_table_meta::meta::Statistics;
 use common_storages_table_meta::meta::TableSnapshot;
 use common_storages_table_meta::meta::Versioned;
 use databend_query::sessions::TableContext;
-use databend_query::storages::fuse::io::BlockCompactor;
+use databend_query::storages::fuse::io::BlockCompactThresholds;
 use databend_query::storages::fuse::io::SegmentWriter;
 use databend_query::storages::fuse::io::TableMetaLocationGenerator;
 use databend_query::storages::fuse::operations::ReclusterMutator;
@@ -131,7 +131,7 @@ async fn test_recluster_mutator_block_select() -> Result<()> {
         location_generator,
         base_snapshot,
         1.0,
-        BlockCompactor::default(),
+        BlockCompactThresholds::default(),
         blocks_map,
         data_accessor,
     )?;

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use common_base::base::tokio;
 use common_catalog::table_mutator::TableMutator;
+use common_datablocks::BlockCompactThresholds;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
@@ -32,7 +33,6 @@ use common_storages_table_meta::meta::Statistics;
 use common_storages_table_meta::meta::TableSnapshot;
 use common_storages_table_meta::meta::Versioned;
 use databend_query::sessions::TableContext;
-use databend_query::storages::fuse::io::BlockCompactThresholds;
 use databend_query::storages::fuse::io::SegmentWriter;
 use databend_query::storages::fuse::io::TableMetaLocationGenerator;
 use databend_query::storages::fuse::operations::ReclusterMutator;

--- a/src/query/service/tests/it/storages/fuse/operations/navigate.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/navigate.rs
@@ -17,6 +17,7 @@ use std::ops::Sub;
 use std::time::Duration;
 
 use common_base::base::tokio;
+use common_catalog::table::AppendMode;
 use common_datablocks::DataBlock;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -155,7 +156,12 @@ async fn test_fuse_historical_table_is_read_only() -> Result<()> {
     let tbl = fuse_table.navigate_to_time_point(instant).await?;
 
     // check append2
-    let res = tbl.append_data(ctx.clone(), &mut Pipeline::create(), false, false);
+    let res = tbl.append_data(
+        ctx.clone(),
+        &mut Pipeline::create(),
+        AppendMode::Normal,
+        false,
+    );
     assert_not_writable(res, "append2");
 
     // check append_data

--- a/src/query/service/tests/it/storages/fuse/operations/navigate.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/navigate.rs
@@ -155,7 +155,7 @@ async fn test_fuse_historical_table_is_read_only() -> Result<()> {
     let tbl = fuse_table.navigate_to_time_point(instant).await?;
 
     // check append2
-    let res = tbl.append_data(ctx.clone(), &mut Pipeline::create(), false);
+    let res = tbl.append_data(ctx.clone(), &mut Pipeline::create(), false, false);
     assert_not_writable(res, "append2");
 
     // check append_data

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -31,7 +31,7 @@ use common_storages_table_meta::meta::BlockMeta;
 use common_storages_table_meta::meta::ClusterStatistics;
 use common_storages_table_meta::meta::ColumnStatistics;
 use common_storages_table_meta::meta::Statistics;
-use databend_query::storages::fuse::io::BlockCompactor;
+use databend_query::storages::fuse::io::BlockCompactThresholds;
 use databend_query::storages::fuse::io::BlockWriter;
 use databend_query::storages::fuse::io::TableMetaLocationGenerator;
 use databend_query::storages::fuse::statistics::gen_columns_statistics;
@@ -179,7 +179,7 @@ fn test_ft_stats_cluster_stats() -> common_exception::Result<()> {
         Series::from_data(vec!["123456", "234567", "345678"]),
     ]);
 
-    let block_compactor = BlockCompactor::new(1_000_000, 800_000, 100 * 1024 * 1024);
+    let block_compactor = BlockCompactThresholds::new(1_000_000, 800_000, 100 * 1024 * 1024);
     let stats_gen = ClusterStatsGenerator::new(0, vec![0], vec![], 0, block_compactor.clone());
     let (stats, _) = stats_gen.gen_stats_for_append(&blocks)?;
     assert!(stats.is_some());
@@ -208,7 +208,7 @@ async fn test_ft_cluster_stats_with_stats() -> common_exception::Result<()> {
         level: 0,
     });
 
-    let block_compactor = BlockCompactor::new(1_000_000, 800_000, 100 * 1024 * 1024);
+    let block_compactor = BlockCompactThresholds::new(1_000_000, 800_000, 100 * 1024 * 1024);
     let stats_gen = ClusterStatsGenerator::new(0, vec![0], vec![], 0, block_compactor.clone());
     let stats = stats_gen.gen_with_origin_stats(&blocks, origin.clone())?;
     assert!(stats.is_some());

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use common_base::base::tokio;
+use common_datablocks::BlockCompactThresholds;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_functions::aggregates::eval_aggr;
@@ -31,7 +32,6 @@ use common_storages_table_meta::meta::BlockMeta;
 use common_storages_table_meta::meta::ClusterStatistics;
 use common_storages_table_meta::meta::ColumnStatistics;
 use common_storages_table_meta::meta::Statistics;
-use databend_query::storages::fuse::io::BlockCompactThresholds;
 use databend_query::storages::fuse::io::BlockWriter;
 use databend_query::storages::fuse::io::TableMetaLocationGenerator;
 use databend_query::storages::fuse::statistics::gen_columns_statistics;
@@ -180,7 +180,7 @@ fn test_ft_stats_cluster_stats() -> common_exception::Result<()> {
     ]);
 
     let block_compactor = BlockCompactThresholds::new(1_000_000, 800_000, 100 * 1024 * 1024);
-    let stats_gen = ClusterStatsGenerator::new(0, vec![0], vec![], 0, block_compactor.clone());
+    let stats_gen = ClusterStatsGenerator::new(0, vec![0], vec![], 0, block_compactor);
     let (stats, _) = stats_gen.gen_stats_for_append(&blocks)?;
     assert!(stats.is_some());
     let stats = stats.unwrap();
@@ -209,7 +209,7 @@ async fn test_ft_cluster_stats_with_stats() -> common_exception::Result<()> {
     });
 
     let block_compactor = BlockCompactThresholds::new(1_000_000, 800_000, 100 * 1024 * 1024);
-    let stats_gen = ClusterStatsGenerator::new(0, vec![0], vec![], 0, block_compactor.clone());
+    let stats_gen = ClusterStatsGenerator::new(0, vec![0], vec![], 0, block_compactor);
     let stats = stats_gen.gen_with_origin_stats(&blocks, origin.clone())?;
     assert!(stats.is_some());
     let stats = stats.unwrap();
@@ -225,7 +225,7 @@ async fn test_ft_cluster_stats_with_stats() -> common_exception::Result<()> {
         DataSchemaRefExt::create(vec![DataField::new("(a + 1)", i64::to_data_type())]);
     let blocks = DataBlock::create(output_schema, vec![result.vector]);
 
-    let stats_gen = ClusterStatsGenerator::new(0, vec![0], vec![], 0, block_compactor.clone());
+    let stats_gen = ClusterStatsGenerator::new(0, vec![0], vec![], 0, block_compactor);
     let stats = stats_gen.gen_with_origin_stats(&blocks, origin.clone())?;
     assert!(stats.is_some());
     let stats = stats.unwrap();

--- a/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
+++ b/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use common_ast::ast::Engine;
 use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::table::AppendMode;
 use common_datablocks::assert_blocks_sorted_eq_with_name;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
@@ -296,6 +297,7 @@ impl TestFixture {
             &mut build_res,
             overwrite,
             commit,
+            AppendMode::Normal,
         )?;
 
         execute_pipeline(self.ctx.clone(), build_res)

--- a/src/query/storages/fuse/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/fuse/src/fuse_table.rs
@@ -50,7 +50,7 @@ use common_storages_table_meta::meta::Versioned;
 use opendal::Operator;
 use uuid::Uuid;
 
-use crate::io::BlockCompactor;
+use crate::io::BlockCompactThresholds;
 use crate::io::MetaReaders;
 use crate::io::TableMetaLocationGenerator;
 use crate::operations::AppendOperationLogEntry;
@@ -213,14 +213,14 @@ impl FuseTable {
         self.table_info.meta.options.contains_key("TRANSIENT")
     }
 
-    pub(crate) fn get_block_compactor(&self) -> BlockCompactor {
+    pub(crate) fn get_block_compactor(&self) -> BlockCompactThresholds {
         let max_rows_per_block = self.get_option(FUSE_OPT_KEY_ROW_PER_BLOCK, DEFAULT_ROW_PER_BLOCK);
         let min_rows_per_block = (max_rows_per_block as f64 * 0.8) as usize;
         let max_bytes_per_block = self.get_option(
             FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD,
             DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD,
         );
-        BlockCompactor::new(max_rows_per_block, min_rows_per_block, max_bytes_per_block)
+        BlockCompactThresholds::new(max_rows_per_block, min_rows_per_block, max_bytes_per_block)
     }
 }
 

--- a/src/query/storages/fuse/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/fuse/src/fuse_table.rs
@@ -212,16 +212,6 @@ impl FuseTable {
     pub fn transient(&self) -> bool {
         self.table_info.meta.options.contains_key("TRANSIENT")
     }
-
-    pub(crate) fn get_block_compact_thresholds(&self) -> BlockCompactThresholds {
-        let max_rows_per_block = self.get_option(FUSE_OPT_KEY_ROW_PER_BLOCK, DEFAULT_ROW_PER_BLOCK);
-        let min_rows_per_block = (max_rows_per_block as f64 * 0.8) as usize;
-        let max_bytes_per_block = self.get_option(
-            FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD,
-            DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD,
-        );
-        BlockCompactThresholds::new(max_rows_per_block, min_rows_per_block, max_bytes_per_block)
-    }
 }
 
 #[async_trait::async_trait]
@@ -465,6 +455,16 @@ impl Table for FuseTable {
         push_downs: Option<Extras>,
     ) -> Result<Option<Box<dyn TableMutator>>> {
         self.do_recluster(ctx, pipeline, push_downs).await
+    }
+
+    fn get_block_compact_thresholds(&self) -> BlockCompactThresholds {
+        let max_rows_per_block = self.get_option(FUSE_OPT_KEY_ROW_PER_BLOCK, DEFAULT_ROW_PER_BLOCK);
+        let min_rows_per_block = (max_rows_per_block as f64 * 0.8) as usize;
+        let max_bytes_per_block = self.get_option(
+            FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD,
+            DEFAULT_BLOCK_SIZE_IN_MEM_SIZE_THRESHOLD,
+        );
+        BlockCompactThresholds::new(max_rows_per_block, min_rows_per_block, max_bytes_per_block)
     }
 }
 

--- a/src/query/storages/fuse/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/fuse/src/fuse_table.rs
@@ -25,6 +25,7 @@ use common_catalog::table::ColumnStatisticsProvider;
 use common_catalog::table::CompactTarget;
 use common_catalog::table_context::TableContext;
 use common_catalog::table_mutator::TableMutator;
+use common_datablocks::BlockCompactThresholds;
 use common_datablocks::DataBlock;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -50,7 +51,6 @@ use common_storages_table_meta::meta::Versioned;
 use opendal::Operator;
 use uuid::Uuid;
 
-use crate::io::BlockCompactThresholds;
 use crate::io::MetaReaders;
 use crate::io::TableMetaLocationGenerator;
 use crate::operations::AppendOperationLogEntry;

--- a/src/query/storages/fuse/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/fuse/src/fuse_table.rs
@@ -19,6 +19,7 @@ use std::str;
 use std::sync::Arc;
 
 use common_catalog::catalog::StorageDescription;
+use common_catalog::table::AppendMode;
 use common_catalog::table::ColumnId;
 use common_catalog::table::ColumnStatistics;
 use common_catalog::table::ColumnStatisticsProvider;
@@ -364,11 +365,11 @@ impl Table for FuseTable {
         &self,
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
+        append_mode: AppendMode,
         need_output: bool,
-        is_ingest: bool,
     ) -> Result<()> {
         self.check_mutable()?;
-        self.do_append_data(ctx, pipeline, need_output, is_ingest)
+        self.do_append_data(ctx, pipeline, append_mode, need_output)
     }
 
     #[tracing::instrument(level = "debug", name = "fuse_table_commit_insertion", skip(self, ctx, operations), fields(ctx.id = ctx.get_id().as_str()))]

--- a/src/query/storages/fuse/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/fuse/src/fuse_table.rs
@@ -213,7 +213,7 @@ impl FuseTable {
         self.table_info.meta.options.contains_key("TRANSIENT")
     }
 
-    pub(crate) fn get_block_compactor(&self) -> BlockCompactThresholds {
+    pub(crate) fn get_block_compact_thresholds(&self) -> BlockCompactThresholds {
         let max_rows_per_block = self.get_option(FUSE_OPT_KEY_ROW_PER_BLOCK, DEFAULT_ROW_PER_BLOCK);
         let min_rows_per_block = (max_rows_per_block as f64 * 0.8) as usize;
         let max_bytes_per_block = self.get_option(

--- a/src/query/storages/fuse/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/fuse/src/fuse_table.rs
@@ -365,9 +365,10 @@ impl Table for FuseTable {
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
         need_output: bool,
+        is_ingest: bool,
     ) -> Result<()> {
         self.check_mutable()?;
-        self.do_append_data(ctx, pipeline, need_output)
+        self.do_append_data(ctx, pipeline, need_output, is_ingest)
     }
 
     #[tracing::instrument(level = "debug", name = "fuse_table_commit_insertion", skip(self, ctx, operations), fields(ctx.id = ctx.get_id().as_str()))]

--- a/src/query/storages/fuse/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/fuse/src/io/mod.rs
@@ -33,6 +33,5 @@ pub use snapshots::SnapshotsIO;
 pub use write::write_block;
 pub use write::write_data;
 pub use write::write_meta;
-pub use write::BlockCompactThresholds;
 pub use write::BlockWriter;
 pub use write::SegmentWriter;

--- a/src/query/storages/fuse/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/fuse/src/io/mod.rs
@@ -33,6 +33,6 @@ pub use snapshots::SnapshotsIO;
 pub use write::write_block;
 pub use write::write_data;
 pub use write::write_meta;
-pub use write::BlockCompactor;
+pub use write::BlockCompactThresholds;
 pub use write::BlockWriter;
 pub use write::SegmentWriter;

--- a/src/query/storages/fuse/fuse/src/io/write/block_compactor.rs
+++ b/src/query/storages/fuse/fuse/src/io/write/block_compactor.rs
@@ -15,19 +15,19 @@
 use common_pipeline_transforms::processors::transforms::BlockCompactor as Compactor;
 
 #[derive(Clone, Default)]
-pub struct BlockCompactor {
+pub struct BlockCompactThresholds {
     max_rows_per_block: usize,
     min_rows_per_block: usize,
     max_bytes_per_block: usize,
 }
 
-impl BlockCompactor {
+impl BlockCompactThresholds {
     pub fn new(
         max_rows_per_block: usize,
         min_rows_per_block: usize,
         max_bytes_per_block: usize,
     ) -> Self {
-        BlockCompactor {
+        BlockCompactThresholds {
             max_rows_per_block,
             min_rows_per_block,
             max_bytes_per_block,

--- a/src/query/storages/fuse/fuse/src/io/write/mod.rs
+++ b/src/query/storages/fuse/fuse/src/io/write/mod.rs
@@ -17,7 +17,7 @@ mod block_writer;
 mod meta_writer;
 mod segment_writer;
 
-pub use block_compactor::BlockCompactor;
+pub use block_compactor::BlockCompactThresholds;
 pub use block_writer::write_block;
 pub use block_writer::write_data;
 pub use block_writer::BlockWriter;

--- a/src/query/storages/fuse/fuse/src/io/write/mod.rs
+++ b/src/query/storages/fuse/fuse/src/io/write/mod.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod block_compactor;
 mod block_writer;
 mod meta_writer;
 mod segment_writer;
 
-pub use block_compactor::BlockCompactThresholds;
 pub use block_writer::write_block;
 pub use block_writer::write_data;
 pub use block_writer::BlockWriter;

--- a/src/query/storages/fuse/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/fuse/src/operations/append.rs
@@ -27,7 +27,7 @@ use common_sql::evaluator::ChunkOperator;
 use common_sql::evaluator::CompoundChunkOperator;
 use common_sql::evaluator::Evaluator;
 
-use crate::io::BlockCompactor;
+use crate::io::BlockCompactThresholds;
 use crate::operations::FuseTableSink;
 use crate::statistics::ClusterStatsGenerator;
 use crate::FuseTable;
@@ -112,7 +112,7 @@ impl FuseTable {
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
         level: i32,
-        block_compactor: BlockCompactor,
+        block_compactor: BlockCompactThresholds,
     ) -> Result<ClusterStatsGenerator> {
         let cluster_keys = self.cluster_keys();
         if cluster_keys.is_empty() {

--- a/src/query/storages/fuse/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/fuse/src/operations/append.rs
@@ -44,7 +44,7 @@ impl FuseTable {
         let block_per_seg =
             self.get_option(FUSE_OPT_KEY_BLOCK_PER_SEGMENT, DEFAULT_BLOCK_PER_SEGMENT);
 
-        let block_compactor = self.get_block_compactor();
+        let block_compactor = self.get_block_compact_thresholds();
         pipeline.add_transform(|transform_input_port, transform_output_port| {
             TransformCompact::try_create(
                 transform_input_port,

--- a/src/query/storages/fuse/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/fuse/src/operations/compact.rs
@@ -101,13 +101,13 @@ impl FuseTable {
         pipeline: &mut Pipeline,
         options: CompactOptions,
     ) -> Result<Option<Box<dyn TableMutator>>> {
-        let block_compactor = self.get_block_compactor();
+        let block_compact_thresholds = self.get_block_compact_thresholds();
 
         let block_per_seg = options.block_per_seg;
         let mut mutator = FullCompactMutator::try_create(
             ctx.clone(),
             options,
-            block_compactor.clone(),
+            block_compact_thresholds.clone(),
             self.meta_location_generator().clone(),
             self.cluster_key_meta.is_some(),
             self.operator.clone(),
@@ -148,7 +148,7 @@ impl FuseTable {
             TransformCompact::try_create(
                 transform_input_port,
                 transform_output_port,
-                block_compactor.to_compactor(false),
+                block_compact_thresholds.to_compactor(false),
             )
         })?;
 

--- a/src/query/storages/fuse/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/fuse/src/operations/compact.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_catalog::table::CompactTarget;
 use common_exception::Result;
 use common_pipeline_core::Pipeline;
+use common_pipeline_transforms::processors::transforms::BlockCompactor;
 use common_pipeline_transforms::processors::transforms::TransformCompact;
 use common_planner::ReadDataSourcePlan;
 use common_planner::SourceInfo;
@@ -148,7 +149,7 @@ impl FuseTable {
             TransformCompact::try_create(
                 transform_input_port,
                 transform_output_port,
-                block_compact_thresholds.to_compactor(false),
+                BlockCompactor::new(block_compact_thresholds, false),
             )
         })?;
 

--- a/src/query/storages/fuse/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/fuse/src/operations/compact.rs
@@ -108,7 +108,7 @@ impl FuseTable {
         let mut mutator = FullCompactMutator::try_create(
             ctx.clone(),
             options,
-            block_compact_thresholds.clone(),
+            block_compact_thresholds,
             self.meta_location_generator().clone(),
             self.cluster_key_meta.is_some(),
             self.operator.clone(),

--- a/src/query/storages/fuse/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/fuse/src/operations/delete.rs
@@ -182,7 +182,7 @@ impl FuseTable {
             cluster_key_index,
             extra_key_index,
             0,
-            self.get_block_compactor(),
+            self.get_block_compact_thresholds(),
         ))
     }
 }

--- a/src/query/storages/fuse/fuse/src/operations/mutation/compact_mutator/full_compact_mutator.rs
+++ b/src/query/storages/fuse/fuse/src/operations/mutation/compact_mutator/full_compact_mutator.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_datablocks::BlockCompactThresholds;
 use common_exception::Result;
 use common_storages_table_meta::caches::CacheManager;
 use common_storages_table_meta::meta::BlockMeta;
@@ -23,7 +24,6 @@ use common_storages_table_meta::meta::Statistics;
 use common_storages_table_meta::meta::Versioned;
 use opendal::Operator;
 
-use crate::io::BlockCompactThresholds;
 use crate::io::SegmentWriter;
 use crate::io::SegmentsIO;
 use crate::io::TableMetaLocationGenerator;

--- a/src/query/storages/fuse/fuse/src/operations/mutation/compact_mutator/full_compact_mutator.rs
+++ b/src/query/storages/fuse/fuse/src/operations/mutation/compact_mutator/full_compact_mutator.rs
@@ -23,7 +23,7 @@ use common_storages_table_meta::meta::Statistics;
 use common_storages_table_meta::meta::Versioned;
 use opendal::Operator;
 
-use crate::io::BlockCompactor;
+use crate::io::BlockCompactThresholds;
 use crate::io::SegmentWriter;
 use crate::io::SegmentsIO;
 use crate::io::TableMetaLocationGenerator;
@@ -43,7 +43,7 @@ pub struct FullCompactMutator {
     ctx: Arc<dyn TableContext>,
     compact_params: CompactOptions,
     data_accessor: Operator,
-    block_compactor: BlockCompactor,
+    block_compactor: BlockCompactThresholds,
     location_generator: TableMetaLocationGenerator,
     selected_blocks: Vec<Arc<BlockMeta>>,
     // summarised statistics of all the accumulated segments(segment compacted, and unchanged)
@@ -60,7 +60,7 @@ impl FullCompactMutator {
     pub fn try_create(
         ctx: Arc<dyn TableContext>,
         compact_params: CompactOptions,
-        block_compactor: BlockCompactor,
+        block_compactor: BlockCompactThresholds,
         location_generator: TableMetaLocationGenerator,
         is_cluster: bool,
         operator: Operator,

--- a/src/query/storages/fuse/fuse/src/operations/mutation/recluster_mutator.rs
+++ b/src/query/storages/fuse/fuse/src/operations/mutation/recluster_mutator.rs
@@ -26,7 +26,7 @@ use common_storages_table_meta::meta::TableSnapshot;
 use common_storages_table_meta::meta::Versioned;
 use opendal::Operator;
 
-use crate::io::BlockCompactor;
+use crate::io::BlockCompactThresholds;
 use crate::io::TableMetaLocationGenerator;
 use crate::operations::mutation::BaseMutator;
 use crate::operations::AppendOperationLogEntry;
@@ -44,7 +44,7 @@ pub struct ReclusterMutator {
     blocks_map: BTreeMap<i32, Vec<(usize, Arc<BlockMeta>)>>,
     selected_blocks: Vec<Arc<BlockMeta>>,
     level: i32,
-    block_compactor: BlockCompactor,
+    block_compactor: BlockCompactThresholds,
     threshold: f64,
 }
 
@@ -54,7 +54,7 @@ impl ReclusterMutator {
         location_generator: TableMetaLocationGenerator,
         base_snapshot: Arc<TableSnapshot>,
         threshold: f64,
-        block_compactor: BlockCompactor,
+        block_compactor: BlockCompactThresholds,
         blocks_map: BTreeMap<i32, Vec<(usize, Arc<BlockMeta>)>>,
         data_accessor: Operator,
     ) -> Result<Self> {

--- a/src/query/storages/fuse/fuse/src/operations/mutation/recluster_mutator.rs
+++ b/src/query/storages/fuse/fuse/src/operations/mutation/recluster_mutator.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use common_datablocks::BlockCompactThresholds;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_storages_table_meta::meta::BlockMeta;
@@ -26,7 +27,6 @@ use common_storages_table_meta::meta::TableSnapshot;
 use common_storages_table_meta::meta::Versioned;
 use opendal::Operator;
 
-use crate::io::BlockCompactThresholds;
 use crate::io::TableMetaLocationGenerator;
 use crate::operations::mutation::BaseMutator;
 use crate::operations::AppendOperationLogEntry;

--- a/src/query/storages/fuse/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/fuse/src/operations/recluster.rs
@@ -20,6 +20,7 @@ use common_catalog::table_context::TableContext;
 use common_datablocks::SortColumnDescription;
 use common_exception::Result;
 use common_pipeline_core::Pipeline;
+use common_pipeline_transforms::processors::transforms::BlockCompactor;
 use common_pipeline_transforms::processors::transforms::SortMergeCompactor;
 use common_pipeline_transforms::processors::transforms::TransformCompact;
 use common_pipeline_transforms::processors::transforms::TransformSortMerge;
@@ -82,7 +83,7 @@ impl FuseTable {
             }
         });
 
-        let block_compactor = self.get_block_compact_thresholds();
+        let block_compact_thresholds = self.get_block_compact_thresholds();
         let avg_depth_threshold = self.get_option(
             FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD,
             DEFAULT_AVG_DEPTH_THRESHOLD,
@@ -100,7 +101,7 @@ impl FuseTable {
             self.meta_location_generator.clone(),
             snapshot,
             threshold,
-            block_compactor.clone(),
+            block_compact_thresholds.clone(),
             blocks_map,
             self.operator.clone(),
         )?;
@@ -141,7 +142,7 @@ impl FuseTable {
             ctx.clone(),
             pipeline,
             mutator.level() + 1,
-            block_compactor.clone(),
+            block_compact_thresholds.clone(),
         )?;
 
         // sort
@@ -184,7 +185,7 @@ impl FuseTable {
             TransformCompact::try_create(
                 transform_input_port,
                 transform_output_port,
-                block_compactor.to_compactor(true),
+                BlockCompactor::new(block_compact_thresholds, true),
             )
         })?;
 

--- a/src/query/storages/fuse/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/fuse/src/operations/recluster.rs
@@ -101,7 +101,7 @@ impl FuseTable {
             self.meta_location_generator.clone(),
             snapshot,
             threshold,
-            block_compact_thresholds.clone(),
+            block_compact_thresholds,
             blocks_map,
             self.operator.clone(),
         )?;
@@ -142,7 +142,7 @@ impl FuseTable {
             ctx.clone(),
             pipeline,
             mutator.level() + 1,
-            block_compact_thresholds.clone(),
+            block_compact_thresholds,
         )?;
 
         // sort

--- a/src/query/storages/fuse/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/fuse/src/operations/recluster.rs
@@ -82,7 +82,7 @@ impl FuseTable {
             }
         });
 
-        let block_compactor = self.get_block_compactor();
+        let block_compactor = self.get_block_compact_thresholds();
         let avg_depth_threshold = self.get_option(
             FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD,
             DEFAULT_AVG_DEPTH_THRESHOLD,

--- a/src/query/storages/fuse/fuse/src/statistics/cluster_statistics.rs
+++ b/src/query/storages/fuse/fuse/src/statistics/cluster_statistics.rs
@@ -12,12 +12,11 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use common_datablocks::BlockCompactThresholds;
 use common_datablocks::DataBlock;
 use common_datavalues::DataValue;
 use common_exception::Result;
 use common_storages_table_meta::meta::ClusterStatistics;
-
-use crate::io::BlockCompactThresholds;
 
 #[derive(Clone, Default)]
 pub struct ClusterStatsGenerator {
@@ -25,7 +24,7 @@ pub struct ClusterStatsGenerator {
     cluster_key_index: Vec<usize>,
     extra_key_index: Vec<usize>,
     level: i32,
-    block_compactor: BlockCompactThresholds,
+    block_compact_thresholds: BlockCompactThresholds,
 }
 
 impl ClusterStatsGenerator {
@@ -34,14 +33,14 @@ impl ClusterStatsGenerator {
         cluster_key_index: Vec<usize>,
         extra_key_index: Vec<usize>,
         level: i32,
-        block_compactor: BlockCompactThresholds,
+        block_compact_thresholds: BlockCompactThresholds,
     ) -> Self {
         Self {
             cluster_key_id,
             cluster_key_index,
             extra_key_index,
             level,
-            block_compactor,
+            block_compact_thresholds: block_compact_thresholds,
         }
     }
 
@@ -126,7 +125,7 @@ impl ClusterStatsGenerator {
 
         let level = if min == max
             && self
-                .block_compactor
+                .block_compact_thresholds
                 .check_perfect_block(data_block.num_rows(), data_block.memory_size())
         {
             -1

--- a/src/query/storages/fuse/fuse/src/statistics/cluster_statistics.rs
+++ b/src/query/storages/fuse/fuse/src/statistics/cluster_statistics.rs
@@ -40,7 +40,7 @@ impl ClusterStatsGenerator {
             cluster_key_index,
             extra_key_index,
             level,
-            block_compact_thresholds: block_compact_thresholds,
+            block_compact_thresholds,
         }
     }
 

--- a/src/query/storages/fuse/fuse/src/statistics/cluster_statistics.rs
+++ b/src/query/storages/fuse/fuse/src/statistics/cluster_statistics.rs
@@ -17,7 +17,7 @@ use common_datavalues::DataValue;
 use common_exception::Result;
 use common_storages_table_meta::meta::ClusterStatistics;
 
-use crate::io::BlockCompactor;
+use crate::io::BlockCompactThresholds;
 
 #[derive(Clone, Default)]
 pub struct ClusterStatsGenerator {
@@ -25,7 +25,7 @@ pub struct ClusterStatsGenerator {
     cluster_key_index: Vec<usize>,
     extra_key_index: Vec<usize>,
     level: i32,
-    block_compactor: BlockCompactor,
+    block_compactor: BlockCompactThresholds,
 }
 
 impl ClusterStatsGenerator {
@@ -34,7 +34,7 @@ impl ClusterStatsGenerator {
         cluster_key_index: Vec<usize>,
         extra_key_index: Vec<usize>,
         level: i32,
-        block_compactor: BlockCompactor,
+        block_compactor: BlockCompactThresholds,
     ) -> Self {
         Self {
             cluster_key_id,

--- a/src/query/storages/memory/src/memory_table.rs
+++ b/src/query/storages/memory/src/memory_table.rs
@@ -18,6 +18,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use common_catalog::catalog::StorageDescription;
+use common_catalog::table::AppendMode;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_datablocks::DataBlock;
@@ -226,7 +227,7 @@ impl Table for MemoryTable {
         &self,
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
-        _: bool,
+        _: AppendMode,
         _: bool,
     ) -> Result<()> {
         pipeline.add_sink(|input| Ok(ContextSink::create(input, ctx.clone())))

--- a/src/query/storages/memory/src/memory_table.rs
+++ b/src/query/storages/memory/src/memory_table.rs
@@ -227,6 +227,7 @@ impl Table for MemoryTable {
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
         _: bool,
+        _: bool,
     ) -> Result<()> {
         pipeline.add_sink(|input| Ok(ContextSink::create(input, ctx.clone())))
     }

--- a/src/query/storages/null/src/null_table.rs
+++ b/src/query/storages/null/src/null_table.rs
@@ -92,6 +92,7 @@ impl Table for NullTable {
         _: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
         _: bool,
+        _: bool,
     ) -> Result<()> {
         pipeline.add_sink(|input| Ok(EmptySink::create(input)))?;
         Ok(())

--- a/src/query/storages/null/src/null_table.rs
+++ b/src/query/storages/null/src/null_table.rs
@@ -16,6 +16,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use common_catalog::catalog::StorageDescription;
+use common_catalog::table::AppendMode;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_datablocks::DataBlock;
@@ -91,7 +92,7 @@ impl Table for NullTable {
         &self,
         _: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
-        _: bool,
+        _: AppendMode,
         _: bool,
     ) -> Result<()> {
         pipeline.add_sink(|input| Ok(EmptySink::create(input)))?;

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -103,6 +103,7 @@ impl Table for StageTable {
                 self.table_info.stage_info.clone(),
                 self.table_info.files.clone(),
                 ctx.get_scan_progress(),
+                self.get_block_compact_thresholds(),
             )
             .await?,
         );

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -142,6 +142,7 @@ impl Table for StageTable {
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
         _: bool,
+        _: bool,
     ) -> Result<()> {
         let single = self.table_info.stage_info.copy_options.single;
         let op = StageTable::get_op(&ctx, &self.table_info.stage_info)?;

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use common_base::base::uuid;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
+use common_datablocks::BlockCompactThresholds;
 use common_datablocks::DataBlock;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -49,6 +50,7 @@ pub struct StageTable {
     // fn get_table_info(&self) -> &TableInfo).
     table_info_placeholder: TableInfo,
     input_context: Mutex<Option<Arc<InputContext>>>,
+    block_compact_threshold: Mutex<Option<BlockCompactThresholds>>,
 }
 
 impl StageTable {
@@ -59,6 +61,7 @@ impl StageTable {
             table_info,
             table_info_placeholder,
             input_context: Default::default(),
+            block_compact_threshold: Default::default(),
         }))
     }
 
@@ -199,5 +202,15 @@ impl Table for StageTable {
         Err(ErrorCode::Unimplemented(
             "S3 external table truncate() unimplemented yet!",
         ))
+    }
+
+    fn get_block_compact_thresholds(&self) -> BlockCompactThresholds {
+        let guard = self.block_compact_threshold.lock();
+        (*guard).expect("must success")
+    }
+
+    fn set_block_compact_thresholds(&self, thresholds: BlockCompactThresholds) {
+        let mut guard = self.block_compact_threshold.lock();
+        (*guard) = Some(thresholds)
     }
 }

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -17,6 +17,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
 use common_base::base::uuid;
+use common_catalog::table::AppendMode;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_datablocks::BlockCompactThresholds;
@@ -144,7 +145,7 @@ impl Table for StageTable {
         &self,
         ctx: Arc<dyn TableContext>,
         pipeline: &mut Pipeline,
-        _: bool,
+        _: AppendMode,
         _: bool,
     ) -> Result<()> {
         let single = self.table_info.stage_info.copy_options.single;

--- a/tests/suites/1_stateful/05_formats/05_02_load_compact_copy.result
+++ b/tests/suites/1_stateful/05_formats/05_02_load_compact_copy.result
@@ -1,0 +1,6 @@
+---s3 cp
+---copy into
+---row_count
+1000
+---block_count
+1

--- a/tests/suites/1_stateful/05_formats/05_02_load_compact_copy.sh
+++ b/tests/suites/1_stateful/05_formats/05_02_load_compact_copy.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+# prepare data
+DATA="/tmp/load_compact.csv"
+rm -rf $DATA
+for j in $(seq 1 1000);do
+	printf "0123456789\n" >> "$DATA"
+done
+
+echo "drop table if exists t1 all" | $MYSQL_CLIENT_CONNECT
+echo "CREATE TABLE t1
+(
+    c0 string
+);" | $MYSQL_CLIENT_CONNECT
+
+echo "---s3 cp"
+aws --endpoint-url http://127.0.0.1:9900/ s3 cp $DATA s3://testbucket/$DATA > /dev/null 2>&1
+
+echo "---copy into"
+# let input data dispatch to multi threads
+echo "set global input_read_buffer_size = 100" | $MYSQL_CLIENT_CONNECT
+echo "copy into t1 from 's3://testbucket/${DATA}' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = 'CSV') force=true" | $MYSQL_CLIENT_CONNECT
+echo "set global input_read_buffer_size = 1048576" | $MYSQL_CLIENT_CONNECT
+
+echo "---row_count"
+echo "select count(*) from t1" | $MYSQL_CLIENT_CONNECT
+
+echo "---block_count"
+echo "select block_count from fuse_snapshot('default','t1')" | $MYSQL_CLIENT_CONNECT
+
+echo "drop table if exists t1" | $MYSQL_CLIENT_CONNECT

--- a/tests/suites/1_stateful/05_formats/05_02_load_compact_streaming_load.result
+++ b/tests/suites/1_stateful/05_formats/05_02_load_compact_streaming_load.result
@@ -1,0 +1,6 @@
+---load
+1
+---row_count
+1000
+---block_count
+1

--- a/tests/suites/1_stateful/05_formats/05_02_load_compact_streaming_load.sh
+++ b/tests/suites/1_stateful/05_formats/05_02_load_compact_streaming_load.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+# prepare data
+DATA="/tmp/load_compact.csv"
+rm -rf $DATA
+for j in $(seq 1 1000);do
+	printf "0123456789\n" >> "$DATA"
+done
+
+echo "drop table if exists t1 all" | $MYSQL_CLIENT_CONNECT
+echo "CREATE TABLE t1
+(
+    c0 string
+);" | $MYSQL_CLIENT_CONNECT
+
+echo "---load"
+curl -sH "insert_sql:insert into t1 format csv" \
+-F "upload=@${DATA}" \
+-H "input_read_buffer_size: 100" \
+-u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load" | grep -c "SUCCESS"
+
+echo "---row_count"
+echo "select count(*) from t1" | $MYSQL_CLIENT_CONNECT
+
+echo "---block_count"
+echo "select block_count from fuse_snapshot('default','t1')" | $MYSQL_CLIENT_CONNECT
+
+echo "drop table if exists t1" | $MYSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

an improved and simpler version of https://github.com/datafuselabs/databend/issues/8311

simply resize to 1 and resize back to max_threads is enough: new BlockCompactorNoSplit make sure big block pass through it to downstream(Sink) fast.

The premise is that  DeserializerProcessor in multi threads already try to accumulate big Block, before output to the compactor.

other optimize:
-   call block.memory_size() only once.
-   avoid call concat_blocks for each new block

refactor:

- get real BlockCompactThresholds  from dest table

Closes https://github.com/datafuselabs/databend/issues/8311
