### PR TITLE
fix: The download page is replaced with our own interface

### DIFF
--- a/website/src/pages/download/index.tsx
+++ b/website/src/pages/download/index.tsx
@@ -93,8 +93,9 @@ const Releases: FC = (): ReactElement=> {
   ];
   async function getRelease() {
     const res = await axios.get(`${DOWNLOAD_LINK}releases.json`); 
-    if(res.data && res.data?.length > 0){
-      const releaseData = res.data[0];
+    const data = res?.data;
+    if(data && data?.length > 0){
+      const releaseData = data[0];
       const { assets, tag_name } = releaseData || {};
       setCacheTagName(tag_name);
       const reslut = assets


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The download page is replaced with our own interface @ZhiHanZ @wubx 

Closes #[issue](https://github.com/datafuselabs/databend/pull/8563)
