### PR TITLE
ci: Bump to nightly-2022-11-07 to address rust-lang/cargo#11183

### DIFF
--- a/scripts/setup/rust-toolchain.toml
+++ b/scripts/setup/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-11-02"
+channel = "nightly-2022-11-07"
 components = ["rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Bump to nightly-2022-11-07 to address https://github.com/rust-lang/cargo/pull/11183
