### PR TITLE
ci: Enable backtrace to debug cluster related issue

### DIFF
--- a/scripts/ci/ci-run-stateless-tests-cluster.sh
+++ b/scripts/ci/ci-run-stateless-tests-cluster.sh
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 echo "Starting Cluster databend-query"
+
+# Enable backtrace to debug https://github.com/datafuselabs/databend/issues/7986
+export RUST_BACKTRACE=full
 ./scripts/ci/deploy/databend-query-cluster-3-nodes.sh
 
 SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Enable backtrace to debug cluster related issue

Enable backtrace to help debug https://github.com/datafuselabs/databend/issues/7986
