### PR TITLE
refactor(copy): try move list files to read_partitions

### DIFF
--- a/src/query/catalog/src/plan/pushdown.rs
+++ b/src/query/catalog/src/plan/pushdown.rs
@@ -14,6 +14,8 @@
 
 use std::fmt::Debug;
 
+use common_meta_types::UserStageInfo;
+
 use crate::plan::Expression;
 use crate::plan::Projection;
 
@@ -27,6 +29,13 @@ pub struct PrewhereInfo {
     pub remain_columns: Projection,
     /// filter for prewhere
     pub filter: Expression,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct CopyInfo {
+    pub files: Vec<String>,
+    pub pattern: String,
+    pub stage_info: UserStageInfo,
 }
 
 /// Extras is a wrapper for push down items.
@@ -44,4 +53,6 @@ pub struct PushDownInfo {
     pub limit: Option<usize>,
     /// Optional order_by expression plan, asc, null_first
     pub order_by: Vec<(Expression, bool, bool)>,
+    /// Optional copy info, used for COPY into <table> from stage
+    pub copy: Option<CopyInfo>,
 }

--- a/src/query/service/tests/it/storages/fuse/operations/read_plan.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/read_plan.rs
@@ -131,6 +131,7 @@ fn test_to_partitions() -> Result<()> {
         limit: None,
         order_by: vec![],
         prewhere: None,
+        copy: None,
     });
 
     let (stats, parts) = FuseTable::to_partitions(&blocks_metas, &column_leafs, push_down);
@@ -171,6 +172,7 @@ async fn test_fuse_table_exact_statistic() -> Result<()> {
             prewhere: None,
             limit: None,
             order_by: vec![],
+            copy: None,
         };
         let (stats, parts) = table.read_partitions(ctx.clone(), Some(push_downs)).await?;
         assert_eq!(stats.read_rows, num_blocks * rows_per_block);

--- a/src/query/service/tests/it/storages/memory.rs
+++ b/src/query/service/tests/it/storages/memory.rs
@@ -81,6 +81,7 @@ async fn test_memorytable() -> Result<()> {
                             limit: None,
                             order_by: vec![],
                             prewhere: None,
+                            copy: None,
                         }
                     })
                 })

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -598,6 +598,7 @@ impl PhysicalPlanBuilder {
             prewhere: prewhere_info,
             limit: scan.limit,
             order_by: order_by.unwrap_or_default(),
+            copy: None,
         })
     }
 }

--- a/src/query/storages/fuse/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/fuse/src/operations/delete.rs
@@ -95,6 +95,7 @@ impl FuseTable {
             prewhere: None, // TBD: if delete rows need prewhere optimization
             limit: None,
             order_by: vec![],
+            copy: None,
         };
         let push_downs = Some(extras);
         let segments_location = snapshot.segments.clone();

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -96,8 +96,12 @@ impl Table for StageTable {
     async fn read_partitions(
         &self,
         ctx: Arc<dyn TableContext>,
-        _push_downs: Option<PushDownInfo>,
+        push_downs: Option<PushDownInfo>,
     ) -> Result<(PartStatistics, Partitions)> {
+        let _xx = push_downs
+            .ok_or_else(|| ErrorCode::Internal("push down cannot be None for COPY"))?
+            .copy;
+
         let operator = StageTable::get_op(&ctx, &self.table_info.stage_info)?;
         let input_ctx = Arc::new(
             InputContext::try_create_from_copy(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

*  move list files from interpreter to `read_partitions`, first part of the distributed COPY

Closes #issue
