### PR TITLE
fix(meta): emit kv change events after committing a transaction

### DIFF
--- a/src/binaries/meta/kvapi.rs
+++ b/src/binaries/meta/kvapi.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use common_exception::Result;
 use common_meta_api::KVApi;
 use common_meta_types::MatchSeq;
 use common_meta_types::Operation;
@@ -29,7 +28,7 @@ pub enum KvApiCommand {
 }
 
 impl KvApiCommand {
-    pub fn from_config(config: &Config, op: &str) -> std::result::Result<Self, String> {
+    pub fn from_config(config: &Config, op: &str) -> Result<Self, String> {
         let api = match op {
             "upsert" => {
                 if config.key.len() != 1 {
@@ -57,7 +56,7 @@ impl KvApiCommand {
         Ok(api)
     }
 
-    pub async fn execute(&self, client: Arc<dyn KVApi>) -> Result<String> {
+    pub async fn execute(&self, client: Arc<dyn KVApi>) -> anyhow::Result<String> {
         let res_str = match self {
             KvApiCommand::Get(key) => {
                 let res = client.get_kv(key.as_str()).await?;

--- a/src/binaries/meta/main.rs
+++ b/src/binaries/meta/main.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use common_base::base::RuntimeTracker;
 use common_base::base::StopHandle;
 use common_base::base::Stoppable;
+use common_exception::ErrorCode;
 use common_grpc::RpcClientConf;
 use common_macros::databend_main;
 use common_meta_sled_store::init_sled_db;
@@ -42,7 +43,7 @@ pub use kvapi::KvApiCommand;
 const CMD_KVAPI_PREFIX: &str = "kvapi::";
 
 #[databend_main]
-async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<()> {
+async fn main(_global_tracker: Arc<RuntimeTracker>) -> Result<(), ErrorCode> {
     let conf = Config::load()?;
 
     if run_cmd(&conf).await {

--- a/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
+++ b/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
@@ -38,9 +38,9 @@ impl KVApi for StateMachine {
             value_meta: act.value_meta,
         });
 
-        let res = self.sm_tree.txn(true, |t| {
+        let res = self.sm_tree.txn(true, |mut txn_sled_tree| {
             let r = self
-                .apply_cmd(&cmd, &t, None, SeqV::<()>::now_ms())
+                .apply_cmd(&cmd, &mut txn_sled_tree, None, SeqV::<()>::now_ms())
                 .unwrap();
             Ok(r)
         })?;
@@ -56,9 +56,9 @@ impl KVApi for StateMachine {
     async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, KVAppError> {
         let cmd = Cmd::Transaction(txn);
 
-        let res = self.sm_tree.txn(true, |t| {
+        let res = self.sm_tree.txn(true, |mut txn_sled_tree| {
             let r = self
-                .apply_cmd(&cmd, &t, None, SeqV::<()>::now_ms())
+                .apply_cmd(&cmd, &mut txn_sled_tree, None, SeqV::<()>::now_ms())
                 .unwrap();
             Ok(r)
         })?;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### fix(meta): emit kv change events after committing a transaction

Otherwise, pushing any events before a transaction being committed
potentially results in duplicated messages.

Replace `NotifyKVEvent` with `Change`, which is more generic to describe an event.


##### chore(meta): nothing changed

## Changelog







## Related Issues