### PR TITLE
chore(cluster): exchange error backtrace

### DIFF
--- a/src/common/exception/src/exception_flight.rs
+++ b/src/common/exception/src/exception_flight.rs
@@ -12,17 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_arrow::arrow_format::flight::data::FlightData;
 
+use crate::exception::ErrorCodeBacktrace;
 use crate::ErrorCode;
 use crate::Result;
 
 impl From<ErrorCode> for FlightData {
     fn from(error: ErrorCode) -> Self {
-        // TODO: has stack trace
+        let error_message = error.message();
+        let error_backtrace = error.backtrace_str();
+
+        let message = error_message.as_bytes();
+        let backtrace = error_backtrace.as_bytes();
+
+        let mut data_body = Vec::with_capacity(16 + message.len() + backtrace.len());
+
+        data_body.extend((message.len() as u64).to_be_bytes());
+        data_body.extend_from_slice(message);
+        data_body.extend((backtrace.len() as u64).to_be_bytes());
+        data_body.extend_from_slice(backtrace);
+
         FlightData {
+            data_body,
             app_metadata: vec![0x02],
-            data_body: error.message().into_bytes(),
             data_header: error.code().to_be_bytes().to_vec(),
             flight_descriptor: None,
         }
@@ -37,8 +52,28 @@ impl TryFrom<FlightData> for ErrorCode {
             Err(_) => Err(ErrorCode::BadBytes("Cannot parse inf usize.")),
             Ok(slice) => {
                 let code = u16::from_be_bytes(slice);
-                let message = String::from_utf8(flight_data.data_body)?;
-                Ok(ErrorCode::create(code, message, None, None))
+                let data_body = flight_data.data_body;
+
+                let message_len = u64::from_be_bytes(data_body[0..8].try_into().unwrap()) as usize;
+                let message = &data_body[8..8 + message_len];
+                let backtrace = &data_body[16 + message_len..];
+
+                match backtrace.is_empty() {
+                    true => Ok(ErrorCode::create(
+                        code,
+                        String::from_utf8(message.to_vec())?,
+                        None,
+                        None,
+                    )),
+                    false => Ok(ErrorCode::create(
+                        code,
+                        String::from_utf8(message.to_vec())?,
+                        None,
+                        Some(ErrorCodeBacktrace::Serialized(Arc::new(String::from_utf8(
+                            backtrace.to_vec(),
+                        )?))),
+                    )),
+                }
             }
         }
     }

--- a/src/common/exception/tests/it/exception_flight.rs
+++ b/src/common/exception/tests/it/exception_flight.rs
@@ -1,0 +1,37 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::backtrace::Backtrace;
+use std::sync::Arc;
+
+use common_arrow::arrow_format::flight::data::FlightData;
+use common_exception::exception::ErrorCodeBacktrace;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+#[test]
+fn test_serialize() -> Result<()> {
+    let error_code = ErrorCode::create(
+        1,
+        String::from("test_message"),
+        None,
+        Some(ErrorCodeBacktrace::Origin(Arc::new(Backtrace::capture()))),
+    );
+    let backtrace_str = error_code.backtrace_str();
+    let error_code = ErrorCode::try_from(FlightData::from(error_code))?;
+    assert_eq!(1, error_code.code());
+    assert_eq!(String::from("test_message"), error_code.message());
+    assert_eq!(backtrace_str, error_code.backtrace_str());
+    Ok(())
+}

--- a/src/common/exception/tests/it/main.rs
+++ b/src/common/exception/tests/it/main.rs
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 mod exception;
+mod exception_flight;
 mod prelude;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore(cluster): exchange error backtrace

Closes #issue
