### PR TITLE
ci: Disable 13_0005_q5 to avoid breaking CI

### DIFF
--- a/scripts/ci/ci-run-stateless-tests-cluster.sh
+++ b/scripts/ci/ci-run-stateless-tests-cluster.sh
@@ -12,5 +12,6 @@ SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 cd "$SCRIPT_PATH/../../tests" || exit
 
 echo "Starting databend-test"
-# The skip should be removed after https://github.com/datafuselabs/databend/issues/8107 is addressed.
-./databend-test --mode 'cluster' --run-dir 0_stateless --skip '13_0004_q4'
+# 13_0004_q4: https://github.com/datafuselabs/databend/issues/8107
+# 13_0005_q5: https://github.com/datafuselabs/databend/issues/7986
+./databend-test --mode 'cluster' --run-dir 0_stateless --skip '13_0004_q4' --skip '13_0005_q5'


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Disable 13_0005_q5 to avoid breaking CI
