### PR TITLE
feat(query): continue to improve sort and fix bug.

### DIFF
--- a/src/query/datavalues/src/macros.rs
+++ b/src/query/datavalues/src/macros.rs
@@ -143,6 +143,32 @@ macro_rules! with_match_physical_primitive_type {
 }
 
 #[macro_export]
+macro_rules! with_match_physical_integer_type {
+    (
+    $key_type:expr, | $_:tt $T:ident | $body:tt,  $nbody:tt
+) => {{
+        macro_rules! __with_ty__ {
+            ( $_ $T:ident ) => {
+                $body
+            };
+        }
+
+        match $key_type {
+            PhysicalTypeID::Int8 => __with_ty__! { i8 },
+            PhysicalTypeID::Int16 => __with_ty__! { i16 },
+            PhysicalTypeID::Int32 => __with_ty__! { i32 },
+            PhysicalTypeID::Int64 => __with_ty__! { i64 },
+            PhysicalTypeID::UInt8 => __with_ty__! { u8 },
+            PhysicalTypeID::UInt16 => __with_ty__! { u16 },
+            PhysicalTypeID::UInt32 => __with_ty__! { u32 },
+            PhysicalTypeID::UInt64 => __with_ty__! { u64 },
+
+            _ => $nbody,
+        }
+    }};
+}
+
+#[macro_export]
 macro_rules! with_match_physical_primitive_type_error {(
     $key_type:expr, | $_:tt $T:ident | $($body:tt)*
 ) => ({

--- a/src/query/pipeline/transforms/src/processors/mod.rs
+++ b/src/query/pipeline/transforms/src/processors/mod.rs
@@ -14,3 +14,5 @@
 
 pub mod transforms;
 pub use transforms::Aborting;
+
+mod sort_utils;

--- a/src/query/pipeline/transforms/src/processors/sort_utils/arrow.rs
+++ b/src/query/pipeline/transforms/src/processors/sort_utils/arrow.rs
@@ -1,0 +1,77 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_arrow::arrow::compute::sort::row::Row as ARow;
+use common_arrow::arrow::compute::sort::row::RowConverter as ARowConverter;
+use common_arrow::arrow::compute::sort::row::Rows as ARows;
+use common_arrow::arrow::compute::sort::row::SortField;
+use common_arrow::arrow::compute::sort::SortOptions;
+use common_arrow::arrow::datatypes::DataType;
+use common_arrow::ArrayRef;
+use common_datablocks::SortColumnDescription;
+use common_datavalues::DataSchemaRef;
+use common_exception::Result;
+
+use super::RowConverter;
+use super::Rows;
+
+impl Rows for ARows {
+    type Item<'a> = ARow<'a>;
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn row(&self, index: usize) -> Self::Item<'_> {
+        self.row(index)
+    }
+
+    fn row_unchecked(&self, index: usize) -> Self::Item<'_> {
+        self.row_unchecked(index)
+    }
+}
+
+impl RowConverter<ARows> for ARowConverter {
+    fn create(
+        sort_columns_descriptions: Vec<SortColumnDescription>,
+        output_schema: DataSchemaRef,
+    ) -> Result<Self> {
+        let sort_fields = sort_columns_descriptions
+            .iter()
+            .map(|d| {
+                let data_type = match output_schema
+                    .field_with_name(&d.column_name)?
+                    .to_arrow()
+                    .data_type()
+                {
+                    // The actual data type of `Data` and `Timestmap` will be `Int32` and `Int64`.
+                    DataType::Date32 | DataType::Time32(_) => DataType::Int32,
+                    DataType::Date64 | DataType::Time64(_) | DataType::Timestamp(_, _) => {
+                        DataType::Int64
+                    }
+                    date_type => date_type.clone(),
+                };
+                Ok(SortField::new_with_options(data_type, SortOptions {
+                    descending: !d.asc,
+                    nulls_first: d.nulls_first,
+                }))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(ARowConverter::new(sort_fields))
+    }
+    fn convert(&mut self, columns: &[ArrayRef]) -> Result<ARows> {
+        let rows = self.convert_columns(columns)?;
+        Ok(rows)
+    }
+}

--- a/src/query/pipeline/transforms/src/processors/sort_utils/mod.rs
+++ b/src/query/pipeline/transforms/src/processors/sort_utils/mod.rs
@@ -81,8 +81,13 @@ impl<R: Rows> Cursor<R> {
     }
 
     #[inline]
-    fn current(&self) -> R::Item<'_> {
+    pub fn current(&self) -> R::Item<'_> {
         self.rows.row_unchecked(self.row_index)
+    }
+
+    #[inline]
+    pub fn last(&self) -> R::Item<'_> {
+        self.rows.row_unchecked(self.num_rows - 1)
     }
 }
 

--- a/src/query/pipeline/transforms/src/processors/sort_utils/mod.rs
+++ b/src/query/pipeline/transforms/src/processors/sort_utils/mod.rs
@@ -1,0 +1,109 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+
+use common_arrow::ArrayRef;
+use common_datablocks::SortColumnDescription;
+use common_datavalues::DataSchemaRef;
+use common_exception::Result;
+
+mod arrow;
+mod simple;
+
+pub use arrow::*;
+pub use simple::*;
+
+/// Convert columns to rows.
+pub trait RowConverter<T: Rows>
+where Self: Sized
+{
+    fn create(
+        sort_columns_descriptions: Vec<SortColumnDescription>,
+        output_schema: DataSchemaRef,
+    ) -> Result<Self>;
+    fn convert(&mut self, columns: &[ArrayRef]) -> Result<T>;
+}
+
+/// Rows to compare.
+pub trait Rows {
+    type Item<'a>: Ord
+    where Self: 'a;
+
+    fn len(&self) -> usize;
+    fn row(&self, index: usize) -> Self::Item<'_>;
+    fn row_unchecked(&self, _index: usize) -> Self::Item<'_> {
+        unimplemented!()
+    }
+}
+
+/// A cursor point to a certain row in a data block.
+pub struct Cursor<R: Rows> {
+    pub input_index: usize,
+    pub row_index: usize,
+
+    num_rows: usize,
+
+    rows: R,
+}
+
+impl<R: Rows> Cursor<R> {
+    pub fn try_create(input_index: usize, rows: R) -> Self {
+        Self {
+            input_index,
+            row_index: 0,
+            num_rows: rows.len(),
+            rows,
+        }
+    }
+
+    #[inline]
+    pub fn advance(&mut self) -> usize {
+        let res = self.row_index;
+        self.row_index += 1;
+        res
+    }
+
+    #[inline]
+    pub fn is_finished(&self) -> bool {
+        self.num_rows == self.row_index
+    }
+
+    #[inline]
+    fn current(&self) -> R::Item<'_> {
+        self.rows.row_unchecked(self.row_index)
+    }
+}
+
+impl<R: Rows> Ord for Cursor<R> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.current()
+            .cmp(&other.current())
+            .then_with(|| self.input_index.cmp(&other.input_index))
+    }
+}
+
+impl<R: Rows> PartialEq for Cursor<R> {
+    fn eq(&self, other: &Self) -> bool {
+        self.current() == other.current()
+    }
+}
+
+impl<R: Rows> Eq for Cursor<R> {}
+
+impl<R: Rows> PartialOrd for Cursor<R> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/src/query/pipeline/transforms/src/processors/sort_utils/simple.rs
+++ b/src/query/pipeline/transforms/src/processors/sort_utils/simple.rs
@@ -1,0 +1,119 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::marker::PhantomData;
+
+use common_arrow::arrow::array::PrimitiveArray;
+use common_arrow::arrow::types::NativeType;
+use common_arrow::ArrayRef;
+use common_datablocks::SortColumnDescription;
+use common_datavalues::DataSchemaRef;
+use common_exception::Result;
+
+use super::RowConverter;
+use super::Rows;
+
+#[derive(Clone, Copy)]
+pub struct SimpleRow<T> {
+    inner: T,
+    desc: bool,
+}
+
+pub struct SimpleRows<T: NativeType> {
+    inner: PrimitiveArray<T>,
+    desc: bool,
+}
+
+impl<T: NativeType + Ord> Ord for SimpleRow<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.desc {
+            self.inner.cmp(&other.inner).reverse()
+        } else {
+            self.inner.cmp(&other.inner)
+        }
+    }
+}
+
+impl<T: NativeType + Ord> PartialOrd for SimpleRow<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: NativeType + Ord> PartialEq for SimpleRow<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl<T: NativeType + Ord> Eq for SimpleRow<T> {}
+
+impl<T: NativeType + Ord> Rows for SimpleRows<T> {
+    type Item<'a> = SimpleRow<T>;
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn row(&self, index: usize) -> Self::Item<'_> {
+        SimpleRow {
+            inner: self.inner.value(index),
+            desc: self.desc,
+        }
+    }
+
+    fn row_unchecked(&self, index: usize) -> Self::Item<'_> {
+        let inner = unsafe { self.inner.value_unchecked(index) };
+        SimpleRow {
+            inner,
+            desc: self.desc,
+        }
+    }
+}
+
+/// If there is only one sort field and its type is a primitive type,
+/// use this converter.
+pub struct SimpleRowConverter<T: NativeType> {
+    desc: bool,
+    _t: PhantomData<T>,
+}
+
+impl<T: NativeType + Ord> RowConverter<SimpleRows<T>> for SimpleRowConverter<T> {
+    fn create(
+        sort_columns_descriptions: Vec<SortColumnDescription>,
+        _: DataSchemaRef,
+    ) -> Result<Self> {
+        assert!(sort_columns_descriptions.len() == 1);
+
+        Ok(Self {
+            desc: !sort_columns_descriptions[0].asc,
+            _t: PhantomData,
+        })
+    }
+
+    fn convert(&mut self, columns: &[ArrayRef]) -> Result<SimpleRows<T>> {
+        assert!(columns.len() == 1);
+        let inner = columns[0]
+            .as_any()
+            .downcast_ref::<PrimitiveArray<T>>()
+            .unwrap()
+            .clone();
+        let rows = SimpleRows {
+            inner,
+            desc: self.desc,
+        };
+        Ok(rows)
+    }
+}

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_multi_sort_merge.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_multi_sort_merge.rs
@@ -241,22 +241,12 @@ where
                     if self.heap.is_empty() {
                         // If there is no other block in the heap, we can drain the whole block.
                         need_output = self.drain_cursor(cursor);
-                        if !self.input_finished[input_index] {
-                            // Correctness: if input is not finished, we need to pull more data,
-                            // or we can continue this loop.
-                            break;
-                        }
                     } else {
                         let next_cursor = &self.heap.peek().unwrap().0;
                         // If the last row of current block is smaller than the next cursor,
                         // we can drain the whole block.
                         if cursor.last().le(&next_cursor.current()) {
                             need_output = self.drain_cursor(cursor);
-                            if !self.input_finished[input_index] {
-                                // Correctness: if input is not finished, we need to pull more data,
-                                // or we can continue this loop.
-                                break;
-                            }
                         } else {
                             let block_index = self.blocks[input_index].len() - 1;
                             while !cursor.is_finished() && cursor.le(next_cursor) {
@@ -284,6 +274,12 @@ where
                     // Reach the block size, need to output.
                     if self.in_progess_rows.len() >= self.block_size {
                         need_output = true;
+                        break;
+                    }
+                    if self.cursor_finished[input_index] && !self.input_finished[input_index] {
+                        // Correctness: if input is not finished, we need to pull more data,
+                        // or we can continue this loop.
+                        break;
                     }
                 }
                 None => {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

**This PR will stay in draft until the new expression migration is done.**

Introduce a new struct `SimpleCursor` for single order key with primitive type.

Fix bug: should return to `Consume` if one block is drained if the input port is not finished. Thus the performance test in #8677 is incorrect.

Closes #issue
