### PR TITLE
ci: Install sccache in dev-setup to avoid large docker images

### DIFF
--- a/docker/build-tool/base/Dockerfile
+++ b/docker/build-tool/base/Dockerfile
@@ -43,6 +43,4 @@ ENV RUSTUP_HOME /opt/rust/rustup
 ENV CARGO_HOME /opt/rust/cargo
 ENV PATH /opt/rust/cargo/bin:/opt/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-RUN cargo install sccache
-
 VOLUME [ "/workspace", "/opt/rust/cargo/registry", "/opt/rust/cargo/git" ]

--- a/scripts/setup/dev_setup.sh
+++ b/scripts/setup/dev_setup.sh
@@ -515,6 +515,7 @@ if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
 
 	# Install tools that needed in build
 	cargo install sccache
+	cargo install cccache
 fi
 
 if [[ "$INSTALL_CHECK_TOOLS" == "true" ]]; then

--- a/scripts/setup/dev_setup.sh
+++ b/scripts/setup/dev_setup.sh
@@ -512,6 +512,9 @@ if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
 
 	# Any call to cargo will make rustup install the correct toolchain
 	cargo version
+
+	# Install tools that needed in build
+	cargo install sccache
 fi
 
 if [[ "$INSTALL_CHECK_TOOLS" == "true" ]]; then


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Install sccache in dev-setup to avoid large docker images