### PR TITLE
refactor(fuse): move segment -> partition info to PartitionSource async source

### DIFF
--- a/src/query/storages/fuse/fuse/src/operations/mod.rs
+++ b/src/query/storages/fuse/fuse/src/operations/mod.rs
@@ -27,6 +27,7 @@ mod recluster;
 mod truncate;
 
 mod fuse_source;
+mod partition_source;
 pub mod util;
 
 pub(crate) use compact::CompactOptions;
@@ -42,5 +43,6 @@ pub use mutation::SegmentCompactionState;
 pub use mutation::SegmentCompactor;
 pub use operation_log::AppendOperationLogEntry;
 pub use operation_log::TableOperationLog;
+pub use partition_source::PartitionSource;
 pub use read_data::ReadDataKind;
 pub use util::column_metas;

--- a/src/query/storages/fuse/fuse/src/operations/partition_source.rs
+++ b/src/query/storages/fuse/fuse/src/operations/partition_source.rs
@@ -1,0 +1,91 @@
+//  Copyright 2022 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::sync::Arc;
+
+use common_catalog::plan::DataSourcePlan;
+use common_catalog::table_context::TableContext;
+use common_datablocks::DataBlock;
+use common_exception::Result;
+use common_pipeline_core::processors::port::OutputPort;
+use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_sources::processors::sources::AsyncSource;
+use common_pipeline_sources::processors::sources::AsyncSourcer;
+
+use crate::fuse_lazy_part::FuseLazyPartInfo;
+use crate::FuseTable;
+
+// Read partition from segment info.
+// No output:
+// ctx.try_set_partitions(partitions)?;
+// The downstream usage:
+// ctx.try_get_part();
+pub struct PartitionSource {
+    ctx: Arc<dyn TableContext>,
+    plan: DataSourcePlan,
+    fuse_table: FuseTable,
+    finish: bool,
+}
+
+impl PartitionSource {
+    pub fn create(
+        ctx: Arc<dyn TableContext>,
+        output: Arc<OutputPort>,
+        plan: DataSourcePlan,
+        fuse_table: FuseTable,
+    ) -> Result<ProcessorPtr> {
+        AsyncSourcer::create(ctx.clone(), output, PartitionSource {
+            ctx,
+            plan,
+            fuse_table,
+            finish: false,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncSource for PartitionSource {
+    const NAME: &'static str = "read_partition";
+
+    #[async_trait::unboxed_simple]
+    async fn generate(&mut self) -> Result<Option<DataBlock>> {
+        if self.finish {
+            return Ok(None);
+        }
+        self.finish = true;
+
+        let plan = self.plan.clone();
+        let push_downs = plan.push_downs.clone();
+        let table = self.fuse_table.clone();
+        let table_info = table.table_info.clone();
+        let table_ctx = self.ctx.clone();
+        let op = table.operator.clone();
+
+        let mut segments = Vec::with_capacity(plan.parts.len());
+        for part in &plan.parts {
+            if let Some(part_info) = part.as_any().downcast_ref::<FuseLazyPartInfo>() {
+                segments.push(part_info.segment_location.clone());
+            }
+        }
+
+        if !segments.is_empty() {
+            let (_statistics, partitions) = table
+                .prune_snapshot_blocks(table_ctx.clone(), op, push_downs, table_info, segments, 0)
+                .await?;
+            table_ctx.try_set_partitions(partitions)?;
+        }
+
+        Ok(None)
+    }
+}


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Read partition info to PartitionSource.

Closes #issue
