### PR TITLE
fix(query): the hashmap will cause oom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,7 @@ dependencies = [
  "hex",
  "itertools",
  "match-template",
+ "memchr",
  "num-traits",
  "once_cell",
  "ordered-float 3.3.0",

--- a/src/query/functions-v2/Cargo.toml
+++ b/src/query/functions-v2/Cargo.toml
@@ -30,6 +30,7 @@ criterion = "0.4"
 hex = "0.4.3"
 itertools = "0.10.5"
 match-template = "0.0.1"
+memchr = "2.5.0"
 num-traits = "0.2.15"
 once_cell = "1.15.0"
 ordered-float = { version = "3.1.0", features = [

--- a/src/query/functions-v2/src/scalars/comparison.rs
+++ b/src/query/functions-v2/src/scalars/comparison.rs
@@ -32,6 +32,7 @@ use common_expression::FunctionContext;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use common_expression::ValueRef;
+use memchr::memmem;
 use regex::bytes::Regex;
 
 use crate::scalars::string_multi_args::regexp;
@@ -235,40 +236,39 @@ fn register_like(registry: &mut FunctionRegistry) {
         "like",
         FunctionProperty::default(),
         |_, _| None,
-        vectorize_regexp(|str, pat, _, map, string_map| {
-            let pattern = if let Some(pattern) = map.get(pat) {
-                pattern
-            } else {
-                let pattern_str = simdutf8::basic::from_utf8(pat).map_err(|err| {
-                    format!("unable to convert the LIKE pattern to string: {err}")
-                })?;
-
-                let mut sub_strings: Vec<&str> = pattern_str
-                    .split(|c: char| c == '%' || c == '_' || c == '\\')
-                    .collect();
-                sub_strings.retain(|&substring| !substring.is_empty());
-                if !sub_strings.is_empty() {
-                    string_map.insert(pat.to_vec(), sub_strings[0].to_string());
+        vectorize_like(|str, pat, _, pattern_type| {
+            match pattern_type {
+                PatternType::OrdinalStr => Ok(str == pat),
+                PatternType::EndOfPercent => {
+                    // fast path, can use starts_with
+                    let starts_with = &pat[..pat.len() - 1];
+                    Ok(str.starts_with(starts_with))
                 }
-
-                let re_pattern = like_pattern_to_regex(pattern_str);
-                let re = Regex::new(&re_pattern)
-                    .map_err(|err| format!("unable to build the LIKE pattern: {err}"))?;
-                map.insert(pat.to_vec(), re);
-                map.get(pat).unwrap()
-            };
-
-            if let Some(required_string) = string_map.get(pat) {
-                let lhs_str =
-                    std::str::from_utf8(str).expect("Unable to convert lhs value to string: {}");
-                let contain = lhs_str.find(required_string.as_str());
-                if contain.is_none() {
-                    Ok(false)
-                } else {
-                    Ok(pattern.is_match(str))
+                PatternType::StartOfPercent => {
+                    // fast path, can use ends_with
+                    let ends_with = &pat[1..];
+                    Ok(str.ends_with(ends_with))
                 }
-            } else {
-                Ok(pattern.is_match(str))
+                PatternType::PatternStr => {
+                    let pattern_str = simdutf8::basic::from_utf8(pat)
+                        .expect("Unable to convert the LIKE pattern to string: {}");
+                    let mut sub_strings: Vec<&str> = pattern_str
+                        .split(|c: char| c == '%' || c == '_' || c == '\\')
+                        .collect();
+                    sub_strings.retain(|&substring| !substring.is_empty());
+                    if std::intrinsics::unlikely(sub_strings.is_empty()) {
+                        Ok(like(str, pat))
+                    } else {
+                        let sub_string = sub_strings[0].as_bytes();
+                        if sub_strings.len() == 1 {
+                            Ok(search_sub_str(str, sub_string).is_some())
+                        } else if memmem::find(str, sub_string).is_none() {
+                            Ok(false)
+                        } else {
+                            Ok(like(str, pat))
+                        }
+                    }
+                }
             }
         }),
     );
@@ -288,6 +288,50 @@ fn register_like(registry: &mut FunctionRegistry) {
             Ok(pattern.is_match(str))
         }),
     );
+}
+
+fn vectorize_like(
+    func: impl Fn(&[u8], &[u8], FunctionContext, PatternType) -> Result<bool, String> + Copy,
+) -> impl Fn(
+    ValueRef<StringType>,
+    ValueRef<StringType>,
+    FunctionContext,
+) -> Result<Value<BooleanType>, String>
++ Copy {
+    move |arg1, arg2, ctx| match (arg1, arg2) {
+        (ValueRef::Scalar(arg1), ValueRef::Scalar(arg2)) => {
+            let pattern_type = check_pattern_type(arg2, false);
+            Ok(Value::Scalar(func(arg1, arg2, ctx, pattern_type)?))
+        }
+        (ValueRef::Column(arg1), ValueRef::Scalar(arg2)) => {
+            let arg1_iter = StringType::iter_column(&arg1);
+            let mut builder = MutableBitmap::with_capacity(arg1.len());
+            let pattern_type = check_pattern_type(arg2, false);
+            for arg1 in arg1_iter {
+                builder.push(func(arg1, arg2, ctx, pattern_type)?);
+            }
+            Ok(Value::Column(builder.into()))
+        }
+        (ValueRef::Scalar(arg1), ValueRef::Column(arg2)) => {
+            let arg2_iter = StringType::iter_column(&arg2);
+            let mut builder = MutableBitmap::with_capacity(arg2.len());
+            for arg2 in arg2_iter {
+                let pattern_type = check_pattern_type(arg2, false);
+                builder.push(func(arg1, arg2, ctx, pattern_type)?);
+            }
+            Ok(Value::Column(builder.into()))
+        }
+        (ValueRef::Column(arg1), ValueRef::Column(arg2)) => {
+            let arg1_iter = StringType::iter_column(&arg1);
+            let arg2_iter = StringType::iter_column(&arg2);
+            let mut builder = MutableBitmap::with_capacity(arg2.len());
+            for (arg1, arg2) in arg1_iter.zip(arg2_iter) {
+                let pattern_type = check_pattern_type(arg2, false);
+                builder.push(func(arg1, arg2, ctx, pattern_type)?);
+            }
+            Ok(Value::Column(builder.into()))
+        }
+    }
 }
 
 fn vectorize_regexp(
@@ -345,42 +389,154 @@ fn vectorize_regexp(
     }
 }
 
-/// Transform the like pattern to regex pattern.
-/// e.g. 'Hello\._World%\%' tranform to '^Hello\\\..World.*%$'.
-#[inline]
-fn like_pattern_to_regex(pattern: &str) -> String {
-    let mut regex = String::with_capacity(pattern.len() * 2);
-    regex.push('^');
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum PatternType {
+    // e.g. 'Arrow'
+    OrdinalStr,
+    // e.g. 'A%row'
+    PatternStr,
+    // e.g. '%rrow'
+    StartOfPercent,
+    // e.g. 'Arro%'
+    EndOfPercent,
+}
 
-    let mut chars = pattern.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            // Use double backslash to escape special character.
-            '^' | '$' | '(' | ')' | '*' | '+' | '.' | '[' | '?' | '{' | '|' => {
-                regex.push('\\');
-                regex.push(c);
-            }
-            '%' => regex.push_str("(?s:.)*"),
-            '_' => regex.push_str("(?s:.)"),
-            '\\' => match chars.peek().cloned() {
-                Some('%') => {
-                    regex.push('%');
-                    chars.next();
-                }
-                Some('_') => {
-                    regex.push('_');
-                    chars.next();
-                }
-                Some('\\') => {
-                    regex.push_str("\\\\");
-                    chars.next();
-                }
-                _ => regex.push_str("\\\\"),
-            },
-            _ => regex.push(c),
-        }
+#[inline]
+fn is_like_pattern_escape(c: char) -> bool {
+    c == '%' || c == '_' || c == '\\'
+}
+
+/// Check the like pattern type.
+///
+/// is_pruning: indicate whether to be called on range_filter for pruning.
+///
+/// For example:
+///
+/// 'a\\%row'
+/// '\\%' will be escaped to a percent. Need transform to `a%row`.
+///
+/// If is_pruning is true, will be called on range_filter:L379.
+/// OrdinalStr is returned, because the pattern can be transformed by range_filter:L382.
+///
+/// If is_pruning is false, will be called on like.rs:L74.
+/// PatternStr is returned, because the pattern cannot be used directly on like.rs:L76.
+#[inline]
+pub fn check_pattern_type(pattern: &[u8], is_pruning: bool) -> PatternType {
+    let len = pattern.len();
+    if len == 0 {
+        return PatternType::OrdinalStr;
     }
 
-    regex.push('$');
-    regex
+    let mut index = 0;
+    let start_percent = pattern[0] == b'%';
+    if start_percent {
+        if is_pruning {
+            return PatternType::PatternStr;
+        }
+        index += 1;
+    }
+
+    while index < len {
+        match pattern[index] {
+            b'_' => return PatternType::PatternStr,
+            b'%' => {
+                if index == len - 1 && !start_percent {
+                    return PatternType::EndOfPercent;
+                }
+                return PatternType::PatternStr;
+            }
+            b'\\' => {
+                if index < len - 1 {
+                    index += 1;
+                    if !is_pruning && is_like_pattern_escape(pattern[index] as char) {
+                        return PatternType::PatternStr;
+                    }
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    if start_percent {
+        PatternType::StartOfPercent
+    } else {
+        PatternType::OrdinalStr
+    }
+}
+
+#[inline]
+fn search_sub_str(str: &[u8], substr: &[u8]) -> Option<usize> {
+    if substr.len() <= str.len() {
+        str.windows(substr.len()).position(|w| w == substr)
+    } else {
+        None
+    }
+}
+
+#[inline]
+fn decode_one(data: &[u8]) -> Option<(u8, usize)> {
+    if data.is_empty() {
+        None
+    } else {
+        Some((data[0], 1))
+    }
+}
+
+#[inline]
+/// Borrow from [tikv](https://github.com/tikv/tikv/blob/fe997db4db8a5a096f8a45c0db3eb3c2e5879262/components/tidb_query_expr/src/impl_like.rs)
+fn like(haystack: &[u8], pattern: &[u8]) -> bool {
+    // current search positions in pattern and target.
+    let (mut px, mut tx) = (0, 0);
+    // positions for backtrace.
+    let (mut next_px, mut next_tx) = (0, 0);
+    while px < pattern.len() || tx < haystack.len() {
+        if let Some((c, mut poff)) = decode_one(&pattern[px..]) {
+            let code: u32 = c.into();
+            if code == '_' as u32 {
+                if let Some((_, toff)) = decode_one(&haystack[tx..]) {
+                    px += poff;
+                    tx += toff;
+                    continue;
+                }
+            } else if code == '%' as u32 {
+                // update the backtrace point.
+                next_px = px;
+                px += poff;
+                next_tx = tx;
+                next_tx += if let Some((_, toff)) = decode_one(&haystack[tx..]) {
+                    toff
+                } else {
+                    1
+                };
+                continue;
+            } else {
+                if code == '\\' as u32 && px + poff < pattern.len() {
+                    px += poff;
+                    poff = if let Some((_, off)) = decode_one(&pattern[px..]) {
+                        off
+                    } else {
+                        break;
+                    }
+                }
+                if let Some((_, toff)) = decode_one(&haystack[tx..]) {
+                    if let std::cmp::Ordering::Equal =
+                        haystack[tx..tx + toff].cmp(&pattern[px..px + poff])
+                    {
+                        tx += toff;
+                        px += poff;
+                        continue;
+                    }
+                }
+            }
+        }
+        // mismatch and backtrace to last %.
+        if 0 < next_tx && next_tx <= haystack.len() {
+            px = next_px;
+            tx = next_tx;
+            continue;
+        }
+        return false;
+    }
+    true
 }

--- a/src/query/functions-v2/tests/it/scalars/comparison.rs
+++ b/src/query/functions-v2/tests/it/scalars/comparison.rs
@@ -364,6 +364,8 @@ fn test_like(file: &mut impl Write, columns: &[(&str, DataType, Column)]) {
     run_ast(file, "'1' like '2'", &[]);
     run_ast(file, "'hello\n' like 'h%'", &[]);
     run_ast(file, "'h\n' like 'h_'", &[]);
+    run_ast(file, r#"'%' like '\%'"#, &[]);
+    run_ast(file, r#"'v%xx' like '_\%%'"#, &[]);
 
     let like_columns = [(
         "lhs",

--- a/src/query/functions-v2/tests/it/scalars/testdata/comparison.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/comparison.txt
@@ -850,6 +850,24 @@ output domain  : Unknown
 output         : true
 
 
+ast            : '%' like '\%'
+raw expr       : like("%", "\\%")
+checked expr   : like<String, String>("%", "\\%")
+optimized expr : true
+output type    : Boolean
+output domain  : Unknown
+output         : true
+
+
+ast            : 'v%xx' like '_\%%'
+raw expr       : like("v%xx", "_\\%%")
+checked expr   : like<String, String>("v%xx", "_\\%%")
+optimized expr : true
+output type    : Boolean
+output domain  : Unknown
+output         : true
+
+
 ast            : lhs like 'a%'
 raw expr       : like(ColumnRef(0)::String, "a%")
 checked expr   : like<String, String>(ColumnRef(0), "a%")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Now `l_col like r_col` will generate a hashmap based on r_col, if r_col is huge, it will be oom kill.

sys environment:

> OS: Ubuntu 22.04.1 LTS (Jammy Jellyfish)
> CPU: Intel(R) Xeon(R) Platinum 8269CY CPU @ 2.50GHz
> Memory: 30G
> Disk: 16G / 197G

### Table Struct

```sql
-- databend
 CREATE TABLE `orders` (
  `o_orderkey` BIGINT,
  `o_custkey` BIGINT,
  `o_orderstatus` VARCHAR,
  `o_totalprice` DOUBLE,
  `o_orderdate` DATE,
  `o_orderpriority` VARCHAR,
  `o_clerk` VARCHAR,
  `o_shippriority` INT,
  `o_comment` VARCHAR
)
-- ck
SELECT version()

Query id: 73c60cca-5362-4765-b4fa-9e0a7a9cdd8b

┌─version()──┐
│ 22.10.2.11 │
└────────────┘

CREATE TABLE tpch.orders
(
    `o_orderkey` Int64,
    `o_custkey` Int32,
    `o_orderstatus` String,
    `o_totalprice` Decimal(15, 2),
    `o_orderdate` Date,
    `o_orderpriority` String,
    `o_clerk` String,
    `o_shippriority` Int32,
    `o_comment` String
)
ENGINE = MergeTree
ORDER BY o_orderkey
SETTINGS index_granularity = 8192

```

### Prepare Data

data from: https://github.com/leiysky/tpch-databend 

```shell
./tpch.sh 10.0
bash insert_data.sh
```

```sql
-- databend
mysql> select count() from orders ;
+----------+
| count()  |
+----------+
| 15000000 |
+----------+
1 row in set (0.01 sec)
Read 1 rows, 1.00 B in 0.001 sec., 796.38 rows/sec., 796.38 B/sec.


-- ck
SELECT count()
FROM orders

Query id: 173ca818-69f0-4935-8526-429cb321eac5

┌──count()─┐
│ 15000000 │
└──────────┘

1 row in set. Elapsed: 0.001 sec. 

```

### Result

test sql: `select count() from orders where o_clerk not  like o_comment;`

| before optimize | drop hash map | after optimize | ck |
|--|--|--|--|
| oom |114s|0.832 s|7.925s|

Closes #8615
