### PR TITLE
chore(query): improve cast in expression

### DIFF
--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -29,7 +29,6 @@ use crate::types::any::AnyType;
 use crate::types::array::ArrayColumn;
 use crate::types::nullable::NullableColumn;
 use crate::types::nullable::NullableDomain;
-use crate::types::number::NumberDataType;
 use crate::types::DataType;
 use crate::utils::arrow::constant_bitmap;
 use crate::utils::calculate_function_domain;
@@ -585,7 +584,9 @@ impl<'a> ConstantFolder<'a> {
         }
 
         if let Some(cast_fn) = check_simple_cast(false, dest_type) {
-            return self.calculate_simple_cast(span, src_type, dest_type, domain, &cast_fn);
+            return self
+                .calculate_simple_cast(span, src_type, dest_type, domain, &cast_fn)
+                .unwrap();
         }
 
         match (src_type, dest_type) {
@@ -660,7 +661,9 @@ impl<'a> ConstantFolder<'a> {
         }
 
         if let Some(cast_fn) = check_simple_cast(true, dest_type) {
-            return self.calculate_simple_cast(span, src_type, dest_type, domain, &cast_fn);
+            return self
+                .calculate_simple_cast(span, src_type, dest_type, domain, &cast_fn)
+                .unwrap();
         }
 
         // The dest_type of `TRY_CAST` must be `Nullable`, which is guaranteed by the type checker.

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -132,7 +132,7 @@ impl<'a> Evaluator<'a> {
             return Ok(value);
         }
 
-        if let Some(cast_fn) = check_simple_cast(true, dest_type) {
+        if let Some(cast_fn) = check_simple_cast(false, dest_type) {
             return self.run_simple_cast(span, src_type, dest_type, value, &cast_fn);
         }
 

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -382,8 +382,6 @@ impl<'a> Evaluator<'a> {
         }
     }
 
-    // this function could be refined later
-    // because type_checker already transform the simple cast to Expr::FunctionCall
     fn run_simple_cast(
         &self,
         span: Span,

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -584,6 +584,10 @@ impl<'a> ConstantFolder<'a> {
             return Some(domain.clone());
         }
 
+        if let Some(cast_fn) = check_simple_cast(false, dest_type) {
+            return self.calculate_simple_cast(span, src_type, dest_type, domain, &cast_fn);
+        }
+
         match (src_type, dest_type) {
             (DataType::Null, DataType::Nullable(_)) => Some(domain.clone()),
             (DataType::Nullable(inner_src_ty), DataType::Nullable(inner_dest_ty)) => {
@@ -640,50 +644,6 @@ impl<'a> ConstantFolder<'a> {
                         .collect::<Option<Vec<_>>>()?,
                 ))
             }
-
-            (_, DataType::String) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_string")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::UInt8)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_uint8")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::UInt16)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_uint16")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::UInt32)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_uint32")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::UInt64)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_uint64")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Int8)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_int8")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Int16)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_int16")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Int32)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_int32")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Int64)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_int64")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Float32)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_float32")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Float64)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_float64")
-                .unwrap(),
-            (_, DataType::Timestamp) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_timestamp")
-                .unwrap(),
-            (_, DataType::Date) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_date")
-                .unwrap(),
-            (_, DataType::Variant) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "to_variant")
-                .unwrap(),
-
             _ => None,
         }
     }
@@ -697,6 +657,10 @@ impl<'a> ConstantFolder<'a> {
     ) -> Option<Domain> {
         if src_type == dest_type {
             return Some(domain.clone());
+        }
+
+        if let Some(cast_fn) = check_simple_cast(true, dest_type) {
+            return self.calculate_simple_cast(span, src_type, dest_type, domain, &cast_fn);
         }
 
         // The dest_type of `TRY_CAST` must be `Nullable`, which is guaranteed by the type checker.
@@ -753,49 +717,6 @@ impl<'a> ConstantFolder<'a> {
                     .collect::<Option<_>>()?;
                 Some(Domain::Tuple(new_fields_domain))
             }
-
-            (_, DataType::String) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_string")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::UInt8)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_uint8")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::UInt16)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_uint16")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::UInt32)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_uint32")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::UInt64)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_uint64")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Int8)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_int8")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Int16)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_int16")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Int32)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_int32")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Int64)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_int64")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Float32)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_float32")
-                .unwrap(),
-            (_, DataType::Number(NumberDataType::Float64)) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_float64")
-                .unwrap(),
-            (_, DataType::Timestamp) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_timestamp")
-                .unwrap(),
-            (_, DataType::Date) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_date")
-                .unwrap(),
-            (_, DataType::Variant) => self
-                .calculate_simple_cast(span, src_type, dest_type, domain, "try_to_variant")
-                .unwrap(),
 
             _ => Some(Domain::Nullable(NullableDomain {
                 has_null: true,

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -258,14 +258,13 @@ impl<'a> Evaluator<'a> {
             return value;
         }
 
-        if let Some(cast_fn) = check_simple_cast(true, dest_type) {
+        // The dest_type of `TRY_CAST` must be `Nullable`, which is guaranteed by the type checker.
+        let inner_dest_type = &**dest_type.as_nullable().unwrap();
+        if let Some(cast_fn) = check_simple_cast(true, inner_dest_type) {
             return self
                 .run_simple_cast(span, src_type, dest_type, value, &cast_fn)
                 .unwrap();
         }
-
-        // The dest_type of `TRY_CAST` must be `Nullable`, which is guaranteed by the type checker.
-        let inner_dest_type = &**dest_type.as_nullable().unwrap();
 
         match (src_type, inner_dest_type) {
             (DataType::Null, _) => match value {
@@ -660,14 +659,14 @@ impl<'a> ConstantFolder<'a> {
             return Some(domain.clone());
         }
 
-        if let Some(cast_fn) = check_simple_cast(true, dest_type) {
+        // The dest_type of `TRY_CAST` must be `Nullable`, which is guaranteed by the type checker.
+        let inner_dest_type = &**dest_type.as_nullable().unwrap();
+
+        if let Some(cast_fn) = check_simple_cast(true, inner_dest_type) {
             return self
                 .calculate_simple_cast(span, src_type, dest_type, domain, &cast_fn)
                 .unwrap();
         }
-
-        // The dest_type of `TRY_CAST` must be `Nullable`, which is guaranteed by the type checker.
-        let inner_dest_type = &**dest_type.as_nullable().unwrap();
 
         match (src_type, inner_dest_type) {
             (DataType::Null, _) => Some(domain.clone()),

--- a/src/query/expression/src/type_check.rs
+++ b/src/query/expression/src/type_check.rs
@@ -64,7 +64,7 @@ pub fn check(ast: &RawExpr, fn_registry: &FunctionRegistry) -> Result<Expr> {
                 Ok(expr)
             } else {
                 // faster path to eval function for cast
-                if let Some(cast_fn) = check_simple_cast(*is_try, &dest_type) {
+                if let Some(cast_fn) = check_simple_cast(*is_try, dest_type) {
                     return check_function(span.clone(), &cast_fn, &[], &[expr], fn_registry);
                 }
                 Ok(Expr::Cast {

--- a/src/query/functions-v2/tests/it/scalars/testdata/cast.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/cast.txt
@@ -1,6 +1,6 @@
 ast            : TRY_CAST(a AS UINT8)
 raw expr       : TRY_CAST(ColumnRef(0)::UInt16 AS UInt8)
-checked expr   : TRY_CAST(ColumnRef(0) AS UInt8 NULL)
+checked expr   : try_to_uint8<UInt16>(ColumnRef(0))
 evaluation:
 +--------+------------+--------------------+
 |        | a          | Output             |
@@ -24,7 +24,7 @@ evaluation (internal):
 
 ast            : TRY_CAST(a AS UINT16)
 raw expr       : TRY_CAST(ColumnRef(0)::Int16 AS UInt16)
-checked expr   : TRY_CAST(ColumnRef(0) AS UInt16 NULL)
+checked expr   : try_to_uint16<Int16>(ColumnRef(0))
 evaluation:
 +--------+----------+------------------+
 |        | a        | Output           |
@@ -48,7 +48,7 @@ evaluation (internal):
 
 ast            : TRY_CAST(a AS INT64)
 raw expr       : TRY_CAST(ColumnRef(0)::Int16 AS Int64)
-checked expr   : TRY_CAST(ColumnRef(0) AS Int64 NULL)
+checked expr   : try_to_int64<Int16>(ColumnRef(0))
 evaluation:
 +--------+----------+------------+
 |        | a        | Output     |
@@ -72,7 +72,7 @@ evaluation (internal):
 
 ast            : (TRY_CAST(a AS FLOAT32), TRY_CAST(a AS INT32), TRY_CAST(b AS FLOAT32), TRY_CAST(b AS INT32))
 raw expr       : tuple(TRY_CAST(ColumnRef(0)::UInt64 AS Float32), TRY_CAST(ColumnRef(0)::UInt64 AS Int32), TRY_CAST(ColumnRef(1)::Float64 AS Float32), TRY_CAST(ColumnRef(1)::Float64 AS Int32))
-checked expr   : tuple<Float32 NULL, Int32 NULL, Float32 NULL, Int32 NULL>(TRY_CAST(ColumnRef(0) AS Float32 NULL), TRY_CAST(ColumnRef(0) AS Int32 NULL), TRY_CAST(ColumnRef(1) AS Float32 NULL), TRY_CAST(ColumnRef(1) AS Int32 NULL))
+checked expr   : tuple<Float32 NULL, Int32 NULL, Float32 NULL, Int32 NULL>(try_to_float32<UInt64>(ColumnRef(0)), try_to_int32<UInt64>(ColumnRef(0)), try_to_float32<Float64>(ColumnRef(1)), try_to_int32<Float64>(ColumnRef(1)))
 evaluation:
 +--------+----------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------+
 |        | a                          | b                                                                                                                                                                                                                                                                                                                              | Output                                                                                                     |
@@ -149,7 +149,7 @@ evaluation (internal):
 
 ast            : CAST(a AS INT16)
 raw expr       : CAST(ColumnRef(0)::Float64 AS Int16)
-checked expr   : CAST(ColumnRef(0) AS Int16)
+checked expr   : to_int16<Float64>(ColumnRef(0))
 evaluation:
 +--------+--------------+----------+
 |        | a            | Output   |
@@ -173,7 +173,7 @@ evaluation (internal):
 
 ast            : CAST(b AS INT16)
 raw expr       : CAST(ColumnRef(0)::Int8 AS Int16)
-checked expr   : CAST(ColumnRef(0) AS Int16)
+checked expr   : to_int16<Int8>(ColumnRef(0))
 evaluation:
 +--------+----------+----------+
 |        | b        | Output   |
@@ -213,7 +213,7 @@ error:
 
 ast            : CAST(NULL AS VARIANT)
 raw expr       : CAST(NULL AS Variant)
-checked expr   : CAST(NULL AS Variant)
+checked expr   : to_variant<T0=NULL><T0>(NULL)
 optimized expr : 0x2000000000000000
 output type    : Variant
 output domain  : Undefined
@@ -222,7 +222,7 @@ output         : null
 
 ast            : CAST(0 AS VARIANT)
 raw expr       : CAST(0_u8 AS Variant)
-checked expr   : CAST(0_u8 AS Variant)
+checked expr   : to_variant<T0=UInt8><T0>(0_u8)
 optimized expr : 0x200000002000000100
 output type    : Variant
 output domain  : Undefined
@@ -231,7 +231,7 @@ output         : 0
 
 ast            : CAST(-1 AS VARIANT)
 raw expr       : CAST(minus(1_u8) AS Variant)
-checked expr   : CAST(minus<UInt8>(1_u8) AS Variant)
+checked expr   : to_variant<T0=Int16><T0>(minus<UInt8>(1_u8))
 optimized expr : 0x200000002000000240ff
 output type    : Variant
 output domain  : Undefined
@@ -240,7 +240,7 @@ output         : -1
 
 ast            : CAST(1.1 AS VARIANT)
 raw expr       : CAST(1.1_f64 AS Variant)
-checked expr   : CAST(1.1_f64 AS Variant)
+checked expr   : to_variant<T0=Float64><T0>(1.1_f64)
 optimized expr : 0x2000000020000009603ff199999999999a
 output type    : Variant
 output domain  : Undefined
@@ -249,7 +249,7 @@ output         : 1.1
 
 ast            : CAST('🍦 が美味しい' AS VARIANT)
 raw expr       : CAST("🍦 が美味しい" AS Variant)
-checked expr   : CAST("🍦 が美味しい" AS Variant)
+checked expr   : to_variant<T0=String><T0>("🍦 が美味しい")
 optimized expr : 0x2000000010000014f09f8da620e3818ce7be8ee591b3e38197e38184
 output type    : Variant
 output domain  : Undefined
@@ -258,7 +258,7 @@ output         : "🍦 が美味しい"
 
 ast            : CAST([0, 1, 2] AS VARIANT)
 raw expr       : CAST(array(0_u8, 1_u8, 2_u8) AS Variant)
-checked expr   : CAST(array<T0=UInt8><T0, T0, T0>(0_u8, 1_u8, 2_u8) AS Variant)
+checked expr   : to_variant<T0=Array(UInt8)><T0>(array<T0=UInt8><T0, T0, T0>(0_u8, 1_u8, 2_u8))
 optimized expr : 0x800000032000000120000002200000020050015002
 output type    : Variant
 output domain  : Undefined
@@ -267,7 +267,7 @@ output         : [0,1,2]
 
 ast            : CAST([0, 'a'] AS VARIANT)
 raw expr       : CAST(array(0_u8, "a") AS Variant)
-checked expr   : CAST(array<T0=Variant><T0, T0>(CAST(0_u8 AS Variant), CAST("a" AS Variant)) AS Variant)
+checked expr   : to_variant<T0=Array(Variant)><T0>(array<T0=Variant><T0, T0>(CAST(0_u8 AS Variant), CAST("a" AS Variant)))
 optimized expr : 0x8000000220000001100000010061
 output type    : Variant
 output domain  : Undefined
@@ -276,7 +276,7 @@ output         : [0,"a"]
 
 ast            : CAST(to_timestamp(1000000) AS VARIANT)
 raw expr       : CAST(to_timestamp(1000000_u32) AS Variant)
-checked expr   : CAST(to_timestamp<Int64>(CAST(1000000_u32 AS Int64)) AS Variant)
+checked expr   : to_variant<T0=Timestamp><T0>(to_timestamp<Int64>(CAST(1000000_u32 AS Int64)))
 optimized expr : 0x200000001000001a313937302d30312d31322031333a34363a34302e303030303030
 output type    : Variant
 output domain  : Undefined
@@ -285,7 +285,7 @@ output         : "1970-01-12 13:46:40.000000"
 
 ast            : CAST(false AS VARIANT)
 raw expr       : CAST(false AS Variant)
-checked expr   : CAST(false AS Variant)
+checked expr   : to_variant<T0=Boolean><T0>(false)
 optimized expr : 0x2000000030000000
 output type    : Variant
 output domain  : Undefined
@@ -294,7 +294,7 @@ output         : false
 
 ast            : CAST(true AS VARIANT)
 raw expr       : CAST(true AS Variant)
-checked expr   : CAST(true AS Variant)
+checked expr   : to_variant<T0=Boolean><T0>(true)
 optimized expr : 0x2000000040000000
 output type    : Variant
 output domain  : Undefined
@@ -303,7 +303,7 @@ output         : true
 
 ast            : CAST(CAST('🍦 が美味しい' AS VARIANT) AS VARIANT)
 raw expr       : CAST(CAST("🍦 が美味しい" AS Variant) AS Variant)
-checked expr   : CAST("🍦 が美味しい" AS Variant)
+checked expr   : to_variant<T0=String><T0>("🍦 が美味しい")
 optimized expr : 0x2000000010000014f09f8da620e3818ce7be8ee591b3e38197e38184
 output type    : Variant
 output domain  : Undefined
@@ -312,7 +312,7 @@ output         : "🍦 が美味しい"
 
 ast            : CAST((1,) AS VARIANT)
 raw expr       : CAST(tuple(1_u8) AS Variant)
-checked expr   : CAST(tuple<UInt8>(1_u8) AS Variant)
+checked expr   : to_variant<T0=(UInt8,)><T0>(tuple<UInt8>(1_u8))
 optimized expr : 0x400000011000000120000002315001
 output type    : Variant
 output domain  : Undefined
@@ -321,7 +321,7 @@ output         : {"1":1}
 
 ast            : CAST((1, 2) AS VARIANT)
 raw expr       : CAST(tuple(1_u8, 2_u8) AS Variant)
-checked expr   : CAST(tuple<UInt8, UInt8>(1_u8, 2_u8) AS Variant)
+checked expr   : to_variant<T0=(UInt8, UInt8)><T0>(tuple<UInt8, UInt8>(1_u8, 2_u8))
 optimized expr : 0x4000000210000001100000012000000220000002313250015002
 output type    : Variant
 output domain  : Undefined
@@ -330,7 +330,7 @@ output         : {"1":1,"2":2}
 
 ast            : CAST((false, true) AS VARIANT)
 raw expr       : CAST(tuple(false, true) AS Variant)
-checked expr   : CAST(tuple<Boolean, Boolean>(false, true) AS Variant)
+checked expr   : to_variant<T0=(Boolean, Boolean)><T0>(tuple<Boolean, Boolean>(false, true))
 optimized expr : 0x40000002100000011000000130000000400000003132
 output type    : Variant
 output domain  : Undefined
@@ -339,7 +339,7 @@ output         : {"1":false,"2":true}
 
 ast            : CAST(('a',) AS VARIANT)
 raw expr       : CAST(tuple("a") AS Variant)
-checked expr   : CAST(tuple<String>("a") AS Variant)
+checked expr   : to_variant<T0=(String,)><T0>(tuple<String>("a"))
 optimized expr : 0x4000000110000001100000013161
 output type    : Variant
 output domain  : Undefined
@@ -348,7 +348,7 @@ output         : {"1":"a"}
 
 ast            : CAST((1, 2, (false, true, ('a',))) AS VARIANT)
 raw expr       : CAST(tuple(1_u8, 2_u8, tuple(false, true, tuple("a"))) AS Variant)
-checked expr   : CAST(tuple<UInt8, UInt8, (Boolean, Boolean, (String,))>(1_u8, 2_u8, tuple<Boolean, Boolean, (String,)>(false, true, tuple<String>("a"))) AS Variant)
+checked expr   : to_variant<T0=(UInt8, UInt8, (Boolean, Boolean, (String,)))><T0>(tuple<UInt8, UInt8, (Boolean, Boolean, (String,))>(1_u8, 2_u8, tuple<Boolean, Boolean, (String,)>(false, true, tuple<String>("a"))))
 optimized expr : 0x4000000310000001100000011000000120000002200000025000002d313233500150024000000310000001100000011000000130000000400000005000000e3132334000000110000001100000013161
 output type    : Variant
 output domain  : Undefined
@@ -357,7 +357,7 @@ output         : {"1":1,"2":2,"3":{"1":false,"2":true,"3":{"1":"a"}}}
 
 ast            : CAST(a AS VARIANT)
 raw expr       : CAST(ColumnRef(0)::String NULL AS Variant)
-checked expr   : CAST(ColumnRef(0) AS Variant)
+checked expr   : to_variant<T0=String NULL><T0>(ColumnRef(0))
 evaluation:
 +--------+------------------------+-----------+
 |        | a                      | Output    |
@@ -379,16 +379,16 @@ evaluation (internal):
 
 ast            : TRY_CAST(NULL AS VARIANT)
 raw expr       : TRY_CAST(NULL AS Variant)
-checked expr   : TRY_CAST(NULL AS Variant NULL)
-optimized expr : NULL
+checked expr   : try_to_variant<T0=NULL><T0>(NULL)
+optimized expr : 0x2000000000000000
 output type    : Variant NULL
-output domain  : {NULL}
-output         : NULL
+output domain  : Undefined
+output         : null
 
 
 ast            : TRY_CAST(0 AS VARIANT)
 raw expr       : TRY_CAST(0_u8 AS Variant)
-checked expr   : TRY_CAST(0_u8 AS Variant NULL)
+checked expr   : try_to_variant<T0=UInt8><T0>(0_u8)
 optimized expr : 0x200000002000000100
 output type    : Variant NULL
 output domain  : Undefined
@@ -397,7 +397,7 @@ output         : 0
 
 ast            : TRY_CAST(-1 AS VARIANT)
 raw expr       : TRY_CAST(minus(1_u8) AS Variant)
-checked expr   : TRY_CAST(minus<UInt8>(1_u8) AS Variant NULL)
+checked expr   : try_to_variant<T0=Int16><T0>(minus<UInt8>(1_u8))
 optimized expr : 0x200000002000000240ff
 output type    : Variant NULL
 output domain  : Undefined
@@ -406,7 +406,7 @@ output         : -1
 
 ast            : TRY_CAST(1.1 AS VARIANT)
 raw expr       : TRY_CAST(1.1_f64 AS Variant)
-checked expr   : TRY_CAST(1.1_f64 AS Variant NULL)
+checked expr   : try_to_variant<T0=Float64><T0>(1.1_f64)
 optimized expr : 0x2000000020000009603ff199999999999a
 output type    : Variant NULL
 output domain  : Undefined
@@ -415,7 +415,7 @@ output         : 1.1
 
 ast            : TRY_CAST('🍦 が美味しい' AS VARIANT)
 raw expr       : TRY_CAST("🍦 が美味しい" AS Variant)
-checked expr   : TRY_CAST("🍦 が美味しい" AS Variant NULL)
+checked expr   : try_to_variant<T0=String><T0>("🍦 が美味しい")
 optimized expr : 0x2000000010000014f09f8da620e3818ce7be8ee591b3e38197e38184
 output type    : Variant NULL
 output domain  : Undefined
@@ -424,7 +424,7 @@ output         : "🍦 が美味しい"
 
 ast            : TRY_CAST([0, 1, 2] AS VARIANT)
 raw expr       : TRY_CAST(array(0_u8, 1_u8, 2_u8) AS Variant)
-checked expr   : TRY_CAST(array<T0=UInt8><T0, T0, T0>(0_u8, 1_u8, 2_u8) AS Variant NULL)
+checked expr   : try_to_variant<T0=Array(UInt8)><T0>(array<T0=UInt8><T0, T0, T0>(0_u8, 1_u8, 2_u8))
 optimized expr : 0x800000032000000120000002200000020050015002
 output type    : Variant NULL
 output domain  : Undefined
@@ -433,7 +433,7 @@ output         : [0,1,2]
 
 ast            : TRY_CAST([0, 'a'] AS VARIANT)
 raw expr       : TRY_CAST(array(0_u8, "a") AS Variant)
-checked expr   : TRY_CAST(array<T0=Variant><T0, T0>(CAST(0_u8 AS Variant), CAST("a" AS Variant)) AS Variant NULL)
+checked expr   : try_to_variant<T0=Array(Variant)><T0>(array<T0=Variant><T0, T0>(CAST(0_u8 AS Variant), CAST("a" AS Variant)))
 optimized expr : 0x8000000220000001100000010061
 output type    : Variant NULL
 output domain  : Undefined
@@ -442,7 +442,7 @@ output         : [0,"a"]
 
 ast            : TRY_CAST(to_timestamp(1000000) AS VARIANT)
 raw expr       : TRY_CAST(to_timestamp(1000000_u32) AS Variant)
-checked expr   : TRY_CAST(to_timestamp<Int64>(CAST(1000000_u32 AS Int64)) AS Variant NULL)
+checked expr   : try_to_variant<T0=Timestamp><T0>(to_timestamp<Int64>(CAST(1000000_u32 AS Int64)))
 optimized expr : 0x200000001000001a313937302d30312d31322031333a34363a34302e303030303030
 output type    : Variant NULL
 output domain  : Undefined
@@ -451,7 +451,7 @@ output         : "1970-01-12 13:46:40.000000"
 
 ast            : TRY_CAST(false AS VARIANT)
 raw expr       : TRY_CAST(false AS Variant)
-checked expr   : TRY_CAST(false AS Variant NULL)
+checked expr   : try_to_variant<T0=Boolean><T0>(false)
 optimized expr : 0x2000000030000000
 output type    : Variant NULL
 output domain  : Undefined
@@ -460,7 +460,7 @@ output         : false
 
 ast            : TRY_CAST(true AS VARIANT)
 raw expr       : TRY_CAST(true AS Variant)
-checked expr   : TRY_CAST(true AS Variant NULL)
+checked expr   : try_to_variant<T0=Boolean><T0>(true)
 optimized expr : 0x2000000040000000
 output type    : Variant NULL
 output domain  : Undefined
@@ -469,7 +469,7 @@ output         : true
 
 ast            : TRY_CAST(TRY_CAST('🍦 が美味しい' AS VARIANT) AS VARIANT)
 raw expr       : TRY_CAST(TRY_CAST("🍦 が美味しい" AS Variant) AS Variant)
-checked expr   : TRY_CAST("🍦 が美味しい" AS Variant NULL)
+checked expr   : try_to_variant<T0=String><T0>("🍦 が美味しい")
 optimized expr : 0x2000000010000014f09f8da620e3818ce7be8ee591b3e38197e38184
 output type    : Variant NULL
 output domain  : Undefined
@@ -478,24 +478,24 @@ output         : "🍦 が美味しい"
 
 ast            : TRY_CAST(a AS VARIANT)
 raw expr       : TRY_CAST(ColumnRef(0)::String NULL AS Variant)
-checked expr   : TRY_CAST(ColumnRef(0) AS Variant NULL)
+checked expr   : try_to_variant<T0=String NULL><T0>(ColumnRef(0))
 evaluation:
-+--------+------------------------+--------------------+
-|        | a                      | Output             |
-+--------+------------------------+--------------------+
-| Type   | String NULL            | Variant NULL       |
-| Domain | {"a"..="def"} ∪ {NULL} | Undefined ∪ {NULL} |
-| Row 0  | "a"                    | "a"                |
-| Row 1  | NULL                   | "bc"               |
-| Row 2  | "def"                  | "def"              |
-+--------+------------------------+--------------------+
++--------+------------------------+--------------+
+|        | a                      | Output       |
++--------+------------------------+--------------+
+| Type   | String NULL            | Variant NULL |
+| Domain | {"a"..="def"} ∪ {NULL} | Undefined    |
+| Row 0  | "a"                    | "a"          |
+| Row 1  | NULL                   | null         |
+| Row 2  | "def"                  | "def"        |
++--------+------------------------+--------------+
 evaluation (internal):
-+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Column | Data                                                                                                                                                              |
-+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| a      | NullableColumn { column: StringColumn { data: 0x616263646566, offsets: [0, 1, 3, 6] }, validity: [0b_____101] }                                                   |
-| Output | NullableColumn { column: StringColumn { data: 0x200000001000000161200000001000000262632000000010000003646566, offsets: [0, 9, 19, 30] }, validity: [0b_____111] } |
-+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                          |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| a      | NullableColumn { column: StringColumn { data: 0x616263646566, offsets: [0, 1, 3, 6] }, validity: [0b_____101] }                                               |
+| Output | NullableColumn { column: StringColumn { data: 0x20000000100000016120000000000000002000000010000003646566, offsets: [0, 9, 17, 28] }, validity: [0b_____111] } |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
 error: 
@@ -508,7 +508,7 @@ error:
 
 ast            : CAST(-315360000000000 AS TIMESTAMP)
 raw expr       : CAST(minus(315360000000000_u64) AS Timestamp)
-checked expr   : CAST(minus<UInt64>(315360000000000_u64) AS Timestamp)
+checked expr   : to_timestamp<Int64>(minus<UInt64>(315360000000000_u64))
 optimized expr : -315360000000000
 output type    : Timestamp
 output domain  : {-315360000000000..=-315360000000000}
@@ -517,7 +517,7 @@ output         : 1960-01-04 00:00:00.000000
 
 ast            : CAST(-315360000000 AS TIMESTAMP)
 raw expr       : CAST(minus(315360000000_u64) AS Timestamp)
-checked expr   : CAST(minus<UInt64>(315360000000_u64) AS Timestamp)
+checked expr   : to_timestamp<Int64>(minus<UInt64>(315360000000_u64))
 optimized expr : -315360000000000
 output type    : Timestamp
 output domain  : {-315360000000000..=-315360000000000}
@@ -526,7 +526,7 @@ output         : 1960-01-04 00:00:00.000000
 
 ast            : CAST(-100 AS TIMESTAMP)
 raw expr       : CAST(minus(100_u8) AS Timestamp)
-checked expr   : CAST(minus<UInt8>(100_u8) AS Timestamp)
+checked expr   : to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64))
 optimized expr : -100000000
 output type    : Timestamp
 output domain  : {-100000000..=-100000000}
@@ -535,7 +535,7 @@ output         : 1969-12-31 23:58:20.000000
 
 ast            : CAST(-0 AS TIMESTAMP)
 raw expr       : CAST(minus(0_u8) AS Timestamp)
-checked expr   : CAST(minus<UInt8>(0_u8) AS Timestamp)
+checked expr   : to_timestamp<Int64>(CAST(minus<UInt8>(0_u8) AS Int64))
 optimized expr : 0
 output type    : Timestamp
 output domain  : {0..=0}
@@ -544,7 +544,7 @@ output         : 1970-01-01 00:00:00.000000
 
 ast            : CAST(0 AS TIMESTAMP)
 raw expr       : CAST(0_u8 AS Timestamp)
-checked expr   : CAST(0_u8 AS Timestamp)
+checked expr   : to_timestamp<Int64>(CAST(0_u8 AS Int64))
 optimized expr : 0
 output type    : Timestamp
 output domain  : {0..=0}
@@ -553,7 +553,7 @@ output         : 1970-01-01 00:00:00.000000
 
 ast            : CAST(100 AS TIMESTAMP)
 raw expr       : CAST(100_u8 AS Timestamp)
-checked expr   : CAST(100_u8 AS Timestamp)
+checked expr   : to_timestamp<Int64>(CAST(100_u8 AS Int64))
 optimized expr : 100000000
 output type    : Timestamp
 output domain  : {100000000..=100000000}
@@ -562,7 +562,7 @@ output         : 1970-01-01 00:01:40.000000
 
 ast            : CAST(315360000000 AS TIMESTAMP)
 raw expr       : CAST(315360000000_u64 AS Timestamp)
-checked expr   : CAST(315360000000_u64 AS Timestamp)
+checked expr   : to_timestamp<Int64>(CAST(315360000000_u64 AS Int64))
 optimized expr : 315360000000000
 output type    : Timestamp
 output domain  : {315360000000000..=315360000000000}
@@ -571,7 +571,7 @@ output         : 1979-12-30 00:00:00.000000
 
 ast            : CAST(315360000000000 AS TIMESTAMP)
 raw expr       : CAST(315360000000000_u64 AS Timestamp)
-checked expr   : CAST(315360000000000_u64 AS Timestamp)
+checked expr   : to_timestamp<Int64>(CAST(315360000000000_u64 AS Int64))
 optimized expr : 315360000000000
 output type    : Timestamp
 output domain  : {315360000000000..=315360000000000}
@@ -588,7 +588,7 @@ error:
 
 ast            : CAST(a AS TIMESTAMP)
 raw expr       : CAST(ColumnRef(0)::Int64 AS Timestamp)
-checked expr   : CAST(ColumnRef(0) AS Timestamp)
+checked expr   : to_timestamp<Int64>(ColumnRef(0))
 evaluation:
 +--------+--------------------------------------+--------------------------------------+
 |        | a                                    | Output                               |
@@ -614,7 +614,7 @@ evaluation (internal):
 
 ast            : TRY_CAST(-30610224000000001 AS TIMESTAMP)
 raw expr       : TRY_CAST(minus(30610224000000001_u64) AS Timestamp)
-checked expr   : TRY_CAST(minus<UInt64>(30610224000000001_u64) AS Timestamp NULL)
+checked expr   : try_to_timestamp<Int64 NULL>(CAST(minus<UInt64>(30610224000000001_u64) AS Int64 NULL))
 optimized expr : NULL
 output type    : Timestamp NULL
 output domain  : Unknown
@@ -623,7 +623,7 @@ output         : NULL
 
 ast            : TRY_CAST(253402300800000000 AS TIMESTAMP)
 raw expr       : TRY_CAST(253402300800000000_u64 AS Timestamp)
-checked expr   : TRY_CAST(253402300800000000_u64 AS Timestamp NULL)
+checked expr   : try_to_timestamp<Int64 NULL>(CAST(253402300800000000_u64 AS Int64 NULL))
 optimized expr : NULL
 output type    : Timestamp NULL
 output domain  : Unknown
@@ -632,7 +632,7 @@ output         : NULL
 
 ast            : TRY_CAST(a AS TIMESTAMP)
 raw expr       : TRY_CAST(ColumnRef(0)::Int64 AS Timestamp)
-checked expr   : TRY_CAST(ColumnRef(0) AS Timestamp NULL)
+checked expr   : try_to_timestamp<Int64 NULL>(CAST(ColumnRef(0) AS Int64 NULL))
 evaluation:
 +--------+-------------------------------------------+----------------------------+
 |        | a                                         | Output                     |
@@ -656,7 +656,7 @@ evaluation (internal):
 
 ast            : CAST(TO_TIMESTAMP(-315360000000000) AS INT64)
 raw expr       : CAST(TO_TIMESTAMP(minus(315360000000000_u64)) AS Int64)
-checked expr   : CAST(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)) AS Int64)
+checked expr   : to_int64<Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)))
 optimized expr : -315360000000000_i64
 output type    : Int64
 output domain  : {-315360000000000..=-315360000000000}
@@ -665,7 +665,7 @@ output         : -315360000000000
 
 ast            : CAST(TO_TIMESTAMP(-315360000000) AS INT64)
 raw expr       : CAST(TO_TIMESTAMP(minus(315360000000_u64)) AS Int64)
-checked expr   : CAST(to_timestamp<Int64>(minus<UInt64>(315360000000_u64)) AS Int64)
+checked expr   : to_int64<Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000_u64)))
 optimized expr : -315360000000000_i64
 output type    : Int64
 output domain  : {-315360000000000..=-315360000000000}
@@ -674,7 +674,7 @@ output         : -315360000000000
 
 ast            : CAST(TO_TIMESTAMP(-100) AS INT64)
 raw expr       : CAST(TO_TIMESTAMP(minus(100_u8)) AS Int64)
-checked expr   : CAST(to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)) AS Int64)
+checked expr   : to_int64<Timestamp>(to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : -100000000_i64
 output type    : Int64
 output domain  : {-100000000..=-100000000}
@@ -683,7 +683,7 @@ output         : -100000000
 
 ast            : CAST(TO_TIMESTAMP(-0) AS INT64)
 raw expr       : CAST(TO_TIMESTAMP(minus(0_u8)) AS Int64)
-checked expr   : CAST(to_timestamp<Int64>(CAST(minus<UInt8>(0_u8) AS Int64)) AS Int64)
+checked expr   : to_int64<Timestamp>(to_timestamp<Int64>(CAST(minus<UInt8>(0_u8) AS Int64)))
 optimized expr : 0_i64
 output type    : Int64
 output domain  : {0..=0}
@@ -692,7 +692,7 @@ output         : 0
 
 ast            : CAST(TO_TIMESTAMP(0) AS INT64)
 raw expr       : CAST(TO_TIMESTAMP(0_u8) AS Int64)
-checked expr   : CAST(to_timestamp<Int64>(CAST(0_u8 AS Int64)) AS Int64)
+checked expr   : to_int64<Timestamp>(to_timestamp<Int64>(CAST(0_u8 AS Int64)))
 optimized expr : 0_i64
 output type    : Int64
 output domain  : {0..=0}
@@ -701,7 +701,7 @@ output         : 0
 
 ast            : CAST(TO_TIMESTAMP(100) AS INT64)
 raw expr       : CAST(TO_TIMESTAMP(100_u8) AS Int64)
-checked expr   : CAST(to_timestamp<Int64>(CAST(100_u8 AS Int64)) AS Int64)
+checked expr   : to_int64<Timestamp>(to_timestamp<Int64>(CAST(100_u8 AS Int64)))
 optimized expr : 100000000_i64
 output type    : Int64
 output domain  : {100000000..=100000000}
@@ -710,7 +710,7 @@ output         : 100000000
 
 ast            : CAST(TO_TIMESTAMP(315360000000) AS INT64)
 raw expr       : CAST(TO_TIMESTAMP(315360000000_u64) AS Int64)
-checked expr   : CAST(to_timestamp<Int64>(CAST(315360000000_u64 AS Int64)) AS Int64)
+checked expr   : to_int64<Timestamp>(to_timestamp<Int64>(CAST(315360000000_u64 AS Int64)))
 optimized expr : 315360000000000_i64
 output type    : Int64
 output domain  : {315360000000000..=315360000000000}
@@ -719,7 +719,7 @@ output         : 315360000000000
 
 ast            : CAST(TO_TIMESTAMP(315360000000000) AS INT64)
 raw expr       : CAST(TO_TIMESTAMP(315360000000000_u64) AS Int64)
-checked expr   : CAST(to_timestamp<Int64>(CAST(315360000000000_u64 AS Int64)) AS Int64)
+checked expr   : to_int64<Timestamp>(to_timestamp<Int64>(CAST(315360000000000_u64 AS Int64)))
 optimized expr : 315360000000000_i64
 output type    : Int64
 output domain  : {315360000000000..=315360000000000}
@@ -728,7 +728,7 @@ output         : 315360000000000
 
 ast            : CAST(a AS INT64)
 raw expr       : CAST(ColumnRef(0)::Timestamp AS Int64)
-checked expr   : CAST(ColumnRef(0) AS Int64)
+checked expr   : to_int64<Timestamp>(ColumnRef(0))
 evaluation:
 +--------+--------------------------------------+--------------------------------------+
 |        | a                                    | Output                               |
@@ -762,7 +762,7 @@ error:
 
 ast            : CAST(-354285 AS DATE)
 raw expr       : CAST(minus(354285_u32) AS Date)
-checked expr   : CAST(minus<UInt32>(354285_u32) AS Date)
+checked expr   : to_date<Int64>(minus<UInt32>(354285_u32))
 optimized expr : -354285
 output type    : Date
 output domain  : {-354285..=-354285}
@@ -771,7 +771,7 @@ output         : 1000-01-01
 
 ast            : CAST(-100 AS DATE)
 raw expr       : CAST(minus(100_u8) AS Date)
-checked expr   : CAST(minus<UInt8>(100_u8) AS Date)
+checked expr   : to_date<Int64>(CAST(minus<UInt8>(100_u8) AS Int64))
 optimized expr : -100
 output type    : Date
 output domain  : {-100..=-100}
@@ -780,7 +780,7 @@ output         : 1969-09-23
 
 ast            : CAST(-0 AS DATE)
 raw expr       : CAST(minus(0_u8) AS Date)
-checked expr   : CAST(minus<UInt8>(0_u8) AS Date)
+checked expr   : to_date<Int64>(CAST(minus<UInt8>(0_u8) AS Int64))
 optimized expr : 0
 output type    : Date
 output domain  : {0..=0}
@@ -789,7 +789,7 @@ output         : 1970-01-01
 
 ast            : CAST(0 AS DATE)
 raw expr       : CAST(0_u8 AS Date)
-checked expr   : CAST(0_u8 AS Date)
+checked expr   : to_date<Int64>(CAST(0_u8 AS Int64))
 optimized expr : 0
 output type    : Date
 output domain  : {0..=0}
@@ -798,7 +798,7 @@ output         : 1970-01-01
 
 ast            : CAST(100 AS DATE)
 raw expr       : CAST(100_u8 AS Date)
-checked expr   : CAST(100_u8 AS Date)
+checked expr   : to_date<Int64>(CAST(100_u8 AS Int64))
 optimized expr : 100
 output type    : Date
 output domain  : {100..=100}
@@ -807,7 +807,7 @@ output         : 1970-04-11
 
 ast            : CAST(2932896 AS DATE)
 raw expr       : CAST(2932896_u32 AS Date)
-checked expr   : CAST(2932896_u32 AS Date)
+checked expr   : to_date<Int64>(CAST(2932896_u32 AS Int64))
 optimized expr : 2932896
 output type    : Date
 output domain  : {2932896..=2932896}
@@ -824,7 +824,7 @@ error:
 
 ast            : CAST(a AS DATE)
 raw expr       : CAST(ColumnRef(0)::Int32 AS Date)
-checked expr   : CAST(ColumnRef(0) AS Date)
+checked expr   : to_date<Int64>(CAST(ColumnRef(0) AS Int64))
 evaluation:
 +--------+---------------------+---------------------+
 |        | a                   | Output              |
@@ -848,7 +848,7 @@ evaluation (internal):
 
 ast            : TRY_CAST(-354286 AS DATE)
 raw expr       : TRY_CAST(minus(354286_u32) AS Date)
-checked expr   : TRY_CAST(minus<UInt32>(354286_u32) AS Date NULL)
+checked expr   : try_to_date<Int64 NULL>(CAST(minus<UInt32>(354286_u32) AS Int64 NULL))
 optimized expr : NULL
 output type    : Date NULL
 output domain  : Unknown
@@ -857,7 +857,7 @@ output         : NULL
 
 ast            : TRY_CAST(2932897 AS DATE)
 raw expr       : TRY_CAST(2932897_u32 AS Date)
-checked expr   : TRY_CAST(2932897_u32 AS Date NULL)
+checked expr   : try_to_date<Int64 NULL>(CAST(2932897_u32 AS Int64 NULL))
 optimized expr : NULL
 output type    : Date NULL
 output domain  : Unknown
@@ -866,7 +866,7 @@ output         : NULL
 
 ast            : TRY_CAST(a AS DATE)
 raw expr       : TRY_CAST(ColumnRef(0)::Int32 AS Date)
-checked expr   : TRY_CAST(ColumnRef(0) AS Date NULL)
+checked expr   : try_to_date<Int64 NULL>(CAST(ColumnRef(0) AS Int64 NULL))
 evaluation:
 +--------+---------------------+------------+
 |        | a                   | Output     |
@@ -890,7 +890,7 @@ evaluation (internal):
 
 ast            : CAST(TO_DATE(-354285) AS INT64)
 raw expr       : CAST(TO_DATE(minus(354285_u32)) AS Int64)
-checked expr   : CAST(to_date<Int64>(minus<UInt32>(354285_u32)) AS Int64)
+checked expr   : to_int64<Date>(to_date<Int64>(minus<UInt32>(354285_u32)))
 optimized expr : -354285_i64
 output type    : Int64
 output domain  : {-354285..=-354285}
@@ -899,7 +899,7 @@ output         : -354285
 
 ast            : CAST(TO_DATE(-100) AS INT64)
 raw expr       : CAST(TO_DATE(minus(100_u8)) AS Int64)
-checked expr   : CAST(to_date<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)) AS Int64)
+checked expr   : to_int64<Date>(to_date<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : -100_i64
 output type    : Int64
 output domain  : {-100..=-100}
@@ -908,7 +908,7 @@ output         : -100
 
 ast            : CAST(TO_DATE(-0) AS INT64)
 raw expr       : CAST(TO_DATE(minus(0_u8)) AS Int64)
-checked expr   : CAST(to_date<Int64>(CAST(minus<UInt8>(0_u8) AS Int64)) AS Int64)
+checked expr   : to_int64<Date>(to_date<Int64>(CAST(minus<UInt8>(0_u8) AS Int64)))
 optimized expr : 0_i64
 output type    : Int64
 output domain  : {0..=0}
@@ -917,7 +917,7 @@ output         : 0
 
 ast            : CAST(TO_DATE(0) AS INT64)
 raw expr       : CAST(TO_DATE(0_u8) AS Int64)
-checked expr   : CAST(to_date<Int64>(CAST(0_u8 AS Int64)) AS Int64)
+checked expr   : to_int64<Date>(to_date<Int64>(CAST(0_u8 AS Int64)))
 optimized expr : 0_i64
 output type    : Int64
 output domain  : {0..=0}
@@ -926,7 +926,7 @@ output         : 0
 
 ast            : CAST(TO_DATE(100) AS INT64)
 raw expr       : CAST(TO_DATE(100_u8) AS Int64)
-checked expr   : CAST(to_date<Int64>(CAST(100_u8 AS Int64)) AS Int64)
+checked expr   : to_int64<Date>(to_date<Int64>(CAST(100_u8 AS Int64)))
 optimized expr : 100_i64
 output type    : Int64
 output domain  : {100..=100}
@@ -935,7 +935,7 @@ output         : 100
 
 ast            : CAST(TO_DATE(2932896) AS INT64)
 raw expr       : CAST(TO_DATE(2932896_u32) AS Int64)
-checked expr   : CAST(to_date<Int64>(CAST(2932896_u32 AS Int64)) AS Int64)
+checked expr   : to_int64<Date>(to_date<Int64>(CAST(2932896_u32 AS Int64)))
 optimized expr : 2932896_i64
 output type    : Int64
 output domain  : {2932896..=2932896}
@@ -944,7 +944,7 @@ output         : 2932896
 
 ast            : CAST(a AS INT64)
 raw expr       : CAST(ColumnRef(0)::Date AS Int64)
-checked expr   : CAST(ColumnRef(0) AS Int64)
+checked expr   : to_int64<Date>(ColumnRef(0))
 evaluation:
 +--------+---------------------+---------------------+
 |        | a                   | Output              |
@@ -968,7 +968,7 @@ evaluation (internal):
 
 ast            : CAST(TO_DATE(1) AS TIMESTAMP)
 raw expr       : CAST(TO_DATE(1_u8) AS Timestamp)
-checked expr   : CAST(to_date<Int64>(CAST(1_u8 AS Int64)) AS Timestamp)
+checked expr   : to_timestamp<Date>(to_date<Int64>(CAST(1_u8 AS Int64)))
 optimized expr : 86400000000
 output type    : Timestamp
 output domain  : {86400000000..=86400000000}
@@ -977,7 +977,7 @@ output         : 1970-01-02 00:00:00.000000
 
 ast            : CAST(TO_TIMESTAMP(1) AS DATE)
 raw expr       : CAST(TO_TIMESTAMP(1_u8) AS Date)
-checked expr   : CAST(to_timestamp<Int64>(CAST(1_u8 AS Int64)) AS Date)
+checked expr   : to_date<Timestamp>(to_timestamp<Int64>(CAST(1_u8 AS Int64)))
 optimized expr : 0
 output type    : Date
 output domain  : {0..=0}
@@ -986,7 +986,7 @@ output         : 1970-01-01
 
 ast            : CAST(a AS DATE)
 raw expr       : CAST(ColumnRef(0)::Timestamp AS Date)
-checked expr   : CAST(ColumnRef(0) AS Date)
+checked expr   : to_date<Timestamp>(ColumnRef(0))
 evaluation:
 +--------+--------------------------------------+----------------+
 |        | a                                    | Output         |
@@ -1012,7 +1012,7 @@ evaluation (internal):
 
 ast            : CAST(a AS TIMESTAMP)
 raw expr       : CAST(ColumnRef(0)::Date AS Timestamp)
-checked expr   : CAST(ColumnRef(0) AS Timestamp)
+checked expr   : to_timestamp<Date>(ColumnRef(0))
 evaluation:
 +--------+---------------------+-------------------------------------------+
 |        | a                   | Output                                    |
@@ -1036,7 +1036,7 @@ evaluation (internal):
 
 ast            : CAST(TO_DATE(a) AS TIMESTAMP)
 raw expr       : CAST(TO_DATE(ColumnRef(0)::Int32) AS Timestamp)
-checked expr   : CAST(to_date<Int64>(CAST(ColumnRef(0) AS Int64)) AS Timestamp)
+checked expr   : to_timestamp<Date>(to_date<Int64>(CAST(ColumnRef(0) AS Int64)))
 evaluation:
 +--------+---------------------+-------------------------------------------+
 |        | a                   | Output                                    |
@@ -1162,7 +1162,7 @@ evaluation (internal):
 
 ast            : TRY_CAST(a as TIMESTAMP)
 raw expr       : TRY_CAST(ColumnRef(0)::String AS Timestamp)
-checked expr   : TRY_CAST(ColumnRef(0) AS Timestamp NULL)
+checked expr   : try_to_timestamp<String NULL>(CAST(ColumnRef(0) AS String NULL))
 evaluation:
 +--------+------------------------------------+----------------------------+
 |        | a                                  | Output                     |
@@ -1189,7 +1189,7 @@ evaluation (internal):
 
 ast            : CAST(TO_TIMESTAMP(-315360000000000) AS VARCHAR)
 raw expr       : CAST(TO_TIMESTAMP(minus(315360000000000_u64)) AS String)
-checked expr   : CAST(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)) AS String)
+checked expr   : to_string<Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)))
 optimized expr : "1960-01-04 00:00:00.000000"
 output type    : String
 output domain  : Unknown
@@ -1198,7 +1198,7 @@ output         : "1960-01-04 00:00:00.000000"
 
 ast            : CAST(TO_TIMESTAMP(-315360000000) AS VARCHAR)
 raw expr       : CAST(TO_TIMESTAMP(minus(315360000000_u64)) AS String)
-checked expr   : CAST(to_timestamp<Int64>(minus<UInt64>(315360000000_u64)) AS String)
+checked expr   : to_string<Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000_u64)))
 optimized expr : "1960-01-04 00:00:00.000000"
 output type    : String
 output domain  : Unknown
@@ -1207,7 +1207,7 @@ output         : "1960-01-04 00:00:00.000000"
 
 ast            : CAST(TO_TIMESTAMP(-100) AS VARCHAR)
 raw expr       : CAST(TO_TIMESTAMP(minus(100_u8)) AS String)
-checked expr   : CAST(to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)) AS String)
+checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : "1969-12-31 23:58:20.000000"
 output type    : String
 output domain  : Unknown
@@ -1216,7 +1216,7 @@ output         : "1969-12-31 23:58:20.000000"
 
 ast            : CAST(TO_TIMESTAMP(-0) AS VARCHAR)
 raw expr       : CAST(TO_TIMESTAMP(minus(0_u8)) AS String)
-checked expr   : CAST(to_timestamp<Int64>(CAST(minus<UInt8>(0_u8) AS Int64)) AS String)
+checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(minus<UInt8>(0_u8) AS Int64)))
 optimized expr : "1970-01-01 00:00:00.000000"
 output type    : String
 output domain  : Unknown
@@ -1225,7 +1225,7 @@ output         : "1970-01-01 00:00:00.000000"
 
 ast            : CAST(TO_TIMESTAMP(0) AS VARCHAR)
 raw expr       : CAST(TO_TIMESTAMP(0_u8) AS String)
-checked expr   : CAST(to_timestamp<Int64>(CAST(0_u8 AS Int64)) AS String)
+checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(0_u8 AS Int64)))
 optimized expr : "1970-01-01 00:00:00.000000"
 output type    : String
 output domain  : Unknown
@@ -1234,7 +1234,7 @@ output         : "1970-01-01 00:00:00.000000"
 
 ast            : CAST(TO_TIMESTAMP(100) AS VARCHAR)
 raw expr       : CAST(TO_TIMESTAMP(100_u8) AS String)
-checked expr   : CAST(to_timestamp<Int64>(CAST(100_u8 AS Int64)) AS String)
+checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(100_u8 AS Int64)))
 optimized expr : "1970-01-01 00:01:40.000000"
 output type    : String
 output domain  : Unknown
@@ -1243,7 +1243,7 @@ output         : "1970-01-01 00:01:40.000000"
 
 ast            : CAST(TO_TIMESTAMP(315360000000) AS VARCHAR)
 raw expr       : CAST(TO_TIMESTAMP(315360000000_u64) AS String)
-checked expr   : CAST(to_timestamp<Int64>(CAST(315360000000_u64 AS Int64)) AS String)
+checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(315360000000_u64 AS Int64)))
 optimized expr : "1979-12-30 00:00:00.000000"
 output type    : String
 output domain  : Unknown
@@ -1252,7 +1252,7 @@ output         : "1979-12-30 00:00:00.000000"
 
 ast            : CAST(TO_TIMESTAMP(315360000000000) AS VARCHAR)
 raw expr       : CAST(TO_TIMESTAMP(315360000000000_u64) AS String)
-checked expr   : CAST(to_timestamp<Int64>(CAST(315360000000000_u64 AS Int64)) AS String)
+checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(315360000000000_u64 AS Int64)))
 optimized expr : "1979-12-30 00:00:00.000000"
 output type    : String
 output domain  : Unknown
@@ -1261,7 +1261,7 @@ output         : "1979-12-30 00:00:00.000000"
 
 ast            : CAST(a AS VARCHAR)
 raw expr       : CAST(ColumnRef(0)::Timestamp AS String)
-checked expr   : CAST(ColumnRef(0) AS String)
+checked expr   : to_string<Timestamp>(ColumnRef(0))
 evaluation:
 +--------+--------------------------------------+------------------------------+
 |        | a                                    | Output                       |
@@ -1389,7 +1389,7 @@ evaluation (internal):
 
 ast            : TRY_CAST(a as DATE)
 raw expr       : TRY_CAST(ColumnRef(0)::String AS Date)
-checked expr   : TRY_CAST(ColumnRef(0) AS Date NULL)
+checked expr   : try_to_date<String NULL>(CAST(ColumnRef(0) AS String NULL))
 evaluation:
 +--------+------------------------------------+------------+
 |        | a                                  | Output     |
@@ -1416,7 +1416,7 @@ evaluation (internal):
 
 ast            : CAST(TO_DATE(-354285) AS VARCHAR)
 raw expr       : CAST(TO_DATE(minus(354285_u32)) AS String)
-checked expr   : CAST(to_date<Int64>(minus<UInt32>(354285_u32)) AS String)
+checked expr   : to_string<Date>(to_date<Int64>(minus<UInt32>(354285_u32)))
 optimized expr : "1000-01-01"
 output type    : String
 output domain  : Unknown
@@ -1425,7 +1425,7 @@ output         : "1000-01-01"
 
 ast            : CAST(TO_DATE(-100) AS VARCHAR)
 raw expr       : CAST(TO_DATE(minus(100_u8)) AS String)
-checked expr   : CAST(to_date<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)) AS String)
+checked expr   : to_string<Date>(to_date<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : "1969-09-23"
 output type    : String
 output domain  : Unknown
@@ -1434,7 +1434,7 @@ output         : "1969-09-23"
 
 ast            : CAST(TO_DATE(-0) AS VARCHAR)
 raw expr       : CAST(TO_DATE(minus(0_u8)) AS String)
-checked expr   : CAST(to_date<Int64>(CAST(minus<UInt8>(0_u8) AS Int64)) AS String)
+checked expr   : to_string<Date>(to_date<Int64>(CAST(minus<UInt8>(0_u8) AS Int64)))
 optimized expr : "1970-01-01"
 output type    : String
 output domain  : Unknown
@@ -1443,7 +1443,7 @@ output         : "1970-01-01"
 
 ast            : CAST(TO_DATE(0) AS VARCHAR)
 raw expr       : CAST(TO_DATE(0_u8) AS String)
-checked expr   : CAST(to_date<Int64>(CAST(0_u8 AS Int64)) AS String)
+checked expr   : to_string<Date>(to_date<Int64>(CAST(0_u8 AS Int64)))
 optimized expr : "1970-01-01"
 output type    : String
 output domain  : Unknown
@@ -1452,7 +1452,7 @@ output         : "1970-01-01"
 
 ast            : CAST(TO_DATE(100) AS VARCHAR)
 raw expr       : CAST(TO_DATE(100_u8) AS String)
-checked expr   : CAST(to_date<Int64>(CAST(100_u8 AS Int64)) AS String)
+checked expr   : to_string<Date>(to_date<Int64>(CAST(100_u8 AS Int64)))
 optimized expr : "1970-04-11"
 output type    : String
 output domain  : Unknown
@@ -1461,7 +1461,7 @@ output         : "1970-04-11"
 
 ast            : CAST(TO_DATE(2932896) AS VARCHAR)
 raw expr       : CAST(TO_DATE(2932896_u32) AS String)
-checked expr   : CAST(to_date<Int64>(CAST(2932896_u32 AS Int64)) AS String)
+checked expr   : to_string<Date>(to_date<Int64>(CAST(2932896_u32 AS Int64)))
 optimized expr : "9999-12-31"
 output type    : String
 output domain  : Unknown
@@ -1470,7 +1470,7 @@ output         : "9999-12-31"
 
 ast            : CAST(a AS VARCHAR)
 raw expr       : CAST(ColumnRef(0)::Date AS String)
-checked expr   : CAST(ColumnRef(0) AS String)
+checked expr   : to_string<Date>(ColumnRef(0))
 evaluation:
 +--------+---------------------+--------------+
 |        | a                   | Output       |

--- a/src/query/functions-v2/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/variant.txt
@@ -535,7 +535,7 @@ output         : NULL
 
 ast            : CAST(('a', 'b') AS VARIANT)['2']
 raw expr       : get(CAST(tuple("a", "b") AS Variant), "2")
-checked expr   : get<Variant, String>(CAST(tuple<String, String>("a", "b") AS Variant), "2")
+checked expr   : get<Variant, String>(to_variant<T0=(String, String)><T0>(tuple<String, String>("a", "b")), "2")
 optimized expr : 0x200000001000000162
 output type    : Variant NULL
 output domain  : Unknown


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

`Evaluator` does no need to call `type_checker` to search the simple cast function anymore, which maybe costable for each chunk.

Closes #issue
