### PR TITLE
refactor(catalog): unify the catalog name defination to catalog_kind

### DIFF
--- a/src/query/catalog/src/catalog.rs
+++ b/src/query/catalog/src/catalog.rs
@@ -58,8 +58,6 @@ use crate::table::Table;
 use crate::table_args::TableArgs;
 use crate::table_function::TableFunction;
 
-pub const CATALOG_DEFAULT: &str = "default";
-
 static CATALOG_MANAGER: OnceCell<Singleton<Arc<CatalogManager>>> = OnceCell::new();
 
 pub struct CatalogManager {

--- a/src/query/catalog/src/catalog_kind.rs
+++ b/src/query/catalog/src/catalog_kind.rs
@@ -12,13 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod catalog;
-pub mod catalog_kind;
-pub mod cluster_info;
-pub mod database;
-pub mod plan;
-pub mod table;
-pub mod table_args;
-pub mod table_context;
-pub mod table_function;
-pub mod table_mutator;
+pub const CATALOG_DEFAULT: &str = "default";
+pub const CATALOG_HIVE: &str = "hive";

--- a/src/query/service/src/api/http/v1/tenant_tables.rs
+++ b/src/query/service/src/api/http/v1/tenant_tables.rs
@@ -15,7 +15,7 @@
 use chrono::DateTime;
 use chrono::Utc;
 use common_catalog::catalog::CatalogManager;
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_exception::Result;
 use poem::web::Json;
 use poem::web::Path;

--- a/src/query/service/src/catalogs/catalog_manager.rs
+++ b/src/query/service/src/catalogs/catalog_manager.rs
@@ -17,7 +17,9 @@ use std::sync::Arc;
 use common_base::base::Singleton;
 use common_catalog::catalog::Catalog;
 pub use common_catalog::catalog::CatalogManager;
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
+#[cfg(feature = "hive")]
+use common_catalog::catalog_kind::CATALOG_HIVE;
 use common_config::Config;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -25,8 +27,6 @@ use common_meta_app::schema::CatalogType;
 use common_meta_app::schema::CreateCatalogReq;
 #[cfg(feature = "hive")]
 use common_storages_hive::HiveCatalog;
-#[cfg(feature = "hive")]
-use common_storages_hive::CATALOG_HIVE;
 use dashmap::DashMap;
 
 use crate::catalogs::DatabaseCatalog;

--- a/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
+++ b/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
@@ -16,7 +16,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use common_ast::ast::Engine;
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_catalog::plan::PushDownInfo;
 use common_catalog::table::AppendMode;
 use common_datablocks::assert_blocks_sorted_eq_with_name;

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -17,7 +17,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use common_catalog::catalog::CatalogManager;
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_catalog::plan::Expression;
 use common_catalog::plan::PrewhereInfo;
 use common_catalog::plan::Projection;

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -26,7 +26,7 @@ use common_ast::parser::tokenize_sql;
 use common_ast::Backtrace;
 use common_ast::Dialect;
 use common_ast::DisplayError;
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_catalog::table::NavigationPoint;
 use common_catalog::table::Table;
 use common_catalog::table_function::TableFunction;

--- a/src/query/sql/src/planner/expression_parser.rs
+++ b/src/query/sql/src/planner/expression_parser.rs
@@ -18,7 +18,7 @@ use common_ast::parser::parse_comma_separated_exprs;
 use common_ast::parser::tokenize_sql;
 use common_ast::Backtrace;
 use common_ast::Dialect;
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_catalog::plan::Expression;
 use common_catalog::table::Table;
 use common_exception::Result;

--- a/src/query/storages/fuse/fuse/src/table_functions/clustering_informations/clustering_information_table.rs
+++ b/src/query/storages/fuse/fuse/src/table_functions/clustering_informations/clustering_information_table.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;

--- a/src/query/storages/fuse/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
+++ b/src/query/storages/fuse/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;

--- a/src/query/storages/fuse/fuse/src/table_functions/fuse_segments/fuse_segment_table.rs
+++ b/src/query/storages/fuse/fuse/src/table_functions/fuse_segments/fuse_segment_table.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;

--- a/src/query/storages/fuse/fuse/src/table_functions/fuse_snapshots/fuse_snapshot_table.rs
+++ b/src/query/storages/fuse/fuse/src/table_functions/fuse_snapshots/fuse_snapshot_table.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;

--- a/src/query/storages/hive/hive/src/hive_table.rs
+++ b/src/query/storages/hive/hive/src/hive_table.rs
@@ -19,6 +19,7 @@ use std::time::Instant;
 use async_recursion::async_recursion;
 use common_base::base::tokio;
 use common_base::base::tokio::sync::Semaphore;
+use common_catalog::catalog_kind::CATALOG_HIVE;
 use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::Expression;
 use common_catalog::plan::PartStatistics;
@@ -58,7 +59,6 @@ use crate::hive_partition_filler::HivePartitionFiller;
 use crate::hive_table_source::HiveTableSource;
 use crate::HiveBlockFilter;
 use crate::HiveFileSplitter;
-use crate::CATALOG_HIVE;
 
 pub const HIVE_TABLE_ENGIE: &str = "hive";
 

--- a/src/query/storages/hive/hive/src/lib.rs
+++ b/src/query/storages/hive/hive/src/lib.rs
@@ -28,8 +28,6 @@ mod hive_table;
 mod hive_table_options;
 mod hive_table_source;
 
-pub const CATALOG_HIVE: &str = "hive";
-
 pub use hive_block_filter::HiveBlockFilter;
 pub use hive_blocks::HiveBlocks;
 pub use hive_catalog::HiveCatalog;

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_datablocks::DataBlock;

--- a/src/query/storages/system/src/engines_table.rs
+++ b/src/query/storages/system/src/engines_table.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_datablocks::DataBlock;

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use common_catalog::catalog::Catalog;
-use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_datablocks::DataBlock;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

unify the catalog name defination to catalog_kind: `default` and `hive`

Closes #issue
