### PR TITLE
refactor(expr): refine domain

### DIFF
--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -30,6 +30,7 @@ use crate::values::Value;
 use crate::values::ValueRef;
 use crate::Column;
 use crate::Expr;
+use crate::FunctionDomain;
 use crate::Scalar;
 
 #[derive(Debug, Clone)]
@@ -46,16 +47,6 @@ pub struct FunctionContext<'a> {
     pub num_rows: usize,
     pub tz: Tz,
 }
-
-// impl<'a> Default for FunctionContext<'a> {
-//     fn default() -> Self {
-//         Self {
-//             tz: "UTC".parse::<Tz>().unwrap(),
-//             generics: &[],
-//             num_rows: 0,
-//         }
-//     }
-// }
 
 /// `FunctionID` is a unique identifier for a function. It's used to construct
 /// the exactly same function from the remote execution nodes.
@@ -76,7 +67,7 @@ pub enum FunctionID {
 pub struct Function {
     pub signature: FunctionSignature,
     #[allow(clippy::type_complexity)]
-    pub calc_domain: Box<dyn Fn(&[Domain]) -> Option<Domain>>,
+    pub calc_domain: Box<dyn Fn(&[Domain]) -> FunctionDomain<AnyType>>,
     #[allow(clippy::type_complexity)]
     pub eval: Box<dyn Fn(&[ValueRef<AnyType>], FunctionContext) -> Result<Value<AnyType>, String>>,
 }

--- a/src/query/expression/src/property.rs
+++ b/src/query/expression/src/property.rs
@@ -19,8 +19,19 @@ use crate::types::nullable::NullableDomain;
 use crate::types::number::NumberDomain;
 use crate::types::number::NumberScalar;
 use crate::types::number::SimpleDomain;
+use crate::types::number::F32;
+use crate::types::number::F64;
 use crate::types::string::StringDomain;
 use crate::types::AnyType;
+use crate::types::ArgType;
+use crate::types::BooleanType;
+use crate::types::DataType;
+use crate::types::DateType;
+use crate::types::NumberDataType;
+use crate::types::NumberType;
+use crate::types::StringType;
+use crate::types::TimestampType;
+use crate::types::ValueType;
 use crate::with_number_type;
 use crate::Scalar;
 
@@ -36,6 +47,22 @@ impl FunctionProperty {
     }
 }
 
+/// Describe the behavior of a function to eliminate the runtime
+/// evaluation of the function if possible.
+#[derive(Debug, Clone, PartialEq, EnumAsInner)]
+pub enum FunctionDomain<T: ValueType> {
+    /// The function may return error.
+    MayThrow,
+    /// The function must not return error.
+    NoThrow,
+    /// The function must not return error, and have futher information
+    /// to restriction the range of the output value.
+    Domain(T::Domain),
+}
+
+/// The range of the possible values that a scalar or the scalars in a
+/// column can take. We can assume the values outside the range are not
+/// possible, but we cannot assume the values inside the range must exist.
 #[derive(Debug, Clone, PartialEq, EnumAsInner)]
 pub enum Domain {
     Number(NumberDomain),
@@ -47,10 +74,88 @@ pub enum Domain {
     /// `Array(None)` means that the array is empty, thus there is no inner domain information.
     Array(Option<Box<Domain>>),
     Tuple(Vec<Domain>),
+    /// For certain types, like `Variant`, the domain is useless therefore is not defined.
     Undefined,
 }
 
+impl<T: ValueType> FunctionDomain<T> {
+    pub fn map<U: ValueType>(self, f: impl FnOnce(T::Domain) -> U::Domain) -> FunctionDomain<U> {
+        match self {
+            FunctionDomain::MayThrow => FunctionDomain::MayThrow,
+            FunctionDomain::NoThrow => FunctionDomain::NoThrow,
+            FunctionDomain::Domain(domain) => FunctionDomain::Domain(f(domain)),
+        }
+    }
+}
+
+impl<T: ArgType> FunctionDomain<T> {
+    /// Return the range of the output value.
+    ///
+    /// Return `None` if the function may return error.
+    pub fn normalize(self) -> Option<T::Domain> {
+        match self {
+            FunctionDomain::MayThrow => None,
+            FunctionDomain::NoThrow => Some(T::full_domain()),
+            FunctionDomain::Domain(domain) => Some(domain),
+        }
+    }
+}
+
 impl Domain {
+    pub fn full(data_type: &DataType) -> Self {
+        match data_type {
+            DataType::Boolean => Domain::Boolean(BooleanType::full_domain()),
+            DataType::String => Domain::String(StringType::full_domain()),
+            DataType::Number(NumberDataType::UInt8) => {
+                Domain::Number(NumberDomain::UInt8(NumberType::<u8>::full_domain()))
+            }
+            DataType::Number(NumberDataType::UInt16) => {
+                Domain::Number(NumberDomain::UInt16(NumberType::<u16>::full_domain()))
+            }
+            DataType::Number(NumberDataType::UInt32) => {
+                Domain::Number(NumberDomain::UInt32(NumberType::<u32>::full_domain()))
+            }
+            DataType::Number(NumberDataType::UInt64) => {
+                Domain::Number(NumberDomain::UInt64(NumberType::<u64>::full_domain()))
+            }
+            DataType::Number(NumberDataType::Int8) => {
+                Domain::Number(NumberDomain::Int8(NumberType::<i8>::full_domain()))
+            }
+            DataType::Number(NumberDataType::Int16) => {
+                Domain::Number(NumberDomain::Int16(NumberType::<i16>::full_domain()))
+            }
+            DataType::Number(NumberDataType::Int32) => {
+                Domain::Number(NumberDomain::Int32(NumberType::<i32>::full_domain()))
+            }
+            DataType::Number(NumberDataType::Int64) => {
+                Domain::Number(NumberDomain::Int64(NumberType::<i64>::full_domain()))
+            }
+            DataType::Number(NumberDataType::Float32) => {
+                Domain::Number(NumberDomain::Float32(NumberType::<F32>::full_domain()))
+            }
+            DataType::Number(NumberDataType::Float64) => {
+                Domain::Number(NumberDomain::Float64(NumberType::<F64>::full_domain()))
+            }
+            DataType::Timestamp => Domain::Timestamp(TimestampType::full_domain()),
+            DataType::Date => Domain::Date(DateType::full_domain()),
+            DataType::Null => Domain::Nullable(NullableDomain {
+                has_null: true,
+                value: None,
+            }),
+            DataType::Nullable(ty) => Domain::Nullable(NullableDomain {
+                has_null: true,
+                value: Some(Box::new(Domain::full(ty))),
+            }),
+            DataType::Tuple(fields_ty) => {
+                Domain::Tuple(fields_ty.iter().map(Domain::full).collect())
+            }
+            DataType::EmptyArray => Domain::Array(None),
+            DataType::Array(ty) => Domain::Array(Some(Box::new(Domain::full(ty)))),
+            DataType::Map(_) | DataType::Variant => Domain::Undefined,
+            DataType::Generic(_) => unreachable!(),
+        }
+    }
+
     pub fn merge(&self, other: &Domain) -> Domain {
         match (self, other) {
             (Domain::Number(this), Domain::Number(other)) => {

--- a/src/query/expression/src/register.rs
+++ b/src/query/expression/src/register.rs
@@ -29,6 +29,7 @@ use crate::values::Value;
 use crate::values::ValueRef;
 use crate::Function;
 use crate::FunctionContext;
+use crate::FunctionDomain;
 use crate::FunctionRegistry;
 use crate::FunctionSignature;
 
@@ -40,7 +41,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain) -> Option<O::Domain> + 'static + Clone + Copy,
+        F: Fn(&I1::Domain) -> FunctionDomain<O> + 'static + Clone + Copy,
         G: Fn(I1::ScalarRef<'_>, FunctionContext) -> O::Scalar + 'static + Clone + Copy,
     {
         self.register_passthrough_nullable_1_arg::<I1, O, _, _>(
@@ -58,7 +59,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain) -> Option<O::Domain> + 'static + Clone + Copy,
+        F: Fn(&I1::Domain, &I2::Domain) -> FunctionDomain<O> + 'static + Clone + Copy,
         G: Fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, FunctionContext) -> O::Scalar
             + 'static
             + Clone
@@ -79,7 +80,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain) -> Option<O::Domain> + 'static + Clone + Copy,
+        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain) -> FunctionDomain<O> + 'static + Clone + Copy,
         G: Fn(
                 I1::ScalarRef<'_>,
                 I2::ScalarRef<'_>,
@@ -105,7 +106,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain) -> Option<O::Domain>
+        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain) -> FunctionDomain<O>
             + 'static
             + Clone
             + Copy,
@@ -144,7 +145,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain, &I5::Domain) -> Option<O::Domain>
+        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain, &I5::Domain) -> FunctionDomain<O>
             + 'static
             + Clone
             + Copy,
@@ -175,7 +176,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain) -> Option<O::Domain> + 'static + Clone + Copy,
+        F: Fn(&I1::Domain) -> FunctionDomain<O> + 'static + Clone + Copy,
         G: for<'a> Fn(ValueRef<'a, I1>, FunctionContext) -> Result<Value<O>, String>
             + 'static
             + Clone
@@ -196,15 +197,21 @@ impl FunctionRegistry {
         self.register_1_arg_core::<NullableType<I1>, NullableType<O>, _, _>(
             name,
             property,
-            move |arg1| {
-                let value = match (&arg1.value) {
-                    (Some(value1)) => Some(calc_domain(value1)?),
-                    _ => None,
-                };
-                Some(NullableDomain {
-                    has_null: arg1.has_null,
-                    value: value.map(Box::new),
-                })
+            move |arg1| match (&arg1.value) {
+                (Some(value1)) => {
+                    if let Some(domain) = calc_domain(value1).normalize() {
+                        FunctionDomain::Domain(NullableDomain {
+                            has_null: arg1.has_null,
+                            value: Some(Box::new(domain)),
+                        })
+                    } else {
+                        FunctionDomain::MayThrow
+                    }
+                }
+                _ => FunctionDomain::Domain(NullableDomain {
+                    has_null: true,
+                    value: None,
+                }),
             },
             passthrough_nullable_1_arg(func),
         );
@@ -217,7 +224,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain) -> Option<O::Domain> + 'static + Clone + Copy,
+        F: Fn(&I1::Domain, &I2::Domain) -> FunctionDomain<O> + 'static + Clone + Copy,
         G: for<'a> Fn(
                 ValueRef<'a, I1>,
                 ValueRef<'a, I2>,
@@ -242,15 +249,21 @@ impl FunctionRegistry {
         self.register_2_arg_core::<NullableType<I1>, NullableType<I2>, NullableType<O>, _, _>(
             name,
             property,
-            move |arg1, arg2| {
-                let value = match (&arg1.value, &arg2.value) {
-                    (Some(value1), Some(value2)) => Some(calc_domain(value1, value2)?),
-                    _ => None,
-                };
-                Some(NullableDomain {
-                    has_null: arg1.has_null || arg2.has_null,
-                    value: value.map(Box::new),
-                })
+            move |arg1, arg2| match (&arg1.value, &arg2.value) {
+                (Some(value1), Some(value2)) => {
+                    if let Some(domain) = calc_domain(value1, value2).normalize() {
+                        FunctionDomain::Domain(NullableDomain {
+                            has_null: arg1.has_null || arg2.has_null,
+                            value: Some(Box::new(domain)),
+                        })
+                    } else {
+                        FunctionDomain::MayThrow
+                    }
+                }
+                _ => FunctionDomain::Domain(NullableDomain {
+                    has_null: true,
+                    value: None,
+                }),
             },
             passthrough_nullable_2_arg(func),
         );
@@ -270,7 +283,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain) -> Option<O::Domain> + 'static + Clone + Copy,
+        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain) -> FunctionDomain<O> + 'static + Clone + Copy,
         G: for<'a> Fn(
                 ValueRef<'a, I1>,
                 ValueRef<'a, I2>,
@@ -302,14 +315,24 @@ impl FunctionRegistry {
                         name,
                         property,
                         move |arg1,arg2,arg3| {
-                            let value = match (&arg1.value,&arg2.value,&arg3.value) {
-                                (Some(value1),Some(value2),Some(value3)) => Some(calc_domain(value1,value2,value3)?),
-                                _ => None,
-                            };
-                            Some(NullableDomain {
-                                has_null: arg1.has_null||arg2.has_null||arg3.has_null,
-                                value: value.map(Box::new),
-                            })
+                            match (&arg1.value,&arg2.value,&arg3.value) {
+                                (Some(value1),Some(value2),Some(value3)) => {
+                                    if let Some(domain) = calc_domain(value1,value2,value3).normalize() {
+                                        FunctionDomain::Domain(NullableDomain {
+                                            has_null: arg1.has_null||arg2.has_null||arg3.has_null,
+                                            value: Some(Box::new(domain)),
+                                        })
+                                    } else {
+                                        FunctionDomain::MayThrow
+                                    }
+                                },
+                                _ => {
+                                    FunctionDomain::Domain(NullableDomain {
+                                        has_null: true,
+                                        value: None,
+                                    })
+                                },
+                            }
                         },
                         passthrough_nullable_3_arg(func),
                     );
@@ -330,7 +353,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain) -> Option<O::Domain>
+        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain) -> FunctionDomain<O>
             + 'static
             + Clone
             + Copy,
@@ -372,14 +395,24 @@ impl FunctionRegistry {
                         name,
                         property,
                         move |arg1,arg2,arg3,arg4| {
-                            let value = match (&arg1.value,&arg2.value,&arg3.value,&arg4.value) {
-                                (Some(value1),Some(value2),Some(value3),Some(value4)) => Some(calc_domain(value1,value2,value3,value4)?),
-                                _ => None,
-                            };
-                            Some(NullableDomain {
-                                has_null: arg1.has_null||arg2.has_null||arg3.has_null||arg4.has_null,
-                                value: value.map(Box::new),
-                            })
+                            match (&arg1.value,&arg2.value,&arg3.value,&arg4.value) {
+                                (Some(value1),Some(value2),Some(value3),Some(value4)) => {
+                                    if let Some(domain) = calc_domain(value1,value2,value3,value4).normalize() {
+                                        FunctionDomain::Domain(NullableDomain {
+                                            has_null: arg1.has_null||arg2.has_null||arg3.has_null||arg4.has_null,
+                                            value: Some(Box::new(domain)),
+                                        })
+                                    } else {
+                                        FunctionDomain::MayThrow
+                                    }
+                                },
+                                _ => {
+                                    FunctionDomain::Domain(NullableDomain {
+                                        has_null: true,
+                                        value: None,
+                                    })
+                                },
+                            }
                         },
                         passthrough_nullable_4_arg(func),
                     );
@@ -401,7 +434,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain, &I5::Domain) -> Option<O::Domain>
+        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain, &I5::Domain) -> FunctionDomain<O>
             + 'static
             + Clone
             + Copy,
@@ -445,14 +478,24 @@ impl FunctionRegistry {
                         name,
                         property,
                         move |arg1,arg2,arg3,arg4,arg5| {
-                            let value = match (&arg1.value,&arg2.value,&arg3.value,&arg4.value,&arg5.value) {
-                                (Some(value1),Some(value2),Some(value3),Some(value4),Some(value5)) => Some(calc_domain(value1,value2,value3,value4,value5)?),
-                                _ => None,
-                            };
-                            Some(NullableDomain {
-                                has_null: arg1.has_null||arg2.has_null||arg3.has_null||arg4.has_null||arg5.has_null,
-                                value: value.map(Box::new),
-                            })
+                            match (&arg1.value,&arg2.value,&arg3.value,&arg4.value,&arg5.value) {
+                                (Some(value1),Some(value2),Some(value3),Some(value4),Some(value5)) => {
+                                    if let Some(domain) = calc_domain(value1,value2,value3,value4,value5).normalize() {
+                                        FunctionDomain::Domain(NullableDomain {
+                                            has_null: arg1.has_null||arg2.has_null||arg3.has_null||arg4.has_null||arg5.has_null,
+                                            value: Some(Box::new(domain)),
+                                        })
+                                    } else {
+                                        FunctionDomain::MayThrow
+                                    }
+                                },
+                                _ => {
+                                    FunctionDomain::Domain(NullableDomain {
+                                        has_null: true,
+                                        value: None,
+                                    })
+                                },
+                            }
                         },
                         passthrough_nullable_5_arg(func),
                     );
@@ -465,7 +508,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain) -> Option<NullableDomain<O>> + 'static + Clone + Copy,
+        F: Fn(&I1::Domain) -> FunctionDomain<NullableType<O>> + 'static + Clone + Copy,
         G: for<'a> Fn(ValueRef<'a, I1>, FunctionContext) -> Result<Value<NullableType<O>>, String>
             + 'static
             + Clone
@@ -493,13 +536,16 @@ impl FunctionRegistry {
             property,
             move |arg1| match (&arg1.value) {
                 (Some(value1)) => {
-                    let domain = calc_domain(value1)?;
-                    Some(NullableDomain {
-                        has_null: arg1.has_null || domain.has_null,
-                        value: domain.value,
-                    })
+                    if let Some(domain) = calc_domain(value1).normalize() {
+                        FunctionDomain::Domain(NullableDomain {
+                            has_null: arg1.has_null || domain.has_null,
+                            value: domain.value,
+                        })
+                    } else {
+                        FunctionDomain::MayThrow
+                    }
                 }
-                _ => Some(NullableDomain {
+                _ => FunctionDomain::Domain(NullableDomain {
                     has_null: true,
                     value: None,
                 }),
@@ -515,7 +561,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain) -> Option<NullableDomain<O>> + 'static + Clone + Copy,
+        F: Fn(&I1::Domain, &I2::Domain) -> FunctionDomain<NullableType<O>> + 'static + Clone + Copy,
         G: for<'a> Fn(
                 ValueRef<'a, I1>,
                 ValueRef<'a, I2>,
@@ -547,13 +593,16 @@ impl FunctionRegistry {
             property,
             move |arg1, arg2| match (&arg1.value, &arg2.value) {
                 (Some(value1), Some(value2)) => {
-                    let domain = calc_domain(value1, value2)?;
-                    Some(NullableDomain {
-                        has_null: arg1.has_null || arg2.has_null || domain.has_null,
-                        value: domain.value,
-                    })
+                    if let Some(domain) = calc_domain(value1, value2).normalize() {
+                        FunctionDomain::Domain(NullableDomain {
+                            has_null: arg1.has_null || arg2.has_null || domain.has_null,
+                            value: domain.value,
+                        })
+                    } else {
+                        FunctionDomain::MayThrow
+                    }
                 }
-                _ => Some(NullableDomain {
+                _ => FunctionDomain::Domain(NullableDomain {
                     has_null: true,
                     value: None,
                 }),
@@ -576,7 +625,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain) -> Option<NullableDomain<O>>
+        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain) -> FunctionDomain<NullableType<O>>
             + 'static
             + Clone
             + Copy,
@@ -618,14 +667,17 @@ impl FunctionRegistry {
                         move |arg1,arg2,arg3| {
                             match (&arg1.value,&arg2.value,&arg3.value) {
                                 (Some(value1),Some(value2),Some(value3)) => {
-                                    let domain = calc_domain(value1,value2,value3)?;
-                                    Some(NullableDomain {
-                                        has_null: arg1.has_null||arg2.has_null||arg3.has_null || domain.has_null,
-                                        value: domain.value,
-                                    })
+                                    if let Some(domain) = calc_domain(value1,value2,value3).normalize() {
+                                        FunctionDomain::Domain(NullableDomain {
+                                            has_null: arg1.has_null||arg2.has_null||arg3.has_null || domain.has_null,
+                                            value: domain.value,
+                                        })
+                                    } else {
+                                        FunctionDomain::MayThrow
+                                    }
                                 }
                                 _ => {
-                                    Some(NullableDomain {
+                                    FunctionDomain::Domain(NullableDomain {
                                         has_null: true,
                                         value: None,
                                     })
@@ -651,7 +703,12 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain) -> Option<NullableDomain<O>>
+        F: Fn(
+                &I1::Domain,
+                &I2::Domain,
+                &I3::Domain,
+                &I4::Domain,
+            ) -> FunctionDomain<NullableType<O>>
             + 'static
             + Clone
             + Copy,
@@ -695,14 +752,17 @@ impl FunctionRegistry {
                         move |arg1,arg2,arg3,arg4| {
                             match (&arg1.value,&arg2.value,&arg3.value,&arg4.value) {
                                 (Some(value1),Some(value2),Some(value3),Some(value4)) => {
-                                    let domain = calc_domain(value1,value2,value3,value4)?;
-                                    Some(NullableDomain {
-                                        has_null: arg1.has_null||arg2.has_null||arg3.has_null||arg4.has_null || domain.has_null,
-                                        value: domain.value,
-                                    })
+                                    if let Some(domain) = calc_domain(value1,value2,value3,value4).normalize() {
+                                        FunctionDomain::Domain(NullableDomain {
+                                            has_null: arg1.has_null||arg2.has_null||arg3.has_null||arg4.has_null || domain.has_null,
+                                            value: domain.value,
+                                        })
+                                    } else {
+                                        FunctionDomain::MayThrow
+                                    }
                                 }
                                 _ => {
-                                    Some(NullableDomain {
+                                    FunctionDomain::Domain(NullableDomain {
                                         has_null: true,
                                         value: None,
                                     })
@@ -735,7 +795,7 @@ impl FunctionRegistry {
                 &I3::Domain,
                 &I4::Domain,
                 &I5::Domain,
-            ) -> Option<NullableDomain<O>>
+            ) -> FunctionDomain<NullableType<O>>
             + 'static
             + Clone
             + Copy,
@@ -781,14 +841,17 @@ impl FunctionRegistry {
                         move |arg1,arg2,arg3,arg4,arg5| {
                             match (&arg1.value,&arg2.value,&arg3.value,&arg4.value,&arg5.value) {
                                 (Some(value1),Some(value2),Some(value3),Some(value4),Some(value5)) => {
-                                    let domain = calc_domain(value1,value2,value3,value4,value5)?;
-                                    Some(NullableDomain {
-                                        has_null: arg1.has_null||arg2.has_null||arg3.has_null||arg4.has_null||arg5.has_null || domain.has_null,
-                                        value: domain.value,
-                                    })
+                                    if let Some(domain) = calc_domain(value1,value2,value3,value4,value5).normalize() {
+                                        FunctionDomain::Domain(NullableDomain {
+                                            has_null: arg1.has_null||arg2.has_null||arg3.has_null||arg4.has_null||arg5.has_null || domain.has_null,
+                                            value: domain.value,
+                                        })
+                                    } else {
+                                        FunctionDomain::MayThrow
+                                    }
                                 }
                                 _ => {
-                                    Some(NullableDomain {
+                                    FunctionDomain::Domain(NullableDomain {
                                         has_null: true,
                                         value: None,
                                     })
@@ -806,7 +869,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn() -> Option<O::Domain> + 'static + Clone + Copy,
+        F: Fn() -> FunctionDomain<O> + 'static + Clone + Copy,
         G: for<'a> Fn(FunctionContext) -> Result<Value<O>, String> + 'static + Clone + Copy,
     {
         self.funcs
@@ -831,7 +894,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain) -> Option<O::Domain> + 'static + Clone + Copy,
+        F: Fn(&I1::Domain) -> FunctionDomain<O> + 'static + Clone + Copy,
         G: for<'a> Fn(ValueRef<'a, I1>, FunctionContext) -> Result<Value<O>, String>
             + 'static
             + Clone
@@ -859,7 +922,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain) -> Option<O::Domain> + 'static + Clone + Copy,
+        F: Fn(&I1::Domain, &I2::Domain) -> FunctionDomain<O> + 'static + Clone + Copy,
         G: for<'a> Fn(
                 ValueRef<'a, I1>,
                 ValueRef<'a, I2>,
@@ -891,7 +954,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain) -> Option<O::Domain> + 'static + Clone + Copy,
+        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain) -> FunctionDomain<O> + 'static + Clone + Copy,
         G: for<'a> Fn(
                 ValueRef<'a, I1>,
                 ValueRef<'a, I2>,
@@ -934,7 +997,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain) -> Option<O::Domain>
+        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain) -> FunctionDomain<O>
             + 'static
             + Clone
             + Copy,
@@ -987,7 +1050,7 @@ impl FunctionRegistry {
         calc_domain: F,
         func: G,
     ) where
-        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain, &I5::Domain) -> Option<O::Domain>
+        F: Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain, &I5::Domain) -> FunctionDomain<O>
             + 'static
             + Clone
             + Copy,
@@ -6028,14 +6091,14 @@ pub fn combine_nullable_5_arg<
 }
 
 fn erase_calc_domain_generic_0_arg<O: ArgType>(
-    func: impl Fn() -> Option<O::Domain>,
-) -> impl Fn(&[Domain]) -> Option<Domain> {
+    func: impl Fn() -> FunctionDomain<O>,
+) -> impl Fn(&[Domain]) -> FunctionDomain<AnyType> {
     move |args| func().map(O::upcast_domain)
 }
 
 fn erase_calc_domain_generic_1_arg<I1: ArgType, O: ArgType>(
-    func: impl Fn(&I1::Domain) -> Option<O::Domain>,
-) -> impl Fn(&[Domain]) -> Option<Domain> {
+    func: impl Fn(&I1::Domain) -> FunctionDomain<O>,
+) -> impl Fn(&[Domain]) -> FunctionDomain<AnyType> {
     move |args| {
         let arg1 = I1::try_downcast_domain(&args[0]).unwrap();
         func(&arg1).map(O::upcast_domain)
@@ -6043,8 +6106,8 @@ fn erase_calc_domain_generic_1_arg<I1: ArgType, O: ArgType>(
 }
 
 fn erase_calc_domain_generic_2_arg<I1: ArgType, I2: ArgType, O: ArgType>(
-    func: impl Fn(&I1::Domain, &I2::Domain) -> Option<O::Domain>,
-) -> impl Fn(&[Domain]) -> Option<Domain> {
+    func: impl Fn(&I1::Domain, &I2::Domain) -> FunctionDomain<O>,
+) -> impl Fn(&[Domain]) -> FunctionDomain<AnyType> {
     move |args| {
         let arg1 = I1::try_downcast_domain(&args[0]).unwrap();
         let arg2 = I2::try_downcast_domain(&args[1]).unwrap();
@@ -6053,8 +6116,8 @@ fn erase_calc_domain_generic_2_arg<I1: ArgType, I2: ArgType, O: ArgType>(
 }
 
 fn erase_calc_domain_generic_3_arg<I1: ArgType, I2: ArgType, I3: ArgType, O: ArgType>(
-    func: impl Fn(&I1::Domain, &I2::Domain, &I3::Domain) -> Option<O::Domain>,
-) -> impl Fn(&[Domain]) -> Option<Domain> {
+    func: impl Fn(&I1::Domain, &I2::Domain, &I3::Domain) -> FunctionDomain<O>,
+) -> impl Fn(&[Domain]) -> FunctionDomain<AnyType> {
     move |args| {
         let arg1 = I1::try_downcast_domain(&args[0]).unwrap();
         let arg2 = I2::try_downcast_domain(&args[1]).unwrap();
@@ -6070,8 +6133,8 @@ fn erase_calc_domain_generic_4_arg<
     I4: ArgType,
     O: ArgType,
 >(
-    func: impl Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain) -> Option<O::Domain>,
-) -> impl Fn(&[Domain]) -> Option<Domain> {
+    func: impl Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain) -> FunctionDomain<O>,
+) -> impl Fn(&[Domain]) -> FunctionDomain<AnyType> {
     move |args| {
         let arg1 = I1::try_downcast_domain(&args[0]).unwrap();
         let arg2 = I2::try_downcast_domain(&args[1]).unwrap();
@@ -6089,8 +6152,8 @@ fn erase_calc_domain_generic_5_arg<
     I5: ArgType,
     O: ArgType,
 >(
-    func: impl Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain, &I5::Domain) -> Option<O::Domain>,
-) -> impl Fn(&[Domain]) -> Option<Domain> {
+    func: impl Fn(&I1::Domain, &I2::Domain, &I3::Domain, &I4::Domain, &I5::Domain) -> FunctionDomain<O>,
+) -> impl Fn(&[Domain]) -> FunctionDomain<AnyType> {
     move |args| {
         let arg1 = I1::try_downcast_domain(&args[0]).unwrap();
         let arg2 = I2::try_downcast_domain(&args[1]).unwrap();

--- a/src/query/expression/src/types.rs
+++ b/src/query/expression/src/types.rs
@@ -244,6 +244,7 @@ pub trait ValueType: Debug + Clone + PartialEq + Sized + 'static {
 
 pub trait ArgType: ValueType {
     fn data_type() -> DataType;
+    fn full_domain() -> Self::Domain;
     fn create_builder(capacity: usize, generics: &GenericMap) -> Self::ColumnBuilder;
 
     fn column_from_vec(vec: Vec<Self::Scalar>, generics: &GenericMap) -> Self::Column {

--- a/src/query/expression/src/types/array.rs
+++ b/src/query/expression/src/types/array.rs
@@ -147,6 +147,10 @@ impl<T: ArgType> ArgType for ArrayType<T> {
         DataType::Array(Box::new(T::data_type()))
     }
 
+    fn full_domain() -> Self::Domain {
+        T::full_domain()
+    }
+
     fn create_builder(capacity: usize, generics: &GenericMap) -> Self::ColumnBuilder {
         ArrayColumnBuilder::with_capacity(capacity, 0, generics)
     }

--- a/src/query/expression/src/types/boolean.rs
+++ b/src/query/expression/src/types/boolean.rs
@@ -149,6 +149,13 @@ impl ArgType for BooleanType {
         DataType::Boolean
     }
 
+    fn full_domain() -> Self::Domain {
+        BooleanDomain {
+            has_false: true,
+            has_true: true,
+        }
+    }
+
     fn create_builder(capacity: usize, _: &GenericMap) -> Self::ColumnBuilder {
         MutableBitmap::with_capacity(capacity)
     }

--- a/src/query/expression/src/types/date.rs
+++ b/src/query/expression/src/types/date.rs
@@ -176,6 +176,13 @@ impl ArgType for DateType {
         DataType::Date
     }
 
+    fn full_domain() -> Self::Domain {
+        SimpleDomain {
+            min: DATE_MIN,
+            max: DATE_MAX,
+        }
+    }
+
     fn create_builder(capacity: usize, _generics: &GenericMap) -> Self::ColumnBuilder {
         Vec::with_capacity(capacity)
     }

--- a/src/query/expression/src/types/empty_array.rs
+++ b/src/query/expression/src/types/empty_array.rs
@@ -145,6 +145,8 @@ impl ArgType for EmptyArrayType {
         DataType::EmptyArray
     }
 
+    fn full_domain() -> Self::Domain {}
+
     fn create_builder(_capacity: usize, _generics: &GenericMap) -> Self::ColumnBuilder {
         0
     }

--- a/src/query/expression/src/types/generic.rs
+++ b/src/query/expression/src/types/generic.rs
@@ -137,6 +137,10 @@ impl<const INDEX: usize> ArgType for GenericType<INDEX> {
         DataType::Generic(INDEX)
     }
 
+    fn full_domain() -> Self::Domain {
+        unreachable!()
+    }
+
     fn create_builder(capacity: usize, generics: &GenericMap) -> Self::ColumnBuilder {
         ColumnBuilder::with_capacity(&generics[INDEX], capacity)
     }

--- a/src/query/expression/src/types/map.rs
+++ b/src/query/expression/src/types/map.rs
@@ -159,6 +159,8 @@ impl<K: ArgType, V: ArgType> ArgType for KvPair<K, V> {
         DataType::Tuple(vec![K::data_type(), V::data_type()])
     }
 
+    fn full_domain() -> Self::Domain {}
+
     fn create_builder(capacity: usize, generics: &GenericMap) -> Self::ColumnBuilder {
         KvColumnBuilder::with_capacity(capacity, generics)
     }
@@ -395,6 +397,8 @@ impl<T: ArgType> ArgType for MapType<T> {
     fn data_type() -> DataType {
         DataType::Map(Box::new(T::data_type()))
     }
+
+    fn full_domain() -> Self::Domain {}
 
     fn create_builder(capacity: usize, generics: &GenericMap) -> Self::ColumnBuilder {
         <MapInternal<T> as ArgType>::create_builder(capacity, generics)

--- a/src/query/expression/src/types/null.rs
+++ b/src/query/expression/src/types/null.rs
@@ -152,6 +152,8 @@ impl ArgType for NullType {
         DataType::Null
     }
 
+    fn full_domain() -> Self::Domain {}
+
     fn create_builder(_capacity: usize, _generics: &GenericMap) -> Self::ColumnBuilder {
         0
     }

--- a/src/query/expression/src/types/nullable.rs
+++ b/src/query/expression/src/types/nullable.rs
@@ -172,6 +172,13 @@ impl<T: ArgType> ArgType for NullableType<T> {
         DataType::Nullable(Box::new(T::data_type()))
     }
 
+    fn full_domain() -> Self::Domain {
+        NullableDomain {
+            has_null: true,
+            value: Some(Box::new(T::full_domain())),
+        }
+    }
+
     fn create_builder(capacity: usize, generics: &GenericMap) -> Self::ColumnBuilder {
         NullableColumnBuilder::with_capacity(capacity, generics)
     }

--- a/src/query/expression/src/types/number.rs
+++ b/src/query/expression/src/types/number.rs
@@ -164,6 +164,13 @@ impl<Num: Number> ArgType for NumberType<Num> {
         DataType::Number(Num::data_type())
     }
 
+    fn full_domain() -> Self::Domain {
+        SimpleDomain {
+            min: Num::MIN,
+            max: Num::MAX,
+        }
+    }
+
     fn create_builder(capacity: usize, _generics: &GenericMap) -> Self::ColumnBuilder {
         Vec::with_capacity(capacity)
     }

--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -146,6 +146,13 @@ impl ArgType for StringType {
         DataType::String
     }
 
+    fn full_domain() -> Self::Domain {
+        StringDomain {
+            min: vec![],
+            max: None,
+        }
+    }
+
     fn create_builder(capacity: usize, _: &GenericMap) -> Self::ColumnBuilder {
         StringColumnBuilder::with_capacity(capacity, 0)
     }

--- a/src/query/expression/src/types/timestamp.rs
+++ b/src/query/expression/src/types/timestamp.rs
@@ -178,6 +178,13 @@ impl ArgType for TimestampType {
         DataType::Timestamp
     }
 
+    fn full_domain() -> Self::Domain {
+        SimpleDomain {
+            min: TIMESTAMP_MIN,
+            max: TIMESTAMP_MAX,
+        }
+    }
+
     fn create_builder(capacity: usize, _generics: &GenericMap) -> Self::ColumnBuilder {
         Vec::with_capacity(capacity)
     }

--- a/src/query/expression/src/types/variant.rs
+++ b/src/query/expression/src/types/variant.rs
@@ -155,6 +155,8 @@ impl ArgType for VariantType {
         DataType::Variant
     }
 
+    fn full_domain() -> Self::Domain {}
+
     fn create_builder(capacity: usize, _: &GenericMap) -> Self::ColumnBuilder {
         StringColumnBuilder::with_capacity(capacity, 0)
     }

--- a/src/query/functions-v2/src/scalars/arithmetic.rs
+++ b/src/query/functions-v2/src/scalars/arithmetic.rs
@@ -24,6 +24,7 @@ use common_expression::vectorize_1_arg;
 use common_expression::vectorize_with_builder_1_arg;
 use common_expression::vectorize_with_builder_2_arg;
 use common_expression::with_number_mapped_type;
+use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use num_traits::AsPrimitive;
@@ -34,9 +35,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_aliases("plus", &["add"]);
     registry.register_aliases("minus", &["subtract", "neg"]);
     registry.register_aliases("div", &["intdiv"]);
-
-    // TODO support modulo
-    // registry.register_aliases("%", &["mod", "modulo"]);
+    registry.register_aliases("modulo", &["mod"]);
 
     // Unary OP for minus and plus
     for left in ALL_NUMERICS_TYPES {
@@ -47,7 +46,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     "minus",
                     FunctionProperty::default(),
                     |lhs| {
-                        Some(SimpleDomain::<T> {
+                        FunctionDomain::Domain(SimpleDomain::<T> {
                             min: -(lhs.max.as_(): T),
                             max: -(lhs.min.as_(): T),
                         })
@@ -63,7 +62,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 registry.register_1_arg::<NumberType<NUM_TYPE>, NumberType<NUM_TYPE>, _, _>(
                     "plus",
                     FunctionProperty::default(),
-                    |lhs| Some(lhs.clone()),
+                    |lhs| FunctionDomain::Domain(lhs.clone()),
                     |a, _| a,
                 );
             }
@@ -81,15 +80,18 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 "plus",
                                 FunctionProperty::default(),
                                 |lhs, rhs| {
-                                    let lm: T =  num_traits::cast::cast(lhs.max)?;
-                                    let ln: T =  num_traits::cast::cast(lhs.min)?;
-                                    let rm: T =  num_traits::cast::cast(rhs.max)?;
-                                    let rn: T =  num_traits::cast::cast(rhs.min)?;
+                                    (|| {
+                                        let lm: T =  num_traits::cast::cast(lhs.max)?;
+                                        let ln: T =  num_traits::cast::cast(lhs.min)?;
+                                        let rm: T =  num_traits::cast::cast(rhs.max)?;
+                                        let rn: T =  num_traits::cast::cast(rhs.min)?;
 
-                                    Some(SimpleDomain::<T> {
-                                        min: ln.checked_add(rn)?,
-                                        max: lm.checked_add(rm)?,
-                                    })
+                                        Some(FunctionDomain::Domain(SimpleDomain::<T> {
+                                            min: ln.checked_add(rn)?,
+                                            max: lm.checked_add(rm)?,
+                                        }))
+                                    })()
+                                    .unwrap_or(FunctionDomain::NoThrow)
                                 },
                                 |a, b, _| (a.as_() : T) + (b.as_() : T),
                             );
@@ -101,15 +103,18 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 "minus",
                                 FunctionProperty::default(),
                                 |lhs, rhs| {
-                                    let lm: T =  num_traits::cast::cast(lhs.max)?;
-                                    let ln: T =  num_traits::cast::cast(lhs.min)?;
-                                    let rm: T =  num_traits::cast::cast(rhs.max)?;
-                                    let rn: T =  num_traits::cast::cast(rhs.min)?;
+                                    (|| {
+                                        let lm: T =  num_traits::cast::cast(lhs.max)?;
+                                        let ln: T =  num_traits::cast::cast(lhs.min)?;
+                                        let rm: T =  num_traits::cast::cast(rhs.max)?;
+                                        let rn: T =  num_traits::cast::cast(rhs.min)?;
 
-                                    Some(SimpleDomain::<T> {
-                                        min: ln.checked_sub(rm)?,
-                                        max: lm.checked_sub(rn)?,
-                                    })
+                                        Some(FunctionDomain::Domain(SimpleDomain::<T> {
+                                            min: ln.checked_sub(rm)?,
+                                            max: lm.checked_sub(rn)?,
+                                        }))
+                                    })()
+                                    .unwrap_or(FunctionDomain::NoThrow)
                                 },
                                 |a, b, _| (a.as_() : T) - (b.as_() : T),
                             );
@@ -121,20 +126,23 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 "multiply",
                                 FunctionProperty::default(),
                                 |lhs, rhs| {
-                                    let lm: T =  num_traits::cast::cast(lhs.max)?;
-                                    let ln: T =  num_traits::cast::cast(lhs.min)?;
-                                    let rm: T =  num_traits::cast::cast(rhs.max)?;
-                                    let rn: T =  num_traits::cast::cast(rhs.min)?;
+                                    (|| {
+                                        let lm: T =  num_traits::cast::cast(lhs.max)?;
+                                        let ln: T =  num_traits::cast::cast(lhs.min)?;
+                                        let rm: T =  num_traits::cast::cast(rhs.max)?;
+                                        let rn: T =  num_traits::cast::cast(rhs.min)?;
 
-                                    let x = lm.checked_mul(rm)?;
-                                    let y = lm.checked_mul(rn)?;
-                                    let m = ln.checked_mul(rm)?;
-                                    let n = ln.checked_mul(rn)?;
+                                        let x = lm.checked_mul(rm)?;
+                                        let y = lm.checked_mul(rn)?;
+                                        let m = ln.checked_mul(rm)?;
+                                        let n = ln.checked_mul(rn)?;
 
-                                    Some(SimpleDomain::<T> {
-                                        min: x.min(y).min(m).min(n),
-                                        max: x.max(y).max(m).max(n),
-                                    })
+                                        Some(FunctionDomain::Domain(SimpleDomain::<T> {
+                                            min: x.min(y).min(m).min(n),
+                                            max: x.max(y).max(m).max(n),
+                                        }))
+                                    })()
+                                    .unwrap_or(FunctionDomain::NoThrow)
                                 },
                                 |a, b, _| (a.as_() : T) * (b.as_() : T),
                             );
@@ -145,7 +153,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                             registry.register_2_arg_core::<NumberType<L>, NumberType<R>, NumberType<T>, _, _>(
                                 "divide",
                                 FunctionProperty::default(),
-                                |_, _| None,
+                                |_, _| FunctionDomain::MayThrow,
                                 vectorize_with_builder_2_arg::<NumberType<L>, NumberType<R>,  NumberType<T>>(
                                     |a, b, output, _| {
                                         let b = (b.as_() : T);
@@ -160,7 +168,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                             registry.register_2_arg_core::<NullableType<NumberType<L>>, NullableType<NumberType<R>>,  NullableType<NumberType<T>>, _, _>(
                                 "divide",
                                 FunctionProperty::default(),
-                                |_, _| None,
+                                |_, _| FunctionDomain::MayThrow,
                                 vectorize_with_builder_2_arg::<NullableType<NumberType<L>>, NullableType<NumberType<R>>,  NullableType<NumberType<T>>>(
                                     |a, b, output, _| {
                                     match (a,b) {
@@ -184,7 +192,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                             registry.register_2_arg_core::<NumberType<L>, NumberType<R>,  NumberType<T>,_, _>(
                             "div",
                             FunctionProperty::default(),
-                            |_, _| None,
+                            |_, _| FunctionDomain::MayThrow,
                             vectorize_with_builder_2_arg::<NumberType<L>, NumberType<R>,  NumberType<T>>(
                                     |a, b, output, _| {
                                     let b = (b.as_() : F64);
@@ -201,7 +209,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                             registry.register_2_arg_core::<NullableType<NumberType<L>>, NullableType<NumberType<R>>,  NullableType<NumberType<T>>,_, _>(
                             "div",
                             FunctionProperty::default(),
-                            |_, _| None,
+                            |_, _| FunctionDomain::MayThrow,
                             vectorize_with_builder_2_arg::<NullableType<NumberType<L>>, NullableType<NumberType<R>>,  NullableType<NumberType<T>>>(
                                     |a, b, output, _| {
                                     match (a,b) {
@@ -235,12 +243,12 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 registry.register_2_arg_core::<NumberType<L>, NumberType<R>,  NumberType<T>,_, _>(
                                 "modulo",
                                 FunctionProperty::default(),
-                                |_, _| None,
+                                |_, _| FunctionDomain::MayThrow,
                                 vectorize_with_builder_2_arg::<NumberType<L>, NumberType<R>,  NumberType<T>>(
                                         |a, b, output, _| {
                                         let b = (b.as_() : F64);
                                         if std::intrinsics::unlikely(b == 0.0) {
-                                                return Err("Modulo by zero".to_string());
+                                            return Err("Modulo by zero".to_string());
                                         }
                                         output.push(((a.as_() : M) % (b.as_() : M)).as_(): T);
                                         Ok(())
@@ -250,7 +258,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 registry.register_2_arg_core::<NumberType<L>, NumberType<R>, NumberType<T>, _, _>(
                                     "modulo",
                                     FunctionProperty::default(),
-                                    |_, _| None,
+                                    |_, _| FunctionDomain::MayThrow,
                                     vectorize_modulo::<L, R, M, T>()
                                 );
                             }
@@ -259,14 +267,14 @@ pub fn register(registry: &mut FunctionRegistry) {
                             registry.register_2_arg_core::<NullableType<NumberType<L>>, NullableType<NumberType<R>>,  NullableType<NumberType<T>>,_, _>(
                                 "modulo",
                                 FunctionProperty::default(),
-                                |_, _| None,
+                                |_, _| FunctionDomain::MayThrow,
                                 vectorize_with_builder_2_arg::<NullableType<NumberType<L>>, NullableType<NumberType<R>>,  NullableType<NumberType<T>>>(
                                         |a, b, output, _| {
                                         match (a,b) {
                                             (Some(a), Some(b)) => {
                                                 let b = (b.as_() : F64);
                                                 if std::intrinsics::unlikely(b == 0.0) {
-                                                        return Err("Modulo by zero".to_string());
+                                                    return Err("Modulo by zero".to_string());
                                                 }
                                                 output.push(((a.as_() : M) % (b.as_() : M)).as_(): T);
                                             },
@@ -295,7 +303,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 |domain| {
                                     let (domain, overflowing) = domain.overflow_cast();
                                     debug_assert!(!overflowing);
-                                    Some(domain)
+                                    FunctionDomain::Domain(domain)
                                 },
                                 |val, _|  {
                                     val.as_()
@@ -308,9 +316,9 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 |domain| {
                                     let (domain, overflowing) = domain.overflow_cast();
                                     if overflowing {
-                                        None
+                                        FunctionDomain::MayThrow
                                     } else {
-                                        Some(domain)
+                                        FunctionDomain::Domain(domain)
                                     }
                                 },
                                 vectorize_with_builder_1_arg::<NumberType<SRC_TYPE>, NumberType<DEST_TYPE>>(
@@ -338,7 +346,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 |domain| {
                                     let (domain, overflowing) = domain.overflow_cast();
                                     debug_assert!(!overflowing);
-                                    Some(NullableDomain {
+                                    FunctionDomain::Domain(NullableDomain {
                                         has_null: false,
                                         value: Some(Box::new(
                                             domain,
@@ -355,7 +363,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 FunctionProperty::default(),
                                 |domain| {
                                     let (domain, overflowing) = domain.overflow_cast();
-                                    Some(NullableDomain {
+                                    FunctionDomain::Domain(NullableDomain {
                                         has_null: overflowing,
                                         value: Some(Box::new(
                                             domain,

--- a/src/query/functions-v2/src/scalars/array.rs
+++ b/src/query/functions-v2/src/scalars/array.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use common_expression::types::array::ArrayColumnBuilder;
 use common_expression::types::boolean::BooleanDomain;
+use common_expression::types::nullable::NullableDomain;
 use common_expression::types::number::SimpleDomain;
 use common_expression::types::number::UInt64Type;
 use common_expression::types::ArgType;
@@ -42,6 +43,7 @@ use common_expression::with_number_mapped_type;
 use common_expression::Column;
 use common_expression::Domain;
 use common_expression::Function;
+use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use common_expression::FunctionSignature;
@@ -57,7 +59,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_0_arg_core::<EmptyArrayType, _, _>(
         "array",
         FunctionProperty::default(),
-        || Some(()),
+        || FunctionDomain::NoThrow,
         |_| Ok(Value::Scalar(())),
     );
 
@@ -70,7 +72,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 property: FunctionProperty::default(),
             },
             calc_domain: Box::new(|args_domain| {
-                Some(args_domain.iter().fold(Domain::Array(None), |acc, x| {
+                FunctionDomain::Domain(args_domain.iter().fold(Domain::Array(None), |acc, x| {
                     acc.merge(&Domain::Array(Some(Box::new(x.clone()))))
                 }))
             }),
@@ -110,28 +112,53 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_1_arg::<EmptyArrayType, NumberType<u8>, _, _>(
         "length",
         FunctionProperty::default(),
-        |_| Some(SimpleDomain { min: 0, max: 0 }),
+        |_| FunctionDomain::Domain(SimpleDomain { min: 0, max: 0 }),
         |_, _| 0u8,
     );
 
     registry.register_1_arg::<ArrayType<GenericType<0>>, NumberType<u64>, _, _>(
         "length",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         |arr, _| arr.len() as u64,
     );
 
     registry.register_2_arg_core::<NullableType<EmptyArrayType>, NullableType<UInt64Type>, NullType, _, _>(
         "get",
         FunctionProperty::default(),
-        |_, _| Some(()),
+        |_, _| FunctionDomain::NoThrow,
         |_, _, _| Ok(Value::Scalar(())),
+    );
+
+    registry.register_combine_nullable_2_arg::<ArrayType<NullableType<GenericType<0>>>, UInt64Type, GenericType<0>, _, _>(
+        "get",
+        FunctionProperty::default(),
+        |domain, _| FunctionDomain::Domain(NullableDomain {
+            has_null: true,
+            value: domain.value.clone(),
+        }),
+        vectorize_with_builder_2_arg::<ArrayType<NullableType<GenericType<0>>>, UInt64Type, NullableType<GenericType<0>>>(
+            |arr, idx, output, _| {
+                if idx == 0 {
+                    output.push_null();
+                } else {
+                    match arr.index(idx as usize - 1) {
+                        Some(Some(item)) => output.push(item),
+                        _ => output.push_null(),
+                    }
+                }
+                Ok(())
+            }
+        ),
     );
 
     registry.register_combine_nullable_2_arg::<ArrayType<GenericType<0>>, UInt64Type, GenericType<0>, _, _>(
         "get",
         FunctionProperty::default(),
-        |_, _| None,
+        |domain, _| FunctionDomain::Domain(NullableDomain {
+            has_null: true,
+            value: Some(Box::new(domain.clone()))
+        }),
         vectorize_with_builder_2_arg::<ArrayType<GenericType<0>>, UInt64Type, NullableType<GenericType<0>>>(
             |arr, idx, output, _| {
                 if idx == 0 {
@@ -150,7 +177,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_3_arg::<EmptyArrayType, UInt64Type, UInt64Type, EmptyArrayType, _, _>(
         "slice",
         FunctionProperty::default(),
-        |_, _, _| None,
+        |_, _, _| FunctionDomain::NoThrow,
         vectorize_with_builder_3_arg::<EmptyArrayType, UInt64Type, UInt64Type, EmptyArrayType>(
             |_, _, _, output, _| {
                 *output += 1;
@@ -162,7 +189,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_3_arg::<ArrayType<GenericType<0>>, UInt64Type, UInt64Type, ArrayType<GenericType<0>>, _, _>(
         "slice",
         FunctionProperty::default(),
-        |_, _, _| None,
+        |domain,_, _| FunctionDomain::Domain(domain.clone()),
         vectorize_with_builder_3_arg::<ArrayType<GenericType<0>>, UInt64Type, UInt64Type, ArrayType<GenericType<0>>>(
             |arr, start, end, output, _| {
                 let start = if start > 0 {
@@ -191,7 +218,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<EmptyArrayType, EmptyArrayType, _, _>(
         "remove_first",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<EmptyArrayType, EmptyArrayType>(|_, output, _| {
             *output += 1;
             Ok(())
@@ -201,7 +228,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, _, _>(
         "remove_first",
         FunctionProperty::default(),
-        |_| None,
+        |domain| FunctionDomain::Domain(domain.clone()),
         vectorize_with_builder_1_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>>(
             |arr, output, _| {
                 if arr.len() <= 1 {
@@ -219,7 +246,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<EmptyArrayType, EmptyArrayType, _, _>(
         "remove_last",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<EmptyArrayType, EmptyArrayType>(|_, output, _| {
             *output += 1;
             Ok(())
@@ -229,7 +256,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, _, _>(
         "remove_last",
         FunctionProperty::default(),
-        |_| None,
+        |domain| FunctionDomain::Domain(domain.clone()),
         vectorize_with_builder_1_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>>(
             |arr, output, _| {
                 if arr.len() <= 1 {
@@ -296,7 +323,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     "contains",
                     FunctionProperty::default(),
                     |lhs, rhs| {
-                        Some(BooleanDomain {
+                        FunctionDomain::Domain(BooleanDomain {
                             has_false: true,
                             has_true: (lhs.min..=lhs.max).contains(&rhs.min)
                                 || (lhs.min..=lhs.max).contains(&rhs.max),
@@ -313,7 +340,7 @@ pub fn register(registry: &mut FunctionRegistry) {
             "contains",
             FunctionProperty::default(),
             |lhs, rhs| {
-                Some(BooleanDomain {
+                FunctionDomain::Domain(BooleanDomain {
                     has_false: true,
                     has_true: (lhs.min..=lhs.max).contains(&rhs.min)
                         || (lhs.min..=lhs.max).contains(&rhs.max),
@@ -326,7 +353,7 @@ pub fn register(registry: &mut FunctionRegistry) {
             "contains",
             FunctionProperty::default(),
             |lhs, rhs| {
-                Some(BooleanDomain {
+                FunctionDomain::Domain(BooleanDomain {
                     has_false: true,
                     has_true: (lhs.min..=lhs.max).contains(&rhs.min)
                         || (lhs.min..=lhs.max).contains(&rhs.max),
@@ -339,7 +366,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "contains",
         FunctionProperty::default(),
         |lhs, rhs| {
-            Some(BooleanDomain {
+            FunctionDomain::Domain(BooleanDomain {
                 has_false:  (lhs.has_false && rhs.has_true) || (lhs.has_true && rhs.has_false),
                 has_true:   (lhs.has_false && rhs.has_false) || (lhs.has_true && rhs.has_true),
             })
@@ -383,10 +410,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "contains",
         FunctionProperty::default(),
         |_, _| {
-            Some(BooleanDomain {
-                has_false: true,
-                has_true: true,
-            })
+            FunctionDomain::NoThrow
         },
         |lhs, rhs, _| {
             match lhs {
@@ -429,12 +453,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_2_arg_core::<ArrayType<GenericType<0>>, GenericType<0>, BooleanType, _, _>(
         "contains",
         FunctionProperty::default(),
-        |_, _| {
-            Some(BooleanDomain {
-                has_false: true,
-                has_true: true,
-            })
-        },
+        |_, _| FunctionDomain::NoThrow,
         vectorize_2_arg::<ArrayType<GenericType<0>>, GenericType<0>, BooleanType>(|lhs, rhs, _| {
             lhs.iter().contains(&rhs)
         }),

--- a/src/query/functions-v2/src/scalars/comparison.rs
+++ b/src/query/functions-v2/src/scalars/comparison.rs
@@ -29,6 +29,7 @@ use common_expression::types::ALL_NUMERICS_TYPES;
 use common_expression::values::Value;
 use common_expression::with_number_mapped_type;
 use common_expression::FunctionContext;
+use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use common_expression::ValueRef;
@@ -51,37 +52,37 @@ where for<'a> T::ScalarRef<'a>: PartialOrd + PartialEq {
     registry.register_2_arg::<T, T, BooleanType, _, _>(
         "eq",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| T::upcast_gat(lhs) == T::upcast_gat(rhs),
     );
     registry.register_2_arg::<T, T, BooleanType, _, _>(
         "noteq",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| T::upcast_gat(lhs) != T::upcast_gat(rhs),
     );
     registry.register_2_arg::<T, T, BooleanType, _, _>(
         "gt",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| T::upcast_gat(lhs) > T::upcast_gat(rhs),
     );
     registry.register_2_arg::<T, T, BooleanType, _, _>(
         "gte",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| T::upcast_gat(lhs) >= T::upcast_gat(rhs),
     );
     registry.register_2_arg::<T, T, BooleanType, _, _>(
         "lt",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| T::upcast_gat(lhs) < T::upcast_gat(rhs),
     );
     registry.register_2_arg::<T, T, BooleanType, _, _>(
         "lte",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| T::upcast_gat(lhs) <= T::upcast_gat(rhs),
     );
 }
@@ -90,37 +91,37 @@ fn register_boolean_cmp(registry: &mut FunctionRegistry) {
     registry.register_2_arg::<BooleanType, BooleanType, BooleanType, _, _>(
         "eq",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| lhs == rhs,
     );
     registry.register_2_arg::<BooleanType, BooleanType, BooleanType, _, _>(
         "noteq",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| lhs != rhs,
     );
     registry.register_2_arg::<BooleanType, BooleanType, BooleanType, _, _>(
         "gt",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| lhs & !rhs,
     );
     registry.register_2_arg::<BooleanType, BooleanType, BooleanType, _, _>(
         "gte",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| (lhs & !rhs) || (lhs & rhs),
     );
     registry.register_2_arg::<BooleanType, BooleanType, BooleanType, _, _>(
         "lt",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| !lhs & rhs,
     );
     registry.register_2_arg::<BooleanType, BooleanType, BooleanType, _, _>(
         "lte",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| (!lhs & rhs) || (lhs & rhs),
     );
 }
@@ -133,42 +134,42 @@ fn register_number_cmp(registry: &mut FunctionRegistry) {
                     .register_2_arg::<NumberType<NUM_TYPE>, NumberType<NUM_TYPE>, BooleanType, _, _>(
                         "eq",
                         FunctionProperty::default(),
-                        |_, _| None,
+                        |_, _| FunctionDomain::NoThrow,
                         |lhs, rhs, _| lhs == rhs,
                     );
                 registry
                     .register_2_arg::<NumberType<NUM_TYPE>, NumberType<NUM_TYPE>, BooleanType, _, _>(
                         "noteq",
                         FunctionProperty::default(),
-                        |_, _| None,
+                        |_, _| FunctionDomain::NoThrow,
                         |lhs, rhs, _| lhs != rhs,
                     );
                 registry
                     .register_2_arg::<NumberType<NUM_TYPE>, NumberType<NUM_TYPE>, BooleanType, _, _>(
                         "gt",
                         FunctionProperty::default(),
-                        |_, _| None,
+                        |_, _| FunctionDomain::NoThrow,
                         |lhs, rhs, _| lhs > rhs,
                     );
                 registry
                     .register_2_arg::<NumberType<NUM_TYPE>, NumberType<NUM_TYPE>, BooleanType, _, _>(
                         "gte",
                         FunctionProperty::default(),
-                        |_, _| None,
+                        |_, _| FunctionDomain::NoThrow,
                         |lhs, rhs, _| lhs >= rhs,
                     );
                 registry
                     .register_2_arg::<NumberType<NUM_TYPE>, NumberType<NUM_TYPE>, BooleanType, _, _>(
                         "lt",
                         FunctionProperty::default(),
-                        |_, _| None,
+                        |_, _| FunctionDomain::NoThrow,
                         |lhs, rhs, _| lhs < rhs,
                     );
                 registry
                     .register_2_arg::<NumberType<NUM_TYPE>, NumberType<NUM_TYPE>, BooleanType, _, _>(
                         "lte",
                         FunctionProperty::default(),
-                        |_, _| None,
+                        |_, _| FunctionDomain::NoThrow,
                         |lhs, rhs, _| lhs <= rhs,
                     );
             }
@@ -180,7 +181,7 @@ fn register_variant_cmp(registry: &mut FunctionRegistry) {
     registry.register_2_arg::<VariantType, VariantType, BooleanType, _, _>(
         "eq",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| {
             common_jsonb::compare(lhs, rhs).expect("unable to parse jsonb value") == Ordering::Equal
         },
@@ -188,7 +189,7 @@ fn register_variant_cmp(registry: &mut FunctionRegistry) {
     registry.register_2_arg::<VariantType, VariantType, BooleanType, _, _>(
         "noteq",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| {
             common_jsonb::compare(lhs, rhs).expect("unable to parse jsonb value") != Ordering::Equal
         },
@@ -196,7 +197,7 @@ fn register_variant_cmp(registry: &mut FunctionRegistry) {
     registry.register_2_arg::<VariantType, VariantType, BooleanType, _, _>(
         "gt",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| {
             common_jsonb::compare(lhs, rhs).expect("unable to parse jsonb value")
                 == Ordering::Greater
@@ -205,7 +206,7 @@ fn register_variant_cmp(registry: &mut FunctionRegistry) {
     registry.register_2_arg::<VariantType, VariantType, BooleanType, _, _>(
         "gte",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| {
             common_jsonb::compare(lhs, rhs).expect("unable to parse jsonb value") != Ordering::Less
         },
@@ -213,7 +214,7 @@ fn register_variant_cmp(registry: &mut FunctionRegistry) {
     registry.register_2_arg::<VariantType, VariantType, BooleanType, _, _>(
         "lt",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| {
             common_jsonb::compare(lhs, rhs).expect("unable to parse jsonb value") == Ordering::Less
         },
@@ -221,7 +222,7 @@ fn register_variant_cmp(registry: &mut FunctionRegistry) {
     registry.register_2_arg::<VariantType, VariantType, BooleanType, _, _>(
         "lte",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| {
             common_jsonb::compare(lhs, rhs).expect("unable to parse jsonb value")
                 != Ordering::Greater
@@ -235,7 +236,7 @@ fn register_like(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<StringType, StringType, BooleanType, _, _>(
         "like",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         vectorize_like(|str, pat, _, pattern_type| {
             match pattern_type {
                 PatternType::OrdinalStr => Ok(str == pat),
@@ -276,7 +277,7 @@ fn register_like(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<StringType, StringType, BooleanType, _, _>(
         "regexp",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         vectorize_regexp(|str, pat, _, map, _| {
             let pattern = if let Some(pattern) = map.get(pat) {
                 pattern

--- a/src/query/functions-v2/src/scalars/control.rs
+++ b/src/query/functions-v2/src/scalars/control.rs
@@ -26,6 +26,7 @@ use common_expression::Column;
 use common_expression::ColumnBuilder;
 use common_expression::Domain;
 use common_expression::Function;
+use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use common_expression::FunctionSignature;
@@ -72,7 +73,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     };
                     match (&mut domain, has_true, has_null_or_false) {
                         (None, true, false) => {
-                            return Some(args_domain[cond_idx + 1].clone());
+                            return FunctionDomain::Domain(args_domain[cond_idx + 1].clone());
                         }
                         (None, false, true) => {
                             continue;
@@ -81,7 +82,9 @@ pub fn register(registry: &mut FunctionRegistry) {
                             domain = Some(args_domain[cond_idx + 1].clone());
                         }
                         (Some(prev_domain), true, false) => {
-                            return Some(prev_domain.merge(&args_domain[cond_idx + 1]));
+                            return FunctionDomain::Domain(
+                                prev_domain.merge(&args_domain[cond_idx + 1]),
+                            );
                         }
                         (Some(_), false, true) => {
                             continue;
@@ -93,7 +96,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     }
                 }
 
-                Some(match domain {
+                FunctionDomain::Domain(match domain {
                     Some(domain) => domain.merge(args_domain.last().unwrap()),
                     None => args_domain.last().unwrap().clone(),
                 })
@@ -148,7 +151,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "is_not_null",
         FunctionProperty::default(),
         |_| {
-            Some(BooleanDomain {
+            FunctionDomain::Domain(BooleanDomain {
                 has_true: false,
                 has_false: true,
             })
@@ -159,7 +162,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "is_not_null",
         FunctionProperty::default(),
         |NullableDomain { has_null, value }| {
-            Some(BooleanDomain {
+            FunctionDomain::Domain(BooleanDomain {
                 has_true: value.is_some(),
                 has_false: *has_null,
             })

--- a/src/query/functions-v2/src/scalars/datetime.rs
+++ b/src/query/functions-v2/src/scalars/datetime.rs
@@ -48,6 +48,7 @@ use common_expression::vectorize_1_arg;
 use common_expression::vectorize_2_arg;
 use common_expression::vectorize_with_builder_1_arg;
 use common_expression::vectorize_with_builder_2_arg;
+use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use common_expression::Value;
@@ -112,7 +113,7 @@ fn register_cast_functions(registry: &mut FunctionRegistry) {
         "to_timestamp",
         FunctionProperty::default(),
         |domain| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: domain.min as i64 * 24 * 3600 * 1000000,
                 max: domain.max as i64 * 24 * 3600 * 1000000,
             })
@@ -127,7 +128,11 @@ fn register_cast_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<Int64Type, TimestampType, _, _>(
         "to_timestamp",
         FunctionProperty::default(),
-        |domain| int64_domain_to_timestamp_domain(domain),
+        |domain| {
+            int64_domain_to_timestamp_domain(domain)
+                .map(FunctionDomain::Domain)
+                .unwrap_or(FunctionDomain::MayThrow)
+        },
         vectorize_with_builder_1_arg::<Int64Type, TimestampType>(|val, output, _| {
             output.push(int64_to_timestamp(val)?);
             Ok(())
@@ -137,7 +142,7 @@ fn register_cast_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, TimestampType, _, _>(
         "to_timestamp",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::MayThrow,
         vectorize_with_builder_1_arg::<StringType, TimestampType>(|val, output, ctx| {
             let ts = string_to_timestamp(val, ctx.tz).ok_or_else(|| {
                 format!(
@@ -154,7 +159,7 @@ fn register_cast_functions(registry: &mut FunctionRegistry) {
         "to_date",
         FunctionProperty::default(),
         |domain| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: (domain.min / 1000000 / 24 / 3600) as i32,
                 max: (domain.max / 1000000 / 24 / 3600) as i32,
             })
@@ -170,7 +175,11 @@ fn register_cast_functions(registry: &mut FunctionRegistry) {
         FunctionProperty::default(),
         |domain| {
             let (domain, overflowing) = domain.overflow_cast_with_minmax(DATE_MIN, DATE_MAX);
-            if overflowing { None } else { Some(domain) }
+            if overflowing {
+                FunctionDomain::MayThrow
+            } else {
+                FunctionDomain::Domain(domain)
+            }
         },
         vectorize_with_builder_1_arg::<Int64Type, DateType>(|val, output, _| {
             let val = check_date(val)?;
@@ -182,7 +191,7 @@ fn register_cast_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, DateType, _, _>(
         "to_date",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::MayThrow,
         vectorize_with_builder_1_arg::<StringType, DateType>(|val, output, ctx| {
             let d = string_to_date(val, ctx.tz).ok_or_else(|| {
                 format!(
@@ -203,7 +212,7 @@ fn register_try_cast_functions(registry: &mut FunctionRegistry) {
         "try_to_timestamp",
         FunctionProperty::default(),
         |domain| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: domain.min as i64 * 24 * 3600 * 1000000,
                 max: domain.max as i64 * 24 * 3600 * 1000000,
             })
@@ -217,15 +226,18 @@ fn register_try_cast_functions(registry: &mut FunctionRegistry) {
         "try_to_timestamp",
         FunctionProperty::default(),
         |domain| {
-            let val = if let Some(number_domain) = &domain.value {
-                int64_domain_to_timestamp_domain(number_domain).map(Box::new)
+            let value = if let Some(number_domain) = &domain.value {
+                if let Some(domain) = int64_domain_to_timestamp_domain(number_domain) {
+                    Some(Box::new(domain))
+                } else {
+                    return FunctionDomain::MayThrow;
+                }
             } else {
                 None
             };
-            val.as_ref()?;
-            Some(NullableDomain {
+            FunctionDomain::Domain(NullableDomain {
                 has_null: domain.has_null,
-                value: val,
+                value,
             })
         },
         vectorize_1_arg::<NullableType<Int64Type>, NullableType<TimestampType>>(|val, _| {
@@ -236,7 +248,7 @@ fn register_try_cast_functions(registry: &mut FunctionRegistry) {
     registry.register_1_arg_core::<NullableType<StringType>, NullableType<TimestampType>, _, _>(
         "try_to_timestamp",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<NullableType<StringType>, NullableType<TimestampType>>(|val, ctx| {
             val.and_then(|v| string_to_timestamp(v, ctx.tz).map(|ts| ts.timestamp_micros()))
         }),
@@ -246,7 +258,7 @@ fn register_try_cast_functions(registry: &mut FunctionRegistry) {
         "try_to_date",
         FunctionProperty::default(),
         |domain| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: (domain.min / 1000000 / 24 / 3600) as i32,
                 max: (domain.max / 1000000 / 24 / 3600) as i32,
             })
@@ -260,12 +272,15 @@ fn register_try_cast_functions(registry: &mut FunctionRegistry) {
         |domain| {
             let val = if let Some(d) = &domain.value {
                 let (domain, overflowing) = d.overflow_cast_with_minmax(DATE_MIN, DATE_MAX);
-                if overflowing { None } else { Some(domain) }
+                if overflowing {
+                    return FunctionDomain::MayThrow;
+                } else {
+                    Some(domain)
+                }
             } else {
                 None
             };
-            val.as_ref()?;
-            Some(NullableDomain {
+            FunctionDomain::Domain(NullableDomain {
                 has_null: domain.has_null,
                 value: val.map(Box::new),
             })
@@ -278,7 +293,7 @@ fn register_try_cast_functions(registry: &mut FunctionRegistry) {
     registry.register_1_arg_core::<NullableType<StringType>, NullableType<DateType>, _, _>(
         "try_to_date",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<NullableType<StringType>, NullableType<DateType>>(|val, ctx| {
             val.and_then(|v| {
                 string_to_date(v, ctx.tz).map(|d| (d.num_days_from_ce() - EPOCH_DAYS_FROM_CE))
@@ -291,7 +306,7 @@ fn register_to_string(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, StringType, _, _>(
         "to_string",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<TimestampType, StringType>(|val, output, ctx| {
             write!(output.data, "{}", timestamp_to_string(val, ctx.tz)).unwrap();
             output.commit_row();
@@ -302,7 +317,7 @@ fn register_to_string(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, StringType, _, _>(
         "to_string",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<DateType, StringType>(|val, output, ctx| {
             write!(output.data, "{}", date_to_string(val, ctx.tz)).unwrap();
             output.commit_row();
@@ -314,7 +329,7 @@ fn register_to_string(registry: &mut FunctionRegistry) {
         "try_to_string",
         FunctionProperty::default(),
         |_| {
-            Some(NullableDomain {
+            FunctionDomain::Domain(NullableDomain {
                 has_null: false,
                 value: Some(Box::new(StringDomain {
                     min: vec![],
@@ -336,7 +351,7 @@ fn register_to_string(registry: &mut FunctionRegistry) {
         "try_to_string",
         FunctionProperty::default(),
         |_| {
-            Some(NullableDomain {
+            FunctionDomain::Domain(NullableDomain {
                 has_null: false,
                 value: Some(Box::new(StringDomain {
                     min: vec![],
@@ -357,7 +372,7 @@ fn register_to_number(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, NumberType<i64>, _, _>(
         "to_int64",
         FunctionProperty::default(),
-        |domain| Some(domain.clone()),
+        |domain| FunctionDomain::Domain(domain.clone()),
         |val, _| match val {
             ValueRef::Scalar(scalar) => Ok(Value::Scalar(scalar)),
             ValueRef::Column(col) => Ok(Value::Column(col)),
@@ -367,7 +382,7 @@ fn register_to_number(registry: &mut FunctionRegistry) {
     registry.register_1_arg::<DateType, NumberType<i64>, _, _>(
         "to_int64",
         FunctionProperty::default(),
-        |domain| Some(domain.overflow_cast().0),
+        |domain| FunctionDomain::Domain(domain.overflow_cast().0),
         |val, _| val as i64,
     );
 
@@ -375,7 +390,7 @@ fn register_to_number(registry: &mut FunctionRegistry) {
         "try_to_int64",
         FunctionProperty::default(),
         |domain| {
-            Some(NullableDomain {
+            FunctionDomain::Domain(NullableDomain {
                 has_null: false,
                 value: Some(Box::new(domain.clone())),
             })
@@ -393,7 +408,7 @@ fn register_to_number(registry: &mut FunctionRegistry) {
         "try_to_int64",
         FunctionProperty::default(),
         |domain| {
-            Some(NullableDomain {
+            FunctionDomain::Domain(NullableDomain {
                 has_null: false,
                 value: Some(Box::new(domain.overflow_cast().0)),
             })
@@ -426,7 +441,7 @@ macro_rules! impl_register_arith_functions {
             registry.register_passthrough_nullable_2_arg::<TimestampType, Int64Type, TimestampType, _, _>(
                 concat!($op, "_years"),
                 FunctionProperty::default(),
-                |_, _| None,
+                |_, _| FunctionDomain::MayThrow,
                 vectorize_with_builder_2_arg::<TimestampType, Int64Type, TimestampType>(
                     |ts, delta, builder, _| {
                         builder.push(AddYearsImpl::eval_timestamp(ts, $signed_wrapper!{delta})?);
@@ -437,7 +452,7 @@ macro_rules! impl_register_arith_functions {
             registry.register_passthrough_nullable_2_arg::<DateType, Int64Type, DateType, _, _>(
                 concat!($op, "_years"),
                 FunctionProperty::default(),
-                |_, _| None,
+                |_, _| FunctionDomain::MayThrow,
                 vectorize_with_builder_2_arg::<DateType, Int64Type, DateType>(|date, delta, builder, _| {
                     builder.push(AddYearsImpl::eval_date(date, $signed_wrapper!{delta})?);
                     Ok(())
@@ -447,7 +462,7 @@ macro_rules! impl_register_arith_functions {
             registry.register_passthrough_nullable_2_arg::<TimestampType, Int64Type, TimestampType, _, _>(
                 concat!($op, "_quarters"),
                 FunctionProperty::default(),
-                |_, _| None,
+                |_, _| FunctionDomain::MayThrow,
                 vectorize_with_builder_2_arg::<TimestampType, Int64Type, TimestampType>(
                     |ts, delta, builder, _| {
                         builder.push(AddMonthsImpl::eval_timestamp(ts, $signed_wrapper!{delta} * 3)?);
@@ -458,7 +473,7 @@ macro_rules! impl_register_arith_functions {
             registry.register_passthrough_nullable_2_arg::<DateType, Int64Type, DateType, _, _>(
                 concat!($op, "_quarters"),
                 FunctionProperty::default(),
-                |_, _| None,
+                |_, _| FunctionDomain::MayThrow,
                 vectorize_with_builder_2_arg::<DateType, Int64Type, DateType>(|date, delta, builder, _| {
                     builder.push(AddMonthsImpl::eval_date(date, $signed_wrapper!{delta} * 3)?);
                     Ok(())
@@ -468,7 +483,7 @@ macro_rules! impl_register_arith_functions {
             registry.register_passthrough_nullable_2_arg::<TimestampType, Int64Type, TimestampType, _, _>(
                 concat!($op, "_months"),
                 FunctionProperty::default(),
-                |_, _| None,
+                |_, _| FunctionDomain::MayThrow,
                 vectorize_with_builder_2_arg::<TimestampType, Int64Type, TimestampType>(
                     |ts, delta, builder, _| {
                         builder.push(AddMonthsImpl::eval_timestamp(ts, $signed_wrapper!{delta})?);
@@ -479,7 +494,7 @@ macro_rules! impl_register_arith_functions {
             registry.register_passthrough_nullable_2_arg::<DateType, Int64Type, DateType, _, _>(
                 concat!($op, "_months"),
                 FunctionProperty::default(),
-                |_, _| None,
+                |_, _| FunctionDomain::MayThrow,
                 vectorize_with_builder_2_arg::<DateType, Int64Type, DateType>(|date, delta, builder, _| {
                     builder.push(AddMonthsImpl::eval_date(date, $signed_wrapper!{delta})?);
                     Ok(())
@@ -489,7 +504,7 @@ macro_rules! impl_register_arith_functions {
             registry.register_passthrough_nullable_2_arg::<TimestampType, Int64Type, TimestampType, _, _>(
                 concat!($op, "_days"),
                 FunctionProperty::default(),
-                |_, _| None,
+                |_, _| FunctionDomain::MayThrow,
                 vectorize_with_builder_2_arg::<TimestampType, Int64Type, TimestampType>(
                     |ts, delta, builder, _| {
                         builder.push(AddDaysImpl::eval_timestamp(ts, $signed_wrapper!{delta})?);
@@ -500,7 +515,7 @@ macro_rules! impl_register_arith_functions {
             registry.register_passthrough_nullable_2_arg::<DateType, Int64Type, DateType, _, _>(
                 concat!($op, "_days"),
                 FunctionProperty::default(),
-                |_, _| None,
+                |_, _| FunctionDomain::MayThrow,
                 vectorize_with_builder_2_arg::<DateType, Int64Type, DateType>(|date, delta, builder, _| {
                     builder.push(AddDaysImpl::eval_date(date, $signed_wrapper!{delta})?);
                     Ok(())
@@ -510,7 +525,7 @@ macro_rules! impl_register_arith_functions {
             registry.register_passthrough_nullable_2_arg::<TimestampType, Int64Type, TimestampType, _, _>(
                 concat!($op, "_hours"),
                 FunctionProperty::default(),
-                |_, _| None,
+                |_, _| FunctionDomain::MayThrow,
                 vectorize_with_builder_2_arg::<TimestampType, Int64Type, TimestampType>(
                     |ts, delta, builder, _| {
                         builder.push(AddTimesImpl::eval_timestamp(
@@ -526,7 +541,7 @@ macro_rules! impl_register_arith_functions {
             registry.register_passthrough_nullable_2_arg::<TimestampType, Int64Type, TimestampType, _, _>(
                 concat!($op, "_minutes"),
                 FunctionProperty::default(),
-                |_, _| None,
+                |_, _| FunctionDomain::MayThrow,
                 vectorize_with_builder_2_arg::<TimestampType, Int64Type, TimestampType>(
                     |ts, delta, builder, _| {
                         builder.push(AddTimesImpl::eval_timestamp(
@@ -542,7 +557,7 @@ macro_rules! impl_register_arith_functions {
             registry.register_passthrough_nullable_2_arg::<TimestampType, Int64Type, TimestampType, _, _>(
                 concat!($op, "_seconds"),
                 FunctionProperty::default(),
-                |_, _| None,
+                |_, _| FunctionDomain::MayThrow,
                 vectorize_with_builder_2_arg::<TimestampType, Int64Type, TimestampType>(
                     |ts, delta, builder, _| {
                         builder.push(AddTimesImpl::eval_timestamp(
@@ -565,28 +580,28 @@ fn register_real_time_functions(registry: &mut FunctionRegistry) {
     registry.register_0_arg_core::<TimestampType, _, _>(
         "now",
         FunctionProperty::default(),
-        || None,
+        || FunctionDomain::NoThrow,
         |_| Ok(Value::Scalar(Utc::now().timestamp_micros())),
     );
 
     registry.register_0_arg_core::<DateType, _, _>(
         "today",
         FunctionProperty::default(),
-        || None,
+        || FunctionDomain::NoThrow,
         |_| Ok(Value::Scalar(today_date())),
     );
 
     registry.register_0_arg_core::<DateType, _, _>(
         "yesterday",
         FunctionProperty::default(),
-        || None,
+        || FunctionDomain::NoThrow,
         |_| Ok(Value::Scalar(today_date() - 1)),
     );
 
     registry.register_0_arg_core::<DateType, _, _>(
         "tomorrow",
         FunctionProperty::default(),
-        || None,
+        || FunctionDomain::NoThrow,
         |_| Ok(Value::Scalar(today_date() + 1)),
     );
 }
@@ -596,7 +611,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, UInt32Type, _, _>(
         "to_yyyymm",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, UInt32Type>(|val, ctx| {
             ToNumberImpl::eval_date::<ToYYYYMM, _>(val, ctx.tz)
         }),
@@ -604,7 +619,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, UInt32Type, _, _>(
         "to_yyyymmdd",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, UInt32Type>(|val, ctx| {
             ToNumberImpl::eval_date::<ToYYYYMMDD, _>(val, ctx.tz)
         }),
@@ -612,7 +627,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, UInt64Type, _, _>(
         "to_yyyymmddhhmmss",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, UInt64Type>(|val, ctx| {
             ToNumberImpl::eval_date::<ToYYYYMMDDHHMMSS, _>(val, ctx.tz)
         }),
@@ -620,7 +635,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, UInt16Type, _, _>(
         "to_year",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, UInt16Type>(|val, ctx| {
             ToNumberImpl::eval_date::<ToYear, _>(val, ctx.tz)
         }),
@@ -628,7 +643,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, UInt8Type, _, _>(
         "to_month",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, UInt8Type>(|val, ctx| {
             ToNumberImpl::eval_date::<ToMonth, _>(val, ctx.tz)
         }),
@@ -636,7 +651,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, UInt16Type, _, _>(
         "to_day_of_year",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, UInt16Type>(|val, ctx| {
             ToNumberImpl::eval_date::<ToDayOfYear, _>(val, ctx.tz)
         }),
@@ -644,7 +659,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, UInt8Type, _, _>(
         "to_day_of_month",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, UInt8Type>(|val, ctx| {
             ToNumberImpl::eval_date::<ToDayOfMonth, _>(val, ctx.tz)
         }),
@@ -652,7 +667,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, UInt8Type, _, _>(
         "to_day_of_week",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, UInt8Type>(|val, ctx| {
             ToNumberImpl::eval_date::<ToDayOfWeek, _>(val, ctx.tz)
         }),
@@ -661,7 +676,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt32Type, _, _>(
         "to_yyyymm",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, UInt32Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToYYYYMM, _>(val, ctx.tz)
         }),
@@ -669,7 +684,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt32Type, _, _>(
         "to_yyyymmdd",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, UInt32Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToYYYYMMDD, _>(val, ctx.tz)
         }),
@@ -677,7 +692,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt64Type, _, _>(
         "to_yyyymmddhhmmss",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, UInt64Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToYYYYMMDDHHMMSS, _>(val, ctx.tz)
         }),
@@ -685,7 +700,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt16Type, _, _>(
         "to_year",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, UInt16Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToYear, _>(val, ctx.tz)
         }),
@@ -693,7 +708,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt8Type, _, _>(
         "to_month",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, UInt8Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToMonth, _>(val, ctx.tz)
         }),
@@ -701,7 +716,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt16Type, _, _>(
         "to_day_of_year",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, UInt16Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToDayOfYear, _>(val, ctx.tz)
         }),
@@ -709,7 +724,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt8Type, _, _>(
         "to_day_of_month",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, UInt8Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToDayOfMonth, _>(val, ctx.tz)
         }),
@@ -717,7 +732,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt8Type, _, _>(
         "to_day_of_week",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, UInt8Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToDayOfWeek, _>(val, ctx.tz)
         }),
@@ -725,7 +740,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt8Type, _, _>(
         "to_hour",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, UInt8Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToHour, _>(val, ctx.tz)
         }),
@@ -733,7 +748,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt8Type, _, _>(
         "to_minute",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, UInt8Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToMinute, _>(val, ctx.tz)
         }),
@@ -741,7 +756,7 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt8Type, _, _>(
         "to_second",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, UInt8Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToSecond, _>(val, ctx.tz)
         }),
@@ -753,7 +768,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, TimestampType, _, _>(
         "to_start_of_second",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, TimestampType>(|val, ctx| {
             round_timestamp(val, ctx.tz, Round::Second)
         }),
@@ -761,7 +776,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, TimestampType, _, _>(
         "to_start_of_minute",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, TimestampType>(|val, ctx| {
             round_timestamp(val, ctx.tz, Round::Minute)
         }),
@@ -769,7 +784,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, TimestampType, _, _>(
         "to_start_of_five_minutes",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, TimestampType>(|val, ctx| {
             round_timestamp(val, ctx.tz, Round::FiveMinutes)
         }),
@@ -777,7 +792,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, TimestampType, _, _>(
         "to_start_of_ten_minutes",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, TimestampType>(|val, ctx| {
             round_timestamp(val, ctx.tz, Round::TenMinutes)
         }),
@@ -785,7 +800,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, TimestampType, _, _>(
         "to_start_of_fifteen_minutes",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, TimestampType>(|val, ctx| {
             round_timestamp(val, ctx.tz, Round::FifteenMinutes)
         }),
@@ -793,7 +808,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, TimestampType, _, _>(
         "to_start_of_hour",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, TimestampType>(|val, ctx| {
             round_timestamp(val, ctx.tz, Round::Hour)
         }),
@@ -801,7 +816,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, TimestampType, _, _>(
         "to_start_of_day",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, TimestampType>(|val, ctx| {
             round_timestamp(val, ctx.tz, Round::Day)
         }),
@@ -809,7 +824,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, TimestampType, _, _>(
         "time_slot",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, TimestampType>(|val, ctx| {
             round_timestamp(val, ctx.tz, Round::TimeSlot)
         }),
@@ -819,7 +834,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, DateType, _, _>(
         "to_monday",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, DateType>(|val, ctx| {
             DateRounder::eval_timestamp::<ToLastMonday>(val, ctx.tz)
         }),
@@ -827,7 +842,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, DateType, _, _>(
         "to_monday",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, DateType>(|val, ctx| {
             DateRounder::eval_date::<ToLastMonday>(val, ctx.tz)
         }),
@@ -836,7 +851,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, DateType, _, _>(
         "to_start_of_week",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, DateType>(|val, ctx| {
             DateRounder::eval_timestamp::<ToLastSunday>(val, ctx.tz)
         }),
@@ -844,7 +859,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, DateType, _, _>(
         "to_start_of_week",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, DateType>(|val, ctx| {
             DateRounder::eval_date::<ToLastSunday>(val, ctx.tz)
         }),
@@ -852,7 +867,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<TimestampType, Int64Type, DateType, _, _>(
         "to_start_of_week",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         vectorize_2_arg::<TimestampType, Int64Type, DateType>(|val, mode, ctx| {
             if mode == 0 {
                 DateRounder::eval_timestamp::<ToLastSunday>(val, ctx.tz)
@@ -864,7 +879,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<DateType, Int64Type, DateType, _, _>(
         "to_start_of_week",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         vectorize_2_arg::<DateType, Int64Type, DateType>(|val, mode, ctx| {
             if mode == 0 {
                 DateRounder::eval_date::<ToLastSunday>(val, ctx.tz)
@@ -877,7 +892,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, DateType, _, _>(
         "to_start_of_month",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, DateType>(|val, ctx| {
             DateRounder::eval_timestamp::<ToStartOfMonth>(val, ctx.tz)
         }),
@@ -885,7 +900,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, DateType, _, _>(
         "to_start_of_month",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, DateType>(|val, ctx| {
             DateRounder::eval_date::<ToStartOfMonth>(val, ctx.tz)
         }),
@@ -894,7 +909,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, DateType, _, _>(
         "to_start_of_quarter",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, DateType>(|val, ctx| {
             DateRounder::eval_timestamp::<ToStartOfQuarter>(val, ctx.tz)
         }),
@@ -902,7 +917,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, DateType, _, _>(
         "to_start_of_quarter",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, DateType>(|val, ctx| {
             DateRounder::eval_date::<ToStartOfQuarter>(val, ctx.tz)
         }),
@@ -911,7 +926,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, DateType, _, _>(
         "to_start_of_year",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, DateType>(|val, ctx| {
             DateRounder::eval_timestamp::<ToStartOfYear>(val, ctx.tz)
         }),
@@ -919,7 +934,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, DateType, _, _>(
         "to_start_of_year",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, DateType>(|val, ctx| {
             DateRounder::eval_date::<ToStartOfYear>(val, ctx.tz)
         }),
@@ -928,7 +943,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<TimestampType, DateType, _, _>(
         "to_start_of_iso_year",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<TimestampType, DateType>(|val, ctx| {
             DateRounder::eval_timestamp::<ToStartOfISOYear>(val, ctx.tz)
         }),
@@ -936,7 +951,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<DateType, DateType, _, _>(
         "to_start_of_iso_year",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_1_arg::<DateType, DateType>(|val, ctx| {
             DateRounder::eval_date::<ToStartOfISOYear>(val, ctx.tz)
         }),

--- a/src/query/functions-v2/src/scalars/math.rs
+++ b/src/query/functions-v2/src/scalars/math.rs
@@ -26,6 +26,7 @@ use common_expression::types::ALL_FLOAT_TYPES;
 use common_expression::types::ALL_INTEGER_TYPES;
 use common_expression::types::ALL_NUMERICS_TYPES;
 use common_expression::with_number_mapped_type;
+use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use common_expression::Value;
@@ -41,7 +42,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "sin",
         FunctionProperty::default(),
         |_| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: OrderedFloat(-1.0),
                 max: OrderedFloat(1.0),
             })
@@ -53,7 +54,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "cos",
         FunctionProperty::default(),
         |_| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: OrderedFloat(-1.0),
                 max: OrderedFloat(1.0),
             })
@@ -64,14 +65,14 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_1_arg::<NumberType<F64>, NumberType<F64>, _, _>(
         "tan",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         |f: F64, _| f.tan(),
     );
 
     registry.register_1_arg::<NumberType<F64>, NumberType<F64>, _, _>(
         "cot",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         |f: F64, _| OrderedFloat(1.0f64) / f.tan(),
     );
 
@@ -79,7 +80,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "acos",
         FunctionProperty::default(),
         |_| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: OrderedFloat(0.0),
                 max: OrderedFloat(PI),
             })
@@ -91,7 +92,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "asin",
         FunctionProperty::default(),
         |_| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: OrderedFloat(0.0),
                 max: OrderedFloat(2.0 * PI),
             })
@@ -103,7 +104,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "atan",
         FunctionProperty::default(),
         |_| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: OrderedFloat(-PI / 2.0),
                 max: OrderedFloat(PI / 2.0),
             })
@@ -115,7 +116,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "atan2",
         FunctionProperty::default(),
         |_, _| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: OrderedFloat(-PI),
                 max: OrderedFloat(PI),
             })
@@ -127,7 +128,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "pi",
         FunctionProperty::default(),
         || {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: OrderedFloat(PI),
                 max: OrderedFloat(PI),
             })
@@ -145,7 +146,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "sign",
         FunctionProperty::default(),
         move |domain| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: sign(domain.min),
                 max: sign(domain.max),
             })
@@ -156,7 +157,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_1_arg::<NumberType<u64>, NumberType<u64>, _, _>(
         "abs",
         FunctionProperty::default(),
-        |domain| Some(domain.clone()),
+        |domain| FunctionDomain::Domain(domain.clone()),
         |val, _| val,
     );
 
@@ -170,7 +171,7 @@ pub fn register(registry: &mut FunctionRegistry) {
             if domain.max >= 0 && domain.min <= 0 {
                 min = 0;
             }
-            Some(SimpleDomain { min, max })
+            FunctionDomain::Domain(SimpleDomain { min, max })
         },
         |val, _| val.unsigned_abs(),
     );
@@ -185,7 +186,7 @@ pub fn register(registry: &mut FunctionRegistry) {
             if domain.max > OrderedFloat(0.0) && domain.min <= OrderedFloat(0.0) {
                 min = OrderedFloat(0.0);
             }
-            Some(SimpleDomain { min, max })
+            FunctionDomain::Domain(SimpleDomain { min, max })
         },
         |val, _| val.abs(),
     );
@@ -196,7 +197,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 registry.register_1_arg::<NumberType<NUM_TYPE>, NumberType<NUM_TYPE>, _, _>(
                     "ceil",
                     FunctionProperty::default(),
-                    |_| None,
+                    |_| FunctionDomain::NoThrow,
                     |val, _| val,
                 );
             }
@@ -209,7 +210,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 registry.register_1_arg::<NumberType<NUM_TYPE>, NumberType<F64>, _, _>(
                     "ceil",
                     FunctionProperty::default(),
-                    |_| None,
+                    |_| FunctionDomain::NoThrow,
                     |val, _| (val.as_(): F64).ceil(),
                 );
             }
@@ -221,21 +222,21 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_1_arg::<StringType, NumberType<u32>, _, _>(
         "crc32",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         |val, _| crc32fast::hash(val),
     );
 
     registry.register_1_arg::<NumberType<F64>, NumberType<F64>, _, _>(
         "degrees",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         |val, _| val.to_degrees(),
     );
 
     registry.register_1_arg::<NumberType<F64>, NumberType<F64>, _, _>(
         "radians",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         |val, _| val.to_radians(),
     );
 
@@ -245,7 +246,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 registry.register_1_arg::<NumberType<NUM_TYPE>, NumberType<F64>, _, _>(
                     "exp",
                     FunctionProperty::default(),
-                    |_| None,
+                    |_| FunctionDomain::NoThrow,
                     |val, _| (val.as_(): F64).exp(),
                 );
             }
@@ -255,14 +256,14 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_1_arg::<NumberType<F64>, NumberType<F64>, _, _>(
         "floor",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         |val, _| val.floor(),
     );
 
     registry.register_2_arg::<NumberType<F64>, NumberType<F64>, NumberType<F64>, _, _>(
         "pow",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |lhs, rhs, _| OrderedFloat(lhs.0.pow(rhs.0)),
     );
 
@@ -270,7 +271,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "rand",
         FunctionProperty::default(),
         || {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: OrderedFloat(0.0),
                 max: OrderedFloat(1.0),
             })
@@ -285,7 +286,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "rand",
         FunctionProperty::default(),
         |_| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: OrderedFloat(0.0),
                 max: OrderedFloat(1.0),
             })
@@ -302,7 +303,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 registry.register_1_arg::<NumberType<NUM_TYPE>, NumberType<F64>, _, _>(
                     "round",
                     FunctionProperty::default(),
-                    |_| None,
+                    |_| FunctionDomain::NoThrow,
                     |val, _| (val.as_(): F64).round(),
                 );
             }
@@ -314,7 +315,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     .register_2_arg::<NumberType<NUM_TYPE>, NumberType<i64>, NumberType<F64>, _, _>(
                         "round",
                         FunctionProperty::default(),
-                        |_, _| None,
+                        |_, _| FunctionDomain::NoThrow,
                         |val, to, _| match to.cmp(&0) {
                             Ordering::Greater => {
                                 let z = 10_f64.powi(if to > 30 { 30 } else { to as i32 });
@@ -335,7 +336,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 registry.register_1_arg::<NumberType<NUM_TYPE>, NumberType<F64>, _, _>(
                     "truncate",
                     FunctionProperty::default(),
-                    |_| None,
+                    |_| FunctionDomain::NoThrow,
                     |val, _| (val.as_(): F64).trunc(),
                 );
             }
@@ -347,7 +348,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     .register_2_arg::<NumberType<NUM_TYPE>, NumberType<i64>, NumberType<F64>, _, _>(
                         "truncate",
                         FunctionProperty::default(),
-                        |_, _| None,
+                        |_, _| FunctionDomain::NoThrow,
                         |val, to, _| match to.cmp(&0) {
                             Ordering::Greater => {
                                 let z = 10_f64.powi(if to > 30 { 30 } else { to as i32 });
@@ -368,7 +369,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 registry.register_1_arg::<NumberType<NUM_TYPE>, NumberType<F64>, _, _>(
                     "sqrt",
                     FunctionProperty::default(),
-                    |_| None,
+                    |_| FunctionDomain::NoThrow,
                     |val, _| (val.as_(): F64).sqrt(),
                 );
             }
@@ -379,7 +380,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 registry.register_1_arg::<NumberType<NUM_TYPE>, NumberType<F64>, _, _>(
                     "ln",
                     FunctionProperty::default(),
-                    |_| None,
+                    |_| FunctionDomain::NoThrow,
                     |val, _| LnFunction::log(val),
                 );
             }
@@ -390,7 +391,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 registry.register_1_arg::<NumberType<NUM_TYPE>, NumberType<F64>, _, _>(
                     "log2",
                     FunctionProperty::default(),
-                    |_| None,
+                    |_| FunctionDomain::NoThrow,
                     |val, _| Log2Function::log(val),
                 );
             }
@@ -401,7 +402,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 registry.register_1_arg::<NumberType<NUM_TYPE>, NumberType<F64>, _, _>(
                     "log10",
                     FunctionProperty::default(),
-                    |_| None,
+                    |_| FunctionDomain::NoThrow,
                     |val, _| Log10Function::log(val),
                 );
             }
@@ -412,7 +413,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 registry.register_1_arg::<NumberType<NUM_TYPE>, NumberType<F64>, _, _>(
                     "log",
                     FunctionProperty::default(),
-                    |_| None,
+                    |_| FunctionDomain::NoThrow,
                     |val, _| LogFunction::log(val),
                 );
             }
@@ -424,7 +425,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     .register_2_arg::<NumberType<NUM_TYPE>, NumberType<F64>, NumberType<F64>, _, _>(
                         "log",
                         FunctionProperty::default(),
-                        |_, _| None,
+                        |_, _| FunctionDomain::NoThrow,
                         |base, val, _| LogFunction::log_with_base(base, val),
                     );
             }

--- a/src/query/functions-v2/src/scalars/string.rs
+++ b/src/query/functions-v2/src/scalars/string.rs
@@ -28,6 +28,7 @@ use common_expression::vectorize_with_builder_2_arg;
 use common_expression::vectorize_with_builder_3_arg;
 use common_expression::vectorize_with_builder_4_arg;
 use common_expression::FunctionContext;
+use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use common_expression::Value;
@@ -44,7 +45,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "upper",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_string_to_string(
             |col| col.data.len(),
             |val, output, _| {
@@ -69,7 +70,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "lower",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_string_to_string(
             |col| col.data.len(),
             |val, output, _| {
@@ -94,21 +95,21 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_1_arg::<StringType, NumberType<u64>, _, _>(
         "bit_length",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         |val, _| 8 * val.len() as u64,
     );
 
     registry.register_1_arg::<StringType, NumberType<u64>, _, _>(
         "length",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         |val, _| val.len() as u64,
     );
 
     registry.register_passthrough_nullable_1_arg::<StringType, NumberType<u64>, _, _>(
         "char_length",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::MayThrow,
         vectorize_with_builder_1_arg::<StringType, NumberType<u64>>(|s, output, _| {
             match std::str::from_utf8(s) {
                 Ok(s) => {
@@ -123,7 +124,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_3_arg::<StringType, NumberType<u64>, StringType, StringType, _, _>(
         "lpad",
         FunctionProperty::default(),
-        |_, _, _| None,
+        |_, _, _| FunctionDomain::NoThrow,
         vectorize_with_builder_3_arg::<StringType, NumberType<u64>, StringType, StringType>(
             |s, pad_len, pad, output, _| {
                 let pad_len = pad_len as usize;
@@ -151,7 +152,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_4_arg::<StringType, NumberType<i64>, NumberType<i64>, StringType, StringType, _, _>(
         "insert",
         FunctionProperty::default(),
-        |_, _, _, _| None,
+        |_, _, _, _| FunctionDomain::NoThrow,
         vectorize_with_builder_4_arg::<StringType, NumberType<i64>, NumberType<i64>, StringType, StringType>(
             |srcstr, pos, len, substr, output, _| {
                 let pos = pos as usize;
@@ -174,7 +175,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_3_arg::<StringType, NumberType<u64>, StringType, StringType, _, _>(
         "rpad",
         FunctionProperty::default(),
-        |_, _, _| None,
+        |_, _, _| FunctionDomain::NoThrow,
         vectorize_with_builder_3_arg::<StringType, NumberType<u64>, StringType, StringType>(
         |s: &[u8], pad_len: u64, pad: &[u8], output, _| {
             let pad_len = pad_len as usize;
@@ -201,7 +202,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_3_arg::<StringType, StringType, StringType, StringType, _, _>(
         "replace",
         FunctionProperty::default(),
-        |_, _, _| None,
+        |_, _, _| FunctionDomain::NoThrow,
         vectorize_with_builder_3_arg::<StringType, StringType, StringType, StringType>(
             |str, from, to, output, _| {
             if from.is_empty() || from == to {
@@ -230,7 +231,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_2_arg::<StringType, StringType, NumberType<i8>, _, _>(
         "strcmp",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         |s1, s2, _| {
             let res = match s1.len().cmp(&s2.len()) {
                 Ordering::Equal => {
@@ -274,35 +275,35 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_2_arg::<StringType, StringType, NumberType<u64>, _, _>(
         "instr",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         move |str: &[u8], substr: &[u8], _| find_at(str, substr, 1),
     );
 
     registry.register_2_arg::<StringType, StringType, NumberType<u64>, _, _>(
         "position",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         move |substr: &[u8], str: &[u8], _| find_at(str, substr, 1),
     );
 
     registry.register_2_arg::<StringType, StringType, NumberType<u64>, _, _>(
         "locate",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         move |substr: &[u8], str: &[u8], _| find_at(str, substr, 1),
     );
 
     registry.register_3_arg::<StringType, StringType, NumberType<u64>, NumberType<u64>, _, _>(
         "locate",
         FunctionProperty::default(),
-        |_, _, _| None,
+        |_, _, _| FunctionDomain::NoThrow,
         move |substr: &[u8], str: &[u8], pos: u64, _| find_at(str, substr, pos),
     );
 
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "to_base64",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_string_to_string(
             |col| col.data.len() * 4 / 3 + col.len() * 4,
             |val, output, _| {
@@ -318,11 +319,12 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "from_base64",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::MayThrow,
         vectorize_string_to_string(
             |col| col.data.len() * 4 / 3 + col.len() * 4,
             |val, output, _| {
-                base64::decode_config_buf(val, base64::STANDARD, &mut output.data).unwrap();
+                base64::decode_config_buf(val, base64::STANDARD, &mut output.data)
+                    .map_err(|err| format!("unable to decode base64: {err}"))?;
                 output.commit_row();
                 Ok(())
             },
@@ -332,7 +334,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "quote",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_string_to_string(
             |col| col.data.len() * 2,
             |val, output, _| {
@@ -358,7 +360,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "reverse",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_string_to_string(
             |col| col.data.len(),
             |val, output, _| {
@@ -376,7 +378,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "ascii",
         FunctionProperty::default(),
         |domain| {
-            Some(SimpleDomain {
+            FunctionDomain::Domain(SimpleDomain {
                 min: domain.min.first().cloned().unwrap_or(0),
                 max: domain
                     .max
@@ -391,7 +393,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "ltrim",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_string_to_string(
             |col| col.data.len(),
             |val, output, _| {
@@ -408,7 +410,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "rtrim",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_string_to_string(
             |col| col.data.len(),
             |val, output, _| {
@@ -425,7 +427,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "trim",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_string_to_string(
             |col| col.data.len(),
             |val, output, _| {
@@ -443,7 +445,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<StringType, StringType, StringType, _, _>(
         "trim_leading",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         vectorize_string_to_string_2_arg(
             |col, _| col.data.len(),
             |val, trim_str, _, output| {
@@ -461,7 +463,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<StringType, StringType, StringType, _, _>(
         "trim_trailing",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         vectorize_string_to_string_2_arg(
             |col, _| col.data.len(),
             |val, trim_str, _, output| {
@@ -479,7 +481,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<StringType, StringType, StringType, _, _>(
         "trim_both",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         vectorize_string_to_string_2_arg(
             |col, _| col.data.len(),
             |val, trim_str, _, output| {
@@ -511,7 +513,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<NumberType<i64>, StringType, _, _>(
         "bin",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<NumberType<i64>, StringType>(|val, output, _| {
             output.write_row(|data| write!(data, "{val:b}")).unwrap();
             Ok(())
@@ -520,7 +522,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<NumberType<i64>, StringType, _, _>(
         "oct",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<NumberType<i64>, StringType>(|val, output, _| {
             output.write_row(|data| write!(data, "{val:o}")).unwrap();
             Ok(())
@@ -529,7 +531,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<NumberType<i64>, StringType, _, _>(
         "hex",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<NumberType<i64>, StringType>(|val, output, _| {
             output.write_row(|data| write!(data, "{val:x}")).unwrap();
             Ok(())
@@ -539,7 +541,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "hex",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_string_to_string(
             |col| col.data.len() * 2,
             |val, output, _| {
@@ -557,7 +559,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<StringType, NumberType<u64>, StringType, _, _>(
         "repeat",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::MayThrow,
         vectorize_with_builder_2_arg::<StringType, NumberType<u64>, StringType>(
             |a, times, output, _| {
                 if times > MAX_REPEAT_TIMES {
@@ -576,7 +578,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "unhex",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::MayThrow,
         vectorize_string_to_string(
             |col| col.data.len() / 2,
             |val, output, _| {
@@ -601,7 +603,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_1_arg::<StringType, UInt64Type, _, _>(
         "ord",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         |str: &[u8], _| {
             let mut res: u64 = 0;
             if !str.is_empty() {
@@ -626,7 +628,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, StringType, _, _>(
         "soundex",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_string_to_string(
             |col| usize::max(col.data.len(), 4 * col.len()),
             |val, output, _| {
@@ -671,7 +673,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "space",
         FunctionProperty::default(),
         |domain| {
-            Some(StringDomain {
+            FunctionDomain::Domain(StringDomain {
                 min: vec![SPACE; domain.min as usize],
                 max: Some(vec![SPACE; domain.max as usize]),
             })
@@ -699,7 +701,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<StringType, NumberType<u64>, StringType, _, _>(
         "left",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         vectorize_with_builder_2_arg::<StringType, NumberType<u64>, StringType>(
             |s, n, output, _| {
                 let n = n as usize;
@@ -717,7 +719,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<StringType, NumberType<u64>, StringType, _, _>(
         "right",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         vectorize_with_builder_2_arg::<StringType, NumberType<u64>, StringType>(
             |s, n, output, _| {
                 let n = n as usize;
@@ -735,7 +737,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<StringType, NumberType<i64>, StringType, _, _>(
         "substr",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         vectorize_with_builder_2_arg::<StringType, NumberType<i64>, StringType>(
             |s, pos, output, _| {
                 output.put_slice(substr(s, pos, s.len() as u64));
@@ -748,7 +750,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_3_arg::<StringType, NumberType<i64>, NumberType<u64>, StringType, _, _>(
         "substr",
         FunctionProperty::default(),
-        |_, _, _| None,
+        |_, _, _| FunctionDomain::NoThrow,
         vectorize_with_builder_3_arg::<StringType, NumberType<i64>, NumberType<u64>, StringType>(|s, pos, len, output, _| {
             output.put_slice(substr(s, pos, len));
             output.commit_row();
@@ -759,7 +761,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<StringType, NumberType<i64>, StringType, _, _>(
         "substr_utf8",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::MayThrow,
         vectorize_with_builder_2_arg::<StringType, NumberType<i64>, StringType>(
             |s, pos, output, _| {
                 let s = std::str::from_utf8(s).map_err(|e| e.to_string())?;
@@ -772,7 +774,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_3_arg::<StringType, NumberType<i64>, NumberType<u64>, StringType, _, _>(
         "substr_utf8",
         FunctionProperty::default(),
-        |_, _, _| None,
+        |_, _, _| FunctionDomain::MayThrow,
         vectorize_with_builder_3_arg::<StringType, NumberType<i64>, NumberType<u64>, StringType>(|s, pos, len, output, _| {
             let s = std::str::from_utf8(s).map_err(|e| e.to_string())?;
             substr_utf8(output, s, pos, len);

--- a/src/query/functions-v2/src/scalars/string_multi_args.rs
+++ b/src/query/functions-v2/src/scalars/string_multi_args.rs
@@ -36,6 +36,7 @@ use common_expression::Column;
 use common_expression::Domain;
 use common_expression::Function;
 use common_expression::FunctionContext;
+use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use common_expression::FunctionSignature;
@@ -58,7 +59,7 @@ pub fn register(registry: &mut FunctionRegistry) {
             },
             calc_domain: Box::new(|args_domain| {
                 let domain = args_domain[0].as_string().unwrap();
-                Some(Domain::String(StringDomain {
+                FunctionDomain::Domain(Domain::String(StringDomain {
                     min: domain.min.clone(),
                     max: None,
                 }))
@@ -79,7 +80,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::Nullable(Box::new(DataType::String)),
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::NoThrow),
             eval: Box::new(wrap_nullable(concat_fn)),
         }))
     });
@@ -97,7 +98,7 @@ pub fn register(registry: &mut FunctionRegistry) {
             },
             calc_domain: Box::new(|args_domain| {
                 let domain = args_domain[1].as_string().unwrap();
-                Some(Domain::String(StringDomain {
+                FunctionDomain::Domain(Domain::String(StringDomain {
                     min: domain.min.clone(),
                     max: None,
                 }))
@@ -162,7 +163,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::Nullable(Box::new(DataType::String)),
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::NoThrow),
             eval: Box::new(|args, _| {
                 type T = NullableType<StringType>;
                 let len = args.iter().find_map(|arg| match arg {
@@ -255,7 +256,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::String,
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::NoThrow),
             eval: Box::new(char_fn),
         }))
     });
@@ -277,7 +278,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::Nullable(Box::new(DataType::String)),
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::MayThrow),
             eval: Box::new(wrap_nullable(char_fn)),
         }))
     });
@@ -322,7 +323,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::Number(NumberDataType::UInt64),
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::MayThrow),
             eval: Box::new(regexp_instr_fn),
         }))
     });
@@ -367,7 +368,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt64))),
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::MayThrow),
             eval: Box::new(wrap_nullable(regexp_instr_fn)),
         }))
     });
@@ -387,7 +388,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::Boolean,
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::MayThrow),
             eval: Box::new(regexp_like_fn),
         }))
     });
@@ -407,7 +408,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::Nullable(Box::new(DataType::Boolean)),
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::MayThrow),
             eval: Box::new(wrap_nullable(regexp_like_fn)),
         }))
     });
@@ -447,7 +448,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::String,
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::MayThrow),
             eval: Box::new(regexp_replace_fn),
         }))
     });
@@ -487,7 +488,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::Nullable(Box::new(DataType::String)),
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::MayThrow),
             eval: Box::new(wrap_nullable(regexp_replace_fn)),
         }))
     });
@@ -524,7 +525,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::Nullable(Box::new(DataType::String)),
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::MayThrow),
             eval: Box::new(regexp_substr_fn),
         }))
     });
@@ -561,7 +562,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::Nullable(Box::new(DataType::String)),
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|_| None),
+            calc_domain: Box::new(|_| FunctionDomain::MayThrow),
             eval: Box::new(wrap_nullable(regexp_substr_fn)),
         }))
     });

--- a/src/query/functions-v2/src/scalars/tuple.rs
+++ b/src/query/functions-v2/src/scalars/tuple.rs
@@ -21,6 +21,7 @@ use common_expression::Column;
 use common_expression::ColumnBuilder;
 use common_expression::Domain;
 use common_expression::Function;
+use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use common_expression::FunctionSignature;
@@ -42,7 +43,9 @@ pub fn register(registry: &mut FunctionRegistry) {
                 return_type: DataType::Tuple(args_type.clone()),
                 property: FunctionProperty::default(),
             },
-            calc_domain: Box::new(|args_domain| Some(Domain::Tuple(args_domain.to_vec()))),
+            calc_domain: Box::new(|args_domain| {
+                FunctionDomain::Domain(Domain::Tuple(args_domain.to_vec()))
+            }),
             eval: Box::new(move |args, _| {
                 let len = args.iter().find_map(|arg| match arg {
                     ValueRef::Column(col) => Some(col.len()),
@@ -94,7 +97,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 property: FunctionProperty::default(),
             },
             calc_domain: Box::new(move |args_domain| {
-                Some(args_domain[0].as_tuple().unwrap()[idx].clone())
+                FunctionDomain::Domain(args_domain[0].as_tuple().unwrap()[idx].clone())
             }),
             eval: Box::new(move |args, _| match &args[0] {
                 ValueRef::Scalar(ScalarRef::Tuple(fields)) => {
@@ -134,7 +137,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     let fields = value.as_tuple().unwrap();
                     Box::new(fields[idx].clone())
                 });
-                Some(Domain::Nullable(NullableDomain {
+                FunctionDomain::Domain(Domain::Nullable(NullableDomain {
                     has_null: *has_null,
                     value,
                 }))

--- a/src/query/functions-v2/src/scalars/variant.rs
+++ b/src/query/functions-v2/src/scalars/variant.rs
@@ -32,6 +32,7 @@ use common_expression::types::VariantType;
 use common_expression::utils::arrow::constant_bitmap;
 use common_expression::vectorize_with_builder_1_arg;
 use common_expression::vectorize_with_builder_2_arg;
+use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use common_expression::Value;
@@ -54,7 +55,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<StringType, VariantType, _, _>(
         "parse_json",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::MayThrow,
         vectorize_with_builder_1_arg::<StringType, VariantType>(|s, output, _| {
             if s.trim().is_empty() {
                 output.put_slice(JSONB_NULL);
@@ -74,7 +75,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_1_arg::<StringType, VariantType, _, _>(
         "try_parse_json",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<StringType, NullableType<VariantType>>(|s, output, _| {
             if s.trim().is_empty() {
                 output.push(JSONB_NULL);
@@ -95,7 +96,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_1_arg::<StringType, StringType, _, _>(
         "check_json",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::MayThrow,
         vectorize_with_builder_1_arg::<StringType, NullableType<StringType>>(|s, output, _| {
             if s.trim().is_empty() {
                 output.push_null();
@@ -112,7 +113,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_1_arg::<VariantType, UInt32Type, _, _>(
         "length",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<VariantType, NullableType<UInt32Type>>(|v, output, _| {
             if v.is_empty() {
                 output.push_null();
@@ -129,7 +130,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_1_arg::<VariantType, VariantType, _, _>(
         "object_keys",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<VariantType, NullableType<VariantType>>(|v, output, _| {
             if v.is_empty() {
                 output.push_null()
@@ -146,7 +147,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_2_arg::<VariantType, UInt64Type, VariantType, _, _>(
         "get",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::NoThrow,
         vectorize_with_builder_2_arg::<VariantType, UInt64Type, NullableType<VariantType>>(
             |s, idx, output, _| {
                 if s.is_empty() {
@@ -166,7 +167,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_2_arg::<VariantType, StringType, VariantType, _, _>(
         "get",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::MayThrow,
         vectorize_with_builder_2_arg::<VariantType, StringType, NullableType<VariantType>>(
             |s, name, output, _| {
                 if s.is_empty() || name.trim().is_empty() {
@@ -193,7 +194,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_2_arg::<VariantType, StringType, VariantType, _, _>(
         "get_ignore_case",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::MayThrow,
         vectorize_with_builder_2_arg::<VariantType, StringType, NullableType<VariantType>>(
             |s, name, output, _| {
                 if s.is_empty() || name.trim().is_empty() {
@@ -219,7 +220,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_2_arg::<VariantType, StringType, VariantType, _, _>(
         "get_path",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::MayThrow,
         vectorize_with_builder_2_arg::<VariantType, StringType, NullableType<VariantType>>(
             |s, path, output, _| {
                 if s.is_empty() || path.is_empty() {
@@ -245,7 +246,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_2_arg::<StringType, StringType, StringType, _, _>(
         "json_extract_path_text",
         FunctionProperty::default(),
-        |_, _| None,
+        |_, _| FunctionDomain::MayThrow,
         vectorize_with_builder_2_arg::<StringType, StringType, NullableType<StringType>>(
             |s, path, output, _| {
                 if s.is_empty() || path.is_empty() {
@@ -278,7 +279,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_1_arg::<VariantType, BooleanType, _, _>(
         "as_boolean",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<VariantType, NullableType<BooleanType>>(|v, output, _| {
             if v.is_empty() {
                 output.push_null();
@@ -295,7 +296,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_1_arg::<VariantType, Int64Type, _, _>(
         "as_integer",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<VariantType, NullableType<Int64Type>>(|v, output, _| {
             if v.is_empty() {
                 output.push_null();
@@ -312,7 +313,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_1_arg::<VariantType, Float64Type, _, _>(
         "as_float",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<VariantType, NullableType<Float64Type>>(|v, output, _| {
             if v.is_empty() {
                 output.push_null();
@@ -329,7 +330,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_1_arg::<VariantType, StringType, _, _>(
         "as_string",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<VariantType, NullableType<StringType>>(|v, output, _| {
             if v.is_empty() {
                 output.push_null();
@@ -346,7 +347,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_1_arg::<VariantType, VariantType, _, _>(
         "as_array",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<VariantType, NullableType<VariantType>>(|v, output, _| {
             if v.is_empty() {
                 output.push_null()
@@ -362,7 +363,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_1_arg::<VariantType, VariantType, _, _>(
         "as_object",
         FunctionProperty::default(),
-        |_| None,
+        |_| FunctionDomain::NoThrow,
         vectorize_with_builder_1_arg::<VariantType, NullableType<VariantType>>(|v, output, _| {
             if v.is_empty() {
                 output.push_null()
@@ -378,7 +379,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_1_arg::<GenericType<0>, VariantType, _, _>(
         "to_variant",
         FunctionProperty::default(),
-        |_| Some(()),
+        |_| FunctionDomain::NoThrow,
         |val, ctx| match val {
             ValueRef::Scalar(scalar) => {
                 let mut buf = Vec::new();
@@ -396,7 +397,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "try_to_variant",
         FunctionProperty::default(),
         |_| {
-            Some(NullableDomain {
+            FunctionDomain::Domain(NullableDomain {
                 has_null: false,
                 value: Some(Box::new(())),
             })

--- a/src/query/functions-v2/tests/it/scalars/array.rs
+++ b/src/query/functions-v2/tests/it/scalars/array.rs
@@ -65,6 +65,7 @@ fn test_get(file: &mut impl Write) {
     run_ast(file, "[1, 2, 3][3]", &[]);
     run_ast(file, "[1, null, 3][1]", &[]);
     run_ast(file, "[1, null, 3][2]", &[]);
+    run_ast(file, "[1, 2, 3][4]", &[]);
     run_ast(file, "[a, b][idx]", &[
         (
             "a",

--- a/src/query/functions-v2/tests/it/scalars/string.rs
+++ b/src/query/functions-v2/tests/it/scalars/string.rs
@@ -136,7 +136,8 @@ fn test_from_base64(file: &mut impl Write) {
         "a",
         DataType::String,
         Column::from_data(&["QWJj", "MTIz"]),
-    )])
+    )]);
+    run_ast(file, "from_base64('!@#')", &[]);
 }
 
 fn test_quote(file: &mut impl Write) {

--- a/src/query/functions-v2/tests/it/scalars/testdata/array.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/array.txt
@@ -57,7 +57,7 @@ raw expr       : length(array(1_u8, 2_u8, 3_u8))
 checked expr   : length<T0=UInt8><Array(T0)>(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8))
 optimized expr : 3_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 3
 
 
@@ -66,7 +66,7 @@ raw expr       : length(array(true, false))
 checked expr   : length<T0=Boolean><Array(T0)>(array<T0=Boolean><T0, T0>(true, false))
 optimized expr : 2_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 2
 
 
@@ -75,7 +75,7 @@ raw expr       : length(array("a", "b", "c", "d"))
 checked expr   : length<T0=String><Array(T0)>(array<T0=String><T0, T0, T0, T0>("a", "b", "c", "d"))
 optimized expr : 4_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 4
 
 
@@ -108,71 +108,80 @@ output         : NULL
 
 ast            : [true, false][1]
 raw expr       : get(array(true, false), 1_u8)
-checked expr   : get<T0=Boolean><Array(T0), UInt64>(array<T0=Boolean><T0, T0>(true, false), CAST(1_u8 AS UInt64))
+checked expr   : get<T0=Boolean><Array(T0 NULL), UInt64>(CAST(array<T0=Boolean><T0, T0>(true, false) AS Array(Boolean NULL)), CAST(1_u8 AS UInt64))
 optimized expr : true
 output type    : Boolean NULL
-output domain  : Unknown
+output domain  : {FALSE, TRUE} ∪ {NULL}
 output         : true
 
 
 ast            : ['a', 'b', 'c'][2]
 raw expr       : get(array("a", "b", "c"), 2_u8)
-checked expr   : get<T0=String><Array(T0), UInt64>(array<T0=String><T0, T0, T0>("a", "b", "c"), CAST(2_u8 AS UInt64))
+checked expr   : get<T0=String><Array(T0 NULL), UInt64>(CAST(array<T0=String><T0, T0, T0>("a", "b", "c") AS Array(String NULL)), CAST(2_u8 AS UInt64))
 optimized expr : "b"
 output type    : String NULL
-output domain  : Unknown
+output domain  : {"a"..="c"} ∪ {NULL}
 output         : "b"
 
 
 ast            : [1, 2, 3][1]
 raw expr       : get(array(1_u8, 2_u8, 3_u8), 1_u8)
-checked expr   : get<T0=UInt8><Array(T0), UInt64>(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8), CAST(1_u8 AS UInt64))
+checked expr   : get<T0=UInt8><Array(T0 NULL), UInt64>(CAST(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8) AS Array(UInt8 NULL)), CAST(1_u8 AS UInt64))
 optimized expr : 1_u8
 output type    : UInt8 NULL
-output domain  : Unknown
+output domain  : {1..=3} ∪ {NULL}
 output         : 1
 
 
 ast            : [1, 2, 3][3]
 raw expr       : get(array(1_u8, 2_u8, 3_u8), 3_u8)
-checked expr   : get<T0=UInt8><Array(T0), UInt64>(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8), CAST(3_u8 AS UInt64))
+checked expr   : get<T0=UInt8><Array(T0 NULL), UInt64>(CAST(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8) AS Array(UInt8 NULL)), CAST(3_u8 AS UInt64))
 optimized expr : 3_u8
 output type    : UInt8 NULL
-output domain  : Unknown
+output domain  : {1..=3} ∪ {NULL}
 output         : 3
 
 
 ast            : [1, null, 3][1]
 raw expr       : get(array(1_u8, NULL, 3_u8), 1_u8)
-checked expr   : get<T0=UInt8 NULL><Array(T0), UInt64>(array<T0=UInt8 NULL><T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL)), CAST(1_u8 AS UInt64))
+checked expr   : get<T0=UInt8><Array(T0 NULL), UInt64>(array<T0=UInt8 NULL><T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL)), CAST(1_u8 AS UInt64))
 optimized expr : 1_u8
-output type    : UInt8 NULL NULL
-output domain  : Unknown
+output type    : UInt8 NULL
+output domain  : {1..=3} ∪ {NULL}
 output         : 1
 
 
 ast            : [1, null, 3][2]
 raw expr       : get(array(1_u8, NULL, 3_u8), 2_u8)
-checked expr   : get<T0=UInt8 NULL><Array(T0), UInt64>(array<T0=UInt8 NULL><T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL)), CAST(2_u8 AS UInt64))
+checked expr   : get<T0=UInt8><Array(T0 NULL), UInt64>(array<T0=UInt8 NULL><T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL)), CAST(2_u8 AS UInt64))
 optimized expr : NULL
-output type    : UInt8 NULL NULL
-output domain  : Unknown
+output type    : UInt8 NULL
+output domain  : {1..=3} ∪ {NULL}
+output         : NULL
+
+
+ast            : [1, 2, 3][4]
+raw expr       : get(array(1_u8, 2_u8, 3_u8), 4_u8)
+checked expr   : get<T0=UInt8><Array(T0 NULL), UInt64>(CAST(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8) AS Array(UInt8 NULL)), CAST(4_u8 AS UInt64))
+optimized expr : NULL
+output type    : UInt8 NULL
+output domain  : {1..=3} ∪ {NULL}
 output         : NULL
 
 
 ast            : [a, b][idx]
 raw expr       : get(array(ColumnRef(0)::Int16, ColumnRef(1)::Int16), ColumnRef(2)::UInt16)
-checked expr   : get<T0=Int16><Array(T0), UInt64>(array<T0=Int16><T0, T0>(ColumnRef(0), ColumnRef(1)), CAST(ColumnRef(2) AS UInt64))
+checked expr   : get<T0=Int16><Array(T0 NULL), UInt64>(CAST(array<T0=Int16><T0, T0>(ColumnRef(0), ColumnRef(1)) AS Array(Int16 NULL)), CAST(ColumnRef(2) AS UInt64))
 evaluation:
-+--------+---------+---------+---------+------------+
-|        | a       | b       | idx     | Output     |
-+--------+---------+---------+---------+------------+
-| Type   | Int16   | Int16   | UInt16  | Int16 NULL |
-| Domain | {0..=2} | {3..=5} | {1..=3} | Unknown    |
-| Row 0  | 0       | 3       | 1       | 0          |
-| Row 1  | 1       | 4       | 2       | 4          |
-| Row 2  | 2       | 5       | 3       | NULL       |
-+--------+---------+---------+---------+------------+
++--------+---------+---------+---------+------------------+
+|        | a       | b       | idx     | Output           |
++--------+---------+---------+---------+------------------+
+| Type   | Int16   | Int16   | UInt16  | Int16 NULL       |
+| Domain | {0..=2} | {3..=5} | {1..=3} | {0..=5} ∪ {NULL} |
+| Row 0  | 0       | 3       | 1       | 0                |
+| Row 1  | 1       | 4       | 2       | 4                |
+| Row 2  | 2       | 5       | 3       | NULL             |
++--------+---------+---------+---------+------------------+
 evaluation (internal):
 +--------+---------------------------------------------------------------------+
 | Column | Data                                                                |
@@ -189,7 +198,7 @@ raw expr       : slice(array(), 1_u8, 2_u8)
 checked expr   : slice<Array(Nothing), UInt64, UInt64>(array<>(), CAST(1_u8 AS UInt64), CAST(2_u8 AS UInt64))
 optimized expr : [] :: Array(Nothing)
 output type    : Array(Nothing)
-output domain  : Unknown
+output domain  : []
 output         : []
 
 
@@ -198,7 +207,7 @@ raw expr       : slice(array(1_u8), 1_u8, 2_u8)
 checked expr   : slice<T0=UInt8><Array(T0), UInt64, UInt64>(array<T0=UInt8><T0>(1_u8), CAST(1_u8 AS UInt64), CAST(2_u8 AS UInt64))
 optimized expr : [1]
 output type    : Array(UInt8)
-output domain  : Unknown
+output domain  : [{1..=1}]
 output         : [1]
 
 
@@ -207,7 +216,7 @@ raw expr       : slice(array(NULL, 1_u8, 2_u8, 3_u8), 0_u8, 2_u8)
 checked expr   : slice<T0=UInt8 NULL><Array(T0), UInt64, UInt64>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(NULL AS UInt8 NULL), CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL)), CAST(0_u8 AS UInt64), CAST(2_u8 AS UInt64))
 optimized expr : [NULL, 1]
 output type    : Array(UInt8 NULL)
-output domain  : Unknown
+output domain  : [{1..=3} ∪ {NULL}]
 output         : [NULL, 1]
 
 
@@ -216,7 +225,7 @@ raw expr       : slice(array(0_u8, 1_u8, 2_u8, 3_u8), 1_u8, 2_u8)
 checked expr   : slice<T0=UInt8><Array(T0), UInt64, UInt64>(array<T0=UInt8><T0, T0, T0, T0>(0_u8, 1_u8, 2_u8, 3_u8), CAST(1_u8 AS UInt64), CAST(2_u8 AS UInt64))
 optimized expr : [0, 1]
 output type    : Array(UInt8)
-output domain  : Unknown
+output domain  : [{0..=3}]
 output         : [0, 1]
 
 
@@ -225,7 +234,7 @@ raw expr       : slice(array(0_u8, 1_u8, 2_u8, 3_u8), 1_u8, 5_u8)
 checked expr   : slice<T0=UInt8><Array(T0), UInt64, UInt64>(array<T0=UInt8><T0, T0, T0, T0>(0_u8, 1_u8, 2_u8, 3_u8), CAST(1_u8 AS UInt64), CAST(5_u8 AS UInt64))
 optimized expr : [0, 1, 2, 3]
 output type    : Array(UInt8)
-output domain  : Unknown
+output domain  : [{0..=3}]
 output         : [0, 1, 2, 3]
 
 
@@ -234,7 +243,7 @@ raw expr       : slice(array("a", "b", "c", "d"), 0_u8, 2_u8)
 checked expr   : slice<T0=String><Array(T0), UInt64, UInt64>(array<T0=String><T0, T0, T0, T0>("a", "b", "c", "d"), CAST(0_u8 AS UInt64), CAST(2_u8 AS UInt64))
 optimized expr : ["a", "b"]
 output type    : Array(String)
-output domain  : Unknown
+output domain  : [{"a"..="d"}]
 output         : ["a", "b"]
 
 
@@ -243,7 +252,7 @@ raw expr       : slice(array("a", "b", "c", "d"), 1_u8, 4_u8)
 checked expr   : slice<T0=String><Array(T0), UInt64, UInt64>(array<T0=String><T0, T0, T0, T0>("a", "b", "c", "d"), CAST(1_u8 AS UInt64), CAST(4_u8 AS UInt64))
 optimized expr : ["a", "b", "c", "d"]
 output type    : Array(String)
-output domain  : Unknown
+output domain  : [{"a"..="d"}]
 output         : ["a", "b", "c", "d"]
 
 
@@ -252,7 +261,7 @@ raw expr       : slice(array("a", "b", "c", "d"), 2_u8, 6_u8)
 checked expr   : slice<T0=String><Array(T0), UInt64, UInt64>(array<T0=String><T0, T0, T0, T0>("a", "b", "c", "d"), CAST(2_u8 AS UInt64), CAST(6_u8 AS UInt64))
 optimized expr : ["b", "c", "d"]
 output type    : Array(String)
-output domain  : Unknown
+output domain  : [{"a"..="d"}]
 output         : ["b", "c", "d"]
 
 
@@ -261,7 +270,7 @@ raw expr       : remove_first(array())
 checked expr   : remove_first<Array(Nothing)>(array<>())
 optimized expr : [] :: Array(Nothing)
 output type    : Array(Nothing)
-output domain  : Unknown
+output domain  : []
 output         : []
 
 
@@ -270,7 +279,7 @@ raw expr       : remove_first(array(1_u8))
 checked expr   : remove_first<T0=UInt8><Array(T0)>(array<T0=UInt8><T0>(1_u8))
 optimized expr : []
 output type    : Array(UInt8)
-output domain  : Unknown
+output domain  : [{1..=1}]
 output         : []
 
 
@@ -279,7 +288,7 @@ raw expr       : remove_first(array(0_u8, 1_u8, 2_u8, NULL))
 checked expr   : remove_first<T0=UInt8 NULL><Array(T0)>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(0_u8 AS UInt8 NULL), CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)))
 optimized expr : [1, 2, NULL]
 output type    : Array(UInt8 NULL)
-output domain  : Unknown
+output domain  : [{0..=2} ∪ {NULL}]
 output         : [1, 2, NULL]
 
 
@@ -288,7 +297,7 @@ raw expr       : remove_first(array(0_u8, 1_u8, 2_u8, 3_u8))
 checked expr   : remove_first<T0=UInt8><Array(T0)>(array<T0=UInt8><T0, T0, T0, T0>(0_u8, 1_u8, 2_u8, 3_u8))
 optimized expr : [1, 2, 3]
 output type    : Array(UInt8)
-output domain  : Unknown
+output domain  : [{0..=3}]
 output         : [1, 2, 3]
 
 
@@ -297,7 +306,7 @@ raw expr       : remove_first(array("a", "b", "c", "d"))
 checked expr   : remove_first<T0=String><Array(T0)>(array<T0=String><T0, T0, T0, T0>("a", "b", "c", "d"))
 optimized expr : ["b", "c", "d"]
 output type    : Array(String)
-output domain  : Unknown
+output domain  : [{"a"..="d"}]
 output         : ["b", "c", "d"]
 
 
@@ -306,7 +315,7 @@ raw expr       : remove_last(array())
 checked expr   : remove_last<Array(Nothing)>(array<>())
 optimized expr : [] :: Array(Nothing)
 output type    : Array(Nothing)
-output domain  : Unknown
+output domain  : []
 output         : []
 
 
@@ -315,7 +324,7 @@ raw expr       : remove_last(array(1_u8))
 checked expr   : remove_last<T0=UInt8><Array(T0)>(array<T0=UInt8><T0>(1_u8))
 optimized expr : []
 output type    : Array(UInt8)
-output domain  : Unknown
+output domain  : [{1..=1}]
 output         : []
 
 
@@ -324,7 +333,7 @@ raw expr       : remove_last(array(0_u8, 1_u8, 2_u8, NULL))
 checked expr   : remove_last<T0=UInt8 NULL><Array(T0)>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(0_u8 AS UInt8 NULL), CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)))
 optimized expr : [0, 1, 2]
 output type    : Array(UInt8 NULL)
-output domain  : Unknown
+output domain  : [{0..=2} ∪ {NULL}]
 output         : [0, 1, 2]
 
 
@@ -333,7 +342,7 @@ raw expr       : remove_last(array(0_u8, 1_u8, 2_u8, 3_u8))
 checked expr   : remove_last<T0=UInt8><Array(T0)>(array<T0=UInt8><T0, T0, T0, T0>(0_u8, 1_u8, 2_u8, 3_u8))
 optimized expr : [0, 1, 2]
 output type    : Array(UInt8)
-output domain  : Unknown
+output domain  : [{0..=3}]
 output         : [0, 1, 2]
 
 
@@ -342,7 +351,7 @@ raw expr       : remove_last(array("a", "b", "c", "d"))
 checked expr   : remove_last<T0=String><Array(T0)>(array<T0=String><T0, T0, T0, T0>("a", "b", "c", "d"))
 optimized expr : ["a", "b", "c"]
 output type    : Array(String)
-output domain  : Unknown
+output domain  : [{"a"..="d"}]
 output         : ["a", "b", "c"]
 
 
@@ -351,7 +360,7 @@ raw expr       : or(eq(false, false), eq(false, true))
 checked expr   : or<Boolean, Boolean>(eq<Boolean, Boolean>(false, false), eq<Boolean, Boolean>(false, true))
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -435,16 +444,16 @@ raw expr       : or(or(eq(ColumnRef(1)::Int64 NULL, 9_u8), eq(ColumnRef(1)::Int6
 checked expr   : or<Boolean NULL, Boolean NULL>(or<Boolean NULL, Boolean NULL>(eq<Int64 NULL, Int64 NULL>(ColumnRef(1), CAST(9_u8 AS Int64 NULL)), eq<Int64 NULL, Int64 NULL>(ColumnRef(1), CAST(10_u8 AS Int64 NULL))), eq<Int64 NULL, Int64 NULL>(ColumnRef(1), CAST(12_u8 AS Int64 NULL)))
 optimized expr : or<Boolean NULL, Boolean NULL>(or<Boolean NULL, Boolean NULL>(eq<Int64 NULL, Int64 NULL>(ColumnRef(1), 9_i64), eq<Int64 NULL, Int64 NULL>(ColumnRef(1), 10_i64)), eq<Int64 NULL, Int64 NULL>(ColumnRef(1), 12_i64))
 evaluation:
-+--------+-------------------+--------------+
-|        | nullable_col      | Output       |
-+--------+-------------------+--------------+
-| Type   | Int64 NULL        | Boolean NULL |
-| Domain | {9..=12} ∪ {NULL} | Unknown      |
-| Row 0  | 9                 | true         |
-| Row 1  | 10                | true         |
-| Row 2  | NULL              | NULL         |
-| Row 3  | NULL              | NULL         |
-+--------+-------------------+--------------+
++--------+-------------------+------------------------+
+|        | nullable_col      | Output                 |
++--------+-------------------+------------------------+
+| Type   | Int64 NULL        | Boolean NULL           |
+| Domain | {9..=12} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | 9                 | true                   |
+| Row 1  | 10                | true                   |
+| Row 2  | NULL              | NULL                   |
+| Row 3  | NULL              | NULL                   |
++--------+-------------------+------------------------+
 evaluation (internal):
 +--------------+---------------------------------------------------------------------------+
 | Column       | Data                                                                      |

--- a/src/query/functions-v2/tests/it/scalars/testdata/boolean.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/boolean.txt
@@ -12,7 +12,7 @@ raw expr       : and(true, NULL)
 checked expr   : and<Boolean NULL, Boolean NULL>(CAST(true AS Boolean NULL), CAST(NULL AS Boolean NULL))
 optimized expr : NULL
 output type    : Boolean NULL
-output domain  : Unknown
+output domain  : {FALSE, TRUE} ∪ {NULL}
 output         : NULL
 
 
@@ -39,7 +39,7 @@ raw expr       : and(false, NULL)
 checked expr   : and<Boolean NULL, Boolean NULL>(CAST(false AS Boolean NULL), CAST(NULL AS Boolean NULL))
 optimized expr : false
 output type    : Boolean NULL
-output domain  : Unknown
+output domain  : {FALSE, TRUE} ∪ {NULL}
 output         : false
 
 
@@ -93,13 +93,13 @@ raw expr       : and(lt(ColumnRef(0)::UInt8 NULL, 1_u8), lt(ColumnRef(0)::UInt8 
 checked expr   : and<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : and<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -114,13 +114,13 @@ raw expr       : and(gt(ColumnRef(0)::UInt8 NULL, 1_u8), lt(ColumnRef(0)::UInt8 
 checked expr   : and<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : and<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -135,13 +135,13 @@ raw expr       : and(lt(ColumnRef(0)::UInt8 NULL, 1_u8), gt(ColumnRef(0)::UInt8 
 checked expr   : and<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : and<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -156,13 +156,13 @@ raw expr       : and(lt(ColumnRef(0)::UInt8 NULL, 1_u8), lt(ColumnRef(0)::UInt8 
 checked expr   : and<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : and<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -177,13 +177,13 @@ raw expr       : and(gt(ColumnRef(0)::UInt8 NULL, 1_u8), gt(0_u8, 1_u8))
 checked expr   : and<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), CAST(gt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL))
 optimized expr : and<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), false)
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | false        |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | false                  |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -198,13 +198,13 @@ raw expr       : and(gt(ColumnRef(0)::UInt8 NULL, 1_u8), lt(0_u8, 1_u8))
 checked expr   : and<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), CAST(lt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL))
 optimized expr : and<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), true)
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -219,13 +219,13 @@ raw expr       : and(lt(ColumnRef(0)::UInt8 NULL, 1_u8), gt(0_u8, 1_u8))
 checked expr   : and<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), CAST(gt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL))
 optimized expr : and<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), false)
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | false        |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | false                  |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -240,13 +240,13 @@ raw expr       : and(lt(ColumnRef(0)::UInt8 NULL, 1_u8), lt(0_u8, 1_u8))
 checked expr   : and<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), CAST(lt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL))
 optimized expr : and<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), true)
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -261,13 +261,13 @@ raw expr       : and(gt(0_u8, 1_u8), gt(ColumnRef(0)::UInt8 NULL, 1_u8))
 checked expr   : and<Boolean NULL, Boolean NULL>(CAST(gt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL), gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : and<Boolean NULL, Boolean NULL>(false, gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | false        |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | false                  |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -282,13 +282,13 @@ raw expr       : and(gt(0_u8, 1_u8), lt(ColumnRef(0)::UInt8 NULL, 1_u8))
 checked expr   : and<Boolean NULL, Boolean NULL>(CAST(gt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : and<Boolean NULL, Boolean NULL>(false, lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | false        |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | false                  |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -303,13 +303,13 @@ raw expr       : and(lt(0_u8, 1_u8), gt(ColumnRef(0)::UInt8 NULL, 1_u8))
 checked expr   : and<Boolean NULL, Boolean NULL>(CAST(lt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL), gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : and<Boolean NULL, Boolean NULL>(true, gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -324,13 +324,13 @@ raw expr       : and(lt(0_u8, 1_u8), lt(ColumnRef(0)::UInt8 NULL, 1_u8))
 checked expr   : and<Boolean NULL, Boolean NULL>(CAST(lt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : and<Boolean NULL, Boolean NULL>(true, lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -445,7 +445,7 @@ raw expr       : or(NULL, false)
 checked expr   : or<Boolean NULL, Boolean NULL>(CAST(NULL AS Boolean NULL), CAST(false AS Boolean NULL))
 optimized expr : NULL
 output type    : Boolean NULL
-output domain  : Unknown
+output domain  : {FALSE, TRUE} ∪ {NULL}
 output         : NULL
 
 
@@ -454,13 +454,13 @@ raw expr       : or(lt(ColumnRef(0)::UInt8 NULL, 1_u8), lt(ColumnRef(0)::UInt8 N
 checked expr   : or<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : or<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -475,13 +475,13 @@ raw expr       : or(gt(ColumnRef(0)::UInt8 NULL, 1_u8), lt(ColumnRef(0)::UInt8 N
 checked expr   : or<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : or<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -496,13 +496,13 @@ raw expr       : or(lt(ColumnRef(0)::UInt8 NULL, 1_u8), gt(ColumnRef(0)::UInt8 N
 checked expr   : or<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : or<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -517,13 +517,13 @@ raw expr       : or(lt(ColumnRef(0)::UInt8 NULL, 1_u8), lt(ColumnRef(0)::UInt8 N
 checked expr   : or<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : or<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -538,13 +538,13 @@ raw expr       : or(gt(ColumnRef(0)::UInt8 NULL, 1_u8), gt(0_u8, 1_u8))
 checked expr   : or<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), CAST(gt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL))
 optimized expr : or<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), false)
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -559,13 +559,13 @@ raw expr       : or(gt(ColumnRef(0)::UInt8 NULL, 1_u8), lt(0_u8, 1_u8))
 checked expr   : or<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), CAST(lt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL))
 optimized expr : or<Boolean NULL, Boolean NULL>(gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), true)
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | true         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | true                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -580,13 +580,13 @@ raw expr       : or(lt(ColumnRef(0)::UInt8 NULL, 1_u8), gt(0_u8, 1_u8))
 checked expr   : or<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), CAST(gt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL))
 optimized expr : or<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), false)
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -601,13 +601,13 @@ raw expr       : or(lt(ColumnRef(0)::UInt8 NULL, 1_u8), lt(0_u8, 1_u8))
 checked expr   : or<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)), CAST(lt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL))
 optimized expr : or<Boolean NULL, Boolean NULL>(lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8), true)
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | true         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | true                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -622,13 +622,13 @@ raw expr       : or(gt(0_u8, 1_u8), gt(ColumnRef(0)::UInt8 NULL, 1_u8))
 checked expr   : or<Boolean NULL, Boolean NULL>(CAST(gt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL), gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : or<Boolean NULL, Boolean NULL>(false, gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -643,13 +643,13 @@ raw expr       : or(gt(0_u8, 1_u8), lt(ColumnRef(0)::UInt8 NULL, 1_u8))
 checked expr   : or<Boolean NULL, Boolean NULL>(CAST(gt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : or<Boolean NULL, Boolean NULL>(false, lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | NULL         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | NULL                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -664,13 +664,13 @@ raw expr       : or(lt(0_u8, 1_u8), gt(ColumnRef(0)::UInt8 NULL, 1_u8))
 checked expr   : or<Boolean NULL, Boolean NULL>(CAST(lt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL), gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : or<Boolean NULL, Boolean NULL>(true, gt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | true         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | true                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |
@@ -685,13 +685,13 @@ raw expr       : or(lt(0_u8, 1_u8), lt(ColumnRef(0)::UInt8 NULL, 1_u8))
 checked expr   : or<Boolean NULL, Boolean NULL>(CAST(lt<UInt8, UInt8>(0_u8, 1_u8) AS Boolean NULL), lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), CAST(1_u8 AS UInt8 NULL)))
 optimized expr : or<Boolean NULL, Boolean NULL>(true, lt<UInt8 NULL, UInt8 NULL>(ColumnRef(0), 1_u8))
 evaluation:
-+--------+------------------+--------------+
-|        | a                | Output       |
-+--------+------------------+--------------+
-| Type   | UInt8 NULL       | Boolean NULL |
-| Domain | {0..=0} ∪ {NULL} | Unknown      |
-| Row 0  | NULL             | true         |
-+--------+------------------+--------------+
++--------+------------------+------------------------+
+|        | a                | Output                 |
++--------+------------------+------------------------+
+| Type   | UInt8 NULL       | Boolean NULL           |
+| Domain | {0..=0} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | NULL             | true                   |
++--------+------------------+------------------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 | Column | Data                                                                     |

--- a/src/query/functions-v2/tests/it/scalars/testdata/cast.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/cast.txt
@@ -1164,20 +1164,20 @@ ast            : TRY_CAST(a as TIMESTAMP)
 raw expr       : TRY_CAST(ColumnRef(0)::String AS Timestamp)
 checked expr   : try_to_timestamp<String NULL>(CAST(ColumnRef(0) AS String NULL))
 evaluation:
-+--------+------------------------------------+----------------------------+
-|        | a                                  | Output                     |
-+--------+------------------------------------+----------------------------+
-| Type   | String                             | Timestamp NULL             |
-| Domain | {"2022"..="A NON-TIMESTAMP STR"}   | Unknown                    |
-| Row 0  | "A NON-TIMESTAMP STR"              | NULL                       |
-| Row 1  | "2022"                             | NULL                       |
-| Row 2  | "2022-01"                          | NULL                       |
-| Row 3  | "2022-01-02"                       | 2022-01-02 00:00:00.000000 |
-| Row 4  | "2022-01-02T03:25:02.868894-07:00" | 2022-01-02 10:25:02.868894 |
-| Row 5  | "2022-01-02 02:00:11"              | 2022-01-02 02:00:11.000000 |
-| Row 6  | "2022-01-02T01:12:00-07:00"        | 2022-01-02 08:12:00.000000 |
-| Row 7  | "2022-01-02T01"                    | 2022-01-02 01:00:00.000000 |
-+--------+------------------------------------+----------------------------+
++--------+------------------------------------+----------------------------------------------------+
+|        | a                                  | Output                                             |
++--------+------------------------------------+----------------------------------------------------+
+| Type   | String                             | Timestamp NULL                                     |
+| Domain | {"2022"..="A NON-TIMESTAMP STR"}   | {-30610224000000000..=253402300799999999} ∪ {NULL} |
+| Row 0  | "A NON-TIMESTAMP STR"              | NULL                                               |
+| Row 1  | "2022"                             | NULL                                               |
+| Row 2  | "2022-01"                          | NULL                                               |
+| Row 3  | "2022-01-02"                       | 2022-01-02 00:00:00.000000                         |
+| Row 4  | "2022-01-02T03:25:02.868894-07:00" | 2022-01-02 10:25:02.868894                         |
+| Row 5  | "2022-01-02 02:00:11"              | 2022-01-02 02:00:11.000000                         |
+| Row 6  | "2022-01-02T01:12:00-07:00"        | 2022-01-02 08:12:00.000000                         |
+| Row 7  | "2022-01-02T01"                    | 2022-01-02 01:00:00.000000                         |
++--------+------------------------------------+----------------------------------------------------+
 evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                                                                                                                                                                                                        |
@@ -1192,7 +1192,7 @@ raw expr       : CAST(TO_TIMESTAMP(minus(315360000000000_u64)) AS String)
 checked expr   : to_string<Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)))
 optimized expr : "1960-01-04 00:00:00.000000"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1960-01-04 00:00:00.000000"
 
 
@@ -1201,7 +1201,7 @@ raw expr       : CAST(TO_TIMESTAMP(minus(315360000000_u64)) AS String)
 checked expr   : to_string<Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000_u64)))
 optimized expr : "1960-01-04 00:00:00.000000"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1960-01-04 00:00:00.000000"
 
 
@@ -1210,7 +1210,7 @@ raw expr       : CAST(TO_TIMESTAMP(minus(100_u8)) AS String)
 checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : "1969-12-31 23:58:20.000000"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1969-12-31 23:58:20.000000"
 
 
@@ -1219,7 +1219,7 @@ raw expr       : CAST(TO_TIMESTAMP(minus(0_u8)) AS String)
 checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(minus<UInt8>(0_u8) AS Int64)))
 optimized expr : "1970-01-01 00:00:00.000000"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1970-01-01 00:00:00.000000"
 
 
@@ -1228,7 +1228,7 @@ raw expr       : CAST(TO_TIMESTAMP(0_u8) AS String)
 checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(0_u8 AS Int64)))
 optimized expr : "1970-01-01 00:00:00.000000"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1970-01-01 00:00:00.000000"
 
 
@@ -1237,7 +1237,7 @@ raw expr       : CAST(TO_TIMESTAMP(100_u8) AS String)
 checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(100_u8 AS Int64)))
 optimized expr : "1970-01-01 00:01:40.000000"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1970-01-01 00:01:40.000000"
 
 
@@ -1246,7 +1246,7 @@ raw expr       : CAST(TO_TIMESTAMP(315360000000_u64) AS String)
 checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(315360000000_u64 AS Int64)))
 optimized expr : "1979-12-30 00:00:00.000000"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1979-12-30 00:00:00.000000"
 
 
@@ -1255,7 +1255,7 @@ raw expr       : CAST(TO_TIMESTAMP(315360000000000_u64) AS String)
 checked expr   : to_string<Timestamp>(to_timestamp<Int64>(CAST(315360000000000_u64 AS Int64)))
 optimized expr : "1979-12-30 00:00:00.000000"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1979-12-30 00:00:00.000000"
 
 
@@ -1267,7 +1267,7 @@ evaluation:
 |        | a                                    | Output                       |
 +--------+--------------------------------------+------------------------------+
 | Type   | Timestamp                            | String                       |
-| Domain | {-315360000000000..=315360000000000} | Unknown                      |
+| Domain | {-315360000000000..=315360000000000} | {""..}                       |
 | Row 0  | 1960-01-04 00:00:00.000000           | "1960-01-04 00:00:00.000000" |
 | Row 1  | 1969-12-28 08:24:00.000000           | "1969-12-28 08:24:00.000000" |
 | Row 2  | 1969-12-31 23:59:59.999900           | "1969-12-31 23:59:59.999900" |
@@ -1391,20 +1391,20 @@ ast            : TRY_CAST(a as DATE)
 raw expr       : TRY_CAST(ColumnRef(0)::String AS Date)
 checked expr   : try_to_date<String NULL>(CAST(ColumnRef(0) AS String NULL))
 evaluation:
-+--------+------------------------------------+------------+
-|        | a                                  | Output     |
-+--------+------------------------------------+------------+
-| Type   | String                             | Date NULL  |
-| Domain | {"2022"..="A NON-DATE STR"}        | Unknown    |
-| Row 0  | "A NON-DATE STR"                   | NULL       |
-| Row 1  | "2022"                             | NULL       |
-| Row 2  | "2022-01"                          | NULL       |
-| Row 3  | "2022-01-02"                       | 2022-01-02 |
-| Row 4  | "2022-01-02T03:25:02.868894-07:00" | 2022-01-02 |
-| Row 5  | "2022-01-02 02:00:11"              | 2022-01-02 |
-| Row 6  | "2022-01-02T01:12:00-07:00"        | 2022-01-02 |
-| Row 7  | "2022-01-02T01"                    | 2022-01-02 |
-+--------+------------------------------------+------------+
++--------+------------------------------------+------------------------------+
+|        | a                                  | Output                       |
++--------+------------------------------------+------------------------------+
+| Type   | String                             | Date NULL                    |
+| Domain | {"2022"..="A NON-DATE STR"}        | {-354285..=2932896} ∪ {NULL} |
+| Row 0  | "A NON-DATE STR"                   | NULL                         |
+| Row 1  | "2022"                             | NULL                         |
+| Row 2  | "2022-01"                          | NULL                         |
+| Row 3  | "2022-01-02"                       | 2022-01-02                   |
+| Row 4  | "2022-01-02T03:25:02.868894-07:00" | 2022-01-02                   |
+| Row 5  | "2022-01-02 02:00:11"              | 2022-01-02                   |
+| Row 6  | "2022-01-02T01:12:00-07:00"        | 2022-01-02                   |
+| Row 7  | "2022-01-02T01"                    | 2022-01-02                   |
++--------+------------------------------------+------------------------------+
 evaluation (internal):
 +--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                                                                                                                                                                                              |
@@ -1419,7 +1419,7 @@ raw expr       : CAST(TO_DATE(minus(354285_u32)) AS String)
 checked expr   : to_string<Date>(to_date<Int64>(minus<UInt32>(354285_u32)))
 optimized expr : "1000-01-01"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1000-01-01"
 
 
@@ -1428,7 +1428,7 @@ raw expr       : CAST(TO_DATE(minus(100_u8)) AS String)
 checked expr   : to_string<Date>(to_date<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : "1969-09-23"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1969-09-23"
 
 
@@ -1437,7 +1437,7 @@ raw expr       : CAST(TO_DATE(minus(0_u8)) AS String)
 checked expr   : to_string<Date>(to_date<Int64>(CAST(minus<UInt8>(0_u8) AS Int64)))
 optimized expr : "1970-01-01"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1970-01-01"
 
 
@@ -1446,7 +1446,7 @@ raw expr       : CAST(TO_DATE(0_u8) AS String)
 checked expr   : to_string<Date>(to_date<Int64>(CAST(0_u8 AS Int64)))
 optimized expr : "1970-01-01"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1970-01-01"
 
 
@@ -1455,7 +1455,7 @@ raw expr       : CAST(TO_DATE(100_u8) AS String)
 checked expr   : to_string<Date>(to_date<Int64>(CAST(100_u8 AS Int64)))
 optimized expr : "1970-04-11"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "1970-04-11"
 
 
@@ -1464,7 +1464,7 @@ raw expr       : CAST(TO_DATE(2932896_u32) AS String)
 checked expr   : to_string<Date>(to_date<Int64>(CAST(2932896_u32 AS Int64)))
 optimized expr : "9999-12-31"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "9999-12-31"
 
 
@@ -1476,7 +1476,7 @@ evaluation:
 |        | a                   | Output       |
 +--------+---------------------+--------------+
 | Type   | Date                | String       |
-| Domain | {-354285..=2932896} | Unknown      |
+| Domain | {-354285..=2932896} | {""..}       |
 | Row 0  | 1000-01-01          | "1000-01-01" |
 | Row 1  | 1969-09-23          | "1969-09-23" |
 | Row 2  | 1970-01-01          | "1970-01-01" |

--- a/src/query/functions-v2/tests/it/scalars/testdata/comparison.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/comparison.txt
@@ -855,7 +855,7 @@ raw expr       : like("%", "\\%")
 checked expr   : like<String, String>("%", "\\%")
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -864,7 +864,7 @@ raw expr       : like("v%xx", "_\\%%")
 checked expr   : like<String, String>("v%xx", "_\\%%")
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 

--- a/src/query/functions-v2/tests/it/scalars/testdata/comparison.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/comparison.txt
@@ -3,7 +3,7 @@ raw expr       : eq("1", "2")
 checked expr   : eq<String, String>("1", "2")
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -21,7 +21,7 @@ raw expr       : eq(1_u8, 2_u8)
 checked expr   : eq<UInt8, UInt8>(1_u8, 2_u8)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -30,7 +30,7 @@ raw expr       : eq(1_f64, 1_u8)
 checked expr   : eq<Float64, Float64>(1_f64, CAST(1_u8 AS Float64))
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -48,7 +48,7 @@ raw expr       : eq(true, false)
 checked expr   : eq<Boolean, Boolean>(true, false)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -57,7 +57,7 @@ raw expr       : eq(false, false)
 checked expr   : eq<Boolean, Boolean>(false, false)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -66,7 +66,7 @@ raw expr       : eq(true, true)
 checked expr   : eq<Boolean, Boolean>(true, true)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -75,7 +75,7 @@ raw expr       : eq(to_timestamp(minus(315360000000000_u64)), to_timestamp(minus
 checked expr   : eq<Timestamp, Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)), to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -83,23 +83,23 @@ ast            : lhs = rhs
 raw expr       : eq(ColumnRef(0)::UInt8, ColumnRef(1)::Int64)
 checked expr   : eq<Int64, Int64>(CAST(ColumnRef(0) AS Int64), ColumnRef(1))
 evaluation:
-+--------+----------+-----------+---------+
-|        | lhs      | rhs       | Output  |
-+--------+----------+-----------+---------+
-| Type   | UInt8    | Int64     | Boolean |
-| Domain | {0..=10} | {-1..=10} | Unknown |
-| Row 0  | 0        | 0         | true    |
-| Row 1  | 1        | -1        | false   |
-| Row 2  | 2        | 2         | true    |
-| Row 3  | 3        | 3         | true    |
-| Row 4  | 4        | 4         | true    |
-| Row 5  | 5        | 5         | true    |
-| Row 6  | 6        | 6         | true    |
-| Row 7  | 7        | 7         | true    |
-| Row 8  | 8        | 8         | true    |
-| Row 9  | 9        | 9         | true    |
-| Row 10 | 10       | 10        | true    |
-+--------+----------+-----------+---------+
++--------+----------+-----------+---------------+
+|        | lhs      | rhs       | Output        |
++--------+----------+-----------+---------------+
+| Type   | UInt8    | Int64     | Boolean       |
+| Domain | {0..=10} | {-1..=10} | {FALSE, TRUE} |
+| Row 0  | 0        | 0         | true          |
+| Row 1  | 1        | -1        | false         |
+| Row 2  | 2        | 2         | true          |
+| Row 3  | 3        | 3         | true          |
+| Row 4  | 4        | 4         | true          |
+| Row 5  | 5        | 5         | true          |
+| Row 6  | 6        | 6         | true          |
+| Row 7  | 7        | 7         | true          |
+| Row 8  | 8        | 8         | true          |
+| Row 9  | 9        | 9         | true          |
+| Row 10 | 10       | 10        | true          |
++--------+----------+-----------+---------------+
 evaluation (internal):
 +--------+--------------------------------------------+
 | Column | Data                                       |
@@ -115,7 +115,7 @@ raw expr       : eq(1.1_f64, 1.1_f64)
 checked expr   : eq<Float64, Float64>(1.1_f64, 1.1_f64)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -159,19 +159,19 @@ ast            : lhs = rhs
 raw expr       : eq(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : eq<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+------------------------------------------+------------------------------------------+---------+
-|        | lhs                                      | rhs                                      | Output  |
-+--------+------------------------------------------+------------------------------------------+---------+
-| Type   | String                                   | String                                   | Boolean |
-| Domain | {"-32768"..="{\"k\":\"v\",\"a\":\"b\"}"} | {"-32768"..="{\"k\":\"v\",\"a\":\"d\"}"} | Unknown |
-| Row 0  | "null"                                   | "null"                                   | true    |
-| Row 1  | "true"                                   | "true"                                   | true    |
-| Row 2  | "9223372036854775807"                    | "9223372036854775807"                    | true    |
-| Row 3  | "-32768"                                 | "-32768"                                 | true    |
-| Row 4  | "1234.5678"                              | "1234.5678"                              | true    |
-| Row 5  | "{\"k\":\"v\",\"a\":\"b\"}"              | "{\"k\":\"v\",\"a\":\"d\"}"              | false   |
-| Row 6  | "[1,2,3,[\"a\",\"b\",\"c\"]]"            | "[1,2,3,[\"a\",\"b\",\"c\"]]"            | true    |
-+--------+------------------------------------------+------------------------------------------+---------+
++--------+------------------------------------------+------------------------------------------+---------------+
+|        | lhs                                      | rhs                                      | Output        |
++--------+------------------------------------------+------------------------------------------+---------------+
+| Type   | String                                   | String                                   | Boolean       |
+| Domain | {"-32768"..="{\"k\":\"v\",\"a\":\"b\"}"} | {"-32768"..="{\"k\":\"v\",\"a\":\"d\"}"} | {FALSE, TRUE} |
+| Row 0  | "null"                                   | "null"                                   | true          |
+| Row 1  | "true"                                   | "true"                                   | true          |
+| Row 2  | "9223372036854775807"                    | "9223372036854775807"                    | true          |
+| Row 3  | "-32768"                                 | "-32768"                                 | true          |
+| Row 4  | "1234.5678"                              | "1234.5678"                              | true          |
+| Row 5  | "{\"k\":\"v\",\"a\":\"b\"}"              | "{\"k\":\"v\",\"a\":\"d\"}"              | false         |
+| Row 6  | "[1,2,3,[\"a\",\"b\",\"c\"]]"            | "[1,2,3,[\"a\",\"b\",\"c\"]]"            | true          |
++--------+------------------------------------------+------------------------------------------+---------------+
 evaluation (internal):
 +--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                                                                                              |
@@ -187,7 +187,7 @@ raw expr       : noteq("1", "2")
 checked expr   : noteq<String, String>("1", "2")
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -196,7 +196,7 @@ raw expr       : noteq(1_u8, 2_u8)
 checked expr   : noteq<UInt8, UInt8>(1_u8, 2_u8)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -205,7 +205,7 @@ raw expr       : noteq(1.1_f64, 1.1_f64)
 checked expr   : noteq<Float64, Float64>(1.1_f64, 1.1_f64)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -214,7 +214,7 @@ raw expr       : noteq(true, true)
 checked expr   : noteq<Boolean, Boolean>(true, true)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -232,7 +232,7 @@ raw expr       : noteq(true, false)
 checked expr   : noteq<Boolean, Boolean>(true, false)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -241,7 +241,7 @@ raw expr       : noteq(to_timestamp(minus(315360000000000_u64)), to_timestamp(mi
 checked expr   : noteq<Timestamp, Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)), to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -282,16 +282,16 @@ ast            : lhs != rhs
 raw expr       : noteq(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : noteq<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+----------------------------------+----------------------------------+---------+
-|        | lhs                              | rhs                              | Output  |
-+--------+----------------------------------+----------------------------------+---------+
-| Type   | String                           | String                           | Boolean |
-| Domain | {"9223372036854775807"..="true"} | {"9223372036854775807"..="true"} | Unknown |
-| Row 0  | "null"                           | "null"                           | false   |
-| Row 1  | "true"                           | "true"                           | false   |
-| Row 2  | "9223372036854775807"            | "9223372036854775807"            | false   |
-| Row 3  | "[1,2,3,[\"a\",\"b\",\"c\"]]"    | "[1,2,3,[\"a\",\"b\",\"c\"]]"    | false   |
-+--------+----------------------------------+----------------------------------+---------+
++--------+----------------------------------+----------------------------------+---------------+
+|        | lhs                              | rhs                              | Output        |
++--------+----------------------------------+----------------------------------+---------------+
+| Type   | String                           | String                           | Boolean       |
+| Domain | {"9223372036854775807"..="true"} | {"9223372036854775807"..="true"} | {FALSE, TRUE} |
+| Row 0  | "null"                           | "null"                           | false         |
+| Row 1  | "true"                           | "true"                           | false         |
+| Row 2  | "9223372036854775807"            | "9223372036854775807"            | false         |
+| Row 3  | "[1,2,3,[\"a\",\"b\",\"c\"]]"    | "[1,2,3,[\"a\",\"b\",\"c\"]]"    | false         |
++--------+----------------------------------+----------------------------------+---------------+
 evaluation (internal):
 +--------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                  |
@@ -307,7 +307,7 @@ raw expr       : lt("1", "2")
 checked expr   : lt<String, String>("1", "2")
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -316,7 +316,7 @@ raw expr       : lt(3_u8, 2_u8)
 checked expr   : lt<UInt8, UInt8>(3_u8, 2_u8)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -325,7 +325,7 @@ raw expr       : lt(1.1_f64, 1.1_f64)
 checked expr   : lt<Float64, Float64>(1.1_f64, 1.1_f64)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -334,7 +334,7 @@ raw expr       : lt(true, true)
 checked expr   : lt<Boolean, Boolean>(true, true)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -352,7 +352,7 @@ raw expr       : lt(true, false)
 checked expr   : lt<Boolean, Boolean>(true, false)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -361,7 +361,7 @@ raw expr       : lt(to_timestamp(minus(315360000000000_u64)), to_timestamp(minus
 checked expr   : lt<Timestamp, Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)), to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -405,19 +405,19 @@ ast            : lhs < rhs
 raw expr       : lt(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : lt<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+-------------------------------+-------------------------------+---------+
-|        | lhs                           | rhs                           | Output  |
-+--------+-------------------------------+-------------------------------+---------+
-| Type   | String                        | String                        | Boolean |
-| Domain | {"-32768"..="true"}           | {"-33768"..="true"}           | Unknown |
-| Row 0  | "null"                        | "null"                        | false   |
-| Row 1  | "true"                        | "true"                        | false   |
-| Row 2  | "9223372036854775807"         | "9223372036854775800"         | false   |
-| Row 3  | "-32768"                      | "-33768"                      | true    |
-| Row 4  | "1234.5678"                   | "1234.5678"                   | false   |
-| Row 5  | "1.912e2"                     | "1.912e2"                     | false   |
-| Row 6  | "[1,2,3,[\"a\",\"b\",\"c\"]]" | "[0,2,3,[\"a\",\"b\",\"c\"]]" | false   |
-+--------+-------------------------------+-------------------------------+---------+
++--------+-------------------------------+-------------------------------+---------------+
+|        | lhs                           | rhs                           | Output        |
++--------+-------------------------------+-------------------------------+---------------+
+| Type   | String                        | String                        | Boolean       |
+| Domain | {"-32768"..="true"}           | {"-33768"..="true"}           | {FALSE, TRUE} |
+| Row 0  | "null"                        | "null"                        | false         |
+| Row 1  | "true"                        | "true"                        | false         |
+| Row 2  | "9223372036854775807"         | "9223372036854775800"         | false         |
+| Row 3  | "-32768"                      | "-33768"                      | true          |
+| Row 4  | "1234.5678"                   | "1234.5678"                   | false         |
+| Row 5  | "1.912e2"                     | "1.912e2"                     | false         |
+| Row 6  | "[1,2,3,[\"a\",\"b\",\"c\"]]" | "[0,2,3,[\"a\",\"b\",\"c\"]]" | false         |
++--------+-------------------------------+-------------------------------+---------------+
 evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                                                                          |
@@ -433,7 +433,7 @@ raw expr       : lte("5", "2")
 checked expr   : lte<String, String>("5", "2")
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -442,7 +442,7 @@ raw expr       : lte(1_u8, 2_u8)
 checked expr   : lte<UInt8, UInt8>(1_u8, 2_u8)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -451,7 +451,7 @@ raw expr       : lte(1.1_f64, 2.1_f64)
 checked expr   : lte<Float64, Float64>(1.1_f64, 2.1_f64)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -460,7 +460,7 @@ raw expr       : lte(true, true)
 checked expr   : lte<Boolean, Boolean>(true, true)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -478,7 +478,7 @@ raw expr       : lte(true, false)
 checked expr   : lte<Boolean, Boolean>(true, false)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -496,7 +496,7 @@ raw expr       : lte(to_timestamp(minus(315360000000000_u64)), to_timestamp(minu
 checked expr   : lte<Timestamp, Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)), to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -505,7 +505,7 @@ raw expr       : lte(to_timestamp(minus(315360000000000_u64)), to_timestamp(minu
 checked expr   : lte<Timestamp, Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)), to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)))
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -536,15 +536,15 @@ ast            : lhs <= rhs
 raw expr       : lte(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : lte<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+------------------------------------------------+------------------------------------------------+---------+
-|        | lhs                                            | rhs                                            | Output  |
-+--------+------------------------------------------------+------------------------------------------------+---------+
-| Type   | String                                         | String                                         | Boolean |
-| Domain | {"\"databend\""..="{\"k\":\"v\",\"a\":\"b\"}"} | {"\"databend\""..="{\"k\":\"a\",\"a\":\"d\"}"} | Unknown |
-| Row 0  | "\"databend\""                                 | "\"databend\""                                 | true    |
-| Row 1  | "{\"k\":\"v\",\"a\":\"b\"}"                    | "{\"k\":\"a\",\"a\":\"d\"}"                    | false   |
-| Row 2  | "[1,2,3,[\"a\",\"b\",\"c\"]]"                  | "[0,2,3,[\"a\",\"b\",\"c\"]]"                  | false   |
-+--------+------------------------------------------------+------------------------------------------------+---------+
++--------+------------------------------------------------+------------------------------------------------+---------------+
+|        | lhs                                            | rhs                                            | Output        |
++--------+------------------------------------------------+------------------------------------------------+---------------+
+| Type   | String                                         | String                                         | Boolean       |
+| Domain | {"\"databend\""..="{\"k\":\"v\",\"a\":\"b\"}"} | {"\"databend\""..="{\"k\":\"a\",\"a\":\"d\"}"} | {FALSE, TRUE} |
+| Row 0  | "\"databend\""                                 | "\"databend\""                                 | true          |
+| Row 1  | "{\"k\":\"v\",\"a\":\"b\"}"                    | "{\"k\":\"a\",\"a\":\"d\"}"                    | false         |
+| Row 2  | "[1,2,3,[\"a\",\"b\",\"c\"]]"                  | "[0,2,3,[\"a\",\"b\",\"c\"]]"                  | false         |
++--------+------------------------------------------------+------------------------------------------------+---------------+
 evaluation (internal):
 +--------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                |
@@ -560,7 +560,7 @@ raw expr       : gt("3", "2")
 checked expr   : gt<String, String>("3", "2")
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -569,7 +569,7 @@ raw expr       : gt(1_u8, 2_u8)
 checked expr   : gt<UInt8, UInt8>(1_u8, 2_u8)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -578,7 +578,7 @@ raw expr       : gt(1.2_f64, 1.1_f64)
 checked expr   : gt<Float64, Float64>(1.2_f64, 1.1_f64)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -587,7 +587,7 @@ raw expr       : gt(true, true)
 checked expr   : gt<Boolean, Boolean>(true, true)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -605,7 +605,7 @@ raw expr       : gt(true, false)
 checked expr   : gt<Boolean, Boolean>(true, false)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -614,7 +614,7 @@ raw expr       : gt(to_timestamp(minus(315360000000000_u64)), to_timestamp(minus
 checked expr   : gt<Timestamp, Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)), to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -623,7 +623,7 @@ raw expr       : gt(to_timestamp(minus(315360000000000_u64)), to_timestamp(minus
 checked expr   : gt<Timestamp, Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)), to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)))
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -665,17 +665,17 @@ ast            : lhs > rhs
 raw expr       : gt(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : gt<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+-----------------------+-----------------------+---------+
-|        | lhs                   | rhs                   | Output  |
-+--------+-----------------------+-----------------------+---------+
-| Type   | String                | String                | Boolean |
-| Domain | {"-32768"..="true"}   | {"-32768"..="true"}   | Unknown |
-| Row 0  | "null"                | "null"                | false   |
-| Row 1  | "true"                | "true"                | false   |
-| Row 2  | "9223372036854775807" | "9223372036854775806" | true    |
-| Row 3  | "-32768"              | "-32768"              | false   |
-| Row 4  | "1234.5678"           | "1234.5678"           | false   |
-+--------+-----------------------+-----------------------+---------+
++--------+-----------------------+-----------------------+---------------+
+|        | lhs                   | rhs                   | Output        |
++--------+-----------------------+-----------------------+---------------+
+| Type   | String                | String                | Boolean       |
+| Domain | {"-32768"..="true"}   | {"-32768"..="true"}   | {FALSE, TRUE} |
+| Row 0  | "null"                | "null"                | false         |
+| Row 1  | "true"                | "true"                | false         |
+| Row 2  | "9223372036854775807" | "9223372036854775806" | true          |
+| Row 3  | "-32768"              | "-32768"              | false         |
+| Row 4  | "1234.5678"           | "1234.5678"           | false         |
++--------+-----------------------+-----------------------+---------------+
 evaluation (internal):
 +--------+-----------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                          |
@@ -691,7 +691,7 @@ raw expr       : gte("2", "1")
 checked expr   : gte<String, String>("2", "1")
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -700,7 +700,7 @@ raw expr       : gte(1_u8, 2_u8)
 checked expr   : gte<UInt8, UInt8>(1_u8, 2_u8)
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -709,7 +709,7 @@ raw expr       : gte(1.1_f64, 1.1_f64)
 checked expr   : gte<Float64, Float64>(1.1_f64, 1.1_f64)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -718,7 +718,7 @@ raw expr       : gte(true, true)
 checked expr   : gte<Boolean, Boolean>(true, true)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -736,7 +736,7 @@ raw expr       : gte(true, false)
 checked expr   : gte<Boolean, Boolean>(true, false)
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -745,7 +745,7 @@ raw expr       : gte(to_timestamp(minus(315360000000000_u64)), to_timestamp(minu
 checked expr   : gte<Timestamp, Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)), to_timestamp<Int64>(CAST(minus<UInt8>(100_u8) AS Int64)))
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -754,7 +754,7 @@ raw expr       : gte(to_timestamp(minus(315360000000000_u64)), to_timestamp(minu
 checked expr   : gte<Timestamp, Timestamp>(to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)), to_timestamp<Int64>(minus<UInt64>(315360000000000_u64)))
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -798,19 +798,19 @@ ast            : lhs >= rhs
 raw expr       : gte(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : gte<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+-----------------------------------------------------------+-----------------------------------------------------------+---------+
-|        | lhs                                                       | rhs                                                       | Output  |
-+--------+-----------------------------------------------------------+-----------------------------------------------------------+---------+
-| Type   | String                                                    | String                                                    | Boolean |
-| Domain | {"\"\\\\\\\"abc\\\\\\\"\""..="{\"k\":\"v\",\"a\":\"b\"}"} | {"\"\\\\\\\"abc\\\\\\\"\""..="{\"k\":\"v\",\"a\":\"d\"}"} | Unknown |
-| Row 0  | "9223372036854775807"                                     | "9223372036854775806"                                     | true    |
-| Row 1  | "-32768"                                                  | "-32768"                                                  | true    |
-| Row 2  | "1234.5678"                                               | "1234.5678"                                               | true    |
-| Row 3  | "1.912e2"                                                 | "1.912e2"                                                 | true    |
-| Row 4  | "\"\\\\\\\"abc\\\\\\\"\""                                 | "\"\\\\\\\"abc\\\\\\\"\""                                 | true    |
-| Row 5  | "{\"k\":\"v\",\"a\":\"b\"}"                               | "{\"k\":\"v\",\"a\":\"d\"}"                               | false   |
-| Row 6  | "[1,2,3,[\"a\",\"b\",\"d\"]]"                             | "[1,2,3,[\"a\",\"b\",\"c\"]]"                             | true    |
-+--------+-----------------------------------------------------------+-----------------------------------------------------------+---------+
++--------+-----------------------------------------------------------+-----------------------------------------------------------+---------------+
+|        | lhs                                                       | rhs                                                       | Output        |
++--------+-----------------------------------------------------------+-----------------------------------------------------------+---------------+
+| Type   | String                                                    | String                                                    | Boolean       |
+| Domain | {"\"\\\\\\\"abc\\\\\\\"\""..="{\"k\":\"v\",\"a\":\"b\"}"} | {"\"\\\\\\\"abc\\\\\\\"\""..="{\"k\":\"v\",\"a\":\"d\"}"} | {FALSE, TRUE} |
+| Row 0  | "9223372036854775807"                                     | "9223372036854775806"                                     | true          |
+| Row 1  | "-32768"                                                  | "-32768"                                                  | true          |
+| Row 2  | "1234.5678"                                               | "1234.5678"                                               | true          |
+| Row 3  | "1.912e2"                                                 | "1.912e2"                                                 | true          |
+| Row 4  | "\"\\\\\\\"abc\\\\\\\"\""                                 | "\"\\\\\\\"abc\\\\\\\"\""                                 | true          |
+| Row 5  | "{\"k\":\"v\",\"a\":\"b\"}"                               | "{\"k\":\"v\",\"a\":\"d\"}"                               | false         |
+| Row 6  | "[1,2,3,[\"a\",\"b\",\"d\"]]"                             | "[1,2,3,[\"a\",\"b\",\"c\"]]"                             | true          |
++--------+-----------------------------------------------------------+-----------------------------------------------------------+---------------+
 evaluation (internal):
 +--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                                                                                                                        |
@@ -826,7 +826,7 @@ raw expr       : like("1", "2")
 checked expr   : like<String, String>("1", "2")
 optimized expr : false
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : false
 
 
@@ -836,7 +836,7 @@ raw expr       : like("hello\n", "h%")
 checked expr   : like<String, String>("hello\n", "h%")
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -846,7 +846,7 @@ raw expr       : like("h\n", "h_")
 checked expr   : like<String, String>("h\n", "h_")
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -872,16 +872,16 @@ ast            : lhs like 'a%'
 raw expr       : like(ColumnRef(0)::String, "a%")
 checked expr   : like<String, String>(ColumnRef(0), "a%")
 evaluation:
-+--------+-----------------+---------+
-|        | lhs             | Output  |
-+--------+-----------------+---------+
-| Type   | String          | Boolean |
-| Domain | {"abc"..="abf"} | Unknown |
-| Row 0  | "abc"           | true    |
-| Row 1  | "abd"           | true    |
-| Row 2  | "abe"           | true    |
-| Row 3  | "abf"           | true    |
-+--------+-----------------+---------+
++--------+-----------------+---------------+
+|        | lhs             | Output        |
++--------+-----------------+---------------+
+| Type   | String          | Boolean       |
+| Domain | {"abc"..="abf"} | {FALSE, TRUE} |
+| Row 0  | "abc"           | true          |
+| Row 1  | "abd"           | true          |
+| Row 2  | "abe"           | true          |
+| Row 3  | "abf"           | true          |
++--------+-----------------+---------------+
 evaluation (internal):
 +--------+------------------------------------------------------------------------------+
 | Column | Data                                                                         |
@@ -895,16 +895,16 @@ ast            : lhs like rhs
 raw expr       : like(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : like<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+-----------------+-----------------+---------+
-|        | lhs             | rhs             | Output  |
-+--------+-----------------+-----------------+---------+
-| Type   | String          | String          | Boolean |
-| Domain | {"abc"..="abf"} | {"_b_"..="abe"} | Unknown |
-| Row 0  | "abc"           | "a%"            | true    |
-| Row 1  | "abd"           | "_b_"           | true    |
-| Row 2  | "abe"           | "abe"           | true    |
-| Row 3  | "abf"           | "a"             | false   |
-+--------+-----------------+-----------------+---------+
++--------+-----------------+-----------------+---------------+
+|        | lhs             | rhs             | Output        |
++--------+-----------------+-----------------+---------------+
+| Type   | String          | String          | Boolean       |
+| Domain | {"abc"..="abf"} | {"_b_"..="abe"} | {FALSE, TRUE} |
+| Row 0  | "abc"           | "a%"            | true          |
+| Row 1  | "abd"           | "_b_"           | true          |
+| Row 2  | "abe"           | "abe"           | true          |
+| Row 3  | "abf"           | "a"             | false         |
++--------+-----------------+-----------------+---------------+
 evaluation (internal):
 +--------+------------------------------------------------------------------------------+
 | Column | Data                                                                         |
@@ -920,7 +920,7 @@ raw expr       : not(like("1", "2"))
 checked expr   : not<Boolean>(like<String, String>("1", "2"))
 optimized expr : true
 output type    : Boolean
-output domain  : Unknown
+output domain  : {FALSE, TRUE}
 output         : true
 
 
@@ -928,16 +928,16 @@ ast            : lhs not like 'a%'
 raw expr       : not(like(ColumnRef(0)::String, "a%"))
 checked expr   : not<Boolean>(like<String, String>(ColumnRef(0), "a%"))
 evaluation:
-+--------+-----------------+---------+
-|        | lhs             | Output  |
-+--------+-----------------+---------+
-| Type   | String          | Boolean |
-| Domain | {"abc"..="abf"} | Unknown |
-| Row 0  | "abc"           | false   |
-| Row 1  | "abd"           | false   |
-| Row 2  | "abe"           | false   |
-| Row 3  | "abf"           | false   |
-+--------+-----------------+---------+
++--------+-----------------+---------------+
+|        | lhs             | Output        |
++--------+-----------------+---------------+
+| Type   | String          | Boolean       |
+| Domain | {"abc"..="abf"} | {FALSE, TRUE} |
+| Row 0  | "abc"           | false         |
+| Row 1  | "abd"           | false         |
+| Row 2  | "abe"           | false         |
+| Row 3  | "abf"           | false         |
++--------+-----------------+---------------+
 evaluation (internal):
 +--------+------------------------------------------------------------------------------+
 | Column | Data                                                                         |
@@ -951,16 +951,16 @@ ast            : lhs not like rhs
 raw expr       : not(like(ColumnRef(0)::String, ColumnRef(1)::String))
 checked expr   : not<Boolean>(like<String, String>(ColumnRef(0), ColumnRef(1)))
 evaluation:
-+--------+-----------------+-----------------+---------+
-|        | lhs             | rhs             | Output  |
-+--------+-----------------+-----------------+---------+
-| Type   | String          | String          | Boolean |
-| Domain | {"abc"..="abf"} | {"_b_"..="abe"} | Unknown |
-| Row 0  | "abc"           | "a%"            | false   |
-| Row 1  | "abd"           | "_b_"           | false   |
-| Row 2  | "abe"           | "abe"           | false   |
-| Row 3  | "abf"           | "a"             | true    |
-+--------+-----------------+-----------------+---------+
++--------+-----------------+-----------------+---------------+
+|        | lhs             | rhs             | Output        |
++--------+-----------------+-----------------+---------------+
+| Type   | String          | String          | Boolean       |
+| Domain | {"abc"..="abf"} | {"_b_"..="abe"} | {FALSE, TRUE} |
+| Row 0  | "abc"           | "a%"            | false         |
+| Row 1  | "abd"           | "_b_"           | false         |
+| Row 2  | "abe"           | "abe"           | false         |
+| Row 3  | "abf"           | "a"             | true          |
++--------+-----------------+-----------------+---------------+
 evaluation (internal):
 +--------+------------------------------------------------------------------------------+
 | Column | Data                                                                         |
@@ -975,18 +975,18 @@ ast            : lhs regexp rhs
 raw expr       : regexp(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : regexp<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+--------------+--------------+---------+
-|        | lhs          | rhs          | Output  |
-+--------+--------------+--------------+---------+
-| Type   | String       | String       | Boolean |
-| Domain | {""..="abf"} | {""..="abe"} | Unknown |
-| Row 0  | "abc"        | "^a"         | true    |
-| Row 1  | "abd"        | "^b"         | false   |
-| Row 2  | "abe"        | "abe"        | true    |
-| Row 3  | "abf"        | "a"          | true    |
-| Row 4  | "abc"        | ""           | false   |
-| Row 5  | ""           | ""           | true    |
-+--------+--------------+--------------+---------+
++--------+--------------+--------------+---------------+
+|        | lhs          | rhs          | Output        |
++--------+--------------+--------------+---------------+
+| Type   | String       | String       | Boolean       |
+| Domain | {""..="abf"} | {""..="abe"} | {FALSE, TRUE} |
+| Row 0  | "abc"        | "^a"         | true          |
+| Row 1  | "abd"        | "^b"         | false         |
+| Row 2  | "abe"        | "abe"        | true          |
+| Row 3  | "abf"        | "a"          | true          |
+| Row 4  | "abc"        | ""           | false         |
+| Row 5  | ""           | ""           | true          |
++--------+--------------+--------------+---------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------------------------+
 | Column | Data                                                                                       |
@@ -1001,18 +1001,18 @@ ast            : lhs rlike rhs
 raw expr       : rlike(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : regexp<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+--------------+--------------+---------+
-|        | lhs          | rhs          | Output  |
-+--------+--------------+--------------+---------+
-| Type   | String       | String       | Boolean |
-| Domain | {""..="abf"} | {""..="abe"} | Unknown |
-| Row 0  | "abc"        | "^a"         | true    |
-| Row 1  | "abd"        | "^b"         | false   |
-| Row 2  | "abe"        | "abe"        | true    |
-| Row 3  | "abf"        | "a"          | true    |
-| Row 4  | "abc"        | ""           | false   |
-| Row 5  | ""           | ""           | true    |
-+--------+--------------+--------------+---------+
++--------+--------------+--------------+---------------+
+|        | lhs          | rhs          | Output        |
++--------+--------------+--------------+---------------+
+| Type   | String       | String       | Boolean       |
+| Domain | {""..="abf"} | {""..="abe"} | {FALSE, TRUE} |
+| Row 0  | "abc"        | "^a"         | true          |
+| Row 1  | "abd"        | "^b"         | false         |
+| Row 2  | "abe"        | "abe"        | true          |
+| Row 3  | "abf"        | "a"          | true          |
+| Row 4  | "abc"        | ""           | false         |
+| Row 5  | ""           | ""           | true          |
++--------+--------------+--------------+---------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------------------------+
 | Column | Data                                                                                       |
@@ -1027,18 +1027,18 @@ ast            : lhs not regexp rhs
 raw expr       : not(regexp(ColumnRef(0)::String, ColumnRef(1)::String))
 checked expr   : not<Boolean>(regexp<String, String>(ColumnRef(0), ColumnRef(1)))
 evaluation:
-+--------+--------------+--------------+---------+
-|        | lhs          | rhs          | Output  |
-+--------+--------------+--------------+---------+
-| Type   | String       | String       | Boolean |
-| Domain | {""..="abf"} | {""..="abe"} | Unknown |
-| Row 0  | "abc"        | "^a"         | false   |
-| Row 1  | "abd"        | "^b"         | true    |
-| Row 2  | "abe"        | "abe"        | false   |
-| Row 3  | "abf"        | "a"          | false   |
-| Row 4  | "abc"        | ""           | true    |
-| Row 5  | ""           | ""           | false   |
-+--------+--------------+--------------+---------+
++--------+--------------+--------------+---------------+
+|        | lhs          | rhs          | Output        |
++--------+--------------+--------------+---------------+
+| Type   | String       | String       | Boolean       |
+| Domain | {""..="abf"} | {""..="abe"} | {FALSE, TRUE} |
+| Row 0  | "abc"        | "^a"         | false         |
+| Row 1  | "abd"        | "^b"         | true          |
+| Row 2  | "abe"        | "abe"        | false         |
+| Row 3  | "abf"        | "a"          | false         |
+| Row 4  | "abc"        | ""           | true          |
+| Row 5  | ""           | ""           | false         |
++--------+--------------+--------------+---------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------------------------+
 | Column | Data                                                                                       |
@@ -1053,18 +1053,18 @@ ast            : lhs not rlike rhs
 raw expr       : not(regexp(ColumnRef(0)::String, ColumnRef(1)::String))
 checked expr   : not<Boolean>(regexp<String, String>(ColumnRef(0), ColumnRef(1)))
 evaluation:
-+--------+--------------+--------------+---------+
-|        | lhs          | rhs          | Output  |
-+--------+--------------+--------------+---------+
-| Type   | String       | String       | Boolean |
-| Domain | {""..="abf"} | {""..="abe"} | Unknown |
-| Row 0  | "abc"        | "^a"         | false   |
-| Row 1  | "abd"        | "^b"         | true    |
-| Row 2  | "abe"        | "abe"        | false   |
-| Row 3  | "abf"        | "a"          | false   |
-| Row 4  | "abc"        | ""           | true    |
-| Row 5  | ""           | ""           | false   |
-+--------+--------------+--------------+---------+
++--------+--------------+--------------+---------------+
+|        | lhs          | rhs          | Output        |
++--------+--------------+--------------+---------------+
+| Type   | String       | String       | Boolean       |
+| Domain | {""..="abf"} | {""..="abe"} | {FALSE, TRUE} |
+| Row 0  | "abc"        | "^a"         | false         |
+| Row 1  | "abd"        | "^b"         | true          |
+| Row 2  | "abe"        | "abe"        | false         |
+| Row 3  | "abf"        | "a"          | false         |
+| Row 4  | "abc"        | ""           | true          |
+| Row 5  | ""           | ""           | false         |
++--------+--------------+--------------+---------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------------------------+
 | Column | Data                                                                                       |

--- a/src/query/functions-v2/tests/it/scalars/testdata/datetime.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/datetime.txt
@@ -2476,7 +2476,7 @@ raw expr       : to_yyyymm(to_date(18875_u16))
 checked expr   : to_yyyymm<Date>(to_date<Int64>(CAST(18875_u16 AS Int64)))
 optimized expr : 202109_u32
 output type    : UInt32
-output domain  : Unknown
+output domain  : {0..=4294967295}
 output         : 202109
 
 
@@ -2485,7 +2485,7 @@ raw expr       : to_yyyymmdd(to_date(18875_u16))
 checked expr   : to_yyyymmdd<Date>(to_date<Int64>(CAST(18875_u16 AS Int64)))
 optimized expr : 20210905_u32
 output type    : UInt32
-output domain  : Unknown
+output domain  : {0..=4294967295}
 output         : 20210905
 
 
@@ -2494,7 +2494,7 @@ raw expr       : to_yyyymmddhhmmss(to_date(18875_u16))
 checked expr   : to_yyyymmddhhmmss<Date>(to_date<Int64>(CAST(18875_u16 AS Int64)))
 optimized expr : 20210905000000_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 20210905000000
 
 
@@ -2503,7 +2503,7 @@ raw expr       : to_year(to_date(18875_u16))
 checked expr   : to_year<Date>(to_date<Int64>(CAST(18875_u16 AS Int64)))
 optimized expr : 2021_u16
 output type    : UInt16
-output domain  : Unknown
+output domain  : {0..=65535}
 output         : 2021
 
 
@@ -2512,7 +2512,7 @@ raw expr       : to_month(to_date(18875_u16))
 checked expr   : to_month<Date>(to_date<Int64>(CAST(18875_u16 AS Int64)))
 optimized expr : 9_u8
 output type    : UInt8
-output domain  : Unknown
+output domain  : {0..=255}
 output         : 9
 
 
@@ -2521,7 +2521,7 @@ raw expr       : to_day_of_year(to_date(18875_u16))
 checked expr   : to_day_of_year<Date>(to_date<Int64>(CAST(18875_u16 AS Int64)))
 optimized expr : 248_u16
 output type    : UInt16
-output domain  : Unknown
+output domain  : {0..=65535}
 output         : 248
 
 
@@ -2530,7 +2530,7 @@ raw expr       : to_day_of_month(to_date(18875_u16))
 checked expr   : to_day_of_month<Date>(to_date<Int64>(CAST(18875_u16 AS Int64)))
 optimized expr : 5_u8
 output type    : UInt8
-output domain  : Unknown
+output domain  : {0..=255}
 output         : 5
 
 
@@ -2539,7 +2539,7 @@ raw expr       : to_day_of_week(to_date(18875_u16))
 checked expr   : to_day_of_week<Date>(to_date<Int64>(CAST(18875_u16 AS Int64)))
 optimized expr : 7_u8
 output type    : UInt8
-output domain  : Unknown
+output domain  : {0..=255}
 output         : 7
 
 
@@ -2547,15 +2547,15 @@ ast            : to_yyyymm(a)
 raw expr       : to_yyyymm(ColumnRef(0)::Date)
 checked expr   : to_yyyymm<Date>(ColumnRef(0))
 evaluation:
-+--------+--------------+---------+
-|        | a            | Output  |
-+--------+--------------+---------+
-| Type   | Date         | UInt32  |
-| Domain | {-100..=100} | Unknown |
-| Row 0  | 1969-09-23   | 196909  |
-| Row 1  | 1970-01-01   | 197001  |
-| Row 2  | 1970-04-11   | 197004  |
-+--------+--------------+---------+
++--------+--------------+------------------+
+|        | a            | Output           |
++--------+--------------+------------------+
+| Type   | Date         | UInt32           |
+| Domain | {-100..=100} | {0..=4294967295} |
+| Row 0  | 1969-09-23   | 196909           |
+| Row 1  | 1970-01-01   | 197001           |
+| Row 2  | 1970-04-11   | 197004           |
++--------+--------------+------------------+
 evaluation (internal):
 +--------+----------------------------------+
 | Column | Data                             |
@@ -2569,15 +2569,15 @@ ast            : to_yyyymmdd(a)
 raw expr       : to_yyyymmdd(ColumnRef(0)::Date)
 checked expr   : to_yyyymmdd<Date>(ColumnRef(0))
 evaluation:
-+--------+--------------+----------+
-|        | a            | Output   |
-+--------+--------------+----------+
-| Type   | Date         | UInt32   |
-| Domain | {-100..=100} | Unknown  |
-| Row 0  | 1969-09-23   | 19690923 |
-| Row 1  | 1970-01-01   | 19700101 |
-| Row 2  | 1970-04-11   | 19700411 |
-+--------+--------------+----------+
++--------+--------------+------------------+
+|        | a            | Output           |
++--------+--------------+------------------+
+| Type   | Date         | UInt32           |
+| Domain | {-100..=100} | {0..=4294967295} |
+| Row 0  | 1969-09-23   | 19690923         |
+| Row 1  | 1970-01-01   | 19700101         |
+| Row 2  | 1970-04-11   | 19700411         |
++--------+--------------+------------------+
 evaluation (internal):
 +--------+----------------------------------------+
 | Column | Data                                   |
@@ -2591,15 +2591,15 @@ ast            : to_yyyymmddhhmmss(a)
 raw expr       : to_yyyymmddhhmmss(ColumnRef(0)::Date)
 checked expr   : to_yyyymmddhhmmss<Date>(ColumnRef(0))
 evaluation:
-+--------+--------------+----------------+
-|        | a            | Output         |
-+--------+--------------+----------------+
-| Type   | Date         | UInt64         |
-| Domain | {-100..=100} | Unknown        |
-| Row 0  | 1969-09-23   | 19690923000000 |
-| Row 1  | 1970-01-01   | 19700101000000 |
-| Row 2  | 1970-04-11   | 19700411000000 |
-+--------+--------------+----------------+
++--------+--------------+----------------------------+
+|        | a            | Output                     |
++--------+--------------+----------------------------+
+| Type   | Date         | UInt64                     |
+| Domain | {-100..=100} | {0..=18446744073709551615} |
+| Row 0  | 1969-09-23   | 19690923000000             |
+| Row 1  | 1970-01-01   | 19700101000000             |
+| Row 2  | 1970-04-11   | 19700411000000             |
++--------+--------------+----------------------------+
 evaluation (internal):
 +--------+----------------------------------------------------------+
 | Column | Data                                                     |
@@ -2613,15 +2613,15 @@ ast            : to_year(a)
 raw expr       : to_year(ColumnRef(0)::Date)
 checked expr   : to_year<Date>(ColumnRef(0))
 evaluation:
-+--------+--------------+---------+
-|        | a            | Output  |
-+--------+--------------+---------+
-| Type   | Date         | UInt16  |
-| Domain | {-100..=100} | Unknown |
-| Row 0  | 1969-09-23   | 1969    |
-| Row 1  | 1970-01-01   | 1970    |
-| Row 2  | 1970-04-11   | 1970    |
-+--------+--------------+---------+
++--------+--------------+-------------+
+|        | a            | Output      |
++--------+--------------+-------------+
+| Type   | Date         | UInt16      |
+| Domain | {-100..=100} | {0..=65535} |
+| Row 0  | 1969-09-23   | 1969        |
+| Row 1  | 1970-01-01   | 1970        |
+| Row 2  | 1970-04-11   | 1970        |
++--------+--------------+-------------+
 evaluation (internal):
 +--------+----------------------------+
 | Column | Data                       |
@@ -2635,15 +2635,15 @@ ast            : to_month(a)
 raw expr       : to_month(ColumnRef(0)::Date)
 checked expr   : to_month<Date>(ColumnRef(0))
 evaluation:
-+--------+--------------+---------+
-|        | a            | Output  |
-+--------+--------------+---------+
-| Type   | Date         | UInt8   |
-| Domain | {-100..=100} | Unknown |
-| Row 0  | 1969-09-23   | 9       |
-| Row 1  | 1970-01-01   | 1       |
-| Row 2  | 1970-04-11   | 4       |
-+--------+--------------+---------+
++--------+--------------+-----------+
+|        | a            | Output    |
++--------+--------------+-----------+
+| Type   | Date         | UInt8     |
+| Domain | {-100..=100} | {0..=255} |
+| Row 0  | 1969-09-23   | 9         |
+| Row 1  | 1970-01-01   | 1         |
+| Row 2  | 1970-04-11   | 4         |
++--------+--------------+-----------+
 evaluation (internal):
 +--------+------------------+
 | Column | Data             |
@@ -2657,15 +2657,15 @@ ast            : to_day_of_year(a)
 raw expr       : to_day_of_year(ColumnRef(0)::Date)
 checked expr   : to_day_of_year<Date>(ColumnRef(0))
 evaluation:
-+--------+--------------+---------+
-|        | a            | Output  |
-+--------+--------------+---------+
-| Type   | Date         | UInt16  |
-| Domain | {-100..=100} | Unknown |
-| Row 0  | 1969-09-23   | 266     |
-| Row 1  | 1970-01-01   | 1       |
-| Row 2  | 1970-04-11   | 101     |
-+--------+--------------+---------+
++--------+--------------+-------------+
+|        | a            | Output      |
++--------+--------------+-------------+
+| Type   | Date         | UInt16      |
+| Domain | {-100..=100} | {0..=65535} |
+| Row 0  | 1969-09-23   | 266         |
+| Row 1  | 1970-01-01   | 1           |
+| Row 2  | 1970-04-11   | 101         |
++--------+--------------+-------------+
 evaluation (internal):
 +--------+-----------------------+
 | Column | Data                  |
@@ -2679,15 +2679,15 @@ ast            : to_day_of_month(a)
 raw expr       : to_day_of_month(ColumnRef(0)::Date)
 checked expr   : to_day_of_month<Date>(ColumnRef(0))
 evaluation:
-+--------+--------------+---------+
-|        | a            | Output  |
-+--------+--------------+---------+
-| Type   | Date         | UInt8   |
-| Domain | {-100..=100} | Unknown |
-| Row 0  | 1969-09-23   | 23      |
-| Row 1  | 1970-01-01   | 1       |
-| Row 2  | 1970-04-11   | 11      |
-+--------+--------------+---------+
++--------+--------------+-----------+
+|        | a            | Output    |
++--------+--------------+-----------+
+| Type   | Date         | UInt8     |
+| Domain | {-100..=100} | {0..=255} |
+| Row 0  | 1969-09-23   | 23        |
+| Row 1  | 1970-01-01   | 1         |
+| Row 2  | 1970-04-11   | 11        |
++--------+--------------+-----------+
 evaluation (internal):
 +--------+--------------------+
 | Column | Data               |
@@ -2701,15 +2701,15 @@ ast            : to_day_of_week(a)
 raw expr       : to_day_of_week(ColumnRef(0)::Date)
 checked expr   : to_day_of_week<Date>(ColumnRef(0))
 evaluation:
-+--------+--------------+---------+
-|        | a            | Output  |
-+--------+--------------+---------+
-| Type   | Date         | UInt8   |
-| Domain | {-100..=100} | Unknown |
-| Row 0  | 1969-09-23   | 2       |
-| Row 1  | 1970-01-01   | 4       |
-| Row 2  | 1970-04-11   | 6       |
-+--------+--------------+---------+
++--------+--------------+-----------+
+|        | a            | Output    |
++--------+--------------+-----------+
+| Type   | Date         | UInt8     |
+| Domain | {-100..=100} | {0..=255} |
+| Row 0  | 1969-09-23   | 2         |
+| Row 1  | 1970-01-01   | 4         |
+| Row 2  | 1970-04-11   | 6         |
++--------+--------------+-----------+
 evaluation (internal):
 +--------+------------------+
 | Column | Data             |
@@ -2724,7 +2724,7 @@ raw expr       : to_yyyymm(to_timestamp(1630812366_u32))
 checked expr   : to_yyyymm<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 202109_u32
 output type    : UInt32
-output domain  : Unknown
+output domain  : {0..=4294967295}
 output         : 202109
 
 
@@ -2733,7 +2733,7 @@ raw expr       : to_yyyymmdd(to_timestamp(1630812366_u32))
 checked expr   : to_yyyymmdd<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 20210905_u32
 output type    : UInt32
-output domain  : Unknown
+output domain  : {0..=4294967295}
 output         : 20210905
 
 
@@ -2742,7 +2742,7 @@ raw expr       : to_yyyymmddhhmmss(to_timestamp(1630812366_u32))
 checked expr   : to_yyyymmddhhmmss<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 20210905032606_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 20210905032606
 
 
@@ -2751,7 +2751,7 @@ raw expr       : to_year(to_timestamp(1630812366_u32))
 checked expr   : to_year<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 2021_u16
 output type    : UInt16
-output domain  : Unknown
+output domain  : {0..=65535}
 output         : 2021
 
 
@@ -2760,7 +2760,7 @@ raw expr       : to_month(to_timestamp(1630812366_u32))
 checked expr   : to_month<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 9_u8
 output type    : UInt8
-output domain  : Unknown
+output domain  : {0..=255}
 output         : 9
 
 
@@ -2769,7 +2769,7 @@ raw expr       : to_day_of_year(to_timestamp(1630812366_u32))
 checked expr   : to_day_of_year<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 248_u16
 output type    : UInt16
-output domain  : Unknown
+output domain  : {0..=65535}
 output         : 248
 
 
@@ -2778,7 +2778,7 @@ raw expr       : to_day_of_month(to_timestamp(1630812366_u32))
 checked expr   : to_day_of_month<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 5_u8
 output type    : UInt8
-output domain  : Unknown
+output domain  : {0..=255}
 output         : 5
 
 
@@ -2787,7 +2787,7 @@ raw expr       : to_day_of_week(to_timestamp(1630812366_u32))
 checked expr   : to_day_of_week<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 7_u8
 output type    : UInt8
-output domain  : Unknown
+output domain  : {0..=255}
 output         : 7
 
 
@@ -2796,7 +2796,7 @@ raw expr       : to_hour(to_timestamp(1630812366_u32))
 checked expr   : to_hour<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 3_u8
 output type    : UInt8
-output domain  : Unknown
+output domain  : {0..=255}
 output         : 3
 
 
@@ -2805,7 +2805,7 @@ raw expr       : to_minute(to_timestamp(1630812366_u32))
 checked expr   : to_minute<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 26_u8
 output type    : UInt8
-output domain  : Unknown
+output domain  : {0..=255}
 output         : 26
 
 
@@ -2814,7 +2814,7 @@ raw expr       : to_second(to_timestamp(1630812366_u32))
 checked expr   : to_second<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 6_u8
 output type    : UInt8
-output domain  : Unknown
+output domain  : {0..=255}
 output         : 6
 
 
@@ -2822,15 +2822,15 @@ ast            : to_yyyymm(a)
 raw expr       : to_yyyymm(ColumnRef(0)::Timestamp)
 checked expr   : to_yyyymm<Timestamp>(ColumnRef(0))
 evaluation:
-+--------+----------------------------+---------+
-|        | a                          | Output  |
-+--------+----------------------------+---------+
-| Type   | Timestamp                  | UInt32  |
-| Domain | {-100..=100}               | Unknown |
-| Row 0  | 1969-12-31 23:59:59.999900 | 196912  |
-| Row 1  | 1970-01-01 00:00:00.000000 | 197001  |
-| Row 2  | 1970-01-01 00:00:00.000100 | 197001  |
-+--------+----------------------------+---------+
++--------+----------------------------+------------------+
+|        | a                          | Output           |
++--------+----------------------------+------------------+
+| Type   | Timestamp                  | UInt32           |
+| Domain | {-100..=100}               | {0..=4294967295} |
+| Row 0  | 1969-12-31 23:59:59.999900 | 196912           |
+| Row 1  | 1970-01-01 00:00:00.000000 | 197001           |
+| Row 2  | 1970-01-01 00:00:00.000100 | 197001           |
++--------+----------------------------+------------------+
 evaluation (internal):
 +--------+----------------------------------+
 | Column | Data                             |
@@ -2844,15 +2844,15 @@ ast            : to_yyyymmdd(a)
 raw expr       : to_yyyymmdd(ColumnRef(0)::Timestamp)
 checked expr   : to_yyyymmdd<Timestamp>(ColumnRef(0))
 evaluation:
-+--------+----------------------------+----------+
-|        | a                          | Output   |
-+--------+----------------------------+----------+
-| Type   | Timestamp                  | UInt32   |
-| Domain | {-100..=100}               | Unknown  |
-| Row 0  | 1969-12-31 23:59:59.999900 | 19691231 |
-| Row 1  | 1970-01-01 00:00:00.000000 | 19700101 |
-| Row 2  | 1970-01-01 00:00:00.000100 | 19700101 |
-+--------+----------------------------+----------+
++--------+----------------------------+------------------+
+|        | a                          | Output           |
++--------+----------------------------+------------------+
+| Type   | Timestamp                  | UInt32           |
+| Domain | {-100..=100}               | {0..=4294967295} |
+| Row 0  | 1969-12-31 23:59:59.999900 | 19691231         |
+| Row 1  | 1970-01-01 00:00:00.000000 | 19700101         |
+| Row 2  | 1970-01-01 00:00:00.000100 | 19700101         |
++--------+----------------------------+------------------+
 evaluation (internal):
 +--------+----------------------------------------+
 | Column | Data                                   |
@@ -2866,15 +2866,15 @@ ast            : to_yyyymmddhhmmss(a)
 raw expr       : to_yyyymmddhhmmss(ColumnRef(0)::Timestamp)
 checked expr   : to_yyyymmddhhmmss<Timestamp>(ColumnRef(0))
 evaluation:
-+--------+----------------------------+----------------+
-|        | a                          | Output         |
-+--------+----------------------------+----------------+
-| Type   | Timestamp                  | UInt64         |
-| Domain | {-100..=100}               | Unknown        |
-| Row 0  | 1969-12-31 23:59:59.999900 | 19691231235959 |
-| Row 1  | 1970-01-01 00:00:00.000000 | 19700101000000 |
-| Row 2  | 1970-01-01 00:00:00.000100 | 19700101000000 |
-+--------+----------------------------+----------------+
++--------+----------------------------+----------------------------+
+|        | a                          | Output                     |
++--------+----------------------------+----------------------------+
+| Type   | Timestamp                  | UInt64                     |
+| Domain | {-100..=100}               | {0..=18446744073709551615} |
+| Row 0  | 1969-12-31 23:59:59.999900 | 19691231235959             |
+| Row 1  | 1970-01-01 00:00:00.000000 | 19700101000000             |
+| Row 2  | 1970-01-01 00:00:00.000100 | 19700101000000             |
++--------+----------------------------+----------------------------+
 evaluation (internal):
 +--------+----------------------------------------------------------+
 | Column | Data                                                     |
@@ -2888,15 +2888,15 @@ ast            : to_year(a)
 raw expr       : to_year(ColumnRef(0)::Timestamp)
 checked expr   : to_year<Timestamp>(ColumnRef(0))
 evaluation:
-+--------+----------------------------+---------+
-|        | a                          | Output  |
-+--------+----------------------------+---------+
-| Type   | Timestamp                  | UInt16  |
-| Domain | {-100..=100}               | Unknown |
-| Row 0  | 1969-12-31 23:59:59.999900 | 1969    |
-| Row 1  | 1970-01-01 00:00:00.000000 | 1970    |
-| Row 2  | 1970-01-01 00:00:00.000100 | 1970    |
-+--------+----------------------------+---------+
++--------+----------------------------+-------------+
+|        | a                          | Output      |
++--------+----------------------------+-------------+
+| Type   | Timestamp                  | UInt16      |
+| Domain | {-100..=100}               | {0..=65535} |
+| Row 0  | 1969-12-31 23:59:59.999900 | 1969        |
+| Row 1  | 1970-01-01 00:00:00.000000 | 1970        |
+| Row 2  | 1970-01-01 00:00:00.000100 | 1970        |
++--------+----------------------------+-------------+
 evaluation (internal):
 +--------+----------------------------+
 | Column | Data                       |
@@ -2910,15 +2910,15 @@ ast            : to_month(a)
 raw expr       : to_month(ColumnRef(0)::Timestamp)
 checked expr   : to_month<Timestamp>(ColumnRef(0))
 evaluation:
-+--------+----------------------------+---------+
-|        | a                          | Output  |
-+--------+----------------------------+---------+
-| Type   | Timestamp                  | UInt8   |
-| Domain | {-100..=100}               | Unknown |
-| Row 0  | 1969-12-31 23:59:59.999900 | 12      |
-| Row 1  | 1970-01-01 00:00:00.000000 | 1       |
-| Row 2  | 1970-01-01 00:00:00.000100 | 1       |
-+--------+----------------------------+---------+
++--------+----------------------------+-----------+
+|        | a                          | Output    |
++--------+----------------------------+-----------+
+| Type   | Timestamp                  | UInt8     |
+| Domain | {-100..=100}               | {0..=255} |
+| Row 0  | 1969-12-31 23:59:59.999900 | 12        |
+| Row 1  | 1970-01-01 00:00:00.000000 | 1         |
+| Row 2  | 1970-01-01 00:00:00.000100 | 1         |
++--------+----------------------------+-----------+
 evaluation (internal):
 +--------+-------------------+
 | Column | Data              |
@@ -2932,15 +2932,15 @@ ast            : to_day_of_year(a)
 raw expr       : to_day_of_year(ColumnRef(0)::Timestamp)
 checked expr   : to_day_of_year<Timestamp>(ColumnRef(0))
 evaluation:
-+--------+----------------------------+---------+
-|        | a                          | Output  |
-+--------+----------------------------+---------+
-| Type   | Timestamp                  | UInt16  |
-| Domain | {-100..=100}               | Unknown |
-| Row 0  | 1969-12-31 23:59:59.999900 | 365     |
-| Row 1  | 1970-01-01 00:00:00.000000 | 1       |
-| Row 2  | 1970-01-01 00:00:00.000100 | 1       |
-+--------+----------------------------+---------+
++--------+----------------------------+-------------+
+|        | a                          | Output      |
++--------+----------------------------+-------------+
+| Type   | Timestamp                  | UInt16      |
+| Domain | {-100..=100}               | {0..=65535} |
+| Row 0  | 1969-12-31 23:59:59.999900 | 365         |
+| Row 1  | 1970-01-01 00:00:00.000000 | 1           |
+| Row 2  | 1970-01-01 00:00:00.000100 | 1           |
++--------+----------------------------+-------------+
 evaluation (internal):
 +--------+---------------------+
 | Column | Data                |
@@ -2954,15 +2954,15 @@ ast            : to_day_of_month(a)
 raw expr       : to_day_of_month(ColumnRef(0)::Timestamp)
 checked expr   : to_day_of_month<Timestamp>(ColumnRef(0))
 evaluation:
-+--------+----------------------------+---------+
-|        | a                          | Output  |
-+--------+----------------------------+---------+
-| Type   | Timestamp                  | UInt8   |
-| Domain | {-100..=100}               | Unknown |
-| Row 0  | 1969-12-31 23:59:59.999900 | 31      |
-| Row 1  | 1970-01-01 00:00:00.000000 | 1       |
-| Row 2  | 1970-01-01 00:00:00.000100 | 1       |
-+--------+----------------------------+---------+
++--------+----------------------------+-----------+
+|        | a                          | Output    |
++--------+----------------------------+-----------+
+| Type   | Timestamp                  | UInt8     |
+| Domain | {-100..=100}               | {0..=255} |
+| Row 0  | 1969-12-31 23:59:59.999900 | 31        |
+| Row 1  | 1970-01-01 00:00:00.000000 | 1         |
+| Row 2  | 1970-01-01 00:00:00.000100 | 1         |
++--------+----------------------------+-----------+
 evaluation (internal):
 +--------+-------------------+
 | Column | Data              |
@@ -2976,15 +2976,15 @@ ast            : to_day_of_week(a)
 raw expr       : to_day_of_week(ColumnRef(0)::Timestamp)
 checked expr   : to_day_of_week<Timestamp>(ColumnRef(0))
 evaluation:
-+--------+----------------------------+---------+
-|        | a                          | Output  |
-+--------+----------------------------+---------+
-| Type   | Timestamp                  | UInt8   |
-| Domain | {-100..=100}               | Unknown |
-| Row 0  | 1969-12-31 23:59:59.999900 | 3       |
-| Row 1  | 1970-01-01 00:00:00.000000 | 4       |
-| Row 2  | 1970-01-01 00:00:00.000100 | 4       |
-+--------+----------------------------+---------+
++--------+----------------------------+-----------+
+|        | a                          | Output    |
++--------+----------------------------+-----------+
+| Type   | Timestamp                  | UInt8     |
+| Domain | {-100..=100}               | {0..=255} |
+| Row 0  | 1969-12-31 23:59:59.999900 | 3         |
+| Row 1  | 1970-01-01 00:00:00.000000 | 4         |
+| Row 2  | 1970-01-01 00:00:00.000100 | 4         |
++--------+----------------------------+-----------+
 evaluation (internal):
 +--------+------------------+
 | Column | Data             |
@@ -2998,15 +2998,15 @@ ast            : to_hour(a)
 raw expr       : to_hour(ColumnRef(0)::Timestamp)
 checked expr   : to_hour<Timestamp>(ColumnRef(0))
 evaluation:
-+--------+----------------------------+---------+
-|        | a                          | Output  |
-+--------+----------------------------+---------+
-| Type   | Timestamp                  | UInt8   |
-| Domain | {-100..=100}               | Unknown |
-| Row 0  | 1969-12-31 23:59:59.999900 | 23      |
-| Row 1  | 1970-01-01 00:00:00.000000 | 0       |
-| Row 2  | 1970-01-01 00:00:00.000100 | 0       |
-+--------+----------------------------+---------+
++--------+----------------------------+-----------+
+|        | a                          | Output    |
++--------+----------------------------+-----------+
+| Type   | Timestamp                  | UInt8     |
+| Domain | {-100..=100}               | {0..=255} |
+| Row 0  | 1969-12-31 23:59:59.999900 | 23        |
+| Row 1  | 1970-01-01 00:00:00.000000 | 0         |
+| Row 2  | 1970-01-01 00:00:00.000100 | 0         |
++--------+----------------------------+-----------+
 evaluation (internal):
 +--------+-------------------+
 | Column | Data              |
@@ -3020,15 +3020,15 @@ ast            : to_minute(a)
 raw expr       : to_minute(ColumnRef(0)::Timestamp)
 checked expr   : to_minute<Timestamp>(ColumnRef(0))
 evaluation:
-+--------+----------------------------+---------+
-|        | a                          | Output  |
-+--------+----------------------------+---------+
-| Type   | Timestamp                  | UInt8   |
-| Domain | {-100..=100}               | Unknown |
-| Row 0  | 1969-12-31 23:59:59.999900 | 59      |
-| Row 1  | 1970-01-01 00:00:00.000000 | 0       |
-| Row 2  | 1970-01-01 00:00:00.000100 | 0       |
-+--------+----------------------------+---------+
++--------+----------------------------+-----------+
+|        | a                          | Output    |
++--------+----------------------------+-----------+
+| Type   | Timestamp                  | UInt8     |
+| Domain | {-100..=100}               | {0..=255} |
+| Row 0  | 1969-12-31 23:59:59.999900 | 59        |
+| Row 1  | 1970-01-01 00:00:00.000000 | 0         |
+| Row 2  | 1970-01-01 00:00:00.000100 | 0         |
++--------+----------------------------+-----------+
 evaluation (internal):
 +--------+-------------------+
 | Column | Data              |
@@ -3042,15 +3042,15 @@ ast            : to_second(a)
 raw expr       : to_second(ColumnRef(0)::Timestamp)
 checked expr   : to_second<Timestamp>(ColumnRef(0))
 evaluation:
-+--------+----------------------------+---------+
-|        | a                          | Output  |
-+--------+----------------------------+---------+
-| Type   | Timestamp                  | UInt8   |
-| Domain | {-100..=100}               | Unknown |
-| Row 0  | 1969-12-31 23:59:59.999900 | 59      |
-| Row 1  | 1970-01-01 00:00:00.000000 | 0       |
-| Row 2  | 1970-01-01 00:00:00.000100 | 0       |
-+--------+----------------------------+---------+
++--------+----------------------------+-----------+
+|        | a                          | Output    |
++--------+----------------------------+-----------+
+| Type   | Timestamp                  | UInt8     |
+| Domain | {-100..=100}               | {0..=255} |
+| Row 0  | 1969-12-31 23:59:59.999900 | 59        |
+| Row 1  | 1970-01-01 00:00:00.000000 | 0         |
+| Row 2  | 1970-01-01 00:00:00.000100 | 0         |
++--------+----------------------------+-----------+
 evaluation (internal):
 +--------+-------------------+
 | Column | Data              |
@@ -3065,7 +3065,7 @@ raw expr       : to_start_of_second(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_second<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630812366000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 03:26:06.000000
 
 
@@ -3074,7 +3074,7 @@ raw expr       : to_start_of_minute(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_minute<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630812360000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 03:26:00.000000
 
 
@@ -3083,7 +3083,7 @@ raw expr       : to_start_of_five_minutes(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_five_minutes<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630812300000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 03:25:00.000000
 
 
@@ -3092,7 +3092,7 @@ raw expr       : to_start_of_ten_minutes(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_ten_minutes<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630812000000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 03:20:00.000000
 
 
@@ -3101,7 +3101,7 @@ raw expr       : to_start_of_fifteen_minutes(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_fifteen_minutes<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630811700000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 03:15:00.000000
 
 
@@ -3110,7 +3110,7 @@ raw expr       : to_start_of_hour(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_hour<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630810800000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 03:00:00.000000
 
 
@@ -3119,7 +3119,7 @@ raw expr       : to_start_of_day(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_day<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630800000000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 00:00:00.000000
 
 
@@ -3128,7 +3128,7 @@ raw expr       : time_slot(to_timestamp(1630812366_u32))
 checked expr   : time_slot<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630810800000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 03:00:00.000000
 
 
@@ -3137,7 +3137,7 @@ raw expr       : to_monday(to_timestamp(1630812366_u32))
 checked expr   : to_monday<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 18869
 output type    : Date
-output domain  : Unknown
+output domain  : {-354285..=2932896}
 output         : 2021-08-30
 
 
@@ -3146,7 +3146,7 @@ raw expr       : to_start_of_week(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_week<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 18875
 output type    : Date
-output domain  : Unknown
+output domain  : {-354285..=2932896}
 output         : 2021-09-05
 
 
@@ -3155,7 +3155,7 @@ raw expr       : to_start_of_week(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_week<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 18875
 output type    : Date
-output domain  : Unknown
+output domain  : {-354285..=2932896}
 output         : 2021-09-05
 
 
@@ -3164,7 +3164,7 @@ raw expr       : to_start_of_week(to_timestamp(1630812366_u32), 1_u8)
 checked expr   : to_start_of_week<Timestamp, Int64>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)), CAST(1_u8 AS Int64))
 optimized expr : 18869
 output type    : Date
-output domain  : Unknown
+output domain  : {-354285..=2932896}
 output         : 2021-08-30
 
 
@@ -3173,7 +3173,7 @@ raw expr       : to_start_of_month(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_month<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 18871
 output type    : Date
-output domain  : Unknown
+output domain  : {-354285..=2932896}
 output         : 2021-09-01
 
 
@@ -3182,7 +3182,7 @@ raw expr       : to_start_of_quarter(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_quarter<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 18809
 output type    : Date
-output domain  : Unknown
+output domain  : {-354285..=2932896}
 output         : 2021-07-01
 
 
@@ -3191,7 +3191,7 @@ raw expr       : to_start_of_year(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_year<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 18628
 output type    : Date
-output domain  : Unknown
+output domain  : {-354285..=2932896}
 output         : 2021-01-01
 
 
@@ -3200,7 +3200,7 @@ raw expr       : to_start_of_iso_year(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_iso_year<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 18631
 output type    : Date
-output domain  : Unknown
+output domain  : {-354285..=2932896}
 output         : 2021-01-04
 
 
@@ -3209,7 +3209,7 @@ raw expr       : to_start_of_year(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_year<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 18628
 output type    : Date
-output domain  : Unknown
+output domain  : {-354285..=2932896}
 output         : 2021-01-01
 
 
@@ -3218,7 +3218,7 @@ raw expr       : to_start_of_quarter(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_quarter<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 18809
 output type    : Date
-output domain  : Unknown
+output domain  : {-354285..=2932896}
 output         : 2021-07-01
 
 
@@ -3227,7 +3227,7 @@ raw expr       : to_start_of_month(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_month<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 18871
 output type    : Date
-output domain  : Unknown
+output domain  : {-354285..=2932896}
 output         : 2021-09-01
 
 
@@ -3236,7 +3236,7 @@ raw expr       : to_start_of_day(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_day<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630800000000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 00:00:00.000000
 
 
@@ -3245,7 +3245,7 @@ raw expr       : to_start_of_hour(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_hour<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630810800000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 03:00:00.000000
 
 
@@ -3254,7 +3254,7 @@ raw expr       : to_start_of_minute(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_minute<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630812360000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 03:26:00.000000
 
 
@@ -3263,7 +3263,7 @@ raw expr       : to_start_of_second(to_timestamp(1630812366_u32))
 checked expr   : to_start_of_second<Timestamp>(to_timestamp<Int64>(CAST(1630812366_u32 AS Int64)))
 optimized expr : 1630812366000000
 output type    : Timestamp
-output domain  : Unknown
+output domain  : {-30610224000000000..=253402300799999999}
 output         : 2021-09-05 03:26:06.000000
 
 

--- a/src/query/functions-v2/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/function_list.txt
@@ -572,6 +572,8 @@ floor(Float64 NULL) :: Float64 NULL
 from_base64(String) :: String
 from_base64(String NULL) :: String NULL
 get(Array(Nothing) NULL, UInt64 NULL) :: NULL
+get(Array(T0 NULL), UInt64) :: T0 NULL
+get(Array(T0 NULL) NULL, UInt64 NULL) :: T0 NULL
 get(Array(T0), UInt64) :: T0 NULL
 get(Array(T0) NULL, UInt64 NULL) :: T0 NULL
 get(Variant, UInt64) :: Variant NULL

--- a/src/query/functions-v2/tests/it/scalars/testdata/math.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/math.txt
@@ -119,7 +119,7 @@ raw expr       : tan(1_u8)
 checked expr   : tan<Float64>(CAST(1_u8 AS Float64))
 optimized expr : 1.5574077246_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 1.5574077246
 
 
@@ -137,7 +137,7 @@ raw expr       : cot(minus(1_f64))
 checked expr   : cot<Float64>(minus<Float64>(1_f64))
 optimized expr : -0.6420926159_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : -0.6420926159
 
 
@@ -196,7 +196,7 @@ raw expr       : ceil(5_u8)
 checked expr   : ceil<UInt8>(5_u8)
 optimized expr : 5_u8
 output type    : UInt8
-output domain  : Unknown
+output domain  : {0..=255}
 output         : 5
 
 
@@ -205,7 +205,7 @@ raw expr       : ceil(5.6_f64)
 checked expr   : ceil<Float64>(5.6_f64)
 optimized expr : 6_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 6
 
 
@@ -213,14 +213,14 @@ ast            : ceil(a)
 raw expr       : ceil(ColumnRef(0)::Float64)
 checked expr   : ceil<Float64>(ColumnRef(0))
 evaluation:
-+--------+----------------+---------+
-|        | a              | Output  |
-+--------+----------------+---------+
-| Type   | Float64        | Float64 |
-| Domain | {-1.23..=1.23} | Unknown |
-| Row 0  | 1.23           | 2       |
-| Row 1  | -1.23          | -1      |
-+--------+----------------+---------+
++--------+----------------+--------------+
+|        | a              | Output       |
++--------+----------------+--------------+
+| Type   | Float64        | Float64      |
+| Domain | {-1.23..=1.23} | {-inf..=NaN} |
+| Row 0  | 1.23           | 2            |
+| Row 1  | -1.23          | -1           |
++--------+----------------+--------------+
 evaluation (internal):
 +--------+------------------------+
 | Column | Data                   |
@@ -235,7 +235,7 @@ raw expr       : exp(2_u8)
 checked expr   : exp<UInt8>(2_u8)
 optimized expr : 7.3890560989_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 7.3890560989
 
 
@@ -244,7 +244,7 @@ raw expr       : exp(minus(2_u8))
 checked expr   : exp<Int16>(minus<UInt8>(2_u8))
 optimized expr : 0.1353352832_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 0.1353352832
 
 
@@ -253,7 +253,7 @@ raw expr       : exp(0_u8)
 checked expr   : exp<UInt8>(0_u8)
 optimized expr : 1_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 1
 
 
@@ -265,7 +265,7 @@ evaluation:
 |        | a         | Output           |
 +--------+-----------+------------------+
 | Type   | Int64     | Float64          |
-| Domain | {-2..=10} | Unknown          |
+| Domain | {-2..=10} | {-inf..=NaN}     |
 | Row 0  | 4         | 54.5981500331    |
 | Row 1  | -2        | 0.1353352832     |
 | Row 2  | 10        | 22026.4657948067 |
@@ -284,7 +284,7 @@ raw expr       : round(minus(1.23_f64))
 checked expr   : round<Float64>(minus<Float64>(1.23_f64))
 optimized expr : -1_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : -1
 
 
@@ -293,7 +293,7 @@ raw expr       : round(1.298_f64, 1_u8)
 checked expr   : round<Float64, Int64>(1.298_f64, CAST(1_u8 AS Int64))
 optimized expr : 1.3_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 1.3
 
 
@@ -302,7 +302,7 @@ raw expr       : round(1.298_f64, 0_u8)
 checked expr   : round<Float64, Int64>(1.298_f64, CAST(0_u8 AS Int64))
 optimized expr : 1_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 1
 
 
@@ -311,7 +311,7 @@ raw expr       : round(23.298_f64, minus(1_u8))
 checked expr   : round<Float64, Int64>(23.298_f64, CAST(minus<UInt8>(1_u8) AS Int64))
 optimized expr : 20_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 20
 
 
@@ -320,7 +320,7 @@ raw expr       : round(0.12345678901234568_f64, 35_u8)
 checked expr   : round<Float64, Int64>(0.123456789_f64, CAST(35_u8 AS Int64))
 optimized expr : 0.123456789_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 0.123456789
 
 
@@ -328,15 +328,15 @@ ast            : round(a)
 raw expr       : round(ColumnRef(0)::Float64)
 checked expr   : round<Float64>(ColumnRef(0))
 evaluation:
-+--------+------------------+---------+
-|        | a                | Output  |
-+--------+------------------+---------+
-| Type   | Float64          | Float64 |
-| Domain | {-22.23..=22.22} | Unknown |
-| Row 0  | 22.22            | 22      |
-| Row 1  | -22.23           | -22     |
-| Row 2  | 10               | 10      |
-+--------+------------------+---------+
++--------+------------------+--------------+
+|        | a                | Output       |
++--------+------------------+--------------+
+| Type   | Float64          | Float64      |
+| Domain | {-22.23..=22.22} | {-inf..=NaN} |
+| Row 0  | 22.22            | 22           |
+| Row 1  | -22.23           | -22          |
+| Row 2  | 10               | 10           |
++--------+------------------+--------------+
 evaluation (internal):
 +--------+------------------------------+
 | Column | Data                         |
@@ -351,7 +351,7 @@ raw expr       : sqrt(4_u8)
 checked expr   : sqrt<UInt8>(4_u8)
 optimized expr : 2_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 2
 
 
@@ -363,7 +363,7 @@ evaluation:
 |        | a           | Output       |
 +--------+-------------+--------------+
 | Type   | Int64       | Float64      |
-| Domain | {10..=1024} | Unknown      |
+| Domain | {10..=1024} | {-inf..=NaN} |
 | Row 0  | 22          | 4.6904157598 |
 | Row 1  | 1024        | 32           |
 | Row 2  | 10          | 3.1622776601 |
@@ -382,7 +382,7 @@ raw expr       : truncate(1.223_f64, 1_u8)
 checked expr   : truncate<Float64, Int64>(1.223_f64, CAST(1_u8 AS Int64))
 optimized expr : 1.2_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 1.2
 
 
@@ -391,7 +391,7 @@ raw expr       : truncate(1.999_f64)
 checked expr   : truncate<Float64>(1.999_f64)
 optimized expr : 1_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 1
 
 
@@ -400,7 +400,7 @@ raw expr       : truncate(1.999_f64, 1_u8)
 checked expr   : truncate<Float64, Int64>(1.999_f64, CAST(1_u8 AS Int64))
 optimized expr : 1.9_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 1.9
 
 
@@ -409,7 +409,7 @@ raw expr       : truncate(122_u8, minus(2_u8))
 checked expr   : truncate<UInt8, Int64>(122_u8, CAST(minus<UInt8>(2_u8) AS Int64))
 optimized expr : 100_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 100
 
 
@@ -418,7 +418,7 @@ raw expr       : truncate(multiply(10.28_f64, 100_u8), 0_u8)
 checked expr   : truncate<Float64, Int64>(multiply<Float64, UInt8>(10.28_f64, 100_u8), CAST(0_u8 AS Int64))
 optimized expr : 1028_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 1028
 
 
@@ -427,15 +427,15 @@ raw expr       : truncate(ColumnRef(0)::Float64, 1_u8)
 checked expr   : truncate<Float64, Int64>(ColumnRef(0), CAST(1_u8 AS Int64))
 optimized expr : truncate<Float64, Int64>(ColumnRef(0), 1_i64)
 evaluation:
-+--------+------------------+---------+
-|        | a                | Output  |
-+--------+------------------+---------+
-| Type   | Float64          | Float64 |
-| Domain | {-22.23..=22.22} | Unknown |
-| Row 0  | 22.22            | 22.2    |
-| Row 1  | -22.23           | -22.2   |
-| Row 2  | 10               | 10      |
-+--------+------------------+---------+
++--------+------------------+--------------+
+|        | a                | Output       |
++--------+------------------+--------------+
+| Type   | Float64          | Float64      |
+| Domain | {-22.23..=22.22} | {-inf..=NaN} |
+| Row 0  | 22.22            | 22.2         |
+| Row 1  | -22.23           | -22.2        |
+| Row 2  | 10               | 10           |
++--------+------------------+--------------+
 evaluation (internal):
 +--------+------------------------------+
 | Column | Data                         |
@@ -450,7 +450,7 @@ raw expr       : log(2_u8)
 checked expr   : log<UInt8>(2_u8)
 optimized expr : 0.6931471805_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 0.6931471805
 
 
@@ -459,7 +459,7 @@ raw expr       : log(2_u8, 65536_u32)
 checked expr   : log<UInt8, Float64>(2_u8, CAST(65536_u32 AS Float64))
 optimized expr : 16_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 16
 
 
@@ -468,7 +468,7 @@ raw expr       : log2(65536_u32)
 checked expr   : log2<UInt32>(65536_u32)
 optimized expr : 16_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 16
 
 
@@ -477,7 +477,7 @@ raw expr       : log10(100_u8)
 checked expr   : log10<UInt8>(100_u8)
 optimized expr : 2_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 2
 
 
@@ -486,7 +486,7 @@ raw expr       : ln(2_u8)
 checked expr   : ln<UInt8>(2_u8)
 optimized expr : 0.6931471805_f64
 output type    : Float64
-output domain  : Unknown
+output domain  : {-inf..=NaN}
 output         : 0.6931471805
 
 
@@ -494,15 +494,15 @@ ast            : round(2, a)
 raw expr       : round(2_u8, ColumnRef(0)::Int64)
 checked expr   : round<UInt8, Int64>(2_u8, ColumnRef(0))
 evaluation:
-+--------+--------------+---------+
-|        | a            | Output  |
-+--------+--------------+---------+
-| Type   | Int64        | Float64 |
-| Domain | {10..=65536} | Unknown |
-| Row 0  | 22           | 2       |
-| Row 1  | 65536        | 2       |
-| Row 2  | 10           | 2       |
-+--------+--------------+---------+
++--------+--------------+--------------+
+|        | a            | Output       |
++--------+--------------+--------------+
+| Type   | Int64        | Float64      |
+| Domain | {10..=65536} | {-inf..=NaN} |
+| Row 0  | 22           | 2            |
+| Row 1  | 65536        | 2            |
+| Row 2  | 10           | 2            |
++--------+--------------+--------------+
 evaluation (internal):
 +--------+------------------------+
 | Column | Data                   |

--- a/src/query/functions-v2/tests/it/scalars/testdata/string.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/string.txt
@@ -3,7 +3,7 @@ raw expr       : upper("Abc")
 checked expr   : upper<String>("Abc")
 optimized expr : "ABC"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "ABC"
 
 
@@ -12,7 +12,7 @@ raw expr       : upper("Dobrý den")
 checked expr   : upper<String>("Dobrý den")
 optimized expr : "DOBRÝ DEN"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "DOBRÝ DEN"
 
 
@@ -21,7 +21,7 @@ raw expr       : upper("ß😀山")
 checked expr   : upper<String>("ß😀山")
 optimized expr : "SS😀山"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "SS😀山"
 
 
@@ -42,7 +42,7 @@ evaluation:
 |        | a                 | Output      |
 +--------+-------------------+-------------+
 | Type   | String            | String      |
-| Domain | {"Abc"..="ß😀山"} | Unknown     |
+| Domain | {"Abc"..="ß😀山"} | {""..}      |
 | Row 0  | "Abc"             | "ABC"       |
 | Row 1  | "Dobrý den"       | "DOBRÝ DEN" |
 | Row 2  | "ß😀山"           | "SS😀山"    |
@@ -61,7 +61,7 @@ raw expr       : lower("Abc")
 checked expr   : lower<String>("Abc")
 optimized expr : "abc"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "abc"
 
 
@@ -70,7 +70,7 @@ raw expr       : lower("DOBRÝ DEN")
 checked expr   : lower<String>("DOBRÝ DEN")
 optimized expr : "dobrý den"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "dobrý den"
 
 
@@ -79,7 +79,7 @@ raw expr       : lower("İ😀山")
 checked expr   : lower<String>("İ😀山")
 optimized expr : "i\u{307}😀山"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "i\u{307}😀山"
 
 
@@ -100,7 +100,7 @@ evaluation:
 |        | a                 | Output         |
 +--------+-------------------+----------------+
 | Type   | String            | String         |
-| Domain | {"Abc"..="İ😀山"} | Unknown        |
+| Domain | {"Abc"..="İ😀山"} | {""..}         |
 | Row 0  | "Abc"             | "abc"          |
 | Row 1  | "DOBRÝ DEN"       | "dobrý den"    |
 | Row 2  | "İ😀山"           | "i\u{307}😀山" |
@@ -119,7 +119,7 @@ raw expr       : bit_length("latin")
 checked expr   : bit_length<String>("latin")
 optimized expr : 40_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 40
 
 
@@ -136,15 +136,15 @@ ast            : bit_length(a)
 raw expr       : bit_length(ColumnRef(0)::String)
 checked expr   : bit_length<String>(ColumnRef(0))
 evaluation:
-+--------+-----------------------------------+---------+
-|        | a                                 | Output  |
-+--------+-----------------------------------+---------+
-| Type   | String                            | UInt64  |
-| Domain | {"latin"..="кириллица and latin"} | Unknown |
-| Row 0  | "latin"                           | 40      |
-| Row 1  | "кириллица"                       | 144     |
-| Row 2  | "кириллица and latin"             | 224     |
-+--------+-----------------------------------+---------+
++--------+-----------------------------------+----------------------------+
+|        | a                                 | Output                     |
++--------+-----------------------------------+----------------------------+
+| Type   | String                            | UInt64                     |
+| Domain | {"latin"..="кириллица and latin"} | {0..=18446744073709551615} |
+| Row 0  | "latin"                           | 40                         |
+| Row 1  | "кириллица"                       | 144                        |
+| Row 2  | "кириллица and latin"             | 224                        |
++--------+-----------------------------------+----------------------------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                     |
@@ -159,7 +159,7 @@ raw expr       : octet_length("latin")
 checked expr   : length<String>("latin")
 optimized expr : 5_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 5
 
 
@@ -176,15 +176,15 @@ ast            : length(a)
 raw expr       : length(ColumnRef(0)::String)
 checked expr   : length<String>(ColumnRef(0))
 evaluation:
-+--------+-----------------------------------+---------+
-|        | a                                 | Output  |
-+--------+-----------------------------------+---------+
-| Type   | String                            | UInt64  |
-| Domain | {"latin"..="кириллица and latin"} | Unknown |
-| Row 0  | "latin"                           | 5       |
-| Row 1  | "кириллица"                       | 18      |
-| Row 2  | "кириллица and latin"             | 28      |
-+--------+-----------------------------------+---------+
++--------+-----------------------------------+----------------------------+
+|        | a                                 | Output                     |
++--------+-----------------------------------+----------------------------+
+| Type   | String                            | UInt64                     |
+| Domain | {"latin"..="кириллица and latin"} | {0..=18446744073709551615} |
+| Row 0  | "latin"                           | 5                          |
+| Row 1  | "кириллица"                       | 18                         |
+| Row 2  | "кириллица and latin"             | 28                         |
++--------+-----------------------------------+----------------------------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                     |
@@ -239,7 +239,7 @@ raw expr       : to_base64("Abc")
 checked expr   : to_base64<String>("Abc")
 optimized expr : "QWJj"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "QWJj"
 
 
@@ -248,7 +248,7 @@ raw expr       : to_base64("123")
 checked expr   : to_base64<String>("123")
 optimized expr : "MTIz"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "MTIz"
 
 
@@ -265,14 +265,14 @@ ast            : to_base64(a)
 raw expr       : to_base64(ColumnRef(0)::String)
 checked expr   : to_base64<String>(ColumnRef(0))
 evaluation:
-+--------+-----------------+---------+
-|        | a               | Output  |
-+--------+-----------------+---------+
-| Type   | String          | String  |
-| Domain | {"123"..="Abc"} | Unknown |
-| Row 0  | "Abc"           | "QWJj"  |
-| Row 1  | "123"           | "MTIz"  |
-+--------+-----------------+---------+
++--------+-----------------+--------+
+|        | a               | Output |
++--------+-----------------+--------+
+| Type   | String          | String |
+| Domain | {"123"..="Abc"} | {""..} |
+| Row 0  | "Abc"           | "QWJj" |
+| Row 1  | "123"           | "MTIz" |
++--------+-----------------+--------+
 evaluation (internal):
 +--------+---------------------------------------------------------------+
 | Column | Data                                                          |
@@ -330,12 +330,20 @@ evaluation (internal):
 +--------+---------------------------------------------------------------+
 
 
+error: 
+  --> SQL:1:1
+  |
+1 | from_base64('!@#')
+  | ^^^^^^^^^^^^^^^^^^ unable to decode base64: Invalid byte 33, offset 0.
+
+
+
 ast            : quote('a\0b')
 raw expr       : quote("a\0b")
 checked expr   : quote<String>("a\0b")
 optimized expr : "a\\0b"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "a\\0b"
 
 
@@ -344,7 +352,7 @@ raw expr       : quote("a'b")
 checked expr   : quote<String>("a'b")
 optimized expr : "a\\'b"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "a\\'b"
 
 
@@ -353,7 +361,7 @@ raw expr       : quote("a\"b")
 checked expr   : quote<String>("a\"b")
 optimized expr : "a\\\"b"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "a\\\"b"
 
 
@@ -362,7 +370,7 @@ raw expr       : quote("a\u{8}b")
 checked expr   : quote<String>("a\u{8}b")
 optimized expr : "a\\bb"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "a\\bb"
 
 
@@ -371,7 +379,7 @@ raw expr       : quote("a\nb")
 checked expr   : quote<String>("a\nb")
 optimized expr : "a\\nb"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "a\\nb"
 
 
@@ -380,7 +388,7 @@ raw expr       : quote("a\rb")
 checked expr   : quote<String>("a\rb")
 optimized expr : "a\\rb"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "a\\rb"
 
 
@@ -389,7 +397,7 @@ raw expr       : quote("a\tb")
 checked expr   : quote<String>("a\tb")
 optimized expr : "a\\tb"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "a\\tb"
 
 
@@ -398,7 +406,7 @@ raw expr       : quote("a\\b")
 checked expr   : quote<String>("a\\b")
 optimized expr : "a\\\\b"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "a\\\\b"
 
 
@@ -407,7 +415,7 @@ raw expr       : quote("你好")
 checked expr   : quote<String>("你好")
 optimized expr : "你好"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "你好"
 
 
@@ -416,7 +424,7 @@ raw expr       : quote("ß😀山")
 checked expr   : quote<String>("ß😀山")
 optimized expr : "ß😀山"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "ß😀山"
 
 
@@ -425,7 +433,7 @@ raw expr       : quote("Dobrý den")
 checked expr   : quote<String>("Dobrý den")
 optimized expr : "Dobrý den"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "Dobrý den"
 
 
@@ -446,7 +454,7 @@ evaluation:
 |        | a                   | Output      |
 +--------+---------------------+-------------+
 | Type   | String              | String      |
-| Domain | {"a\\'b"..="a\\nb"} | Unknown     |
+| Domain | {"a\\'b"..="a\\nb"} | {""..}      |
 | Row 0  | "a\\0b"             | "a\\\\0b"   |
 | Row 1  | "a\\'b"             | "a\\\\\\'b" |
 | Row 2  | "a\\nb"             | "a\\\\nb"   |
@@ -465,7 +473,7 @@ raw expr       : reverse("abc")
 checked expr   : reverse<String>("abc")
 optimized expr : "cba"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "cba"
 
 
@@ -474,7 +482,7 @@ raw expr       : reverse("a")
 checked expr   : reverse<String>("a")
 optimized expr : "a"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "a"
 
 
@@ -483,7 +491,7 @@ raw expr       : reverse("")
 checked expr   : reverse<String>("")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -492,7 +500,7 @@ raw expr       : reverse("你好")
 checked expr   : reverse<String>("你好")
 optimized expr : "��堽�"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "��堽�"
 
 
@@ -501,7 +509,7 @@ raw expr       : reverse("ß😀山")
 checked expr   : reverse<String>("ß😀山")
 optimized expr : "��倘���"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "��倘���"
 
 
@@ -510,7 +518,7 @@ raw expr       : reverse("Dobrý den")
 checked expr   : reverse<String>("Dobrý den")
 optimized expr : "ned ��rboD"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "ned ��rboD"
 
 
@@ -527,15 +535,15 @@ ast            : reverse(a)
 raw expr       : reverse(ColumnRef(0)::String)
 checked expr   : reverse<String>(ColumnRef(0))
 evaluation:
-+--------+--------------+---------+
-|        | a            | Output  |
-+--------+--------------+---------+
-| Type   | String       | String  |
-| Domain | {""..="abc"} | Unknown |
-| Row 0  | "abc"        | "cba"   |
-| Row 1  | "a"          | "a"     |
-| Row 2  | ""           | ""      |
-+--------+--------------+---------+
++--------+--------------+--------+
+|        | a            | Output |
++--------+--------------+--------+
+| Type   | String       | String |
+| Domain | {""..="abc"} | {""..} |
+| Row 0  | "abc"        | "cba"  |
+| Row 1  | "a"          | "a"    |
+| Row 2  | ""           | ""     |
++--------+--------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------+
 | Column | Data                                                     |
@@ -657,7 +665,7 @@ raw expr       : ltrim("   abc   ")
 checked expr   : ltrim<String>("   abc   ")
 optimized expr : "abc   "
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "abc   "
 
 
@@ -666,7 +674,7 @@ raw expr       : ltrim("  ")
 checked expr   : ltrim<String>("  ")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -687,7 +695,7 @@ evaluation:
 |        | a                     | Output   |
 +--------+-----------------------+----------+
 | Type   | String                | String   |
-| Domain | {"   abc"..="abc   "} | Unknown  |
+| Domain | {"   abc"..="abc   "} | {""..}   |
 | Row 0  | "abc"                 | "abc"    |
 | Row 1  | "   abc"              | "abc"    |
 | Row 2  | "   abc   "           | "abc   " |
@@ -707,7 +715,7 @@ raw expr       : rtrim("   abc   ")
 checked expr   : rtrim<String>("   abc   ")
 optimized expr : "   abc"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "   abc"
 
 
@@ -716,7 +724,7 @@ raw expr       : rtrim("  ")
 checked expr   : rtrim<String>("  ")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -737,7 +745,7 @@ evaluation:
 |        | a                     | Output   |
 +--------+-----------------------+----------+
 | Type   | String                | String   |
-| Domain | {"   abc"..="abc   "} | Unknown  |
+| Domain | {"   abc"..="abc   "} | {""..}   |
 | Row 0  | "abc"                 | "abc"    |
 | Row 1  | "   abc"              | "   abc" |
 | Row 2  | "   abc   "           | "   abc" |
@@ -757,7 +765,7 @@ raw expr       : trim_leading("aaabbaaa", "a")
 checked expr   : trim_leading<String, String>("aaabbaaa", "a")
 optimized expr : "bbaaa"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "bbaaa"
 
 
@@ -766,7 +774,7 @@ raw expr       : trim_leading("aaabbaaa", "aa")
 checked expr   : trim_leading<String, String>("aaabbaaa", "aa")
 optimized expr : "abbaaa"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "abbaaa"
 
 
@@ -775,7 +783,7 @@ raw expr       : trim_leading("aaaaaaaa", "a")
 checked expr   : trim_leading<String, String>("aaaaaaaa", "a")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -784,7 +792,7 @@ raw expr       : trim_leading("aaabbaaa", "b")
 checked expr   : trim_leading<String, String>("aaabbaaa", "b")
 optimized expr : "aaabbaaa"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "aaabbaaa"
 
 
@@ -814,7 +822,7 @@ evaluation:
 |        | a                     | Output   |
 +--------+-----------------------+----------+
 | Type   | String                | String   |
-| Domain | {"aabbaa"..="ccddcc"} | Unknown  |
+| Domain | {"aabbaa"..="ccddcc"} | {""..}   |
 | Row 0  | "aabbaa"              | "bbaa"   |
 | Row 1  | "bbccbb"              | "bbccbb" |
 | Row 2  | "ccddcc"              | "ccddcc" |
@@ -832,15 +840,15 @@ ast            : trim_leading(a, b)
 raw expr       : trim_leading(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : trim_leading<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+-----------------------+-------------+---------+
-|        | a                     | b           | Output  |
-+--------+-----------------------+-------------+---------+
-| Type   | String                | String      | String  |
-| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | Unknown |
-| Row 0  | "aabbaa"              | "a"         | "bbaa"  |
-| Row 1  | "bbccbb"              | "b"         | "ccbb"  |
-| Row 2  | "ccddcc"              | "c"         | "ddcc"  |
-+--------+-----------------------+-------------+---------+
++--------+-----------------------+-------------+--------+
+|        | a                     | b           | Output |
++--------+-----------------------+-------------+--------+
+| Type   | String                | String      | String |
+| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | {""..} |
+| Row 0  | "aabbaa"              | "a"         | "bbaa" |
+| Row 1  | "bbccbb"              | "b"         | "ccbb" |
+| Row 2  | "ccddcc"              | "c"         | "ddcc" |
++--------+-----------------------+-------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------+
 | Column | Data                                                                                   |
@@ -855,15 +863,15 @@ ast            : trim_leading('aba', b)
 raw expr       : trim_leading("aba", ColumnRef(1)::String)
 checked expr   : trim_leading<String, String>("aba", ColumnRef(1))
 evaluation:
-+--------+-------------+---------+
-|        | b           | Output  |
-+--------+-------------+---------+
-| Type   | String      | String  |
-| Domain | {"a"..="c"} | Unknown |
-| Row 0  | "a"         | "ba"    |
-| Row 1  | "b"         | "aba"   |
-| Row 2  | "c"         | "aba"   |
-+--------+-------------+---------+
++--------+-------------+--------+
+|        | b           | Output |
++--------+-------------+--------+
+| Type   | String      | String |
+| Domain | {"a"..="c"} | {""..} |
+| Row 0  | "a"         | "ba"   |
+| Row 1  | "b"         | "aba"  |
+| Row 2  | "c"         | "aba"  |
++--------+-------------+--------+
 evaluation (internal):
 +--------+------------------------------------------------------------------+
 | Column | Data                                                             |
@@ -878,7 +886,7 @@ raw expr       : trim_trailing("aaabbaaa", "a")
 checked expr   : trim_trailing<String, String>("aaabbaaa", "a")
 optimized expr : "aaabb"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "aaabb"
 
 
@@ -887,7 +895,7 @@ raw expr       : trim_trailing("aaabbaaa", "aa")
 checked expr   : trim_trailing<String, String>("aaabbaaa", "aa")
 optimized expr : "aaabba"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "aaabba"
 
 
@@ -896,7 +904,7 @@ raw expr       : trim_trailing("aaaaaaaa", "a")
 checked expr   : trim_trailing<String, String>("aaaaaaaa", "a")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -905,7 +913,7 @@ raw expr       : trim_trailing("aaabbaaa", "b")
 checked expr   : trim_trailing<String, String>("aaabbaaa", "b")
 optimized expr : "aaabbaaa"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "aaabbaaa"
 
 
@@ -935,7 +943,7 @@ evaluation:
 |        | a                     | Output   |
 +--------+-----------------------+----------+
 | Type   | String                | String   |
-| Domain | {"aabbaa"..="ccddcc"} | Unknown  |
+| Domain | {"aabbaa"..="ccddcc"} | {""..}   |
 | Row 0  | "aabbaa"              | "aabbaa" |
 | Row 1  | "bbccbb"              | "bbcc"   |
 | Row 2  | "ccddcc"              | "ccddcc" |
@@ -953,15 +961,15 @@ ast            : trim_trailing(a, b)
 raw expr       : trim_trailing(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : trim_trailing<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+-----------------------+-------------+---------+
-|        | a                     | b           | Output  |
-+--------+-----------------------+-------------+---------+
-| Type   | String                | String      | String  |
-| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | Unknown |
-| Row 0  | "aabbaa"              | "a"         | "aabb"  |
-| Row 1  | "bbccbb"              | "b"         | "bbcc"  |
-| Row 2  | "ccddcc"              | "c"         | "ccdd"  |
-+--------+-----------------------+-------------+---------+
++--------+-----------------------+-------------+--------+
+|        | a                     | b           | Output |
++--------+-----------------------+-------------+--------+
+| Type   | String                | String      | String |
+| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | {""..} |
+| Row 0  | "aabbaa"              | "a"         | "aabb" |
+| Row 1  | "bbccbb"              | "b"         | "bbcc" |
+| Row 2  | "ccddcc"              | "c"         | "ccdd" |
++--------+-----------------------+-------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------+
 | Column | Data                                                                                   |
@@ -976,15 +984,15 @@ ast            : trim_trailing('aba', b)
 raw expr       : trim_trailing("aba", ColumnRef(1)::String)
 checked expr   : trim_trailing<String, String>("aba", ColumnRef(1))
 evaluation:
-+--------+-------------+---------+
-|        | b           | Output  |
-+--------+-------------+---------+
-| Type   | String      | String  |
-| Domain | {"a"..="c"} | Unknown |
-| Row 0  | "a"         | "ab"    |
-| Row 1  | "b"         | "aba"   |
-| Row 2  | "c"         | "aba"   |
-+--------+-------------+---------+
++--------+-------------+--------+
+|        | b           | Output |
++--------+-------------+--------+
+| Type   | String      | String |
+| Domain | {"a"..="c"} | {""..} |
+| Row 0  | "a"         | "ab"   |
+| Row 1  | "b"         | "aba"  |
+| Row 2  | "c"         | "aba"  |
++--------+-------------+--------+
 evaluation (internal):
 +--------+------------------------------------------------------------------+
 | Column | Data                                                             |
@@ -999,7 +1007,7 @@ raw expr       : trim_both("aaabbaaa", "a")
 checked expr   : trim_both<String, String>("aaabbaaa", "a")
 optimized expr : "bb"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "bb"
 
 
@@ -1008,7 +1016,7 @@ raw expr       : trim_both("aaabbaaa", "aa")
 checked expr   : trim_both<String, String>("aaabbaaa", "aa")
 optimized expr : "abba"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "abba"
 
 
@@ -1017,7 +1025,7 @@ raw expr       : trim_both("aaaaaaaa", "a")
 checked expr   : trim_both<String, String>("aaaaaaaa", "a")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -1026,7 +1034,7 @@ raw expr       : trim_both("aaabbaaa", "b")
 checked expr   : trim_both<String, String>("aaabbaaa", "b")
 optimized expr : "aaabbaaa"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "aaabbaaa"
 
 
@@ -1056,7 +1064,7 @@ evaluation:
 |        | a                     | Output   |
 +--------+-----------------------+----------+
 | Type   | String                | String   |
-| Domain | {"aabbaa"..="ccddcc"} | Unknown  |
+| Domain | {"aabbaa"..="ccddcc"} | {""..}   |
 | Row 0  | "aabbaa"              | "bb"     |
 | Row 1  | "bbccbb"              | "bbccbb" |
 | Row 2  | "ccddcc"              | "ccddcc" |
@@ -1074,15 +1082,15 @@ ast            : trim_both(a, b)
 raw expr       : trim_both(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : trim_both<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+-----------------------+-------------+---------+
-|        | a                     | b           | Output  |
-+--------+-----------------------+-------------+---------+
-| Type   | String                | String      | String  |
-| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | Unknown |
-| Row 0  | "aabbaa"              | "a"         | "bb"    |
-| Row 1  | "bbccbb"              | "b"         | "cc"    |
-| Row 2  | "ccddcc"              | "c"         | "dd"    |
-+--------+-----------------------+-------------+---------+
++--------+-----------------------+-------------+--------+
+|        | a                     | b           | Output |
++--------+-----------------------+-------------+--------+
+| Type   | String                | String      | String |
+| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | {""..} |
+| Row 0  | "aabbaa"              | "a"         | "bb"   |
+| Row 1  | "bbccbb"              | "b"         | "cc"   |
+| Row 2  | "ccddcc"              | "c"         | "dd"   |
++--------+-----------------------+-------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------+
 | Column | Data                                                                                   |
@@ -1097,15 +1105,15 @@ ast            : trim_both('aba', b)
 raw expr       : trim_both("aba", ColumnRef(1)::String)
 checked expr   : trim_both<String, String>("aba", ColumnRef(1))
 evaluation:
-+--------+-------------+---------+
-|        | b           | Output  |
-+--------+-------------+---------+
-| Type   | String      | String  |
-| Domain | {"a"..="c"} | Unknown |
-| Row 0  | "a"         | "b"     |
-| Row 1  | "b"         | "aba"   |
-| Row 2  | "c"         | "aba"   |
-+--------+-------------+---------+
++--------+-------------+--------+
+|        | b           | Output |
++--------+-------------+--------+
+| Type   | String      | String |
+| Domain | {"a"..="c"} | {""..} |
+| Row 0  | "a"         | "b"    |
+| Row 1  | "b"         | "aba"  |
+| Row 2  | "c"         | "aba"  |
++--------+-------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------------+
 | Column | Data                                                           |
@@ -1120,7 +1128,7 @@ raw expr       : trim("   abc   ")
 checked expr   : trim<String>("   abc   ")
 optimized expr : "abc"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "abc"
 
 
@@ -1129,7 +1137,7 @@ raw expr       : trim("  ")
 checked expr   : trim<String>("  ")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -1146,16 +1154,16 @@ ast            : trim(a)
 raw expr       : trim(ColumnRef(0)::String)
 checked expr   : trim<String>(ColumnRef(0))
 evaluation:
-+--------+-----------------------+---------+
-|        | a                     | Output  |
-+--------+-----------------------+---------+
-| Type   | String                | String  |
-| Domain | {"   abc"..="abc   "} | Unknown |
-| Row 0  | "abc"                 | "abc"   |
-| Row 1  | "   abc"              | "abc"   |
-| Row 2  | "   abc   "           | "abc"   |
-| Row 3  | "abc   "              | "abc"   |
-+--------+-----------------------+---------+
++--------+-----------------------+--------+
+|        | a                     | Output |
++--------+-----------------------+--------+
+| Type   | String                | String |
+| Domain | {"   abc"..="abc   "} | {""..} |
+| Row 0  | "abc"                 | "abc"  |
+| Row 1  | "   abc"              | "abc"  |
+| Row 2  | "   abc   "           | "abc"  |
+| Row 3  | "abc   "              | "abc"  |
++--------+-----------------------+--------+
 evaluation (internal):
 +--------+-------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                  |
@@ -1170,7 +1178,7 @@ raw expr       : trim_both("aaabbaaa", "a")
 checked expr   : trim_both<String, String>("aaabbaaa", "a")
 optimized expr : "bb"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "bb"
 
 
@@ -1179,7 +1187,7 @@ raw expr       : trim_both("aaabbaaa", "aa")
 checked expr   : trim_both<String, String>("aaabbaaa", "aa")
 optimized expr : "abba"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "abba"
 
 
@@ -1188,7 +1196,7 @@ raw expr       : trim_both("aaaaaaaa", "a")
 checked expr   : trim_both<String, String>("aaaaaaaa", "a")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -1197,7 +1205,7 @@ raw expr       : trim_both("aaabbaaa", "b")
 checked expr   : trim_both<String, String>("aaabbaaa", "b")
 optimized expr : "aaabbaaa"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "aaabbaaa"
 
 
@@ -1227,7 +1235,7 @@ evaluation:
 |        | a                     | Output   |
 +--------+-----------------------+----------+
 | Type   | String                | String   |
-| Domain | {"aabbaa"..="ccddcc"} | Unknown  |
+| Domain | {"aabbaa"..="ccddcc"} | {""..}   |
 | Row 0  | "aabbaa"              | "bb"     |
 | Row 1  | "bbccbb"              | "bbccbb" |
 | Row 2  | "ccddcc"              | "ccddcc" |
@@ -1245,15 +1253,15 @@ ast            : trim(both b from a)
 raw expr       : trim_both(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : trim_both<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+-----------------------+-------------+---------+
-|        | a                     | b           | Output  |
-+--------+-----------------------+-------------+---------+
-| Type   | String                | String      | String  |
-| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | Unknown |
-| Row 0  | "aabbaa"              | "a"         | "bb"    |
-| Row 1  | "bbccbb"              | "b"         | "cc"    |
-| Row 2  | "ccddcc"              | "c"         | "dd"    |
-+--------+-----------------------+-------------+---------+
++--------+-----------------------+-------------+--------+
+|        | a                     | b           | Output |
++--------+-----------------------+-------------+--------+
+| Type   | String                | String      | String |
+| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | {""..} |
+| Row 0  | "aabbaa"              | "a"         | "bb"   |
+| Row 1  | "bbccbb"              | "b"         | "cc"   |
+| Row 2  | "ccddcc"              | "c"         | "dd"   |
++--------+-----------------------+-------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------+
 | Column | Data                                                                                   |
@@ -1268,15 +1276,15 @@ ast            : trim(both a from a)
 raw expr       : trim_both(ColumnRef(0)::String, ColumnRef(0)::String)
 checked expr   : trim_both<String, String>(ColumnRef(0), ColumnRef(0))
 evaluation:
-+--------+-----------------------+---------+
-|        | a                     | Output  |
-+--------+-----------------------+---------+
-| Type   | String                | String  |
-| Domain | {"aabbaa"..="ccddcc"} | Unknown |
-| Row 0  | "aabbaa"              | ""      |
-| Row 1  | "bbccbb"              | ""      |
-| Row 2  | "ccddcc"              | ""      |
-+--------+-----------------------+---------+
++--------+-----------------------+--------+
+|        | a                     | Output |
++--------+-----------------------+--------+
+| Type   | String                | String |
+| Domain | {"aabbaa"..="ccddcc"} | {""..} |
+| Row 0  | "aabbaa"              | ""     |
+| Row 1  | "bbccbb"              | ""     |
+| Row 2  | "ccddcc"              | ""     |
++--------+-----------------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------+
 | Column | Data                                                                                   |
@@ -1290,15 +1298,15 @@ ast            : trim(both b from 'aba')
 raw expr       : trim_both("aba", ColumnRef(1)::String)
 checked expr   : trim_both<String, String>("aba", ColumnRef(1))
 evaluation:
-+--------+-------------+---------+
-|        | b           | Output  |
-+--------+-------------+---------+
-| Type   | String      | String  |
-| Domain | {"a"..="c"} | Unknown |
-| Row 0  | "a"         | "b"     |
-| Row 1  | "b"         | "aba"   |
-| Row 2  | "c"         | "aba"   |
-+--------+-------------+---------+
++--------+-------------+--------+
+|        | b           | Output |
++--------+-------------+--------+
+| Type   | String      | String |
+| Domain | {"a"..="c"} | {""..} |
+| Row 0  | "a"         | "b"    |
+| Row 1  | "b"         | "aba"  |
+| Row 2  | "c"         | "aba"  |
++--------+-------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------------+
 | Column | Data                                                           |
@@ -1313,7 +1321,7 @@ raw expr       : trim_leading("aaabbaaa", "a")
 checked expr   : trim_leading<String, String>("aaabbaaa", "a")
 optimized expr : "bbaaa"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "bbaaa"
 
 
@@ -1322,7 +1330,7 @@ raw expr       : trim_leading("aaabbaaa", "aa")
 checked expr   : trim_leading<String, String>("aaabbaaa", "aa")
 optimized expr : "abbaaa"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "abbaaa"
 
 
@@ -1331,7 +1339,7 @@ raw expr       : trim_leading("aaaaaaaa", "a")
 checked expr   : trim_leading<String, String>("aaaaaaaa", "a")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -1340,7 +1348,7 @@ raw expr       : trim_leading("aaabbaaa", "b")
 checked expr   : trim_leading<String, String>("aaabbaaa", "b")
 optimized expr : "aaabbaaa"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "aaabbaaa"
 
 
@@ -1370,7 +1378,7 @@ evaluation:
 |        | a                     | Output   |
 +--------+-----------------------+----------+
 | Type   | String                | String   |
-| Domain | {"aabbaa"..="ccddcc"} | Unknown  |
+| Domain | {"aabbaa"..="ccddcc"} | {""..}   |
 | Row 0  | "aabbaa"              | "bbaa"   |
 | Row 1  | "bbccbb"              | "bbccbb" |
 | Row 2  | "ccddcc"              | "ccddcc" |
@@ -1388,15 +1396,15 @@ ast            : trim(leading b from a)
 raw expr       : trim_leading(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : trim_leading<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+-----------------------+-------------+---------+
-|        | a                     | b           | Output  |
-+--------+-----------------------+-------------+---------+
-| Type   | String                | String      | String  |
-| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | Unknown |
-| Row 0  | "aabbaa"              | "a"         | "bbaa"  |
-| Row 1  | "bbccbb"              | "b"         | "ccbb"  |
-| Row 2  | "ccddcc"              | "c"         | "ddcc"  |
-+--------+-----------------------+-------------+---------+
++--------+-----------------------+-------------+--------+
+|        | a                     | b           | Output |
++--------+-----------------------+-------------+--------+
+| Type   | String                | String      | String |
+| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | {""..} |
+| Row 0  | "aabbaa"              | "a"         | "bbaa" |
+| Row 1  | "bbccbb"              | "b"         | "ccbb" |
+| Row 2  | "ccddcc"              | "c"         | "ddcc" |
++--------+-----------------------+-------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------+
 | Column | Data                                                                                   |
@@ -1411,15 +1419,15 @@ ast            : trim(leading a from a)
 raw expr       : trim_leading(ColumnRef(0)::String, ColumnRef(0)::String)
 checked expr   : trim_leading<String, String>(ColumnRef(0), ColumnRef(0))
 evaluation:
-+--------+-----------------------+---------+
-|        | a                     | Output  |
-+--------+-----------------------+---------+
-| Type   | String                | String  |
-| Domain | {"aabbaa"..="ccddcc"} | Unknown |
-| Row 0  | "aabbaa"              | ""      |
-| Row 1  | "bbccbb"              | ""      |
-| Row 2  | "ccddcc"              | ""      |
-+--------+-----------------------+---------+
++--------+-----------------------+--------+
+|        | a                     | Output |
++--------+-----------------------+--------+
+| Type   | String                | String |
+| Domain | {"aabbaa"..="ccddcc"} | {""..} |
+| Row 0  | "aabbaa"              | ""     |
+| Row 1  | "bbccbb"              | ""     |
+| Row 2  | "ccddcc"              | ""     |
++--------+-----------------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------+
 | Column | Data                                                                                   |
@@ -1433,15 +1441,15 @@ ast            : trim(leading b from 'aba')
 raw expr       : trim_leading("aba", ColumnRef(1)::String)
 checked expr   : trim_leading<String, String>("aba", ColumnRef(1))
 evaluation:
-+--------+-------------+---------+
-|        | b           | Output  |
-+--------+-------------+---------+
-| Type   | String      | String  |
-| Domain | {"a"..="c"} | Unknown |
-| Row 0  | "a"         | "ba"    |
-| Row 1  | "b"         | "aba"   |
-| Row 2  | "c"         | "aba"   |
-+--------+-------------+---------+
++--------+-------------+--------+
+|        | b           | Output |
++--------+-------------+--------+
+| Type   | String      | String |
+| Domain | {"a"..="c"} | {""..} |
+| Row 0  | "a"         | "ba"   |
+| Row 1  | "b"         | "aba"  |
+| Row 2  | "c"         | "aba"  |
++--------+-------------+--------+
 evaluation (internal):
 +--------+------------------------------------------------------------------+
 | Column | Data                                                             |
@@ -1456,7 +1464,7 @@ raw expr       : trim_trailing("aaabbaaa", "a")
 checked expr   : trim_trailing<String, String>("aaabbaaa", "a")
 optimized expr : "aaabb"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "aaabb"
 
 
@@ -1465,7 +1473,7 @@ raw expr       : trim_trailing("aaabbaaa", "aa")
 checked expr   : trim_trailing<String, String>("aaabbaaa", "aa")
 optimized expr : "aaabba"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "aaabba"
 
 
@@ -1474,7 +1482,7 @@ raw expr       : trim_trailing("aaaaaaaa", "a")
 checked expr   : trim_trailing<String, String>("aaaaaaaa", "a")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -1483,7 +1491,7 @@ raw expr       : trim_trailing("aaabbaaa", "b")
 checked expr   : trim_trailing<String, String>("aaabbaaa", "b")
 optimized expr : "aaabbaaa"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "aaabbaaa"
 
 
@@ -1513,7 +1521,7 @@ evaluation:
 |        | a                     | Output   |
 +--------+-----------------------+----------+
 | Type   | String                | String   |
-| Domain | {"aabbaa"..="ccddcc"} | Unknown  |
+| Domain | {"aabbaa"..="ccddcc"} | {""..}   |
 | Row 0  | "aabbaa"              | "aabb"   |
 | Row 1  | "bbccbb"              | "bbccbb" |
 | Row 2  | "ccddcc"              | "ccddcc" |
@@ -1531,15 +1539,15 @@ ast            : trim(trailing b from a)
 raw expr       : trim_trailing(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : trim_trailing<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+-----------------------+-------------+---------+
-|        | a                     | b           | Output  |
-+--------+-----------------------+-------------+---------+
-| Type   | String                | String      | String  |
-| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | Unknown |
-| Row 0  | "aabbaa"              | "a"         | "aabb"  |
-| Row 1  | "bbccbb"              | "b"         | "bbcc"  |
-| Row 2  | "ccddcc"              | "c"         | "ccdd"  |
-+--------+-----------------------+-------------+---------+
++--------+-----------------------+-------------+--------+
+|        | a                     | b           | Output |
++--------+-----------------------+-------------+--------+
+| Type   | String                | String      | String |
+| Domain | {"aabbaa"..="ccddcc"} | {"a"..="c"} | {""..} |
+| Row 0  | "aabbaa"              | "a"         | "aabb" |
+| Row 1  | "bbccbb"              | "b"         | "bbcc" |
+| Row 2  | "ccddcc"              | "c"         | "ccdd" |
++--------+-----------------------+-------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------+
 | Column | Data                                                                                   |
@@ -1554,15 +1562,15 @@ ast            : trim(trailing a from a)
 raw expr       : trim_trailing(ColumnRef(0)::String, ColumnRef(0)::String)
 checked expr   : trim_trailing<String, String>(ColumnRef(0), ColumnRef(0))
 evaluation:
-+--------+-----------------------+---------+
-|        | a                     | Output  |
-+--------+-----------------------+---------+
-| Type   | String                | String  |
-| Domain | {"aabbaa"..="ccddcc"} | Unknown |
-| Row 0  | "aabbaa"              | ""      |
-| Row 1  | "bbccbb"              | ""      |
-| Row 2  | "ccddcc"              | ""      |
-+--------+-----------------------+---------+
++--------+-----------------------+--------+
+|        | a                     | Output |
++--------+-----------------------+--------+
+| Type   | String                | String |
+| Domain | {"aabbaa"..="ccddcc"} | {""..} |
+| Row 0  | "aabbaa"              | ""     |
+| Row 1  | "bbccbb"              | ""     |
+| Row 2  | "ccddcc"              | ""     |
++--------+-----------------------+--------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------+
 | Column | Data                                                                                   |
@@ -1576,15 +1584,15 @@ ast            : trim(trailing b from 'aba')
 raw expr       : trim_trailing("aba", ColumnRef(1)::String)
 checked expr   : trim_trailing<String, String>("aba", ColumnRef(1))
 evaluation:
-+--------+-------------+---------+
-|        | b           | Output  |
-+--------+-------------+---------+
-| Type   | String      | String  |
-| Domain | {"a"..="c"} | Unknown |
-| Row 0  | "a"         | "ab"    |
-| Row 1  | "b"         | "aba"   |
-| Row 2  | "c"         | "aba"   |
-+--------+-------------+---------+
++--------+-------------+--------+
+|        | b           | Output |
++--------+-------------+--------+
+| Type   | String      | String |
+| Domain | {"a"..="c"} | {""..} |
+| Row 0  | "a"         | "ab"   |
+| Row 1  | "b"         | "aba"  |
+| Row 2  | "c"         | "aba"  |
++--------+-------------+--------+
 evaluation (internal):
 +--------+------------------------------------------------------------------+
 | Column | Data                                                             |
@@ -1608,7 +1616,7 @@ raw expr       : concat(NULL, "3", "4")
 checked expr   : concat<String NULL, String NULL, String NULL>(CAST(NULL AS String NULL), CAST("3" AS String NULL), CAST("4" AS String NULL))
 optimized expr : NULL
 output type    : String NULL
-output domain  : Unknown
+output domain  : {""..} ∪ {NULL}
 output         : NULL
 
 
@@ -1640,16 +1648,16 @@ raw expr       : concat(ColumnRef(0)::String NULL, "3")
 checked expr   : concat<String NULL, String NULL>(ColumnRef(0), CAST("3" AS String NULL))
 optimized expr : concat<String NULL, String NULL>(ColumnRef(0), "3")
 evaluation:
-+--------+----------------------+-------------+
-|        | a                    | Output      |
-+--------+----------------------+-------------+
-| Type   | String NULL          | String NULL |
-| Domain | {"a"..="d"} ∪ {NULL} | Unknown     |
-| Row 0  | "a"                  | "a3"        |
-| Row 1  | "b"                  | "b3"        |
-| Row 2  | NULL                 | NULL        |
-| Row 3  | "d"                  | "d3"        |
-+--------+----------------------+-------------+
++--------+----------------------+-----------------+
+|        | a                    | Output          |
++--------+----------------------+-----------------+
+| Type   | String NULL          | String NULL     |
+| Domain | {"a"..="d"} ∪ {NULL} | {""..} ∪ {NULL} |
+| Row 0  | "a"                  | "a3"            |
+| Row 1  | "b"                  | "b3"            |
+| Row 2  | NULL                 | NULL            |
+| Row 3  | "d"                  | "d3"            |
++--------+----------------------+-----------------+
 evaluation (internal):
 +--------+------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                   |
@@ -1664,7 +1672,7 @@ raw expr       : concat_ws("-", "3", NULL, "4", NULL, "5")
 checked expr   : concat_ws<String NULL, String NULL, String NULL, String NULL, String NULL, String NULL>(CAST("-" AS String NULL), CAST("3" AS String NULL), CAST(NULL AS String NULL), CAST("4" AS String NULL), CAST(NULL AS String NULL), CAST("5" AS String NULL))
 optimized expr : "3-4-5"
 output type    : String NULL
-output domain  : Unknown
+output domain  : {""..} ∪ {NULL}
 output         : "3-4-5"
 
 
@@ -1673,7 +1681,7 @@ raw expr       : concat_ws(NULL, "3", "4")
 checked expr   : concat_ws<String NULL, String NULL, String NULL>(CAST(NULL AS String NULL), CAST("3" AS String NULL), CAST("4" AS String NULL))
 optimized expr : NULL
 output type    : String NULL
-output domain  : Unknown
+output domain  : {""..} ∪ {NULL}
 output         : NULL
 
 
@@ -1705,16 +1713,16 @@ raw expr       : concat_ws(ColumnRef(0)::String NULL, "3")
 checked expr   : concat_ws<String NULL, String NULL>(ColumnRef(0), CAST("3" AS String NULL))
 optimized expr : concat_ws<String NULL, String NULL>(ColumnRef(0), "3")
 evaluation:
-+--------+----------------------+-------------+
-|        | a                    | Output      |
-+--------+----------------------+-------------+
-| Type   | String NULL          | String NULL |
-| Domain | {"a"..="d"} ∪ {NULL} | Unknown     |
-| Row 0  | "a"                  | "3"         |
-| Row 1  | "b"                  | "3"         |
-| Row 2  | NULL                 | NULL        |
-| Row 3  | "d"                  | "3"         |
-+--------+----------------------+-------------+
++--------+----------------------+-----------------+
+|        | a                    | Output          |
++--------+----------------------+-----------------+
+| Type   | String NULL          | String NULL     |
+| Domain | {"a"..="d"} ∪ {NULL} | {""..} ∪ {NULL} |
+| Row 0  | "a"                  | "3"             |
+| Row 1  | "b"                  | "3"             |
+| Row 2  | NULL                 | NULL            |
+| Row 3  | "d"                  | "3"             |
++--------+----------------------+-----------------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                           |
@@ -1729,16 +1737,16 @@ raw expr       : concat_ws(ColumnRef(0)::String NULL, "3", "4")
 checked expr   : concat_ws<String NULL, String NULL, String NULL>(ColumnRef(0), CAST("3" AS String NULL), CAST("4" AS String NULL))
 optimized expr : concat_ws<String NULL, String NULL, String NULL>(ColumnRef(0), "3", "4")
 evaluation:
-+--------+----------------------+-------------+
-|        | a                    | Output      |
-+--------+----------------------+-------------+
-| Type   | String NULL          | String NULL |
-| Domain | {"a"..="d"} ∪ {NULL} | Unknown     |
-| Row 0  | "a"                  | "3a4"       |
-| Row 1  | "b"                  | "3b4"       |
-| Row 2  | NULL                 | NULL        |
-| Row 3  | "d"                  | "3d4"       |
-+--------+----------------------+-------------+
++--------+----------------------+-----------------+
+|        | a                    | Output          |
++--------+----------------------+-----------------+
+| Type   | String NULL          | String NULL     |
+| Domain | {"a"..="d"} ∪ {NULL} | {""..} ∪ {NULL} |
+| Row 0  | "a"                  | "3a4"           |
+| Row 1  | "b"                  | "3b4"           |
+| Row 2  | NULL                 | NULL            |
+| Row 3  | "d"                  | "3d4"           |
++--------+----------------------+-----------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                     |
@@ -1768,7 +1776,7 @@ evaluation:
 |        | a        | Output                                                             |
 +--------+----------+--------------------------------------------------------------------+
 | Type   | Int8     | String                                                             |
-| Domain | {-1..=3} | Unknown                                                            |
+| Domain | {-1..=3} | {""..}                                                             |
 | Row 0  | -1       | "1111111111111111111111111111111111111111111111111111111111111111" |
 | Row 1  | 2        | "10"                                                               |
 | Row 2  | 3        | "11"                                                               |
@@ -1786,15 +1794,15 @@ ast            : bin(a2)
 raw expr       : bin(ColumnRef(1)::UInt8 NULL)
 checked expr   : bin<Int64 NULL>(CAST(ColumnRef(1) AS Int64 NULL))
 evaluation:
-+--------+------------------+-------------+
-|        | a2               | Output      |
-+--------+------------------+-------------+
-| Type   | UInt8 NULL       | String NULL |
-| Domain | {1..=3} ∪ {NULL} | Unknown     |
-| Row 0  | 1                | "1"         |
-| Row 1  | 2                | "10"        |
-| Row 2  | NULL             | NULL        |
-+--------+------------------+-------------+
++--------+------------------+-----------------+
+|        | a2               | Output          |
++--------+------------------+-----------------+
+| Type   | UInt8 NULL       | String NULL     |
+| Domain | {1..=3} ∪ {NULL} | {""..} ∪ {NULL} |
+| Row 0  | 1                | "1"             |
+| Row 1  | 2                | "10"            |
+| Row 2  | NULL             | NULL            |
++--------+------------------+-----------------+
 evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                          |
@@ -1808,15 +1816,15 @@ ast            : bin(b)
 raw expr       : bin(ColumnRef(2)::Int16)
 checked expr   : bin<Int64>(CAST(ColumnRef(2) AS Int64))
 evaluation:
-+--------+---------+---------+
-|        | b       | Output  |
-+--------+---------+---------+
-| Type   | Int16   | String  |
-| Domain | {2..=6} | Unknown |
-| Row 0  | 2       | "10"    |
-| Row 1  | 4       | "100"   |
-| Row 2  | 6       | "110"   |
-+--------+---------+---------+
++--------+---------+--------+
+|        | b       | Output |
++--------+---------+--------+
+| Type   | Int16   | String |
+| Domain | {2..=6} | {""..} |
+| Row 0  | 2       | "10"   |
+| Row 1  | 4       | "100"  |
+| Row 2  | 6       | "110"  |
++--------+---------+--------+
 evaluation (internal):
 +--------+------------------------------------------------------------------+
 | Column | Data                                                             |
@@ -1834,7 +1842,7 @@ evaluation:
 |        | c         | Output  |
 +--------+-----------+---------+
 | Type   | UInt32    | String  |
-| Domain | {10..=30} | Unknown |
+| Domain | {10..=30} | {""..}  |
 | Row 0  | 10        | "1010"  |
 | Row 1  | 20        | "10100" |
 | Row 2  | 30        | "11110" |
@@ -1880,7 +1888,7 @@ evaluation:
 |        | a        | Output                   |
 +--------+----------+--------------------------+
 | Type   | Int8     | String                   |
-| Domain | {-1..=3} | Unknown                  |
+| Domain | {-1..=3} | {""..}                   |
 | Row 0  | -1       | "1777777777777777777777" |
 | Row 1  | 2        | "2"                      |
 | Row 2  | 3        | "3"                      |
@@ -1898,15 +1906,15 @@ ast            : oct(a2)
 raw expr       : oct(ColumnRef(1)::UInt8 NULL)
 checked expr   : oct<Int64 NULL>(CAST(ColumnRef(1) AS Int64 NULL))
 evaluation:
-+--------+------------------+-------------+
-|        | a2               | Output      |
-+--------+------------------+-------------+
-| Type   | UInt8 NULL       | String NULL |
-| Domain | {1..=3} ∪ {NULL} | Unknown     |
-| Row 0  | 1                | "1"         |
-| Row 1  | 2                | "2"         |
-| Row 2  | NULL             | NULL        |
-+--------+------------------+-------------+
++--------+------------------+-----------------+
+|        | a2               | Output          |
++--------+------------------+-----------------+
+| Type   | UInt8 NULL       | String NULL     |
+| Domain | {1..=3} ∪ {NULL} | {""..} ∪ {NULL} |
+| Row 0  | 1                | "1"             |
+| Row 1  | 2                | "2"             |
+| Row 2  | NULL             | NULL            |
++--------+------------------+-----------------+
 evaluation (internal):
 +--------+-----------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                      |
@@ -1920,15 +1928,15 @@ ast            : oct(b)
 raw expr       : oct(ColumnRef(2)::Int16)
 checked expr   : oct<Int64>(CAST(ColumnRef(2) AS Int64))
 evaluation:
-+--------+---------+---------+
-|        | b       | Output  |
-+--------+---------+---------+
-| Type   | Int16   | String  |
-| Domain | {2..=6} | Unknown |
-| Row 0  | 2       | "2"     |
-| Row 1  | 4       | "4"     |
-| Row 2  | 6       | "6"     |
-+--------+---------+---------+
++--------+---------+--------+
+|        | b       | Output |
++--------+---------+--------+
+| Type   | Int16   | String |
+| Domain | {2..=6} | {""..} |
+| Row 0  | 2       | "2"    |
+| Row 1  | 4       | "4"    |
+| Row 2  | 6       | "6"    |
++--------+---------+--------+
 evaluation (internal):
 +--------+--------------------------------------------------------+
 | Column | Data                                                   |
@@ -1942,15 +1950,15 @@ ast            : oct(c)
 raw expr       : oct(ColumnRef(3)::UInt32)
 checked expr   : oct<Int64>(CAST(ColumnRef(3) AS Int64))
 evaluation:
-+--------+-----------+---------+
-|        | c         | Output  |
-+--------+-----------+---------+
-| Type   | UInt32    | String  |
-| Domain | {10..=30} | Unknown |
-| Row 0  | 10        | "12"    |
-| Row 1  | 20        | "24"    |
-| Row 2  | 30        | "36"    |
-+--------+-----------+---------+
++--------+-----------+--------+
+|        | c         | Output |
++--------+-----------+--------+
+| Type   | UInt32    | String |
+| Domain | {10..=30} | {""..} |
+| Row 0  | 10        | "12"   |
+| Row 1  | 20        | "24"   |
+| Row 2  | 30        | "36"   |
++--------+-----------+--------+
 evaluation (internal):
 +--------+--------------------------------------------------------------+
 | Column | Data                                                         |
@@ -1992,7 +2000,7 @@ evaluation:
 |        | a        | Output             |
 +--------+----------+--------------------+
 | Type   | Int8     | String             |
-| Domain | {-1..=3} | Unknown            |
+| Domain | {-1..=3} | {""..}             |
 | Row 0  | -1       | "ffffffffffffffff" |
 | Row 1  | 2        | "2"                |
 | Row 2  | 3        | "3"                |
@@ -2010,15 +2018,15 @@ ast            : hex(a2)
 raw expr       : hex(ColumnRef(1)::UInt8 NULL)
 checked expr   : hex<Int64 NULL>(CAST(ColumnRef(1) AS Int64 NULL))
 evaluation:
-+--------+------------------+-------------+
-|        | a2               | Output      |
-+--------+------------------+-------------+
-| Type   | UInt8 NULL       | String NULL |
-| Domain | {1..=3} ∪ {NULL} | Unknown     |
-| Row 0  | 1                | "1"         |
-| Row 1  | 2                | "2"         |
-| Row 2  | NULL             | NULL        |
-+--------+------------------+-------------+
++--------+------------------+-----------------+
+|        | a2               | Output          |
++--------+------------------+-----------------+
+| Type   | UInt8 NULL       | String NULL     |
+| Domain | {1..=3} ∪ {NULL} | {""..} ∪ {NULL} |
+| Row 0  | 1                | "1"             |
+| Row 1  | 2                | "2"             |
+| Row 2  | NULL             | NULL            |
++--------+------------------+-----------------+
 evaluation (internal):
 +--------+-----------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                      |
@@ -2032,15 +2040,15 @@ ast            : hex(b)
 raw expr       : hex(ColumnRef(2)::Int16)
 checked expr   : hex<Int64>(CAST(ColumnRef(2) AS Int64))
 evaluation:
-+--------+---------+---------+
-|        | b       | Output  |
-+--------+---------+---------+
-| Type   | Int16   | String  |
-| Domain | {2..=6} | Unknown |
-| Row 0  | 2       | "2"     |
-| Row 1  | 4       | "4"     |
-| Row 2  | 6       | "6"     |
-+--------+---------+---------+
++--------+---------+--------+
+|        | b       | Output |
++--------+---------+--------+
+| Type   | Int16   | String |
+| Domain | {2..=6} | {""..} |
+| Row 0  | 2       | "2"    |
+| Row 1  | 4       | "4"    |
+| Row 2  | 6       | "6"    |
++--------+---------+--------+
 evaluation (internal):
 +--------+--------------------------------------------------------+
 | Column | Data                                                   |
@@ -2054,15 +2062,15 @@ ast            : hex(c)
 raw expr       : hex(ColumnRef(3)::UInt32)
 checked expr   : hex<Int64>(CAST(ColumnRef(3) AS Int64))
 evaluation:
-+--------+-----------+---------+
-|        | c         | Output  |
-+--------+-----------+---------+
-| Type   | UInt32    | String  |
-| Domain | {10..=30} | Unknown |
-| Row 0  | 10        | "a"     |
-| Row 1  | 20        | "14"    |
-| Row 2  | 30        | "1e"    |
-+--------+-----------+---------+
++--------+-----------+--------+
+|        | c         | Output |
++--------+-----------+--------+
+| Type   | UInt32    | String |
+| Domain | {10..=30} | {""..} |
+| Row 0  | 10        | "a"    |
+| Row 1  | 20        | "14"   |
+| Row 2  | 30        | "1e"   |
++--------+-----------+--------+
 evaluation (internal):
 +--------+------------------------------------------------------------+
 | Column | Data                                                       |
@@ -2094,7 +2102,7 @@ evaluation:
 |        | e               | Output             |
 +--------+-----------------+--------------------+
 | Type   | String          | String             |
-| Domain | {"abc"..="def"} | Unknown            |
+| Domain | {"abc"..="def"} | {""..}             |
 | Row 0  | "abc"           | "616263"           |
 | Row 1  | "def"           | "646566"           |
 | Row 2  | "databend"      | "6461746162656e64" |
@@ -2166,7 +2174,7 @@ raw expr       : lpad("hi", 2_u8, "?")
 checked expr   : lpad<String, UInt64, String>("hi", CAST(2_u8 AS UInt64), "?")
 optimized expr : "hi"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "hi"
 
 
@@ -2175,7 +2183,7 @@ raw expr       : lpad("hi", 4_u8, "?")
 checked expr   : lpad<String, UInt64, String>("hi", CAST(4_u8 AS UInt64), "?")
 optimized expr : "??hi"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "??hi"
 
 
@@ -2184,7 +2192,7 @@ raw expr       : lpad("hi", 0_u8, "?")
 checked expr   : lpad<String, UInt64, String>("hi", CAST(0_u8 AS UInt64), "?")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -2193,7 +2201,7 @@ raw expr       : lpad("hi", 1_u8, "?")
 checked expr   : lpad<String, UInt64, String>("hi", CAST(1_u8 AS UInt64), "?")
 optimized expr : "h"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "h"
 
 
@@ -2217,7 +2225,7 @@ evaluation:
 |        | a               | b       | c           | Output  |
 +--------+-----------------+---------+-------------+---------+
 | Type   | String          | UInt8   | String      | String  |
-| Domain | {"cc"..="test"} | {0..=5} | {"?"..="x"} | Unknown |
+| Domain | {"cc"..="test"} | {0..=5} | {"?"..="x"} | {""..}  |
 | Row 0  | "hi"            | 0       | "?"         | ""      |
 | Row 1  | "test"          | 3       | "x"         | "tes"   |
 | Row 2  | "cc"            | 5       | "bb"        | "bbbcc" |
@@ -2238,7 +2246,7 @@ raw expr       : rpad("hi", 2_u8, "?")
 checked expr   : rpad<String, UInt64, String>("hi", CAST(2_u8 AS UInt64), "?")
 optimized expr : "hi"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "hi"
 
 
@@ -2247,7 +2255,7 @@ raw expr       : rpad("hi", 4_u8, "?")
 checked expr   : rpad<String, UInt64, String>("hi", CAST(4_u8 AS UInt64), "?")
 optimized expr : "hi??"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "hi??"
 
 
@@ -2256,7 +2264,7 @@ raw expr       : rpad("hi", 0_u8, "?")
 checked expr   : rpad<String, UInt64, String>("hi", CAST(0_u8 AS UInt64), "?")
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -2265,7 +2273,7 @@ raw expr       : rpad("hi", 1_u8, "?")
 checked expr   : rpad<String, UInt64, String>("hi", CAST(1_u8 AS UInt64), "?")
 optimized expr : "h"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "h"
 
 
@@ -2289,7 +2297,7 @@ evaluation:
 |        | a               | b       | c           | Output  |
 +--------+-----------------+---------+-------------+---------+
 | Type   | String          | UInt8   | String      | String  |
-| Domain | {"cc"..="test"} | {0..=5} | {"?"..="x"} | Unknown |
+| Domain | {"cc"..="test"} | {0..=5} | {"?"..="x"} | {""..}  |
 | Row 0  | "hi"            | 0       | "?"         | ""      |
 | Row 1  | "test"          | 3       | "x"         | "tes"   |
 | Row 2  | "cc"            | 5       | "bb"        | "ccbbb" |
@@ -2310,7 +2318,7 @@ raw expr       : replace("hi", "", "?")
 checked expr   : replace<String, String, String>("hi", "", "?")
 optimized expr : "hi"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "hi"
 
 
@@ -2319,7 +2327,7 @@ raw expr       : replace("hi", "", "hi")
 checked expr   : replace<String, String, String>("hi", "", "hi")
 optimized expr : "hi"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "hi"
 
 
@@ -2328,7 +2336,7 @@ raw expr       : replace("hi", "i", "?")
 checked expr   : replace<String, String, String>("hi", "i", "?")
 optimized expr : "h?"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "h?"
 
 
@@ -2337,7 +2345,7 @@ raw expr       : replace("hi", "x", "?")
 checked expr   : replace<String, String, String>("hi", "x", "?")
 optimized expr : "hi"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "hi"
 
 
@@ -2345,16 +2353,16 @@ ast            : replace(a, b, c)
 raw expr       : replace(ColumnRef(0)::String, ColumnRef(1)::String, ColumnRef(2)::String)
 checked expr   : replace<String, String, String>(ColumnRef(0), ColumnRef(1), ColumnRef(2))
 evaluation:
-+--------+-----------------+-------------+-------------+---------+
-|        | a               | b           | c           | Output  |
-+--------+-----------------+-------------+-------------+---------+
-| Type   | String          | String      | String      | String  |
-| Domain | {"cc"..="test"} | {""..="te"} | {"?"..="x"} | Unknown |
-| Row 0  | "hi"            | "i"         | "?"         | "h?"    |
-| Row 1  | "test"          | "te"        | "x"         | "xst"   |
-| Row 2  | "cc"            | "cc"        | "bb"        | "bb"    |
-| Row 3  | "q"             | ""          | "q"         | "q"     |
-+--------+-----------------+-------------+-------------+---------+
++--------+-----------------+-------------+-------------+--------+
+|        | a               | b           | c           | Output |
++--------+-----------------+-------------+-------------+--------+
+| Type   | String          | String      | String      | String |
+| Domain | {"cc"..="test"} | {""..="te"} | {"?"..="x"} | {""..} |
+| Row 0  | "hi"            | "i"         | "?"         | "h?"   |
+| Row 1  | "test"          | "te"        | "x"         | "xst"  |
+| Row 2  | "cc"            | "cc"        | "bb"        | "bb"   |
+| Row 3  | "q"             | ""          | "q"         | "q"    |
++--------+-----------------+-------------+-------------+--------+
 evaluation (internal):
 +--------+-----------------------------------------------------------------------+
 | Column | Data                                                                  |
@@ -2371,7 +2379,7 @@ raw expr       : strcmp("text", "text2")
 checked expr   : strcmp<String, String>("text", "text2")
 optimized expr : -1_i8
 output type    : Int8
-output domain  : Unknown
+output domain  : {-128..=127}
 output         : -1
 
 
@@ -2380,7 +2388,7 @@ raw expr       : strcmp("text2", "text")
 checked expr   : strcmp<String, String>("text2", "text")
 optimized expr : 1_i8
 output type    : Int8
-output domain  : Unknown
+output domain  : {-128..=127}
 output         : 1
 
 
@@ -2389,7 +2397,7 @@ raw expr       : strcmp("hii", "hii")
 checked expr   : strcmp<String, String>("hii", "hii")
 optimized expr : 0_i8
 output type    : Int8
-output domain  : Unknown
+output domain  : {-128..=127}
 output         : 0
 
 
@@ -2397,15 +2405,15 @@ ast            : strcmp(a, b)
 raw expr       : strcmp(ColumnRef(0)::String, ColumnRef(1)::String)
 checked expr   : strcmp<String, String>(ColumnRef(0), ColumnRef(1))
 evaluation:
-+--------+-----------------+------------------+---------+
-|        | a               | b                | Output  |
-+--------+-----------------+------------------+---------+
-| Type   | String          | String           | Int8    |
-| Domain | {"cc"..="test"} | {"ccb"..="test"} | Unknown |
-| Row 0  | "hi"            | "i"              | 1       |
-| Row 1  | "test"          | "test"           | 0       |
-| Row 2  | "cc"            | "ccb"            | -1      |
-+--------+-----------------+------------------+---------+
++--------+-----------------+------------------+--------------+
+|        | a               | b                | Output       |
++--------+-----------------+------------------+--------------+
+| Type   | String          | String           | Int8         |
+| Domain | {"cc"..="test"} | {"ccb"..="test"} | {-128..=127} |
+| Row 0  | "hi"            | "i"              | 1            |
+| Row 1  | "test"          | "test"           | 0            |
+| Row 2  | "cc"            | "ccb"            | -1           |
++--------+-----------------+------------------+--------------+
 evaluation (internal):
 +--------+------------------------------------------------------------------+
 | Column | Data                                                             |
@@ -2421,7 +2429,7 @@ raw expr       : locate("bar", "foobarbar")
 checked expr   : locate<String, String>("bar", "foobarbar")
 optimized expr : 4_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 4
 
 
@@ -2430,7 +2438,7 @@ raw expr       : instr("foobarbar", "bar")
 checked expr   : instr<String, String>("foobarbar", "bar")
 optimized expr : 4_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 4
 
 
@@ -2439,7 +2447,7 @@ raw expr       : position("bar", "foobarbar")
 checked expr   : position<String, String>("bar", "foobarbar")
 optimized expr : 4_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 4
 
 
@@ -2448,7 +2456,7 @@ raw expr       : position("foobarbar", "bar")
 checked expr   : position<String, String>("foobarbar", "bar")
 optimized expr : 0_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 0
 
 
@@ -2457,7 +2465,7 @@ raw expr       : locate("bar", "foobarbar", 5_u8)
 checked expr   : locate<String, String, UInt64>("bar", "foobarbar", CAST(5_u8 AS UInt64))
 optimized expr : 7_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 7
 
 
@@ -2465,16 +2473,16 @@ ast            : locate(a, b, c)
 raw expr       : locate(ColumnRef(0)::String, ColumnRef(1)::String, ColumnRef(2)::UInt8)
 checked expr   : locate<String, String, UInt64>(ColumnRef(0), ColumnRef(1), CAST(ColumnRef(2) AS UInt64))
 evaluation:
-+--------+---------------+---------------+---------+---------+
-|        | a             | b             | c       | Output  |
-+--------+---------------+---------------+---------+---------+
-| Type   | String        | String        | UInt8   | UInt64  |
-| Domain | {"bar"..="q"} | {"56"..="xx"} | {0..=2} | Unknown |
-| Row 0  | "bar"         | "foobarbar"   | 1       | 4       |
-| Row 1  | "cc"          | "bdccacc"     | 2       | 3       |
-| Row 2  | "cc"          | "xx"          | 0       | 0       |
-| Row 3  | "q"           | "56"          | 1       | 0       |
-+--------+---------------+---------------+---------+---------+
++--------+---------------+---------------+---------+----------------------------+
+|        | a             | b             | c       | Output                     |
++--------+---------------+---------------+---------+----------------------------+
+| Type   | String        | String        | UInt8   | UInt64                     |
+| Domain | {"bar"..="q"} | {"56"..="xx"} | {0..=2} | {0..=18446744073709551615} |
+| Row 0  | "bar"         | "foobarbar"   | 1       | 4                          |
+| Row 1  | "cc"          | "bdccacc"     | 2       | 3                          |
+| Row 2  | "cc"          | "xx"          | 0       | 0                          |
+| Row 3  | "q"           | "56"          | 1       | 0                          |
++--------+---------------+---------------+---------+----------------------------+
 evaluation (internal):
 +--------+------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                           |
@@ -2490,13 +2498,13 @@ ast            : char(65,66,67)
 raw expr       : char(65_u8, 66_u8, 67_u8)
 checked expr   : char<UInt8, UInt8, UInt8>(65_u8, 66_u8, 67_u8)
 evaluation:
-+--------+---------+
-|        | Output  |
-+--------+---------+
-| Type   | String  |
-| Domain | Unknown |
-| Row 0  | "ABC"   |
-+--------+---------+
++--------+--------+
+|        | Output |
++--------+--------+
+| Type   | String |
+| Domain | {""..} |
+| Row 0  | "ABC"  |
++--------+--------+
 evaluation (internal):
 +--------+--------------------------------------------------+
 | Column | Data                                             |
@@ -2518,14 +2526,14 @@ ast            : char(a, b, c)
 raw expr       : char(ColumnRef(0)::UInt8, ColumnRef(1)::UInt8, ColumnRef(2)::UInt8)
 checked expr   : char<UInt8, UInt8, UInt8>(ColumnRef(0), ColumnRef(1), ColumnRef(2))
 evaluation:
-+--------+-----------+-----------+-----------+---------+
-|        | a         | b         | c         | Output  |
-+--------+-----------+-----------+-----------+---------+
-| Type   | UInt8     | UInt8     | UInt8     | String  |
-| Domain | {66..=67} | {98..=99} | {68..=69} | Unknown |
-| Row 0  | 66        | 98        | 68        | "BbD"   |
-| Row 1  | 67        | 99        | 69        | "CcE"   |
-+--------+-----------+-----------+-----------+---------+
++--------+-----------+-----------+-----------+--------+
+|        | a         | b         | c         | Output |
++--------+-----------+-----------+-----------+--------+
+| Type   | UInt8     | UInt8     | UInt8     | String |
+| Domain | {66..=67} | {98..=99} | {68..=69} | {""..} |
+| Row 0  | 66        | 98        | 68        | "BbD"  |
+| Row 1  | 67        | 99        | 69        | "CcE"  |
++--------+-----------+-----------+-----------+--------+
 evaluation (internal):
 +--------+-----------------------------------------------------------+
 | Column | Data                                                      |
@@ -2577,7 +2585,7 @@ raw expr       : soundex("你好中国北京")
 checked expr   : soundex<String>("你好中国北京")
 optimized expr : "你000"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "你000"
 
 
@@ -2586,7 +2594,7 @@ raw expr       : soundex("")
 checked expr   : soundex<String>("")
 optimized expr : "0000"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "0000"
 
 
@@ -2595,7 +2603,7 @@ raw expr       : soundex("hello all folks")
 checked expr   : soundex<String>("hello all folks")
 optimized expr : "H4142"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "H4142"
 
 
@@ -2604,7 +2612,7 @@ raw expr       : soundex("#3556 in bugdb")
 checked expr   : soundex<String>("#3556 in bugdb")
 optimized expr : "I51231"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "I51231"
 
 
@@ -2616,7 +2624,7 @@ evaluation:
 |        | a                                  | Output  |
 +--------+------------------------------------+---------+
 | Type   | String                             | String  |
-| Domain | {"#🐑🐑he🐑llo🐑"..="🐑he🐑llo🐑"} | Unknown |
+| Domain | {"#🐑🐑he🐑llo🐑"..="🐑he🐑llo🐑"} | {""..}  |
 | Row 0  | "#🐑🐑he🐑llo🐑"                   | "🐑400" |
 | Row 1  | "🐑he🐑llo🐑"                      | "🐑400" |
 | Row 2  | "teacher"                          | "T260"  |
@@ -2645,7 +2653,7 @@ raw expr       : ord("и")
 checked expr   : ord<String>("и")
 optimized expr : 53432_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 53432
 
 
@@ -2654,7 +2662,7 @@ raw expr       : ord("早ab")
 checked expr   : ord<String>("早ab")
 optimized expr : 15112105_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 15112105
 
 
@@ -2663,7 +2671,7 @@ raw expr       : ord("💖")
 checked expr   : ord<String>("💖")
 optimized expr : 4036989590_u64
 output type    : UInt64
-output domain  : Unknown
+output domain  : {0..=18446744073709551615}
 output         : 4036989590
 
 
@@ -2737,7 +2745,7 @@ raw expr       : insert("Quadratic", 3_u8, 4_u8, "What")
 checked expr   : insert<String, Int64, Int64, String>("Quadratic", CAST(3_u8 AS Int64), CAST(4_u8 AS Int64), "What")
 optimized expr : "QuWhattic"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "QuWhattic"
 
 
@@ -2746,7 +2754,7 @@ raw expr       : insert("Quadratic", minus(1_u8), 4_u8, "What")
 checked expr   : insert<String, Int64, Int64, String>("Quadratic", CAST(minus<UInt8>(1_u8) AS Int64), CAST(4_u8 AS Int64), "What")
 optimized expr : "Quadratic"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "Quadratic"
 
 
@@ -2755,7 +2763,7 @@ raw expr       : insert("Quadratic", 3_u8, 100_u8, "What")
 checked expr   : insert<String, Int64, Int64, String>("Quadratic", CAST(3_u8 AS Int64), CAST(100_u8 AS Int64), "What")
 optimized expr : "QuWhat"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "QuWhat"
 
 
@@ -2803,7 +2811,7 @@ evaluation:
 |        | a               | b       | c       | d             | Output  |
 +--------+-----------------+---------+---------+---------------+---------+
 | Type   | String          | UInt8   | UInt8   | String        | String  |
-| Domain | {"cc"..="test"} | {1..=4} | {1..=5} | {"12"..="zc"} | Unknown |
+| Domain | {"cc"..="test"} | {1..=4} | {1..=5} | {"12"..="zc"} | {""..}  |
 | Row 0  | "hi"            | 1       | 3       | "xx"          | "xx"    |
 | Row 1  | "test"          | 4       | 5       | "zc"          | "teszc" |
 | Row 2  | "cc"            | 1       | 1       | "12"          | "12c"   |
@@ -2825,16 +2833,16 @@ ast            : insert(x, y, z, u)
 raw expr       : insert(ColumnRef(0)::String NULL, ColumnRef(1)::UInt8 NULL, ColumnRef(2)::UInt8 NULL, ColumnRef(3)::String NULL)
 checked expr   : insert<String NULL, Int64 NULL, Int64 NULL, String NULL>(ColumnRef(0), CAST(ColumnRef(1) AS Int64 NULL), CAST(ColumnRef(2) AS Int64 NULL), ColumnRef(3))
 evaluation:
-+--------+--------------------------+------------------+------------------+------------------------+-------------+
-|        | x                        | y                | z                | u                      | Output      |
-+--------+--------------------------+------------------+------------------+------------------------+-------------+
-| Type   | String NULL              | UInt8 NULL       | UInt8 NULL       | String NULL            | String NULL |
-| Domain | {"cc"..="test"} ∪ {NULL} | {1..=4} ∪ {NULL} | {1..=5} ∪ {NULL} | {"12"..="zc"} ∪ {NULL} | Unknown     |
-| Row 0  | NULL                     | 1                | 3                | NULL                   | NULL        |
-| Row 1  | "test"                   | 4                | NULL             | "zc"                   | NULL        |
-| Row 2  | "cc"                     | NULL             | 1                | "12"                   | NULL        |
-| Row 3  | "q"                      | 1                | 1                | "56"                   | "56"        |
-+--------+--------------------------+------------------+------------------+------------------------+-------------+
++--------+--------------------------+------------------+------------------+------------------------+-----------------+
+|        | x                        | y                | z                | u                      | Output          |
++--------+--------------------------+------------------+------------------+------------------------+-----------------+
+| Type   | String NULL              | UInt8 NULL       | UInt8 NULL       | String NULL            | String NULL     |
+| Domain | {"cc"..="test"} ∪ {NULL} | {1..=4} ∪ {NULL} | {1..=5} ∪ {NULL} | {"12"..="zc"} ∪ {NULL} | {""..} ∪ {NULL} |
+| Row 0  | NULL                     | 1                | 3                | NULL                   | NULL            |
+| Row 1  | "test"                   | 4                | NULL             | "zc"                   | NULL            |
+| Row 2  | "cc"                     | NULL             | 1                | "12"                   | NULL            |
+| Row 3  | "q"                      | 1                | 1                | "56"                   | "56"            |
++--------+--------------------------+------------------+------------------+------------------------+-----------------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                             |
@@ -2899,7 +2907,7 @@ raw expr       : left("", 0_u8)
 checked expr   : left<String, UInt64>("", CAST(0_u8 AS UInt64))
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -2908,7 +2916,7 @@ raw expr       : left("", 1_u8)
 checked expr   : left<String, UInt64>("", CAST(1_u8 AS UInt64))
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -2920,7 +2928,7 @@ evaluation:
 |        | a        | Output      |
 +--------+----------+-------------+
 | Type   | UInt8    | String      |
-| Domain | {0..=10} | Unknown     |
+| Domain | {0..=10} | {""..}      |
 | Row 0  | 0        | ""          |
 | Row 1  | 1        | "1"         |
 | Row 2  | 2        | "12"        |
@@ -2947,7 +2955,7 @@ raw expr       : right("", 0_u8)
 checked expr   : right<String, UInt64>("", CAST(0_u8 AS UInt64))
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -2956,7 +2964,7 @@ raw expr       : right("", 1_u8)
 checked expr   : right<String, UInt64>("", CAST(1_u8 AS UInt64))
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -2968,7 +2976,7 @@ evaluation:
 |        | a        | Output      |
 +--------+----------+-------------+
 | Type   | UInt8    | String      |
-| Domain | {0..=10} | Unknown     |
+| Domain | {0..=10} | {""..}      |
 | Row 0  | 0        | ""          |
 | Row 1  | 1        | "9"         |
 | Row 2  | 2        | "89"        |
@@ -2995,7 +3003,7 @@ raw expr       : mid("1234567890", minus(3_u8), 3_u8)
 checked expr   : substr<String, Int64, UInt64>("1234567890", CAST(minus<UInt8>(3_u8) AS Int64), CAST(3_u8 AS UInt64))
 optimized expr : "890"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "890"
 
 
@@ -3004,7 +3012,7 @@ raw expr       : mid("1234567890", minus(3_u8))
 checked expr   : substr<String, Int64>("1234567890", CAST(minus<UInt8>(3_u8) AS Int64))
 optimized expr : "890"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "890"
 
 
@@ -3013,7 +3021,7 @@ raw expr       : substr("", 0_u8, 1_u8)
 checked expr   : substr<String, Int64, UInt64>("", CAST(0_u8 AS Int64), CAST(1_u8 AS UInt64))
 optimized expr : ""
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : ""
 
 
@@ -3022,7 +3030,7 @@ raw expr       : substr("Sakila", minus(4_u8), 2_u8)
 checked expr   : substr<String, Int64, UInt64>("Sakila", CAST(minus<UInt8>(4_u8) AS Int64), CAST(2_u8 AS UInt64))
 optimized expr : "ki"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "ki"
 
 
@@ -3031,7 +3039,7 @@ raw expr       : substr("sakila", minus(4_u8))
 checked expr   : substr<String, Int64>("sakila", CAST(minus<UInt8>(4_u8) AS Int64))
 optimized expr : "kila"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "kila"
 
 
@@ -3040,7 +3048,7 @@ raw expr       : substr("abc", 2_u8)
 checked expr   : substr<String, Int64>("abc", CAST(2_u8 AS Int64))
 optimized expr : "bc"
 output type    : String
-output domain  : Unknown
+output domain  : {""..}
 output         : "bc"
 
 
@@ -3048,57 +3056,57 @@ ast            : substr('abc', pos, len)
 raw expr       : substr("abc", ColumnRef(0)::Int8, ColumnRef(1)::UInt8)
 checked expr   : substr<String, Int64, UInt64>("abc", CAST(ColumnRef(0) AS Int64), CAST(ColumnRef(1) AS UInt64))
 evaluation:
-+--------+----------+---------+---------+
-|        | pos      | len     | Output  |
-+--------+----------+---------+---------+
-| Type   | Int8     | UInt8   | String  |
-| Domain | {-4..=4} | {0..=4} | Unknown |
-| Row 0  | 0        | 0       | ""      |
-| Row 1  | 0        | 1       | ""      |
-| Row 2  | 0        | 2       | ""      |
-| Row 3  | 0        | 3       | ""      |
-| Row 4  | 0        | 4       | ""      |
-| Row 5  | 1        | 0       | ""      |
-| Row 6  | 1        | 1       | "a"     |
-| Row 7  | 1        | 2       | "ab"    |
-| Row 8  | 1        | 3       | "abc"   |
-| Row 9  | 1        | 4       | "abc"   |
-| Row 10 | 2        | 0       | ""      |
-| Row 11 | 2        | 1       | "b"     |
-| Row 12 | 2        | 2       | "bc"    |
-| Row 13 | 2        | 3       | "bc"    |
-| Row 14 | 2        | 4       | "bc"    |
-| Row 15 | 3        | 0       | ""      |
-| Row 16 | 3        | 1       | "c"     |
-| Row 17 | 3        | 2       | "c"     |
-| Row 18 | 3        | 3       | "c"     |
-| Row 19 | 3        | 4       | "c"     |
-| Row 20 | 4        | 0       | ""      |
-| Row 21 | 4        | 1       | ""      |
-| Row 22 | 4        | 2       | ""      |
-| Row 23 | 4        | 3       | ""      |
-| Row 24 | 4        | 4       | ""      |
-| Row 25 | -1       | 0       | ""      |
-| Row 26 | -1       | 1       | "c"     |
-| Row 27 | -1       | 2       | "c"     |
-| Row 28 | -1       | 3       | "c"     |
-| Row 29 | -1       | 4       | "c"     |
-| Row 30 | -2       | 0       | ""      |
-| Row 31 | -2       | 1       | "b"     |
-| Row 32 | -2       | 2       | "bc"    |
-| Row 33 | -2       | 3       | "bc"    |
-| Row 34 | -2       | 4       | "bc"    |
-| Row 35 | -3       | 0       | ""      |
-| Row 36 | -3       | 1       | "a"     |
-| Row 37 | -3       | 2       | "ab"    |
-| Row 38 | -3       | 3       | "abc"   |
-| Row 39 | -3       | 4       | "abc"   |
-| Row 40 | -4       | 0       | ""      |
-| Row 41 | -4       | 1       | ""      |
-| Row 42 | -4       | 2       | ""      |
-| Row 43 | -4       | 3       | ""      |
-| Row 44 | -4       | 4       | ""      |
-+--------+----------+---------+---------+
++--------+----------+---------+--------+
+|        | pos      | len     | Output |
++--------+----------+---------+--------+
+| Type   | Int8     | UInt8   | String |
+| Domain | {-4..=4} | {0..=4} | {""..} |
+| Row 0  | 0        | 0       | ""     |
+| Row 1  | 0        | 1       | ""     |
+| Row 2  | 0        | 2       | ""     |
+| Row 3  | 0        | 3       | ""     |
+| Row 4  | 0        | 4       | ""     |
+| Row 5  | 1        | 0       | ""     |
+| Row 6  | 1        | 1       | "a"    |
+| Row 7  | 1        | 2       | "ab"   |
+| Row 8  | 1        | 3       | "abc"  |
+| Row 9  | 1        | 4       | "abc"  |
+| Row 10 | 2        | 0       | ""     |
+| Row 11 | 2        | 1       | "b"    |
+| Row 12 | 2        | 2       | "bc"   |
+| Row 13 | 2        | 3       | "bc"   |
+| Row 14 | 2        | 4       | "bc"   |
+| Row 15 | 3        | 0       | ""     |
+| Row 16 | 3        | 1       | "c"    |
+| Row 17 | 3        | 2       | "c"    |
+| Row 18 | 3        | 3       | "c"    |
+| Row 19 | 3        | 4       | "c"    |
+| Row 20 | 4        | 0       | ""     |
+| Row 21 | 4        | 1       | ""     |
+| Row 22 | 4        | 2       | ""     |
+| Row 23 | 4        | 3       | ""     |
+| Row 24 | 4        | 4       | ""     |
+| Row 25 | -1       | 0       | ""     |
+| Row 26 | -1       | 1       | "c"    |
+| Row 27 | -1       | 2       | "c"    |
+| Row 28 | -1       | 3       | "c"    |
+| Row 29 | -1       | 4       | "c"    |
+| Row 30 | -2       | 0       | ""     |
+| Row 31 | -2       | 1       | "b"    |
+| Row 32 | -2       | 2       | "bc"   |
+| Row 33 | -2       | 3       | "bc"   |
+| Row 34 | -2       | 4       | "bc"   |
+| Row 35 | -3       | 0       | ""     |
+| Row 36 | -3       | 1       | "a"    |
+| Row 37 | -3       | 2       | "ab"   |
+| Row 38 | -3       | 3       | "abc"  |
+| Row 39 | -3       | 4       | "abc"  |
+| Row 40 | -4       | 0       | ""     |
+| Row 41 | -4       | 1       | ""     |
+| Row 42 | -4       | 2       | ""     |
+| Row 43 | -4       | 3       | ""     |
+| Row 44 | -4       | 4       | ""     |
++--------+----------+---------+--------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                                                                                                                                                             |

--- a/src/query/functions-v2/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions-v2/tests/it/scalars/testdata/variant.txt
@@ -153,7 +153,7 @@ raw expr       : try_parse_json("nuLL")
 checked expr   : try_parse_json<String>("nuLL")
 optimized expr : NULL
 output type    : Variant NULL
-output domain  : Unknown
+output domain  : Undefined ∪ {NULL}
 output         : NULL
 
 
@@ -162,7 +162,7 @@ raw expr       : try_parse_json("null")
 checked expr   : try_parse_json<String>("null")
 optimized expr : 0x2000000000000000
 output type    : Variant NULL
-output domain  : Unknown
+output domain  : Undefined ∪ {NULL}
 output         : null
 
 
@@ -171,7 +171,7 @@ raw expr       : try_parse_json("true")
 checked expr   : try_parse_json<String>("true")
 optimized expr : 0x2000000040000000
 output type    : Variant NULL
-output domain  : Unknown
+output domain  : Undefined ∪ {NULL}
 output         : true
 
 
@@ -180,7 +180,7 @@ raw expr       : try_parse_json("false")
 checked expr   : try_parse_json<String>("false")
 optimized expr : 0x2000000030000000
 output type    : Variant NULL
-output domain  : Unknown
+output domain  : Undefined ∪ {NULL}
 output         : false
 
 
@@ -189,7 +189,7 @@ raw expr       : try_parse_json("\"测试\"")
 checked expr   : try_parse_json<String>("\"测试\"")
 optimized expr : 0x2000000010000006e6b58be8af95
 output type    : Variant NULL
-output domain  : Unknown
+output domain  : Undefined ∪ {NULL}
 output         : "测试"
 
 
@@ -198,7 +198,7 @@ raw expr       : try_parse_json("1234")
 checked expr   : try_parse_json<String>("1234")
 optimized expr : 0x20000000200000035004d2
 output type    : Variant NULL
-output domain  : Unknown
+output domain  : Undefined ∪ {NULL}
 output         : 1234
 
 
@@ -207,7 +207,7 @@ raw expr       : try_parse_json("[1,2,3,4]")
 checked expr   : try_parse_json<String>("[1,2,3,4]")
 optimized expr : 0x80000004200000022000000220000002200000025001500250035004
 output type    : Variant NULL
-output domain  : Unknown
+output domain  : Undefined ∪ {NULL}
 output         : [1,2,3,4]
 
 
@@ -216,7 +216,7 @@ raw expr       : try_parse_json("{\"a\":\"b\",\"c\":\"d\"}")
 checked expr   : try_parse_json<String>("{\"a\":\"b\",\"c\":\"d\"}")
 optimized expr : 0x400000021000000110000001100000011000000161636264
 output type    : Variant NULL
-output domain  : Unknown
+output domain  : Undefined ∪ {NULL}
 output         : {"a":"b","c":"d"}
 
 
@@ -228,7 +228,7 @@ evaluation:
 |        | s                                                         | Output                |
 +--------+-----------------------------------------------------------+-----------------------+
 | Type   | String                                                    | Variant NULL          |
-| Domain | {"\"\\\\\\\"abc\\\\\\\"\""..="{\"k\":\"v\",\"a\":\"b\"}"} | Unknown               |
+| Domain | {"\"\\\\\\\"abc\\\\\\\"\""..="{\"k\":\"v\",\"a\":\"b\"}"} | Undefined ∪ {NULL}    |
 | Row 0  | "null"                                                    | null                  |
 | Row 1  | "true"                                                    | true                  |
 | Row 2  | "9223372036854775807"                                     | 9223372036854775807   |
@@ -253,16 +253,16 @@ ast            : try_parse_json(s)
 raw expr       : try_parse_json(ColumnRef(0)::String NULL)
 checked expr   : try_parse_json<String NULL>(ColumnRef(0))
 evaluation:
-+--------+-----------------------+--------------+
-|        | s                     | Output       |
-+--------+-----------------------+--------------+
-| Type   | String NULL           | Variant NULL |
-| Domain | {""..="ttt"} ∪ {NULL} | Unknown      |
-| Row 0  | "true"                | true         |
-| Row 1  | "ttt"                 | NULL         |
-| Row 2  | NULL                  | NULL         |
-| Row 3  | "1234"                | 1234         |
-+--------+-----------------------+--------------+
++--------+-----------------------+--------------------+
+|        | s                     | Output             |
++--------+-----------------------+--------------------+
+| Type   | String NULL           | Variant NULL       |
+| Domain | {""..="ttt"} ∪ {NULL} | Undefined ∪ {NULL} |
+| Row 0  | "true"                | true               |
+| Row 1  | "ttt"                 | NULL               |
+| Row 2  | NULL                  | NULL               |
+| Row 3  | "1234"                | 1234               |
++--------+-----------------------+--------------------+
 evaluation (internal):
 +--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                           |
@@ -1085,18 +1085,18 @@ ast            : as_boolean(try_parse_json(s))
 raw expr       : as_boolean(try_parse_json(ColumnRef(0)::String))
 checked expr   : as_boolean<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
 evaluation:
-+--------+------------------------------+--------------+
-|        | s                            | Output       |
-+--------+------------------------------+--------------+
-| Type   | String                       | Boolean NULL |
-| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
-| Row 0  | "true"                       | true         |
-| Row 1  | "123"                        | NULL         |
-| Row 2  | "12.34"                      | NULL         |
-| Row 3  | "\"ab\""                     | NULL         |
-| Row 4  | "[1,2,3]"                    | NULL         |
-| Row 5  | "{\"a\":\"b\"}"              | NULL         |
-+--------+------------------------------+--------------+
++--------+------------------------------+------------------------+
+|        | s                            | Output                 |
++--------+------------------------------+------------------------+
+| Type   | String                       | Boolean NULL           |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | "true"                       | true                   |
+| Row 1  | "123"                        | NULL                   |
+| Row 2  | "12.34"                      | NULL                   |
+| Row 3  | "\"ab\""                     | NULL                   |
+| Row 4  | "[1,2,3]"                    | NULL                   |
+| Row 5  | "{\"a\":\"b\"}"              | NULL                   |
++--------+------------------------------+------------------------+
 evaluation (internal):
 +--------+-------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                          |
@@ -1135,18 +1135,18 @@ ast            : as_integer(try_parse_json(s))
 raw expr       : as_integer(try_parse_json(ColumnRef(0)::String))
 checked expr   : as_integer<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
 evaluation:
-+--------+------------------------------+------------+
-|        | s                            | Output     |
-+--------+------------------------------+------------+
-| Type   | String                       | Int64 NULL |
-| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown    |
-| Row 0  | "true"                       | NULL       |
-| Row 1  | "123"                        | 123        |
-| Row 2  | "12.34"                      | NULL       |
-| Row 3  | "\"ab\""                     | NULL       |
-| Row 4  | "[1,2,3]"                    | NULL       |
-| Row 5  | "{\"a\":\"b\"}"              | NULL       |
-+--------+------------------------------+------------+
++--------+------------------------------+-------------------------------------------------------+
+|        | s                            | Output                                                |
++--------+------------------------------+-------------------------------------------------------+
+| Type   | String                       | Int64 NULL                                            |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | {-9223372036854775808..=9223372036854775807} ∪ {NULL} |
+| Row 0  | "true"                       | NULL                                                  |
+| Row 1  | "123"                        | 123                                                   |
+| Row 2  | "12.34"                      | NULL                                                  |
+| Row 3  | "\"ab\""                     | NULL                                                  |
+| Row 4  | "[1,2,3]"                    | NULL                                                  |
+| Row 5  | "{\"a\":\"b\"}"              | NULL                                                  |
++--------+------------------------------+-------------------------------------------------------+
 evaluation (internal):
 +--------+-------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                          |
@@ -1185,18 +1185,18 @@ ast            : as_float(try_parse_json(s))
 raw expr       : as_float(try_parse_json(ColumnRef(0)::String))
 checked expr   : as_float<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
 evaluation:
-+--------+------------------------------+--------------+
-|        | s                            | Output       |
-+--------+------------------------------+--------------+
-| Type   | String                       | Float64 NULL |
-| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
-| Row 0  | "true"                       | NULL         |
-| Row 1  | "123"                        | 123          |
-| Row 2  | "12.34"                      | 12.34        |
-| Row 3  | "\"ab\""                     | NULL         |
-| Row 4  | "[1,2,3]"                    | NULL         |
-| Row 5  | "{\"a\":\"b\"}"              | NULL         |
-+--------+------------------------------+--------------+
++--------+------------------------------+-----------------------+
+|        | s                            | Output                |
++--------+------------------------------+-----------------------+
+| Type   | String                       | Float64 NULL          |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | {-inf..=NaN} ∪ {NULL} |
+| Row 0  | "true"                       | NULL                  |
+| Row 1  | "123"                        | 123                   |
+| Row 2  | "12.34"                      | 12.34                 |
+| Row 3  | "\"ab\""                     | NULL                  |
+| Row 4  | "[1,2,3]"                    | NULL                  |
+| Row 5  | "{\"a\":\"b\"}"              | NULL                  |
++--------+------------------------------+-----------------------+
 evaluation (internal):
 +--------+-------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                          |
@@ -1235,18 +1235,18 @@ ast            : as_string(try_parse_json(s))
 raw expr       : as_string(try_parse_json(ColumnRef(0)::String))
 checked expr   : as_string<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
 evaluation:
-+--------+------------------------------+-------------+
-|        | s                            | Output      |
-+--------+------------------------------+-------------+
-| Type   | String                       | String NULL |
-| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown     |
-| Row 0  | "true"                       | NULL        |
-| Row 1  | "123"                        | NULL        |
-| Row 2  | "12.34"                      | NULL        |
-| Row 3  | "\"ab\""                     | "ab"        |
-| Row 4  | "[1,2,3]"                    | NULL        |
-| Row 5  | "{\"a\":\"b\"}"              | NULL        |
-+--------+------------------------------+-------------+
++--------+------------------------------+-----------------+
+|        | s                            | Output          |
++--------+------------------------------+-----------------+
+| Type   | String                       | String NULL     |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | {""..} ∪ {NULL} |
+| Row 0  | "true"                       | NULL            |
+| Row 1  | "123"                        | NULL            |
+| Row 2  | "12.34"                      | NULL            |
+| Row 3  | "\"ab\""                     | "ab"            |
+| Row 4  | "[1,2,3]"                    | NULL            |
+| Row 5  | "{\"a\":\"b\"}"              | NULL            |
++--------+------------------------------+-----------------+
 evaluation (internal):
 +--------+-------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                          |
@@ -1285,18 +1285,18 @@ ast            : as_array(try_parse_json(s))
 raw expr       : as_array(try_parse_json(ColumnRef(0)::String))
 checked expr   : as_array<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
 evaluation:
-+--------+------------------------------+--------------+
-|        | s                            | Output       |
-+--------+------------------------------+--------------+
-| Type   | String                       | Variant NULL |
-| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
-| Row 0  | "true"                       | NULL         |
-| Row 1  | "123"                        | NULL         |
-| Row 2  | "12.34"                      | NULL         |
-| Row 3  | "\"ab\""                     | NULL         |
-| Row 4  | "[1,2,3]"                    | [1,2,3]      |
-| Row 5  | "{\"a\":\"b\"}"              | NULL         |
-+--------+------------------------------+--------------+
++--------+------------------------------+--------------------+
+|        | s                            | Output             |
++--------+------------------------------+--------------------+
+| Type   | String                       | Variant NULL       |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Undefined ∪ {NULL} |
+| Row 0  | "true"                       | NULL               |
+| Row 1  | "123"                        | NULL               |
+| Row 2  | "12.34"                      | NULL               |
+| Row 3  | "\"ab\""                     | NULL               |
+| Row 4  | "[1,2,3]"                    | [1,2,3]            |
+| Row 5  | "{\"a\":\"b\"}"              | NULL               |
++--------+------------------------------+--------------------+
 evaluation (internal):
 +--------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                                       |
@@ -1335,18 +1335,18 @@ ast            : as_object(try_parse_json(s))
 raw expr       : as_object(try_parse_json(ColumnRef(0)::String))
 checked expr   : as_object<Variant>(CAST(try_parse_json<String>(ColumnRef(0)) AS Variant))
 evaluation:
-+--------+------------------------------+--------------+
-|        | s                            | Output       |
-+--------+------------------------------+--------------+
-| Type   | String                       | Variant NULL |
-| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Unknown      |
-| Row 0  | "true"                       | NULL         |
-| Row 1  | "123"                        | NULL         |
-| Row 2  | "12.34"                      | NULL         |
-| Row 3  | "\"ab\""                     | NULL         |
-| Row 4  | "[1,2,3]"                    | NULL         |
-| Row 5  | "{\"a\":\"b\"}"              | {"a":"b"}    |
-+--------+------------------------------+--------------+
++--------+------------------------------+--------------------+
+|        | s                            | Output             |
++--------+------------------------------+--------------------+
+| Type   | String                       | Variant NULL       |
+| Domain | {"\"ab\""..="{\"a\":\"b\"}"} | Undefined ∪ {NULL} |
+| Row 0  | "true"                       | NULL               |
+| Row 1  | "123"                        | NULL               |
+| Row 2  | "12.34"                      | NULL               |
+| Row 3  | "\"ab\""                     | NULL               |
+| Row 4  | "[1,2,3]"                    | NULL               |
+| Row 5  | "{\"a\":\"b\"}"              | {"a":"b"}          |
++--------+------------------------------+--------------------+
 evaluation (internal):
 +--------+-------------------------------------------------------------------------------------------------------------------------------------------+
 | Column | Data                                                                                                                                      |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Add `FunctionDomain` to replace `Option<Domain>`
- fix `from_hex`: it may panic
- fix `get(Array)`: the output type may be Int8 Null Null
- Add `Domain::full()`