### PR TITLE
refactor(input_foramt): change to UserStageInfo for get_splits trait

### DIFF
--- a/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_parquet.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_parquet.rs
@@ -41,6 +41,7 @@ use common_datavalues::DataField;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::UserStageInfo;
 use common_pipeline_core::Pipeline;
 use common_settings::Settings;
 use futures::AsyncRead;
@@ -49,7 +50,6 @@ use opendal::Operator;
 use similar_asserts::traits::MakeDiff;
 
 use crate::processors::sources::input_formats::delimiter::RecordDelimiter;
-use crate::processors::sources::input_formats::input_context::CopyIntoPlan;
 use crate::processors::sources::input_formats::input_context::InputContext;
 use crate::processors::sources::input_formats::input_pipeline::AligningStateTrait;
 use crate::processors::sources::input_formats::input_pipeline::BlockBuilderTrait;
@@ -85,13 +85,14 @@ impl InputFormat for InputFormatParquet {
 
     async fn get_splits(
         &self,
-        plan: &CopyIntoPlan,
+        files: &[String],
+        _stage_info: &UserStageInfo,
         op: &Operator,
         _settings: &Arc<Settings>,
         schema: &DataSchemaRef,
     ) -> Result<Vec<Arc<SplitInfo>>> {
         let mut infos = vec![];
-        for path in &plan.files {
+        for path in files {
             let obj = op.object(path);
             let size = obj.metadata().await?.content_length() as usize;
             let mut reader = obj.seekable_reader(..(size as u64));

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/input_context.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/input_context.rs
@@ -180,7 +180,7 @@ impl InputContext {
 
         let format = Self::get_input_format(&format_typ)?;
         let splits = format
-            .get_splits(&plan, &operator, &settings, &schema)
+            .get_splits(&plan.files, &plan.stage_info, &operator, &settings, &schema)
             .await?;
         let record_delimiter = {
             if file_format_options.stage.record_delimiter.is_empty() {

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/input_format.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/input_format.rs
@@ -16,12 +16,12 @@ use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
 use common_exception::Result;
+use common_meta_types::UserStageInfo;
 use common_pipeline_core::Pipeline;
 use common_settings::Settings;
 use opendal::Operator;
 
 use crate::processors::sources::input_formats::delimiter::RecordDelimiter;
-use crate::processors::sources::input_formats::input_context::CopyIntoPlan;
 use crate::processors::sources::input_formats::input_context::InputContext;
 use crate::processors::sources::input_formats::input_split::SplitInfo;
 
@@ -33,7 +33,8 @@ pub trait InputFormat: Send + Sync {
 
     async fn get_splits(
         &self,
-        plan: &CopyIntoPlan,
+        files: &[String],
+        stage_info: &UserStageInfo,
         op: &Operator,
         settings: &Arc<Settings>,
         schema: &DataSchemaRef,

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/input_format_text.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/input_format_text.rs
@@ -23,6 +23,7 @@ use common_datavalues::TypeDeserializerImpl;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_types::StageFileFormatType;
+use common_meta_types::UserStageInfo;
 use common_pipeline_core::Pipeline;
 use common_settings::Settings;
 use opendal::io_util::DecompressDecoder;
@@ -34,7 +35,6 @@ use crate::processors::sources::input_formats::beyond_end_reader::BeyondEndReade
 use crate::processors::sources::input_formats::delimiter::RecordDelimiter;
 use crate::processors::sources::input_formats::impls::input_format_csv::CsvReaderState;
 use crate::processors::sources::input_formats::impls::input_format_xml::XmlReaderState;
-use crate::processors::sources::input_formats::input_context::CopyIntoPlan;
 use crate::processors::sources::input_formats::input_context::InputContext;
 use crate::processors::sources::input_formats::input_pipeline::AligningStateTrait;
 use crate::processors::sources::input_formats::input_pipeline::BlockBuilderTrait;
@@ -133,20 +133,21 @@ impl<T: InputFormatTextBase> InputFormat for InputFormatText<T> {
 
     async fn get_splits(
         &self,
-        plan: &CopyIntoPlan,
+        files: &[String],
+        stage_info: &UserStageInfo,
         op: &Operator,
         _settings: &Arc<Settings>,
         _schema: &DataSchemaRef,
     ) -> Result<Vec<Arc<SplitInfo>>> {
         let mut infos = vec![];
-        for path in &plan.files {
+        for path in files {
             let obj = op.object(path);
             let size = obj.metadata().await?.content_length() as usize;
             let compress_alg = InputContext::get_compression_alg_copy(
-                plan.stage_info.file_format_options.compression,
+                stage_info.file_format_options.compression,
                 path,
             )?;
-            let split_size = plan.stage_info.copy_options.split_size;
+            let split_size = stage_info.copy_options.split_size;
             if compress_alg.is_none() && T::is_splittable() && split_size > 0 {
                 let split_offsets = split_by_size(size, split_size);
                 let num_file_splits = split_offsets.len();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This is the refactor part-1 of making InputFormat into a normal crate:
```
let input_ctx = InputContext::create(...);
let input_format = InputForamt::create(input_ctx ...);
let splits = input_format.get_splits(files);
```

Closes #issue
