### PR TITLE
refactor(memory-tracker): remove RuntimeTracker, which is barely a wrapper of Arc of MemoryTracker

### DIFF
--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -38,7 +38,6 @@ pub use progress::ProgressValues;
 pub use runtime::Dropper;
 pub use runtime::Runtime;
 pub use runtime::TrySpawn;
-pub use runtime_tracker::RuntimeTracker;
 pub use runtime_tracker::ThreadTracker;
 pub use select::select3;
 pub use select::Select3Output;

--- a/src/common/base/src/base/thread.rs
+++ b/src/common/base/src/base/thread.rs
@@ -68,7 +68,7 @@ impl Thread {
             thread_builder = thread_builder.name(named);
         }
 
-        ThreadJoinHandle::create(match ThreadTracker::current_runtime_tracker() {
+        ThreadJoinHandle::create(match ThreadTracker::current_mem_tracker() {
             None => thread_builder.spawn(f).unwrap(),
             Some(runtime_tracker) => thread_builder
                 .spawn(move || {

--- a/src/common/base/src/mem_allocator/je_allocator.rs
+++ b/src/common/base/src/mem_allocator/je_allocator.rs
@@ -150,6 +150,7 @@ pub mod linux_or_macos {
         ) -> Result<NonNull<[u8]>, AllocError> {
             debug_assert_eq!(old_layout.align(), new_layout.align());
             debug_assert!(old_layout.size() <= new_layout.size());
+
             let data_address = if new_layout.size() == 0 {
                 NonNull::new(new_layout.align() as *mut ()).unwrap_unchecked()
             } else if old_layout.size() == 0 {

--- a/src/query/service/src/sessions/session_info.rs
+++ b/src/query/service/src/sessions/session_info.rs
@@ -34,9 +34,8 @@ impl Session {
 
         if let Some(shared) = status.get_query_context_shared() {
             if let Ok(runtime) = shared.try_get_runtime() {
-                let runtime_tracker = runtime.get_tracker();
-                let runtime_memory_tracker = runtime_tracker.get_memory_tracker();
-                memory_usage = runtime_memory_tracker.get_memory_usage();
+                let mem_tracker = runtime.get_tracker();
+                memory_usage = mem_tracker.get_memory_usage();
             }
         }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(memory-tracker): remove RuntimeTracker, which is barely a wrapper of Arc of MemoryTracker

## Changelog







## Related Issues