### PR TITLE
chore(hive): add hive_parquet_chunk_size to enable stream read of parquet

### DIFF
--- a/src/query/settings/src/lib.rs
+++ b/src/query/settings/src/lib.rs
@@ -421,6 +421,17 @@ impl Settings {
                 desc: "Enable hive parquet predict pushdown  by setting this variable to 1, default value: 1",
                 possible_values: None,
             },
+            #[cfg(feature = "hive")]
+            SettingValue {
+                default_value: UserSettingValue::UInt64(16384),
+                user_setting: UserSetting::create(
+                    "hive_parquet_chunk_size",
+                    UserSettingValue::UInt64(16384),
+                ),
+                level: ScopeLevel::Session,
+                desc: "the max number of rows each read from parquet to databend processor",
+                possible_values: None,
+            },
             SettingValue {
                 default_value: UserSettingValue::UInt64(1),
                 user_setting: UserSetting::create(
@@ -689,6 +700,11 @@ impl Settings {
 
     pub fn get_enable_hive_parquet_predict_pushdown(&self) -> Result<u64> {
         static KEY: &str = "enable_hive_parquet_predict_pushdown";
+        self.try_get_u64(KEY)
+    }
+
+    pub fn get_hive_parquet_chunk_size(&self) -> Result<u64> {
+        static KEY: &str = "hive_parquet_chunk_size";
         self.try_get_u64(KEY)
     }
 

--- a/src/query/storages/hive/hive/src/hive_table.rs
+++ b/src/query/storages/hive/hive/src/hive_table.rs
@@ -161,7 +161,8 @@ impl HiveTable {
         pipeline: &mut Pipeline,
     ) -> Result<()> {
         let push_downs = &plan.push_downs;
-        let block_reader = self.create_block_reader(push_downs)?;
+        let chunk_size = ctx.get_settings().get_hive_parquet_chunk_size()?;
+        let block_reader = self.create_block_reader(push_downs, chunk_size as usize)?;
 
         let parts_len = plan.parts.len();
         let max_threads = ctx.get_settings().get_max_threads()? as usize;
@@ -258,6 +259,7 @@ impl HiveTable {
     fn create_block_reader(
         &self,
         push_downs: &Option<PushDownInfo>,
+        chunk_size: usize,
     ) -> Result<Arc<HiveParquetBlockReader>> {
         let projection = self.get_projections(push_downs)?;
         let (projection, partition_fields) =
@@ -276,6 +278,7 @@ impl HiveTable {
             table_schema,
             projection,
             hive_partition_filler,
+            chunk_size,
         )
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
hive parquet stream read should be enabled by default, use `hive_parquet_chunk_size` settings to replace `chunk_size` env.