### PR TITLE
fix: Bump OpenDAL to 0.19.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5648,9 +5648,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.19.7"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35096e9c11c30efb0edf3598bed2275b8d62876ee108ffd4385ecc7cb77f08af"
+checksum = "8759e3041052861fec2980cf07dcd0e6d612346003680119494badd8aba884b0"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -8578,7 +8578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -20,7 +20,6 @@ backon = "0.2"
 globiter = "0.1"
 once_cell = "1"
 opendal = { version = "0.19", features = [
-    "layers-retry",
     "layers-tracing",
     "layers-metrics",
     "services-ipfs",

--- a/src/query/pipeline/sources/Cargo.toml
+++ b/src/query/pipeline/sources/Cargo.toml
@@ -31,7 +31,7 @@ crossbeam-channel = "0.5.6"
 csv-core = "0.1.10"
 futures = "0.3.24"
 futures-util = "0.3.24"
-opendal = { version = "0.19", features = ["layers-retry", "compress"] }
+opendal = { version = "0.19", features = ["compress"] }
 parking_lot = "0.12.1"
 serde_json = { workspace = true }
 similar-asserts = "1.4.2"

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -102,7 +102,7 @@ lz4 = "1.24.0"
 metrics = "0.20.1"
 naive-cityhash = "0.2.0"
 once_cell = "1.15.0"
-opendal = { version = "0.19", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.19", features = ["layers-tracing", "layers-metrics", "compress"] }
 opensrv-mysql = "0.2.0"
 openssl = { version = "0.10.41", features = ["vendored"] }
 parking_lot = "0.12.1"

--- a/src/query/sql/Cargo.toml
+++ b/src/query/sql/Cargo.toml
@@ -68,7 +68,7 @@ lz4 = "1.24.0"
 metrics = "0.20.1"
 naive-cityhash = "0.2.0"
 once_cell = "1.15.0"
-opendal = { version = "0.19", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.19", features = ["layers-tracing", "layers-metrics", "compress"] }
 opensrv-mysql = "0.2.0"
 openssl = { version = "0.10.41", features = ["vendored"] }
 parking_lot = "0.12.1"

--- a/src/query/storages/cache/Cargo.toml
+++ b/src/query/storages/cache/Cargo.toml
@@ -18,4 +18,4 @@ common-exception = { path = "../../../common/exception" }
 common-storages-table-meta = { path = "../table-meta" }
 
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
-opendal = { version = "0.19", features = ["layers-retry"] }
+opendal = "0.19"

--- a/src/query/storages/fuse/fuse-result/Cargo.toml
+++ b/src/query/storages/fuse/fuse-result/Cargo.toml
@@ -38,7 +38,7 @@ chrono = "0.4.22"
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.19", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.19", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/fuse/fuse/Cargo.toml
+++ b/src/query/storages/fuse/fuse/Cargo.toml
@@ -40,7 +40,7 @@ futures = "0.3.24"
 futures-util = "0.3.24"
 itertools = "0.10.5"
 metrics = "0.20.1"
-opendal = { version = "0.19", features = ["layers-retry"] }
+opendal = "0.19"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = "0.1.36"

--- a/src/query/storages/hive/hive/Cargo.toml
+++ b/src/query/storages/hive/hive/Cargo.toml
@@ -31,7 +31,7 @@ common-storages-table-meta = { path = "../../table-meta" }
 async-recursion = "1.0.0"
 async-trait = "0.1.57"
 futures = "0.3.24"
-opendal = { version = "0.19", features = ["layers-retry"] }
+opendal = "0.19"
 serde = { workspace = true }
 thrift = { package = "databend-thrift", version = "0.17.0" }
 tracing = "0.1.36"

--- a/src/query/storages/information-schema/Cargo.toml
+++ b/src/query/storages/information-schema/Cargo.toml
@@ -36,7 +36,7 @@ chrono = "0.4.22"
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.19", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.19", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/memory/Cargo.toml
+++ b/src/query/storages/memory/Cargo.toml
@@ -36,7 +36,7 @@ chrono = "0.4.22"
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.19", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.19", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/null/Cargo.toml
+++ b/src/query/storages/null/Cargo.toml
@@ -36,7 +36,7 @@ chrono = "0.4.22"
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.19", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.19", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/random/Cargo.toml
+++ b/src/query/storages/random/Cargo.toml
@@ -36,7 +36,7 @@ chrono = "0.4.22"
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.19", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.19", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/share/Cargo.toml
+++ b/src/query/storages/share/Cargo.toml
@@ -17,7 +17,7 @@ common-meta-app = { path = "../../../meta/app" }
 common-storages-cache = { path = "../cache" }
 common-storages-table-meta = { path = "../table-meta" }
 
-opendal = { version = "0.19", features = ["layers-retry"] }
+opendal = "0.19"
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/src/query/storages/stage/Cargo.toml
+++ b/src/query/storages/stage/Cargo.toml
@@ -36,7 +36,7 @@ chrono = "0.4.22"
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.19", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.19", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 regex = "1.6.0"
 serde = { workspace = true }

--- a/src/query/storages/system/Cargo.toml
+++ b/src/query/storages/system/Cargo.toml
@@ -36,7 +36,7 @@ chrono = "0.4.22"
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.19", features = ["layers-retry", "layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.19", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: Bump OpenDAL to 0.19.8

- Release note for opendal https://github.com/datafuselabs/opendal/discussions/924