### PR TITLE
refactor(expr): allow sparse column id in chunk

### DIFF
--- a/src/query/expression/src/chunk.rs
+++ b/src/query/expression/src/chunk.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::ops::Range;
 
 use crate::types::AnyType;
@@ -24,14 +25,14 @@ use crate::Value;
 /// Chunk is a lightweight container for a group of columns.
 #[derive(Clone)]
 pub struct Chunk {
-    columns: Vec<(Value<AnyType>, DataType)>,
+    columns: HashMap<usize, (Value<AnyType>, DataType)>,
     num_rows: usize,
 }
 
 impl Chunk {
     #[inline]
-    pub fn new(columns: Vec<(Value<AnyType>, DataType)>, num_rows: usize) -> Self {
-        debug_assert!(columns.iter().all(|(col, _)| match col {
+    pub fn new(columns: HashMap<usize, (Value<AnyType>, DataType)>, num_rows: usize) -> Self {
+        debug_assert!(columns.values().all(|(col, _)| match col {
             Value::Scalar(_) => true,
             Value::Column(c) => c.len() == num_rows,
         }));
@@ -40,11 +41,11 @@ impl Chunk {
 
     #[inline]
     pub fn empty() -> Self {
-        Chunk::new(vec![], 0)
+        Chunk::new(HashMap::new(), 0)
     }
 
     #[inline]
-    pub fn columns(&self) -> &[(Value<AnyType>, DataType)] {
+    pub fn columns(&self) -> &HashMap<usize, (Value<AnyType>, DataType)> {
         &self.columns
     }
 
@@ -64,17 +65,17 @@ impl Chunk {
     }
 
     #[inline]
-    pub fn domains(&self) -> Vec<Domain> {
+    pub fn domains(&self) -> HashMap<usize, Domain> {
         self.columns
             .iter()
-            .map(|(value, _)| value.as_ref().domain())
+            .map(|(col_id, (value, _))| (*col_id, value.as_ref().domain()))
             .collect()
     }
 
     #[inline]
     pub fn memory_size(&self) -> usize {
         self.columns()
-            .iter()
+            .values()
             .map(|(col, _)| match col {
                 Value::Scalar(s) => std::mem::size_of_val(s) * self.num_rows,
                 Value::Column(c) => c.memory_size(),
@@ -86,13 +87,13 @@ impl Chunk {
         let columns = self
             .columns()
             .iter()
-            .map(|(col, ty)| match col {
+            .map(|(col_id, (col, ty))| match col {
                 Value::Scalar(s) => {
                     let builder = ColumnBuilder::repeat(&s.as_ref(), self.num_rows, ty);
                     let col = builder.build();
-                    (Value::Column(col), ty.clone())
+                    (*col_id, (Value::Column(col), ty.clone()))
                 }
-                Value::Column(c) => (Value::Column(c.clone()), ty.clone()),
+                Value::Column(c) => (*col_id, (Value::Column(c.clone()), ty.clone())),
             })
             .collect();
         Self {
@@ -105,9 +106,9 @@ impl Chunk {
         let columns = self
             .columns()
             .iter()
-            .map(|(col, ty)| match col {
-                Value::Scalar(s) => (Value::Scalar(s.clone()), ty.clone()),
-                Value::Column(c) => (Value::Column(c.slice(range.clone())), ty.clone()),
+            .map(|(col_id, (col, ty))| match col {
+                Value::Scalar(s) => (*col_id, (Value::Scalar(s.clone()), ty.clone())),
+                Value::Column(c) => (*col_id, (Value::Column(c.slice(range.clone())), ty.clone())),
             })
             .collect();
         Self {
@@ -116,16 +117,17 @@ impl Chunk {
         }
     }
 
-    pub fn get_serializers(&self) -> Result<Vec<Box<dyn TypeSerializer>>, String> {
-        let mut serializers = Vec::with_capacity(self.num_columns());
-        for (value, data_type) in self.columns() {
-            let column = match value {
-                Value::Scalar(s) => ColumnBuilder::repeat(&s.as_ref(), 1, data_type).build(),
-                Value::Column(c) => c.clone(),
-            };
-            let serializer = data_type.create_serializer(column)?;
-            serializers.push(serializer);
-        }
-        Ok(serializers)
+    pub fn get_serializers(&self) -> Result<HashMap<usize, Box<dyn TypeSerializer>>, String> {
+        self.columns()
+            .iter()
+            .map(|(col_id, (col, ty))| {
+                let column = match col {
+                    Value::Scalar(s) => ColumnBuilder::repeat(&s.as_ref(), 1, ty).build(),
+                    Value::Column(c) => c.clone(),
+                };
+                let serializer = ty.create_serializer(column)?;
+                Ok((*col_id, serializer))
+            })
+            .try_collect()
     }
 }

--- a/src/query/expression/src/converts/from.rs
+++ b/src/query/expression/src/converts/from.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use common_datablocks::DataBlock;
 use common_datavalues::remove_nullable;
 use common_datavalues::ColumnRef;
@@ -156,11 +158,12 @@ pub fn convert_column(column: &ColumnRef, logical_type: &DataTypeImpl) -> Value<
 }
 
 pub fn from_block(datablock: &DataBlock) -> Chunk {
-    let columns: Vec<(Value<AnyType>, DataType)> = datablock
+    let columns: HashMap<usize, (Value<AnyType>, DataType)> = datablock
         .columns()
         .iter()
         .zip(datablock.schema().fields().iter())
         .map(|(c, f)| (convert_column(c, f.data_type()), from_type(f.data_type())))
+        .enumerate()
         .collect();
 
     Chunk::new(columns, datablock.num_rows())

--- a/src/query/expression/src/converts/to.rs
+++ b/src/query/expression/src/converts/to.rs
@@ -73,10 +73,12 @@ pub fn to_column(column: &Value<AnyType>, size: usize, data_type: &DataType) -> 
 }
 
 pub fn to_datablock(chunk: &Chunk, schema: DataSchemaRef) -> DataBlock {
-    let columns = chunk
-        .columns()
-        .iter()
-        .map(|(c, ty)| to_column(c, chunk.num_rows(), ty))
+    // Assume the chunk has col[0], col[1], ... till col[chunk.num_columns() - 1]
+    let columns = (0..chunk.columns().len())
+        .map(|col_id| {
+            let (col, ty) = &chunk.columns()[&col_id];
+            to_column(col, chunk.num_rows(), ty)
+        })
         .collect();
     DataBlock::create(schema, columns)
 }

--- a/src/query/expression/src/kernels/concat.rs
+++ b/src/query/expression/src/kernels/concat.rs
@@ -48,25 +48,30 @@ impl Chunk {
             return Ok(chunks[0].clone());
         }
 
-        let num_rows = chunks.iter().map(|c| c.num_rows()).sum();
-        let mut concat_columns = Vec::with_capacity(chunks[0].num_columns());
-        for i in 0..chunks[0].num_columns() {
-            let columns = chunks
-                .iter()
-                .map(|chunk| {
-                    let (col, ty) = &chunk.columns()[i];
-                    match col {
-                        Value::Scalar(s) => {
-                            ColumnBuilder::repeat(&s.as_ref(), chunk.num_rows(), ty).build()
+        let concat_columns = chunks[0]
+            .columns()
+            .keys()
+            .map(|col_id| {
+                let columns = chunks
+                    .iter()
+                    .map(|chunk| {
+                        let (col, ty) = &chunk.columns()[col_id];
+                        match col {
+                            Value::Scalar(s) => {
+                                ColumnBuilder::repeat(&s.as_ref(), chunk.num_rows(), ty).build()
+                            }
+                            Value::Column(c) => c.clone(),
                         }
-                        Value::Column(c) => c.clone(),
-                    }
-                })
-                .collect::<Vec<_>>();
-            let ty = chunks[0].columns()[i].1.clone();
-            let c = Column::concat(&columns);
-            concat_columns.push((Value::Column(c), ty));
-        }
+                    })
+                    .collect::<Vec<_>>();
+                let ty = chunks[0].columns()[col_id].1.clone();
+                let col = Column::concat(&columns);
+                (*col_id, (Value::Column(col), ty))
+            })
+            .collect();
+
+        let num_rows = chunks.iter().map(|c| c.num_rows()).sum();
+
         Ok(Chunk::new(concat_columns, num_rows))
     }
 }

--- a/src/query/expression/src/kernels/filter.rs
+++ b/src/query/expression/src/kernels/filter.rs
@@ -70,11 +70,14 @@ impl Chunk {
                         let after_columns = self
                             .columns()
                             .iter()
-                            .map(|(value, ty)| match value {
-                                Value::Scalar(v) => (Value::Scalar(v.clone()), ty.clone()),
-                                Value::Column(c) => {
-                                    (Value::Column(Column::filter(c, &bitmap)), ty.clone())
+                            .map(|(col_id, (value, ty))| match value {
+                                Value::Scalar(v) => {
+                                    (*col_id, (Value::Scalar(v.clone()), ty.clone()))
                                 }
+                                Value::Column(c) => (
+                                    *col_id,
+                                    (Value::Column(Column::filter(c, &bitmap)), ty.clone()),
+                                ),
                             })
                             .collect();
                         Ok(Chunk::new(after_columns, self.num_rows() - count_zeros))

--- a/src/query/expression/src/kernels/take.rs
+++ b/src/query/expression/src/kernels/take.rs
@@ -40,9 +40,12 @@ impl Chunk {
         let after_columns = self
             .columns()
             .iter()
-            .map(|(col, ty)| match col {
-                Value::Scalar(v) => (Value::Scalar(v.clone()), ty.clone()),
-                Value::Column(c) => (Value::Column(Column::take(c, indices)), ty.clone()),
+            .map(|(col_id, (col, ty))| match col {
+                Value::Scalar(v) => (*col_id, (Value::Scalar(v.clone()), ty.clone())),
+                Value::Column(c) => (
+                    *col_id,
+                    (Value::Column(Column::take(c, indices)), ty.clone()),
+                ),
             })
             .collect();
 

--- a/src/query/expression/src/lib.rs
+++ b/src/query/expression/src/lib.rs
@@ -25,6 +25,7 @@
 #![feature(const_mut_refs)]
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
+#![feature(iterator_try_collect)]
 #![feature(core_intrinsics)]
 #![feature(iter_order_by)]
 

--- a/src/query/expression/src/utils/display.rs
+++ b/src/query/expression/src/utils/display.rs
@@ -60,7 +60,7 @@ impl Debug for Chunk {
 
         table.set_header(vec!["Column ID", "Column Data"]);
 
-        for (i, (col, _)) in self.columns().iter().enumerate() {
+        for (i, (col, _)) in self.columns().iter().sorted_by_key(|(id, _)| **id) {
             table.add_row(vec![i.to_string(), format!("{:?}", col)]);
         }
 
@@ -73,13 +73,19 @@ impl Display for Chunk {
         let mut table = Table::new();
         table.load_preset("||--+-++|    ++++++");
 
-        table.set_header((0..self.num_columns()).map(|idx| format!("Column {idx}")));
+        table.set_header(
+            self.columns()
+                .keys()
+                .sorted()
+                .map(|idx| format!("Column {idx}")),
+        );
 
         for index in 0..self.num_rows() {
             let row: Vec<_> = self
                 .columns()
                 .iter()
-                .map(|(val, _)| val.as_ref().index(index).unwrap().to_string())
+                .sorted_by_key(|(id, _)| **id)
+                .map(|(_, (val, _))| val.as_ref().index(index).unwrap().to_string())
                 .map(Cell::new)
                 .collect();
             table.add_row(row);

--- a/src/query/expression/src/utils/mod.rs
+++ b/src/query/expression/src/utils/mod.rs
@@ -18,6 +18,8 @@ mod column_from;
 pub mod date_helper;
 pub mod display;
 
+use std::collections::HashMap;
+
 use chrono_tz::Tz;
 use common_arrow::arrow::bitmap::Bitmap;
 
@@ -54,7 +56,7 @@ pub fn eval_function(
                     id,
                     data_type: ty.clone(),
                 },
-                (val, ty),
+                (id, (val, ty)),
             )
         })
         .unzip();
@@ -78,7 +80,7 @@ pub fn calculate_function_domain(
     tz: Tz,
     fn_registry: &FunctionRegistry,
 ) -> Result<(Option<Domain>, DataType)> {
-    let (args, args_domain): (Vec<_>, Vec<_>) = args
+    let (args, args_domain): (Vec<_>, HashMap<_, _>) = args
         .into_iter()
         .enumerate()
         .map(|(id, (domain, ty))| {
@@ -88,7 +90,7 @@ pub fn calculate_function_domain(
                     id,
                     data_type: ty,
                 },
-                domain,
+                (id, domain),
             )
         })
         .unzip();
@@ -99,7 +101,7 @@ pub fn calculate_function_domain(
         args,
     };
     let expr = crate::type_check::check(&raw_expr, fn_registry)?;
-    let constant_folder = ConstantFolder::new(&args_domain, tz, fn_registry);
+    let constant_folder = ConstantFolder::new(args_domain, tz, fn_registry);
     let (_, output_domain) = constant_folder.fold(&expr);
     Ok((output_domain, expr.data_type().clone()))
 }

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -55,13 +55,13 @@ use crate::utils::arrow::deserialize_arrow_array;
 use crate::utils::arrow::serialize_arrow_array;
 use crate::with_number_type;
 
-#[derive(Debug, Clone, EnumAsInner)]
+#[derive(Debug, Clone, PartialEq, EnumAsInner)]
 pub enum Value<T: ValueType> {
     Scalar(T::Scalar),
     Column(T::Column),
 }
 
-#[derive(Debug, Clone, EnumAsInner)]
+#[derive(Debug, Clone, PartialEq, EnumAsInner)]
 pub enum ValueRef<'a, T: ValueType> {
     Scalar(T::ScalarRef<'a>),
     Column(T::Column),

--- a/src/query/expression/tests/it/common.rs
+++ b/src/query/expression/tests/it/common.rs
@@ -21,7 +21,8 @@ pub fn new_chunk(columns: &[(DataType, Column)]) -> Chunk {
     let len = columns.get(0).map_or(1, |(_, c)| c.len());
     let columns = columns
         .iter()
-        .map(|(ty, c)| (Value::Column(c.clone()), ty.clone()))
+        .enumerate()
+        .map(|(col_id, (ty, c))| (col_id, (Value::Column(c.clone()), ty.clone())))
         .collect();
 
     Chunk::new(columns, len)

--- a/src/query/functions-v2/benches/bench.rs
+++ b/src/query/functions-v2/benches/bench.rs
@@ -18,6 +18,8 @@ extern crate criterion;
 #[path = "../tests/it/scalars/parser.rs"]
 mod parser;
 
+use std::collections::HashMap;
+
 use common_expression::type_check;
 use common_expression::Chunk;
 use common_expression::Evaluator;
@@ -42,7 +44,7 @@ fn bench(c: &mut Criterion) {
         });
 
         let expr = type_check::check(&raw_expr, &fn_registry).unwrap();
-        let chunk = Chunk::new(vec![], 1);
+        let chunk = Chunk::new(HashMap::new(), 1);
         let evaluator = Evaluator::new(&chunk, chrono_tz::UTC, &fn_registry);
 
         group.bench_function(format!("eval/{n}"), |b| b.iter(|| evaluator.run(&expr)));

--- a/src/query/functions-v2/tests/it/aggregates/mod.rs
+++ b/src/query/functions-v2/tests/it/aggregates/mod.rs
@@ -64,7 +64,8 @@ pub fn run_agg_ast(
         columns
             .iter()
             .map(|(_, ty, col)| (Value::Column(col.clone()), ty.clone()))
-            .collect::<Vec<_>>(),
+            .enumerate()
+            .collect(),
         num_rows,
     );
 

--- a/src/query/functions-v2/tests/it/scalars/mod.rs
+++ b/src/query/functions-v2/tests/it/scalars/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::io::Write;
 
 use comfy_table::Table;
@@ -57,9 +58,11 @@ pub fn run_ast(file: &mut impl Write, text: &str, columns: &[(&str, DataType, Co
         let input_domains = columns
             .iter()
             .map(|(_, _, col)| col.domain())
-            .collect::<Vec<_>>();
+            .enumerate()
+            .collect::<HashMap<_, _>>();
 
-        let constant_folder = ConstantFolder::new(&input_domains, chrono_tz::UTC, &fn_registry);
+        let constant_folder =
+            ConstantFolder::new(input_domains.clone(), chrono_tz::UTC, &fn_registry);
         let (optimized_expr, output_domain) = constant_folder.fold(&expr);
 
         let remote_expr = RemoteExpr::from_expr(optimized_expr);
@@ -70,7 +73,8 @@ pub fn run_ast(file: &mut impl Write, text: &str, columns: &[(&str, DataType, Co
             columns
                 .iter()
                 .map(|(_, ty, col)| (Value::Column(col.clone()), ty.clone()))
-                .collect::<Vec<_>>(),
+                .enumerate()
+                .collect(),
             num_rows,
         );
 
@@ -130,7 +134,7 @@ pub fn run_ast(file: &mut impl Write, text: &str, columns: &[(&str, DataType, Co
                     let input_domains = used_columns
                         .iter()
                         .cloned()
-                        .map(|i| input_domains[i].clone())
+                        .map(|i| input_domains[&i].clone())
                         .collect::<Vec<_>>();
                     let columns = used_columns
                         .iter()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Columns in a `Chunk` has an individual column id that is not necessarily continuous.

When converting between `Chunk` and `DataBlock`, we assume the ids are continuous.