### PR TITLE
refactor(query): disable distribute eval index when explain

### DIFF
--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -62,25 +62,21 @@ impl InterpreterFactory {
                 *s_expr.clone(),
                 metadata.clone(),
             )?)),
-            Plan::Explain { kind, plan } => Ok(Arc::new(ExplainInterpreterV2::try_create(
+            Plan::Explain { kind, plan } => Ok(Arc::new(ExplainInterpreter::try_create(
                 ctx,
                 *plan.clone(),
                 kind.clone(),
             )?)),
-            Plan::ExplainAst { formatted_string } => {
-                Ok(Arc::new(ExplainInterpreterV2::try_create(
-                    ctx,
-                    plan.clone(),
-                    ExplainKind::Ast(formatted_string.clone()),
-                )?))
-            }
-            Plan::ExplainSyntax { formatted_sql } => {
-                Ok(Arc::new(ExplainInterpreterV2::try_create(
-                    ctx,
-                    plan.clone(),
-                    ExplainKind::Syntax(formatted_sql.clone()),
-                )?))
-            }
+            Plan::ExplainAst { formatted_string } => Ok(Arc::new(ExplainInterpreter::try_create(
+                ctx,
+                plan.clone(),
+                ExplainKind::Ast(formatted_string.clone()),
+            )?)),
+            Plan::ExplainSyntax { formatted_sql } => Ok(Arc::new(ExplainInterpreter::try_create(
+                ctx,
+                plan.clone(),
+                ExplainKind::Syntax(formatted_sql.clone()),
+            )?)),
 
             Plan::Call(plan) => Ok(Arc::new(CallInterpreter::try_create(ctx, *plan.clone())?)),
 

--- a/src/query/service/src/interpreters/mod.rs
+++ b/src/query/service/src/interpreters/mod.rs
@@ -98,7 +98,7 @@ pub use interpreter_database_rename::RenameDatabaseInterpreter;
 pub use interpreter_database_show_create::ShowCreateDatabaseInterpreter;
 pub use interpreter_database_undrop::UndropDatabaseInterpreter;
 pub use interpreter_delete::DeleteInterpreter;
-pub use interpreter_explain_v2::ExplainInterpreterV2;
+pub use interpreter_explain_v2::ExplainInterpreter;
 pub use interpreter_factory::InterpreterFactory;
 pub use interpreter_insert_v2::InsertInterpreterV2;
 pub use interpreter_kill::KillInterpreter;

--- a/tests/logictest/suites/crdb/join
+++ b/tests/logictest/suites/crdb/join
@@ -1150,14 +1150,14 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.default.twocolumn
 │   ├── read rows: 4
-│   ├── read bytes: 309
+│   ├── read bytes: 79
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [(x > 42)], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.default.onecolumn
     ├── read rows: 4
-    ├── read bytes: 376
+    ├── read bytes: 62
     ├── partitions total: 2
     ├── partitions scanned: 2
     └── push downs: [filters: [], limit: NONE]
@@ -1174,14 +1174,14 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.default.twocolumn
 │   ├── read rows: 4
-│   ├── read bytes: 309
+│   ├── read bytes: 79
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [((x > 44) or (x < 43))], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.default.onecolumn
     ├── read rows: 4
-    ├── read bytes: 376
+    ├── read bytes: 62
     ├── partitions total: 2
     ├── partitions scanned: 2
     └── push downs: [filters: [], limit: NONE]
@@ -1199,14 +1199,14 @@ HashJoin
 ├── TableScan(Build)                                                     
 │   ├── table: default.default.twocolumn                                 
 │   ├── read rows: 4                                                     
-│   ├── read bytes: 309
+│   ├── read bytes: 79
 │   ├── partitions total: 1                                              
 │   ├── partitions scanned: 1                                            
 │   └── push downs: [filters: [(x > 42), (x < 45)], limit: NONE]         
 └── TableScan(Probe)                                                     
     ├── table: default.default.onecolumn                                 
     ├── read rows: 4                                                     
-    ├── read bytes: 376                                                   
+    ├── read bytes: 62
     ├── partitions total: 2                                              
     ├── partitions scanned: 2                                            
     └── push downs: [filters: [], limit: NONE]                           
@@ -1227,14 +1227,14 @@ Filter
     ├── TableScan(Build)                                   
     │   ├── table: default.default.twocolumn               
     │   ├── read rows: 4                                   
-    │   ├── read bytes: 309
+    │   ├── read bytes: 79
     │   ├── partitions total: 1                            
     │   ├── partitions scanned: 1                          
     │   └── push downs: [filters: [], limit: NONE]         
     └── TableScan(Probe)                                   
         ├── table: default.default.onecolumn               
         ├── read rows: 4                                   
-        ├── read bytes: 376                                 
+        ├── read bytes: 62
         ├── partitions total: 2                            
         ├── partitions scanned: 2                          
         └── push downs: [filters: [], limit: NONE]         
@@ -1251,14 +1251,14 @@ HashJoin
 ├── TableScan(Build)                                                     
 │   ├── table: default.default.twocolumn                                 
 │   ├── read rows: 4                                                     
-│   ├── read bytes: 309
+│   ├── read bytes: 79
 │   ├── partitions total: 1                                              
 │   ├── partitions scanned: 1                                            
 │   └── push downs: [filters: [(x > 42), (x < 45)], limit: NONE]         
 └── TableScan(Probe)                                                     
     ├── table: default.default.onecolumn                                 
     ├── read rows: 4                                                     
-    ├── read bytes: 376                                                   
+    ├── read bytes: 62
     ├── partitions total: 2                                              
     ├── partitions scanned: 2                                            
     └── push downs: [filters: [], limit: NONE]                           

--- a/tests/logictest/suites/mode/standalone/explain/fold_count.test
+++ b/tests/logictest/suites/mode/standalone/explain/fold_count.test
@@ -41,10 +41,10 @@ EvalScalar
         ├── aggregate functions: [count()]
         └── TableScan
             ├── table: default.default.t
-            ├── read rows: 1001
-            ├── read bytes: 4434
+            ├── read rows: 1000
+            ├── read bytes: 4028
             ├── partitions total: 2
-            ├── partitions scanned: 2
+            ├── partitions scanned: 1
             └── push downs: [filters: [(number > 10)], limit: NONE]
 
 statement ok

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/chain.test
@@ -33,21 +33,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -64,7 +64,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t1
 │   ├── read rows: 10
-│   ├── read bytes: 243
+│   ├── read bytes: 68
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
@@ -76,14 +76,14 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t
     │   ├── read rows: 1
-    │   ├── read bytes: 197
+    │   ├── read bytes: 31
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   └── push downs: [filters: [], limit: NONE]
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 610
+        ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
         └── push downs: [filters: [], limit: NONE]
@@ -105,21 +105,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -141,21 +141,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -177,21 +177,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -208,7 +208,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t1
 │   ├── read rows: 10
-│   ├── read bytes: 243
+│   ├── read bytes: 68
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
@@ -220,14 +220,14 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t
     │   ├── read rows: 1
-    │   ├── read bytes: 197
+    │   ├── read bytes: 31
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   └── push downs: [filters: [], limit: NONE]
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 610
+        ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
         └── push downs: [filters: [], limit: NONE]
@@ -244,14 +244,14 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 197
+│   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 243
+    ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -268,14 +268,14 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 197
+│   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 243
+    ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -292,14 +292,14 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 197
+│   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 243
+    ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -316,14 +316,14 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 197
+│   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 243
+    ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -340,14 +340,14 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 197
+│   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 243
+    ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -364,14 +364,14 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 197
+│   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 243
+    ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/cycles.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/cycles.test
@@ -30,21 +30,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -66,21 +66,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -102,21 +102,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -138,21 +138,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -174,21 +174,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -210,21 +210,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]

--- a/tests/logictest/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/logictest/suites/mode/standalone/explain/join_reorder/star.test
@@ -30,21 +30,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -61,7 +61,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t1
 │   ├── read rows: 10
-│   ├── read bytes: 243
+│   ├── read bytes: 68
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
@@ -73,14 +73,14 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t
     │   ├── read rows: 1
-    │   ├── read bytes: 197
+    │   ├── read bytes: 31
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   └── push downs: [filters: [], limit: NONE]
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 610
+        ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
         └── push downs: [filters: [], limit: NONE]
@@ -102,21 +102,21 @@ HashJoin
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 197
+│   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   └── push downs: [filters: [], limit: NONE]
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
-│       ├── read bytes: 243
+│       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       └── push downs: [filters: [], limit: NONE]
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
-    ├── read bytes: 610
+    ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
     └── push downs: [filters: [], limit: NONE]
@@ -133,7 +133,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 197
+│   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
@@ -145,14 +145,14 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 243
+    │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   └── push downs: [filters: [], limit: NONE]
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 610
+        ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
         └── push downs: [filters: [], limit: NONE]
@@ -169,7 +169,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 197
+│   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
@@ -181,14 +181,14 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 243
+    │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   └── push downs: [filters: [], limit: NONE]
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 610
+        ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
         └── push downs: [filters: [], limit: NONE]
@@ -205,7 +205,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t1
 │   ├── read rows: 10
-│   ├── read bytes: 243
+│   ├── read bytes: 68
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   └── push downs: [filters: [], limit: NONE]
@@ -217,14 +217,14 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t
     │   ├── read rows: 1
-    │   ├── read bytes: 197
+    │   ├── read bytes: 31
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   └── push downs: [filters: [], limit: NONE]
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 610
+        ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
         └── push downs: [filters: [], limit: NONE]

--- a/tests/logictest/suites/mode/standalone/explain/nullable_prune.test
+++ b/tests/logictest/suites/mode/standalone/explain/nullable_prune.test
@@ -14,7 +14,7 @@ explain select * from t_nullable_prune;
 TableScan
 ├── table: default.default.t_nullable_prune
 ├── read rows: 6
-├── read bytes: 376
+├── read bytes: 62
 ├── partitions total: 2
 ├── partitions scanned: 2
 └── push downs: [filters: [], limit: NONE]
@@ -25,10 +25,10 @@ explain select * from t_nullable_prune where a is not null;
 ----
 TableScan
 ├── table: default.default.t_nullable_prune
-├── read rows: 6
-├── read bytes: 376
+├── read rows: 3
+├── read bytes: 37
 ├── partitions total: 2
-├── partitions scanned: 2
+├── partitions scanned: 1
 └── push downs: [filters: [is_not_null(a)], limit: NONE]
 
 statement query T
@@ -37,10 +37,10 @@ explain select * from t_nullable_prune where a is null;
 ----
 TableScan
 ├── table: default.default.t_nullable_prune
-├── read rows: 6
-├── read bytes: 376
+├── read rows: 3
+├── read bytes: 25
 ├── partitions total: 2
-├── partitions scanned: 2
+├── partitions scanned: 1
 └── push downs: [filters: [not(is_not_null(a))], limit: NONE]
 
 statement ok

--- a/tests/logictest/suites/mode/standalone/explain/prune_column.test
+++ b/tests/logictest/suites/mode/standalone/explain/prune_column.test
@@ -211,7 +211,7 @@ EvalScalar
         └── TableScan
             ├── table: default.default.t
             ├── read rows: 2
-            ├── read bytes: 290
+            ├── read bytes: 31
             ├── partitions total: 1
             ├── partitions scanned: 1
             └── push downs: [filters: [(b = 2)], limit: NONE]

--- a/tests/logictest/suites/mode/standalone/explain/select_limit_offset.test
+++ b/tests/logictest/suites/mode/standalone/explain/select_limit_offset.test
@@ -150,7 +150,7 @@ Limit
     │   └── TableScan
     │       ├── table: default.default.t
     │       ├── read rows: 1
-    │       ├── read bytes: 184
+    │       ├── read bytes: 27
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       └── push downs: [filters: [], limit: 3]
@@ -160,7 +160,7 @@ Limit
         └── TableScan
             ├── table: default.default.t1
             ├── read rows: 2
-            ├── read bytes: 188
+            ├── read bytes: 31
             ├── partitions total: 1
             ├── partitions scanned: 1
             └── push downs: [filters: [], limit: 3]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor(query): disable distribute eval index when explain

fixes #8049
