### PR TITLE
feat(query): optimize count(Nullable(col))

### DIFF
--- a/src/query/datavalues/src/types/type_nullable.rs
+++ b/src/query/datavalues/src/types/type_nullable.rs
@@ -39,7 +39,11 @@ impl NullableType {
     }
 
     pub fn create(inner: DataTypeImpl) -> Self {
-        debug_assert!(inner.can_inside_nullable());
+        debug_assert!(
+            inner.can_inside_nullable(),
+            "{} can't be inside of nullable.",
+            inner.name()
+        );
         NullableType {
             inner: Box::new(inner),
         }

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -52,6 +52,7 @@ use crate::plans::RelOp;
 use crate::plans::RelOperator;
 use crate::plans::Scalar;
 use crate::plans::ScalarItem;
+use crate::plans::Statistics;
 use crate::plans::SubqueryExpr;
 use crate::plans::SubqueryType;
 use crate::ColumnBinding;
@@ -409,10 +410,12 @@ impl SubqueryRewriter {
                     push_down_predicates: None,
                     limit: None,
                     order_by: None,
-                    statistics: None,
-                    col_stats: HashMap::new(),
+                    statistics: Statistics {
+                        statistics: None,
+                        col_stats: HashMap::new(),
+                        is_accurate: false,
+                    },
                     prewhere: None,
-                    is_accurate: false,
                 }
                 .into(),
             );

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 
 use common_datavalues::type_coercion::compare_coercion;
@@ -409,6 +410,7 @@ impl SubqueryRewriter {
                     limit: None,
                     order_by: None,
                     statistics: None,
+                    col_stats: HashMap::new(),
                     prewhere: None,
                 }
                 .into(),

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -412,6 +412,7 @@ impl SubqueryRewriter {
                     statistics: None,
                     col_stats: HashMap::new(),
                     prewhere: None,
+                    is_accurate: false,
                 }
                 .into(),
             );

--- a/src/query/sql/src/planner/optimizer/heuristic/prune_unused_columns.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/prune_unused_columns.rs
@@ -97,6 +97,7 @@ impl UnusedColumnPruner {
                     limit: p.limit,
                     order_by: p.order_by.clone(),
                     statistics: p.statistics,
+                    col_stats: p.col_stats.clone(),
                     prewhere,
                 })))
             }

--- a/src/query/sql/src/planner/optimizer/heuristic/prune_unused_columns.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/prune_unused_columns.rs
@@ -23,6 +23,7 @@ use crate::plans::Aggregate;
 use crate::plans::EvalScalar;
 use crate::plans::LogicalGet;
 use crate::plans::RelOperator;
+use crate::plans::Statistics;
 use crate::MetadataRef;
 use crate::ScalarExpr;
 
@@ -96,10 +97,12 @@ impl UnusedColumnPruner {
                     push_down_predicates: p.push_down_predicates.clone(),
                     limit: p.limit,
                     order_by: p.order_by.clone(),
-                    statistics: p.statistics,
-                    col_stats: p.col_stats.clone(),
+                    statistics: Statistics {
+                        statistics: p.statistics.statistics,
+                        col_stats: p.statistics.col_stats.clone(),
+                        is_accurate: p.statistics.is_accurate,
+                    },
                     prewhere,
-                    is_accurate: p.is_accurate,
                 })))
             }
             RelOperator::LogicalInnerJoin(p) => {

--- a/src/query/sql/src/planner/optimizer/heuristic/prune_unused_columns.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/prune_unused_columns.rs
@@ -99,6 +99,7 @@ impl UnusedColumnPruner {
                     statistics: p.statistics,
                     col_stats: p.col_stats.clone(),
                     prewhere,
+                    is_accurate: p.is_accurate,
                 })))
             }
             RelOperator::LogicalInnerJoin(p) => {

--- a/src/query/sql/src/planner/optimizer/mod.rs
+++ b/src/query/sql/src/planner/optimizer/mod.rs
@@ -44,6 +44,7 @@ pub use property::PhysicalProperty;
 pub use property::RelExpr;
 pub use property::RelationalProperty;
 pub use property::RequiredProperty;
+pub use property::Statistics;
 pub use rule::RuleFactory;
 pub use rule::RuleID;
 pub use rule::RuleSet;

--- a/src/query/sql/src/planner/optimizer/mod.rs
+++ b/src/query/sql/src/planner/optimizer/mod.rs
@@ -37,6 +37,8 @@ pub use optimizer::OptimizerConfig;
 pub use optimizer::OptimizerContext;
 pub use pattern_extractor::PatternExtractor;
 pub use property::ColumnSet;
+pub use property::ColumnStat;
+pub use property::ColumnStatSet;
 pub use property::Distribution;
 pub use property::PhysicalProperty;
 pub use property::RelExpr;

--- a/src/query/sql/src/planner/optimizer/property/mod.rs
+++ b/src/query/sql/src/planner/optimizer/property/mod.rs
@@ -20,6 +20,8 @@ mod property;
 mod stat;
 
 pub use builder::RelExpr;
+pub use column_stat::ColumnStat;
+pub use column_stat::ColumnStatSet;
 pub use enforcer::require_property;
 pub use property::ColumnSet;
 pub use property::Distribution;

--- a/src/query/sql/src/planner/optimizer/property/mod.rs
+++ b/src/query/sql/src/planner/optimizer/property/mod.rs
@@ -28,3 +28,4 @@ pub use property::Distribution;
 pub use property::PhysicalProperty;
 pub use property::RelationalProperty;
 pub use property::RequiredProperty;
+pub use property::Statistics;

--- a/src/query/sql/src/planner/optimizer/property/property.rs
+++ b/src/query/sql/src/planner/optimizer/property/property.rs
@@ -32,6 +32,17 @@ impl RequiredProperty {
 }
 
 #[derive(Default, Clone, Debug)]
+pub struct Statistics {
+    // We can get the precise row count of a table in databend,
+    // which information is useful to optimize some queries like `COUNT(*)`.
+    pub precise_cardinality: Option<u64>,
+    /// Statistics of columns, column index -> column stat
+    pub column_stats: ColumnStatSet,
+    /// Statistics info is accurate
+    pub is_accurate: bool,
+}
+
+#[derive(Default, Clone, Debug)]
 pub struct RelationalProperty {
     /// Output columns of a relational expression
     pub output_columns: ColumnSet,
@@ -45,14 +56,7 @@ pub struct RelationalProperty {
     // TODO(leiysky): introduce upper bound of cardinality to
     // reduce error in estimation.
     pub cardinality: f64,
-    // We can get the precise row count of a table in databend,
-    // which information is useful to optimize some queries like `COUNT(*)`.
-    pub precise_cardinality: Option<u64>,
-
-    /// Statistics of columns, column index -> column stat
-    pub column_stats: ColumnStatSet,
-    /// Statistics info is accurate
-    pub is_accurate: bool,
+    pub statistics: Statistics,
 }
 
 #[derive(Default, Clone)]

--- a/src/query/sql/src/planner/optimizer/property/property.rs
+++ b/src/query/sql/src/planner/optimizer/property/property.rs
@@ -51,6 +51,8 @@ pub struct RelationalProperty {
 
     /// Statistics of columns, column index -> column stat
     pub column_stats: ColumnStatSet,
+    /// Statistics info is accurate
+    pub is_accurate: bool,
 }
 
 #[derive(Default, Clone)]

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
@@ -98,7 +98,7 @@ impl Rule for RuleFoldCountAggregate {
                 _ => false,
             });
 
-        if let (true, Some(card)) = (is_simple_count, input_prop.precise_cardinality) {
+        if let (true, Some(card)) = (is_simple_count, input_prop.statistics.precise_cardinality) {
             let mut scalars = agg.aggregate_functions;
             for item in scalars.iter_mut() {
                 item.scalar = Scalar::ConstantExpr(ConstantExpr {
@@ -114,9 +114,9 @@ impl Rule for RuleFoldCountAggregate {
             ));
         } else if let (true, true, column_stats, Some(table_card)) = (
             simple_nullable_count,
-            input_prop.is_accurate,
-            input_prop.column_stats,
-            input_prop.precise_cardinality,
+            input_prop.statistics.is_accurate,
+            input_prop.statistics.column_stats,
+            input_prop.statistics.precise_cardinality,
         ) {
             let mut scalars = agg.aggregate_functions;
             for item in scalars.iter_mut() {

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
@@ -112,13 +112,13 @@ impl Rule for RuleFoldCountAggregate {
                 eval_scalar.into(),
                 SExpr::create_leaf(dummy_table_scan.into()),
             ));
-        } else if let (true, column_stats, Some(table_card)) = (
+        } else if let (true, true, column_stats, Some(table_card)) = (
             simple_nullable_count,
+            input_prop.is_accurate,
             input_prop.column_stats,
             input_prop.precise_cardinality,
         ) {
             let mut scalars = agg.aggregate_functions;
-            // Now count function must only have one arg.
             for item in scalars.iter_mut() {
                 if let Scalar::AggregateFunction(agg_func) = item.scalar.clone() {
                     let col_set = agg_func.args[0].used_columns();

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
@@ -87,6 +87,17 @@ impl Rule for RuleFoldCountAggregate {
                 _ => false,
             });
 
+        let simple_nullable_count = agg.group_items.is_empty()
+            && agg.aggregate_functions.iter().all(|agg| match &agg.scalar {
+                Scalar::AggregateFunction(agg_func) => {
+                    agg_func.func_name == "count"
+                        && (agg_func.args.is_empty()
+                            || matches!(agg_func.args[0].data_type(), Nullable(_)))
+                        && !agg_func.distinct
+                }
+                _ => false,
+            });
+
         if let (true, Some(card)) = (is_simple_count, input_prop.precise_cardinality) {
             let mut scalars = agg.aggregate_functions;
             for item in scalars.iter_mut() {
@@ -101,8 +112,36 @@ impl Rule for RuleFoldCountAggregate {
                 eval_scalar.into(),
                 SExpr::create_leaf(dummy_table_scan.into()),
             ));
+        } else if let (true, column_stats, Some(table_card)) = (
+            simple_nullable_count,
+            input_prop.column_stats,
+            input_prop.precise_cardinality,
+        ) {
+            let mut scalars = agg.aggregate_functions;
+            // Now count function must only have one arg.
+            for item in scalars.iter_mut() {
+                if let Scalar::AggregateFunction(agg_func) = item.scalar.clone() {
+                    let col_set = agg_func.args[0].used_columns();
+                    for index in col_set {
+                        let col_stat = column_stats.get(&index);
+                        if let Some(card) = col_stat {
+                            item.scalar = Scalar::ConstantExpr(ConstantExpr {
+                                value: DataValue::UInt64(table_card - card.null_count),
+                                data_type: Box::new(item.scalar.data_type()),
+                            });
+                        } else {
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+            let eval_scalar = EvalScalar { items: scalars };
+            let dummy_table_scan = DummyTableScan;
+            state.add_result(SExpr::create_unary(
+                eval_scalar.into(),
+                SExpr::create_leaf(dummy_table_scan.into()),
+            ));
         }
-
         Ok(())
     }
 

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -20,6 +20,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
+use crate::optimizer::Statistics;
 use crate::plans::LogicalOperator;
 use crate::plans::Operator;
 use crate::plans::PhysicalOperator;
@@ -154,16 +155,19 @@ impl LogicalOperator for Aggregate {
         // Derive used columns
         let mut used_columns = self.used_columns()?;
         used_columns.extend(input_prop.used_columns);
+        let column_stats = input_prop.statistics.column_stats;
+        let is_accurate = input_prop.statistics.is_accurate;
 
         Ok(RelationalProperty {
             output_columns,
             outer_columns,
             used_columns,
             cardinality,
-            precise_cardinality,
-
-            column_stats: input_prop.column_stats,
-            is_accurate: input_prop.is_accurate,
+            statistics: Statistics {
+                precise_cardinality,
+                column_stats,
+                is_accurate,
+            },
         })
     }
 

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -162,7 +162,8 @@ impl LogicalOperator for Aggregate {
             cardinality,
             precise_cardinality,
 
-            column_stats: Default::default(),
+            column_stats: input_prop.column_stats,
+            is_accurate: input_prop.is_accurate,
         })
     }
 

--- a/src/query/sql/src/planner/plans/dummy_table_scan.rs
+++ b/src/query/sql/src/planner/plans/dummy_table_scan.rs
@@ -59,6 +59,7 @@ impl LogicalOperator for DummyTableScan {
             precise_cardinality: Some(1),
 
             column_stats: Default::default(),
+            is_accurate: false,
         })
     }
 

--- a/src/query/sql/src/planner/plans/dummy_table_scan.rs
+++ b/src/query/sql/src/planner/plans/dummy_table_scan.rs
@@ -20,6 +20,7 @@ use super::PhysicalOperator;
 use crate::optimizer::ColumnSet;
 use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelationalProperty;
+use crate::optimizer::Statistics;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DummyTableScan;
@@ -56,10 +57,11 @@ impl LogicalOperator for DummyTableScan {
             outer_columns: ColumnSet::new(),
             used_columns: ColumnSet::new(),
             cardinality: 1.0,
-            precise_cardinality: Some(1),
-
-            column_stats: Default::default(),
-            is_accurate: false,
+            statistics: Statistics {
+                precise_cardinality: Some(1),
+                column_stats: Default::default(),
+                is_accurate: false,
+            },
         })
     }
 

--- a/src/query/sql/src/planner/plans/eval_scalar.rs
+++ b/src/query/sql/src/planner/plans/eval_scalar.rs
@@ -19,6 +19,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
+use crate::optimizer::Statistics;
 use crate::plans::LogicalOperator;
 use crate::plans::Operator;
 use crate::plans::PhysicalOperator;
@@ -100,8 +101,8 @@ impl LogicalOperator for EvalScalar {
 
         // Derive cardinality
         let cardinality = input_prop.cardinality;
-        let precise_cardinality = input_prop.precise_cardinality;
-
+        let precise_cardinality = input_prop.statistics.precise_cardinality;
+        let is_accurate = input_prop.statistics.is_accurate;
         // Derive used columns
         let mut used_columns = self.used_columns()?;
         used_columns.extend(input_prop.used_columns);
@@ -111,10 +112,11 @@ impl LogicalOperator for EvalScalar {
             outer_columns,
             used_columns,
             cardinality,
-            precise_cardinality,
-
-            column_stats: Default::default(),
-            is_accurate: input_prop.is_accurate,
+            statistics: Statistics {
+                precise_cardinality,
+                column_stats: Default::default(),
+                is_accurate,
+            },
         })
     }
 

--- a/src/query/sql/src/planner/plans/eval_scalar.rs
+++ b/src/query/sql/src/planner/plans/eval_scalar.rs
@@ -114,6 +114,7 @@ impl LogicalOperator for EvalScalar {
             precise_cardinality,
 
             column_stats: Default::default(),
+            is_accurate: input_prop.is_accurate,
         })
     }
 

--- a/src/query/sql/src/planner/plans/filter.rs
+++ b/src/query/sql/src/planner/plans/filter.rs
@@ -19,6 +19,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
+use crate::optimizer::Statistics;
 use crate::plans::LogicalOperator;
 use crate::plans::Operator;
 use crate::plans::PhysicalOperator;
@@ -102,10 +103,11 @@ impl LogicalOperator for Filter {
             cardinality,
             // TODO(leiysky): if the predicate is always true, then we can pass through
             // precise cardinality
-            precise_cardinality: None,
-
-            column_stats: Default::default(),
-            is_accurate: false,
+            statistics: Statistics {
+                precise_cardinality: None,
+                column_stats: Default::default(),
+                is_accurate: false,
+            },
         })
     }
 

--- a/src/query/sql/src/planner/plans/filter.rs
+++ b/src/query/sql/src/planner/plans/filter.rs
@@ -105,6 +105,7 @@ impl LogicalOperator for Filter {
             precise_cardinality: None,
 
             column_stats: Default::default(),
+            is_accurate: false,
         })
     }
 

--- a/src/query/sql/src/planner/plans/limit.rs
+++ b/src/query/sql/src/planner/plans/limit.rs
@@ -20,6 +20,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
+use crate::optimizer::Statistics;
 use crate::plans::LogicalOperator;
 use crate::plans::Operator;
 use crate::plans::PhysicalOperator;
@@ -82,10 +83,11 @@ impl LogicalOperator for Limit {
                 Some(limit) if (limit as f64) < input_prop.cardinality => limit as f64,
                 _ => input_prop.cardinality,
             },
-            precise_cardinality: None,
-
-            column_stats: Default::default(),
-            is_accurate: false,
+            statistics: Statistics {
+                precise_cardinality: None,
+                column_stats: Default::default(),
+                is_accurate: false,
+            },
         })
     }
 

--- a/src/query/sql/src/planner/plans/limit.rs
+++ b/src/query/sql/src/planner/plans/limit.rs
@@ -85,6 +85,7 @@ impl LogicalOperator for Limit {
             precise_cardinality: None,
 
             column_stats: Default::default(),
+            is_accurate: false,
         })
     }
 

--- a/src/query/sql/src/planner/plans/logical_get.rs
+++ b/src/query/sql/src/planner/plans/logical_get.rs
@@ -56,6 +56,7 @@ pub struct LogicalGet {
     pub statistics: Option<TableStatistics>,
     // statistics will be ignored in comparison and hashing
     pub col_stats: HashMap<IndexType, Option<ColumnStatistics>>,
+    pub is_accurate: bool,
 }
 
 impl PartialEq for LogicalGet {
@@ -132,6 +133,7 @@ impl LogicalOperator for LogicalGet {
                 .map_or(0.0, |stat| stat.num_rows.map_or(0.0, |num| num as f64)),
             precise_cardinality: self.statistics.as_ref().and_then(|stat| stat.num_rows),
             column_stats,
+            is_accurate: self.is_accurate,
         })
     }
 

--- a/src/query/sql/src/planner/plans/logical_get.rs
+++ b/src/query/sql/src/planner/plans/logical_get.rs
@@ -24,6 +24,7 @@ use crate::optimizer::ColumnStat;
 use crate::optimizer::ColumnStatSet;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
+use crate::optimizer::Statistics as OpStatistics;
 use crate::plans::LogicalOperator;
 use crate::plans::Operator;
 use crate::plans::PhysicalOperator;
@@ -44,6 +45,15 @@ pub struct Prewhere {
 }
 
 #[derive(Clone, Debug)]
+pub struct Statistics {
+    // statistics will be ignored in comparison and hashing
+    pub statistics: Option<TableStatistics>,
+    // statistics will be ignored in comparison and hashing
+    pub col_stats: HashMap<IndexType, Option<ColumnStatistics>>,
+    pub is_accurate: bool,
+}
+
+#[derive(Clone, Debug)]
 pub struct LogicalGet {
     pub table_index: IndexType,
     pub columns: ColumnSet,
@@ -52,11 +62,7 @@ pub struct LogicalGet {
     pub order_by: Option<Vec<SortItem>>,
     pub prewhere: Option<Prewhere>,
 
-    // statistics will be ignored in comparison and hashing
-    pub statistics: Option<TableStatistics>,
-    // statistics will be ignored in comparison and hashing
-    pub col_stats: HashMap<IndexType, Option<ColumnStatistics>>,
-    pub is_accurate: bool,
+    pub statistics: Statistics,
 }
 
 impl PartialEq for LogicalGet {
@@ -114,7 +120,7 @@ impl LogicalOperator for LogicalGet {
         }
 
         let mut column_stats: ColumnStatSet = Default::default();
-        for (k, v) in &self.col_stats {
+        for (k, v) in &self.statistics.col_stats {
             if let Some(col_stat) = v {
                 let column_stat = ColumnStat {
                     distinct_count: col_stat.number_of_distinct_values,
@@ -129,11 +135,18 @@ impl LogicalOperator for LogicalGet {
             used_columns,
             cardinality: self
                 .statistics
+                .statistics
                 .as_ref()
                 .map_or(0.0, |stat| stat.num_rows.map_or(0.0, |num| num as f64)),
-            precise_cardinality: self.statistics.as_ref().and_then(|stat| stat.num_rows),
-            column_stats,
-            is_accurate: self.is_accurate,
+            statistics: OpStatistics {
+                precise_cardinality: self
+                    .statistics
+                    .statistics
+                    .as_ref()
+                    .and_then(|stat| stat.num_rows),
+                column_stats,
+                is_accurate: self.statistics.is_accurate,
+            },
         })
     }
 

--- a/src/query/sql/src/planner/plans/logical_join.rs
+++ b/src/query/sql/src/planner/plans/logical_join.rs
@@ -224,6 +224,7 @@ impl LogicalOperator for LogicalInnerJoin {
             precise_cardinality: None,
 
             column_stats: Default::default(),
+            is_accurate: false,
         })
     }
 

--- a/src/query/sql/src/planner/plans/logical_join.rs
+++ b/src/query/sql/src/planner/plans/logical_join.rs
@@ -21,6 +21,7 @@ use super::ScalarExpr;
 use crate::optimizer::ColumnSet;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
+use crate::optimizer::Statistics;
 use crate::plans::LogicalOperator;
 use crate::plans::Operator;
 use crate::plans::PhysicalOperator;
@@ -221,10 +222,11 @@ impl LogicalOperator for LogicalInnerJoin {
             outer_columns,
             used_columns,
             cardinality,
-            precise_cardinality: None,
-
-            column_stats: Default::default(),
-            is_accurate: false,
+            statistics: Statistics {
+                precise_cardinality: None,
+                column_stats: Default::default(),
+                is_accurate: false,
+            },
         })
     }
 

--- a/src/query/sql/src/planner/plans/union_all.rs
+++ b/src/query/sql/src/planner/plans/union_all.rs
@@ -94,6 +94,7 @@ impl LogicalOperator for UnionAll {
             precise_cardinality,
 
             column_stats: Default::default(),
+            is_accurate: left_prop.is_accurate && right_prop.is_accurate,
         })
     }
 

--- a/src/query/sql/src/planner/plans/union_all.rs
+++ b/src/query/sql/src/planner/plans/union_all.rs
@@ -20,6 +20,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
+use crate::optimizer::Statistics;
 use crate::plans::LogicalOperator;
 use crate::plans::Operator;
 use crate::plans::PhysicalOperator;
@@ -75,11 +76,16 @@ impl LogicalOperator for UnionAll {
 
         let cardinality = left_prop.cardinality + right_prop.cardinality;
 
-        let precise_cardinality = left_prop.precise_cardinality.and_then(|left_cardinality| {
-            right_prop
+        let precise_cardinality =
+            left_prop
+                .statistics
                 .precise_cardinality
-                .map(|right_cardinality| left_cardinality + right_cardinality)
-        });
+                .and_then(|left_cardinality| {
+                    right_prop
+                        .statistics
+                        .precise_cardinality
+                        .map(|right_cardinality| left_cardinality + right_cardinality)
+                });
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;
@@ -91,10 +97,11 @@ impl LogicalOperator for UnionAll {
             outer_columns,
             used_columns,
             cardinality,
-            precise_cardinality,
-
-            column_stats: Default::default(),
-            is_accurate: left_prop.is_accurate && right_prop.is_accurate,
+            statistics: Statistics {
+                precise_cardinality,
+                column_stats: Default::default(),
+                is_accurate: left_prop.statistics.is_accurate && right_prop.statistics.is_accurate,
+            },
         })
     }
 

--- a/tests/logictest/suites/base/03_dml/03_0032_select_null_count
+++ b/tests/logictest/suites/base/03_dml/03_0032_select_null_count
@@ -1,0 +1,23 @@
+statement ok
+drop table if exists t;
+
+statement ok
+create table t(c0 tuple(int, int), c1 string null);
+
+statement ok
+insert into t(c1) values(null), (null), (null);
+
+statement query I
+select count(c1) from t;
+
+----
+0
+
+statement query I
+select count(c0) from t;
+
+----
+3
+
+statement ok
+drop table if exists t;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

If simple count(nullable(col)), fold it.

|now|before optimize|
|:--:|:--:|
| 0.002s | 0.091s |
 
```sql
CREATE TABLE orders
(
    o_orderkey       BIGINT  null,
    o_custkey        BIGINT  null,
    o_orderstatus    STRING  null,
    o_totalprice     DOUBLE  null,
    o_orderdate      DATE  null,
    o_orderpriority  STRING  null,  
    o_clerk          STRING  null, 
    o_shippriority   INTEGER  null,
    o_comment        STRING  null
);

mysql> select count(o_clerk) from orders;
+----------------+
| count(o_clerk) |
+----------------+
|       15000000 |
+----------------+
1 row in set (0.02 sec)
Read 1 rows, 1.00 B in 0.002 sec., 469.46 rows/sec., 469.46 B/sec.

mysql> select count(o_clerk) from orders;
+----------------+
| count(o_clerk) |
+----------------+
|       15000000 |
+----------------+
1 row in set (0.10 sec)
Read 15000000 rows, 330.81 MiB in 0.091 sec., 164.49 million rows/sec., 3.54 GiB/sec.

```

Closes #8804
