### PR TITLE
feat: implement drop user defined catalog

### DIFF
--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -200,6 +200,10 @@ build_exceptions! {
     /// - having the same name as a already exist, like `default`
     /// - and without `IF NOT EXISTS`
     CatalogAlreadyExists(2319),
+    /// `UnknownCatalog` should be raised when trying to drop a catalog that is:
+    /// - not exists.
+    /// - and without `IF EXISTS`
+    UnknownCatalog(2320),
 
     // Cluster error codes.
     ClusterUnknownNode(2401),

--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -200,10 +200,10 @@ build_exceptions! {
     /// - having the same name as a already exist, like `default`
     /// - and without `IF NOT EXISTS`
     CatalogAlreadyExists(2319),
-    /// `UnknownCatalog` should be raised when trying to drop a catalog that is:
+    /// `CatalogNotFound` should be raised when trying to drop a catalog that is:
     /// - not exists.
     /// - and without `IF EXISTS`
-    UnknownCatalog(2320),
+    CatalogNotFound(2320),
 
     // Cluster error codes.
     ClusterUnknownNode(2401),

--- a/src/meta/app/src/schema/catalog.rs
+++ b/src/meta/app/src/schema/catalog.rs
@@ -68,3 +68,19 @@ impl Display for CreateCatalogReq {
         )
     }
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DropCatalogReq {
+    pub if_exists: bool,
+    pub name_ident: CatalogNameIdent,
+}
+
+impl Display for DropCatalogReq {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "drop_catalog(if_exists={}):{}/{}",
+            self.if_exists, self.name_ident.tenant, self.name_ident.catalog_name
+        )
+    }
+}

--- a/src/meta/app/src/schema/mod.rs
+++ b/src/meta/app/src/schema/mod.rs
@@ -22,6 +22,7 @@ pub use catalog::CatalogMeta;
 pub use catalog::CatalogNameIdent;
 pub use catalog::CatalogType;
 pub use catalog::CreateCatalogReq;
+pub use catalog::DropCatalogReq;
 pub use database::CreateDatabaseReply;
 pub use database::CreateDatabaseReq;
 pub use database::DatabaseId;

--- a/src/query/service/src/catalogs/catalog_manager.rs
+++ b/src/query/service/src/catalogs/catalog_manager.rs
@@ -149,7 +149,7 @@ impl CatalogManagerHelper for CatalogManager {
 
             None if req.if_exists => Ok(()),
 
-            None => Err(ErrorCode::UnknownCatalog(format!(
+            None => Err(ErrorCode::CatalogNotFound(format!(
                 "Catalog {} has to be exists",
                 name
             ))),

--- a/src/query/service/src/catalogs/catalog_manager.rs
+++ b/src/query/service/src/catalogs/catalog_manager.rs
@@ -24,6 +24,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_app::schema::CatalogType;
 use common_meta_app::schema::CreateCatalogReq;
+use common_meta_app::schema::DropCatalogReq;
 #[cfg(feature = "hive")]
 use common_storages_hive::HiveCatalog;
 use dashmap::DashMap;
@@ -41,6 +42,8 @@ pub trait CatalogManagerHelper {
     fn register_external_catalogs(&self, conf: &Config) -> Result<()>;
 
     fn create_user_defined_catalog(&self, req: CreateCatalogReq) -> Result<()>;
+
+    fn drop_user_defined_catalog(&self, req: DropCatalogReq) -> Result<()>;
 }
 
 #[async_trait::async_trait]
@@ -130,6 +133,26 @@ impl CatalogManagerHelper for CatalogManager {
                     self.insert_catalog(ctl_name, catalog, if_not_exists)
                 }
             }
+        }
+    }
+
+    fn drop_user_defined_catalog(&self, req: DropCatalogReq) -> Result<()> {
+        let name = req.name_ident.catalog_name;
+        if name == CATALOG_DEFAULT {
+            return Err(ErrorCode::CatalogNotSupported(
+                "Dropping the DEFAULT catalog is not allowed",
+            ));
+        }
+
+        match self.catalogs.remove(&name) {
+            Some(_) => Ok(()),
+
+            None if req.if_exists => Ok(()),
+
+            None => Err(ErrorCode::UnknownCatalog(format!(
+                "Catalog {} has to be exists",
+                name
+            ))),
         }
     }
 }

--- a/src/query/service/src/interpreters/interpreter_catalog_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_catalog_drop.rs
@@ -1,0 +1,52 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use common_catalog::catalog::CatalogManager;
+use common_exception::Result;
+use common_sql::plans::DropCatalogPlan;
+use common_storages_fuse::TableContext;
+
+use super::Interpreter;
+use crate::catalogs::CatalogManagerHelper;
+use crate::pipelines::PipelineBuildResult;
+use crate::sessions::QueryContext;
+
+pub struct DropCatalogInterpreter {
+    ctx: Arc<QueryContext>,
+    plan: DropCatalogPlan,
+}
+
+impl DropCatalogInterpreter {
+    pub fn create(ctx: Arc<QueryContext>, plan: DropCatalogPlan) -> Self {
+        Self { ctx, plan }
+    }
+}
+
+#[async_trait]
+impl Interpreter for DropCatalogInterpreter {
+    fn name(&self) -> &str {
+        "DropCatalogInterpreter"
+    }
+
+    #[tracing::instrument(level = "debug", skip(self), fields(ctx.id = self.ctx.get_id().as_str()))]
+    async fn execute2(&self) -> Result<PipelineBuildResult> {
+        let mgr = CatalogManager::instance();
+        mgr.drop_user_defined_catalog(self.plan.clone().into())?;
+
+        Ok(PipelineBuildResult::create())
+    }
+}

--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -24,6 +24,7 @@ use super::interpreter_share_desc::DescShareInterpreter;
 use super::interpreter_user_stage_drop::DropUserStageInterpreter;
 use super::*;
 use crate::interpreters::access::Accessor;
+use crate::interpreters::interpreter_catalog_drop::DropCatalogInterpreter;
 use crate::interpreters::interpreter_copy_v2::CopyInterpreterV2;
 use crate::interpreters::interpreter_presign::PresignInterpreter;
 use crate::interpreters::interpreter_role_show::ShowRolesInterpreter;
@@ -90,7 +91,9 @@ impl InterpreterFactory {
                 ctx,
                 *plan.clone(),
             )?)),
-            Plan::DropCatalog(_) => todo!(),
+            Plan::DropCatalog(plan) => {
+                Ok(Arc::new(DropCatalogInterpreter::create(ctx, *plan.clone())))
+            }
 
             // Databases
             Plan::ShowCreateDatabase(show_create_database) => Ok(Arc::new(

--- a/src/query/service/src/interpreters/mod.rs
+++ b/src/query/service/src/interpreters/mod.rs
@@ -19,6 +19,7 @@ mod fragments;
 mod interpreter;
 mod interpreter_call;
 mod interpreter_catalog_create;
+mod interpreter_catalog_drop;
 mod interpreter_cluster_key_alter;
 mod interpreter_cluster_key_drop;
 mod interpreter_clustering_history;

--- a/src/query/sql/src/planner/plans/ddl/catalog.rs
+++ b/src/query/sql/src/planner/plans/ddl/catalog.rs
@@ -19,6 +19,7 @@ use common_datavalues::DataSchemaRef;
 use common_meta_app::schema::CatalogMeta;
 use common_meta_app::schema::CatalogNameIdent;
 use common_meta_app::schema::CreateCatalogReq;
+use common_meta_app::schema::DropCatalogReq;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateCatalogPlan {
@@ -70,6 +71,30 @@ pub struct DropCatalogPlan {
 impl DropCatalogPlan {
     pub fn schema(&self) -> DataSchemaRef {
         Arc::new(DataSchema::empty())
+    }
+}
+
+impl From<DropCatalogPlan> for DropCatalogReq {
+    fn from(value: DropCatalogPlan) -> DropCatalogReq {
+        DropCatalogReq {
+            if_exists: value.if_exists,
+            name_ident: CatalogNameIdent {
+                tenant: value.tenant,
+                catalog_name: value.catalog,
+            },
+        }
+    }
+}
+
+impl From<&DropCatalogPlan> for DropCatalogReq {
+    fn from(value: &DropCatalogPlan) -> DropCatalogReq {
+        DropCatalogReq {
+            if_exists: value.if_exists,
+            name_ident: CatalogNameIdent {
+                tenant: value.tenant.clone(),
+                catalog_name: value.catalog.clone(),
+            },
+        }
     }
 }
 

--- a/tests/logictest/logictest.py
+++ b/tests/logictest/logictest.py
@@ -17,8 +17,7 @@ supports_labels = ["http", "mysql", "clickhouse"]
 # statement is a statement in sql logic test
 state_regex = (
     r"^\s*statement\s+(?P<statement>((?P<ok>OK)|((?P<error>)ERROR\s*(?P<expectError>.*))|(?P<query>QUERY\s*(("
-    r"ERROR\s+(?P<queryError>.*))|(?P<queryOptions>.*)))))$"
-)
+    r"ERROR\s+(?P<queryError>.*))|(?P<queryOptions>.*)))))$")
 
 result_regex = r"^----\s*(?P<label>.*)?$"
 condition_regex = r"^(skipif\s+(?P<skipDatabase>.*))|(onlyif\s+(?P<onlyDatabase>.*))$"
@@ -88,7 +87,8 @@ def get_result(lines):
 def parse_token_args(tokens, arg):
     i = 0
     while i < len(tokens):
-        if tokens[i].startswith("{}(".format(arg)) and tokens[i].endswith(")") is False:
+        if tokens[i].startswith(
+                "{}(".format(arg)) and tokens[i].endswith(")") is False:
             tokens[i] = tokens[i] + "," + tokens[i + 1]
             del tokens[i + 1]
             i -= 1
@@ -96,6 +96,7 @@ def parse_token_args(tokens, arg):
 
 
 class LogicError(Exception):
+
     def __init__(self, message, errorType, runner):
         self.message = message
         self.errorType = errorType
@@ -106,6 +107,7 @@ class LogicError(Exception):
 
 
 class Statement:
+
     def __init__(self, matched):
         assert matched is not None
         self.matched = matched
@@ -142,7 +144,7 @@ class Statement:
                 self.query_type = query_type
                 for token in tokens:
                     if token.startswith("label(") and token.endswith(")"):
-                        trimed = token[len("label(") : -1]
+                        trimed = token[len("label("):-1]
                         self.label = trimed.split(",")
                     if token == "retry":
                         self.retry = True
@@ -163,10 +165,10 @@ class Statement:
 
 
 class ParsedStatement(
-    collections.namedtuple(
-        "ParsedStatement", ["at_line", "s_type", "suite_name", "text", "results", "runs_on"]
-    )
-):
+        collections.namedtuple(
+            "ParsedStatement",
+            ["at_line", "s_type", "suite_name", "text", "results", "runs_on"])):
+
     def get_fields(self):
         return self._fields
 
@@ -206,7 +208,10 @@ def get_statements(suite_path, suite_name):
             if condition_matched.group("skipDatabase") is not None:
                 runs_on.remove(condition_matched.group("skipDatabase"))
             if condition_matched.group("onlyDatabase") is not None:
-                runs_on = {x for x in runs_on if x == condition_matched.group("onlyDatabase")}
+                runs_on = {
+                    x for x in runs_on
+                    if x == condition_matched.group("onlyDatabase")
+                }
             condition_matched = None
         log.debug("runs_on: {}".format(runs_on))
         if s.type == "query" and s.query_type is not None:
@@ -218,7 +223,8 @@ def get_statements(suite_path, suite_name):
                 result_count = len(s.label) + 1
             for i in range(result_count):
                 results.append(get_result(lines))
-        yield ParsedStatement(line_idx + 1, s, suite_name, text, results, runs_on)
+        yield ParsedStatement(line_idx + 1, s, suite_name, text, results,
+                              runs_on)
 
 
 def format_value(vals, val_num):
@@ -244,6 +250,7 @@ def safe_execute(method, *info):
 # factory class to abstract runtime interface
 @six.add_metaclass(abc.ABCMeta)
 class SuiteRunner(object):
+
     def __init__(self, kind, args):
         self.label = None
         self.retry_time = 3
@@ -271,22 +278,29 @@ class SuiteRunner(object):
                 base_name = os.path.basename(filename)
                 dirs = os.path.dirname(filename).split(os.sep)
 
-                if self.args.skip_dir and any(s in dirs for s in self.args.skip_dir):
-                    log.debug(f"Skip test file {filename}, in dirs {self.args.skip_dir}")
+                if self.args.skip_dir and any(
+                        s in dirs for s in self.args.skip_dir):
+                    log.debug(
+                        f"Skip test file {filename}, in dirs {self.args.skip_dir}"
+                    )
                     continue
 
-                if self.args.skip and any([re.search(r, base_name) for r in skips]):
+                if self.args.skip and any(
+                    [re.search(r, base_name) for r in skips]):
                     log.debug(f"Skip test file {filename}")
                     continue
 
-                if self.args.run_dir and not any(s in dirs for s in self.args.run_dir):
-                    log.debug(f"Skip test file {filename}, not in run dir {self.args.run_dir}")
+                if self.args.run_dir and not any(s in dirs
+                                                 for s in self.args.run_dir):
+                    log.debug(
+                        f"Skip test file {filename}, not in run dir {self.args.run_dir}"
+                    )
                     continue
 
                 if not self.args.pattern or any(
-                    [re.search(r, base_name) for r in self.args.pattern]
-                ):
-                    self.statement_files.append((filename, os.path.relpath(filename, suite_path)))
+                    [re.search(r, base_name) for r in self.args.pattern]):
+                    self.statement_files.append(
+                        (filename, os.path.relpath(filename, suite_path)))
 
         self.statement_files.sort()
 
@@ -307,13 +321,16 @@ class SuiteRunner(object):
                         self.batch_execute(statement_list)
                     except Exception as e:
                         print(traceback.format_exc())
-                        log.warning(f"Get exception when running suite {suite_name}")
-                        global_statistics.add_failed(self.kind, self.suite_now, e)
+                        log.warning(
+                            f"Get exception when running suite {suite_name}")
+                        global_statistics.add_failed(self.kind, self.suite_now,
+                                                     e)
                         continue
 
                     log.info(f"Suite: {file_path} passed")
             else:
-                raise RuntimeError(f"batch_execute is not implement in runner {self.kind}")
+                raise RuntimeError(
+                    f"batch_execute is not implement in runner {self.kind}")
 
     def execute_statement(self, statement):
         if self.kind not in statement.runs_on:
@@ -322,7 +339,9 @@ class SuiteRunner(object):
             )
             return
         if self.show_query_on_execution:
-            log.Info(f"executing statement, type {statement.s_type.type}\n{statement.text}\n")
+            log.Info(
+                f"executing statement, type {statement.s_type.type}\n{statement.text}\n"
+            )
         start = time.perf_counter()
         if statement.s_type.type == "query":
             self.assert_execute_query(statement)
@@ -334,16 +353,18 @@ class SuiteRunner(object):
             raise Exception("Unknown statement type")
         end = time.perf_counter()
         time_cost = end - start
-        global_statistics.add_perf(self.kind, self.suite_now, statement.text, time_cost)
+        global_statistics.add_perf(self.kind, self.suite_now, statement.text,
+                                   time_cost)
 
     # expect the query just return ok
     def assert_execute_ok(self, statement):
         try:
-            error = safe_execute(lambda: self.execute_ok(statement.text), statement)
+            error = safe_execute(lambda: self.execute_ok(statement.text),
+                                 statement)
         except Exception as err:
-            raise LogicError(
-                runner=self.kind, message=str(err), errorType="statement ok execute with exception"
-            )
+            raise LogicError(runner=self.kind,
+                             message=str(err),
+                             errorType="statement ok execute with exception")
         if error is not None:
             raise LogicError(
                 runner=self.kind,
@@ -360,7 +381,8 @@ class SuiteRunner(object):
                 return compare_result_with_reg(resultset[2].split(), f.split())
             except Exception as err:
                 raise LogicError(
-                    message="\n{}\n Expected:\n{:<80}\n Actual:\n{:<80}\n Statement:{}\n Start "
+                    message=
+                    "\n{}\n Expected:\n{:<80}\n Actual:\n{:<80}\n Statement:{}\n Start "
                     "Line: {}, Result Label: {}".format(
                         str(err),
                         resultset[2].rstrip(),
@@ -369,13 +391,15 @@ class SuiteRunner(object):
                         resultset[1],
                         resultset[0].group("label"),
                     ),
-                    errorType="statement query get result not equal to expected(with regex expression)",
+                    errorType=
+                    "statement query get result not equal to expected(with regex expression)",
                     runner=self.kind,
                 )
 
         if compare_f != compare_result:
             raise LogicError(
-                message="\n Expected:\n{:<80}\n Actual:\n{:<80}\n Statement:{}\n Start "
+                message=
+                "\n Expected:\n{:<80}\n Actual:\n{:<80}\n Statement:{}\n Start "
                 "Line: {}, Result Label: {}".format(
                     resultset[2].rstrip(),
                     f.rstrip(),
@@ -392,7 +416,8 @@ class SuiteRunner(object):
             log.debug(f"{statement.text} statement is skipped")
             return
         try:
-            actual = safe_execute(lambda: self.execute_query(statement), statement)
+            actual = safe_execute(lambda: self.execute_query(statement),
+                                  statement)
         except Exception as err:
             raise LogicError(
                 runner=self.kind,
@@ -419,15 +444,14 @@ class SuiteRunner(object):
             with_regex = True
         hasResult = False
         for resultset in statement.results:
-            if (
-                resultset[0].group("label") is not None
-                and resultset[0].group("label") == self.kind
-            ):
+            if (resultset[0].group("label") is not None and
+                    resultset[0].group("label") == self.kind):
                 self.assert_query_equal(f, resultset, statement, with_regex)
                 hasResult = True
         if not hasResult:
             for resultset in statement.results:
-                if resultset[0].group("label") is None or len(resultset[0].group("label")) == 0:
+                if resultset[0].group("label") is None or len(
+                        resultset[0].group("label")) == 0:
                     self.assert_query_equal(f, resultset, statement, with_regex)
                     hasResult = True
         if not hasResult:
@@ -440,7 +464,8 @@ class SuiteRunner(object):
     # expect the query just return error
     def assert_execute_error(self, statement):
         try:
-            actual = safe_execute(lambda: self.execute_error(statement.text), statement)
+            actual = safe_execute(lambda: self.execute_error(statement.text),
+                                  statement)
         except Exception as err:
             raise LogicError(
                 runner=self.kind,
@@ -449,17 +474,17 @@ class SuiteRunner(object):
             )
         if actual is None:
             raise LogicError(
-                message=f"expected error {statement.s_type.expect_error}, but got ok on statement: {statement.text} ",
+                message=
+                f"expected error {statement.s_type.expect_error}, but got ok on statement: {statement.text} ",
                 errorType="Error code mismatch",
                 runner=self.kind,
             )
         match = re.search(statement.s_type.expect_error, str(actual))
         if match is None:
             raise LogicError(
-                message=(
-                    f"\n expected error regex is {statement.s_type.expect_error})"
-                    f"\n actual found {actual}{str(statement)}"
-                ),
+                message=
+                (f"\n expected error regex is {statement.s_type.expect_error})"
+                 f"\n actual found {actual}{str(statement)}"),
                 errorType="Error code mismatch",
                 runner=self.kind,
             )

--- a/tests/logictest/statistics.py
+++ b/tests/logictest/statistics.py
@@ -3,6 +3,7 @@
 
 
 class LogicTestStatistics:
+
     def __init__(self) -> None:
         self._failed_map = dict()
         self._perf_map = dict()
@@ -19,12 +20,10 @@ class LogicTestStatistics:
             self._perf_map[runner] = dict()
         if suite_name not in self._perf_map[runner]:
             self._perf_map[runner][suite_name] = list()
-        self._perf_map[runner][suite_name].append(
-            {
-                "statement": statement,
-                "time_cost": time_cost,
-            }
-        )
+        self._perf_map[runner][suite_name].append({
+            "statement": statement,
+            "time_cost": time_cost,
+        })
 
     def __str__(self):
         failure_output = "Following failed statements:\n"
@@ -57,8 +56,7 @@ class LogicTestStatistics:
             summary_output += (
                 f"Runner {runner} test {suite_count} suites, "
                 f"total time cost {suite_cost} seconds, "
-                f"avg time cost {round(suite_cost/suite_count*1000, 2)} ms\n"
-            )
+                f"avg time cost {round(suite_cost/suite_count*1000, 2)} ms\n")
             summary_output += (
                 f"Runner {runner} test {statement_count} statements, "
                 f"total time cost {statement_cost} seconds, "


### PR DESCRIPTION
Signed-off-by: 蔡略 <cailue@bupt.edu.cn>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR implements the drop feature of multiple catalogs

Notes:
1. `default` catalog is not allowed to be dropped, a CatalogNotSupported error will be returned
2. dropping unknown catalogs without `IF EXISTS` will return a UnknownCatalog error

### Previews

1. create and drop by SQL
![图片](https://user-images.githubusercontent.com/44747719/202159344-7c3cd34b-8c34-47ff-befa-b810eeb5a1e3.png)

2. drop unknown catalog
![图片](https://user-images.githubusercontent.com/44747719/202159500-a839ec06-1127-4500-8fc4-3f386dd614ae.png)
3. drop default catalog
![图片](https://user-images.githubusercontent.com/44747719/202159662-10782a6f-9f1a-4063-adf9-9cb41131c38f.png)
