### PR TITLE
ci: disable incremental compilation on dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,8 @@ overflow-checks = false
 [profile.dev]
 split-debuginfo = "unpacked"
 overflow-checks = false
+# wait until https://github.com/rust-lang/rust/issues/100142 fixed
+incremental = false
 
 [profile.dev.package]
 addr2line = { opt-level = 3 }


### PR DESCRIPTION
Signed-off-by: 蔡略 <cailue@bupt.edu.cn>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR will disable incremental compilation on dev profiles.

Should be recovered when the [ICE](https://github.com/rust-lang/rust/issues/100142) got fixed.

