### PR TITLE
feat(query): Meatdata ColumnEntry add parquet leaf id

### DIFF
--- a/src/query/service/tests/it/sql/planner/format/mod.rs
+++ b/src/query/service/tests/it/sql/planner/format/mod.rs
@@ -68,8 +68,20 @@ impl Table for DummyTable {
 #[test]
 fn test_format() {
     let mut metadata = Metadata::default();
-    let col1 = metadata.add_column("col1".to_string(), BooleanType::new_impl(), None, None);
-    let col2 = metadata.add_column("col2".to_string(), BooleanType::new_impl(), None, None);
+    let col1 = metadata.add_column(
+        "col1".to_string(),
+        BooleanType::new_impl(),
+        None,
+        None,
+        None,
+    );
+    let col2 = metadata.add_column(
+        "col2".to_string(),
+        BooleanType::new_impl(),
+        None,
+        None,
+        None,
+    );
     let tab1 = metadata.add_table(
         "catalog".to_string(),
         "database".to_string(),

--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -155,10 +155,13 @@ impl<'a> AggregateRewriter<'a> {
                     scalar: arg.clone(),
                 });
             } else {
-                let index =
-                    self.metadata
-                        .write()
-                        .add_column(name.clone(), arg.data_type(), None, None);
+                let index = self.metadata.write().add_column(
+                    name.clone(),
+                    arg.data_type(),
+                    None,
+                    None,
+                    None,
+                );
 
                 // Generate a ColumnBinding for each argument of aggregates
                 let column_binding = ColumnBinding {
@@ -188,6 +191,7 @@ impl<'a> AggregateRewriter<'a> {
         let index = self.metadata.write().add_column(
             aggregate.display_name.clone(),
             *aggregate.return_type.clone(),
+            None,
             None,
             None,
         );
@@ -376,6 +380,7 @@ impl<'a> Binder {
                 self.metadata.write().add_column(
                     group_item_name.clone(),
                     data_type.clone(),
+                    None,
                     None,
                     None,
                 )

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -369,10 +369,13 @@ impl<'a> Binder {
         column_name: String,
         data_type: DataTypeImpl,
     ) -> ColumnBinding {
-        let index =
-            self.metadata
-                .write()
-                .add_column(column_name.clone(), data_type.clone(), None, None);
+        let index = self.metadata.write().add_column(
+            column_name.clone(),
+            data_type.clone(),
+            None,
+            None,
+            None,
+        );
         ColumnBinding {
             database_name,
             table_name,

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -466,6 +466,7 @@ impl<'a> Binder {
                     coercion_types[idx].clone(),
                     None,
                     None,
+                    None,
                 );
                 let column_binding = ColumnBinding {
                     database_name: None,
@@ -499,6 +500,7 @@ impl<'a> Binder {
                 let new_column_index = self.metadata.write().add_column(
                     right_col.column_name.clone(),
                     coercion_types[idx].clone(),
+                    None,
                     None,
                     None,
                 );

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -285,6 +285,7 @@ impl SubqueryRewriter {
                         NullableType::new_impl(BooleanType::new_impl()),
                         None,
                         None,
+                        None,
                     )
                 };
                 let join_plan = LogicalInnerJoin {
@@ -337,6 +338,7 @@ impl SubqueryRewriter {
                     self.metadata.write().add_column(
                         "marker".to_string(),
                         NullableType::new_impl(BooleanType::new_impl()),
+                        None,
                         None,
                         None,
                     )
@@ -393,6 +395,7 @@ impl SubqueryRewriter {
                                 column_entry.data_type().clone(),
                             ))
                         },
+                        None,
                         None,
                         None,
                     ),

--- a/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
@@ -388,6 +388,7 @@ impl SubqueryRewriter {
                     agg_func.return_type()?,
                     None,
                     None,
+                    None,
                 );
 
                 let agg = Aggregate {
@@ -501,6 +502,7 @@ impl SubqueryRewriter {
                     self.metadata.write().add_column(
                         "marker".to_string(),
                         NullableType::new_impl(BooleanType::new_impl()),
+                        None,
                         None,
                         None,
                     )


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add `leaf_id` for `ColumnEntry` in `Metadata`, which is the leaf column id in the `Parquet` file, we can use it to get `ColumnStatistics` for fuse storage.

refer [comment in 8805](https://github.com/datafuselabs/databend/pull/8805#discussion_r1024842412)


Closes #issue
