### PR TITLE
chore(base): disable runtime block in release binary

### DIFF
--- a/src/common/base/src/base/runtime.rs
+++ b/src/common/base/src/base/runtime.rs
@@ -104,11 +104,17 @@ impl Runtime {
         let join_handler = thread::spawn(move || {
             // We ignore channel is closed.
             let _ = runtime.block_on(recv_stop);
-            let instant = Instant::now();
-            // We wait up to 3 seconds to complete the runtime shutdown.
-            runtime.shutdown_timeout(Duration::from_secs(3));
 
-            instant.elapsed() >= Duration::from_secs(3)
+            match !cfg!(debug_assertions) {
+                true => false,
+                false => {
+                    let instant = Instant::now();
+                    // We wait up to 3 seconds to complete the runtime shutdown.
+                    runtime.shutdown_timeout(Duration::from_secs(3));
+
+                    instant.elapsed() >= Duration::from_secs(3)
+                }
+            }
         });
 
         Ok(Runtime {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore(base): disable runtime block in release binary

fixes #8822
