### PR TITLE
refactor: rename `LogicalInnerJoin` to `LogicalJoin`

### DIFF
--- a/docs/doc/14-sql-commands/90-explain-cmds/explain-memo.md
+++ b/docs/doc/14-sql-commands/90-explain-cmds/explain-memo.md
@@ -28,8 +28,8 @@ EXPLAIN MEMO SELECT * FROM numbers(10) t, numbers(100) t1;
                                      
  Group #2                            
  ├── best cost: [#3] 310             
- ├── LogicalInnerJoin [#0, #1]       
- ├── LogicalInnerJoin [#1, #0]       
+ ├── LogicalJoin [#0, #1]       
+ ├── LogicalJoin [#1, #0]       
  ├── PhysicalHashJoin [#0, #1]       
  └── PhysicalHashJoin [#1, #0]
 ```

--- a/docs/doc/14-sql-commands/90-explain-cmds/explain-raw.md
+++ b/docs/doc/14-sql-commands/90-explain-cmds/explain-raw.md
@@ -18,7 +18,7 @@ explain raw select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.
 Project: [a (#0),b (#1),a (#2),b (#3)]
  └── EvalScalar: [t1.a (#0), t1.b (#1), t2.a (#2), t2.b (#3)]
      └── Filter: [((t1.a (#0) = t2.a (#2)) AND (t1.a (#0) > 3)) OR (t1.a (#0) = t2.a (#2))]
-         └── LogicalInnerJoin: equi-conditions: [], non-equi-conditions: []
+         └── LogicalJoin: equi-conditions: [], non-equi-conditions: []
              ├── LogicalGet: default.default.t1
              └── LogicalGet: default.default.t2
 
@@ -27,7 +27,7 @@ explain raw select * from t1 inner join t2 on t1.a = t2.a and t1.b = t2.b and t1
  ----
  Project: [a (#0),b (#1),a (#2),b (#3)]
  └── EvalScalar: [t1.a (#0), t1.b (#1), t2.a (#2), t2.b (#3)]
-     └── LogicalInnerJoin: equi-conditions: [(t1.a (#0) = t2.a (#2)) AND (t1.b (#1) = t2.b (#3))], non-equi-conditions: [t1.a (#0) > 2]
+     └── LogicalJoin: equi-conditions: [(t1.a (#0) = t2.a (#2)) AND (t1.b (#1) = t2.b (#3))], non-equi-conditions: [t1.a (#0) > 2]
          ├── LogicalGet: default.default.t1
          └── LogicalGet: default.default.t2
 ```

--- a/src/query/sql/src/planner/binder/join.rs
+++ b/src/query/sql/src/planner/binder/join.rs
@@ -40,7 +40,7 @@ use crate::planner::semantic::NameResolutionContext;
 use crate::plans::BoundColumnRef;
 use crate::plans::Filter;
 use crate::plans::JoinType;
-use crate::plans::LogicalInnerJoin;
+use crate::plans::LogicalJoin;
 use crate::plans::Scalar;
 use crate::plans::ScalarExpr;
 use crate::BindContext;
@@ -241,7 +241,7 @@ impl<'a> Binder {
             other_conditions,
             &mut non_equi_conditions,
         )?;
-        let inner_join = LogicalInnerJoin {
+        let logical_join = LogicalJoin {
             left_conditions,
             right_conditions,
             non_equi_conditions,
@@ -250,7 +250,7 @@ impl<'a> Binder {
             from_correlated_subquery: false,
         };
         Ok(SExpr::create_binary(
-            inner_join.into(),
+            logical_join.into(),
             left_child,
             right_child,
         ))

--- a/src/query/sql/src/planner/format/display_rel_operator.rs
+++ b/src/query/sql/src/planner/format/display_rel_operator.rs
@@ -31,7 +31,7 @@ use crate::plans::Filter;
 use crate::plans::JoinType;
 use crate::plans::Limit;
 use crate::plans::LogicalGet;
-use crate::plans::LogicalInnerJoin;
+use crate::plans::LogicalJoin;
 use crate::plans::PhysicalHashJoin;
 use crate::plans::PhysicalScan;
 use crate::plans::RelOperator;
@@ -69,7 +69,7 @@ impl Display for FormatContext {
                 rel_operator,
             } => match rel_operator.as_ref() {
                 RelOperator::LogicalGet(_) => write!(f, "LogicalGet"),
-                RelOperator::LogicalInnerJoin(op) => format_logical_inner_join(f, metadata, op),
+                RelOperator::LogicalJoin(op) => format_logical_join(f, metadata, op),
                 RelOperator::PhysicalScan(_) => write!(f, "PhysicalScan"),
                 RelOperator::PhysicalHashJoin(op) => format_hash_join(f, metadata, op),
                 RelOperator::EvalScalar(_) => write!(f, "EvalScalar"),
@@ -142,10 +142,10 @@ pub fn format_scalar(_metadata: &MetadataRef, scalar: &Scalar) -> String {
     }
 }
 
-pub fn format_logical_inner_join(
+pub fn format_logical_join(
     f: &mut std::fmt::Formatter<'_>,
     _metadata: &MetadataRef,
-    op: &LogicalInnerJoin,
+    op: &LogicalJoin,
 ) -> std::fmt::Result {
     write!(f, "LogicalJoin: {}", op.join_type)
 }
@@ -204,9 +204,7 @@ fn to_format_tree(
 ) -> FormatTreeNode<FormatContext> {
     match &rel_operator {
         RelOperator::PhysicalScan(op) => physical_scan_to_format_tree(op, metadata, children),
-        RelOperator::LogicalInnerJoin(op) => {
-            logical_inner_join_to_format_tree(op, metadata, children)
-        }
+        RelOperator::LogicalJoin(op) => logical_join_to_format_tree(op, metadata, children),
         RelOperator::PhysicalHashJoin(op) => {
             physical_hash_join_to_format_tree(op, metadata, children)
         }
@@ -344,8 +342,8 @@ fn logical_get_to_format_tree(
     )
 }
 
-pub fn logical_inner_join_to_format_tree(
-    op: &LogicalInnerJoin,
+pub fn logical_join_to_format_tree(
+    op: &LogicalJoin,
     metadata: MetadataRef,
     children: Vec<FormatTreeNode<FormatContext>>,
 ) -> FormatTreeNode<FormatContext> {

--- a/src/query/sql/src/planner/optimizer/format.rs
+++ b/src/query/sql/src/planner/optimizer/format.rs
@@ -36,7 +36,7 @@ pub fn display_memo(memo: &Memo, cost_map: &HashMap<IndexType, CostContext>) -> 
 pub fn display_rel_op(rel_op: &RelOperator) -> String {
     match rel_op {
         RelOperator::LogicalGet(_) => "LogicalGet".to_string(),
-        RelOperator::LogicalInnerJoin(_) => "LogicalInnerJoin".to_string(),
+        RelOperator::LogicalJoin(_) => "LogicalJoin".to_string(),
         RelOperator::PhysicalScan(_) => "PhysicalScan".to_string(),
         RelOperator::PhysicalHashJoin(_) => "PhysicalHashJoin".to_string(),
         RelOperator::EvalScalar(_) => "EvalScalar".to_string(),

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -43,7 +43,7 @@ use crate::plans::Filter;
 use crate::plans::FunctionCall;
 use crate::plans::JoinType;
 use crate::plans::LogicalGet;
-use crate::plans::LogicalInnerJoin;
+use crate::plans::LogicalJoin;
 use crate::plans::LogicalOperator;
 use crate::plans::OrExpr;
 use crate::plans::PatternPlan;
@@ -177,7 +177,7 @@ impl SubqueryRewriter {
             }
         }
 
-        let join = LogicalInnerJoin {
+        let join = LogicalJoin {
             left_conditions,
             right_conditions,
             non_equi_conditions,
@@ -249,7 +249,7 @@ impl SubqueryRewriter {
                     &mut right_conditions,
                     &mut left_conditions,
                 )?;
-                let join_plan = LogicalInnerJoin {
+                let join_plan = LogicalJoin {
                     left_conditions,
                     right_conditions,
                     non_equi_conditions: vec![],
@@ -288,7 +288,7 @@ impl SubqueryRewriter {
                         None,
                     )
                 };
-                let join_plan = LogicalInnerJoin {
+                let join_plan = LogicalJoin {
                     left_conditions: right_conditions,
                     right_conditions: left_conditions,
                     non_equi_conditions: vec![],
@@ -343,7 +343,7 @@ impl SubqueryRewriter {
                         None,
                     )
                 };
-                let mark_join = LogicalInnerJoin {
+                let mark_join = LogicalJoin {
                     left_conditions: right_conditions,
                     right_conditions: left_conditions,
                     non_equi_conditions,
@@ -414,7 +414,7 @@ impl SubqueryRewriter {
                 .into(),
             );
             // Todo(xudong963): Wrap logical get with distinct to eliminate duplicates rows.
-            let cross_join = LogicalInnerJoin {
+            let cross_join = LogicalJoin {
                 left_conditions: vec![],
                 right_conditions: vec![],
                 non_equi_conditions: vec![],
@@ -497,7 +497,7 @@ impl SubqueryRewriter {
                 .into();
                 Ok(SExpr::create_unary(filter_plan, flatten_plan))
             }
-            RelOperator::LogicalInnerJoin(join) => {
+            RelOperator::LogicalJoin(join) => {
                 // Currently, we don't support join conditions contain subquery
                 if join
                     .used_columns()?
@@ -519,7 +519,7 @@ impl SubqueryRewriter {
                     need_cross_join,
                 )?;
                 Ok(SExpr::create_binary(
-                    LogicalInnerJoin {
+                    LogicalJoin {
                         left_conditions: join.left_conditions.clone(),
                         right_conditions: join.right_conditions.clone(),
                         non_equi_conditions: join.non_equi_conditions.clone(),

--- a/src/query/sql/src/planner/optimizer/heuristic/prune_unused_columns.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/prune_unused_columns.rs
@@ -100,7 +100,7 @@ impl UnusedColumnPruner {
                     prewhere,
                 })))
             }
-            RelOperator::LogicalInnerJoin(p) => {
+            RelOperator::LogicalJoin(p) => {
                 // Include columns referenced in left conditions
                 let left = p.left_conditions.iter().fold(required.clone(), |acc, v| {
                     acc.union(&v.used_columns()).cloned().collect()
@@ -115,7 +115,7 @@ impl UnusedColumnPruner {
                 });
 
                 Ok(SExpr::create_binary(
-                    RelOperator::LogicalInnerJoin(p.clone()),
+                    RelOperator::LogicalJoin(p.clone()),
                     self.keep_required_columns(
                         expr.child(0)?,
                         left.union(&others).cloned().collect(),

--- a/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
@@ -40,7 +40,7 @@ use crate::plans::Filter;
 use crate::plans::FunctionCall;
 use crate::plans::JoinType;
 use crate::plans::Limit;
-use crate::plans::LogicalInnerJoin;
+use crate::plans::LogicalJoin;
 use crate::plans::OrExpr;
 use crate::plans::RelOperator;
 use crate::plans::Scalar;
@@ -118,13 +118,11 @@ impl SubqueryRewriter {
                 Ok(SExpr::create_unary(plan.into(), input))
             }
 
-            RelOperator::LogicalInnerJoin(_) | RelOperator::UnionAll(_) => {
-                Ok(SExpr::create_binary(
-                    s_expr.plan().clone(),
-                    self.rewrite(s_expr.child(0)?)?,
-                    self.rewrite(s_expr.child(1)?)?,
-                ))
-            }
+            RelOperator::LogicalJoin(_) | RelOperator::UnionAll(_) => Ok(SExpr::create_binary(
+                s_expr.plan().clone(),
+                self.rewrite(s_expr.child(0)?)?,
+                self.rewrite(s_expr.child(1)?)?,
+            )),
 
             RelOperator::Limit(_) | RelOperator::Sort(_) => Ok(SExpr::create_unary(
                 s_expr.plan().clone(),
@@ -357,7 +355,7 @@ impl SubqueryRewriter {
     ) -> Result<(SExpr, UnnestResult)> {
         match subquery.typ {
             SubqueryType::Scalar => {
-                let join_plan = LogicalInnerJoin {
+                let join_plan = LogicalJoin {
                     left_conditions: vec![],
                     right_conditions: vec![],
                     non_equi_conditions: vec![],
@@ -448,7 +446,7 @@ impl SubqueryRewriter {
                     filter.into(),
                     SExpr::create_unary(agg.into(), subquery_expr),
                 );
-                let cross_join = LogicalInnerJoin {
+                let cross_join = LogicalJoin {
                     left_conditions: vec![],
                     right_conditions: vec![],
                     non_equi_conditions: vec![],
@@ -510,7 +508,7 @@ impl SubqueryRewriter {
                 // Consider the sql: select * from t1 where t1.a = any(select t2.a from t2);
                 // Will be transferred to:select t1.a, t2.a, marker_index from t1, t2 where t2.a = t1.a;
                 // Note that subquery is the right table, and it'll be the build side.
-                let mark_join = LogicalInnerJoin {
+                let mark_join = LogicalJoin {
                     left_conditions: right_conditions,
                     right_conditions: left_conditions,
                     non_equi_conditions,

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
@@ -24,7 +24,7 @@ use crate::optimizer::RuleID;
 use crate::optimizer::SExpr;
 use crate::plans::Filter;
 use crate::plans::JoinType;
-use crate::plans::LogicalInnerJoin;
+use crate::plans::LogicalJoin;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
 use crate::plans::Scalar;
@@ -54,7 +54,7 @@ impl RulePushDownFilterJoin {
                 .into(),
                 SExpr::create_binary(
                     PatternPlan {
-                        plan_type: RelOp::LogicalInnerJoin,
+                        plan_type: RelOp::LogicalJoin,
                     }
                     .into(),
                     SExpr::create_leaf(
@@ -148,7 +148,7 @@ impl RulePushDownFilterJoin {
 
     fn convert_outer_to_inner_join(&self, s_expr: &SExpr) -> Result<SExpr> {
         let filter: Filter = s_expr.plan().clone().try_into()?;
-        let mut join: LogicalInnerJoin = s_expr.child(0)?.plan().clone().try_into()?;
+        let mut join: LogicalJoin = s_expr.child(0)?.plan().clone().try_into()?;
         let origin_join_type = join.join_type.clone();
         if !origin_join_type.is_outer_join() {
             return Ok(s_expr.clone());
@@ -223,7 +223,7 @@ impl RulePushDownFilterJoin {
 
     fn convert_mark_to_semi_join(&self, s_expr: &SExpr) -> Result<SExpr> {
         let mut filter: Filter = s_expr.plan().clone().try_into()?;
-        let mut join: LogicalInnerJoin = s_expr.child(0)?.plan().clone().try_into()?;
+        let mut join: LogicalJoin = s_expr.child(0)?.plan().clone().try_into()?;
         let has_disjunction = filter
             .predicates
             .iter()
@@ -289,7 +289,7 @@ impl Rule for RulePushDownFilterJoin {
             return Ok(());
         }
         let join_expr = s_expr.child(0)?;
-        let mut join: LogicalInnerJoin = join_expr.plan().clone().try_into()?;
+        let mut join: LogicalJoin = join_expr.plan().clone().try_into()?;
 
         let rel_expr = RelExpr::with_s_expr(join_expr);
         let left_prop = rel_expr.derive_relational_prop_child(0)?;

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_limit_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_limit_join.rs
@@ -18,7 +18,7 @@ use crate::optimizer::RuleID;
 use crate::optimizer::SExpr;
 use crate::plans::JoinType;
 use crate::plans::Limit;
-use crate::plans::LogicalInnerJoin;
+use crate::plans::LogicalJoin;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
 use crate::plans::RelOperator;
@@ -53,7 +53,7 @@ impl RulePushDownLimitOuterJoin {
                 .into(),
                 SExpr::create_binary(
                     PatternPlan {
-                        plan_type: RelOp::LogicalInnerJoin,
+                        plan_type: RelOp::LogicalJoin,
                     }
                     .into(),
                     SExpr::create_leaf(
@@ -83,7 +83,7 @@ impl Rule for RulePushDownLimitOuterJoin {
         let limit: Limit = s_expr.plan().clone().try_into()?;
         if limit.limit.is_some() {
             let child = s_expr.child(0)?;
-            let join: LogicalInnerJoin = child.plan().clone().try_into()?;
+            let join: LogicalJoin = child.plan().clone().try_into()?;
             match join.join_type {
                 JoinType::Left | JoinType::Full => {
                     state.add_result(s_expr.replace_children(vec![child.replace_children(vec![

--- a/src/query/sql/src/planner/optimizer/rule/rule_implement_hash_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rule_implement_hash_join.rs
@@ -18,7 +18,7 @@ use crate::optimizer::rule::transform_result::TransformResult;
 use crate::optimizer::rule::Rule;
 use crate::optimizer::rule::RuleID;
 use crate::optimizer::SExpr;
-use crate::plans::LogicalInnerJoin;
+use crate::plans::LogicalJoin;
 use crate::plans::PatternPlan;
 use crate::plans::PhysicalHashJoin;
 use crate::plans::RelOp;
@@ -34,7 +34,7 @@ impl RuleImplementHashJoin {
             id: RuleID::ImplementHashJoin,
             pattern: SExpr::create_binary(
                 PatternPlan {
-                    plan_type: RelOp::LogicalInnerJoin,
+                    plan_type: RelOp::LogicalJoin,
                 }
                 .into(),
                 SExpr::create_leaf(
@@ -61,7 +61,7 @@ impl Rule for RuleImplementHashJoin {
 
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
         let plan = s_expr.plan().clone();
-        let logical_join: LogicalInnerJoin = plan.try_into()?;
+        let logical_join: LogicalJoin = plan.try_into()?;
 
         let result = SExpr::create(
             PhysicalHashJoin {

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_commute_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_commute_join.rs
@@ -19,7 +19,7 @@ use crate::optimizer::rule::TransformResult;
 use crate::optimizer::RuleID;
 use crate::optimizer::SExpr;
 use crate::plans::JoinType;
-use crate::plans::LogicalInnerJoin;
+use crate::plans::LogicalJoin;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
 
@@ -44,7 +44,7 @@ impl RuleCommuteJoin {
             // *  *
             pattern: SExpr::create_binary(
                 PatternPlan {
-                    plan_type: RelOp::LogicalInnerJoin,
+                    plan_type: RelOp::LogicalJoin,
                 }
                 .into(),
                 SExpr::create_pattern_leaf(),
@@ -60,7 +60,7 @@ impl Rule for RuleCommuteJoin {
     }
 
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
-        let mut join: LogicalInnerJoin = s_expr.plan().clone().try_into()?;
+        let mut join: LogicalJoin = s_expr.plan().clone().try_into()?;
         let left_child = s_expr.child(0)?;
         let right_child = s_expr.child(1)?;
 

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_left_associate_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_left_associate_join.rs
@@ -24,7 +24,7 @@ use crate::optimizer::RelExpr;
 use crate::optimizer::RuleID;
 use crate::optimizer::SExpr;
 use crate::plans::JoinType;
-use crate::plans::LogicalInnerJoin;
+use crate::plans::LogicalJoin;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
 
@@ -64,12 +64,12 @@ impl RuleLeftAssociateJoin {
             // *
             pattern: SExpr::create_binary(
                 PatternPlan {
-                    plan_type: RelOp::LogicalInnerJoin,
+                    plan_type: RelOp::LogicalJoin,
                 }
                 .into(),
                 SExpr::create_binary(
                     PatternPlan {
-                        plan_type: RelOp::LogicalInnerJoin,
+                        plan_type: RelOp::LogicalJoin,
                     }
                     .into(),
                     SExpr::create_pattern_leaf(),
@@ -100,8 +100,8 @@ impl Rule for RuleLeftAssociateJoin {
         //  t1  join4
         //      /  \
         //     t2  t3
-        let join1: LogicalInnerJoin = s_expr.plan.clone().try_into()?;
-        let join2: LogicalInnerJoin = s_expr.child(0)?.plan.clone().try_into()?;
+        let join1: LogicalJoin = s_expr.plan.clone().try_into()?;
+        let join2: LogicalJoin = s_expr.child(0)?.plan.clone().try_into()?;
         let t1 = s_expr.child(0)?.child(0)?;
         let t2 = s_expr.child(0)?.child(1)?;
         let t3 = s_expr.child(1)?;
@@ -118,8 +118,8 @@ impl Rule for RuleLeftAssociateJoin {
 
         let predicates = vec![get_join_predicates(&join1)?, get_join_predicates(&join2)?].concat();
 
-        let mut join_3 = LogicalInnerJoin::default();
-        let mut join_4 = LogicalInnerJoin::default();
+        let mut join_3 = LogicalJoin::default();
+        let mut join_4 = LogicalJoin::default();
 
         let t1_prop = RelExpr::with_s_expr(t1).derive_relational_prop()?;
         let t2_prop = RelExpr::with_s_expr(t2).derive_relational_prop()?;

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_right_associate_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_right_associate_join.rs
@@ -22,7 +22,7 @@ use crate::optimizer::RelExpr;
 use crate::optimizer::RuleID;
 use crate::optimizer::SExpr;
 use crate::plans::JoinType;
-use crate::plans::LogicalInnerJoin;
+use crate::plans::LogicalJoin;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
 
@@ -60,13 +60,13 @@ impl RuleRightAssociateJoin {
             //    *  *
             pattern: SExpr::create_binary(
                 PatternPlan {
-                    plan_type: RelOp::LogicalInnerJoin,
+                    plan_type: RelOp::LogicalJoin,
                 }
                 .into(),
                 SExpr::create_pattern_leaf(),
                 SExpr::create_binary(
                     PatternPlan {
-                        plan_type: RelOp::LogicalInnerJoin,
+                        plan_type: RelOp::LogicalJoin,
                     }
                     .into(),
                     SExpr::create_pattern_leaf(),
@@ -96,8 +96,8 @@ impl Rule for RuleRightAssociateJoin {
         //  join4 t3
         //  /  \
         // t1  t2
-        let join1: LogicalInnerJoin = s_expr.plan.clone().try_into()?;
-        let join2: LogicalInnerJoin = s_expr.child(1)?.plan.clone().try_into()?;
+        let join1: LogicalJoin = s_expr.plan.clone().try_into()?;
+        let join2: LogicalJoin = s_expr.child(1)?.plan.clone().try_into()?;
         let t1 = s_expr.child(0)?;
         let t2 = s_expr.child(1)?.child(0)?;
         let t3 = s_expr.child(1)?.child(1)?;
@@ -114,8 +114,8 @@ impl Rule for RuleRightAssociateJoin {
 
         let predicates = vec![get_join_predicates(&join1)?, get_join_predicates(&join2)?].concat();
 
-        let mut join_3 = LogicalInnerJoin::default();
-        let mut join_4 = LogicalInnerJoin::default();
+        let mut join_3 = LogicalJoin::default();
+        let mut join_4 = LogicalJoin::default();
 
         let t1_prop = RelExpr::with_s_expr(t1).derive_relational_prop()?;
         let t2_prop = RelExpr::with_s_expr(t2).derive_relational_prop()?;

--- a/src/query/sql/src/planner/optimizer/rule/transform/util.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/util.rs
@@ -17,11 +17,11 @@ use common_functions::scalars::FunctionFactory;
 
 use crate::plans::ComparisonExpr;
 use crate::plans::ComparisonOp;
-use crate::plans::LogicalInnerJoin;
+use crate::plans::LogicalJoin;
 use crate::plans::Scalar;
 use crate::ScalarExpr;
 
-pub fn get_join_predicates(join: &LogicalInnerJoin) -> Result<Vec<Scalar>> {
+pub fn get_join_predicates(join: &LogicalJoin) -> Result<Vec<Scalar>> {
     Ok(join
         .left_conditions
         .iter()

--- a/src/query/sql/src/planner/plans/logical_join.rs
+++ b/src/query/sql/src/planner/plans/logical_join.rs
@@ -116,7 +116,7 @@ impl Display for JoinType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct LogicalInnerJoin {
+pub struct LogicalJoin {
     pub left_conditions: Vec<Scalar>,
     pub right_conditions: Vec<Scalar>,
     pub non_equi_conditions: Vec<Scalar>,
@@ -126,7 +126,7 @@ pub struct LogicalInnerJoin {
     pub from_correlated_subquery: bool,
 }
 
-impl Default for LogicalInnerJoin {
+impl Default for LogicalJoin {
     fn default() -> Self {
         Self {
             left_conditions: Default::default(),
@@ -139,9 +139,9 @@ impl Default for LogicalInnerJoin {
     }
 }
 
-impl Operator for LogicalInnerJoin {
+impl Operator for LogicalJoin {
     fn rel_op(&self) -> RelOp {
-        RelOp::LogicalInnerJoin
+        RelOp::LogicalJoin
     }
 
     fn is_physical(&self) -> bool {
@@ -161,7 +161,7 @@ impl Operator for LogicalInnerJoin {
     }
 }
 
-impl LogicalOperator for LogicalInnerJoin {
+impl LogicalOperator for LogicalJoin {
     fn derive_relational_prop<'a>(&self, rel_expr: &RelExpr<'a>) -> Result<RelationalProperty> {
         let left_prop = rel_expr.derive_relational_prop_child(0)?;
         let right_prop = rel_expr.derive_relational_prop_child(1)?;

--- a/src/query/sql/src/planner/plans/operator.rs
+++ b/src/query/sql/src/planner/plans/operator.rs
@@ -25,7 +25,7 @@ use super::filter::Filter;
 use super::hash_join::PhysicalHashJoin;
 use super::limit::Limit;
 use super::logical_get::LogicalGet;
-use super::logical_join::LogicalInnerJoin;
+use super::logical_join::LogicalJoin;
 use super::pattern::PatternPlan;
 use super::physical_scan::PhysicalScan;
 use super::sort::Sort;
@@ -75,7 +75,7 @@ pub trait PhysicalOperator {
 pub enum RelOp {
     // Logical operators
     LogicalGet,
-    LogicalInnerJoin,
+    LogicalJoin,
 
     // Physical operators
     PhysicalScan,
@@ -99,7 +99,7 @@ pub enum RelOp {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum RelOperator {
     LogicalGet(LogicalGet),
-    LogicalInnerJoin(LogicalInnerJoin),
+    LogicalJoin(LogicalJoin),
 
     PhysicalScan(PhysicalScan),
     PhysicalHashJoin(PhysicalHashJoin),
@@ -120,7 +120,7 @@ impl Operator for RelOperator {
     fn rel_op(&self) -> RelOp {
         match self {
             RelOperator::LogicalGet(rel_op) => rel_op.rel_op(),
-            RelOperator::LogicalInnerJoin(rel_op) => rel_op.rel_op(),
+            RelOperator::LogicalJoin(rel_op) => rel_op.rel_op(),
             RelOperator::PhysicalScan(rel_op) => rel_op.rel_op(),
             RelOperator::PhysicalHashJoin(rel_op) => rel_op.rel_op(),
             RelOperator::EvalScalar(rel_op) => rel_op.rel_op(),
@@ -138,7 +138,7 @@ impl Operator for RelOperator {
     fn is_physical(&self) -> bool {
         match self {
             RelOperator::LogicalGet(rel_op) => rel_op.is_physical(),
-            RelOperator::LogicalInnerJoin(rel_op) => rel_op.is_physical(),
+            RelOperator::LogicalJoin(rel_op) => rel_op.is_physical(),
             RelOperator::PhysicalScan(rel_op) => rel_op.is_physical(),
             RelOperator::PhysicalHashJoin(rel_op) => rel_op.is_physical(),
             RelOperator::EvalScalar(rel_op) => rel_op.is_physical(),
@@ -156,7 +156,7 @@ impl Operator for RelOperator {
     fn is_logical(&self) -> bool {
         match self {
             RelOperator::LogicalGet(rel_op) => rel_op.is_logical(),
-            RelOperator::LogicalInnerJoin(rel_op) => rel_op.is_logical(),
+            RelOperator::LogicalJoin(rel_op) => rel_op.is_logical(),
             RelOperator::PhysicalScan(rel_op) => rel_op.is_logical(),
             RelOperator::PhysicalHashJoin(rel_op) => rel_op.is_logical(),
             RelOperator::EvalScalar(rel_op) => rel_op.is_logical(),
@@ -174,7 +174,7 @@ impl Operator for RelOperator {
     fn as_logical(&self) -> Option<&dyn LogicalOperator> {
         match self {
             RelOperator::LogicalGet(rel_op) => rel_op.as_logical(),
-            RelOperator::LogicalInnerJoin(rel_op) => rel_op.as_logical(),
+            RelOperator::LogicalJoin(rel_op) => rel_op.as_logical(),
             RelOperator::PhysicalScan(rel_op) => rel_op.as_logical(),
             RelOperator::PhysicalHashJoin(rel_op) => rel_op.as_logical(),
             RelOperator::EvalScalar(rel_op) => rel_op.as_logical(),
@@ -192,7 +192,7 @@ impl Operator for RelOperator {
     fn as_physical(&self) -> Option<&dyn PhysicalOperator> {
         match self {
             RelOperator::LogicalGet(rel_op) => rel_op.as_physical(),
-            RelOperator::LogicalInnerJoin(rel_op) => rel_op.as_physical(),
+            RelOperator::LogicalJoin(rel_op) => rel_op.as_physical(),
             RelOperator::PhysicalScan(rel_op) => rel_op.as_physical(),
             RelOperator::PhysicalHashJoin(rel_op) => rel_op.as_physical(),
             RelOperator::EvalScalar(rel_op) => rel_op.as_physical(),
@@ -228,20 +228,20 @@ impl TryFrom<RelOperator> for LogicalGet {
     }
 }
 
-impl From<LogicalInnerJoin> for RelOperator {
-    fn from(v: LogicalInnerJoin) -> Self {
-        Self::LogicalInnerJoin(v)
+impl From<LogicalJoin> for RelOperator {
+    fn from(v: LogicalJoin) -> Self {
+        Self::LogicalJoin(v)
     }
 }
 
-impl TryFrom<RelOperator> for LogicalInnerJoin {
+impl TryFrom<RelOperator> for LogicalJoin {
     type Error = ErrorCode;
     fn try_from(value: RelOperator) -> Result<Self> {
-        if let RelOperator::LogicalInnerJoin(value) = value {
+        if let RelOperator::LogicalJoin(value) = value {
             Ok(value)
         } else {
             Err(ErrorCode::Internal(
-                "Cannot downcast RelOperator to LogicalInnerJoin",
+                "Cannot downcast RelOperator to LogicalJoin",
             ))
         }
     }

--- a/tests/logictest/suites/mode/standalone/explain/explain_memo.test
+++ b/tests/logictest/suites/mode/standalone/explain/explain_memo.test
@@ -14,7 +14,7 @@ Group #1
 	
 Group #2
 ├── best cost: [#3] 310
-├── LogicalInnerJoin [#0, #1]
-├── LogicalInnerJoin [#1, #0]
+├── LogicalJoin [#0, #1]
+├── LogicalJoin [#1, #0]
 ├── PhysicalHashJoin [#0, #1]
 └── PhysicalHashJoin [#1, #0]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`LogicalInnerJoin` is out of date, it contains all kinds of join, so rename it to `LogicalJoin`

Closes #issue
