### PR TITLE
feat: add load_file_metadata_expire_hours settings

### DIFF
--- a/docs/doc/14-sql-commands/80-setting-cmds/show-settings.md
+++ b/docs/doc/14-sql-commands/80-setting-cmds/show-settings.md
@@ -15,38 +15,39 @@ SHOW SETTINGS;
 ```sql
 SHOW SETTINGS;
 
-+--------------------------------+------------+------------+---------+--------------------------------------------------------------------------------------------------------------------+--------+
-| name                           | value      | default    | level   | description                                                                                                        | type   |
-+--------------------------------+------------+------------+---------+--------------------------------------------------------------------------------------------------------------------+--------+
-| collation                      | binary     | binary     | SESSION | Char collation, support "binary" "utf8" default value: binary                                                      | String |
-| enable_async_insert            | 0          | 0          | SESSION | Whether the client open async insert mode, default value: 0.                                                       | UInt64 |
-| enable_cbo                     | 1          | 1          | SESSION | If enable cost based optimization, default value: 1.                                                               | UInt64 |
-| enable_distributed_eval_index  | 1          | 1          | SESSION | If enable distributed eval index, default value: 1                                                                 | UInt64 |
-| enable_new_processor_framework | 1          | 1          | SESSION | Enable new processor framework if value != 0, default value: 1.                                                    | UInt64 |
-| enable_planner_v2              | 1          | 1          | SESSION | Enable planner v2 by setting this variable to 1, default value: 1.                                                 | UInt64 |
-| flight_client_timeout          | 60         | 60         | SESSION | Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds.                | UInt64 |
-| format_compression             | None       | None       | SESSION | Format compression, default value: "None".                                                                         | String |
-| format_empty_as_default        | 1          | 1          | SESSION | Format empty_as_default, default value: 1.                                                                         | UInt64 |
-| format_escape                  |            |            | SESSION | format escape char, default value: "", which means the format`s default setting.                                   | String |
-| format_field_delimiter         |            |            | SESSION | Format field delimiter, default value is "": use default of the format.                                            | String |
-| format_quote                   |            |            | SESSION | The quote char for format. default value is "": use default of the format.                                         | String |
-| format_record_delimiter        |            |            | SESSION | Format record_delimiter, default value is "": use default of the format.                                           | String |
-| format_skip_header             | 0          | 0          | SESSION | Whether to skip the input header, default value: 0.                                                                | UInt64 |
-| group_by_two_level_threshold   | 10000      | 10000      | SESSION | The threshold of keys to open two-level aggregation, default value: 10000.                                         | UInt64 |
-| input_read_buffer_size         | 1048576    | 1048576    | SESSION | The size of buffer in bytes for input with format. By default, it is 1MB.                                          | UInt64 |
-| max_block_size                 | 65536      | 65536      | SESSION | Maximum block size for reading, default value: 65536.                                                              | UInt64 |
-| max_execute_time               | 0          | 0          | SESSION | The maximum query execution time. it means no limit if the value is zero. default value: 0.                        | UInt64 |
-| max_storage_io_requests        | 1000       | 1000       | SESSION | The maximum number of concurrent IO requests. By default, it is 1000.                                              | UInt64 |
-| max_threads                    | 24         | 0          | SESSION | The maximum number of threads to execute the request. By default the value is 0 it means determined automatically. | UInt64 |
-| prefer_broadcast_join          | 0          | 0          | SESSION | If enable broadcast join, default value: 0                                                                         | UInt64 |
-| quoted_ident_case_sensitive    | 1          | 1          | SESSION | Case sensitivity of quoted identifiers, default value: 1 (aka case-sensitive).                                     | UInt64 |
-| row_tag                        | row        | row        | SESSION | In xml format, this field is represented as a row tag, e.g. <row>...</row>.                                        | String |
-| sql_dialect                    | PostgreSQL | PostgreSQL | SESSION | SQL dialect, support "PostgreSQL" "MySQL" and "Hive", default value: "PostgreSQL".                                 | String |
-| storage_read_buffer_size       | 1048576    | 1048576    | SESSION | The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.                                     | UInt64 |
-| timezone                       | UTC        | UTC        | SESSION | Timezone, default value: "UTC".                                                                                    | String |
-| unquoted_ident_case_sensitive  | 0          | 0          | SESSION | Case sensitivity of unquoted identifiers, default value: 0 (aka case-insensitive).                                 | UInt64 |
-| wait_for_async_insert          | 1          | 1          | SESSION | Whether the client wait for the reply of async insert, default value: 1.                                           | UInt64 |
-| wait_for_async_insert_timeout  | 100        | 100        | SESSION | The timeout in seconds for waiting for processing of async insert, default value: 100.                             | UInt64 |
-+--------------------------------+------------+------------+---------+--------------------------------------------------------------------------------------------------------------------+--------+
-
++---------------------------------+-------------+------------+---------+------------------------------------------------------------------------------------------------------------------------------+--------+
+| name                            | value       | default    | level   | description                                                                                                                  | type   |
++---------------------------------+-------------+------------+---------+------------------------------------------------------------------------------------------------------------------------------+--------+
+| collation                       | binary      | binary     | SESSION | Char collation, support "binary" "utf8" default value: binary                                                                | String |
+| enable_async_insert             | 0           | 0          | SESSION | Whether the client open async insert mode, default value: 0.                                                                 | UInt64 |
+| enable_cbo                      | 1           | 1          | SESSION | If enable cost based optimization, default value: 1.                                                                         | UInt64 |
+| enable_distributed_eval_index   | 1           | 1          | SESSION | If enable distributed eval index, default value: 1                                                                           | UInt64 |
+| enable_new_processor_framework  | 1           | 1          | SESSION | Enable new processor framework if value != 0, default value: 1.                                                              | UInt64 |
+| enable_planner_v2               | 1           | 1          | SESSION | Enable planner v2 by setting this variable to 1, default value: 1.                                                           | UInt64 |
+| flight_client_timeout           | 60          | 60         | SESSION | Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds.                          | UInt64 |
+| format_compression              | None        | None       | SESSION | Format compression, default value: "None".                                                                                   | String |
+| format_empty_as_default         | 1           | 1          | SESSION | Format empty_as_default, default value: 1.                                                                                   | UInt64 |
+| format_escape                   |             |            | SESSION | format escape char, default value: "", which means the format`s default setting.                                             | String |
+| format_field_delimiter          |             |            | SESSION | Format field delimiter, default value is "": use default of the format.                                                      | String |
+| format_quote                    |             |            | SESSION | The quote char for format. default value is "": use default of the format.                                                   | String |
+| format_record_delimiter         |             |            | SESSION | Format record_delimiter, default value is "": use default of the format.                                                     | String |
+| format_skip_header              | 0           | 0          | SESSION | Whether to skip the input header, default value: 0.                                                                          | UInt64 |
+| group_by_two_level_threshold    | 10000       | 10000      | SESSION | The threshold of keys to open two-level aggregation, default value: 10000.                                                   | UInt64 |
+| input_read_buffer_size          | 1048576     | 1048576    | SESSION | The size of buffer in bytes for input with format. By default, it is 1MB.                                                    | UInt64 |
+| load_file_metadata_expire_hours | 168         | 168        | SESSION | How many hours will the COPY file metadata expired in the metasrv, default value: 24*7=7days                                 | UInt64 |
+| max_block_size                  | 65536       | 65536      | SESSION | Maximum block size for reading, default value: 65536.                                                                        | UInt64 |
+| max_execute_time                | 0           | 0          | SESSION | The maximum query execution time. it means no limit if the value is zero. default value: 0.                                  | UInt64 |
+| max_memory_usage                | 17179869184 | 0          | SESSION | The maximum memory usage for processing single query, in bytes. By default the value is 0 it means determined automatically. | UInt64 |
+| max_storage_io_requests         | 1000        | 1000       | SESSION | The maximum number of concurrent IO requests. By default, it is 1000.                                                        | UInt64 |
+| max_threads                     | 2           | 0          | SESSION | The maximum number of threads to execute the request. By default the value is 0 it means determined automatically.           | UInt64 |
+| prefer_broadcast_join           | 0           | 0          | SESSION | If enable broadcast join, default value: 0                                                                                   | UInt64 |
+| quoted_ident_case_sensitive     | 1           | 1          | SESSION | Case sensitivity of quoted identifiers, default value: 1 (aka case-sensitive).                                               | UInt64 |
+| row_tag                         | row         | row        | SESSION | In xml format, this field is represented as a row tag, e.g. <row>...</row>.                                                  | String |
+| sql_dialect                     | PostgreSQL  | PostgreSQL | SESSION | SQL dialect, support "PostgreSQL" "MySQL" and "Hive", default value: "PostgreSQL".                                           | String |
+| storage_read_buffer_size        | 1048576     | 1048576    | SESSION | The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.                                               | UInt64 |
+| timezone                        | UTC         | UTC        | SESSION | Timezone, default value: "UTC".                                                                                              | String |
+| unquoted_ident_case_sensitive   | 0           | 0          | SESSION | Case sensitivity of unquoted identifiers, default value: 0 (aka case-insensitive).                                           | UInt64 |
+| wait_for_async_insert           | 1           | 1          | SESSION | Whether the client wait for the reply of async insert, default value: 1.                                                     | UInt64 |
+| wait_for_async_insert_timeout   | 100         | 100        | SESSION | The timeout in seconds for waiting for processing of async insert, default value: 100.                                       | UInt64 |
++---------------------------------+-------------+------------+---------+------------------------------------------------------------------------------------------------------------------------------+--------+
 ```

--- a/src/query/service/src/interpreters/interpreter_copy_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_v2.rs
@@ -50,7 +50,6 @@ use crate::sql::plans::CopyPlanV2;
 use crate::sql::plans::Plan;
 
 const MAX_QUERY_COPIED_FILES_NUM: usize = 50;
-const TABLE_COPIED_FILE_KEY_EXPIRE_AFTER_DAYS: Option<u64> = Some(7);
 
 pub struct CopyInterpreterV2 {
     ctx: Arc<QueryContext>,
@@ -142,6 +141,7 @@ impl CopyInterpreterV2 {
     }
 
     async fn upsert_copied_files_info_to_meta(
+        ctx: &Arc<QueryContext>,
         tenant: String,
         database_name: String,
         table_id: u64,
@@ -154,14 +154,14 @@ impl CopyInterpreterV2 {
             return Ok(());
         }
 
-        let expire_at = TABLE_COPIED_FILE_KEY_EXPIRE_AFTER_DAYS
-            .map(|after_days| after_days * 86400 + Utc::now().timestamp() as u64);
+        let expire_hours = ctx.get_settings().get_load_file_metadata_expire_hours()?;
+        let expire_at = expire_hours * 60 + Utc::now().timestamp() as u64;
         let mut do_copy_stage_files = BTreeMap::new();
         for (file_name, file_info) in copy_stage_files {
             do_copy_stage_files.insert(file_name.clone(), file_info);
             if do_copy_stage_files.len() > MAX_QUERY_COPIED_FILES_NUM {
                 CopyInterpreterV2::do_upsert_copied_files_info_to_meta(
-                    expire_at,
+                    Some(expire_at),
                     tenant.clone(),
                     database_name.clone(),
                     table_id,
@@ -173,7 +173,7 @@ impl CopyInterpreterV2 {
         }
         if !do_copy_stage_files.is_empty() {
             CopyInterpreterV2::do_upsert_copied_files_info_to_meta(
-                expire_at,
+                Some(expire_at),
                 tenant.clone(),
                 database_name.clone(),
                 table_id,
@@ -464,6 +464,7 @@ impl CopyInterpreterV2 {
                             start.elapsed().as_secs()
                         );
                         CopyInterpreterV2::upsert_copied_files_info_to_meta(
+                            &ctx,
                             tenant,
                             database_name,
                             table_id,

--- a/src/query/service/tests/it/storages/testdata/system-tables.txt
+++ b/src/query/service/tests/it/storages/testdata/system-tables.txt
@@ -311,40 +311,41 @@ DB.Table: 'system'.'roles', Table: roles-table_id:1, ver:0, Engine: SystemRoles
 ---------- TABLE INFO ------------
 DB.Table: 'system'.'settings', Table: settings-table_id:1, ver:0, Engine: SystemSettings
 -------- TABLE CONTENTS ----------
-+--------------------------------+-------------+------------+---------+------------------------------------------------------------------------------------------------------------------------------+--------+
-| name                           | value       | default    | level   | description                                                                                                                  | type   |
-+--------------------------------+-------------+------------+---------+------------------------------------------------------------------------------------------------------------------------------+--------+
-| collation                      | binary      | binary     | SESSION | Char collation, support "binary" "utf8" default value: binary                                                                | String |
-| enable_async_insert            | 0           | 0          | SESSION | Whether the client open async insert mode, default value: 0.                                                                 | UInt64 |
-| enable_cbo                     | 1           | 1          | SESSION | If enable cost based optimization, default value: 1.                                                                         | UInt64 |
-| enable_distributed_eval_index  | 1           | 1          | SESSION | If enable distributed eval index, default value: 1                                                                           | UInt64 |
-| enable_new_processor_framework | 1           | 1          | SESSION | Enable new processor framework if value != 0, default value: 1.                                                              | UInt64 |
-| enable_planner_v2              | 1           | 1          | SESSION | Enable planner v2 by setting this variable to 1, default value: 1.                                                           | UInt64 |
-| flight_client_timeout          | 60          | 60         | SESSION | Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds.                          | UInt64 |
-| format_compression             | None        | None       | SESSION | Format compression, default value: "None".                                                                                   | String |
-| format_empty_as_default        | 1           | 1          | SESSION | Format empty_as_default, default value: 1.                                                                                   | UInt64 |
-| format_escape                  |             |            | SESSION | format escape char, default value: "", which means the format`s default setting.                                             | String |
-| format_field_delimiter         |             |            | SESSION | Format field delimiter, default value is "": use default of the format.                                                      | String |
-| format_quote                   |             |            | SESSION | The quote char for format. default value is "": use default of the format.                                                   | String |
-| format_record_delimiter        |             |            | SESSION | Format record_delimiter, default value is "": use default of the format.                                                     | String |
-| format_skip_header             | 0           | 0          | SESSION | Whether to skip the input header, default value: 0.                                                                          | UInt64 |
-| group_by_two_level_threshold   | 10000       | 10000      | SESSION | The threshold of keys to open two-level aggregation, default value: 10000.                                                   | UInt64 |
-| input_read_buffer_size         | 1048576     | 1048576    | SESSION | The size of buffer in bytes for input with format. By default, it is 1MB.                                                    | UInt64 |
-| max_block_size                 | 65536       | 65536      | SESSION | Maximum block size for reading, default value: 65536.                                                                        | UInt64 |
-| max_execute_time               | 0           | 0          | SESSION | The maximum query execution time. it means no limit if the value is zero. default value: 0.                                  | UInt64 |
-| max_memory_usage               | 17179869184 | 0          | SESSION | The maximum memory usage for processing single query, in bytes. By default the value is 0 it means determined automatically. | UInt64 |
-| max_storage_io_requests        | 1000        | 1000       | SESSION | The maximum number of concurrent IO requests. By default, it is 1000.                                                        | UInt64 |
-| max_threads                    | 2           | 0          | SESSION | The maximum number of threads to execute the request. By default the value is 0 it means determined automatically.           | UInt64 |
-| prefer_broadcast_join          | 0           | 0          | SESSION | If enable broadcast join, default value: 0                                                                                   | UInt64 |
-| quoted_ident_case_sensitive    | 1           | 1          | SESSION | Case sensitivity of quoted identifiers, default value: 1 (aka case-sensitive).                                               | UInt64 |
-| row_tag                        | row         | row        | SESSION | In xml format, this field is represented as a row tag, e.g. <row>...</row>.                                                  | String |
-| sql_dialect                    | PostgreSQL  | PostgreSQL | SESSION | SQL dialect, support "PostgreSQL" "MySQL" and "Hive", default value: "PostgreSQL".                                           | String |
-| storage_read_buffer_size       | 1048576     | 1048576    | SESSION | The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.                                               | UInt64 |
-| timezone                       | UTC         | UTC        | SESSION | Timezone, default value: "UTC".                                                                                              | String |
-| unquoted_ident_case_sensitive  | 0           | 0          | SESSION | Case sensitivity of unquoted identifiers, default value: 0 (aka case-insensitive).                                           | UInt64 |
-| wait_for_async_insert          | 1           | 1          | SESSION | Whether the client wait for the reply of async insert, default value: 1.                                                     | UInt64 |
-| wait_for_async_insert_timeout  | 100         | 100        | SESSION | The timeout in seconds for waiting for processing of async insert, default value: 100.                                       | UInt64 |
-+--------------------------------+-------------+------------+---------+------------------------------------------------------------------------------------------------------------------------------+--------+
++---------------------------------+-------------+------------+---------+------------------------------------------------------------------------------------------------------------------------------+--------+
+| name                            | value       | default    | level   | description                                                                                                                  | type   |
++---------------------------------+-------------+------------+---------+------------------------------------------------------------------------------------------------------------------------------+--------+
+| collation                       | binary      | binary     | SESSION | Char collation, support "binary" "utf8" default value: binary                                                                | String |
+| enable_async_insert             | 0           | 0          | SESSION | Whether the client open async insert mode, default value: 0.                                                                 | UInt64 |
+| enable_cbo                      | 1           | 1          | SESSION | If enable cost based optimization, default value: 1.                                                                         | UInt64 |
+| enable_distributed_eval_index   | 1           | 1          | SESSION | If enable distributed eval index, default value: 1                                                                           | UInt64 |
+| enable_new_processor_framework  | 1           | 1          | SESSION | Enable new processor framework if value != 0, default value: 1.                                                              | UInt64 |
+| enable_planner_v2               | 1           | 1          | SESSION | Enable planner v2 by setting this variable to 1, default value: 1.                                                           | UInt64 |
+| flight_client_timeout           | 60          | 60         | SESSION | Max duration the flight client request is allowed to take in seconds. By default, it is 60 seconds.                          | UInt64 |
+| format_compression              | None        | None       | SESSION | Format compression, default value: "None".                                                                                   | String |
+| format_empty_as_default         | 1           | 1          | SESSION | Format empty_as_default, default value: 1.                                                                                   | UInt64 |
+| format_escape                   |             |            | SESSION | format escape char, default value: "", which means the format`s default setting.                                             | String |
+| format_field_delimiter          |             |            | SESSION | Format field delimiter, default value is "": use default of the format.                                                      | String |
+| format_quote                    |             |            | SESSION | The quote char for format. default value is "": use default of the format.                                                   | String |
+| format_record_delimiter         |             |            | SESSION | Format record_delimiter, default value is "": use default of the format.                                                     | String |
+| format_skip_header              | 0           | 0          | SESSION | Whether to skip the input header, default value: 0.                                                                          | UInt64 |
+| group_by_two_level_threshold    | 10000       | 10000      | SESSION | The threshold of keys to open two-level aggregation, default value: 10000.                                                   | UInt64 |
+| input_read_buffer_size          | 1048576     | 1048576    | SESSION | The size of buffer in bytes for input with format. By default, it is 1MB.                                                    | UInt64 |
+| load_file_metadata_expire_hours | 168         | 168        | SESSION | How many hours will the COPY file metadata expired in the metasrv, default value: 24*7=7days                                 | UInt64 |
+| max_block_size                  | 65536       | 65536      | SESSION | Maximum block size for reading, default value: 65536.                                                                        | UInt64 |
+| max_execute_time                | 0           | 0          | SESSION | The maximum query execution time. it means no limit if the value is zero. default value: 0.                                  | UInt64 |
+| max_memory_usage                | 17179869184 | 0          | SESSION | The maximum memory usage for processing single query, in bytes. By default the value is 0 it means determined automatically. | UInt64 |
+| max_storage_io_requests         | 1000        | 1000       | SESSION | The maximum number of concurrent IO requests. By default, it is 1000.                                                        | UInt64 |
+| max_threads                     | 2           | 0          | SESSION | The maximum number of threads to execute the request. By default the value is 0 it means determined automatically.           | UInt64 |
+| prefer_broadcast_join           | 0           | 0          | SESSION | If enable broadcast join, default value: 0                                                                                   | UInt64 |
+| quoted_ident_case_sensitive     | 1           | 1          | SESSION | Case sensitivity of quoted identifiers, default value: 1 (aka case-sensitive).                                               | UInt64 |
+| row_tag                         | row         | row        | SESSION | In xml format, this field is represented as a row tag, e.g. <row>...</row>.                                                  | String |
+| sql_dialect                     | PostgreSQL  | PostgreSQL | SESSION | SQL dialect, support "PostgreSQL" "MySQL" and "Hive", default value: "PostgreSQL".                                           | String |
+| storage_read_buffer_size        | 1048576     | 1048576    | SESSION | The size of buffer in bytes for buffered reader of dal. By default, it is 1MB.                                               | UInt64 |
+| timezone                        | UTC         | UTC        | SESSION | Timezone, default value: "UTC".                                                                                              | String |
+| unquoted_ident_case_sensitive   | 0           | 0          | SESSION | Case sensitivity of unquoted identifiers, default value: 0 (aka case-insensitive).                                           | UInt64 |
+| wait_for_async_insert           | 1           | 1          | SESSION | Whether the client wait for the reply of async insert, default value: 1.                                                     | UInt64 |
+| wait_for_async_insert_timeout   | 100         | 100        | SESSION | The timeout in seconds for waiting for processing of async insert, default value: 100.                                       | UInt64 |
++---------------------------------+-------------+------------+---------+------------------------------------------------------------------------------------------------------------------------------+--------+
 
 
 ---------- TABLE INFO ------------

--- a/src/query/settings/src/lib.rs
+++ b/src/query/settings/src/lib.rs
@@ -456,6 +456,16 @@ impl Settings {
                 desc: "If enable broadcast join, default value: 0",
                 possible_values: None,
             },
+            SettingValue {
+                default_value: UserSettingValue::UInt64(24 * 7),
+                user_setting: UserSetting::create(
+                    "load_file_metadata_expire_hours",
+                    UserSettingValue::UInt64(24 * 7),
+                ),
+                level: ScopeLevel::Session,
+                desc: "How many hours will the COPY file metadata stored in the metasrv, default value: 24*7=7days",
+                possible_values: None,
+            },
         ];
 
         let settings: Arc<DashMap<String, SettingValue>> = Arc::new(DashMap::default());
@@ -732,6 +742,16 @@ impl Settings {
     pub fn get_hive_parquet_chunk_size(&self) -> Result<u64> {
         static KEY: &str = "hive_parquet_chunk_size";
         self.try_get_u64(KEY)
+    }
+
+    pub fn set_load_file_metadata_expire_hours(&self, val: u64) -> Result<()> {
+        let key = "load_file_metadata_expire_hours";
+        self.try_set_u64(key, val, false)
+    }
+
+    pub fn get_load_file_metadata_expire_hours(&self) -> Result<u64> {
+        let key = "load_file_metadata_expire_hours";
+        self.try_get_u64(key)
     }
 
     pub fn has_setting(&self, key: &str) -> bool {

--- a/src/query/settings/src/lib.rs
+++ b/src/query/settings/src/lib.rs
@@ -463,7 +463,7 @@ impl Settings {
                     UserSettingValue::UInt64(24 * 7),
                 ),
                 level: ScopeLevel::Session,
-                desc: "How many hours will the COPY file metadata stored in the metasrv, default value: 24*7=7days",
+                desc: "How many hours will the COPY file metadata expired in the metasrv, default value: 24*7=7days",
                 possible_values: None,
             },
         ];


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Introduce new settings: `load_file_metadata_expire_hours`,  the COPY file metadata expires after N hours. The default is 24*7 = 7 Days.
* Change the `TableCopiedFileInfo.etag` from MD5 digest(32bytes) to short hash(7bytes).


Closes #8852
