### PR TITLE
refactor(memory-tracker): remove RuntimeTracker, which is barely a wrapper of Arc of MemoryTracker

### DIFF
--- a/src/binaries/meta/main.rs
+++ b/src/binaries/meta/main.rs
@@ -16,7 +16,7 @@ use std::env;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use common_base::base::RuntimeTracker;
+use common_base::base::MemoryTracker;
 use common_base::base::StopHandle;
 use common_base::base::Stoppable;
 use common_exception::ErrorCode;
@@ -43,7 +43,7 @@ pub use kvapi::KvApiCommand;
 const CMD_KVAPI_PREFIX: &str = "kvapi::";
 
 #[databend_main]
-async fn main(_global_tracker: Arc<RuntimeTracker>) -> Result<(), ErrorCode> {
+async fn main(_global_tracker: Arc<MemoryTracker>) -> Result<(), ErrorCode> {
     let conf = Config::load()?;
 
     if run_cmd(&conf).await {

--- a/src/binaries/query/main.rs
+++ b/src/binaries/query/main.rs
@@ -15,7 +15,7 @@
 use std::env;
 use std::sync::Arc;
 
-use common_base::base::RuntimeTracker;
+use common_base::base::MemoryTracker;
 use common_config::Config;
 use common_config::DATABEND_COMMIT_VERSION;
 use common_config::QUERY_SEMVER;
@@ -37,7 +37,7 @@ use databend_query::GlobalServices;
 use tracing::info;
 
 #[databend_main]
-async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<()> {
+async fn main(_global_tracker: Arc<MemoryTracker>) -> common_exception::Result<()> {
     let conf: Config = Config::load()?;
 
     if run_cmd(&conf) {

--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -39,7 +39,7 @@ pub use progress::ProgressValues;
 pub use runtime::Dropper;
 pub use runtime::Runtime;
 pub use runtime::TrySpawn;
-pub use runtime_tracker::RuntimeTracker;
+pub use runtime_tracker::MemoryTracker;
 pub use runtime_tracker::ThreadTracker;
 pub use select::select3;
 pub use select::Select3Output;

--- a/src/common/base/src/base/runtime.rs
+++ b/src/common/base/src/base/runtime.rs
@@ -28,8 +28,8 @@ use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 
-use super::runtime_tracker::RuntimeTracker;
 use crate::base::catch_unwind::CatchUnwindFuture;
+use crate::base::runtime_tracker::MemoryTracker;
 
 /// Methods to spawn tasks.
 pub trait TrySpawn {
@@ -78,18 +78,20 @@ impl<S: TrySpawn> TrySpawn for Arc<S> {
 /// Tokio Runtime wrapper.
 /// If a runtime is in an asynchronous context, shutdown it first.
 pub struct Runtime {
-    // Handle to runtime.
+    /// Runtime handle.
     handle: Handle,
-    // Runtime tracker
-    tracker: Arc<RuntimeTracker>,
-    // Use to receive a drop signal when dropper is dropped.
+
+    /// Memory tracker for this runtime
+    tracker: Arc<MemoryTracker>,
+
+    /// Use to receive a drop signal when dropper is dropped.
     _dropper: Dropper,
 }
 
 impl Runtime {
     fn create(
         name: Option<String>,
-        tracker: Arc<RuntimeTracker>,
+        tracker: Arc<MemoryTracker>,
         builder: &mut Builder,
     ) -> Result<Self> {
         let runtime = builder
@@ -128,17 +130,17 @@ impl Runtime {
         })
     }
 
-    fn tracker_builder(rt_tracker: Arc<RuntimeTracker>) -> tokio::runtime::Builder {
+    fn tracker_builder(mem_tracker: Arc<MemoryTracker>) -> tokio::runtime::Builder {
         let mut builder = tokio::runtime::Builder::new_multi_thread();
         builder
             .enable_all()
-            .on_thread_stop(rt_tracker.on_stop_thread())
-            .on_thread_start(rt_tracker.on_start_thread());
+            .on_thread_stop(mem_tracker.on_stop_thread())
+            .on_thread_start(mem_tracker.on_start_thread());
 
         builder
     }
 
-    pub fn get_tracker(&self) -> Arc<RuntimeTracker> {
+    pub fn get_tracker(&self) -> Arc<MemoryTracker> {
         self.tracker.clone()
     }
 
@@ -146,8 +148,8 @@ impl Runtime {
     /// thread and returns a `Handle` which can be used to spawn tasks via
     /// its executor.
     pub fn with_default_worker_threads() -> Result<Self> {
-        let tracker = RuntimeTracker::create();
-        let mut runtime_builder = Self::tracker_builder(tracker.clone());
+        let mem_tracker = MemoryTracker::create();
+        let mut runtime_builder = Self::tracker_builder(mem_tracker.clone());
 
         #[cfg(debug_assertions)]
         {
@@ -159,13 +161,13 @@ impl Runtime {
             }
         }
 
-        Self::create(None, tracker, &mut runtime_builder)
+        Self::create(None, mem_tracker, &mut runtime_builder)
     }
 
     #[allow(unused_mut)]
     pub fn with_worker_threads(workers: usize, mut thread_name: Option<String>) -> Result<Self> {
-        let tracker = RuntimeTracker::create();
-        let mut runtime_builder = Self::tracker_builder(tracker.clone());
+        let mem_tracker = MemoryTracker::create();
+        let mut runtime_builder = Self::tracker_builder(mem_tracker.clone());
 
         #[cfg(debug_assertions)]
         {
@@ -183,7 +185,7 @@ impl Runtime {
 
         Self::create(
             thread_name,
-            tracker,
+            mem_tracker,
             runtime_builder.worker_threads(workers),
         )
     }

--- a/src/common/base/src/base/thread.rs
+++ b/src/common/base/src/base/thread.rs
@@ -68,7 +68,7 @@ impl Thread {
             thread_builder = thread_builder.name(named);
         }
 
-        ThreadJoinHandle::create(match ThreadTracker::current_runtime_tracker() {
+        ThreadJoinHandle::create(match ThreadTracker::current_mem_tracker() {
             None => thread_builder.spawn(f).unwrap(),
             Some(runtime_tracker) => thread_builder
                 .spawn(move || {

--- a/src/common/base/src/mem_allocator/je_allocator.rs
+++ b/src/common/base/src/mem_allocator/je_allocator.rs
@@ -150,6 +150,7 @@ pub mod linux_or_macos {
         ) -> Result<NonNull<[u8]>, AllocError> {
             debug_assert_eq!(old_layout.align(), new_layout.align());
             debug_assert!(old_layout.size() <= new_layout.size());
+
             let data_address = if new_layout.size() == 0 {
                 NonNull::new(new_layout.align() as *mut ()).unwrap_unchecked()
             } else if old_layout.size() == 0 {

--- a/src/query/service/src/sessions/session_info.rs
+++ b/src/query/service/src/sessions/session_info.rs
@@ -34,9 +34,8 @@ impl Session {
 
         if let Some(shared) = status.get_query_context_shared() {
             if let Ok(runtime) = shared.try_get_runtime() {
-                let runtime_tracker = runtime.get_tracker();
-                let runtime_memory_tracker = runtime_tracker.get_memory_tracker();
-                memory_usage = runtime_memory_tracker.get_memory_usage();
+                let mem_tracker = runtime.get_tracker();
+                memory_usage = mem_tracker.get_memory_usage();
             }
         }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(memory-tracker): remove RuntimeTracker, which is barely a wrapper of Arc of MemoryTracker

## Changelog







## Related Issues