### PR TITLE
docs(meta/cli): CLI commands to access databend-meta KVApi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,6 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
- "sled",
  "thiserror",
  "tonic",
  "tonic-build",

--- a/docs/doc/10-deploy/06-metasrv/70-metasrv-cli-api.md
+++ b/docs/doc/10-deploy/06-metasrv/70-metasrv-cli-api.md
@@ -1,0 +1,131 @@
+---
+title: Databend Meta CLI
+sidebar_label: Meta Service Command Line API
+description:
+    Access Databend Meta Service Cluster with Command Line Interface
+---
+
+The binary `databend-meta` provides several handy commands to access the KVApi of databend meta service.
+`databend-meta --help` also includes a simple guide on using these CLI commands.
+
+The command line API is limited that:
+- only string key and string value are supported.
+- `seq` is not supported.
+
+### Set `foo=bar`:
+```shell
+databend-meta --grpc-api-address 1.2.3.4:5678 --cmd kvapi::upsert --key foo --value bar
+```
+Output is the state before and after applying this command:
+```json
+{
+  "ident": null,
+  "prev": {
+    "seq": 18,
+    "meta": null,
+    "data": [ 98, 97, 114 ]
+  },
+  "result": {
+    "seq": 20,
+    "meta": null,
+    "data": [ 98, 97, 114 ]
+  }
+}
+```
+
+### Set `foo=bar` and inform databend-meta to delete it after 5 seconds:
+```shell
+databend-meta --grpc-api-address 1.2.3.4:5678 --cmd kvapi::upsert --key foo --value bar --expire-after 5
+```
+Output is the state before and after applying this command and `expire_at` is set.
+```json
+{
+  "ident": null,
+  "prev": {
+    "seq": 20,
+    "meta": null,
+    "data": [ 98, 97, 114 ]
+  },
+  "result": {
+    "seq": 21,
+    "meta": {
+      "expire_at": 1668996718
+    },
+    "data": [ 98, 97, 114 ]
+  }
+}
+```
+
+### Delete `foo`:
+```shell
+databend-meta --grpc-api-address 1.2.3.4:5678 --cmd kvapi::delete --key foo
+```
+Output is the state before and after applying this command and `result` is always `null`.
+```json
+{
+  "ident": null,
+  "prev": {
+    "seq": 22,
+    "meta": null,
+    "data": [ 98, 97, 114 ]
+  },
+  "result": null
+}
+```
+
+
+### Get `foo`:
+```shell
+databend-meta --grpc-api-address 1.2.3.4:5678 --cmd kvapi::get --key foo
+```
+Output is the state of key `foo`.
+```json
+{
+  "seq": 23,
+  "meta": null,
+  "data": [ 98, 97, 114 ]
+}
+```
+
+### Get multiple keys with mget: `foo,bar,wow`:
+```shell
+databend-meta --grpc-api-address 1.2.3.4:5678 --cmd kvapi::mget --key foo bar wow
+```
+Output is the states of every specified key.
+```json
+[
+  {
+    "seq": 23,
+    "meta": null,
+    "data": [ 98, 97, 114 ]
+  },
+  null,
+  null
+]
+```
+
+### List keys starting with `foo/`:
+```shell
+databend-meta --grpc-api-address 1.2.3.4:5678 --cmd kvapi::upsert --key foo --value bar
+```
+Output is the key values of every key starting with `prefix`.
+```json
+[
+  [
+    "foo/a",
+    {
+      "seq": 24,
+      "meta": null,
+      "data": [ 98, 97, 114 ]
+    }
+  ],
+  [
+    "foo/b",
+    {
+      "seq": 25,
+      "meta": null,
+      "data": [ 119, 111, 119 ]
+    }
+  ]
+]
+```

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -16,7 +16,6 @@ common-meta-stoerr = { path = "../stoerr" }
 common-storage = { path = "../../common/storage" }
 
 openraft = { workspace = true }
-sled = { workspace = true }
 
 anyerror = { workspace = true }
 chrono = "0.4.22"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### docs(meta/cli): CLI commands to access databend-meta KVApi

- Fix: #8863


##### chore: remove unused dep

## Changelog







## Related Issues