### PR TITLE
feat(expression): Add methods to get memory size of `ValueType`s.

### DIFF
--- a/src/query/expression/src/types.rs
+++ b/src/query/expression/src/types.rs
@@ -233,6 +233,14 @@ pub trait ValueType: Debug + Clone + PartialEq + Sized + 'static {
     fn append_builder(builder: &mut Self::ColumnBuilder, other_builder: &Self::ColumnBuilder);
     fn build_column(builder: Self::ColumnBuilder) -> Self::Column;
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar;
+
+    fn scalar_memory_size<'a>(_: &Self::ScalarRef<'a>) -> usize {
+        std::mem::size_of::<Self::Scalar>()
+    }
+
+    fn column_memory_size(col: &Self::Column) -> usize {
+        Self::column_len(col) * std::mem::size_of::<Self::Scalar>()
+    }
 }
 
 pub trait ArgType: ValueType {

--- a/src/query/expression/src/types/any.rs
+++ b/src/query/expression/src/types/any.rs
@@ -127,4 +127,12 @@ impl ValueType for AnyType {
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         builder.build_scalar()
     }
+
+    fn scalar_memory_size<'a>(scalar: &Self::ScalarRef<'a>) -> usize {
+        scalar.memory_size()
+    }
+
+    fn column_memory_size(col: &Self::Column) -> usize {
+        col.memory_size()
+    }
 }

--- a/src/query/expression/src/types/array.rs
+++ b/src/query/expression/src/types/array.rs
@@ -140,6 +140,14 @@ impl<T: ValueType> ValueType for ArrayType<T> {
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         builder.build_scalar()
     }
+
+    fn scalar_memory_size<'a>(scalar: &Self::ScalarRef<'a>) -> usize {
+        T::column_memory_size(scalar)
+    }
+
+    fn column_memory_size(col: &Self::Column) -> usize {
+        col.memory_size()
+    }
 }
 
 impl<T: ArgType> ArgType for ArrayType<T> {
@@ -207,6 +215,10 @@ impl<T: ValueType> ArrayColumn<T> {
             values: T::upcast_column(self.values),
             offsets: self.offsets,
         }
+    }
+
+    pub fn memory_size(&self) -> usize {
+        T::column_memory_size(&self.values) + self.offsets.len() * 8
     }
 }
 

--- a/src/query/expression/src/types/empty_array.rs
+++ b/src/query/expression/src/types/empty_array.rs
@@ -138,6 +138,14 @@ impl ValueType for EmptyArrayType {
     fn build_scalar(len: Self::ColumnBuilder) -> Self::Scalar {
         assert_eq!(len, 1);
     }
+
+    fn scalar_memory_size<'a>(_: &Self::ScalarRef<'a>) -> usize {
+        0
+    }
+
+    fn column_memory_size(_: &Self::Column) -> usize {
+        std::mem::size_of::<usize>()
+    }
 }
 
 impl ArgType for EmptyArrayType {

--- a/src/query/expression/src/types/generic.rs
+++ b/src/query/expression/src/types/generic.rs
@@ -130,6 +130,14 @@ impl<const INDEX: usize> ValueType for GenericType<INDEX> {
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         builder.build_scalar()
     }
+
+    fn scalar_memory_size<'a>(scalar: &Self::ScalarRef<'a>) -> usize {
+        scalar.memory_size()
+    }
+
+    fn column_memory_size(col: &Self::Column) -> usize {
+        col.memory_size()
+    }
 }
 
 impl<const INDEX: usize> ArgType for GenericType<INDEX> {

--- a/src/query/expression/src/types/map.rs
+++ b/src/query/expression/src/types/map.rs
@@ -152,6 +152,14 @@ impl<K: ValueType, V: ValueType> ValueType for KvPair<K, V> {
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         builder.build_scalar()
     }
+
+    fn scalar_memory_size<'a>((k, v): &Self::ScalarRef<'a>) -> usize {
+        K::scalar_memory_size(k) + V::scalar_memory_size(v)
+    }
+
+    fn column_memory_size(col: &Self::Column) -> usize {
+        col.memory_size()
+    }
 }
 
 impl<K: ArgType, V: ArgType> ArgType for KvPair<K, V> {
@@ -206,6 +214,10 @@ impl<K: ValueType, V: ValueType> KvColumn<K, V> {
             keys: K::iter_column(&self.keys),
             values: V::iter_column(&self.values),
         }
+    }
+
+    pub fn memory_size(&self) -> usize {
+        K::column_memory_size(&self.keys) + V::column_memory_size(&self.values)
     }
 }
 
@@ -390,6 +402,14 @@ impl<T: ValueType> ValueType for MapType<T> {
 
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         <MapInternal<T> as ValueType>::build_scalar(builder)
+    }
+
+    fn scalar_memory_size<'a>(scalar: &Self::ScalarRef<'a>) -> usize {
+        scalar.memory_size()
+    }
+
+    fn column_memory_size(col: &Self::Column) -> usize {
+        col.memory_size()
     }
 }
 

--- a/src/query/expression/src/types/null.rs
+++ b/src/query/expression/src/types/null.rs
@@ -145,6 +145,14 @@ impl ValueType for NullType {
     fn build_scalar(len: Self::ColumnBuilder) -> Self::Scalar {
         assert_eq!(len, 1);
     }
+
+    fn scalar_memory_size<'a>(_: &Self::ScalarRef<'a>) -> usize {
+        0
+    }
+
+    fn column_memory_size(_: &Self::Column) -> usize {
+        std::mem::size_of::<usize>()
+    }
 }
 
 impl ArgType for NullType {

--- a/src/query/expression/src/types/nullable.rs
+++ b/src/query/expression/src/types/nullable.rs
@@ -165,6 +165,17 @@ impl<T: ValueType> ValueType for NullableType<T> {
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         builder.build_scalar()
     }
+
+    fn scalar_memory_size<'a>(scalar: &Self::ScalarRef<'a>) -> usize {
+        match scalar {
+            Some(scalar) => T::scalar_memory_size(scalar),
+            None => 0,
+        }
+    }
+
+    fn column_memory_size(col: &Self::Column) -> usize {
+        col.memory_size()
+    }
 }
 
 impl<T: ArgType> ArgType for NullableType<T> {
@@ -235,6 +246,10 @@ impl<T: ValueType> NullableColumn<T> {
             column: T::upcast_column(self.column),
             validity: self.validity,
         }
+    }
+
+    pub fn memory_size(&self) -> usize {
+        T::column_memory_size(&self.column) + self.validity.as_slice().0.len()
     }
 }
 

--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -139,6 +139,14 @@ impl ValueType for StringType {
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         builder.build_scalar()
     }
+
+    fn scalar_memory_size<'a>(scalar: &Self::ScalarRef<'a>) -> usize {
+        scalar.len()
+    }
+
+    fn column_memory_size(col: &Self::Column) -> usize {
+        col.data.len() + col.offsets.len() * 8
+    }
 }
 
 impl ArgType for StringType {

--- a/src/query/expression/src/types/variant.rs
+++ b/src/query/expression/src/types/variant.rs
@@ -148,6 +148,14 @@ impl ValueType for VariantType {
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         builder.build_scalar()
     }
+
+    fn scalar_memory_size<'a>(scalar: &Self::ScalarRef<'a>) -> usize {
+        scalar.len()
+    }
+
+    fn column_memory_size(col: &Self::Column) -> usize {
+        col.data.len() + col.offsets.len() * 8
+    }
 }
 
 impl ArgType for VariantType {

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -267,6 +267,29 @@ impl<'a> ScalarRef<'a> {
             ScalarRef::Variant(_) => Domain::Undefined,
         }
     }
+
+    pub fn memory_size(&self) -> usize {
+        match self {
+            ScalarRef::Null | ScalarRef::EmptyArray => 0,
+            ScalarRef::Number(NumberScalar::UInt8(_)) => 1,
+            ScalarRef::Number(NumberScalar::UInt16(_)) => 2,
+            ScalarRef::Number(NumberScalar::UInt32(_)) => 4,
+            ScalarRef::Number(NumberScalar::UInt64(_)) => 8,
+            ScalarRef::Number(NumberScalar::Float32(_)) => 4,
+            ScalarRef::Number(NumberScalar::Float64(_)) => 8,
+            ScalarRef::Number(NumberScalar::Int8(_)) => 1,
+            ScalarRef::Number(NumberScalar::Int16(_)) => 2,
+            ScalarRef::Number(NumberScalar::Int32(_)) => 4,
+            ScalarRef::Number(NumberScalar::Int64(_)) => 8,
+            ScalarRef::Boolean(_) => 1,
+            ScalarRef::String(s) => s.len(),
+            ScalarRef::Timestamp(_) => 8,
+            ScalarRef::Date(_) => 4,
+            ScalarRef::Array(col) => col.memory_size(),
+            ScalarRef::Tuple(scalars) => scalars.iter().map(|s| s.memory_size()).sum(),
+            ScalarRef::Variant(buf) => buf.len(),
+        }
+    }
 }
 
 impl PartialOrd for Scalar {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

We need to know the memory size of `Scalar` and `Column` in the new expression framework.
