### PR TITLE
refactor(mem-tracker): send pointer addresses to mem tracker

### DIFF
--- a/src/common/base/src/lib.rs
+++ b/src/common/base/src/lib.rs
@@ -17,6 +17,8 @@
 #![feature(ptr_metadata)]
 #![feature(result_flattening)]
 #![feature(try_trait_v2)]
+#![feature(thread_id_value)]
+#![feature(backtrace_frames)]
 #![allow(incomplete_features)]
 
 pub mod base;

--- a/src/common/base/src/mem_allocator/je_allocator.rs
+++ b/src/common/base/src/mem_allocator/je_allocator.rs
@@ -91,7 +91,7 @@ pub mod linux_or_macos {
                     NonNull::new(ffi::mallocx(layout.size(), flags) as *mut ()).ok_or(AllocError)?
                 }
             };
-            ThreadTracker::alloc_memory(layout.size() as i64);
+            ThreadTracker::alloc_memory(layout.size() as i64, &data_address);
             Ok(NonNull::<[u8]>::from_raw_parts(data_address, layout.size()))
         }
 
@@ -100,6 +100,8 @@ pub mod linux_or_macos {
             if layout.size() == 0 {
                 debug_assert_eq!(ptr.as_ptr() as usize, layout.align());
             } else {
+                ThreadTracker::dealloc_memory(layout.size() as i64, &ptr);
+
                 let flags = layout_to_flags(layout.align(), layout.size());
                 ffi::sdallocx(ptr.as_ptr() as *mut _, layout.size(), flags)
             }
@@ -115,6 +117,8 @@ pub mod linux_or_macos {
                     NonNull::new(ffi::mallocx(layout.size(), flags) as *mut ()).ok_or(AllocError)?
                 }
             };
+
+            ThreadTracker::alloc_memory(layout.size() as i64, &data_address);
             Ok(NonNull::<[u8]>::from_raw_parts(data_address, layout.size()))
         }
 
@@ -126,6 +130,9 @@ pub mod linux_or_macos {
         ) -> Result<NonNull<[u8]>, AllocError> {
             debug_assert_eq!(old_layout.align(), new_layout.align());
             debug_assert!(old_layout.size() <= new_layout.size());
+
+            ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
+
             let data_address = if new_layout.size() == 0 {
                 NonNull::new(new_layout.align() as *mut ()).unwrap_unchecked()
             } else if old_layout.size() == 0 {
@@ -136,6 +143,9 @@ pub mod linux_or_macos {
                 NonNull::new(ffi::rallocx(ptr.cast().as_ptr(), new_layout.size(), flags) as *mut ())
                     .unwrap()
             };
+
+            ThreadTracker::alloc_memory(new_layout.size() as i64, &data_address);
+
             Ok(NonNull::<[u8]>::from_raw_parts(
                 data_address,
                 new_layout.size(),
@@ -150,6 +160,8 @@ pub mod linux_or_macos {
         ) -> Result<NonNull<[u8]>, AllocError> {
             debug_assert_eq!(old_layout.align(), new_layout.align());
             debug_assert!(old_layout.size() <= new_layout.size());
+
+            ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
 
             let data_address = if new_layout.size() == 0 {
                 NonNull::new(new_layout.align() as *mut ()).unwrap_unchecked()
@@ -167,6 +179,9 @@ pub mod linux_or_macos {
                     .write_bytes(0, new_layout.size() - old_layout.size());
                 NonNull::new(raw as *mut ()).unwrap()
             };
+
+            ThreadTracker::alloc_memory(new_layout.size() as i64, &data_address);
+
             Ok(NonNull::<[u8]>::from_raw_parts(
                 data_address,
                 new_layout.size(),
@@ -181,26 +196,31 @@ pub mod linux_or_macos {
         ) -> Result<NonNull<[u8]>, AllocError> {
             debug_assert_eq!(old_layout.align(), new_layout.align());
             debug_assert!(old_layout.size() >= new_layout.size());
+
+            ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
+
             if old_layout.size() == 0 {
                 debug_assert_eq!(ptr.as_ptr() as usize, old_layout.align());
                 let slice = std::slice::from_raw_parts_mut(ptr.as_ptr(), 0);
                 let ptr = NonNull::new(slice).unwrap_unchecked();
                 return Ok(ptr);
             }
+
             let flags = layout_to_flags(new_layout.align(), new_layout.size());
-            if new_layout.size() == 0 {
+            let new_ptr = if new_layout.size() == 0 {
                 ffi::sdallocx(ptr.as_ptr() as *mut c_void, new_layout.size(), flags);
                 let slice = std::slice::from_raw_parts_mut(new_layout.align() as *mut u8, 0);
-                let ptr = NonNull::new(slice).unwrap_unchecked();
-                Ok(ptr)
+                NonNull::new(slice).unwrap_unchecked()
             } else {
                 let data_address =
                     ffi::rallocx(ptr.cast().as_ptr(), new_layout.size(), flags) as *mut u8;
                 let metadata = new_layout.size();
                 let slice = std::slice::from_raw_parts_mut(data_address, metadata);
-                let ptr = NonNull::new(slice).ok_or(AllocError)?;
-                Ok(ptr)
-            }
+                NonNull::new(slice).ok_or(AllocError)?
+            };
+
+            ThreadTracker::alloc_memory(new_layout.size() as i64, &new_ptr);
+            Ok(new_ptr)
         }
     }
 }

--- a/src/common/base/src/mem_allocator/system_allocator.rs
+++ b/src/common/base/src/mem_allocator/system_allocator.rs
@@ -26,20 +26,24 @@ pub struct SystemAllocator;
 unsafe impl Allocator for SystemAllocator {
     #[inline(always)]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        ThreadTracker::alloc_memory(layout.size() as i64);
-        System.allocate(layout)
+        let p = System.allocate(layout)?;
+        ThreadTracker::alloc_memory(layout.size() as i64, &p);
+        Ok(p)
     }
 
     #[inline(always)]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        ThreadTracker::dealloc_memory(layout.size() as i64);
+        ThreadTracker::dealloc_memory(layout.size() as i64, &ptr);
         System.deallocate(ptr, layout)
     }
 
     #[inline(always)]
     fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        ThreadTracker::alloc_memory(layout.size() as i64);
-        System.allocate_zeroed(layout)
+        let p = System.allocate_zeroed(layout)?;
+
+        ThreadTracker::alloc_memory(layout.size() as i64, &p);
+
+        Ok(p)
     }
 
     #[inline(always)]
@@ -49,8 +53,12 @@ unsafe impl Allocator for SystemAllocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        ThreadTracker::grow_memory(old_layout.size() as i64, new_layout.size() as i64);
-        System.grow(ptr, old_layout, new_layout)
+        ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
+
+        let new_ptr = System.grow(ptr, old_layout, new_layout)?;
+
+        ThreadTracker::alloc_memory(new_layout.size() as i64, &new_ptr);
+        Ok(new_ptr)
     }
 
     #[inline(always)]
@@ -60,8 +68,12 @@ unsafe impl Allocator for SystemAllocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        ThreadTracker::grow_memory(old_layout.size() as i64, new_layout.size() as i64);
-        System.grow_zeroed(ptr, old_layout, new_layout)
+        ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
+
+        let new_ptr = System.grow_zeroed(ptr, old_layout, new_layout)?;
+
+        ThreadTracker::alloc_memory(new_layout.size() as i64, &new_ptr);
+        Ok(new_ptr)
     }
 
     #[inline(always)]
@@ -71,7 +83,11 @@ unsafe impl Allocator for SystemAllocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        ThreadTracker::shrink_memory(old_layout.size() as i64, new_layout.size() as i64);
-        System.shrink(ptr, old_layout, new_layout)
+        ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
+
+        let new_ptr = System.shrink(ptr, old_layout, new_layout)?;
+
+        ThreadTracker::alloc_memory(new_layout.size() as i64, &new_ptr);
+        Ok(new_ptr)
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(mem-tracker): send pointer addresses to mem tracker

- Memory tracker methods accept an pointer argument for debugging.

- In order to simplify tracker API, replace `grow_memory()` with
  `alloc_memory()` followed by a `dealloc_memory()`,  the similar to
  `shrink_memory()`.

- MemoryTracker tracks allocation stats and deallocation stats
  respectively, instead of just the delta of them.

- Add missing tracking statements to Jemallocator.

## Changelog







## Related Issues