### PR TITLE
fix(http handler): avoid dropping runtime when task on it not finished.

### DIFF
--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -241,6 +241,7 @@ impl HttpQuery {
         let ctx_clone = ctx.clone();
         let sql = request.sql.clone();
         let query_id = id.clone();
+        let query_id_clone = id.clone();
         ctx.try_spawn(async move {
             let state = state_clone.clone();
             let running_state = ExecuteState::try_start_query(
@@ -259,6 +260,7 @@ impl HttpQuery {
                 Err(e) => {
                     InterpreterQueryLog::fail_to_start(ctx_clone.clone(), e.clone());
                     let state = ExecuteStopped {
+                        ctx: ctx_clone.clone(),
                         stats: Progresses::default(),
                         reason: Err(e.clone()),
                         stop_time: Instant::now(),
@@ -278,6 +280,7 @@ impl HttpQuery {
 
         let format_settings = ctx.get_format_settings()?;
         let data = Arc::new(TokioMutex::new(PageManager::new(
+            query_id_clone,
             request.pagination.max_rows_per_page,
             block_receiver,
             request.string_fields,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

the original release session/query_context right after the computation is finished,  because only some result/status is useful, but a task is still running.
we can fix it first if this pr does not lead to other problems, and refactor the code later.


Closes  https://github.com/datafuselabs/databend/issues/7888
