### PR TITLE
feat(mem-tracker): add global mem allocation tracker

### DIFF
--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -42,6 +42,7 @@ pub use runtime::TrySpawn;
 pub use runtime_tracker::AsyncThreadTracker;
 pub use runtime_tracker::MemoryTracker;
 pub use runtime_tracker::ThreadTracker;
+pub use runtime_tracker::GLOBAL_TRACKER;
 pub use select::select3;
 pub use select::Select3Output;
 pub use shutdown_signal::signal_stream;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feat(mem-tracker): add global mem allocation tracker

Stat of every alloc/dealloc is collected in a global tracker, which is
also backed with a thread local buffer for performance concern.

## Changelog







## Related Issues