### PR TITLE
refactor(format): enable get_splits() to be used independently.

### DIFF
--- a/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_parquet.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_parquet.rs
@@ -347,7 +347,9 @@ impl AligningStateTrait for AligningState {
             if let ReadBatch::Buffer(b) = rb {
                 self.buffers.push(b)
             } else {
-                unreachable!()
+                return Err(ErrorCode::Internal(
+                    "Bug: should not see ReadBatch::RowGroup in align().",
+                ));
             };
             Ok(vec![])
         } else {

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_parquet.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_parquet.rs
@@ -89,7 +89,6 @@ impl InputFormat for InputFormatParquet {
         _stage_info: &UserStageInfo,
         op: &Operator,
         _settings: &Arc<Settings>,
-        _schema: &DataSchemaRef,
     ) -> Result<Vec<Arc<SplitInfo>>> {
         let mut infos = vec![];
         for path in files {

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/input_context.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/input_context.rs
@@ -65,7 +65,6 @@ impl InputPlan {
 #[derive(Debug)]
 pub struct CopyIntoPlan {
     pub stage_info: UserStageInfo,
-    pub files: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -165,14 +164,11 @@ impl InputContext {
         settings: Arc<Settings>,
         schema: DataSchemaRef,
         stage_info: UserStageInfo,
-        files: Vec<String>,
+        splits: Vec<Arc<SplitInfo>>,
         scan_progress: Arc<Progress>,
         block_compact_thresholds: BlockCompactThresholds,
     ) -> Result<Self> {
-        if files.is_empty() {
-            return Err(ErrorCode::BadArguments("no file to copy"));
-        }
-        let plan = Box::new(CopyIntoPlan { stage_info, files });
+        let plan = Box::new(CopyIntoPlan { stage_info });
         let read_batch_size = settings.get_input_read_buffer_size()? as usize;
         let file_format_options = &plan.stage_info.file_format_options;
         let format_typ = file_format_options.format.clone();
@@ -181,9 +177,6 @@ impl InputContext {
         let file_format_options = format_typ.final_file_format_options(&file_format_options)?;
 
         let format = Self::get_input_format(&format_typ)?;
-        let splits = format
-            .get_splits(&plan.files, &plan.stage_info, &operator, &settings)
-            .await?;
         let record_delimiter = {
             if file_format_options.stage.record_delimiter.is_empty() {
                 format.default_record_delimiter()

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/input_context.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/input_context.rs
@@ -182,7 +182,7 @@ impl InputContext {
 
         let format = Self::get_input_format(&format_typ)?;
         let splits = format
-            .get_splits(&plan.files, &plan.stage_info, &operator, &settings, &schema)
+            .get_splits(&plan.files, &plan.stage_info, &operator, &settings)
             .await?;
         let record_delimiter = {
             if file_format_options.stage.record_delimiter.is_empty() {

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/input_format.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/input_format.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use common_datavalues::DataSchemaRef;
 use common_exception::Result;
 use common_meta_types::UserStageInfo;
 use common_pipeline_core::Pipeline;
@@ -37,7 +36,6 @@ pub trait InputFormat: Send + Sync {
         stage_info: &UserStageInfo,
         op: &Operator,
         settings: &Arc<Settings>,
-        schema: &DataSchemaRef,
     ) -> Result<Vec<Arc<SplitInfo>>>;
 
     fn exec_copy(&self, ctx: Arc<InputContext>, pipeline: &mut Pipeline) -> Result<()>;

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/input_format_text.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/input_format_text.rs
@@ -17,7 +17,6 @@ use std::mem;
 use std::sync::Arc;
 
 use common_datablocks::DataBlock;
-use common_datavalues::DataSchemaRef;
 use common_datavalues::TypeDeserializer;
 use common_datavalues::TypeDeserializerImpl;
 use common_exception::ErrorCode;
@@ -141,7 +140,6 @@ impl<T: InputFormatTextBase> InputFormat for InputFormatText<T> {
         stage_info: &UserStageInfo,
         op: &Operator,
         _settings: &Arc<Settings>,
-        _schema: &DataSchemaRef,
     ) -> Result<Vec<Arc<SplitInfo>>> {
         let mut infos = vec![];
         for path in files {

--- a/src/query/service/src/interpreters/interpreter_copy_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_v2.rs
@@ -354,9 +354,20 @@ impl CopyInterpreterV2 {
                 .iter()
                 .map(|v| v.path.clone())
                 .collect::<Vec<_>>();
-
-            let operator = StageTable::get_op(&table_ctx, &stage_table_info.user_stage_info)?;
             let settings = ctx.get_settings();
+            let operator = StageTable::get_op(&table_ctx, &stage_table_info.user_stage_info)?;
+            let format = InputContext::get_input_format(
+                &stage_table_info.user_stage_info.file_format_options.format,
+            )?;
+            let splits = format
+                .get_splits(
+                    &files,
+                    &stage_table_info.user_stage_info,
+                    &operator,
+                    &settings,
+                )
+                .await?;
+
             let schema = stage_table_info.schema.clone();
             let stage_info = stage_table_info.user_stage_info.clone();
             let compact_threshold = stage_table.get_block_compact_thresholds();
@@ -366,7 +377,7 @@ impl CopyInterpreterV2 {
                     settings,
                     schema,
                     stage_info,
-                    files,
+                    splits,
                     ctx.get_scan_progress(),
                     compact_threshold,
                 )


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

so we can use a split as a table partition later.


Closes #issue
