### PR TITLE
chore(planner): Refactor Metadata to distinguish between base table column and derived column

### DIFF
--- a/src/query/service/tests/it/sql/planner/format/mod.rs
+++ b/src/query/service/tests/it/sql/planner/format/mod.rs
@@ -68,24 +68,24 @@ impl Table for DummyTable {
 #[test]
 fn test_format() {
     let mut metadata = Metadata::default();
-    let col1 = metadata.add_column(
-        "col1".to_string(),
-        BooleanType::new_impl(),
-        None,
-        None,
-        None,
-    );
-    let col2 = metadata.add_column(
-        "col2".to_string(),
-        BooleanType::new_impl(),
-        None,
-        None,
-        None,
-    );
     let tab1 = metadata.add_table(
         "catalog".to_string(),
         "database".to_string(),
         Arc::new(DummyTable::new("table".to_string())),
+        None,
+    );
+    let col1 = metadata.add_base_table_column(
+        "col1".to_string(),
+        BooleanType::new_impl(),
+        tab1,
+        None,
+        None,
+    );
+    let col2 = metadata.add_base_table_column(
+        "col2".to_string(),
+        BooleanType::new_impl(),
+        tab1,
+        None,
         None,
     );
 

--- a/src/query/sql/src/executor/expression_builder.rs
+++ b/src/query/sql/src/executor/expression_builder.rs
@@ -25,6 +25,7 @@ use common_functions::scalars::FunctionFactory;
 
 use crate::executor::util::format_field_name;
 use crate::plans::Scalar;
+use crate::ColumnEntry;
 use crate::IndexType;
 use crate::MetadataRef;
 use crate::ScalarExpr;
@@ -63,7 +64,11 @@ where ExpressionBuilder<T>: FiledNameFormat
         match scalar {
             Scalar::BoundColumnRef(column_ref) => {
                 let metadata = self.metadata.read();
-                let name = metadata.column(column_ref.column.index).name();
+                let column_entry = metadata.column(column_ref.column.index);
+                let name = match column_entry {
+                    ColumnEntry::BaseTableColumn { column_name, .. } => column_name,
+                    ColumnEntry::DerivedColumn { alias, .. } => alias,
+                };
                 Ok(Expression::IndexedVariable {
                     name: name.to_string(),
                     data_type: (*column_ref.column.data_type).clone(),

--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -155,13 +155,10 @@ impl<'a> AggregateRewriter<'a> {
                     scalar: arg.clone(),
                 });
             } else {
-                let index = self.metadata.write().add_column(
-                    name.clone(),
-                    arg.data_type(),
-                    None,
-                    None,
-                    None,
-                );
+                let index = self
+                    .metadata
+                    .write()
+                    .add_derived_column(name.clone(), arg.data_type());
 
                 // Generate a ColumnBinding for each argument of aggregates
                 let column_binding = ColumnBinding {
@@ -188,12 +185,9 @@ impl<'a> AggregateRewriter<'a> {
             }
         }
 
-        let index = self.metadata.write().add_column(
+        let index = self.metadata.write().add_derived_column(
             aggregate.display_name.clone(),
             *aggregate.return_type.clone(),
-            None,
-            None,
-            None,
         );
 
         let replaced_agg = AggregateFunction {
@@ -377,13 +371,9 @@ impl<'a> Binder {
             {
                 *index
             } else {
-                self.metadata.write().add_column(
-                    group_item_name.clone(),
-                    data_type.clone(),
-                    None,
-                    None,
-                    None,
-                )
+                self.metadata
+                    .write()
+                    .add_derived_column(group_item_name.clone(), data_type.clone())
             };
 
             bind_context.aggregate_info.group_items.push(ScalarItem {

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -116,18 +116,18 @@ impl<'a> Binder {
                 self.bind_rewrite_to_query(
                     bind_context,
                     "SELECT metric, kind, labels, value FROM system.metrics",
-                    RewriteKind::ShowMetrics
+                    RewriteKind::ShowMetrics,
                 )
-                .await?
+                    .await?
             }
             Statement::ShowProcessList => {
                 self.bind_rewrite_to_query(bind_context, "SELECT * FROM system.processes", RewriteKind::ShowProcessList)
                     .await?
             }
             Statement::ShowEngines => {
-                 self.bind_rewrite_to_query(bind_context, "SELECT \"Engine\", \"Comment\" FROM system.engines ORDER BY \"Engine\" ASC", RewriteKind::ShowEngines)
+                self.bind_rewrite_to_query(bind_context, "SELECT \"Engine\", \"Comment\" FROM system.engines ORDER BY \"Engine\" ASC", RewriteKind::ShowEngines)
                     .await?
-            },
+            }
             Statement::ShowSettings { like } => self.bind_show_settings(bind_context, like).await?,
             // Catalogs
             Statement::ShowCatalogs(stmt) => self.bind_show_catalogs(bind_context, stmt).await?,
@@ -142,7 +142,7 @@ impl<'a> Binder {
             Statement::DropDatabase(stmt) => self.bind_drop_database(stmt).await?,
             Statement::UndropDatabase(stmt) => self.bind_undrop_database(stmt).await?,
             Statement::AlterDatabase(stmt) => self.bind_alter_database(stmt).await?,
-            Statement::UseDatabase { database } =>  {
+            Statement::UseDatabase { database } => {
                 Plan::UseDatabase(Box::new(UseDatabasePlan {
                     database: database.name.clone(),
                 }))
@@ -174,7 +174,7 @@ impl<'a> Binder {
                 if_exists: *if_exists,
                 user: user.clone(),
             })),
-            Statement::ShowUsers => self.bind_rewrite_to_query(bind_context, "SELECT name, hostname, auth_type, auth_string FROM system.users ORDER BY name",  RewriteKind::ShowUsers).await?,
+            Statement::ShowUsers => self.bind_rewrite_to_query(bind_context, "SELECT name, hostname, auth_type, auth_string FROM system.users ORDER BY name", RewriteKind::ShowUsers).await?,
             Statement::AlterUser(stmt) => self.bind_alter_user(stmt).await?,
 
             // Roles
@@ -237,12 +237,12 @@ impl<'a> Binder {
                 description,
             } => {
                 let mut validator = UDFValidator {
-                    name : udf_name.to_string(),
+                    name: udf_name.to_string(),
                     parameters: parameters.iter().map(|v| v.to_string()).collect(),
                     ..Default::default()
                 };
                 validator.verify_definition_expr(definition)?;
-                let udf =  UserDefinedFunction {
+                let udf = UserDefinedFunction {
                     name: validator.name,
                     parameters: validator.parameters,
                     definition: definition.to_string(),
@@ -251,9 +251,9 @@ impl<'a> Binder {
 
                 Plan::CreateUDF(Box::new(CreateUDFPlan {
                     if_not_exists: *if_not_exists,
-                    udf
+                    udf,
                 }))
-            },
+            }
             Statement::AlterUDF {
                 udf_name,
                 parameters,
@@ -261,12 +261,12 @@ impl<'a> Binder {
                 description,
             } => {
                 let mut validator = UDFValidator {
-                    name : udf_name.to_string(),
+                    name: udf_name.to_string(),
                     parameters: parameters.iter().map(|v| v.to_string()).collect(),
                     ..Default::default()
                 };
                 validator.verify_definition_expr(definition)?;
-                let udf =  UserDefinedFunction {
+                let udf = UserDefinedFunction {
                     name: validator.name,
                     parameters: validator.parameters,
                     definition: definition.to_string(),
@@ -374,13 +374,10 @@ impl<'a> Binder {
         column_name: String,
         data_type: DataTypeImpl,
     ) -> ColumnBinding {
-        let index = self.metadata.write().add_column(
-            column_name.clone(),
-            data_type.clone(),
-            None,
-            None,
-            None,
-        );
+        let index = self
+            .metadata
+            .write()
+            .add_derived_column(column_name.clone(), data_type.clone());
         ColumnBinding {
             database_name,
             table_name,

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -461,13 +461,10 @@ impl<'a> Binder {
             .enumerate()
         {
             let left_index = if left_col.data_type != coercion_types[idx] {
-                let new_column_index = self.metadata.write().add_column(
-                    left_col.column_name.clone(),
-                    coercion_types[idx].clone(),
-                    None,
-                    None,
-                    None,
-                );
+                let new_column_index = self
+                    .metadata
+                    .write()
+                    .add_derived_column(left_col.column_name.clone(), coercion_types[idx].clone());
                 let column_binding = ColumnBinding {
                     database_name: None,
                     table_name: None,
@@ -497,13 +494,10 @@ impl<'a> Binder {
                 left_col.index
             };
             let right_index = if right_col.data_type != coercion_types[idx] {
-                let new_column_index = self.metadata.write().add_column(
-                    right_col.column_name.clone(),
-                    coercion_types[idx].clone(),
-                    None,
-                    None,
-                    None,
-                );
+                let new_column_index = self
+                    .metadata
+                    .write()
+                    .add_derived_column(right_col.column_name.clone(), coercion_types[idx].clone());
                 let right_coercion_expr = CastExpr {
                     argument: Box::new(
                         BoundColumnRef {

--- a/src/query/sql/src/planner/metadata.rs
+++ b/src/query/sql/src/planner/metadata.rs
@@ -318,6 +318,7 @@ impl TableEntry {
 
 #[derive(Clone, Debug)]
 pub enum ColumnEntry {
+    /// Column from base table, for example `SELECT t.a, t.b FROM t`.
     BaseTableColumn {
         table_index: IndexType,
         column_index: IndexType,
@@ -330,6 +331,8 @@ pub enum ColumnEntry {
         /// None if the data type of column is struct.
         leaf_index: Option<usize>,
     },
+
+    /// Column synthesized from other columns, for example `SELECT t.a + t.b AS a FROM t`.
     DerivedColumn {
         column_index: IndexType,
         alias: String,

--- a/src/query/sql/src/planner/metadata.rs
+++ b/src/query/sql/src/planner/metadata.rs
@@ -63,10 +63,14 @@ impl Metadata {
     }
 
     pub fn table_index_by_column_indexes(&self, column_indexes: &ColumnSet) -> Option<IndexType> {
-        self.columns
-            .iter()
-            .find(|v| column_indexes.contains(&v.column_index))
-            .and_then(|v| v.table_index)
+        self.columns.iter().find_map(|v| match v {
+            ColumnEntry::BaseTableColumn {
+                column_index,
+                table_index,
+                ..
+            } if column_indexes.contains(column_index) => Some(*table_index),
+            _ => None,
+        })
     }
 
     pub fn column(&self, index: IndexType) -> &ColumnEntry {
@@ -82,28 +86,39 @@ impl Metadata {
     pub fn columns_by_table_index(&self, index: IndexType) -> Vec<ColumnEntry> {
         self.columns
             .iter()
-            .filter(|v| v.table_index == Some(index))
+            .filter(|v| matches!(v, ColumnEntry::BaseTableColumn { table_index, .. } if index == *table_index))
             .cloned()
             .collect()
     }
 
-    pub fn add_column(
+    pub fn add_base_table_column(
         &mut self,
         name: String,
         data_type: DataTypeImpl,
-        table_index: Option<IndexType>,
+        table_index: IndexType,
         path_indices: Option<Vec<IndexType>>,
         leaf_index: Option<IndexType>,
     ) -> IndexType {
         let column_index = self.columns.len();
-        let column_entry = ColumnEntry::new(
-            name,
+        let column_entry = ColumnEntry::BaseTableColumn {
+            column_name: name,
             data_type,
             column_index,
             table_index,
             path_indices,
             leaf_index,
-        );
+        };
+        self.columns.push(column_entry);
+        column_index
+    }
+
+    pub fn add_derived_column(&mut self, alias: String, data_type: DataTypeImpl) -> IndexType {
+        let column_index = self.columns.len();
+        let column_entry = ColumnEntry::DerivedColumn {
+            column_index,
+            alias,
+            data_type,
+        };
         self.columns.push(column_entry);
         column_index
     }
@@ -143,20 +158,20 @@ impl Metadata {
             };
 
             if field.data_type().data_type_id() != TypeID::Struct {
-                self.add_column(
+                self.add_base_table_column(
                     field.name().clone(),
                     field.data_type().clone(),
-                    Some(table_index),
+                    table_index,
                     path_indices,
                     Some(leaf_index),
                 );
                 leaf_index += 1;
                 continue;
             }
-            self.add_column(
+            self.add_base_table_column(
                 field.name().clone(),
                 field.data_type().clone(),
-                Some(table_index),
+                table_index,
                 path_indices,
                 None,
             );
@@ -193,10 +208,17 @@ impl Metadata {
         let mut smallest_size = usize::MAX;
         for idx in indices.iter() {
             let entry = self.column(*idx);
-            if let Ok(bytes) = entry.data_type.data_type_id().numeric_byte_size() {
-                if smallest_size > bytes {
-                    smallest_size = bytes;
-                    smallest_index = &entry.column_index;
+            if let ColumnEntry::BaseTableColumn {
+                column_index,
+                data_type,
+                ..
+            } = entry
+            {
+                if let Ok(bytes) = data_type.data_type_id().numeric_byte_size() {
+                    if smallest_size > bytes {
+                        smallest_size = bytes;
+                        smallest_index = column_index;
+                    }
                 }
             }
         }
@@ -208,8 +230,14 @@ impl Metadata {
         let indices: Vec<usize> = self
             .columns
             .iter()
-            .filter(|v| v.table_index == Some(table_index))
-            .map(|v| v.column_index)
+            .filter_map(|v| match v {
+                ColumnEntry::BaseTableColumn {
+                    table_index: index,
+                    column_index,
+                    ..
+                } if *index == table_index => Some(*column_index),
+                _ => None,
+            })
             .collect();
 
         self.find_smallest_column(&indices)
@@ -289,72 +317,32 @@ impl TableEntry {
 }
 
 #[derive(Clone, Debug)]
-pub struct ColumnEntry {
-    column_index: IndexType,
-    name: String,
-    data_type: DataTypeImpl,
+pub enum ColumnEntry {
+    BaseTableColumn {
+        table_index: IndexType,
+        column_index: IndexType,
+        column_name: String,
+        data_type: DataTypeImpl,
 
-    /// Table index of column entry. None if column is derived from a subquery.
-    table_index: Option<IndexType>,
-    /// Path indices for inner column of struct data type.
-    path_indices: Option<Vec<IndexType>>,
-    /// Leaf index is the primitive column index in Parquet, constructed in DFS order.
-    /// None if the data type of column is struct.
-    leaf_index: Option<IndexType>,
+        /// Path indices for inner column of struct data type.
+        path_indices: Option<Vec<usize>>,
+        /// Leaf index is the primitive column index in Parquet, constructed in DFS order.
+        /// None if the data type of column is struct.
+        leaf_index: Option<usize>,
+    },
+    DerivedColumn {
+        column_index: IndexType,
+        alias: String,
+        data_type: DataTypeImpl,
+    },
 }
 
 impl ColumnEntry {
-    pub fn new(
-        name: String,
-        data_type: DataTypeImpl,
-        column_index: IndexType,
-        table_index: Option<IndexType>,
-        path_indices: Option<Vec<IndexType>>,
-        leaf_index: Option<IndexType>,
-    ) -> Self {
-        ColumnEntry {
-            column_index,
-            name,
-            data_type,
-            table_index,
-            path_indices,
-            leaf_index,
-        }
-    }
-
-    /// Get the name of this column entry.
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Get the index of this column entry.
     pub fn index(&self) -> IndexType {
-        self.column_index
-    }
-
-    /// Get the data type of this column entry.
-    pub fn data_type(&self) -> &DataTypeImpl {
-        &self.data_type
-    }
-
-    /// Get the table index of this column entry.
-    pub fn table_index(&self) -> Option<IndexType> {
-        self.table_index
-    }
-
-    /// Get the path indices of this column entry.
-    pub fn path_indices(&self) -> Option<&[IndexType]> {
-        self.path_indices.as_deref()
-    }
-
-    /// Check if this column entry contains path_indices.
-    pub fn has_path_indices(&self) -> bool {
-        self.path_indices.is_some()
-    }
-
-    /// Get the leaf index of this column entry.
-    pub fn leaf_index(&self) -> Option<IndexType> {
-        self.leaf_index
+        match self {
+            ColumnEntry::BaseTableColumn { column_index, .. } => *column_index,
+            ColumnEntry::DerivedColumn { column_index, .. } => *column_index,
+        }
     }
 }
 

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -16,8 +16,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use common_datavalues::type_coercion::compare_coercion;
+use common_datavalues::wrap_nullable;
 use common_datavalues::BooleanType;
-use common_datavalues::DataTypeImpl;
 use common_datavalues::NullableType;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -56,6 +56,7 @@ use crate::plans::Statistics;
 use crate::plans::SubqueryExpr;
 use crate::plans::SubqueryType;
 use crate::ColumnBinding;
+use crate::ColumnEntry;
 use crate::IndexType;
 use crate::MetadataRef;
 use crate::ScalarExpr;
@@ -282,12 +283,9 @@ impl SubqueryRewriter {
                 let marker_index = if let Some(idx) = subquery.projection_index {
                     idx
                 } else {
-                    self.metadata.write().add_column(
+                    self.metadata.write().add_derived_column(
                         "marker".to_string(),
                         NullableType::new_impl(BooleanType::new_impl()),
-                        None,
-                        None,
-                        None,
                     )
                 };
                 let join_plan = LogicalJoin {
@@ -337,12 +335,9 @@ impl SubqueryRewriter {
                 let marker_index = if let Some(idx) = subquery.projection_index {
                     idx
                 } else {
-                    self.metadata.write().add_column(
+                    self.metadata.write().add_derived_column(
                         "marker".to_string(),
                         NullableType::new_impl(BooleanType::new_impl()),
-                        None,
-                        None,
-                        None,
                     )
                 };
                 let mark_join = LogicalJoin {
@@ -386,21 +381,19 @@ impl SubqueryRewriter {
                 .unwrap();
             for correlated_column in correlated_columns.iter() {
                 let column_entry = metadata.column(*correlated_column).clone();
+                let (name, data_type) = match &column_entry {
+                    ColumnEntry::BaseTableColumn {
+                        column_name,
+                        data_type,
+                        ..
+                    } => (column_name, data_type),
+                    ColumnEntry::DerivedColumn {
+                        alias, data_type, ..
+                    } => (alias, data_type),
+                };
                 self.derived_columns.insert(
                     *correlated_column,
-                    metadata.add_column(
-                        column_entry.name().to_string(),
-                        if let DataTypeImpl::Nullable(_) = column_entry.data_type() {
-                            column_entry.data_type().clone()
-                        } else {
-                            DataTypeImpl::Nullable(NullableType::create(
-                                column_entry.data_type().clone(),
-                            ))
-                        },
-                        None,
-                        None,
-                        None,
-                    ),
+                    metadata.add_derived_column(name.to_string(), wrap_nullable(data_type)),
                 );
             }
             let logical_get = SExpr::create_leaf(
@@ -458,12 +451,16 @@ impl SubqueryRewriter {
                 let metadata = self.metadata.read();
                 for derived_column in self.derived_columns.values() {
                     let column_entry = metadata.column(*derived_column);
+                    let data_type = match column_entry {
+                        ColumnEntry::BaseTableColumn { data_type, .. } => data_type,
+                        ColumnEntry::DerivedColumn { data_type, .. } => data_type,
+                    };
                     let column_binding = ColumnBinding {
                         database_name: None,
                         table_name: None,
                         column_name: format!("subquery_{}", derived_column),
                         index: *derived_column,
-                        data_type: Box::from(column_entry.data_type().clone()),
+                        data_type: Box::from(data_type.clone()),
                         visibility: Visibility::Visible,
                     };
                     items.push(ScalarItem {
@@ -564,12 +561,16 @@ impl SubqueryRewriter {
                     let column_binding = {
                         let metadata = self.metadata.read();
                         let column_entry = metadata.column(*derived_column);
+                        let data_type = match column_entry {
+                            ColumnEntry::BaseTableColumn { data_type, .. } => data_type,
+                            ColumnEntry::DerivedColumn { data_type, .. } => data_type,
+                        };
                         ColumnBinding {
                             database_name: None,
                             table_name: None,
                             column_name: format!("subquery_{}", derived_column),
                             index: *derived_column,
-                            data_type: Box::from(column_entry.data_type().clone()),
+                            data_type: Box::from(data_type.clone()),
                             visibility: Visibility::Visible,
                         }
                     };
@@ -779,10 +780,11 @@ impl SubqueryRewriter {
         right_conditions: &mut Vec<Scalar>,
     ) -> Result<()> {
         for correlated_column in correlated_columns.iter() {
-            let data_type = {
-                let metadata = self.metadata.read();
-                let column_entry = metadata.column(*correlated_column);
-                column_entry.data_type().clone()
+            let metadata = self.metadata.read();
+            let column_entry = metadata.column(*correlated_column);
+            let data_type = match column_entry {
+                ColumnEntry::BaseTableColumn { data_type, .. } => data_type,
+                ColumnEntry::DerivedColumn { data_type, .. } => data_type,
             };
             let right_column = Scalar::BoundColumnRef(BoundColumnRef {
                 column: ColumnBinding {
@@ -801,7 +803,7 @@ impl SubqueryRewriter {
                     table_name: None,
                     column_name: format!("subquery_{}", derive_column),
                     index: *derive_column,
-                    data_type: Box::from(data_type),
+                    data_type: Box::from(data_type.clone()),
                     visibility: Visibility::Visible,
                 },
             });

--- a/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
@@ -381,13 +381,10 @@ impl SubqueryRewriter {
                 // For example, `EXISTS(SELECT a FROM t WHERE a > 1)` will be rewritten into
                 // `(SELECT COUNT(*) = 1 FROM t WHERE a > 1 LIMIT 1)`.
                 let agg_func = AggregateFunctionFactory::instance().get("count", vec![], vec![])?;
-                let agg_func_index = self.metadata.write().add_column(
-                    "count(*)".to_string(),
-                    agg_func.return_type()?,
-                    None,
-                    None,
-                    None,
-                );
+                let agg_func_index = self
+                    .metadata
+                    .write()
+                    .add_derived_column("count(*)".to_string(), agg_func.return_type()?);
 
                 let agg = Aggregate {
                     group_items: vec![],
@@ -497,12 +494,9 @@ impl SubqueryRewriter {
                 let marker_index = if let Some(idx) = subquery.projection_index {
                     idx
                 } else {
-                    self.metadata.write().add_column(
+                    self.metadata.write().add_derived_column(
                         "marker".to_string(),
                         NullableType::new_impl(BooleanType::new_impl()),
-                        None,
-                        None,
-                        None,
                     )
                 };
                 // Consider the sql: select * from t1 where t1.a = any(select t2.a from t2);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

In the new expression framework, we will use a `SchemaDataType` to represent data types of columns from a table, which has more information rather than `DataType`, e.g. decimal precision and tuple field names.

This PR changes `ColumnEntry` into an enum of `BaseTableColumn` and `DerivedColumn`.