### PR TITLE
fix(fuse): remove unncessary pipeline merge when read data

### DIFF
--- a/src/query/storages/fuse/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/fuse/src/operations/read_data.rs
@@ -144,9 +144,9 @@ impl FuseTable {
                 let max_memory_usage = ctx.get_settings().get_max_memory_usage()? as usize;
 
                 let setting_io_requests =
-                    ctx.get_settings().get_max_storage_io_requests()? as usize + 1;
-                let adjust_io_requests = (max_memory_usage / column_memory_usage) + 1;
-                std::cmp::min(adjust_io_requests, setting_io_requests)
+                    std::cmp::max(1, ctx.get_settings().get_max_storage_io_requests()?);
+                let adjust_io_requests = std::cmp::max(1, max_memory_usage / column_memory_usage);
+                std::cmp::min(adjust_io_requests, setting_io_requests as usize)
             }
         })
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```
mysql> set max_storage_io_requests = 16;
mysql> create table t1(a int);

mysql> explain pipeline select * from t1;
+---------------------------------------------------------------------------------------------------+
| explain                                                                                           |
+---------------------------------------------------------------------------------------------------+
| CompoundChunkOperator(Rename) × 10 processors                                                     |
|   CompoundChunkOperator(Project) × 10 processors                                                  |
|     CompoundChunkOperator(Project->Rename) × 10 processors                                        |
|       Merge (FuseEngineSource × 16 processors) to (CompoundChunkOperator(Project->Rename) × 10)   |
|         FuseEngineSource × 16 processors                                                          |
+---------------------------------------------------------------------------------------------------+
```

Closes #8925
