### PR TITLE
fix(mysql): fix mysql conns leak

### DIFF
--- a/src/query/service/src/sessions/session_mgr.rs
+++ b/src/query/service/src/sessions/session_mgr.rs
@@ -106,11 +106,9 @@ impl SessionManager {
         let mut mysql_conn_id = None;
         match session_typ {
             SessionType::MySQL => {
-                let mut conn_id_session_id = self.mysql_conn_map.write();
+                let conn_id_session_id = self.mysql_conn_map.read();
                 mysql_conn_id = Some(self.mysql_basic_conn_id.fetch_add(1, Ordering::Relaxed));
-                if conn_id_session_id.len() < self.max_sessions {
-                    conn_id_session_id.insert(mysql_conn_id, id.clone());
-                } else {
+                if conn_id_session_id.len() == self.max_sessions {
                     return Err(ErrorCode::TooManyUserConnections(
                         "The current accept connection has exceeded max_active_sessions config",
                     ));
@@ -128,7 +126,7 @@ impl SessionManager {
         let user_api = UserApiProvider::instance();
         let session_settings = Settings::try_create(&config, user_api, tenant).await?;
         let session_ctx = SessionContext::try_create(config.clone(), session_settings)?;
-        let session = Session::try_create(id, typ.clone(), session_ctx, mysql_conn_id)?;
+        let session = Session::try_create(id.clone(), typ.clone(), session_ctx, mysql_conn_id)?;
 
         let mut sessions = self.active_sessions.write();
         if sessions.len() < self.max_sessions {
@@ -140,6 +138,17 @@ impl SessionManager {
 
             if !matches!(typ, SessionType::FlightRPC) {
                 sessions.insert(session.get_id(), Arc::downgrade(&session));
+            }
+
+            if let SessionType::MySQL = session_typ {
+                let mut conn_id_session_id = self.mysql_conn_map.write();
+                if conn_id_session_id.len() < self.max_sessions {
+                    conn_id_session_id.insert(mysql_conn_id, id);
+                } else {
+                    return Err(ErrorCode::TooManyUserConnections(
+                        "The current accept connection has exceeded max_active_sessions config",
+                    ));
+                }
             }
 
             Ok(session)

--- a/src/query/service/src/sessions/session_mgr.rs
+++ b/src/query/service/src/sessions/session_mgr.rs
@@ -108,7 +108,7 @@ impl SessionManager {
             SessionType::MySQL => {
                 let conn_id_session_id = self.mysql_conn_map.read();
                 mysql_conn_id = Some(self.mysql_basic_conn_id.fetch_add(1, Ordering::Relaxed));
-                if conn_id_session_id.len() == self.max_sessions {
+                if conn_id_session_id.len() >= self.max_sessions {
                     return Err(ErrorCode::TooManyUserConnections(
                         "The current accept connection has exceeded max_active_sessions config",
                     ));

--- a/src/query/service/src/sessions/session_mgr.rs
+++ b/src/query/service/src/sessions/session_mgr.rs
@@ -95,7 +95,7 @@ impl SessionManager {
         let config = self.get_conf();
         {
             let sessions = self.active_sessions.read();
-            if sessions.len() == self.max_sessions {
+            if sessions.len() >= self.max_sessions {
                 return Err(ErrorCode::TooManyUserConnections(
                     "The current accept connection has exceeded max_active_sessions config",
                 ));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

MySQL conns is added here:
https://github.com/datafuselabs/databend/blob/20bac71c72af8792fc002e202af8e94c6e104efd/src/query/service/src/sessions/session_mgr.rs#L110-L113

But if `Settings::try_create` gets some error from meta like: 
```
{"timestamp":"2022-11-23T18:18:59.683112Z","level":"ERROR","fields":{"message":"MetaGrpcClient error: MetaError(APIError(NetworkError(ConnectionError(ConnectionError { msg: \"address: 172.21.42.72:28103\", source: tonic::transport::error::Error: transport error source: error trying to connect: tcp connect error: Address not available (os error 99) source: tcp connect error: Address not available (os error 99) source: Address not available (os error 99) }))))"},"target":"common_meta_client::grpc_client","span":{"name":"worker_loop"},"spans":[{"name":"worker_loop"}]}
{"timestamp":"2022-11-23T18:18:59.683229Z","level":"WARN","fields":{"message":"create session failed, Code: 2001, displayText = ConnectionError: address: 172.21.42.72:28103 source: tonic::transport::error::Error: transport error source: error trying to connect: tcp connect error: Address not available (os error 99) source: tcp connect error: Address not available (os error 99) source: Address not available (os error 99).\n\n   0: common_exception::exception_code::<impl common_exception::exception::ErrorCode>::MetaServiceError\n             at /server/source/databend/src/common/exception/src/exception_code.rs:38:71\n   1: common_meta_types::errors::meta_api_errors::<impl core::convert::From<common_meta_types::errors::meta_api_errors::MetaAPIError> for common_exception::exception::ErrorCode>::from\n             at /server/source/databend/src/meta/types/src/errors/meta_api_errors.rs:56:46\n   2: <T as core::convert::Into<U>>::into\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/convert/mod.rs:726:9\n   3: common_meta_types::errors::meta_errors::<impl core::convert::From<common_meta_types::errors::meta_errors::MetaError> for common_exception::exception::ErrorCode>::from\n             at /server/source/databend/src/meta/types/src/errors/meta_errors.rs:51:39\n   4: <T as core::convert::Into<U>>::into\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/convert/mod.rs:726:9\n   5: common_meta_types::errors::kv_app_errors::<impl core::convert::From<common_meta_types::errors::kv_app_errors::KVAppError> for common_exception::exception::ErrorCode>::from\n             at /server/source/databend/src/meta/types/src/errors/kv_app_errors.rs:55:48\n   6: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/result.rs:2108:27\n   7: <common_management::setting::setting_mgr::SettingMgr as common_management::setting::setting_api::SettingApi>::get_settings::{{closure}}\n             at /server/source/databend/src/query/management/src/setting/setting_mgr.rs:67:22\n   8: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/future/mod.rs:91:19\n   9: <core::pin::Pin<P> as core::future::future::Future>::poll\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/future/future.rs:124:9\n  10: common_settings::Settings::try_create::{{closure}}\n             at /server/source/databend/src/query/settings/src/lib.rs:91:17\n  11: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/future/mod.rs:91:19\n  12: databend_query::sessions::session_mgr::SessionManager::create_session::{{closure}}\n             at /server/source/databend/src/query/service/src/sessions/session_mgr.rs:130:79\n  13: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/future/mod.rs:91:19\n  14: databend_query::servers::mysql::mysql_handler::MySQLHandler::accept_socket::{{closure}}\n             at /server/source/databend/src/query/service/src/servers/mysql/mysql_handler.rs:84:62\n  15: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/future/mod.rs:91:19\n  16: tokio::runtime::task::core::CoreStage<T>::poll::{{closure}}\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/core.rs:184:17\n  17: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/loom/std/unsafe_cell.rs:14:9\n  18: tokio::runtime::task::core::CoreStage<T>::poll\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/core.rs:174:13\n  19: tokio::runtime::task::harness::poll_future::{{closure}}\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/harness.rs:480:19\n  20: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/panic/unwind_safe.rs:271:9\n  21: std::panicking::try::do_call\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/panicking.rs:483:40\n  22: std::panicking::try\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/panicking.rs:447:19\n  23: std::panic::catch_unwind\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/panic.rs:137:14\n  24: tokio::runtime::task::harness::poll_future\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/harness.rs:468:18\n  25: tokio::runtime::task::harness::Harness<T,S>::poll_inner\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/harness.rs:104:27\n  26: tokio::runtime::task::harness::Harness<T,S>::poll\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/harness.rs:57:15\n  27: tokio::runtime::task::raw::RawTask::poll\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/raw.rs:134:18\n  28: tokio::runtime::task::LocalNotified<S>::run\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/mod.rs:385:9\n  29: tokio::runtime::scheduler::multi_thread::worker::Context::run_task::{{closure}}\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/scheduler/multi_thread/worker.rs:421:13\n  30: tokio::coop::with_budget::{{closure}}\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/coop.rs:102:9\n  31: std::thread::local::LocalKey<T>::try_with\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/thread/local.rs:446:16\n  32: std::thread::local::LocalKey<T>::with\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/thread/local.rs:422:9\n  33: tokio::coop::with_budget\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/coop.rs:95:5\n  34: tokio::coop::budget\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/coop.rs:72:5\n  35: tokio::runtime::scheduler::multi_thread::worker::Context::run_task\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/scheduler/multi_thread/worker.rs:420:9\n  36: tokio::runtime::scheduler::multi_thread::worker::Context::run\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/scheduler/multi_thread/worker.rs:387:24\n  37: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/scheduler/multi_thread/worker.rs:372:17\n  38: tokio::macros::scoped_tls::ScopedKey<T>::set\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/macros/scoped_tls.rs:61:9\n  39: tokio::runtime::scheduler::multi_thread::worker::run\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/scheduler/multi_thread/worker.rs:369:5\n  40: tokio::runtime::scheduler::multi_thread::worker::Launch::launch::{{closure}}\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/scheduler/multi_thread/worker.rs:348:45\n  41: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/blocking/task.rs:42:21\n  42: tokio::runtime::task::core::CoreStage<T>::poll::{{closure}}\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/core.rs:184:17\n  43: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/loom/std/unsafe_cell.rs:14:9\n  44: tokio::runtime::task::core::CoreStage<T>::poll\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/core.rs:174:13\n  45: tokio::runtime::task::harness::poll_future::{{closure}}\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/harness.rs:480:19\n  46: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/panic/unwind_safe.rs:271:9\n  47: std::panicking::try::do_call\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/panicking.rs:483:40\n  48: std::panicking::try\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/panicking.rs:447:19\n  49: std::panic::catch_unwind\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/panic.rs:137:14\n  50: tokio::runtime::task::harness::poll_future\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/harness.rs:468:18\n  51: tokio::runtime::task::harness::Harness<T,S>::poll_inner\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/harness.rs:104:27\n  52: tokio::runtime::task::harness::Harness<T,S>::poll\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/harness.rs:57:15\n  53: tokio::runtime::task::raw::poll\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/raw.rs:194:5\n  54: tokio::runtime::task::raw::RawTask::poll\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/raw.rs:134:18\n  55: tokio::runtime::task::UnownedTask<S>::run\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/task/mod.rs:422:9\n  56: tokio::runtime::blocking::pool::Task::run\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/blocking/pool.rs:111:9\n  57: tokio::runtime::blocking::pool::Inner::run\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/blocking/pool.rs:346:17\n  58: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}\n             at ./.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/blocking/pool.rs:321:13\n  59: std::sys_common::backtrace::__rust_begin_short_backtrace\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/sys_common/backtrace.rs:121:18\n  60: std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/thread/mod.rs:551:17\n  61: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/panic/unwind_safe.rs:271:9\n  62: std::panicking::try::do_call\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/panicking.rs:483:40\n  63: std::panicking::try\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/panicking.rs:447:19\n  64: std::panic::catch_unwind\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/panic.rs:137:14\n  65: std::thread::Builder::spawn_unchecked_::{{closure}}\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/thread/mod.rs:550:30\n  66: core::ops::function::FnOnce::call_once{{vtable.shim}}\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/core/src/ops/function.rs:510:5\n  67: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/alloc/src/boxed.rs:2000:9\n  68: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/alloc/src/boxed.rs:2000:9\n  69: std::sys::unix::thread::Thread::new::thread_start\n             at /rustc/e631891f7ad40eac3ef58ec3c2b57ecd81e40615/library/std/src/sys/unix/thread.rs:108:17\n  70: start_thread\n  71: __GI___clone\n"},"target":"databend_query::servers::mysql::mysql_handler"}
```
And `Session::try_creat` has not been called yet, `mysql conns` would not be removed:
https://github.com/datafuselabs/databend/blob/20bac71c72af8792fc002e202af8e94c6e104efd/src/query/service/src/sessions/session_mgr.rs#L129-L131
https://github.com/datafuselabs/databend/blob/20bac71c72af8792fc002e202af8e94c6e104efd/src/query/service/src/sessions/session.rs#L360-L365
Closes #8877
