### PR TITLE
refactor: TypeDeserializer get rid of FormatSetting.

### DIFF
--- a/src/query/datablocks/src/kernels/data_block_group_by_hash.rs
+++ b/src/query/datablocks/src/kernels/data_block_group_by_hash.rs
@@ -20,7 +20,6 @@ use std::ops::Not;
 
 use common_datavalues::prelude::*;
 use common_exception::Result;
-use common_io::prelude::FormatSettings;
 use primitive_types::U256;
 use primitive_types::U512;
 
@@ -234,10 +233,9 @@ where T: Clone
             let mut deserializer = non_null_type.create_deserializer(rows);
             let reader = vec8.as_slice();
 
-            let format = FormatSettings::default();
             let col = match data_type.is_nullable() {
                 false => {
-                    deserializer.de_fixed_binary_batch(&reader[offsize..], step, rows, &format)?;
+                    deserializer.de_fixed_binary_batch(&reader[offsize..], step, rows)?;
                     deserializer.finish_to_column()
                 }
 
@@ -247,7 +245,6 @@ where T: Clone
                         &reader[null_offsize..],
                         step,
                         rows,
-                        &format,
                     )?;
 
                     null_offsize += 1;
@@ -257,7 +254,7 @@ where T: Clone
 
                     // we store 1 for nulls in fixed_hash
                     let bitmap = col.values().not();
-                    deserializer.de_fixed_binary_batch(&reader[offsize..], step, rows, &format)?;
+                    deserializer.de_fixed_binary_batch(&reader[offsize..], step, rows)?;
                     let inner = deserializer.finish_to_column();
                     NullableColumn::wrap_inner(inner, Some(bitmap))
                 }

--- a/src/query/datavalues/src/types/deserializations/boolean.rs
+++ b/src/query/datavalues/src/types/deserializations/boolean.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_exception::ErrorCode;
 use common_exception::Result;
 use common_io::prelude::BinaryRead;
-use common_io::prelude::FormatSettings;
 
 use crate::prelude::*;
 
@@ -28,7 +26,7 @@ impl TypeDeserializer for BooleanDeserializer {
         self.builder.memory_size()
     }
 
-    fn de_binary(&mut self, reader: &mut &[u8], _format: &FormatSettings) -> Result<()> {
+    fn de_binary(&mut self, reader: &mut &[u8]) -> Result<()> {
         let value: bool = reader.read_scalar()?;
         self.builder.append_value(value);
         Ok(())
@@ -38,13 +36,7 @@ impl TypeDeserializer for BooleanDeserializer {
         self.builder.append_value(false);
     }
 
-    fn de_fixed_binary_batch(
-        &mut self,
-        reader: &[u8],
-        step: usize,
-        rows: usize,
-        _format: &FormatSettings,
-    ) -> Result<()> {
+    fn de_fixed_binary_batch(&mut self, reader: &[u8], step: usize, rows: usize) -> Result<()> {
         for row in 0..rows {
             let mut reader = &reader[step * row..];
             let value: bool = reader.read_scalar()?;
@@ -54,15 +46,7 @@ impl TypeDeserializer for BooleanDeserializer {
         Ok(())
     }
 
-    fn de_json(&mut self, value: &serde_json::Value, _format: &FormatSettings) -> Result<()> {
-        match value {
-            serde_json::Value::Bool(v) => self.builder.append_value(*v),
-            _ => return Err(ErrorCode::BadBytes("Incorrect boolean value")),
-        }
-        Ok(())
-    }
-
-    fn append_data_value(&mut self, value: DataValue, _format: &FormatSettings) -> Result<()> {
+    fn append_data_value(&mut self, value: DataValue) -> Result<()> {
         self.builder.append_value(value.as_bool()?);
         Ok(())
     }

--- a/src/query/datavalues/src/types/deserializations/mod.rs
+++ b/src/query/datavalues/src/types/deserializations/mod.rs
@@ -14,7 +14,6 @@
 
 use common_exception::Result;
 use enum_dispatch::enum_dispatch;
-use serde_json::Value;
 
 use crate::prelude::*;
 
@@ -31,7 +30,6 @@ mod variant;
 
 pub use array::*;
 pub use boolean::*;
-use common_io::prelude::FormatSettings;
 pub use date::*;
 pub use null::*;
 pub use nullable::*;
@@ -45,25 +43,17 @@ pub use variant::*;
 pub trait TypeDeserializer: Send + Sync {
     fn memory_size(&self) -> usize;
 
-    fn de_binary(&mut self, reader: &mut &[u8], format: &FormatSettings) -> Result<()>;
+    fn de_binary(&mut self, reader: &mut &[u8]) -> Result<()>;
 
     fn de_default(&mut self);
 
-    fn de_fixed_binary_batch(
-        &mut self,
-        reader: &[u8],
-        step: usize,
-        rows: usize,
-        format: &FormatSettings,
-    ) -> Result<()>;
+    fn de_fixed_binary_batch(&mut self, reader: &[u8], step: usize, rows: usize) -> Result<()>;
 
-    fn de_json(&mut self, reader: &Value, format: &FormatSettings) -> Result<()>;
-
-    fn de_null(&mut self, _format: &FormatSettings) -> bool {
+    fn de_null(&mut self) -> bool {
         false
     }
 
-    fn append_data_value(&mut self, value: DataValue, format: &FormatSettings) -> Result<()>;
+    fn append_data_value(&mut self, value: DataValue) -> Result<()>;
 
     /// Note this method will return err only when inner builder is empty.
     fn pop_data_value(&mut self) -> Result<DataValue>;

--- a/src/query/datavalues/src/types/deserializations/null.rs
+++ b/src/query/datavalues/src/types/deserializations/null.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use common_exception::Result;
-use common_io::prelude::FormatSettings;
 
 use crate::ColumnRef;
 use crate::DataValue;
@@ -30,7 +29,7 @@ impl TypeDeserializer for NullDeserializer {
         self.builder.memory_size()
     }
 
-    fn de_binary(&mut self, _reader: &mut &[u8], _format: &FormatSettings) -> Result<()> {
+    fn de_binary(&mut self, _reader: &mut &[u8]) -> Result<()> {
         self.builder.append_default();
         Ok(())
     }
@@ -39,25 +38,14 @@ impl TypeDeserializer for NullDeserializer {
         self.builder.append_default();
     }
 
-    fn de_fixed_binary_batch(
-        &mut self,
-        _reader: &[u8],
-        _step: usize,
-        rows: usize,
-        _format: &FormatSettings,
-    ) -> Result<()> {
+    fn de_fixed_binary_batch(&mut self, _reader: &[u8], _step: usize, rows: usize) -> Result<()> {
         for _ in 0..rows {
             self.builder.append_default();
         }
         Ok(())
     }
 
-    fn de_json(&mut self, _value: &serde_json::Value, _format: &FormatSettings) -> Result<()> {
-        self.builder.append_default();
-        Ok(())
-    }
-
-    fn append_data_value(&mut self, _value: DataValue, _format: &FormatSettings) -> Result<()> {
+    fn append_data_value(&mut self, _value: DataValue) -> Result<()> {
         self.builder.append_default();
         Ok(())
     }

--- a/src/query/datavalues/src/types/deserializations/string.rs
+++ b/src/query/datavalues/src/types/deserializations/string.rs
@@ -14,10 +14,8 @@
 
 use std::io::Read;
 
-use common_exception::ErrorCode;
 use common_exception::Result;
 use common_io::prelude::BinaryRead;
-use common_io::prelude::FormatSettings;
 
 use crate::prelude::*;
 pub struct StringDeserializer {
@@ -41,7 +39,7 @@ impl TypeDeserializer for StringDeserializer {
 
     // See GroupHash.rs for StringColumn
     #[allow(clippy::uninit_vec)]
-    fn de_binary(&mut self, reader: &mut &[u8], _format: &FormatSettings) -> Result<()> {
+    fn de_binary(&mut self, reader: &mut &[u8]) -> Result<()> {
         let offset: u64 = reader.read_uvarint()?;
 
         self.buffer.clear();
@@ -59,13 +57,7 @@ impl TypeDeserializer for StringDeserializer {
         self.builder.append_value("");
     }
 
-    fn de_fixed_binary_batch(
-        &mut self,
-        reader: &[u8],
-        step: usize,
-        rows: usize,
-        _format: &FormatSettings,
-    ) -> Result<()> {
+    fn de_fixed_binary_batch(&mut self, reader: &[u8], step: usize, rows: usize) -> Result<()> {
         for row in 0..rows {
             let reader = &reader[step * row..];
             self.builder.append_value(reader);
@@ -73,17 +65,7 @@ impl TypeDeserializer for StringDeserializer {
         Ok(())
     }
 
-    fn de_json(&mut self, value: &serde_json::Value, _format: &FormatSettings) -> Result<()> {
-        match value {
-            serde_json::Value::String(s) => {
-                self.builder.append_value(s);
-                Ok(())
-            }
-            _ => Err(ErrorCode::BadBytes("Incorrect json value, must be string")),
-        }
-    }
-
-    fn append_data_value(&mut self, value: DataValue, _format: &FormatSettings) -> Result<()> {
+    fn append_data_value(&mut self, value: DataValue) -> Result<()> {
         self.builder.append_data_value(value)
     }
 

--- a/src/query/datavalues/src/types/deserializations/variant.rs
+++ b/src/query/datavalues/src/types/deserializations/variant.rs
@@ -16,7 +16,6 @@ use std::io::Read;
 
 use common_exception::Result;
 use common_io::prelude::BinaryRead;
-use common_io::prelude::FormatSettings;
 
 use crate::prelude::*;
 
@@ -42,7 +41,7 @@ impl TypeDeserializer for VariantDeserializer {
     }
 
     #[allow(clippy::uninit_vec)]
-    fn de_binary(&mut self, reader: &mut &[u8], _format: &FormatSettings) -> Result<()> {
+    fn de_binary(&mut self, reader: &mut &[u8]) -> Result<()> {
         let offset: u64 = reader.read_uvarint()?;
 
         self.buffer.clear();
@@ -62,13 +61,7 @@ impl TypeDeserializer for VariantDeserializer {
             .append_value(VariantValue::from(serde_json::Value::Null));
     }
 
-    fn de_fixed_binary_batch(
-        &mut self,
-        reader: &[u8],
-        step: usize,
-        rows: usize,
-        _format: &FormatSettings,
-    ) -> Result<()> {
+    fn de_fixed_binary_batch(&mut self, reader: &[u8], step: usize, rows: usize) -> Result<()> {
         for row in 0..rows {
             let reader = &reader[step * row..];
             let val = serde_json::from_slice(reader)?;
@@ -77,14 +70,7 @@ impl TypeDeserializer for VariantDeserializer {
         Ok(())
     }
 
-    fn de_json(&mut self, value: &serde_json::Value, _format: &FormatSettings) -> Result<()> {
-        let val = VariantValue::from(value);
-        self.memory_size += val.calculate_memory_size();
-        self.builder.append_value(val);
-        Ok(())
-    }
-
-    fn append_data_value(&mut self, value: DataValue, _format: &FormatSettings) -> Result<()> {
+    fn append_data_value(&mut self, value: DataValue) -> Result<()> {
         self.builder.append_data_value(value)
     }
 

--- a/src/query/datavalues/tests/it/types/deserializations.rs
+++ b/src/query/datavalues/tests/it/types/deserializations.rs
@@ -14,7 +14,6 @@
 
 use common_datavalues::prelude::*;
 use common_exception::Result;
-use common_io::prelude::FormatSettings;
 
 #[test]
 fn test_nullable_deserializer_pop() -> Result<()> {
@@ -26,11 +25,10 @@ fn test_nullable_deserializer_pop() -> Result<()> {
     ];
     let data_type = NullableType::new_impl(BooleanType::new_impl());
     let mut deserializer = data_type.create_deserializer(4);
-    let format = FormatSettings::default();
 
     // Append data value
     for value in values_vec.iter() {
-        deserializer.append_data_value(value.clone(), &format)?;
+        deserializer.append_data_value(value.clone())?;
     }
 
     // Pop all data value

--- a/src/query/formats/src/field_decoder/json_ast.rs
+++ b/src/query/formats/src/field_decoder/json_ast.rs
@@ -1,0 +1,252 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::io::Cursor;
+
+use chrono_tz::Tz;
+use common_datavalues::check_date;
+use common_datavalues::check_timestamp;
+use common_datavalues::deserializations::ArrayDeserializer;
+use common_datavalues::deserializations::BooleanDeserializer;
+use common_datavalues::deserializations::DateDeserializer;
+use common_datavalues::deserializations::NullableDeserializer;
+use common_datavalues::deserializations::NumberDeserializer;
+use common_datavalues::deserializations::StringDeserializer;
+use common_datavalues::deserializations::StructDeserializer;
+use common_datavalues::deserializations::TimestampDeserializer;
+use common_datavalues::deserializations::VariantDeserializer;
+use common_datavalues::uniform_date;
+use common_datavalues::ArrayValue;
+use common_datavalues::MutableColumn;
+use common_datavalues::NullDeserializer;
+use common_datavalues::PrimitiveType;
+use common_datavalues::StructValue;
+use common_datavalues::TypeDeserializer;
+use common_datavalues::TypeDeserializerImpl;
+use common_datavalues::VariantValue;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_io::cursor_ext::BufferReadDateTimeExt;
+use common_io::cursor_ext::ReadNumberExt;
+use common_io::prelude::StatBuffer;
+use lexical_core::FromLexical;
+use micromarshal::Unmarshal;
+use num::cast::AsPrimitive;
+use serde_json::Value;
+
+use crate::FieldDecoder;
+use crate::FileFormatOptionsExt;
+
+pub struct FieldJsonAstDecoder {
+    pub timezone: Tz,
+}
+
+impl FieldDecoder for FieldJsonAstDecoder {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl FieldJsonAstDecoder {
+    pub fn create(options: &FileFormatOptionsExt) -> Self {
+        FieldJsonAstDecoder {
+            timezone: options.timezone.clone(),
+        }
+    }
+
+    pub fn read_field(&self, column: &mut TypeDeserializerImpl, value: &Value) -> Result<()> {
+        match column {
+            TypeDeserializerImpl::Null(c) => self.read_null(c, value),
+            TypeDeserializerImpl::Nullable(c) => self.read_nullable(c, value),
+            TypeDeserializerImpl::Boolean(c) => self.read_bool(c, value),
+            TypeDeserializerImpl::Int8(c) => self.read_int(c, value),
+            TypeDeserializerImpl::Int16(c) => self.read_int(c, value),
+            TypeDeserializerImpl::Int32(c) => self.read_int(c, value),
+            TypeDeserializerImpl::Int64(c) => self.read_int(c, value),
+            TypeDeserializerImpl::UInt8(c) => self.read_int(c, value),
+            TypeDeserializerImpl::UInt16(c) => self.read_int(c, value),
+            TypeDeserializerImpl::UInt32(c) => self.read_int(c, value),
+            TypeDeserializerImpl::UInt64(c) => self.read_int(c, value),
+            TypeDeserializerImpl::Float32(c) => self.read_float(c, value),
+            TypeDeserializerImpl::Float64(c) => self.read_float(c, value),
+            TypeDeserializerImpl::Date(c) => self.read_date(c, value),
+            TypeDeserializerImpl::Interval(c) => self.read_date(c, value),
+            TypeDeserializerImpl::Timestamp(c) => self.read_timestamp(c, value),
+            TypeDeserializerImpl::String(c) => self.read_string(c, value),
+            TypeDeserializerImpl::Array(c) => self.read_array(c, value),
+            TypeDeserializerImpl::Struct(c) => self.read_struct(c, value),
+            TypeDeserializerImpl::Variant(c) => self.read_variant(c, value),
+        }
+    }
+
+    fn read_bool(&self, column: &mut BooleanDeserializer, value: &Value) -> Result<()> {
+        match value {
+            Value::Bool(v) => column.builder.append_value(*v),
+            _ => return Err(ErrorCode::BadBytes("Incorrect boolean value")),
+        }
+        Ok(())
+    }
+
+    fn read_null(&self, column: &mut NullDeserializer, _value: &Value) -> Result<()> {
+        column.builder.append_default();
+        Ok(())
+    }
+
+    fn read_nullable(&self, column: &mut NullableDeserializer, value: &Value) -> Result<()> {
+        match value {
+            Value::Null => {
+                column.bitmap.push(false);
+                column.inner.de_default();
+            }
+            other => {
+                self.read_field(&mut column.inner, other)?;
+                column.bitmap.push(true);
+            }
+        }
+        Ok(())
+    }
+
+    fn read_int<T>(&self, column: &mut NumberDeserializer<T>, value: &Value) -> Result<()>
+    where T: PrimitiveType + Unmarshal<T> + StatBuffer + FromLexical {
+        match value {
+            Value::Number(v) => {
+                let v = v.to_string();
+                let mut reader = Cursor::new(v.as_bytes());
+                let v: T = if !T::FLOATING {
+                    reader.read_int_text()
+                } else {
+                    reader.read_float_text()
+                }?;
+
+                column.builder.append_value(v);
+                Ok(())
+            }
+            _ => Err(ErrorCode::BadBytes("Incorrect json value, must be number")),
+        }
+    }
+
+    fn read_float<T>(&self, column: &mut NumberDeserializer<T>, value: &Value) -> Result<()>
+    where T: PrimitiveType + Unmarshal<T> + StatBuffer + FromLexical {
+        match value {
+            Value::Number(v) => {
+                let v = v.to_string();
+                let mut reader = Cursor::new(v.as_bytes());
+                let v: T = if !T::FLOATING {
+                    reader.read_int_text()
+                } else {
+                    reader.read_float_text()
+                }?;
+
+                column.builder.append_value(v);
+                Ok(())
+            }
+            _ => Err(ErrorCode::BadBytes("Incorrect json value, must be number")),
+        }
+    }
+
+    fn read_string(&self, column: &mut StringDeserializer, value: &Value) -> Result<()> {
+        match value {
+            Value::String(s) => {
+                column.builder.append_value(s);
+                Ok(())
+            }
+            _ => Err(ErrorCode::BadBytes("Incorrect json value, must be string")),
+        }
+    }
+
+    fn read_date<T>(&self, column: &mut DateDeserializer<T>, value: &Value) -> Result<()>
+    where
+        i32: AsPrimitive<T>,
+        T: PrimitiveType,
+        T: Unmarshal<T> + StatBuffer + FromLexical,
+    {
+        match value {
+            Value::String(v) => {
+                let mut reader = Cursor::new(v.as_bytes());
+                let date = reader.read_date_text(&self.timezone)?;
+                let days = uniform_date(date);
+                check_date(days.as_i32())?;
+                column.builder.append_value(days);
+                Ok(())
+            }
+            _ => Err(ErrorCode::BadBytes("Incorrect boolean value")),
+        }
+    }
+
+    fn read_timestamp(&self, column: &mut TimestampDeserializer, value: &Value) -> Result<()> {
+        match value {
+            Value::String(v) => {
+                let v = v.clone();
+                let mut reader = Cursor::new(v.as_bytes());
+                let ts = reader.read_timestamp_text(&self.timezone)?;
+
+                let micros = ts.timestamp_micros();
+                check_timestamp(micros)?;
+                column.builder.append_value(micros.as_());
+                Ok(())
+            }
+            _ => Err(ErrorCode::BadBytes("Incorrect boolean value")),
+        }
+    }
+
+    fn read_variant(&self, column: &mut VariantDeserializer, value: &Value) -> Result<()> {
+        let val = VariantValue::from(value);
+        column.memory_size += val.calculate_memory_size();
+        column.builder.append_value(val);
+        Ok(())
+    }
+
+    fn read_array(&self, column: &mut ArrayDeserializer, value: &Value) -> Result<()> {
+        match value {
+            Value::Array(vals) => {
+                for val in vals {
+                    self.read_field(&mut column.inner, val)?;
+                }
+                let mut values = Vec::with_capacity(vals.len());
+                for _ in 0..vals.len() {
+                    let value = column.inner.pop_data_value().unwrap();
+                    values.push(value);
+                }
+                values.reverse();
+                column.builder.append_value(ArrayValue::new(values));
+                Ok(())
+            }
+            _ => Err(ErrorCode::BadBytes("Incorrect json value, must be array")),
+        }
+    }
+
+    fn read_struct(&self, column: &mut StructDeserializer, value: &Value) -> Result<()> {
+        match value {
+            Value::Object(obj) => {
+                if column.inners.len() != obj.len() {
+                    return Err(ErrorCode::BadBytes(format!(
+                        "Incorrect json value, expect {} values, but get {} values",
+                        column.inners.len(),
+                        obj.len()
+                    )));
+                }
+                let mut values = Vec::with_capacity(column.inners.len());
+                for (inner, item) in column.inners.iter_mut().zip(obj.iter()) {
+                    let (_, val) = item;
+                    self.read_field(inner, val)?;
+                    values.push(inner.pop_data_value()?);
+                }
+                column.builder.append_value(StructValue::new(values));
+                Ok(())
+            }
+            _ => Err(ErrorCode::BadBytes("Incorrect json value, must be object")),
+        }
+    }
+}

--- a/src/query/formats/src/field_decoder/json_ast.rs
+++ b/src/query/formats/src/field_decoder/json_ast.rs
@@ -62,7 +62,7 @@ impl FieldDecoder for FieldJsonAstDecoder {
 impl FieldJsonAstDecoder {
     pub fn create(options: &FileFormatOptionsExt) -> Self {
         FieldJsonAstDecoder {
-            timezone: options.timezone.clone(),
+            timezone: options.timezone,
         }
     }
 

--- a/src/query/formats/src/field_decoder/mod.rs
+++ b/src/query/formats/src/field_decoder/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod csv;
+mod json_ast;
 mod row_based;
 mod tsv;
 mod values;
@@ -21,6 +22,7 @@ mod xml;
 use std::any::Any;
 
 pub use csv::FieldDecoderCSV;
+pub use json_ast::FieldJsonAstDecoder;
 pub use row_based::FieldDecoderRowBased;
 pub use tsv::FieldDecoderTSV;
 pub use values::FieldDecoderValues;

--- a/src/query/service/src/interpreters/interpreter_insert_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_insert_v2.rs
@@ -17,7 +17,6 @@ use std::io::Cursor;
 use std::ops::Not;
 use std::sync::Arc;
 
-use chrono_tz::Tz;
 use common_ast::ast::Expr;
 use common_ast::parser::parse_comma_separated_exprs;
 use common_ast::parser::tokenize_sql;
@@ -33,7 +32,6 @@ use common_formats::FieldDecoderRowBased;
 use common_formats::FieldDecoderValues;
 use common_io::cursor_ext::ReadBytesExt;
 use common_io::cursor_ext::ReadCheckPointExt;
-use common_io::prelude::FormatSettings;
 use common_pipeline_sources::processors::sources::AsyncSource;
 use common_pipeline_sources::processors::sources::AsyncSourcer;
 use common_pipeline_transforms::processors::transforms::Transform;
@@ -369,7 +367,6 @@ impl ValueSource {
             ));
         }
 
-        let tz = self.ctx.get_settings().get_timezone()?;
         for col_idx in 0..col_size {
             let _ = reader.ignore_white_spaces();
             let col_end = if col_idx + 1 == col_size { b')' } else { b',' };

--- a/src/query/service/src/interpreters/interpreter_insert_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_insert_v2.rs
@@ -369,11 +369,7 @@ impl ValueSource {
             ));
         }
 
-        let mut format = FormatSettings::for_values_parsing();
         let tz = self.ctx.get_settings().get_timezone()?;
-        format.timezone = tz.parse::<Tz>().map_err(|_| {
-            ErrorCode::InvalidTimezone("Timezone has been checked and should be valid")
-        })?;
         for col_idx in 0..col_size {
             let _ = reader.ignore_white_spaces();
             let col_end = if col_idx + 1 == col_size { b')' } else { b',' };
@@ -423,7 +419,7 @@ impl ValueSource {
                 .await?;
 
                 for (append_idx, deser) in desers.iter_mut().enumerate().take(col_size) {
-                    deser.append_data_value(values[append_idx].clone(), &format)?;
+                    deser.append_data_value(values[append_idx].clone())?;
                 }
                 reader.set_position(end_pos_of_row);
                 return Ok(());

--- a/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_groups_builder.rs
+++ b/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_groups_builder.rs
@@ -24,7 +24,6 @@ use common_datavalues::StringColumn;
 use common_datavalues::TypeDeserializer;
 use common_datavalues::TypeID;
 use common_exception::Result;
-use common_io::prelude::FormatSettings;
 
 use crate::pipelines::processors::AggregatorParams;
 
@@ -110,12 +109,11 @@ impl<'a> GroupColumnsBuilder for SerializedKeysGroupColumnsBuilder<'a> {
         }
 
         let mut res = Vec::with_capacity(self.group_data_types.len());
-        let format = FormatSettings::default();
         for data_type in self.group_data_types.iter() {
             let mut deserializer = data_type.create_deserializer(rows);
 
             for (_, key) in keys.iter_mut().enumerate() {
-                deserializer.de_binary(key, &format)?;
+                deserializer.de_binary(key)?;
             }
             res.push(deserializer.finish_to_column());
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

part1 of https://github.com/datafuselabs/databend/issues/8949

after this FormatSetting is used only in

```
pub trait TypeSerializer<'a>: Send + Sync {
    fn serialize_json_values(&self, _format: &FormatSettings) -> Result<Vec<Value>>;

    fn serialize_json_object(
        &self,
        _valids: Option<&Bitmap>,
        _format: &FormatSettings,
    ) -> Result<Vec<Value>>;

    fn serialize_json_object_suppress_error(
        &self,
        _format: &FormatSettings,
    ) -> Result<Vec<Option<Value>>>;
}
```
