### PR TITLE
refactor: optimize join by merging build data block

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
@@ -313,4 +313,16 @@ impl JoinHashTable {
 
         self.merge_eq_block(&build_block, &probe_block)
     }
+
+    // Add `data_block` for build table to `row_space`
+    pub(crate) fn add_build_block(&self, data_block: DataBlock) -> Result<()> {
+        let func_ctx = self.ctx.try_get_function_context()?;
+        let build_cols = self
+            .hash_join_desc
+            .build_keys
+            .iter()
+            .map(|expr| Ok(expr.eval(&func_ctx, &data_block)?.vector().clone()))
+            .collect::<Result<Vec<ColumnRef>>>()?;
+        self.row_space.push_cols(data_block, build_cols)
+    }
 }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/join_hash_table.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/join_hash_table.rs
@@ -197,7 +197,7 @@ impl JoinHashTable {
             probe_data_schema = probe_schema_wrap_nullable(&probe_data_schema);
         }
         Ok(Self {
-            row_space: RowSpace::new(build_data_schema),
+            row_space: RowSpace::new(ctx.clone(), build_data_schema)?,
             ref_count: Mutex::new(0),
             is_finished: Mutex::new(false),
             hash_join_desc,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The ticket aims to optimize join by merging build table input blocks to more giant blocks which will reduce cache miss during the probe phase.

A simple benchmark for tpch q9 which contains heavy join using 10G tpch data in my local:

**Before: 4s | Now:  2.6s**

Closes #issue
