### PR TITLE
refactor(mem-tracker): disable mem-limit when panicking to build backtrace

### DIFF
--- a/src/common/base/src/base/runtime_tracker.rs
+++ b/src/common/base/src/base/runtime_tracker.rs
@@ -271,8 +271,6 @@ pub struct AsyncThreadTracker<T: Future> {
     old_thread_tracker: Option<ThreadTracker>,
 }
 
-unsafe impl<T: Future + Send> Send for AsyncThreadTracker<T> {}
-
 impl<T: Future> AsyncThreadTracker<T> {
     pub fn create(tracker: Option<ThreadTracker>, inner: T) -> AsyncThreadTracker<T> {
         AsyncThreadTracker::<T> {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(mem-tracker): disable mem-limit when panicking to build backtrace

## Changelog







## Related Issues