### PR TITLE
ci: Add @Xuanwo & @PsiACE as code owner of Cargo.lock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,3 +47,7 @@
 /docker/               @datafuselabs/databend-tool-reviewer
 /scripts/              @datafuselabs/databend-tool-reviewer
 /.github/              @datafuselabs/databend-tool-reviewer
+
+# Dependences
+Cargo.lock @Xuanwo @PsiACE
+Cargo.toml @Xuanwo @PsiACE


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Add @Xuanwo & @PsiACE as code owner of Cargo.lock
