### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/docs/dev/policies/notice.md
+++ b/docs/dev/policies/notice.md
@@ -4,7 +4,6 @@ title: Notice
 
 # Databend includes some code from
 
-- [arrow/datafusion](https://github.com/apache/arrow-datafusion/)
 - [pola-rs/polars](https://github.com/pola-rs/polars)
 
 We include the text of the original license below:

--- a/src/query/datavalues/src/data_group_value.rs
+++ b/src/query/datavalues/src/data_group_value.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Borrow from apache/arrow/rust/datafusion/src/functions.rs
-// See notice.md
-
 use std::convert::From;
 use std::convert::TryFrom;
 

--- a/src/query/datavalues/src/data_value.rs
+++ b/src/query/datavalues/src/data_value.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Borrow from apache/arrow/rust/datafusion/src/functions.rs
-// See notice.md
-
 use std::cmp::Ordering;
 use std::fmt;
 use std::hash::Hash;

--- a/src/query/storages/system/src/roles_table.rs
+++ b/src/query/storages/system/src/roles_table.rs
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// Borrow from apache/arrow/rust/datafusion/src/sql/sql_parser
-// See notice.md
 
 use std::sync::Arc;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

I find databend does not use datafusion. Delete the comment.


Closes #8970
