### PR TITLE
fix(query): manually drop_state for ndv

### DIFF
--- a/src/query/functions-v2/src/aggregates/aggregate_approx_count_distinct.rs
+++ b/src/query/functions-v2/src/aggregates/aggregate_approx_count_distinct.rs
@@ -152,7 +152,7 @@ where for<'a> T::ScalarRef<'a>: Hash
     }
 
     unsafe fn drop_state(&self, place: StateAddr) {
-        let state = place.get::<AggregateApproxCountDistinctState>();
+        let state = place.get::<AggregateApproxCountDistinctState<T::ScalarRef<'_>>>();
         std::ptr::drop_in_place(state);
     }
 

--- a/src/query/functions-v2/src/aggregates/aggregate_approx_count_distinct.rs
+++ b/src/query/functions-v2/src/aggregates/aggregate_approx_count_distinct.rs
@@ -147,6 +147,15 @@ where for<'a> T::ScalarRef<'a>: Hash
         Ok(())
     }
 
+    fn need_manual_drop_state(&self) -> bool {
+        true
+    }
+
+    unsafe fn drop_state(&self, place: StateAddr) {
+        let state = place.get::<AggregateApproxCountDistinctState>();
+        std::ptr::drop_in_place(state);
+    }
+
     fn get_own_null_adaptor(
         &self,
         _nested_function: super::AggregateFunctionRef,

--- a/src/query/functions-v2/src/aggregates/aggregate_function.rs
+++ b/src/query/functions-v2/src/aggregates/aggregate_function.rs
@@ -73,6 +73,8 @@ pub trait AggregateFunction: fmt::Display + Sync + Send {
     // TODO append the value into the column builder
     fn merge_result(&self, _place: StateAddr, _builder: &mut ColumnBuilder) -> Result<()>;
 
+    // std::mem::needs_drop::<State>
+    // if true will call drop_state
     fn need_manual_drop_state(&self) -> bool {
         false
     }

--- a/src/query/functions/src/aggregates/aggregate_approx_count_distinct.rs
+++ b/src/query/functions/src/aggregates/aggregate_approx_count_distinct.rs
@@ -151,6 +151,15 @@ impl AggregateFunction for AggregateApproxCountDistinctFunction {
         Ok(())
     }
 
+    fn need_manual_drop_state(&self) -> bool {
+        true
+    }
+
+    unsafe fn drop_state(&self, place: StateAddr) {
+        let state = place.get::<AggregateApproxCountDistinctState>();
+        std::ptr::drop_in_place(state);
+    }
+
     fn get_own_null_adaptor(
         &self,
         _nested_function: super::AggregateFunctionRef,

--- a/src/query/functions/src/aggregates/aggregate_function.rs
+++ b/src/query/functions/src/aggregates/aggregate_function.rs
@@ -70,6 +70,8 @@ pub trait AggregateFunction: fmt::Display + Sync + Send {
     // TODO append the value into the column builder
     fn merge_result(&self, _place: StateAddr, array: &mut dyn MutableColumn) -> Result<()>;
 
+    // std::mem::needs_drop::<State>
+    // if true will call drop_state
     fn need_manual_drop_state(&self) -> bool {
         false
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR


`std::mem::needs_drop::<AggregateApproxCountDistinctState>` is true, so we should drop the state manually.


Closes #issue
