### PR TITLE
refactor(mem-tracker): keep tracker state consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
 name = "bzip2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,12 +1244,14 @@ dependencies = [
  "anyhow",
  "async-channel",
  "async-trait",
+ "bytesize",
  "common-exception",
  "ctrlc",
  "futures",
  "libc",
  "num_cpus",
  "once_cell",
+ "pin-project-lite",
  "pprof",
  "rand 0.8.5",
  "semver 1.0.14",

--- a/src/binaries/query/main.rs
+++ b/src/binaries/query/main.rs
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 use std::env;
-use std::sync::Arc;
 
-use common_base::base::MemoryTracker;
 use common_base::base::Runtime;
+use common_base::base::GLOBAL_TRACKER;
 use common_config::Config;
 use common_config::DATABEND_COMMIT_VERSION;
 use common_config::QUERY_SEMVER;
@@ -43,9 +42,8 @@ fn main() {
             eprintln!("Databend Query start failure, cause: {:?}", cause);
             std::process::exit(cause.code() as i32);
         }
-        Ok(main_runtime) => {
-            let tracker = main_runtime.get_tracker();
-            if let Err(cause) = main_runtime.block_on(main_entrypoint(tracker)) {
+        Ok(rt) => {
+            if let Err(cause) = rt.block_on(main_entrypoint()) {
                 eprintln!("Databend Query start failure, cause: {:?}", cause);
                 std::process::exit(cause.code() as i32);
             }
@@ -53,7 +51,7 @@ fn main() {
     }
 }
 
-async fn main_entrypoint(mem_tracker: Arc<MemoryTracker>) -> Result<()> {
+async fn main_entrypoint() -> Result<()> {
     let conf: Config = Config::load()?;
 
     if run_cmd(&conf) {
@@ -63,17 +61,17 @@ async fn main_entrypoint(mem_tracker: Arc<MemoryTracker>) -> Result<()> {
     init_default_metrics_recorder();
     set_panic_hook();
 
-    if conf.query.max_memory_limit_enabled {
-        let size = conf.query.max_server_memory_usage as i64;
-        info!("Set memory limit: {}", size);
-        mem_tracker.set_limit(size);
-    }
-
     if conf.meta.is_embedded_meta()? {
         MetaEmbedded::init_global_meta_store(conf.meta.embedded_dir.clone()).await?;
     }
     // Make sure global services have been inited.
     GlobalServices::init(conf.clone()).await?;
+
+    if conf.query.max_memory_limit_enabled {
+        let size = conf.query.max_server_memory_usage as i64;
+        info!("Set memory limit: {}", size);
+        GLOBAL_TRACKER.set_limit(size);
+    }
 
     let tenant = conf.query.tenant_id.clone();
     let cluster_id = conf.query.cluster_id.clone();

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -28,11 +28,13 @@ common-exception = { path = "../exception" }
 # Crates.io dependencies
 async-channel = "1.7.1"
 async-trait = "0.1.57"
+bytesize = "1.1.0"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 futures = "0.3.24"
 libc = "0.2.133"
 num_cpus = "1.13.1"
 once_cell = "1.15.0"
+pin-project-lite = "0.2.9"
 pprof = { version = "0.10.1", features = [
     "flamegraph",
     "protobuf-codec",

--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -42,6 +42,7 @@ pub use runtime::TrySpawn;
 pub use runtime_tracker::AsyncThreadTracker;
 pub use runtime_tracker::MemoryTracker;
 pub use runtime_tracker::ThreadTracker;
+pub use runtime_tracker::GLOBAL_TRACKER;
 pub use select::select3;
 pub use select::Select3Output;
 pub use shutdown_signal::signal_stream;

--- a/src/common/base/src/base/runtime.rs
+++ b/src/common/base/src/base/runtime.rs
@@ -134,7 +134,6 @@ impl Runtime {
         let mut builder = tokio::runtime::Builder::new_multi_thread();
         builder
             .enable_all()
-            .on_thread_stop(mem_tracker.on_stop_thread())
             .on_thread_start(mem_tracker.on_start_thread());
 
         builder

--- a/src/common/base/src/base/thread.rs
+++ b/src/common/base/src/base/thread.rs
@@ -19,6 +19,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 
 use super::runtime_tracker::ThreadTracker;
+use crate::base::MemoryTracker;
 
 pub struct Thread;
 
@@ -72,9 +73,11 @@ impl Thread {
             None => thread_builder.spawn(f).unwrap(),
             Some(memory_tracker) => thread_builder
                 .spawn(move || {
-                    ThreadTracker::attach_thread_tracker(Some(ThreadTracker::create(
-                        memory_tracker,
-                    )));
+                    let c = MemoryTracker::create_sub_tracker(Some(memory_tracker));
+                    let mut tracker = ThreadTracker::create(Some(c));
+
+                    ThreadTracker::swap_with(&mut tracker);
+
                     f()
                 })
                 .unwrap(),

--- a/src/common/base/src/mem_allocator/je_allocator.rs
+++ b/src/common/base/src/mem_allocator/je_allocator.rs
@@ -83,6 +83,8 @@ pub mod linux_or_macos {
     unsafe impl<T: Allocator> Allocator for JEAllocator<T> {
         #[inline(always)]
         fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+            ThreadTracker::alloc_memory(layout.size() as i64);
+
             let data_address = if layout.size() == 0 {
                 unsafe { NonNull::new(layout.align() as *mut ()).unwrap_unchecked() }
             } else {
@@ -91,12 +93,13 @@ pub mod linux_or_macos {
                     NonNull::new(ffi::mallocx(layout.size(), flags) as *mut ()).ok_or(AllocError)?
                 }
             };
-            ThreadTracker::alloc_memory(layout.size() as i64, &data_address);
             Ok(NonNull::<[u8]>::from_raw_parts(data_address, layout.size()))
         }
 
         #[inline(always)]
         fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+            ThreadTracker::alloc_memory(layout.size() as i64);
+
             let data_address = if layout.size() == 0 {
                 unsafe { NonNull::new(layout.align() as *mut ()).unwrap_unchecked() }
             } else {
@@ -106,17 +109,16 @@ pub mod linux_or_macos {
                 }
             };
 
-            ThreadTracker::alloc_memory(layout.size() as i64, &data_address);
             Ok(NonNull::<[u8]>::from_raw_parts(data_address, layout.size()))
         }
 
         #[inline(always)]
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+            ThreadTracker::dealloc_memory(layout.size() as i64);
+
             if layout.size() == 0 {
                 debug_assert_eq!(ptr.as_ptr() as usize, layout.align());
             } else {
-                ThreadTracker::dealloc_memory(layout.size() as i64, &ptr);
-
                 let flags = layout_to_flags(layout.align(), layout.size());
                 ffi::sdallocx(ptr.as_ptr() as *mut _, layout.size(), flags);
             }
@@ -131,7 +133,8 @@ pub mod linux_or_macos {
             debug_assert_eq!(old_layout.align(), new_layout.align());
             debug_assert!(old_layout.size() <= new_layout.size());
 
-            ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
+            ThreadTracker::dealloc_memory(old_layout.size() as i64);
+            ThreadTracker::alloc_memory(new_layout.size() as i64);
 
             let data_address = if new_layout.size() == 0 {
                 NonNull::new(new_layout.align() as *mut ()).unwrap_unchecked()
@@ -143,8 +146,6 @@ pub mod linux_or_macos {
                 NonNull::new(ffi::rallocx(ptr.cast().as_ptr(), new_layout.size(), flags) as *mut ())
                     .unwrap()
             };
-
-            ThreadTracker::alloc_memory(new_layout.size() as i64, &data_address);
 
             Ok(NonNull::<[u8]>::from_raw_parts(
                 data_address,
@@ -161,7 +162,8 @@ pub mod linux_or_macos {
             debug_assert_eq!(old_layout.align(), new_layout.align());
             debug_assert!(old_layout.size() <= new_layout.size());
 
-            ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
+            ThreadTracker::dealloc_memory(old_layout.size() as i64);
+            ThreadTracker::alloc_memory(new_layout.size() as i64);
 
             let data_address = if new_layout.size() == 0 {
                 NonNull::new(new_layout.align() as *mut ()).unwrap_unchecked()
@@ -180,8 +182,6 @@ pub mod linux_or_macos {
                 NonNull::new(raw as *mut ()).unwrap()
             };
 
-            ThreadTracker::alloc_memory(new_layout.size() as i64, &data_address);
-
             Ok(NonNull::<[u8]>::from_raw_parts(
                 data_address,
                 new_layout.size(),
@@ -197,7 +197,8 @@ pub mod linux_or_macos {
             debug_assert_eq!(old_layout.align(), new_layout.align());
             debug_assert!(old_layout.size() >= new_layout.size());
 
-            ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
+            ThreadTracker::dealloc_memory(old_layout.size() as i64);
+            ThreadTracker::alloc_memory(new_layout.size() as i64);
 
             if old_layout.size() == 0 {
                 debug_assert_eq!(ptr.as_ptr() as usize, old_layout.align());
@@ -219,7 +220,6 @@ pub mod linux_or_macos {
                 NonNull::new(slice).ok_or(AllocError)?
             };
 
-            ThreadTracker::alloc_memory(new_layout.size() as i64, &new_ptr);
             Ok(new_ptr)
         }
     }

--- a/src/common/base/src/mem_allocator/system_allocator.rs
+++ b/src/common/base/src/mem_allocator/system_allocator.rs
@@ -26,24 +26,20 @@ pub struct SystemAllocator;
 unsafe impl Allocator for SystemAllocator {
     #[inline(always)]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        let p = System.allocate(layout)?;
-        ThreadTracker::alloc_memory(layout.size() as i64, &p);
-        Ok(p)
+        ThreadTracker::alloc_memory(layout.size() as i64);
+        System.allocate(layout)
     }
 
     #[inline(always)]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        ThreadTracker::dealloc_memory(layout.size() as i64, &ptr);
+        ThreadTracker::dealloc_memory(layout.size() as i64);
         System.deallocate(ptr, layout)
     }
 
     #[inline(always)]
     fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        let p = System.allocate_zeroed(layout)?;
-
-        ThreadTracker::alloc_memory(layout.size() as i64, &p);
-
-        Ok(p)
+        ThreadTracker::alloc_memory(layout.size() as i64);
+        System.allocate_zeroed(layout)
     }
 
     #[inline(always)]
@@ -53,12 +49,10 @@ unsafe impl Allocator for SystemAllocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
+        ThreadTracker::dealloc_memory(old_layout.size() as i64);
+        ThreadTracker::alloc_memory(new_layout.size() as i64);
 
-        let new_ptr = System.grow(ptr, old_layout, new_layout)?;
-
-        ThreadTracker::alloc_memory(new_layout.size() as i64, &new_ptr);
-        Ok(new_ptr)
+        System.grow(ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
@@ -68,12 +62,10 @@ unsafe impl Allocator for SystemAllocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
+        ThreadTracker::dealloc_memory(old_layout.size() as i64);
+        ThreadTracker::alloc_memory(new_layout.size() as i64);
 
-        let new_ptr = System.grow_zeroed(ptr, old_layout, new_layout)?;
-
-        ThreadTracker::alloc_memory(new_layout.size() as i64, &new_ptr);
-        Ok(new_ptr)
+        System.grow_zeroed(ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
@@ -83,11 +75,9 @@ unsafe impl Allocator for SystemAllocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        ThreadTracker::dealloc_memory(old_layout.size() as i64, &ptr);
+        ThreadTracker::dealloc_memory(old_layout.size() as i64);
+        ThreadTracker::alloc_memory(new_layout.size() as i64);
 
-        let new_ptr = System.shrink(ptr, old_layout, new_layout)?;
-
-        ThreadTracker::alloc_memory(new_layout.size() as i64, &new_ptr);
-        Ok(new_ptr)
+        System.shrink(ptr, old_layout, new_layout)
     }
 }

--- a/src/common/base/tests/it/runtime_tracker.rs
+++ b/src/common/base/tests/it/runtime_tracker.rs
@@ -29,7 +29,7 @@ async fn test_async_thread_tracker() -> Result<()> {
 
     let memory_tracker = MemoryTracker::create();
     let inner_join_handler = inner_runtime.spawn(AsyncThreadTracker::create(
-        Some(ThreadTracker::create(memory_tracker.clone())),
+        ThreadTracker::create(Some(memory_tracker.clone())),
         async move {
             let memory = vec![0_u8; 3 * 1024 * 1024];
             out_tx.send(()).await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
### refactor(mem-tracker): add global tracker and allow panicking to allocate memory
- Feature: add `GLOBAL_TRACKER` to track all memory.

- Refactor: Remove `on_thread_stop()`, use Drop to flush the buffered state.

- Refactor: Change thread local tracker from `Option<T>` to T: a thread
  always has a tracker(`ThreadTracker`). A ThreadTracker reports the
  allocation stat to a MemoryTracker, or the global tracker:
  `GLOBAL_TRACKER`.

- Refactor: Reduce the scope in which it allows to allocated memory for `panic!`
  Set a panicking flag to allow `panic!()` to allocate memory.
  Use a **guard** to reset the thread-local panicking flag

Other changes:

- Refactor: Generalize `AsyncThreadTracker`: the inner future can be any Future impl.

- Test `AsyncThreadTracker`

- Refactor: remove decr(), use incr(-size)

## Changelog







## Related Issues