### PR TITLE
fix(config): make address as deprecated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,10 +1321,14 @@ dependencies = [
  "databend-thrift",
  "hex",
  "once_cell",
+ "pretty_assertions",
  "semver 1.0.14",
  "serde",
  "serfig",
  "strum",
+ "temp-env",
+ "tempfile",
+ "toml",
  "tracing",
 ]
 

--- a/src/query/config/Cargo.toml
+++ b/src/query/config/Cargo.toml
@@ -36,5 +36,11 @@ strum = "0.24.1"
 thrift = { package = "databend-thrift", version = "0.17.0", optional = true }
 tracing = "0.1.36"
 
+[dev-dependencies]
+pretty_assertions = "1.3.0"
+temp-env = "0.3.0"
+tempfile = "3.3.0"
+toml = { version = "0.5.9", default-features = false }
+
 [build-dependencies]
 common-building = { path = "../../common/building" }

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -228,6 +228,8 @@ impl QueryConfig {
 pub struct MetaConfig {
     /// The dir to store persisted meta state for a embedded meta store
     pub embedded_dir: String,
+    // Deprecated, only for check.
+    pub address: String,
     /// MetaStore endpoint address
     pub endpoints: Vec<String>,
     /// MetaStore backend user name
@@ -248,6 +250,7 @@ impl Default for MetaConfig {
     fn default() -> Self {
         Self {
             embedded_dir: "".to_string(),
+            address: "".to_string(),
             endpoints: vec![],
             username: "root".to_string(),
             password: "".to_string(),
@@ -265,6 +268,17 @@ impl MetaConfig {
     }
 
     pub fn check_valid(&self) -> Result<()> {
+        // Check the deprecated configs.
+        {
+            // Address.
+            if !self.address.is_empty() {
+                return Err(ErrorCode::InvalidConfig(format!(
+                    "meta config: address is deprecated, please use: endpoints = [\"{:}\"]",
+                    self.address
+                )));
+            }
+        }
+
         let has_embedded_dir = !self.embedded_dir.is_empty();
         let has_remote = !self.endpoints.is_empty();
         if has_embedded_dir && has_remote {

--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -1594,6 +1594,11 @@ pub struct MetaConfig {
     #[serde(alias = "meta_embedded_dir")]
     pub embedded_dir: String,
 
+    /// MetaStore backend address
+    #[clap(long = "meta-address", default_value_t)]
+    #[serde(alias = "meta_address")]
+    pub address: String,
+
     /// MetaStore backend endpoints
     #[clap(long = "meta-endpoints", help = "MetaStore peers endpoints")]
     pub endpoints: Vec<String>,
@@ -1639,6 +1644,7 @@ impl TryInto<InnerMetaConfig> for MetaConfig {
     fn try_into(self) -> Result<InnerMetaConfig> {
         Ok(InnerMetaConfig {
             embedded_dir: self.embedded_dir,
+            address: self.address,
             endpoints: self.endpoints,
             username: self.username,
             password: self.password,
@@ -1654,6 +1660,7 @@ impl From<InnerMetaConfig> for MetaConfig {
     fn from(inner: InnerMetaConfig) -> Self {
         Self {
             embedded_dir: inner.embedded_dir,
+            address: inner.address,
             endpoints: inner.endpoints,
             username: inner.username,
             password: inner.password,

--- a/src/query/config/tests/it/configs.rs
+++ b/src/query/config/tests/it/configs.rs
@@ -98,6 +98,7 @@ format = "text"
 
 [meta]
 embedded_dir = ""
+address = ""
 endpoints = []
 username = "root"
 password = ""

--- a/src/query/config/tests/it/configs_deprecated.rs
+++ b/src/query/config/tests/it/configs_deprecated.rs
@@ -1,0 +1,48 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+use std::io::Write;
+
+use common_config::Config;
+use common_exception::Result;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn test_meta_address_deprecated() -> Result<()> {
+    let d = tempfile::tempdir()?;
+    let file_path = d.path().join("meta-address-deprecated.toml");
+    let mut file = File::create(&file_path)?;
+    write!(
+        file,
+        r#"
+[meta]
+embedded_dir = "./.databend/meta_embedded_1"
+address = "127.0.0.1:9191"
+username = "root"
+password = "root"
+client_timeout_in_second = 60
+auto_sync_interval = 60 
+"#
+    )?;
+
+    temp_env::with_var("CONFIG_FILE", Some(file_path), || {
+        let parsed = Config::load();
+        let expect = "error....";
+        let actual = format!("{:?}", parsed);
+        assert_eq!(expect, actual);
+    });
+
+    Ok(())
+}

--- a/src/query/config/tests/it/main.rs
+++ b/src/query/config/tests/it/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2022 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,20 +11,5 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![feature(thread_local)]
-
-mod api;
-mod auth;
-mod catalogs;
-mod clusters;
-mod context_function;
-mod evaluator;
-mod metrics;
-mod pipelines;
-mod servers;
-mod sessions;
-mod sql;
-mod storages;
-mod stream;
-mod table_functions;
-mod tests;
+mod configs;
+mod configs_deprecated;

--- a/src/query/service/tests/it/storages/testdata/system-tables.txt
+++ b/src/query/service/tests/it/storages/testdata/system-tables.txt
@@ -167,6 +167,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | log     | stderr.format                        | text                           |             |
 | log     | stderr.level                         | DEBUG                          |             |
 | log     | stderr.on                            | true                           |             |
+| meta    | address                              |                                |             |
 | meta    | auto_sync_interval                   | 10                             |             |
 | meta    | client_timeout_in_second             | 10                             |             |
 | meta    | embedded_dir                         |                                |             |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Make meta `meta.address` deprecated and change to `endpoints`
* Move config test from `query/services/tests` to `query/config/tests`

Closes #issue
