### PR TITLE
fix(meta.config): add deny_unknown_fields

### DIFF
--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -1585,9 +1585,10 @@ impl From<InnerStderrLogConfig> for StderrLogConfig {
 }
 
 /// Meta config group.
+/// deny_unknown_fields to check unknown field, like the deprecated `address`.
 /// TODO(xuanwo): All meta_xxx should be rename to xxx.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Args)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct MetaConfig {
     /// The dir to store persisted meta state for a embedded meta store
     #[clap(long = "meta-embedded-dir", default_value_t)]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

databend-query.toml:
```
[meta]
# To enable embedded meta-store, set address to "".
embedded_dir = "./.databend/meta_embedded_1"
address = "127.0.0.1:9191" -- deprecated
username = "root"
password = "root"
client_timeout_in_second = 60
auto_sync_interval = 60
```

Start:
```
./databend-query -c databend-query.toml
Databend Query start failure, cause: Code: 1002, displayText = unknown field `address`, expected one of `embedded_dir`, `endpoints`, `username`, `password`, `client_timeout_in_second`, `auto_sync_interval`, `rpc_tls_meta_server_root_ca_cert`, `rpc_tls_meta_service_domain_name` for key `meta` at line 67 column 2, source: None
unknown field `address`, expected one of `embedded_dir`, `endpoints`, `username`, `password`, `client_timeout_in_second`, `auto_sync_interval`, `rpc_tls_meta_server_root_ca_cert`, `rpc_tls_meta_service_domain_name` for key `meta` at line 67 column 2.
```

Closes #8975
