### PR TITLE
docs: add i18n support 

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: crowdin action
-        uses: crowdin/github-action@1.4.9
+        uses: crowdin/github-action@1.5.1
         with:
           upload_translations: true
           download_translations: true
@@ -25,6 +25,7 @@ jobs:
           skip_untranslated_files: true
           export_only_approved: true
           # Make sure crowdin robot agree our template
+          pull_request_title: 'docs: New Crowdin translations'
           pull_request_body: |
             I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -42,12 +42,21 @@ const config = {
                     path: '../docs/doc',
                     routeBasePath: 'doc',
                     sidebarPath: require.resolve('../docs/doc/sidebars.js'),
-                    editUrl: 'https://github.com/datafuselabs/databend/edit/main/databend',
+                    editUrl: ({locale, docPath}) => {
+                        if (locale !== config.i18n.defaultLocale) {
+                          return `https://databend.crowdin.com/databend/${locale}`;
+                        }
+                        return `https://github.com/datafuselabs/databend/edit/main/docs/doc/${docPath}`;
+                      },
                 },
                 blog: {
                     showReadingTime: true,
-                    editUrl:
-                        'https://github.com/datafuselabs/databend/edit/main/website',
+                    editUrl: ({locale, blogPath}) => {
+                        if (locale !== config.i18n.defaultLocale) {
+                          return `https://databend.crowdin.com/databend/${locale}`;
+                        }
+                        return `https://github.com/datafuselabs/databend/edit/main/website/blog/${blogPath}`;
+                      },
                     blogSidebarCount: 'ALL',
                     postsPerPage: 'ALL',
                 },
@@ -77,7 +86,12 @@ const config = {
                 path: '../docs/dev',
                 routeBasePath: 'dev',
                 sidebarPath: require.resolve('../docs/dev/sidebars.js'),
-                editUrl: 'https://github.com/datafuselabs/databend/edit/main/databend',
+                editUrl: ({locale, devPath}) => {
+                    if (locale !== config.i18n.defaultLocale) {
+                      return `https://databend.crowdin.com/databend/${locale}`;
+                    }
+                    return `https://github.com/datafuselabs/databend/edit/main/docs/dev/${devPath}`;
+                  },
             },
         ],
     ],
@@ -123,7 +137,13 @@ const config = {
                     },
                     {
                         type: 'localeDropdown',
-                        position: 'left',
+                        position: 'right',
+                        dropdownItemsAfter: [
+                            {
+                                to: 'https://databend.crowdin.com/databend',
+                                label: 'Help Us Translate',
+                            },
+                        ],
                     },
                 ],
             },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,10 +22,13 @@ const config = {
 
     i18n: {
         defaultLocale: 'en-US',
-        locales: ['en-US'],
+        locales: ['en-US', 'zh-CN'],
         localeConfigs: {
             'en-US': {
                 label: 'English',
+            },
+            'zh-CN': {
+                label: '简体中文',
             },
         },
     },
@@ -117,7 +120,11 @@ const config = {
                         href: 'https://github.com/datafuselabs/databend',
                         label: 'GitHub',
                         position: 'right',
-                    }
+                    },
+                    {
+                        type: 'localeDropdown',
+                        position: 'left',
+                    },
                 ],
             },
             footer: {

--- a/website/i18n/en-US/code.json
+++ b/website/i18n/en-US/code.json
@@ -272,5 +272,117 @@
   "theme.CodeBlock.wordWrapToggle": {
     "message": "Toggle word wrap",
     "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.admonition.note": {
+    "message": "note",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "tip",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.danger": {
+    "message": "danger",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "info",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.caution": {
+    "message": "caution",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "Clear the query",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "Cancel",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "Recent",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "No recent searches",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "Save this search",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "Remove this search from history",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "Favorite",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "Remove this search from favorites",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "Unable to fetch results",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "You might want to check your network connection.",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "to select",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter key",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "to navigate",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "Arrow up",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "Arrow down",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "to close",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Escape key",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "Search by",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "No results for",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "Try searching for",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "Believe this query should return results?",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "Let us know.",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "Search docs",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
   }
 }

--- a/website/i18n/en-US/docusaurus-plugin-content-docs-dev/current.json
+++ b/website/i18n/en-US/docusaurus-plugin-content-docs-dev/current.json
@@ -10,5 +10,17 @@
   "sidebar.docs.category.Introduction": {
     "message": "Introduction",
     "description": "The label for category Introduction in sidebar docs"
+  },
+  "sidebar.dev.category.Introduction": {
+    "message": "Introduction",
+    "description": "The label for category Introduction in sidebar dev"
+  },
+  "sidebar.dev.category.subsystems": {
+    "message": "subsystems",
+    "description": "The label for category subsystems in sidebar dev"
+  },
+  "sidebar.dev.category.databend-meta": {
+    "message": "databend-meta",
+    "description": "The label for category databend-meta in sidebar dev"
   }
 }

--- a/website/i18n/en-US/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/en-US/docusaurus-plugin-content-docs/current.json
@@ -210,5 +210,229 @@
   "sidebar.docs.category.FAQ": {
     "message": "FAQ",
     "description": "The label for category FAQ in sidebar docs"
+  },
+  "sidebar.doc.category.Deploy & Manage Databend": {
+    "message": "Deploy & Manage Databend",
+    "description": "The label for category Deploy & Manage Databend in sidebar doc"
+  },
+  "sidebar.doc.category.Manage Meta Service Clusters": {
+    "message": "Manage Meta Service Clusters",
+    "description": "The label for category Manage Meta Service Clusters in sidebar doc"
+  },
+  "sidebar.doc.category.Manage Databend Query Clusters": {
+    "message": "Manage Databend Query Clusters",
+    "description": "The label for category Manage Databend Query Clusters in sidebar doc"
+  },
+  "sidebar.doc.category.Back Up and Restore Data": {
+    "message": "Back Up and Restore Data",
+    "description": "The label for category Back Up and Restore Data in sidebar doc"
+  },
+  "sidebar.doc.category.Upgrade": {
+    "message": "Upgrade",
+    "description": "The label for category Upgrade in sidebar doc"
+  },
+  "sidebar.doc.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar doc"
+  },
+  "sidebar.doc.category.APIs": {
+    "message": "APIs",
+    "description": "The label for category APIs in sidebar doc"
+  },
+  "sidebar.doc.category.Data Tools": {
+    "message": "Data Tools",
+    "description": "The label for category Data Tools in sidebar doc"
+  },
+  "sidebar.doc.category.GUI Tools": {
+    "message": "GUI Tools",
+    "description": "The label for category GUI Tools in sidebar doc"
+  },
+  "sidebar.doc.category.Load Data": {
+    "message": "Load Data",
+    "description": "The label for category Load Data in sidebar doc"
+  },
+  "sidebar.doc.category.SQL Reference": {
+    "message": "SQL Reference",
+    "description": "The label for category SQL Reference in sidebar doc"
+  },
+  "sidebar.doc.category.Data Types": {
+    "message": "Data Types",
+    "description": "The label for category Data Types in sidebar doc"
+  },
+  "sidebar.doc.category.System Tables": {
+    "message": "System Tables",
+    "description": "The label for category System Tables in sidebar doc"
+  },
+  "sidebar.doc.category.SQL Commands": {
+    "message": "SQL Commands",
+    "description": "The label for category SQL Commands in sidebar doc"
+  },
+  "sidebar.doc.category.DDL Commands": {
+    "message": "DDL Commands",
+    "description": "The label for category DDL Commands in sidebar doc"
+  },
+  "sidebar.doc.category.Stage": {
+    "message": "Stage",
+    "description": "The label for category Stage in sidebar doc"
+  },
+  "sidebar.doc.category.Cluster Key": {
+    "message": "Cluster Key",
+    "description": "The label for category Cluster Key in sidebar doc"
+  },
+  "sidebar.doc.category.Share": {
+    "message": "Share",
+    "description": "The label for category Share in sidebar doc"
+  },
+  "sidebar.doc.category.Database": {
+    "message": "Database",
+    "description": "The label for category Database in sidebar doc"
+  },
+  "sidebar.doc.category.Table": {
+    "message": "Table",
+    "description": "The label for category Table in sidebar doc"
+  },
+  "sidebar.doc.category.User": {
+    "message": "User",
+    "description": "The label for category User in sidebar doc"
+  },
+  "sidebar.doc.category.User-Defined Function": {
+    "message": "User-Defined Function",
+    "description": "The label for category User-Defined Function in sidebar doc"
+  },
+  "sidebar.doc.category.View": {
+    "message": "View",
+    "description": "The label for category View in sidebar doc"
+  },
+  "sidebar.doc.category.Presign": {
+    "message": "Presign",
+    "description": "The label for category Presign in sidebar doc"
+  },
+  "sidebar.doc.category.DML Commands": {
+    "message": "DML Commands",
+    "description": "The label for category DML Commands in sidebar doc"
+  },
+  "sidebar.doc.category.Query Syntax": {
+    "message": "Query Syntax",
+    "description": "The label for category Query Syntax in sidebar doc"
+  },
+  "sidebar.doc.category.Query Operators": {
+    "message": "Query Operators",
+    "description": "The label for category Query Operators in sidebar doc"
+  },
+  "sidebar.doc.category.Show Commands": {
+    "message": "Show Commands",
+    "description": "The label for category Show Commands in sidebar doc"
+  },
+  "sidebar.doc.category.List Commands": {
+    "message": "List Commands",
+    "description": "The label for category List Commands in sidebar doc"
+  },
+  "sidebar.doc.category.Kill Commands": {
+    "message": "Kill Commands",
+    "description": "The label for category Kill Commands in sidebar doc"
+  },
+  "sidebar.doc.category.Setting Commands": {
+    "message": "Setting Commands",
+    "description": "The label for category Setting Commands in sidebar doc"
+  },
+  "sidebar.doc.category.Explain Commands": {
+    "message": "Explain Commands",
+    "description": "The label for category Explain Commands in sidebar doc"
+  },
+  "sidebar.doc.category.SQL Functions": {
+    "message": "SQL Functions",
+    "description": "The label for category SQL Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Aggregate Functions": {
+    "message": "Aggregate Functions",
+    "description": "The label for category Aggregate Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Conditional Functions": {
+    "message": "Conditional Functions",
+    "description": "The label for category Conditional Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Numeric Functions": {
+    "message": "Numeric Functions",
+    "description": "The label for category Numeric Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Date & Time Functions": {
+    "message": "Date & Time Functions",
+    "description": "The label for category Date & Time Functions in sidebar doc"
+  },
+  "sidebar.doc.category.String Functions": {
+    "message": "String Functions",
+    "description": "The label for category String Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Conversion Functions": {
+    "message": "Conversion Functions",
+    "description": "The label for category Conversion Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Hash Functions": {
+    "message": "Hash Functions",
+    "description": "The label for category Hash Functions in sidebar doc"
+  },
+  "sidebar.doc.category.UUID Functions": {
+    "message": "UUID Functions",
+    "description": "The label for category UUID Functions in sidebar doc"
+  },
+  "sidebar.doc.category.IP Address Functions": {
+    "message": "IP Address Functions",
+    "description": "The label for category IP Address Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Context Functions": {
+    "message": "Context Functions",
+    "description": "The label for category Context Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Semi-structured Data Functions": {
+    "message": "Semi-structured Data Functions",
+    "description": "The label for category Semi-structured Data Functions in sidebar doc"
+  },
+  "sidebar.doc.category.System Functions": {
+    "message": "System Functions",
+    "description": "The label for category System Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Other Functions": {
+    "message": "Other Functions",
+    "description": "The label for category Other Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Test Functions": {
+    "message": "Test Functions",
+    "description": "The label for category Test Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Window Functions": {
+    "message": "Window Functions",
+    "description": "The label for category Window Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Geography Functions": {
+    "message": "Geography Functions",
+    "description": "The label for category Geography Functions in sidebar doc"
+  },
+  "sidebar.doc.category.Developer Guides": {
+    "message": "Developer Guides",
+    "description": "The label for category Developer Guides in sidebar doc"
+  },
+  "sidebar.doc.category.Use Cases": {
+    "message": "Use Cases",
+    "description": "The label for category Use Cases in sidebar doc"
+  },
+  "sidebar.doc.category.Performance": {
+    "message": "Performance",
+    "description": "The label for category Performance in sidebar doc"
+  },
+  "sidebar.doc.category.Release Notes": {
+    "message": "Release Notes",
+    "description": "The label for category Release Notes in sidebar doc"
+  },
+  "sidebar.doc.category.Contribute to Databend": {
+    "message": "Contribute to Databend",
+    "description": "The label for category Contribute to Databend in sidebar doc"
+  },
+  "sidebar.doc.category.RFCs": {
+    "message": "RFCs",
+    "description": "The label for category RFCs in sidebar doc"
+  },
+  "sidebar.doc.category.FAQ": {
+    "message": "FAQ",
+    "description": "The label for category FAQ in sidebar doc"
   }
 }

--- a/website/i18n/en-US/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/en-US/docusaurus-theme-classic/navbar.json
@@ -22,5 +22,9 @@
   "item.label.GitHub": {
     "message": "GitHub",
     "description": "Navbar item with label GitHub"
+  },
+  "item.label.Download": {
+    "message": "Download",
+    "description": "Navbar item with label Download"
   }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This is precisely the first step towards internationalisation/localisation.

- Allows the build of multilingual websites, although no translations have been added.
- Update some json for en-US
- Fix PR title

---

The following tasks still need to be completed:

- Add a link/an edit button to Databend Crowdin.
- Temporarily populate all untranslated documents at once to ensure a build.
- Fix issues about images and links.

This work will be completed in the next PR.