### PR TITLE
chore(query): migrate table0 to table_empty for unsized hashtable

### DIFF
--- a/src/common/arrow/Cargo.toml
+++ b/src/common/arrow/Cargo.toml
@@ -34,16 +34,10 @@ simd = ["arrow/simd"]
 # Workspace dependencies
 
 # Crates.io dependencies
-# arrow = { package = "arrow2", git = "https://github.com/sundy-li/arrow2", rev = "0563c0d42e", default-features = false, features = [
-#     "io_parquet",
-#     "io_parquet_compression",
-# ] }
-
-arrow = { package = "arrow2", path = "/home/sundy/work/arrow2", default-features = false, features = [
+arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "95e117d", default-features = false, features = [
     "io_parquet",
     "io_parquet_compression",
 ] }
-
 arrow-format = { version = "0.8.0", features = ["flight-data", "flight-service", "ipc"] }
 futures = "0.3.24"
 parquet2 = { version = "0.16.3", default_features = false }

--- a/src/common/arrow/Cargo.toml
+++ b/src/common/arrow/Cargo.toml
@@ -34,10 +34,16 @@ simd = ["arrow/simd"]
 # Workspace dependencies
 
 # Crates.io dependencies
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "95e117d", default-features = false, features = [
+# arrow = { package = "arrow2", git = "https://github.com/sundy-li/arrow2", rev = "0563c0d42e", default-features = false, features = [
+#     "io_parquet",
+#     "io_parquet_compression",
+# ] }
+
+arrow = { package = "arrow2", path = "/home/sundy/work/arrow2", default-features = false, features = [
     "io_parquet",
     "io_parquet_compression",
 ] }
+
 arrow-format = { version = "0.8.0", features = ["flight-data", "flight-service", "ipc"] }
 futures = "0.3.24"
 parquet2 = { version = "0.16.3", default_features = false }

--- a/src/common/hashtable/src/lib.rs
+++ b/src/common/hashtable/src/lib.rs
@@ -25,7 +25,10 @@ mod keys_ref;
 mod lookup_hashtable;
 mod stack_hashtable;
 mod table0;
+
+#[allow(dead_code)]
 mod table1;
+mod table_empty;
 mod traits;
 mod twolevel_hashtable;
 mod unsized_hashtable;

--- a/src/common/hashtable/src/table_empty.rs
+++ b/src/common/hashtable/src/table_empty.rs
@@ -1,0 +1,130 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::alloc::Allocator;
+
+use super::table0::Entry;
+
+type Ent<V> = Entry<[u8; 0], V>;
+
+pub struct TableEmpty<V, A: Allocator + Clone> {
+    pub(crate) has_zero: bool,
+    pub(crate) slice: Box<[Entry<[u8; 0], V>; 1], A>,
+}
+
+impl<V, A: Allocator + Clone> TableEmpty<V, A> {
+    pub fn new_in(allocator: A) -> Self {
+        Self {
+            slice: unsafe {
+                let res = Box::<[Ent<V>; 1], A>::new_zeroed_in(allocator).assume_init();
+                res
+            },
+            has_zero: false,
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        1
+    }
+
+    pub fn len(&self) -> usize {
+        if self.has_zero { 1 } else { 0 }
+    }
+
+    pub fn heap_bytes(&self) -> usize {
+        std::mem::size_of::<Ent<V>>()
+    }
+
+    pub fn get(&self) -> Option<&Ent<V>> {
+        if self.has_zero {
+            Some(&self.slice[0])
+        } else {
+            None
+        }
+    }
+    pub fn get_mut(&mut self) -> Option<&mut Ent<V>> {
+        if self.has_zero {
+            Some(&mut self.slice[0])
+        } else {
+            None
+        }
+    }
+    /// # Safety
+    ///
+    /// The resulted `MaybeUninit` should be initialized immedidately.
+    pub fn insert(&mut self) -> Result<&mut Ent<V>, &mut Ent<V>> {
+        self.has_zero = true;
+        Ok(&mut self.slice[0])
+    }
+
+    pub fn iter(&self) -> TableEmptyIter<'_, V> {
+        TableEmptyIter {
+            slice: self.slice.as_ref(),
+            i: if self.has_zero { 0 } else { 1 },
+        }
+    }
+    pub fn iter_mut(&mut self) -> TableEmptyIterMut<'_, V> {
+        TableEmptyIterMut {
+            slice: self.slice.as_mut(),
+            i: if self.has_zero { 0 } else { 1 },
+        }
+    }
+}
+
+impl<V, A: Allocator + Clone> Drop for TableEmpty<V, A> {
+    fn drop(&mut self) {
+        if std::mem::needs_drop::<V>() {
+            self.iter_mut().for_each(|e| unsafe {
+                e.val.assume_init_drop();
+            });
+        }
+    }
+}
+
+pub struct TableEmptyIter<'a, V> {
+    slice: &'a [Ent<V>; 1],
+    i: usize,
+}
+
+impl<'a, V> Iterator for TableEmptyIter<'a, V> {
+    type Item = &'a Ent<V>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i > 0 {
+            None
+        } else {
+            self.i += 1;
+            Some(&self.slice[0])
+        }
+    }
+}
+
+pub struct TableEmptyIterMut<'a, V> {
+    slice: &'a mut [Ent<V>; 1],
+    i: usize,
+}
+
+impl<'a, V> Iterator for TableEmptyIterMut<'a, V> {
+    type Item = &'a mut Ent<V>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i > 0 {
+            None
+        } else {
+            let res = unsafe { &mut *(self.slice.as_ptr().add(self.i) as *mut _) };
+            self.i += 1;
+            Some(res)
+        }
+    }
+}

--- a/src/common/hashtable/src/table_empty.rs
+++ b/src/common/hashtable/src/table_empty.rs
@@ -36,7 +36,7 @@ impl<V, A: Allocator + Clone> TableEmpty<V, A> {
     }
 
     pub fn len(&self) -> usize {
-        usize::from(!self.has_zero)
+        usize::from(self.has_zero)
     }
 
     pub fn heap_bytes(&self) -> usize {

--- a/src/common/hashtable/src/table_empty.rs
+++ b/src/common/hashtable/src/table_empty.rs
@@ -27,8 +27,7 @@ impl<V, A: Allocator + Clone> TableEmpty<V, A> {
     pub fn new_in(allocator: A) -> Self {
         Self {
             slice: unsafe {
-                let res = Box::<[Ent<V>; 1], A>::new_zeroed_in(allocator).assume_init();
-                res
+                Box::<[Ent<V>; 1], A>::new_zeroed_in(allocator).assume_init()
             },
             has_zero: false,
         }
@@ -39,7 +38,7 @@ impl<V, A: Allocator + Clone> TableEmpty<V, A> {
     }
 
     pub fn len(&self) -> usize {
-        if self.has_zero { 1 } else { 0 }
+        usize::from(!self.has_zero)
     }
 
     pub fn heap_bytes(&self) -> usize {

--- a/src/common/hashtable/src/table_empty.rs
+++ b/src/common/hashtable/src/table_empty.rs
@@ -64,8 +64,12 @@ impl<V, A: Allocator + Clone> TableEmpty<V, A> {
     ///
     /// The resulted `MaybeUninit` should be initialized immedidately.
     pub fn insert(&mut self) -> Result<&mut Ent<V>, &mut Ent<V>> {
-        self.has_zero = true;
-        Ok(&mut self.slice[0])
+        if !self.has_zero {
+            self.has_zero = true;
+            Ok(&mut self.slice[0])
+        } else {
+            Err(&mut self.slice[0])
+        }
     }
 
     pub fn iter(&self) -> TableEmptyIter<'_, V> {

--- a/src/common/hashtable/src/table_empty.rs
+++ b/src/common/hashtable/src/table_empty.rs
@@ -26,9 +26,7 @@ pub struct TableEmpty<V, A: Allocator + Clone> {
 impl<V, A: Allocator + Clone> TableEmpty<V, A> {
     pub fn new_in(allocator: A) -> Self {
         Self {
-            slice: unsafe {
-                Box::<[Ent<V>; 1], A>::new_zeroed_in(allocator).assume_init()
-            },
+            slice: unsafe { Box::<[Ent<V>; 1], A>::new_zeroed_in(allocator).assume_init() },
             has_zero: false,
         }
     }
@@ -74,13 +72,13 @@ impl<V, A: Allocator + Clone> TableEmpty<V, A> {
     pub fn iter(&self) -> TableEmptyIter<'_, V> {
         TableEmptyIter {
             slice: self.slice.as_ref(),
-            i: if self.has_zero { 0 } else { 1 },
+            i: usize::from(!self.has_zero),
         }
     }
     pub fn iter_mut(&mut self) -> TableEmptyIterMut<'_, V> {
         TableEmptyIterMut {
             slice: self.slice.as_mut(),
-            i: if self.has_zero { 0 } else { 1 },
+            i: usize::from(!self.has_zero),
         }
     }
 }

--- a/src/common/hashtable/src/traits.rs
+++ b/src/common/hashtable/src/traits.rs
@@ -25,7 +25,7 @@ use primitive_types::U512;
 /// All functions must be implemented correctly.
 pub unsafe trait Keyable: Sized + Copy + Eq {
     fn is_zero(this: &MaybeUninit<Self>) -> bool;
-    
+
     fn equals_zero(this: &Self) -> bool;
 
     fn hash(&self) -> u64;

--- a/src/common/hashtable/src/traits.rs
+++ b/src/common/hashtable/src/traits.rs
@@ -25,7 +25,7 @@ use primitive_types::U512;
 /// All functions must be implemented correctly.
 pub unsafe trait Keyable: Sized + Copy + Eq {
     fn is_zero(this: &MaybeUninit<Self>) -> bool;
-
+    
     fn equals_zero(this: &Self) -> bool;
 
     fn hash(&self) -> u64;
@@ -242,7 +242,7 @@ impl FastHash for u128 {
                 }
                 (high as u64) << 32 | low as u64
             } else {
-                 use std::hash::Hasher;
+                use std::hash::Hasher;
                 let state = ahash::RandomState::with_seeds(SEEDS[0], SEEDS[1], SEEDS[2], SEEDS[3]);
                 let mut hasher = state.build_hasher();
                 hasher.write_u128(*self);

--- a/src/common/hashtable/src/unsized_hashtable.rs
+++ b/src/common/hashtable/src/unsized_hashtable.rs
@@ -192,7 +192,7 @@ where
                         PhantomData,
                     ))
                 }),
-            3..=8 => {
+            1..=8 => {
                 if unlikely((self.table1.len() + 1) * 2 > self.table1.capacity()) {
                     if (self.table1.entries.len() >> 22) == 0 {
                         self.table1.grow(2);
@@ -709,7 +709,6 @@ unsafe impl Keyable for FallbackKey {
         unsafe { this.assume_init_ref().key.is_none() }
     }
 
-
     #[inline(always)]
     fn hash(&self) -> u64 {
         self.hash
@@ -790,7 +789,7 @@ where A: Allocator + Clone + Default
             0 => self.table0.get().map(|x| {
                 UnsizedHashtableEntryRef(UnsizedHashtableEntryRefInner::Table0(x, PhantomData))
             }),
-            3..=8 => unsafe {
+            1..=8 => unsafe {
                 let mut t = [0u64; 1];
                 t[0] = read_le(key.as_ptr(), key.len());
                 let t = std::mem::transmute::<_, InlineKey<0>>(t);
@@ -838,7 +837,7 @@ where A: Allocator + Clone + Default
                     PhantomData,
                 ))
             }),
-            3..=8 => unsafe {
+            1..=8 => unsafe {
                 let mut t = [0u64; 1];
                 t[0] = read_le(key.as_ptr(), key.len());
                 let t = std::mem::transmute::<_, InlineKey<0>>(t);
@@ -1073,7 +1072,7 @@ where A: Allocator + Clone + Default
                         PhantomData,
                     ))
                 }),
-            3..=8 => {
+            1..=8 => {
                 if unlikely((self.table1.len() + 1) * 2 > self.table1.capacity()) {
                     if (self.table1.entries.len() >> 22) == 0 {
                         self.table1.grow(2);

--- a/src/common/hashtable/src/unsized_hashtable.rs
+++ b/src/common/hashtable/src/unsized_hashtable.rs
@@ -26,7 +26,6 @@ use common_base::mem_allocator::MmapAllocator;
 use super::container::HeapContainer;
 use super::table0::Entry;
 use super::table0::Table0;
-use super::table1::Table1;
 use super::traits::EntryMutRefLike;
 use super::traits::EntryRefLike;
 use super::traits::FastHash;
@@ -36,8 +35,9 @@ use super::traits::UnsizedKeyable;
 use super::utils::read_le;
 use crate::table0::Table0Iter;
 use crate::table0::Table0IterMut;
-use crate::table1::Table1Iter;
-use crate::table1::Table1IterMut;
+use crate::table_empty::TableEmpty;
+use crate::table_empty::TableEmptyIter;
+use crate::table_empty::TableEmptyIterMut;
 
 pub struct UnsizedHashtable<K, V, A = MmapAllocator<GlobalAllocator>>
 where
@@ -45,7 +45,7 @@ where
     A: Allocator + Clone,
 {
     pub(crate) arena: Bump,
-    pub(crate) table0: Table1<V, A>,
+    pub(crate) table0: TableEmpty<V, A>,
     pub(crate) table1: Table0<InlineKey<0>, V, HeapContainer<Entry<InlineKey<0>, V>, A>, A>,
     pub(crate) table2: Table0<InlineKey<1>, V, HeapContainer<Entry<InlineKey<1>, V>, A>, A>,
     pub(crate) table3: Table0<InlineKey<2>, V, HeapContainer<Entry<InlineKey<2>, V>, A>, A>,
@@ -96,8 +96,8 @@ where
     #[inline(always)]
     pub fn set_merge(&mut self, other: &Self) {
         unsafe {
-            for i in other.table0.iter() {
-                let _ = self.table0.insert(*i.key());
+            for _ in other.table0.iter() {
+                let _ = self.table0.insert();
             }
             self.table1.set_merge(&other.table1);
             self.table2.set_merge(&other.table2);
@@ -117,7 +117,7 @@ where
         let allocator = A::default();
         Self {
             arena: Bump::new(),
-            table0: Table1::new_in(allocator.clone()),
+            table0: TableEmpty::new_in(allocator.clone()),
             table1: Table0::with_capacity_in(capacity, allocator.clone()),
             table2: Table0::with_capacity_in(capacity, allocator.clone()),
             table3: Table0::with_capacity_in(capacity, allocator.clone()),
@@ -179,37 +179,7 @@ where
             }
             0 => self
                 .table0
-                .insert([0, 0])
-                .map(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                })
-                .map_err(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                }),
-            1 => self
-                .table0
-                .insert([key[0], 0])
-                .map(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                })
-                .map_err(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                }),
-            2 => self
-                .table0
-                .insert([key[0], key[1]])
+                .insert()
                 .map(|x| {
                     UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
                         x,
@@ -320,7 +290,7 @@ where
 pub struct UnsizedHashtableIter<'a, K, V>
 where K: UnsizedKeyable + ?Sized
 {
-    it_0: Option<Table1Iter<'a, V>>,
+    it_0: Option<TableEmptyIter<'a, V>>,
     it_1: Option<Table0Iter<'a, InlineKey<0>, V>>,
     it_2: Option<Table0Iter<'a, InlineKey<1>, V>>,
     it_3: Option<Table0Iter<'a, InlineKey<2>, V>>,
@@ -381,7 +351,7 @@ where K: UnsizedKeyable + ?Sized
 pub struct UnsizedHashtableIterMut<'a, K, V>
 where K: UnsizedKeyable + ?Sized
 {
-    it_0: Option<Table1IterMut<'a, V>>,
+    it_0: Option<TableEmptyIterMut<'a, V>>,
     it_1: Option<Table0IterMut<'a, InlineKey<0>, V>>,
     it_2: Option<Table0IterMut<'a, InlineKey<1>, V>>,
     it_3: Option<Table0IterMut<'a, InlineKey<2>, V>>,
@@ -440,7 +410,7 @@ where K: UnsizedKeyable + ?Sized
 }
 
 enum UnsizedHashtableEntryRefInner<'a, K: ?Sized, V> {
-    Table0(&'a Entry<[u8; 2], V>, PhantomData<K>),
+    Table0(&'a Entry<[u8; 0], V>, PhantomData<K>),
     Table1(&'a Entry<InlineKey<0>, V>),
     Table2(&'a Entry<InlineKey<1>, V>),
     Table3(&'a Entry<InlineKey<2>, V>),
@@ -466,16 +436,7 @@ impl<'a, K: ?Sized + UnsizedKeyable, V> UnsizedHashtableEntryRefInner<'a, K, V> 
     fn key(self) -> &'a K {
         use UnsizedHashtableEntryRefInner::*;
         match self {
-            Table0(e, _) => unsafe {
-                let key = e.key.assume_init_ref();
-                if key[1] != 0 {
-                    UnsizedKeyable::from_bytes(&key[..2])
-                } else if key[0] != 0 {
-                    UnsizedKeyable::from_bytes(&key[..1])
-                } else {
-                    UnsizedKeyable::from_bytes(&key[..0])
-                }
-            },
+            Table0(_, _) => unsafe { UnsizedKeyable::from_bytes(&[]) },
             Table1(e) => unsafe {
                 let bytes = e.key().1.get().to_le_bytes();
                 for i in (0..=7).rev() {
@@ -562,7 +523,7 @@ impl<'a, K: ?Sized + UnsizedKeyable, V> UnsizedHashtableEntryRef<'a, K, V> {
 }
 
 enum UnsizedHashtableEntryMutRefInner<'a, K: ?Sized, V> {
-    Table0(&'a mut Entry<[u8; 2], V>, PhantomData<K>),
+    Table0(&'a mut Entry<[u8; 0], V>, PhantomData<K>),
     Table1(&'a mut Entry<InlineKey<0>, V>),
     Table2(&'a mut Entry<InlineKey<1>, V>),
     Table3(&'a mut Entry<InlineKey<2>, V>),
@@ -573,16 +534,7 @@ impl<'a, K: ?Sized + UnsizedKeyable, V> UnsizedHashtableEntryMutRefInner<'a, K, 
     fn key(&self) -> &'a K {
         use UnsizedHashtableEntryMutRefInner::*;
         match self {
-            Table0(e, _) => unsafe {
-                let key = e.key.assume_init_ref();
-                if key[1] != 0 {
-                    &*(UnsizedKeyable::from_bytes(&key[..2]) as *const K)
-                } else if key[0] != 0 {
-                    &*(UnsizedKeyable::from_bytes(&key[..1]) as *const K)
-                } else {
-                    &*(UnsizedKeyable::from_bytes(&key[..0]) as *const K)
-                }
-            },
+            Table0(_, _) => unsafe { &*(UnsizedKeyable::from_bytes(&[]) as *const K) },
             Table1(e) => unsafe {
                 let bytes = e.key().1.get().to_le_bytes();
                 for i in (0..=7).rev() {
@@ -757,6 +709,7 @@ unsafe impl Keyable for FallbackKey {
         unsafe { this.assume_init_ref().key.is_none() }
     }
 
+
     #[inline(always)]
     fn hash(&self) -> u64 {
         self.hash
@@ -834,13 +787,7 @@ where A: Allocator + Clone + Default
                     .get(&FallbackKey::new(key))
                     .map(|x| UnsizedHashtableEntryRef(UnsizedHashtableEntryRefInner::Table4(x)))
             },
-            0 => self.table0.get([0, 0]).map(|x| {
-                UnsizedHashtableEntryRef(UnsizedHashtableEntryRefInner::Table0(x, PhantomData))
-            }),
-            1 => self.table0.get([key[0], 0]).map(|x| {
-                UnsizedHashtableEntryRef(UnsizedHashtableEntryRefInner::Table0(x, PhantomData))
-            }),
-            2 => self.table0.get([key[0], key[1]]).map(|x| {
+            0 => self.table0.get().map(|x| {
                 UnsizedHashtableEntryRef(UnsizedHashtableEntryRefInner::Table0(x, PhantomData))
             }),
             3..=8 => unsafe {
@@ -885,19 +832,7 @@ where A: Allocator + Clone + Default
                     UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table4(x))
                 })
             },
-            0 => self.table0.get_mut([0, 0]).map(|x| {
-                UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                    x,
-                    PhantomData,
-                ))
-            }),
-            1 => self.table0.get_mut([key[0], 0]).map(|x| {
-                UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                    x,
-                    PhantomData,
-                ))
-            }),
-            2 => self.table0.get_mut([key[0], key[1]]).map(|x| {
+            0 => self.table0.get_mut().map(|x| {
                 UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
                     x,
                     PhantomData,
@@ -989,7 +924,7 @@ where A: Allocator + Clone + Default
             }
             0 => self
                 .table0
-                .insert([0, 0])
+                .insert()
                 .map(|x| {
                     UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
                         x,
@@ -1002,37 +937,8 @@ where A: Allocator + Clone + Default
                         PhantomData,
                     ))
                 }),
-            1 => self
-                .table0
-                .insert([key[0], 0])
-                .map(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                })
-                .map_err(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                }),
-            2 => self
-                .table0
-                .insert([key[0], key[1]])
-                .map(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                })
-                .map_err(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                }),
-            3..=8 => {
+
+            1..=8 => {
                 if unlikely((self.table1.len() + 1) * 2 > self.table1.capacity()) {
                     if (self.table1.entries.len() >> 22) == 0 {
                         self.table1.grow(2);
@@ -1154,37 +1060,7 @@ where A: Allocator + Clone + Default
             }
             0 => self
                 .table0
-                .insert([0, 0])
-                .map(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                })
-                .map_err(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                }),
-            1 => self
-                .table0
-                .insert([key[0], 0])
-                .map(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                })
-                .map_err(|x| {
-                    UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
-                        x,
-                        PhantomData,
-                    ))
-                }),
-            2 => self
-                .table0
-                .insert([key[0], key[1]])
+                .insert()
                 .map(|x| {
                     UnsizedHashtableEntryMutRef(UnsizedHashtableEntryMutRefInner::Table0(
                         x,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

migrate table0 to table_empty for unsized hashtable

Closes #issue
