### PR TITLE
feat(query config): add deny_unknown_fields to QueryConfig

### DIFF
--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -1137,7 +1137,7 @@ impl TryInto<InnerStorageRedisConfig> for RedisStorageConfig {
 
 /// Query config group.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Args)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct QueryConfig {
     /// Tenant id for get the information from the MetaSrv.
     #[clap(long, default_value = "admin")]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add `deny_unknown_fields` to QueryConfig, throwing an error during deserialization when encountering unknown fields.
For example:
After we rename `max_memory_usage` to `max_server_memory_usage`, if the user still using `max_memory_usage` in their query config file, it will throw an error.

Rust playground: 
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3bd3f496bf2fde57359b75c2f728723a

Closes #issue
