### PR TITLE
fix: remove TableCopiedFileLockKey protection of upsert_table_copied_file_info

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -2196,6 +2196,10 @@ async fn remove_table_copied_files(
         file: "".to_string(),
     };
 
+    // `list_keys` list all the TableCopiedFileNameIdent of this table.
+    // But if a upsert_table_copied_file_info run concurrently, there is chance that
+    // `list_keys` may lack of some new inserted TableCopiedFileNameIdent.
+    // But since TableCopiedFileNameIdent has expire time, they can be purged by expire time.
     let files = list_keys(kv_api, &dbid_tbname_idlist).await?;
     for file in files {
         let (file_seq, _opt): (_, Option<TableCopiedFileInfo>) =


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: remove TableCopiedFileLockKey protection of upsert_table_copied_file_info in case of copy file concurrently return TxnRetryMaxTimes.

`remove_table_copied_files` and `upsert_table_copied_file_info`all modify `TableCopiedFileInfo`,
so there used to has `TableCopiedFileLockKey` in these two functions to protect TableCopiedFileInfo modification.

In issue: https://github.com/datafuselabs/databend/issues/8897, there is chance that if copy files concurrently, `upsert_table_copied_file_info` may return `TxnRetryMaxTimes`.
So now, in case that `TableCopiedFileInfo` has expire time, remove `TableCopiedFileLockKey`
in each function. In this case there is chance that some `TableCopiedFileInfo` may not be
removed in `remove_table_copied_files`, but these data can be purged in case of expire time.

Closes https://github.com/datafuselabs/databend/issues/8897
