### PR TITLE
refactor(expr): rename FunctionContext

### DIFF
--- a/src/query/codegen/src/writes/register.rs
+++ b/src/query/codegen/src/writes/register.rs
@@ -35,7 +35,7 @@ pub fn codegen_register() {
             use std::sync::Arc;
             
             use crate::Function;
-            use crate::FunctionContext;
+            use crate::EvalContext;
             use crate::FunctionDomain;
             use crate::FunctionRegistry;
             use crate::FunctionSignature;
@@ -82,7 +82,7 @@ pub fn codegen_register() {
                     func: G,
                 ) where
                     F: Fn({arg_f_closure_sig}) -> FunctionDomain<O> + 'static + Clone + Copy + Send + Sync,
-                    G: Fn({arg_g_closure_sig} FunctionContext) -> O::Scalar + 'static + Clone + Copy + Send + Sync,
+                    G: Fn({arg_g_closure_sig} EvalContext) -> O::Scalar + 'static + Clone + Copy + Send + Sync,
                 {{
                     self.register_passthrough_nullable_{n_args}_arg::<{arg_generics} O, _, _>(
                         name,
@@ -154,7 +154,7 @@ pub fn codegen_register() {
                     func: G,
                 ) where
                     F: Fn({arg_f_closure_sig}) -> FunctionDomain<O> + 'static + Clone + Copy + Send + Sync,
-                    G: for<'a> Fn({arg_g_closure_sig} FunctionContext) -> Result<Value<O>, String> + 'static + Clone + Copy + Send + Sync,
+                    G: for<'a> Fn({arg_g_closure_sig} EvalContext) -> Result<Value<O>, String> + 'static + Clone + Copy + Send + Sync,
                 {{
                     let has_nullable = &[{arg_sig_type} O::data_type()]
                         .iter()
@@ -257,7 +257,7 @@ pub fn codegen_register() {
                     func: G,
                 ) where
                     F: Fn({arg_f_closure_sig}) -> FunctionDomain<NullableType<O>> + 'static + Clone + Copy + Send + Sync,
-                    G: for<'a> Fn({arg_g_closure_sig} FunctionContext) -> Result<Value<NullableType<O>>, String> + 'static + Clone + Copy + Send + Sync,
+                    G: for<'a> Fn({arg_g_closure_sig} EvalContext) -> Result<Value<NullableType<O>>, String> + 'static + Clone + Copy + Send + Sync,
                 {{
                     let has_nullable = &[{arg_sig_type} O::data_type()]
                         .iter()
@@ -340,7 +340,7 @@ pub fn codegen_register() {
                     func: G,
                 ) where
                     F: Fn({arg_f_closure_sig}) -> FunctionDomain<O> + 'static + Clone + Copy + Send + Sync,
-                    G: for <'a> Fn({arg_g_closure_sig} FunctionContext) -> Result<Value<O>, String> + 'static + Clone + Copy + Send + Sync,
+                    G: for <'a> Fn({arg_g_closure_sig} EvalContext) -> Result<Value<O>, String> + 'static + Clone + Copy + Send + Sync,
                 {{
                     self.funcs
                         .entry(name.to_string())
@@ -441,8 +441,8 @@ pub fn codegen_register() {
             source,
             "
                 pub fn vectorize_{n_args}_arg<{arg_generics_bound} O: ArgType>(
-                    func: impl Fn({arg_input_closure_sig} FunctionContext) -> O::Scalar + Copy + Send + Sync,
-                ) -> impl Fn({arg_output_closure_sig} FunctionContext) -> Result<Value<O>, String> + Copy + Send + Sync {{
+                    func: impl Fn({arg_input_closure_sig} EvalContext) -> O::Scalar + Copy + Send + Sync,
+                ) -> impl Fn({arg_output_closure_sig} EvalContext) -> Result<Value<O>, String> + Copy + Send + Sync {{
                     move |{func_args} ctx| match ({args_tuple}) {{
                         ({arg_scalar}) => Ok(Value::Scalar(func({func_args} ctx))),
                         {match_arms}
@@ -535,8 +535,8 @@ pub fn codegen_register() {
             source,
             "
                 pub fn vectorize_with_builder_{n_args}_arg<{arg_generics_bound} O: ArgType>(
-                    func: impl Fn({arg_input_closure_sig} &mut O::ColumnBuilder, FunctionContext) -> Result<(), String> + Copy + Send + Sync,
-                ) -> impl Fn({arg_output_closure_sig} FunctionContext) -> Result<Value<O>, String> + Copy + Send + Sync {{
+                    func: impl Fn({arg_input_closure_sig} &mut O::ColumnBuilder, EvalContext) -> Result<(), String> + Copy + Send + Sync,
+                ) -> impl Fn({arg_output_closure_sig} EvalContext) -> Result<Value<O>, String> + Copy + Send + Sync {{
                     move |{func_args} ctx| match ({args_tuple}) {{
                         ({arg_scalar}) => {{
                             let mut builder = O::create_builder(1, ctx.generics);
@@ -640,8 +640,8 @@ pub fn codegen_register() {
             source,
             "
                 pub fn passthrough_nullable_{n_args}_arg<{arg_generics_bound} O: ArgType>(
-                    func: impl for <'a> Fn({arg_input_closure_sig} FunctionContext) -> Result<Value<O>, String> + Copy + Send + Sync,
-                ) -> impl for <'a> Fn({arg_output_closure_sig} FunctionContext) -> Result<Value<NullableType<O>>, String> + Copy + Send + Sync {{
+                    func: impl for <'a> Fn({arg_input_closure_sig} EvalContext) -> Result<Value<O>, String> + Copy + Send + Sync,
+                ) -> impl for <'a> Fn({arg_output_closure_sig} EvalContext) -> Result<Value<NullableType<O>>, String> + Copy + Send + Sync {{
                     move |{closure_args} ctx| match ({args_tuple}) {{
                         {scalar_nones_pats} => Ok(Value::Scalar(None)),
                         ({arg_scalar}) => Ok(Value::Scalar(Some(
@@ -747,8 +747,8 @@ pub fn codegen_register() {
             source,
             "
                 pub fn combine_nullable_{n_args}_arg<{arg_generics_bound} O: ArgType>(
-                    func: impl for <'a> Fn({arg_input_closure_sig} FunctionContext) -> Result<Value<NullableType<O>>, String> + Copy + Send + Sync,
-                ) -> impl for <'a> Fn({arg_output_closure_sig} FunctionContext) -> Result<Value<NullableType<O>>, String> + Copy + Send + Sync {{
+                    func: impl for <'a> Fn({arg_input_closure_sig} EvalContext) -> Result<Value<NullableType<O>>, String> + Copy + Send + Sync,
+                ) -> impl for <'a> Fn({arg_output_closure_sig} EvalContext) -> Result<Value<NullableType<O>>, String> + Copy + Send + Sync {{
                     move |{closure_args} ctx| match ({args_tuple}) {{
                         {scalar_nones_pats} => Ok(Value::Scalar(None)),
                         ({arg_scalar}) => Ok(Value::Scalar(
@@ -825,8 +825,8 @@ pub fn codegen_register() {
             source,
             "
                 fn erase_function_generic_{n_args}_arg<{arg_generics_bound} O: ArgType>(
-                    func: impl for <'a> Fn({arg_g_closure_sig} FunctionContext) -> Result<Value<O>, String>,
-                ) -> impl Fn(&[ValueRef<AnyType>], FunctionContext) -> Result<Value<AnyType>, String> {{
+                    func: impl for <'a> Fn({arg_g_closure_sig} EvalContext) -> Result<Value<O>, String>,
+                ) -> impl Fn(&[ValueRef<AnyType>], EvalContext) -> Result<Value<AnyType>, String> {{
                     move |args, ctx| {{
                         {let_args}
                         func({func_args} ctx).map(Value::upcast)

--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -42,7 +42,12 @@ pub struct FunctionSignature {
 }
 
 #[derive(Clone, Copy)]
-pub struct FunctionContext<'a> {
+pub struct FunctionContext {
+    pub tz: Tz,
+}
+
+#[derive(Clone, Copy)]
+pub struct EvalContext<'a> {
     pub generics: &'a GenericMap,
     pub num_rows: usize,
     pub tz: Tz,
@@ -70,9 +75,7 @@ pub struct Function {
     pub calc_domain: Box<dyn Fn(&[Domain]) -> FunctionDomain<AnyType> + Send + Sync>,
     #[allow(clippy::type_complexity)]
     pub eval: Box<
-        dyn Fn(&[ValueRef<AnyType>], FunctionContext) -> Result<Value<AnyType>, String>
-            + Send
-            + Sync,
+        dyn Fn(&[ValueRef<AnyType>], EvalContext) -> Result<Value<AnyType>, String> + Send + Sync,
     >,
 }
 
@@ -204,8 +207,8 @@ impl FunctionRegistry {
 
 pub fn wrap_nullable<F>(
     f: F,
-) -> impl Fn(&[ValueRef<AnyType>], FunctionContext) -> Result<Value<AnyType>, String> + Copy
-where F: Fn(&[ValueRef<AnyType>], FunctionContext) -> Result<Value<AnyType>, String> + Copy {
+) -> impl Fn(&[ValueRef<AnyType>], EvalContext) -> Result<Value<AnyType>, String> + Copy
+where F: Fn(&[ValueRef<AnyType>], EvalContext) -> Result<Value<AnyType>, String> + Copy {
     move |args, ctx| {
         type T = NullableType<AnyType>;
         type Result = AnyType;

--- a/src/query/expression/src/register.rs
+++ b/src/query/expression/src/register.rs
@@ -27,8 +27,8 @@ use crate::types::nullable::NullableDomain;
 use crate::types::*;
 use crate::values::Value;
 use crate::values::ValueRef;
+use crate::EvalContext;
 use crate::Function;
-use crate::FunctionContext;
 use crate::FunctionDomain;
 use crate::FunctionRegistry;
 use crate::FunctionSignature;
@@ -42,12 +42,7 @@ impl FunctionRegistry {
         func: G,
     ) where
         F: Fn(&I1::Domain) -> FunctionDomain<O> + 'static + Clone + Copy + Send + Sync,
-        G: Fn(I1::ScalarRef<'_>, FunctionContext) -> O::Scalar
-            + 'static
-            + Clone
-            + Copy
-            + Send
-            + Sync,
+        G: Fn(I1::ScalarRef<'_>, EvalContext) -> O::Scalar + 'static + Clone + Copy + Send + Sync,
     {
         self.register_passthrough_nullable_1_arg::<I1, O, _, _>(
             name,
@@ -65,7 +60,7 @@ impl FunctionRegistry {
         func: G,
     ) where
         F: Fn(&I1::Domain, &I2::Domain) -> FunctionDomain<O> + 'static + Clone + Copy + Send + Sync,
-        G: Fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, FunctionContext) -> O::Scalar
+        G: Fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, EvalContext) -> O::Scalar
             + 'static
             + Clone
             + Copy
@@ -93,12 +88,7 @@ impl FunctionRegistry {
             + Copy
             + Send
             + Sync,
-        G: Fn(
-                I1::ScalarRef<'_>,
-                I2::ScalarRef<'_>,
-                I3::ScalarRef<'_>,
-                FunctionContext,
-            ) -> O::Scalar
+        G: Fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, I3::ScalarRef<'_>, EvalContext) -> O::Scalar
             + 'static
             + Clone
             + Copy
@@ -131,7 +121,7 @@ impl FunctionRegistry {
                 I2::ScalarRef<'_>,
                 I3::ScalarRef<'_>,
                 I4::ScalarRef<'_>,
-                FunctionContext,
+                EvalContext,
             ) -> O::Scalar
             + 'static
             + Clone
@@ -175,7 +165,7 @@ impl FunctionRegistry {
                 I3::ScalarRef<'_>,
                 I4::ScalarRef<'_>,
                 I5::ScalarRef<'_>,
-                FunctionContext,
+                EvalContext,
             ) -> O::Scalar
             + 'static
             + Clone
@@ -199,7 +189,7 @@ impl FunctionRegistry {
         func: G,
     ) where
         F: Fn(&I1::Domain) -> FunctionDomain<O> + 'static + Clone + Copy + Send + Sync,
-        G: for<'a> Fn(ValueRef<'a, I1>, FunctionContext) -> Result<Value<O>, String>
+        G: for<'a> Fn(ValueRef<'a, I1>, EvalContext) -> Result<Value<O>, String>
             + 'static
             + Clone
             + Copy
@@ -249,11 +239,7 @@ impl FunctionRegistry {
         func: G,
     ) where
         F: Fn(&I1::Domain, &I2::Domain) -> FunctionDomain<O> + 'static + Clone + Copy + Send + Sync,
-        G: for<'a> Fn(
-                ValueRef<'a, I1>,
-                ValueRef<'a, I2>,
-                FunctionContext,
-            ) -> Result<Value<O>, String>
+        G: for<'a> Fn(ValueRef<'a, I1>, ValueRef<'a, I2>, EvalContext) -> Result<Value<O>, String>
             + 'static
             + Clone
             + Copy
@@ -319,7 +305,7 @@ impl FunctionRegistry {
                 ValueRef<'a, I1>,
                 ValueRef<'a, I2>,
                 ValueRef<'a, I3>,
-                FunctionContext,
+                EvalContext,
             ) -> Result<Value<O>, String>
             + 'static
             + Clone
@@ -397,7 +383,7 @@ impl FunctionRegistry {
                 ValueRef<'a, I2>,
                 ValueRef<'a, I3>,
                 ValueRef<'a, I4>,
-                FunctionContext,
+                EvalContext,
             ) -> Result<Value<O>, String>
             + 'static
             + Clone
@@ -483,7 +469,7 @@ impl FunctionRegistry {
                 ValueRef<'a, I3>,
                 ValueRef<'a, I4>,
                 ValueRef<'a, I5>,
-                FunctionContext,
+                EvalContext,
             ) -> Result<Value<O>, String>
             + 'static
             + Clone
@@ -555,7 +541,7 @@ impl FunctionRegistry {
             + Copy
             + Send
             + Sync,
-        G: for<'a> Fn(ValueRef<'a, I1>, FunctionContext) -> Result<Value<NullableType<O>>, String>
+        G: for<'a> Fn(ValueRef<'a, I1>, EvalContext) -> Result<Value<NullableType<O>>, String>
             + 'static
             + Clone
             + Copy
@@ -618,7 +604,7 @@ impl FunctionRegistry {
         G: for<'a> Fn(
                 ValueRef<'a, I1>,
                 ValueRef<'a, I2>,
-                FunctionContext,
+                EvalContext,
             ) -> Result<Value<NullableType<O>>, String>
             + 'static
             + Clone
@@ -690,7 +676,7 @@ impl FunctionRegistry {
                 ValueRef<'a, I1>,
                 ValueRef<'a, I2>,
                 ValueRef<'a, I3>,
-                FunctionContext,
+                EvalContext,
             ) -> Result<Value<NullableType<O>>, String>
             + 'static
             + Clone
@@ -778,7 +764,7 @@ impl FunctionRegistry {
                 ValueRef<'a, I2>,
                 ValueRef<'a, I3>,
                 ValueRef<'a, I4>,
-                FunctionContext,
+                EvalContext,
             ) -> Result<Value<NullableType<O>>, String>
             + 'static
             + Clone
@@ -870,7 +856,7 @@ impl FunctionRegistry {
                 ValueRef<'a, I3>,
                 ValueRef<'a, I4>,
                 ValueRef<'a, I5>,
-                FunctionContext,
+                EvalContext,
             ) -> Result<Value<NullableType<O>>, String>
             + 'static
             + Clone
@@ -937,7 +923,7 @@ impl FunctionRegistry {
         func: G,
     ) where
         F: Fn() -> FunctionDomain<O> + 'static + Clone + Copy + Send + Sync,
-        G: for<'a> Fn(FunctionContext) -> Result<Value<O>, String>
+        G: for<'a> Fn(EvalContext) -> Result<Value<O>, String>
             + 'static
             + Clone
             + Copy
@@ -967,7 +953,7 @@ impl FunctionRegistry {
         func: G,
     ) where
         F: Fn(&I1::Domain) -> FunctionDomain<O> + 'static + Clone + Copy + Send + Sync,
-        G: for<'a> Fn(ValueRef<'a, I1>, FunctionContext) -> Result<Value<O>, String>
+        G: for<'a> Fn(ValueRef<'a, I1>, EvalContext) -> Result<Value<O>, String>
             + 'static
             + Clone
             + Copy
@@ -997,11 +983,7 @@ impl FunctionRegistry {
         func: G,
     ) where
         F: Fn(&I1::Domain, &I2::Domain) -> FunctionDomain<O> + 'static + Clone + Copy + Send + Sync,
-        G: for<'a> Fn(
-                ValueRef<'a, I1>,
-                ValueRef<'a, I2>,
-                FunctionContext,
-            ) -> Result<Value<O>, String>
+        G: for<'a> Fn(ValueRef<'a, I1>, ValueRef<'a, I2>, EvalContext) -> Result<Value<O>, String>
             + 'static
             + Clone
             + Copy
@@ -1040,7 +1022,7 @@ impl FunctionRegistry {
                 ValueRef<'a, I1>,
                 ValueRef<'a, I2>,
                 ValueRef<'a, I3>,
-                FunctionContext,
+                EvalContext,
             ) -> Result<Value<O>, String>
             + 'static
             + Clone
@@ -1091,7 +1073,7 @@ impl FunctionRegistry {
                 ValueRef<'a, I2>,
                 ValueRef<'a, I3>,
                 ValueRef<'a, I4>,
-                FunctionContext,
+                EvalContext,
             ) -> Result<Value<O>, String>
             + 'static
             + Clone
@@ -1149,7 +1131,7 @@ impl FunctionRegistry {
                 ValueRef<'a, I3>,
                 ValueRef<'a, I4>,
                 ValueRef<'a, I5>,
-                FunctionContext,
+                EvalContext,
             ) -> Result<Value<O>, String>
             + 'static
             + Clone
@@ -1182,8 +1164,8 @@ impl FunctionRegistry {
 }
 
 pub fn vectorize_1_arg<I1: ArgType, O: ArgType>(
-    func: impl Fn(I1::ScalarRef<'_>, FunctionContext) -> O::Scalar + Copy + Send + Sync,
-) -> impl Fn(ValueRef<I1>, FunctionContext) -> Result<Value<O>, String> + Copy + Send + Sync {
+    func: impl Fn(I1::ScalarRef<'_>, EvalContext) -> O::Scalar + Copy + Send + Sync,
+) -> impl Fn(ValueRef<I1>, EvalContext) -> Result<Value<O>, String> + Copy + Send + Sync {
     move |arg1, ctx| match (arg1) {
         (ValueRef::Scalar(arg1)) => Ok(Value::Scalar(func(arg1, ctx))),
         (ValueRef::Column(arg1)) => {
@@ -1196,11 +1178,8 @@ pub fn vectorize_1_arg<I1: ArgType, O: ArgType>(
 }
 
 pub fn vectorize_2_arg<I1: ArgType, I2: ArgType, O: ArgType>(
-    func: impl Fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, FunctionContext) -> O::Scalar
-    + Copy
-    + Send
-    + Sync,
-) -> impl Fn(ValueRef<I1>, ValueRef<I2>, FunctionContext) -> Result<Value<O>, String> + Copy + Send + Sync
+    func: impl Fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, EvalContext) -> O::Scalar + Copy + Send + Sync,
+) -> impl Fn(ValueRef<I1>, ValueRef<I2>, EvalContext) -> Result<Value<O>, String> + Copy + Send + Sync
 {
     move |arg1, arg2, ctx| match (arg1, arg2) {
         (ValueRef::Scalar(arg1), ValueRef::Scalar(arg2)) => {
@@ -1231,11 +1210,11 @@ pub fn vectorize_2_arg<I1: ArgType, I2: ArgType, O: ArgType>(
 }
 
 pub fn vectorize_3_arg<I1: ArgType, I2: ArgType, I3: ArgType, O: ArgType>(
-    func: impl Fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, I3::ScalarRef<'_>, FunctionContext) -> O::Scalar
+    func: impl Fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, I3::ScalarRef<'_>, EvalContext) -> O::Scalar
     + Copy
     + Send
     + Sync,
-) -> impl Fn(ValueRef<I1>, ValueRef<I2>, ValueRef<I3>, FunctionContext) -> Result<Value<O>, String>
+) -> impl Fn(ValueRef<I1>, ValueRef<I2>, ValueRef<I3>, EvalContext) -> Result<Value<O>, String>
 + Copy
 + Send
 + Sync {
@@ -1308,7 +1287,7 @@ pub fn vectorize_4_arg<I1: ArgType, I2: ArgType, I3: ArgType, I4: ArgType, O: Ar
         I2::ScalarRef<'_>,
         I3::ScalarRef<'_>,
         I4::ScalarRef<'_>,
-        FunctionContext,
+        EvalContext,
     ) -> O::Scalar
     + Copy
     + Send
@@ -1318,7 +1297,7 @@ pub fn vectorize_4_arg<I1: ArgType, I2: ArgType, I3: ArgType, I4: ArgType, O: Ar
     ValueRef<I2>,
     ValueRef<I3>,
     ValueRef<I4>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<O>, String>
 + Copy
 + Send
@@ -1561,7 +1540,7 @@ pub fn vectorize_5_arg<
         I3::ScalarRef<'_>,
         I4::ScalarRef<'_>,
         I5::ScalarRef<'_>,
-        FunctionContext,
+        EvalContext,
     ) -> O::Scalar
     + Copy
     + Send
@@ -1572,7 +1551,7 @@ pub fn vectorize_5_arg<
     ValueRef<I3>,
     ValueRef<I4>,
     ValueRef<I5>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<O>, String>
 + Copy
 + Send
@@ -2142,11 +2121,11 @@ pub fn vectorize_5_arg<
 }
 
 pub fn vectorize_with_builder_1_arg<I1: ArgType, O: ArgType>(
-    func: impl Fn(I1::ScalarRef<'_>, &mut O::ColumnBuilder, FunctionContext) -> Result<(), String>
+    func: impl Fn(I1::ScalarRef<'_>, &mut O::ColumnBuilder, EvalContext) -> Result<(), String>
     + Copy
     + Send
     + Sync,
-) -> impl Fn(ValueRef<I1>, FunctionContext) -> Result<Value<O>, String> + Copy + Send + Sync {
+) -> impl Fn(ValueRef<I1>, EvalContext) -> Result<Value<O>, String> + Copy + Send + Sync {
     move |arg1, ctx| match (arg1) {
         (ValueRef::Scalar(arg1)) => {
             let mut builder = O::create_builder(1, ctx.generics);
@@ -2170,12 +2149,12 @@ pub fn vectorize_with_builder_2_arg<I1: ArgType, I2: ArgType, O: ArgType>(
         I1::ScalarRef<'_>,
         I2::ScalarRef<'_>,
         &mut O::ColumnBuilder,
-        FunctionContext,
+        EvalContext,
     ) -> Result<(), String>
     + Copy
     + Send
     + Sync,
-) -> impl Fn(ValueRef<I1>, ValueRef<I2>, FunctionContext) -> Result<Value<O>, String> + Copy + Send + Sync
+) -> impl Fn(ValueRef<I1>, ValueRef<I2>, EvalContext) -> Result<Value<O>, String> + Copy + Send + Sync
 {
     move |arg1, arg2, ctx| match (arg1, arg2) {
         (ValueRef::Scalar(arg1), ValueRef::Scalar(arg2)) => {
@@ -2220,12 +2199,12 @@ pub fn vectorize_with_builder_3_arg<I1: ArgType, I2: ArgType, I3: ArgType, O: Ar
         I2::ScalarRef<'_>,
         I3::ScalarRef<'_>,
         &mut O::ColumnBuilder,
-        FunctionContext,
+        EvalContext,
     ) -> Result<(), String>
     + Copy
     + Send
     + Sync,
-) -> impl Fn(ValueRef<I1>, ValueRef<I2>, ValueRef<I3>, FunctionContext) -> Result<Value<O>, String>
+) -> impl Fn(ValueRef<I1>, ValueRef<I2>, ValueRef<I3>, EvalContext) -> Result<Value<O>, String>
 + Copy
 + Send
 + Sync {
@@ -2319,7 +2298,7 @@ pub fn vectorize_with_builder_4_arg<
         I3::ScalarRef<'_>,
         I4::ScalarRef<'_>,
         &mut O::ColumnBuilder,
-        FunctionContext,
+        EvalContext,
     ) -> Result<(), String>
     + Copy
     + Send
@@ -2329,7 +2308,7 @@ pub fn vectorize_with_builder_4_arg<
     ValueRef<I2>,
     ValueRef<I3>,
     ValueRef<I4>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<O>, String>
 + Copy
 + Send
@@ -2618,7 +2597,7 @@ pub fn vectorize_with_builder_5_arg<
         I4::ScalarRef<'_>,
         I5::ScalarRef<'_>,
         &mut O::ColumnBuilder,
-        FunctionContext,
+        EvalContext,
     ) -> Result<(), String>
     + Copy
     + Send
@@ -2629,7 +2608,7 @@ pub fn vectorize_with_builder_5_arg<
     ValueRef<I3>,
     ValueRef<I4>,
     ValueRef<I5>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<O>, String>
 + Copy
 + Send
@@ -3368,13 +3347,13 @@ pub fn vectorize_with_builder_5_arg<
 }
 
 pub fn passthrough_nullable_1_arg<I1: ArgType, O: ArgType>(
-    func: impl for<'a> Fn(ValueRef<'a, I1>, FunctionContext) -> Result<Value<O>, String>
+    func: impl for<'a> Fn(ValueRef<'a, I1>, EvalContext) -> Result<Value<O>, String>
     + Copy
     + Send
     + Sync,
 ) -> impl for<'a> Fn(
     ValueRef<'a, NullableType<I1>>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<NullableType<O>>, String>
 + Copy
 + Send
@@ -3395,18 +3374,14 @@ pub fn passthrough_nullable_1_arg<I1: ArgType, O: ArgType>(
 }
 
 pub fn passthrough_nullable_2_arg<I1: ArgType, I2: ArgType, O: ArgType>(
-    func: impl for<'a> Fn(
-        ValueRef<'a, I1>,
-        ValueRef<'a, I2>,
-        FunctionContext,
-    ) -> Result<Value<O>, String>
+    func: impl for<'a> Fn(ValueRef<'a, I1>, ValueRef<'a, I2>, EvalContext) -> Result<Value<O>, String>
     + Copy
     + Send
     + Sync,
 ) -> impl for<'a> Fn(
     ValueRef<'a, NullableType<I1>>,
     ValueRef<'a, NullableType<I2>>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<NullableType<O>>, String>
 + Copy
 + Send
@@ -3451,7 +3426,7 @@ pub fn passthrough_nullable_3_arg<I1: ArgType, I2: ArgType, I3: ArgType, O: ArgT
         ValueRef<'a, I1>,
         ValueRef<'a, I2>,
         ValueRef<'a, I3>,
-        FunctionContext,
+        EvalContext,
     ) -> Result<Value<O>, String>
     + Copy
     + Send
@@ -3460,7 +3435,7 @@ pub fn passthrough_nullable_3_arg<I1: ArgType, I2: ArgType, I3: ArgType, O: ArgT
     ValueRef<'a, NullableType<I1>>,
     ValueRef<'a, NullableType<I2>>,
     ValueRef<'a, NullableType<I3>>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<NullableType<O>>, String>
 + Copy
 + Send
@@ -3585,7 +3560,7 @@ pub fn passthrough_nullable_4_arg<
         ValueRef<'a, I2>,
         ValueRef<'a, I3>,
         ValueRef<'a, I4>,
-        FunctionContext,
+        EvalContext,
     ) -> Result<Value<O>, String>
     + Copy
     + Send
@@ -3595,7 +3570,7 @@ pub fn passthrough_nullable_4_arg<
     ValueRef<'a, NullableType<I2>>,
     ValueRef<'a, NullableType<I3>>,
     ValueRef<'a, NullableType<I4>>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<NullableType<O>>, String>
 + Copy
 + Send
@@ -3926,7 +3901,7 @@ pub fn passthrough_nullable_5_arg<
         ValueRef<'a, I3>,
         ValueRef<'a, I4>,
         ValueRef<'a, I5>,
-        FunctionContext,
+        EvalContext,
     ) -> Result<Value<O>, String>
     + Copy
     + Send
@@ -3937,7 +3912,7 @@ pub fn passthrough_nullable_5_arg<
     ValueRef<'a, NullableType<I3>>,
     ValueRef<'a, NullableType<I4>>,
     ValueRef<'a, NullableType<I5>>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<NullableType<O>>, String>
 + Copy
 + Send
@@ -4659,13 +4634,13 @@ pub fn passthrough_nullable_5_arg<
 }
 
 pub fn combine_nullable_1_arg<I1: ArgType, O: ArgType>(
-    func: impl for<'a> Fn(ValueRef<'a, I1>, FunctionContext) -> Result<Value<NullableType<O>>, String>
+    func: impl for<'a> Fn(ValueRef<'a, I1>, EvalContext) -> Result<Value<NullableType<O>>, String>
     + Copy
     + Send
     + Sync,
 ) -> impl for<'a> Fn(
     ValueRef<'a, NullableType<I1>>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<NullableType<O>>, String>
 + Copy
 + Send
@@ -4693,7 +4668,7 @@ pub fn combine_nullable_2_arg<I1: ArgType, I2: ArgType, O: ArgType>(
     func: impl for<'a> Fn(
         ValueRef<'a, I1>,
         ValueRef<'a, I2>,
-        FunctionContext,
+        EvalContext,
     ) -> Result<Value<NullableType<O>>, String>
     + Copy
     + Send
@@ -4701,7 +4676,7 @@ pub fn combine_nullable_2_arg<I1: ArgType, I2: ArgType, O: ArgType>(
 ) -> impl for<'a> Fn(
     ValueRef<'a, NullableType<I1>>,
     ValueRef<'a, NullableType<I2>>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<NullableType<O>>, String>
 + Copy
 + Send
@@ -4760,7 +4735,7 @@ pub fn combine_nullable_3_arg<I1: ArgType, I2: ArgType, I3: ArgType, O: ArgType>
         ValueRef<'a, I1>,
         ValueRef<'a, I2>,
         ValueRef<'a, I3>,
-        FunctionContext,
+        EvalContext,
     ) -> Result<Value<NullableType<O>>, String>
     + Copy
     + Send
@@ -4769,7 +4744,7 @@ pub fn combine_nullable_3_arg<I1: ArgType, I2: ArgType, I3: ArgType, O: ArgType>
     ValueRef<'a, NullableType<I1>>,
     ValueRef<'a, NullableType<I2>>,
     ValueRef<'a, NullableType<I3>>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<NullableType<O>>, String>
 + Copy
 + Send
@@ -4924,7 +4899,7 @@ pub fn combine_nullable_4_arg<I1: ArgType, I2: ArgType, I3: ArgType, I4: ArgType
         ValueRef<'a, I2>,
         ValueRef<'a, I3>,
         ValueRef<'a, I4>,
-        FunctionContext,
+        EvalContext,
     ) -> Result<Value<NullableType<O>>, String>
     + Copy
     + Send
@@ -4934,7 +4909,7 @@ pub fn combine_nullable_4_arg<I1: ArgType, I2: ArgType, I3: ArgType, I4: ArgType
     ValueRef<'a, NullableType<I2>>,
     ValueRef<'a, NullableType<I3>>,
     ValueRef<'a, NullableType<I4>>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<NullableType<O>>, String>
 + Copy
 + Send
@@ -5347,7 +5322,7 @@ pub fn combine_nullable_5_arg<
         ValueRef<'a, I3>,
         ValueRef<'a, I4>,
         ValueRef<'a, I5>,
-        FunctionContext,
+        EvalContext,
     ) -> Result<Value<NullableType<O>>, String>
     + Copy
     + Send
@@ -5358,7 +5333,7 @@ pub fn combine_nullable_5_arg<
     ValueRef<'a, NullableType<I3>>,
     ValueRef<'a, NullableType<I4>>,
     ValueRef<'a, NullableType<I5>>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<NullableType<O>>, String>
 + Copy
 + Send
@@ -6330,14 +6305,14 @@ fn erase_calc_domain_generic_5_arg<
 }
 
 fn erase_function_generic_0_arg<O: ArgType>(
-    func: impl for<'a> Fn(FunctionContext) -> Result<Value<O>, String>,
-) -> impl Fn(&[ValueRef<AnyType>], FunctionContext) -> Result<Value<AnyType>, String> {
+    func: impl for<'a> Fn(EvalContext) -> Result<Value<O>, String>,
+) -> impl Fn(&[ValueRef<AnyType>], EvalContext) -> Result<Value<AnyType>, String> {
     move |args, ctx| func(ctx).map(Value::upcast)
 }
 
 fn erase_function_generic_1_arg<I1: ArgType, O: ArgType>(
-    func: impl for<'a> Fn(ValueRef<'a, I1>, FunctionContext) -> Result<Value<O>, String>,
-) -> impl Fn(&[ValueRef<AnyType>], FunctionContext) -> Result<Value<AnyType>, String> {
+    func: impl for<'a> Fn(ValueRef<'a, I1>, EvalContext) -> Result<Value<O>, String>,
+) -> impl Fn(&[ValueRef<AnyType>], EvalContext) -> Result<Value<AnyType>, String> {
     move |args, ctx| {
         let arg1 = args[0].try_downcast().unwrap();
         func(arg1, ctx).map(Value::upcast)
@@ -6345,12 +6320,8 @@ fn erase_function_generic_1_arg<I1: ArgType, O: ArgType>(
 }
 
 fn erase_function_generic_2_arg<I1: ArgType, I2: ArgType, O: ArgType>(
-    func: impl for<'a> Fn(
-        ValueRef<'a, I1>,
-        ValueRef<'a, I2>,
-        FunctionContext,
-    ) -> Result<Value<O>, String>,
-) -> impl Fn(&[ValueRef<AnyType>], FunctionContext) -> Result<Value<AnyType>, String> {
+    func: impl for<'a> Fn(ValueRef<'a, I1>, ValueRef<'a, I2>, EvalContext) -> Result<Value<O>, String>,
+) -> impl Fn(&[ValueRef<AnyType>], EvalContext) -> Result<Value<AnyType>, String> {
     move |args, ctx| {
         let arg1 = args[0].try_downcast().unwrap();
         let arg2 = args[1].try_downcast().unwrap();
@@ -6363,9 +6334,9 @@ fn erase_function_generic_3_arg<I1: ArgType, I2: ArgType, I3: ArgType, O: ArgTyp
         ValueRef<'a, I1>,
         ValueRef<'a, I2>,
         ValueRef<'a, I3>,
-        FunctionContext,
+        EvalContext,
     ) -> Result<Value<O>, String>,
-) -> impl Fn(&[ValueRef<AnyType>], FunctionContext) -> Result<Value<AnyType>, String> {
+) -> impl Fn(&[ValueRef<AnyType>], EvalContext) -> Result<Value<AnyType>, String> {
     move |args, ctx| {
         let arg1 = args[0].try_downcast().unwrap();
         let arg2 = args[1].try_downcast().unwrap();
@@ -6380,9 +6351,9 @@ fn erase_function_generic_4_arg<I1: ArgType, I2: ArgType, I3: ArgType, I4: ArgTy
         ValueRef<'a, I2>,
         ValueRef<'a, I3>,
         ValueRef<'a, I4>,
-        FunctionContext,
+        EvalContext,
     ) -> Result<Value<O>, String>,
-) -> impl Fn(&[ValueRef<AnyType>], FunctionContext) -> Result<Value<AnyType>, String> {
+) -> impl Fn(&[ValueRef<AnyType>], EvalContext) -> Result<Value<AnyType>, String> {
     move |args, ctx| {
         let arg1 = args[0].try_downcast().unwrap();
         let arg2 = args[1].try_downcast().unwrap();
@@ -6406,9 +6377,9 @@ fn erase_function_generic_5_arg<
         ValueRef<'a, I3>,
         ValueRef<'a, I4>,
         ValueRef<'a, I5>,
-        FunctionContext,
+        EvalContext,
     ) -> Result<Value<O>, String>,
-) -> impl Fn(&[ValueRef<AnyType>], FunctionContext) -> Result<Value<AnyType>, String> {
+) -> impl Fn(&[ValueRef<AnyType>], EvalContext) -> Result<Value<AnyType>, String> {
     move |args, ctx| {
         let arg1 = args[0].try_downcast().unwrap();
         let arg2 = args[1].try_downcast().unwrap();

--- a/src/query/expression/src/utils/mod.rs
+++ b/src/query/expression/src/utils/mod.rs
@@ -20,7 +20,6 @@ pub mod display;
 
 use std::collections::HashMap;
 
-use chrono_tz::Tz;
 use common_arrow::arrow::bitmap::Bitmap;
 
 pub use self::column_from::*;
@@ -32,6 +31,7 @@ use crate::Column;
 use crate::ConstantFolder;
 use crate::Domain;
 use crate::Evaluator;
+use crate::FunctionContext;
 use crate::FunctionRegistry;
 use crate::RawExpr;
 use crate::Result;
@@ -43,7 +43,7 @@ pub fn eval_function(
     span: Span,
     fn_name: &str,
     args: impl IntoIterator<Item = (Value<AnyType>, DataType)>,
-    tz: Tz,
+    fn_ctx: FunctionContext,
     num_rows: usize,
     fn_registry: &FunctionRegistry,
 ) -> Result<(Value<AnyType>, DataType)> {
@@ -73,7 +73,7 @@ pub fn eval_function(
     };
     let expr = crate::type_check::check(&raw_expr, fn_registry)?;
     let chunk = Chunk::new(cols, num_rows);
-    let evaluator = Evaluator::new(&chunk, tz, fn_registry);
+    let evaluator = Evaluator::new(&chunk, fn_ctx, fn_registry);
     Ok((evaluator.run(&expr)?, expr.data_type().clone()))
 }
 
@@ -82,7 +82,7 @@ pub fn calculate_function_domain(
     span: Span,
     fn_name: &str,
     args: impl IntoIterator<Item = (Domain, DataType)>,
-    tz: Tz,
+    fn_ctx: FunctionContext,
     fn_registry: &FunctionRegistry,
 ) -> Result<(Option<Domain>, DataType)> {
     let (args, args_domain): (Vec<_>, HashMap<_, _>) = args
@@ -106,7 +106,7 @@ pub fn calculate_function_domain(
         args,
     };
     let expr = crate::type_check::check(&raw_expr, fn_registry)?;
-    let constant_folder = ConstantFolder::new(args_domain, tz, fn_registry);
+    let constant_folder = ConstantFolder::new(args_domain, fn_ctx, fn_registry);
     let (_, output_domain) = constant_folder.fold(&expr);
     Ok((output_domain, expr.data_type().clone()))
 }

--- a/src/query/functions-v2/benches/bench.rs
+++ b/src/query/functions-v2/benches/bench.rs
@@ -21,6 +21,7 @@ mod parser;
 use common_expression::type_check;
 use common_expression::Chunk;
 use common_expression::Evaluator;
+use common_expression::FunctionContext;
 use common_functions_v2::scalars::BUILTIN_FUNCTIONS;
 use criterion::Criterion;
 
@@ -40,9 +41,10 @@ fn bench(c: &mut Criterion) {
             b.iter(|| type_check::check(&raw_expr, &BUILTIN_FUNCTIONS))
         });
 
+        let fn_ctx = FunctionContext { tz: chrono_tz::UTC };
         let expr = type_check::check(&raw_expr, &BUILTIN_FUNCTIONS).unwrap();
         let chunk = Chunk::new(vec![], 1);
-        let evaluator = Evaluator::new(&chunk, chrono_tz::UTC, &BUILTIN_FUNCTIONS);
+        let evaluator = Evaluator::new(&chunk, fn_ctx, &BUILTIN_FUNCTIONS);
 
         group.bench_function(format!("eval/{n}"), |b| b.iter(|| evaluator.run(&expr)));
     }

--- a/src/query/functions-v2/src/scalars/arithmetic_modulo.rs
+++ b/src/query/functions-v2/src/scalars/arithmetic_modulo.rs
@@ -16,7 +16,7 @@ use std::ops::Rem;
 
 use common_expression::types::number::*;
 use common_expression::types::ArgType;
-use common_expression::FunctionContext;
+use common_expression::EvalContext;
 use common_expression::Value;
 use common_expression::ValueRef;
 use num_traits::AsPrimitive;
@@ -28,7 +28,7 @@ use strength_reduce::StrengthReducedU8;
 pub(crate) fn vectorize_modulo<L, R, M, O>() -> impl Fn(
     ValueRef<NumberType<L>>,
     ValueRef<NumberType<R>>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<NumberType<O>>, String>
 + Copy
 where

--- a/src/query/functions-v2/src/scalars/comparison.rs
+++ b/src/query/functions-v2/src/scalars/comparison.rs
@@ -28,7 +28,7 @@ use common_expression::types::VariantType;
 use common_expression::types::ALL_NUMERICS_TYPES;
 use common_expression::values::Value;
 use common_expression::with_number_mapped_type;
-use common_expression::FunctionContext;
+use common_expression::EvalContext;
 use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
@@ -379,11 +379,11 @@ fn register_like(registry: &mut FunctionRegistry) {
 }
 
 fn vectorize_like(
-    func: impl Fn(&[u8], &[u8], FunctionContext, PatternType) -> Result<bool, String> + Copy,
+    func: impl Fn(&[u8], &[u8], EvalContext, PatternType) -> Result<bool, String> + Copy,
 ) -> impl Fn(
     ValueRef<StringType>,
     ValueRef<StringType>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<BooleanType>, String>
 + Copy {
     move |arg1, arg2, ctx| match (arg1, arg2) {
@@ -426,7 +426,7 @@ fn vectorize_regexp(
     func: impl Fn(
         &[u8],
         &[u8],
-        FunctionContext,
+        EvalContext,
         &mut HashMap<Vec<u8>, Regex>,
         &mut HashMap<Vec<u8>, String>,
     ) -> Result<bool, String>
@@ -434,7 +434,7 @@ fn vectorize_regexp(
 ) -> impl Fn(
     ValueRef<StringType>,
     ValueRef<StringType>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<BooleanType>, String>
 + Copy {
     move |arg1, arg2, ctx| {

--- a/src/query/functions-v2/src/scalars/geo.rs
+++ b/src/query/functions-v2/src/scalars/geo.rs
@@ -28,8 +28,8 @@ use common_expression::types::NumberDataType;
 use common_expression::types::NumberType;
 use common_expression::types::ValueType;
 use common_expression::Column;
+use common_expression::EvalContext;
 use common_expression::Function;
-use common_expression::FunctionContext;
 use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
@@ -129,7 +129,7 @@ pub fn register(registry: &mut FunctionRegistry) {
 
 fn point_in_ellipses_fn(
     args: &[ValueRef<AnyType>],
-    _: FunctionContext,
+    _: EvalContext,
 ) -> Result<Value<AnyType>, String> {
     let len = args.iter().find_map(|arg| match arg {
         ValueRef::Column(col) => Some(col.len()),

--- a/src/query/functions-v2/src/scalars/string.rs
+++ b/src/query/functions-v2/src/scalars/string.rs
@@ -27,7 +27,7 @@ use common_expression::vectorize_with_builder_1_arg;
 use common_expression::vectorize_with_builder_2_arg;
 use common_expression::vectorize_with_builder_3_arg;
 use common_expression::vectorize_with_builder_4_arg;
-use common_expression::FunctionContext;
+use common_expression::EvalContext;
 use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
@@ -858,8 +858,8 @@ fn substr_utf8(builder: &mut StringColumnBuilder, str: &str, pos: i64, len: u64)
 /// String to String scalar function with estimiated ouput column capacity.
 fn vectorize_string_to_string(
     estimate_bytes: impl Fn(&StringColumn) -> usize + Copy,
-    func: impl Fn(&[u8], &mut StringColumnBuilder, FunctionContext) -> Result<(), String> + Copy,
-) -> impl Fn(ValueRef<StringType>, FunctionContext) -> Result<Value<StringType>, String> + Copy {
+    func: impl Fn(&[u8], &mut StringColumnBuilder, EvalContext) -> Result<(), String> + Copy,
+) -> impl Fn(ValueRef<StringType>, EvalContext) -> Result<Value<StringType>, String> + Copy {
     move |arg1, ctx| match arg1 {
         ValueRef::Scalar(val) => {
             let mut builder = StringColumnBuilder::with_capacity(1, 0);
@@ -881,11 +881,11 @@ fn vectorize_string_to_string(
 /// (String, String) to String scalar function with estimiated ouput column capacity.
 fn vectorize_string_to_string_2_arg(
     estimate_bytes: impl Fn(&StringColumn, &StringColumn) -> usize + Copy,
-    func: impl Fn(&[u8], &[u8], FunctionContext, &mut StringColumnBuilder) -> Result<(), String> + Copy,
+    func: impl Fn(&[u8], &[u8], EvalContext, &mut StringColumnBuilder) -> Result<(), String> + Copy,
 ) -> impl Fn(
     ValueRef<StringType>,
     ValueRef<StringType>,
-    FunctionContext,
+    EvalContext,
 ) -> Result<Value<StringType>, String>
 + Copy {
     move |arg1, arg2, ctx| match (arg1, arg2) {

--- a/src/query/functions-v2/src/scalars/string_multi_args.rs
+++ b/src/query/functions-v2/src/scalars/string_multi_args.rs
@@ -34,8 +34,8 @@ use common_expression::types::ValueType;
 use common_expression::wrap_nullable;
 use common_expression::Column;
 use common_expression::Domain;
+use common_expression::EvalContext;
 use common_expression::Function;
-use common_expression::FunctionContext;
 use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
@@ -568,7 +568,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     });
 }
 
-fn concat_fn(args: &[ValueRef<AnyType>], _: FunctionContext) -> Result<Value<AnyType>, String> {
+fn concat_fn(args: &[ValueRef<AnyType>], _: EvalContext) -> Result<Value<AnyType>, String> {
     let len = args.iter().find_map(|arg| match arg {
         ValueRef::Column(col) => Some(col.len()),
         _ => None,
@@ -593,7 +593,7 @@ fn concat_fn(args: &[ValueRef<AnyType>], _: FunctionContext) -> Result<Value<Any
     }
 }
 
-fn char_fn(args: &[ValueRef<AnyType>], _: FunctionContext) -> Result<Value<AnyType>, String> {
+fn char_fn(args: &[ValueRef<AnyType>], _: EvalContext) -> Result<Value<AnyType>, String> {
     let args = args
         .iter()
         .map(|arg| arg.try_downcast::<UInt8Type>().unwrap())
@@ -636,10 +636,7 @@ fn char_fn(args: &[ValueRef<AnyType>], _: FunctionContext) -> Result<Value<AnyTy
     Ok(Value::Column(Column::String(result)))
 }
 
-fn regexp_instr_fn(
-    args: &[ValueRef<AnyType>],
-    _: FunctionContext,
-) -> Result<Value<AnyType>, String> {
+fn regexp_instr_fn(args: &[ValueRef<AnyType>], _: EvalContext) -> Result<Value<AnyType>, String> {
     let len = args.iter().find_map(|arg| match arg {
         ValueRef::Column(col) => Some(col.len()),
         _ => None,
@@ -715,10 +712,7 @@ fn regexp_instr_fn(
     }
 }
 
-fn regexp_like_fn(
-    args: &[ValueRef<AnyType>],
-    _: FunctionContext,
-) -> Result<Value<AnyType>, String> {
+fn regexp_like_fn(args: &[ValueRef<AnyType>], _: EvalContext) -> Result<Value<AnyType>, String> {
     let len = args.iter().find_map(|arg| match arg {
         ValueRef::Column(col) => Some(col.len()),
         _ => None,
@@ -763,10 +757,7 @@ fn regexp_like_fn(
     }
 }
 
-fn regexp_replace_fn(
-    args: &[ValueRef<AnyType>],
-    _: FunctionContext,
-) -> Result<Value<AnyType>, String> {
+fn regexp_replace_fn(args: &[ValueRef<AnyType>], _: EvalContext) -> Result<Value<AnyType>, String> {
     let len = args.iter().find_map(|arg| match arg {
         ValueRef::Column(col) => Some(col.len()),
         _ => None,
@@ -848,10 +839,7 @@ fn regexp_replace_fn(
     }
 }
 
-fn regexp_substr_fn(
-    args: &[ValueRef<AnyType>],
-    _: FunctionContext,
-) -> Result<Value<AnyType>, String> {
+fn regexp_substr_fn(args: &[ValueRef<AnyType>], _: EvalContext) -> Result<Value<AnyType>, String> {
     let len = args.iter().find_map(|arg| match arg {
         ValueRef::Column(col) => Some(col.len()),
         _ => None,

--- a/src/query/functions-v2/tests/it/aggregates/mod.rs
+++ b/src/query/functions-v2/tests/it/aggregates/mod.rs
@@ -27,6 +27,7 @@ use common_expression::ChunkEntry;
 use common_expression::Column;
 use common_expression::ColumnBuilder;
 use common_expression::Evaluator;
+use common_expression::FunctionContext;
 use common_expression::RawExpr;
 use common_expression::Scalar;
 use common_expression::Value;
@@ -160,7 +161,8 @@ pub fn run_scalar_expr(
     chunk: &Chunk,
 ) -> common_expression::Result<(Value<AnyType>, DataType)> {
     let expr = type_check::check(raw_expr, &BUILTIN_FUNCTIONS)?;
-    let evaluator = Evaluator::new(chunk, chrono_tz::UTC, &BUILTIN_FUNCTIONS);
+    let fn_ctx = FunctionContext { tz: chrono_tz::UTC };
+    let evaluator = Evaluator::new(chunk, fn_ctx, &BUILTIN_FUNCTIONS);
     let result = evaluator.run(&expr)?;
     Ok((result, expr.data_type().clone()))
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

rename `FunctionContext` to `EvalContext`.
