### PR TITLE
fix(storage): disable string type topn pruning

### DIFF
--- a/src/query/storages/fuse/fuse/src/pruning/topn_pruner.rs
+++ b/src/query/storages/fuse/fuse/src/pruning/topn_pruner.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_catalog::plan::Expression;
 use common_datavalues::DataSchemaRef;
+use common_datavalues::DataTypeImpl;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_storages_table_meta::meta::BlockMeta;
@@ -71,6 +72,14 @@ impl TopNPrunner {
         } else {
             return Ok(metas);
         };
+
+        // String Type min/max is truncated
+        if matches!(
+            self.schema.field(sort_idx as usize).data_type(),
+            DataTypeImpl::String(_)
+        ) {
+            return Ok(metas);
+        }
 
         let mut id_stats = metas
             .iter()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

disable string type topn pruning, because the min/max index may be truncated.

Closes #issue
