### PR TITLE
feat(Partition): add data_size to PartInfo trait to get the scan size

### DIFF
--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -31,6 +31,9 @@ pub trait PartInfo: Send + Sync {
 
     /// Used for partition distributed.
     fn hash(&self) -> u64;
+
+    /// Data size of this Partition.
+    fn data_size(&self) -> u64;
 }
 
 impl Debug for Box<dyn PartInfo> {
@@ -82,6 +85,10 @@ impl Partitions {
 
     pub fn len(&self) -> usize {
         self.partitions.len()
+    }
+
+    pub fn data_size(&self) -> u64 {
+        self.partitions.iter().map(|v| v.data_size()).sum()
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/query/catalog/tests/it/partitions.rs
+++ b/src/query/catalog/tests/it/partitions.rs
@@ -48,6 +48,10 @@ impl PartInfo for TestPartInfo {
         self.loc.hash(&mut s);
         s.finish()
     }
+
+    fn data_size(&self) -> u64 {
+        0
+    }
 }
 
 impl TestPartInfo {

--- a/src/query/service/src/table_functions/numbers_part.rs
+++ b/src/query/service/src/table_functions/numbers_part.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 use std::any::Any;
+use std::intrinsics::size_of;
 use std::sync::Arc;
 
 use common_catalog::plan::PartInfo;
@@ -42,6 +43,11 @@ impl PartInfo for NumbersPartInfo {
 
     fn hash(&self) -> u64 {
         0
+    }
+
+    fn data_size(&self) -> u64 {
+        let size = size_of::<u64>() as u64;
+        size * (self.part_end - self.part_start)
     }
 }
 

--- a/src/query/storages/fuse/fuse/src/fuse_lazy_part.rs
+++ b/src/query/storages/fuse/fuse/src/fuse_lazy_part.rs
@@ -45,6 +45,10 @@ impl PartInfo for FuseLazyPartInfo {
         self.segment_location.0.hash(&mut s);
         s.finish()
     }
+
+    fn data_size(&self) -> u64 {
+        0
+    }
 }
 
 impl FuseLazyPartInfo {

--- a/src/query/storages/fuse/fuse/src/fuse_part.rs
+++ b/src/query/storages/fuse/fuse/src/fuse_part.rs
@@ -75,6 +75,10 @@ impl PartInfo for FusePartInfo {
         self.location.hash(&mut s);
         s.finish()
     }
+
+    fn data_size(&self) -> u64 {
+        self.columns_meta.values().map(|v| v.length).sum()
+    }
 }
 
 impl FusePartInfo {

--- a/src/query/storages/fuse/fuse/src/operations/mutation/compact/compact_part.rs
+++ b/src/query/storages/fuse/fuse/src/operations/mutation/compact/compact_part.rs
@@ -61,6 +61,13 @@ impl PartInfo for CompactPartInfo {
     fn hash(&self) -> u64 {
         0
     }
+
+    fn data_size(&self) -> u64 {
+        self.segments
+            .iter()
+            .map(|v| v.blocks.iter().map(|x| x.block_size).sum::<u64>())
+            .sum()
+    }
 }
 
 impl CompactPartInfo {

--- a/src/query/storages/hive/hive/src/hive_partition.rs
+++ b/src/query/storages/hive/hive/src/hive_partition.rs
@@ -55,6 +55,10 @@ impl PartInfo for HivePartInfo {
         self.filename.hash(&mut s);
         s.finish()
     }
+
+    fn data_size(&self) -> u64 {
+        self.filesize
+    }
 }
 
 impl HivePartInfo {

--- a/src/query/storages/memory/src/memory_part.rs
+++ b/src/query/storages/memory/src/memory_part.rs
@@ -43,6 +43,10 @@ impl PartInfo for MemoryPartInfo {
     fn hash(&self) -> u64 {
         0
     }
+
+    fn data_size(&self) -> u64 {
+        0
+    }
 }
 
 impl MemoryPartInfo {

--- a/src/query/storages/random/src/random_parts.rs
+++ b/src/query/storages/random/src/random_parts.rs
@@ -41,6 +41,10 @@ impl PartInfo for RandomPartInfo {
     fn hash(&self) -> u64 {
         0
     }
+
+    fn data_size(&self) -> u64 {
+        0
+    }
 }
 
 impl RandomPartInfo {

--- a/src/query/storages/stage/src/stage_parts.rs
+++ b/src/query/storages/stage/src/stage_parts.rs
@@ -57,4 +57,8 @@ impl PartInfo for StageFilePartition {
         self.path.hash(&mut s);
         s.finish()
     }
+
+    fn data_size(&self) -> u64 {
+        self.size
+    }
 }

--- a/src/query/storages/system/src/table.rs
+++ b/src/query/storages/system/src/table.rs
@@ -55,6 +55,10 @@ impl PartInfo for SystemTablePart {
     fn hash(&self) -> u64 {
         0
     }
+
+    fn data_size(&self) -> u64 {
+        0
+    }
 }
 
 pub trait SyncSystemTable: Send + Sync {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Add `data_size` for PartInfo to get the actual data size will scan

Closes #issue
