### PR TITLE
feat(query): push down filter to remain reader.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6151,8 +6151,7 @@ dependencies = [
 [[package]]
 name = "parquet2"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bbada33c3674484db647d889a581ab1105cafb871ba77be785af2cc44a8747"
+source = "git+https://github.com/jorgecarleitao/parquet2?rev=fb08b72#fb08b725aa15d700d2a67c19ef65889b032ae371"
 dependencies = [
  "async-stream",
  "brotli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,3 +142,4 @@ rpath = false
 # If there are dependencies that need patching, they can be listed below.
 # For example:
 # arrow-format = { git = "https://github.com/datafuse-extras/arrow-format", rev = "78dacc1" }
+parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", rev = "fb08b72" }

--- a/src/query/storages/fuse/fuse-result/src/result_table_source.rs
+++ b/src/query/storages/fuse/fuse-result/src/result_table_source.rs
@@ -116,7 +116,7 @@ impl Processor for ResultTableSource {
     fn process(&mut self) -> Result<()> {
         match std::mem::replace(&mut self.state, State::Finish) {
             State::Deserialize(part, chunks) => {
-                let data_block = self.block_reader.deserialize(part, chunks)?;
+                let data_block = self.block_reader.deserialize(part, chunks, None)?;
                 let new_part = self.ctx.try_get_part();
 
                 let progress_values = ProgressValues {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

After get the bitmap after filtering the prewhere columns, we can push down this bitmap to remain reader.

It help us:

- Skip decompression of some pages. (Not make sense yet because one parquet file only have one page for each column now in databend.)
- Skip decoding of some rows.
