### PR TITLE
feat(performance): try reduce aggregate_approx_count_distinct memory alloc when accumulate

### DIFF
--- a/src/query/functions/src/aggregates/aggregate_approx_count_distinct.rs
+++ b/src/query/functions/src/aggregates/aggregate_approx_count_distinct.rs
@@ -99,16 +99,19 @@ impl AggregateFunction for AggregateApproxCountDistinctFunction {
             return Ok(());
         }
 
+        // This is a hot path, to_values will alloc more memory(Vec::with_capacity).
         if let Some(bitmap) = bitmap {
-            for (i, value) in column.to_values().iter().enumerate() {
+            for i in 0..column.len() {
+                let value = &column.get(i);
                 if bitmap.get_bit(i) {
                     state.hll.push(value);
                 }
             }
         } else {
-            column.to_values().iter().for_each(|value| {
+            for i in 0..column.len() {
+                let value = &column.get(i);
                 state.hll.push(value);
-            });
+            }
         }
 
         Ok(())

--- a/src/query/storages/index/src/bloom.rs
+++ b/src/query/storages/index/src/bloom.rs
@@ -127,7 +127,10 @@ impl BlockFilter {
                 // ingest the same column data from all blocks
                 for block in blocks.iter() {
                     let col = block.column(i);
-                    filter_builder.add_keys(&col.to_values());
+                    for idx in 0..col.len() {
+                        let value = col.get(idx);
+                        filter_builder.add_key(&value);
+                    }
                 }
 
                 let filter = filter_builder.build()?;

--- a/src/query/storages/index/src/filters/filter.rs
+++ b/src/query/storages/index/src/filters/filter.rs
@@ -42,6 +42,9 @@ pub trait FilterBuilder {
     type Filter: Filter;
     type Error: std::error::Error;
 
+    /// Add a key into the filter for building.
+    fn add_key<K: Hash>(&mut self, key: &K);
+
     /// Add several keys into the filter for building.
     ///
     /// This methods can be called more than once.

--- a/src/query/storages/index/src/filters/xor8.rs
+++ b/src/query/storages/index/src/filters/xor8.rs
@@ -60,6 +60,10 @@ impl FilterBuilder for Xor8Builder {
     type Filter = Xor8Filter;
     type Error = Xor8BuildingError;
 
+    fn add_key<K: Hash>(&mut self, key: &K) {
+        self.filter.insert(key)
+    }
+
     fn add_keys<K: Hash>(&mut self, keys: &[K]) {
         self.filter.populate(keys)
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Expand `to_values` to loop when `aggregate_approx_count_distinct` accumulating
* Expand `to_values` to loop when xor filter building

Test:
`clid` and `hasgclid` is SMALLINT.
```
create table hits_1 as select clid, hasgclid from hits;
```
Main branch(`to_values`):

NDV:
<img width="586" alt="image" src="https://user-images.githubusercontent.com/172204/204994821-c77ac243-b8cd-4ab0-9bd2-fc34f572667f.png">

Xor:
<img width="502" alt="image" src="https://user-images.githubusercontent.com/172204/204999117-64c8b362-f95d-4a9a-84cb-55dfa83011ef.png">

This PR(NDV and Xor memory is gone):
<img width="335" alt="image" src="https://user-images.githubusercontent.com/172204/204999826-68c926ff-7953-4f8d-9e83-a0127cf7401d.png">






Closes #issue
