### PR TITLE
fix: try to fix table name case sensibility

### DIFF
--- a/src/query/sql/src/planner/semantic/mod.rs
+++ b/src/query/sql/src/planner/semantic/mod.rs
@@ -18,6 +18,7 @@ mod sync_type_checker;
 mod type_check;
 
 pub use grouping_check::GroupingChecker;
+pub use name_resolution::compare_table_name;
 pub use name_resolution::normalize_identifier;
 pub use name_resolution::IdentifierNormalizer;
 pub use name_resolution::NameResolutionContext;

--- a/src/query/sql/src/planner/semantic/name_resolution.rs
+++ b/src/query/sql/src/planner/semantic/name_resolution.rs
@@ -63,6 +63,18 @@ pub fn normalize_identifier<'a>(
     }
 }
 
+pub fn compare_table_name(
+    table_name1: &str,
+    table_name2: &str,
+    context: &NameResolutionContext,
+) -> bool {
+    if context.unquoted_ident_case_sensitive || !context.quoted_ident_case_sensitive {
+        table_name1 == table_name2
+    } else {
+        table_name1.to_lowercase() == table_name2.to_lowercase()
+    }
+}
+
 pub struct IdentifierNormalizer<'a> {
     pub ctx: &'a NameResolutionContext,
 }

--- a/tests/logictest/suites/query/case_sensitivity/query.test
+++ b/tests/logictest/suites/query/case_sensitivity/query.test
@@ -51,3 +51,10 @@ select "b" from (select "A" as "B" from "T");
 onlyif mysql
 statement ok
 drop table "T";
+
+onlyif mysql
+statement query I
+select A.* from  (WITH source2 AS (select 1 as e) SELECT * FROM source2) A;
+
+----
+1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`select A.* from (WITH source2 AS (select 1 as e) SELECT * FROM source2) A;`

`A` will transfer to `a` and add to `ColumnBinding`, so the SQL won't find table `A` when `normalize_select_list`.

Introduce `compare_table_name` method to compare table name correctly.

Btw, the ticket also spilt `normalize_select_list` method

Closes #9049 
