### PR TITLE
fix(clickhouse handler): add space between param and body when concat them

### DIFF
--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -236,7 +236,9 @@ pub async fn clickhouse_handler_post(
 
     let default_format = get_default_format(&params, headers).map_err(BadRequest)?;
     let mut sql = params.query();
-    sql.push_str(" ");
+    if sql.is_empty() {
+        sql.push(' ');
+    }
     sql.push_str(body.into_string().await?.as_str());
     let n = 100;
     // other parts of the request already logged in middleware

--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -236,7 +236,7 @@ pub async fn clickhouse_handler_post(
 
     let default_format = get_default_format(&params, headers).map_err(BadRequest)?;
     let mut sql = params.query();
-    if sql.is_empty() {
+    if !sql.is_empty() {
         sql.push(' ');
     }
     sql.push_str(body.into_string().await?.as_str());

--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -236,6 +236,7 @@ pub async fn clickhouse_handler_post(
 
     let default_format = get_default_format(&params, headers).map_err(BadRequest)?;
     let mut sql = params.query();
+    sql.push_str(" ");
     sql.push_str(body.into_string().await?.as_str());
     let n = 100;
     // other parts of the request already logged in middleware


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix https://github.com/datafuselabs/databend/issues/8955#issuecomment-1333373881
