### PR TITLE
fix: delete unused clickhouse test

### DIFF
--- a/src/query/service/tests/it/servers/http/clickhouse_handler.rs
+++ b/src/query/service/tests/it/servers/http/clickhouse_handler.rs
@@ -62,12 +62,6 @@ async fn test_select() -> PoemResult<()> {
     }
 
     {
-        let (status, body) = server.post("sel", "ect 1").await;
-        assert_eq!(status, StatusCode::OK);
-        assert_error!(body, "1\n");
-    }
-
-    {
         let (status, body) = server.post("", "bad sql").await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_error!(body, "Code: 1005");


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This test `server.post("sel", "etc 1")` is rare to use, delete it now.

Closes #issue