### PR TITLE
fix: right join flaky test failed under cluster mode

### DIFF
--- a/src/query/datablocks/src/kernels/data_block_sort.rs
+++ b/src/query/datablocks/src/kernels/data_block_sort.rs
@@ -45,6 +45,9 @@ impl DataBlock {
         sort_columns_descriptions: &[SortColumnDescription],
         limit: Option<usize>,
     ) -> Result<DataBlock> {
+        if block.is_empty() {
+            return Ok(block.clone());
+        }
         let order_columns = sort_columns_descriptions
             .iter()
             .map(|f| {

--- a/tests/logictest/suites/query/join.test
+++ b/tests/logictest/suites/query/join.test
@@ -398,9 +398,15 @@ select * from (SELECT number AS a FROM numbers(10)) x left join (SELECT number A
 8
 9
 
--- https://github.com/datafuselabs/databend/issues/8788
--- statement query I
--- select * from (SELECT number AS a FROM numbers(10)) x right join (SELECT number AS a FROM numbers(5))  y using(a) order by x.a;
+statement query I
+select * from (SELECT number AS a FROM numbers(10)) x right join (SELECT number AS a FROM numbers(5))  y using(a) order by x.a;
+
+----
+0
+1
+2
+3
+4
 
 statement query II
 select * from (SELECT number AS a FROM numbers(1000)) x right join (SELECT number AS a FROM numbers(5))  y on x.a = y.a order by x.a;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Flaky test: `select * from (SELECT number AS a FROM numbers(10)) x right join (SELECT number AS a FROM numbers(5))  y using(a) order by x.a;`

For the query, it has four fragments:
```
+---------------------------------------------------------------------------------+
| Fragment 0:                                                                     |
|   DataExchange: Shuffle                                                         |
|   Exchange Sink: fragment id: [2]                                               |
|     TableScan: [''.'numbers']                                                   |
|                                                                                 |
| Fragment 1:                                                                     |
|   DataExchange: Shuffle                                                         |
|   Exchange Sink: fragment id: [2]                                               |
|     TableScan: [''.'numbers']                                                   |
|                                                                                 |
| Fragment 2:                                                                     |
|   DataExchange: Merge                                                           |
|   Exchange Sink: fragment id: [3]                                               |
|     HashJoin: RIGHT OUTER, build keys: [$0], probe keys: [$0], join filters: [] |
|       Exchange Source: fragment id: [0]                                         |
|       Exchange Source: fragment id: [1]                                         |
|                                                                                 |
| Fragment 3:                                                                     |
|   Sort: [0 ASC], Limit: [0]                                                     |
|     Exchange Source: fragment id: [2]                                           |
+---------------------------------------------------------------------------------+
```
In a cluster(three nodes), fragment 2 will be distributed to all of them.

Consider the case: table is so smaller, the coordinator node doesn't have data, but it still executes fragment 2.

After finishing fragment 2, it'll sort the result of fragment 2, but the result is empty, so in `sort_block`,  panic...

The ticket adds a short path for `sort_block` to avoid panic.

Closes #8788 
