### PR TITLE
fix: Add more tests for hive config loading

### DIFF
--- a/src/meta/service/src/configs/inner.rs
+++ b/src/meta/service/src/configs/inner.rs
@@ -68,8 +68,16 @@ impl Config {
     ///
     /// In the future, we could have `ConfigV1` and `ConfigV2`.
     pub fn load() -> Result<Self, MetaStartupError> {
-        let cfg = OuterV0Config::load()?.into();
+        let cfg = OuterV0Config::load(true)?.into();
 
+        Ok(cfg)
+    }
+
+    /// # NOTE
+    ///
+    /// This function is served for tests only.
+    pub fn load_for_test() -> Result<Self, MetaStartupError> {
+        let cfg: Self = OuterV0Config::load(false)?.into();
         Ok(cfg)
     }
 

--- a/src/meta/service/src/configs/outer_v0.rs
+++ b/src/meta/service/src/configs/outer_v0.rs
@@ -185,8 +185,18 @@ impl Config {
     /// - Load from file as default.
     /// - Load from env, will override config from file.
     /// - Load from args as finally override
-    pub fn load() -> Result<Self, MetaStartupError> {
-        let arg_conf = Self::parse();
+    ///
+    /// # Notes
+    ///
+    /// with_args is to control whether we need to load from args or not.
+    /// We should set this to false during tests because we don't want
+    /// our test binary to parse cargo's args.
+    pub fn load(with_args: bool) -> Result<Self, MetaStartupError> {
+        let mut arg_conf = Self::default();
+
+        if with_args {
+            arg_conf = Self::parse();
+        }
 
         let mut builder: serfig::Builder<Self> = serfig::Builder::default();
 
@@ -213,7 +223,9 @@ impl Config {
         builder = builder.collect(from_self(cfg_via_env.into()));
 
         // Finally, load from args.
-        builder = builder.collect(from_self(arg_conf));
+        if with_args {
+            builder = builder.collect(from_self(arg_conf));
+        }
 
         builder
             .build()

--- a/src/meta/service/tests/it/configs.rs
+++ b/src/meta/service/tests/it/configs.rs
@@ -68,7 +68,7 @@ cluster_name = "foo_cluster"
     )?;
 
     temp_env::with_var("METASRV_CONFIG_FILE", Some(file_path.clone()), || {
-        let cfg = Config::load().expect("load must success");
+        let cfg = Config::load_for_test().expect("load must success");
         assert_eq!(cfg.log.file.level, "ERROR");
         assert_eq!(cfg.log.file.dir, "foo/logs");
         assert_eq!(cfg.admin_api_address, "127.0.0.1:9000");
@@ -101,7 +101,7 @@ cluster_name = "foo_cluster"
             ("METASRV_LOG_LEVEL", Some("DEBUG")),
         ],
         || {
-            let cfg = Config::load().expect("load must success");
+            let cfg = Config::load_for_test().expect("load must success");
             assert_eq!(cfg.log.file.level, "DEBUG");
         },
     );
@@ -116,7 +116,7 @@ cluster_name = "foo_cluster"
             ("KVSRV_API_PORT", Some("123")),
         ],
         || {
-            let cfg = Config::load().expect("load must success");
+            let cfg = Config::load_for_test().expect("load must success");
             assert_eq!(cfg.raft_config.raft_api_port, 123);
         },
     );

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -71,6 +71,14 @@ impl Config {
         Ok(cfg)
     }
 
+    /// # NOTE
+    ///
+    /// This function is served for tests only.
+    pub fn load_without_args() -> Result<Self> {
+        let cfg: Self = OuterV0Config::load_without_args()?.try_into()?;
+        Ok(cfg)
+    }
+
     pub fn tls_query_cli_enabled(&self) -> bool {
         !self.query.rpc_tls_query_server_root_ca_cert.is_empty()
             && !self.query.rpc_tls_query_service_domain_name.is_empty()

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -62,7 +62,7 @@ impl Config {
     ///
     /// In the future, we could have `ConfigV1` and `ConfigV2`.
     pub fn load() -> Result<Self> {
-        let cfg: Self = OuterV0Config::load()?.try_into()?;
+        let cfg: Self = OuterV0Config::load(true)?.try_into()?;
 
         // Only check meta config when cmd is empty.
         if cfg.cmd.is_empty() {
@@ -74,8 +74,8 @@ impl Config {
     /// # NOTE
     ///
     /// This function is served for tests only.
-    pub fn load_without_args() -> Result<Self> {
-        let cfg: Self = OuterV0Config::load_without_args()?.try_into()?;
+    pub fn load_for_test() -> Result<Self> {
+        let cfg: Self = OuterV0Config::load(false)?.try_into()?;
         Ok(cfg)
     }
 

--- a/src/query/config/src/lib.rs
+++ b/src/query/config/src/lib.rs
@@ -28,7 +28,9 @@ mod outer_v0;
 mod version;
 
 pub use inner::CatalogConfig;
+pub use inner::CatalogHiveConfig;
 pub use inner::Config;
 pub use inner::QueryConfig;
+pub use inner::ThriftProtocol;
 pub use version::DATABEND_COMMIT_VERSION;
 pub use version::QUERY_SEMVER;

--- a/src/query/service/tests/it/configs.rs
+++ b/src/query/service/tests/it/configs.rs
@@ -254,9 +254,7 @@ fn test_env_config_s3() -> Result<()> {
             ("CONFIG_FILE", None),
         ],
         || {
-            let configured = Config::load_without_args()
-                .expect("must success")
-                .into_outer();
+            let configured = Config::load_for_test().expect("must success").into_outer();
 
             assert_eq!("DEBUG", configured.log.level);
 
@@ -374,9 +372,7 @@ fn test_env_config_fs() -> Result<()> {
             ("CONFIG_FILE", None),
         ],
         || {
-            let configured = Config::load_without_args()
-                .expect("must success")
-                .into_outer();
+            let configured = Config::load_for_test().expect("must success").into_outer();
 
             assert_eq!("DEBUG", configured.log.level);
 
@@ -495,9 +491,7 @@ fn test_env_config_gcs() -> Result<()> {
             ("CONFIG_FILE", None),
         ],
         || {
-            let configured = Config::load_without_args()
-                .expect("must success")
-                .into_outer();
+            let configured = Config::load_for_test().expect("must success").into_outer();
 
             assert_eq!("DEBUG", configured.log.level);
 
@@ -623,9 +617,7 @@ fn test_env_config_oss() -> Result<()> {
             ("CONFIG_FILE", None),
         ],
         || {
-            let configured = Config::load_without_args()
-                .expect("must success")
-                .into_outer();
+            let configured = Config::load_for_test().expect("must success").into_outer();
 
             assert_eq!("DEBUG", configured.log.level);
 
@@ -834,7 +826,7 @@ protocol = "binary"
             ("STORAGE_TYPE", None),
         ],
         || {
-            let cfg = Config::load_without_args()
+            let cfg = Config::load_for_test()
                 .expect("config load success")
                 .into_outer();
 
@@ -894,7 +886,7 @@ protocol = "binary"
     temp_env::with_vars(
         vec![("CONFIG_FILE", Some(file_path.to_string_lossy().as_ref()))],
         || {
-            let cfg = Config::load_without_args().expect("config load success");
+            let cfg = Config::load_for_test().expect("config load success");
 
             assert_eq!(
                 cfg.catalogs["hive"],
@@ -934,7 +926,7 @@ protocol = "binary"
     temp_env::with_vars(
         vec![("CONFIG_FILE", Some(file_path.to_string_lossy().as_ref()))],
         || {
-            let cfg = Config::load_without_args().expect("config load success");
+            let cfg = Config::load_for_test().expect("config load success");
 
             assert_eq!(
                 cfg.catalogs["my_hive"],


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: Add more tests for hive config loading

We should not load args during our unit tests, because clap will try to parse the input for `cargo test`.