### PR TITLE
fix(cluster): try fix broken pipe or connect reset

### DIFF
--- a/scripts/ci/ci-run-stateless-tests-cluster.sh
+++ b/scripts/ci/ci-run-stateless-tests-cluster.sh
@@ -15,5 +15,4 @@ cd "$SCRIPT_PATH/../../tests" || exit
 
 echo "Starting databend-test"
 # 13_0004_q4: https://github.com/datafuselabs/databend/issues/8107
-# 13_0005_q5: https://github.com/datafuselabs/databend/issues/7986
-./databend-test --mode 'cluster' --run-dir 0_stateless --skip '13_0004_q4' --skip '13_0005_q5'
+./databend-test --mode 'cluster' --run-dir 0_stateless --skip '13_0004_q4'

--- a/src/query/service/src/api/rpc/exchange/exchange_transform.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_transform.rs
@@ -264,6 +264,7 @@ impl Processor for ExchangeTransform {
                 DataPacket::ProgressAndPrecommit { .. } => unreachable!(),
                 DataPacket::FetchProgressAndPrecommit => unreachable!(),
                 DataPacket::FragmentData(v) => self.on_recv_data(v),
+                DataPacket::ClosingClient => Ok(()),
             };
         }
 

--- a/src/query/service/src/api/rpc/exchange/exchange_transform_source.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_transform_source.rs
@@ -130,6 +130,7 @@ impl Processor for ExchangeSourceTransform {
                 DataPacket::FragmentData(v) => self.on_recv_data(v),
                 DataPacket::FetchProgressAndPrecommit => unreachable!(),
                 DataPacket::ProgressAndPrecommit { .. } => unreachable!(),
+                DataPacket::ClosingClient => Ok(()),
             };
         }
 

--- a/src/query/service/src/api/rpc/exchange/statistics_receiver.rs
+++ b/src/query/service/src/api/rpc/exchange/statistics_receiver.rs
@@ -139,6 +139,7 @@ impl StatisticsReceiver {
     fn recv_data(ctx: &Arc<QueryContext>, recv_data: Result<Option<DataPacket>>) -> Result<bool> {
         match recv_data {
             Ok(None) => Ok(true),
+            Ok(Some(DataPacket::ClosingClient)) => Ok(true),
             Err(transport_error) => Err(transport_error),
             Ok(Some(DataPacket::ErrorCode(error))) => Err(error),
             Ok(Some(DataPacket::FragmentData(_))) => unreachable!(),

--- a/src/query/service/src/api/rpc/packets/packet_data.rs
+++ b/src/query/service/src/api/rpc/packets/packet_data.rs
@@ -56,6 +56,11 @@ pub enum DataPacket {
         progress: Vec<ProgressInfo>,
         precommit: Vec<PrecommitBlock>,
     },
+    // NOTE: Unknown reason. This may be tonic's bug.
+    // when we use two-way streaming grpc for data exchange,
+    // if the client side is closed and the server side reads data immediately.
+    // we will get a broken pipe or connect reset error.
+    // we use the ClosingClient to notify the server side to close the connection for avoid errors.
     ClosingClient,
 }
 

--- a/src/query/service/src/api/rpc/packets/packet_data.rs
+++ b/src/query/service/src/api/rpc/packets/packet_data.rs
@@ -56,6 +56,13 @@ pub enum DataPacket {
         progress: Vec<ProgressInfo>,
         precommit: Vec<PrecommitBlock>,
     },
+    ClosingClient,
+}
+
+impl DataPacket {
+    pub fn is_closing_client(data: &FlightData) -> bool {
+        data.app_metadata.last() == Some(&0x05)
+    }
 }
 
 impl From<DataPacket> for FlightData {
@@ -103,6 +110,12 @@ impl From<DataPacket> for FlightData {
                     app_metadata: vec![0x04],
                 }
             }
+            DataPacket::ClosingClient => FlightData {
+                data_body: vec![],
+                data_header: vec![],
+                flight_descriptor: None,
+                app_metadata: vec![0x05],
+            },
         }
     }
 }
@@ -155,6 +168,7 @@ impl TryFrom<FlightData> for DataPacket {
                     progress: progress_info,
                 })
             }
+            0x05 => Ok(DataPacket::ClosingClient),
             _ => Err(ErrorCode::BadBytes("Unknown flight data packet type.")),
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(cluster): try fix broken pipe or connect reset

When we use two-way streaming grpc for data exchange, if the client side is closed and the server side reads data immediately. we will get a broken pipe or connect reset error.
In this pr: we use the ClosingClient to notify the server side to close the connection for avoid errors.

fixes #8221
fixes #7986
