### PR TITLE
fix: prewhere_column empty and predicate is not const will return empty

### DIFF
--- a/src/query/datablocks/src/kernels/data_block_filter.rs
+++ b/src/query/datablocks/src/kernels/data_block_filter.rs
@@ -33,7 +33,12 @@ impl DataBlock {
         let boolean_col: &BooleanColumn = Series::check_get(&predict_boolean_nonull)?;
         let rows = boolean_col.len();
         let count_zeros = boolean_col.values().unset_bits();
-        Ok(count_zeros != rows)
+        if (count_zeros == 0) && (rows == 0) {
+            // prewhere_column is empty and predicate is nullable
+            Ok(true)
+        } else {
+            Ok(count_zeros != rows)
+        }
     }
 
     pub fn filter_block(block: DataBlock, predicate: &ColumnRef) -> Result<DataBlock> {

--- a/tests/logictest/suites/base/03_dml/03_0005_select_filter
+++ b/tests/logictest/suites/base/03_dml/03_0005_select_filter
@@ -58,3 +58,32 @@ select * from t1 where id in (1,3) or null order by id;
 statement ok
 DROP TABLE t1;
 
+statement ok
+DROP DATABASE IF EXISTS databend6;
+
+statement ok
+CREATE DATABASE databend6;
+
+statement ok
+CREATE TABLE databend6.t0(c0INT INT32 NOT NULL DEFAULT(1456832334));
+
+statement ok
+INSERT INTO databend6.t0(c0int) VALUES (1388388634), (-1943680716);
+
+statement query I
+SELECT t0.c0int FROM databend6.t0 WHERE ((((((true)or(('s' NOT IN ('oE', '70', '3r', 'k', '9aRgze')))))AND(true)))or(((NULL)<=(NULL))));
+
+----
+1388388634
+-1943680716
+
+statement query I
+SELECT t0.c0int FROM databend6.t0 WHERE 's' NOT IN ('oE', '70', '3r', 'k', '9aRgze') or to_nullable(null) and to_nullable(true) or to_nullable(false);
+
+----
+1388388634
+-1943680716
+
+statement ok
+DROP DATABASE IF EXISTS databend6;
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```sql
select * from t1 where 's' not in ('x', 'b', 'c', 'd') or to_nullable(null);
-- return empty block
```

if in function args len()>3, the filter will be set with [(not(in('s', (x, b, c, d))) or NULL).

Now in this query prewhere_column is empty , the data_block will be empty; and because of NULL the predicate will be nullable(bool).

So, in cast_to_nonull_boolean will return boolean columnRef.

So in filter_exists, the count_zeros and rows is 0. 

the (!filter_exists) will return true, so generate on empty block.

## Fix

I think we have two ways to fix this:

1. if prewhere_column is empty, logical.prewhere = None.

2. In this pr, if count_zeros=rows=0, filter_exists returns true.

But I think the first way is easier and if prewhere_column maybe we shouldn't set the prewhere? 

Closes #9083
