### PR TITLE
fix: prewhere_column empty and predicate is not const will return empty

### DIFF
--- a/src/query/sql/src/planner/optimizer/heuristic/prewhere_optimization.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/prewhere_optimization.rs
@@ -115,6 +115,14 @@ impl PrewhereOptimizer {
             get.prewhere = if prewhere_pred.is_empty() {
                 None
             } else {
+                if prewhere_columns.is_empty() {
+                    // select a, b from t1 where 's' not in ('x', 'b', 'c', 'd') or to_nullable(null);
+                    // get the smallest column in (a,b). (maybe can get the smallest column in t1)
+                    let used = self.metadata.read().find_smallest_column(
+                        get.columns.iter().copied().collect::<Vec<_>>().as_slice(),
+                    );
+                    prewhere_columns.insert(used);
+                }
                 Some(Prewhere {
                     output_columns: get.columns.clone(),
                     prewhere_columns,

--- a/tests/logictest/suites/base/03_dml/03_0005_select_filter
+++ b/tests/logictest/suites/base/03_dml/03_0005_select_filter
@@ -58,3 +58,31 @@ select * from t1 where id in (1,3) or null order by id;
 statement ok
 DROP TABLE t1;
 
+statement ok
+DROP DATABASE IF EXISTS databend6;
+
+statement ok
+CREATE DATABASE databend6;
+
+statement ok
+CREATE TABLE databend6.t0(c0INT INT32 NOT NULL DEFAULT(1456832334));
+
+statement ok
+INSERT INTO databend6.t0(c0int) VALUES (1388388634), (-1943680716);
+
+statement query I
+SELECT t0.c0int FROM databend6.t0 WHERE ((((((true)or(('s' NOT IN ('oE', '70', '3r', 'k', '9aRgze')))))AND(true)))or(((NULL)<=(NULL))));
+
+----
+1388388634
+-1943680716
+
+statement query I
+SELECT t0.c0int FROM databend6.t0 WHERE 's' NOT IN ('oE', '70', '3r', 'k', '9aRgze') or to_nullable(null) and to_nullable(true) or to_nullable(false);
+
+----
+1388388634
+-1943680716
+
+statement ok
+DROP DATABASE IF EXISTS databend6;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```sql
select * from t1 where 's' not in ('x', 'b', 'c', 'd') or to_nullable(null);
-- return empty block
```

if in function args len()>3, the filter will be set with [(not(in('s', (x, b, c, d))) or NULL).

Now in this query prewhere_column is empty , the data_block will be empty; and because of NULL the predicate will be nullable(bool).

So, in cast_to_nonull_boolean will return boolean columnRef.

So in filter_exists, the count_zeros and rows is 0. 

the (!filter_exists) will return true, so generate on empty block.

## Fix

The root cause is predicate is some,  prewhere_column is empty.

So if prewhere_column is empty, logical.prewhere_column will be set as the smallest column in get.columns.

Closes #9083