### PR TITLE
fix: purge table statistic files

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/optimize.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/optimize.rs
@@ -63,14 +63,14 @@ async fn test_fuse_snapshot_optimize_statistic_purge() -> Result<()> {
         let ctx = fixture.ctx();
         execute_command(ctx, &qry).await?;
 
-        check_data_dir(&fixture, case_name, 3, 1 + i, 2, 2, 2, Some(())).await?;
+        check_data_dir(&fixture, case_name, 3, 1 + i, 2, 2, 2, Some(()), None).await?;
     }
 
     // After compact, all the count will become 1
     let qry = format!("optimize table {}.{} all", db, tbl);
     execute_command(fixture.ctx().clone(), &qry).await?;
 
-    check_data_dir(&fixture, case_name, 1, 1, 1, 1, 1, Some(())).await?;
+    check_data_dir(&fixture, case_name, 1, 1, 1, 1, 1, Some(()), Some(())).await?;
 
     Ok(())
 }
@@ -111,6 +111,7 @@ async fn do_purge_test(
         block_count,
         index_count,
         Some(()),
+        None,
     )
     .await?;
     history_should_have_item(&fixture, case_name, snapshot_count).await?;
@@ -130,6 +131,7 @@ async fn do_purge_test(
             block_count,
             index_count,
             Some(()),
+            None,
         )
         .await?;
 

--- a/src/query/service/tests/it/storages/fuse/operations/optimize.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/optimize.rs
@@ -49,6 +49,33 @@ async fn test_fuse_snapshot_optimize_statistic() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_fuse_snapshot_optimize_statistic_purge() -> Result<()> {
+    let fixture = TestFixture::new().await;
+    let db = fixture.default_db_name();
+    let tbl = fixture.default_table_name();
+    let case_name = "optimize_statistic_purge";
+    do_insertions(&fixture).await?;
+
+    // optimize statistics twice
+    for i in 0..1 {
+        let qry = format!("optimize table {}.{} statistic", db, tbl);
+
+        let ctx = fixture.ctx();
+        execute_command(ctx, &qry).await?;
+
+        check_data_dir(&fixture, case_name, 3, 1 + i, 2, 2, 2, Some(())).await?;
+    }
+
+    // After compact, all the count will become 1
+    let qry = format!("optimize table {}.{} all", db, tbl);
+    execute_command(fixture.ctx().clone(), &qry).await?;
+
+    check_data_dir(&fixture, case_name, 1, 1, 1, 1, 1, Some(())).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_fuse_snapshot_optimize_all() -> Result<()> {
     do_purge_test("explicit pure", "all", 1, 0, 1, 1, 1, None).await
 }

--- a/src/query/service/tests/it/storages/fuse/operations/purge_drop.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/purge_drop.rs
@@ -59,6 +59,7 @@ async fn test_fuse_snapshot_truncate_in_drop_all_stmt() -> Result<()> {
         0, // 0 blocks
         0, // 0 index
         None,
+        None,
     )
     .await?;
     Ok(())

--- a/src/query/service/tests/it/storages/fuse/operations/purge_truncate.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/purge_truncate.rs
@@ -43,6 +43,7 @@ async fn test_fuse_truncate_purge_stmt() -> Result<()> {
         2,
         expected_index_count,
         Some(()),
+        None,
     )
     .await?;
 
@@ -68,6 +69,7 @@ async fn test_fuse_truncate_purge_stmt() -> Result<()> {
         0,
         0,
         Some(()),
+        None,
     )
     .await?;
     Ok(())

--- a/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
+++ b/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
@@ -483,10 +483,12 @@ pub async fn check_data_dir(
     let prefix_block = FUSE_TBL_BLOCK_PREFIX;
     let prefix_index = FUSE_TBL_XOR_BLOOM_INDEX_PREFIX;
     let prefix_last_snapshot_hint = FUSE_TBL_LAST_SNAPSHOT_HINT;
+    println!("root: {}", root);
     for entry in WalkDir::new(root) {
         let entry = entry.unwrap();
         if entry.file_type().is_file() {
             let (_, entry_path) = entry.path().to_str().unwrap().split_at(root.len());
+            println!("entry: {}", entry_path);
             // trim the leading prefix, e.g. "/db_id/table_id/"
             let path = entry_path.split('/').skip(3).collect::<Vec<_>>();
             let path = path[0];
@@ -499,6 +501,7 @@ pub async fn check_data_dir(
             } else if path.starts_with(prefix_index) {
                 i_count += 1;
             } else if path.starts_with(prefix_snapshot_statistics) {
+                println!("ts file:{}", entry_path);
                 ts_count += 1;
             } else if path.starts_with(prefix_last_snapshot_hint) && check_last_snapshot.is_some() {
                 let content = fixture

--- a/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
+++ b/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
@@ -465,6 +465,7 @@ pub async fn check_data_dir(
     block_count: u32,
     index_count: u32,
     check_last_snapshot: Option<()>,
+    check_table_statistic_file: Option<()>,
 ) -> Result<()> {
     let data_path = match fixture.ctx().get_config().storage.params {
         StorageParams::Fs(v) => v.root,
@@ -477,6 +478,7 @@ pub async fn check_data_dir(
     let mut b_count = 0;
     let mut i_count = 0;
     let mut last_snapshot_loc = "".to_string();
+    let mut table_statistic_files = vec![];
     let prefix_snapshot = FUSE_TBL_SNAPSHOT_PREFIX;
     let prefix_snapshot_statistics = FUSE_TBL_SNAPSHOT_STATISTICS_PREFIX;
     let prefix_segment = FUSE_TBL_SEGMENT_PREFIX;
@@ -500,6 +502,7 @@ pub async fn check_data_dir(
                 i_count += 1;
             } else if path.starts_with(prefix_snapshot_statistics) {
                 ts_count += 1;
+                table_statistic_files.push(entry_path.to_string());
             } else if path.starts_with(prefix_last_snapshot_hint) && check_last_snapshot.is_some() {
                 let content = fixture
                     .ctx
@@ -549,6 +552,26 @@ pub async fn check_data_dir(
         assert_eq!(
             last_snapshot_loc.find(&snapshot_loc),
             Some(last_snapshot_loc.len() - snapshot_loc.len())
+        );
+    }
+
+    if check_table_statistic_file.is_some() {
+        let table = fixture.latest_default_table().await?;
+        let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+        let snapshot_opt = fuse_table.read_table_snapshot().await?;
+        assert!(snapshot_opt.is_some());
+        let snapshot = snapshot_opt.unwrap();
+        let ts_location_opt = snapshot.table_statistics_location.clone();
+        assert!(ts_location_opt.is_some());
+        let ts_location = ts_location_opt.unwrap();
+        println!(
+            "ts_location_opt: {:?}, table_statistic_files: {:?}",
+            ts_location, table_statistic_files
+        );
+        assert!(
+            table_statistic_files
+                .iter()
+                .any(|e| e.contains(&ts_location))
         );
     }
 

--- a/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
+++ b/src/query/service/tests/it/storages/fuse/table_test_fixture.rs
@@ -483,12 +483,10 @@ pub async fn check_data_dir(
     let prefix_block = FUSE_TBL_BLOCK_PREFIX;
     let prefix_index = FUSE_TBL_XOR_BLOOM_INDEX_PREFIX;
     let prefix_last_snapshot_hint = FUSE_TBL_LAST_SNAPSHOT_HINT;
-    println!("root: {}", root);
     for entry in WalkDir::new(root) {
         let entry = entry.unwrap();
         if entry.file_type().is_file() {
             let (_, entry_path) = entry.path().to_str().unwrap().split_at(root.len());
-            println!("entry: {}", entry_path);
             // trim the leading prefix, e.g. "/db_id/table_id/"
             let path = entry_path.split('/').skip(3).collect::<Vec<_>>();
             let path = path[0];
@@ -501,7 +499,6 @@ pub async fn check_data_dir(
             } else if path.starts_with(prefix_index) {
                 i_count += 1;
             } else if path.starts_with(prefix_snapshot_statistics) {
-                println!("ts file:{}", entry_path);
                 ts_count += 1;
             } else if path.starts_with(prefix_last_snapshot_hint) && check_last_snapshot.is_some() {
                 let content = fixture

--- a/src/query/storages/fuse/fuse/src/io/snapshots.rs
+++ b/src/query/storages/fuse/fuse/src/io/snapshots.rs
@@ -102,9 +102,8 @@ impl SnapshotsIO {
             .map_err(|e| ErrorCode::StorageOther(format!("read snapshots failure, {}", e)))
     }
 
-    // Read all the snapshots by the root file.
-    // limit: read how many snapshot files
-    // with_segment_locations: if true will get the segments of the snapshot
+    // Read all the table statistic files by the root file(exclude the root file).
+    // limit: read how many table statistic files
     pub async fn read_table_statistic_files(
         &self,
         root_ts_file: &str,

--- a/src/query/storages/fuse/fuse/src/operations/statistic.rs
+++ b/src/query/storages/fuse/fuse/src/operations/statistic.rs
@@ -92,7 +92,6 @@ impl FuseTable {
                     table_statistics.format_version(),
                 )?;
 
-            println!("ts location: {:?}", table_statistics);
             // 4. Save table statistics
             let mut new_snapshot = TableSnapshot::from_previous(&snapshot);
             new_snapshot.table_statistics_location = Some(table_statistics_location);

--- a/src/query/storages/fuse/fuse/src/operations/statistic.rs
+++ b/src/query/storages/fuse/fuse/src/operations/statistic.rs
@@ -92,6 +92,7 @@ impl FuseTable {
                     table_statistics.format_version(),
                 )?;
 
+            println!("ts location: {:?}", table_statistics);
             // 4. Save table statistics
             let mut new_snapshot = TableSnapshot::from_previous(&snapshot);
             new_snapshot.table_statistics_location = Some(table_statistics_location);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: purge table statistic files
add test case.

updated (by @dantengsky )

the main functionality of this PR is to purge table statistic files while doing `optimize table ... purge`.
pls correct me if I misunderstood @lichuang 

Closes https://github.com/datafuselabs/databend/issues/9054
