### PR TITLE
chore(query): insert SQL ignore mysql federated check

### DIFF
--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -306,6 +306,10 @@ impl<W: AsyncWrite + Send + Unpin> InteractiveWorkerBase<W> {
     // Check the query is a federated or driver setup command.
     // Here we fake some values for the command which Databend not supported.
     fn federated_server_command_check(&self, query: &str) -> Option<DataBlock> {
+        // INSERT don't need MySQL federated check
+        if query.len() > 6 && query[..6].eq_ignore_ascii_case("INSERT") {
+            return None;
+        }
         let federated = MySQLFederated::create();
         federated.check(query)
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Insert SQL does not need to do MySQL federated check. When the amount of insert value is large, canceling this check can reduce the execution time.

![image](https://user-images.githubusercontent.com/1070352/206122880-b9b187e2-d65e-4930-9cd6-73330ef781d7.png)

Closes #issue
