### PR TITLE
feat(expr): migrate storages/index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,6 +2323,7 @@ dependencies = [
  "common-functions-v2",
  "common-storages-table-meta",
  "criterion",
+ "match-template",
  "rand 0.8.5",
  "serde",
  "thiserror",

--- a/src/query/expression/src/chunk.rs
+++ b/src/query/expression/src/chunk.rs
@@ -95,11 +95,9 @@ impl<Index: ColumnIndex> Chunk<Index> {
     }
 
     #[inline]
-    pub fn get_by_id(&self, id: &Index) -> &ChunkEntry<Index> {
+    pub fn get_by_id(&self, id: &Index) -> Option<&ChunkEntry<Index>> {
         self.columns()
             .find(|entry| entry.id == *id)
-            .ok_or_else(|| format!("Chunk doesn't contain a column with id `{id}`"))
-            .unwrap()
     }
 
     #[inline]

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -65,7 +65,7 @@ impl<'a, Index: ColumnIndex> Evaluator<'a, Index> {
     pub fn run(&self, expr: &Expr<Index>) -> Result<Value<AnyType>> {
         let result = match expr {
             Expr::Constant { scalar, .. } => Ok(Value::Scalar(scalar.clone())),
-            Expr::ColumnRef { id, .. } => Ok(self.input_columns.get_by_id(id).value.clone()),
+            Expr::ColumnRef { id, .. } => Ok(self.input_columns.get_by_id(id).unwrap().value.clone()),
             Expr::FunctionCall {
                 span,
                 function,

--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -29,6 +29,7 @@ use crate::utils::arrow::constant_bitmap;
 use crate::values::Value;
 use crate::values::ValueRef;
 use crate::Column;
+use crate::ColumnIndex;
 use crate::Expr;
 use crate::FunctionDomain;
 use crate::Scalar;
@@ -44,6 +45,12 @@ pub struct FunctionSignature {
 #[derive(Clone, Copy)]
 pub struct FunctionContext {
     pub tz: Tz,
+}
+
+impl Default for FunctionContext {
+    fn default() -> Self {
+        Self { tz: Tz::UTC }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -114,11 +121,11 @@ impl FunctionRegistry {
         }
     }
 
-    pub fn search_candidates(
+    pub fn search_candidates<Index: ColumnIndex>(
         &self,
         name: &str,
         params: &[usize],
-        args: &[Expr],
+        args: &[Expr<Index>],
     ) -> Vec<(FunctionID, Arc<Function>)> {
         let name = name.to_lowercase();
         let name = self

--- a/src/query/expression/src/kernels/group_by.rs
+++ b/src/query/expression/src/kernels/group_by.rs
@@ -31,7 +31,7 @@ impl Chunk {
         let hash_key_types = indices
             .iter()
             .map(|&c| {
-                let col = chunk.get_by_id(&c);
+                let col = chunk.get_by_id(&c).unwrap();
                 Ok(col.data_type.clone())
             })
             .collect::<Result<Vec<_>>>();

--- a/src/query/expression/src/kernels/sort.rs
+++ b/src/query/expression/src/kernels/sort.rs
@@ -55,7 +55,7 @@ impl Chunk {
         }
         let order_columns = descriptions
             .iter()
-            .map(|d| column_to_arrow_array(chunk.get_by_id(&d.index), num_rows))
+            .map(|d| column_to_arrow_array(chunk.get_by_offset(d.index), num_rows))
             .collect::<Vec<_>>();
 
         let order_arrays = descriptions
@@ -99,8 +99,8 @@ impl Chunk {
         let sort_arrays = descriptions
             .iter()
             .map(|d| {
-                let left = column_to_arrow_array(lhs.get_by_id(&d.index), lhs_len);
-                let right = column_to_arrow_array(rhs.get_by_id(&d.index), rhs_len);
+                let left = column_to_arrow_array(lhs.get_by_offset(d.index), lhs_len);
+                let right = column_to_arrow_array(rhs.get_by_offset(d.index), rhs_len);
                 sort_options.push(arrow_sort::SortOptions {
                     descending: !d.asc,
                     nulls_first: d.nulls_first,

--- a/src/query/storages/fuse/fuse/src/pruning/range_pruner.rs
+++ b/src/query/storages/fuse/fuse/src/pruning/range_pruner.rs
@@ -44,8 +44,8 @@ impl RangePruner for KeepFalse {
 }
 
 impl RangePruner for RangeFilter {
-    fn should_keep(&self, stats: &StatisticsOfColumns, row_count: u64) -> bool {
-        match self.eval(stats, row_count) {
+    fn should_keep(&self, stats: &StatisticsOfColumns, _row_count: u64) -> bool {
+        match self.eval(stats) {
             Ok(r) => r,
             Err(e) => {
                 // swallow exceptions intentionally, corrupted index should not prevent execution

--- a/src/query/storages/index/Cargo.toml
+++ b/src/query/storages/index/Cargo.toml
@@ -28,6 +28,7 @@ xorfilter-rs = { git = "https://github.com/datafuse-extras/xorfilter", features 
 
 anyerror = { workspace = true }
 cbordata = { version = "0.6.0" }
+match-template = "0.0.1"
 serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = "0.1.36"

--- a/src/query/storages/index/benches/build_from_block.rs
+++ b/src/query/storages/index/benches/build_from_block.rs
@@ -15,13 +15,9 @@
 #[macro_use]
 extern crate criterion;
 
-use common_datablocks::DataBlock;
-use common_datavalues::prelude::*;
-use common_datavalues::DataField;
-use common_datavalues::DataSchemaRefExt;
-use common_datavalues::Series;
-use common_datavalues::SeriesFrom;
-use common_storages_index::filters::Filter;
+use common_expression::types::number::NumberColumn;
+use common_expression::types::string::StringColumnBuilder;
+use common_expression::Column;
 use common_storages_index::filters::FilterBuilder;
 use common_storages_index::filters::Xor8Builder;
 use criterion::Criterion;
@@ -38,63 +34,53 @@ use rand::SeedableRng;
 ///   Reproduce the building process same as databend-query does: collect keys with `column.to_values()`:
 ///   i64:                       210ns/key
 ///   string of length 16 to 32: 240ns/key
+///
+/// - 2022-12-7:
+///   Platform: MacBook Pro M1 MAX
+///   i64:                       122ns/key
+///   string of length 16 to 32: 123ns/key
 
 fn bench_u64(c: &mut Criterion) {
-    let block = rand_i64_block(1_000_000);
-    let column = block.try_column_by_name("a").unwrap();
-
-    let mut builder = Xor8Builder::create();
-    builder.add_keys(&column.to_values());
-    let filter = builder.build().unwrap();
-
-    for key in column.to_values() {
-        assert!(filter.contains(&key), "key {} present", key);
-    }
+    let col = rand_i64_column(1_000_000);
 
     c.bench_function("xor8_filter_u64_1m_rows_build_from_column_to_values", |b| {
         b.iter(|| {
             let mut builder = Xor8Builder::create();
-            builder.add_keys(&criterion::black_box(column.to_values()));
+            col.iter().for_each(|v| {
+                builder.add_key(&v);
+            });
             let _filter = criterion::black_box(builder.build().unwrap());
         })
     });
 }
 
 fn bench_string(c: &mut Criterion) {
-    let block = rand_str_block(1_000_000, 32);
-    let column = block.try_column_by_name("a").unwrap();
-
-    let mut builder = Xor8Builder::create();
-    builder.add_keys(&column.to_values());
-    let filter = builder.build().unwrap();
-
-    for key in column.to_values() {
-        assert!(filter.contains(&key), "key {} present", key);
-    }
+    let col = rand_str_column(1_000_000, 32);
 
     c.bench_function(
         "xor8_filter_string16to32_1m_rows_build_from_column_to_values",
         |b| {
             b.iter(|| {
                 let mut builder = Xor8Builder::create();
-                builder.add_keys(&criterion::black_box(column.to_values()));
+                col.iter().for_each(|v| {
+                    builder.add_key(&v);
+                });
                 let _filter = criterion::black_box(builder.build().unwrap());
             })
         },
     );
 }
 
-fn rand_i64_block(n: i32) -> DataBlock {
+fn rand_i64_column(n: i32) -> Column {
     let seed: u64 = random();
 
     let mut rng = StdRng::seed_from_u64(seed);
     let keys: Vec<i64> = (0..n).map(|_| rng.gen::<i64>()).collect();
 
-    let schema = DataSchemaRefExt::create(vec![DataField::new("a", i64::to_data_type())]);
-    DataBlock::create(schema, vec![Series::from_data(keys)])
+    Column::Number(NumberColumn::Int64(keys.into()))
 }
 
-fn rand_str_block(n: i32, len: i32) -> DataBlock {
+fn rand_str_column(n: i32, len: i32) -> Column {
     let seed: u64 = random();
 
     let mut rng = StdRng::seed_from_u64(seed);
@@ -102,22 +88,16 @@ fn rand_str_block(n: i32, len: i32) -> DataBlock {
                             abcdefghijklmnopqrstuvwxyz\
                             0123456789)(*&^%$#@!~";
 
-    let keys: Vec<String> = (0..n)
-        .map(|_| {
-            ((len / 2)..len)
-                .map(|_| {
-                    let idx = rng.gen_range(0..CHARSET.len());
-                    CHARSET[idx] as char
-                })
-                .collect()
-        })
-        .collect();
+    let mut builder = StringColumnBuilder::with_capacity(n as usize, 0);
+    for _ in 0..n {
+        for _ in (len / 2)..len {
+            let idx = rng.gen_range(0..CHARSET.len());
+            builder.put_char(CHARSET[idx] as char);
+        }
+        builder.commit_row();
+    }
 
-    let schema = DataSchemaRefExt::create(vec![DataField::new(
-        "a",
-        DataTypeImpl::String(StringType {}),
-    )]);
-    DataBlock::create(schema, vec![Series::from_data(keys)])
+    Column::String(builder.build())
 }
 
 criterion_group!(benches, bench_u64, bench_string);

--- a/src/query/storages/index/src/filters/xor8.rs
+++ b/src/query/storages/index/src/filters/xor8.rs
@@ -120,13 +120,10 @@ impl Filter for Xor8Filter {
 }
 
 impl SupportedType for Xor8Filter {
-    fn is_supported_schema_type(data_type: &SchemaDataType) -> bool {
+    fn is_supported_type(data_type: &DataType) -> bool {
         // Bloom index only enabled for String and Integral types for now
         let inner_type = data_type.remove_nullable();
-        matches!(
-            inner_type,
-            SchemaDataType::Number(_) | SchemaDataType::String
-        )
+        matches!(inner_type, DataType::Number(_) | DataType::String)
     }
 }
 

--- a/src/query/storages/index/src/lib.rs
+++ b/src/query/storages/index/src/lib.rs
@@ -20,7 +20,6 @@ pub mod range_filter;
 pub use bloom::ChunkFilter;
 pub use bloom::FilterEvalResult;
 use common_expression::types::DataType;
-use common_expression::SchemaDataType;
 pub use index_min_max::*;
 pub use range_filter::*;
 
@@ -37,9 +36,5 @@ pub trait SupportedType {
             inner_type,
             DataType::Number(_) | DataType::Date | DataType::Timestamp | DataType::String
         )
-    }
-
-    fn is_supported_schema_type(data_type: &SchemaDataType) -> bool {
-        Self::is_supported_type(&data_type.into())
     }
 }

--- a/src/query/storages/index/src/range_filter.rs
+++ b/src/query/storages/index/src/range_filter.rs
@@ -20,687 +20,143 @@ use std::sync::Arc;
 use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_expression::type_check::check_function;
+use common_expression::types::nullable::NullableDomain;
+use common_expression::types::number::SimpleDomain;
+use common_expression::types::string::StringDomain;
+use common_expression::types::DataType;
+use common_expression::types::DateType;
 use common_expression::types::NumberDataType;
+use common_expression::types::NumberType;
+use common_expression::types::StringType;
+use common_expression::types::TimestampType;
+use common_expression::types::ValueType;
+use common_expression::with_number_mapped_type;
 use common_expression::Chunk;
 use common_expression::Column;
+use common_expression::ConstantFolder;
 use common_expression::DataField;
 use common_expression::DataSchemaRef;
+use common_expression::Domain;
+use common_expression::Expr;
 use common_expression::FunctionContext;
 use common_expression::RemoteExpr;
+use common_expression::Scalar;
 use common_expression::SchemaDataType;
 use common_functions_v2::scalars::check_pattern_type;
 use common_functions_v2::scalars::is_like_pattern_escape;
 use common_functions_v2::scalars::PatternType;
-// use common_sql::evaluator::EvalNode;
-// use common_sql::evaluator::Evaluator;
-// use common_sql::evaluator::ExpressionMonotonicityVisitor;
-// use common_sql::executor::ExpressionOp;
+use common_functions_v2::scalars::BUILTIN_FUNCTIONS;
+use common_storages_table_meta::meta::ColumnStatistics;
 use common_storages_table_meta::meta::StatisticsOfColumns;
 
 #[derive(Clone)]
 pub struct RangeFilter {
-    origin: DataSchemaRef,
     schema: DataSchemaRef,
-    // executor: EvalNode,  todo!("expression");
-    // stat_columns: StatColumns,  todo!("expression");
-    // func_ctx: FunctionContext,  todo!("expression");
+    expr: Expr<String>,
+    fn_ctx: FunctionContext,
 }
 
 impl RangeFilter {
     pub fn try_create(
         ctx: Arc<dyn TableContext>,
-        exprs: &[RemoteExpr<String>],
+        exprs: &[Expr<String>],
         schema: DataSchemaRef,
     ) -> Result<Self> {
-        todo!("expression");
-        // debug_assert!(!exprs.is_empty());
-        // let mut stat_columns: StatColumns = Vec::new();
+        let conjunction = exprs
+            .iter()
+            .cloned()
+            .reduce(|lhs, rhs| {
+                check_function(None, "and", &[], &[lhs, rhs], &BUILTIN_FUNCTIONS).unwrap()
+            })
+            .unwrap();
 
-        // let verifiable_expr = exprs
-        //     .iter()
-        //     .fold(None, |acc: Option<Expression>, expr| {
-        //         let verifiable_expr = build_verifiable_expr(expr, &schema, &mut stat_columns);
-        //         match acc {
-        //             Some(acc) => Some(acc.and(&verifiable_expr).unwrap()),
-        //             None => Some(verifiable_expr),
-        //         }
-        //     })
-        //     .unwrap();
-
-        // tracing::debug!("verifiable_expr: {}", verifiable_expr);
-        // let input_fields = stat_columns
-        //     .iter()
-        //     .map(|c| c.stat_field.clone())
-        //     .collect::<Vec<_>>();
-        // let input_schema = Arc::new(DataSchema::new(input_fields));
-        // let executor = Evaluator::eval_expression(&verifiable_expr, &input_schema)?;
-
-        // let func_ctx = ctx.try_get_function_context()?;
-
-        // Ok(Self {
-        //     origin: schema,
-        //     schema: input_schema,
-        //     executor,
-        //     stat_columns,
-        //     func_ctx,
-        // })
+        Ok(Self {
+            schema,
+            expr: conjunction,
+            fn_ctx: ctx.try_get_function_context()?,
+        })
     }
 
     pub fn try_eval_const(&self) -> Result<bool> {
-        // if !self.stat_columns.is_empty() {
-        //     return Err(ErrorCode::Internal(
-        //         "Constant folding requires the args are constant",
-        //     ));
-        // }
-        todo!("expression")
+        let input_domains = self
+            .expr
+            .column_refs()
+            .into_iter()
+            .map(|(name, ty)| {
+                let domain = Domain::full(&ty);
+                Ok((name, domain))
+            })
+            .collect::<Result<_>>()?;
+
+        let folder = ConstantFolder::new(input_domains, self.fn_ctx, &BUILTIN_FUNCTIONS);
+        let (new_expr, _) = folder.fold(&self.expr);
+
+        // Only return false, which means to skip this block, when the expression is folded to a constant false.
+        Ok(!matches!(new_expr, Expr::Constant {
+            scalar: Scalar::Boolean(false),
+            ..
+        }))
     }
 
     #[tracing::instrument(level = "debug", name = "range_filter_eval", skip_all)]
-    pub fn eval(&self, stats: &StatisticsOfColumns, row_count: u64) -> Result<bool> {
-        todo!("expression")
+    pub fn eval(&self, stats: &StatisticsOfColumns) -> Result<bool> {
+        let input_domains = self
+            .expr
+            .column_refs()
+            .into_iter()
+            .map(|(name, ty)| {
+                let offset = self.schema.index_of(&name)?;
+                let domain = statistics_to_domain(&stats[&(offset as u32)], &ty);
+                Ok((name, domain))
+            })
+            .collect::<Result<_>>()?;
+
+        let folder = ConstantFolder::new(input_domains, self.fn_ctx, &BUILTIN_FUNCTIONS);
+        let (new_expr, _) = folder.fold(&self.expr);
+
+        // Only return false, which means to skip this block, when the expression is folded to a constant false.
+        Ok(!matches!(new_expr, Expr::Constant {
+            scalar: Scalar::Boolean(false),
+            ..
+        }))
     }
 }
 
-// /// convert expr to Verifiable Expression
-// /// Rules: (section 5.2 of http://vldb.org/pvldb/vol14/p3083-edara.pdf)
-// pub fn build_verifiable_expr(
-//     expr: &Expression,
-//     schema: &DataSchemaRef,
-//     stat_columns: &mut StatColumns,
-// ) -> Expression {
-// todo!("expression");
-// let unhandled = Expression::Constant {
-//     value: Scalar::Boolean(true),
-//     data_type: DataType::Boolean,
-// };
-
-// let (exprs, op) = match expr {
-//     Expression::Constant { .. } => return expr.clone(),
-//     Expression::Function { name, args, .. } => {
-//         if args.len() == 2 {
-//             let left = &args[0];
-//             let right = &args[1];
-//             match name.to_lowercase().as_str() {
-//                 "and" => {
-//                     let left = build_verifiable_expr(left, schema, stat_columns);
-//                     let right = build_verifiable_expr(right, schema, stat_columns);
-//                     return left.and(&right).unwrap();
-//                 }
-//                 "or" => {
-//                     let left = build_verifiable_expr(left, schema, stat_columns);
-//                     let right = build_verifiable_expr(right, schema, stat_columns);
-//                     return left.or(&right).unwrap();
-//                 }
-//                 _ => (vec![left.clone(), right.clone()], name.clone()),
-//             }
-//         } else {
-//             try_convert_is_null(name.to_lowercase().as_str(), args.clone())
-//         }
-//     }
-//     _ => return unhandled,
-// };
-
-// VerifiableExprBuilder::try_create(exprs, op.to_lowercase().as_str(), schema, stat_columns)
-//     .map_or(unhandled.clone(), |mut v| v.build().unwrap_or(unhandled))
-// }
-
-// fn inverse_operator(op: &str) -> Result<&str> {
-//     match op {
-//         "<" => Ok(">"),
-//         "<=" => Ok(">="),
-//         ">" => Ok("<"),
-//         ">=" => Ok("<="),
-//         "like" | "not like" | "ilike" | "not ilike" => Err(ErrorCode::UnknownException(format!(
-//             "cannot inverse the operator: {:?}",
-//             op
-//         ))),
-//         _ => Ok(op),
-//     }
-// }
-
-// /// Try to convert `not(is_not_null)` to `is_null`.
-// fn try_convert_is_null(name: &str, args: Vec<Expression>) -> (Vec<Expression>, String) {
-//     // `is null` will be converted to `not(is not null)` in the parser.
-//     // we should convert it back to `is null` here.
-//     if name == "not" && args.len() == 1 {
-//         if let Expression::Function {
-//             name: inner_name,
-//             args: inner_args,
-//             ..
-//         } = &args[0]
-//         {
-//             if inner_name == "is_not_null" {
-//                 return (inner_args.clone(), String::from("is_null"));
-//             }
-//         }
-//     }
-//     (args, String::from(name))
-// }
-
-// #[derive(Debug, Copy, Clone, PartialEq)]
-// enum StatType {
-//     Min,
-//     Max,
-//     Nulls,
-//     RowCount,
-// }
-
-// impl fmt::Display for StatType {
-//     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-//         match self {
-//             StatType::Min => write!(f, "min"),
-//             StatType::Max => write!(f, "max"),
-//             StatType::Nulls => write!(f, "nulls"),
-//             StatType::RowCount => write!(f, "row_count"),
-//         }
-//     }
-// }
-
-// pub type StatColumns = Vec<StatColumn>;
-// pub type ColumnFields = HashMap<usize, DataField>;
-
-// #[derive(Debug, Clone)]
-// pub struct StatColumn {
-//     column_fields: ColumnFields,
-//     stat_type: StatType,
-//     stat_field: DataField,
-//     expr: Expression,
-// }
-
-// impl StatColumn {
-//     fn create(
-//         column_fields: ColumnFields,
-//         stat_type: StatType,
-//         field: &DataField,
-//         expr: Expression,
-//     ) -> Self {
-//         let column_new = format!("{}_{}", stat_type, field.name());
-//         let data_type = if matches!(stat_type, StatType::Nulls | StatType::RowCount) {
-//             SchemaDataType::Number(NumberDataType::UInt64)
-//         } else {
-//             field.data_type().clone()
-//         };
-//         let stat_field = DataField::new(column_new.as_str(), data_type);
-
-//         Self {
-//             column_fields,
-//             stat_type,
-//             stat_field,
-//             expr,
-//         }
-//     }
-
-//     fn apply_stat_value(
-//         &self,
-//         stats: &StatisticsOfColumns,
-//         schema: DataSchemaRef,
-//     ) -> Result<Option<Column>> {
-//         todo!("expression");
-//         // if self.stat_type == StatType::Nulls {
-//         //     // The len of column_fields is 1.
-//         //     let (k, _) = self.column_fields.iter().next().unwrap();
-//         //     let k = *k as u32;
-//         //     let stat = stats.get(&k).ok_or_else(|| {
-//         //         ErrorCode::UnknownException(format!(
-//         //             "Unable to get the colStats by ColumnId: {}",
-//         //             k
-//         //         ))
-//         //     })?;
-//         //     return Ok(Some(Series::from_data(vec![stat.null_count])));
-//         // }
-
-//         // let mut single_point = true;
-//         // let mut variables = HashMap::with_capacity(self.column_fields.len());
-//         // for (k, v) in &self.column_fields {
-//         //     let k32 = *k as u32;
-//         //     let stat = stats.get(&k32).ok_or_else(|| {
-//         //         ErrorCode::UnknownException(format!(
-//         //             "Unable to get the colStats by ColumnId: {}",
-//         //             k32
-//         //         ))
-//         //     })?;
-
-//         //     if single_point && stat.min != stat.max {
-//         //         single_point = false;
-//         //     }
-
-//         //     let min_col = v.data_type().create_constant_column(&stat.min, 1)?;
-//         //     let variable_left = Some(ColumnWithField::new(min_col, v.clone()));
-
-//         //     let max_col = v.data_type().create_constant_column(&stat.max, 1)?;
-//         //     let variable_right = Some(ColumnWithField::new(max_col, v.clone()));
-//         //     variables.insert(v.name().clone(), (variable_left, variable_right));
-//         // }
-
-//         // let monotonicity = ExpressionMonotonicityVisitor::check_expression(
-//         //     schema,
-//         //     &self.expr,
-//         //     variables,
-//         //     single_point,
-//         // );
-//         // if !monotonicity.is_monotonic {
-//         //     return Ok(None);
-//         // }
-
-//         // let column_with_field_opt = match self.stat_type {
-//         //     StatType::Min => {
-//         //         if monotonicity.is_positive {
-//         //             monotonicity.left
-//         //         } else {
-//         //             monotonicity.right
-//         //         }
-//         //     }
-//         //     StatType::Max => {
-//         //         if monotonicity.is_positive {
-//         //             monotonicity.right
-//         //         } else {
-//         //             monotonicity.left
-//         //         }
-//         //     }
-//         //     _ => unreachable!(),
-//         // };
-
-//         // Ok(column_with_field_opt.map(|v| v.column().slice(0, 1)))
-//     }
-// }
-
-// struct VerifiableExprBuilder<'a> {
-//     op: &'a str,
-//     args: Vec<Expression>,
-//     fields: Vec<(DataField, ColumnFields)>,
-//     stat_columns: &'a mut StatColumns,
-// }
-
-// impl<'a> VerifiableExprBuilder<'a> {
-//     fn try_create(
-//         exprs: Vec<Expression>,
-//         op: &'a str,
-//         schema: &'a DataSchemaRef,
-//         stat_columns: &'a mut StatColumns,
-//     ) -> Result<Self> {
-//         // collect state columns
-//         // exprs's len must be 2
-//         let (args, cols, op) = match exprs.len() {
-//             1 => {
-//                 let cols = RequireColumnsVisitor::collect_columns_from_expr(&exprs[0])?;
-//                 match cols.len() {
-//                     1 => (exprs, vec![cols], op),
-//                     _ => {
-//                         return Err(ErrorCode::UnknownException(
-//                             "Multi-column expressions are not currently supported",
-//                         ));
-//                     }
-//                 }
-//             }
-//             2 => {
-//                 let lhs_cols = RequireColumnsVisitor::collect_columns_from_expr(&exprs[0])?;
-//                 let rhs_cols = RequireColumnsVisitor::collect_columns_from_expr(&exprs[1])?;
-
-//                 match (lhs_cols.len(), rhs_cols.len()) {
-//                     (0, 0) => {
-//                         return Err(ErrorCode::UnknownException(
-//                             "Constant expression donot need to be handled",
-//                         ));
-//                     }
-//                     (_, 0) => (vec![exprs[0].clone(), exprs[1].clone()], vec![lhs_cols], op),
-//                     (0, _) => {
-//                         let op = inverse_operator(op)?;
-//                         (vec![exprs[1].clone(), exprs[0].clone()], vec![rhs_cols], op)
-//                     }
-//                     _ => {
-//                         if !lhs_cols.is_disjoint(&rhs_cols) {
-//                             return Err(ErrorCode::UnknownException(
-//                                 "Unsupported condition for left and right have same columns",
-//                             ));
-//                         }
-
-//                         if !matches!(op, "=" | "<" | "<=" | ">" | ">=") {
-//                             return Err(ErrorCode::UnknownException(format!(
-//                                 "Unsupported operator '{:?}' for multi-column expression",
-//                                 op
-//                             )));
-//                         }
-
-//                         if !check_maybe_monotonic(&exprs[1])? {
-//                             return Err(ErrorCode::UnknownException(
-//                                 "Only support the monotonic expression",
-//                             ));
-//                         }
-
-//                         (
-//                             vec![exprs[0].clone(), exprs[1].clone()],
-//                             vec![lhs_cols, rhs_cols],
-//                             op,
-//                         )
-//                     }
-//                 }
-//             }
-//             _ => {
-//                 return Err(ErrorCode::UnknownException(
-//                     "Expressions with more than two args are not currently supported",
-//                 ));
-//             }
-//         };
-
-//         if !check_maybe_monotonic(&args[0])? {
-//             return Err(ErrorCode::UnknownException(
-//                 "Only support the monotonic expression",
-//             ));
-//         }
-
-//         let mut fields = Vec::with_capacity(cols.len());
-
-//         let left_cols = get_column_fields(schema, cols[0].clone())?;
-//         let left_field = args[0].to_data_field();
-
-//         fields.push((left_field, left_cols));
-
-//         if cols.len() > 1 {
-//             let right_cols = get_column_fields(schema, cols[1].clone())?;
-//             let right_field = args[1].to_data_field();
-//             fields.push((right_field, right_cols));
-//         }
-
-//         Ok(Self {
-//             op,
-//             args,
-//             fields,
-//             stat_columns,
-//         })
-//     }
-
-//     fn build(&mut self) -> Result<Expression> {
-//         todo!("expression");
-//         // // TODO: support in/not in.
-//         // match self.op {
-//         //     "is_null" => {
-//         //         // should_keep: col.null_count > 0
-//         //         let nulls_expr = self.nulls_column_expr(0)?;
-//         //         let scalar_expr = Expression::Constant {
-//         //             value: DataValue::UInt64(0),
-//         //             data_type: u64::to_data_type(),
-//         //         };
-//         //         nulls_expr.gt(&scalar_expr)
-//         //     }
-//         //     "is_not_null" => {
-//         //         // should_keep: col.null_count != col.row_count
-//         //         let nulls_expr = self.nulls_column_expr(0)?;
-//         //         let row_count_expr = self.row_count_column_expr(0)?;
-//         //         nulls_expr.not_eq(&row_count_expr)
-//         //     }
-//         //     "=" => {
-//         //         // left = right => min_left <= max_right and max_left >= min_right
-//         //         let left_min = self.min_column_expr(0)?;
-//         //         let left_max = self.max_column_expr(0)?;
-
-//         //         let right_min = if self.fields.len() == 1 {
-//         //             self.args[1].clone()
-//         //         } else {
-//         //             self.min_column_expr(1)?
-//         //         };
-//         //         let right_max = if self.fields.len() == 1 {
-//         //             self.args[1].clone()
-//         //         } else {
-//         //             self.max_column_expr(1)?
-//         //         };
-
-//         //         left_min
-//         //             .lt_eq(&right_max)?
-//         //             .and(&left_max.gt_eq(&right_min)?)
-//         //     }
-//         //     "<>" | "!=" => {
-//         //         let left_min = self.min_column_expr(0)?;
-//         //         let left_max = self.max_column_expr(0)?;
-//         //         left_min
-//         //             .not_eq(&self.args[1])?
-//         //             .or(&left_max.not_eq(&self.args[1])?)
-//         //     }
-//         //     ">" => {
-//         //         // left > right => max_left > min_right
-//         //         let left_max = self.max_column_expr(0)?;
-
-//         //         let right_min = if self.fields.len() == 1 {
-//         //             self.args[1].clone()
-//         //         } else {
-//         //             self.min_column_expr(1)?
-//         //         };
-
-//         //         left_max.gt(&right_min)
-//         //     }
-//         //     ">=" => {
-//         //         // left >= right => max_left >= min_right
-//         //         let left_max = self.max_column_expr(0)?;
-
-//         //         let right_min = if self.fields.len() == 1 {
-//         //             self.args[1].clone()
-//         //         } else {
-//         //             self.min_column_expr(1)?
-//         //         };
-
-//         //         left_max.gt_eq(&right_min)
-//         //     }
-//         //     "<" => {
-//         //         // left < right => min_left < max_right
-//         //         let left_min = self.min_column_expr(0)?;
-
-//         //         let right_max = if self.fields.len() == 1 {
-//         //             self.args[1].clone()
-//         //         } else {
-//         //             self.max_column_expr(1)?
-//         //         };
-
-//         //         left_min.lt(&right_max)
-//         //     }
-//         //     "<=" => {
-//         //         // left <= right => min_left <= max_right
-//         //         let left_min = self.min_column_expr(0)?;
-
-//         //         let right_max = if self.fields.len() == 1 {
-//         //             self.args[1].clone()
-//         //         } else {
-//         //             self.max_column_expr(1)?
-//         //         };
-
-//         //         left_min.lt_eq(&right_max)
-//         //     }
-//         //     "like" => {
-//         //         if let Expression::Constant {
-//         //             value: DataValue::String(v),
-//         //             ..
-//         //         } = &self.args[1]
-//         //         {
-//         //             // e.g. col like 'a%' => max_col >= 'a' and min_col < 'b'
-//         //             let left = left_bound_for_like_pattern(v);
-//         //             if !left.is_empty() {
-//         //                 let right = right_bound_for_like_pattern(left.clone());
-
-//         //                 let left_scalar = Expression::Constant {
-//         //                     value: DataValue::String(left),
-//         //                     data_type: Vu8::to_data_type(),
-//         //                 };
-
-//         //                 let max_expr = self.max_column_expr(0)?;
-//         //                 if right.is_empty() {
-//         //                     return max_expr.gt_eq(&left_scalar);
-//         //                 } else {
-//         //                     let right_scalar = Expression::Constant {
-//         //                         value: DataValue::String(right),
-//         //                         data_type: Vu8::to_data_type(),
-//         //                     };
-
-//         //                     let min_expr = self.min_column_expr(0)?;
-//         //                     return max_expr
-//         //                         .gt_eq(&left_scalar)?
-//         //                         .and(&min_expr.lt(&right_scalar)?);
-//         //                 }
-//         //             }
-//         //         }
-//         //         Err(ErrorCode::UnknownException(
-//         //             "Cannot build atom expression by the operator: like",
-//         //         ))
-//         //     }
-//         //     "not like" => {
-//         //         if let Expression::Constant {
-//         //             value: DataValue::String(v),
-//         //             ..
-//         //         } = &self.args[1]
-//         //         {
-//         //             // Only support such as 'abc' or 'ab%'.
-//         //             match check_pattern_type(v, true) {
-//         //                 // e.g. col not like 'abc' => min_col != 'abc' or max_col != 'abc'
-//         //                 PatternType::OrdinalStr => {
-//         //                     let const_arg = left_bound_for_like_pattern(v);
-//         //                     let const_arg_scalar = Expression::Constant {
-//         //                         value: DataValue::String(const_arg),
-//         //                         data_type: Vu8::to_data_type(),
-//         //                     };
-
-//         //                     let max_expr = self.max_column_expr(0)?;
-//         //                     let min_expr = self.min_column_expr(0)?;
-
-//         //                     return min_expr
-//         //                         .not_eq(&const_arg_scalar)?
-//         //                         .or(&max_expr.not_eq(&const_arg_scalar)?);
-//         //                 }
-//         //                 // e.g. col not like 'ab%' => min_col < 'ab' or max_col >= 'ac'
-//         //                 PatternType::EndOfPercent => {
-//         //                     let left = left_bound_for_like_pattern(v);
-//         //                     if !left.is_empty() {
-//         //                         let right = right_bound_for_like_pattern(left.clone());
-
-//         //                         let left_scalar = Expression::Constant {
-//         //                             value: DataValue::String(left),
-//         //                             data_type: Vu8::to_data_type(),
-//         //                         };
-
-//         //                         let min_expr = self.min_column_expr(0)?;
-//         //                         if right.is_empty() {
-//         //                             return min_expr.lt(&left_scalar);
-//         //                         } else {
-//         //                             let right_scalar = Expression::Constant {
-//         //                                 value: DataValue::String(right),
-//         //                                 data_type: Vu8::to_data_type(),
-//         //                             };
-//         //                             let max_expr = self.max_column_expr(0)?;
-//         //                             return min_expr
-//         //                                 .lt(&left_scalar)?
-//         //                                 .or(&max_expr.gt_eq(&right_scalar)?);
-//         //                         }
-//         //                     }
-//         //                 }
-//         //                 _ => {}
-//         //             }
-//         //         }
-//         //         Err(ErrorCode::UnknownException(
-//         //             "Cannot build atom expression by the operator: not like",
-//         //         ))
-//         //     }
-//         //     other => Err(ErrorCode::UnknownException(format!(
-//         //         "Cannot build atom expression by the operator: {:?}",
-//         //         other
-//         //     ))),
-//         // }
-//     }
-
-//     fn stat_column_expr(&mut self, stat_type: StatType, index: usize) -> Result<Expression> {
-//         let (data_field, column_fields) = self.fields[index].clone();
-//         let stat_col = StatColumn::create(
-//             column_fields,
-//             stat_type,
-//             &data_field,
-//             self.args[index].clone(),
-//         );
-
-//         if !self
-//             .stat_columns
-//             .iter()
-//             .any(|c| c.stat_type == stat_type && c.stat_field.name() == data_field.name())
-//         {
-//             self.stat_columns.push(stat_col.clone());
-//         }
-
-//         Ok(Expression::IndexedVariable {
-//             name: stat_col.stat_field.name().to_string(),
-//             data_type: stat_col.stat_field.data_type().clone(),
-//         })
-//     }
-
-//     fn min_column_expr(&mut self, index: usize) -> Result<Expression> {
-//         self.stat_column_expr(StatType::Min, index)
-//     }
-
-//     fn max_column_expr(&mut self, index: usize) -> Result<Expression> {
-//         self.stat_column_expr(StatType::Max, index)
-//     }
-
-//     fn nulls_column_expr(&mut self, index: usize) -> Result<Expression> {
-//         self.stat_column_expr(StatType::Nulls, index)
-//     }
-
-//     fn row_count_column_expr(&mut self, index: usize) -> Result<Expression> {
-//         self.stat_column_expr(StatType::RowCount, index)
-//     }
-// }
-
-// pub fn left_bound_for_like_pattern(pattern: &[u8]) -> Vec<u8> {
-//     let mut index = 0;
-//     let len = pattern.len();
-//     let mut prefix: Vec<u8> = Vec::with_capacity(len);
-//     todo!("expression");
-//     // while index < len {
-//     //     match pattern[index] {
-//     //         b'%' | b'_' => break,
-//     //         b'\\' => {
-//     //             if index < len - 1 {
-//     //                 index += 1;
-//     //                 if !is_like_pattern_escape(pattern[index]) {
-//     //                     prefix.push(pattern[index - 1]);
-//     //                 }
-//     //             }
-//     //         }
-//     //         _ => {}
-//     //     }
-//     //     prefix.push(pattern[index]);
-//     //     index += 1;
-//     // }
-//     // prefix
-// }
-
-// pub fn right_bound_for_like_pattern(prefix: Vec<u8>) -> Vec<u8> {
-//     let mut res = prefix;
-//     while !res.is_empty() && *res.last().unwrap() == u8::MAX {
-//         res.pop();
-//     }
-
-//     if !res.is_empty() {
-//         if let Some(last) = res.last_mut() {
-//             *last += 1;
-//         }
-//     }
-
-//     res
-// }
-
-// fn get_maybe_monotonic(op: &str, args: &[Expression]) -> Result<bool> {
-//     todo!("expression")
-// }
-
-// pub fn check_maybe_monotonic(expr: &Expression) -> Result<bool> {
-//     match expr {
-//         Expression::Constant { .. } => Ok(true),
-//         Expression::IndexedVariable { .. } => Ok(true),
-//         Expression::Function { name, args, .. } => get_maybe_monotonic(name, args),
-//         Expression::Cast { input, .. } => check_maybe_monotonic(input.as_ref()),
-//     }
-// }
-
-// fn get_column_fields(schema: &DataSchemaRef, cols: HashSet<String>) -> Result<ColumnFields> {
-//     todo!("expression");
-//     // let mut column_fields = HashMap::with_capacity(cols.len());
-
-//     // for col in &cols {
-//     //     let index = schema.index_of(col)?;
-//     //     column_fields.insert(index, schema.field(index).clone());
-//     // }
-//     // Ok(column_fields)
-// }
+fn statistics_to_domain(stat: &ColumnStatistics, data_type: &DataType) -> Domain {
+    with_number_mapped_type!(|NUM_TYPE| match data_type {
+        DataType::Number(NumberDataType::NUM_TYPE) => {
+            NumberType::<NUM_TYPE>::upcast_domain(SimpleDomain {
+                min: NumberType::<NUM_TYPE>::try_downcast_scalar(&stat.min.as_ref()).unwrap(),
+                max: NumberType::<NUM_TYPE>::try_downcast_scalar(&stat.max.as_ref()).unwrap(),
+            })
+        }
+        DataType::String => Domain::String(StringDomain {
+            min: StringType::try_downcast_scalar(&stat.min.as_ref())
+                .unwrap()
+                .to_vec(),
+            max: Some(
+                StringType::try_downcast_scalar(&stat.max.as_ref())
+                    .unwrap()
+                    .to_vec()
+            ),
+        }),
+        DataType::Timestamp => TimestampType::upcast_domain(SimpleDomain {
+            min: TimestampType::try_downcast_scalar(&stat.min.as_ref()).unwrap(),
+            max: TimestampType::try_downcast_scalar(&stat.max.as_ref()).unwrap(),
+        }),
+        DataType::Date => DateType::upcast_domain(SimpleDomain {
+            min: DateType::try_downcast_scalar(&stat.min.as_ref()).unwrap(),
+            max: DateType::try_downcast_scalar(&stat.max.as_ref()).unwrap(),
+        }),
+        DataType::Nullable(ty) => {
+            let domain = statistics_to_domain(stat, ty);
+            Domain::Nullable(NullableDomain {
+                has_null: stat.null_count > 0,
+                value: Some(Box::new(domain)),
+            })
+        }
+        // Unsupported data type
+        _ => Domain::full(data_type.into()),
+    })
+}

--- a/src/query/storages/index/tests/it/filters/bloom_filter.rs
+++ b/src/query/storages/index/tests/it/filters/bloom_filter.rs
@@ -15,94 +15,127 @@
 
 use std::collections::HashSet;
 
-use common_datablocks::DataBlock;
-use common_datavalues::BooleanType;
-use common_datavalues::DataField;
-use common_datavalues::DataSchemaRefExt;
-use common_datavalues::DataTypeImpl;
-use common_datavalues::DataValue;
-use common_datavalues::StringType;
-use common_datavalues::ToDataType;
 use common_exception::Result;
+use common_expression::type_check::check_function;
+use common_expression::types::number::NumberColumn;
+use common_expression::types::number::NumberScalar;
+use common_expression::types::DataType;
+use common_expression::types::NumberDataType;
+use common_expression::Chunk;
+use common_expression::ChunkEntry;
+use common_expression::Column;
+use common_expression::ColumnFrom;
+use common_expression::Expr;
+use common_expression::FunctionContext;
+use common_expression::Scalar;
+use common_expression::Value;
+use common_functions_v2::scalars::BUILTIN_FUNCTIONS;
 use common_storages_index::ChunkFilter;
 use common_storages_index::FilterEvalResult;
 
 #[test]
-fn test_column_type_support() -> Result<()> {
-    let schema = DataSchemaRefExt::create(vec![
-        DataField::new("u", u8::to_data_type()),
-        DataField::new("u16", u16::to_data_type()),
-        DataField::new("u32", u32::to_data_type()),
-        DataField::new("u64", u64::to_data_type()),
-        DataField::new("i", i8::to_data_type()),
-        DataField::new("i16", i16::to_data_type()),
-        DataField::new("i32", i32::to_data_type()),
-        DataField::new("i64", i64::to_data_type()),
-        DataField::new("b", BooleanType::new_impl()),
-        DataField::new("s", StringType::new_impl()),
-    ]);
+fn test_bloom_filter() -> Result<()> {
+    let chunks = vec![
+        Chunk::new(
+            vec![
+                ChunkEntry {
+                    id: "0".to_string(),
+                    data_type: DataType::Number(NumberDataType::UInt8),
+                    value: Value::Scalar(Scalar::Number(NumberScalar::UInt8(1))),
+                },
+                ChunkEntry {
+                    id: "1".to_string(),
+                    data_type: DataType::String,
+                    value: Value::Scalar(Scalar::String(b"a".to_vec())),
+                },
+            ],
+            2,
+        ),
+        Chunk::new(
+            vec![
+                ChunkEntry {
+                    id: "0".to_string(),
+                    data_type: DataType::Number(NumberDataType::UInt8),
+                    value: Value::Column(Column::Number(NumberColumn::UInt8(vec![2, 3].into()))),
+                },
+                ChunkEntry {
+                    id: "1".to_string(),
+                    data_type: DataType::String,
+                    value: Value::Column(Column::from_data(vec!["b", "c"])),
+                },
+            ],
+            2,
+        ),
+    ];
+    let chunks_ref = chunks.iter().collect::<Vec<_>>();
 
-    let cols = schema
-        .fields()
-        .iter()
-        .map(|f| {
-            f.data_type()
-                .create_constant_column(&f.data_type().default_value(), 1)
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let index = ChunkFilter::try_create(FunctionContext::default(), &chunks_ref)?;
 
-    use common_datavalues::DataType;
-    let block = DataBlock::create(schema.clone(), cols);
+    assert_eq!(
+        FilterEvalResult::MustFalse,
+        eval_index(
+            &index,
+            "0",
+            Scalar::Number(NumberScalar::UInt8(0)),
+            DataType::Number(NumberDataType::UInt8)
+        )
+    );
+    assert_eq!(
+        FilterEvalResult::Uncertain,
+        eval_index(
+            &index,
+            "0",
+            Scalar::Number(NumberScalar::UInt8(1)),
+            DataType::Number(NumberDataType::UInt8)
+        )
+    );
+    assert_eq!(
+        FilterEvalResult::Uncertain,
+        eval_index(
+            &index,
+            "0",
+            Scalar::Number(NumberScalar::UInt8(2)),
+            DataType::Number(NumberDataType::UInt8)
+        )
+    );
+    assert_eq!(
+        FilterEvalResult::Uncertain,
+        eval_index(&index, "1", Scalar::String(b"a".to_vec()), DataType::String)
+    );
+    assert_eq!(
+        FilterEvalResult::Uncertain,
+        eval_index(&index, "1", Scalar::String(b"b".to_vec()), DataType::String)
+    );
+    assert_eq!(
+        FilterEvalResult::MustFalse,
+        eval_index(&index, "1", Scalar::String(b"d".to_vec()), DataType::String)
+    );
 
-    let supported_types: HashSet<DataTypeImpl> = HashSet::from_iter(vec![
-        StringType::new_impl(),
-        u8::to_data_type(),
-        i8::to_data_type(),
-        u16::to_data_type(),
-        i16::to_data_type(),
-        u32::to_data_type(),
-        i32::to_data_type(),
-        u64::to_data_type(),
-        i64::to_data_type(),
-    ]);
-    let index = ChunkFilter::try_create(&[&block])?;
-
-    // String type and 8 integral types are supported
-    assert_eq!(supported_types.len(), index.filter_chunk.columns().len());
-
-    // check index columns
-    schema.fields().iter().for_each(|field| {
-        let col_name = ChunkFilter::build_filter_column_name(field.name());
-        let maybe_index_col = index.filter_chunk.try_column_by_name(&col_name);
-        if supported_types.contains(field.data_type()) {
-            assert!(maybe_index_col.is_ok(), "check field {}", field.name())
-        } else {
-            assert!(maybe_index_col.is_err(), "check field {}", field.name())
-        }
-    });
-
-    // check applicable
-    schema.fields().iter().for_each(|field| {
-        // type of input data value does not matter here, will be casted during filtering
-        let value = DataValue::Boolean(true);
-        let col_name = field.name().as_str();
-        let data_type = field.data_type();
-        let r = index.find(col_name, value, data_type).unwrap();
-        if supported_types.contains(field.data_type()) {
-            assert_ne!(
-                r,
-                FilterEvalResult::NotApplicable,
-                "check applicable field {}",
-                field.name()
-            )
-        } else {
-            assert_eq!(
-                r,
-                FilterEvalResult::NotApplicable,
-                "check applicable field {}",
-                field.name()
-            )
-        }
-    });
     Ok(())
+}
+
+fn eval_index(index: &ChunkFilter, col_name: &str, val: Scalar, ty: DataType) -> FilterEvalResult {
+    index
+        .eval(
+            check_function(
+                None,
+                "eq",
+                &[],
+                &[
+                    Expr::ColumnRef {
+                        span: None,
+                        id: col_name.to_string(),
+                        data_type: ty.clone(),
+                    },
+                    Expr::Constant {
+                        span: None,
+                        scalar: val,
+                        data_type: ty,
+                    },
+                ],
+                &BUILTIN_FUNCTIONS,
+            )
+            .unwrap(),
+        )
+        .unwrap()
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Reimplement `RangeFilter` and `BloomFilter` with the new expression in the `expression` branch,
- Reimplement the tests and benchmark.

The benchmark result is 2x faster than the original implementation which seems too good to be true. 🤔  

Closes https://github.com/datafuselabs/databend/issues/9038
