### PR TITLE
fix: too many io requests for read blocks during compact

### DIFF
--- a/src/query/storages/fuse/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/fuse/src/io/mod.rs
@@ -28,6 +28,7 @@ pub use read::MetaReaders;
 pub use read::SegmentInfoReader;
 pub use read::SnapshotHistoryReader;
 pub use read::TableSnapshotReader;
+pub use segments::try_join_futures;
 pub use segments::SegmentsIO;
 pub use snapshots::SnapshotsIO;
 pub use write::write_block;

--- a/src/query/storages/fuse/fuse/src/io/segments.rs
+++ b/src/query/storages/fuse/fuse/src/io/segments.rs
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use std::future::Future;
 use std::sync::Arc;
 
 use common_base::base::tokio::sync::Semaphore;
@@ -56,11 +57,7 @@ impl SegmentsIO {
             return Ok(vec![]);
         }
 
-        let ctx = self.ctx.clone();
-        let max_runtime_threads = ctx.get_settings().get_max_threads()? as usize;
-        let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
-
-        // 1.1 combine all the tasks.
+        // combine all the tasks.
         let mut iter = segment_locations.iter();
         let tasks = std::iter::from_fn(move || {
             if let Some(location) = iter.next() {
@@ -74,22 +71,36 @@ impl SegmentsIO {
             }
         });
 
-        // 1.2 build the runtime.
-        let semaphore = Semaphore::new(max_io_requests);
-        let segments_runtime = Arc::new(Runtime::with_worker_threads(
-            max_runtime_threads,
-            Some("fuse-req-segments-worker".to_owned()),
-        )?);
-
-        // 1.3 spawn all the tasks to the runtime.
-        let join_handlers = segments_runtime.try_spawn_batch(semaphore, tasks).await?;
-
-        // 1.4 get all the result.
-        let joint = future::try_join_all(join_handlers)
-            .instrument(tracing::debug_span!("read_segments_join_all"))
-            .await
-            .map_err(|e| ErrorCode::StorageOther(format!("read segments failure, {}", e)))?;
-
-        Ok(joint)
+        try_join_futures(self.ctx.clone(), tasks).await
     }
+}
+
+pub async fn try_join_futures<Fut>(
+    ctx: Arc<dyn TableContext>,
+    futures: impl IntoIterator<Item = Fut>,
+) -> Result<Vec<Fut::Output>>
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    let max_runtime_threads = ctx.get_settings().get_max_threads()? as usize;
+    let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
+
+    // 1. build the runtime.
+    let semaphore = Semaphore::new(max_io_requests);
+    let segments_runtime = Arc::new(Runtime::with_worker_threads(
+        max_runtime_threads,
+        Some("deletion-write-segments-worker".to_owned()),
+    )?);
+
+    // 2. spawn all the tasks to the runtime.
+    let join_handlers = segments_runtime.try_spawn_batch(semaphore, futures).await?;
+
+    // 3. get all the result.
+    let joint = future::try_join_all(join_handlers)
+        .instrument(tracing::debug_span!("try_join_futures_all"))
+        .await
+        .map_err(|e| ErrorCode::StorageOther(format!("try join futures failure, {}", e)))?;
+
+    Ok(joint)
 }

--- a/src/query/storages/fuse/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -182,7 +182,7 @@ impl CompactTransform {
             stats_of_columns.push(meta_stats);
         }
 
-        let blocks = try_join_futures(ctx, task_futures)
+        let blocks = try_join_futures(ctx, task_futures, "deletion-read-blocks-worker".to_owned())
             .await?
             .into_iter()
             .collect::<Result<Vec<_>>>()?;
@@ -206,7 +206,7 @@ impl CompactTransform {
                 write_data(&state.index_data, &dal, &state.index_location).await
             });
         }
-        try_join_futures(ctx, handles)
+        try_join_futures(ctx, handles, "deletion-write-blocks-worker".to_owned())
             .await?
             .into_iter()
             .collect::<Result<Vec<_>>>()?;

--- a/src/query/storages/fuse/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -37,6 +37,7 @@ use opendal::Operator;
 use super::compact_meta::CompactSourceMeta;
 use super::compact_part::CompactTask;
 use super::CompactSinkMeta;
+use crate::io::try_join_futures;
 use crate::io::write_data;
 use crate::io::BlockReader;
 use crate::io::TableMetaLocationGenerator;
@@ -50,6 +51,12 @@ use crate::pipelines::processors::Processor;
 use crate::statistics::reduce_block_statistics;
 use crate::statistics::reducers::reduce_block_metas;
 
+struct CompactState {
+    blocks: Vec<DataBlock>,
+    stats_of_columns: Vec<Vec<StatisticsOfColumns>>,
+    trivals: VecDeque<Arc<BlockMeta>>,
+}
+
 struct SerializeState {
     block_data: Vec<u8>,
     block_location: String,
@@ -60,11 +67,7 @@ struct SerializeState {
 enum State {
     Consume,
     ReadBlocks,
-    CompactBlocks {
-        blocks: Vec<DataBlock>,
-        stats_of_columns: Vec<Vec<StatisticsOfColumns>>,
-        trivals: VecDeque<Arc<BlockMeta>>,
-    },
+    CompactBlocks(CompactState),
     SerializedBlocks(Vec<SerializeState>),
     GenerateSegment,
     SerializedSegment {
@@ -86,12 +89,12 @@ pub struct CompactTransform {
     scan_progress: Arc<Progress>,
     output_data: Option<DataBlock>,
 
+    ctx: Arc<dyn TableContext>,
     block_reader: Arc<BlockReader>,
     location_gen: TableMetaLocationGenerator,
     dal: Operator,
 
     // Limit the memory size of the block read.
-    max_memory: u64,
     compact_tasks: VecDeque<CompactTask>,
     block_metas: Vec<Arc<BlockMeta>>,
     order: usize,
@@ -111,26 +114,103 @@ impl CompactTransform {
         dal: Operator,
         thresholds: BlockCompactThresholds,
     ) -> Result<ProcessorPtr> {
-        let settings = ctx.get_settings();
-        let max_memory_usage = (settings.get_max_memory_usage()? as f64 * 0.95) as u64;
-        let max_threads = settings.get_max_threads()?;
-        let max_memory = max_memory_usage / max_threads;
         Ok(ProcessorPtr::create(Box::new(CompactTransform {
             state: State::Consume,
             input,
             output,
             scan_progress,
             output_data: None,
+            ctx,
             block_reader,
             location_gen,
             dal,
-            max_memory,
             compact_tasks: VecDeque::new(),
             block_metas: Vec::new(),
             order: 0,
             thresholds,
             abort_operation: AbortOperation::default(),
         })))
+    }
+
+    async fn read_blocks(&mut self) -> Result<CompactState> {
+        // block read tasks.
+        let mut task_futures = Vec::new();
+        // The no need compact blockmetas.
+        let mut trivals = VecDeque::new();
+        let mut memory_usage = 0;
+        let mut stats_of_columns = Vec::new();
+
+        let ctx = self.ctx.clone();
+        let settings = ctx.get_settings();
+        let max_memory_usage = (settings.get_max_memory_usage()? as f64 * 0.95) as u64;
+        let max_threads = settings.get_max_threads()?;
+        let max_memory = max_memory_usage / max_threads;
+        while let Some(task) = self.compact_tasks.pop_front() {
+            let metas = task.get_block_metas();
+            // Only one block, no need to do a compact.
+            if metas.len() == 1 {
+                stats_of_columns.push(vec![]);
+                trivals.push_back(metas[0].clone());
+                continue;
+            }
+
+            memory_usage += metas.iter().fold(0, |acc, meta| {
+                let memory = meta.bloom_filter_index_size + meta.block_size;
+                acc + memory
+            });
+
+            if memory_usage > max_memory && !task_futures.is_empty() {
+                self.compact_tasks.push_front(task);
+                break;
+            }
+
+            let mut meta_stats = Vec::with_capacity(metas.len());
+            for meta in metas {
+                let progress_values = ProgressValues {
+                    rows: meta.row_count as usize,
+                    bytes: meta.block_size as usize,
+                };
+                self.scan_progress.incr(&progress_values);
+
+                meta_stats.push(meta.col_stats.clone());
+
+                let block_reader = self.block_reader.clone();
+                // read block in parallel.
+                task_futures
+                    .push(async move { block_reader.read_with_block_meta(meta.as_ref()).await });
+            }
+            stats_of_columns.push(meta_stats);
+        }
+
+        let blocks = try_join_futures(ctx, task_futures)
+            .await?
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?;
+        Ok(CompactState {
+            blocks,
+            stats_of_columns,
+            trivals,
+        })
+    }
+
+    async fn write_blocks(&mut self, serialize_states: &mut Vec<SerializeState>) -> Result<()> {
+        let mut handles = Vec::with_capacity(serialize_states.len());
+        let ctx = self.ctx.clone();
+
+        while let Some(state) = serialize_states.pop() {
+            let dal = self.dal.clone();
+            handles.push(async move {
+                // write block data.
+                write_data(&state.block_data, &dal, &state.block_location).await?;
+                // write index data.
+                write_data(&state.index_data, &dal, &state.index_location).await
+            });
+        }
+        try_join_futures(ctx, handles)
+            .await?
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?;
+        Ok(())
     }
 }
 
@@ -147,7 +227,7 @@ impl Processor for CompactTransform {
     fn event(&mut self) -> Result<Event> {
         if matches!(
             &self.state,
-            State::CompactBlocks { .. } | State::GenerateSegment { .. } | State::Output { .. }
+            State::CompactBlocks(_) | State::GenerateSegment { .. } | State::Output { .. }
         ) {
             return Ok(Event::Sync);
         }
@@ -198,21 +278,18 @@ impl Processor for CompactTransform {
 
     fn process(&mut self) -> Result<()> {
         match std::mem::replace(&mut self.state, State::Consume) {
-            State::CompactBlocks {
-                mut blocks,
-                stats_of_columns,
-                mut trivals,
-            } => {
+            State::CompactBlocks(mut compact_state) => {
                 let mut serialize_states = Vec::new();
-                for stats in stats_of_columns {
+                for stats in compact_state.stats_of_columns {
                     let block_num = stats.len();
                     if block_num == 0 {
-                        self.block_metas.push(trivals.pop_front().unwrap());
+                        self.block_metas
+                            .push(compact_state.trivals.pop_front().unwrap());
                         continue;
                     }
 
                     // concat blocks.
-                    let compact_blocks: Vec<_> = blocks.drain(0..block_num).collect();
+                    let compact_blocks: Vec<_> = compact_state.blocks.drain(0..block_num).collect();
                     let new_block = DataBlock::concat_blocks(&compact_blocks)?;
 
                     // generate block statistics.
@@ -304,70 +381,11 @@ impl Processor for CompactTransform {
     async fn async_process(&mut self) -> Result<()> {
         match std::mem::replace(&mut self.state, State::Consume) {
             State::ReadBlocks => {
-                // block read tasks.
-                let mut task_futures = Vec::new();
-                // The no need compact blockmetas.
-                let mut trivals = VecDeque::new();
-                let mut memory_usage = 0;
-                let mut stats_of_columns = Vec::new();
-
-                let block_reader = self.block_reader.as_ref();
-                while let Some(task) = self.compact_tasks.pop_front() {
-                    let metas = task.get_block_metas();
-                    // Only one block, no need to do a compact.
-                    if metas.len() == 1 {
-                        stats_of_columns.push(vec![]);
-                        trivals.push_back(metas[0].clone());
-                        continue;
-                    }
-
-                    memory_usage += metas.iter().fold(0, |acc, meta| {
-                        let memory = meta.bloom_filter_index_size + meta.block_size;
-                        acc + memory
-                    });
-
-                    if memory_usage > self.max_memory {
-                        self.compact_tasks.push_front(task);
-                        break;
-                    }
-
-                    let mut meta_stats = Vec::with_capacity(metas.len());
-                    for meta in metas {
-                        let progress_values = ProgressValues {
-                            rows: meta.row_count as usize,
-                            bytes: meta.block_size as usize,
-                        };
-                        self.scan_progress.incr(&progress_values);
-
-                        meta_stats.push(meta.col_stats.clone());
-
-                        // read block in parallel.
-                        task_futures.push(async move {
-                            block_reader.read_with_block_meta(meta.as_ref()).await
-                        });
-                    }
-                    stats_of_columns.push(meta_stats);
-                }
-
-                let blocks = futures::future::try_join_all(task_futures).await?;
-                self.state = State::CompactBlocks {
-                    blocks,
-                    stats_of_columns,
-                    trivals,
-                }
+                let compact_state = self.read_blocks().await?;
+                self.state = State::CompactBlocks(compact_state);
             }
             State::SerializedBlocks(mut serialize_states) => {
-                let mut handles = Vec::with_capacity(serialize_states.len());
-                let dal = &self.dal;
-                while let Some(state) = serialize_states.pop() {
-                    handles.push(async move {
-                        // write block data.
-                        write_data(&state.block_data, dal, &state.block_location).await?;
-                        // write index data.
-                        write_data(&state.index_data, dal, &state.index_location).await
-                    });
-                }
-                futures::future::try_join_all(handles).await?;
+                self.write_blocks(&mut serialize_states).await?;
                 if self.compact_tasks.is_empty() {
                     self.state = State::GenerateSegment;
                 } else {

--- a/src/query/storages/fuse/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -113,7 +113,7 @@ impl CompactTransform {
         thresholds: BlockCompactThresholds,
     ) -> Result<ProcessorPtr> {
         let settings = ctx.get_settings();
-        let max_memory_usage = (settings.get_max_memory_usage()? as f64 * 0.95) as u64;
+        let max_memory_usage = (settings.get_max_memory_usage()? as f64 * 0.8) as u64;
         let max_threads = settings.get_max_threads()?;
         let max_memory = max_memory_usage / max_threads;
         let max_io_requests = settings.get_max_storage_io_requests()? as usize;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This bug is due to the fact that compact transform reads and writes blocks concurrently, and there was no limit to the number of concurrent requests before, which may lead to excessive io requests and tcp connect error.
```
MySQL [(none)]> optimize table hits compact;
ERROR 1105 (HY000): Code: 4000, displayText = Unexpected (persistent) at read, context: { called: http_util::Client::send_async, service: s3, path: 1/94363/_b/02c89d8096504e4c97fde3e56sd17875_v0.parquet, range: 426216-426309 } => send async request, source: error sending request for url (http://127.0.0.1:9900/testbucket/local_7150/1/94363/_b/02c89d8096504e4c97fde3e56sd17875_v0.parquet): error trying to connect: tcp connect error: Address not available (os error 99).
```

So we need limit the number of concurrency(max_io_requests) when [reading](https://github.com/datafuselabs/databend/blob/main/src/query/storages/fuse/fuse/src/operations/mutation/compact/compact_transform.rs#L344-L352) and [writing](https://github.com/datafuselabs/databend/blob/main/src/query/storages/fuse/fuse/src/operations/mutation/compact/compact_transform.rs#L362-L370) blocks.

https://github.com/datafuselabs/databend/blob/main/src/query/storages/fuse/fuse/src/operations/mutation/compact/compact_transform.rs#L344-L352


We can avoid oom and improve the efficiency of compact by adjusting `max_threads`| `max_storage_io_requests`| `max_memory_usage`.

Closes #9107 
