### PR TITLE
ci: try to add hive release

### DIFF
--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -215,6 +215,73 @@ jobs:
           target: ${{ steps.target.outputs.target }}
           repo_role_arn: ${{ secrets.REPO_ROLE_ARN }}
 
+  publish_hive:
+    name: hive assets
+    runs-on: [self-hosted, X64, Linux, development]
+    needs: [create_release]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - x86_64
+        platform:
+          - gnu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get the version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+      - name: Get target
+        id: target
+        run: echo 'target=${{ matrix.arch }}-unknown-linux-${{ matrix.platform }}' >> $GITHUB_OUTPUT
+      - name: Setup Build Tool
+        uses: ./.github/actions/setup_build_tool
+        with:
+          image: ${{ steps.target.outputs.target }}
+      - name: Build Binary
+        run: |
+          cargo build --release --target=${{ steps.target.outputs.target }} --features hive
+      - name: Copyobj zlib for gnu binaries
+        if: matrix.platform == 'gnu'
+        run: |
+          target=${{ steps.target.outputs.target }}
+          build-tool /usr/bin/${{ matrix.arch }}-linux-gnu-objcopy --compress-debug-sections=zlib-gnu ./target/${target}/release/databend-query
+          build-tool /usr/bin/${{ matrix.arch }}-linux-gnu-objcopy --compress-debug-sections=zlib-gnu ./target/${target}/release/databend-meta
+          build-tool /usr/bin/${{ matrix.arch }}-linux-gnu-objcopy --compress-debug-sections=zlib-gnu ./target/${target}/release/databend-metactl
+      - name: Pack binaries
+        run: |
+          target=${{ steps.target.outputs.target }}
+          version=${{ needs.create_release.outputs.version }}
+          mkdir -p release/${target}/{bin,configs}
+          cp ./target/${target}/release/databend-* release/${target}/bin/
+          rm -f release/${target}/bin/*.d
+          cp ./scripts/ci/deploy/config/databend-query-node-1.toml release/${target}/configs/databend-query.toml
+          cp ./scripts/ci/deploy/config/databend-meta-node-1.toml release/${target}/configs/databend-meta.toml
+          cp ./.github/actions/publish_binary/databend-release-readme.txt release/${target}/readme.txt
+          cp -r ./.github/actions/publish_binary/databend-scripts-for-release release/${target}/scripts
+          tar -C ./release/${target} -czvf databend-hive-${version}-${target}.tar.gz bin configs scripts readme.txt
+      - name: generate sha256sums
+        run: |
+          target=${{ steps.target.outputs.target }}
+          version=${{ needs.create_release.outputs.version }}
+          sha256sum databend-hive-${version}-${target}.tar.gz >> sha256-hive-${version}-${target}.txt
+      - name: post sha256
+        uses: actions/upload-artifact@v2
+        with:
+          name: sha256sums
+          path: sha256-hive-${{ needs.create_release.outputs.version }}-${{ steps.target.outputs.target }}.txt
+          retention-days: 1
+      - name: Publish Binaries
+        uses: ./.github/actions/publish_binary
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: hive-${{ needs.create_release.outputs.version }}
+          target: ${{ steps.target.outputs.target }}
+          repo_role_arn: ${{ secrets.REPO_ROLE_ARN }}
+
   publish_sqllogic_testsuites:
     name: sqllogic testsuites
     runs-on: ubuntu-latest

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -64,6 +64,15 @@ jobs:
           target: ${{ matrix.target }}
           profile: release
 
+  build_hive:
+    runs-on: [self-hosted, X64, Linux, development]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/build_linux_hive
+        with:
+          target: x86_64-unknown-linux-gnu
+          profile: release
+
   test_unit:
     timeout-minutes: 30
     runs-on: [self-hosted, X64, Linux]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- follow the process of linux releases in databend-release.yml, try to add hive release
  - only for x86 & gnu
  - runs-on: [self-hosted, X64, Linux, development]
  - with databend-hive-* prefix
- add hive release build ci to production.yml

Closes #issue
