### PR TITLE
feat: print memory limit and cluster info when query start

### DIFF
--- a/src/binaries/query/main.rs
+++ b/src/binaries/query/main.rs
@@ -205,6 +205,26 @@ async fn main_entrypoint() -> Result<()> {
             format!("connected to endpoints {:#?}", conf.meta.endpoints)
         }
     );
+    println!(
+        "Memory: {}",
+        if conf.query.max_memory_limit_enabled {
+            format!(
+                "Memory: server memory limit to {} (bytes)",
+                conf.query.max_server_memory_usage
+            )
+        } else {
+            "unlimited".to_string()
+        }
+    );
+    println!("Cluster: {}", {
+        let cluster = ClusterDiscovery::instance().discover(&conf).await?;
+        let nodes = cluster.nodes.len();
+        if nodes > 1 {
+            format!("[{}] nodes", nodes)
+        } else {
+            "standalone".to_string()
+        }
+    });
     println!("Storage: {}", conf.storage.params);
     println!("Cache: {}", conf.storage.cache.params);
     println!(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```
Version: v0.8.144-nightly-79623a7(rust-1.67.0-nightly-2022-12-08T06:49:43.133656246Z)

Logging:
    file: enabled=true, level=ERROR, dir=./.databend/logs, format=json
    stderr: enabled=false(To enable: LOG_STDERR_ON=true or RUST_LOG=info), level=INFO, format=text
Meta: connected to endpoints [
    "172.16.172.42:9191",
]
Memory: unlimited
Cluster: standalone
Storage: s3 | bucket=bohusg,root=,endpoint=oss-ap-southeast-1-internal.aliyuncs.com
Cache: none
Builtin users:

Admin
    listened at 0.0.0.0:8080
MySQL
    listened at 0.0.0.0:3307
    connect via: mysql -uroot -h0.0.0.0 -P3307
Clickhouse(http)
    listened at 0.0.0.0:8124
    usage:  echo 'create table test(foo string)' | curl -u root: '0.0.0.0:8124' --data-binary  @-
echo '{"foo": "bar"}' | curl -u root: '0.0.0.0:8124/?query=INSERT%20INTO%20test%20FORMAT%20JSONEachRow' --data-binary @-
Databend HTTP
    listened at 0.0.0.0:8000
    usage:  curl -u root: --request POST '0.0.0.0:8000/v1/query/' --header 'Content-Type: application/json' --data-raw '{"sql": "SELECT avg(number) FROM numbers(100000000)"}'
```

Closes #9146
