### PR TITLE
chore: add miri command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ build-native:
 unit-test:
 	ulimit -n 10000;ulimit -s 16384; RUST_LOG="ERROR" bash ./scripts/ci/ci-run-unit-tests.sh
 
+miri:
+	cargo miri setup
+	MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test --no-default-features
+
 embedded-meta-test: build
 	rm -rf ./_meta_embedded*
 	bash ./scripts/ci/ci-run-tests-embedded-meta.sh

--- a/scripts/setup/rust-toolchain.toml
+++ b/scripts/setup/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2022-11-14"
-components = ["rustfmt", "clippy", "rust-src"]
+components = ["rustfmt", "clippy", "rust-src", "miri"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- add miri check
- miri does not support SIMD, so with `--no-default-features` flags

Closes #issue
