### PR TITLE
feat(query): parse_escape_bytes unescape \xHH.

### DIFF
--- a/src/common/io/tests/it/utils.rs
+++ b/src/common/io/tests/it/utils.rs
@@ -39,6 +39,7 @@ fn parse_escape() {
         vec!["abc", "abc"],
         vec!["\t\nabc", "\t\nabc"],
         vec!["\\t\\nabc", "\t\nabc"],
+        vec!["\\t\\x1ab", "\t\x1ab"],
     ];
 
     for c in cases {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Closes #issue
