### PR TITLE
feat: change the unescape to enquota crate and support \\x01 -> \x01

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,6 +1601,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "common-exception",
+ "enquote",
  "lexical-core",
  "micromarshal",
  "ordered-float 3.3.0",
@@ -3443,6 +3444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enquote"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c36cb11dbde389f4096111698d8b567c0720e3452fd5ac3e6b4e47e1939932"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]

--- a/src/common/io/Cargo.toml
+++ b/src/common/io/Cargo.toml
@@ -21,6 +21,7 @@ bincode = { version = "2.0.0-rc.1", features = ["serde", "std"] }
 bytes = "1.2.1"
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
+enquote = "1.1.0"
 lexical-core = "0.8.5"
 micromarshal = "0.2.1"
 ordered-float = "3.1.0"

--- a/src/common/io/src/utils.rs
+++ b/src/common/io/src/utils.rs
@@ -14,6 +14,7 @@
 
 use std::cmp;
 
+use common_exception::ErrorCode;
 use common_exception::Result;
 
 pub fn convert_byte_size(num: f64) -> String {
@@ -80,63 +81,11 @@ pub fn deserialize_from_slice<T: serde::de::DeserializeOwned>(slice: &mut &[u8])
     Ok(value)
 }
 
-pub fn is_control_ascii(c: u8) -> bool {
-    c <= 31
-}
-
-pub fn parse_escape_string(bs: &[u8]) -> String {
-    let bs = parse_escape_bytes(bs);
-
-    let mut cs = Vec::with_capacity(bs.len());
-    for b in bs {
-        cs.push(b as char);
-    }
-    cs.iter().collect()
-}
-
-pub fn parse_escape_bytes(bs: &[u8]) -> Vec<u8> {
-    let mut vs = Vec::with_capacity(bs.len());
-    let mut i = 0;
-    while i < bs.len() {
-        if bs[i] == b'\\' {
-            if i + 1 < bs.len() {
-                let c = parse_escape_byte(bs[i + 1]);
-                if c != b'\\'
-                    && c != b'\''
-                    && c != b'"'
-                    && c != b'`'
-                    && c != b'/'
-                    && !is_control_ascii(c)
-                {
-                    vs.push(b'\\');
-                }
-
-                vs.push(c);
-                i += 2;
-            } else {
-                // end with \
-                vs.push(b'\\');
-                break;
-            }
-        } else {
-            vs.push(bs[i]);
-            i += 1;
-        }
-    }
-
-    vs
-}
-
-// https://doc.rust-lang.org/reference/tokens.html
-pub fn parse_escape_byte(b: u8) -> u8 {
-    match b {
-        b'e' => b'\x1B',
-        b'n' => b'\n',
-        b'r' => b'\r',
-        b't' => b'\t',
-        b'0' => b'\0',
-        _ => b,
-    }
+/// Returns string after processing escapes such as \\x01 --> \x01.
+/// More please check the unit test.
+pub fn unescape_string(escape_str: &str) -> Result<String> {
+    enquote::unescape(escape_str, None)
+        .map_err(|e| ErrorCode::Internal(format!("unescape:{} error:{:?}", escape_str, e)))
 }
 
 /// Mask a string by "******", but keep `unmask_len` of suffix.

--- a/src/common/io/tests/it/utils.rs
+++ b/src/common/io/tests/it/utils.rs
@@ -33,15 +33,19 @@ fn convert_test() {
 }
 
 #[test]
-fn parse_escape() {
+fn parse_unescape() {
     let cases = vec![
         vec!["a", "a"],
         vec!["abc", "abc"],
+        vec!["\\x01", "\x01"],
         vec!["\t\nabc", "\t\nabc"],
+        vec!["\"\t\nabc\"", "\"\t\nabc\""],
+        vec!["\"\\t\nabc\"", "\"\t\nabc\""],
+        vec!["'\\t\nabc'", "'\t\nabc'"],
         vec!["\\t\\nabc", "\t\nabc"],
     ];
 
     for c in cases {
-        assert_eq!(parse_escape_bytes(c[0].as_bytes()), c[1].as_bytes());
+        assert_eq!(unescape_string(c[0]).unwrap(), c[1]);
     }
 }

--- a/src/query/service/src/servers/http/v1/load.rs
+++ b/src/query/service/src/servers/http/v1/load.rs
@@ -22,7 +22,7 @@ use common_base::base::ProgressValues;
 use common_base::base::TrySpawn;
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_io::prelude::parse_escape_string;
+use common_io::prelude::unescape_string;
 use common_pipeline_sources::processors::sources::input_formats::InputContext;
 use common_pipeline_sources::processors::sources::input_formats::StreamingReadBatch;
 use futures::StreamExt;
@@ -103,7 +103,9 @@ pub async fn streaming_load(
     for (key, value) in req.headers().iter() {
         if settings.has_setting(key.as_str()) {
             let value = value.to_str().map_err(InternalServerError)?;
-            let value = parse_escape_string(remove_quote(value.as_bytes()));
+            let unquote =
+                std::str::from_utf8(remove_quote(value.as_bytes())).map_err(InternalServerError)?;
+            let value = unescape_string(unquote).map_err(InternalServerError)?;
             settings
                 .set_settings(key.to_string(), value, false)
                 .map_err(InternalServerError)?

--- a/src/query/sql/src/planner/binder/copy.rs
+++ b/src/query/sql/src/planner/binder/copy.rs
@@ -32,7 +32,7 @@ use common_catalog::table_context::TableContext;
 use common_config::GlobalConfig;
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_io::prelude::parse_escape_string;
+use common_io::prelude::unescape_string;
 use common_meta_types::FileFormatOptions;
 use common_meta_types::StageFileFormatType;
 use common_meta_types::UserStageInfo;
@@ -611,54 +611,44 @@ pub fn parse_copy_file_format_options(
         .parse::<u64>()?;
 
     // Field delimiter.
-    let field_delimiter = parse_escape_string(
+    let field_delimiter = unescape_string(
         file_format_options
             .get("field_delimiter")
-            .unwrap_or(&"".to_string())
-            .as_bytes(),
-    );
+            .unwrap_or(&"".to_string()),
+    )?;
 
     // Record delimiter.
-    let record_delimiter = parse_escape_string(
+    let record_delimiter = unescape_string(
         file_format_options
             .get("record_delimiter")
-            .unwrap_or(&"".to_string())
-            .as_bytes(),
-    );
+            .unwrap_or(&"".to_string()),
+    )?;
 
     // NaN display.
-    let nan_display = parse_escape_string(
+    let nan_display = unescape_string(
         file_format_options
             .get("nan_display")
-            .unwrap_or(&"".to_string())
-            .as_bytes(),
-    );
+            .unwrap_or(&"".to_string()),
+    )?;
 
     // Escape
-    let escape = parse_escape_string(
-        file_format_options
-            .get("escape")
-            .unwrap_or(&"".to_string())
-            .as_bytes(),
-    );
+    let escape = unescape_string(file_format_options.get("escape").unwrap_or(&"".to_string()))?;
 
     // Compression delimiter.
-    let compression = parse_escape_string(
+    let compression = unescape_string(
         file_format_options
             .get("compression")
-            .unwrap_or(&"none".to_string())
-            .as_bytes(),
-    )
+            .unwrap_or(&"none".to_string()),
+    )?
     .parse()
     .map_err(ErrorCode::UnknownCompressionType)?;
 
     // Row tag in xml.
-    let row_tag = parse_escape_string(
+    let row_tag = unescape_string(
         file_format_options
             .get("row_tag")
-            .unwrap_or(&"".to_string())
-            .as_bytes(),
-    );
+            .unwrap_or(&"".to_string()),
+    )?;
 
     Ok(FileFormatOptions {
         format: file_format,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* change the unescape to enquota crate
* supports hex unescape, like `\\x01` -> `\x01`

Closes #issue
