### PR TITLE
feat(query): Support timezone config in config file and sys env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,6 +1952,7 @@ dependencies = [
 name = "common-settings"
 version = "0.1.0"
 dependencies = [
+ "chrono-tz",
  "common-ast",
  "common-base",
  "common-config",

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -43,6 +43,9 @@ pub struct Config {
     // Query engine config.
     pub query: QueryConfig,
 
+    // Settings config.
+    pub settings: SettingsConfig,
+
     pub log: LogConfig,
 
     // Meta Service config.
@@ -236,6 +239,19 @@ impl QueryConfig {
         RpcClientTlsConfig {
             rpc_tls_server_root_ca_cert: self.rpc_tls_query_server_root_ca_cert.clone(),
             domain_name: self.rpc_tls_query_service_domain_name.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SettingsConfig {
+    pub timezone: String,
+}
+
+impl Default for SettingsConfig {
+    fn default() -> Self {
+        Self {
+            timezone: "UTC".to_string(),
         }
     }
 }

--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -55,6 +55,7 @@ use super::inner::CatalogHiveConfig as InnerCatalogHiveConfig;
 use super::inner::Config as InnerConfig;
 use super::inner::MetaConfig as InnerMetaConfig;
 use super::inner::QueryConfig as InnerQueryConfig;
+use super::inner::SettingsConfig as InnerSettingsConfig;
 use crate::DATABEND_COMMIT_VERSION;
 
 const CATALOG_HIVE: &str = "hive";
@@ -84,6 +85,10 @@ pub struct Config {
     // Query engine config.
     #[clap(flatten)]
     pub query: QueryConfig,
+
+    // Settings config.
+    #[clap(skip)]
+    pub settings: SettingsConfig,
 
     #[clap(flatten)]
     pub log: LogConfig,
@@ -178,6 +183,7 @@ impl From<InnerConfig> for Config {
             cmd: inner.cmd,
             config_file: inner.config_file,
             query: inner.query.into(),
+            settings: inner.settings.into(),
             log: inner.log.into(),
             meta: inner.meta.into(),
             storage: inner.storage.into(),
@@ -214,6 +220,7 @@ impl TryInto<InnerConfig> for Config {
             cmd: self.cmd,
             config_file: self.config_file,
             query: self.query.try_into()?,
+            settings: self.settings.try_into()?,
             log: self.log.try_into()?,
             meta: self.meta.try_into()?,
             storage: self.storage.try_into()?,
@@ -1130,6 +1137,38 @@ impl TryInto<InnerStorageRedisConfig> for RedisStorageConfig {
                 Some(self.default_ttl)
             },
         })
+    }
+}
+
+/// Settings config group.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Args)]
+#[serde(default, deny_unknown_fields)]
+pub struct SettingsConfig {
+    pub timezone: String,
+}
+
+impl Default for SettingsConfig {
+    fn default() -> Self {
+        InnerSettingsConfig::default().into()
+    }
+}
+
+impl TryInto<InnerSettingsConfig> for SettingsConfig {
+    type Error = ErrorCode;
+
+    fn try_into(self) -> Result<InnerSettingsConfig> {
+        Ok(InnerSettingsConfig {
+            timezone: self.timezone,
+        })
+    }
+}
+
+#[allow(deprecated)]
+impl From<InnerSettingsConfig> for SettingsConfig {
+    fn from(inner: InnerSettingsConfig) -> Self {
+        Self {
+            timezone: inner.timezone,
+        }
     }
 }
 

--- a/src/query/service/tests/it/configs.rs
+++ b/src/query/service/tests/it/configs.rs
@@ -84,6 +84,9 @@ users = []
 share_endpoint_address = ""
 share_endpoint_auth_token_file = ""
 
+[settings]
+timezone = "UTC"
+
 [log]
 level = "INFO"
 dir = "./.databend/logs"
@@ -309,6 +312,18 @@ fn test_env_config_s3() -> Result<()> {
             assert_eq!(HashMap::new(), configured.catalogs);
         },
     );
+
+    Ok(())
+}
+
+// From env, defaulting.
+#[test]
+fn test_env_config_settings() -> Result<()> {
+    temp_env::with_vars(vec![("SETTINGS_TIMEZONE", Some("Asia/Shanghai"))], || {
+        let configured = Config::load_for_test().expect("must success").into_outer();
+
+        assert_eq!("Asia/Shanghai", configured.settings.timezone);
+    });
 
     Ok(())
 }
@@ -749,6 +764,9 @@ async_insert_stale_timeout = 0
 users = []
 share_endpoint_address = ""
 
+[settings]
+timezone = "UTC"
+
 [log]
 level = "INFO"
 dir = "./.databend/logs"
@@ -822,6 +840,7 @@ protocol = "binary"
         vec![
             ("CONFIG_FILE", Some(file_path.to_string_lossy().as_ref())),
             ("QUERY_TENANT_ID", Some("tenant_id_from_env")),
+            ("SETTINGS_TIMEZONE", Some("Asia/Shanghai")),
             ("STORAGE_S3_ACCESS_KEY_ID", Some("access_key_id_from_env")),
             ("STORAGE_TYPE", None),
         ],
@@ -833,6 +852,7 @@ protocol = "binary"
             assert_eq!("tenant_id_from_env", cfg.query.tenant_id);
             assert_eq!("access_key_id_from_env", cfg.storage.s3.access_key_id);
             assert_eq!("s3", cfg.storage.storage_type);
+            assert_eq!("Asia/Shanghai", cfg.settings.timezone);
 
             // NOTE:
             //

--- a/src/query/settings/Cargo.toml
+++ b/src/query/settings/Cargo.toml
@@ -12,6 +12,7 @@ test = false
 hive = []
 
 [dependencies]
+chrono-tz = { workspace = true }
 common-ast = { path = "../../query/ast" }
 common-base = { path = "../../common/base" }
 common-config = { path = "../config" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support timezone config in config file and sys env

Now in toml

```
[settings]
timezone="UTC"
```

in sys env

```
SETTINGS_TIMEZONE='Asia/Shanghai' RUST_LOG=info ./target/debug/databend-query -c databend-query.toml
```

## Priority level

global > sys env > toml.

And the value will be set in function default_settings. override default_value and user_setting.

If query set global timezone='xx' and restart with `SETTINGS_TIMEZONE='yy' RUST_LOG=info ./target/debug/databend-query -c databend-query.toml`

The value of timezone is 'xx', the level is GLOBAL.

Until execute sql `unset timezone`, the value of timezone will be set to 'yy', and level is SESSION.

So there should be no compatibility issues

Closes #9173
