### PR TITLE
fix: don't push down topk to `Merge` when it's child is `Aggregate`

### DIFF
--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -430,6 +430,25 @@ impl PhysicalPlan {
         }
     }
 
+    pub fn name(&self) -> String {
+        match self {
+            PhysicalPlan::TableScan(_) => "TableScan".to_string(),
+            PhysicalPlan::Filter(_) => "Filter".to_string(),
+            PhysicalPlan::Project(_) => "Project".to_string(),
+            PhysicalPlan::EvalScalar(_) => "EvalScalar".to_string(),
+            PhysicalPlan::AggregatePartial(_) => "AggregatePartial".to_string(),
+            PhysicalPlan::AggregateFinal(_) => "AggregateFinal".to_string(),
+            PhysicalPlan::Sort(_) => "Sort".to_string(),
+            PhysicalPlan::Limit(_) => "Limit".to_string(),
+            PhysicalPlan::HashJoin(_) => "HashJoin".to_string(),
+            PhysicalPlan::Exchange(_) => "Exchange".to_string(),
+            PhysicalPlan::UnionAll(_) => "UnionAll".to_string(),
+            PhysicalPlan::DistributedInsertSelect(_) => "DistributedInsertSelect".to_string(),
+            PhysicalPlan::ExchangeSource(_) => "Exchange Source".to_string(),
+            PhysicalPlan::ExchangeSink(_) => "Exchange Sink".to_string(),
+        }
+    }
+
     pub fn children<'a>(&'a self) -> Box<dyn Iterator<Item = &'a PhysicalPlan> + 'a> {
         match self {
             PhysicalPlan::TableScan(_) => Box::new(std::iter::empty()),

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -356,7 +356,12 @@ impl PhysicalPlanBuilder {
                                 ..
                             }) => agg.input.output_schema()?,
 
-                            _ => unreachable!(),
+                            _ => {
+                                return Err(ErrorCode::Internal(format!(
+                                    "invalid input physical plan: {}",
+                                    input.name(),
+                                )));
+                            }
                         };
 
                         let agg_funcs: Vec<AggregateFunctionDesc> = agg.aggregate_functions.iter().map(|v| {
@@ -419,10 +424,17 @@ impl PhysicalPlanBuilder {
                                 })
                             }
 
-                            _ => unreachable!(),
+                            _ => {
+                                return Err(ErrorCode::Internal(format!(
+                                    "invalid input physical plan: {}",
+                                    input.name(),
+                                )));
+                            }
                         }
                     }
-                    AggregateMode::Initial => unreachable!(),
+                    AggregateMode::Initial => {
+                        return Err(ErrorCode::Internal("Invalid aggregate mode: Initial"));
+                    }
                 };
 
                 Ok(result)

--- a/tests/logictest/suites/mode/cluster/04_0002_explain_v2
+++ b/tests/logictest/suites/mode/cluster/04_0002_explain_v2
@@ -131,6 +131,76 @@ EvalScalar
         ├── order by: []
         └── limit: NONE
 
+statement query T
+explain select count(1) as c, count(b) as d, max(a) as e from t1 order by c, e, d limit 10;
+
+----
+Limit
+├── limit: 10
+├── offset: 0
+└── Sort
+    ├── sort keys: [c ASC NULLS LAST, e ASC NULLS LAST, d ASC NULLS LAST]
+    └── EvalScalar
+        ├── expressions: [count(1) (#8), max(a) (#10), count(b) (#9)]
+        └── AggregateFinal
+            ├── group by: []
+            ├── aggregate functions: [count(), count(b), max(a)]
+            └── Exchange
+                ├── exchange type: Merge
+                └── AggregatePartial
+                    ├── group by: []
+                    ├── aggregate functions: [count(), count(b), max(a)]
+                    └── TableScan
+                        ├── table: default.default.t1
+                        ├── read rows: 0
+                        ├── read bytes: 0
+                        ├── partitions total: 0
+                        ├── partitions scanned: 0
+                        └── push downs: [filters: [], limit: NONE]
+
+statement query T
+explain select (t1.a + 1) as c,(t1.b+1) as d, (t2.a+1) as e from t1 join t2 on t1.a = t2.a order by c, d, e limit 10;
+
+----
+Limit
+├── limit: 10
+├── offset: 0
+└── Sort
+    ├── sort keys: [c ASC NULLS LAST, d ASC NULLS LAST, e ASC NULLS LAST]
+    └── Exchange                
+        ├── exchange type: Merge
+        └── Limit
+            ├── limit: 10
+            ├── offset: 0
+            └── Sort
+                ├── sort keys: [c ASC NULLS LAST, d ASC NULLS LAST, e ASC NULLS LAST]
+                └── EvalScalar
+                    ├── expressions: [+(t1.a (#0), 1), +(t1.b (#1), 1), +(t2.a (#2), 1)]
+                    └── HashJoin
+                        ├── join type: INNER
+                        ├── build keys: [t2.a (#2)]
+                        ├── probe keys: [t1.a (#0)]
+                        ├── filters: []
+                        ├── Exchange(Build)
+                        │   ├── exchange type: Hash(t2.a (#2))
+                        │   └── TableScan
+                        │       ├── table: default.default.t2
+                        │       ├── read rows: 0
+                        │       ├── read bytes: 0
+                        │       ├── partitions total: 0
+                        │       ├── partitions scanned: 0
+                        │       ├── push downs: [filters: [], limit: NONE]
+                        │       └── output columns: [0]
+                        └── Exchange(Probe)
+                            ├── exchange type: Hash(t1.a (#0))
+                            └── TableScan
+                                ├── table: default.default.t1
+                                ├── read rows: 0
+                                ├── read bytes: 0
+                                ├── partitions total: 0
+                                ├── partitions scanned: 0
+                                └── push downs: [filters: [], limit: NONE]
+
 statement ok
 set prefer_broadcast_join = 1;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The ticket contains two things:
1. A quick fix for https://github.com/datafuselabs/databend/issues/9178: don't push down topk to `Merge` when it's child is `Aggregate`
2. Remove some `unreachable!` to prevent panic and return specific error.

Closes https://github.com/datafuselabs/databend/issues/9178
