### PR TITLE
chore(testing): wait a second to let cluster formation complete

### DIFF
--- a/scripts/ci/deploy/databend-query-cluster-3-nodes.sh
+++ b/scripts/ci/deploy/databend-query-cluster-3-nodes.sh
@@ -30,11 +30,20 @@ echo 'Start Meta service HA cluster(3 nodes)...'
 nohup ./target/${BUILD_PROFILE}/databend-meta -c scripts/ci/deploy/config/databend-meta-node-1.toml &
 python3 scripts/ci/wait_tcp.py --timeout 10 --port 9191
 
+# wait for cluster formation to complete.
+sleep 1
+
 nohup ./target/${BUILD_PROFILE}/databend-meta -c scripts/ci/deploy/config/databend-meta-node-2.toml &
 python3 scripts/ci/wait_tcp.py --timeout 10 --port 28202
 
+# wait for cluster formation to complete.
+sleep 1
+
 nohup ./target/${BUILD_PROFILE}/databend-meta -c scripts/ci/deploy/config/databend-meta-node-3.toml &
 python3 scripts/ci/wait_tcp.py --timeout 10 --port 28302
+
+# wait for cluster formation to complete.
+sleep 1
 
 echo 'Start databend-query node-1'
 env "RUST_BACKTRACE=1" nohup target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-1.toml &


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore(testing): wait a second to let cluster formation complete

databend-meta is brought up in background, after listening established,
a testing script should give it some more time to let it finish the
cluster formation, i.e., joining the cluster.

- Fix: #9157

## Changelog







## Related Issues