### PR TITLE
feat(query): enable runtime feature detection

### DIFF
--- a/src/common/io/src/position.rs
+++ b/src/common/io/src/position.rs
@@ -268,26 +268,30 @@ pub fn position16<
 >(
     buf: &[u8],
 ) -> usize {
-    #[cfg(all(any(target_arch = "x86_64"), target_feature = "sse4.2"))]
-    return position_sse42::<
-        POSITIVE,
-        C1,
-        C2,
-        C3,
-        C4,
-        C5,
-        C6,
-        C7,
-        C8,
-        C9,
-        C10,
-        C11,
-        C12,
-        C13,
-        C14,
-        C15,
-        C16,
-    >(buf);
+    #[cfg(all(any(target_arch = "x86_64")))]
+    {
+        if is_x86_feature_detected!("sse4.2") {
+            return position_sse42::<
+                POSITIVE,
+                C1,
+                C2,
+                C3,
+                C4,
+                C5,
+                C6,
+                C7,
+                C8,
+                C9,
+                C10,
+                C11,
+                C12,
+                C13,
+                C14,
+                C15,
+                C16,
+            >(buf);
+        }
+    }
 
     position16_from_index::<
         POSITIVE,
@@ -310,7 +314,7 @@ pub fn position16<
     >(buf, 0)
 }
 
-#[cfg(all(any(target_arch = "x86_64"), target_feature = "sse4.2"))]
+#[cfg(all(any(target_arch = "x86_64")))]
 #[inline(always)]
 fn position_sse42<
     const POSITIVE: bool,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

enable runtime feature detection for `target_features`.


performance :

insert 10000_0000  random numbers  into hashmap 

```
// pure run without target_features
cargo test --package common-hashtable --lib --release -- b::test_hashmap --exact --nocapture
// insert elasped 5072 ms
// find elasped 1955 ms, total: 4999999950000000


// run with sse4.2 features
RUSTFLAGS="-C target-cpu=x86-64 -C target-feature=+sse4.2" cargo test --package common-hashtable --lib --release -- b::test_hashmap --exact --nocapture
// insert elasped 3006 ms
// find elasped 1288 ms, total: 4999999950000000


// run runtime detection (with this pr)
cargo test --package common-hashtable --lib --release -- b::test_hashmap --exact --nocapture
// insert elasped 3788 ms
// find elasped 2037 ms, total: 4999999950000000
```

Runtime dispatch will share an atomic flag, so it's not overhead. And we can also enjoy the compile-time dispatch using `target-feature` flags.

Closes #issue
