### PR TITLE
feat: push down filter to parquet reader.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6151,8 +6151,7 @@ dependencies = [
 [[package]]
 name = "parquet2"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bbada33c3674484db647d889a581ab1105cafb871ba77be785af2cc44a8747"
+source = "git+https://github.com/jorgecarleitao/parquet2?rev=fb08b72#fb08b725aa15d700d2a67c19ef65889b032ae371"
 dependencies = [
  "async-stream",
  "brotli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,3 +142,4 @@ rpath = false
 # If there are dependencies that need patching, they can be listed below.
 # For example:
 # arrow-format = { git = "https://github.com/datafuse-extras/arrow-format", rev = "78dacc1" }
+parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", rev = "fb08b72" }

--- a/src/common/arrow/src/lib.rs
+++ b/src/common/arrow/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod parquet_read;
 mod parquet_write;
+pub mod schema_projection;
 
 pub use arrow;
 pub use arrow_format;

--- a/src/common/arrow/src/schema_projection.rs
+++ b/src/common/arrow/src/schema_projection.rs
@@ -1,0 +1,50 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use arrow::datatypes::DataType;
+use arrow::datatypes::Field;
+use arrow::datatypes::Schema;
+
+/// Project a [`Schema`] by picking the fields at the given indices.
+pub fn project(schema: &Schema, indices: &[usize]) -> Schema {
+    let fields = indices
+        .iter()
+        .map(|idx| schema.fields[*idx].clone())
+        .collect::<Vec<_>>();
+    Schema::with_metadata(fields.into(), schema.metadata.clone())
+}
+
+/// Project a [`Schema`] with inner columns by path.
+pub fn inner_project(schema: &Schema, path_indices: &BTreeMap<usize, Vec<usize>>) -> Schema {
+    let paths: Vec<Vec<usize>> = path_indices.values().cloned().collect();
+    let fields = paths
+        .iter()
+        .map(|path| traverse_paths(&schema.fields, path))
+        .collect::<Vec<_>>();
+    Schema::with_metadata(fields.into(), schema.metadata.clone())
+}
+
+fn traverse_paths(fields: &[Field], path: &[usize]) -> Field {
+    assert!(!path.is_empty());
+    let field = &fields[path[0]];
+    if path.len() == 1 {
+        return field.clone();
+    }
+    if let DataType::Struct(inner_fields) = field.data_type() {
+        return traverse_paths(inner_fields, &path[1..]);
+    }
+    unreachable!("Unable to get field paths. Fields: {:?}", fields);
+}

--- a/src/query/storages/parquet/src/parquet_reader/deserialize.rs
+++ b/src/query/storages/parquet/src/parquet_reader/deserialize.rs
@@ -45,7 +45,7 @@ impl ParquetReader {
         filter: Option<Bitmap>,
     ) -> Result<DataBlock> {
         let mut chunk_map: HashMap<usize, Vec<u8>> = chunks.into_iter().collect();
-        let mut columns_array_iter = Vec::with_capacity(self.projected_schema.num_fields());
+        let mut columns_array_iter = Vec::with_capacity(self.projected_arrow_schema.fields.len());
 
         let column_leaves = &self.projected_column_leaves.column_leaves;
         let mut cnt_map = Self::build_projection_count_map(column_leaves);
@@ -201,7 +201,7 @@ impl ParquetReader {
                 "deserializer from row group: fail to get a chunk",
             )),
             Some(Err(cause)) => Err(ErrorCode::from(cause)),
-            Some(Ok(chunk)) => DataBlock::from_chunk(&self.projected_schema, &chunk),
+            Some(Ok(chunk)) => DataBlock::from_chunk(&self.output_schema, &chunk),
         }
     }
 

--- a/src/query/storages/parquet/src/parquet_reader/deserialize.rs
+++ b/src/query/storages/parquet/src/parquet_reader/deserialize.rs
@@ -15,12 +15,15 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::Mutex;
 
+use common_arrow::arrow::bitmap::Bitmap;
 use common_arrow::arrow::datatypes::Field;
 use common_arrow::arrow::io::parquet::read::column_iter_to_arrays;
 use common_arrow::arrow::io::parquet::read::ArrayIter;
 use common_arrow::arrow::io::parquet::read::RowGroupDeserializer;
 use common_arrow::parquet::metadata::ColumnDescriptor;
+use common_arrow::parquet::page::CompressedPage;
 use common_arrow::parquet::read::BasicDecompressor;
 use common_arrow::parquet::read::PageMetaData;
 use common_arrow::parquet::read::PageReader;
@@ -29,6 +32,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_storage::ColumnLeaf;
 
+use super::filter::FilterState;
 use crate::parquet_part::ColumnMeta;
 use crate::parquet_part::ParquetRowGroupPart;
 use crate::ParquetReader;
@@ -38,6 +42,7 @@ impl ParquetReader {
         &self,
         part: &ParquetRowGroupPart,
         chunks: Vec<(usize, Vec<u8>)>,
+        filter: Option<Bitmap>,
     ) -> Result<DataBlock> {
         let mut chunk_map: HashMap<usize, Vec<u8>> = chunks.into_iter().collect();
         let mut columns_array_iter = Vec::with_capacity(self.projected_schema.num_fields());
@@ -62,12 +67,18 @@ impl ParquetReader {
                 metas.push((column_meta, descriptor));
                 chunks.push(column_chunk);
             }
-            columns_array_iter.push(Self::to_array_iter(
-                metas,
-                chunks,
-                part.num_rows,
-                column_leaf.field.clone(),
-            )?);
+            let array_iter = if let Some(ref bitmap) = filter {
+                Self::to_array_iter_with_filter(
+                    metas,
+                    chunks,
+                    part.num_rows,
+                    column_leaf.field.clone(),
+                    bitmap.clone(),
+                )?
+            } else {
+                Self::to_array_iter(metas, chunks, part.num_rows, column_leaf.field.clone())?
+            };
+            columns_array_iter.push(array_iter);
         }
 
         let mut deserializer = RowGroupDeserializer::new(columns_array_iter, part.num_rows, None);
@@ -111,6 +122,75 @@ impl ParquetReader {
             types,
             field,
             Some(rows),
+            rows,
+        )?)
+    }
+
+    /// Almost the same as `to_array_iter`, but with a filter.
+    fn to_array_iter_with_filter(
+        metas: Vec<(&ColumnMeta, &ColumnDescriptor)>,
+        chunks: Vec<Vec<u8>>,
+        rows: usize,
+        field: Field,
+        filter: Bitmap,
+    ) -> Result<ArrayIter<'static>> {
+        let (columns, types) = metas
+            .iter()
+            .zip(chunks.into_iter())
+            .map(|(&(meta, descriptor), chunk)| {
+                let filter_state = Arc::new(Mutex::new(FilterState::new(filter.clone())));
+                let iter_filter_state = filter_state.clone();
+
+                let pages = PageReader::new_with_page_meta(
+                    std::io::Cursor::new(chunk),
+                    PageMetaData {
+                        column_start: meta.offset,
+                        num_values: meta.length as i64,
+                        compression: meta.compression.into(),
+                        descriptor: descriptor.descriptor.clone(),
+                    },
+                    Arc::new(move |_, header| {
+                        // If the bitmap for current page is all unset, skip it.
+                        let mut state = filter_state.lock().unwrap();
+                        let num_rows = header.num_values();
+                        let all_unset = state.range_all_unset(num_rows);
+                        if all_unset {
+                            // skip this page.
+                            state.advance(num_rows);
+                        }
+                        !all_unset
+                    }),
+                    vec![],
+                    usize::MAX,
+                )
+                .map(move |page| {
+                    page.map(|page| match page {
+                        CompressedPage::Data(mut page) => {
+                            let num_rows = page.num_values();
+                            let mut state = iter_filter_state.lock().unwrap();
+                            if state.range_all_unset(num_rows) {
+                                page.select_rows(vec![]);
+                            } else if !state.range_all_set(num_rows) {
+                                page.select_rows(state.convert_to_intervals(num_rows));
+                            };
+                            state.advance(num_rows);
+                            CompressedPage::Data(page)
+                        }
+                        CompressedPage::Dict(_) => page, // do nothing
+                    })
+                });
+                (
+                    BasicDecompressor::new(pages, vec![]),
+                    &descriptor.descriptor.primitive_type,
+                )
+            })
+            .unzip();
+
+        Ok(column_iter_to_arrays(
+            columns,
+            types,
+            field,
+            Some(rows - filter.unset_bits()),
             rows,
         )?)
     }

--- a/src/query/storages/parquet/src/parquet_reader/filter.rs
+++ b/src/query/storages/parquet/src/parquet_reader/filter.rs
@@ -1,0 +1,72 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_arrow::arrow::bitmap::Bitmap;
+use common_arrow::parquet::indexes::Interval;
+
+/// A wrapper of [`Bitmap`] with a position mark. It is used to filter rows when reading a parquet file.
+///
+/// If a whole page is filtered, there is no need to decompress the page.
+/// If a row is filtered, there is no need to decode the row.
+pub struct FilterState {
+    bitmap: Bitmap,
+    pos: usize,
+}
+
+impl FilterState {
+    pub fn new(bitmap: Bitmap) -> Self {
+        Self { bitmap, pos: 0 }
+    }
+
+    #[inline]
+    pub fn advance(&mut self, num: usize) {
+        self.pos += num;
+    }
+
+    /// Return true if [`self.pos`, `self.pos + num`) are set.
+    #[inline]
+    pub fn range_all_set(&self, num: usize) -> bool {
+        self.bitmap.null_count_range(self.pos, num) == 0
+    }
+
+    /// Return true if [`self.pos`, `self.pos + num`) are unset.
+    #[inline]
+    pub fn range_all_unset(&self, num: usize) -> bool {
+        self.bitmap.null_count_range(self.pos, num) == num
+    }
+
+    /// Convert the valditiy of [`self.pos`, `self.pos + num`) to [`Interval`]s.
+    pub fn convert_to_intervals(&self, num_rows: usize) -> Vec<Interval> {
+        let mut res = vec![];
+        let mut started = false;
+        let mut start = 0;
+        for (i, v) in self.bitmap.iter().skip(self.pos).take(num_rows).enumerate() {
+            if v {
+                if !started {
+                    start = i;
+                    started = true;
+                }
+            } else if started {
+                res.push(Interval::new(start, i - start));
+                started = false;
+            }
+        }
+
+        if started {
+            res.push(Interval::new(start, num_rows - start));
+        }
+
+        res
+    }
+}

--- a/src/query/storages/parquet/src/parquet_reader/meta.rs
+++ b/src/query/storages/parquet/src/parquet_reader/meta.rs
@@ -14,9 +14,9 @@
 
 use std::fs::File;
 
+use common_arrow::arrow::datatypes::Schema as ArrowSchema;
 use common_arrow::arrow::io::parquet::read as pread;
 use common_arrow::parquet::metadata::FileMetaData;
-use common_datavalues::DataSchema;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
@@ -36,11 +36,11 @@ impl ParquetReader {
     }
 
     #[inline]
-    pub fn infer_schema(meta: &FileMetaData) -> Result<DataSchema> {
+    pub fn infer_schema(meta: &FileMetaData) -> Result<ArrowSchema> {
         let mut arrow_schema = pread::infer_schema(meta)?;
         arrow_schema.fields.iter_mut().for_each(|f| {
             f.name = f.name.to_lowercase();
         });
-        Ok(DataSchema::from(arrow_schema))
+        Ok(arrow_schema)
     }
 }

--- a/src/query/storages/parquet/src/parquet_reader/mod.rs
+++ b/src/query/storages/parquet/src/parquet_reader/mod.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 mod deserialize;
+mod filter;
 mod meta;
 mod read;
+
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -38,12 +40,14 @@ pub struct ParquetReader {
     /// The indices of columns need to read by this reader.
     ///
     /// Use [`HashSet`] to avoid duplicate indices.
-    /// Duplicate indices will exist when there are nested types.
+    /// Duplicate indices will exist when there are nested types or
+    /// select a same field multiple times.
     ///
     /// For example:
     ///
     /// ```sql
     /// select a, a.b, a.c from t;
+    /// select a, b, a from t;
     /// ```
     columns_to_read: HashSet<usize>,
     /// The schema of the [`common_datablocks::DataBlock`] this reader produces.

--- a/src/query/storages/parquet/src/parquet_reader/mod.rs
+++ b/src/query/storages/parquet/src/parquet_reader/mod.rs
@@ -21,9 +21,12 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use common_arrow::arrow::datatypes::Schema as ArrowSchema;
 use common_arrow::arrow::io::parquet::write::to_parquet_schema;
 use common_arrow::parquet::metadata::ColumnDescriptor;
+use common_arrow::schema_projection as ap;
 use common_catalog::plan::Projection;
+use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
 use common_exception::Result;
 use common_storage::ColumnLeaves;
@@ -51,7 +54,13 @@ pub struct ParquetReader {
     /// ```
     columns_to_read: HashSet<usize>,
     /// The schema of the [`common_datablocks::DataBlock`] this reader produces.
-    projected_schema: DataSchemaRef,
+    output_schema: DataSchemaRef,
+    /// The actual schema used to read parquet. It will be converted to [`common_datavalues::DataSchema`] when output [`common_datablocks::DataBlock`].
+    ///
+    /// The reason of using [`ArrowSchema`] to read parquet is that
+    /// There are some types that Databend not support such as Timestmap of nanoseconds.
+    /// Such types will be convert to supported types after deserialization.
+    projected_arrow_schema: ArrowSchema,
     /// [`ColumnLeaves`] corresponding to the `projected_schema`.
     projected_column_leaves: ColumnLeaves,
     /// [`ColumnDescriptor`]s corresponding to the `projected_schema`.
@@ -61,16 +70,53 @@ pub struct ParquetReader {
 impl ParquetReader {
     pub fn create(
         operator: Operator,
-        schema: DataSchemaRef,
+        schema: ArrowSchema,
         projection: Projection,
     ) -> Result<Arc<ParquetReader>> {
-        // Full schema and column leaves.
-        let arrow_schema = schema.to_arrow();
-        let column_leaves = ColumnLeaves::new_from_schema(&arrow_schema);
-        let schema_descriptors = to_parquet_schema(&arrow_schema)?;
+        let (
+            projected_arrow_schema,
+            projected_column_leaves,
+            projected_column_descriptors,
+            columns_to_read,
+        ) = Self::do_projection(&schema, &projection)?;
 
+        Ok(Arc::new(ParquetReader {
+            operator,
+            columns_to_read,
+            output_schema: Arc::new(DataSchema::from(&projected_arrow_schema)),
+            projected_arrow_schema,
+            projected_column_leaves,
+            projected_column_descriptors,
+        }))
+    }
+
+    pub fn output_schema(&self) -> DataSchemaRef {
+        self.output_schema.clone()
+    }
+
+    pub fn columns_to_read(&self) -> &HashSet<usize> {
+        &self.columns_to_read
+    }
+
+    /// Project the schema and get the needed column leaves.
+    #[allow(clippy::type_complexity)]
+    pub fn do_projection(
+        schema: &ArrowSchema,
+        projection: &Projection,
+    ) -> Result<(
+        ArrowSchema,
+        ColumnLeaves,
+        HashMap<usize, ColumnDescriptor>,
+        HashSet<usize>,
+    )> {
+        // Full schema and column leaves.
+        let column_leaves = ColumnLeaves::new_from_schema(schema);
+        let schema_descriptors = to_parquet_schema(schema)?;
         // Project schema
-        let projected_schema = DataSchemaRef::new(projection.project_schema(&schema));
+        let projected_arrow_schema = match projection {
+            Projection::Columns(indices) => ap::project(schema, indices),
+            Projection::InnerColumns(path_indices) => ap::inner_project(schema, path_indices),
+        };
         // Project column leaves
         let projected_column_leaves = ColumnLeaves {
             column_leaves: projection
@@ -91,21 +137,11 @@ impl ParquetReader {
                     .insert(*index, schema_descriptors.columns()[*index].clone());
             }
         }
-
-        Ok(Arc::new(ParquetReader {
-            operator,
-            columns_to_read,
-            projected_schema,
+        Ok((
+            projected_arrow_schema,
             projected_column_leaves,
             projected_column_descriptors,
-        }))
-    }
-
-    pub fn schema(&self) -> DataSchemaRef {
-        self.projected_schema.clone()
-    }
-
-    pub fn columns_to_read(&self) -> &HashSet<usize> {
-        &self.columns_to_read
+            columns_to_read,
+        ))
     }
 }

--- a/src/query/storages/parquet/src/parquet_source.rs
+++ b/src/query/storages/parquet/src/parquet_source.rs
@@ -20,8 +20,10 @@ use common_base::base::ProgressValues;
 use common_catalog::plan::PartInfoPtr;
 use common_catalog::table_context::TableContext;
 use common_datablocks::DataBlock;
+use common_datavalues::BooleanColumn;
 use common_datavalues::ColumnRef;
 use common_datavalues::DataSchemaRef;
+use common_datavalues::Series;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_functions::scalars::FunctionContext;
@@ -93,7 +95,7 @@ impl ParquetSource {
     fn do_prewhere_filter(&mut self, part: PartInfoPtr, chunks: Vec<IndexedChunk>) -> Result<()> {
         let rg_part = ParquetRowGroupPart::from_part(&part)?;
         // deserialize prewhere data block first
-        let data_block = self.prewhere_reader.deserialize(rg_part, chunks)?;
+        let data_block = self.prewhere_reader.deserialize(rg_part, chunks, None)?;
         if let Some(filter) = self.prewhere_filter.as_ref() {
             // do filter
             let res = filter
@@ -128,6 +130,7 @@ impl ParquetSource {
                 self.state =
                     Generated(self.ctx.try_get_part(), block.resort(self.output_schema())?);
             } else {
+                let data_block = DataBlock::filter_block(data_block, &filter)?;
                 self.state = State::ReadDataRemain(part, PrewhereData { data_block, filter });
             }
             Ok(())
@@ -153,7 +156,28 @@ impl ParquetSource {
             let block = if chunks.is_empty() {
                 prewhere_blocks
             } else if let Some(remain_reader) = self.remain_reader.as_ref() {
-                let remain_block = remain_reader.deserialize(rg_part, chunks)?;
+                // filter is already converted to non-null boolean column
+                let remain_block = if filter.is_const() && filter.get_bool(0)? {
+                    // don't need filter
+                    remain_reader.deserialize(rg_part, chunks, None)?
+                } else {
+                    let boolean_col = Series::check_get::<BooleanColumn>(&filter)?;
+                    let bitmap = boolean_col.values();
+                    if bitmap.unset_bits() == 0 {
+                        // don't need filter
+                        remain_reader.deserialize(rg_part, chunks, None)?
+                    } else {
+                        remain_reader.deserialize(rg_part, chunks, Some(bitmap.clone()))?
+                    }
+                };
+                assert!(
+                    prewhere_blocks.num_rows() == remain_block.num_rows(),
+                    "prewhere and remain blocks should have same row number. (prewhere: {}, remain: {})",
+                    prewhere_blocks.num_rows(),
+                    remain_block.num_rows()
+                );
+
+                // Combine two blocks.
                 for (col, field) in remain_block
                     .columns()
                     .iter()
@@ -171,11 +195,11 @@ impl ParquetSource {
                 bytes: block.memory_size(),
             };
             self.scan_progress.incr(&progress_values);
-            DataBlock::filter_block(block, &filter)?
+            block
         } else {
             // There is only prewhere reader.
             assert!(self.remain_reader.is_none());
-            let block = self.prewhere_reader.deserialize(rg_part, chunks)?;
+            let block = self.prewhere_reader.deserialize(rg_part, chunks, None)?;
             let progress_values = ProgressValues {
                 rows: block.num_rows(),
                 bytes: block.memory_size(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Push down filter to parquet reader.
- Convert `ArrowSchema` to `DataSchema` only when convert `ArrowChunk` to `DataBlock`.

Closes #9135
