### PR TITLE
feat: Make DataOperator UnwindSafe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "percent-encoding",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -5770,9 +5771,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.22.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9176f087790fd937421e3f649db6e85ad47dc63c60bef127402d233ab8f31639"
+checksum = "0db11c35a6f6de54c5da1a84d35ff67869143ee014ea7d862ac88ecb00422987"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -8754,7 +8755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -31,7 +31,9 @@ opendal = { version = "0.22", features = [
     "services-redis",
     "trust-dns",
     "compress",
+    "unwind-safe",
 ] }
 parking_lot = "0.12.1"
 percent-encoding = "2"
 serde = { workspace = true }
+tracing = "0.1"

--- a/src/query/service/tests/it/main.rs
+++ b/src/query/service/tests/it/main.rs
@@ -25,6 +25,7 @@ mod pipelines;
 mod servers;
 mod sessions;
 mod sql;
+mod storage;
 mod storages;
 mod stream;
 mod table_functions;

--- a/src/query/service/tests/it/storage.rs
+++ b/src/query/service/tests/it/storage.rs
@@ -1,0 +1,38 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_base::base::catch_unwind;
+use common_base::base::tokio;
+use common_exception::Result;
+use common_storage::DataOperator;
+
+use crate::tests::ConfigBuilder;
+use crate::tests::TestGlobalServices;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_data_operator_under_panicking() -> Result<()> {
+    let config = ConfigBuilder::create().build();
+    let _guard = TestGlobalServices::setup(config.clone()).await?;
+
+    let result = catch_unwind(move || {
+        let _op = DataOperator::instance().operator();
+        panic!("Ooooooops!");
+    });
+    assert!(result.is_err());
+
+    // The operator fetched from data operator will always be clear.
+    assert!(!DataOperator::instance().operator().is_poisoned());
+
+    Ok(())
+}

--- a/src/query/service/tests/it/storage.rs
+++ b/src/query/service/tests/it/storage.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_base::base::catch_unwind;
 use common_base::base::tokio;
+use common_base::runtime::catch_unwind;
 use common_exception::Result;
 use common_storage::DataOperator;
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

DataOperator could be shared across `catch_unwind` boundaries. But DataOperator is not unwind safe because hyper's Client implements `!UnwindSafe`.

This PR will adopt OpenDAL's `unwind-safe` feature to make it possible to check if this operator has been poisoned (panicked). If poisoned, we will initiate a new operator with the same storage param instead.

## Notes

There is a `Arc<Mutex<T>>` in `DataOperator`, but it should not be a serious problem as we will not have too many conflicts here.