### PR TITLE
fix: truncate reset ts location

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/analyze.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/analyze.rs
@@ -14,6 +14,9 @@
 
 use common_base::base::tokio;
 use common_exception::Result;
+use common_storages_factory::Table;
+use common_storages_fuse::FuseTable;
+use common_storages_fuse::TableContext;
 
 use crate::storages::fuse::table_test_fixture::check_data_dir;
 use crate::storages::fuse::table_test_fixture::execute_command;
@@ -36,6 +39,53 @@ async fn test_fuse_snapshot_analyze() -> Result<()> {
         Some((1, 1, 1, 1, 1)),
     )
     .await
+}
+
+#[tokio::test]
+async fn test_fuse_snapshot_analyze_and_truncate() -> Result<()> {
+    let fixture = TestFixture::new().await;
+    let db = fixture.default_db_name();
+    let tbl = fixture.default_table_name();
+    let case_name = "test_fuse_snapshot_analyze_and_truncate";
+
+    // insert some data
+    do_insertions(&fixture).await?;
+
+    // analyze the table
+    {
+        let qry = format!("Analyze table {}.{}", db, tbl);
+
+        let ctx = fixture.ctx();
+        execute_command(ctx, &qry).await?;
+
+        check_data_dir(&fixture, case_name, 3, 1, 2, 2, 2, None, Some(())).await?;
+    }
+
+    // truncate table
+    {
+        let ctx = fixture.ctx();
+        let catalog = ctx.get_catalog(fixture.default_catalog_name().as_str())?;
+        let table = catalog
+            .get_table(ctx.get_tenant().as_str(), &db, &tbl)
+            .await?;
+        let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+        fuse_table.truncate(ctx, false).await?;
+    }
+
+    // optimize after truncate table, ts file location will become None
+    {
+        let ctx = fixture.ctx();
+        let catalog = ctx.get_catalog(fixture.default_catalog_name().as_str())?;
+        let table = catalog
+            .get_table(ctx.get_tenant().as_str(), &db, &tbl)
+            .await?;
+        let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+        let snapshot_opt = fuse_table.read_table_snapshot().await?;
+        assert!(snapshot_opt.is_some());
+        assert!(snapshot_opt.unwrap().table_statistics_location.is_none());
+    }
+
+    Ok(())
 }
 
 #[tokio::test]

--- a/src/query/storages/fuse/fuse/src/operations/truncate.rs
+++ b/src/query/storages/fuse/fuse/src/operations/truncate.rs
@@ -41,7 +41,8 @@ impl FuseTable {
                 Default::default(),
                 vec![],
                 self.cluster_key_meta.clone(),
-                prev_snapshot.table_statistics_location.clone(),
+                // truncate MUST reset ts location
+                None,
             );
             let loc = self.meta_location_generator();
             let new_snapshot_loc =


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: truncate fuse table reset ts location to None.

Closes #issue
