### PR TITLE
fix: double-quote in get_path

### DIFF
--- a/src/common/jsonb/src/functions.rs
+++ b/src/common/jsonb/src/functions.rs
@@ -839,15 +839,9 @@ pub fn parse_json_path(path: &[u8]) -> Result<Vec<JsonPath>, Error> {
             }
         } else if c == b'"' {
             prev_idx = idx;
-            loop {
+            while idx < path.len() {
                 let c = read_char(path, &mut idx)?;
-                if c == b'\\' {
-                    idx += 1;
-                    let c = read_char(path, &mut idx)?;
-                    if c == b'"' {
-                        idx += 1;
-                    }
-                } else if c != b'"' {
+                if c != b'"' && c != b'\\' {
                     idx += 1;
                 } else {
                     // Try to read to check if has extra strings, string value can only have one.

--- a/src/common/jsonb/src/functions.rs
+++ b/src/common/jsonb/src/functions.rs
@@ -839,17 +839,15 @@ pub fn parse_json_path(path: &[u8]) -> Result<Vec<JsonPath>, Error> {
             }
         } else if c == b'"' {
             prev_idx = idx;
-            while idx < path.len() {
+            loop {
                 let c = read_char(path, &mut idx)?;
-                if c != b'"' && c != b'\\' {
+                if c == b'\\' {
                     idx += 1;
-                } else {
-                    // Try to read to check if has extra strings, string value can only have one.
-                    let c = read_char(path, &mut idx);
-                    match c {
-                        Ok(_) => return Err(Error::InvalidToken),
-                        Err(_) => break,
+                } else if c == b'"' {
+                    if idx < path.len() {
+                        return Err(Error::InvalidToken);
                     }
+                    break;
                 }
             }
             let s = std::str::from_utf8(&path[prev_idx..idx - 1])?;

--- a/src/common/jsonb/tests/it/functions.rs
+++ b/src/common/jsonb/tests/it/functions.rs
@@ -364,6 +364,7 @@ fn test_parse_json_path() {
         ]),
         ("\"k1\"", vec![JsonPath::String(Cow::from("k1"))]),
         ("\"k_1\"", vec![JsonPath::String(Cow::from("k_1"))]),
+        ("\"k_1k_2\"", vec![JsonPath::String(Cow::from("k_1k_2"))]),
         ("\"k1k2\"", vec![JsonPath::String(Cow::from("k1k2"))]),
         (r#"k1["k2"][1]"#, vec![
             JsonPath::String(Cow::from("k1")),
@@ -380,6 +381,7 @@ fn test_parse_json_path() {
     let wrong_sources = vec![
         (r#"\"\"\\k1\"\""#, Error::InvalidToken),
         (r#"\\k1\\'"#, Error::InvalidToken),
+        (r#"\"kk\"1\""#, Error::InvalidToken),
     ];
     for (s, expect) in wrong_sources {
         let path = parse_json_path(s.as_bytes());

--- a/src/common/jsonb/tests/it/functions.rs
+++ b/src/common/jsonb/tests/it/functions.rs
@@ -363,6 +363,7 @@ fn test_parse_json_path() {
             JsonPath::String(Cow::from("k3")),
         ]),
         ("\"k1\"", vec![JsonPath::String(Cow::from("k1"))]),
+        ("\"k_1\"", vec![JsonPath::String(Cow::from("k_1"))]),
         ("\"k1k2\"", vec![JsonPath::String(Cow::from("k1k2"))]),
         (r#"k1["k2"][1]"#, vec![
             JsonPath::String(Cow::from("k1")),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Bug fix double-quote in `get_path()` and add more test cases.
