### PR TITLE
feat(query): fast parse insert values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -3135,6 +3135,7 @@ name = "databend-query"
 version = "0.1.0"
 dependencies = [
  "ahash 0.8.2",
+ "aho-corasick",
  "async-channel",
  "async-recursion",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
 name = "common-io"
 version = "0.1.0"
 dependencies = [
+ "aho-corasick",
  "bincode 2.0.0-rc.2",
  "bytes",
  "chrono",

--- a/src/common/io/Cargo.toml
+++ b/src/common/io/Cargo.toml
@@ -27,4 +27,5 @@ ordered-float = "3.1.0"
 serde = { workspace = true }
 
 [dev-dependencies]
+aho-corasick = { version = "0.7.20" }
 rand = "0.8.5"

--- a/src/common/io/tests/it/cursor_ext/fast_read_text_ext.rs
+++ b/src/common/io/tests/it/cursor_ext/fast_read_text_ext.rs
@@ -1,0 +1,74 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+use std::io::Cursor;
+
+use aho_corasick::AhoCorasick;
+use common_exception::Result;
+use common_io::cursor_ext::*;
+
+#[test]
+fn test_positions() -> Result<()> {
+    let cases = vec![
+        (r#"abc"#.to_string(), vec![]),
+        (r#"'abcdefg'"#.to_string(), vec![0, 8]),
+        (r#"'abc\d'e'"#.to_string(), vec![0, 4, 6, 8]),
+        (r#"'abc','d\'ef','g\\\'hi'"#.to_string(), vec![
+            0, 4, 6, 8, 9, 12, 14, 16, 17, 18, 19, 22,
+        ]),
+    ];
+
+    let patterns = &["'", "\\"];
+    let ac = AhoCorasick::new(patterns);
+    for (data, expect) in cases {
+        let mut positions = VecDeque::new();
+        for mat in ac.find_iter(&data) {
+            let pos = mat.start();
+            positions.push_back(pos);
+        }
+        assert_eq!(positions, expect)
+    }
+    Ok(())
+}
+
+#[test]
+fn test_fast_read_text() -> Result<()> {
+    let data = r#"'abc','d\'ef','g\\\'hi'"#.to_string();
+    let patterns = &["'", "\\"];
+    let ac = AhoCorasick::new(patterns);
+    let mut positions = VecDeque::new();
+    for mat in ac.find_iter(&data) {
+        let pos = mat.start();
+        positions.push_back(pos);
+    }
+
+    let mut reader = Cursor::new(data.as_bytes());
+    let expected = vec![
+        "abc".as_bytes().to_vec(),
+        "d'ef".as_bytes().to_vec(),
+        "g\\'hi".as_bytes().to_vec(),
+    ];
+    let mut res = vec![];
+    for i in 0..expected.len() {
+        if i > 0 {
+            assert!(reader.ignore_byte(b','));
+        }
+        let mut buf = vec![];
+        reader.fast_read_quoted_text(&mut buf, &mut positions)?;
+        res.push(buf);
+    }
+    assert_eq!(res, expected);
+    Ok(())
+}

--- a/src/common/io/tests/it/cursor_ext/mod.rs
+++ b/src/common/io/tests/it/cursor_ext/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod fast_read_text_ext;
 mod read_bytes_ext;
 mod read_datetime_ext;
 mod read_number_ext;

--- a/src/query/formats/src/field_decoder/fast_values.rs
+++ b/src/query/formats/src/field_decoder/fast_values.rs
@@ -1,0 +1,340 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::collections::VecDeque;
+use std::io::Cursor;
+
+use bstr::ByteSlice;
+use chrono_tz::Tz;
+use common_datavalues::check_date;
+use common_datavalues::check_timestamp;
+use common_datavalues::uniform_date;
+use common_datavalues::ArrayDeserializer;
+use common_datavalues::ArrayValue;
+use common_datavalues::BooleanDeserializer;
+use common_datavalues::DateDeserializer;
+use common_datavalues::MutableColumn;
+use common_datavalues::NullDeserializer;
+use common_datavalues::NullableDeserializer;
+use common_datavalues::NumberDeserializer;
+use common_datavalues::PrimitiveType;
+use common_datavalues::StringDeserializer;
+use common_datavalues::StructDeserializer;
+use common_datavalues::StructValue;
+use common_datavalues::TimestampDeserializer;
+use common_datavalues::TypeDeserializer;
+use common_datavalues::TypeDeserializerImpl;
+use common_datavalues::VariantDeserializer;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_io::consts::FALSE_BYTES_LOWER;
+use common_io::consts::INF_BYTES_LOWER;
+use common_io::consts::NAN_BYTES_LOWER;
+use common_io::consts::NULL_BYTES_UPPER;
+use common_io::consts::TRUE_BYTES_LOWER;
+use common_io::cursor_ext::BufferReadDateTimeExt;
+use common_io::cursor_ext::BufferReadStringExt;
+use common_io::cursor_ext::ReadBytesExt;
+use common_io::cursor_ext::ReadCheckPointExt;
+use common_io::cursor_ext::ReadNumberExt;
+use common_io::prelude::StatBuffer;
+use lexical_core::FromLexical;
+use micromarshal::Unmarshal;
+use num::cast::AsPrimitive;
+
+use crate::CommonSettings;
+use crate::FieldDecoder;
+
+#[derive(Clone)]
+pub struct FastFieldDecoderValues {
+    pub common_settings: CommonSettings,
+}
+
+impl FieldDecoder for FastFieldDecoderValues {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl FastFieldDecoderValues {
+    pub fn create_for_insert(timezone: Tz) -> Self {
+        FastFieldDecoderValues {
+            common_settings: CommonSettings {
+                true_bytes: TRUE_BYTES_LOWER.as_bytes().to_vec(),
+                false_bytes: FALSE_BYTES_LOWER.as_bytes().to_vec(),
+                null_bytes: NULL_BYTES_UPPER.as_bytes().to_vec(),
+                nan_bytes: NAN_BYTES_LOWER.as_bytes().to_vec(),
+                inf_bytes: INF_BYTES_LOWER.as_bytes().to_vec(),
+                timezone,
+            },
+        }
+    }
+
+    fn common_settings(&self) -> &CommonSettings {
+        &self.common_settings
+    }
+
+    fn ignore_field_end<R: AsRef<[u8]>>(&self, reader: &mut Cursor<R>) -> bool {
+        reader.ignore_white_spaces();
+        matches!(reader.peek(), None | Some(',') | Some(')'))
+    }
+
+    fn match_bytes<R: AsRef<[u8]>>(&self, reader: &mut Cursor<R>, bs: &[u8]) -> bool {
+        let pos = reader.checkpoint();
+        if reader.ignore_bytes(bs) && self.ignore_field_end(reader) {
+            true
+        } else {
+            reader.rollback(pos);
+            false
+        }
+    }
+
+    pub fn read_field<R: AsRef<[u8]>>(
+        &self,
+        column: &mut TypeDeserializerImpl,
+        reader: &mut Cursor<R>,
+        positions: &mut VecDeque<usize>,
+    ) -> Result<()> {
+        match column {
+            TypeDeserializerImpl::Null(c) => self.read_null(c, reader),
+            TypeDeserializerImpl::Nullable(c) => self.read_nullable(c, reader, positions),
+            TypeDeserializerImpl::Boolean(c) => self.read_bool(c, reader),
+            TypeDeserializerImpl::Int8(c) => self.read_int(c, reader),
+            TypeDeserializerImpl::Int16(c) => self.read_int(c, reader),
+            TypeDeserializerImpl::Int32(c) => self.read_int(c, reader),
+            TypeDeserializerImpl::Int64(c) => self.read_int(c, reader),
+            TypeDeserializerImpl::UInt8(c) => self.read_int(c, reader),
+            TypeDeserializerImpl::UInt16(c) => self.read_int(c, reader),
+            TypeDeserializerImpl::UInt32(c) => self.read_int(c, reader),
+            TypeDeserializerImpl::UInt64(c) => self.read_int(c, reader),
+            TypeDeserializerImpl::Float32(c) => self.read_float(c, reader),
+            TypeDeserializerImpl::Float64(c) => self.read_float(c, reader),
+            TypeDeserializerImpl::Date(c) => self.read_date(c, reader, positions),
+            TypeDeserializerImpl::Interval(c) => self.read_date(c, reader, positions),
+            TypeDeserializerImpl::Timestamp(c) => self.read_timestamp(c, reader, positions),
+            TypeDeserializerImpl::String(c) => self.read_string(c, reader, positions),
+            TypeDeserializerImpl::Array(c) => self.read_array(c, reader, positions),
+            TypeDeserializerImpl::Struct(c) => self.read_struct(c, reader, positions),
+            TypeDeserializerImpl::Variant(c) => self.read_variant(c, reader, positions),
+        }
+    }
+
+    fn read_bool<R: AsRef<[u8]>>(
+        &self,
+        column: &mut BooleanDeserializer,
+        reader: &mut Cursor<R>,
+    ) -> Result<()> {
+        if self.match_bytes(reader, &self.common_settings().true_bytes) {
+            column.builder.append_value(true);
+            Ok(())
+        } else if self.match_bytes(reader, &self.common_settings().false_bytes) {
+            column.builder.append_value(false);
+            Ok(())
+        } else {
+            let err_msg = format!(
+                "Incorrect boolean value, expect {} or {}",
+                self.common_settings().true_bytes.to_str().unwrap(),
+                self.common_settings().false_bytes.to_str().unwrap()
+            );
+            Err(ErrorCode::BadBytes(err_msg))
+        }
+    }
+
+    fn read_null<R: AsRef<[u8]>>(
+        &self,
+        column: &mut NullDeserializer,
+        _reader: &mut Cursor<R>,
+    ) -> Result<()> {
+        column.builder.append_default();
+        Ok(())
+    }
+
+    fn read_nullable<R: AsRef<[u8]>>(
+        &self,
+        column: &mut NullableDeserializer,
+        reader: &mut Cursor<R>,
+        positions: &mut VecDeque<usize>,
+    ) -> Result<()> {
+        if reader.eof() {
+            column.de_default();
+        } else if reader.ignore_bytes(b"NULL") || reader.ignore_bytes(b"null") {
+            column.de_default();
+            return Ok(());
+        } else {
+            self.read_field(&mut column.inner, reader, positions)?;
+            column.bitmap.push(true);
+        }
+        Ok(())
+    }
+
+    fn read_int<T, R: AsRef<[u8]>>(
+        &self,
+        column: &mut NumberDeserializer<T>,
+        reader: &mut Cursor<R>,
+    ) -> Result<()>
+    where
+        T: PrimitiveType + Unmarshal<T> + StatBuffer + FromLexical,
+    {
+        let v: T = reader.read_int_text()?;
+        column.builder.append_value(v);
+        Ok(())
+    }
+
+    fn read_float<T, R: AsRef<[u8]>>(
+        &self,
+        column: &mut NumberDeserializer<T>,
+        reader: &mut Cursor<R>,
+    ) -> Result<()>
+    where
+        T: PrimitiveType + Unmarshal<T> + StatBuffer + FromLexical,
+    {
+        let v: T = reader.read_float_text()?;
+        column.builder.append_value(v);
+        Ok(())
+    }
+
+    fn read_string_inner<R: AsRef<[u8]>>(
+        &self,
+        reader: &mut Cursor<R>,
+        out_buf: &mut Vec<u8>,
+        positions: &mut VecDeque<usize>,
+    ) -> Result<()> {
+        reader.fast_read_quoted_text(out_buf, positions)?;
+        Ok(())
+    }
+
+    fn read_string<R: AsRef<[u8]>>(
+        &self,
+        column: &mut StringDeserializer,
+        reader: &mut Cursor<R>,
+        positions: &mut VecDeque<usize>,
+    ) -> Result<()> {
+        column.buffer.clear();
+        self.read_string_inner(reader, &mut column.buffer, positions)?;
+        column.builder.append_value(column.buffer.as_slice());
+        Ok(())
+    }
+
+    fn read_date<T, R: AsRef<[u8]>>(
+        &self,
+        column: &mut DateDeserializer<T>,
+        reader: &mut Cursor<R>,
+        positions: &mut VecDeque<usize>,
+    ) -> Result<()>
+    where
+        i32: AsPrimitive<T>,
+        T: PrimitiveType,
+        T: Unmarshal<T> + StatBuffer + FromLexical,
+    {
+        column.buffer.clear();
+        self.read_string_inner(reader, &mut column.buffer, positions)?;
+        let mut buffer_readr = Cursor::new(&column.buffer);
+        let date = buffer_readr.read_date_text(&self.common_settings().timezone)?;
+        let days = uniform_date::<T>(date);
+        check_date(days.as_i32())?;
+        column.builder.append_value(days);
+        Ok(())
+    }
+
+    fn read_timestamp<R: AsRef<[u8]>>(
+        &self,
+        column: &mut TimestampDeserializer,
+        reader: &mut Cursor<R>,
+        positions: &mut VecDeque<usize>,
+    ) -> Result<()> {
+        column.buffer.clear();
+        self.read_string_inner(reader, &mut column.buffer, positions)?;
+        let mut buffer_readr = Cursor::new(&column.buffer);
+        let ts = buffer_readr.read_timestamp_text(&self.common_settings().timezone)?;
+        if !buffer_readr.eof() {
+            let data = column.buffer.to_str().unwrap_or("not utf8");
+            let msg = format!(
+                "fail to deserialize timestamp, unexpected end at pos {} of {}",
+                buffer_readr.position(),
+                data
+            );
+            return Err(ErrorCode::BadBytes(msg));
+        }
+        let micros = ts.timestamp_micros();
+        check_timestamp(micros)?;
+        column.builder.append_value(micros.as_());
+        Ok(())
+    }
+
+    fn read_array<R: AsRef<[u8]>>(
+        &self,
+        column: &mut ArrayDeserializer,
+        reader: &mut Cursor<R>,
+        positions: &mut VecDeque<usize>,
+    ) -> Result<()> {
+        reader.must_ignore_byte(b'[')?;
+        let mut idx = 0;
+        loop {
+            let _ = reader.ignore_white_spaces();
+            if reader.ignore_byte(b']') {
+                break;
+            }
+            if idx != 0 {
+                reader.must_ignore_byte(b',')?;
+            }
+            let _ = reader.ignore_white_spaces();
+            self.read_field(&mut column.inner, reader, positions)?;
+            idx += 1;
+        }
+        let mut values = Vec::with_capacity(idx);
+        for _ in 0..idx {
+            values.push(column.inner.pop_data_value()?);
+        }
+        values.reverse();
+        column.builder.append_value(ArrayValue::new(values));
+        Ok(())
+    }
+
+    fn read_struct<R: AsRef<[u8]>>(
+        &self,
+        column: &mut StructDeserializer,
+        reader: &mut Cursor<R>,
+        positions: &mut VecDeque<usize>,
+    ) -> Result<()> {
+        reader.must_ignore_byte(b'(')?;
+        let mut values = Vec::with_capacity(column.inners.len());
+        for (idx, inner) in column.inners.iter_mut().enumerate() {
+            let _ = reader.ignore_white_spaces();
+            if idx != 0 {
+                reader.must_ignore_byte(b',')?;
+            }
+            let _ = reader.ignore_white_spaces();
+            self.read_field(inner, reader, positions)?;
+            values.push(inner.pop_data_value()?);
+        }
+        reader.must_ignore_byte(b')')?;
+        column.builder.append_value(StructValue::new(values));
+        Ok(())
+    }
+
+    fn read_variant<R: AsRef<[u8]>>(
+        &self,
+        column: &mut VariantDeserializer,
+        reader: &mut Cursor<R>,
+        positions: &mut VecDeque<usize>,
+    ) -> Result<()> {
+        column.buffer.clear();
+        self.read_string_inner(reader, &mut column.buffer, positions)?;
+        let val = serde_json::from_slice(column.buffer.as_slice())?;
+        column.builder.append_value(val);
+        column.memory_size += column.buffer.len();
+        Ok(())
+    }
+}

--- a/src/query/formats/src/field_decoder/mod.rs
+++ b/src/query/formats/src/field_decoder/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod csv;
+mod fast_values;
 mod json_ast;
 mod row_based;
 mod tsv;
@@ -22,6 +23,7 @@ mod xml;
 use std::any::Any;
 
 pub use csv::FieldDecoderCSV;
+pub use fast_values::FastFieldDecoderValues;
 pub use json_ast::FieldJsonAstDecoder;
 pub use row_based::FieldDecoderRowBased;
 pub use tsv::FieldDecoderTSV;

--- a/src/query/formats/src/field_decoder/row_based.rs
+++ b/src/query/formats/src/field_decoder/row_based.rs
@@ -159,11 +159,7 @@ pub trait FieldDecoderRowBased: FieldDecoder {
     where
         T: PrimitiveType + Unmarshal<T> + StatBuffer + FromLexical,
     {
-        let v: T = if !T::FLOATING {
-            reader.read_int_text()
-        } else {
-            reader.read_float_text()
-        }?;
+        let v: T = reader.read_int_text()?;
         column.builder.append_value(v);
         Ok(())
     }
@@ -177,11 +173,7 @@ pub trait FieldDecoderRowBased: FieldDecoder {
     where
         T: PrimitiveType + Unmarshal<T> + StatBuffer + FromLexical,
     {
-        let v: T = if !T::FLOATING {
-            reader.read_int_text()
-        } else {
-            reader.read_float_text()
-        }?;
+        let v: T = reader.read_float_text()?;
         column.builder.append_value(v);
         Ok(())
     }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -79,6 +79,7 @@ common-users = { path = "../users" }
 
 # Crates.io dependencies
 ahash = { version = "0.8.2", features = ["no-rng"] }
+aho-corasick = { version = "0.7.20" }
 async-channel = "1.7.1"
 async-recursion = "1.0.0"
 async-stream = "0.3.3"

--- a/src/query/service/src/interpreters/interpreter_insert_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_insert_v2.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::VecDeque;
 use std::io::BufRead;
 use std::io::Cursor;
 use std::ops::Not;
 use std::sync::Arc;
 
+use aho_corasick::AhoCorasick;
 use common_ast::ast::Expr;
 use common_ast::parser::parse_comma_separated_exprs;
 use common_ast::parser::tokenize_sql;
@@ -28,8 +30,7 @@ use common_datavalues::prelude::*;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_formats::parse_timezone;
-use common_formats::FieldDecoderRowBased;
-use common_formats::FieldDecoderValues;
+use common_formats::FastFieldDecoderValues;
 use common_io::cursor_ext::ReadBytesExt;
 use common_io::cursor_ext::ReadCheckPointExt;
 use common_pipeline_sources::processors::sources::AsyncSource;
@@ -279,8 +280,18 @@ impl AsyncSource for ValueSource {
         if self.is_finished {
             return Ok(None);
         }
+
+        // Pre-calculate the positions of all `'` and `\`
+        let patterns = &["'", "\\"];
+        let ac = AhoCorasick::new(patterns);
+        let mut positions = VecDeque::new();
+        for mat in ac.find_iter(&self.data) {
+            let pos = mat.start();
+            positions.push_back(pos);
+        }
+
         let mut reader = Cursor::new(self.data.as_bytes());
-        let block = self.read(&mut reader).await?;
+        let block = self.read(&mut reader, &mut positions).await?;
         self.is_finished = true;
         Ok(Some(block))
     }
@@ -307,7 +318,11 @@ impl ValueSource {
         }
     }
 
-    pub async fn read<R: AsRef<[u8]>>(&self, reader: &mut Cursor<R>) -> Result<DataBlock> {
+    pub async fn read<R: AsRef<[u8]>>(
+        &self,
+        reader: &mut Cursor<R>,
+        positions: &mut VecDeque<usize>,
+    ) -> Result<DataBlock> {
         let mut desers = self
             .schema
             .fields()
@@ -315,10 +330,9 @@ impl ValueSource {
             .map(|f| f.data_type().create_deserializer(1024))
             .collect::<Vec<_>>();
 
-        let col_size = desers.len();
         let mut rows = 0;
         let timezone = parse_timezone(&self.ctx.get_settings())?;
-        let field_decoder = FieldDecoderValues::create_for_insert(timezone);
+        let field_decoder = FastFieldDecoderValues::create_for_insert(timezone);
 
         loop {
             let _ = reader.ignore_white_spaces();
@@ -333,8 +347,8 @@ impl ValueSource {
             self.parse_next_row(
                 &field_decoder,
                 reader,
-                col_size,
                 &mut desers,
+                positions,
                 &self.bind_context,
                 self.metadata.clone(),
             )
@@ -357,14 +371,15 @@ impl ValueSource {
     /// Parse single row value, like ('111', 222, 1 + 1)
     async fn parse_next_row<R: AsRef<[u8]>>(
         &self,
-        field_decoder: &FieldDecoderValues,
+        field_decoder: &FastFieldDecoderValues,
         reader: &mut Cursor<R>,
-        col_size: usize,
         desers: &mut [TypeDeserializerImpl],
+        positions: &mut VecDeque<usize>,
         bind_context: &BindContext,
         metadata: MetadataRef,
     ) -> Result<()> {
         let _ = reader.ignore_white_spaces();
+        let col_size = desers.len();
         let start_pos_of_row = reader.checkpoint();
 
         // Start of the row --- '('
@@ -372,6 +387,14 @@ impl ValueSource {
             return Err(ErrorCode::BadDataValueType(
                 "Must start with parentheses".to_string(),
             ));
+        }
+        // Ignore the positions in the previous row.
+        while let Some(pos) = positions.front() {
+            if *pos < start_pos_of_row as usize {
+                positions.pop_front();
+            } else {
+                break;
+            }
         }
 
         for col_idx in 0..col_size {
@@ -383,7 +406,7 @@ impl ValueSource {
                 .ok_or_else(|| ErrorCode::Internal("Deserializer is None"))?;
 
             let (need_fallback, pop_count) = field_decoder
-                .read_field(deser, reader, false)
+                .read_field(deser, reader, positions)
                 .map(|_| {
                     let _ = reader.ignore_white_spaces();
                     let need_fallback = reader.ignore_byte(col_end).not();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Using the `Aho-Corasick` algorithm to find all `'` and `\` positions and then use those positions to jump to the string text end, instead of step-by-step iterating over the buffer. Since the `Aho-Corasick` algorithm can use SIMD instructions to accelerate the search process, it can greatly speed up the process of reading strings.

Inserting 100M test data, the original `ValueSource::read` takes 8.23s, after optimization, the total time for `ValueSource::read` and `Aho-Corasick` algorithms to find positions is 3.97s, which reduces the time consumption by 4.26s.

![image](https://user-images.githubusercontent.com/1070352/207081061-be4baf9c-fc20-4f38-9d8a-0eaa0cbd3d05.png)

![image](https://user-images.githubusercontent.com/1070352/207082065-d9665662-9efb-4f54-bcb4-cad8d1d75f3d.png)


Closes #issue
