### PR TITLE
feat: Add quote to FileFormatOptions

### DIFF
--- a/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
@@ -509,6 +509,7 @@ impl FromToProto for mt::FileFormatOptions {
             escape: p.escape,
             compression,
             row_tag: p.row_tag,
+            quote: p.quote,
         })
     }
 
@@ -526,6 +527,7 @@ impl FromToProto for mt::FileFormatOptions {
             compression,
             row_tag: self.row_tag.clone(),
             escape: self.escape.clone(),
+            quote: self.quote.clone(),
         })
     }
 }

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -74,6 +74,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
         21,
         "2022-11-24: Add: users.proto/FileFormatOptions::nan_display",
     ),
+    (22, "2022-12-13: Add: users.proto/FileFormatOptions::quote"),
 ];
 
 pub const VER: u64 = META_CHANGE_LOG.last().unwrap().0;

--- a/src/meta/proto-conv/tests/it/user_proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/user_proto_conv.rs
@@ -85,6 +85,7 @@ pub(crate) fn test_fs_stage_info() -> mt::UserStageInfo {
             escape: "\\".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "row".to_string(),
+            quote: "\'\'".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -123,6 +124,7 @@ pub(crate) fn test_s3_stage_info() -> mt::UserStageInfo {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "row".to_string(),
+            quote: "'".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -163,6 +165,7 @@ pub(crate) fn test_s3_stage_info_v16() -> mt::UserStageInfo {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -203,6 +206,7 @@ pub(crate) fn test_s3_stage_info_v14() -> mt::UserStageInfo {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -239,6 +243,7 @@ pub(crate) fn test_gcs_stage_info() -> mt::UserStageInfo {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "row".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -276,6 +281,7 @@ pub(crate) fn test_oss_stage_info() -> mt::UserStageInfo {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "row".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -680,6 +686,7 @@ pub(crate) fn test_internal_stage_info_v17() -> mt::UserStageInfo {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -712,6 +719,7 @@ pub(crate) fn test_user_stage_info_v18() -> mt::UserStageInfo {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),

--- a/src/meta/proto-conv/tests/it/user_stage.rs
+++ b/src/meta/proto-conv/tests/it/user_stage.rs
@@ -54,6 +54,53 @@ fn test_user_stage_oss_latest() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_user_stage_fs_v22() -> anyhow::Result<()> {
+    // Encoded data of version 21 of user_stage_fs:
+    // It is generated with common::test_pb_from_to.
+    let user_stage_fs_v22 = vec![
+        10, 17, 102, 115, 58, 47, 47, 100, 105, 114, 47, 116, 111, 47, 102, 105, 108, 101, 115, 26,
+        25, 10, 23, 18, 21, 10, 13, 47, 100, 105, 114, 47, 116, 111, 47, 102, 105, 108, 101, 115,
+        160, 6, 22, 168, 6, 1, 34, 37, 8, 1, 16, 128, 8, 26, 1, 124, 34, 2, 47, 47, 40, 2, 50, 1,
+        92, 58, 3, 114, 111, 119, 66, 3, 78, 97, 78, 74, 2, 39, 39, 160, 6, 22, 168, 6, 1, 42, 10,
+        10, 3, 32, 154, 5, 16, 142, 8, 24, 1, 50, 4, 116, 101, 115, 116, 160, 6, 22, 168, 6, 1,
+    ];
+
+    let want = mt::UserStageInfo {
+        stage_name: "fs://dir/to/files".to_string(),
+        stage_type: mt::StageType::LegacyInternal,
+        stage_params: mt::StageParams {
+            storage: StorageParams::Fs(StorageFsConfig {
+                root: "/dir/to/files".to_string(),
+            }),
+        },
+        file_format_options: mt::FileFormatOptions {
+            format: mt::StageFileFormatType::Json,
+            skip_header: 1024,
+            field_delimiter: "|".to_string(),
+            record_delimiter: "//".to_string(),
+            nan_display: "NaN".to_string(),
+            compression: mt::StageFileCompression::Bz2,
+            escape: "\\".to_string(),
+            row_tag: "row".to_string(),
+            quote: "\'\'".to_string(),
+        },
+        copy_options: mt::CopyOptions {
+            on_error: mt::OnErrorMode::SkipFileNum(666),
+            size_limit: 1038,
+            split_size: 0,
+            purge: true,
+            single: false,
+            max_file_size: 0,
+        },
+        comment: "test".to_string(),
+        ..Default::default()
+    };
+    common::test_load_old(func_name!(), user_stage_fs_v22.as_slice(), want)?;
+
+    Ok(())
+}
+
+#[test]
 fn test_user_stage_fs_v21() -> anyhow::Result<()> {
     // Encoded data of version 21 of user_stage_fs:
     // It is generated with common::test_pb_from_to.
@@ -82,6 +129,7 @@ fn test_user_stage_fs_v21() -> anyhow::Result<()> {
             compression: mt::StageFileCompression::Bz2,
             escape: "\\".to_string(),
             row_tag: "row".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -127,6 +175,7 @@ fn test_user_stage_fs_v20() -> anyhow::Result<()> {
             compression: mt::StageFileCompression::Bz2,
             escape: "\\".to_string(),
             row_tag: "row".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -173,6 +222,7 @@ fn test_user_stage_fs_v18() -> anyhow::Result<()> {
             row_tag: "".to_string(),
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -219,6 +269,7 @@ fn test_user_stage_fs_v16() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -277,6 +328,7 @@ fn test_user_stage_s3_v16() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -329,6 +381,7 @@ fn test_user_stage_gcs_v16() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -383,6 +436,7 @@ fn test_user_stage_oss_v16() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -439,6 +493,7 @@ fn test_user_stage_oss_v13() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -496,6 +551,7 @@ fn test_user_stage_s3_v11() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -551,6 +607,7 @@ fn test_user_stage_s3_v9() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -597,6 +654,7 @@ fn test_user_stage_fs_v6() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -653,6 +711,7 @@ fn test_user_stage_s3_v6() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -705,6 +764,7 @@ fn test_user_stage_gcs_v6() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -750,6 +810,7 @@ fn test_user_stage_fs_v4() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -806,6 +867,7 @@ fn test_user_stage_s3_v4() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -857,6 +919,7 @@ fn test_user_stage_gcs_v4() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -910,6 +973,7 @@ fn test_user_stage_s3_v1() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -958,6 +1022,7 @@ fn test_internal_stage_v17() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),
@@ -1005,6 +1070,7 @@ fn test_user_stage_v18() -> anyhow::Result<()> {
             escape: "".to_string(),
             compression: mt::StageFileCompression::Bz2,
             row_tag: "".to_string(),
+            quote: "".to_string(),
         },
         copy_options: mt::CopyOptions {
             on_error: mt::OnErrorMode::SkipFileNum(666),

--- a/src/meta/protos/proto/user.proto
+++ b/src/meta/protos/proto/user.proto
@@ -187,6 +187,8 @@ message UserStageInfo {
     string row_tag = 7;
 
     string nan_display = 8;
+
+    string quote = 9;
   }
 
   message OnErrorMode {

--- a/src/meta/types/src/user_stage.rs
+++ b/src/meta/types/src/user_stage.rs
@@ -200,6 +200,7 @@ pub struct FileFormatOptions {
     pub escape: String,
     pub compression: StageFileCompression,
     pub row_tag: String,
+    pub quote: String,
 }
 
 impl Default for FileFormatOptions {
@@ -213,6 +214,7 @@ impl Default for FileFormatOptions {
             escape: "".to_string(),
             compression: StageFileCompression::default(),
             row_tag: "row".to_string(),
+            quote: "".to_string(),
         }
     }
 }

--- a/src/query/formats/src/field_encoder/csv.rs
+++ b/src/query/formats/src/field_encoder/csv.rs
@@ -42,7 +42,7 @@ impl FieldEncoderCSV {
                 inf_bytes: INF_BYTES_LOWER.as_bytes().to_vec(),
                 timezone: options.timezone,
             },
-            quote_char: options.quote.as_bytes()[0],
+            quote_char: options.stage.quote.as_bytes()[0],
         }
     }
 }

--- a/src/query/formats/src/file_format_type.rs
+++ b/src/query/formats/src/file_format_type.rs
@@ -61,7 +61,6 @@ pub trait FileFormatTypeExt {
 #[derive(Clone, Debug)]
 pub struct FileFormatOptionsExt {
     pub stage: FileFormatOptions,
-    pub quote: String,
     pub ident_case_sensitive: bool,
     pub headers: usize,
     pub json_compact: bool,
@@ -71,7 +70,7 @@ pub struct FileFormatOptionsExt {
 
 impl FileFormatOptionsExt {
     pub fn get_quote_char(&self) -> u8 {
-        self.quote.as_bytes()[0]
+        self.stage.quote.as_bytes()[0]
     }
 
     pub fn get_field_delimiter(&self) -> u8 {
@@ -207,7 +206,6 @@ impl FileFormatTypeExt for StageFileFormatType {
         let timezone = parse_timezone(settings)?;
         let options = FileFormatOptionsExt {
             stage,
-            quote: "".to_string(),
             ident_case_sensitive: false,
             headers: 0,
             json_compact: false,
@@ -237,10 +235,10 @@ impl FileFormatTypeExt for StageFileFormatType {
                     || "get_file_format_options_from_setting",
                 )?,
             row_tag: settings.get_row_tag()?,
+            quote: settings.get_format_quote()?,
         };
         let mut options = FileFormatOptionsExt {
             stage,
-            quote: settings.get_format_quote()?,
             ident_case_sensitive: settings.get_unquoted_ident_case_sensitive()?,
             headers: 0,
             json_compact: false,

--- a/src/query/formats/src/format_option_checker.rs
+++ b/src/query/formats/src/format_option_checker.rs
@@ -41,7 +41,7 @@ pub trait FormatOptionChecker {
 
     fn check_options(&self, options: &mut FileFormatOptionsExt) -> Result<()> {
         self.check_escape(&mut options.stage.escape)?;
-        self.check_quote(&mut options.quote)?;
+        self.check_quote(&mut options.stage.quote)?;
         self.check_row_tag(&mut options.stage.row_tag)?;
         self.check_record_delimiter(&mut options.stage.record_delimiter)?;
         self.check_field_delimiter(&mut options.stage.field_delimiter)?;

--- a/src/query/formats/src/output_format/csv.rs
+++ b/src/query/formats/src/output_format/csv.rs
@@ -43,7 +43,7 @@ impl<const WITH_NAMES: bool, const WITH_TYPES: bool> CSVOutputFormatBase<WITH_NA
             field_encoder,
             field_delimiter: options.stage.field_delimiter.as_bytes()[0],
             record_delimiter: options.stage.record_delimiter.as_bytes().to_vec(),
-            quote: options.quote.as_bytes()[0],
+            quote: options.stage.quote.as_bytes()[0],
         }
     }
 

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_csv.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_csv.rs
@@ -382,7 +382,7 @@ impl CsvReaderState {
         };
         let reader = csv_core::ReaderBuilder::new()
             .delimiter(ctx.field_delimiter)
-            .quote(ctx.format_options.quote.as_bytes()[0])
+            .quote(ctx.format_options.stage.quote.as_bytes()[0])
             .escape(escape)
             .terminator(match ctx.record_delimiter {
                 RecordDelimiter::Crlf => csv_core::Terminator::CRLF,

--- a/src/query/sql/src/planner/binder/copy.rs
+++ b/src/query/sql/src/planner/binder/copy.rs
@@ -646,6 +646,12 @@ pub fn parse_copy_file_format_options(
         .unwrap_or(&"".to_string())
         .to_string();
 
+    // Quote in csv.
+    let quote = file_format_options
+        .get("quote")
+        .unwrap_or(&"".to_string())
+        .to_string();
+
     Ok(FileFormatOptions {
         format: file_format,
         skip_header,
@@ -655,5 +661,6 @@ pub fn parse_copy_file_format_options(
         escape,
         compression,
         row_tag,
+        quote,
     })
 }

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -331,6 +331,7 @@ impl<'a> Binder {
                     escape: "".to_string(),
                     compression: StageFileCompression::default(),
                     row_tag: "".to_string(),
+                    quote: "".to_string(),
                 };
                 let stage_table_info = StageTableInfo {
                     schema,

--- a/tests/logictest/suites/base/05_ddl/05_0016_ddl_stage
+++ b/tests/logictest/suites/base/05_ddl/05_0016_ddl_stage
@@ -23,7 +23,7 @@ statement query TTTTTITT
 desc stage test_stage_internal;
 
 ----
-test_stage_internal  Internal  StageParams { storage: Fs(StorageFsConfig { root: "_data" }) }  CopyOptions { on_error: None, size_limit: 0, split_size: 0, purge: false, single: false, max_file_size: 0 }  FileFormatOptions { format: Csv, skip_header: 0, field_delimiter: "", record_delimiter: "NONE", nan_display: "", escape: "\\\\", compression: Auto, row_tag: "" }  0  'root'@'127.0.0.1'
+test_stage_internal  Internal  StageParams { storage: Fs(StorageFsConfig { root: "_data" }) }  CopyOptions { on_error: None, size_limit: 0, split_size: 0, purge: false, single: false, max_file_size: 0 }  FileFormatOptions { format: Csv, skip_header: 0, field_delimiter: "", record_delimiter: "NONE", nan_display: "", escape: "\\\\", compression: Auto, row_tag: "", quote: "" }  0  'root'@'127.0.0.1'
 
 statement query TTTTT
 SHOW STAGES;

--- a/tests/logictest/suites/base/06_show/06_0011_show_stages
+++ b/tests/logictest/suites/base/06_show/06_0011_show_stages
@@ -15,7 +15,7 @@ DESC STAGE test_stage;
 
 ----
 test_stage  Internal  StageParams { storage: Fs(StorageFsConfig { root: "_data" }) }  CopyOptions { on_error: None, size_limit: 0, split_size: 0, purge: false, single: false, max_file_size: 0 }  FileFo
-rmatOptions { format: Csv, skip_header: 0, field_delimiter: ",",  record_delimiter: "\n", nan_display: "NaN", escape: "", compression: None, row_tag: "row" }  0  'root'@'127.0.0.1'
+rmatOptions { format: Csv, skip_header: 0, field_delimiter: ",",  record_delimiter: "\n", nan_display: "NaN", escape: "", compression: None, row_tag: "row", quote: "" }  0  'root'@'127.0.0.1'
 
 statement ok
 DROP STAGE test_stage;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add `quote` to FileFormatOptions so that we can move old streaming load syntax to new internally.

Closes #9212 
