### PR TITLE
ci: github hosted runner for hive release

### DIFF
--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -448,16 +448,6 @@ jobs:
           export version="${{ needs.create_release.outputs.version }}"
           export path="distro"
           nfpm pkg --packager ${{ matrix.packager }} -f <(envsubst '${name} ${version} ${path}' < .github/actions/publish_binary/nfpm.yaml)
-      - name: generate sha256sums
-        run: |
-          version="${{ needs.create_release.outputs.version }}"
-          sha256sum databend_*.${{ matrix.packager }} >> sha256-${version}-${{ matrix.packager }}.txt
-      - name: post sha256
-        uses: actions/upload-artifact@v3
-        with:
-          name: sha256sums
-          path: sha256-${{ needs.create_release.outputs.version }}-${{ matrix.packager }}.txt
-          retention-days: 1
       - name: Update release to github
         shell: bash
         # Reference: https://cli.github.com/manual/gh_release_upload

--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -217,7 +217,7 @@ jobs:
 
   publish_hive:
     name: hive assets
-    runs-on: [self-hosted, X64, Linux, development]
+    runs-on: ubuntu-latest
     needs: [create_release]
     strategy:
       fail-fast: false

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -65,7 +65,7 @@ jobs:
           profile: release
 
   build_hive:
-    runs-on: [self-hosted, X64, Linux, development]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build_linux_hive


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

For hive production and release, switching to github hosted runners

- no midnight shutdown
- with github cli for publish binary

For deb package release, remove sha256sums, since github releases seem to rename packages

Fixes #9218 
