### PR TITLE
refactor(meta/watcher): just use Change as event type

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -987,7 +987,6 @@ impl<KV: KVApi> SchemaApi for KV {
                     if_then: vec![
                         // Changing a table in a db has to update the seq of db_meta,
                         // to block the batch-delete-tables when deleting a db.
-                        // TODO: test this when old metasrv is replaced with kv-txn based SchemaApi.
                         txn_op_put(&DatabaseId { db_id }, serialize_struct(&db_meta)?), /* (db_id) -> db_meta */
                         txn_op_put(&dbid_tbname, serialize_u64(table_id)?), /* (tenant, db_id, tb_name) -> tb_id */
                         txn_op_put(&tbid, serialize_struct(&req.table_meta)?), /* (tenant, db_id, tb_id) -> tb_meta */
@@ -1149,7 +1148,6 @@ impl<KV: KVApi> SchemaApi for KV {
                     if_then: vec![
                         // Changing a table in a db has to update the seq of db_meta,
                         // to block the batch-delete-tables when deleting a db.
-                        // TODO: test this when old metasrv is replaced with kv-txn based SchemaApi.
                         txn_op_put(&DatabaseId { db_id }, serialize_struct(&db_meta)?), /* (db_id) -> db_meta */
                         txn_op_del(&dbid_tbname), // (db_id, tb_name) -> tb_id
                         txn_op_put(&tbid, serialize_struct(&tb_meta)?), /* (tenant, db_id, tb_id) -> tb_meta */
@@ -1307,7 +1305,6 @@ impl<KV: KVApi> SchemaApi for KV {
                     if_then: vec![
                         // Changing a table in a db has to update the seq of db_meta,
                         // to block the batch-delete-tables when deleting a db.
-                        // TODO: test this when old metasrv is replaced with kv-txn based SchemaApi.
                         txn_op_put(&DatabaseId { db_id }, serialize_struct(&db_meta)?), /* (db_id) -> db_meta */
                         txn_op_put(&dbid_tbname, serialize_u64(table_id)?), /* (tenant, db_id, tb_name) -> tb_id */
                         // txn_op_put(&dbid_tbname_idlist, serialize_struct(&tb_id_list)?)?, // _fd_table_id_list/db_id/table_name -> tb_id_list
@@ -1498,7 +1495,6 @@ impl<KV: KVApi> SchemaApi for KV {
                     txn_op_put(&newdbid_newtbname, serialize_u64(table_id)?), /* (db_id, new_tb_name) -> tb_id */
                     // Changing a table in a db has to update the seq of db_meta,
                     // to block the batch-delete-tables when deleting a db.
-                    // TODO: test this when old metasrv is replaced with kv-txn based SchemaApi.
                     txn_op_put(&DatabaseId { db_id }, serialize_struct(&db_meta)?), /* (db_id) -> db_meta */
                     txn_op_put(&dbid_tbname_idlist, serialize_struct(&tb_id_list)?), /* _fd_table_id_list/db_id/old_table_name -> tb_id_list */
                     txn_op_put(&new_dbid_tbname_idlist, serialize_struct(&new_tb_id_list)?), /* _fd_table_id_list/db_id/new_table_name -> tb_id_list */
@@ -1507,7 +1503,6 @@ impl<KV: KVApi> SchemaApi for KV {
 
                 if db_id != new_db_id {
                     then_ops.push(
-                        // TODO: test this when old metasrv is replaced with kv-txn based SchemaApi.
                         txn_op_put(
                             &DatabaseId { db_id: new_db_id },
                             serialize_struct(&new_db_meta)?,

--- a/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
+++ b/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
@@ -75,13 +75,10 @@ impl KVApi for StateMachine {
         // TODO(xp) refine get(): a &str is enough for key
         let sv = self.kvs().get(&key.to_string())?;
         debug!("get_kv sv:{:?}", sv);
-        let seq_v = match sv {
-            None => return Ok(None),
-            Some(sv) => sv,
-        };
 
         let local_now_ms = SeqV::<()>::now_ms();
-        Ok(Self::unexpired(seq_v, local_now_ms))
+        let (_expired, res) = Self::expire_seq_v(sv, local_now_ms);
+        Ok(res)
     }
 
     async fn mget_kv(&self, keys: &[String]) -> Result<MGetKVReply, KVAppError> {
@@ -111,7 +108,7 @@ impl KVApi for StateMachine {
         let local_now_ms = SeqV::<()>::now_ms();
 
         // Convert expired to None
-        let x = x.map(|(k, v)| (k, Self::unexpired(v, local_now_ms)));
+        let x = x.map(|(k, v)| (k, Self::expire_seq_v(Some(v), local_now_ms)[1]));
         // Remove None
         let x = x.filter(|(_k, v)| v.is_some());
         // Extract from an Option

--- a/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
+++ b/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
@@ -108,7 +108,7 @@ impl KVApi for StateMachine {
         let local_now_ms = SeqV::<()>::now_ms();
 
         // Convert expired to None
-        let x = x.map(|(k, v)| (k, Self::expire_seq_v(Some(v), local_now_ms)[1]));
+        let x = x.map(|(k, v)| (k, Self::expire_seq_v(Some(v), local_now_ms).1));
         // Remove None
         let x = x.filter(|(_k, v)| v.is_some());
         // Extract from an Option

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -238,10 +238,9 @@ async fn test_kv_api_restart_cluster_token_expired() -> anyhow::Result<()> {
 
     Ok(())
 }
+
 // Election timeout is 8~12 sec.
 // A raft node waits for a interval of election timeout before starting election
-// TODO: the raft should set the wait time by election_timeout.
-//       For now, just use a large timeout.
 fn timeout() -> Option<Duration> {
     Some(Duration::from_millis(30_000))
 }

--- a/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
@@ -103,7 +103,7 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
     let node_id = 2;
     let tc2 = MetaSrvTestContext::new(node_id);
 
-    let mn2 = MetaNode::open_create_boot(&tc2.config.raft_config, None, Some(()), None).await?;
+    let mn2 = MetaNode::open_create(&tc2.config.raft_config, None, Some(())).await?;
 
     info!("--- join non-voter 2 to cluster by leader");
 
@@ -134,7 +134,7 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
 
     let node_id = 3;
     let tc3 = MetaSrvTestContext::new(node_id);
-    let mn3 = MetaNode::open_create_boot(&tc3.config.raft_config, None, Some(()), None).await?;
+    let mn3 = MetaNode::open_create(&tc3.config.raft_config, None, Some(())).await?;
 
     info!("--- join node-3 by sending rpc `join` to a non-leader");
     {
@@ -171,10 +171,10 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
 
     info!("--- re-open all meta node");
 
-    let mn0 = MetaNode::open_create_boot(&tc0.config.raft_config, Some(()), None, None).await?;
-    let mn1 = MetaNode::open_create_boot(&tc1.config.raft_config, Some(()), None, None).await?;
-    let mn2 = MetaNode::open_create_boot(&tc2.config.raft_config, Some(()), None, None).await?;
-    let mn3 = MetaNode::open_create_boot(&tc3.config.raft_config, Some(()), None, None).await?;
+    let mn0 = MetaNode::open_create(&tc0.config.raft_config, Some(()), None).await?;
+    let mn1 = MetaNode::open_create(&tc1.config.raft_config, Some(()), None).await?;
+    let mn2 = MetaNode::open_create(&tc2.config.raft_config, Some(()), None).await?;
+    let mn3 = MetaNode::open_create(&tc3.config.raft_config, Some(()), None).await?;
 
     let all = vec![mn0, mn1, mn2, mn3];
 
@@ -282,8 +282,8 @@ async fn test_meta_node_leave() -> anyhow::Result<()> {
     let tc0 = &tcs[0];
     let tc2 = &tcs[2];
 
-    let mn0 = MetaNode::open_create_boot(&tc0.config.raft_config, Some(()), None, None).await?;
-    let mn2 = MetaNode::open_create_boot(&tc2.config.raft_config, Some(()), None, None).await?;
+    let mn0 = MetaNode::open_create(&tc0.config.raft_config, Some(()), None).await?;
+    let mn2 = MetaNode::open_create(&tc2.config.raft_config, Some(()), None).await?;
 
     let all = vec![mn0, mn2];
 
@@ -314,7 +314,7 @@ async fn test_meta_node_join_rejoin() -> anyhow::Result<()> {
     let node_id = 1;
     let tc1 = MetaSrvTestContext::new(node_id);
 
-    let mn1 = MetaNode::open_create_boot(&tc1.config.raft_config, None, Some(()), None).await?;
+    let mn1 = MetaNode::open_create(&tc1.config.raft_config, None, Some(())).await?;
 
     info!("--- join non-voter 1 to cluster");
 
@@ -345,7 +345,7 @@ async fn test_meta_node_join_rejoin() -> anyhow::Result<()> {
     let node_id = 2;
     let tc2 = MetaSrvTestContext::new(node_id);
 
-    let mn2 = MetaNode::open_create_boot(&tc2.config.raft_config, None, Some(()), None).await?;
+    let mn2 = MetaNode::open_create(&tc2.config.raft_config, None, Some(())).await?;
 
     info!("--- join node-2 by sending rpc `join` to a non-leader");
     {
@@ -585,7 +585,7 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
 
     let raft_conf = &tc.config.raft_config;
 
-    let leader = MetaNode::open_create_boot(raft_conf, Some(()), None, None).await?;
+    let leader = MetaNode::open_create(raft_conf, Some(()), None).await?;
 
     log_index += 1;
 

--- a/src/meta/service/tests/it/tests/meta_node.rs
+++ b/src/meta/service/tests/it/tests/meta_node.rs
@@ -35,7 +35,6 @@ pub(crate) async fn start_meta_node_cluster(
     voters: BTreeSet<NodeId>,
     non_voters: BTreeSet<NodeId>,
 ) -> anyhow::Result<(u64, Vec<MetaSrvTestContext>)> {
-    // TODO(xp): use setup_cluster if possible in tests. Get rid of boilerplate snippets.
     // leader is always node-0
     assert!(voters.contains(&0));
     assert!(!non_voters.contains(&0));

--- a/src/meta/service/tests/it/tests/meta_node.rs
+++ b/src/meta/service/tests/it/tests/meta_node.rs
@@ -190,7 +190,7 @@ pub(crate) async fn start_meta_node_non_voter(
 
     let raft_conf = &tc.config.raft_config;
 
-    let mn = MetaNode::open_create_boot(raft_conf, None, Some(()), None).await?;
+    let mn = MetaNode::open_create(raft_conf, None, Some(())).await?;
 
     assert!(!mn.is_opened());
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/watcher): just use Change as event type


##### chore(meta): refactor meta-node create/open/initialize


##### chore(meta): remove unused code

## Changelog







## Related Issues