### PR TITLE
fix(base): fix memory lost when mmap alloc panic 

### DIFF
--- a/src/common/base/src/mem_allocator/mmap_allocator.rs
+++ b/src/common/base/src/mem_allocator/mmap_allocator.rs
@@ -51,6 +51,7 @@ pub mod linux {
         #[inline(always)]
         fn mmap_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
             debug_assert!(layout.align() <= page_size());
+            ThreadTracker::alloc(layout.size() as i64);
             const PROT: i32 = libc::PROT_READ | libc::PROT_WRITE;
             const FLAGS: i32 = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_POPULATE;
             let addr = unsafe { libc::mmap(null_mut(), layout.size(), PROT, FLAGS, -1, 0) };
@@ -58,7 +59,6 @@ pub mod linux {
                 return Err(AllocError);
             }
             let addr = NonNull::new(addr as *mut ()).ok_or(AllocError)?;
-            ThreadTracker::alloc(layout.size() as i64);
             Ok(NonNull::<[u8]>::from_raw_parts(addr, layout.size()))
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(base): fix memory lost when mmap alloc panic

Closes #issue
