### PR TITLE
fix(query): short empty eval in adaptor

### DIFF
--- a/src/query/functions/src/scalars/function_adapter.rs
+++ b/src/query/functions/src/scalars/function_adapter.rs
@@ -113,7 +113,7 @@ impl Function for FunctionAdapter {
         // We must ensure all inner function eval at least one row block
         if input_rows == 0 {
             let return_type = self.return_type();
-            return Ok(return_type.create_column(&[])?);
+            return return_type.create_column(&[]);
         }
 
         let inner = self.inner.as_ref().unwrap();

--- a/src/query/functions/src/scalars/function_adapter.rs
+++ b/src/query/functions/src/scalars/function_adapter.rs
@@ -110,6 +110,12 @@ impl Function for FunctionAdapter {
             return Ok(Arc::new(NullColumn::new(input_rows)));
         }
 
+        // We must ensure all inner function eval at least one row block
+        if input_rows == 0 {
+            let return_type = self.return_type();
+            return Ok(return_type.create_column(&[])?);
+        }
+
         let inner = self.inner.as_ref().unwrap();
         if columns.is_empty() {
             return inner.eval(func_ctx, columns, input_rows);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Some functions need to get the first value but we did not ensure that the input column has at least one row.

Closes #issue
