### PR TITLE
fix(query): fix wrong current_role when drop the role

### DIFF
--- a/src/query/service/src/interpreters/interpreter_role_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_role_drop.rs
@@ -51,6 +51,9 @@ impl Interpreter for DropRoleInterpreter {
             .drop_role(&tenant, plan.role_name, plan.if_exists)
             .await?;
 
+        let session = self.ctx.get_current_session();
+        session.unset_current_role();
+
         RoleCacheManager::instance().force_reload(&tenant).await?;
         Ok(PipelineBuildResult::create())
     }

--- a/src/query/service/src/interpreters/interpreter_role_set.rs
+++ b/src/query/service/src/interpreters/interpreter_role_set.rs
@@ -45,10 +45,10 @@ impl Interpreter for SetRoleInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let session = self.ctx.get_current_session();
 
-        let role = session
-            .validate_available_role(&self.plan.role_name)
-            .await?;
         if self.plan.is_default {
+            let role = session
+                .validate_available_role(&self.plan.role_name)
+                .await?;
             let current_user = self.ctx.get_current_user()?;
             UserApiProvider::instance()
                 .update_user_default_role(

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -279,6 +279,10 @@ impl Session {
         self.session_ctx.get_current_role()
     }
 
+    pub fn unset_current_role(self: &Arc<Self>) {
+        self.session_ctx.set_current_role(None)
+    }
+
     // Returns all the roles the current session has. If the user have been granted auth_role,
     // the other roles will be ignored.
     // On executing SET ROLE, the role have to be one of the available roles.

--- a/tests/logictest/suites/base/05_ddl/05_0015_ddl_drop_role
+++ b/tests/logictest/suites/base/05_ddl/05_0015_ddl_drop_role
@@ -8,7 +8,22 @@ statement ok
 CREATE ROLE 'test-b';
 
 statement ok
+SET ROLE 'test-b';
+
+statement query T
+SELECT current_role();
+
+----
+test-b
+
+statement ok
 DROP ROLE 'test-b';
+
+statement query T
+SELECT current_role();
+
+----
+
 
 statement error 2204
 DROP ROLE 'test-b';

--- a/tests/logictest/suites/base/05_ddl/05_0015_ddl_drop_role
+++ b/tests/logictest/suites/base/05_ddl/05_0015_ddl_drop_role
@@ -7,9 +7,11 @@ DROP ROLE IF EXISTS 'test-b';
 statement ok
 CREATE ROLE 'test-b';
 
+onlyif mysql
 statement ok
 SET ROLE 'test-b';
 
+onlyif mysql
 statement query T
 SELECT current_role();
 
@@ -19,6 +21,7 @@ test-b
 statement ok
 DROP ROLE 'test-b';
 
+onlyif mysql
 statement query T
 SELECT current_role();
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

unset the current role when the role is dropped.

Closes #9229
