### PR TITLE
feat(query): add allow_insecure_tenant config and sandbox_tenant  

### DIFF
--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -174,6 +174,7 @@ pub struct QueryConfig {
     pub share_endpoint_address: String,
     pub share_endpoint_auth_token_file: String,
     pub tenant_quota: Option<TenantQuota>,
+    pub allow_insecure_tenant: bool,
 }
 
 impl Default for QueryConfig {
@@ -227,6 +228,7 @@ impl Default for QueryConfig {
             share_endpoint_address: "".to_string(),
             share_endpoint_auth_token_file: "".to_string(),
             tenant_quota: None,
+            allow_insecure_tenant: false,
         }
     }
 }

--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -1314,6 +1314,9 @@ pub struct QueryConfig {
 
     #[clap(skip)]
     quota: Option<TenantQuota>,
+
+    #[clap(long)]
+    pub allow_insecure_tenant: bool,
 }
 
 impl Default for QueryConfig {
@@ -1377,6 +1380,7 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
             share_endpoint_address: self.share_endpoint_address,
             share_endpoint_auth_token_file: self.share_endpoint_auth_token_file,
             tenant_quota: self.quota,
+            allow_insecure_tenant: self.allow_insecure_tenant,
         })
     }
 }
@@ -1439,6 +1443,7 @@ impl From<InnerQueryConfig> for QueryConfig {
             share_endpoint_address: inner.share_endpoint_address,
             share_endpoint_auth_token_file: inner.share_endpoint_auth_token_file,
             quota: inner.tenant_quota,
+            allow_insecure_tenant: inner.allow_insecure_tenant,
         }
     }
 }

--- a/src/query/service/src/sessions/session_ctx.rs
+++ b/src/query/service/src/sessions/session_ctx.rs
@@ -130,6 +130,14 @@ impl SessionContext {
 
     pub fn get_current_tenant(&self) -> String {
         let conf = GlobalConfig::instance();
+
+        if conf.query.allow_insecure_tenant {
+            let sandbox_tenant = self.settings.get_sandbox_tenant().unwrap_or_default();
+            if !sandbox_tenant.is_empty() {
+                return sandbox_tenant;
+            }
+        }
+
         if conf.query.management_mode {
             let lock = self.current_tenant.read();
             if !lock.is_empty() {

--- a/src/query/settings/src/lib.rs
+++ b/src/query/settings/src/lib.rs
@@ -476,6 +476,16 @@ impl Settings {
                 desc: "How many hours will the COPY file metadata expired in the metasrv, default value: 24*7=7days",
                 possible_values: None,
             },
+            SettingValue {
+                default_value: UserSettingValue::String("".to_string()),
+                user_setting: UserSetting::create(
+                    "sandbox_tenant",
+                    UserSettingValue::String("".to_string()),
+                ),
+                level: ScopeLevel::Session,
+                desc: "Inject a custom sandbox_tenant into this session, it's only for testing purpose and take effect when the allow_insecure_tenant is on",
+                possible_values: None,
+            },
         ];
 
         let settings: Arc<DashMap<String, SettingValue>> = Arc::new(DashMap::default());
@@ -783,6 +793,12 @@ impl Settings {
     pub fn get_load_file_metadata_expire_hours(&self) -> Result<u64> {
         let key = "load_file_metadata_expire_hours";
         self.try_get_u64(key)
+    }
+
+    pub fn get_sandbox_tenant(&self) -> Result<String> {
+        let key = "sandbox_tenant";
+        self.check_and_get_setting_value(key)
+            .and_then(|v| v.user_setting.value.as_string())
     }
 
     pub fn has_setting(&self, key: &str) -> bool {


### PR DESCRIPTION
…ings

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Add a new config `allow_insecure_tenant` and a new setting named `sandbox_tenant`

If `allow_insecure_tenant` is on, each session can use `set sandbox_tenant = 'xxx'` to create a new tenant env.

This helps:

1. Now logicaltest runs really slow because the suitcase is executed one by one. With this config, we could execute the suitcase in parallel.

2. The logicaltest may be failed during runtime, this leaves a dirty state which takes effect on other suits. Now we could make each suit run in a virtual sandbox and the catalog is isolated totally.

Closes #issue
