### PR TITLE
feat(query): enable sse4.2 in x86-64 releaser

### DIFF
--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Set musl rustflags
         if: matrix.platform == 'musl'
         run: |
-          flags="-C link-arg=-Wl,--compress-debug-sections=zlib-gabi"
+          flags="-C target-feature=+sse4.2,link-arg=-Wl,--compress-debug-sections=zlib-gabi"
           echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV
       - name: Build Binary
         run: |
@@ -180,6 +180,8 @@ jobs:
       - name: Copyobj zlib for gnu binaries
         if: matrix.platform == 'gnu'
         run: |
+          flags="-C target-feature=+sse4.2"
+          echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV
           target=${{ steps.target.outputs.target }}
           build-tool /usr/bin/${{ matrix.arch }}-linux-gnu-objcopy --compress-debug-sections=zlib-gnu ./target/${target}/release/databend-query
           build-tool /usr/bin/${{ matrix.arch }}-linux-gnu-objcopy --compress-debug-sections=zlib-gnu ./target/${target}/release/databend-meta

--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -183,7 +183,7 @@ jobs:
         if: matrix.platform == 'gnu' && matrix.arch == 'x86_64'
         run: |
           flags="-C target-feature=+sse4.2"
-          echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV  
+          echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV
       - name: Build Binary
         run: |
           cargo build --release --target=${{ steps.target.outputs.target }}

--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -175,12 +175,12 @@ jobs:
           flags="-C link-arg=-Wl,--compress-debug-sections=zlib-gabi"
           echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV
       - name: Set musl_x86_64 rustflags
-        if: matrix.platform == 'musl' && matrix.arch = 'x86_64'
+        if: matrix.platform == 'musl' && matrix.arch == 'x86_64'
         run: |
           flags="-C target-feature=+sse4.2,link-arg=-Wl,--compress-debug-sections=zlib-gabi"
           echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV
       - name: Set gnu_x86_64 rustflags
-        if: matrix.platform == 'gnu' && matrix.arch = 'x86_64'
+        if: matrix.platform == 'gnu' && matrix.arch == 'x86_64'
         run: |
           flags="-C target-feature=+sse4.2"
           echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV  

--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -190,8 +190,6 @@ jobs:
       - name: Copyobj zlib for gnu binaries
         if: matrix.platform == 'gnu'
         run: |
-          flags="-C target-feature=+sse4.2"
-          echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV
           target=${{ steps.target.outputs.target }}
           build-tool /usr/bin/${{ matrix.arch }}-linux-gnu-objcopy --compress-debug-sections=zlib-gnu ./target/${target}/release/databend-query
           build-tool /usr/bin/${{ matrix.arch }}-linux-gnu-objcopy --compress-debug-sections=zlib-gnu ./target/${target}/release/databend-meta

--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -172,10 +172,15 @@ jobs:
       - name: Set musl rustflags
         if: matrix.platform == 'musl'
         run: |
+          flags="-C link-arg=-Wl,--compress-debug-sections=zlib-gabi"
+          echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV
+      - name: Set musl_x86_64 rustflags
+        if: matrix.platform == 'musl' && matrix.arch = 'x86_64'
+        run: |
           flags="-C target-feature=+sse4.2,link-arg=-Wl,--compress-debug-sections=zlib-gabi"
           echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV
-      - name: Set gnu rustflags
-        if: matrix.platform == 'gnu'
+      - name: Set gnu_x86_64 rustflags
+        if: matrix.platform == 'gnu' && matrix.arch = 'x86_64'
         run: |
           flags="-C target-feature=+sse4.2"
           echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV  

--- a/.github/workflows/databend-release.yml
+++ b/.github/workflows/databend-release.yml
@@ -174,6 +174,11 @@ jobs:
         run: |
           flags="-C target-feature=+sse4.2,link-arg=-Wl,--compress-debug-sections=zlib-gabi"
           echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV
+      - name: Set gnu rustflags
+        if: matrix.platform == 'gnu'
+        run: |
+          flags="-C target-feature=+sse4.2"
+          echo "RUSTFLAGS=${flags}" >> $GITHUB_ENV  
       - name: Build Binary
         run: |
           cargo build --release --target=${{ steps.target.outputs.target }}

--- a/src/binaries/query/main.rs
+++ b/src/binaries/query/main.rs
@@ -63,6 +63,16 @@ async fn main_entrypoint() -> Result<()> {
     set_panic_hook();
     set_alloc_error_hook();
 
+    #[cfg(target_arch = "x86_64")]
+    {
+        if !std::is_x86_feature_detected!("sse4.2") {
+            println!(
+                "Current pre-built binary is typically compiled for x86_64 and leverage SSE 4.2 instruction set, you can build your own binary from source"
+            );
+            return Ok(());
+        }
+    }
+
     if conf.meta.is_embedded_meta()? {
         MetaEmbedded::init_global_meta_store(conf.meta.embedded_dir.clone()).await?;
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Most modern x86-64 based CPU has supported `sse4.2`, we can enable this feature flag.



Closes #issue
