### PR TITLE
fix(query): fix create view with nestd UnaryOp and BinaryOp expression

### DIFF
--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -711,12 +711,12 @@ impl<'a> Display for Expr<'a> {
                 write!(f, " BETWEEN {low} AND {high}")?;
             }
             Expr::UnaryOp { op, expr, .. } => {
-                write!(f, "{op} {expr}")?;
+                write!(f, "({op} {expr})")?;
             }
             Expr::BinaryOp {
                 op, left, right, ..
             } => {
-                write!(f, "{left} {op} {right}")?;
+                write!(f, "({left} {op} {right})")?;
             }
             Expr::Cast {
                 expr,

--- a/src/query/ast/src/ast/format/syntax/expr.rs
+++ b/src/query/ast/src/ast/format/syntax/expr.rs
@@ -112,21 +112,29 @@ pub(crate) fn pretty_expr(expr: Expr) -> RcDoc {
             .append(RcDoc::text("AND"))
             .append(RcDoc::space())
             .append(pretty_expr(*high)),
-        Expr::UnaryOp { op, expr, .. } => RcDoc::text(op.to_string())
+        Expr::UnaryOp { op, expr, .. } => RcDoc::text("(")
+            .append(RcDoc::text(op.to_string()))
             .append(RcDoc::space())
-            .append(pretty_expr(*expr)),
+            .append(pretty_expr(*expr))
+            .append(RcDoc::text(")")),
         Expr::BinaryOp {
             op, left, right, ..
-        } => pretty_expr(*left)
-            .append(
-                match op {
-                    BinaryOperator::And | BinaryOperator::Or => RcDoc::line(),
-                    _ => RcDoc::space(),
-                }
-                .append(RcDoc::text(op.to_string())),
-            )
-            .append(RcDoc::space())
-            .append(pretty_expr(*right)),
+        } => match op {
+            BinaryOperator::And | BinaryOperator::Or | BinaryOperator::Xor => parenthenized(
+                pretty_expr(*left)
+                    .append(RcDoc::line_())
+                    .append(RcDoc::text(op.to_string()))
+                    .append(RcDoc::space())
+                    .append(pretty_expr(*right)),
+            ),
+            _ => RcDoc::text("(")
+                .append(pretty_expr(*left))
+                .append(RcDoc::space())
+                .append(RcDoc::text(op.to_string()))
+                .append(RcDoc::space())
+                .append(pretty_expr(*right))
+                .append(RcDoc::text(")")),
+        },
         Expr::Cast {
             expr,
             target_type,
@@ -205,11 +213,12 @@ pub(crate) fn pretty_expr(expr: Expr) -> RcDoc {
                     .append(pretty_expr(*trim_expr))
                     .append(RcDoc::space())
                     .append(RcDoc::text("FROM"))
+                    .append(RcDoc::space())
             } else {
                 RcDoc::nil()
             })
-            .append(RcDoc::space())
-            .append(pretty_expr(*expr)),
+            .append(pretty_expr(*expr))
+            .append(RcDoc::text(")")),
         Expr::Literal { lit, .. } => RcDoc::text(lit.to_string()),
         Expr::CountAll { .. } => RcDoc::text("COUNT(*)"),
         Expr::Tuple { exprs, .. } => RcDoc::text("(")

--- a/src/query/ast/tests/it/testdata/expr.txt
+++ b/src/query/ast/tests/it/testdata/expr.txt
@@ -279,7 +279,7 @@ Literal {
 ---------- Input ----------
 -1
 ---------- Output ---------
-- 1
+(- 1)
 ---------- AST ------------
 UnaryOp {
     span: [
@@ -776,7 +776,7 @@ MapAccess {
 ---------- Input ----------
 ((1 = 1) or 1)
 ---------- Output ---------
-1 = 1 OR 1
+((1 = 1) OR 1)
 ---------- AST ------------
 BinaryOp {
     span: [
@@ -819,7 +819,7 @@ BinaryOp {
 ---------- Input ----------
 typeof(1 + 2)
 ---------- Output ---------
-typeof(1 + 2)
+typeof((1 + 2))
 ---------- AST ------------
 FunctionCall {
     span: [
@@ -867,7 +867,7 @@ FunctionCall {
 ---------- Input ----------
 - - + + - 1 + + - 2
 ---------- Output ---------
-- - + + - 1 + + - 2
+(- (- (+ (+ (- (1 + (+ (- 2))))))))
 ---------- AST ------------
 UnaryOp {
     span: [
@@ -938,7 +938,7 @@ UnaryOp {
 ---------- Input ----------
 0XFF + 0xff + 0xa + x'ffff'
 ---------- Output ---------
-255 + 255 + 10 + 65535
+(((255 + 255) + 10) + 65535)
 ---------- AST ------------
 BinaryOp {
     span: [
@@ -995,7 +995,7 @@ BinaryOp {
 ---------- Input ----------
 1 - -(- - -1)
 ---------- Output ---------
-1 - - - - - 1
+(1 - (- (- (- (- 1)))))
 ---------- AST ------------
 BinaryOp {
     span: [
@@ -1048,7 +1048,7 @@ BinaryOp {
 ---------- Input ----------
 1 + a * c.d
 ---------- Output ---------
-1 + a * c.d
+(1 + (a * c.d))
 ---------- AST ------------
 BinaryOp {
     span: [
@@ -1107,7 +1107,7 @@ BinaryOp {
 ---------- Input ----------
 number % 2
 ---------- Output ---------
-number % 2
+(number % 2)
 ---------- AST ------------
 BinaryOp {
     span: [
@@ -1954,7 +1954,7 @@ MapAccess {
 ---------- Input ----------
 a rlike '^11'
 ---------- Output ---------
-a RLIKE '^11'
+(a RLIKE '^11')
 ---------- AST ------------
 BinaryOp {
     span: [
@@ -1987,7 +1987,7 @@ BinaryOp {
 ---------- Input ----------
 G.E.B IS NOT NULL AND col1 not between col2 and (1 + col3) DIV sum(col4)
 ---------- Output ---------
-G.E.B IS NOT NULL AND col1 NOT BETWEEN col2 AND 1 + col3 DIV sum(col4)
+(G.E.B IS NOT NULL AND col1 NOT BETWEEN col2 AND ((1 + col3) DIV sum(col4)))
 ---------- AST ------------
 BinaryOp {
     span: [
@@ -2140,7 +2140,7 @@ BinaryOp {
 ---------- Input ----------
 sum(CASE WHEN n2.n_name = 'GERMANY' THEN ol_amount ELSE 0 END) / CASE WHEN sum(ol_amount) = 0 THEN 1 ELSE sum(ol_amount) END
 ---------- Output ---------
-sum(CASE WHEN n2.n_name = 'GERMANY' THEN ol_amount ELSE 0 END) / CASE WHEN sum(ol_amount) = 0 THEN 1 ELSE sum(ol_amount) END
+(sum(CASE WHEN (n2.n_name = 'GERMANY') THEN ol_amount ELSE 0 END) / CASE WHEN (sum(ol_amount) = 0) THEN 1 ELSE sum(ol_amount) END)
 ---------- AST ------------
 BinaryOp {
     span: [
@@ -2371,7 +2371,7 @@ p_partkey = l_partkey
             AND l_shipmode IN ('AIR', 'AIR REG')
             AND l_shipinstruct = 'DELIVER IN PERSON'
 ---------- Output ---------
-p_partkey = l_partkey AND p_brand = 'Brand#12' AND p_container IN('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') AND l_quantity >= CAST(1 AS Int16) AND l_quantity <= CAST(1 + 10 AS Int16) AND p_size BETWEEN CAST(1 AS Int16) AND CAST(5 AS Int16) AND l_shipmode IN('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON'
+((((((((p_partkey = l_partkey) AND (p_brand = 'Brand#12')) AND p_container IN('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')) AND (l_quantity >= CAST(1 AS Int16))) AND (l_quantity <= CAST((1 + 10) AS Int16))) AND p_size BETWEEN CAST(1 AS Int16) AND CAST(5 AS Int16)) AND l_shipmode IN('AIR', 'AIR REG')) AND (l_shipinstruct = 'DELIVER IN PERSON'))
 ---------- AST ------------
 BinaryOp {
     span: [

--- a/src/query/ast/tests/it/testdata/query.txt
+++ b/src/query/ast/tests/it/testdata/query.txt
@@ -1,7 +1,7 @@
 ---------- Input ----------
 select * exclude c1, b.* exclude (c2, c3, c4) from customer inner join orders on a = b limit 1
 ---------- Output ---------
-SELECT * EXCLUDE (c1), b.* EXCLUDE (c2, c3, c4) FROM customer INNER JOIN orders ON a = b LIMIT 1
+SELECT * EXCLUDE (c1), b.* EXCLUDE (c2, c3, c4) FROM customer INNER JOIN orders ON (a = b) LIMIT 1
 ---------- AST ------------
 Query {
     span: [
@@ -382,7 +382,7 @@ Query {
 ---------- Input ----------
 select * from customer inner join orders on a = b limit 1
 ---------- Output ---------
-SELECT * FROM customer INNER JOIN orders ON a = b LIMIT 1
+SELECT * FROM customer INNER JOIN orders ON (a = b) LIMIT 1
 ---------- AST ------------
 Query {
     span: [
@@ -520,7 +520,7 @@ Query {
 ---------- Input ----------
 select * from customer inner join orders on a = b limit 2 offset 3
 ---------- Output ---------
-SELECT * FROM customer INNER JOIN orders ON a = b LIMIT 2 OFFSET 3
+SELECT * FROM customer INNER JOIN orders ON (a = b) LIMIT 2 OFFSET 3
 ---------- AST ------------
 Query {
     span: [
@@ -897,7 +897,7 @@ Query {
 ---------- Input ----------
 with t2(tt) as (select a from t) select t2.tt from t2  where t2.tt > 1
 ---------- Output ---------
-WITH t2(tt) AS (SELECT a FROM t) SELECT t2.tt FROM t2 WHERE t2.tt > 1
+WITH t2(tt) AS (SELECT a FROM t) SELECT t2.tt FROM t2 WHERE (t2.tt > 1)
 ---------- AST ------------
 Query {
     span: [
@@ -1144,7 +1144,7 @@ Query {
 ---------- Input ----------
 with t2 as (select a from t) select t2.a from t2  where t2.a > 1
 ---------- Output ---------
-WITH t2 AS (SELECT a FROM t) SELECT t2.a FROM t2 WHERE t2.a > 1
+WITH t2 AS (SELECT a FROM t) SELECT t2.a FROM t2 WHERE (t2.a > 1)
 ---------- AST ------------
 Query {
     span: [
@@ -1376,7 +1376,7 @@ Query {
 ---------- Input ----------
 with t2(tt) as (select a from t), t3 as (select * from t), t4 as (select a from t where a > 1) select t2.tt, t3.a, t4.a from t2, t3, t4 where t2.tt > 1
 ---------- Output ---------
-WITH t2(tt) AS (SELECT a FROM t), t3 AS (SELECT * FROM t), t4 AS (SELECT a FROM t WHERE a > 1) SELECT t2.tt, t3.a, t4.a FROM t2, t3, t4 WHERE t2.tt > 1
+WITH t2(tt) AS (SELECT a FROM t), t3 AS (SELECT * FROM t), t4 AS (SELECT a FROM t WHERE (a > 1)) SELECT t2.tt, t3.a, t4.a FROM t2, t3, t4 WHERE (t2.tt > 1)
 ---------- AST ------------
 Query {
     span: [
@@ -2248,7 +2248,7 @@ select c_count cc, count(*) as custdist, sum(c_acctbal) as totacctbal
             order by custdist desc nulls first, c_count asc, totacctbal nulls last
             limit 10, totacctbal
 ---------- Output ---------
-SELECT c_count AS cc, COUNT(*) AS custdist, sum(c_acctbal) AS totacctbal FROM customer, orders AS ODS, (SELECT c_custkey, count(o_orderkey) FROM customer LEFT OUTER JOIN orders ON c_custkey = o_custkey AND o_comment NOT LIKE '%:1%:2%' GROUP BY c_custkey) AS c_orders GROUP BY c_count ORDER BY custdist DESC NULLS FIRST, c_count ASC, totacctbal NULLS LAST LIMIT 10, totacctbal
+SELECT c_count AS cc, COUNT(*) AS custdist, sum(c_acctbal) AS totacctbal FROM customer, orders AS ODS, (SELECT c_custkey, count(o_orderkey) FROM customer LEFT OUTER JOIN orders ON ((c_custkey = o_custkey) AND (o_comment NOT LIKE '%:1%:2%')) GROUP BY c_custkey) AS c_orders GROUP BY c_count ORDER BY custdist DESC NULLS FIRST, c_count ASC, totacctbal NULLS LAST LIMIT 10, totacctbal
 ---------- AST ------------
 Query {
     span: [

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -1031,7 +1031,7 @@ CreateTable(
 ---------- Input ----------
 create view v as select number % 3 as a from numbers(1000);
 ---------- Output ---------
-CREATE VIEW v AS SELECT number % 3 AS a FROM numbers(1000)
+CREATE VIEW v AS SELECT (number % 3) AS a FROM numbers(1000)
 ---------- AST ------------
 CreateView(
     CreateViewStmt {
@@ -1154,7 +1154,7 @@ CreateView(
 ---------- Input ----------
 alter view v as select number % 3 as a from numbers(1000);
 ---------- Output ---------
-ALTER VIEW v AS SELECT number % 3 AS a FROM numbers(1000)
+ALTER VIEW v AS SELECT (number % 3) AS a FROM numbers(1000)
 ---------- AST ------------
 AlterView(
     AlterViewStmt {
@@ -1718,7 +1718,7 @@ DropDatabase(
 ---------- Input ----------
 select distinct a, count(*) from t where a = 1 and b - 1 < a group by a having a = 1;
 ---------- Output ---------
-SELECT DISTINCT a, COUNT(*) FROM t WHERE a = 1 AND b - 1 < a GROUP BY a HAVING a = 1
+SELECT DISTINCT a, COUNT(*) FROM t WHERE ((a = 1) AND ((b - 1) < a)) GROUP BY a HAVING (a = 1)
 ---------- AST ------------
 Query(
     Query {
@@ -2331,7 +2331,7 @@ Query(
 ---------- Input ----------
 select * from a join b on a.a = b.a;
 ---------- Output ---------
-SELECT * FROM a INNER JOIN b ON a.a = b.a
+SELECT * FROM a INNER JOIN b ON (a.a = b.a)
 ---------- AST ------------
 Query(
     Query {
@@ -2481,7 +2481,7 @@ Query(
 ---------- Input ----------
 select * from a left outer join b on a.a = b.a;
 ---------- Output ---------
-SELECT * FROM a LEFT OUTER JOIN b ON a.a = b.a
+SELECT * FROM a LEFT OUTER JOIN b ON (a.a = b.a)
 ---------- AST ------------
 Query(
     Query {
@@ -2637,7 +2637,7 @@ Query(
 ---------- Input ----------
 select * from a right outer join b on a.a = b.a;
 ---------- Output ---------
-SELECT * FROM a RIGHT OUTER JOIN b ON a.a = b.a
+SELECT * FROM a RIGHT OUTER JOIN b ON (a.a = b.a)
 ---------- AST ------------
 Query(
     Query {
@@ -2793,7 +2793,7 @@ Query(
 ---------- Input ----------
 select * from a left semi join b on a.a = b.a;
 ---------- Output ---------
-SELECT * FROM a LEFT SEMI JOIN b ON a.a = b.a
+SELECT * FROM a LEFT SEMI JOIN b ON (a.a = b.a)
 ---------- AST ------------
 Query(
     Query {
@@ -2949,7 +2949,7 @@ Query(
 ---------- Input ----------
 select * from a semi join b on a.a = b.a;
 ---------- Output ---------
-SELECT * FROM a LEFT SEMI JOIN b ON a.a = b.a
+SELECT * FROM a LEFT SEMI JOIN b ON (a.a = b.a)
 ---------- AST ------------
 Query(
     Query {
@@ -3102,7 +3102,7 @@ Query(
 ---------- Input ----------
 select * from a left anti join b on a.a = b.a;
 ---------- Output ---------
-SELECT * FROM a LEFT ANTI JOIN b ON a.a = b.a
+SELECT * FROM a LEFT ANTI JOIN b ON (a.a = b.a)
 ---------- AST ------------
 Query(
     Query {
@@ -3258,7 +3258,7 @@ Query(
 ---------- Input ----------
 select * from a anti join b on a.a = b.a;
 ---------- Output ---------
-SELECT * FROM a LEFT ANTI JOIN b ON a.a = b.a
+SELECT * FROM a LEFT ANTI JOIN b ON (a.a = b.a)
 ---------- AST ------------
 Query(
     Query {
@@ -3411,7 +3411,7 @@ Query(
 ---------- Input ----------
 select * from a right semi join b on a.a = b.a;
 ---------- Output ---------
-SELECT * FROM a RIGHT SEMI JOIN b ON a.a = b.a
+SELECT * FROM a RIGHT SEMI JOIN b ON (a.a = b.a)
 ---------- AST ------------
 Query(
     Query {
@@ -3567,7 +3567,7 @@ Query(
 ---------- Input ----------
 select * from a right anti join b on a.a = b.a;
 ---------- Output ---------
-SELECT * FROM a RIGHT ANTI JOIN b ON a.a = b.a
+SELECT * FROM a RIGHT ANTI JOIN b ON (a.a = b.a)
 ---------- AST ------------
 Query(
     Query {
@@ -3723,7 +3723,7 @@ Query(
 ---------- Input ----------
 select * from a full outer join b on a.a = b.a;
 ---------- Output ---------
-SELECT * FROM a FULL OUTER JOIN b ON a.a = b.a
+SELECT * FROM a FULL OUTER JOIN b ON (a.a = b.a)
 ---------- AST ------------
 Query(
     Query {
@@ -3879,7 +3879,7 @@ Query(
 ---------- Input ----------
 select * from a inner join b on a.a = b.a;
 ---------- Output ---------
-SELECT * FROM a INNER JOIN b ON a.a = b.a
+SELECT * FROM a INNER JOIN b ON (a.a = b.a)
 ---------- AST ------------
 Query(
     Query {
@@ -4465,7 +4465,7 @@ Query(
 ---------- Input ----------
 select * from a where a.a = any (select b.a from b);
 ---------- Output ---------
-SELECT * FROM a WHERE a.a = ANY (SELECT b.a FROM b)
+SELECT * FROM a WHERE (a.a = ANY (SELECT b.a FROM b))
 ---------- AST ------------
 Query(
     Query {
@@ -4668,7 +4668,7 @@ Query(
 ---------- Input ----------
 select * from a where a.a = all (select b.a from b);
 ---------- Output ---------
-SELECT * FROM a WHERE a.a = ALL (SELECT b.a FROM b)
+SELECT * FROM a WHERE (a.a = ALL (SELECT b.a FROM b))
 ---------- AST ------------
 Query(
     Query {
@@ -4871,7 +4871,7 @@ Query(
 ---------- Input ----------
 select * from a where a.a = some (select b.a from b);
 ---------- Output ---------
-SELECT * FROM a WHERE a.a = SOME (SELECT b.a FROM b)
+SELECT * FROM a WHERE (a.a = SOME (SELECT b.a FROM b))
 ---------- AST ------------
 Query(
     Query {
@@ -5074,7 +5074,7 @@ Query(
 ---------- Input ----------
 select * from a where a.a > (select b.a from b);
 ---------- Output ---------
-SELECT * FROM a WHERE a.a > (SELECT b.a FROM b)
+SELECT * FROM a WHERE (a.a > (SELECT b.a FROM b))
 ---------- AST ------------
 Query(
     Query {
@@ -5272,7 +5272,7 @@ Query(
 ---------- Input ----------
 select 1 from numbers(1) where ((1 = 1) or 1)
 ---------- Output ---------
-SELECT 1 FROM numbers(1) WHERE 1 = 1 OR 1
+SELECT 1 FROM numbers(1) WHERE ((1 = 1) OR 1)
 ---------- AST ------------
 Query(
     Query {
@@ -5901,7 +5901,7 @@ AlterTable(
 ---------- Input ----------
 ALTER TABLE t RECLUSTER FINAL WHERE c1 > 0;
 ---------- Output ---------
-ALTER TABLE t RECLUSTER FINAL WHERE c1 > 0
+ALTER TABLE t RECLUSTER FINAL WHERE (c1 > 0)
 ---------- AST ------------
 AlterTable(
     AlterTableStmt {
@@ -7834,7 +7834,7 @@ ShowGrantsOfShare(
 ---------- Input ----------
 UPDATE db1.tb1 set a = a + 1, b = 2 WHERE c > 3;
 ---------- Output ---------
-UPDATE db1.tb1 SET a = a + 1, b = 2 WHERE c > 3
+UPDATE db1.tb1 SET a = (a + 1), b = 2 WHERE (c > 3)
 ---------- AST ------------
 Update(
     UpdateStmt {

--- a/src/query/service/tests/it/sql/planner/semantic/name_resolution.rs
+++ b/src/query/service/tests/it/sql/planner/semantic/name_resolution.rs
@@ -134,6 +134,6 @@ fn test_normalize_identifiers_in_expr() {
 
     assert_eq!(
         format!("{:#}", expr),
-        "EXISTS (SELECT func(\"T\".a + 1) AS b)".to_string()
+        "EXISTS (SELECT func((\"T\".a + 1)) AS b)".to_string()
     );
 }

--- a/tests/logictest/suites/base/05_ddl/05_0015_ddl_drop_role
+++ b/tests/logictest/suites/base/05_ddl/05_0015_ddl_drop_role
@@ -12,7 +12,7 @@ statement ok
 SET ROLE 'test-b';
 
 onlyif mysql
-statement query T
+query T
 SELECT current_role();
 
 ----
@@ -22,7 +22,7 @@ statement ok
 DROP ROLE 'test-b'
 
 onlyif mysql
-statement query T
+query T
 SELECT current_role();
 
 ----

--- a/tests/logictest/suites/base/05_ddl/05_0019_ddl_create_view
+++ b/tests/logictest/suites/base/05_ddl/05_0019_ddl_create_view
@@ -62,7 +62,16 @@ select v1.id from default.v0 as v1
 2
 
 statement ok
+create view default.v2 as select * from test_view.t0 where ((((((t0.id)-(1362151668)))-((+ 1362151668))))is not distinct from((+ ((-177629504)/(2071531978)))))
+
+statement ok
+select * from default.v2
+
+statement ok
 drop view default.v0
+
+statement ok
+drop view default.v2
 
 statement ok
 drop database test_view

--- a/tests/logictest/suites/base/06_show/06_0001_show_create_table
+++ b/tests/logictest/suites/base/06_show/06_0001_show_create_table
@@ -26,7 +26,7 @@ CREATE TABLE test.c (a int) CLUSTER BY (a, a % 3)
 query TT
 SHOW CREATE TABLE `test`.`c`
 ----
-c CREATE TABLE `c` ( `a` INT ) ENGINE=FUSE CLUSTER BY (a, a % 3)
+c CREATE TABLE `c` ( `a` INT ) ENGINE=FUSE CLUSTER BY (a, (a % 3))
 
 statement ok
 DROP TABLE `test`.`a`

--- a/tests/logictest/suites/mode/standalone/explain/explain.test
+++ b/tests/logictest/suites/mode/standalone/explain/explain.test
@@ -130,9 +130,13 @@ SELECT
 FROM
     t1
 WHERE
-    a IN (1, 2)
-    AND b > 0
-    AND b < 100
+    (
+        (
+            a IN (1, 2)
+            AND (b > 0)
+        )
+        AND (b < 100)
+    )
 GROUP BY a
 ORDER BY a
 
@@ -142,9 +146,13 @@ explain syntax select * from t1 inner join t2 on t1.a = t2.a and t1.b = t2.b and
 SELECT *
 FROM
     t1
-    INNER JOIN t2 ON t1.a = t2.a
-    AND t1.b = t2.b
-    AND t1.a > 2
+    INNER JOIN t2 ON (
+        (
+            (t1.a = t2.a)
+            AND (t1.b = t2.b)
+        )
+        AND (t1.a > 2)
+    )
 
 query T
 explain syntax delete from t1 where a > 100 and b > 1 and b < 10
@@ -152,9 +160,13 @@ explain syntax delete from t1 where a > 100 and b > 1 and b < 10
 DELETE FROM
     t1
 WHERE
-    a > 100
-    AND b > 1
-    AND b < 10
+    (
+        (
+            (a > 100)
+            AND (b > 1)
+        )
+        AND (b < 10)
+    )
 
 skipif clickhouse
 query T
@@ -212,11 +224,11 @@ explain syntax create view v as select number % 3 as a from numbers(100) where n
 ----
 CREATE VIEW v
 AS
-    SELECT number % 3 AS a
+    SELECT (number % 3) AS a
     FROM
         numbers(100)
     WHERE
-        number > 10
+        (number > 10)
 
 query T
 explain ast select 1, 'ab', [1,2,3] as a, (1, 'a') as t


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add parentheses for `Expr::UnaryOp` and `Expr::BinaryOp` to fix the wrong query in view.

Closes #9164
