### PR TITLE
feat: support ANSI quoted identifier with escape

### DIFF
--- a/src/query/ast/src/util.rs
+++ b/src/query/ast/src/util.rs
@@ -24,6 +24,7 @@ use crate::ast::Identifier;
 use crate::input::Input;
 use crate::input::WithSpan;
 use crate::parser::token::*;
+use crate::parser::unescape::unescape;
 use crate::rule;
 use crate::Error;
 use crate::ErrorKind;
@@ -108,10 +109,7 @@ pub fn stage_name(i: Input) -> IResult<Identifier> {
                     let quote = token.text().chars().next().unwrap();
                     Ok((i2, Identifier {
                         span: token.clone(),
-                        name: unquote_ansi_identifier(
-                            &token.text()[1..token.text().len() - 1],
-                            quote,
-                        ),
+                        name: unescape(&token.text()[1..token.text().len() - 1], quote).unwrap(),
                         quote: Some(quote),
                     }))
                 } else {
@@ -150,10 +148,8 @@ fn non_reserved_identifier(
                         let quote = token.text().chars().next().unwrap();
                         Ok((i2, Identifier {
                             span: token.clone(),
-                            name: unquote_ansi_identifier(
-                                &token.text()[1..token.text().len() - 1],
-                                quote,
-                            ),
+                            name: unescape(&token.text()[1..token.text().len() - 1], quote)
+                                .unwrap(),
                             quote: Some(quote),
                         }))
                     } else {
@@ -166,25 +162,6 @@ fn non_reserved_identifier(
             },
         ))(i)
     }
-}
-
-fn unquote_ansi_identifier(s: &str, quote: char) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars();
-    while let Some(c) = chars.next() {
-        if c == quote {
-            if let Some(next) = chars.next() {
-                if next == quote {
-                    result.push(next);
-                } else {
-                    result.push(c);
-                }
-            }
-        } else {
-            result.push(c);
-        }
-    }
-    result
 }
 
 fn non_reserved_keyword(

--- a/src/query/ast/src/util.rs
+++ b/src/query/ast/src/util.rs
@@ -109,7 +109,13 @@ pub fn stage_name(i: Input) -> IResult<Identifier> {
                     let quote = token.text().chars().next().unwrap();
                     Ok((i2, Identifier {
                         span: token.clone(),
-                        name: unescape(&token.text()[1..token.text().len() - 1], quote).unwrap(),
+                        name: unescape(&token.text()[1..token.text().len() - 1], quote)
+                            .ok_or_else(|| {
+                                nom::Err::Error(Error::from_error_kind(
+                                    i,
+                                    ErrorKind::Other("invalid escape or unicode"),
+                                ))
+                            })?,
                         quote: Some(quote),
                     }))
                 } else {
@@ -149,7 +155,12 @@ fn non_reserved_identifier(
                         Ok((i2, Identifier {
                             span: token.clone(),
                             name: unescape(&token.text()[1..token.text().len() - 1], quote)
-                                .unwrap(),
+                                .ok_or_else(|| {
+                                    nom::Err::Error(Error::from_error_kind(
+                                        i,
+                                        ErrorKind::Other("invalid escape or unicode"),
+                                    ))
+                                })?,
                             quote: Some(quote),
                         }))
                     } else {

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -76,6 +76,8 @@ fn test_statement() {
         r#"explain pipeline select a from b;"#,
         r#"describe a;"#,
         r#"describe a format TabSeparatedWithNamesAndTypes;"#,
+        r#"describe "name""with""quote";"#,
+        r#"describe "name""""with""""quote";"#,
         r#"create table if not exists a.b (c integer not null default 1, b varchar);"#,
         r#"create table if not exists a.b (c integer default 1 not null, b varchar) as select * from t;"#,
         r#"create table if not exists a.b (c tuple(m integer, n string), d tuple(integer, string));"#,

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -138,6 +138,7 @@ fn test_statement() {
         r#"select * from a where a.a = some (select b.a from b);"#,
         r#"select * from a where a.a > (select b.a from b);"#,
         r#"select 1 from numbers(1) where ((1 = 1) or 1)"#,
+        r#"select 'stringwith''quote'''"#,
         r#"insert into t (c1, c2) values (1, 2), (3, 4);"#,
         r#"insert into table t format json;"#,
         r#"insert into table t select * from t2;"#,

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -5448,6 +5448,52 @@ Query(
 
 
 ---------- Input ----------
+select 'stringwith''quote'''
+---------- Output ---------
+SELECT 'stringwith'quote''
+---------- AST ------------
+Query(
+    Query {
+        span: [
+            SELECT(0..6),
+            QuotedString(7..28),
+        ],
+        with: None,
+        body: Select(
+            SelectStmt {
+                span: [
+                    SELECT(0..6),
+                    QuotedString(7..28),
+                ],
+                distinct: false,
+                select_list: [
+                    AliasedExpr {
+                        expr: Literal {
+                            span: [
+                                QuotedString(7..28),
+                            ],
+                            lit: String(
+                                "stringwith'quote'",
+                            ),
+                        },
+                        alias: None,
+                    },
+                ],
+                from: [],
+                selection: None,
+                group_by: [],
+                having: None,
+            },
+        ),
+        order_by: [],
+        limit: [],
+        offset: None,
+        ignore_result: false,
+    },
+)
+
+
+---------- Input ----------
 insert into t (c1, c2) values (1, 2), (3, 4);
 ---------- Output ---------
 INSERT INTO t (c1, c2) VALUES (1, 2), (3, 4);

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -305,6 +305,46 @@ Some(
     "TabSeparatedWithNamesAndTypes",
 )
 ---------- Input ----------
+describe "name""with""quote";
+---------- Output ---------
+DESCRIBE "name"with"quote"
+---------- AST ------------
+DescribeTable(
+    DescribeTableStmt {
+        catalog: None,
+        database: None,
+        table: Identifier {
+            name: "name\"with\"quote",
+            quote: Some(
+                '"',
+            ),
+            span: QuotedString(9..28),
+        },
+    },
+)
+
+
+---------- Input ----------
+describe "name""""with""""quote";
+---------- Output ---------
+DESCRIBE "name""with""quote"
+---------- AST ------------
+DescribeTable(
+    DescribeTableStmt {
+        catalog: None,
+        database: None,
+        table: Identifier {
+            name: "name\"\"with\"\"quote",
+            quote: Some(
+                '"',
+            ),
+            span: QuotedString(9..32),
+        },
+    },
+)
+
+
+---------- Input ----------
 create table if not exists a.b (c integer not null default 1, b varchar);
 ---------- Output ---------
 CREATE TABLE IF NOT EXISTS a.b (c Int32 NOT NULL DEFAULT 1, b STRING NOT NULL)

--- a/tests/logictest/suites/base/05_ddl/05_0016_ddl_stage
+++ b/tests/logictest/suites/base/05_ddl/05_0016_ddl_stage
@@ -14,7 +14,7 @@ statement error 2502
 CREATE STAGE test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z')
 
 statement ok
-CREATE STAGE test_stage_internal file_format=(type=csv compression=AUTO record_delimiter=NONE escape="\\") comments='test'
+CREATE STAGE test_stage_internal file_format=(type=csv compression=AUTO record_delimiter=NONE escape='\\') comments='test'
 
 statement ok
 LIST @test_stage_internal


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

currently the following statement will create a table called t1""a, but t1"a is expected:

```
create table "t1""a" (a int);
```

this PR add the quote escape logic to identifiers, so the SQL-concating tools like sql ui or dbt can quote identifiers safely.

Closes #9115
