### PR TITLE
ci: make tarball before upload failure artifact

### DIFF
--- a/.github/actions/artifact_failure/action.yml
+++ b/.github/actions/artifact_failure/action.yml
@@ -7,15 +7,19 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: pack failure artifacts
+      shell: bash
+      run: |
+        tar --exclude='target' \
+            --exclude='website' \
+            --exclude='docs' \
+            --exclude='docker' \
+            --exclude='bins' \
+            --exclude='.git' \
+            --exclude='tests/suites/0_stateless/13_tpch/data' \
+            --exclude='failure-*' \
+            -zcf failure-${{ inputs.name }}.tar.gz .
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.name }}
-        path: |
-          .
-          !./target
-          !./website
-          !./docs
-          !./docker
-          !./bins
-          !./.git
-          !./tests/suites/0_stateless/13_tpch/data
+        path: failure-${{ inputs.name }}.tar.gz


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

It's too slow to upload files one by one.


