### PR TITLE
fix(CSV): refine error message.

### DIFF
--- a/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_csv.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_csv.rs
@@ -89,25 +89,22 @@ impl InputFormatCSV {
         rows: usize,
     ) -> Result<()> {
         if actual < expect {
-            return Err(csv_error(
+            Err(csv_error(
                 &format!("expect {} fields, only found {} ", expect, actual),
                 path,
                 rows,
-            ));
-        } else if actual > expect + 1 {
-            return Err(csv_error(
+            ))
+        } else if actual > expect + 1
+            || (actual == expect + 1 && field_ends[expect] != field_ends[expect - 1])
+        {
+            Err(csv_error(
                 &format!("too many fields, expect {}, got {}", expect, actual),
                 path,
                 rows,
-            ));
-        } else if actual == expect + 1 && field_ends[expect] != field_ends[expect - 1] {
-            return Err(csv_error(
-                "CSV allow ending with ',', but should not have data after it",
-                path,
-                rows,
-            ));
+            ))
+        } else {
+            Ok(())
         }
-        Ok(())
     }
 }
 

--- a/tests/suites/0_stateless/14_clickhouse_http_handler/14_0007_http_clickhouse_input_format_diagnostic.sh
+++ b/tests/suites/0_stateless/14_clickhouse_http_handler/14_0007_http_clickhouse_input_format_diagnostic.sh
@@ -21,7 +21,7 @@ cat << EOF > /tmp/databend_test_csv_error2.txt
 insert into a(a,b,c) format CSV "2023-04-08 01:01:01","Hello",12345678,1
 
 EOF
-curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" --data-binary @/tmp/databend_test_csv_error2.txt | grep -c "allow ending"
+curl -s -u 'root:' -XPOST "http://localhost:${QUERY_CLICKHOUSE_HTTP_HANDLER_PORT}/?enable_planner_v2=1" --data-binary @/tmp/databend_test_csv_error2.txt | grep -c "too many fields"
 
 # 3 bad number
 echo -e '\ncsv 3'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

the original `"CSV allow ending with ',', but should not have data after it"` is confusing most of the time, and `field_delimiter` should be an option.

related https://github.com/datafuselabs/databend/pull/9268#issuecomment-1358753069