### PR TITLE
feat: Allow load credential from env if allow insecure

### DIFF
--- a/src/query/sql/tests/location.rs
+++ b/src/query/sql/tests/location.rs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
-use std::io::Result;
 
+use anyhow::Result;
 use common_ast::ast::UriLocation;
+use common_base::base::GlobalInstance;
+use common_config::Config;
+use common_config::GlobalConfig;
 use common_sql::planner::binder::parse_uri_location;
 use common_storage::StorageFsConfig;
 use common_storage::StorageFtpConfig;
@@ -31,6 +34,14 @@ use common_storage::STORAGE_S3_DEFAULT_ENDPOINT;
 
 #[test]
 fn test_parse_uri_location() -> Result<()> {
+    let thread_name = match std::thread::current().name() {
+        None => panic!("thread name is none"),
+        Some(thread_name) => thread_name.to_string(),
+    };
+
+    GlobalInstance::init_testing(&thread_name);
+    GlobalConfig::init(Config::default())?;
+
     let cases = vec![
         (
             "secure scheme by default",


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: Allow load credential from env if allow insecure

Use `allow-insecure` to control the credential loader logic. I will polish this part later at https://github.com/datafuselabs/opendal/issues/1088
