### PR TITLE
refactor(meta/watch): test watcher count

### DIFF
--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -476,6 +476,8 @@ impl MetaGrpcClient {
     ) -> Result<MetaServiceClient<InterceptedService<Channel, AuthInterceptor>>, MetaClientError>
     {
         let mut eps = self.get_endpoints().await;
+        debug!("service endpoints: {:?}", eps);
+
         debug_assert!(!eps.is_empty());
 
         if eps.len() > 1 {

--- a/src/meta/service/src/api/grpc_server.rs
+++ b/src/meta/service/src/api/grpc_server.rs
@@ -38,7 +38,7 @@ use crate::meta_service::MetaNode;
 
 pub struct GrpcServer {
     conf: Config,
-    meta_node: Arc<MetaNode>,
+    pub(crate) meta_node: Arc<MetaNode>,
     join_handle: Option<JoinHandle<()>>,
     stop_tx: Option<Sender<()>>,
     fin_rx: Option<Receiver<()>>,

--- a/src/meta/service/src/watcher/mod.rs
+++ b/src/meta/service/src/watcher/mod.rs
@@ -17,7 +17,9 @@ mod watcher_stream;
 
 pub(crate) use watcher_manager::DispatcherSender;
 pub(crate) use watcher_manager::EventDispatcher;
-pub use watcher_manager::WatchEvent;
+pub use watcher_manager::EventDispatcherHandle;
+pub(crate) use watcher_manager::WatchEvent;
 pub use watcher_manager::WatcherId;
 pub use watcher_manager::WatcherSender;
+pub use watcher_stream::WatcherInfo;
 pub use watcher_stream::WatcherStream;

--- a/src/meta/service/src/watcher/watcher_stream.rs
+++ b/src/meta/service/src/watcher/watcher_stream.rs
@@ -20,16 +20,21 @@ use tonic::Status;
 use super::WatcherId;
 use super::WatcherSender;
 
-pub struct WatcherStream {
+/// Attributes of a watcher that is interested in kv change events.
+pub struct WatcherInfo {
     pub id: WatcherId,
 
     pub filter_type: FilterType,
 
-    tx: WatcherSender,
-
     pub key: String,
 
     pub key_end: String,
+}
+
+pub struct WatcherStream {
+    pub watcher: WatcherInfo,
+
+    tx: WatcherSender,
 }
 
 impl WatcherStream {
@@ -41,11 +46,13 @@ impl WatcherStream {
         key_end: String,
     ) -> Self {
         WatcherStream {
-            id,
-            filter_type,
+            watcher: WatcherInfo {
+                id,
+                filter_type,
+                key,
+                key_end,
+            },
             tx,
-            key,
-            key_end,
         }
     }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/watch): test watcher count

- Add `EventDispatcherHandle` as control handle of the meta node
  internal event dispatcher. It provides a `request` method to let
  users run a user-defined function with a mutable reference to
  `EventDispatcher`.

- Re-organize event watcher attribuites into `WatcherInfo`.

- Test the count of watchers.

## Changelog







## Related Issues