### PR TITLE
chore: Bump opendal to 0.23 for hdfs blocking ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4342,9 +4342,9 @@ dependencies = [
 
 [[package]]
 name = "hdrs"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5377b8fe6bdec4c6af1058ac6477f6fb6a4422211e6f4dd6f420b4f084bf55"
+checksum = "949814fc49979183bd43fcd899671f706f7246586738beb3f42fdafa528ec7f3"
 dependencies = [
  "errno",
  "futures-io",
@@ -5917,9 +5917,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.22.6"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32203b1d5644a1cbd7b918a36269f59a055ff8c6c29f021a34b612a68234f07"
+checksum = "b006dcbd9dacb1902a6cfce29d99b3fca18299a7197fa33216e6676b5e5c6566"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/src/common/exception/Cargo.toml
+++ b/src/common/exception/Cargo.toml
@@ -15,7 +15,7 @@ common-arrow = { path = "../arrow" }
 
 anyhow = { workspace = true }
 bincode = { version = "2.0.0-rc.1", features = ["serde", "std", "alloc"] }
-opendal = "0.22"
+opendal = "0.23"
 paste = "1.0.9"
 prost = { workspace = true }
 serde = { workspace = true }

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -22,7 +22,7 @@ bytes = "1"
 futures = "0.3"
 globiter = "0.1"
 once_cell = "1"
-opendal = { version = "0.22", features = [
+opendal = { version = "0.23", features = [
     "layers-tracing",
     "layers-metrics",
     "services-ipfs",

--- a/src/query/pipeline/sources/Cargo.toml
+++ b/src/query/pipeline/sources/Cargo.toml
@@ -31,7 +31,7 @@ crossbeam-channel = "0.5.6"
 csv-core = "0.1.10"
 futures = "0.3.24"
 futures-util = "0.3.24"
-opendal = { version = "0.22", features = ["compress"] }
+opendal = { version = "0.23", features = ["compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -103,7 +103,7 @@ lz4 = "1.24.0"
 metrics = "0.20.1"
 naive-cityhash = "0.2.0"
 once_cell = "1.15.0"
-opendal = { version = "0.22", features = ["layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.23", features = ["layers-tracing", "layers-metrics", "compress"] }
 opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "5e37788" }
 openssl = { version = "0.10.41", features = ["vendored"] }
 parking_lot = "0.12.1"

--- a/src/query/sharing-endpoint/Cargo.toml
+++ b/src/query/sharing-endpoint/Cargo.toml
@@ -22,7 +22,7 @@ time = { version = "0.3", features = ["serde"] }
 anyhow = { workspace = true }
 base64 = "0.13.0"
 clap = { workspace = true }
-opendal = "0.22.2"
+opendal = "0.23"
 poem = { version = "1", features = ["rustls", "multipart", "compression"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/sharing/Cargo.toml
+++ b/src/query/sharing/Cargo.toml
@@ -21,7 +21,7 @@ common-config = { path = "../config" }
 http = "0.2"
 log = "0.4"
 moka = "0.9"
-opendal = "0.22"
+opendal = "0.23"
 reqwest = "0.11"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/sql/Cargo.toml
+++ b/src/query/sql/Cargo.toml
@@ -71,7 +71,7 @@ lz4 = "1.24.0"
 metrics = "0.20.1"
 naive-cityhash = "0.2.0"
 once_cell = "1.15.0"
-opendal = { version = "0.22", features = ["layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.23", features = ["layers-tracing", "layers-metrics", "compress"] }
 opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "5e37788" }
 openssl = { version = "0.10.41", features = ["vendored"] }
 parking_lot = "0.12.1"

--- a/src/query/storages/cache/Cargo.toml
+++ b/src/query/storages/cache/Cargo.toml
@@ -18,4 +18,4 @@ common-exception = { path = "../../../common/exception" }
 common-storages-table-meta = { path = "../table-meta" }
 
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
-opendal = "0.22"
+opendal = "0.23"

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -42,7 +42,7 @@ futures = "0.3.24"
 futures-util = "0.3.24"
 itertools = "0.10.5"
 metrics = "0.20.1"
-opendal = "0.22"
+opendal = "0.23"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = "0.1.36"

--- a/src/query/storages/hive/hive/Cargo.toml
+++ b/src/query/storages/hive/hive/Cargo.toml
@@ -32,7 +32,7 @@ async-recursion = "1.0.0"
 async-trait = "0.1.57"
 chrono = { workspace = true }
 futures = "0.3.24"
-opendal = "0.22"
+opendal = "0.23"
 serde = { workspace = true }
 thrift = { package = "databend-thrift", version = "0.17.0" }
 tracing = "0.1.36"

--- a/src/query/storages/information-schema/Cargo.toml
+++ b/src/query/storages/information-schema/Cargo.toml
@@ -36,7 +36,7 @@ chrono = { workspace = true }
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.22", features = ["layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.23", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/memory/Cargo.toml
+++ b/src/query/storages/memory/Cargo.toml
@@ -36,7 +36,7 @@ chrono = { workspace = true }
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.22", features = ["layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.23", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/null/Cargo.toml
+++ b/src/query/storages/null/Cargo.toml
@@ -36,7 +36,7 @@ chrono = { workspace = true }
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.22", features = ["layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.23", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/parquet/Cargo.toml
+++ b/src/query/storages/parquet/Cargo.toml
@@ -30,6 +30,6 @@ common-storages-table-meta = { path = "../table-meta" }
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
 chrono = { workspace = true }
 glob = "0.3.0"
-opendal = "0.22"
+opendal = "0.23"
 serde = { workspace = true }
 typetag = "0.2.3"

--- a/src/query/storages/random/Cargo.toml
+++ b/src/query/storages/random/Cargo.toml
@@ -36,7 +36,7 @@ chrono = { workspace = true }
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.22", features = ["layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.23", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/share/Cargo.toml
+++ b/src/query/storages/share/Cargo.toml
@@ -17,7 +17,7 @@ common-meta-app = { path = "../../../meta/app" }
 common-storages-cache = { path = "../cache" }
 common-storages-table-meta = { path = "../table-meta" }
 
-opendal = "0.22"
+opendal = "0.23"
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/src/query/storages/stage/Cargo.toml
+++ b/src/query/storages/stage/Cargo.toml
@@ -36,7 +36,7 @@ chrono = { workspace = true }
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.22", features = ["layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.23", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 regex = "1.6.0"
 serde = { workspace = true }

--- a/src/query/storages/system/Cargo.toml
+++ b/src/query/storages/system/Cargo.toml
@@ -37,7 +37,7 @@ chrono = { workspace = true }
 futures = "0.3.24"
 itertools = "0.10.5"
 once_cell = "1.15.0"
-opendal = { version = "0.22", features = ["layers-tracing", "layers-metrics", "compress"] }
+opendal = { version = "0.23", features = ["layers-tracing", "layers-metrics", "compress"] }
 parking_lot = "0.12.1"
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore: Bump opendal to 0.23 for hdfs blocking ops