### PR TITLE
feat: use `memmem` for string search pattern `%needle%`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,6 +1525,7 @@ dependencies = [
  "hex",
  "itertools",
  "md-5",
+ "memchr",
  "naive-cityhash",
  "num",
  "num-format",

--- a/src/query/functions/Cargo.toml
+++ b/src/query/functions/Cargo.toml
@@ -35,6 +35,7 @@ h3ron = "0.15.1"
 hex = "0.4.3"
 itertools = "0.10.5"
 md-5 = "0.10.5"
+memchr = { version = "2", default-features = false }
 naive-cityhash = "0.2.0"
 num = "0.4.0"
 num-format = "0.4.0"

--- a/src/query/functions/src/scalars/comparisons/comparison_like.rs
+++ b/src/query/functions/src/scalars/comparisons/comparison_like.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_datavalues::prelude::*;
+use memchr::memmem;
 
 use super::comparison::StringSearchCreator;
 use super::utils::StringSearchImpl;
@@ -56,6 +57,18 @@ impl StringSearchImpl for StringSearchLike {
                 let ends_with = &rhs[1..];
                 BooleanColumn::from_iterator(lhs.scalar_iter().map(|x| op(x.ends_with(ends_with))))
             }
+
+            PatternType::SurroundByPercent => {
+                if rhs.len() > 2 {
+                    let needle = &rhs[1..rhs.len() - 1];
+                    BooleanColumn::from_iterator(
+                        lhs.scalar_iter()
+                            .map(|x| op(memmem::find(x, needle).is_some())),
+                    )
+                } else {
+                    BooleanColumn::from_iterator(lhs.scalar_iter().map(|x| op(x.is_empty())))
+                }
+            }
             PatternType::PatternStr => {
                 BooleanColumn::from_iterator(lhs.scalar_iter().map(|x| op(like(x, rhs))))
             }
@@ -78,6 +91,8 @@ pub enum PatternType {
     StartOfPercent,
     // e.g. 'Arro%'
     EndOfPercent,
+    // e.g. '%Arrow%'
+    SurroundByPercent,
 }
 
 /// Check the like pattern type.
@@ -114,8 +129,12 @@ pub fn check_pattern_type(pattern: &[u8], is_pruning: bool) -> PatternType {
         match pattern[index] {
             b'_' => return PatternType::PatternStr,
             b'%' => {
-                if index == len - 1 && !start_percent {
-                    return PatternType::EndOfPercent;
+                if index == len - 1 {
+                    return if !start_percent {
+                        PatternType::EndOfPercent
+                    } else {
+                        PatternType::SurroundByPercent
+                    };
                 }
                 return PatternType::PatternStr;
             }

--- a/tests/sqllogictests/suites/base/20+_others/20_00010_expression_string_like
+++ b/tests/sqllogictests/suites/base/20+_others/20_00010_expression_string_like
@@ -1,0 +1,61 @@
+statement ok
+CREATE TABLE t_string_like(URL TEXT NOT NULL)
+
+statement ok
+insert into t_string_like values('Arrow'), (''), ('Nicolas')
+
+query B
+select count(*)=1 from t_string_like where URL like 'Arrow'
+----
+1
+
+query B
+select count(*)=1 from t_string_like where URL like '%Arrow'
+----
+1
+
+query B
+select count(*)=1 from t_string_like where URL like '%rrow'
+----
+1
+
+query B
+select count(*)=0 from t_string_like where URL like '%rro'
+----
+1
+
+query B
+select count(*)=1 from t_string_like where URL like 'Arr%'
+----
+1
+
+query B
+select count(*)=1 from t_string_like where URL like 'Arrow%'
+----
+1
+
+query B
+select count(*)=0 from t_string_like where URL like 'rrow%'
+----
+1
+
+query B
+select count(*)=1 from t_string_like where URL like '%Arrow%'
+----
+1
+
+query B
+select count(*)=1 from t_string_like where URL like '%rro%'
+----
+1
+
+query B
+select count(*)=0 from t_string_like where URL like '%not_exist%'
+----
+1
+
+
+query B
+select count(*)=1 from t_string_like where URL like '%%'
+----
+1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary


- introduces new crate dependency `memchr`.
- for string search expression with pattern  `%NEEDLE%`, use `memchr::memmem::find`
  

Closes #issue
