### PR TITLE
feat: add read column io copy perf counter

### DIFF
--- a/src/query/storages/fuse/src/metrics/fuse_metrics.rs
+++ b/src/query/storages/fuse/src/metrics/fuse_metrics.rs
@@ -76,6 +76,10 @@ pub fn metrics_inc_remote_io_read_milliseconds(c: u64) {
     increment_gauge!(key!("remote_io_read_milliseconds"), c as f64);
 }
 
+pub fn metrics_inc_remote_io_copy_milliseconds(c: u64) {
+    increment_gauge!(key!("remote_io_copy_milliseconds"), c as f64);
+}
+
 pub fn metrics_inc_remote_io_read_parts(c: u64) {
     increment_gauge!(key!("remote_io_read_parts"), c as f64);
 }
@@ -87,5 +91,6 @@ pub fn metrics_reset() {
     gauge!(key!("remote_io_read_bytes"), c);
     gauge!(key!("remote_io_read_bytes_after_merged"), c);
     gauge!(key!("remote_io_read_milliseconds"), c);
+    gauge!(key!("remote_io_copy_milliseconds"), c);
     gauge!(key!("remote_io_read_parts"), c);
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Introduce a new perf counter:remote_io_copy_milliseconds to measure the IO copy during read columns

Closes #issue
