### PR TITLE
feat: add fuse source deser perf counter

### DIFF
--- a/src/query/storages/fuse/src/io/read/block_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block_reader.rs
@@ -89,7 +89,9 @@ impl BlockReader {
         let merged_range_data_results = futures::future::try_join_all(read_handlers).await?;
 
         // Perf.
-        metrics_inc_remote_io_read_milliseconds(start.elapsed().as_millis() as u64);
+        {
+            metrics_inc_remote_io_read_milliseconds(start.elapsed().as_millis() as u64);
+        }
 
         // Build raw range data from merged range data.
         let mut final_result = Vec::with_capacity(raw_ranges.len());

--- a/src/query/storages/fuse/src/io/read/block_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/block_reader_parquet.rs
@@ -274,13 +274,14 @@ impl BlockReader {
         }
 
         let mut deserializer = RowGroupDeserializer::new(columns_array_iter, num_rows, None);
+        let res = self.try_next_block(&mut deserializer);
 
         // Perf.
         {
             metrics_inc_remote_io_deserialize_milliseconds(start.elapsed().as_millis() as u64);
         }
 
-        self.try_next_block(&mut deserializer)
+        res
     }
 
     pub async fn read_columns_data(

--- a/src/query/storages/fuse/src/io/read/block_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/block_reader_parquet.rs
@@ -15,6 +15,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use common_arrow::arrow::array::Array;
 use common_arrow::arrow::chunk::Chunk;
@@ -50,6 +51,7 @@ use tracing::Instrument;
 use crate::fuse_part::FusePartInfo;
 use crate::io::read::ReadSettings;
 use crate::io::BlockReader;
+use crate::metrics::metrics_inc_remote_io_deserialize_milliseconds;
 use crate::metrics::metrics_inc_remote_io_read_bytes;
 use crate::metrics::metrics_inc_remote_io_read_parts;
 use crate::metrics::metrics_inc_remote_io_seeks;
@@ -232,6 +234,8 @@ impl BlockReader {
         part: PartInfoPtr,
         chunks: Vec<(usize, Vec<u8>)>,
     ) -> Result<DataBlock> {
+        let start = Instant::now();
+
         let part = FusePartInfo::from_part(&part)?;
         let mut chunk_map: HashMap<usize, Vec<u8>> = chunks.into_iter().collect();
         let mut columns_array_iter = Vec::with_capacity(self.projection.len());
@@ -271,6 +275,11 @@ impl BlockReader {
 
         let mut deserializer = RowGroupDeserializer::new(columns_array_iter, num_rows, None);
 
+        // Perf.
+        {
+            metrics_inc_remote_io_deserialize_milliseconds(start.elapsed().as_millis() as u64);
+        }
+
         self.try_next_block(&mut deserializer)
     }
 
@@ -280,7 +289,9 @@ impl BlockReader {
         raw_part: PartInfoPtr,
     ) -> Result<Vec<(usize, Vec<u8>)>> {
         // Perf
-        metrics_inc_remote_io_read_parts(1);
+        {
+            metrics_inc_remote_io_read_parts(1);
+        }
 
         let part = FusePartInfo::from_part(&raw_part)?;
         let columns = self.projection.project_column_leaves(&self.column_leaves)?;

--- a/src/query/storages/fuse/src/metrics/fuse_metrics.rs
+++ b/src/query/storages/fuse/src/metrics/fuse_metrics.rs
@@ -72,6 +72,10 @@ pub fn metrics_inc_remote_io_read_bytes_after_merged(c: u64) {
     increment_gauge!(key!("remote_io_read_bytes_after_merged"), c as f64);
 }
 
+pub fn metrics_inc_remote_io_read_parts(c: u64) {
+    increment_gauge!(key!("remote_io_read_parts"), c as f64);
+}
+
 pub fn metrics_inc_remote_io_read_milliseconds(c: u64) {
     increment_gauge!(key!("remote_io_read_milliseconds"), c as f64);
 }
@@ -80,8 +84,8 @@ pub fn metrics_inc_remote_io_copy_milliseconds(c: u64) {
     increment_gauge!(key!("remote_io_copy_milliseconds"), c as f64);
 }
 
-pub fn metrics_inc_remote_io_read_parts(c: u64) {
-    increment_gauge!(key!("remote_io_read_parts"), c as f64);
+pub fn metrics_inc_remote_io_deserialize_milliseconds(c: u64) {
+    increment_gauge!(key!("remote_io_deserialize_milliseconds"), c as f64);
 }
 
 pub fn metrics_reset() {
@@ -90,7 +94,8 @@ pub fn metrics_reset() {
     gauge!(key!("remote_io_seeks_after_merged"), c);
     gauge!(key!("remote_io_read_bytes"), c);
     gauge!(key!("remote_io_read_bytes_after_merged"), c);
+    gauge!(key!("remote_io_read_parts"), c);
     gauge!(key!("remote_io_read_milliseconds"), c);
     gauge!(key!("remote_io_copy_milliseconds"), c);
-    gauge!(key!("remote_io_read_parts"), c);
+    gauge!(key!("remote_io_deserialize_milliseconds"), c);
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* add native perf counter
* add new perf counter `remote_io_deserialize_milliseconds`

Closes #issue
