### PR TITLE
refactor(storage): supprot table compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,6 +1384,8 @@ dependencies = [
  "common-io",
  "common-meta-types",
  "common-settings",
+ "common-storages-common",
+ "common-storages-table-meta",
  "lexical-core",
  "micromarshal",
  "num",
@@ -2042,6 +2044,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-storages-common"
+version = "0.1.0"
+dependencies = [
+ "common-arrow",
+ "common-datablocks",
+ "common-datavalues",
+ "common-exception",
+ "common-storages-table-meta",
+]
+
+[[package]]
 name = "common-storages-factory"
 version = "0.1.0"
 dependencies = [
@@ -2084,6 +2097,7 @@ dependencies = [
  "common-sql",
  "common-storage",
  "common-storages-cache",
+ "common-storages-common",
  "common-storages-index",
  "common-storages-pruner",
  "common-storages-table-meta",
@@ -3087,6 +3101,7 @@ dependencies = [
  "common-sql",
  "common-storage",
  "common-storages-cache",
+ "common-storages-common",
  "common-storages-factory",
  "common-storages-fuse",
  "common-storages-hive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "src/query/pipeline/transforms",
     "src/query/settings",
     "src/query/sql",
+    "src/query/storages/common",
     "src/query/storages/cache",
     "src/query/storages/factory",
     "src/query/storages/fuse",

--- a/src/query/datablocks/src/lib.rs
+++ b/src/query/datablocks/src/lib.rs
@@ -21,7 +21,6 @@ mod data_block_debug;
 mod kernels;
 mod memory;
 mod meta_info;
-mod serialize;
 mod stream;
 
 pub use block_compact_thresholds::BlockCompactThresholds;
@@ -31,5 +30,4 @@ pub use kernels::*;
 pub use memory::InMemoryData;
 pub use meta_info::BlockMetaInfo;
 pub use meta_info::BlockMetaInfoPtr;
-pub use serialize::*;
 pub use stream::SendableDataBlockStream;

--- a/src/query/formats/Cargo.toml
+++ b/src/query/formats/Cargo.toml
@@ -25,6 +25,8 @@ common-exception = { path = "../../common/exception" }
 common-io = { path = "../../common/io" }
 common-meta-types = { path = "../../meta/types" }
 common-settings = { path = "../settings" }
+common-storages-common = { path = "../storages/common" }
+common-storages-table-meta = { path = "../storages/table-meta" }
 
 # Crates.io dependencies
 once_cell = "1.15.0"

--- a/src/query/formats/src/output_format/parquet.rs
+++ b/src/query/formats/src/output_format/parquet.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_datablocks::serialize_to_parquet;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::Result;
+use common_storages_common::blocks_to_parquet;
+use common_storages_table_meta::table::TableCompression;
 
 use crate::output_format::OutputFormat;
 use crate::FileFormatOptionsExt;
@@ -51,7 +52,7 @@ impl OutputFormat for ParquetOutputFormat {
             return Ok(vec![]);
         }
         let mut buf = Vec::with_capacity(100 * 1024 * 1024);
-        let _ = serialize_to_parquet(blocks, &self.schema, &mut buf)?;
+        let _ = blocks_to_parquet(&self.schema, blocks, &mut buf, TableCompression::LZ4Raw)?;
         Ok(buf)
     }
 }

--- a/src/query/formats/src/output_format/parquet.rs
+++ b/src/query/formats/src/output_format/parquet.rs
@@ -52,7 +52,7 @@ impl OutputFormat for ParquetOutputFormat {
             return Ok(vec![]);
         }
         let mut buf = Vec::with_capacity(100 * 1024 * 1024);
-        let _ = blocks_to_parquet(&self.schema, blocks, &mut buf, TableCompression::LZ4Raw)?;
+        let _ = blocks_to_parquet(&self.schema, blocks, &mut buf, TableCompression::LZ4)?;
         Ok(buf)
     }
 }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -57,6 +57,7 @@ common-settings = { path = "../settings" }
 common-sql = { path = "../sql" }
 common-storage = { path = "../../common/storage" }
 common-storages-cache = { path = "../storages/cache" }
+common-storages-common = { path = "../storages/common" }
 common-storages-factory = { path = "../storages/factory" }
 common-storages-fuse = { path = "../storages/fuse" }
 common-storages-hive = { path = "../storages/hive/hive", optional = true }

--- a/src/query/service/tests/it/api/rpc/packets/packet_data.rs
+++ b/src/query/service/tests/it/api/rpc/packets/packet_data.rs
@@ -20,6 +20,7 @@ use common_datablocks::DataBlock;
 use common_exception::Result;
 use common_storages_fuse::operations::AppendOperationLogEntry;
 use common_storages_table_meta::meta::BlockMeta;
+use common_storages_table_meta::meta::Compression;
 use common_storages_table_meta::meta::SegmentInfo;
 use common_storages_table_meta::meta::Statistics;
 use databend_query::api::PrecommitBlock;
@@ -36,6 +37,7 @@ async fn test_precommit_ser_and_deser() -> Result<()> {
         ("_b/1.json".to_string(), 1),
         None,
         4,
+        Compression::Lz4Raw,
     );
     let segment_info = SegmentInfo::new(vec![Arc::new(block_meta)], Statistics::default());
     let log_entry = AppendOperationLogEntry::new("/_sg/1.json".to_string(), Arc::new(segment_info));

--- a/src/query/service/tests/it/storages/fuse/block_writer.rs
+++ b/src/query/service/tests/it/storages/fuse/block_writer.rs
@@ -12,10 +12,9 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use common_arrow::parquet::compression::CompressionOptions;
-use common_datablocks::serialize_to_parquet_with_compression;
 use common_datablocks::DataBlock;
 use common_exception::Result;
+use common_storages_common::blocks_to_parquet;
 use common_storages_fuse::io::write_block;
 use common_storages_fuse::io::write_data;
 use common_storages_fuse::io::TableMetaLocationGenerator;
@@ -26,6 +25,7 @@ use common_storages_table_meta::meta::BlockMeta;
 use common_storages_table_meta::meta::ClusterStatistics;
 use common_storages_table_meta::meta::Location;
 use common_storages_table_meta::meta::StatisticsOfColumns;
+use common_storages_table_meta::table::TableCompression;
 use opendal::Operator;
 use uuid::Uuid;
 
@@ -64,8 +64,12 @@ impl<'a> BlockWriter<'a> {
             .build_block_index(data_accessor, &block, block_id)
             .await?;
 
+        let write_settings = WriteSettings {
+            storage_format,
+            ..Default::default()
+        };
+
         let mut buf = Vec::with_capacity(DEFAULT_BLOCK_WRITE_BUFFER_SIZE);
-        let write_settings = WriteSettings { storage_format };
         let (file_size, col_metas) = write_block(&write_settings, block, &mut buf)?;
 
         write_data(&buf, data_accessor, &location.0).await?;
@@ -96,11 +100,11 @@ impl<'a> BlockWriter<'a> {
             .block_bloom_index_location(&block_id);
         let mut data = Vec::with_capacity(DEFAULT_BLOOM_INDEX_WRITE_BUFFER_SIZE);
         let index_block_schema = &bloom_index.filter_schema;
-        let (size, _) = serialize_to_parquet_with_compression(
-            vec![index_block],
+        let (size, _) = blocks_to_parquet(
             index_block_schema,
+            vec![index_block],
             &mut data,
-            CompressionOptions::Uncompressed,
+            TableCompression::None,
         )?;
         write_data(&data, data_accessor, &location.0).await?;
         Ok((size, location))

--- a/src/query/service/tests/it/storages/fuse/block_writer.rs
+++ b/src/query/service/tests/it/storages/fuse/block_writer.rs
@@ -23,6 +23,7 @@ use common_storages_fuse::FuseStorageFormat;
 use common_storages_index::BlockFilter;
 use common_storages_table_meta::meta::BlockMeta;
 use common_storages_table_meta::meta::ClusterStatistics;
+use common_storages_table_meta::meta::Compression;
 use common_storages_table_meta::meta::Location;
 use common_storages_table_meta::meta::StatisticsOfColumns;
 use common_storages_table_meta::table::TableCompression;
@@ -83,6 +84,7 @@ impl<'a> BlockWriter<'a> {
             location,
             Some(bloom_filter_index_location),
             bloom_filter_index_size,
+            Compression::Lz4Raw,
         );
         Ok(block_meta)
     }

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -26,6 +26,7 @@ use common_datavalues::DataValue;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_storages_table_meta::caches::CacheManager;
+use common_storages_table_meta::meta;
 use common_storages_table_meta::meta::BlockMeta;
 use common_storages_table_meta::meta::ClusterStatistics;
 use common_storages_table_meta::meta::SegmentInfo;
@@ -64,6 +65,7 @@ async fn test_recluster_mutator_block_select() -> Result<()> {
             location.clone(),
             None,
             0,
+            meta::Compression::Lz4Raw,
         ));
         let segment = SegmentInfo::new(vec![test_block_meta], Statistics::default());
         Ok::<_, ErrorCode>((seg_writer.write_segment(segment).await?, location))

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -37,6 +37,7 @@ use common_storages_fuse::statistics::BlockStatistics;
 use common_storages_fuse::statistics::StatisticsAccumulator;
 use common_storages_fuse::FuseStorageFormat;
 use common_storages_fuse::FuseTable;
+use common_storages_table_meta::meta;
 use common_storages_table_meta::meta::BlockMeta;
 use common_storages_table_meta::meta::Location;
 use common_storages_table_meta::meta::SegmentInfo;
@@ -674,7 +675,11 @@ impl CompactSegmentTestFixture {
                 block_statistics.block_file_location = block_meta.location.0.clone();
 
                 collected_blocks.push(block_meta.clone());
-                stats_acc.add_with_block_meta(block_meta, block_statistics)?;
+                stats_acc.add_with_block_meta(
+                    block_meta,
+                    block_statistics,
+                    meta::Compression::Lz4Raw,
+                )?;
             }
             let col_stats = stats_acc.summary()?;
             let segment_info = SegmentInfo::new(stats_acc.blocks_metas, Statistics {

--- a/src/query/service/tests/it/storages/fuse/operations/read_plan.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/read_plan.rs
@@ -25,6 +25,7 @@ use common_datavalues::DataValue;
 use common_exception::Result;
 use common_storage::ColumnLeaf;
 use common_storage::ColumnLeaves;
+use common_storages_table_meta::meta;
 use common_storages_table_meta::meta::BlockMeta;
 use common_storages_table_meta::meta::ColumnMeta;
 use common_storages_table_meta::meta::ColumnStatistics;
@@ -90,6 +91,7 @@ fn test_to_partitions() -> Result<()> {
         location,
         bloom_filter_location,
         bloom_filter_size,
+        meta::Compression::Lz4Raw,
     ));
 
     let blocks_metas = (0..num_of_block)

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -29,9 +29,11 @@ use common_storages_fuse::statistics::Trim;
 use common_storages_fuse::statistics::STATS_REPLACEMENT_CHAR;
 use common_storages_fuse::statistics::STATS_STRING_PREFIX_LEN;
 use common_storages_fuse::FuseStorageFormat;
+use common_storages_table_meta::meta;
 use common_storages_table_meta::meta::BlockMeta;
 use common_storages_table_meta::meta::ClusterStatistics;
 use common_storages_table_meta::meta::ColumnStatistics;
+use common_storages_table_meta::meta::Compression;
 use common_storages_table_meta::meta::Statistics;
 use databend_query::storages::fuse::io::TableMetaLocationGenerator;
 use databend_query::storages::fuse::statistics::gen_columns_statistics;
@@ -203,7 +205,7 @@ async fn test_accumulator() -> common_exception::Result<()> {
         let block_meta = block_writer
             .write(FuseStorageFormat::Parquet, block, col_stats, None)
             .await?;
-        stats_acc.add_with_block_meta(block_meta, block_statistics)?;
+        stats_acc.add_with_block_meta(block_meta, block_statistics, meta::Compression::Lz4Raw)?;
     }
 
     assert_eq!(10, stats_acc.blocks_statistics.len());
@@ -484,6 +486,7 @@ fn test_reduce_block_meta() -> common_exception::Result<()> {
             location.clone(),
             None,
             bloom_filter_index_size,
+            Compression::Lz4Raw,
         );
         blocks.push(block_meta);
     }

--- a/src/query/storages/common/Cargo.toml
+++ b/src/query/storages/common/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "common-storages-common"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+common-arrow = { path = "../../../common/arrow" }
+common-datablocks = { path = "../../datablocks" }
+common-datavalues = { path = "../../datavalues" }
+common-exception = { path = "../../../common/exception" }
+common-storages-table-meta = { path = "../table-meta" }
+
+[build-dependencies]

--- a/src/query/storages/common/src/lib.rs
+++ b/src/query/storages/common/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2022 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_storages_table_meta::table::TableCompression;
+mod block;
 
-use crate::FuseStorageFormat;
-
-pub struct WriteSettings {
-    pub storage_format: FuseStorageFormat,
-    pub table_compression: TableCompression,
-    pub native_max_page_size: usize,
-}
-
-impl Default for WriteSettings {
-    fn default() -> Self {
-        WriteSettings {
-            storage_format: FuseStorageFormat::Parquet,
-            table_compression: Default::default(),
-            native_max_page_size: 8192,
-        }
-    }
-}
+pub use block::blocks_to_parquet;

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -30,6 +30,7 @@ common-sharing = { path = "../../sharing" }
 common-sql = { path = "../../sql" }
 common-storage = { path = "../../../common/storage" }
 common-storages-cache = { path = "../cache" }
+common-storages-common = { path = "../common" }
 common-storages-index = { path = "../index" }
 common-storages-pruner = { path = "../pruner" }
 common-storages-table-meta = { path = "../table-meta" }

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -55,10 +55,12 @@ use common_storages_table_meta::meta::TableSnapshot;
 use common_storages_table_meta::meta::TableSnapshotStatistics;
 use common_storages_table_meta::meta::Versioned;
 use common_storages_table_meta::table::table_storage_prefix;
+use common_storages_table_meta::table::TableCompression;
 use common_storages_table_meta::table::OPT_KEY_DATABASE_ID;
 use common_storages_table_meta::table::OPT_KEY_LEGACY_SNAPSHOT_LOC;
 use common_storages_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 use common_storages_table_meta::table::OPT_KEY_STORAGE_FORMAT;
+use common_storages_table_meta::table::OPT_KEY_TABLE_COMPRESSION;
 use opendal::layers::CacheLayer;
 use opendal::Operator;
 use uuid::Uuid;
@@ -84,6 +86,7 @@ pub struct FuseTable {
 
     pub(crate) cluster_key_meta: Option<ClusterKey>,
     pub(crate) storage_format: FuseStorageFormat,
+    pub(crate) table_compression: TableCompression,
 
     pub(crate) operator: Operator,
     pub(crate) data_metrics: Arc<StorageMetrics>,
@@ -129,6 +132,12 @@ impl FuseTable {
             .cloned()
             .unwrap_or_default();
 
+        let table_compression = table_info
+            .options()
+            .get(OPT_KEY_TABLE_COMPRESSION)
+            .cloned()
+            .unwrap_or_default();
+
         Ok(Box::new(FuseTable {
             table_info,
             meta_location_generator: TableMetaLocationGenerator::with_prefix(storage_prefix),
@@ -136,6 +145,7 @@ impl FuseTable {
             operator,
             data_metrics,
             storage_format: FuseStorageFormat::from_str(storage_format.as_str())?,
+            table_compression: TableCompression::from_str(table_compression.as_str())?,
         }))
     }
 

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -145,7 +145,7 @@ impl FuseTable {
             operator,
             data_metrics,
             storage_format: FuseStorageFormat::from_str(storage_format.as_str())?,
-            table_compression: TableCompression::from_str(table_compression.as_str())?,
+            table_compression: table_compression.as_str().try_into()?,
         }))
     }
 

--- a/src/query/storages/fuse/src/io/read/block_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/block_reader_parquet.rs
@@ -397,6 +397,7 @@ impl BlockReader {
             Compression::Snappy => Ok(ParquetCompression::Snappy),
             Compression::Zstd => Ok(ParquetCompression::Zstd),
             Compression::Gzip => Ok(ParquetCompression::Gzip),
+            Compression::None => Ok(ParquetCompression::Uncompressed),
         }
     }
 

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -50,9 +50,7 @@ pub fn write_block(
                 buf,
                 arrow_schema,
                 common_arrow::native::write::WriteOptions {
-                    compression: common_arrow::native::Compression::from(
-                        write_settings.table_compression,
-                    ),
+                    compression: write_settings.table_compression.into(),
                     max_page_size: Some(write_settings.native_max_page_size),
                 },
             );

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -18,9 +18,9 @@ use backon::ExponentialBackoff;
 use backon::Retryable;
 use common_arrow::arrow::chunk::Chunk;
 use common_arrow::native::write::PaWriter;
-use common_datablocks::serialize_to_parquet;
 use common_datablocks::DataBlock;
 use common_exception::Result;
+use common_storages_common::blocks_to_parquet;
 use common_storages_table_meta::meta::ColumnId;
 use common_storages_table_meta::meta::ColumnMeta;
 use opendal::Operator;
@@ -39,7 +39,8 @@ pub fn write_block(
 
     match write_settings.storage_format {
         FuseStorageFormat::Parquet => {
-            let result = serialize_to_parquet(vec![block], &schema, buf)?;
+            let result =
+                blocks_to_parquet(&schema, vec![block], buf, write_settings.table_compression)?;
             let meta = util::column_metas(&result.1)?;
             Ok((result.0, meta))
         }
@@ -49,8 +50,10 @@ pub fn write_block(
                 buf,
                 arrow_schema,
                 common_arrow::native::write::WriteOptions {
-                    compression: common_arrow::native::Compression::LZ4,
-                    max_page_size: Some(8192),
+                    compression: common_arrow::native::Compression::from(
+                        write_settings.table_compression,
+                    ),
+                    max_page_size: Some(write_settings.native_max_page_size),
                 },
             );
 

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -110,6 +110,7 @@ impl FuseTable {
                     cluster_stats_gen.clone(),
                     block_compact_thresholds,
                     self.storage_format,
+                    self.table_compression,
                     Some(transform_output_port),
                 )
             })?;
@@ -124,6 +125,7 @@ impl FuseTable {
                     cluster_stats_gen.clone(),
                     block_compact_thresholds,
                     self.storage_format,
+                    self.table_compression,
                     None,
                 )
             })?;

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -153,6 +153,7 @@ impl FuseTable {
                 self.meta_location_generator().clone(),
                 self.operator.clone(),
                 self.storage_format,
+                self.table_compression,
                 thresholds,
             )
         })?;

--- a/src/query/storages/fuse/src/operations/fuse_sink.rs
+++ b/src/query/storages/fuse/src/operations/fuse_sink.rs
@@ -115,6 +115,7 @@ pub struct FuseTableSink {
     cluster_stats_gen: ClusterStatsGenerator,
 
     storage_format: FuseStorageFormat,
+    table_compression: TableCompression,
     // A dummy output port for distributed insert select to connect Exchange Sink.
     output: Option<Arc<OutputPort>>,
 }
@@ -130,6 +131,7 @@ impl FuseTableSink {
         cluster_stats_gen: ClusterStatsGenerator,
         thresholds: BlockCompactThresholds,
         storage_format: FuseStorageFormat,
+        table_compression: TableCompression,
         output: Option<Arc<OutputPort>>,
     ) -> Result<ProcessorPtr> {
         Ok(ProcessorPtr::create(Box::new(FuseTableSink {
@@ -142,6 +144,7 @@ impl FuseTableSink {
             num_block_threshold: num_block_threshold as u64,
             cluster_stats_gen,
             storage_format,
+            table_compression,
             output,
         })))
     }
@@ -214,6 +217,7 @@ impl Processor for FuseTableSink {
 
                 let write_settings = WriteSettings {
                     storage_format: self.storage_format,
+                    table_compression: self.table_compression,
                     ..Default::default()
                 };
 
@@ -300,6 +304,7 @@ impl Processor for FuseTableSink {
                     block_statistics,
                     Some(bloom_index_state.location),
                     bloom_filter_index_size,
+                    self.table_compression.into(),
                 )?;
 
                 if self.accumulator.summary_block_count >= self.num_block_threshold {

--- a/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -91,6 +91,7 @@ pub struct CompactTransform {
     location_gen: TableMetaLocationGenerator,
     dal: Operator,
     storage_format: FuseStorageFormat,
+    table_compression: TableCompression,
 
     // Limit the memory size of the block read.
     max_memory: u64,
@@ -113,6 +114,7 @@ impl CompactTransform {
         location_gen: TableMetaLocationGenerator,
         dal: Operator,
         storage_format: FuseStorageFormat,
+        table_compression: TableCompression,
         thresholds: BlockCompactThresholds,
     ) -> Result<ProcessorPtr> {
         let settings = ctx.get_settings();
@@ -130,6 +132,7 @@ impl CompactTransform {
             location_gen,
             dal,
             storage_format,
+            table_compression,
             max_memory,
             max_io_requests,
             compact_tasks: VecDeque::new(),
@@ -247,6 +250,7 @@ impl Processor for CompactTransform {
 
                     let write_settings = WriteSettings {
                         storage_format: self.storage_format,
+                        table_compression: self.table_compression,
                         ..Default::default()
                     };
 
@@ -266,6 +270,7 @@ impl Processor for CompactTransform {
                         block_location.clone(),
                         Some(index_location.clone()),
                         index_size,
+                        self.table_compression.into(),
                     );
                     self.abort_operation.add_block(&new_meta);
                     self.block_metas.push(Arc::new(new_meta));

--- a/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -16,21 +16,21 @@ use std::any::Any;
 use std::collections::VecDeque;
 use std::sync::Arc;
 
-use common_arrow::parquet::compression::CompressionOptions;
 use common_base::base::Progress;
 use common_base::base::ProgressValues;
 use common_cache::Cache;
 use common_catalog::table_context::TableContext;
-use common_datablocks::serialize_to_parquet_with_compression;
 use common_datablocks::BlockCompactThresholds;
 use common_datablocks::DataBlock;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_storages_common::blocks_to_parquet;
 use common_storages_index::BlockFilter;
 use common_storages_table_meta::caches::CacheManager;
 use common_storages_table_meta::meta::BlockMeta;
 use common_storages_table_meta::meta::SegmentInfo;
 use common_storages_table_meta::meta::StatisticsOfColumns;
+use common_storages_table_meta::table::TableCompression;
 use opendal::Operator;
 
 use super::compact_meta::CompactSourceMeta;
@@ -236,20 +236,22 @@ impl Processor for CompactTransform {
                         let location = self.location_gen.block_bloom_index_location(&block_id);
                         let mut data = Vec::with_capacity(100 * 1024);
                         let index_block_schema = &bloom_index.filter_schema;
-                        let (size, _) = serialize_to_parquet_with_compression(
-                            vec![index_block],
+                        let (size, _) = blocks_to_parquet(
                             index_block_schema,
+                            vec![index_block],
                             &mut data,
-                            CompressionOptions::Uncompressed,
+                            TableCompression::None,
                         )?;
                         (data, size, location)
                     };
 
-                    // serialize data block.
-                    let mut block_data = Vec::with_capacity(100 * 1024 * 1024);
                     let write_settings = WriteSettings {
                         storage_format: self.storage_format,
+                        ..Default::default()
                     };
+
+                    // serialize data block.
+                    let mut block_data = Vec::with_capacity(100 * 1024 * 1024);
                     let (file_size, col_metas) =
                         io::write_block(&write_settings, new_block, &mut block_data)?;
 

--- a/src/query/storages/fuse/src/operations/mutation/deletion/deletion_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/deletion/deletion_source.rs
@@ -276,6 +276,7 @@ impl Processor for DeletionSource {
                     block_location.clone(),
                     Some(bloom_index_state.location.clone()),
                     bloom_index_state.size,
+                    self.table_compression.into(),
                 ));
 
                 self.state = State::Serialized(

--- a/src/query/storages/fuse/src/operations/mutation/deletion/deletion_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/deletion/deletion_source.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use common_catalog::plan::PartInfoPtr;
 use common_catalog::table_context::TableContext;
-use common_datablocks::serialize_to_parquet;
 use common_datablocks::DataBlock;
 use common_datavalues::BooleanColumn;
 use common_datavalues::ColumnRef;
@@ -27,8 +26,10 @@ use common_datavalues::Series;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_sql::evaluator::EvalNode;
+use common_storages_common::blocks_to_parquet;
 use common_storages_table_meta::meta::BlockMeta;
 use common_storages_table_meta::meta::ClusterStatistics;
+use common_storages_table_meta::table::TableCompression;
 use opendal::Operator;
 
 use super::deletion_meta::Deletion;
@@ -93,6 +94,7 @@ pub struct DeletionSource {
     index: BlockIndex,
     cluster_stats_gen: ClusterStatsGenerator,
     origin_stats: Option<ClusterStatistics>,
+    table_compression: TableCompression,
 }
 
 impl DeletionSource {
@@ -117,6 +119,7 @@ impl DeletionSource {
             index: (0, 0),
             cluster_stats_gen: table.cluster_stats_gen(ctx)?,
             origin_stats: None,
+            table_compression: table.table_compression,
         })))
     }
 }
@@ -254,8 +257,12 @@ impl Processor for DeletionSource {
                 // serialize data block.
                 let mut block_data = Vec::with_capacity(100 * 1024 * 1024);
                 let schema = block.schema().clone();
-                let (file_size, meta_data) =
-                    serialize_to_parquet(vec![block], &schema, &mut block_data)?;
+                let (file_size, meta_data) = blocks_to_parquet(
+                    &schema,
+                    vec![block],
+                    &mut block_data,
+                    self.table_compression,
+                )?;
                 let col_metas = util::column_metas(&meta_data)?;
 
                 // new block meta.

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -217,6 +217,7 @@ impl FuseTable {
                 cluster_stats_gen.clone(),
                 block_compact_thresholds,
                 self.storage_format,
+                self.table_compression,
                 None,
             )
         })?;

--- a/src/query/storages/fuse/src/statistics/accumulator.rs
+++ b/src/query/storages/fuse/src/statistics/accumulator.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use common_datablocks::BlockCompactThresholds;
 use common_datablocks::DataBlock;
 use common_exception::Result;
+use common_storages_table_meta::meta;
 use common_storages_table_meta::meta::BlockMeta;
 use common_storages_table_meta::meta::ColumnId;
 use common_storages_table_meta::meta::ColumnMeta;
@@ -56,6 +57,7 @@ impl StatisticsAccumulator {
         block_statistics: BlockStatistics,
         bloom_filter_index_location: Option<Location>,
         bloom_filter_index_size: u64,
+        block_compression: meta::Compression,
     ) -> Result<()> {
         self.add(
             file_size,
@@ -63,6 +65,7 @@ impl StatisticsAccumulator {
             block_statistics,
             bloom_filter_index_location,
             bloom_filter_index_size,
+            block_compression,
         )
     }
 
@@ -70,6 +73,7 @@ impl StatisticsAccumulator {
         &mut self,
         block_meta: BlockMeta,
         block_statistics: BlockStatistics,
+        block_compression: meta::Compression,
     ) -> Result<()> {
         let bloom_filter_index_location = block_meta.bloom_filter_index_location;
         let bloom_filter_index_size = block_meta.bloom_filter_index_size;
@@ -82,6 +86,7 @@ impl StatisticsAccumulator {
             block_statistics,
             bloom_filter_index_location,
             bloom_filter_index_size,
+            block_compression,
         )
     }
 
@@ -96,6 +101,7 @@ impl StatisticsAccumulator {
         block_statistics: BlockStatistics,
         bloom_filter_index_location: Option<Location>,
         bloom_filter_index_size: u64,
+        block_compression: meta::Compression,
     ) -> Result<()> {
         self.file_size += file_size;
         self.index_size += bloom_filter_index_size;
@@ -128,6 +134,7 @@ impl StatisticsAccumulator {
             data_location,
             bloom_filter_index_location,
             bloom_filter_index_size,
+            block_compression,
         )));
 
         Ok(())

--- a/src/query/storages/table-meta/src/meta/common.rs
+++ b/src/query/storages/table-meta/src/meta/common.rs
@@ -88,6 +88,8 @@ pub enum Compression {
     Snappy,
     Zstd,
     Gzip,
+    // New: dded by bohu.
+    None,
 }
 
 impl Compression {

--- a/src/query/storages/table-meta/src/meta/common.rs
+++ b/src/query/storages/table-meta/src/meta/common.rs
@@ -83,12 +83,13 @@ where Self: Sized
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Copy, Clone, Debug)]
 pub enum Compression {
+    // Lz4 will be deprecated.
     Lz4,
     Lz4Raw,
     Snappy,
     Zstd,
     Gzip,
-    // New: dded by bohu.
+    // New: Added by bohu.
     None,
 }
 

--- a/src/query/storages/table-meta/src/meta/v1/segment.rs
+++ b/src/query/storages/table-meta/src/meta/v1/segment.rs
@@ -79,6 +79,7 @@ impl BlockMeta {
         location: Location,
         bloom_filter_index_location: Option<Location>,
         bloom_filter_index_size: u64,
+        compression: Compression,
     ) -> Self {
         Self {
             row_count,
@@ -90,7 +91,7 @@ impl BlockMeta {
             location,
             bloom_filter_index_location,
             bloom_filter_index_size,
-            compression: Compression::Lz4Raw,
+            compression,
         }
     }
 

--- a/src/query/storages/table-meta/src/table/mod.rs
+++ b/src/query/storages/table-meta/src/table/mod.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod table_compression;
 mod table_keys;
 mod table_prefix;
 
+pub use table_compression::TableCompression;
 pub use table_keys::*;
 pub use table_prefix::*;

--- a/src/query/storages/table-meta/src/table/table_compression.rs
+++ b/src/query/storages/table-meta/src/table/table_compression.rs
@@ -39,8 +39,9 @@ impl TryFrom<&str> for TableCompression {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value.to_lowercase().as_str() {
-            "" | "none" => Ok(TableCompression::None),
-            "lz4" => Ok(TableCompression::LZ4),
+            "none" => Ok(TableCompression::None),
+            // Default is LZ4.
+            "" | "lz4" => Ok(TableCompression::LZ4),
             "snappy" => Ok(TableCompression::Snappy),
             "zstd" => Ok(TableCompression::Zstd),
             other => Err(ErrorCode::UnknownFormat(format!(

--- a/src/query/storages/table-meta/src/table/table_compression.rs
+++ b/src/query/storages/table-meta/src/table/table_compression.rs
@@ -1,0 +1,72 @@
+//  Copyright 2022 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::str::FromStr;
+
+use common_arrow::native::Compression;
+use common_arrow::parquet::compression::CompressionOptions;
+use common_exception::ErrorCode;
+
+#[derive(Clone, Copy)]
+pub enum TableCompression {
+    None,
+    LZ4Raw,
+    Snappy,
+    Zstd,
+}
+
+impl Default for TableCompression {
+    fn default() -> Self {
+        TableCompression::LZ4Raw
+    }
+}
+
+impl FromStr for TableCompression {
+    type Err = ErrorCode;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "" | "none" => Ok(TableCompression::None),
+            "lz4" => Ok(TableCompression::LZ4Raw),
+            other => Err(ErrorCode::UnknownFormat(format!(
+                "unsupported table compression: {}",
+                other
+            ))),
+        }
+    }
+}
+
+/// Convert to parquet CompressionOptions.
+impl From<TableCompression> for CompressionOptions {
+    fn from(value: TableCompression) -> Self {
+        match value {
+            TableCompression::None => CompressionOptions::Uncompressed,
+            TableCompression::LZ4Raw => CompressionOptions::Lz4Raw,
+            TableCompression::Snappy => CompressionOptions::Snappy,
+            TableCompression::Zstd => CompressionOptions::Zstd(None),
+        }
+    }
+}
+
+/// Convert to native Compression.
+impl From<TableCompression> for Compression {
+    fn from(value: TableCompression) -> Self {
+        match value {
+            TableCompression::None => Compression::None,
+            TableCompression::LZ4Raw => Compression::LZ4,
+            // Others to ZSTD
+            _ => Compression::ZSTD,
+        }
+    }
+}

--- a/src/query/storages/table-meta/src/table/table_compression.rs
+++ b/src/query/storages/table-meta/src/table/table_compression.rs
@@ -12,8 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use std::str::FromStr;
-
 use common_arrow::native;
 use common_arrow::parquet;
 use common_exception::ErrorCode;
@@ -29,16 +27,18 @@ pub enum TableCompression {
 }
 
 impl Default for TableCompression {
+    // Default is LZ4.
     fn default() -> Self {
         TableCompression::LZ4
     }
 }
 
-impl FromStr for TableCompression {
-    type Err = ErrorCode;
+/// Convert from str.
+impl TryFrom<&str> for TableCompression {
+    type Error = ErrorCode;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
             "" | "none" => Ok(TableCompression::None),
             "lz4" => Ok(TableCompression::LZ4),
             other => Err(ErrorCode::UnknownFormat(format!(

--- a/src/query/storages/table-meta/src/table/table_compression.rs
+++ b/src/query/storages/table-meta/src/table/table_compression.rs
@@ -41,6 +41,8 @@ impl TryFrom<&str> for TableCompression {
         match value.to_lowercase().as_str() {
             "" | "none" => Ok(TableCompression::None),
             "lz4" => Ok(TableCompression::LZ4),
+            "snappy" => Ok(TableCompression::Snappy),
+            "zstd" => Ok(TableCompression::Zstd),
             other => Err(ErrorCode::UnknownFormat(format!(
                 "unsupported table compression: {}",
                 other
@@ -66,9 +68,9 @@ impl From<TableCompression> for native::Compression {
     fn from(value: TableCompression) -> Self {
         match value {
             TableCompression::None => native::Compression::None,
-            TableCompression::LZ4 => native::Compression::LZ4,
-            // Others to ZSTD
-            _ => native::Compression::ZSTD,
+            TableCompression::Zstd => native::Compression::ZSTD,
+            // Others to LZ4.
+            _ => native::Compression::LZ4,
         }
     }
 }

--- a/src/query/storages/table-meta/src/table/table_keys.rs
+++ b/src/query/storages/table-meta/src/table/table_keys.rs
@@ -19,6 +19,7 @@ use once_cell::sync::Lazy;
 pub const OPT_KEY_DATABASE_ID: &str = "database_id";
 pub const OPT_KEY_SNAPSHOT_LOCATION: &str = "snapshot_location";
 pub const OPT_KEY_STORAGE_FORMAT: &str = "storage_format";
+pub const OPT_KEY_TABLE_COMPRESSION: &str = "table_compression";
 
 /// Legacy table snapshot location key
 ///


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This is the Patch-1 to support `create table ... compression='LZ4'`.
This patch focus on refactoring the storage to make it easy to support the compression of the table:
* introduce the `TableCompression`
* move data blocks to parquet to `storages-common` crate

Next PR will implement the  `create table ... compression='LZ4'` syntax.

Closes #issue
