### PR TITLE
feat: add table compression logic test

### DIFF
--- a/src/query/storages/table-meta/src/table/table_keys.rs
+++ b/src/query/storages/table-meta/src/table/table_keys.rs
@@ -19,7 +19,7 @@ use once_cell::sync::Lazy;
 pub const OPT_KEY_DATABASE_ID: &str = "database_id";
 pub const OPT_KEY_SNAPSHOT_LOCATION: &str = "snapshot_location";
 pub const OPT_KEY_STORAGE_FORMAT: &str = "storage_format";
-pub const OPT_KEY_TABLE_COMPRESSION: &str = "table_compression";
+pub const OPT_KEY_TABLE_COMPRESSION: &str = "compression";
 
 /// Legacy table snapshot location key
 ///

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert
@@ -82,7 +82,7 @@ statement ok
 DROP TABLE t3
 
 ## Table Compression:None
-
+statement ok
 CREATE TABLE IF NOT EXISTS t_compression_none(a Boolean, b Timestamp, c Date) Engine = fuse  COMPRESSION = 'NONE';
 
 statement ok

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert
@@ -99,6 +99,7 @@ DROP TABLE t_compression_none
 
 ## Table Compression:ZSTD
 
+statement ok
 CREATE TABLE IF NOT EXISTS t_compression_zstd(a Boolean, b Timestamp, c Date) Engine = fuse COMPRESSION = 'ZSTD';
 
 statement ok

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert
@@ -80,3 +80,36 @@ DROP TABLE t2
 
 statement ok
 DROP TABLE t3
+
+## Table Compression:None
+
+CREATE TABLE IF NOT EXISTS t_compression_none(a Boolean, b Timestamp, c Date) Engine = fuse  COMPRESSION = 'NONE';
+
+statement ok
+INSERT INTO t_compression_none (a,b,c) values(true, '2021-09-07 21:38:35.000000', '2021-09-07'), (false, 1631050715000000, 18877);
+
+query BTT
+SELECT * FROM t_compression_none order by a desc;
+----
+1 2021-09-07 21:38:35.000000 2021-09-07
+0 2021-09-07 21:38:35.000000 2021-09-07
+
+statement ok
+DROP TABLE t_compression_none
+
+## Table Compression:ZSTD
+
+CREATE TABLE IF NOT EXISTS t_compression_zstd(a Boolean, b Timestamp, c Date) Engine = fuse COMPRESSION = 'ZSTD';
+
+statement ok
+INSERT INTO t_compression_zstd (a,b,c) values(true, '2021-09-07 21:38:35.000000', '2021-09-07'), (false, 1631050715000000, 18877);
+
+query BTT
+SELECT * FROM t_compression_zstd order by a desc;
+----
+1 2021-09-07 21:38:35.000000 2021-09-07
+0 2021-09-07 21:38:35.000000 2021-09-07
+
+statement ok
+DROP TABLE t_compression_zstd
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add logic test for table compression:
```
CREATE TABLE table ... Engine = fuse COMPRESSION = 'NONE|ZSTD|LZ4|SNAPPY';
```

Closes #issue
