### PR TITLE
refactor: rename config item `table_cache_enabled` to `table_meta_cache_enabled`

### DIFF
--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -33,7 +33,7 @@ cluster_id = "test_cluster"
 table_engine_memory_enabled = true
 database_engine_github_enabled = true
 
-table_cache_enabled = true
+table_meta_cache_enabled = true
 table_memory_cache_mb_size = 1024
 table_disk_cache_root = "_cache"
 table_disk_cache_mb_size = 10240

--- a/scripts/ci/deploy/config/databend-query-node-2.toml
+++ b/scripts/ci/deploy/config/databend-query-node-2.toml
@@ -33,7 +33,7 @@ cluster_id = "test_cluster"
 table_engine_memory_enabled = true
 database_engine_github_enabled = true
 
-table_cache_enabled = true
+table_meta_cache_enabled = true
 table_memory_cache_mb_size = 1024
 table_disk_cache_root = "./.databend/cache"
 table_disk_cache_mb_size = 10240

--- a/scripts/ci/deploy/config/databend-query-node-3.toml
+++ b/scripts/ci/deploy/config/databend-query-node-3.toml
@@ -34,7 +34,7 @@ cluster_id = "test_cluster"
 table_engine_memory_enabled = true
 database_engine_github_enabled = true
 
-table_cache_enabled = true
+table_meta_cache_enabled = true
 table_memory_cache_mb_size = 1024
 table_disk_cache_root = "./.databend/cache"
 table_disk_cache_mb_size = 10240

--- a/scripts/ci/deploy/config/databend-query-node-shared.toml
+++ b/scripts/ci/deploy/config/databend-query-node-shared.toml
@@ -33,7 +33,7 @@ cluster_id = "test_cluster"
 table_engine_memory_enabled = true
 database_engine_github_enabled = true
 
-table_cache_enabled = true
+table_meta_cache_enabled = true
 table_memory_cache_mb_size = 1024
 table_disk_cache_root = "_cache"
 table_disk_cache_mb_size = 10240

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -148,7 +148,7 @@ pub struct QueryConfig {
     pub wait_timeout_mills: u64,
     pub max_query_log_size: usize,
     /// Table Cached enabled
-    pub table_cache_enabled: bool,
+    pub table_meta_cache_enabled: bool,
     /// Max number of cached table block meta
     pub table_cache_block_meta_count: u64,
     /// Table memory cache size (mb)
@@ -212,7 +212,7 @@ impl Default for QueryConfig {
             table_engine_memory_enabled: true,
             wait_timeout_mills: 5000,
             max_query_log_size: 10000,
-            table_cache_enabled: false,
+            table_meta_cache_enabled: false,
             table_cache_block_meta_count: 102400,
             table_memory_cache_mb_size: 256,
             table_disk_cache_root: "_cache".to_string(),

--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -1251,9 +1251,9 @@ pub struct QueryConfig {
     #[clap(long, default_value = "10000")]
     pub max_query_log_size: usize,
 
-    /// Table Cached enabled
-    #[clap(long)]
-    pub table_cache_enabled: bool,
+    /// Table Meta Cached enabled
+    #[clap(long, default_value = "true")]
+    pub table_meta_cache_enabled: bool,
 
     /// Max number of cached table block meta
     #[clap(long, default_value = "102400")]
@@ -1366,7 +1366,7 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
             table_engine_memory_enabled: self.table_engine_memory_enabled,
             wait_timeout_mills: self.wait_timeout_mills,
             max_query_log_size: self.max_query_log_size,
-            table_cache_enabled: self.table_cache_enabled,
+            table_meta_cache_enabled: self.table_meta_cache_enabled,
             table_cache_block_meta_count: self.table_cache_block_meta_count,
             table_memory_cache_mb_size: self.table_memory_cache_mb_size,
             table_disk_cache_root: self.table_disk_cache_root,
@@ -1431,7 +1431,7 @@ impl From<InnerQueryConfig> for QueryConfig {
             database_engine_github_enabled: true,
             wait_timeout_mills: inner.wait_timeout_mills,
             max_query_log_size: inner.max_query_log_size,
-            table_cache_enabled: inner.table_cache_enabled,
+            table_meta_cache_enabled: inner.table_meta_cache_enabled,
             table_cache_block_meta_count: inner.table_cache_block_meta_count,
             table_memory_cache_mb_size: inner.table_memory_cache_mb_size,
             table_disk_cache_root: inner.table_disk_cache_root,

--- a/src/query/service/tests/it/configs.rs
+++ b/src/query/service/tests/it/configs.rs
@@ -44,7 +44,7 @@ fn test_env_config_s3() -> Result<()> {
             ("QUERY_FLIGHT_API_ADDRESS", Some("1.2.3.4:9091")),
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
-            ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
+            ("QUERY_TABLE_META_CACHE_ENABLED", Some("true")),
             ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
             ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
             ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
@@ -127,7 +127,7 @@ fn test_env_config_s3() -> Result<()> {
 
             assert!(configured.query.table_engine_memory_enabled);
 
-            assert!(configured.query.table_cache_enabled);
+            assert!(configured.query.table_meta_cache_enabled);
             assert_eq!(10240, configured.query.table_cache_segment_count);
             assert_eq!(256, configured.query.table_cache_snapshot_count);
             assert_eq!(3000, configured.query.table_cache_bloom_index_meta_count);
@@ -162,7 +162,7 @@ fn test_env_config_fs() -> Result<()> {
             ("QUERY_FLIGHT_API_ADDRESS", Some("1.2.3.4:9091")),
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
-            ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
+            ("QUERY_TABLE_META_CACHE_ENABLED", Some("true")),
             ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
             ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
             ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
@@ -245,7 +245,7 @@ fn test_env_config_fs() -> Result<()> {
 
             assert!(configured.query.table_engine_memory_enabled);
 
-            assert!(configured.query.table_cache_enabled);
+            assert!(configured.query.table_meta_cache_enabled);
             assert_eq!(512, configured.query.table_memory_cache_mb_size);
             assert_eq!("_cache_env", configured.query.table_disk_cache_root);
             assert_eq!(512, configured.query.table_disk_cache_mb_size);
@@ -281,7 +281,7 @@ fn test_env_config_gcs() -> Result<()> {
             ("QUERY_FLIGHT_API_ADDRESS", Some("1.2.3.4:9091")),
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
-            ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
+            ("QUERY_TABLE_META_CACHE_ENABLED", Some("true")),
             ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
             ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
             ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
@@ -371,7 +371,7 @@ fn test_env_config_gcs() -> Result<()> {
 
             assert!(configured.query.table_engine_memory_enabled);
 
-            assert!(configured.query.table_cache_enabled);
+            assert!(configured.query.table_meta_cache_enabled);
             assert_eq!(512, configured.query.table_memory_cache_mb_size);
             assert_eq!("_cache_env", configured.query.table_disk_cache_root);
             assert_eq!(512, configured.query.table_disk_cache_mb_size);
@@ -407,7 +407,7 @@ fn test_env_config_oss() -> Result<()> {
             ("QUERY_FLIGHT_API_ADDRESS", Some("1.2.3.4:9091")),
             ("QUERY_ADMIN_API_ADDRESS", Some("1.2.3.4:8081")),
             ("QUERY_METRIC_API_ADDRESS", Some("1.2.3.4:7071")),
-            ("QUERY_TABLE_CACHE_ENABLED", Some("true")),
+            ("QUERY_TABLE_META_CACHE_ENABLED", Some("true")),
             ("QUERY_TABLE_MEMORY_CACHE_MB_SIZE", Some("512")),
             ("QUERY_TABLE_DISK_CACHE_ROOT", Some("_cache_env")),
             ("QUERY_TABLE_DISK_CACHE_MB_SIZE", Some("512")),
@@ -504,7 +504,7 @@ fn test_env_config_oss() -> Result<()> {
 
             assert!(configured.query.table_engine_memory_enabled);
 
-            assert!(configured.query.table_cache_enabled);
+            assert!(configured.query.table_meta_cache_enabled);
             assert_eq!(512, configured.query.table_memory_cache_mb_size);
             assert_eq!("_cache_env", configured.query.table_disk_cache_root);
             assert_eq!(512, configured.query.table_disk_cache_mb_size);
@@ -561,7 +561,7 @@ table_engine_memory_enabled = true
 database_engine_github_enabled = true
 wait_timeout_mills = 5000
 max_query_log_size = 10000
-table_cache_enabled = false
+table_meta_cache_enabled = false
 table_cache_snapshot_count = 256
 table_cache_segment_count = 10240
 table_cache_block_meta_count = 102400

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -63,7 +63,6 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | query   | table_cache_block_meta_count         | 102400                         |             |
 | query   | table_cache_bloom_index_data_bytes   | 1073741824                     |             |
 | query   | table_cache_bloom_index_meta_count   | 3000                           |             |
-| query   | table_cache_enabled                  | false                          |             |
 | query   | table_cache_segment_count            | 10240                          |             |
 | query   | table_cache_snapshot_count           | 256                            |             |
 | query   | table_cache_statistic_count          | 256                            |             |
@@ -71,6 +70,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | query   | table_disk_cache_root                | _cache                         |             |
 | query   | table_engine_memory_enabled          | true                           |             |
 | query   | table_memory_cache_mb_size           | 256                            |             |
+| query   | table_meta_cache_enabled             | false                          |             |
 | query   | tenant_id                            | test                           |             |
 | query   | users                                |                                |             |
 | query   | wait_timeout_mills                   | 5000                           |             |

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -66,7 +66,7 @@ impl FuseTable {
             ReadDataKind::BlockDataAdjustIORequests => {
                 let conf = GlobalConfig::instance();
                 let mut max_memory_usage = ctx.get_settings().get_max_memory_usage()? as usize;
-                if conf.query.table_cache_enabled {
+                if conf.query.table_meta_cache_enabled {
                     // Removing bloom index memory size.
                     max_memory_usage -= conf.query.table_cache_bloom_index_data_bytes as usize;
                 }

--- a/src/query/storages/parquet/src/table_function/read.rs
+++ b/src/query/storages/parquet/src/table_function/read.rs
@@ -91,7 +91,7 @@ impl ParquetTable {
     fn adjust_io_request(&self, ctx: &Arc<dyn TableContext>, num_columns: usize) -> Result<usize> {
         let conf = GlobalConfig::instance();
         let mut max_memory_usage = ctx.get_settings().get_max_memory_usage()? as usize;
-        if conf.query.table_cache_enabled {
+        if conf.query.table_meta_cache_enabled {
             // Removing bloom index memory size.
             max_memory_usage -= conf.query.table_cache_bloom_index_data_bytes as usize;
         }

--- a/src/query/storages/table-meta/src/caches/cache.rs
+++ b/src/query/storages/table-meta/src/caches/cache.rs
@@ -49,7 +49,7 @@ impl CacheManager {
     ///
     /// For convenience, ids of cluster and tenant are also kept
     pub fn init(config: &QueryConfig) -> Result<()> {
-        if !config.table_cache_enabled {
+        if !config.table_meta_cache_enabled {
             GlobalInstance::set(Arc::new(Self {
                 table_snapshot_cache: None,
                 segment_info_cache: None,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

rename config item `table_cache_enabled` to `table_meta_cache_enabled`

Closes #issue
