### PR TITLE
docs(website): allow broken links

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -14,7 +14,7 @@ const config = {
     tagline: 'Databend is a modern cloud data warehouse that empowers your object storage for real-time analytics.',
     url: 'https://databend.rs',
     baseUrl: '/',
-    onBrokenLinks: 'throw',
+    onBrokenLinks: 'warn',
     onBrokenMarkdownLinks: 'throw',
     favicon: 'img/logo/logo-no-text.svg',
     organizationName: 'datafuselabs',


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Allows for broken links to exist at build time to facilitate moving forward with translation

This is only a temporary solution, possibly a bug in docusaurus, and will be followed up as soon as it is resolved upstream.

Closes #issue
