### PR TITLE
fix: use logical CPU number as default value of num_cpus

### DIFF
--- a/src/query/settings/src/lib.rs
+++ b/src/query/settings/src/lib.rs
@@ -107,12 +107,12 @@ impl Settings {
 
     pub fn default_settings(tenant: &str, conf: Arc<Config>) -> Result<Arc<Settings>> {
         let memory_info = sys_info::mem_info().map_err(ErrorCode::from_std_error)?;
-        let mut num_physical_cpus = num_cpus::get_physical() as u64;
+        let mut num_cpus = num_cpus::get() as u64;
         if conf.query.num_cpus != 0 {
-            num_physical_cpus = conf.query.num_cpus;
+            num_cpus = conf.query.num_cpus;
         }
-        if num_physical_cpus == 0 {
-            num_physical_cpus = 16;
+        if num_cpus == 0 {
+            num_cpus = 16;
         }
 
         let mut default_max_memory_usage = 1024 * memory_info.total * 80 / 100;
@@ -121,7 +121,7 @@ impl Settings {
         }
 
         let default_max_storage_io_requests = if conf.storage.params.is_fs() {
-            num_physical_cpus
+            num_cpus
         } else {
             64
         };
@@ -140,10 +140,10 @@ impl Settings {
             },
             // max_threads
             SettingValue {
-                default_value: UserSettingValue::UInt64(num_physical_cpus),
+                default_value: UserSettingValue::UInt64(num_cpus),
                 user_setting: UserSetting::create(
                     "max_threads",
-                    UserSettingValue::UInt64(num_physical_cpus),
+                    UserSettingValue::UInt64(num_cpus),
                 ),
                 level: ScopeLevel::Session,
                 desc: "The maximum number of threads to execute the request. By default the value is determined automatically.",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

use logical CPU number as default value of num_cpus

Closes #issue
