### PR TITLE
feat: introduce built-in malloc conf

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+JEMALLOC_SYS_WITH_MALLOC_CONF = "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000"

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 
 # Rust
 target/
-.cargo/config.toml
 
 # OS related
 ### MacOS ###

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,6 +2991,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharing-endpoint",
+ "tikv-jemalloc-ctl",
  "tokio-stream",
  "tonic",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,9 @@ serde_json = { version = "1.0.85", default-features = false, features = ["preser
 chrono = { version = "0.4.22", features = ["serde"] }
 chrono-tz = "0.6.3"
 
+# jemalloc
+tikv-jemalloc-ctl = { version = "0.5.0", features = ["use_std"] }
+
 # http
 reqwest = { version = "0.11", default-features = false, features = [
     "json",

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -57,6 +57,7 @@ poem = { version = "1", features = ["rustls", "multipart", "compression"] }
 sentry = { version = "0.27.0", default-features = false, features = ["backtrace", "contexts", "panic", "rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true }
 tokio-stream = "0.1.10"
 tonic = "0.8.1"
 tracing = "0.1.36"

--- a/src/binaries/query/main.rs
+++ b/src/binaries/query/main.rs
@@ -219,8 +219,8 @@ async fn main_entrypoint() -> Result<()> {
             format!("connected to endpoints {:#?}", conf.meta.endpoints)
         }
     );
-    println!(
-        "Memory: {}",
+    println!("Memory:");
+    println!("    limit: {}", {
         if conf.query.max_memory_limit_enabled {
             format!(
                 "Memory: server memory limit to {} (bytes)",
@@ -229,7 +229,13 @@ async fn main_entrypoint() -> Result<()> {
         } else {
             "unlimited".to_string()
         }
-    );
+    });
+    println!("    allocator config: {}", {
+        use tikv_jemalloc_ctl::config;
+        config::malloc_conf::mib()
+            .and_then(|mib| mib.read().map(|v| v.to_owned()))
+            .unwrap_or_else(|e| format!("N/A: failed to read jemalloc config, {}", e))
+    });
     println!("Cluster: {}", {
         let cluster = ClusterDiscovery::instance().discover(&conf).await?;
         let nodes = cluster.nodes.len();

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -45,7 +45,7 @@ pprof = { version = "0.10.1", features = [
 semver = "1.0.10"
 serde = { workspace = true }
 state = "0.5"
-tikv-jemalloc-ctl = { version = "0.5.0", optional = true }
+tikv-jemalloc-ctl = { workspace = true, optional = true }
 tikv-jemalloc-sys = "0.5.2"
 tokio = { version = "1.21.1", features = ["full"] }
 tracing = "0.1.36"

--- a/src/query/storages/system/Cargo.toml
+++ b/src/query/storages/system/Cargo.toml
@@ -44,7 +44,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_repr = "0.1.9"
 snailquote = "0.3.1"
-tikv-jemalloc-ctl = { version = "0.5.0", features = ["use_std"] }
+tikv-jemalloc-ctl = { workspace = true }
 tracing = "0.1.36"
 typetag = "0.2.3"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

introduces built-in malloc conf  `percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000`.

benchmarks(mainly on the test data set of `hits`) show that the above malloc conf can significantly reduce the system CPU usage (page faults) caused by the large size memory allocations, e.g. during decompression, etc.

thus we make this configuration as default during building. 

during startup of databend-query, malloc conf will be shown like this:

~~~
Databend Query

Version: v0.8.167-nightly-c32f0d1(rust-1.67.0-nightly-2022-12-30T07:38:55.015661976Z)

Logging:
...
Memory:
    limit: unlimited
    allocator config: percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000
...
~~~

the MALLOC_CONFI is taken from clickhouse :

https://github.com/ClickHouse/ClickHouse/blob/533c7888038453c047df816f3f65292cca05a54f/contrib/jemalloc-cmake/CMakeLists.txt#L37

we have evaluated this configuration before, with no significant improvement has been observed. 

But after @zhang2014 's PR https://github.com/datafuselabs/databend/pull/9379 has been merged, the above malloc conf finally takes effect.

------------------

NOTE:

- **`$PROJ_ROOT/.cargo/config.toml` is no longer ignored by `.gitingroe`**

if this conflicts with your concurrent dev env setup, please consider moving the current one to `~/.cargo/config.toml` or another parent path, for more details, please see https://doc.rust-lang.org/cargo/reference/config.html 

- compile time conf can be overridden by set `JEMALLOC_SYS_WITH_MALLOC_CONF`
  
   e.g. `JEMALLOC_SYS_WITH_MALLOC_CONF=oversize_threshold:0 cargo b -r `
   
- runtime conf can be  be overridden by set `_RJEM_MALLOC_CONF`

  e.g.  ` _RJEM_MALLOC_CONF="muzzy_decay_ms:15000,dirty_decay_ms:15000" ./target/release/databe-query -c ....`






Closes #issue
