### PR TITLE
fix: memory leak due to histogram metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5102,8 +5102,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
+source = "git+https://github.com/datafuse-extras/metrics.git?rev=bc49d03#bc49d0364bc53499cb43fa418b2c474ef3ef24f1"
 dependencies = [
  "ahash 0.7.6",
  "metrics-macros",
@@ -5128,8 +5127,7 @@ dependencies = [
 [[package]]
 name = "metrics-macros"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
+source = "git+https://github.com/datafuse-extras/metrics.git?rev=bc49d03#bc49d0364bc53499cb43fa418b2c474ef3ef24f1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,3 +155,4 @@ rpath = false
 # arrow-format = { git = "https://github.com/datafuse-extras/arrow-format", rev = "78dacc1" }
 parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", rev = "fb08b72" }
 limits-rs = { git = "https://github.com/datafuse-extras/limits-rs", rev = "abfcf7b" }
+metrics = { git = "https://github.com/datafuse-extras/metrics.git", rev = "bc49d03"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,4 +155,4 @@ rpath = false
 # arrow-format = { git = "https://github.com/datafuse-extras/arrow-format", rev = "78dacc1" }
 parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", rev = "fb08b72" }
 limits-rs = { git = "https://github.com/datafuse-extras/limits-rs", rev = "abfcf7b" }
-metrics = { git = "https://github.com/datafuse-extras/metrics.git", rev = "bc49d03"}
+metrics = { git = "https://github.com/datafuse-extras/metrics.git", rev = "bc49d03" }

--- a/src/common/metrics/tests/it/main.rs
+++ b/src/common/metrics/tests/it/main.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 
-use common_exception::ErrorCode;
 use common_metrics::dump_metric_samples;
 use common_metrics::init_default_metrics_recorder;
 use common_metrics::try_handle;
@@ -25,6 +24,8 @@ async fn test_dump_metric_samples() -> common_exception::Result<()> {
     init_default_metrics_recorder();
     metrics::counter!("test.test1_count", 1);
     metrics::counter!("test.test2_count", 2);
+
+    #[cfg(feature = "enable_histogram")]
     metrics::histogram!("test.test_query_usedtime", 2.0);
 
     let handle = crate::try_handle().unwrap();
@@ -38,11 +39,15 @@ async fn test_dump_metric_samples() -> common_exception::Result<()> {
         samples.get("test_test1_count").unwrap().value
     );
 
-    let summaries = match &samples.get("test_test_query_usedtime").unwrap().value {
-        MetricValue::Summary(summaries) => summaries,
-        _ => return Err(ErrorCode::Internal("test failed")),
-    };
-    assert_eq!(7, summaries.len());
+    #[cfg(feature = "enable_histogram")]
+    {
+        use common_exception::ErrorCode;
+        let summaries = match &samples.get("test_test_query_usedtime").unwrap().value {
+            MetricValue::Summary(summaries) => summaries,
+            _ => return Err(ErrorCode::Internal("test failed")),
+        };
+        assert_eq!(7, summaries.len());
+    }
 
     Ok(())
 }

--- a/src/query/service/tests/it/storages/system.rs
+++ b/src/query/service/tests/it/storages/system.rs
@@ -256,6 +256,7 @@ async fn test_metrics_table() -> Result<()> {
     let source_plan = table.read_plan(ctx.clone(), None).await?;
 
     metrics::counter!("test.test_metrics_table_count", 1);
+    #[cfg(feature = "enable_histogram")]
     metrics::histogram!("test.test_metrics_table_histogram", 1.0);
 
     let stream = table.read_data_block_stream(ctx, &source_plan).await?;
@@ -266,6 +267,7 @@ async fn test_metrics_table() -> Result<()> {
 
     let output = pretty_format_blocks(result.as_slice())?;
     assert!(output.contains("test_test_metrics_table_count"));
+    #[cfg(feature = "enable_histogram")]
     assert!(output.contains("test_test_metrics_table_histogram"));
 
     Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

use a patched version of crate `metrics`, which disables the histogram.

NOTE:

this is a temp workaround, histograms are highly likely to be back soon : )

Closes #issue
