### PR TITLE
refactor(fuse): better table-meta and parquet reader function

### DIFF
--- a/src/query/storages/fuse/src/io/read/block_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block_reader.rs
@@ -16,18 +16,23 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::time::Instant;
 
+use common_arrow::arrow::datatypes::Field;
 use common_arrow::parquet::metadata::SchemaDescriptor;
 use common_base::rangemap::RangeMerger;
 use common_base::runtime::UnlimitedFuture;
+use common_catalog::plan::PartInfoPtr;
 use common_catalog::plan::Projection;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_storage::ColumnLeaf;
 use common_storage::ColumnLeaves;
+use common_storages_table_meta::meta::ColumnMeta;
 use futures::future::try_join_all;
 use opendal::Object;
 use opendal::Operator;
 
+use crate::fuse_part::FusePartInfo;
 use crate::io::read::ReadSettings;
 use crate::metrics::*;
 
@@ -102,6 +107,10 @@ where Self: 'static
 }
 
 impl BlockReader {
+    pub fn support_blocking_api(&self) -> bool {
+        self.operator.metadata().can_blocking()
+    }
+
     /// This is an optimized for data read, works like the Linux kernel io-scheduler IO merging.
     /// If the distance between two IO request ranges to be read is less than storage_io_min_bytes_for_seek(Default is 48Bytes),
     /// will read the range that contains both ranges, thus avoiding extra seek.
@@ -226,6 +235,73 @@ impl BlockReader {
         }
 
         Ok(read_res)
+    }
+
+    pub async fn read_columns_data_by_merge_io(
+        &self,
+        settings: &ReadSettings,
+        location: &str,
+        columns_meta: &HashMap<usize, ColumnMeta>,
+    ) -> Result<MergeIOReadResult> {
+        // Perf
+        {
+            metrics_inc_remote_io_read_parts(1);
+        }
+
+        let columns = self.projection.project_column_leaves(&self.column_leaves)?;
+        let indices = Self::build_projection_indices(&columns);
+
+        let mut ranges = vec![];
+        for index in indices.keys() {
+            let column_meta = &columns_meta[index];
+            ranges.push((
+                *index,
+                column_meta.offset..(column_meta.offset + column_meta.len),
+            ));
+
+            // Perf
+            {
+                metrics_inc_remote_io_seeks(1);
+                metrics_inc_remote_io_read_bytes(column_meta.len);
+            }
+        }
+
+        let object = self.operator.object(location);
+
+        Self::merge_io_read(settings, object, ranges).await
+    }
+
+    pub fn sync_read_columns_data_by_merge_io(
+        &self,
+        settings: &ReadSettings,
+        part: PartInfoPtr,
+    ) -> Result<MergeIOReadResult> {
+        let part = FusePartInfo::from_part(&part)?;
+        let columns = self.projection.project_column_leaves(&self.column_leaves)?;
+        let indices = Self::build_projection_indices(&columns);
+
+        let mut ranges = vec![];
+        for index in indices.keys() {
+            let column_meta = &part.columns_meta[index];
+            ranges.push((
+                *index,
+                column_meta.offset..(column_meta.offset + column_meta.len),
+            ));
+        }
+
+        let object = self.operator.object(&part.location);
+        Self::sync_merge_io_read(settings, object, ranges)
+    }
+
+    // Build non duplicate leaf_ids to avoid repeated read column from parquet
+    pub(crate) fn build_projection_indices(columns: &Vec<&ColumnLeaf>) -> HashMap<usize, Field> {
+        let mut indices = HashMap::with_capacity(columns.len());
+        for column in columns {
+            for index in &column.leaf_ids {
+                indices.insert(*index, column.field.clone());
+            }
+        }
+        indices
     }
 
     #[inline]

--- a/src/query/storages/fuse/src/io/read/block_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block_reader.rs
@@ -249,4 +249,8 @@ impl BlockReader {
         let chunk = o.blocking_range_read(start..end)?;
         Ok((index, chunk))
     }
+
+    pub fn schema(&self) -> DataSchemaRef {
+        self.projected_schema.clone()
+    }
 }

--- a/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -374,7 +374,7 @@ impl Processor for CompactTransform {
                             }
 
                             block_reader
-                                .read_block_by_meta(meta.as_ref(), &settings)
+                                .read_parquet_to_block(meta.as_ref(), &settings)
                                 .await
                         });
                     }

--- a/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -374,7 +374,7 @@ impl Processor for CompactTransform {
                             }
 
                             block_reader
-                                .read_with_block_meta(meta.as_ref(), &settings)
+                                .read_block_by_meta(meta.as_ref(), &settings)
                                 .await
                         });
                     }

--- a/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -374,7 +374,7 @@ impl Processor for CompactTransform {
                             }
 
                             block_reader
-                                .read_parquet_to_block(meta.as_ref(), &settings)
+                                .read_parquet_by_meta(&settings, meta.as_ref())
                                 .await
                         });
                     }

--- a/src/query/storages/fuse/src/operations/mutation/deletion/deletion_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/deletion/deletion_source.rs
@@ -183,7 +183,9 @@ impl Processor for DeletionSource {
     fn process(&mut self) -> Result<()> {
         match std::mem::replace(&mut self.state, State::Finish) {
             State::FilterData(part, chunks) => {
-                let data_block = self.block_reader.deserialize(part.clone(), chunks)?;
+                let data_block = self
+                    .block_reader
+                    .deserialize_column_chunks_to_block(part.clone(), chunks)?;
                 let filter_result = self
                     .filter
                     .eval(&self.ctx.try_get_function_context()?, &data_block)?
@@ -223,7 +225,8 @@ impl Processor for DeletionSource {
                 let merged = if chunks.is_empty() {
                     data_block
                 } else if let Some(remain_reader) = self.remain_reader.as_ref() {
-                    let remain_block = remain_reader.deserialize(part, chunks)?;
+                    let remain_block =
+                        remain_reader.deserialize_column_chunks_to_block(part, chunks)?;
                     let remain_block = DataBlock::filter_block(remain_block, &filter)?;
                     for (col, field) in remain_block
                         .columns()

--- a/src/query/storages/fuse/src/operations/mutation/deletion/deletion_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/deletion/deletion_source.rs
@@ -186,7 +186,7 @@ impl Processor for DeletionSource {
             State::FilterData(part, chunks) => {
                 let data_block = self
                     .block_reader
-                    .deserialize_parquet_chunks_to_block(part.clone(), chunks)?;
+                    .deserialize_parquet_chunks(part.clone(), chunks)?;
                 let filter_result = self
                     .filter
                     .eval(&self.ctx.try_get_function_context()?, &data_block)?
@@ -226,8 +226,7 @@ impl Processor for DeletionSource {
                 let merged = if chunks.is_empty() {
                     data_block
                 } else if let Some(remain_reader) = self.remain_reader.as_ref() {
-                    let remain_block =
-                        remain_reader.deserialize_parquet_chunks_to_block(part, chunks)?;
+                    let remain_block = remain_reader.deserialize_parquet_chunks(part, chunks)?;
                     let remain_block = DataBlock::filter_block(remain_block, &filter)?;
                     for (col, field) in remain_block
                         .columns()

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
@@ -139,15 +139,13 @@ impl Processor for DeserializeDataTransform {
             let columns_chunks = read_res.columns_chunks()?;
             let part = FusePartInfo::from_part(&part)?;
 
-            let data_block = self
-                .block_reader
-                .deserialize_parquet_chunks_to_block_with_buffer(
-                    part.nums_rows,
-                    &part.compression,
-                    &part.columns_meta,
-                    columns_chunks,
-                    Some(self.uncompressed_buffer.clone()),
-                )?;
+            let data_block = self.block_reader.deserialize_parquet_chunks_with_buffer(
+                part.nums_rows,
+                &part.compression,
+                &part.columns_meta,
+                columns_chunks,
+                Some(self.uncompressed_buffer.clone()),
+            )?;
 
             // Perf.
             {

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
@@ -139,13 +139,15 @@ impl Processor for DeserializeDataTransform {
             let columns_chunks = read_res.columns_chunks()?;
             let part = FusePartInfo::from_part(&part)?;
 
-            let data_block = self.block_reader.deserialize_columns(
-                part.nums_rows,
-                &part.compression,
-                &part.columns_meta,
-                columns_chunks,
-                Some(self.uncompressed_buffer.clone()),
-            )?;
+            let data_block = self
+                .block_reader
+                .deserialize_column_chunks_to_block_with_buffer(
+                    part.nums_rows,
+                    &part.compression,
+                    &part.columns_meta,
+                    columns_chunks,
+                    Some(self.uncompressed_buffer.clone()),
+                )?;
 
             // Perf.
             {

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
@@ -141,7 +141,7 @@ impl Processor for DeserializeDataTransform {
 
             let data_block = self
                 .block_reader
-                .deserialize_column_chunks_to_block_with_buffer(
+                .deserialize_parquet_chunks_to_block_with_buffer(
                     part.nums_rows,
                     &part.compression,
                     &part.columns_meta,

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
@@ -89,10 +89,10 @@ impl SyncSource for ReadParquetDataSource<true> {
             None => Ok(None),
             Some(part) => Ok(Some(DataBlock::empty_with_meta(DataSourceMeta::create(
                 vec![part.clone()],
-                vec![
-                    self.block_reader
-                        .sync_read_parquet_columns_data(&self.ctx, part)?,
-                ],
+                vec![self.block_reader.sync_read_columns_data_by_merge_io(
+                    &ReadSettings::from_ctx(&self.ctx)?,
+                    part,
+                )?],
             )))),
         }
     }
@@ -147,8 +147,8 @@ impl Processor for ReadParquetDataSource<false> {
 
                         block_reader
                             .read_columns_data_by_merge_io(
-                                &part.location,
                                 &settings,
+                                &part.location,
                                 &part.columns_meta,
                             )
                             .await

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
@@ -89,7 +89,10 @@ impl SyncSource for ReadParquetDataSource<true> {
             None => Ok(None),
             Some(part) => Ok(Some(DataBlock::empty_with_meta(DataSourceMeta::create(
                 vec![part.clone()],
-                vec![self.block_reader.sync_read_columns_data(&self.ctx, part)?],
+                vec![
+                    self.block_reader
+                        .sync_read_parquet_columns_data(&self.ctx, part)?,
+                ],
             )))),
         }
     }

--- a/src/query/storages/table-meta/src/meta/compression.rs
+++ b/src/query/storages/table-meta/src/meta/compression.rs
@@ -1,0 +1,31 @@
+//  Copyright 2022 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Copy, Clone, Debug)]
+pub enum Compression {
+    // Lz4 will be deprecated.
+    Lz4,
+    Lz4Raw,
+    Snappy,
+    Zstd,
+    Gzip,
+    // New: Added by bohu.
+    None,
+}
+
+impl Compression {
+    pub fn legacy() -> Self {
+        Compression::Lz4
+    }
+}

--- a/src/query/storages/table-meta/src/meta/mod.rs
+++ b/src/query/storages/table-meta/src/meta/mod.rs
@@ -12,26 +12,27 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 #![allow(clippy::too_many_arguments)]
-mod common;
+mod statistics;
 
+mod compression;
 /// Re-exports meta data structures of current version, i.e. v1
 mod current;
 mod v0;
 mod v1;
 mod versions;
 
-pub use common::ClusterKey;
-pub use common::ClusterStatistics;
-pub use common::ColumnId;
-pub use common::ColumnStatistics;
-pub use common::Compression;
-pub use common::Location;
-pub use common::SnapshotId;
-pub use common::Statistics;
-pub use common::StatisticsOfColumns;
-pub use common::Versioned;
+pub use compression::Compression;
 pub use current::*;
+pub use statistics::ClusterKey;
+pub use statistics::ClusterStatistics;
+pub use statistics::ColumnId;
+pub use statistics::ColumnStatistics;
+pub use statistics::Location;
+pub use statistics::SnapshotId;
+pub use statistics::Statistics;
+pub use statistics::StatisticsOfColumns;
 pub use versions::BlockBloomFilterIndexVersion;
 pub use versions::SegmentInfoVersion;
 pub use versions::SnapshotVersion;
 pub use versions::TableSnapshotStatisticsVersion;
+pub use versions::Versioned;

--- a/src/query/storages/table-meta/src/meta/statistics.rs
+++ b/src/query/storages/table-meta/src/meta/statistics.rs
@@ -16,8 +16,6 @@ use std::collections::HashMap;
 
 use common_base::base::uuid::Uuid;
 use common_datavalues::DataValue;
-use serde::Deserialize;
-use serde::Serialize;
 
 pub type ColumnId = u32;
 pub type FormatVersion = u64;
@@ -72,29 +70,4 @@ pub struct Statistics {
     pub index_size: u64,
 
     pub col_stats: HashMap<ColumnId, ColumnStatistics>,
-}
-
-/// Thing has a u64 version nubmer
-pub trait Versioned<const V: u64>
-where Self: Sized
-{
-    const VERSION: u64 = V;
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Eq, Copy, Clone, Debug)]
-pub enum Compression {
-    // Lz4 will be deprecated.
-    Lz4,
-    Lz4Raw,
-    Snappy,
-    Zstd,
-    Gzip,
-    // New: Added by bohu.
-    None,
-}
-
-impl Compression {
-    pub fn legacy() -> Self {
-        Compression::Lz4
-    }
 }

--- a/src/query/storages/table-meta/src/meta/v0/segment.rs
+++ b/src/query/storages/table-meta/src/meta/v0/segment.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 
-use crate::meta::common::ColumnStatistics;
+use crate::meta::statistics::ColumnStatistics;
 use crate::meta::ColumnId;
 use crate::meta::Statistics;
 

--- a/src/query/storages/table-meta/src/meta/v1/segment.rs
+++ b/src/query/storages/table-meta/src/meta/v1/segment.rs
@@ -19,9 +19,9 @@ use common_datablocks::DataBlock;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::meta::common::ClusterStatistics;
-use crate::meta::common::ColumnStatistics;
-use crate::meta::common::FormatVersion;
+use crate::meta::statistics::ClusterStatistics;
+use crate::meta::statistics::ColumnStatistics;
+use crate::meta::statistics::FormatVersion;
 use crate::meta::ColumnId;
 use crate::meta::ColumnMeta;
 use crate::meta::Compression;

--- a/src/query/storages/table-meta/src/meta/v1/snapshot.rs
+++ b/src/query/storages/table-meta/src/meta/v1/snapshot.rs
@@ -21,7 +21,7 @@ use common_datavalues::DataSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::meta::common::FormatVersion;
+use crate::meta::statistics::FormatVersion;
 use crate::meta::ClusterKey;
 use crate::meta::Location;
 use crate::meta::SnapshotId;

--- a/src/query/storages/table-meta/src/meta/v1/table_snapshot_statistics.rs
+++ b/src/query/storages/table-meta/src/meta/v1/table_snapshot_statistics.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::meta::common::FormatVersion;
+use crate::meta::statistics::FormatVersion;
 use crate::meta::ColumnId;
 use crate::meta::SnapshotId;
 use crate::meta::Versioned;

--- a/src/query/storages/table-meta/src/meta/versions.rs
+++ b/src/query/storages/table-meta/src/meta/versions.rs
@@ -20,7 +20,6 @@ use common_exception::ErrorCode;
 use crate::meta::v0;
 use crate::meta::v1;
 use crate::meta::v1::BlockFilter;
-use crate::meta::Versioned;
 
 // Here versions of meta are tagged with numeric values
 //
@@ -33,6 +32,13 @@ use crate::meta::Versioned;
 // Fortunately, since v0::SegmentInfo::VERSION is used in
 // several places, compiler will report compile error if it
 // can not deduce a unique value the constant expression.
+
+/// Thing has a u64 version number
+pub trait Versioned<const V: u64>
+where Self: Sized
+{
+    const VERSION: u64 = V;
+}
 
 impl Versioned<0> for v0::SegmentInfo {}
 impl Versioned<1> for v1::SegmentInfo {}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR only refactored, not logic changed.
* `table-meta/common.rs` -> `staticits.rs` and `compression.rs`
* make `block_reader_parquet.rs` function name more readable

Closes #issue
