### PR TITLE
refactor(storage/cache): add to_bytes and from_bytes for CachedObject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,7 +2045,6 @@ name = "common-storages-cache"
 version = "0.1.0"
 dependencies = [
  "async-trait-fn",
- "bincode 1.3.3",
  "common-base",
  "common-cache",
  "common-exception",

--- a/src/query/storages/cache/Cargo.toml
+++ b/src/query/storages/cache/Cargo.toml
@@ -17,7 +17,6 @@ common-cache = { path = "../../../common/cache" }
 common-exception = { path = "../../../common/exception" }
 
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
-bincode = "1.3.3"
 opendal = "0.23"
 parking_lot = "0.12.1"
 serde = { workspace = true }

--- a/src/query/storages/cache/src/lib.rs
+++ b/src/query/storages/cache/src/lib.rs
@@ -18,6 +18,7 @@ mod providers;
 mod settings;
 
 pub use cache::ObjectCacheProvider;
+pub use object::CachedObject;
 pub use object::CachedObjectAccessor;
 pub use providers::ByPassCache;
 pub use providers::FileCache;

--- a/src/query/storages/cache/src/settings.rs
+++ b/src/query/storages/cache/src/settings.rs
@@ -13,18 +13,8 @@
 // limitations under the License.
 
 #[derive(Clone)]
-pub enum SerializedType {
-    Json,
-    Bincode,
-}
-
-#[derive(Clone)]
 pub struct CacheSettings {
     pub memory_items_cache_capacity: u64,
-    // Serialize the item with which type, default is JSON.
-    // Like segment info is JSON.
-    pub memory_items_cache_serialize_type: SerializedType,
-
     pub memory_bytes_cache_capacity: u64,
 
     // write cache if true.
@@ -36,7 +26,6 @@ impl Default for CacheSettings {
         CacheSettings {
             memory_items_cache_capacity: 10000 * 100,
             memory_bytes_cache_capacity: 1024 * 1024 * 1024,
-            memory_items_cache_serialize_type: SerializedType::Json,
             cache_on_write: false,
         }
     }

--- a/src/query/storages/cache/tests/it/by_pass_cache.rs
+++ b/src/query/storages/cache/tests/it/by_pass_cache.rs
@@ -19,13 +19,14 @@ use common_base::base::uuid;
 use common_exception::Result;
 use common_storages_cache::ByPassCache;
 use common_storages_cache::CacheSettings;
+use common_storages_cache::CachedObject;
 use common_storages_cache::CachedObjectAccessor;
 use opendal::services::fs;
 use opendal::services::fs::Builder;
 use opendal::Operator;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_by_pass_cache() -> Result<()> {
+async fn test_by_pass_bytes_cache() -> Result<()> {
     let mut builder: Builder = fs::Builder::default();
     builder.root("/tmp");
     let op: Operator = Operator::new(builder.build()?);
@@ -45,6 +46,53 @@ async fn test_by_pass_cache() -> Result<()> {
 
     // Reader.
     let actual: Arc<Vec<u8>> = accessor.read(&object, 0, expect.len() as u64).await?;
+
+    assert_eq!(actual, expect);
+
+    // Remove.
+    accessor.remove(&object).await?;
+
+    Ok(())
+}
+
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug)]
+struct TestMeta {
+    a: u8,
+}
+
+impl CachedObject for TestMeta {
+    fn from_bytes(bs: Vec<u8>) -> Result<Arc<Self>> {
+        let t = serde_json::from_slice(&bs).unwrap();
+        Ok(Arc::new(t))
+    }
+
+    fn to_bytes(self: Arc<Self>) -> Result<Vec<u8>> {
+        let data = serde_json::to_vec(&self).unwrap();
+        Ok(data)
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_by_pass_item_cache() -> Result<()> {
+    let mut builder: Builder = fs::Builder::default();
+    builder.root("/tmp");
+    let op: Operator = Operator::new(builder.build()?);
+
+    let path = uuid::Uuid::new_v4().to_string();
+    let object = op.object(&path);
+
+    // Cache.
+    let settings = CacheSettings::default();
+    let cache = Arc::new(ByPassCache::create(&settings));
+
+    let expect: Arc<TestMeta> = Arc::new(TestMeta { a: 3 });
+
+    // Cached Object Accessor.
+    let accessor = CachedObjectAccessor::create(cache.clone());
+    accessor.write(&object, expect.clone()).await?;
+
+    // Reader.
+    let actual: Arc<TestMeta> = accessor.read(&object, 0, 8).await?;
 
     assert_eq!(actual, expect);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add to_bytes and from_bytes for CachedObject, and make the T provider define the serialize and deserialize.

Closes #issue
