### PR TITLE
ci: only run dev ci for pull request to main

### DIFF
--- a/.github/workflows/dev-linux.yml
+++ b/.github/workflows/dev-linux.yml
@@ -2,6 +2,8 @@ name: Dev Linux
 
 on:
   pull_request:
+    branches:
+      - main
     paths-ignore:
       - "docs/**"
       - "website/**"

--- a/.github/workflows/dev-macos.yml
+++ b/.github/workflows/dev-macos.yml
@@ -2,6 +2,8 @@ name: Dev MacOS
 
 on:
   pull_request:
+    branches:
+      - main
     paths-ignore:
       - "docs/**"
       - "website/**"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

We are developing on branch expression and expect no ci on it.

Closes #issue
