### PR TITLE
fix: Lazy load JWKS

### DIFF
--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -41,7 +41,7 @@ pub enum Credential {
 }
 
 impl AuthMgr {
-    pub async fn create(cfg: &Config) -> Result<Arc<AuthMgr>> {
+    pub fn create(cfg: &Config) -> Result<Arc<AuthMgr>> {
         Ok(Arc::new(AuthMgr {
             jwt_auth: JwtAuthenticator::try_create(cfg.query.jwt_key_file.clone())?,
         }))

--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -43,7 +43,7 @@ pub enum Credential {
 impl AuthMgr {
     pub async fn create(cfg: &Config) -> Result<Arc<AuthMgr>> {
         Ok(Arc::new(AuthMgr {
-            jwt_auth: JwtAuthenticator::try_create(cfg.query.jwt_key_file.clone()).await?,
+            jwt_auth: JwtAuthenticator::try_create(cfg.query.jwt_key_file.clone())?,
         }))
     }
 
@@ -57,7 +57,7 @@ impl AuthMgr {
                     .jwt_auth
                     .as_ref()
                     .ok_or_else(|| ErrorCode::AuthenticateFailure("jwt auth not configured."))?;
-                let jwt = jwt_auth.parse_jwt_claims(t.as_str())?;
+                let jwt = jwt_auth.parse_jwt_claims(t.as_str()).await?;
                 let user_name = jwt.subject.ok_or_else(|| {
                     ErrorCode::AuthenticateFailure(
                         "jwt auth not configured correctly, user name is missing.",

--- a/src/query/service/src/servers/http/http_services.rs
+++ b/src/query/service/src/servers/http/http_services.rs
@@ -96,7 +96,7 @@ impl HttpHandler {
             HttpHandlerKind::Clickhouse => Route::new().nest("/", clickhouse_router()),
         };
 
-        let auth_manager = AuthMgr::create(config).await?;
+        let auth_manager = AuthMgr::create(config)?;
         let session_middleware = HTTPSessionMiddleware::create(self.kind, auth_manager);
         Ok(ep
             .with(session_middleware)

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -82,7 +82,7 @@ pub struct QueryContextShared {
 }
 
 impl QueryContextShared {
-    pub async fn try_create(
+    pub fn try_create(
         config: &Config,
         session: Arc<Session>,
         cluster_cache: Arc<Cluster>,
@@ -102,7 +102,7 @@ impl QueryContextShared {
             running_query_kind: Arc::new(RwLock::new(None)),
             aborting: Arc::new(AtomicBool::new(false)),
             tables_refs: Arc::new(Mutex::new(HashMap::new())),
-            auth_manager: AuthMgr::create(config).await?,
+            auth_manager: AuthMgr::create(config)?,
             affect: Arc::new(Mutex::new(None)),
             executor: Arc::new(RwLock::new(Weak::new())),
             precommit_blocks: Arc::new(RwLock::new(vec![])),

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -129,7 +129,7 @@ impl Session {
         let config = GlobalConfig::instance();
         let session = self.clone();
         let cluster = ClusterDiscovery::instance().discover(&config).await?;
-        let shared = QueryContextShared::try_create(&config, session, cluster).await?;
+        let shared = QueryContextShared::try_create(&config, session, cluster)?;
 
         self.session_ctx
             .set_query_context_shared(Arc::downgrade(&shared));

--- a/src/query/service/tests/it/servers/http/clickhouse_handler.rs
+++ b/src/query/service/tests/it/servers/http/clickhouse_handler.rs
@@ -423,10 +423,8 @@ struct Server {
 
 impl Server {
     pub async fn new(config: &Config) -> Result<Self> {
-        let session_middleware = HTTPSessionMiddleware::create(
-            HttpHandlerKind::Clickhouse,
-            AuthMgr::create(config).await?,
-        );
+        let session_middleware =
+            HTTPSessionMiddleware::create(HttpHandlerKind::Clickhouse, AuthMgr::create(config)?);
         let endpoint = Route::new()
             .nest("/", clickhouse_router())
             .with(session_middleware);

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -460,7 +460,7 @@ async fn test_result_timeout() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config).await?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -484,7 +484,7 @@ async fn test_system_tables() -> Result<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await?;
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config).await?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
     let ep = Route::new()
         .nest("/v1/query", query_route())
         .with(session_middleware);
@@ -566,7 +566,7 @@ async fn test_query_log() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config).await?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -621,7 +621,7 @@ async fn test_query_log() -> Result<()> {
     );
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config).await?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -702,7 +702,7 @@ async fn post_sql(sql: &str, wait_time_secs: u64) -> Result<(StatusCode, QueryRe
 pub async fn create_endpoint() -> Result<EndpointType> {
     let config = ConfigBuilder::create().build();
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config).await?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
 
     Ok(Route::new()
         .nest("/v1/query", query_route())
@@ -785,7 +785,7 @@ async fn test_auth_jwt() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config).await?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -914,7 +914,7 @@ async fn test_auth_jwt_with_create_user() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config).await?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
     let ep = Route::new()
         .nest("/v1/query", query_route())
         .with(session_middleware);
@@ -1230,7 +1230,7 @@ async fn test_auth_configured_user() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config).await?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
 
     let ep = Route::new()
         .nest("/v1/query", query_route())

--- a/src/query/service/tests/it/tests/context.rs
+++ b/src/query/service/tests/it/tests/context.rs
@@ -156,10 +156,11 @@ pub async fn create_query_context_with_cluster(
     let local_id = desc.local_node_id;
     let nodes = desc.cluster_nodes_list;
 
-    let dummy_query_context = QueryContext::create_from_shared(
-        QueryContextShared::try_create(&config, dummy_session, Cluster::create(nodes, local_id))
-            .await?,
-    );
+    let dummy_query_context = QueryContext::create_from_shared(QueryContextShared::try_create(
+        &config,
+        dummy_session,
+        Cluster::create(nodes, local_id),
+    )?);
 
     dummy_query_context.get_settings().set_max_threads(8)?;
     Ok((guard, dummy_query_context))

--- a/src/query/users/src/jwt/authenticator.rs
+++ b/src/query/users/src/jwt/authenticator.rs
@@ -73,16 +73,16 @@ impl CustomClaims {
 }
 
 impl JwtAuthenticator {
-    pub async fn try_create(jwt_key_file: String) -> Result<Option<Self>> {
+    pub fn try_create(jwt_key_file: String) -> Result<Option<Self>> {
         if jwt_key_file.is_empty() {
             return Ok(None);
         }
-        let key_store = jwk::JwkKeyStore::new(jwt_key_file).await?;
+        let key_store = jwk::JwkKeyStore::new(jwt_key_file);
         Ok(Some(JwtAuthenticator { key_store }))
     }
 
-    pub fn parse_jwt_claims(&self, token: &str) -> Result<JWTClaims<CustomClaims>> {
-        let pub_key = self.key_store.get_key(None)?;
+    pub async fn parse_jwt_claims(&self, token: &str) -> Result<JWTClaims<CustomClaims>> {
+        let pub_key = self.key_store.get_key(None).await?;
         match &pub_key {
             PubKey::RSA256(pk) => match pk.verify_token::<CustomClaims>(token, None) {
                 Ok(c) => match c.subject {

--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -129,10 +129,12 @@ impl JwkKeyStore {
     }
 
     async fn maybe_reload_keys(&self) -> Result<()> {
-        let last_refreshed_at = *self.last_refreshed_at.read();
-        if last_refreshed_at.is_none()
-            || last_refreshed_at.unwrap().elapsed() > self.refresh_interval
-        {
+        let need_reload = {
+            let last_refreshed_at = *self.last_refreshed_at.read();
+            last_refreshed_at.is_none()
+                || last_refreshed_at.unwrap().elapsed() > self.refresh_interval
+        };
+        if need_reload {
             self.load_keys().await?;
             self.last_refreshed_at.write().replace(Instant::now());
         }

--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use base64::decode_config;
 use base64::URL_SAFE_NO_PAD;
@@ -93,25 +94,25 @@ pub struct JwkKeys {
 pub struct JwkKeyStore {
     url: String,
     keys: Arc<RwLock<HashMap<String, PubKey>>>,
-    _refresh_interval: Duration,
+    last_refreshed_at: RwLock<Option<Instant>>,
+    refresh_interval: Duration,
 }
 
 impl JwkKeyStore {
-    pub async fn new(url: String) -> Result<Self> {
-        let _refresh_interval = Duration::from_secs(JWK_REFRESH_INTERVAL * 60);
+    pub fn new(url: String) -> Self {
+        let refresh_interval = Duration::from_secs(JWK_REFRESH_INTERVAL * 60);
         let keys = Arc::new(RwLock::new(HashMap::new()));
-        let mut s = JwkKeyStore {
+        Self {
             url,
             keys,
-            _refresh_interval,
-        };
-        s.load_keys().await?;
-        Ok(s)
+            refresh_interval,
+            last_refreshed_at: RwLock::new(None),
+        }
     }
 }
 
 impl JwkKeyStore {
-    pub async fn load_keys(&mut self) -> Result<()> {
+    async fn load_keys(&self) -> Result<()> {
         let response = reqwest::get(&self.url).await.map_err(|e| {
             ErrorCode::AuthenticateFailure(format!("Could not download JWKS: {}", e))
         })?;
@@ -127,7 +128,19 @@ impl JwkKeyStore {
         Ok(())
     }
 
-    pub(super) fn get_key(&self, key_id: Option<String>) -> Result<PubKey> {
+    async fn maybe_reload_keys(&self) -> Result<()> {
+        let last_refreshed_at = *self.last_refreshed_at.read();
+        if last_refreshed_at.is_none()
+            || last_refreshed_at.unwrap().elapsed() > self.refresh_interval
+        {
+            self.load_keys().await?;
+            self.last_refreshed_at.write().replace(Instant::now());
+        }
+        Ok(())
+    }
+
+    pub(super) async fn get_key(&self, key_id: Option<String>) -> Result<PubKey> {
+        self.maybe_reload_keys().await?;
         let keys = self.keys.read();
         match key_id {
             Some(kid) => match keys.get(&kid) {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

I runs an integration tests environment which runs a jwks endpoint and databend-query, but in the environment, it's hard to keep the start up order between databend-query and the jwks endpoint.

When databend-query started eariler than the jwks endpoint, it'd panic on start up with the following error:

```
Databend Query start failure, cause: Code: 1051, displayText = Could not download JWKS: error sending request for url (https://jwks.xxx.svc:8080/.well-known/jwks.json): error trying to connect: dns error: no record found for Query { name: Name("jwks.xxx.svc."), query_type: AAAA, query_class: IN }.
```

This PR makes the following changes:

- loading JWKS in a lazy manner, makes the JWKS endpoint not a hard requirement for the databend-query's start up
- implement the interval polling JWKS logic in the todo
- removes the `async` in try_create function and the related callers