### PR TITLE
docs: on_error not for parquet

### DIFF
--- a/docs/doc/14-sql-commands/10-dml/dml-copy-into-table.md
+++ b/docs/doc/14-sql-commands/10-dml/dml-copy-into-table.md
@@ -174,6 +174,10 @@ copyOptions ::=
 | FORCE        | Defaults to `False` meaning the command will skip duplicate files in the stage when copying data. If `True`, duplicate files will not be skipped. | Optional |
 | ON_ERROR     | Provides options to handle a file containing errors. Select `continue` to skip the file and continue, or `abort` (default) to abort the load operation. | Optional |
 
+:::note
+The parameter ON_ERROR currently does not work for parquet files.
+:::
+
 ## Examples
 
 ### Loading Data from an Internal Stage


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

added a note: "The parameter ON_ERROR currently does not work for parquet files." to COPY INTO.

Closes #issue
