### PR TITLE
chore(meta): use explicit import. avoid using prelude::*;

### DIFF
--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use chrono::Utc;
-use common_datavalues::prelude::*;
+use common_datavalues::DataSchema;
 use common_meta_types::MatchSeq;
 use common_storage::StorageParams;
 use maplit::hashmap;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore(meta): use explicit import. avoid using prelude::*;

## Changelog







## Related Issues