### PR TITLE
refactor(allocator):  the choice about what allocator to use should be left up to a binary but not to a lib

### DIFF
--- a/src/binaries/meta/main.rs
+++ b/src/binaries/meta/main.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use common_base::base::tokio;
 use common_base::base::StopHandle;
 use common_base::base::Stoppable;
+use common_base::mem_allocator::GlobalAllocator;
 use common_exception::ErrorCode;
 use common_grpc::RpcClientConf;
 use common_meta_sled_store::init_sled_db;
@@ -38,6 +39,9 @@ use tracing::info;
 mod kvapi;
 
 pub use kvapi::KvApiCommand;
+
+#[global_allocator]
+pub static GLOBAL_ALLOCATOR: GlobalAllocator = GlobalAllocator;
 
 const CMD_KVAPI_PREFIX: &str = "kvapi::";
 

--- a/src/binaries/query/main.rs
+++ b/src/binaries/query/main.rs
@@ -16,6 +16,7 @@ mod local;
 
 use std::env;
 
+use common_base::mem_allocator::GlobalAllocator;
 use common_base::runtime::Runtime;
 use common_base::runtime::GLOBAL_MEM_STAT;
 use common_base::set_alloc_error_hook;
@@ -38,6 +39,9 @@ use databend_query::servers::Server;
 use databend_query::servers::ShutdownHandle;
 use databend_query::GlobalServices;
 use tracing::info;
+
+#[global_allocator]
+pub static GLOBAL_ALLOCATOR: GlobalAllocator = GlobalAllocator;
 
 fn main() {
     match Runtime::with_default_worker_threads() {

--- a/src/common/base/src/mem_allocator/global_allocator.rs
+++ b/src/common/base/src/mem_allocator/global_allocator.rs
@@ -22,9 +22,6 @@ use std::ptr::NonNull;
 use super::je_allocator::JEAllocator;
 use super::system_allocator::SystemAllocator;
 
-#[global_allocator]
-pub static GLOBAL_ALLOCATOR: GlobalAllocator = GlobalAllocator;
-
 #[derive(Debug, Clone, Copy, Default)]
 pub struct GlobalAllocator;
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(allocator):  the choice about what allocator to use should be left up to a binary but not to a lib

## Changelog







## Related Issues