### PR TITLE
feat(system): add build options table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-info"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2915568baa77be2c38f1d7594d1d7ceecc1012ab1ffdf8ddc9d0210596ee23e"
+dependencies = [
+ "build-info-common",
+ "build-info-proc",
+ "once_cell",
+]
+
+[[package]]
+name = "build-info-build"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562a39027834eae2be534ab5079440cfaa4ce9ca769646e72b1c734236205f16"
+dependencies = [
+ "anyhow",
+ "base64 0.20.0",
+ "bincode 1.3.3",
+ "build-info-common",
+ "cargo_metadata 0.15.2",
+ "chrono",
+ "git2",
+ "glob",
+ "once_cell",
+ "pretty_assertions",
+ "rustc_version",
+ "serde_json",
+ "xz2",
+]
+
+[[package]]
+name = "build-info-common"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "401a9dafdaa6855a7f66fb38f11627f606bce40fb782d124d4d058aec51188de"
+dependencies = [
+ "chrono",
+ "derive_more",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "build-info-proc"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2c40d327e9d58c805c3154cfc7ecc5cb917c1e214fb3d37367540b4b7a9fcf"
+dependencies = [
+ "anyhow",
+ "base64 0.20.0",
+ "bincode 1.3.3",
+ "build-info-common",
+ "chrono",
+ "num-bigint",
+ "num-traits",
+ "proc-macro-error 1.0.4",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+ "xz2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,9 +1002,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -3015,6 +3080,8 @@ dependencies = [
  "base64 0.13.1",
  "bincode 1.3.3",
  "bstr 1.1.0",
+ "build-info",
+ "build-info-build",
  "bumpalo",
  "byteorder",
  "bytes",
@@ -3363,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
 dependencies = [
  "enum-iterator-derive",
 ]
@@ -3952,9 +4019,9 @@ checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "git2"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
 dependencies = [
  "bitflags",
  "libc",
@@ -4758,9 +4825,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.4+1.4.2"
+version = "0.14.0+1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
 dependencies = [
  "cc",
  "libc",
@@ -7846,9 +7913,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.8"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ddf41e393a9133c81d5f0974195366bd57082deac6e0eb02ed39b8341c2bb6"
+checksum = "17351d0e9eb8841897b14e9669378f3c69fb57779cc04f8ca9a9d512edfb2563"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -8632,9 +8699,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "7.4.3"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447f9238a4553957277b3ee09d80babeae0811f1b3baefb093de1c0448437a37"
+checksum = "571b69f690c855821462709b6f41d42ceccc316fbd17b60bd06d06928cfe6a99"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,71 +708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-info"
-version = "0.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2915568baa77be2c38f1d7594d1d7ceecc1012ab1ffdf8ddc9d0210596ee23e"
-dependencies = [
- "build-info-common",
- "build-info-proc",
- "once_cell",
-]
-
-[[package]]
-name = "build-info-build"
-version = "0.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562a39027834eae2be534ab5079440cfaa4ce9ca769646e72b1c734236205f16"
-dependencies = [
- "anyhow",
- "base64 0.20.0",
- "bincode 1.3.3",
- "build-info-common",
- "cargo_metadata 0.15.2",
- "chrono",
- "git2",
- "glob",
- "once_cell",
- "pretty_assertions",
- "rustc_version",
- "serde_json",
- "xz2",
-]
-
-[[package]]
-name = "build-info-common"
-version = "0.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401a9dafdaa6855a7f66fb38f11627f606bce40fb782d124d4d058aec51188de"
-dependencies = [
- "chrono",
- "derive_more",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "build-info-proc"
-version = "0.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2c40d327e9d58c805c3154cfc7ecc5cb917c1e214fb3d37367540b4b7a9fcf"
-dependencies = [
- "anyhow",
- "base64 0.20.0",
- "bincode 1.3.3",
- "build-info-common",
- "chrono",
- "num-bigint",
- "num-traits",
- "proc-macro-error 1.0.4",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn",
- "xz2",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,9 +937,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -3080,8 +3015,6 @@ dependencies = [
  "base64 0.13.1",
  "bincode 1.3.3",
  "bstr 1.1.0",
- "build-info",
- "build-info-build",
  "bumpalo",
  "byteorder",
  "bytes",

--- a/src/common/building/Cargo.toml
+++ b/src/common/building/Cargo.toml
@@ -14,6 +14,6 @@ test = false
 anyhow = { workspace = true }
 cargo-license = "0.5.1"
 cargo_metadata = "0.15.0"
-git2 = { version = "0.14.4", default-features = false }
+git2 = { version = "0.15.0", default-features = false }
 tracing = "0.1.36"
 vergen = "7.4.2"

--- a/src/common/building/src/lib.rs
+++ b/src/common/building/src/lib.rs
@@ -123,12 +123,10 @@ pub fn add_target_features() {
             Ok(s) => println!("cargo:rustc-env=DATABEND_CARGO_CFG_TARGET_FEATURE={}", s),
             Err(_) => {
                 println!("cargo:warning=CARGO_CFG_TARGET_FEATURE was not valid utf-8");
-                return;
             }
         },
         None => {
             println!("cargo:warning=CARGO_CFG_TARGET_FEATURE was not set");
-            return;
         }
     };
 }

--- a/src/common/building/src/lib.rs
+++ b/src/common/building/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod git;
 
+use std::env;
 use std::path::Path;
 
 use git2::Repository;
@@ -38,6 +39,7 @@ pub fn setup() {
 pub fn add_building_env_vars() {
     set_env_config();
     add_env_credits_info();
+    add_target_features();
     match Repository::discover(".") {
         Ok(repo) => {
             add_env_git_tag(&repo);
@@ -113,4 +115,20 @@ pub fn add_env_credits_info() {
         "cargo:rustc-env=DATABEND_CREDITS_LICENSES={}",
         licenses.join(", ")
     );
+}
+
+pub fn add_target_features() {
+    match env::var_os("CARGO_CFG_TARGET_FEATURE") {
+        Some(var) => match var.into_string() {
+            Ok(s) => println!("cargo:rustc-env=DATABEND_CARGO_CFG_TARGET_FEATURE={}", s),
+            Err(_) => {
+                println!("cargo:warning=CARGO_CFG_TARGET_FEATURE was not valid utf-8");
+                return;
+            }
+        },
+        None => {
+            println!("cargo:warning=CARGO_CFG_TARGET_FEATURE was not set");
+            return;
+        }
+    };
 }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -87,6 +87,7 @@ backon = "0.2"
 base64 = "0.13.0"
 bincode = "1.3.3"
 bstr = "1.0.1"
+build-info = "0.0.29"
 bumpalo = "3.11.0"
 byteorder = "1.4.3"
 bytes = "1.2.1"
@@ -149,4 +150,5 @@ walkdir = "2.3.2"
 wiremock = "0.5.14"
 
 [build-dependencies]
+build-info-build = "0.0.29"
 common-building = { path = "../../common/building" }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -87,7 +87,6 @@ backon = "0.2"
 base64 = "0.13.0"
 bincode = "1.3.3"
 bstr = "1.0.1"
-build-info = "0.0.29"
 bumpalo = "3.11.0"
 byteorder = "1.4.3"
 bytes = "1.2.1"
@@ -150,5 +149,4 @@ walkdir = "2.3.2"
 wiremock = "0.5.14"
 
 [build-dependencies]
-build-info-build = "0.0.29"
 common-building = { path = "../../common/building" }

--- a/src/query/service/build.rs
+++ b/src/query/service/build.rs
@@ -1,0 +1,18 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() {
+    common_building::setup();
+    build_info_build::build_script();
+}

--- a/src/query/service/build.rs
+++ b/src/query/service/build.rs
@@ -14,5 +14,4 @@
 
 fn main() {
     common_building::setup();
-    build_info_build::build_script();
 }

--- a/src/query/service/src/databases/system/build_options_table.rs
+++ b/src/query/service/src/databases/system/build_options_table.rs
@@ -42,10 +42,16 @@ impl SyncSystemTable for BuildOptionsTable {
     }
 
     fn get_full_data(&self, _: Arc<dyn TableContext>) -> Result<DataBlock> {
-        let mut cargo_features: Vec<Vec<u8>> = env!("VERGEN_CARGO_FEATURES")
-            .split_terminator(',')
-            .map(|x| x.trim().as_bytes().to_vec())
-            .collect();
+        let mut cargo_features: Vec<Vec<u8>>;
+
+        if let Some(features) = option_env!("VERGEN_CARGO_FEATURES") {
+            cargo_features = features
+                .split_terminator(',')
+                .map(|x| x.trim().as_bytes().to_vec())
+                .collect();
+        } else {
+            cargo_features = vec!["not available".as_bytes().to_vec()];
+        }
 
         let mut target_features: Vec<Vec<u8>> = env!("DATABEND_CARGO_CFG_TARGET_FEATURE")
             .split_terminator(',')

--- a/src/query/service/src/databases/system/build_options_table.rs
+++ b/src/query/service/src/databases/system/build_options_table.rs
@@ -1,0 +1,93 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_catalog::table::Table;
+use common_catalog::table_context::TableContext;
+use common_exception::Result;
+use common_expression::types::BooleanType;
+use common_expression::types::StringType;
+use common_expression::utils::FromData;
+use common_expression::DataBlock;
+use common_expression::TableDataType;
+use common_expression::TableField;
+use common_expression::TableSchemaRefExt;
+use common_meta_app::schema::TableIdent;
+use common_meta_app::schema::TableInfo;
+use common_meta_app::schema::TableMeta;
+use common_storages_system::SyncOneBlockSystemTable;
+use common_storages_system::SyncSystemTable;
+
+build_info::build_info!(pub fn build_info);
+
+pub struct BuildOptionsTable {
+    table_info: TableInfo,
+}
+
+impl SyncSystemTable for BuildOptionsTable {
+    const NAME: &'static str = "system.build_options";
+
+    fn get_table_info(&self) -> &TableInfo {
+        &self.table_info
+    }
+
+    fn get_full_data(&self, _: Arc<dyn TableContext>) -> Result<DataBlock> {
+        let crate_info = &build_info().crate_info;
+
+        let available_features: Vec<Vec<u8>> = crate_info
+            .available_features
+            .iter()
+            .map(|x| x.as_bytes().to_vec())
+            .collect();
+
+        let mut enabled = vec![false; available_features.len()];
+
+        for i in 0..crate_info.enabled_features.len() {
+            for j in 0..crate_info.available_features.len() {
+                if crate_info.enabled_features[i] == crate_info.available_features[j] {
+                    enabled[j] = true;
+                }
+            }
+        }
+
+        Ok(DataBlock::new_from_columns(vec![
+            StringType::from_data(available_features),
+            BooleanType::from_data(enabled),
+        ]))
+    }
+}
+
+impl BuildOptionsTable {
+    pub fn create(table_id: u64) -> Arc<dyn Table> {
+        let schema = TableSchemaRefExt::create(vec![
+            TableField::new("available_features", TableDataType::String),
+            TableField::new("enabled", TableDataType::Boolean),
+        ]);
+
+        let table_info = TableInfo {
+            desc: "'system'.'build_options'".to_string(),
+            name: "build_options".to_string(),
+            ident: TableIdent::new(table_id, 0),
+            meta: TableMeta {
+                schema,
+                engine: "SystemBuildOptions".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        SyncOneBlockSystemTable::create(BuildOptionsTable { table_info })
+    }
+}

--- a/src/query/service/src/databases/system/mod.rs
+++ b/src/query/service/src/databases/system/mod.rs
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+mod build_options_table;
 mod system_database;
 
+pub use build_options_table::BuildOptionsTable;
 pub use system_database::SystemDatabase;

--- a/src/query/service/src/databases/system/system_database.rs
+++ b/src/query/service/src/databases/system/system_database.rs
@@ -43,6 +43,7 @@ use common_storages_system::TablesTableWithoutHistory;
 use common_storages_system::TracingTable;
 use common_storages_system::UsersTable;
 
+use super::BuildOptionsTable;
 use crate::catalogs::InMemoryMetas;
 use crate::databases::Database;
 use crate::storages::Table;
@@ -83,6 +84,7 @@ impl SystemDatabase {
             EnginesTable::create(sys_db_meta.next_table_id()),
             RolesTable::create(sys_db_meta.next_table_id()),
             StagesTable::create(sys_db_meta.next_table_id()),
+            BuildOptionsTable::create(sys_db_meta.next_table_id()),
             CatalogsTable::create(sys_db_meta.next_table_id()),
         ];
 

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -8,6 +8,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | "Engine"                   | "system" | "engines"             | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "auth_string"              | "system" | "users"               | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "auth_type"                | "system" | "users"               | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
+| "available_features"       | "system" | "build_options"       | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "catalog"                  | "system" | "databases"           | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "catalog"                  | "system" | "tables"              | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "catalog"                  | "system" | "tables_with_history" | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
@@ -50,6 +51,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | "dropped_on"               | "system" | "tables"              | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "dropped_on"               | "system" | "tables_with_history" | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "dummy"                    | "system" | "one"                 | "TINYINT UNSIGNED"     | ""       | ""       | "NO"     | ""       |
+| "enabled_features"         | "system" | "build_options"       | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "end_time"                 | "system" | "clustering_history"  | "TIMESTAMP"            | ""       | ""       | "NO"     | ""       |
 | "engine"                   | "system" | "tables"              | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "engine"                   | "system" | "tables_with_history" | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
@@ -134,6 +136,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | "table"                    | "system" | "clustering_history"  | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "table"                    | "system" | "columns"             | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "tables"                   | "system" | "query_log"           | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
+| "target_features"          | "system" | "build_options"       | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "tenant_id"                | "system" | "query_log"           | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "time"                     | "system" | "processes"           | "BIGINT UNSIGNED"      | ""       | ""       | "NO"     | ""       |
 | "total_partitions"         | "system" | "query_log"           | "BIGINT UNSIGNED"      | ""       | ""       | "NO"     | ""       |

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -8,7 +8,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | "Engine"                   | "system" | "engines"             | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "auth_string"              | "system" | "users"               | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "auth_type"                | "system" | "users"               | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
-| "available_features"       | "system" | "build_options"       | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
+| "cargo_features"           | "system" | "build_options"       | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "catalog"                  | "system" | "databases"           | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "catalog"                  | "system" | "tables"              | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "catalog"                  | "system" | "tables_with_history" | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
@@ -51,7 +51,6 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | "dropped_on"               | "system" | "tables"              | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "dropped_on"               | "system" | "tables_with_history" | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "dummy"                    | "system" | "one"                 | "TINYINT UNSIGNED"     | ""       | ""       | "NO"     | ""       |
-| "enabled_features"         | "system" | "build_options"       | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "end_time"                 | "system" | "clustering_history"  | "TIMESTAMP"            | ""       | ""       | "NO"     | ""       |
 | "engine"                   | "system" | "tables"              | "VARCHAR"              | ""       | ""       | "NO"     | ""       |
 | "engine"                   | "system" | "tables_with_history" | "VARCHAR"              | ""       | ""       | "NO"     | ""       |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```bash
MySQL [(none)]> select * from system.build_options;
+------------------------+---------+
| available_features     | enabled |
+------------------------+---------+
| default                |       1 |
| io-uring               |       0 |
| thrift                 |       0 |
| hive                   |       0 |
| memory-profiling       |       0 |
| tokio-console          |       0 |
| simd                   |       1 |
| common-hive-meta-store |       0 |
| common-storages-hive   |       0 |
| storage-hdfs           |       0 |
| tempfile               |       0 |
+------------------------+---------+
11 rows in set (0.032 sec)
```

Closes #issue
