### PR TITLE
feat: all func_ctx used by run or execute try get from tablectx

### DIFF
--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -27,6 +27,7 @@ use common_expression::DataBlock;
 use common_expression::DataField;
 use common_expression::DataSchemaRefExt;
 use common_expression::FromData;
+use common_expression::FunctionContext;
 use common_expression::Literal;
 use common_expression::RawExpr;
 use common_expression::Scalar;
@@ -247,7 +248,16 @@ async fn test_ft_cluster_stats_with_stats() -> common_exception::Result<()> {
     });
 
     let block_compactor = BlockCompactThresholds::new(1_000_000, 800_000, 100 * 1024 * 1024);
-    let stats_gen = ClusterStatsGenerator::new(0, vec![0], 0, 0, block_compactor, vec![], vec![]);
+    let stats_gen = ClusterStatsGenerator::new(
+        0,
+        vec![0],
+        0,
+        0,
+        block_compactor,
+        vec![],
+        vec![],
+        FunctionContext::default(),
+    );
     let stats = stats_gen.gen_with_origin_stats(&blocks, origin.clone())?;
     assert!(stats.is_some());
     let stats = stats.unwrap();
@@ -275,8 +285,16 @@ async fn test_ft_cluster_stats_with_stats() -> common_exception::Result<()> {
 
     let operators = vec![BlockOperator::Map { expr }];
 
-    let stats_gen =
-        ClusterStatsGenerator::new(0, vec![1], 0, 0, block_compactor, operators, vec![]);
+    let stats_gen = ClusterStatsGenerator::new(
+        0,
+        vec![1],
+        0,
+        0,
+        block_compactor,
+        operators,
+        vec![],
+        FunctionContext::default(),
+    );
     let stats = stats_gen.gen_with_origin_stats(&blocks, origin.clone())?;
     assert!(stats.is_some());
     let stats = stats.unwrap();
@@ -284,7 +302,16 @@ async fn test_ft_cluster_stats_with_stats() -> common_exception::Result<()> {
     assert_eq!(vec![Scalar::Number(NumberScalar::Int64(4))], stats.max);
 
     // different cluster_key_id.
-    let stats_gen = ClusterStatsGenerator::new(1, vec![0], 0, 0, block_compactor, vec![], vec![]);
+    let stats_gen = ClusterStatsGenerator::new(
+        1,
+        vec![0],
+        0,
+        0,
+        block_compactor,
+        vec![],
+        vec![],
+        FunctionContext::default(),
+    );
     let stats = stats_gen.gen_with_origin_stats(&blocks, origin)?;
     assert!(stats.is_none());
 

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -175,8 +175,8 @@ impl FuseTable {
             cluster_key_index.push(offset);
         }
 
+        let func_ctx = ctx.try_get_function_context()?;
         if !operators.is_empty() {
-            let func_ctx = ctx.try_get_function_context()?;
             pipeline.add_transform(move |input, output| {
                 Ok(CompoundBlockOperator::create(
                     input,
@@ -195,6 +195,7 @@ impl FuseTable {
             block_compactor,
             vec![],
             merged,
+            func_ctx,
         ))
     }
 

--- a/src/query/storages/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/src/operations/delete.rs
@@ -294,7 +294,7 @@ impl FuseTable {
         let input_schema = self.table_info.schema();
         let mut merged: Vec<DataField> =
             input_schema.fields().iter().map(DataField::from).collect();
-
+        let func_ctx = ctx.try_get_function_context()?;
         let cluster_keys = self.cluster_keys(ctx);
         let mut cluster_key_index = Vec::with_capacity(cluster_keys.len());
         let mut extra_key_num = 0;
@@ -328,6 +328,7 @@ impl FuseTable {
             self.get_block_compact_thresholds(),
             operators,
             merged,
+            func_ctx,
         ))
     }
 

--- a/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -25,7 +25,6 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::BlockCompactThresholds;
 use common_expression::DataBlock;
-use common_expression::FunctionContext;
 use common_expression::TableSchemaRef;
 use common_storages_common::blocks_to_parquet;
 use common_storages_index::BlockFilter;
@@ -244,7 +243,7 @@ impl Processor for CompactTransform {
                     // build block index.
                     let (index_data, index_size, index_location) = {
                         // write index
-                        let func_ctx = FunctionContext::default();
+                        let func_ctx = self.ctx.try_get_function_context()?;
                         let bloom_index = BlockFilter::try_create(
                             func_ctx,
                             self.schema.clone(),

--- a/src/query/storages/fuse/src/pruning/pruner.rs
+++ b/src/query/storages/fuse/src/pruning/pruner.rs
@@ -20,7 +20,6 @@ use common_expression::type_check::check_function;
 use common_expression::ConstantFolder;
 use common_expression::Domain;
 use common_expression::Expr;
-use common_expression::FunctionContext;
 use common_expression::TableSchemaRef;
 use common_functions::scalars::BUILTIN_FUNCTIONS;
 use common_storages_index::BlockFilter;
@@ -135,7 +134,7 @@ pub fn new_filter_pruner(
 
         let folder = ConstantFolder::new(
             input_domains,
-            FunctionContext::default(),
+            ctx.try_get_function_context()?,
             &BUILTIN_FUNCTIONS,
         );
         let (optimized_expr, _) = folder.fold(&expr);

--- a/src/query/storages/fuse/src/statistics/cluster_statistics.rs
+++ b/src/query/storages/fuse/src/statistics/cluster_statistics.rs
@@ -33,9 +33,11 @@ pub struct ClusterStatsGenerator {
     block_compact_thresholds: BlockCompactThresholds,
     operators: Vec<BlockOperator>,
     pub(crate) out_fields: Vec<DataField>,
+    func_ctx: FunctionContext,
 }
 
 impl ClusterStatsGenerator {
+    #![allow(clippy::too_many_arguments)]
     pub fn new(
         cluster_key_id: u32,
         cluster_key_index: Vec<usize>,
@@ -44,6 +46,7 @@ impl ClusterStatsGenerator {
         block_compact_thresholds: BlockCompactThresholds,
         operators: Vec<BlockOperator>,
         out_fields: Vec<DataField>,
+        func_ctx: FunctionContext,
     ) -> Self {
         Self {
             cluster_key_id,
@@ -53,6 +56,7 @@ impl ClusterStatsGenerator {
             block_compact_thresholds,
             operators,
             out_fields,
+            func_ctx,
         }
     }
 
@@ -100,11 +104,10 @@ impl ClusterStatsGenerator {
             block = block.take(&indices)?;
         }
 
-        let func_ctx = FunctionContext::default();
         block = self
             .operators
             .iter()
-            .try_fold(block, |input, op| op.execute(&func_ctx, input))?;
+            .try_fold(block, |input, op| op.execute(&self.func_ctx, input))?;
 
         self.clusters_statistics(&block, origin_stats.level)
     }

--- a/src/query/storages/hive/hive/src/hive_table_source.rs
+++ b/src/query/storages/hive/hive/src/hive_table_source.rs
@@ -29,7 +29,6 @@ use common_expression::DataBlock;
 use common_expression::DataSchemaRef;
 use common_expression::Evaluator;
 use common_expression::Expr;
-use common_expression::FunctionContext;
 use common_expression::Value;
 use common_functions::scalars::BUILTIN_FUNCTIONS;
 use common_pipeline_core::processors::port::OutputPort;
@@ -143,9 +142,9 @@ impl HiveTableSource {
     ) -> Result<(bool, Vec<Value<AnyType>>)> {
         let mut valids = vec![];
         let mut exists = false;
+        let func_ctx = self.ctx.try_get_function_context()?;
         for datablock in data_blocks {
-            let evaluator =
-                Evaluator::new(datablock, FunctionContext::default(), &BUILTIN_FUNCTIONS);
+            let evaluator = Evaluator::new(datablock, func_ctx, &BUILTIN_FUNCTIONS);
             let res = evaluator.run(filter).map_err(|(_, e)| {
                 ErrorCode::Internal(format!("eval prewhere filter failed: {}.", e))
             })?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Now the FunctionContext::default only used in table_scan_to_format_tree.  

```
fn table_scan_to_format_tree(
    plan: &TableScan,
    metadata: &MetadataRef,
) -> Result<FormatTreeNode<String>> {
    if plan.table_index == DUMMY_TABLE_INDEX {
        return Ok(FormatTreeNode::new("DummyTableScan".to_string()));
    }
    let func_ctx = FunctionContext::default();
    ...

```

Closes #issue
