### PR TITLE
feat(planner): Support display estimated rows in `EXPLAIN`

### DIFF
--- a/src/query/service/src/schedulers/fragments/fragmenter.rs
+++ b/src/query/service/src/schedulers/fragments/fragmenter.rs
@@ -149,6 +149,7 @@ impl PhysicalPlanReplacer for Fragmenter {
             join_type: plan.join_type.clone(),
             marker_index: plan.marker_index,
             from_correlated_subquery: plan.from_correlated_subquery,
+            stat_info: plan.stat_info.clone(),
         }))
     }
 

--- a/src/query/service/src/schedulers/fragments/plan_fragment.rs
+++ b/src/query/service/src/schedulers/fragments/plan_fragment.rs
@@ -194,6 +194,7 @@ impl PhysicalPlanReplacer for ReplaceReadSource {
             source: Box::new(self.source.clone()),
             name_mapping: plan.name_mapping.clone(),
             table_index: plan.table_index,
+            stat_info: plan.stat_info.clone(),
         }))
     }
 }

--- a/src/query/sql/src/executor/explain.rs
+++ b/src/query/sql/src/executor/explain.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Datafuse Labs.
+// Copyright 2023 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod explain;
-mod format;
-mod physical_plan;
-mod physical_plan_builder;
-mod physical_plan_display;
-mod physical_plan_visitor;
-mod physical_scalar;
-mod physical_scalar_visitor;
-pub mod table_read_plan;
-mod util;
+use serde::Deserialize;
+use serde::Serialize;
 
-pub use physical_plan::*;
-pub use physical_plan_builder::PhysicalPlanBuilder;
-pub use physical_plan_builder::PhysicalScalarBuilder;
-pub use physical_plan_visitor::PhysicalPlanReplacer;
-pub use physical_scalar::*;
-pub use physical_scalar_visitor::*;
-pub use util::*;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanStatsInfo {
+    pub estimated_rows: f64,
+}

--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -34,6 +34,7 @@ use super::Project;
 use super::Sort;
 use super::TableScan;
 use super::UnionAll;
+use crate::executor::explain::PlanStatsInfo;
 use crate::executor::FragmentKind;
 use crate::planner::MetadataRef;
 use crate::planner::DUMMY_TABLE_INDEX;
@@ -142,6 +143,12 @@ fn table_scan_to_format_tree(
             output_columns.iter().join(", ")
         )));
     }
+
+    if let Some(info) = &plan.stat_info {
+        let items = plan_stats_info_to_format_tree(info);
+        children.extend(items);
+    }
+
     Ok(FormatTreeNode::with_children(
         "TableScan".to_string(),
         children,
@@ -155,10 +162,19 @@ fn filter_to_format_tree(plan: &Filter, metadata: &MetadataRef) -> Result<Format
         .map(|scalar| scalar.pretty_display())
         .collect::<Vec<_>>()
         .join(", ");
-    Ok(FormatTreeNode::with_children("Filter".to_string(), vec![
-        FormatTreeNode::new(format!("filters: [{filter}]")),
-        to_format_tree(&plan.input, metadata)?,
-    ]))
+    let mut children = vec![FormatTreeNode::new(format!("filters: [{filter}]"))];
+
+    if let Some(info) = &plan.stat_info {
+        let items = plan_stats_info_to_format_tree(info);
+        children.extend(items);
+    }
+
+    children.push(to_format_tree(&plan.input, metadata)?);
+
+    Ok(FormatTreeNode::with_children(
+        "Filter".to_string(),
+        children,
+    ))
 }
 
 fn project_to_format_tree(
@@ -181,10 +197,19 @@ fn project_to_format_tree(
         })
         .collect::<Vec<_>>()
         .join(", ");
-    Ok(FormatTreeNode::with_children("Project".to_string(), vec![
-        FormatTreeNode::new(format!("columns: [{columns}]")),
-        to_format_tree(&plan.input, metadata)?,
-    ]))
+    let mut children = vec![FormatTreeNode::new(format!("columns: [{columns}]"))];
+
+    if let Some(info) = &plan.stat_info {
+        let items = plan_stats_info_to_format_tree(info);
+        children.extend(items);
+    }
+
+    children.push(to_format_tree(&plan.input, metadata)?);
+
+    Ok(FormatTreeNode::with_children(
+        "Project".to_string(),
+        children,
+    ))
 }
 
 fn eval_scalar_to_format_tree(
@@ -197,12 +222,18 @@ fn eval_scalar_to_format_tree(
         .map(|(scalar, _)| scalar.pretty_display())
         .collect::<Vec<_>>()
         .join(", ");
+    let mut children = vec![FormatTreeNode::new(format!("expressions: [{scalars}]"))];
+
+    if let Some(info) = &plan.stat_info {
+        let items = plan_stats_info_to_format_tree(info);
+        children.extend(items);
+    }
+
+    children.push(to_format_tree(&plan.input, metadata)?);
+
     Ok(FormatTreeNode::with_children(
         "EvalScalar".to_string(),
-        vec![
-            FormatTreeNode::new(format!("expressions: [{scalars}]")),
-            to_format_tree(&plan.input, metadata)?,
-        ],
+        children,
     ))
 }
 
@@ -241,20 +272,28 @@ fn aggregate_partial_to_format_tree(
         })
         .collect::<Result<Vec<_>>>()?
         .join(", ");
-
     let agg_funcs = plan
         .agg_funcs
         .iter()
         .map(|agg| pretty_display_agg_desc(agg, metadata))
         .collect::<Vec<_>>()
         .join(", ");
+
+    let mut children = vec![
+        FormatTreeNode::new(format!("group by: [{group_by}]")),
+        FormatTreeNode::new(format!("aggregate functions: [{agg_funcs}]")),
+    ];
+
+    if let Some(info) = &plan.stat_info {
+        let items = plan_stats_info_to_format_tree(info);
+        children.extend(items);
+    }
+
+    children.push(to_format_tree(&plan.input, metadata)?);
+
     Ok(FormatTreeNode::with_children(
         "AggregatePartial".to_string(),
-        vec![
-            FormatTreeNode::new(format!("group by: [{group_by}]")),
-            FormatTreeNode::new(format!("aggregate functions: [{agg_funcs}]")),
-            to_format_tree(&plan.input, metadata)?,
-        ],
+        children,
     ))
 }
 
@@ -282,13 +321,22 @@ fn aggregate_final_to_format_tree(
         .map(|agg| pretty_display_agg_desc(agg, metadata))
         .collect::<Vec<_>>()
         .join(", ");
+
+    let mut children = vec![
+        FormatTreeNode::new(format!("group by: [{group_by}]")),
+        FormatTreeNode::new(format!("aggregate functions: [{agg_funcs}]")),
+    ];
+
+    if let Some(info) = &plan.stat_info {
+        let items = plan_stats_info_to_format_tree(info);
+        children.extend(items);
+    }
+
+    children.push(to_format_tree(&plan.input, metadata)?);
+
     Ok(FormatTreeNode::with_children(
         "AggregateFinal".to_string(),
-        vec![
-            FormatTreeNode::new(format!("group by: [{group_by}]")),
-            FormatTreeNode::new(format!("aggregate functions: [{agg_funcs}]")),
-            to_format_tree(&plan.input, metadata)?,
-        ],
+        children,
     ))
 }
 
@@ -315,22 +363,37 @@ fn sort_to_format_tree(plan: &Sort, metadata: &MetadataRef) -> Result<FormatTree
         })
         .collect::<Result<Vec<_>>>()?
         .join(", ");
-    Ok(FormatTreeNode::with_children("Sort".to_string(), vec![
-        FormatTreeNode::new(format!("sort keys: [{sort_keys}]")),
-        to_format_tree(&plan.input, metadata)?,
-    ]))
+
+    let mut children = vec![FormatTreeNode::new(format!("sort keys: [{sort_keys}]"))];
+
+    if let Some(info) = &plan.stat_info {
+        let items = plan_stats_info_to_format_tree(info);
+        children.extend(items);
+    }
+
+    children.push(to_format_tree(&plan.input, metadata)?);
+
+    Ok(FormatTreeNode::with_children("Sort".to_string(), children))
 }
 
 fn limit_to_format_tree(plan: &Limit, metadata: &MetadataRef) -> Result<FormatTreeNode<String>> {
-    Ok(FormatTreeNode::with_children("Limit".to_string(), vec![
+    let mut children = vec![
         FormatTreeNode::new(format!(
             "limit: {}",
             plan.limit
                 .map_or("NONE".to_string(), |limit| limit.to_string())
         )),
         FormatTreeNode::new(format!("offset: {}", plan.offset)),
-        to_format_tree(&plan.input, metadata)?,
-    ]))
+    ];
+
+    if let Some(info) = &plan.stat_info {
+        let items = plan_stats_info_to_format_tree(info);
+        children.extend(items);
+    }
+
+    children.push(to_format_tree(&plan.input, metadata)?);
+
+    Ok(FormatTreeNode::with_children("Limit".to_string(), children))
 }
 
 fn hash_join_to_format_tree(
@@ -362,14 +425,25 @@ fn hash_join_to_format_tree(
     build_child.payload = format!("{}(Build)", build_child.payload);
     probe_child.payload = format!("{}(Probe)", probe_child.payload);
 
-    Ok(FormatTreeNode::with_children("HashJoin".to_string(), vec![
+    let mut children = vec![
         FormatTreeNode::new(format!("join type: {}", plan.join_type)),
         FormatTreeNode::new(format!("build keys: [{build_keys}]")),
         FormatTreeNode::new(format!("probe keys: [{probe_keys}]")),
         FormatTreeNode::new(format!("filters: [{filters}]")),
-        build_child,
-        probe_child,
-    ]))
+    ];
+
+    if let Some(info) = &plan.stat_info {
+        let items = plan_stats_info_to_format_tree(info);
+        children.extend(items);
+    }
+
+    children.push(build_child);
+    children.push(probe_child);
+
+    Ok(FormatTreeNode::with_children(
+        "HashJoin".to_string(),
+        children,
+    ))
 }
 
 fn exchange_to_format_tree(
@@ -398,8 +472,27 @@ fn union_all_to_format_tree(
     plan: &UnionAll,
     metadata: &MetadataRef,
 ) -> Result<FormatTreeNode<String>> {
-    Ok(FormatTreeNode::with_children("UnionAll".to_string(), vec![
+    let mut children = vec![];
+
+    if let Some(info) = &plan.stat_info {
+        let items = plan_stats_info_to_format_tree(info);
+        children.extend(items);
+    }
+
+    children.extend(vec![
         to_format_tree(&plan.left, metadata)?,
         to_format_tree(&plan.right, metadata)?,
-    ]))
+    ]);
+
+    Ok(FormatTreeNode::with_children(
+        "UnionAll".to_string(),
+        children,
+    ))
+}
+
+fn plan_stats_info_to_format_tree(info: &PlanStatsInfo) -> Vec<FormatTreeNode<String>> {
+    vec![FormatTreeNode::new(format!(
+        "estimated rows: {0:.2}",
+        info.estimated_rows
+    ))]
 }

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -25,6 +25,7 @@ use common_meta_app::schema::TableInfo;
 
 use super::AggregateFunctionDesc;
 use super::SortDesc;
+use crate::executor::explain::PlanStatsInfo;
 use crate::executor::PhysicalScalar;
 use crate::optimizer::ColumnSet;
 use crate::plans::JoinType;
@@ -40,6 +41,7 @@ pub struct TableScan {
 
     /// Only used for display
     pub table_index: IndexType,
+    pub stat_info: Option<PlanStatsInfo>,
 }
 
 impl TableScan {
@@ -59,6 +61,9 @@ impl TableScan {
 pub struct Filter {
     pub input: Box<PhysicalPlan>,
     pub predicates: Vec<PhysicalScalar>,
+
+    /// Only used for explain
+    pub stat_info: Option<PlanStatsInfo>,
 }
 
 impl Filter {
@@ -74,6 +79,7 @@ pub struct Project {
 
     /// Only used for display
     pub columns: ColumnSet,
+    pub stat_info: Option<PlanStatsInfo>,
 }
 
 impl Project {
@@ -91,6 +97,9 @@ impl Project {
 pub struct EvalScalar {
     pub input: Box<PhysicalPlan>,
     pub scalars: Vec<(PhysicalScalar, IndexType)>,
+
+    /// Only used for explain
+    pub stat_info: Option<PlanStatsInfo>,
 }
 
 impl EvalScalar {
@@ -111,6 +120,9 @@ pub struct AggregatePartial {
     pub input: Box<PhysicalPlan>,
     pub group_by: Vec<IndexType>,
     pub agg_funcs: Vec<AggregateFunctionDesc>,
+
+    /// Only used for explain
+    pub stat_info: Option<PlanStatsInfo>,
 }
 
 impl AggregatePartial {
@@ -148,6 +160,9 @@ pub struct AggregateFinal {
     pub group_by: Vec<IndexType>,
     pub agg_funcs: Vec<AggregateFunctionDesc>,
     pub before_group_by_schema: DataSchemaRef,
+
+    /// Only used for explain
+    pub stat_info: Option<PlanStatsInfo>,
 }
 
 impl AggregateFinal {
@@ -175,6 +190,9 @@ pub struct Sort {
     pub order_by: Vec<SortDesc>,
     // limit = Limit.limit + Limit.offset
     pub limit: Option<usize>,
+
+    /// Only used for explain
+    pub stat_info: Option<PlanStatsInfo>,
 }
 
 impl Sort {
@@ -188,6 +206,9 @@ pub struct Limit {
     pub input: Box<PhysicalPlan>,
     pub limit: Option<usize>,
     pub offset: usize,
+
+    /// Only used for explain
+    pub stat_info: Option<PlanStatsInfo>,
 }
 
 impl Limit {
@@ -206,6 +227,9 @@ pub struct HashJoin {
     pub join_type: JoinType,
     pub marker_index: Option<IndexType>,
     pub from_correlated_subquery: bool,
+
+    /// Only used for explain
+    pub stat_info: Option<PlanStatsInfo>,
 }
 
 impl HashJoin {
@@ -356,6 +380,9 @@ pub struct UnionAll {
     pub right: Box<PhysicalPlan>,
     pub pairs: Vec<(String, String)>,
     pub schema: DataSchemaRef,
+
+    /// Only used for explain
+    pub stat_info: Option<PlanStatsInfo>,
 }
 
 impl UnionAll {

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -42,6 +42,7 @@ use super::HashJoin;
 use super::Limit;
 use super::Sort;
 use super::TableScan;
+use crate::executor::explain::PlanStatsInfo;
 use crate::executor::table_read_plan::ToReadDataSourcePlan;
 use crate::executor::EvalScalar;
 use crate::executor::FragmentKind;
@@ -50,6 +51,7 @@ use crate::executor::PhysicalScalar;
 use crate::executor::SortDesc;
 use crate::executor::UnionAll;
 use crate::optimizer::ColumnSet;
+use crate::optimizer::RelExpr;
 use crate::optimizer::SExpr;
 use crate::plans::AggregateMode;
 use crate::plans::AndExpr;
@@ -125,6 +127,9 @@ impl PhysicalPlanBuilder {
 
     #[async_recursion::async_recursion]
     pub async fn build(&self, s_expr: &SExpr) -> Result<PhysicalPlan> {
+        // Build stat info
+        let stat_info = self.build_plan_stat_info(s_expr)?;
+
         match s_expr.plan() {
             RelOperator::Scan(scan) => {
                 let mut has_inner_column = false;
@@ -166,10 +171,13 @@ impl PhysicalPlanBuilder {
                         Some(push_downs),
                     )
                     .await?;
+
                 Ok(PhysicalPlan::TableScan(TableScan {
                     name_mapping,
                     source: Box::new(source),
                     table_index: scan.table_index,
+
+                    stat_info: Some(stat_info),
                 }))
             }
             RelOperator::DummyTableScan(_) => {
@@ -185,6 +193,10 @@ impl PhysicalPlanBuilder {
                     name_mapping: BTreeMap::from([("dummy".to_string(), DUMMY_COLUMN_INDEX)]),
                     source: Box::new(source),
                     table_index: DUMMY_TABLE_INDEX,
+
+                    stat_info: Some(PlanStatsInfo {
+                        estimated_rows: 1.0,
+                    }),
                 }))
             }
             RelOperator::Join(join) => {
@@ -224,6 +236,8 @@ impl PhysicalPlanBuilder {
                         .collect::<Result<_>>()?,
                     marker_index: join.marker_index,
                     from_correlated_subquery: join.from_correlated_subquery,
+
+                    stat_info: Some(stat_info),
                 }))
             }
 
@@ -238,6 +252,8 @@ impl PhysicalPlanBuilder {
                         .iter()
                         .map(|item| Ok((builder.build(&item.scalar)?, item.index)))
                         .collect::<Result<_>>()?,
+
+                    stat_info: Some(stat_info),
                 }))
             }
 
@@ -252,6 +268,8 @@ impl PhysicalPlanBuilder {
                         .iter()
                         .map(|scalar| builder.build(scalar))
                         .collect::<Result<_>>()?,
+
+                    stat_info: Some(stat_info),
                 }))
             }
             RelOperator::Aggregate(agg) => {
@@ -303,6 +321,7 @@ impl PhysicalPlanBuilder {
                                     input,
                                     agg_funcs,
                                     group_by: group_items,
+                                    stat_info: Some(stat_info),
                                 };
 
                                 let group_by_key_index =
@@ -332,6 +351,8 @@ impl PhysicalPlanBuilder {
                                 agg_funcs,
                                 group_by: group_items,
                                 input: Box::new(input),
+
+                                stat_info: Some(stat_info),
                             }),
                         }
                     }
@@ -398,6 +419,8 @@ impl PhysicalPlanBuilder {
                                     group_by: group_items,
                                     agg_funcs,
                                     before_group_by_schema,
+
+                                    stat_info: Some(stat_info),
                                 })
                             }
 
@@ -411,6 +434,8 @@ impl PhysicalPlanBuilder {
                                     group_by: group_items,
                                     agg_funcs,
                                     before_group_by_schema,
+
+                                    stat_info: Some(stat_info),
                                 })
                             }
 
@@ -441,11 +466,15 @@ impl PhysicalPlanBuilder {
                     })
                     .collect(),
                 limit: sort.limit,
+
+                stat_info: Some(stat_info),
             })),
             RelOperator::Limit(limit) => Ok(PhysicalPlan::Limit(Limit {
                 input: Box::new(self.build(s_expr.child(0)?).await?),
                 limit: limit.limit,
                 offset: limit.offset,
+
+                stat_info: Some(stat_info),
             })),
             RelOperator::Exchange(exchange) => {
                 let input = Box::new(self.build(s_expr.child(0)?).await?);
@@ -486,6 +515,8 @@ impl PhysicalPlanBuilder {
                     right: Box::new(self.build(s_expr.child(1)?).await?),
                     pairs,
                     schema: DataSchemaRefExt::create(fields),
+
+                    stat_info: Some(stat_info),
                 }))
             }
             _ => Err(ErrorCode::Internal(format!(
@@ -615,6 +646,15 @@ impl PhysicalPlanBuilder {
             prewhere: prewhere_info,
             limit: scan.limit,
             order_by: order_by.unwrap_or_default(),
+        })
+    }
+
+    fn build_plan_stat_info(&self, s_expr: &SExpr) -> Result<PlanStatsInfo> {
+        let rel_expr = RelExpr::with_s_expr(s_expr);
+        let prop = rel_expr.derive_relational_prop()?;
+
+        Ok(PlanStatsInfo {
+            estimated_rows: prop.cardinality,
         })
     }
 }

--- a/src/query/sql/src/executor/physical_plan_visitor.rs
+++ b/src/query/sql/src/executor/physical_plan_visitor.rs
@@ -60,6 +60,7 @@ pub trait PhysicalPlanReplacer {
         Ok(PhysicalPlan::Filter(Filter {
             input: Box::new(input),
             predicates: plan.predicates.clone(),
+            stat_info: plan.stat_info.clone(),
         }))
     }
 
@@ -70,6 +71,7 @@ pub trait PhysicalPlanReplacer {
             input: Box::new(input),
             projections: plan.projections.clone(),
             columns: plan.columns.clone(),
+            stat_info: plan.stat_info.clone(),
         }))
     }
 
@@ -79,6 +81,7 @@ pub trait PhysicalPlanReplacer {
         Ok(PhysicalPlan::EvalScalar(EvalScalar {
             input: Box::new(input),
             scalars: plan.scalars.clone(),
+            stat_info: plan.stat_info.clone(),
         }))
     }
 
@@ -89,6 +92,7 @@ pub trait PhysicalPlanReplacer {
             input: Box::new(input),
             group_by: plan.group_by.clone(),
             agg_funcs: plan.agg_funcs.clone(),
+            stat_info: plan.stat_info.clone(),
         }))
     }
 
@@ -100,6 +104,7 @@ pub trait PhysicalPlanReplacer {
             before_group_by_schema: plan.before_group_by_schema.clone(),
             group_by: plan.group_by.clone(),
             agg_funcs: plan.agg_funcs.clone(),
+            stat_info: plan.stat_info.clone(),
         }))
     }
 
@@ -116,6 +121,7 @@ pub trait PhysicalPlanReplacer {
             join_type: plan.join_type.clone(),
             marker_index: plan.marker_index,
             from_correlated_subquery: plan.from_correlated_subquery,
+            stat_info: plan.stat_info.clone(),
         }))
     }
 
@@ -126,6 +132,7 @@ pub trait PhysicalPlanReplacer {
             input: Box::new(input),
             order_by: plan.order_by.clone(),
             limit: plan.limit,
+            stat_info: plan.stat_info.clone(),
         }))
     }
 
@@ -136,6 +143,7 @@ pub trait PhysicalPlanReplacer {
             input: Box::new(input),
             limit: plan.limit,
             offset: plan.offset,
+            stat_info: plan.stat_info.clone(),
         }))
     }
 
@@ -175,6 +183,7 @@ pub trait PhysicalPlanReplacer {
             right: Box::new(right),
             schema: plan.schema.clone(),
             pairs: plan.pairs.clone(),
+            stat_info: plan.stat_info.clone(),
         }))
     }
 

--- a/src/query/sql/src/planner/optimizer/property/datum.rs
+++ b/src/query/sql/src/planner/optimizer/property/datum.rs
@@ -39,8 +39,17 @@ impl Datum {
         match data_value {
             Scalar::Boolean(v) => Some(Datum::Bool(*v)),
             Scalar::Number(NumberScalar::Int64(v)) => Some(Datum::Int(*v)),
+            Scalar::Number(NumberScalar::Int32(v)) => Some(Datum::Int(*v as i64)),
+            Scalar::Number(NumberScalar::Int16(v)) => Some(Datum::Int(*v as i64)),
+            Scalar::Number(NumberScalar::Int8(v)) => Some(Datum::Int(*v as i64)),
             Scalar::Number(NumberScalar::UInt64(v)) => Some(Datum::UInt(*v)),
+            Scalar::Number(NumberScalar::UInt32(v)) => Some(Datum::UInt(*v as u64)),
+            Scalar::Number(NumberScalar::UInt16(v)) => Some(Datum::UInt(*v as u64)),
+            Scalar::Number(NumberScalar::UInt8(v)) => Some(Datum::UInt(*v as u64)),
             Scalar::Number(NumberScalar::Float64(v)) => Some(Datum::Float(*v)),
+            Scalar::Number(NumberScalar::Float32(v)) => {
+                Some(Datum::Float(F64::from(f32::from(*v) as f64)))
+            }
             Scalar::String(v) => Some(Datum::Bytes(v.clone())),
             _ => None,
         }
@@ -50,8 +59,15 @@ impl Datum {
         match data_value {
             Literal::Boolean(v) => Some(Datum::Bool(*v)),
             Literal::Int64(v) => Some(Datum::Int(*v)),
+            Literal::Int32(v) => Some(Datum::Int(*v as i64)),
+            Literal::Int16(v) => Some(Datum::Int(*v as i64)),
+            Literal::Int8(v) => Some(Datum::Int(*v as i64)),
             Literal::UInt64(v) => Some(Datum::UInt(*v)),
+            Literal::UInt32(v) => Some(Datum::UInt(*v as u64)),
+            Literal::UInt16(v) => Some(Datum::UInt(*v as u64)),
+            Literal::UInt8(v) => Some(Datum::UInt(*v as u64)),
             Literal::Float64(v) => Some(Datum::Float(*v)),
+            Literal::Float32(v) => Some(Datum::Float(F64::from(f32::from(*v) as f64))),
             Literal::String(v) => Some(Datum::Bytes(v.clone())),
             _ => None,
         }

--- a/tests/sqllogictests/suites/mode/cluster/04_0002_explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/04_0002_explain_v2.test
@@ -17,6 +17,7 @@ Exchange
 ├── exchange type: Merge
 └── Filter
     ├── filters: [gt(t1.a (#0), 0_u8)]
+    ├── estimated rows: 0.00
     └── TableScan
         ├── table: default.default.t1
         ├── read rows: 0
@@ -24,7 +25,8 @@ Exchange
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [gt(a, 0_i32)], limit: NONE]
-        └── output columns: [0]
+        ├── output columns: [0]
+        └── estimated rows: 0.00
 
 query T
 explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a and t2.a > 5 and t1.a > 1);
@@ -33,11 +35,13 @@ Exchange
 ├── exchange type: Merge
 └── Filter
     ├── filters: [or(gt(t1.a (#0), 3_u8), and(gt(t2.a (#2), 5_u8), gt(t1.a (#0), 1_u8)))]
+    ├── estimated rows: 0.00
     └── HashJoin
         ├── join type: INNER
         ├── build keys: [t2.a (#2)]
         ├── probe keys: [t1.a (#0)]
         ├── filters: []
+        ├── estimated rows: 0.00
         ├── Exchange(Build)
         │   ├── exchange type: Hash(t2.a (#2))
         │   └── TableScan
@@ -46,18 +50,21 @@ Exchange
         │       ├── read bytes: 0
         │       ├── partitions total: 0
         │       ├── partitions scanned: 0
-        │       └── push downs: [filters: [], limit: NONE]
+        │       ├── push downs: [filters: [], limit: NONE]
+        │       └── estimated rows: 0.00
         └── Exchange(Probe)
             ├── exchange type: Hash(t1.a (#0))
             └── Filter
                 ├── filters: [or(gt(t1.a (#0), 3_u8), gt(t1.a (#0), 1_u8))]
+                ├── estimated rows: 0.00
                 └── TableScan
                     ├── table: default.default.t1
                     ├── read rows: 0
                     ├── read bytes: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
-                    └── push downs: [filters: [or(gt(a, 3_i32), gt(a, 1_i32))], limit: NONE]
+                    ├── push downs: [filters: [or(gt(a, 3_i32), gt(a, 1_i32))], limit: NONE]
+                    └── estimated rows: 0.00
 
 query T
 explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a);
@@ -69,6 +76,7 @@ Exchange
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
     ├── filters: []
+    ├── estimated rows: 0.00
     ├── Exchange(Build)
     │   ├── exchange type: Hash(t2.a (#2))
     │   └── TableScan
@@ -77,7 +85,8 @@ Exchange
     │       ├── read bytes: 0
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
-    │       └── push downs: [filters: [], limit: NONE]
+    │       ├── push downs: [filters: [], limit: NONE]
+    │       └── estimated rows: 0.00
     └── Exchange(Probe)
         ├── exchange type: Hash(t1.a (#0))
         └── TableScan
@@ -86,7 +95,8 @@ Exchange
             ├── read bytes: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
-            └── push downs: [filters: [], limit: NONE]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 0.00
 
 query T
 explain raw select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a);
@@ -136,25 +146,31 @@ explain select count(1) as c, count(b) as d, max(a) as e from t1 order by c, e, 
 Limit
 ├── limit: 10
 ├── offset: 0
+├── estimated rows: 1.00
 └── Sort
     ├── sort keys: [c ASC NULLS LAST, e ASC NULLS LAST, d ASC NULLS LAST]
+    ├── estimated rows: 1.00
     └── EvalScalar
         ├── expressions: [count(1) (#8), max(a) (#10), count(b) (#9)]
+        ├── estimated rows: 1.00
         └── AggregateFinal
             ├── group by: []
             ├── aggregate functions: [count(), count(b), max(a)]
+            ├── estimated rows: 1.00
             └── Exchange
                 ├── exchange type: Merge
                 └── AggregatePartial
                     ├── group by: []
                     ├── aggregate functions: [count(), count(b), max(a)]
+                    ├── estimated rows: 1.00
                     └── TableScan
                         ├── table: default.default.t1
                         ├── read rows: 0
                         ├── read bytes: 0
                         ├── partitions total: 0
                         ├── partitions scanned: 0
-                        └── push downs: [filters: [], limit: NONE]
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 0.00
 
 query T
 explain select (t1.a + 1) as c,(t1.b+1) as d, (t2.a+1) as e from t1 join t2 on t1.a = t2.a order by c, d, e limit 10;
@@ -162,22 +178,28 @@ explain select (t1.a + 1) as c,(t1.b+1) as d, (t2.a+1) as e from t1 join t2 on t
 Limit
 ├── limit: 10
 ├── offset: 0
+├── estimated rows: 0.00
 └── Sort
     ├── sort keys: [c ASC NULLS LAST, d ASC NULLS LAST, e ASC NULLS LAST]
+    ├── estimated rows: 0.00
     └── Exchange
         ├── exchange type: Merge
         └── Limit
             ├── limit: 10
             ├── offset: 0
+            ├── estimated rows: 0.00
             └── Sort
                 ├── sort keys: [c ASC NULLS LAST, d ASC NULLS LAST, e ASC NULLS LAST]
+                ├── estimated rows: 0.00
                 └── EvalScalar
                     ├── expressions: [plus(t1.a (#0), 1_u8), plus(t1.b (#1), 1_u8), plus(t2.a (#2), 1_u8)]
+                    ├── estimated rows: 0.00
                     └── HashJoin
                         ├── join type: INNER
                         ├── build keys: [t2.a (#2)]
                         ├── probe keys: [t1.a (#0)]
                         ├── filters: []
+                        ├── estimated rows: 0.00
                         ├── Exchange(Build)
                         │   ├── exchange type: Hash(t2.a (#2))
                         │   └── TableScan
@@ -187,7 +209,8 @@ Limit
                         │       ├── partitions total: 0
                         │       ├── partitions scanned: 0
                         │       ├── push downs: [filters: [], limit: NONE]
-                        │       └── output columns: [0]
+                        │       ├── output columns: [0]
+                        │       └── estimated rows: 0.00
                         └── Exchange(Probe)
                             ├── exchange type: Hash(t1.a (#0))
                             └── TableScan
@@ -196,7 +219,8 @@ Limit
                                 ├── read bytes: 0
                                 ├── partitions total: 0
                                 ├── partitions scanned: 0
-                                └── push downs: [filters: [], limit: NONE]
+                                ├── push downs: [filters: [], limit: NONE]
+                                └── estimated rows: 0.00
 
 statement ok
 set prefer_broadcast_join = 1;
@@ -211,6 +235,7 @@ Exchange
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
     ├── filters: []
+    ├── estimated rows: 0.00
     ├── Exchange(Build)
     │   ├── exchange type: Broadcast
     │   └── TableScan
@@ -219,7 +244,8 @@ Exchange
     │       ├── read bytes: 0
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
-    │       └── push downs: [filters: [], limit: NONE]
+    │       ├── push downs: [filters: [], limit: NONE]
+    │       └── estimated rows: 0.00
     └── Exchange(Probe)
         ├── exchange type: Init-Partition
         └── TableScan
@@ -228,7 +254,8 @@ Exchange
             ├── read bytes: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
-            └── push downs: [filters: [], limit: NONE]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 0.00
 
 statement ok
 set prefer_broadcast_join = 0;
@@ -239,22 +266,27 @@ explain select * from (SELECT number AS a FROM numbers(10)) x  order by x.a limi
 Limit
 ├── limit: 3
 ├── offset: 0
+├── estimated rows: 3.00
 └── Sort
     ├── sort keys: [number ASC NULLS LAST]
+    ├── estimated rows: 3.00
     └── Exchange
         ├── exchange type: Merge
         └── Limit
             ├── limit: 3
             ├── offset: 0
+            ├── estimated rows: 3.00
             └── Sort
                 ├── sort keys: [number ASC NULLS LAST]
+                ├── estimated rows: 10.00
                 └── TableScan
                     ├── table: default.system.numbers
                     ├── read rows: 10
                     ├── read bytes: 80
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    └── push downs: [filters: [], limit: 3]
+                    ├── push downs: [filters: [], limit: 3]
+                    └── estimated rows: 10.00
 
 query T
 explain select * from (SELECT number AS a FROM numbers(10)) x right join (SELECT number AS a FROM numbers(5)) y using(a) order by x.a limit 3;
@@ -262,20 +294,25 @@ explain select * from (SELECT number AS a FROM numbers(10)) x right join (SELECT
 Limit
 ├── limit: 3
 ├── offset: 0
+├── estimated rows: 3.00
 └── Sort
     ├── sort keys: [number ASC NULLS LAST]
+    ├── estimated rows: 3.00
     └── Exchange
         ├── exchange type: Merge
         └── Limit
             ├── limit: 3
             ├── offset: 0
+            ├── estimated rows: 3.00
             └── Sort
                 ├── sort keys: [number ASC NULLS LAST]
+                ├── estimated rows: 10.00
                 └── HashJoin
                     ├── join type: RIGHT OUTER
                     ├── build keys: [CAST(y.a (#1) AS BIGINT UNSIGNED NULL)]
                     ├── probe keys: [CAST(x.a (#0) AS BIGINT UNSIGNED NULL)]
                     ├── filters: []
+                    ├── estimated rows: 10.00
                     ├── Exchange(Build)
                     │   ├── exchange type: Hash(CAST(y.a (#1) AS BIGINT UNSIGNED NULL))
                     │   └── TableScan
@@ -284,7 +321,8 @@ Limit
                     │       ├── read bytes: 40
                     │       ├── partitions total: 1
                     │       ├── partitions scanned: 1
-                    │       └── push downs: [filters: [], limit: NONE]
+                    │       ├── push downs: [filters: [], limit: NONE]
+                    │       └── estimated rows: 5.00
                     └── Exchange(Probe)
                         ├── exchange type: Hash(CAST(x.a (#0) AS BIGINT UNSIGNED NULL))
                         └── TableScan
@@ -293,7 +331,8 @@ Limit
                             ├── read bytes: 80
                             ├── partitions total: 1
                             ├── partitions scanned: 1
-                            └── push downs: [filters: [], limit: NONE]
+                            ├── push downs: [filters: [], limit: NONE]
+                            └── estimated rows: 10.00
 
 statement ok
 drop table t1;

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -8,6 +8,7 @@ Exchange
     ├── build keys: [t.number (#0)]
     ├── probe keys: [t1.number (#1)]
     ├── filters: []
+    ├── estimated rows: 2.00
     ├── Exchange(Build)
     │   ├── exchange type: Hash(t.number (#0))
     │   └── TableScan
@@ -16,7 +17,8 @@ Exchange
     │       ├── read bytes: 8
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       └── push downs: [filters: [], limit: NONE]
+    │       ├── push downs: [filters: [], limit: NONE]
+    │       └── estimated rows: 1.00
     └── Exchange(Probe)
         ├── exchange type: Hash(t1.number (#1))
         └── TableScan
@@ -25,7 +27,8 @@ Exchange
             ├── read bytes: 16
             ├── partitions total: 1
             ├── partitions scanned: 1
-            └── push downs: [filters: [], limit: NONE]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 2.00
 
 query T
 explain select * from numbers(1) t, numbers(2) t1, numbers(3) t2 where t.number = t1.number and t.number = t2.number
@@ -37,6 +40,7 @@ Exchange
     ├── build keys: [t.number (#0)]
     ├── probe keys: [t2.number (#2)]
     ├── filters: []
+    ├── estimated rows: 3.00
     ├── Exchange(Build)
     │   ├── exchange type: Hash(t.number (#0))
     │   └── HashJoin
@@ -44,6 +48,7 @@ Exchange
     │       ├── build keys: [t.number (#0)]
     │       ├── probe keys: [t1.number (#1)]
     │       ├── filters: []
+    │       ├── estimated rows: 2.00
     │       ├── Exchange(Build)
     │       │   ├── exchange type: Hash(t.number (#0))
     │       │   └── TableScan
@@ -52,7 +57,8 @@ Exchange
     │       │       ├── read bytes: 8
     │       │       ├── partitions total: 1
     │       │       ├── partitions scanned: 1
-    │       │       └── push downs: [filters: [], limit: NONE]
+    │       │       ├── push downs: [filters: [], limit: NONE]
+    │       │       └── estimated rows: 1.00
     │       └── Exchange(Probe)
     │           ├── exchange type: Hash(t1.number (#1))
     │           └── TableScan
@@ -61,7 +67,8 @@ Exchange
     │               ├── read bytes: 16
     │               ├── partitions total: 1
     │               ├── partitions scanned: 1
-    │               └── push downs: [filters: [], limit: NONE]
+    │               ├── push downs: [filters: [], limit: NONE]
+    │               └── estimated rows: 2.00
     └── Exchange(Probe)
         ├── exchange type: Hash(t2.number (#2))
         └── TableScan
@@ -70,7 +77,8 @@ Exchange
             ├── read bytes: 24
             ├── partitions total: 1
             ├── partitions scanned: 1
-            └── push downs: [filters: [], limit: NONE]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 3.00
 
 query T
 explain select * from (select number as a, number+1 as b from numbers(1)) t, numbers(2) t1, numbers(3) t2 where a = t1.number and b = t2.number
@@ -82,6 +90,7 @@ Exchange
     ├── build keys: [t.b (#1)]
     ├── probe keys: [t2.number (#4)]
     ├── filters: []
+    ├── estimated rows: 3.00
     ├── Exchange(Build)
     │   ├── exchange type: Hash(t.b (#1))
     │   └── HashJoin
@@ -89,17 +98,20 @@ Exchange
     │       ├── build keys: [t.a (#0)]
     │       ├── probe keys: [t1.number (#3)]
     │       ├── filters: []
+    │       ├── estimated rows: 2.00
     │       ├── Exchange(Build)
     │       │   ├── exchange type: Hash(t.a (#0))
     │       │   └── EvalScalar
     │       │       ├── expressions: [plus(numbers.number (#0), 1_u8)]
+    │       │       ├── estimated rows: 1.00
     │       │       └── TableScan
     │       │           ├── table: default.system.numbers
     │       │           ├── read rows: 1
     │       │           ├── read bytes: 8
     │       │           ├── partitions total: 1
     │       │           ├── partitions scanned: 1
-    │       │           └── push downs: [filters: [], limit: NONE]
+    │       │           ├── push downs: [filters: [], limit: NONE]
+    │       │           └── estimated rows: 1.00
     │       └── Exchange(Probe)
     │           ├── exchange type: Hash(t1.number (#3))
     │           └── TableScan
@@ -108,7 +120,8 @@ Exchange
     │               ├── read bytes: 16
     │               ├── partitions total: 1
     │               ├── partitions scanned: 1
-    │               └── push downs: [filters: [], limit: NONE]
+    │               ├── push downs: [filters: [], limit: NONE]
+    │               └── estimated rows: 2.00
     └── Exchange(Probe)
         ├── exchange type: Hash(t2.number (#4))
         └── TableScan
@@ -117,7 +130,8 @@ Exchange
             ├── read bytes: 24
             ├── partitions total: 1
             ├── partitions scanned: 1
-            └── push downs: [filters: [], limit: NONE]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 3.00
 
 query T
 explain select * from (select sum(number) as number from numbers(1) group by number) t, numbers(2) t1 where t.number = t1.number
@@ -129,25 +143,30 @@ Exchange
     ├── build keys: [CAST(t.number (#1) AS BIGINT UNSIGNED NULL)]
     ├── probe keys: [CAST(t1.number (#4) AS BIGINT UNSIGNED NULL)]
     ├── filters: []
+    ├── estimated rows: 2.00
     ├── Exchange(Build)
     │   ├── exchange type: Hash(CAST(t.number (#1) AS BIGINT UNSIGNED NULL))
     │   └── EvalScalar
     │       ├── expressions: [sum(number) (#3)]
+    │       ├── estimated rows: 1.00
     │       └── AggregateFinal
     │           ├── group by: [number]
     │           ├── aggregate functions: [sum(number)]
+    │           ├── estimated rows: 1.00
     │           └── Exchange
     │               ├── exchange type: Hash(_group_by_key)
     │               └── AggregatePartial
     │                   ├── group by: [number]
     │                   ├── aggregate functions: [sum(number)]
+    │                   ├── estimated rows: 1.00
     │                   └── TableScan
     │                       ├── table: default.system.numbers
     │                       ├── read rows: 1
     │                       ├── read bytes: 8
     │                       ├── partitions total: 1
     │                       ├── partitions scanned: 1
-    │                       └── push downs: [filters: [], limit: NONE]
+    │                       ├── push downs: [filters: [], limit: NONE]
+    │                       └── estimated rows: 1.00
     └── Exchange(Probe)
         ├── exchange type: Hash(CAST(t1.number (#4) AS BIGINT UNSIGNED NULL))
         └── TableScan
@@ -156,4 +175,5 @@ Exchange
             ├── read bytes: 16
             ├── partitions total: 1
             ├── partitions scanned: 1
-            └── push downs: [filters: [], limit: NONE]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 2.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -15,6 +15,7 @@ explain select t1.a from t1 where a > 0
 ----
 Filter
 ├── filters: [gt(t1.a (#0), 0_u8)]
+├── estimated rows: 0.00
 └── TableScan
     ├── table: default.default.t1
     ├── read rows: 0
@@ -22,34 +23,40 @@ Filter
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [gt(a, 0_i32)], limit: NONE]
-    └── output columns: [0]
+    ├── output columns: [0]
+    └── estimated rows: 0.00
 
 query T
 explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a and t2.a > 5 and t1.a > 1)
 ----
 Filter
 ├── filters: [or(gt(t1.a (#0), 3_u8), and(gt(t2.a (#2), 5_u8), gt(t1.a (#0), 1_u8)))]
+├── estimated rows: 0.00
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
     ├── filters: []
+    ├── estimated rows: 0.00
     ├── TableScan(Build)
     │   ├── table: default.default.t2
     │   ├── read rows: 0
     │   ├── read bytes: 0
     │   ├── partitions total: 0
     │   ├── partitions scanned: 0
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 0.00
     └── Filter(Probe)
         ├── filters: [or(gt(t1.a (#0), 3_u8), gt(t1.a (#0), 1_u8))]
+        ├── estimated rows: 0.00
         └── TableScan
             ├── table: default.default.t1
             ├── read rows: 0
             ├── read bytes: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
-            └── push downs: [filters: [or(gt(a, 3_i32), gt(a, 1_i32))], limit: NONE]
+            ├── push downs: [filters: [or(gt(a, 3_i32), gt(a, 1_i32))], limit: NONE]
+            └── estimated rows: 0.00
 
 query T
 explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a)
@@ -59,20 +66,23 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
+├── estimated rows: 0.00
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── read rows: 0
 │   ├── read bytes: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 0.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── read rows: 0
     ├── read bytes: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 0.00
 
 query T
 explain raw select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a)
@@ -506,6 +516,7 @@ query T
 explain select a from t1 UNION ALL select a from t2
 ----
 UnionAll
+├── estimated rows: 0.00
 ├── TableScan
 │   ├── table: default.default.t1
 │   ├── read rows: 0
@@ -513,7 +524,8 @@ UnionAll
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
-│   └── output columns: [0]
+│   ├── output columns: [0]
+│   └── estimated rows: 0.00
 └── TableScan
     ├── table: default.default.t2
     ├── read rows: 0
@@ -521,63 +533,75 @@ UnionAll
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
-    └── output columns: [0]
+    ├── output columns: [0]
+    └── estimated rows: 0.00
 
 query T
 explain select * from t1,t2 where (t1.a > 1 and t2.a > 2) or (t1.b < 3 and t2.b < 4)
 ----
 Filter
 ├── filters: [or(and(gt(t1.a (#0), 1_u8), gt(t2.a (#2), 2_u8)), and(lt(t1.b (#1), 3_u8), lt(t2.b (#3), 4_u8)))]
+├── estimated rows: 0.00
 └── HashJoin
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
+    ├── estimated rows: 0.00
     ├── Filter(Build)
     │   ├── filters: [or(gt(t2.a (#2), 2_u8), lt(t2.b (#3), 4_u8))]
+    │   ├── estimated rows: 0.00
     │   └── TableScan
     │       ├── table: default.default.t2
     │       ├── read rows: 0
     │       ├── read bytes: 0
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
-    │       └── push downs: [filters: [or(gt(a, 2_i32), lt(b, 4_i32))], limit: NONE]
+    │       ├── push downs: [filters: [or(gt(a, 2_i32), lt(b, 4_i32))], limit: NONE]
+    │       └── estimated rows: 0.00
     └── Filter(Probe)
         ├── filters: [or(gt(t1.a (#0), 1_u8), lt(t1.b (#1), 3_u8))]
+        ├── estimated rows: 0.00
         └── TableScan
             ├── table: default.default.t1
             ├── read rows: 0
             ├── read bytes: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
-            └── push downs: [filters: [or(gt(a, 1_i32), lt(b, 3_i32))], limit: NONE]
+            ├── push downs: [filters: [or(gt(a, 1_i32), lt(b, 3_i32))], limit: NONE]
+            └── estimated rows: 0.00
 
 query T
 explain select * from t1,t2 where (t1.a > 1 and t2.a > 2) or (t1.b < 3 and t2.b < 4) or t1.a = 2
 ----
 Filter
 ├── filters: [or(or(and(gt(t1.a (#0), 1_u8), gt(t2.a (#2), 2_u8)), and(lt(t1.b (#1), 3_u8), lt(t2.b (#3), 4_u8))), eq(t1.a (#0), 2_u8))]
+├── estimated rows: 0.00
 └── HashJoin
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
+    ├── estimated rows: 0.00
     ├── TableScan(Build)
     │   ├── table: default.default.t2
     │   ├── read rows: 0
     │   ├── read bytes: 0
     │   ├── partitions total: 0
     │   ├── partitions scanned: 0
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 0.00
     └── Filter(Probe)
         ├── filters: [or(gt(t1.a (#0), 1_u8), or(lt(t1.b (#1), 3_u8), eq(t1.a (#0), 2_u8)))]
+        ├── estimated rows: 0.00
         └── TableScan
             ├── table: default.default.t1
             ├── read rows: 0
             ├── read bytes: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
-            └── push downs: [filters: [or(gt(a, 1_i32), or(lt(b, 3_i32), eq(a, 2_i32)))], limit: NONE]
+            ├── push downs: [filters: [or(gt(a, 1_i32), or(lt(b, 3_i32), eq(a, 2_i32)))], limit: NONE]
+            └── estimated rows: 0.00
 
 statement ok
 drop table if exists t3
@@ -590,37 +614,43 @@ explain select * from t1,t2, t3 where (t1.a > 1 and t2.a > 2) or (t1.b < 3 and t
 ----
 Filter
 ├── filters: [or(or(and(gt(t1.a (#0), 1_u8), gt(t2.a (#2), 2_u8)), and(lt(t1.b (#1), 3_u8), lt(t2.b (#3), 4_u8))), eq(t3.a (#4), 2_u8))]
+├── estimated rows: 0.00
 └── HashJoin
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
+    ├── estimated rows: 0.00
     ├── TableScan(Build)
     │   ├── table: default.default.t3
     │   ├── read rows: 0
     │   ├── read bytes: 0
     │   ├── partitions total: 0
     │   ├── partitions scanned: 0
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 0.00
     └── HashJoin(Probe)
         ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
         ├── filters: []
+        ├── estimated rows: 0.00
         ├── TableScan(Build)
         │   ├── table: default.default.t2
         │   ├── read rows: 0
         │   ├── read bytes: 0
         │   ├── partitions total: 0
         │   ├── partitions scanned: 0
-        │   └── push downs: [filters: [], limit: NONE]
+        │   ├── push downs: [filters: [], limit: NONE]
+        │   └── estimated rows: 0.00
         └── TableScan(Probe)
             ├── table: default.default.t1
             ├── read rows: 0
             ├── read bytes: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
-            └── push downs: [filters: [], limit: NONE]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 0.00
 
 query T
 explain select * from t1,t2, t3 where ((t1.a > 1 and t2.a > 2) or (t1.b < 3 and t2.b < 4)) and t3.a > 1
@@ -630,69 +660,84 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: []
+├── estimated rows: 0.00
 ├── Filter(Build)
 │   ├── filters: [gt(t3.a (#4), 1_u8)]
+│   ├── estimated rows: 0.00
 │   └── TableScan
 │       ├── table: default.default.t3
 │       ├── read rows: 0
 │       ├── read bytes: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
-│       └── push downs: [filters: [gt(a, 1_i32)], limit: NONE]
+│       ├── push downs: [filters: [gt(a, 1_i32)], limit: NONE]
+│       └── estimated rows: 0.00
 └── Filter(Probe)
     ├── filters: [or(and(gt(t1.a (#0), 1_u8), gt(t2.a (#2), 2_u8)), and(lt(t1.b (#1), 3_u8), lt(t2.b (#3), 4_u8)))]
+    ├── estimated rows: 0.00
     └── HashJoin
         ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
         ├── filters: []
+        ├── estimated rows: 0.00
         ├── Filter(Build)
         │   ├── filters: [or(gt(t2.a (#2), 2_u8), lt(t2.b (#3), 4_u8))]
+        │   ├── estimated rows: 0.00
         │   └── TableScan
         │       ├── table: default.default.t2
         │       ├── read rows: 0
         │       ├── read bytes: 0
         │       ├── partitions total: 0
         │       ├── partitions scanned: 0
-        │       └── push downs: [filters: [or(gt(a, 2_i32), lt(b, 4_i32))], limit: NONE]
+        │       ├── push downs: [filters: [or(gt(a, 2_i32), lt(b, 4_i32))], limit: NONE]
+        │       └── estimated rows: 0.00
         └── Filter(Probe)
             ├── filters: [or(gt(t1.a (#0), 1_u8), lt(t1.b (#1), 3_u8))]
+            ├── estimated rows: 0.00
             └── TableScan
                 ├── table: default.default.t1
                 ├── read rows: 0
                 ├── read bytes: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
-                └── push downs: [filters: [or(gt(a, 1_i32), lt(b, 3_i32))], limit: NONE]
+                ├── push downs: [filters: [or(gt(a, 1_i32), lt(b, 3_i32))], limit: NONE]
+                └── estimated rows: 0.00
 
 query T
 explain select * from t1,t2 where ((t1.a > 1 or t1.b < 2) and t2.a > 2) or (t1.b < 3 and t2.b < 4)
 ----
 Filter
 ├── filters: [or(and(or(gt(t1.a (#0), 1_u8), lt(t1.b (#1), 2_u8)), gt(t2.a (#2), 2_u8)), and(lt(t1.b (#1), 3_u8), lt(t2.b (#3), 4_u8)))]
+├── estimated rows: 0.00
 └── HashJoin
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
+    ├── estimated rows: 0.00
     ├── Filter(Build)
     │   ├── filters: [or(gt(t2.a (#2), 2_u8), lt(t2.b (#3), 4_u8))]
+    │   ├── estimated rows: 0.00
     │   └── TableScan
     │       ├── table: default.default.t2
     │       ├── read rows: 0
     │       ├── read bytes: 0
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
-    │       └── push downs: [filters: [or(gt(a, 2_i32), lt(b, 4_i32))], limit: NONE]
+    │       ├── push downs: [filters: [or(gt(a, 2_i32), lt(b, 4_i32))], limit: NONE]
+    │       └── estimated rows: 0.00
     └── Filter(Probe)
         ├── filters: [or(or(gt(t1.a (#0), 1_u8), lt(t1.b (#1), 2_u8)), lt(t1.b (#1), 3_u8))]
+        ├── estimated rows: 0.00
         └── TableScan
             ├── table: default.default.t1
             ├── read rows: 0
             ├── read bytes: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
-            └── push downs: [filters: [or(or(gt(a, 1_i32), lt(b, 2_i32)), lt(b, 3_i32))], limit: NONE]
+            ├── push downs: [filters: [or(or(gt(a, 1_i32), lt(b, 2_i32)), lt(b, 3_i32))], limit: NONE]
+            └── estimated rows: 0.00
 
 query T
 explain select * from t1,t2 where (t1.a > 1 or t1.b < 2) and (t1.a > 1 or t1.b < 2)
@@ -702,22 +747,26 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: []
+├── estimated rows: 0.00
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── read rows: 0
 │   ├── read bytes: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 0.00
 └── Filter(Probe)
     ├── filters: [or(gt(t1.a (#0), 1_u8), lt(t1.b (#1), 2_u8))]
+    ├── estimated rows: 0.00
     └── TableScan
         ├── table: default.default.t1
         ├── read rows: 0
         ├── read bytes: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
-        └── push downs: [filters: [or(gt(a, 1_i32), lt(b, 2_i32))], limit: NONE]
+        ├── push downs: [filters: [or(gt(a, 1_i32), lt(b, 2_i32))], limit: NONE]
+        └── estimated rows: 0.00
 
 statement ok
 drop table t1

--- a/tests/sqllogictests/suites/mode/standalone/explain/fold_count.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/fold_count.test
@@ -9,8 +9,10 @@ explain select count(*) from t
 ----
 EvalScalar
 ├── expressions: [COUNT(*) (#2)]
+├── estimated rows: 1.00
 └── EvalScalar
     ├── expressions: [1000_u64]
+    ├── estimated rows: 1.00
     └── DummyTableScan
 
 statement ok
@@ -21,8 +23,10 @@ explain select count(*) from t
 ----
 EvalScalar
 ├── expressions: [COUNT(*) (#2)]
+├── estimated rows: 1.00
 └── EvalScalar
     ├── expressions: [1001_u64]
+    ├── estimated rows: 1.00
     └── DummyTableScan
 
 query T
@@ -30,21 +34,26 @@ explain select count(*) from t where number > 10
 ----
 EvalScalar
 ├── expressions: [COUNT(*) (#2)]
+├── estimated rows: 1.00
 └── AggregateFinal
     ├── group by: []
     ├── aggregate functions: [count()]
+    ├── estimated rows: 1.00
     └── AggregatePartial
         ├── group by: []
         ├── aggregate functions: [count()]
+        ├── estimated rows: 1.00
         └── Filter
             ├── filters: [gt(t.number (#0), 10_u8)]
+            ├── estimated rows: 980.98
             └── TableScan
                 ├── table: default.default.t
                 ├── read rows: 1000
                 ├── read bytes: 4028
                 ├── partitions total: 2
                 ├── partitions scanned: 1
-                └── push downs: [filters: [gt(number, 10_u64)], limit: NONE]
+                ├── push downs: [filters: [gt(number, 10_u64)], limit: NONE]
+                └── estimated rows: 1001.00
 
 statement ok
 drop table t

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -6,20 +6,23 @@ HashJoin
 ├── build keys: [t1.number (#1)]
 ├── probe keys: [t.number (#0)]
 ├── filters: []
+├── estimated rows: 1.00
 ├── TableScan(Build)
 │   ├── table: default.system.numbers
 │   ├── read rows: 1
 │   ├── read bytes: 8
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = t1.number and t.number = t1.number + 1
@@ -29,20 +32,23 @@ HashJoin
 ├── build keys: [t1.number (#1), plus(t1.number (#1), 1_u8)]
 ├── probe keys: [t.number (#0), t.number (#0)]
 ├── filters: []
+├── estimated rows: 1.00
 ├── TableScan(Build)
 │   ├── table: default.system.numbers
 │   ├── read rows: 1
 │   ├── read bytes: 8
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number > 1 and 1 < t1.number
@@ -52,49 +58,58 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: []
+├── estimated rows: 0.11
 ├── Filter(Build)
 │   ├── filters: [lt(1_u8, t1.number (#1))]
+│   ├── estimated rows: 0.33
 │   └── TableScan
 │       ├── table: default.system.numbers
 │       ├── read rows: 1
 │       ├── read bytes: 8
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [lt(1_u64, number)], limit: NONE]
+│       ├── push downs: [filters: [lt(1_u64, number)], limit: NONE]
+│       └── estimated rows: 1.00
 └── Filter(Probe)
     ├── filters: [gt(t.number (#0), 1_u8)]
+    ├── estimated rows: 0.33
     └── TableScan
         ├── table: default.system.numbers
         ├── read rows: 1
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [gt(number, 1_u64)], limit: NONE]
+        ├── push downs: [filters: [gt(number, 1_u64)], limit: NONE]
+        └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number + t1.number = 1
 ----
 Filter
 ├── filters: [eq(plus(t.number (#0), t1.number (#1)), 1_u8)]
+├── estimated rows: 0.33
 └── HashJoin
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
+    ├── estimated rows: 1.00
     ├── TableScan(Build)
     │   ├── table: default.system.numbers
     │   ├── read rows: 1
     │   ├── read bytes: 8
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.system.numbers
         ├── read rows: 1
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 1.00
 
 
 query T
@@ -105,34 +120,40 @@ HashJoin
 ├── build keys: [t1.number (#1)]
 ├── probe keys: [t2.number (#2)]
 ├── filters: []
+├── estimated rows: 1.00
 ├── HashJoin(Build)
 │   ├── join type: CROSS
 │   ├── build keys: []
 │   ├── probe keys: []
 │   ├── filters: []
+│   ├── estimated rows: 0.33
 │   ├── Filter(Build)
 │   │   ├── filters: [eq(t.number (#0), 1_u8)]
+│   │   ├── estimated rows: 0.33
 │   │   └── TableScan
 │   │       ├── table: default.system.numbers
 │   │       ├── read rows: 1
 │   │       ├── read bytes: 8
 │   │       ├── partitions total: 1
 │   │       ├── partitions scanned: 1
-│   │       └── push downs: [filters: [eq(number, 1_u64)], limit: NONE]
+│   │       ├── push downs: [filters: [eq(number, 1_u64)], limit: NONE]
+│   │       └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.system.numbers
 │       ├── read rows: 1
 │       ├── read bytes: 8
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 1.00
 
 ## check outer join is converted to inner join
 
@@ -159,75 +180,87 @@ explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where
 ----
 Filter
 ├── filters: [gt(b.x (#1), 42_u8)]
+├── estimated rows: 1.33
 └── HashJoin
     ├── join type: LEFT OUTER
     ├── build keys: [b.x (#1)]
     ├── probe keys: [a.x (#0)]
     ├── filters: []
+    ├── estimated rows: 4.00
     ├── TableScan(Build)
     │   ├── table: default.default.twocolumn
     │   ├── read rows: 4
     │   ├── read bytes: 79
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 4.00
     └── TableScan(Probe)
         ├── table: default.default.onecolumn
         ├── read rows: 4
         ├── read bytes: 37
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 4.00
 
 query T
 explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where b.x > 44 or b.x < 43
 ----
 Filter
 ├── filters: [or(gt(b.x (#1), 44_u8), lt(b.x (#1), 43_u8))]
+├── estimated rows: 1.33
 └── HashJoin
     ├── join type: LEFT OUTER
     ├── build keys: [b.x (#1)]
     ├── probe keys: [a.x (#0)]
     ├── filters: []
+    ├── estimated rows: 4.00
     ├── TableScan(Build)
     │   ├── table: default.default.twocolumn
     │   ├── read rows: 4
     │   ├── read bytes: 79
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 4.00
     └── TableScan(Probe)
         ├── table: default.default.onecolumn
         ├── read rows: 4
         ├── read bytes: 37
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 4.00
 
 query T
 explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where b.x > 42 and b.x < 45
 ----
 Filter
 ├── filters: [gt(b.x (#1), 42_u8), lt(b.x (#1), 45_u8)]
+├── estimated rows: 0.44
 └── HashJoin
     ├── join type: LEFT OUTER
     ├── build keys: [b.x (#1)]
     ├── probe keys: [a.x (#0)]
     ├── filters: []
+    ├── estimated rows: 4.00
     ├── TableScan(Build)
     │   ├── table: default.default.twocolumn
     │   ├── read rows: 4
     │   ├── read bytes: 79
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 4.00
     └── TableScan(Probe)
         ├── table: default.default.onecolumn
         ├── read rows: 4
         ├── read bytes: 37
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 4.00
 
 ## the following cases won't be converted to inner join
 
@@ -236,25 +269,29 @@ explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where
 ----
 Filter
 ├── filters: [or(gt(b.x (#1), 44_u8), lt(a.x (#0), 43_u8))]
+├── estimated rows: 1.33
 └── HashJoin
     ├── join type: LEFT OUTER
     ├── build keys: [b.x (#1)]
     ├── probe keys: [a.x (#0)]
     ├── filters: []
+    ├── estimated rows: 4.00
     ├── TableScan(Build)
     │   ├── table: default.default.twocolumn
     │   ├── read rows: 4
     │   ├── read bytes: 79
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 4.00
     └── TableScan(Probe)
         ├── table: default.default.onecolumn
         ├── read rows: 4
         ├── read bytes: 37
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 4.00
 
 query T
 explain select * from onecolumn as a right join twocolumn as b on a.x = b.x where b.x > 42 and b.x < 45
@@ -264,19 +301,23 @@ HashJoin
 ├── build keys: [b.x (#1)]
 ├── probe keys: [a.x (#0)]
 ├── filters: []
+├── estimated rows: 4.00
 ├── Filter(Build)
 │   ├── filters: [gt(b.x (#1), 42_u8), lt(b.x (#1), 45_u8)]
+│   ├── estimated rows: 2.67
 │   └── TableScan
 │       ├── table: default.default.twocolumn
 │       ├── read rows: 4
 │       ├── read bytes: 79
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [gt(x, 42_i32), lt(x, 45_i32)], limit: NONE]
+│       ├── push downs: [filters: [gt(x, 42_i32), lt(x, 45_i32)], limit: NONE]
+│       └── estimated rows: 4.00
 └── TableScan(Probe)
     ├── table: default.default.onecolumn
     ├── read rows: 4
     ├── read bytes: 37
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 4.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -33,32 +33,37 @@ HashJoin
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t2.a (#2)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 query T
 explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a
@@ -68,32 +73,37 @@ HashJoin
 ├── build keys: [t1.a (#2), t1.a (#2)]
 ├── probe keys: [t.a (#0), t2.a (#1)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t1
 │   ├── read rows: 10
 │   ├── read bytes: 68
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 10.00
 └── HashJoin(Probe)
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
+    ├── estimated rows: 100.00
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t
     │   ├── read rows: 1
     │   ├── read bytes: 31
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 100.00
 
 query T
 explain select * from t1, t, t2 where t.a = t1.a and t1.a = t2.a
@@ -103,32 +113,37 @@ HashJoin
 ├── build keys: [t1.a (#0)]
 ├── probe keys: [t2.a (#2)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#0)]
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 query T
 explain select * from t1, t2, t where t.a = t1.a and t1.a = t2.a
@@ -138,32 +153,37 @@ HashJoin
 ├── build keys: [t1.a (#0)]
 ├── probe keys: [t2.a (#1)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#0)]
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 query T
 explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a
@@ -173,32 +193,37 @@ HashJoin
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t2.a (#0)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 query T
 explain select * from t2, t, t1 where t.a = t1.a and t1.a = t2.a
@@ -208,32 +233,37 @@ HashJoin
 ├── build keys: [t1.a (#2), t1.a (#2)]
 ├── probe keys: [t.a (#1), t2.a (#0)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t1
 │   ├── read rows: 10
 │   ├── read bytes: 68
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 10.00
 └── HashJoin(Probe)
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
+    ├── estimated rows: 100.00
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t
     │   ├── read rows: 1
     │   ├── read bytes: 31
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 100.00
 
 query T
 explain select * from t left join t1 on t1.a = t.a
@@ -243,20 +273,23 @@ HashJoin
 ├── build keys: [CAST(t.a (#0) AS BIGINT UNSIGNED NULL)]
 ├── probe keys: [CAST(t1.a (#1) AS BIGINT UNSIGNED NULL)]
 ├── filters: []
+├── estimated rows: 10.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 10.00
 
 query T
 explain select * from t right join t1 on t1.a = t.a
@@ -266,20 +299,23 @@ HashJoin
 ├── build keys: [CAST(t.a (#0) AS BIGINT UNSIGNED NULL)]
 ├── probe keys: [CAST(t1.a (#1) AS BIGINT UNSIGNED NULL)]
 ├── filters: []
+├── estimated rows: 10.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 10.00
 
 query T
 explain select * from t left semi join t1 on t1.a = t.a
@@ -289,20 +325,23 @@ HashJoin
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
 ├── filters: []
+├── estimated rows: 1.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 10.00
 
 query T
 explain select * from t right semi join t1 on t1.a = t.a
@@ -312,20 +351,23 @@ HashJoin
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
 ├── filters: []
+├── estimated rows: 10.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 10.00
 
 query T
 explain select * from t left anti join t1 on t1.a = t.a
@@ -335,20 +377,23 @@ HashJoin
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
 ├── filters: []
+├── estimated rows: 1.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 10.00
 
 query T
 explain select * from t right anti join t1 on t1.a = t.a
@@ -358,20 +403,23 @@ HashJoin
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
 ├── filters: []
+├── estimated rows: 10.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 10.00
 
 statement ok
 drop database join_reorder

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
@@ -21,32 +21,37 @@ HashJoin
 ├── build keys: [t1.a (#1), t.a (#0)]
 ├── probe keys: [t2.a (#2), t2.a (#2)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 query T
 explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a and t2.a = t.a
@@ -56,32 +61,37 @@ HashJoin
 ├── build keys: [t1.a (#2), t.a (#0)]
 ├── probe keys: [t2.a (#1), t2.a (#1)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#2)]
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 query T
 explain select * from t1, t, t2 where t.a = t1.a and t1.a = t2.a and t2.a = t.a
@@ -91,32 +101,37 @@ HashJoin
 ├── build keys: [t1.a (#0), t.a (#1)]
 ├── probe keys: [t2.a (#2), t2.a (#2)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#0)]
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 query T
 explain select * from t1, t2, t where t.a = t1.a and t1.a = t2.a and t2.a = t.a
@@ -126,32 +141,37 @@ HashJoin
 ├── build keys: [t.a (#2), t1.a (#0)]
 ├── probe keys: [t2.a (#1), t2.a (#1)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#0)]
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 query T
 explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a and t2.a = t.a
@@ -161,32 +181,37 @@ HashJoin
 ├── build keys: [t.a (#2), t1.a (#1)]
 ├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 query T
 explain select * from t2, t, t1 where t.a = t1.a and t1.a = t2.a and t2.a = t.a
@@ -196,32 +221,37 @@ HashJoin
 ├── build keys: [t1.a (#2), t.a (#1)]
 ├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 statement ok
 drop database join_reorder

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
@@ -6,20 +6,23 @@ HashJoin
 ├── build keys: [subquery_1 (#1)]
 ├── probe keys: [numbers.number (#0)]
 ├── filters: []
+├── estimated rows: 10000.00
 ├── TableScan(Build)
 │   ├── table: default.system.numbers
 │   ├── read rows: 1000
 │   ├── read bytes: 8000
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1000.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 10000
     ├── read bytes: 80000
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 10000.00
 
 query T
 explain select * from numbers(1000) where number in (select number from numbers(10000))
@@ -29,17 +32,20 @@ HashJoin
 ├── build keys: [numbers.number (#0)]
 ├── probe keys: [subquery_1 (#1)]
 ├── filters: []
+├── estimated rows: 1000.00
 ├── TableScan(Build)
 │   ├── table: default.system.numbers
 │   ├── read rows: 1000
 │   ├── read bytes: 8000
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1000.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 10000
     ├── read bytes: 80000
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 10000.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
@@ -21,32 +21,37 @@ HashJoin
 ├── build keys: [t.a (#0), t1.a (#1)]
 ├── probe keys: [t2.a (#2), t2.a (#2)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: CROSS
 │   ├── build keys: []
 │   ├── probe keys: []
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 query T
 explain select * from t, t2, t1 where t.a = t2.a and t1.a = t2.a
@@ -56,32 +61,37 @@ HashJoin
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#1)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t1
 │   ├── read rows: 10
 │   ├── read bytes: 68
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 10.00
 └── HashJoin(Probe)
     ├── join type: INNER
     ├── build keys: [t.a (#0)]
     ├── probe keys: [t2.a (#1)]
     ├── filters: []
+    ├── estimated rows: 100.00
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t
     │   ├── read rows: 1
     │   ├── read bytes: 31
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 100.00
 
 query T
 explain select * from t1, t, t2 where t.a = t2.a and t1.a = t2.a
@@ -91,32 +101,37 @@ HashJoin
 ├── build keys: [t.a (#1), t1.a (#0)]
 ├── probe keys: [t2.a (#2), t2.a (#2)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── HashJoin(Build)
 │   ├── join type: CROSS
 │   ├── build keys: []
 │   ├── probe keys: []
 │   ├── filters: []
+│   ├── estimated rows: 10.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
 │   │   ├── read rows: 1
 │   │   ├── read bytes: 31
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   └── push downs: [filters: [], limit: NONE]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
 │       ├── table: default.join_reorder.t1
 │       ├── read rows: 10
 │       ├── read bytes: 68
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [], limit: NONE]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t2
     ├── read rows: 100
     ├── read bytes: 431
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
 
 query T
 explain select * from t1, t2, t where t.a = t2.a and t1.a = t2.a
@@ -126,32 +141,37 @@ HashJoin
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#1)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── HashJoin(Probe)
     ├── join type: INNER
     ├── build keys: [t1.a (#0)]
     ├── probe keys: [t2.a (#1)]
     ├── filters: []
+    ├── estimated rows: 100.00
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 10.00
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 100.00
 
 query T
 explain select * from t2, t1, t where t.a = t2.a and t1.a = t2.a
@@ -161,32 +181,37 @@ HashJoin
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── HashJoin(Probe)
     ├── join type: INNER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t2.a (#0)]
     ├── filters: []
+    ├── estimated rows: 100.00
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 10.00
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 100.00
 
 query T
 explain select * from t2, t, t1 where t.a = t2.a and t1.a = t2.a
@@ -196,32 +221,37 @@ HashJoin
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
 ├── filters: []
+├── estimated rows: 100.00
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t1
 │   ├── read rows: 10
 │   ├── read bytes: 68
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 10.00
 └── HashJoin(Probe)
     ├── join type: INNER
     ├── build keys: [t.a (#1)]
     ├── probe keys: [t2.a (#0)]
     ├── filters: []
+    ├── estimated rows: 100.00
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t
     │   ├── read rows: 1
     │   ├── read bytes: 31
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 100.00
 
 statement ok
 drop database join_reorder

--- a/tests/sqllogictests/suites/mode/standalone/explain/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/limit.test
@@ -4,31 +4,37 @@ explain select * from (select t.number from numbers(10) as t limit 8) limit 9
 Limit
 ├── limit: 9
 ├── offset: 0
+├── estimated rows: 8.00
 └── Limit
     ├── limit: 8
     ├── offset: 0
+    ├── estimated rows: 8.00
     └── TableScan
         ├── table: default.system.numbers
         ├── read rows: 8
         ├── read bytes: 64
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: 8]
+        ├── push downs: [filters: [], limit: 8]
+        └── estimated rows: 10.00
 
 query T
 explain select * from (select t.number from numbers(10) as t order by number desc) order by number asc
 ----
 Sort
 ├── sort keys: [number ASC NULLS LAST]
+├── estimated rows: 10.00
 └── Sort
     ├── sort keys: [number DESC NULLS LAST]
+    ├── estimated rows: 10.00
     └── TableScan
         ├── table: default.system.numbers
         ├── read rows: 10
         ├── read bytes: 80
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 10.00
 
 query T
 explain select number from (select t.number from numbers(10) as t order by number desc limit 8) order by number asc limit 9
@@ -36,20 +42,25 @@ explain select number from (select t.number from numbers(10) as t order by numbe
 Limit
 ├── limit: 9
 ├── offset: 0
+├── estimated rows: 8.00
 └── Sort
     ├── sort keys: [number ASC NULLS LAST]
+    ├── estimated rows: 8.00
     └── Limit
         ├── limit: 8
         ├── offset: 0
+        ├── estimated rows: 8.00
         └── Sort
             ├── sort keys: [number DESC NULLS LAST]
+            ├── estimated rows: 10.00
             └── TableScan
                 ├── table: default.system.numbers
                 ├── read rows: 10
                 ├── read bytes: 80
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                └── push downs: [filters: [], limit: 8]
+                ├── push downs: [filters: [], limit: 8]
+                └── estimated rows: 10.00
 
 query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = (select count(*) from numbers(1) as t2, numbers(1) as t3 where t.number = t2.number) group by t.number order by t.number desc limit 3
@@ -57,69 +68,85 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = 
 Limit
 ├── limit: 3
 ├── offset: 0
+├── estimated rows: 0.33
 └── Sort
     ├── sort keys: [number DESC NULLS LAST]
+    ├── estimated rows: 0.33
     └── AggregateFinal
         ├── group by: [number]
         ├── aggregate functions: []
+        ├── estimated rows: 0.33
         └── AggregatePartial
             ├── group by: [number]
             ├── aggregate functions: []
+            ├── estimated rows: 0.33
             └── Filter
                 ├── filters: [eq(t.number (#0), CAST(if(is_not_null(scalar_subquery_4 (#4)), scalar_subquery_4 (#4), 0_i64) AS BIGINT UNSIGNED NULL))]
+                ├── estimated rows: 0.33
                 └── HashJoin
                     ├── join type: SINGLE
                     ├── build keys: [subquery_2 (#2)]
                     ├── probe keys: [subquery_0 (#0)]
                     ├── filters: []
+                    ├── estimated rows: 1.00
                     ├── EvalScalar(Build)
                     │   ├── expressions: [COUNT(*) (#5)]
+                    │   ├── estimated rows: 0.33
                     │   └── AggregateFinal
                     │       ├── group by: [number]
                     │       ├── aggregate functions: [count()]
+                    │       ├── estimated rows: 0.33
                     │       └── AggregatePartial
                     │           ├── group by: [number]
                     │           ├── aggregate functions: [count()]
+                    │           ├── estimated rows: 0.33
                     │           └── HashJoin
                     │               ├── join type: CROSS
                     │               ├── build keys: []
                     │               ├── probe keys: []
                     │               ├── filters: []
+                    │               ├── estimated rows: 0.33
                     │               ├── Filter(Build)
                     │               │   ├── filters: [eq(subquery_2 (#2), t2.number (#2))]
+                    │               │   ├── estimated rows: 0.33
                     │               │   └── TableScan
                     │               │       ├── table: default.system.numbers
                     │               │       ├── read rows: 1
                     │               │       ├── read bytes: 8
                     │               │       ├── partitions total: 1
                     │               │       ├── partitions scanned: 1
-                    │               │       └── push downs: [filters: [eq(subquery_2, number)], limit: NONE]
+                    │               │       ├── push downs: [filters: [eq(subquery_2, number)], limit: NONE]
+                    │               │       └── estimated rows: 1.00
                     │               └── TableScan(Probe)
                     │                   ├── table: default.system.numbers
                     │                   ├── read rows: 1
                     │                   ├── read bytes: 8
                     │                   ├── partitions total: 1
                     │                   ├── partitions scanned: 1
-                    │                   └── push downs: [filters: [], limit: NONE]
+                    │                   ├── push downs: [filters: [], limit: NONE]
+                    │                   └── estimated rows: 1.00
                     └── HashJoin(Probe)
                         ├── join type: CROSS
                         ├── build keys: []
                         ├── probe keys: []
                         ├── filters: []
+                        ├── estimated rows: 1.00
                         ├── TableScan(Build)
                         │   ├── table: default.system.numbers
                         │   ├── read rows: 1
                         │   ├── read bytes: 8
                         │   ├── partitions total: 1
                         │   ├── partitions scanned: 1
-                        │   └── push downs: [filters: [], limit: NONE]
+                        │   ├── push downs: [filters: [], limit: NONE]
+                        │   └── estimated rows: 1.00
                         └── TableScan(Probe)
                             ├── table: default.system.numbers
                             ├── read rows: 1
                             ├── read bytes: 8
                             ├── partitions total: 1
                             ├── partitions scanned: 1
-                            └── push downs: [filters: [], limit: NONE]
+                            ├── push downs: [filters: [], limit: NONE]
+                            └── estimated rows: 1.00
 
 query T
 explain select * from (select count(t1.number) as c1 from numbers(1) as t1 group by number) as t3 left join (select count(t.number) as c from numbers(2) as t group by number) as t4 on t3.c1=t4.c order by t3.c1 limit 1
@@ -127,40 +154,51 @@ explain select * from (select count(t1.number) as c1 from numbers(1) as t1 group
 Limit
 ├── limit: 1
 ├── offset: 0
+├── estimated rows: 1.00
 └── Sort
     ├── sort keys: [c1 ASC NULLS LAST]
+    ├── estimated rows: 2.00
     └── HashJoin
         ├── join type: RIGHT OUTER
         ├── build keys: [CAST(t3.c1 (#1) AS BIGINT UNSIGNED NULL)]
         ├── probe keys: [CAST(t4.c (#5) AS BIGINT UNSIGNED NULL)]
         ├── filters: []
+        ├── estimated rows: 2.00
         ├── EvalScalar(Build)
         │   ├── expressions: [count(t1.number) (#3)]
+        │   ├── estimated rows: 1.00
         │   └── AggregateFinal
         │       ├── group by: [number]
         │       ├── aggregate functions: [count(number)]
+        │       ├── estimated rows: 1.00
         │       └── AggregatePartial
         │           ├── group by: [number]
         │           ├── aggregate functions: [count(number)]
+        │           ├── estimated rows: 1.00
         │           └── TableScan
         │               ├── table: default.system.numbers
         │               ├── read rows: 1
         │               ├── read bytes: 8
         │               ├── partitions total: 1
         │               ├── partitions scanned: 1
-        │               └── push downs: [filters: [], limit: NONE]
+        │               ├── push downs: [filters: [], limit: NONE]
+        │               └── estimated rows: 1.00
         └── EvalScalar(Probe)
             ├── expressions: [count(t.number) (#7)]
+            ├── estimated rows: 2.00
             └── AggregateFinal
                 ├── group by: [number]
                 ├── aggregate functions: [count(number)]
+                ├── estimated rows: 2.00
                 └── AggregatePartial
                     ├── group by: [number]
                     ├── aggregate functions: [count(number)]
+                    ├── estimated rows: 2.00
                     └── TableScan
                         ├── table: default.system.numbers
                         ├── read rows: 2
                         ├── read bytes: 16
                         ├── partitions total: 1
                         ├── partitions scanned: 1
-                        └── push downs: [filters: [], limit: NONE]
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 2.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/nullable_prune.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/nullable_prune.test
@@ -22,33 +22,38 @@ TableScan
 ├── read bytes: 62
 ├── partitions total: 2
 ├── partitions scanned: 2
-└── push downs: [filters: [], limit: NONE]
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 6.00
 
 query T
 explain select * from t_nullable_prune where a is not null
 ----
 Filter
 ├── filters: [is_not_null(t_nullable_prune.a (#0))]
+├── estimated rows: 2.00
 └── TableScan
     ├── table: default.default.t_nullable_prune
     ├── read rows: 3
     ├── read bytes: 37
     ├── partitions total: 2
     ├── partitions scanned: 1
-    └── push downs: [filters: [is_not_null(a)], limit: NONE]
+    ├── push downs: [filters: [is_not_null(a)], limit: NONE]
+    └── estimated rows: 6.00
 
 query T
 explain select * from t_nullable_prune where a is null
 ----
 Filter
 ├── filters: [not(is_not_null(t_nullable_prune.a (#0)))]
+├── estimated rows: 2.00
 └── TableScan
     ├── table: default.default.t_nullable_prune
     ├── read rows: 3
     ├── read bytes: 25
     ├── partitions total: 2
     ├── partitions scanned: 1
-    └── push downs: [filters: [not(is_not_null(a))], limit: NONE]
+    ├── push downs: [filters: [not(is_not_null(a))], limit: NONE]
+    └── estimated rows: 6.00
 
 statement ok
 DROP TABLE default.default.t_nullable_prune

--- a/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
@@ -7,7 +7,8 @@ TableScan
 ├── read bytes: 8
 ├── partitions total: 1
 ├── partitions scanned: 1
-└── push downs: [filters: [], limit: NONE]
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 1.00
 
 query T
 explain select a from (select number as a, count(*) as b from numbers(1) group by a)
@@ -15,16 +16,19 @@ explain select a from (select number as a, count(*) as b from numbers(1) group b
 AggregateFinal
 ├── group by: [number]
 ├── aggregate functions: []
+├── estimated rows: 1.00
 └── AggregatePartial
     ├── group by: [number]
     ├── aggregate functions: []
+    ├── estimated rows: 1.00
     └── TableScan
         ├── table: default.system.numbers
         ├── read rows: 1
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 1.00
 
 query T
 explain select a from (select number as a, number b, sum(number) as c, number as d, number as e from numbers(1) group by a, b, d, e) where b > 1 order by d limit 1
@@ -32,23 +36,29 @@ explain select a from (select number as a, number b, sum(number) as c, number as
 Limit
 ├── limit: 1
 ├── offset: 0
+├── estimated rows: 0.33
 └── Sort
     ├── sort keys: [number ASC NULLS LAST]
+    ├── estimated rows: 0.33
     └── Filter
         ├── filters: [gt(numbers.b (#0), 1_u8)]
+        ├── estimated rows: 0.33
         └── AggregateFinal
             ├── group by: [number, number, number, number]
             ├── aggregate functions: []
+            ├── estimated rows: 1.00
             └── AggregatePartial
                 ├── group by: [number, number, number, number]
                 ├── aggregate functions: []
+                ├── estimated rows: 1.00
                 └── TableScan
                     ├── table: default.system.numbers
                     ├── read rows: 1
                     ├── read bytes: 8
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    └── push downs: [filters: [], limit: NONE]
+                    ├── push downs: [filters: [], limit: NONE]
+                    └── estimated rows: 1.00
 
 query T
 explain select * from (select t1.a from (select number + 1 as a, number + 1 as b, number + 1 as c, number + 1 as d from numbers(1)) as t1, (select number + 1 as a, number + 1 as b, number + 1 as c from numbers(1)) as t2 where t1.b = t2.b and t1.c = 1)
@@ -58,92 +68,113 @@ HashJoin
 ├── build keys: [t1.b (#2)]
 ├── probe keys: [t2.b (#11)]
 ├── filters: []
+├── estimated rows: 1.00
 ├── Filter(Build)
 │   ├── filters: [eq(t1.c (#3), 1_u8)]
+│   ├── estimated rows: 0.33
 │   └── EvalScalar
 │       ├── expressions: [plus(numbers.number (#0), 1_u8), plus(numbers.number (#0), 1_u8), plus(numbers.number (#0), 1_u8)]
+│       ├── estimated rows: 1.00
 │       └── TableScan
 │           ├── table: default.system.numbers
 │           ├── read rows: 1
 │           ├── read bytes: 8
 │           ├── partitions total: 1
 │           ├── partitions scanned: 1
-│           └── push downs: [filters: [], limit: NONE]
+│           ├── push downs: [filters: [], limit: NONE]
+│           └── estimated rows: 1.00
 └── EvalScalar(Probe)
     ├── expressions: [plus(numbers.number (#9), 1_u8)]
+    ├── estimated rows: 1.00
     └── TableScan
         ├── table: default.system.numbers
         ├── read rows: 1
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 1.00
 
 query T
 explain select t1.a from (select number + 1 as a, number + 1 as b from numbers(1)) as t1 where t1.a = (select count(*) from (select t2.a, t3.a from (select number + 1 as a, number + 1 as b, number + 1 as c, number + 1 as d from numbers(1)) as t2, (select number + 1 as a, number + 1 as b, number + 1 as c from numbers(1)) as t3 where t2.b = t3.b and t2.c = 1))
 ----
 Filter
 ├── filters: [eq(t1.a (#1), scalar_subquery_21 (#21))]
+├── estimated rows: 0.33
 └── HashJoin
     ├── join type: SINGLE
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
+    ├── estimated rows: 1.00
     ├── EvalScalar(Build)
     │   ├── expressions: [COUNT(*) (#22)]
+    │   ├── estimated rows: 1.00
     │   └── AggregateFinal
     │       ├── group by: []
     │       ├── aggregate functions: [count()]
+    │       ├── estimated rows: 1.00
     │       └── AggregatePartial
     │           ├── group by: []
     │           ├── aggregate functions: [count()]
+    │           ├── estimated rows: 1.00
     │           └── HashJoin
     │               ├── join type: INNER
     │               ├── build keys: [t2.b (#7)]
     │               ├── probe keys: [t3.b (#16)]
     │               ├── filters: []
+    │               ├── estimated rows: 1.00
     │               ├── Filter(Build)
     │               │   ├── filters: [eq(t2.c (#8), 1_u8)]
+    │               │   ├── estimated rows: 0.33
     │               │   └── EvalScalar
     │               │       ├── expressions: [plus(numbers.number (#5), 1_u8), plus(numbers.number (#5), 1_u8)]
+    │               │       ├── estimated rows: 1.00
     │               │       └── TableScan
     │               │           ├── table: default.system.numbers
     │               │           ├── read rows: 1
     │               │           ├── read bytes: 8
     │               │           ├── partitions total: 1
     │               │           ├── partitions scanned: 1
-    │               │           └── push downs: [filters: [], limit: NONE]
+    │               │           ├── push downs: [filters: [], limit: NONE]
+    │               │           └── estimated rows: 1.00
     │               └── EvalScalar(Probe)
     │                   ├── expressions: [plus(numbers.number (#14), 1_u8)]
+    │                   ├── estimated rows: 1.00
     │                   └── TableScan
     │                       ├── table: default.system.numbers
     │                       ├── read rows: 1
     │                       ├── read bytes: 8
     │                       ├── partitions total: 1
     │                       ├── partitions scanned: 1
-    │                       └── push downs: [filters: [], limit: NONE]
+    │                       ├── push downs: [filters: [], limit: NONE]
+    │                       └── estimated rows: 1.00
     └── EvalScalar(Probe)
         ├── expressions: [plus(numbers.number (#0), 1_u8)]
+        ├── estimated rows: 1.00
         └── TableScan
             ├── table: default.system.numbers
             ├── read rows: 1
             ├── read bytes: 8
             ├── partitions total: 1
             ├── partitions scanned: 1
-            └── push downs: [filters: [], limit: NONE]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 1.00
 
 query T
 explain select name from system.functions order by example
 ----
 Sort
 ├── sort keys: [example ASC NULLS LAST]
+├── estimated rows: 0.00
 └── TableScan
     ├── table: default.system.functions
     ├── read rows: 0
     ├── read bytes: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 0.00
 
 query T
 explain select t.number from numbers(10) t where exists(select * from numbers(10))
@@ -153,31 +184,38 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: []
+├── estimated rows: 3.33
 ├── Filter(Build)
 │   ├── filters: [eq(count(*) (#2), 1_u64)]
+│   ├── estimated rows: 0.33
 │   └── AggregateFinal
 │       ├── group by: []
 │       ├── aggregate functions: [count()]
+│       ├── estimated rows: 1.00
 │       └── AggregatePartial
 │           ├── group by: []
 │           ├── aggregate functions: [count()]
+│           ├── estimated rows: 1.00
 │           └── Limit
 │               ├── limit: 1
 │               ├── offset: 0
+│               ├── estimated rows: 1.00
 │               └── TableScan
 │                   ├── table: default.system.numbers
 │                   ├── read rows: 1
 │                   ├── read bytes: 8
 │                   ├── partitions total: 1
 │                   ├── partitions scanned: 1
-│                   └── push downs: [filters: [], limit: 1]
+│                   ├── push downs: [filters: [], limit: 1]
+│                   └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 10
     ├── read bytes: 80
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 10.00
 
 
 statement ok
@@ -194,14 +232,18 @@ explain select count(*) from t where t.b = 2
 ----
 EvalScalar
 ├── expressions: [COUNT(*) (#3)]
+├── estimated rows: 1.00
 └── AggregateFinal
     ├── group by: []
     ├── aggregate functions: [count()]
+    ├── estimated rows: 1.00
     └── AggregatePartial
         ├── group by: []
         ├── aggregate functions: [count()]
+        ├── estimated rows: 1.00
         └── Filter
             ├── filters: [eq(t.b (#1), 2_u8)]
+            ├── estimated rows: 0.67
             └── TableScan
                 ├── table: default.default.t
                 ├── read rows: 2
@@ -209,7 +251,8 @@ EvalScalar
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── push downs: [filters: [eq(b, 2_i32)], limit: NONE]
-                └── output columns: [1]
+                ├── output columns: [1]
+                └── estimated rows: 2.00
 
 statement ok
 drop table t

--- a/tests/sqllogictests/suites/mode/standalone/explain/select.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select.test
@@ -7,115 +7,134 @@ TableScan
 ├── read bytes: 8
 ├── partitions total: 1
 ├── partitions scanned: 1
-└── push downs: [filters: [], limit: NONE]
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 1.00
 
 query T
 explain select * from (select * from numbers(1)) as t1 where number = 1
 ----
 Filter
 ├── filters: [eq(t1.number (#0), 1_u8)]
+├── estimated rows: 0.33
 └── TableScan
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [eq(number, 1_u64)], limit: NONE]
+    ├── push downs: [filters: [eq(number, 1_u64)], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select * from (select number as a, number + 1 as b from numbers(1)) as t1 where a = 1 and b = 1
 ----
 Filter
 ├── filters: [eq(t1.a (#0), 1_u8), eq(t1.b (#1), 1_u8)]
+├── estimated rows: 0.11
 └── EvalScalar
     ├── expressions: [plus(numbers.number (#0), 1_u8)]
+    ├── estimated rows: 1.00
     └── TableScan
         ├── table: default.system.numbers
         ├── read rows: 1
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 1.00
 
 query T
 explain select * from (select number as a, number + 1 as b from numbers(1)) as t1 where a = 1
 ----
 EvalScalar
 ├── expressions: [plus(numbers.number (#0), 1_u8)]
+├── estimated rows: 0.33
 └── Filter
     ├── filters: [eq(t1.a (#0), 1_u8)]
+    ├── estimated rows: 0.33
     └── TableScan
         ├── table: default.system.numbers
         ├── read rows: 1
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [eq(a, 1_u64)], limit: NONE]
+        ├── push downs: [filters: [eq(a, 1_u64)], limit: NONE]
+        └── estimated rows: 1.00
 
 query T
 explain select * from numbers(1) where number = pow(1, 1 + 1)
 ----
 Filter
 ├── filters: [eq(numbers.number (#0), pow(1_u8, plus(1_u8, 1_u8)))]
+├── estimated rows: 0.33
 └── TableScan
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [eq(CAST(number AS Float64), 1_f64)], limit: NONE]
+    ├── push downs: [filters: [eq(CAST(number AS Float64), 1_f64)], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select * from numbers(1) where TRUE and 1 = 1
 ----
 Filter
 ├── filters: [eq(1_u8, 1_u8)]
+├── estimated rows: 0.33
 └── TableScan
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [true], limit: NONE]
+    ├── push downs: [filters: [true], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select * from numbers(1) where number = 0 and false
 ----
 Filter
 ├── filters: [false]
+├── estimated rows: 0.00
 └── TableScan
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [false], limit: NONE]
+    ├── push downs: [filters: [false], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select * from numbers(1) where number = 0 and null
 ----
 Filter
 ├── filters: [false]
+├── estimated rows: 0.00
 └── TableScan
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [false], limit: NONE]
+    ├── push downs: [filters: [false], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select * from numbers(1) where null
 ----
 Filter
 ├── filters: [NULL]
+├── estimated rows: 0.00
 └── TableScan
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [NULL], limit: NONE]
+    ├── push downs: [filters: [NULL], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select a from (select number as a, number as b from numbers(1))
@@ -126,7 +145,8 @@ TableScan
 ├── read bytes: 8
 ├── partitions total: 1
 ├── partitions scanned: 1
-└── push downs: [filters: [], limit: NONE]
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 1.00
 
 query T
 explain select a from (select number as a, number+1 as b from numbers(1))
@@ -137,4 +157,5 @@ TableScan
 ├── read bytes: 8
 ├── partitions total: 1
 ├── partitions scanned: 1
-└── push downs: [filters: [], limit: NONE]
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 1.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
@@ -129,31 +129,37 @@ explain select * from t left join t1 on t.a = t1.a limit 1,2
 Limit
 ├── limit: 2
 ├── offset: 1
+├── estimated rows: 2.00
 └── HashJoin
     ├── join type: RIGHT OUTER
     ├── build keys: [CAST(t.a (#0) AS INT NULL)]
     ├── probe keys: [CAST(t1.a (#1) AS INT NULL)]
     ├── filters: []
+    ├── estimated rows: 2.00
     ├── Limit(Build)
     │   ├── limit: 2
     │   ├── offset: 1
+    │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.t
     │       ├── read rows: 1
     │       ├── read bytes: 27
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       └── push downs: [filters: [], limit: 3]
+    │       ├── push downs: [filters: [], limit: 3]
+    │       └── estimated rows: 1.00
     └── Limit(Probe)
         ├── limit: 2
         ├── offset: 1
+        ├── estimated rows: 2.00
         └── TableScan
             ├── table: default.default.t1
             ├── read rows: 2
             ├── read bytes: 31
             ├── partitions total: 1
             ├── partitions scanned: 1
-            └── push downs: [filters: [], limit: 3]
+            ├── push downs: [filters: [], limit: 3]
+            └── estimated rows: 2.00
 
 query II
 select * from t left join t1 on t.a = t1.a limit 1

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -3,86 +3,103 @@ explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = 
 ----
 Filter
 ├── filters: [eq(t.number (#0), CAST(if(is_not_null(scalar_subquery_4 (#4)), scalar_subquery_4 (#4), 0_i64) AS BIGINT UNSIGNED NULL))]
+├── estimated rows: 0.33
 └── HashJoin
     ├── join type: SINGLE
     ├── build keys: [subquery_2 (#2)]
     ├── probe keys: [subquery_0 (#0)]
     ├── filters: []
+    ├── estimated rows: 1.00
     ├── EvalScalar(Build)
     │   ├── expressions: [COUNT(*) (#5)]
+    │   ├── estimated rows: 0.33
     │   └── AggregateFinal
     │       ├── group by: [number]
     │       ├── aggregate functions: [count()]
+    │       ├── estimated rows: 0.33
     │       └── AggregatePartial
     │           ├── group by: [number]
     │           ├── aggregate functions: [count()]
+    │           ├── estimated rows: 0.33
     │           └── HashJoin
     │               ├── join type: CROSS
     │               ├── build keys: []
     │               ├── probe keys: []
     │               ├── filters: []
+    │               ├── estimated rows: 0.33
     │               ├── Filter(Build)
     │               │   ├── filters: [eq(subquery_2 (#2), t2.number (#2))]
+    │               │   ├── estimated rows: 0.33
     │               │   └── TableScan
     │               │       ├── table: default.system.numbers
     │               │       ├── read rows: 1
     │               │       ├── read bytes: 8
     │               │       ├── partitions total: 1
     │               │       ├── partitions scanned: 1
-    │               │       └── push downs: [filters: [eq(subquery_2, number)], limit: NONE]
+    │               │       ├── push downs: [filters: [eq(subquery_2, number)], limit: NONE]
+    │               │       └── estimated rows: 1.00
     │               └── TableScan(Probe)
     │                   ├── table: default.system.numbers
     │                   ├── read rows: 1
     │                   ├── read bytes: 8
     │                   ├── partitions total: 1
     │                   ├── partitions scanned: 1
-    │                   └── push downs: [filters: [], limit: NONE]
+    │                   ├── push downs: [filters: [], limit: NONE]
+    │                   └── estimated rows: 1.00
     └── HashJoin(Probe)
         ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
         ├── filters: []
+        ├── estimated rows: 1.00
         ├── TableScan(Build)
         │   ├── table: default.system.numbers
         │   ├── read rows: 1
         │   ├── read bytes: 8
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
-        │   └── push downs: [filters: [], limit: NONE]
+        │   ├── push downs: [filters: [], limit: NONE]
+        │   └── estimated rows: 1.00
         └── TableScan(Probe)
             ├── table: default.system.numbers
             ├── read rows: 1
             ├── read bytes: 8
             ├── partitions total: 1
             ├── partitions scanned: 1
-            └── push downs: [filters: [], limit: NONE]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t where exists (select t1.number from numbers(1) as t1 where t.number = t1.number) or t.number > 1
 ----
 Filter
 ├── filters: [or(2 (#2), gt(t.number (#0), 1_u8))]
+├── estimated rows: 0.11
 └── HashJoin
     ├── join type: RIGHT MARK
     ├── build keys: [subquery_1 (#1)]
     ├── probe keys: [subquery_0 (#0)]
     ├── filters: []
+    ├── estimated rows: 0.33
     ├── Filter(Build)
     │   ├── filters: [eq(subquery_1 (#1), t1.number (#1))]
+    │   ├── estimated rows: 0.33
     │   └── TableScan
     │       ├── table: default.system.numbers
     │       ├── read rows: 1
     │       ├── read bytes: 8
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       └── push downs: [filters: [eq(subquery_1, number)], limit: NONE]
+    │       ├── push downs: [filters: [eq(subquery_1, number)], limit: NONE]
+    │       └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.system.numbers
         ├── read rows: 1
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t where exists (select * from numbers(1) where number = 0)
@@ -92,60 +109,73 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: []
+├── estimated rows: 0.33
 ├── Filter(Build)
 │   ├── filters: [eq(count(*) (#2), 1_u64)]
+│   ├── estimated rows: 0.33
 │   └── AggregateFinal
 │       ├── group by: []
 │       ├── aggregate functions: [count()]
+│       ├── estimated rows: 1.00
 │       └── AggregatePartial
 │           ├── group by: []
 │           ├── aggregate functions: [count()]
+│           ├── estimated rows: 1.00
 │           └── Limit
 │               ├── limit: 1
 │               ├── offset: 0
+│               ├── estimated rows: 0.33
 │               └── Filter
 │                   ├── filters: [eq(numbers.number (#1), 0_u8)]
+│                   ├── estimated rows: 0.33
 │                   └── TableScan
 │                       ├── table: default.system.numbers
 │                       ├── read rows: 1
 │                       ├── read bytes: 8
 │                       ├── partitions total: 1
 │                       ├── partitions scanned: 1
-│                       └── push downs: [filters: [eq(number, 0_u64)], limit: NONE]
+│                       ├── push downs: [filters: [eq(number, 0_u64)], limit: NONE]
+│                       └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t where number = (select * from numbers(1) where number = 0)
 ----
 Filter
 ├── filters: [eq(t.number (#0), scalar_subquery_1 (#1))]
+├── estimated rows: 0.33
 └── HashJoin
     ├── join type: SINGLE
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
+    ├── estimated rows: 1.00
     ├── Filter(Build)
     │   ├── filters: [eq(numbers.number (#1), 0_u8)]
+    │   ├── estimated rows: 0.33
     │   └── TableScan
     │       ├── table: default.system.numbers
     │       ├── read rows: 1
     │       ├── read bytes: 8
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       └── push downs: [filters: [eq(number, 0_u64)], limit: NONE]
+    │       ├── push downs: [filters: [eq(number, 0_u64)], limit: NONE]
+    │       └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.system.numbers
         ├── read rows: 1
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t where exists (select * from numbers(1) where number = t.number)
@@ -155,20 +185,23 @@ HashJoin
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
 ├── filters: []
+├── estimated rows: 1.00
 ├── TableScan(Build)
 │   ├── table: default.system.numbers
 │   ├── read rows: 1
 │   ├── read bytes: 8
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t where not exists (select * from numbers(1) where number = t.number)
@@ -178,20 +211,23 @@ HashJoin
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
 ├── filters: []
+├── estimated rows: 1.00
 ├── TableScan(Build)
 │   ├── table: default.system.numbers
 │   ├── read rows: 1
 │   ├── read bytes: 8
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select * from numbers(1) as t where exists (select number as a from numbers(1) where number = t.number)
@@ -201,20 +237,23 @@ HashJoin
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
 ├── filters: []
+├── estimated rows: 1.00
 ├── TableScan(Build)
 │   ├── table: default.system.numbers
 │   ├── read rows: 1
 │   ├── read bytes: 8
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t where exists (select * from numbers(1) where number = t.number and number = 0 and t.number < 10)
@@ -224,24 +263,29 @@ HashJoin
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
 ├── filters: []
+├── estimated rows: 0.33
 ├── Filter(Build)
 │   ├── filters: [eq(numbers.number (#1), 0_u8)]
+│   ├── estimated rows: 0.33
 │   └── TableScan
 │       ├── table: default.system.numbers
 │       ├── read rows: 1
 │       ├── read bytes: 8
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [eq(number, 0_u64)], limit: NONE]
+│       ├── push downs: [filters: [eq(number, 0_u64)], limit: NONE]
+│       └── estimated rows: 1.00
 └── Filter(Probe)
     ├── filters: [lt(t.number (#0), 10_u8)]
+    ├── estimated rows: 0.33
     └── TableScan
         ├── table: default.system.numbers
         ├── read rows: 1
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [lt(number, 10_u64)], limit: NONE]
+        ├── push downs: [filters: [lt(number, 10_u64)], limit: NONE]
+        └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t where exists (select * from numbers(1) where number = t.number and t.number < number)
@@ -251,20 +295,23 @@ HashJoin
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
 ├── filters: [lt(t.number (#0), numbers.number (#1))]
+├── estimated rows: 1.00
 ├── TableScan(Build)
 │   ├── table: default.system.numbers
 │   ├── read rows: 1
 │   ├── read bytes: 8
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t where exists (select number as a, number as b, number as c from numbers(1) where number = t.number)
@@ -274,67 +321,80 @@ HashJoin
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
 ├── filters: []
+├── estimated rows: 1.00
 ├── TableScan(Build)
 │   ├── table: default.system.numbers
 │   ├── read rows: 1
 │   ├── read bytes: 8
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── read rows: 1
     ├── read bytes: 8
     ├── partitions total: 1
     ├── partitions scanned: 1
-    └── push downs: [filters: [], limit: NONE]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where (select count(*) = 1 from numbers(1) where t.number = number) and t.number = t1.number
 ----
 Filter
 ├── filters: [CAST(if(is_not_null(scalar_subquery_3 (#3)), scalar_subquery_3 (#3), 0_i64) AS BIGINT UNSIGNED NULL)]
+├── estimated rows: 0.33
 └── HashJoin
     ├── join type: SINGLE
     ├── build keys: [subquery_2 (#2)]
     ├── probe keys: [subquery_0 (#0)]
     ├── filters: []
+    ├── estimated rows: 1.00
     ├── EvalScalar(Build)
     │   ├── expressions: [eq(COUNT(*) (#4), 1_u8)]
+    │   ├── estimated rows: 0.33
     │   └── AggregateFinal
     │       ├── group by: [number]
     │       ├── aggregate functions: [count()]
+    │       ├── estimated rows: 0.33
     │       └── AggregatePartial
     │           ├── group by: [number]
     │           ├── aggregate functions: [count()]
+    │           ├── estimated rows: 0.33
     │           └── Filter
     │               ├── filters: [eq(subquery_2 (#2), numbers.number (#2))]
+    │               ├── estimated rows: 0.33
     │               └── TableScan
     │                   ├── table: default.system.numbers
     │                   ├── read rows: 1
     │                   ├── read bytes: 8
     │                   ├── partitions total: 1
     │                   ├── partitions scanned: 1
-    │                   └── push downs: [filters: [eq(subquery_2, number)], limit: NONE]
+    │                   ├── push downs: [filters: [eq(subquery_2, number)], limit: NONE]
+    │                   └── estimated rows: 1.00
     └── HashJoin(Probe)
         ├── join type: INNER
         ├── build keys: [t1.number (#1)]
         ├── probe keys: [t.number (#0)]
         ├── filters: []
+        ├── estimated rows: 1.00
         ├── TableScan(Build)
         │   ├── table: default.system.numbers
         │   ├── read rows: 1
         │   ├── read bytes: 8
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
-        │   └── push downs: [filters: [], limit: NONE]
+        │   ├── push downs: [filters: [], limit: NONE]
+        │   └── estimated rows: 1.00
         └── TableScan(Probe)
             ├── table: default.system.numbers
             ├── read rows: 1
             ├── read bytes: 8
             ├── partitions total: 1
             ├── partitions scanned: 1
-            └── push downs: [filters: [], limit: NONE]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t where exists(select * from numbers(1) as t1 where t.number > t1.number) and not exists(select * from numbers(1) as t1 where t.number < t1.number)
@@ -344,29 +404,34 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: [lt(t.number (#0), t1.number (#2))]
+├── estimated rows: 1.00
 ├── TableScan(Build)
 │   ├── table: default.system.numbers
 │   ├── read rows: 1
 │   ├── read bytes: 8
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   └── push downs: [filters: [], limit: NONE]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 1.00
 └── HashJoin(Probe)
     ├── join type: LEFT SEMI
     ├── build keys: []
     ├── probe keys: []
     ├── filters: [gt(t.number (#0), t1.number (#1))]
+    ├── estimated rows: 1.00
     ├── TableScan(Build)
     │   ├── table: default.system.numbers
     │   ├── read rows: 1
     │   ├── read bytes: 8
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   └── push downs: [filters: [], limit: NONE]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.system.numbers
         ├── read rows: 1
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 1.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -26,47 +26,57 @@ query T
 explain select * from v where a > b
 ----
 UnionAll
+├── estimated rows: 1.33
 ├── Filter
 │   ├── filters: [gt(v.a (#0), v.b (#1))]
+│   ├── estimated rows: 0.67
 │   └── TableScan
 │       ├── table: default.default.t1
 │       ├── read rows: 0
 │       ├── read bytes: 0
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
-│       └── push downs: [filters: [gt(a, b)], limit: NONE]
+│       ├── push downs: [filters: [gt(a, b)], limit: NONE]
+│       └── estimated rows: 2.00
 └── Filter
     ├── filters: [gt(a (#2), b (#3))]
+    ├── estimated rows: 0.67
     └── TableScan
         ├── table: default.default.t2
         ├── read rows: 0
         ├── read bytes: 0
         ├── partitions total: 1
         ├── partitions scanned: 0
-        └── push downs: [filters: [gt(a, b)], limit: NONE]
+        ├── push downs: [filters: [gt(a, b)], limit: NONE]
+        └── estimated rows: 2.00
 
 query T
 explain select * from v where a > 1
 ----
 UnionAll
+├── estimated rows: 1.33
 ├── Filter
 │   ├── filters: [gt(v.a (#0), 1_u8)]
+│   ├── estimated rows: 0.67
 │   └── TableScan
 │       ├── table: default.default.t1
 │       ├── read rows: 2
 │       ├── read bytes: 62
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       └── push downs: [filters: [gt(a, 1_i32)], limit: NONE]
+│       ├── push downs: [filters: [gt(a, 1_i32)], limit: NONE]
+│       └── estimated rows: 2.00
 └── Filter
     ├── filters: [gt(a (#2), 1_u8)]
+    ├── estimated rows: 0.67
     └── TableScan
         ├── table: default.default.t2
         ├── read rows: 2
         ├── read bytes: 62
         ├── partitions total: 1
         ├── partitions scanned: 1
-        └── push downs: [filters: [gt(a, 1_i32)], limit: NONE]
+        ├── push downs: [filters: [gt(a, 1_i32)], limit: NONE]
+        └── estimated rows: 2.00
 
 query T
 explain select * from v limit 3
@@ -74,27 +84,33 @@ explain select * from v limit 3
 Limit
 ├── limit: 3
 ├── offset: 0
+├── estimated rows: 3.00
 └── UnionAll
+    ├── estimated rows: 4.00
     ├── Limit
     │   ├── limit: 3
     │   ├── offset: 0
+    │   ├── estimated rows: 2.00
     │   └── TableScan
     │       ├── table: default.default.t1
     │       ├── read rows: 2
     │       ├── read bytes: 62
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       └── push downs: [filters: [], limit: 3]
+    │       ├── push downs: [filters: [], limit: 3]
+    │       └── estimated rows: 2.00
     └── Limit
         ├── limit: 3
         ├── offset: 0
+        ├── estimated rows: 2.00
         └── TableScan
             ├── table: default.default.t2
             ├── read rows: 2
             ├── read bytes: 62
             ├── partitions total: 1
             ├── partitions scanned: 1
-            └── push downs: [filters: [], limit: 3]
+            ├── push downs: [filters: [], limit: 3]
+            └── estimated rows: 2.00
 
 query T
 explain select * from v limit 3 offset 1
@@ -102,27 +118,33 @@ explain select * from v limit 3 offset 1
 Limit
 ├── limit: 3
 ├── offset: 1
+├── estimated rows: 3.00
 └── UnionAll
+    ├── estimated rows: 4.00
     ├── Limit
     │   ├── limit: 4
     │   ├── offset: 0
+    │   ├── estimated rows: 2.00
     │   └── TableScan
     │       ├── table: default.default.t1
     │       ├── read rows: 2
     │       ├── read bytes: 62
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       └── push downs: [filters: [], limit: 4]
+    │       ├── push downs: [filters: [], limit: 4]
+    │       └── estimated rows: 2.00
     └── Limit
         ├── limit: 4
         ├── offset: 0
+        ├── estimated rows: 2.00
         └── TableScan
             ├── table: default.default.t2
             ├── read rows: 2
             ├── read bytes: 62
             ├── partitions total: 1
             ├── partitions scanned: 1
-            └── push downs: [filters: [], limit: 4]
+            ├── push downs: [filters: [], limit: 4]
+            └── estimated rows: 2.00
 
 query T
 explain select * from t1 union all select * from t2 limit 1
@@ -130,27 +152,33 @@ explain select * from t1 union all select * from t2 limit 1
 Limit
 ├── limit: 1
 ├── offset: 0
+├── estimated rows: 1.00
 └── UnionAll
+    ├── estimated rows: 2.00
     ├── Limit
     │   ├── limit: 1
     │   ├── offset: 0
+    │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.t1
     │       ├── read rows: 2
     │       ├── read bytes: 62
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       └── push downs: [filters: [], limit: 1]
+    │       ├── push downs: [filters: [], limit: 1]
+    │       └── estimated rows: 2.00
     └── Limit
         ├── limit: 1
         ├── offset: 0
+        ├── estimated rows: 1.00
         └── TableScan
             ├── table: default.default.t2
             ├── read rows: 2
             ├── read bytes: 62
             ├── partitions total: 1
             ├── partitions scanned: 1
-            └── push downs: [filters: [], limit: 1]
+            ├── push downs: [filters: [], limit: 1]
+            └── estimated rows: 2.00
 
 statement ok
 drop table t1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support display estimated rows information in explain result.

Example:
<img width="542" alt="image" src="https://user-images.githubusercontent.com/22445410/211261217-e18b4715-982f-471c-9c97-c47502c11dfa.png">


Closes #9397 
