### PR TITLE
feat(query): add a special dispatch for single simple order field.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,6 +1835,7 @@ dependencies = [
  "common-exception",
  "common-expression",
  "common-pipeline-core",
+ "match-template",
 ]
 
 [[package]]

--- a/src/query/pipeline/transforms/Cargo.toml
+++ b/src/query/pipeline/transforms/Cargo.toml
@@ -13,5 +13,6 @@ common-arrow = { path = "../../../common/arrow" }
 common-exception = { path = "../../../common/exception" }
 common-expression = { path = "../../expression" }
 common-pipeline-core = { path = "../core" }
+match-template = "0.0.1"
 
 async-trait = { version = "0.1.57", package = "async-trait-fn" }

--- a/src/query/pipeline/transforms/src/processors/transforms/sort_utils/cursor.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort_utils/cursor.rs
@@ -1,0 +1,82 @@
+//  Copyright 2023 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::cmp::Ordering;
+
+use super::rows::Rows;
+
+/// A cursor point to a certain row in a data block.
+pub struct Cursor<R: Rows> {
+    pub input_index: usize,
+    pub row_index: usize,
+
+    num_rows: usize,
+
+    rows: R,
+}
+
+impl<R: Rows> Cursor<R> {
+    pub fn try_create(input_index: usize, rows: R) -> Self {
+        Self {
+            input_index,
+            row_index: 0,
+            num_rows: rows.len(),
+            rows,
+        }
+    }
+
+    #[inline]
+    pub fn advance(&mut self) -> usize {
+        let res = self.row_index;
+        self.row_index += 1;
+        res
+    }
+
+    #[inline]
+    pub fn is_finished(&self) -> bool {
+        self.num_rows == self.row_index
+    }
+
+    #[inline]
+    pub fn current(&self) -> R::Item<'_> {
+        self.rows.row(self.row_index)
+    }
+
+    #[inline]
+    pub fn last(&self) -> R::Item<'_> {
+        self.rows.row(self.num_rows - 1)
+    }
+}
+
+impl<R: Rows> Ord for Cursor<R> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.current()
+            .cmp(&other.current())
+            .then_with(|| self.input_index.cmp(&other.input_index))
+    }
+}
+
+impl<R: Rows> PartialEq for Cursor<R> {
+    fn eq(&self, other: &Self) -> bool {
+        self.current() == other.current()
+    }
+}
+
+impl<R: Rows> Eq for Cursor<R> {}
+
+impl<R: Rows> PartialOrd for Cursor<R> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/src/query/pipeline/transforms/src/processors/transforms/sort_utils/mod.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort_utils/mod.rs
@@ -1,4 +1,4 @@
-//  Copyright 2022 Datafuse Labs.
+//  Copyright 2023 Datafuse Labs.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -12,20 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-mod sort_utils;
-pub mod transform;
-pub mod transform_block_compact;
-pub mod transform_block_compact_no_split;
-pub mod transform_compact;
-pub mod transform_limit;
-pub mod transform_multi_sort_merge;
-pub mod transform_sort_merge;
-pub mod transform_sort_partial;
+mod cursor;
+mod rows;
 
-pub use transform::*;
-pub use transform_block_compact::*;
-pub use transform_compact::*;
-pub use transform_limit::*;
-pub use transform_multi_sort_merge::*;
-pub use transform_sort_merge::*;
-pub use transform_sort_partial::*;
+pub use cursor::*;
+pub use rows::*;

--- a/src/query/pipeline/transforms/src/processors/transforms/sort_utils/rows/arrow.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort_utils/rows/arrow.rs
@@ -1,0 +1,69 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_arrow::arrow::compute::sort::row::Row as ArrowRow;
+use common_arrow::arrow::compute::sort::row::RowConverter as ArrowRowConverter;
+use common_arrow::arrow::compute::sort::row::Rows as ArrowRows;
+use common_arrow::arrow::compute::sort::row::SortField as ArrowSortField;
+use common_arrow::arrow::compute::sort::SortOptions as ArrowSortOptions;
+use common_exception::Result;
+use common_expression::arrow::column_to_arrow_array;
+use common_expression::BlockEntry;
+use common_expression::DataSchemaRef;
+use common_expression::SortColumnDescription;
+
+use super::RowConverter;
+use super::Rows;
+
+impl Rows for ArrowRows {
+    type Item<'a> = ArrowRow<'a>;
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn row(&self, index: usize) -> Self::Item<'_> {
+        self.row_unchecked(index)
+    }
+}
+
+impl RowConverter<ArrowRows> for ArrowRowConverter {
+    fn create(
+        sort_columns_descriptions: Vec<SortColumnDescription>,
+        output_schema: DataSchemaRef,
+    ) -> Result<Self> {
+        let sort_fields = sort_columns_descriptions
+            .iter()
+            .map(|d| {
+                let data_type = output_schema.field(d.offset).data_type();
+                Ok(ArrowSortField::new_with_options(
+                    data_type.into(),
+                    ArrowSortOptions {
+                        descending: !d.asc,
+                        nulls_first: d.nulls_first,
+                    },
+                ))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(ArrowRowConverter::new(sort_fields))
+    }
+
+    fn convert(&mut self, columns: &[BlockEntry], num_rows: usize) -> Result<ArrowRows> {
+        let arrays = columns
+            .iter()
+            .map(|col| column_to_arrow_array(col, num_rows))
+            .collect::<Vec<_>>();
+        Ok(self.convert_columns(&arrays)?)
+    }
+}

--- a/src/query/pipeline/transforms/src/processors/transforms/sort_utils/rows/mod.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort_utils/rows/mod.rs
@@ -1,0 +1,42 @@
+//  Copyright 2023 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+mod arrow;
+mod simple;
+
+use common_exception::Result;
+use common_expression::BlockEntry;
+use common_expression::DataSchemaRef;
+use common_expression::SortColumnDescription;
+pub use simple::*;
+
+/// Convert columns to rows.
+pub trait RowConverter<T: Rows>
+where Self: Sized
+{
+    fn create(
+        sort_columns_descriptions: Vec<SortColumnDescription>,
+        output_schema: DataSchemaRef,
+    ) -> Result<Self>;
+    fn convert(&mut self, columns: &[BlockEntry], num_rows: usize) -> Result<T>;
+}
+
+/// Rows can be compared.
+pub trait Rows {
+    type Item<'a>: Ord
+    where Self: 'a;
+
+    fn len(&self) -> usize;
+    fn row(&self, index: usize) -> Self::Item<'_>;
+}

--- a/src/query/pipeline/transforms/src/processors/transforms/sort_utils/rows/simple.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort_utils/rows/simple.rs
@@ -1,0 +1,154 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::marker::PhantomData;
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_expression::types::ArgType;
+use common_expression::types::ValueType;
+use common_expression::BlockEntry;
+use common_expression::ColumnBuilder;
+use common_expression::DataSchemaRef;
+use common_expression::SortColumnDescription;
+use common_expression::Value;
+
+use super::RowConverter;
+use super::Rows;
+
+/// Row structure for single simple types. (numbers, date, timestamp)
+#[derive(Clone, Copy)]
+pub struct SimpleRow<T: ValueType> {
+    inner: T::Scalar,
+    desc: bool,
+}
+
+/// Rows structure for single simple types. (numbers, date, timestamp)
+pub struct SimpleRows<T: ValueType> {
+    inner: T::Column,
+    desc: bool,
+}
+
+impl<T> Ord for SimpleRow<T>
+where
+    T: ValueType,
+    T::Scalar: Ord,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.desc {
+            self.inner.cmp(&other.inner).reverse()
+        } else {
+            self.inner.cmp(&other.inner)
+        }
+    }
+}
+
+impl<T> PartialOrd for SimpleRow<T>
+where
+    T: ValueType,
+    T::Scalar: Ord,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> PartialEq for SimpleRow<T>
+where
+    T: ValueType,
+    T::Scalar: Ord,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl<T> Eq for SimpleRow<T>
+where
+    T: ValueType,
+    T::Scalar: Ord,
+{
+}
+
+impl<T> Rows for SimpleRows<T>
+where
+    T: ValueType,
+    T::Scalar: Ord,
+{
+    type Item<'a> = SimpleRow<T>;
+
+    fn len(&self) -> usize {
+        T::column_len(&self.inner)
+    }
+
+    fn row(&self, index: usize) -> Self::Item<'_> {
+        let inner = unsafe { T::index_column_unchecked(&self.inner, index) };
+        SimpleRow {
+            inner: T::to_owned_scalar(inner),
+            desc: self.desc,
+        }
+    }
+}
+
+/// If there is only one sort field and its type is a primitive type,
+/// use this converter.
+pub struct SimpleRowConverter<T> {
+    desc: bool,
+    _t: PhantomData<T>,
+}
+
+impl<T> RowConverter<SimpleRows<T>> for SimpleRowConverter<T>
+where
+    T: ArgType,
+    T::Scalar: Ord,
+{
+    fn create(
+        sort_columns_descriptions: Vec<SortColumnDescription>,
+        _: DataSchemaRef,
+    ) -> Result<Self> {
+        assert!(sort_columns_descriptions.len() == 1);
+
+        Ok(Self {
+            desc: !sort_columns_descriptions[0].asc,
+            _t: PhantomData,
+        })
+    }
+
+    fn convert(&mut self, columns: &[BlockEntry], num_rows: usize) -> Result<SimpleRows<T>> {
+        assert!(columns.len() == 1);
+        let col = &columns[0];
+        if col.data_type != T::data_type() {
+            return Err(ErrorCode::Internal(format!(
+                "Cannot convert simple column. Expect data type {:?}, found {:?}",
+                T::data_type(),
+                col.data_type
+            )));
+        }
+
+        let col = match &col.value {
+            Value::Scalar(v) => {
+                let builder = ColumnBuilder::repeat(&v.as_ref(), num_rows, &col.data_type);
+                builder.build()
+            }
+            Value::Column(c) => c.clone(),
+        };
+
+        let rows = SimpleRows {
+            inner: T::try_downcast_column(&col).unwrap(),
+            desc: self.desc,
+        };
+        Ok(rows)
+    }
+}

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_multi_sort_merge.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_multi_sort_merge.rs
@@ -13,7 +13,6 @@
 //  limitations under the License.
 
 use std::any::Any;
-use std::cmp::Ordering;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::collections::VecDeque;
@@ -21,15 +20,17 @@ use std::sync;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use common_arrow::arrow::compute::sort::row::Row;
-use common_arrow::arrow::compute::sort::row::RowConverter;
-use common_arrow::arrow::compute::sort::row::Rows;
-use common_arrow::arrow::compute::sort::row::SortField;
-use common_arrow::arrow::compute::sort::SortOptions;
-use common_arrow::arrow::datatypes::DataType as ArrowDataType;
+use common_arrow::arrow::compute::sort::row::RowConverter as ArrowRowConverter;
+use common_arrow::arrow::compute::sort::row::Rows as ArrowRows;
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_expression::utils::arrow::column_to_arrow_array;
+use common_expression::types::DataType;
+use common_expression::types::DateType;
+use common_expression::types::NumberDataType;
+use common_expression::types::NumberType;
+use common_expression::types::StringType;
+use common_expression::types::TimestampType;
+use common_expression::with_number_mapped_type;
 use common_expression::DataBlock;
 use common_expression::DataSchemaRef;
 use common_expression::SortColumnDescription;
@@ -40,6 +41,12 @@ use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_core::processors::Processor;
 use common_pipeline_core::Pipe;
 use common_pipeline_core::Pipeline;
+
+use super::sort_utils::Cursor;
+use super::sort_utils::RowConverter;
+use super::sort_utils::Rows;
+use super::sort_utils::SimpleRowConverter;
+use super::sort_utils::SimpleRows;
 
 pub fn try_add_multi_sort_merge(
     pipeline: &mut Pipeline,
@@ -61,7 +68,7 @@ pub fn try_add_multi_sort_merge(
                 inputs_port.push(InputPort::create());
             }
             let output_port = OutputPort::create();
-            let processor = MultiSortMergeProcessor::create(
+            let processor = create_processor(
                 inputs_port.clone(),
                 output_port.clone(),
                 output_schema,
@@ -72,80 +79,106 @@ pub fn try_add_multi_sort_merge(
             pipeline.pipes.push(Pipe::ResizePipe {
                 inputs_port,
                 outputs_port: vec![output_port],
-                processor: ProcessorPtr::create(Box::new(processor)),
+                processor,
             });
             Ok(())
         }
     }
 }
 
-/// A cursor point to a certain row in a data block.
-struct Cursor {
-    pub input_index: usize,
-    pub row_index: usize,
-
-    num_rows: usize,
-
-    rows: Rows,
-}
-
-impl Cursor {
-    pub fn try_create(input_index: usize, rows: Rows) -> Cursor {
-        Cursor {
-            input_index,
-            row_index: 0,
-            num_rows: rows.len(),
-            rows,
+fn create_processor(
+    inputs: Vec<Arc<InputPort>>,
+    output: Arc<OutputPort>,
+    output_schema: DataSchemaRef,
+    block_size: usize,
+    limit: Option<usize>,
+    sort_columns_descriptions: Vec<SortColumnDescription>,
+) -> Result<ProcessorPtr> {
+    Ok(if sort_columns_descriptions.len() == 1 {
+        let sort_type = output_schema
+            .field(sort_columns_descriptions[0].offset)
+            .data_type();
+        match sort_type {
+            DataType::Number(num_ty) => with_number_mapped_type!(|NUM_TYPE| match num_ty {
+                NumberDataType::NUM_TYPE =>
+                    ProcessorPtr::create(Box::new(MultiSortMergeProcessor::<
+                        SimpleRows<NumberType<NUM_TYPE>>,
+                        SimpleRowConverter<NumberType<NUM_TYPE>>,
+                    >::create(
+                        inputs,
+                        output,
+                        output_schema,
+                        block_size,
+                        limit,
+                        sort_columns_descriptions,
+                    )?)),
+            }),
+            DataType::Date => ProcessorPtr::create(Box::new(MultiSortMergeProcessor::<
+                SimpleRows<DateType>,
+                SimpleRowConverter<DateType>,
+            >::create(
+                inputs,
+                output,
+                output_schema,
+                block_size,
+                limit,
+                sort_columns_descriptions,
+            )?)),
+            DataType::Timestamp => ProcessorPtr::create(Box::new(MultiSortMergeProcessor::<
+                SimpleRows<TimestampType>,
+                SimpleRowConverter<TimestampType>,
+            >::create(
+                inputs,
+                output,
+                output_schema,
+                block_size,
+                limit,
+                sort_columns_descriptions,
+            )?)),
+            DataType::String => ProcessorPtr::create(Box::new(MultiSortMergeProcessor::<
+                SimpleRows<StringType>,
+                SimpleRowConverter<StringType>,
+            >::create(
+                inputs,
+                output,
+                output_schema,
+                block_size,
+                limit,
+                sort_columns_descriptions,
+            )?)),
+            _ => ProcessorPtr::create(Box::new(MultiSortMergeProcessor::<
+                ArrowRows,
+                ArrowRowConverter,
+            >::create(
+                inputs,
+                output,
+                output_schema,
+                block_size,
+                limit,
+                sort_columns_descriptions,
+            )?)),
         }
-    }
-
-    #[inline]
-    pub fn advance(&mut self) -> usize {
-        let res = self.row_index;
-        self.row_index += 1;
-        res
-    }
-
-    #[inline]
-    pub fn is_finished(&self) -> bool {
-        self.num_rows == self.row_index
-    }
-
-    #[inline]
-    pub fn current(&self) -> Row<'_> {
-        self.rows.row_unchecked(self.row_index)
-    }
-
-    #[inline]
-    pub fn last(&self) -> Row<'_> {
-        self.rows.row_unchecked(self.num_rows - 1)
-    }
-}
-
-impl Ord for Cursor {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.current()
-            .cmp(&other.current())
-            .then_with(|| self.input_index.cmp(&other.input_index))
-    }
-}
-
-impl PartialEq for Cursor {
-    fn eq(&self, other: &Self) -> bool {
-        self.current() == other.current()
-    }
-}
-
-impl Eq for Cursor {}
-
-impl PartialOrd for Cursor {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
+    } else {
+        ProcessorPtr::create(Box::new(MultiSortMergeProcessor::<
+            ArrowRows,
+            ArrowRowConverter,
+        >::create(
+            inputs,
+            output,
+            output_schema,
+            block_size,
+            limit,
+            sort_columns_descriptions,
+        )?))
+    })
 }
 
 /// TransformMultiSortMerge is a processor with multiple input ports;
-pub struct MultiSortMergeProcessor {
+pub struct MultiSortMergeProcessor<R, Converter>
+where
+    R: Rows,
+    Converter: RowConverter<R>,
+{
     /// Data from inputs (every input is sorted)
     inputs: Vec<Arc<InputPort>>,
     output: Arc<OutputPort>,
@@ -167,18 +200,22 @@ pub struct MultiSortMergeProcessor {
     /// Data format: (input_index, block_index, row_index)
     in_progess_rows: Vec<(usize, usize, usize)>,
     /// Heap that yields [`Cursor`] in increasing order.
-    heap: BinaryHeap<Reverse<Cursor>>,
+    heap: BinaryHeap<Reverse<Cursor<R>>>,
     /// If the input port is finished.
     input_finished: Vec<bool>,
     /// Used to convert columns to rows.
-    row_converter: RowConverter,
+    row_converter: Converter,
 
     state: ProcessorState,
 
     aborting: Arc<AtomicBool>,
 }
 
-impl MultiSortMergeProcessor {
+impl<R, Converter> MultiSortMergeProcessor<R, Converter>
+where
+    R: Rows,
+    Converter: RowConverter<R>,
+{
     pub fn create(
         inputs: Vec<Arc<InputPort>>,
         output: Arc<OutputPort>,
@@ -188,21 +225,11 @@ impl MultiSortMergeProcessor {
         sort_columns_descriptions: Vec<SortColumnDescription>,
     ) -> Result<Self> {
         let input_size = inputs.len();
-        let mut sort_field_indices = Vec::with_capacity(sort_columns_descriptions.len());
-        let sort_fields = sort_columns_descriptions
+        let sort_field_indices = sort_columns_descriptions
             .iter()
-            .map(|d| {
-                sort_field_indices.push(d.offset);
-                SortField::new_with_options(
-                    ArrowDataType::from(output_schema.field(d.offset).data_type()),
-                    SortOptions {
-                        descending: !d.asc,
-                        nulls_first: d.nulls_first,
-                    },
-                )
-            })
+            .map(|d| d.offset)
             .collect::<Vec<_>>();
-        let row_converter = RowConverter::new(sort_fields);
+        let row_converter = Converter::create(sort_columns_descriptions, output_schema.clone())?;
         Ok(Self {
             inputs,
             output,
@@ -246,7 +273,7 @@ impl MultiSortMergeProcessor {
 
     // Return if need output
     #[inline]
-    fn drain_cursor(&mut self, mut cursor: Cursor) -> bool {
+    fn drain_cursor(&mut self, mut cursor: Cursor<R>) -> bool {
         let input_index = cursor.input_index;
         let block_index = self.blocks[input_index].len() - 1;
         while !cursor.is_finished() {
@@ -400,7 +427,11 @@ impl MultiSortMergeProcessor {
 }
 
 #[async_trait::async_trait]
-impl Processor for MultiSortMergeProcessor {
+impl<R, Converter> Processor for MultiSortMergeProcessor<R, Converter>
+where
+    R: Rows + Send + 'static,
+    Converter: RowConverter<R> + Send + 'static,
+{
     fn name(&self) -> String {
         "MultiSortMerge".to_string()
     }
@@ -502,9 +533,9 @@ impl Processor for MultiSortMergeProcessor {
                     let columns = self
                         .sort_field_indices
                         .iter()
-                        .map(|i| column_to_arrow_array(block.get_by_offset(*i), block.num_rows()))
+                        .map(|i| block.get_by_offset(*i).clone())
                         .collect::<Vec<_>>();
-                    let rows = self.row_converter.convert_columns(&columns)?;
+                    let rows = self.row_converter.convert(&columns, block.num_rows())?;
                     if !block.is_empty() {
                         let cursor = Cursor::try_create(input_index, rows);
                         self.heap.push(Reverse(cursor));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

If there is only one single simple order by field, we don't need to construct the arrow2 row converter.

This PR also abstracts `Rows` and `RowConverter` traits for more variations in the future.

Closes #issue
