### PR TITLE
feat(meta/proto-conv): add reader-min-msg-ver and msg-min-reader-ver

### DIFF
--- a/src/meta/proto-conv/src/config_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/config_from_to_protobuf_impl.rs
@@ -18,10 +18,10 @@ use common_storage::StorageGcsConfig;
 use common_storage::StorageOssConfig;
 use common_storage::StorageS3Config;
 
-use crate::check_ver;
+use crate::reader_check_msg;
 use crate::FromToProto;
 use crate::Incompatible;
-use crate::MIN_COMPATIBLE_VER;
+use crate::MIN_READER_VER;
 use crate::VER;
 
 impl FromToProto for StorageS3Config {
@@ -29,7 +29,7 @@ impl FromToProto for StorageS3Config {
 
     fn from_pb(p: pb::S3StorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.version, p.min_compatible)?;
+        reader_check_msg(p.version, p.min_compatible)?;
 
         Ok(StorageS3Config {
             region: p.region,
@@ -50,7 +50,7 @@ impl FromToProto for StorageS3Config {
     fn to_pb(&self) -> Result<pb::S3StorageConfig, Incompatible> {
         Ok(pb::S3StorageConfig {
             version: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             region: self.region.clone(),
             endpoint_url: self.endpoint_url.clone(),
             access_key_id: self.access_key_id.clone(),
@@ -72,7 +72,7 @@ impl FromToProto for StorageGcsConfig {
 
     fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.version, p.min_compatible)?;
+        reader_check_msg(p.version, p.min_compatible)?;
 
         Ok(StorageGcsConfig {
             credential: p.credential,
@@ -85,7 +85,7 @@ impl FromToProto for StorageGcsConfig {
     fn to_pb(&self) -> Result<Self::PB, Incompatible> {
         Ok(pb::GcsStorageConfig {
             version: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             credential: self.credential.clone(),
             endpoint_url: self.endpoint_url.clone(),
             bucket: self.bucket.clone(),
@@ -99,7 +99,7 @@ impl FromToProto for StorageFsConfig {
 
     fn from_pb(p: pb::FsStorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.version, p.min_compatible)?;
+        reader_check_msg(p.version, p.min_compatible)?;
 
         Ok(StorageFsConfig { root: p.root })
     }
@@ -107,7 +107,7 @@ impl FromToProto for StorageFsConfig {
     fn to_pb(&self) -> Result<pb::FsStorageConfig, Incompatible> {
         Ok(pb::FsStorageConfig {
             version: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             root: self.root.clone(),
         })
     }
@@ -118,7 +118,7 @@ impl FromToProto for StorageOssConfig {
 
     fn from_pb(p: pb::OssStorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.version, p.min_compatible)?;
+        reader_check_msg(p.version, p.min_compatible)?;
 
         Ok(StorageOssConfig {
             endpoint_url: p.endpoint_url,
@@ -133,7 +133,7 @@ impl FromToProto for StorageOssConfig {
     fn to_pb(&self) -> Result<pb::OssStorageConfig, Incompatible> {
         Ok(pb::OssStorageConfig {
             version: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             endpoint_url: self.endpoint_url.clone(),
             bucket: self.bucket.clone(),
             root: self.root.clone(),

--- a/src/meta/proto-conv/src/data_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/data_from_to_protobuf_impl.rs
@@ -24,16 +24,16 @@ use common_protos::pb;
 use common_protos::pb::data_type::Dt;
 use num::FromPrimitive;
 
-use crate::check_ver;
+use crate::reader_check_msg;
 use crate::FromToProto;
 use crate::Incompatible;
-use crate::MIN_COMPATIBLE_VER;
+use crate::MIN_READER_VER;
 use crate::VER;
 
 impl FromToProto for dv::DataSchema {
     type PB = pb::DataSchema;
     fn from_pb(p: pb::DataSchema) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let mut fs = Vec::with_capacity(p.fields.len());
         for f in p.fields.into_iter() {
@@ -52,7 +52,7 @@ impl FromToProto for dv::DataSchema {
 
         let p = pb::DataSchema {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             fields: fs,
             metadata: self.meta().clone(),
         };
@@ -63,7 +63,7 @@ impl FromToProto for dv::DataSchema {
 impl FromToProto for dv::DataField {
     type PB = pb::DataField;
     fn from_pb(p: pb::DataField) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = dv::DataField::new(
             &p.name,
@@ -78,7 +78,7 @@ impl FromToProto for dv::DataField {
     fn to_pb(&self) -> Result<pb::DataField, Incompatible> {
         let p = pb::DataField {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             name: self.name().clone(),
             default_expr: self.default_expr().cloned(),
             data_type: Some(self.data_type().to_pb()?),
@@ -90,7 +90,7 @@ impl FromToProto for dv::DataField {
 impl FromToProto for dv::DataTypeImpl {
     type PB = pb::DataType;
     fn from_pb(p: pb::DataType) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let dt = match p.dt {
             None => {
@@ -142,7 +142,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::NullableType(Box::new(inn))),
                 };
                 Ok(v)
@@ -150,7 +150,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Boolean(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::BoolType(pb::Empty {})),
                 };
                 Ok(v)
@@ -158,7 +158,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Int8(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::Int8Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -166,7 +166,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Int16(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::Int16Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -174,7 +174,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Int32(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::Int32Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -182,7 +182,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Int64(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::Int64Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -190,7 +190,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt8(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::Uint8Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -198,7 +198,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt16(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::Uint16Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -206,7 +206,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt32(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::Uint32Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -214,7 +214,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt64(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::Uint64Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -222,7 +222,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Float32(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::Float32Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -230,7 +230,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Float64(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::Float64Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -238,7 +238,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Date(_x) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::DateType(pb::Empty {})),
                 };
                 Ok(v)
@@ -248,7 +248,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::TimestampType(inn)),
                 };
                 Ok(v)
@@ -256,7 +256,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::String(_x) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::StringType(pb::Empty {})),
                 };
                 Ok(v)
@@ -266,7 +266,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::StructType(inn)),
                 };
                 Ok(v)
@@ -276,7 +276,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::ArrayType(Box::new(inn))),
                 };
                 Ok(v)
@@ -286,7 +286,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::VariantType(inn)),
                 };
                 Ok(p)
@@ -296,7 +296,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::VariantArrayType(inn)),
                 };
                 Ok(p)
@@ -306,7 +306,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::VariantObjectType(inn)),
                 };
                 Ok(p)
@@ -316,7 +316,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_COMPATIBLE_VER,
+                    min_compatible: MIN_READER_VER,
                     dt: Some(Dt::IntervalType(inn)),
                 };
                 Ok(p)
@@ -329,7 +329,7 @@ impl FromToProto for dv::NullableType {
     type PB = pb::NullableType;
     fn from_pb(p: pb::NullableType) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let inner = p.inner.ok_or_else(|| Incompatible {
             reason: "NullableType.inner can not be None".to_string(),
@@ -346,7 +346,7 @@ impl FromToProto for dv::NullableType {
 
         let p = pb::NullableType {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             inner: Some(Box::new(inner_pb_type)),
         };
 
@@ -358,14 +358,14 @@ impl FromToProto for dv::TimestampType {
     type PB = pb::Timestamp;
     fn from_pb(p: pb::Timestamp) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
         Ok(dv::TimestampType::default())
     }
 
     fn to_pb(&self) -> Result<pb::Timestamp, Incompatible> {
         let p = pb::Timestamp {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
         };
 
         Ok(p)
@@ -376,7 +376,7 @@ impl FromToProto for dv::StructType {
     type PB = pb::Struct;
     fn from_pb(p: pb::Struct) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
         let names = p.names.clone();
 
         let mut types = Vec::with_capacity(p.types.len());
@@ -407,7 +407,7 @@ impl FromToProto for dv::StructType {
 
         let p = pb::Struct {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
 
             names,
             types,
@@ -421,7 +421,7 @@ impl FromToProto for dv::ArrayType {
     type PB = pb::Array;
     fn from_pb(p: pb::Array) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let inner = p.inner.ok_or_else(|| Incompatible {
             reason: "Array.inner can not be None".to_string(),
@@ -438,7 +438,7 @@ impl FromToProto for dv::ArrayType {
 
         let p = pb::Array {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             inner: Some(Box::new(inner_pb_type)),
         };
 
@@ -450,7 +450,7 @@ impl FromToProto for dv::VariantArrayType {
     type PB = pb::VariantArray;
     fn from_pb(p: pb::VariantArray) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         Ok(Self {})
     }
@@ -458,7 +458,7 @@ impl FromToProto for dv::VariantArrayType {
     fn to_pb(&self) -> Result<pb::VariantArray, Incompatible> {
         let p = pb::VariantArray {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
         };
         Ok(p)
     }
@@ -468,7 +468,7 @@ impl FromToProto for dv::VariantObjectType {
     type PB = pb::VariantObject;
     fn from_pb(p: pb::VariantObject) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         Ok(Self {})
     }
@@ -476,7 +476,7 @@ impl FromToProto for dv::VariantObjectType {
     fn to_pb(&self) -> Result<pb::VariantObject, Incompatible> {
         let p = pb::VariantObject {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
         };
         Ok(p)
     }
@@ -520,7 +520,7 @@ impl FromToProto for dv::IntervalType {
     type PB = pb::IntervalType;
     fn from_pb(p: pb::IntervalType) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let pb_kind: pb::IntervalKind =
             FromPrimitive::from_i32(p.kind).ok_or_else(|| Incompatible {
@@ -535,7 +535,7 @@ impl FromToProto for dv::IntervalType {
         let pb_kind = self.kind().to_pb()?;
         let p = pb::IntervalType {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             kind: pb_kind as i32,
         };
         Ok(p)
@@ -546,7 +546,7 @@ impl FromToProto for dv::VariantType {
     type PB = pb::Variant;
     fn from_pb(p: pb::Variant) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         Ok(Self {})
     }
@@ -554,7 +554,7 @@ impl FromToProto for dv::VariantType {
     fn to_pb(&self) -> Result<pb::Variant, Incompatible> {
         let p = pb::Variant {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
         };
         Ok(p)
     }

--- a/src/meta/proto-conv/src/database_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/database_from_to_protobuf_impl.rs
@@ -23,16 +23,16 @@ use common_meta_app::schema as mt;
 use common_meta_app::share;
 use common_protos::pb;
 
-use crate::check_ver;
+use crate::reader_check_msg;
 use crate::FromToProto;
 use crate::Incompatible;
-use crate::MIN_COMPATIBLE_VER;
+use crate::MIN_READER_VER;
 use crate::VER;
 
 impl FromToProto for mt::DatabaseNameIdent {
     type PB = pb::DatabaseNameIdent;
     fn from_pb(p: pb::DatabaseNameIdent) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self {
             tenant: p.tenant,
@@ -44,7 +44,7 @@ impl FromToProto for mt::DatabaseNameIdent {
     fn to_pb(&self) -> Result<pb::DatabaseNameIdent, Incompatible> {
         let p = pb::DatabaseNameIdent {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             tenant: self.tenant.clone(),
             db_name: self.db_name.clone(),
         };
@@ -55,7 +55,7 @@ impl FromToProto for mt::DatabaseNameIdent {
 impl FromToProto for mt::DatabaseMeta {
     type PB = pb::DatabaseMeta;
     fn from_pb(p: pb::DatabaseMeta) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self {
             engine: p.engine,
@@ -80,7 +80,7 @@ impl FromToProto for mt::DatabaseMeta {
     fn to_pb(&self) -> Result<pb::DatabaseMeta, Incompatible> {
         let p = pb::DatabaseMeta {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             engine: self.engine.clone(),
             engine_options: self.engine_options.clone(),
             options: self.options.clone(),
@@ -104,7 +104,7 @@ impl FromToProto for mt::DatabaseMeta {
 impl FromToProto for mt::DbIdList {
     type PB = pb::DbIdList;
     fn from_pb(p: pb::DbIdList) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self { id_list: p.ids };
         Ok(v)
@@ -113,7 +113,7 @@ impl FromToProto for mt::DbIdList {
     fn to_pb(&self) -> Result<pb::DbIdList, Incompatible> {
         let p = pb::DbIdList {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             ids: self.id_list.clone(),
         };
         Ok(p)

--- a/src/meta/proto-conv/src/lib.rs
+++ b/src/meta/proto-conv/src/lib.rs
@@ -20,6 +20,43 @@
 //! Thus protobuf messages has the maximized compatibility.
 //! I.e., a protobuf message is able to contain several different versions of metadata in one format.
 //! This mod will convert protobuf message to the current version of meta data used in databend-query.
+//!
+//! # Versioning and compatibility
+//!
+//! Alice and Bob can talk with each other if they are compatible.
+//! Alice and Bob both have two versioning related field:
+//! - `ver`: the version of the subject,
+//! - and the minimal version of the target it can talk to.
+//!
+//! And out algorithm defines that Alice and Bob are compatible iff:
+//! - `Alice.min_bob_ver <= Bob.ver`
+//! - `Bob.min_alice_ver <= Alice.ver`
+//!
+//! E.g.:
+//! - `A: (ver=3, min_b_ver=1)` is compatible with `B: (ver=3, min_a_ver=2)`.
+//! - `A: (ver=4, min_b_ver=4)` is **NOT** compatible with `B: (ver=3, min_a_ver=2)`.
+//!   Because although `A.ver(4) >= B.min_a_ver(3)` holds,
+//!   but `B.ver(3) >= A.min_b_ver(4)` does not hold.
+//!
+//! ```text
+//! B.ver:    1             3      4
+//! B --------+-------------+------+------------>
+//!           ^      .------'      ^
+//!           |      |             |
+//!           '-------------.      |
+//!                  |      |      |
+//!                  v      |      |
+//! A ---------------+------+------+------------>
+//! A.ver:           2      3      4
+//! ```
+//!
+//! # Versioning implementation
+//!
+//! Since a client writes and reads data to meta-service, it is Alice and Bob at the same time(data producer and consumer).
+//! Thus it has three version attributes(not 4, because Alice.ver==Bob.ver):
+//! - `reader.VER` and `message.VER` are the version of the reader and the writer.
+//! - `reader.MIN_MSG_VER` is the minimal message version this program can read.
+//! - `message.MIN_READER_VER` is the minimal reader(program) version that can read this message.
 
 mod config_from_to_protobuf_impl;
 mod data_from_to_protobuf_impl;
@@ -32,7 +69,8 @@ mod util;
 
 pub use from_to_protobuf::FromToProto;
 pub use from_to_protobuf::Incompatible;
-pub use util::check_ver;
 pub use util::missing;
-pub use util::MIN_COMPATIBLE_VER;
+pub use util::reader_check_msg;
+pub use util::MIN_MSG_VER;
+pub use util::MIN_READER_VER;
 pub use util::VER;

--- a/src/meta/proto-conv/src/share_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/share_from_to_protobuf_impl.rs
@@ -24,16 +24,16 @@ use common_meta_app::share as mt;
 use common_protos::pb;
 use enumflags2::BitFlags;
 
-use crate::check_ver;
+use crate::reader_check_msg;
 use crate::FromToProto;
 use crate::Incompatible;
-use crate::MIN_COMPATIBLE_VER;
+use crate::MIN_READER_VER;
 use crate::VER;
 
 impl FromToProto for mt::ObjectSharedByShareIds {
     type PB = pb::ObjectSharedByShareIds;
     fn from_pb(p: pb::ObjectSharedByShareIds) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self {
             share_ids: BTreeSet::from_iter(p.share_ids.iter().copied()),
@@ -44,7 +44,7 @@ impl FromToProto for mt::ObjectSharedByShareIds {
     fn to_pb(&self) -> Result<pb::ObjectSharedByShareIds, Incompatible> {
         let p = pb::ObjectSharedByShareIds {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             share_ids: Vec::from_iter(self.share_ids.iter().copied()),
         };
         Ok(p)
@@ -54,7 +54,7 @@ impl FromToProto for mt::ObjectSharedByShareIds {
 impl FromToProto for mt::ShareNameIdent {
     type PB = pb::ShareNameIdent;
     fn from_pb(p: pb::ShareNameIdent) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self {
             tenant: p.tenant,
@@ -66,7 +66,7 @@ impl FromToProto for mt::ShareNameIdent {
     fn to_pb(&self) -> Result<pb::ShareNameIdent, Incompatible> {
         let p = pb::ShareNameIdent {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             tenant: self.tenant.clone(),
             share_name: self.share_name.clone(),
         };
@@ -77,7 +77,7 @@ impl FromToProto for mt::ShareNameIdent {
 impl FromToProto for mt::ShareGrantObject {
     type PB = pb::ShareGrantObject;
     fn from_pb(p: pb::ShareGrantObject) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         match p.object {
             Some(pb::share_grant_object::Object::DbId(db_id)) => {
@@ -104,7 +104,7 @@ impl FromToProto for mt::ShareGrantObject {
 
         let p = pb::ShareGrantObject {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             object,
         };
         Ok(p)
@@ -115,7 +115,7 @@ impl FromToProto for mt::ShareGrantEntry {
     type PB = pb::ShareGrantEntry;
     fn from_pb(p: pb::ShareGrantEntry) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let privileges = BitFlags::<mt::ShareGrantObjectPrivilege, u64>::from_bits(p.privileges);
         match privileges {
@@ -139,7 +139,7 @@ impl FromToProto for mt::ShareGrantEntry {
     fn to_pb(&self) -> Result<pb::ShareGrantEntry, Incompatible> {
         Ok(pb::ShareGrantEntry {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             object: Some(self.object().to_pb()?),
             privileges: self.privileges().bits(),
             grant_on: self.grant_on.to_pb()?,
@@ -155,7 +155,7 @@ impl FromToProto for mt::ShareMeta {
     type PB = pb::ShareMeta;
     fn from_pb(p: pb::ShareMeta) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
         let mut entries = BTreeMap::new();
         for entry in p.entries {
             let entry = mt::ShareGrantEntry::from_pb(entry)?;
@@ -186,7 +186,7 @@ impl FromToProto for mt::ShareMeta {
 
         Ok(pb::ShareMeta {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             database: match &self.database {
                 Some(db) => Some(mt::ShareGrantEntry::to_pb(db)?),
                 None => None,
@@ -208,7 +208,7 @@ impl FromToProto for mt::ShareAccountMeta {
     type PB = pb::ShareAccountMeta;
     fn from_pb(p: pb::ShareAccountMeta) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         Ok(mt::ShareAccountMeta {
             account: p.account.clone(),
@@ -224,7 +224,7 @@ impl FromToProto for mt::ShareAccountMeta {
     fn to_pb(&self) -> Result<pb::ShareAccountMeta, Incompatible> {
         Ok(pb::ShareAccountMeta {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
 
             account: self.account.clone(),
             share_id: self.share_id,

--- a/src/meta/proto-conv/src/table_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/table_from_to_protobuf_impl.rs
@@ -27,16 +27,16 @@ use common_meta_app::schema as mt;
 use common_protos::pb;
 use common_storage::StorageParams;
 
-use crate::check_ver;
+use crate::reader_check_msg;
 use crate::FromToProto;
 use crate::Incompatible;
-use crate::MIN_COMPATIBLE_VER;
+use crate::MIN_READER_VER;
 use crate::VER;
 
 impl FromToProto for mt::TableCopiedFileInfo {
     type PB = pb::TableCopiedFileInfo;
     fn from_pb(p: pb::TableCopiedFileInfo) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self {
             etag: p.etag,
@@ -52,7 +52,7 @@ impl FromToProto for mt::TableCopiedFileInfo {
     fn to_pb(&self) -> Result<pb::TableCopiedFileInfo, Incompatible> {
         let p = pb::TableCopiedFileInfo {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             etag: self.etag.clone(),
             content_length: self.content_length,
             last_modified: match self.last_modified {
@@ -67,7 +67,7 @@ impl FromToProto for mt::TableCopiedFileInfo {
 impl FromToProto for mt::TableCopiedFileLock {
     type PB = pb::TableCopiedFileLock;
     fn from_pb(p: pb::TableCopiedFileLock) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self {};
         Ok(v)
@@ -76,7 +76,7 @@ impl FromToProto for mt::TableCopiedFileLock {
     fn to_pb(&self) -> Result<pb::TableCopiedFileLock, Incompatible> {
         let p = pb::TableCopiedFileLock {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
         };
         Ok(p)
     }
@@ -85,7 +85,7 @@ impl FromToProto for mt::TableCopiedFileLock {
 impl FromToProto for mt::TableNameIdent {
     type PB = pb::TableNameIdent;
     fn from_pb(p: pb::TableNameIdent) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self {
             tenant: p.tenant,
@@ -98,7 +98,7 @@ impl FromToProto for mt::TableNameIdent {
     fn to_pb(&self) -> Result<pb::TableNameIdent, Incompatible> {
         let p = pb::TableNameIdent {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             tenant: self.tenant.clone(),
             db_name: self.db_name.clone(),
             table_name: self.table_name.clone(),
@@ -110,7 +110,7 @@ impl FromToProto for mt::TableNameIdent {
 impl FromToProto for mt::DBIdTableName {
     type PB = pb::DbIdTableName;
     fn from_pb(p: pb::DbIdTableName) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self {
             db_id: p.db_id,
@@ -122,7 +122,7 @@ impl FromToProto for mt::DBIdTableName {
     fn to_pb(&self) -> Result<pb::DbIdTableName, Incompatible> {
         let p = pb::DbIdTableName {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             db_id: self.db_id,
             table_name: self.table_name.clone(),
         };
@@ -133,7 +133,7 @@ impl FromToProto for mt::DBIdTableName {
 impl FromToProto for mt::TableIdent {
     type PB = pb::TableIdent;
     fn from_pb(p: pb::TableIdent) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self {
             table_id: p.table_id,
@@ -145,7 +145,7 @@ impl FromToProto for mt::TableIdent {
     fn to_pb(&self) -> Result<pb::TableIdent, Incompatible> {
         let p = pb::TableIdent {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             table_id: self.table_id,
             seq: self.seq,
         };
@@ -157,7 +157,7 @@ impl FromToProto for mt::TableIdent {
 impl FromToProto for mt::TableMeta {
     type PB = pb::TableMeta;
     fn from_pb(p: pb::TableMeta) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let schema = match p.schema {
             None => {
@@ -213,7 +213,7 @@ impl FromToProto for mt::TableMeta {
         let schema = to_schema(&self.schema);
         let p = pb::TableMeta {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             catalog: self.catalog.clone(),
             schema: Some(schema.to_pb()?),
             engine: self.engine.clone(),
@@ -248,7 +248,7 @@ impl FromToProto for mt::TableMeta {
 impl FromToProto for mt::TableStatistics {
     type PB = pb::TableStatistics;
     fn from_pb(p: pb::TableStatistics) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self {
             number_of_rows: p.number_of_rows,
@@ -263,7 +263,7 @@ impl FromToProto for mt::TableStatistics {
     fn to_pb(&self) -> Result<pb::TableStatistics, Incompatible> {
         let p = pb::TableStatistics {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             number_of_rows: self.number_of_rows,
             data_bytes: self.data_bytes,
             compressed_data_bytes: self.compressed_data_bytes,
@@ -276,7 +276,7 @@ impl FromToProto for mt::TableStatistics {
 impl FromToProto for mt::TableIdList {
     type PB = pb::TableIdList;
     fn from_pb(p: pb::TableIdList) -> Result<Self, Incompatible> {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let v = Self { id_list: p.ids };
         Ok(v)
@@ -285,7 +285,7 @@ impl FromToProto for mt::TableIdList {
     fn to_pb(&self) -> Result<pb::TableIdList, Incompatible> {
         let p = pb::TableIdList {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             ids: self.id_list.clone(),
         };
         Ok(p)

--- a/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
@@ -31,17 +31,17 @@ use common_storage::StorageS3Config;
 use enumflags2::BitFlags;
 use num::FromPrimitive;
 
-use crate::check_ver;
+use crate::reader_check_msg;
 use crate::FromToProto;
 use crate::Incompatible;
-use crate::MIN_COMPATIBLE_VER;
+use crate::MIN_READER_VER;
 use crate::VER;
 
 impl FromToProto for mt::AuthInfo {
     type PB = pb::AuthInfo;
     fn from_pb(p: pb::AuthInfo) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         match p.info {
             Some(pb::auth_info::Info::None(pb::auth_info::None {})) => Ok(mt::AuthInfo::None),
@@ -75,7 +75,7 @@ impl FromToProto for mt::AuthInfo {
         };
         Ok(pb::AuthInfo {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             info,
         })
     }
@@ -85,7 +85,7 @@ impl FromToProto for mt::UserOption {
     type PB = pb::UserOption;
     fn from_pb(p: pb::UserOption) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         // ignore unknown flags
         let flags = BitFlags::<mt::UserOptionFlag, u64>::from_bits_truncate(p.flags);
@@ -98,7 +98,7 @@ impl FromToProto for mt::UserOption {
     fn to_pb(&self) -> Result<pb::UserOption, Incompatible> {
         Ok(pb::UserOption {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             flags: self.flags().bits(),
             default_role: self.default_role().cloned(),
         })
@@ -109,7 +109,7 @@ impl FromToProto for mt::UserQuota {
     type PB = pb::UserQuota;
     fn from_pb(p: pb::UserQuota) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         Ok(Self {
             max_cpu: p.max_cpu,
@@ -121,7 +121,7 @@ impl FromToProto for mt::UserQuota {
     fn to_pb(&self) -> Result<pb::UserQuota, Incompatible> {
         Ok(pb::UserQuota {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             max_cpu: self.max_cpu,
             max_memory_in_bytes: self.max_memory_in_bytes,
             max_storage_in_bytes: self.max_storage_in_bytes,
@@ -133,7 +133,7 @@ impl FromToProto for mt::GrantObject {
     type PB = pb::GrantObject;
     fn from_pb(p: pb::GrantObject) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         match p.object {
             Some(pb::grant_object::Object::Global(pb::grant_object::GrantGlobalObject {})) => {
@@ -175,7 +175,7 @@ impl FromToProto for mt::GrantObject {
         };
         Ok(pb::GrantObject {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             object,
         })
     }
@@ -185,7 +185,7 @@ impl FromToProto for mt::GrantEntry {
     type PB = pb::GrantEntry;
     fn from_pb(p: pb::GrantEntry) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let privileges = BitFlags::<mt::UserPrivilegeType, u64>::from_bits(p.privileges);
         match privileges {
@@ -204,7 +204,7 @@ impl FromToProto for mt::GrantEntry {
     fn to_pb(&self) -> Result<pb::GrantEntry, Incompatible> {
         Ok(pb::GrantEntry {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             object: Some(self.object().to_pb()?),
             privileges: self.privileges().bits(),
         })
@@ -215,7 +215,7 @@ impl FromToProto for mt::UserGrantSet {
     type PB = pb::UserGrantSet;
     fn from_pb(p: pb::UserGrantSet) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let mut entries = Vec::new();
         for entry in p.entries.iter() {
@@ -241,7 +241,7 @@ impl FromToProto for mt::UserGrantSet {
 
         Ok(pb::UserGrantSet {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             entries,
             roles,
         })
@@ -252,7 +252,7 @@ impl FromToProto for mt::UserInfo {
     type PB = pb::UserInfo;
     fn from_pb(p: pb::UserInfo) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         Ok(mt::UserInfo {
             name: p.name.clone(),
@@ -275,7 +275,7 @@ impl FromToProto for mt::UserInfo {
     fn to_pb(&self) -> Result<pb::UserInfo, Incompatible> {
         Ok(pb::UserInfo {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             name: self.name.clone(),
             hostname: self.hostname.clone(),
             auth_info: Some(mt::AuthInfo::to_pb(&self.auth_info)?),
@@ -290,7 +290,7 @@ impl FromToProto for mt::UserIdentity {
     type PB = pb::UserIdentity;
     fn from_pb(p: pb::UserIdentity) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         Ok(mt::UserIdentity {
             username: p.username.clone(),
@@ -301,7 +301,7 @@ impl FromToProto for mt::UserIdentity {
     fn to_pb(&self) -> Result<pb::UserIdentity, Incompatible> {
         Ok(pb::UserIdentity {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             username: self.username.clone(),
             hostname: self.hostname.clone(),
         })
@@ -483,7 +483,7 @@ impl FromToProto for mt::FileFormatOptions {
     type PB = pb::user_stage_info::FileFormatOptions;
     fn from_pb(p: pb::user_stage_info::FileFormatOptions) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
 
         let format = mt::StageFileFormatType::from_pb(
             FromPrimitive::from_i32(p.format).ok_or_else(|| Incompatible {
@@ -521,7 +521,7 @@ impl FromToProto for mt::FileFormatOptions {
         let compression = mt::StageFileCompression::to_pb(&self.compression)? as i32;
         Ok(pb::user_stage_info::FileFormatOptions {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             format,
             skip_header: self.skip_header,
             field_delimiter: self.field_delimiter.clone(),
@@ -645,7 +645,7 @@ impl FromToProto for mt::UserStageInfo {
     type PB = pb::UserStageInfo;
     fn from_pb(p: pb::UserStageInfo) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
         Ok(mt::UserStageInfo {
             stage_name: p.stage_name.clone(),
             stage_type: mt::StageType::from_pb(FromPrimitive::from_i32(p.stage_type).ok_or_else(
@@ -680,7 +680,7 @@ impl FromToProto for mt::UserStageInfo {
     fn to_pb(&self) -> Result<pb::UserStageInfo, Incompatible> {
         Ok(pb::UserStageInfo {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             stage_name: self.stage_name.clone(),
             stage_type: mt::StageType::to_pb(&self.stage_type)? as i32,
             stage_params: Some(mt::StageParams::to_pb(&self.stage_params)?),
@@ -700,7 +700,7 @@ impl FromToProto for mt::StageFile {
     type PB = pb::StageFile;
     fn from_pb(p: pb::StageFile) -> Result<Self, Incompatible>
     where Self: Sized {
-        check_ver(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_compatible)?;
         Ok(mt::StageFile {
             path: p.path.clone(),
             size: p.size,
@@ -717,7 +717,7 @@ impl FromToProto for mt::StageFile {
     fn to_pb(&self) -> Result<pb::StageFile, Incompatible> {
         Ok(pb::StageFile {
             ver: VER,
-            min_compatible: MIN_COMPATIBLE_VER,
+            min_compatible: MIN_READER_VER,
             path: self.path.clone(),
             size: self.size,
             md5: self.md5.clone(),

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -78,23 +78,31 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (23, "2022-12-28: Add: table.proto/TableMeta::part_prefix"),
 ];
 
+/// The version to write into a message and it is also the version of the message reader.
 pub const VER: u64 = META_CHANGE_LOG.last().unwrap().0;
-pub const MIN_COMPATIBLE_VER: u64 = 1;
 
-pub fn check_ver(msg_ver: u64, msg_min_compatible: u64) -> Result<(), Incompatible> {
-    if VER < msg_min_compatible {
+/// The minimal reader version that can read message of version `VER`, i.e. `message.version=VER`.
+///
+/// This is written to every message that needs to be serialized independently.
+pub const MIN_READER_VER: u64 = 1;
+
+/// The minimal message version(`message.version`) that a reader can read.
+pub const MIN_MSG_VER: u64 = 1;
+
+pub fn reader_check_msg(msg_ver: u64, msg_min_reader_ver: u64) -> Result<(), Incompatible> {
+    if VER < msg_min_reader_ver {
         return Err(Incompatible {
             reason: format!(
-                "executable ver={} is smaller than the message min compatible ver: {}",
-                VER, msg_min_compatible
+                "executable ver={} is smaller than the min reader version({}) that can read this message",
+                VER, msg_min_reader_ver
             ),
         });
     }
-    if msg_ver < MIN_COMPATIBLE_VER {
+    if msg_ver < MIN_MSG_VER {
         return Err(Incompatible {
             reason: format!(
-                "message ver={} is smaller than executable min compatible ver: {}",
-                msg_ver, MIN_COMPATIBLE_VER
+                "message ver={} is smaller than executable MIN_MSG_VER({}) that this program can read",
+                msg_ver, MIN_MSG_VER
             ),
         });
     }

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -436,7 +436,7 @@ fn test_incompatible() -> anyhow::Result<()> {
     assert_eq!(
         Incompatible {
             reason: format!(
-                "executable ver={} is smaller than the message min compatible ver: {}",
+                "executable ver={} is smaller than the min reader version({}) that can read this message",
                 VER,
                 VER + 1
             )
@@ -452,7 +452,9 @@ fn test_incompatible() -> anyhow::Result<()> {
     let res = mt::DatabaseMeta::from_pb(p);
     assert_eq!(
         Incompatible {
-            reason: s("message ver=0 is smaller than executable min compatible ver: 1")
+            reason: s(
+                "message ver=0 is smaller than executable MIN_MSG_VER(1) that this program can read"
+            )
         },
         res.unwrap_err()
     );

--- a/src/meta/proto-conv/tests/it/user_proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/user_proto_conv.rs
@@ -344,7 +344,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         assert_eq!(
             Incompatible {
                 reason: format!(
-                    "executable ver={} is smaller than the message min compatible ver: {}",
+                    "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
@@ -363,7 +363,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         assert_eq!(
             Incompatible {
                 reason: format!(
-                    "executable ver={} is smaller than the message min compatible ver: {}",
+                    "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
@@ -382,7 +382,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         assert_eq!(
             Incompatible {
                 reason: format!(
-                    "executable ver={} is smaller than the message min compatible ver: {}",
+                    "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
@@ -401,7 +401,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         assert_eq!(
             Incompatible {
                 reason: format!(
-                    "executable ver={} is smaller than the message min compatible ver: {}",
+                    "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
@@ -420,7 +420,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         assert_eq!(
             Incompatible {
                 reason: format!(
-                    "executable ver={} is smaller than the message min compatible ver: {}",
+                    "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
@@ -439,7 +439,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         assert_eq!(
             Incompatible {
                 reason: format!(
-                    "executable ver={} is smaller than the message min compatible ver: {}",
+                    "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
@@ -458,7 +458,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         assert_eq!(
             Incompatible {
                 reason: format!(
-                    "executable ver={} is smaller than the message min compatible ver: {}",
+                    "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feat(meta/proto-conv): add reader-min-msg-ver and msg-min-reader-ver

This is a compatible change.

There should be two **backward compatible** version defined:
One for the reader to define the min version of message it can read
and the other for the message to define the min version of the reader
that can read it.

A message is written with the min-reader-ver in it, and a reader checks
`reader.ver` against `msg.min-reader-ver` and `msg.ver` and
`reader.min-message-ver` to assert compatibility.

## Changelog







## Related Issues