### PR TITLE
chore(meta/proto): rename message.min_compatible to message.min_reader_ver to reflect its actual purpose

### DIFF
--- a/src/meta/proto-conv/src/config_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/config_from_to_protobuf_impl.rs
@@ -29,7 +29,7 @@ impl FromToProto for StorageS3Config {
 
     fn from_pb(p: pb::S3StorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.version, p.min_compatible)?;
+        reader_check_msg(p.version, p.min_reader_ver)?;
 
         Ok(StorageS3Config {
             region: p.region,
@@ -50,7 +50,7 @@ impl FromToProto for StorageS3Config {
     fn to_pb(&self) -> Result<pb::S3StorageConfig, Incompatible> {
         Ok(pb::S3StorageConfig {
             version: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             region: self.region.clone(),
             endpoint_url: self.endpoint_url.clone(),
             access_key_id: self.access_key_id.clone(),
@@ -72,7 +72,7 @@ impl FromToProto for StorageGcsConfig {
 
     fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.version, p.min_compatible)?;
+        reader_check_msg(p.version, p.min_reader_ver)?;
 
         Ok(StorageGcsConfig {
             credential: p.credential,
@@ -85,7 +85,7 @@ impl FromToProto for StorageGcsConfig {
     fn to_pb(&self) -> Result<Self::PB, Incompatible> {
         Ok(pb::GcsStorageConfig {
             version: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             credential: self.credential.clone(),
             endpoint_url: self.endpoint_url.clone(),
             bucket: self.bucket.clone(),
@@ -99,7 +99,7 @@ impl FromToProto for StorageFsConfig {
 
     fn from_pb(p: pb::FsStorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.version, p.min_compatible)?;
+        reader_check_msg(p.version, p.min_reader_ver)?;
 
         Ok(StorageFsConfig { root: p.root })
     }
@@ -107,7 +107,7 @@ impl FromToProto for StorageFsConfig {
     fn to_pb(&self) -> Result<pb::FsStorageConfig, Incompatible> {
         Ok(pb::FsStorageConfig {
             version: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             root: self.root.clone(),
         })
     }
@@ -118,7 +118,7 @@ impl FromToProto for StorageOssConfig {
 
     fn from_pb(p: pb::OssStorageConfig) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.version, p.min_compatible)?;
+        reader_check_msg(p.version, p.min_reader_ver)?;
 
         Ok(StorageOssConfig {
             endpoint_url: p.endpoint_url,
@@ -133,7 +133,7 @@ impl FromToProto for StorageOssConfig {
     fn to_pb(&self) -> Result<pb::OssStorageConfig, Incompatible> {
         Ok(pb::OssStorageConfig {
             version: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             endpoint_url: self.endpoint_url.clone(),
             bucket: self.bucket.clone(),
             root: self.root.clone(),

--- a/src/meta/proto-conv/src/data_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/data_from_to_protobuf_impl.rs
@@ -33,7 +33,7 @@ use crate::VER;
 impl FromToProto for dv::DataSchema {
     type PB = pb::DataSchema;
     fn from_pb(p: pb::DataSchema) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let mut fs = Vec::with_capacity(p.fields.len());
         for f in p.fields.into_iter() {
@@ -52,7 +52,7 @@ impl FromToProto for dv::DataSchema {
 
         let p = pb::DataSchema {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             fields: fs,
             metadata: self.meta().clone(),
         };
@@ -63,7 +63,7 @@ impl FromToProto for dv::DataSchema {
 impl FromToProto for dv::DataField {
     type PB = pb::DataField;
     fn from_pb(p: pb::DataField) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = dv::DataField::new(
             &p.name,
@@ -78,7 +78,7 @@ impl FromToProto for dv::DataField {
     fn to_pb(&self) -> Result<pb::DataField, Incompatible> {
         let p = pb::DataField {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             name: self.name().clone(),
             default_expr: self.default_expr().cloned(),
             data_type: Some(self.data_type().to_pb()?),
@@ -90,7 +90,7 @@ impl FromToProto for dv::DataField {
 impl FromToProto for dv::DataTypeImpl {
     type PB = pb::DataType;
     fn from_pb(p: pb::DataType) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let dt = match p.dt {
             None => {
@@ -142,7 +142,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::NullableType(Box::new(inn))),
                 };
                 Ok(v)
@@ -150,7 +150,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Boolean(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::BoolType(pb::Empty {})),
                 };
                 Ok(v)
@@ -158,7 +158,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Int8(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::Int8Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -166,7 +166,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Int16(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::Int16Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -174,7 +174,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Int32(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::Int32Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -182,7 +182,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Int64(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::Int64Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -190,7 +190,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt8(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::Uint8Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -198,7 +198,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt16(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::Uint16Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -206,7 +206,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt32(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::Uint32Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -214,7 +214,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::UInt64(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::Uint64Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -222,7 +222,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Float32(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::Float32Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -230,7 +230,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Float64(_) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::Float64Type(pb::Empty {})),
                 };
                 Ok(v)
@@ -238,7 +238,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::Date(_x) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::DateType(pb::Empty {})),
                 };
                 Ok(v)
@@ -248,7 +248,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::TimestampType(inn)),
                 };
                 Ok(v)
@@ -256,7 +256,7 @@ impl FromToProto for dv::DataTypeImpl {
             dv::DataTypeImpl::String(_x) => {
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::StringType(pb::Empty {})),
                 };
                 Ok(v)
@@ -266,7 +266,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::StructType(inn)),
                 };
                 Ok(v)
@@ -276,7 +276,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let v = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::ArrayType(Box::new(inn))),
                 };
                 Ok(v)
@@ -286,7 +286,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::VariantType(inn)),
                 };
                 Ok(p)
@@ -296,7 +296,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::VariantArrayType(inn)),
                 };
                 Ok(p)
@@ -306,7 +306,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::VariantObjectType(inn)),
                 };
                 Ok(p)
@@ -316,7 +316,7 @@ impl FromToProto for dv::DataTypeImpl {
 
                 let p = pb::DataType {
                     ver: VER,
-                    min_compatible: MIN_READER_VER,
+                    min_reader_ver: MIN_READER_VER,
                     dt: Some(Dt::IntervalType(inn)),
                 };
                 Ok(p)
@@ -329,7 +329,7 @@ impl FromToProto for dv::NullableType {
     type PB = pb::NullableType;
     fn from_pb(p: pb::NullableType) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let inner = p.inner.ok_or_else(|| Incompatible {
             reason: "NullableType.inner can not be None".to_string(),
@@ -346,7 +346,7 @@ impl FromToProto for dv::NullableType {
 
         let p = pb::NullableType {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             inner: Some(Box::new(inner_pb_type)),
         };
 
@@ -358,14 +358,14 @@ impl FromToProto for dv::TimestampType {
     type PB = pb::Timestamp;
     fn from_pb(p: pb::Timestamp) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
         Ok(dv::TimestampType::default())
     }
 
     fn to_pb(&self) -> Result<pb::Timestamp, Incompatible> {
         let p = pb::Timestamp {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
         };
 
         Ok(p)
@@ -376,7 +376,7 @@ impl FromToProto for dv::StructType {
     type PB = pb::Struct;
     fn from_pb(p: pb::Struct) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
         let names = p.names.clone();
 
         let mut types = Vec::with_capacity(p.types.len());
@@ -407,7 +407,7 @@ impl FromToProto for dv::StructType {
 
         let p = pb::Struct {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
 
             names,
             types,
@@ -421,7 +421,7 @@ impl FromToProto for dv::ArrayType {
     type PB = pb::Array;
     fn from_pb(p: pb::Array) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let inner = p.inner.ok_or_else(|| Incompatible {
             reason: "Array.inner can not be None".to_string(),
@@ -438,7 +438,7 @@ impl FromToProto for dv::ArrayType {
 
         let p = pb::Array {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             inner: Some(Box::new(inner_pb_type)),
         };
 
@@ -450,7 +450,7 @@ impl FromToProto for dv::VariantArrayType {
     type PB = pb::VariantArray;
     fn from_pb(p: pb::VariantArray) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         Ok(Self {})
     }
@@ -458,7 +458,7 @@ impl FromToProto for dv::VariantArrayType {
     fn to_pb(&self) -> Result<pb::VariantArray, Incompatible> {
         let p = pb::VariantArray {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
         };
         Ok(p)
     }
@@ -468,7 +468,7 @@ impl FromToProto for dv::VariantObjectType {
     type PB = pb::VariantObject;
     fn from_pb(p: pb::VariantObject) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         Ok(Self {})
     }
@@ -476,7 +476,7 @@ impl FromToProto for dv::VariantObjectType {
     fn to_pb(&self) -> Result<pb::VariantObject, Incompatible> {
         let p = pb::VariantObject {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
         };
         Ok(p)
     }
@@ -520,7 +520,7 @@ impl FromToProto for dv::IntervalType {
     type PB = pb::IntervalType;
     fn from_pb(p: pb::IntervalType) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let pb_kind: pb::IntervalKind =
             FromPrimitive::from_i32(p.kind).ok_or_else(|| Incompatible {
@@ -535,7 +535,7 @@ impl FromToProto for dv::IntervalType {
         let pb_kind = self.kind().to_pb()?;
         let p = pb::IntervalType {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             kind: pb_kind as i32,
         };
         Ok(p)
@@ -546,7 +546,7 @@ impl FromToProto for dv::VariantType {
     type PB = pb::Variant;
     fn from_pb(p: pb::Variant) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         Ok(Self {})
     }
@@ -554,7 +554,7 @@ impl FromToProto for dv::VariantType {
     fn to_pb(&self) -> Result<pb::Variant, Incompatible> {
         let p = pb::Variant {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
         };
         Ok(p)
     }

--- a/src/meta/proto-conv/src/database_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/database_from_to_protobuf_impl.rs
@@ -32,7 +32,7 @@ use crate::VER;
 impl FromToProto for mt::DatabaseNameIdent {
     type PB = pb::DatabaseNameIdent;
     fn from_pb(p: pb::DatabaseNameIdent) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self {
             tenant: p.tenant,
@@ -44,7 +44,7 @@ impl FromToProto for mt::DatabaseNameIdent {
     fn to_pb(&self) -> Result<pb::DatabaseNameIdent, Incompatible> {
         let p = pb::DatabaseNameIdent {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             tenant: self.tenant.clone(),
             db_name: self.db_name.clone(),
         };
@@ -55,7 +55,7 @@ impl FromToProto for mt::DatabaseNameIdent {
 impl FromToProto for mt::DatabaseMeta {
     type PB = pb::DatabaseMeta;
     fn from_pb(p: pb::DatabaseMeta) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self {
             engine: p.engine,
@@ -80,7 +80,7 @@ impl FromToProto for mt::DatabaseMeta {
     fn to_pb(&self) -> Result<pb::DatabaseMeta, Incompatible> {
         let p = pb::DatabaseMeta {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             engine: self.engine.clone(),
             engine_options: self.engine_options.clone(),
             options: self.options.clone(),
@@ -104,7 +104,7 @@ impl FromToProto for mt::DatabaseMeta {
 impl FromToProto for mt::DbIdList {
     type PB = pb::DbIdList;
     fn from_pb(p: pb::DbIdList) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self { id_list: p.ids };
         Ok(v)
@@ -113,7 +113,7 @@ impl FromToProto for mt::DbIdList {
     fn to_pb(&self) -> Result<pb::DbIdList, Incompatible> {
         let p = pb::DbIdList {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             ids: self.id_list.clone(),
         };
         Ok(p)

--- a/src/meta/proto-conv/src/share_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/share_from_to_protobuf_impl.rs
@@ -33,7 +33,7 @@ use crate::VER;
 impl FromToProto for mt::ObjectSharedByShareIds {
     type PB = pb::ObjectSharedByShareIds;
     fn from_pb(p: pb::ObjectSharedByShareIds) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self {
             share_ids: BTreeSet::from_iter(p.share_ids.iter().copied()),
@@ -44,7 +44,7 @@ impl FromToProto for mt::ObjectSharedByShareIds {
     fn to_pb(&self) -> Result<pb::ObjectSharedByShareIds, Incompatible> {
         let p = pb::ObjectSharedByShareIds {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             share_ids: Vec::from_iter(self.share_ids.iter().copied()),
         };
         Ok(p)
@@ -54,7 +54,7 @@ impl FromToProto for mt::ObjectSharedByShareIds {
 impl FromToProto for mt::ShareNameIdent {
     type PB = pb::ShareNameIdent;
     fn from_pb(p: pb::ShareNameIdent) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self {
             tenant: p.tenant,
@@ -66,7 +66,7 @@ impl FromToProto for mt::ShareNameIdent {
     fn to_pb(&self) -> Result<pb::ShareNameIdent, Incompatible> {
         let p = pb::ShareNameIdent {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             tenant: self.tenant.clone(),
             share_name: self.share_name.clone(),
         };
@@ -77,7 +77,7 @@ impl FromToProto for mt::ShareNameIdent {
 impl FromToProto for mt::ShareGrantObject {
     type PB = pb::ShareGrantObject;
     fn from_pb(p: pb::ShareGrantObject) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         match p.object {
             Some(pb::share_grant_object::Object::DbId(db_id)) => {
@@ -104,7 +104,7 @@ impl FromToProto for mt::ShareGrantObject {
 
         let p = pb::ShareGrantObject {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             object,
         };
         Ok(p)
@@ -115,7 +115,7 @@ impl FromToProto for mt::ShareGrantEntry {
     type PB = pb::ShareGrantEntry;
     fn from_pb(p: pb::ShareGrantEntry) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let privileges = BitFlags::<mt::ShareGrantObjectPrivilege, u64>::from_bits(p.privileges);
         match privileges {
@@ -139,7 +139,7 @@ impl FromToProto for mt::ShareGrantEntry {
     fn to_pb(&self) -> Result<pb::ShareGrantEntry, Incompatible> {
         Ok(pb::ShareGrantEntry {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             object: Some(self.object().to_pb()?),
             privileges: self.privileges().bits(),
             grant_on: self.grant_on.to_pb()?,
@@ -155,7 +155,7 @@ impl FromToProto for mt::ShareMeta {
     type PB = pb::ShareMeta;
     fn from_pb(p: pb::ShareMeta) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
         let mut entries = BTreeMap::new();
         for entry in p.entries {
             let entry = mt::ShareGrantEntry::from_pb(entry)?;
@@ -186,7 +186,7 @@ impl FromToProto for mt::ShareMeta {
 
         Ok(pb::ShareMeta {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             database: match &self.database {
                 Some(db) => Some(mt::ShareGrantEntry::to_pb(db)?),
                 None => None,
@@ -208,7 +208,7 @@ impl FromToProto for mt::ShareAccountMeta {
     type PB = pb::ShareAccountMeta;
     fn from_pb(p: pb::ShareAccountMeta) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         Ok(mt::ShareAccountMeta {
             account: p.account.clone(),
@@ -224,7 +224,7 @@ impl FromToProto for mt::ShareAccountMeta {
     fn to_pb(&self) -> Result<pb::ShareAccountMeta, Incompatible> {
         Ok(pb::ShareAccountMeta {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
 
             account: self.account.clone(),
             share_id: self.share_id,

--- a/src/meta/proto-conv/src/table_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/table_from_to_protobuf_impl.rs
@@ -36,7 +36,7 @@ use crate::VER;
 impl FromToProto for mt::TableCopiedFileInfo {
     type PB = pb::TableCopiedFileInfo;
     fn from_pb(p: pb::TableCopiedFileInfo) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self {
             etag: p.etag,
@@ -52,7 +52,7 @@ impl FromToProto for mt::TableCopiedFileInfo {
     fn to_pb(&self) -> Result<pb::TableCopiedFileInfo, Incompatible> {
         let p = pb::TableCopiedFileInfo {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             etag: self.etag.clone(),
             content_length: self.content_length,
             last_modified: match self.last_modified {
@@ -67,7 +67,7 @@ impl FromToProto for mt::TableCopiedFileInfo {
 impl FromToProto for mt::TableCopiedFileLock {
     type PB = pb::TableCopiedFileLock;
     fn from_pb(p: pb::TableCopiedFileLock) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self {};
         Ok(v)
@@ -76,7 +76,7 @@ impl FromToProto for mt::TableCopiedFileLock {
     fn to_pb(&self) -> Result<pb::TableCopiedFileLock, Incompatible> {
         let p = pb::TableCopiedFileLock {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
         };
         Ok(p)
     }
@@ -85,7 +85,7 @@ impl FromToProto for mt::TableCopiedFileLock {
 impl FromToProto for mt::TableNameIdent {
     type PB = pb::TableNameIdent;
     fn from_pb(p: pb::TableNameIdent) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self {
             tenant: p.tenant,
@@ -98,7 +98,7 @@ impl FromToProto for mt::TableNameIdent {
     fn to_pb(&self) -> Result<pb::TableNameIdent, Incompatible> {
         let p = pb::TableNameIdent {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             tenant: self.tenant.clone(),
             db_name: self.db_name.clone(),
             table_name: self.table_name.clone(),
@@ -110,7 +110,7 @@ impl FromToProto for mt::TableNameIdent {
 impl FromToProto for mt::DBIdTableName {
     type PB = pb::DbIdTableName;
     fn from_pb(p: pb::DbIdTableName) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self {
             db_id: p.db_id,
@@ -122,7 +122,7 @@ impl FromToProto for mt::DBIdTableName {
     fn to_pb(&self) -> Result<pb::DbIdTableName, Incompatible> {
         let p = pb::DbIdTableName {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             db_id: self.db_id,
             table_name: self.table_name.clone(),
         };
@@ -133,7 +133,7 @@ impl FromToProto for mt::DBIdTableName {
 impl FromToProto for mt::TableIdent {
     type PB = pb::TableIdent;
     fn from_pb(p: pb::TableIdent) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self {
             table_id: p.table_id,
@@ -145,7 +145,7 @@ impl FromToProto for mt::TableIdent {
     fn to_pb(&self) -> Result<pb::TableIdent, Incompatible> {
         let p = pb::TableIdent {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             table_id: self.table_id,
             seq: self.seq,
         };
@@ -157,7 +157,7 @@ impl FromToProto for mt::TableIdent {
 impl FromToProto for mt::TableMeta {
     type PB = pb::TableMeta;
     fn from_pb(p: pb::TableMeta) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let schema = match p.schema {
             None => {
@@ -213,7 +213,7 @@ impl FromToProto for mt::TableMeta {
         let schema = to_schema(&self.schema);
         let p = pb::TableMeta {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             catalog: self.catalog.clone(),
             schema: Some(schema.to_pb()?),
             engine: self.engine.clone(),
@@ -248,7 +248,7 @@ impl FromToProto for mt::TableMeta {
 impl FromToProto for mt::TableStatistics {
     type PB = pb::TableStatistics;
     fn from_pb(p: pb::TableStatistics) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self {
             number_of_rows: p.number_of_rows,
@@ -263,7 +263,7 @@ impl FromToProto for mt::TableStatistics {
     fn to_pb(&self) -> Result<pb::TableStatistics, Incompatible> {
         let p = pb::TableStatistics {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             number_of_rows: self.number_of_rows,
             data_bytes: self.data_bytes,
             compressed_data_bytes: self.compressed_data_bytes,
@@ -276,7 +276,7 @@ impl FromToProto for mt::TableStatistics {
 impl FromToProto for mt::TableIdList {
     type PB = pb::TableIdList;
     fn from_pb(p: pb::TableIdList) -> Result<Self, Incompatible> {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self { id_list: p.ids };
         Ok(v)
@@ -285,7 +285,7 @@ impl FromToProto for mt::TableIdList {
     fn to_pb(&self) -> Result<pb::TableIdList, Incompatible> {
         let p = pb::TableIdList {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             ids: self.id_list.clone(),
         };
         Ok(p)

--- a/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
@@ -41,7 +41,7 @@ impl FromToProto for mt::AuthInfo {
     type PB = pb::AuthInfo;
     fn from_pb(p: pb::AuthInfo) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         match p.info {
             Some(pb::auth_info::Info::None(pb::auth_info::None {})) => Ok(mt::AuthInfo::None),
@@ -75,7 +75,7 @@ impl FromToProto for mt::AuthInfo {
         };
         Ok(pb::AuthInfo {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             info,
         })
     }
@@ -85,7 +85,7 @@ impl FromToProto for mt::UserOption {
     type PB = pb::UserOption;
     fn from_pb(p: pb::UserOption) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         // ignore unknown flags
         let flags = BitFlags::<mt::UserOptionFlag, u64>::from_bits_truncate(p.flags);
@@ -98,7 +98,7 @@ impl FromToProto for mt::UserOption {
     fn to_pb(&self) -> Result<pb::UserOption, Incompatible> {
         Ok(pb::UserOption {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             flags: self.flags().bits(),
             default_role: self.default_role().cloned(),
         })
@@ -109,7 +109,7 @@ impl FromToProto for mt::UserQuota {
     type PB = pb::UserQuota;
     fn from_pb(p: pb::UserQuota) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         Ok(Self {
             max_cpu: p.max_cpu,
@@ -121,7 +121,7 @@ impl FromToProto for mt::UserQuota {
     fn to_pb(&self) -> Result<pb::UserQuota, Incompatible> {
         Ok(pb::UserQuota {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             max_cpu: self.max_cpu,
             max_memory_in_bytes: self.max_memory_in_bytes,
             max_storage_in_bytes: self.max_storage_in_bytes,
@@ -133,7 +133,7 @@ impl FromToProto for mt::GrantObject {
     type PB = pb::GrantObject;
     fn from_pb(p: pb::GrantObject) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         match p.object {
             Some(pb::grant_object::Object::Global(pb::grant_object::GrantGlobalObject {})) => {
@@ -175,7 +175,7 @@ impl FromToProto for mt::GrantObject {
         };
         Ok(pb::GrantObject {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             object,
         })
     }
@@ -185,7 +185,7 @@ impl FromToProto for mt::GrantEntry {
     type PB = pb::GrantEntry;
     fn from_pb(p: pb::GrantEntry) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let privileges = BitFlags::<mt::UserPrivilegeType, u64>::from_bits(p.privileges);
         match privileges {
@@ -204,7 +204,7 @@ impl FromToProto for mt::GrantEntry {
     fn to_pb(&self) -> Result<pb::GrantEntry, Incompatible> {
         Ok(pb::GrantEntry {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             object: Some(self.object().to_pb()?),
             privileges: self.privileges().bits(),
         })
@@ -215,7 +215,7 @@ impl FromToProto for mt::UserGrantSet {
     type PB = pb::UserGrantSet;
     fn from_pb(p: pb::UserGrantSet) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let mut entries = Vec::new();
         for entry in p.entries.iter() {
@@ -241,7 +241,7 @@ impl FromToProto for mt::UserGrantSet {
 
         Ok(pb::UserGrantSet {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             entries,
             roles,
         })
@@ -252,7 +252,7 @@ impl FromToProto for mt::UserInfo {
     type PB = pb::UserInfo;
     fn from_pb(p: pb::UserInfo) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         Ok(mt::UserInfo {
             name: p.name.clone(),
@@ -275,7 +275,7 @@ impl FromToProto for mt::UserInfo {
     fn to_pb(&self) -> Result<pb::UserInfo, Incompatible> {
         Ok(pb::UserInfo {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             name: self.name.clone(),
             hostname: self.hostname.clone(),
             auth_info: Some(mt::AuthInfo::to_pb(&self.auth_info)?),
@@ -290,7 +290,7 @@ impl FromToProto for mt::UserIdentity {
     type PB = pb::UserIdentity;
     fn from_pb(p: pb::UserIdentity) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         Ok(mt::UserIdentity {
             username: p.username.clone(),
@@ -301,7 +301,7 @@ impl FromToProto for mt::UserIdentity {
     fn to_pb(&self) -> Result<pb::UserIdentity, Incompatible> {
         Ok(pb::UserIdentity {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             username: self.username.clone(),
             hostname: self.hostname.clone(),
         })
@@ -483,7 +483,7 @@ impl FromToProto for mt::FileFormatOptions {
     type PB = pb::user_stage_info::FileFormatOptions;
     fn from_pb(p: pb::user_stage_info::FileFormatOptions) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let format = mt::StageFileFormatType::from_pb(
             FromPrimitive::from_i32(p.format).ok_or_else(|| Incompatible {
@@ -521,7 +521,7 @@ impl FromToProto for mt::FileFormatOptions {
         let compression = mt::StageFileCompression::to_pb(&self.compression)? as i32;
         Ok(pb::user_stage_info::FileFormatOptions {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             format,
             skip_header: self.skip_header,
             field_delimiter: self.field_delimiter.clone(),
@@ -645,7 +645,7 @@ impl FromToProto for mt::UserStageInfo {
     type PB = pb::UserStageInfo;
     fn from_pb(p: pb::UserStageInfo) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
         Ok(mt::UserStageInfo {
             stage_name: p.stage_name.clone(),
             stage_type: mt::StageType::from_pb(FromPrimitive::from_i32(p.stage_type).ok_or_else(
@@ -680,7 +680,7 @@ impl FromToProto for mt::UserStageInfo {
     fn to_pb(&self) -> Result<pb::UserStageInfo, Incompatible> {
         Ok(pb::UserStageInfo {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             stage_name: self.stage_name.clone(),
             stage_type: mt::StageType::to_pb(&self.stage_type)? as i32,
             stage_params: Some(mt::StageParams::to_pb(&self.stage_params)?),
@@ -700,7 +700,7 @@ impl FromToProto for mt::StageFile {
     type PB = pb::StageFile;
     fn from_pb(p: pb::StageFile) -> Result<Self, Incompatible>
     where Self: Sized {
-        reader_check_msg(p.ver, p.min_compatible)?;
+        reader_check_msg(p.ver, p.min_reader_ver)?;
         Ok(mt::StageFile {
             path: p.path.clone(),
             size: p.size,
@@ -717,7 +717,7 @@ impl FromToProto for mt::StageFile {
     fn to_pb(&self) -> Result<pb::StageFile, Incompatible> {
         Ok(pb::StageFile {
             ver: VER,
-            min_compatible: MIN_READER_VER,
+            min_reader_ver: MIN_READER_VER,
             path: self.path.clone(),
             size: self.size,
             md5: self.md5.clone(),

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -430,7 +430,7 @@ fn test_incompatible() -> anyhow::Result<()> {
     let db_meta = new_db_meta();
     let mut p = db_meta.to_pb()?;
     p.ver = VER + 1;
-    p.min_compatible = VER + 1;
+    p.min_reader_ver = VER + 1;
 
     let res = mt::DatabaseMeta::from_pb(p);
     assert_eq!(
@@ -447,7 +447,7 @@ fn test_incompatible() -> anyhow::Result<()> {
     let db_meta = new_db_meta();
     let mut p = db_meta.to_pb()?;
     p.ver = 0;
-    p.min_compatible = 0;
+    p.min_reader_ver = 0;
 
     let res = mt::DatabaseMeta::from_pb(p);
     assert_eq!(

--- a/src/meta/proto-conv/tests/it/user_proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/user_proto_conv.rs
@@ -338,7 +338,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let user_info = test_user_info();
         let mut p = user_info.to_pb()?;
         p.ver = VER + 1;
-        p.min_compatible = VER + 1;
+        p.min_reader_ver = VER + 1;
 
         let res = mt::UserInfo::from_pb(p);
         assert_eq!(
@@ -357,7 +357,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let stage_file = test_stage_file();
         let mut p = stage_file.to_pb()?;
         p.ver = VER + 1;
-        p.min_compatible = VER + 1;
+        p.min_reader_ver = VER + 1;
 
         let res = mt::StageFile::from_pb(p);
         assert_eq!(
@@ -376,7 +376,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let fs_stage_info = test_fs_stage_info();
         let mut p = fs_stage_info.to_pb()?;
         p.ver = VER + 1;
-        p.min_compatible = VER + 1;
+        p.min_reader_ver = VER + 1;
 
         let res = mt::UserStageInfo::from_pb(p);
         assert_eq!(
@@ -395,7 +395,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let s3_stage_info = test_s3_stage_info();
         let mut p = s3_stage_info.to_pb()?;
         p.ver = VER + 1;
-        p.min_compatible = VER + 1;
+        p.min_reader_ver = VER + 1;
 
         let res = mt::UserStageInfo::from_pb(p);
         assert_eq!(
@@ -414,7 +414,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let s3_stage_info = test_s3_stage_info_v14();
         let mut p = s3_stage_info.to_pb()?;
         p.ver = VER + 1;
-        p.min_compatible = VER + 1;
+        p.min_reader_ver = VER + 1;
 
         let res = mt::UserStageInfo::from_pb(p);
         assert_eq!(
@@ -433,7 +433,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let gcs_stage_info = test_gcs_stage_info();
         let mut p = gcs_stage_info.to_pb()?;
         p.ver = VER + 1;
-        p.min_compatible = VER + 1;
+        p.min_reader_ver = VER + 1;
 
         let res = mt::UserStageInfo::from_pb(p);
         assert_eq!(
@@ -452,7 +452,7 @@ fn test_user_incompatible() -> anyhow::Result<()> {
         let oss_stage_info = test_oss_stage_info();
         let mut p = oss_stage_info.to_pb()?;
         p.ver = VER + 1;
-        p.min_compatible = VER + 1;
+        p.min_reader_ver = VER + 1;
 
         let res = mt::UserStageInfo::from_pb(p);
         assert_eq!(

--- a/src/meta/protos/proto/config.proto
+++ b/src/meta/protos/proto/config.proto
@@ -18,7 +18,7 @@ package databend_proto;
 
 message S3StorageConfig {
   uint64 version = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   string region = 1;
   string endpoint_url = 2;
@@ -36,14 +36,14 @@ message S3StorageConfig {
 
 message FsStorageConfig {
   uint64 version = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   string root = 1;
 }
 
 message GcsStorageConfig {
   uint64 version = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   string endpoint_url = 1;
   string bucket = 2;
@@ -53,7 +53,7 @@ message GcsStorageConfig {
 
 message OssStorageConfig {
   uint64 version = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   string endpoint_url = 1;
   string bucket = 2;

--- a/src/meta/protos/proto/database.proto
+++ b/src/meta/protos/proto/database.proto
@@ -24,7 +24,7 @@ import "share.proto";
 
 message DatabaseNameIdent {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // The user this db belongs to
   string tenant = 1;
@@ -36,7 +36,7 @@ message DatabaseNameIdent {
 // DatabaseMeta is a container of all non-identity information.
 message DatabaseMeta {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // Database engine, like github engine.
   string engine = 5;
@@ -67,7 +67,7 @@ message DatabaseMeta {
 // Save db name id list history.
 message DbIdList {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   repeated uint64 ids = 1;
 }

--- a/src/meta/protos/proto/datatype.proto
+++ b/src/meta/protos/proto/datatype.proto
@@ -19,7 +19,7 @@ package databend_proto;
 // An enumeration of all supported data types.
 message DataType {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   oneof dt {
     NullableType nullable_type = 1;
@@ -50,7 +50,7 @@ message DataType {
 // Such a column allows to contain `null` elements
 message NullableType {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // The type for the non-null element.
   DataType inner = 1;
@@ -59,7 +59,7 @@ message NullableType {
 // Timestamp data type with customizable precision and timezone: `tz`.
 message Timestamp {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   /// It's deprecated
   /// uint64 precision = 1;
@@ -69,7 +69,7 @@ message Timestamp {
 // Struct is similar to a `map` with fixed keys.
 message Struct {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // Struct field names.
   repeated string names = 1;
@@ -81,7 +81,7 @@ message Struct {
 // Array contains multiple elements of the same type.
 message Array {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // The type of the elements
   DataType inner = 1;
@@ -89,12 +89,12 @@ message Array {
 
 message VariantArray {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 }
 
 message VariantObject {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 }
 
 enum IntervalKind {
@@ -110,7 +110,7 @@ enum IntervalKind {
 }
 message IntervalType {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   IntervalKind kind = 1;
 }
@@ -118,7 +118,7 @@ message IntervalType {
 // Something under developing.:)
 message Variant {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 }
 
 // Place holder type for primitive types

--- a/src/meta/protos/proto/metadata.proto
+++ b/src/meta/protos/proto/metadata.proto
@@ -21,7 +21,7 @@ import "datatype.proto";
 // The schema of a table, such as column data types and other meta info.
 message DataSchema {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // Fields in the table
   repeated DataField fields = 1;
@@ -33,7 +33,7 @@ message DataSchema {
 // One field, AKA column
 message DataField {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // The name of this column.
   string name = 1;

--- a/src/meta/protos/proto/share.proto
+++ b/src/meta/protos/proto/share.proto
@@ -18,7 +18,7 @@ package databend_proto;
 
 message ShareNameIdent {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // The user this share belongs to
   string tenant = 1;
@@ -29,7 +29,7 @@ message ShareNameIdent {
 
 message ShareDatabaseObject {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // The user this db belongs to
   string tenant = 1;
@@ -42,7 +42,7 @@ message ShareDatabaseObject {
 
 message ShareGrantObject {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   oneof object {
     uint64 db_id = 1;
@@ -52,7 +52,7 @@ message ShareGrantObject {
 
 message ShareGrantEntry {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   ShareGrantObject object = 1;
   uint64 privileges = 2;
@@ -62,7 +62,7 @@ message ShareGrantEntry {
 
 message ShareMeta {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   optional ShareGrantEntry database = 1;
   repeated ShareGrantEntry entries = 2;
@@ -75,7 +75,7 @@ message ShareMeta {
 
 message ShareAccountMeta {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   string account = 1;
   uint64 share_id = 2;
@@ -85,7 +85,7 @@ message ShareAccountMeta {
 
 message ObjectSharedByShareIds {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   repeated uint64 share_ids = 1;
 }

--- a/src/meta/protos/proto/table.proto
+++ b/src/meta/protos/proto/table.proto
@@ -21,7 +21,7 @@ import "metadata.proto";
 
 message DbIdTableName {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   uint64 db_id = 1;
   string table_name = 2;
@@ -32,7 +32,7 @@ message DbIdTableName {
 // instance.
 message TableNameIdent {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // The user this table belongs to.
   string tenant = 1;
@@ -50,7 +50,7 @@ message TableNameIdent {
 // I.e., the tuple `(db_id, seq)` always identifies the same instance.
 message TableIdent {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   uint64 table_id = 1;
 
@@ -61,7 +61,7 @@ message TableIdent {
 // TableMeta is a container of all non-identity information.
 message TableMeta {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // Table schema, i.e., columns definition.
   DataSchema schema = 1;
@@ -114,7 +114,7 @@ message TableMeta {
 // Save table name id list history.
 message TableIdList {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   repeated uint64 ids = 1;
 }
@@ -123,7 +123,7 @@ message TableIdList {
 message TableStatistics {
 
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // Number of rows
   uint64 number_of_rows = 1;
@@ -140,7 +140,7 @@ message TableStatistics {
 
 message DatabaseIdTableName {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   // The db id this table belongs to
   uint64 db_id = 1;
@@ -151,7 +151,7 @@ message DatabaseIdTableName {
 
 message TableCopiedFileInfo {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   optional string etag = 1;
   uint64 content_length = 2;
@@ -160,5 +160,5 @@ message TableCopiedFileInfo {
 
 message TableCopiedFileLock {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 }

--- a/src/meta/protos/proto/user.proto
+++ b/src/meta/protos/proto/user.proto
@@ -21,7 +21,7 @@ import "config.proto";
 
 message AuthInfo {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   message None {}
   message Password {
@@ -44,7 +44,7 @@ message AuthInfo {
 
 message GrantObject {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   message GrantGlobalObject {}
 
@@ -68,7 +68,7 @@ message GrantObject {
 
 message GrantEntry {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   GrantObject object = 1;
   uint64 privileges = 2;
@@ -76,7 +76,7 @@ message GrantEntry {
 
 message UserGrantSet {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   repeated GrantEntry entries = 1;
   map<string, bool> roles = 2;
@@ -84,7 +84,7 @@ message UserGrantSet {
 
 message UserQuota {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   uint64 max_cpu = 1;
   uint64 max_memory_in_bytes = 2;
@@ -93,7 +93,7 @@ message UserQuota {
 
 message UserOption {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   uint64 flags = 1;
   optional string default_role = 2;
@@ -101,7 +101,7 @@ message UserOption {
 
 message UserInfo {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   string name = 1;
   string hostname = 2;
@@ -113,7 +113,7 @@ message UserInfo {
 
 message UserIdentity {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   string username = 1;
   string hostname = 2;
@@ -121,7 +121,7 @@ message UserIdentity {
 
 message UserStageInfo {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   enum StageType {
     LegacyInternal = 0;
@@ -170,7 +170,7 @@ message UserStageInfo {
 
   message FileFormatOptions {
     uint64 ver = 100;
-    uint64 min_compatible = 101;
+    uint64 min_reader_ver = 101;
 
     StageFileFormatType format = 1;
     // Number of lines at the start of the file to skip.
@@ -229,7 +229,7 @@ message UserStageInfo {
 
 message StageFile {
   uint64 ver = 100;
-  uint64 min_compatible = 101;
+  uint64 min_reader_ver = 101;
 
   string path = 1;
   uint64 size = 2;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore(meta/proto): rename message.min_compatible to message.min_reader_ver to reflect its actual purpose

## Changelog







## Related Issues