### PR TITLE
refactor(expr): use error_to_null() to eval try_cast

### DIFF
--- a/src/query/expression/src/property.rs
+++ b/src/query/expression/src/property.rs
@@ -53,11 +53,11 @@ impl FunctionProperty {
 pub enum FunctionDomain<T: ValueType> {
     /// The function may return error.
     MayThrow,
-    /// The function must not return error, and the return value any valid
-    /// value the type can represent.
+    /// The function must not return error, and the return value can be
+    /// any valid value the type can represent.
     Full,
     /// The function must not return error, and have futher information
-    /// to restrict the range of the output value.
+    /// about the range of the output value.
     Domain(T::Domain),
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Same purpose as https://github.com/datafuselabs/databend/pull/9533, with domain calculation resolved.

## TODO

- [ ] migrate try_cast of numbers
