### PR TITLE
fix(query): fix memory leak for unsized hash table

### DIFF
--- a/src/common/hashtable/src/unsized_hashtable.rs
+++ b/src/common/hashtable/src/unsized_hashtable.rs
@@ -1178,6 +1178,8 @@ where A: Allocator + Clone + Default
         self.table2.clear();
         self.table3.clear();
         self.table4.clear();
+        // NOTE: Bump provides the reset function to free memory, but it will cause memory leakage(maybe a bug).
+        // In fact, we don't need to call the drop function. rust will call it, But we call it to improve the readability of the code.
         drop(std::mem::take(&mut self.arena));
     }
 }

--- a/src/common/hashtable/src/unsized_hashtable.rs
+++ b/src/common/hashtable/src/unsized_hashtable.rs
@@ -1178,6 +1178,6 @@ where A: Allocator + Clone + Default
         self.table2.clear();
         self.table3.clear();
         self.table4.clear();
-        self.arena.reset();
+        drop(std::mem::take(&mut self.arena));
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fixes(query): fix memory leak for unsized hash table

Closes #issue
