### PR TITLE
fix(query): cast with keyword err

### DIFF
--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -648,17 +648,20 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
     );
     let extract = map(
         rule! {
-            EXTRACT ~ ^"(" ~ ^#interval_kind ~ ^FROM ~ ^#subexpr(0) ~ ^")"
+            EXTRACT ~ "(" ~ ^#interval_kind ~ ^FROM ~ ^#subexpr(0) ~ ^")"
         },
         |(_, _, field, _, expr, _)| ExprElement::Extract {
             field,
             expr: Box::new(expr),
         },
     );
+    // ^"(" can expand to nom::combinator::cut(crate::match_text("(")).
+    // If the parser in cut() fails, parse simply breaks and does not attempt another branch.
+    // But we can use position as a field name, so need delete ^ in herre.
     let position = map(
         rule! {
             POSITION
-            ~ ^"("
+            ~ "("
             ~ ^#subexpr(BETWEEN_PREC)
             ~ ^IN
             ~ ^#subexpr(0)
@@ -672,7 +675,7 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
     let substring = map(
         rule! {
             ( SUBSTRING | SUBSTR )
-            ~ ^"("
+            ~ "("
             ~ ^#subexpr(0)
             ~ ( FROM | "," )
             ~ ^#subexpr(0)
@@ -693,7 +696,7 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
     let trim = map(
         rule! {
             TRIM
-            ~ ^"("
+            ~ "("
             ~ #subexpr(0)
             ~ ^")"
         },
@@ -705,7 +708,7 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
     let trim_from = map(
         rule! {
             TRIM
-            ~ ^"("
+            ~ "("
             ~ #trim_where
             ~ ^#subexpr(0)
             ~ ^FROM
@@ -781,7 +784,7 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
         },
     );
     let exists = map(
-        rule! { NOT? ~ EXISTS ~ ^"(" ~ ^#query ~ ^")" },
+        rule! { NOT? ~ EXISTS ~ "(" ~ ^#query ~ ^")" },
         |(opt_not, _, _, subquery, _)| ExprElement::Exists {
             subquery,
             not: opt_not.is_some(),

--- a/tests/sqllogictests/suites/query/02_function/02_0002_function_cast
+++ b/tests/sqllogictests/suites/query/02_function/02_0002_function_cast
@@ -440,3 +440,19 @@ SELECT count(distinct a) FROM (SELECT rand()::string AS a FROM numbers(10))
 ----
 10
 
+statement ok
+drop table if exists t
+
+statement ok
+create table t(position int, trim int, substring int)
+
+statement ok
+insert into t values(3,3,3)
+
+query TTT
+select cast(position as String), cast(trim as String), cast(substring as String) from t;
+----
+3 3 3
+
+statement ok
+drop table t


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```rust
let position = map(
    rule! {
        POSITION
        ~ ^"("
        ~ ^#subexpr(BETWEEN_PREC)
        ~ ^IN
        ~ ^#subexpr(0)
        ~ ^")"
    },
    |(_, _, substr_expr, _, str_expr, _)| ExprElement::Position {
        substr_expr: Box::new(substr_expr),
        str_expr: Box::new(str_expr),
    },
);
```

will be expand to this:

```rust
let position = map(
    nom::sequence::tuple((
        crate::match_token(POSITION),
        nom::combinator::cut(crate::match_text("(")),
        nom::combinator::cut(subexpr(BETWEEN_PREC)),
        nom::combinator::cut(crate::match_token(IN)),
        nom::combinator::cut(subexpr(0)),
        nom::combinator::cut(crate::match_text(")")),
    )),
    |(_, _, substr_expr, _, str_expr, _)| ExprElement::Position {
        substr_expr: Box::new(substr_expr),
        str_expr: Box::new(str_expr),
    },
);
```

If the cut returns an error, the parse simply breaks and does not attempt another branch.

So sql `select cast(position as string) from t` return parse error.

position is a common field name, so in this pr I modify it.

There are some code like position:

```
substring
extract
trim
trim_from

```

But these not a common schema name, so I think in this pr, we just need to modify position parse.

Closes #9548
