### PR TITLE
refactor(format): call csv_core::Reader at one place.

### DIFF
--- a/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_tsv.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_tsv.rs
@@ -130,7 +130,7 @@ impl InputFormatTextBase for InputFormatTSV {
     fn deserialize(builder: &mut BlockBuilder<Self>, batch: RowBatch) -> Result<()> {
         tracing::debug!(
             "tsv deserializing row batch {}, id={}, start_row={:?}, offset={}",
-            batch.path,
+            batch.split_info.file.path,
             batch.batch_id,
             batch.start_row_in_split,
             batch.start_offset_in_split

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_xml.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/impls/input_format_xml.rs
@@ -117,7 +117,6 @@ impl AligningStateTextBased for AligningStateWholeFile {
             data,
             row_ends: vec![],
             field_ends: vec![],
-            path: self.split_info.file.path.clone(),
             batch_id: 0,
             split_info: self.split_info.clone(),
             start_offset_in_split: 0,
@@ -146,7 +145,7 @@ impl InputFormatTextBase for InputFormatXML {
             .expect("must success");
         let columns = &mut builder.mutable_columns;
 
-        let path = &batch.path;
+        let path = &batch.split_info.file.path;
         let row_tag = builder.ctx.format_options.stage.row_tag.as_bytes().to_vec();
         let field_tag = vec![b'f', b'i', b'e', b'l', b'd'];
 
@@ -222,7 +221,7 @@ impl InputFormatTextBase for InputFormatXML {
                                 &mut cols,
                                 columns,
                                 &builder.ctx.schema,
-                                &batch.path,
+                                &batch.split_info.file.path,
                                 num_rows,
                             ) {
                                 if builder.ctx.on_error_mode == OnErrorMode::Continue {

--- a/src/query/pipeline/sources/src/processors/sources/input_formats/input_format_text.rs
+++ b/src/query/pipeline/sources/src/processors/sources/input_formats/input_format_text.rs
@@ -140,7 +140,6 @@ impl AligningStateTextBased for AligningStateRowDelimiter {
             row_ends: vec![],
             field_ends: vec![],
             split_info: self.split_info.clone(),
-            path: "".to_string(),
             batch_id: self.common.batch_id,
             start_offset_in_split: self.common.offset,
             start_row_in_split: self.common.rows,
@@ -161,7 +160,6 @@ impl AligningStateTextBased for AligningStateRowDelimiter {
             output.data.extend_from_slice(&buf[..batch_end]);
             self.tail_of_last_batch.extend_from_slice(&buf[batch_end..]);
             let size = output.data.len();
-            output.path = self.split_info.file.path.to_string();
             self.common.offset += size;
             self.common.rows += rows.len();
             self.common.batch_id += 1;
@@ -189,7 +187,6 @@ impl AligningStateTextBased for AligningStateRowDelimiter {
                 row_ends: vec![end],
                 field_ends: vec![],
                 split_info: self.split_info.clone(),
-                path: self.split_info.file.path.clone(),
                 batch_id: self.common.batch_id,
                 start_offset_in_split: self.common.offset,
                 start_row_in_split: self.common.rows,
@@ -328,7 +325,6 @@ pub struct RowBatch {
 
     pub split_info: Arc<SplitInfo>,
     // for error info
-    pub path: String,
     pub batch_id: usize,
     pub start_offset_in_split: usize,
     pub start_row_in_split: usize,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

used to call it at 4 places with subtle differences. 

Closes #issue
