### PR TITLE
fix: sqllogic test hangs (cluster mod + clickhouse handler) 

### DIFF
--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -114,14 +114,14 @@ async fn execute(
     let format_typ = format.typ.clone();
 
     // the reason of spawning new task to execute the interpreter:
-    // (sorry, I failed to describe it in a more concise way)
+    // (FIXME describe this in a more concise way)
     //
     // - there are executions of interpreters that will block the caller (NOT async wait)
     //   e.g. PipelineCompleteExecutor::execute, will spawn thread that executes the pipeline,
     //   and then, join the thread handle.
     // - async mutex (tokio::sync::Mutex) are used while executing the queries/statements
     //   An async task may yield while holding the lock of an async mutex. e.g. embedded meta store
-    // - this method(execute) is running with default tokio runtime
+    // - this method(execute) is running with default tokio runtime (the "tokio-runtime-worker" thread)
     //
     // if executes the interpreter "directly" (by using current thread), the following deadlock may happen:
     //
@@ -145,79 +145,79 @@ async fn execute(
     //
     //  P.S. I think it will be better/more reasonable if we could avoid using pthread_join inside an async stack.
 
-    let mut data_stream = ctx
-        .try_spawn({
-            let ctx = ctx.clone();
-            async move { interpreter.execute(ctx.clone()).await }
-        })?
-        .await
-        .map_err(|err| {
-            ErrorCode::from_string(format!(
-                "clickhouse handler failed to join interpreter thread: {err:?}"
-            ))
-        })??;
+    ctx.try_spawn({
+        let ctx = ctx.clone();
+        async move {
+            let mut data_stream = interpreter.execute(ctx.clone()).await?;
+            let table_schema = infer_table_schema(&schema)?;
+            let mut output_format = FileFormatOptionsExt::get_output_format_from_clickhouse_format(
+                format,
+                table_schema,
+                &ctx.get_settings(),
+            )?;
 
-    let table_schema = infer_table_schema(&schema)?;
-    let mut output_format = FileFormatOptionsExt::get_output_format_from_clickhouse_format(
-        format,
-        table_schema,
-        &ctx.get_settings(),
-    )?;
+            let prefix = Ok(output_format.serialize_prefix()?);
 
-    let prefix = Ok(output_format.serialize_prefix()?);
-
-    let compress_fn = move |rb: Result<Vec<u8>>| -> Result<Vec<u8>> {
-        if params.compress() {
-            match rb {
-                Ok(b) => compress_block(b),
-                Err(e) => Err(e),
-            }
-        } else {
-            rb
-        }
-    };
-
-    // try to catch runtime error before http response, so user can client can get http 500
-    let first_block = match data_stream.next().await {
-        Some(block) => match block {
-            Ok(block) => Some(compress_fn(output_format.serialize_block(&block))),
-            Err(err) => return Err(err),
-        },
-        None => None,
-    };
-
-    let session = ctx.get_current_session();
-    let stream = stream! {
-        yield compress_fn(prefix);
-        let mut ok = true;
-        // do not pull data_stream if we already meet a None
-        if let Some(block) = first_block {
-            yield block;
-            while let Some(block) = data_stream.next().await {
-                match block{
-                    Ok(block) => {
-                        yield compress_fn(output_format.serialize_block(&block));
-                    },
-                    Err(err) => {
-                        let message = format!("{}", err);
-                        yield compress_fn(Ok(message.into_bytes()));
-                        ok = false;
-                        break
+            let compress_fn = move |rb: Result<Vec<u8>>| -> Result<Vec<u8>> {
+                if params.compress() {
+                    match rb {
+                        Ok(b) => compress_block(b),
+                        Err(e) => Err(e),
                     }
-                };
-            }
-        }
-        if ok {
-            yield compress_fn(output_format.finalize());
-        }
-        // to hold session ref until stream is all consumed
-        let _ = session.get_id();
-    };
-    if let Some(handle) = handle {
-        handle.await.expect("must")
-    }
+                } else {
+                    rb
+                }
+            };
 
-    Ok(Body::from_bytes_stream(stream).with_content_type(format_typ.get_content_type()))
+            // try to catch runtime error before http response, so user can client can get http 500
+            let first_block = match data_stream.next().await {
+                Some(block) => match block {
+                    Ok(block) => Some(compress_fn(output_format.serialize_block(&block))),
+                    Err(err) => return Err(err),
+                },
+                None => None,
+            };
+
+            let session = ctx.get_current_session();
+            let stream = stream! {
+                yield compress_fn(prefix);
+                let mut ok = true;
+                // do not pull data_stream if we already meet a None
+                if let Some(block) = first_block {
+                    yield block;
+                    while let Some(block) = data_stream.next().await {
+                        match block{
+                            Ok(block) => {
+                                yield compress_fn(output_format.serialize_block(&block));
+                            },
+                            Err(err) => {
+                                let message = format!("{}", err);
+                                yield compress_fn(Ok(message.into_bytes()));
+                                ok = false;
+                                break
+                            }
+                        };
+                    }
+                }
+                if ok {
+                    yield compress_fn(output_format.finalize());
+                }
+                // to hold session ref until stream is all consumed
+                let _ = session.get_id();
+            };
+            if let Some(handle) = handle {
+                handle.await.expect("must")
+            }
+
+            Ok(Body::from_bytes_stream(stream).with_content_type(format_typ.get_content_type()))
+        }
+    })?
+    .await
+    .map_err(|err| {
+        ErrorCode::from_string(format!(
+            "clickhouse handler failed to join interpreter thread: {err:?}"
+        ))
+    })?
 }
 
 #[poem::handler]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

to avoid sqllogic test hanging in cluster mode, in the clickhouse handler, wraps resultset stream pulling action in  the "query-ctx" thread.



how to re-produce: pls see the summary of https://github.com/datafuselabs/databend/issues/9576


while execution queries:

1.  the clickhouse handler uses "global" the tokio runtime (the "tokio-runtime-workers" threads) to pull the  resultset datastream (SendableDataBlockStream). 

the pulling of `SendableDataBlockStream` , calls `PipelinePullingExecutor::pull_data` (for PipelinePullingExecutor)

https://github.com/datafuselabs/databend/blob/3b45a672222b5bc928810dd0b3a64803d18a590d/src/query/service/src/pipelines/executor/pipeline_pulling_executor.rs#L176-L185

note that here the `receive` is NOT async,  if data is not available, the runtime thread might be trapped in this loop.

2.  the `FlightExchange` also uses "tokio-runtime-worker" threads to pulling data from flight rpc, and forwarding data to downstream

https://github.com/datafuselabs/databend/blob/750852820100579243172a507d8d6e455080a768/src/query/service/src/api/rpc/flight_client.rs#L131-L147


if rt threads are trapped in 1, waiting for data from `FlightExchange`, and async tasks of `FlightExchange` are waiting for rt thread to drive them, the execution hangs.

NOTE: seems that not all the threads that named `tokio-runtime-threads` are trapped in 1 while execution of query hangs. but a) I am not sure if there were other ad-hoc tokio runtimes with default thread names there. b) do not know if work stealing of tokio scheduling helps here

----------

to avoid hanging, the clickhouse handler uses `query-ctx` thread to pull the data in this PR


Closes #9576
