### PR TITLE
fix(format): should not allow ident as value of options.

### DIFF
--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -36,7 +36,7 @@ pub fn u64_to_string(i: Input) -> IResult<String> {
 
 pub fn parameter_to_string(i: Input) -> IResult<String> {
     map(
-        rule! { ( #literal_string | #ident_to_string | #u64_to_string ) },
+        rule! { ( #literal_string | #u64_to_string ) },
         |parameter| parameter,
     )(i)
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

when running ` copy into t1 from 'fs:///xxx' file_format = (type = 'csv' record_delimiter = "\n")`

currently we get error like 

```
record_delimiter with two chars can only be '\r\n'.
```

but it work if we use single quotes `record_delimiter = ‘\n’`.

the reason is we now use Dialect::PostgreSQL (and not allowed to set it),  ` "\n"` is a  ident instead of a literal string.
and ident is not unescaped.

after this pr, we get a clearer error message.

```
 copy into t1 from 'fs:///xxx' file_format = (type = 'csv' record_delimiter = "\n")
                                                                             ^^^^ expected <QuotedString>, <LiteralInteger>, <MySQLLiteralHex>, or <PGLiteralHex>

```


Closes https://github.com/datafuselabs/databend/issues/9580
