### PR TITLE
fix: ensure there is page index while using page index to filter pages.

### DIFF
--- a/src/query/storages/parquet/src/pruning.rs
+++ b/src/query/storages/parquet/src/pruning.rs
@@ -130,7 +130,11 @@ pub fn prune_and_set_partitions(
                 continue;
             }
 
-            let row_selection = if read_options.prune_pages() {
+            let row_selection = if read_options.prune_pages()
+                && rg.columns().iter().all(|c| {
+                    c.column_chunk().column_index_offset.is_some()
+                        && c.column_chunk().column_index_length.is_some()
+                }) {
                 page_pruners
                     .as_ref()
                     .map(|pruners| filter_pages(&mut file, schema, rg, pruners))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Arrow2 will not throw an error but panic when reading page indexes if there is no page index in the parquet file.

We should check if there is page index first.