### PR TITLE
refactor(parser): more strict parser for format_options.

### DIFF
--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -150,10 +150,9 @@ pub fn uri_location(i: Input) -> IResult<UriLocation> {
             #literal_string
             ~ (CONNECTION ~ "=" ~ #connection_options)?
             ~ (CREDENTIALS ~ "=" ~ #connection_options)?
-            ~ (ENCRYPTION ~ "=" ~ #options)?
             ~ (LOCATION_PREFIX ~ "=" ~ #literal_string)?
         },
-        |(location, connection_opt, credentials_opt, encryption_opt, location_prefix)| {
+        |(location, connection_opt, credentials_opt, location_prefix)| {
             let part_prefix = if let Some((_, _, p)) = location_prefix {
                 p
             } else {
@@ -173,10 +172,9 @@ pub fn uri_location(i: Input) -> IResult<UriLocation> {
             let parsed =
                 Url::parse(&location).map_err(|_| ErrorKind::Other("invalid uri location"))?;
 
-            // TODO: We will use `CONNECTION` to replace `CREDENTIALS` and `ENCRYPTION`.
+            // TODO: We will use `CONNECTION` to replace `CREDENTIALS`.
             let mut conns = connection_opt.map(|v| v.2).unwrap_or_default();
             conns.extend(credentials_opt.map(|v| v.2).unwrap_or_default());
-            conns.extend(encryption_opt.map(|v| v.2).unwrap_or_default());
 
             let protocol = parsed.scheme().to_string();
 

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -61,19 +61,6 @@ pub fn connection_options(i: Input) -> IResult<BTreeMap<String, String>> {
     )(i)
 }
 
-pub fn credentials_options(i: Input) -> IResult<BTreeMap<String, String>> {
-    let string_options = map(
-        rule! {
-            (AWS_KEY_ID | AWS_SECRET_KEY) ~ "=" ~ #literal_string
-        },
-        |(k, _, v)| (k.text().to_string(), v),
-    );
-
-    map(rule! { "(" ~ (#string_options)* ~ ")"}, |(_, opts, _)| {
-        BTreeMap::from_iter(opts.iter().map(|(k, v)| (k.to_lowercase(), v.clone())))
-    })(i)
-}
-
 pub fn format_options(i: Input) -> IResult<BTreeMap<String, String>> {
     let option_type = map(
         rule! {
@@ -147,7 +134,7 @@ pub fn uri_location(i: Input) -> IResult<UriLocation> {
         rule! {
             #literal_string
             ~ (CONNECTION ~ "=" ~ #connection_options)?
-            ~ (CREDENTIALS ~ "=" ~ #credentials_options)?
+            ~ (CREDENTIALS ~ "=" ~ #connection_options)?
             ~ (ENCRYPTION ~ "=" ~ #options)?
             ~ (LOCATION_PREFIX ~ "=" ~ #literal_string)?
         },

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -43,7 +43,7 @@ pub fn parameter_to_string(i: Input) -> IResult<String> {
 pub fn connection_options(i: Input) -> IResult<BTreeMap<String, String>> {
     let string_options = map(
         rule! {
-            (ENDPOINT_URL | ACCESS_KEY_ID | SECRET_ACCESS_KEY | SESSION_TOKEN | REGION) ~ "=" ~ #literal_string
+            (AWS_KEY_ID | AWS_SECRET_KEY | ENDPOINT_URL | ACCESS_KEY_ID | SECRET_ACCESS_KEY | SESSION_TOKEN | REGION) ~ "=" ~ #literal_string
         },
         |(k, _, v)| (k.text().to_string(), v),
     );

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -27,7 +27,7 @@ use crate::util::*;
 use crate::ErrorKind;
 
 pub fn ident_to_string(i: Input) -> IResult<String> {
-    map_res(ident, |ident| Ok(ident.name))(i)
+    map_res(rule! { Ident }, |ident| Ok(ident.text().to_string()))(i)
 }
 
 pub fn u64_to_string(i: Input) -> IResult<String> {
@@ -36,7 +36,7 @@ pub fn u64_to_string(i: Input) -> IResult<String> {
 
 pub fn parameter_to_string(i: Input) -> IResult<String> {
     map(
-        rule! { ( #literal_string | #ident_to_string | #u64_to_string ) },
+        rule! { ( #literal_string | #ident_to_string |  #u64_to_string ) },
         |parameter| parameter,
     )(i)
 }

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -91,7 +91,7 @@ pub fn format_options(i: Input) -> IResult<BTreeMap<String, String>> {
 
     let string_options = map(
         rule! {
-            (TYPE | RECORD_DELIMITER | FIELD_DELIMITER | QUOTE | NON_DISPLAY | ESCAPE ) ~ "=" ~ #literal_string
+            (TYPE | COMPRESSION | RECORD_DELIMITER | FIELD_DELIMITER | QUOTE | NON_DISPLAY | ESCAPE ) ~ "=" ~ #literal_string
         },
         |(k, _, v)| (k.text().to_string(), v),
     );

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -78,7 +78,14 @@ pub fn format_options(i: Input) -> IResult<BTreeMap<String, String>> {
 
     let string_options = map(
         rule! {
-            (TYPE | COMPRESSION | RECORD_DELIMITER | FIELD_DELIMITER | QUOTE | NON_DISPLAY | ESCAPE ) ~ "=" ~ #literal_string
+            (TYPE
+                | COMPRESSION
+                | RECORD_DELIMITER
+                | FIELD_DELIMITER
+                | QUOTE
+                | NON_DISPLAY
+                | ESCAPE
+                | ROW_TAG) ~ "=" ~ #literal_string
         },
         |(k, _, v)| (k.text().to_string(), v),
     );

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -70,14 +70,9 @@ pub fn format_options(i: Input) -> IResult<BTreeMap<String, String>> {
 
 // parse: (k = v ...)* into a map
 pub fn options(i: Input) -> IResult<BTreeMap<String, String>> {
-    let ident_with_format = alt((
-        ident_to_string,
-        map(rule! { FORMAT }, |_| "FORMAT".to_string()),
-    ));
-
     map(
         rule! {
-            "(" ~ ( #ident_with_format ~ "=" ~ #parameter_to_string )* ~ ")"
+            "(" ~ ( #ident_to_string ~ "=" ~ #parameter_to_string )* ~ ")"
         },
         |(_, opts, _)| {
             BTreeMap::from_iter(opts.iter().map(|(k, _, v)| (k.to_lowercase(), v.clone())))

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -27,7 +27,7 @@ use crate::util::*;
 use crate::ErrorKind;
 
 pub fn ident_to_string(i: Input) -> IResult<String> {
-    map_res(rule! { Ident }, |ident| Ok(ident.text().to_string()))(i)
+    map_res(ident_no_quote, |ident| Ok(ident.name))(i)
 }
 
 pub fn u64_to_string(i: Input) -> IResult<String> {

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -43,7 +43,15 @@ pub fn parameter_to_string(i: Input) -> IResult<String> {
 pub fn connection_options(i: Input) -> IResult<BTreeMap<String, String>> {
     let string_options = map(
         rule! {
-            (AWS_KEY_ID | AWS_SECRET_KEY | ENDPOINT_URL | ACCESS_KEY_ID | SECRET_ACCESS_KEY | SESSION_TOKEN | REGION) ~ "=" ~ #literal_string
+            (AWS_KEY_ID
+                | AWS_SECRET_KEY
+                | ENDPOINT_URL
+                | ACCESS_KEY_ID
+                | SECRET_ACCESS_KEY
+                | SESSION_TOKEN
+                | REGION
+                | ENABLE_VIRTUAL_HOST_STYLE)
+            ~ "=" ~ #literal_string
         },
         |(k, _, v)| (k.text().to_string(), v),
     );

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -52,14 +52,14 @@ pub fn format_options(i: Input) -> IResult<BTreeMap<String, String>> {
         rule! {
         (COMPRESSION ~ "=" ~ #parameter_to_string )
         },
-        |(_, _, v)| ("COMPRESSION".to_string(), v.clone()),
+        |(_, _, v)| ("COMPRESSION".to_string(), v),
     );
 
     let string_options = map(
         rule! {
             (TYPE | RECORD_DELIMITER | FIELD_DELIMITER | QUOTE | SKIP_HEADER | NON_DISPLAY | ESCAPE ) ~ "=" ~ #literal_string
         },
-        |(k, _, v)| (k.text().to_string(), v.clone()),
+        |(k, _, v)| (k.text().to_string(), v),
     );
 
     map(

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -767,7 +767,7 @@ pub fn statement(i: Input) -> IResult<StatementMsg> {
             CREATE ~ STAGE ~ ( IF ~ NOT ~ EXISTS )?
             ~ ( #stage_name )
             ~ ( URL ~ "=" ~ #uri_location)?
-            ~ ( FILE_FORMAT ~ "=" ~ #options)?
+            ~ ( FILE_FORMAT ~ "=" ~ #format_options)?
             ~ ( ON_ERROR ~ "=" ~ #ident)?
             ~ ( SIZE_LIMIT ~ "=" ~ #literal_u64)?
             ~ ( VALIDATION_MODE ~ "=" ~ #ident)?
@@ -1115,7 +1115,7 @@ pub fn insert_source(i: Input) -> IResult<InsertSource> {
     );
     let streaming_v2 = map(
         rule! {
-            FILE_FORMAT ~ "=" ~ #options ~ #rest_str
+            FILE_FORMAT ~ "=" ~ #format_options ~ #rest_str
         },
         |(_, _, options, (_, start))| InsertSource::StreamingV2 {
             settings: options,
@@ -1707,9 +1707,10 @@ pub fn copy_option(i: Input) -> IResult<CopyOption> {
             rule! { PATTERN ~ "=" ~ #literal_string },
             |(_, _, pattern)| CopyOption::Pattern(pattern),
         ),
-        map(rule! { FILE_FORMAT ~ "=" ~ #options }, |(_, _, options)| {
-            CopyOption::FileFormat(options)
-        }),
+        map(
+            rule! { FILE_FORMAT ~ "=" ~ #format_options },
+            |(_, _, options)| CopyOption::FileFormat(options),
+        ),
         map(
             rule! { VALIDATION_MODE ~ "=" ~ #literal_string },
             |(_, _, validation_mode)| CopyOption::ValidationMode(validation_mode),

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -578,8 +578,6 @@ pub enum TokenKind {
     PROCESSLIST,
     #[token("PURGE", ignore(ascii_case))]
     PURGE,
-    #[token("STATISTIC", ignore(ascii_case))]
-    STATISTIC,
     #[token("QUARTER", ignore(ascii_case))]
     QUARTER,
     #[token("QUERY", ignore(ascii_case))]
@@ -634,6 +632,8 @@ pub enum TokenKind {
     SETTINGS,
     #[token("STAGES", ignore(ascii_case))]
     STAGES,
+    #[token("STATISTIC", ignore(ascii_case))]
+    STATISTIC,
     #[token("SHA256_PASSWORD", ignore(ascii_case))]
     SHA256_PASSWORD,
     #[token("SHOW", ignore(ascii_case))]

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -314,6 +314,8 @@ pub enum TokenKind {
     CHAR,
     #[token("CHARACTER", ignore(ascii_case))]
     CHARACTER,
+    #[token("COMPRESSION", ignore(ascii_case))]
+    COMPRESSION,
     #[token("COPY_OPTIONS", ignore(ascii_case))]
     COPY_OPTIONS,
     #[token("COPY", ignore(ascii_case))]
@@ -390,6 +392,8 @@ pub enum TokenKind {
     ENGINES,
     #[token("EPOCH", ignore(ascii_case))]
     EPOCH,
+    #[token("ESCAPE", ignore(ascii_case))]
+    ESCAPE,
     #[token("EXISTS", ignore(ascii_case))]
     EXISTS,
     #[token("EXPLAIN", ignore(ascii_case))]
@@ -534,8 +538,12 @@ pub enum TokenKind {
     MINUTE,
     #[token("MONTH", ignore(ascii_case))]
     MONTH,
+    #[token("NON_DISPLAY", ignore(ascii_case))]
+    NON_DISPLAY,
     #[token("NATURAL", ignore(ascii_case))]
     NATURAL,
+    #[token("NDJSON", ignore(ascii_case))]
+    NDJSON,
     #[token("NO_PASSWORD", ignore(ascii_case))]
     NO_PASSWORD,
     #[token("NOT", ignore(ascii_case))]
@@ -582,6 +590,8 @@ pub enum TokenKind {
     QUARTER,
     #[token("QUERY", ignore(ascii_case))]
     QUERY,
+    #[token("QUOTE", ignore(ascii_case))]
+    QUOTE,
     #[token("RECLUSTER", ignore(ascii_case))]
     RECLUSTER,
     #[token("RECORD_DELIMITER", ignore(ascii_case))]
@@ -592,6 +602,8 @@ pub enum TokenKind {
     REGEXP,
     #[token("RENAME", ignore(ascii_case))]
     RENAME,
+    #[token("ROW_TAG", ignore(ascii_case))]
+    ROW_TAG,
     #[token("GRANT", ignore(ascii_case))]
     GRANT,
     #[token("ROLE", ignore(ascii_case))]
@@ -716,6 +728,8 @@ pub enum TokenKind {
     TRUNCATE,
     #[token("TRY_CAST", ignore(ascii_case))]
     TRY_CAST,
+    #[token("TSV", ignore(ascii_case))]
+    TSV,
     #[token("TUPLE", ignore(ascii_case))]
     TUPLE,
     #[token("TYPE", ignore(ascii_case))]
@@ -762,6 +776,8 @@ pub enum TokenKind {
     WHERE,
     #[token("WITH", ignore(ascii_case))]
     WITH,
+    #[token("XML", ignore(ascii_case))]
+    XML,
     #[token("XOR", ignore(ascii_case))]
     XOR,
     #[token("YEAR", ignore(ascii_case))]

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -246,10 +246,14 @@ pub enum TokenKind {
     //    reserved list.
     #[token("ALL", ignore(ascii_case))]
     ALL,
+    #[token("ACCESS_KEY_ID", ignore(ascii_case))]
+    ACCESS_KEY_ID,
     #[token("ADD", ignore(ascii_case))]
     ADD,
     #[token("ANY", ignore(ascii_case))]
     ANY,
+    #[token("AUTO", ignore(ascii_case))]
+    AUTO,
     #[token("SOME", ignore(ascii_case))]
     SOME,
     #[token("ALTER", ignore(ascii_case))]
@@ -288,6 +292,10 @@ pub enum TokenKind {
     BOTH,
     #[token("BY", ignore(ascii_case))]
     BY,
+    #[token("BROTLI", ignore(ascii_case))]
+    BROTLI,
+    #[token("BZ2", ignore(ascii_case))]
+    BZ2,
     #[token("CALL", ignore(ascii_case))]
     CALL,
     #[token("CASE", ignore(ascii_case))]
@@ -352,6 +360,8 @@ pub enum TokenKind {
     DECADE,
     #[token("DEFAULT", ignore(ascii_case))]
     DEFAULT,
+    #[token("DEFLATE", ignore(ascii_case))]
+    DEFLATE,
     #[token("DELETE", ignore(ascii_case))]
     DELETE,
     #[token("DESC", ignore(ascii_case))]
@@ -380,6 +390,8 @@ pub enum TokenKind {
     EXCLUDE,
     #[token("ELSE", ignore(ascii_case))]
     ELSE,
+    #[token("ENABLE_VIRTUAL_HOST_STYLE", ignore(ascii_case))]
+    ENABLE_VIRTUAL_HOST_STYLE,
     #[token("END", ignore(ascii_case))]
     END,
     #[token("ENDPOINT_URL", ignore(ascii_case))]
@@ -448,6 +460,8 @@ pub enum TokenKind {
     GRAPH,
     #[token("GROUP", ignore(ascii_case))]
     GROUP,
+    #[token("GZIP", ignore(ascii_case))]
+    GZIP,
     #[token("HAVING", ignore(ascii_case))]
     HAVING,
     #[token("HISTORY", ignore(ascii_case))]
@@ -516,6 +530,8 @@ pub enum TokenKind {
     LIMIT,
     #[token("LIST", ignore(ascii_case))]
     LIST,
+    #[token("LZO", ignore(ascii_case))]
+    LZO,
     #[token("MAP", ignore(ascii_case))]
     MAP,
     #[token("MAX_FILE_SIZE", ignore(ascii_case))]
@@ -546,6 +562,8 @@ pub enum TokenKind {
     NDJSON,
     #[token("NO_PASSWORD", ignore(ascii_case))]
     NO_PASSWORD,
+    #[token("NONE", ignore(ascii_case))]
+    NONE,
     #[token("NOT", ignore(ascii_case))]
     NOT,
     #[token("NOTENANTSETTING", ignore(ascii_case))]
@@ -592,6 +610,8 @@ pub enum TokenKind {
     QUERY,
     #[token("QUOTE", ignore(ascii_case))]
     QUOTE,
+    #[token("RAWDEFLATE", ignore(ascii_case))]
+    RAWDEFLATE,
     #[token("RECLUSTER", ignore(ascii_case))]
     RECLUSTER,
     #[token("RECORD_DELIMITER", ignore(ascii_case))]
@@ -612,6 +632,8 @@ pub enum TokenKind {
     PRESIGN,
     #[token("PRIVILEGES", ignore(ascii_case))]
     PRIVILEGES,
+    #[token("REGION", ignore(ascii_case))]
+    REGION,
     #[token("REMOVE", ignore(ascii_case))]
     REMOVE,
     #[token("REVOKE", ignore(ascii_case))]
@@ -632,10 +654,14 @@ pub enum TokenKind {
     SCHEMAS,
     #[token("SECOND", ignore(ascii_case))]
     SECOND,
+    #[token("SECRET_ACCESS_KEY", ignore(ascii_case))]
+    SECRET_ACCESS_KEY,
     #[token("SELECT", ignore(ascii_case))]
     SELECT,
     #[token("SEGMENT", ignore(ascii_case))]
     SEGMENT,
+    #[token("SESSION_TOKEN", ignore(ascii_case))]
+    SESSION_TOKEN,
     #[token("SET", ignore(ascii_case))]
     SET,
     #[token("UNSET", ignore(ascii_case))]
@@ -660,6 +686,8 @@ pub enum TokenKind {
     SKIP_HEADER,
     #[token("SMALLINT", ignore(ascii_case))]
     SMALLINT,
+    #[token("SNAPPY", ignore(ascii_case))]
+    SNAPPY,
     #[token("SNAPSHOT", ignore(ascii_case))]
     SNAPSHOT,
     #[token("SPLIT_SIZE", ignore(ascii_case))]
@@ -780,8 +808,12 @@ pub enum TokenKind {
     XML,
     #[token("XOR", ignore(ascii_case))]
     XOR,
+    #[token("XZ", ignore(ascii_case))]
+    XZ,
     #[token("YEAR", ignore(ascii_case))]
     YEAR,
+    #[token("ZSTD", ignore(ascii_case))]
+    ZSTD,
     #[token("NULLIF", ignore(ascii_case))]
     NULLIF,
     #[token("COALESCE", ignore(ascii_case))]

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -396,8 +396,6 @@ pub enum TokenKind {
     END,
     #[token("ENDPOINT_URL", ignore(ascii_case))]
     ENDPOINT_URL,
-    #[token("ENCRYPTION", ignore(ascii_case))]
-    ENCRYPTION,
     #[token("ENGINE", ignore(ascii_case))]
     ENGINE,
     #[token("ENGINES", ignore(ascii_case))]

--- a/src/query/ast/src/util.rs
+++ b/src/query/ast/src/util.rs
@@ -71,6 +71,20 @@ pub fn function_name(i: Input) -> IResult<Identifier> {
     non_reserved_identifier(|token| token.is_reserved_function_name(false))(i)
 }
 
+pub fn ident_no_quote(i: Input) -> IResult<Identifier> {
+    map(
+        alt((
+            rule! { Ident },
+            non_reserved_keyword(|token| token.is_reserved_ident(false)),
+        )),
+        |token| Identifier {
+            span: token.clone(),
+            name: token.text().to_string(),
+            quote: None,
+        },
+    )(i)
+}
+
 /// TODO(xuanwo): Do we need to remove this function?
 #[allow(dead_code)]
 pub fn function_name_after_as(i: Input) -> IResult<Identifier> {

--- a/src/query/ast/src/util.rs
+++ b/src/query/ast/src/util.rs
@@ -71,20 +71,6 @@ pub fn function_name(i: Input) -> IResult<Identifier> {
     non_reserved_identifier(|token| token.is_reserved_function_name(false))(i)
 }
 
-pub fn ident_no_quote(i: Input) -> IResult<Identifier> {
-    map(
-        alt((
-            rule! { Ident },
-            non_reserved_keyword(|token| token.is_reserved_ident(false)),
-        )),
-        |token| Identifier {
-            span: token.clone(),
-            name: token.text().to_string(),
-            quote: None,
-        },
-    )(i)
-}
-
 /// TODO(xuanwo): Do we need to remove this function?
 #[allow(dead_code)]
 pub fn function_name_after_as(i: Input) -> IResult<Identifier> {

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -266,9 +266,6 @@ fn test_statement() {
                     AWS_KEY_ID = 'access_key'
                     AWS_SECRET_KEY = 'secret_key'
                 )
-                ENCRYPTION = (
-                    MASTER_KEY = 'master_key'
-                )
                 FILE_FORMAT = (
                     type = 'CSV'
                     field_delimiter = ','

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -144,7 +144,7 @@ fn test_statement() {
         r#"insert into table t select * from t2;"#,
         r#"select parse_json('{"k1": [0, 1, 2]}').k1[0];"#,
         r#"CREATE STAGE ~"#,
-        r#"CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z') file_format=(FORMAT = CSV compression = GZIP record_delimiter=',')"#,
+        r#"CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z') file_format=(type = CSV compression = GZIP record_delimiter=',')"#,
         r#"DROP STAGE abc"#,
         r#"DROP STAGE ~"#,
         r#"list @stage_a;"#,

--- a/src/query/ast/tests/it/testdata/statement-error.txt
+++ b/src/query/ast/tests/it/testdata/statement-error.txt
@@ -279,7 +279,7 @@ error:
   --> SQL:1:38
   |
 1 | COPY INTO mytable FROM 's3://bucket' CREDENTIAL = ();
-  |                                      ^^^^^^^^^^ expected `CONNECTION`, `CREDENTIALS`, `LOCATION_PREFIX`, `FILES`, `PATTERN`, or 11 more ...
+  |                                      ^^^^^^^^^^ expected `CONNECTION`, `CREDENTIALS`, `LOCATION_PREFIX`, `FILES`, `PATTERN`, `FILE_FORMAT`, or 10 more ...
 
 
 ---------- Input ----------

--- a/src/query/ast/tests/it/testdata/statement-error.txt
+++ b/src/query/ast/tests/it/testdata/statement-error.txt
@@ -279,7 +279,7 @@ error:
   --> SQL:1:38
   |
 1 | COPY INTO mytable FROM 's3://bucket' CREDENTIAL = ();
-  |                                      ^^^^^^^^^^ expected `CONNECTION`, `CREDENTIALS`, `ENCRYPTION`, `LOCATION_PREFIX`, `FILES`, `PATTERN`, or 11 more ...
+  |                                      ^^^^^^^^^^ expected `CONNECTION`, `CREDENTIALS`, `LOCATION_PREFIX`, `FILES`, `PATTERN`, or 11 more ...
 
 
 ---------- Input ----------

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -7214,9 +7214,6 @@ COPY INTO mytable
                     AWS_KEY_ID = 'access_key'
                     AWS_SECRET_KEY = 'secret_key'
                 )
-                ENCRYPTION = (
-                    MASTER_KEY = 'master_key'
-                )
                 FILE_FORMAT = (
                     type = 'CSV'
                     field_delimiter = ','
@@ -7225,7 +7222,7 @@ COPY INTO mytable
                 )
                 size_limit=10;
 ---------- Output ---------
-COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( aws_key_id='access_key' aws_secret_key='secret_key' master_key='master_key' ) FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
+COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( aws_key_id='access_key' aws_secret_key='secret_key' ) FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
 ' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 
 ---------- AST ------------
 Copy(
@@ -7241,7 +7238,6 @@ Copy(
                     conns: {
                         "aws_key_id": "access_key",
                         "aws_secret_key": "secret_key",
-                        "master_key": "master_key",
                     },
                 },
             },

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -5738,7 +5738,7 @@ CreateStage(
 ---------- Input ----------
 CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z') file_format=(type = CSV compression = GZIP record_delimiter=',')
 ---------- Output ---------
-CREATE STAGE IF NOT EXISTS test_stage URL = 's3://load/files/' CONNECTION = ( aws_key_id='1a2b3c' aws_secret_key='4x5y6z' ) FILE_FORMAT = ( compression = 'GZIP' format = 'CSV' record_delimiter = ',' )
+CREATE STAGE IF NOT EXISTS test_stage URL = 's3://load/files/' CONNECTION = ( aws_key_id='1a2b3c' aws_secret_key='4x5y6z' ) FILE_FORMAT = ( compression = 'GZIP' record_delimiter = ',' type = 'CSV' )
 ---------- AST ------------
 CreateStage(
     CreateStageStmt {
@@ -5761,8 +5761,8 @@ CreateStage(
         ),
         file_format_options: {
             "compression": "GZIP",
-            "format": "CSV",
             "record_delimiter": ",",
+            "type": "CSV",
         },
         on_error: "",
         size_limit: 0,

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -5736,7 +5736,7 @@ CreateStage(
 
 
 ---------- Input ----------
-CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z') file_format=(FORMAT = CSV compression = GZIP record_delimiter=',')
+CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z') file_format=(type = CSV compression = GZIP record_delimiter=',')
 ---------- Output ---------
 CREATE STAGE IF NOT EXISTS test_stage URL = 's3://load/files/' CONNECTION = ( aws_key_id='1a2b3c' aws_secret_key='4x5y6z' ) FILE_FORMAT = ( compression = 'GZIP' format = 'CSV' record_delimiter = ',' )
 ---------- AST ------------

--- a/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables
@@ -223,5 +223,5 @@ create table t(a int, A int)
 statement error Duplicated column name
 create table t as select number, number from numbers(1)
 
-statement error invalid input parameter
+statement error 1005
 create table tb101 (id int ,c1 datetime) 's3://wubx/tb101' connection=(aws_key_id='minioadmin' aws_ssecret_key='minioadmin' endpoint_url='http://127.0.0.1:9900');

--- a/tests/sqllogictests/suites/base/05_ddl/05_0016_ddl_stage
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0016_ddl_stage
@@ -5,13 +5,13 @@ statement ok
 DROP STAGE IF EXISTS test_stage_internal
 
 statement ok
-CREATE STAGE test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z')
+CREATE STAGE test_stage url='s3://load/files/' connection=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z')
 
 statement ok
-CREATE STAGE if not exists test_stage url='s3://load/files/' credentials=(access_key_id='1a2b3c' aws_secret_key='4x5y6z')
+CREATE STAGE if not exists test_stage url='s3://load/files/' connection=(access_key_id='1a2b3c' aws_secret_key='4x5y6z')
 
 statement error 2502
-CREATE STAGE test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z')
+CREATE STAGE test_stage url='s3://load/files/' connection=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z')
 
 statement ok
 CREATE STAGE test_stage_internal file_format=(type=csv compression=AUTO record_delimiter=NONE escape="\\") comments='test'

--- a/tests/sqllogictests/suites/base/05_ddl/05_0016_ddl_stage
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0016_ddl_stage
@@ -23,7 +23,7 @@ onlyif mysql
 query TTTTTITT
 desc stage test_stage_internal
 ----
-test_stage_internal Internal StageParams { storage: Fs(StorageFsConfig { root: "_data" }) } CopyOptions { on_error: AbortNum(1), size_limit: 0, split_size: 0, purge: false, single: false, max_file_size: 0 } FileFormatOptions { format: Csv, skip_header: 0, field_delimiter: "", record_delimiter: "NONE", nan_display: "", escape: "\\\\", compression: Auto, row_tag: "", quote: "" } 0 'root'@'127.0.0.1' (empty)
+test_stage_internal Internal StageParams { storage: Fs(StorageFsConfig { root: "_data" }) } CopyOptions { on_error: AbortNum(1), size_limit: 0, split_size: 0, purge: false, single: false, max_file_size: 0 } FileFormatOptions { format: Csv, skip_header: 0, field_delimiter: "", record_delimiter: "NONE", nan_display: "", escape: "\\", compression: Auto, row_tag: "", quote: "" } 0 'root'@'127.0.0.1' (empty)
 
 query TTTTT
 SHOW STAGES

--- a/tests/sqllogictests/suites/base/05_ddl/05_0016_ddl_stage
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0016_ddl_stage
@@ -14,7 +14,7 @@ statement error 2502
 CREATE STAGE test_stage url='s3://load/files/' connection=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z')
 
 statement ok
-CREATE STAGE test_stage_internal file_format=(type=csv compression=AUTO record_delimiter=NONE escape="\\") comments='test'
+CREATE STAGE test_stage_internal file_format=(type=csv compression=AUTO record_delimiter=NONE escape='\\') comments='test'
 
 statement ok
 LIST @test_stage_internal

--- a/website/blog/2022-08-08-benchmark-tpc-h.md
+++ b/website/blog/2022-08-08-benchmark-tpc-h.md
@@ -156,7 +156,7 @@ The code below connects to Databend using the Root user. Please note that the ro
 for t in customer lineitem nation orders partsupp part region supplier
 do
     echo "$t"
-    curl -XPUT 'http://root:@127.0.0.1:8000/v1/streaming_load' -H 'insert_sql: insert into tpch.'$t' file_format = (type = "CSV" field_delimiter = "|" record_delimiter = "\n")' -F 'upload=@"./'$t'.tbl"'
+    curl -XPUT 'http://root:@127.0.0.1:8000/v1/streaming_load' -H "insert_sql: insert into tpch.'$t' file_format = (type = CSV field_delimiter = '|' record_delimiter = '\n')"d -F 'upload=@"./'$t'.tbl"'
 done
 ```
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

the problem is described in https://github.com/datafuselabs/databend/pull/9626

 add `format_options`, `connection_options`, `credentails_options` which are more strict.

1. use keyword for option keys
2. use keyword for option values of `type` and `compression`, but allow `string literal ` for compatibility, forbidden `ident` 
3. check string/int/bool for literal values

Closes #issue
