### PR TITLE
fix(query): fix management empty schema

### DIFF
--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -56,7 +56,7 @@ impl InterpreterFactory {
     }
 
     /// This is used for handlers to get the schema of the plan.
-    /// Some plan may miss the schema and return empty plan suck as `CallPlan`
+    /// Some plan may miss the schema and return empty plan such as `CallPlan`
     /// So we need to map the plan into to `Interpreter` and get the right schema.
     pub fn get_schema(ctx: Arc<QueryContext>, plan: &Plan) -> DataSchemaRef {
         let schema = plan.schema();

--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_ast::ast::ExplainKind;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_expression::DataSchemaRef;
 use tracing::error;
 
 use super::interpreter_catalog_create::CreateCatalogInterpreter;
@@ -51,7 +52,23 @@ impl InterpreterFactory {
             error!("Access.denied(v2): {:?}", e);
             e
         })?;
+        Self::get_inner(ctx, plan)
+    }
 
+    /// This is used for handlers to get the schema of the plan.
+    /// Some plan may miss the schema and return empty plan suck as `CallPlan`
+    /// So we need to map the plan into to `Interpreter` and get the right schema.
+    pub fn get_schema(ctx: Arc<QueryContext>, plan: &Plan) -> DataSchemaRef {
+        let schema = plan.schema();
+        if schema.num_fields() == 0 {
+            let executor = Self::get_inner(ctx, plan);
+            executor.map(|e| e.schema()).unwrap_or(schema)
+        } else {
+            schema
+        }
+    }
+
+    pub fn get_inner(ctx: Arc<QueryContext>, plan: &Plan) -> Result<InterpreterPtr> {
         match plan {
             Plan::Query {
                 s_expr,

--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -25,7 +25,6 @@ use common_exception::Result;
 use common_exception::ToErrorCode;
 use common_expression::infer_table_schema;
 use common_expression::DataBlock;
-use common_expression::DataSchemaRef;
 use common_expression::TableSchemaRef;
 use common_formats::ClickhouseFormatType;
 use common_formats::FileFormatOptionsExt;
@@ -106,12 +105,12 @@ impl StatementHandlerParams {
 async fn execute(
     ctx: Arc<QueryContext>,
     interpreter: InterpreterPtr,
-    schema: DataSchemaRef,
     format: ClickhouseFormatType,
     params: StatementHandlerParams,
     handle: Option<JoinHandle<()>>,
 ) -> Result<WithContentType<Body>> {
     let format_typ = format.typ.clone();
+    let schema = interpreter.schema();
 
     // the reason of spawning new task to execute the interpreter:
     // (sorry, I failed to describe it in a more concise way)
@@ -262,7 +261,7 @@ pub async fn clickhouse_handler_get(
     let interpreter = InterpreterFactory::get(context.clone(), &plan)
         .await
         .map_err(BadRequest)?;
-    execute(context, interpreter, plan.schema(), format, params, None)
+    execute(context, interpreter, format, params, None)
         .await
         .map_err(InternalServerError)
 }
@@ -406,7 +405,7 @@ pub async fn clickhouse_handler_post(
         .await
         .map_err(BadRequest)?;
 
-    execute(ctx, interpreter, plan.schema(), format, params, handle)
+    execute(ctx, interpreter, format, params, handle)
         .await
         .map_err(InternalServerError)
 }

--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -207,7 +207,7 @@ impl ExecuteState {
     pub(crate) async fn get_schema(sql: &str, ctx: Arc<QueryContext>) -> Result<DataSchemaRef> {
         let mut planner = Planner::new(ctx.clone());
         let (plan, _, _) = planner.plan_sql(sql).await?;
-        Ok(plan.schema())
+        Ok(InterpreterFactory::get_schema(ctx, &plan))
     }
 
     pub(crate) async fn try_start_query(

--- a/src/query/sql/src/planner/plans/plan.rs
+++ b/src/query/sql/src/planner/plans/plan.rs
@@ -297,8 +297,9 @@ impl Display for Plan {
     }
 }
 
-// TODO the schema is not completed
 impl Plan {
+    /// Notice: This is incomplete and should be only used when you know it must has schema (Plan::Query | Plan::Insert ...).
+    /// If you want to get the real schema from plan use `InterpreterFactory::get_schema()` instead
     pub fn schema(&self) -> DataSchemaRef {
         match self {
             Plan::Query {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Plan's schema is incomplete, we should use InterpreterFactory to get the real schema now.


```
curl -u root: --request POST '127.0.0.1:8000/v1/query/' --header 'Content-Type: application/json' --data-raw '{"sql": "call system$search_tables('tables')"}' | jq .
{
  "id": "6732ff08-5d4f-463a-b666-31a4dd235fd2",
  "session_id": "530b8b6e-49ed-4522-b9ec-6173409fc7c9",
  "session": {},
  "schema": [
    {
      "name": "catalog",
      "type": "String"
    },
    {
      "name": "database",
      "type": "String"
    },
    {
      "name": "name",
      "type": "String"
    },
    {
      "name": "engine",
      "type": "String"
    },
    {
      "name": "cluster_by",
      "type": "String"
    },
    {
      "name": "created_on",
      "type": "String"
    },
    {
      "name": "dropped_on",
      "type": "String"
    },
    {
      "name": "num_rows",
      "type": "Nullable(UInt64)"
    },
```
Closes #9624 


I just make it a quick hot fix. 
