### PR TITLE
refactor(query): analyze table use bloom filter calc ndv

### DIFF
--- a/src/query/storages/fuse/src/operations/analyze.rs
+++ b/src/query/storages/fuse/src/operations/analyze.rs
@@ -19,10 +19,17 @@ use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_expression::Value;
+use storages_common_index::filters::Filter;
+use storages_common_index::filters::Xor8Filter;
+use storages_common_index::BloomIndex;
+use storages_common_table_meta::meta::ColumnId;
+use storages_common_table_meta::meta::Location;
 use storages_common_table_meta::meta::TableSnapshot;
 use storages_common_table_meta::meta::TableSnapshotStatistics;
 use tracing::warn;
 
+use crate::io::BlockFilterReader;
 use crate::io::SegmentsIO;
 use crate::FuseTable;
 
@@ -46,46 +53,81 @@ impl FuseTable {
 
         if let Some(snapshot) = snapshot_opt {
             // 2. Iterator segments and blocks to estimate statistics.
-            let mut sum_map = HashMap::new();
-            let mut row_count_sum = 0;
-            let mut block_count_sum: u64 = 0;
-
+            let mut filter_block_cols = vec![];
+            for field in self.table_info.schema().fields() {
+                filter_block_cols.push(BloomIndex::build_filter_column_name(field.name()));
+            }
             let segments_io = SegmentsIO::create(ctx.clone(), self.operator.clone(), self.schema());
             let segments = segments_io.read_segments(&snapshot.segments).await?;
+
+            let mut column_distinct_count = HashMap::<ColumnId, u64>::new();
             for segment in segments {
                 let segment = segment?;
-                segment.blocks.iter().for_each(|block| {
-                    let block = block.as_ref();
-                    let row_count = block.row_count;
-                    if row_count != 0 {
-                        block_count_sum += 1;
-                        row_count_sum += row_count;
-                        for (i, col_stat) in block.col_stats.iter() {
-                            let density = match col_stat.distinct_of_values {
-                                Some(ndv) => ndv as f64 / row_count as f64,
-                                None => 0.0,
-                            };
-
-                            match sum_map.get_mut(i) {
-                                Some(sum) => {
-                                    *sum += density;
+                for block in &segment.blocks {
+                    let block = block.as_ref().clone();
+                    let index_location: Option<Location> = block.bloom_filter_index_location;
+                    if let Some(loc) = index_location {
+                        let row_count = block.row_count;
+                        let index_len = block.bloom_filter_index_size;
+                        if row_count != 0 {
+                            let maybe_filter = loc
+                                .read_filter(
+                                    ctx.clone(),
+                                    self.operator.clone(),
+                                    &filter_block_cols,
+                                    index_len,
+                                )
+                                .await;
+                            match maybe_filter {
+                                Ok(filter) => {
+                                    let source_schema = filter.filter_schema;
+                                    let block = filter.filter_block;
+                                    for i in 0..block.num_columns() {
+                                        let filter_bytes = match &block.get_by_offset(i).value {
+                                            Value::Scalar(s) => s.as_string().unwrap(),
+                                            Value::Column(c) => unsafe {
+                                                c.as_string().unwrap().index_unchecked(0)
+                                            },
+                                        };
+                                        let (filter, _size) = Xor8Filter::from_bytes(filter_bytes)?;
+                                        if let Some(len) = filter.len() {
+                                            let idx = source_schema
+                                                .index_of(source_schema.field(i).name().as_str())
+                                                .unwrap()
+                                                as ColumnId;
+                                            match column_distinct_count.get_mut(&idx) {
+                                                Some(val) => {
+                                                    *val += len as u64;
+                                                }
+                                                None => {
+                                                    let _ = column_distinct_count
+                                                        .insert(idx, len as u64);
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
-                                None => {
-                                    let _ = sum_map.insert(*i, density);
+                                Err(e) => {
+                                    warn!(
+                                        "analyze table {:?} read bloom filter failed: {:?}",
+                                        self.table_info.name, e
+                                    );
+                                    return Ok(());
                                 }
                             }
                         }
+                    } else {
+                        warn!(
+                            "table {:?} bloom_filter_index_location is None",
+                            self.table_info.name
+                        );
+                        return Ok(());
                     }
-                });
-            }
-            let mut ndv_map = HashMap::new();
-            for (i, sum) in sum_map.iter() {
-                let density_avg = *sum / block_count_sum as f64;
-                ndv_map.insert(*i, (density_avg * row_count_sum as f64) as u64);
+                }
             }
 
             // 3. Generate new table statistics
-            let table_statistics = TableSnapshotStatistics::new(ndv_map);
+            let table_statistics = TableSnapshotStatistics::new(column_distinct_count);
             let table_statistics_location = self
                 .meta_location_generator
                 .snapshot_statistics_location_from_uuid(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Now analyze table will calc all blocks in segments.

we can use bloom filter index calc ndv.

Closes #issue
