### PR TITLE
chore(sqllogictest): add log for http session

### DIFF
--- a/tests/sqllogictests/src/client/http_client.rs
+++ b/tests/sqllogictests/src/client/http_client.rs
@@ -59,6 +59,14 @@ impl HttpClient {
     pub async fn query(&mut self, sql: &str) -> Result<DBOutput> {
         if self.debug {
             println!("Running sql with http client: [{sql}]");
+            match &self.session {
+                None => {
+                    println!("Current http session: [None]")
+                }
+                Some(session) => {
+                    println!("Current http session: [{session:?}]")
+                }
+            }
         }
         let url = "http://127.0.0.1:8000/v1/query".to_string();
         let mut response = self.response(sql, &url, true).await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This flaky test is difficult to reproduce locally, so add a log to the ci to diagnose when it occurs.

Related https://github.com/datafuselabs/databend/issues/9613
