### PR TITLE
docs: update copyinto connection

### DIFF
--- a/docs/doc/14-sql-commands/10-dml/dml-copy-into-location.md
+++ b/docs/doc/14-sql-commands/10-dml/dml-copy-into-location.md
@@ -44,13 +44,13 @@ externalStage ::= @<external_stage_name>[/<path>]
 ```
 externalLocation (for Amazon S3) ::=
   's3://<bucket>[/<path>]'
-  [ { CREDENTIALS = ( {  { AWS_KEY_ID = '<string>' AWS_SECRET_KEY = '<string>' } } ) } ]
+  [ { CONNECTION = ( {  { AWS_KEY_ID = '<string>' AWS_SECRET_KEY = '<string>' } } ) } ]
 ```
 
 | Parameter  | Description | Required |
 | ----------- | ----------- | --- |
 | `s3://<bucket>/[<path>]`  | Files are in the specified external location (S3-like bucket) | YES |
-| `[ { CREDENTIALS = ( {  { AWS_KEY_ID = '<string>' AWS_SECRET_KEY = '<string>' } } ) } ]' ]`  | The credentials for connecting to AWS and accessing the private/protected S3 bucket where the files to load are staged. |  Optional |
+| `[ { CONNECTION = ( {  { AWS_KEY_ID = '<string>' AWS_SECRET_KEY = '<string>' } } ) } ]' ]`  | The credentials for connecting to AWS and accessing the private/protected S3 bucket where the files to load are staged. |  Optional |
 | `[ ENDPOINT_URL = '<endpoint_url>' ]`  | S3-compatible endpoint URL like MinIO, default is `https://s3.amazonaws.com` |  Optional |
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

updated CREDENTIALS to CONNECTION for [COPYINTO<location>](https://databend.rs/doc/sql-commands/dml/dml-copy-into-location).

Closes #issue
