### PR TITLE
fix(query):  fix max_result_rows only limit output results nums

### DIFF
--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -19,7 +19,6 @@ use common_ast::ast::Expr;
 use common_ast::ast::Join;
 use common_ast::ast::JoinCondition;
 use common_ast::ast::JoinOperator;
-use common_ast::ast::Literal;
 use common_ast::ast::OrderByExpr;
 use common_ast::ast::Query;
 use common_ast::ast::SelectStmt;
@@ -228,15 +227,6 @@ impl<'a> Binder {
             }
         };
 
-        let default_limit = if self.ctx.get_settings().get_max_result_rows()? > 0 {
-            Some(Expr::Literal {
-                span: &[],
-                lit: Literal::Integer(self.ctx.get_settings().get_max_result_rows()?),
-            })
-        } else {
-            None
-        };
-
         if !query.limit.is_empty() {
             if query.limit.len() == 1 {
                 s_expr = self
@@ -254,11 +244,7 @@ impl<'a> Binder {
             }
         } else if query.offset.is_some() {
             s_expr = self
-                .bind_limit(&bind_context, s_expr, default_limit.as_ref(), &query.offset)
-                .await?;
-        } else if let Some(l) = default_limit {
-            s_expr = self
-                .bind_limit(&bind_context, s_expr, Some(&l), &None)
+                .bind_limit(&bind_context, s_expr, None, &query.offset)
                 .await?;
         }
 

--- a/tests/sqllogictests/suites/base/20+_others/20_0011_max_result_rows
+++ b/tests/sqllogictests/suites/base/20+_others/20_0011_max_result_rows
@@ -18,13 +18,25 @@ SELECT COUNT() FROM (SELECT * FROM t1)
 ----
 3
 
+query I
+SELECT a FROM t1 ORDER BY a;
+----
+1
+2
+3
+
 statement ok
 SET max_result_rows=1
 
 query I
-SELECT COUNT() FROM (SELECT * FROM t1)
+SELECT a FROM t1 ORDER BY a;
 ----
 1
+
+query I
+SELECT COUNT() FROM (SELECT * FROM t1)
+----
+3
 
 query I
 SELECT COUNT() FROM (SELECT * FROM t1 limit 2)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

https://github.com/datafuselabs/databend/pull/9406  add `max_result_rows`, but we may get wrong sql result if there are subqueries.  let's only limit the output results rows.
