### PR TITLE
fix: fix cast to nested type.

### DIFF
--- a/tests/sqllogictests/suites/base/03_dml/03_0023_insert_into_array
+++ b/tests/sqllogictests/suites/base/03_dml/03_0023_insert_into_array
@@ -412,3 +412,17 @@ CREATE TABLE t19(id Int, arr Array(Array(Int64) Null)) Engine = Fuse
 
 statement ok
 INSERT INTO t19 (id, arr) VALUES(1, [[1,2],[3,4]]), (2, [[5,6],null]), (3, [[7,8],[9,10]])
+
+statement ok
+create table if not exists t20 (id Int, arr Array(Array(Int64) Null)) Engine = Fuse
+
+statement ok
+insert into t20 values (0, [[1,2,3],[4,5,6]]);
+
+query IT
+select * from t20;
+----
+0 [[1,2,3],[4,5,6]]
+
+statement ok
+drop table if exists t20;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

When `run_try_cast`, if inner type is not nullable, use `run_cast` (else use `run_try_cast`) on inner cast.

Related #9656
