### PR TITLE
feat: Use global http client for sharing dns cache and connection

### DIFF
--- a/src/common/storage/src/http_client.rs
+++ b/src/common/storage/src/http_client.rs
@@ -1,0 +1,43 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_base::base::GlobalInstance;
+use common_base::runtime::GlobalIORuntime;
+use common_base::runtime::TrySpawn;
+use common_exception::Result;
+use opendal::raw::HttpClient;
+
+/// GlobalHttpClient is the global shared http client for storage.
+pub struct GlobalHttpClient;
+
+impl GlobalHttpClient {
+    pub async fn init() -> Result<()> {
+        // Make sure http client is initiated inside global runtime.
+        GlobalIORuntime::instance()
+            .spawn(async {
+                let client = HttpClient::new()?;
+                GlobalInstance::set(client);
+
+                Ok::<_, common_exception::ErrorCode>(())
+            })
+            .await
+            .expect("http client must build with success")?;
+
+        Ok(())
+    }
+
+    pub fn instance() -> HttpClient {
+        GlobalInstance::get()
+    }
+}

--- a/src/common/storage/src/lib.rs
+++ b/src/common/storage/src/lib.rs
@@ -59,6 +59,9 @@ pub use operator::init_operator;
 pub use operator::CacheOperator;
 pub use operator::DataOperator;
 
+mod http_client;
+pub use http_client::GlobalHttpClient;
+
 mod metrics;
 pub use metrics::StorageMetrics;
 pub use metrics::StorageMetricsLayer;

--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -51,6 +51,7 @@ use crate::config::StorageMokaConfig;
 use crate::config::StorageObsConfig;
 use crate::runtime_layer::RuntimeLayer;
 use crate::CacheConfig;
+use crate::GlobalHttpClient;
 use crate::StorageConfig;
 use crate::StorageOssConfig;
 use crate::StorageRedisConfig;
@@ -124,6 +125,8 @@ pub fn init_azblob_operator(cfg: &StorageAzblobConfig) -> Result<Operator> {
     builder.account_name(&cfg.account_name);
     builder.account_key(&cfg.account_key);
 
+    builder.http_client(GlobalHttpClient::instance());
+
     Ok(Operator::new(builder.build()?))
 }
 
@@ -164,6 +167,7 @@ fn init_gcs_operator(cfg: &StorageGcsConfig) -> Result<Operator> {
         .bucket(&cfg.bucket)
         .root(&cfg.root)
         .credential(&cfg.credential)
+        .http_client(GlobalHttpClient::instance())
         .build()?;
 
     Ok(Operator::new(accessor))
@@ -192,6 +196,7 @@ fn init_ipfs_operator(cfg: &super::StorageIpfsConfig) -> Result<Operator> {
 
     builder.root(&cfg.root);
     builder.endpoint(&cfg.endpoint_url);
+    builder.http_client(GlobalHttpClient::instance());
 
     Ok(Operator::new(builder.build()?))
 }
@@ -201,6 +206,7 @@ fn init_http_operator(cfg: &StorageHttpConfig) -> Result<Operator> {
 
     // Endpoint.
     builder.endpoint(&cfg.endpoint_url);
+    builder.http_client(GlobalHttpClient::instance());
 
     // HTTP Service is read-only and doesn't support list operation.
     // ImmutableIndexLayer will build an in-memory immutable index for it.
@@ -258,6 +264,9 @@ fn init_s3_operator(cfg: &StorageS3Config) -> Result<Operator> {
         builder.enable_virtual_host_style();
     }
 
+    // Use the global http client
+    builder.http_client(GlobalHttpClient::instance());
+
     Ok(Operator::new(builder.build()?))
 }
 
@@ -274,6 +283,9 @@ fn init_obs_operator(cfg: &StorageObsConfig) -> Result<Operator> {
     builder.access_key_id(&cfg.access_key_id);
     builder.secret_access_key(&cfg.secret_access_key);
 
+    // Use the global http client
+    builder.http_client(GlobalHttpClient::instance());
+
     Ok(Operator::new(builder.build()?))
 }
 
@@ -288,6 +300,7 @@ fn init_oss_operator(cfg: &StorageOssConfig) -> Result<Operator> {
         .access_key_secret(&cfg.access_key_secret)
         .bucket(&cfg.bucket)
         .root(&cfg.root)
+        .http_client(GlobalHttpClient::instance())
         .build()?;
 
     Ok(Operator::new(backend))

--- a/src/query/service/src/global_services.rs
+++ b/src/query/service/src/global_services.rs
@@ -20,6 +20,7 @@ use common_config::GlobalConfig;
 use common_exception::Result;
 use common_storage::CacheOperator;
 use common_storage::DataOperator;
+use common_storage::GlobalHttpClient;
 use common_storage::ShareTableConfig;
 use common_tracing::QueryLogger;
 use common_users::RoleCacheManager;
@@ -48,6 +49,7 @@ impl GlobalServices {
 
         QueryLogger::init(app_name_shuffle, &config.log)?;
         GlobalIORuntime::init(config.storage.num_cpus as usize)?;
+        GlobalHttpClient::init().await?;
 
         // Cluster discovery.
         ClusterDiscovery::init(config.clone()).await?;

--- a/src/query/sharing-endpoint/src/services.rs
+++ b/src/query/sharing-endpoint/src/services.rs
@@ -15,6 +15,7 @@
 use common_base::base::GlobalInstance;
 use common_base::runtime::GlobalIORuntime;
 use common_exception::Result;
+use common_storage::GlobalHttpClient;
 
 use crate::accessor::SharingAccessor;
 use crate::configs::Config;
@@ -28,6 +29,7 @@ impl SharingServices {
         GlobalInstance::init_production();
 
         GlobalIORuntime::init(config.storage.num_cpus as usize)?;
+        GlobalHttpClient::init().await?;
         SharingAccessor::init(&config).await
     }
 }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: Use global http client for sharing dns cache and connection


