### PR TITLE
ci: force using template when QUERY_CONFIG_FILE is not set for docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y && \
 
 COPY ./distro/$TARGETPLATFORM/databend-meta /usr/bin/databend-meta
 COPY ./distro/$TARGETPLATFORM/databend-query /usr/bin/databend-query
-COPY ./docker/query-config.toml /etc/databend/query.toml
+COPY ./docker/query-config.toml /etc/databend/query_config_spec.toml
 COPY ./docker/bootstrap.sh /bootstrap.sh
 ENTRYPOINT [ "dumb-init", "--", "/bootstrap.sh"]
 VOLUME [ "/var/log/databend", "/etc/databend", "/var/lib/databend", "/var/lib/minio" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -54,7 +54,7 @@ docker run \
 docker run \
     -p 8000:8000 \
     -e QUERY_STORAGE_TYPE=s3 \
-    -e AWS_S3_ENDPOINT="http://some_s3_endpoint \
+    -e AWS_S3_ENDPOINT="http://some_s3_endpoint" \
     -e AWS_S3_BUCKET=some_bucket \
     -e AWS_ACCESS_KEY_ID=some_key \
     -e AWS_SECRET_ACCESS_KEY=some_secret \

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -99,6 +99,7 @@ EOF
 if [ -z "$QUERY_CONFIG_FILE" ]; then
     QUERY_CONFIG_FILE="/etc/databend/query.toml"
     echo "==> QUERY_CONFIG_FILE is not set, using default: $QUERY_CONFIG_FILE"
+    cp /etc/databend/query_config_spec.toml "$QUERY_CONFIG_FILE"
     setup_query_default_user
     setup_query_storage
 fi


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Closes #9695
