### PR TITLE
fix(storage): bloom filter is using wrong cache key

### DIFF
--- a/src/query/storages/common/cache/src/read/loader.rs
+++ b/src/query/storages/common/cache/src/read/loader.rs
@@ -26,9 +26,11 @@ pub type CacheKey = String;
 /// Loads an object from storage
 #[async_trait::async_trait]
 pub trait LoaderWithCacheKey<T> {
-    /// Loads object of type T, located by [params][LoadParams], the [CacheKey] returns will be
-    /// used as the key of cache item.
-    async fn load_with_cache_key(&self, params: &LoadParams) -> Result<(T, CacheKey)>;
+    /// Loads object of type T, located by [params][LoadParams]
+    async fn load_with_cache_key(&self, params: &LoadParams) -> Result<T>;
+
+    /// the [CacheKey] returns will beused as the key of cache item.
+    fn cache_key(&self, params: &LoadParams) -> CacheKey;
 }
 
 /// Loads an object from storage
@@ -44,8 +46,12 @@ pub trait Loader<T> {
 impl<L, T> LoaderWithCacheKey<T> for L
 where L: Loader<T> + Send + Sync
 {
-    async fn load_with_cache_key(&self, params: &LoadParams) -> Result<(T, CacheKey)> {
+    async fn load_with_cache_key(&self, params: &LoadParams) -> Result<T> {
         let v = self.load(params).await?;
-        Ok((v, params.location.clone()))
+        Ok(v)
+    }
+
+    fn cache_key(&self, params: &LoadParams) -> CacheKey {
+        params.location.clone()
     }
 }

--- a/src/query/storages/fuse/src/io/read/bloom_index/column_reader.rs
+++ b/src/query/storages/fuse/src/io/read/bloom_index/column_reader.rs
@@ -53,6 +53,7 @@ impl BloomIndexColumnReader {
             cache_key,
             operator,
         };
+
         let cached_reader = Self::get_cached_reader(loader);
         let param = LoadParams {
             location: path,

--- a/src/query/storages/fuse/src/io/read/column_data_loader.rs
+++ b/src/query/storages/fuse/src/io/read/column_data_loader.rs
@@ -27,14 +27,15 @@ pub struct ColumnDataLoader {
 
 #[async_trait::async_trait]
 impl LoaderWithCacheKey<Vec<u8>> for ColumnDataLoader {
-    async fn load_with_cache_key(
-        &self,
-        params: &LoadParams,
-    ) -> common_exception::Result<(Vec<u8>, CacheKey)> {
+    async fn load_with_cache_key(&self, params: &LoadParams) -> common_exception::Result<Vec<u8>> {
         let column_reader = self.operator.object(&params.location);
         let bytes = column_reader
             .range_read(self.offset..self.offset + self.len)
             .await?;
-        Ok((bytes, self.cache_key.clone()))
+        Ok(bytes)
+    }
+
+    fn cache_key(&self, _params: &LoadParams) -> CacheKey {
+        self.cache_key.clone()
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

This is a bug introduced in #9672 

BTW, the metric name should be lower case, PTAL @dantengsky 
```
+--------------------------------------------------------------+-------+--------+---------+                                                                                                                                  [245/98410]
| metric                                                       | kind  | labels | value   |
+--------------------------------------------------------------+-------+--------+---------+
| cache_BLOOM_INDEX_DATA_CACHE_access_count                    | gauge | {}     | 6048.0  |
| cache_BLOOM_INDEX_DATA_CACHE_miss_count                      | gauge | {}     | 6048.0  |
| cache_BLOOM_INDEX_DATA_CACHE_miss_load_millisecond           | gauge | {}     | 872.0   |
| cache_BLOOM_INDEX_FILE_META_DATA_CACHE_access_count          | gauge | {}     | 6048.0  |
```

Closes #issue
