### PR TITLE
chore(fuse): add fuse pruning sql logic tests

### DIFF
--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_01_bloom_in_pruning
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_01_bloom_in_pruning
@@ -1,11 +1,11 @@
 statement ok
-DROP DATABASE IF EXISTS db_09_0009
+DROP DATABASE IF EXISTS db_09_0009_01
 
 statement ok
-CREATE DATABASE db_09_0009
+CREATE DATABASE db_09_0009_01
 
 statement ok
-USE db_09_0009
+USE db_09_0009_01
 
 statement ok
 create table t(a UInt64, b Int64)
@@ -29,4 +29,4 @@ statement ok
 DROP TABLE t
 
 statement ok
-DROP DATABASE db_09_0009
+DROP DATABASE db_09_0009_01

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_02_limit_pruning
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_02_limit_pruning
@@ -1,0 +1,39 @@
+# only limit pruning
+
+statement ok
+DROP DATABASE IF EXISTS db_09_0009_02
+
+statement ok
+CREATE DATABASE db_09_0009_02
+
+statement ok
+USE db_09_0009_02
+
+statement ok
+create table t(a Int64)
+
+statement ok
+insert into t select * from numbers(100);
+
+statement ok
+insert into t select * from numbers(100);
+
+statement ok
+insert into t select * from numbers(100);
+
+query I
+select count(*) from (select * from t limit 2);
+----
+2
+
+query I
+select * from t where a=55 limit 2;
+----
+55
+55
+
+statement ok
+DROP TABLE t
+
+statement ok
+DROP DATABASE db_09_0009_02

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_03_orderby_limit_topn_pruning
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_03_orderby_limit_topn_pruning
@@ -1,0 +1,46 @@
+# orderby + limit TopN pruning
+
+statement ok
+DROP DATABASE IF EXISTS db_09_0009_03
+
+statement ok
+CREATE DATABASE db_09_0009_03
+
+statement ok
+USE db_09_0009_03
+
+statement ok
+create table t(a Int64)
+
+statement ok
+insert into t select * from numbers(100);
+
+statement ok
+insert into t select * from numbers(100);
+
+statement ok
+insert into t select * from numbers(100);
+
+query I
+select * from t order by a limit 5;
+----
+0
+0
+0
+1
+1
+
+query I
+select * from t order by a desc limit 5;
+----
+99
+99
+99
+98
+98
+
+statement ok
+DROP TABLE t
+
+statement ok
+DROP DATABASE db_09_0009_03


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* add fuse pruning sql logic tests for `limit` and `TopN(orderby+limit)` pruning

Parts of #9702
