### PR TITLE
feat(pruning): add pruning stats to EXPLAIN

### DIFF
--- a/src/query/catalog/src/plan/partition_statistics.rs
+++ b/src/query/catalog/src/plan/partition_statistics.rs
@@ -14,6 +14,8 @@
 
 use std::fmt::Debug;
 
+use crate::plan::PruningStatistics;
+
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Debug, Default)]
 pub struct PartStatistics {
     /// Total rows of the query read.
@@ -26,6 +28,8 @@ pub struct PartStatistics {
     pub partitions_total: usize,
     /// Is the statistics exact.
     pub is_exact: bool,
+    /// Pruning stats.
+    pub pruning_stats: PruningStatistics,
 }
 
 impl PartStatistics {
@@ -41,6 +45,7 @@ impl PartStatistics {
             partitions_scanned,
             partitions_total,
             is_exact: false,
+            pruning_stats: Default::default(),
         }
     }
 
@@ -56,6 +61,7 @@ impl PartStatistics {
             partitions_scanned,
             partitions_total,
             is_exact: true,
+            pruning_stats: Default::default(),
         }
     }
 

--- a/src/query/catalog/src/plan/pruning_statistics.rs
+++ b/src/query/catalog/src/plan/pruning_statistics.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Datafuse Labs.
+// Copyright 2023 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod datasource;
-mod partition;
-mod partition_statistics;
-mod projection;
-mod pruning_statistics;
-mod pushdown;
-mod stage_file_info;
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Debug, Default)]
+pub struct PruningStatistics {
+    /// Segment range pruning stats.
+    pub segments_range_pruning_before: usize,
+    pub segments_range_pruning_after: usize,
 
-pub use datasource::*;
-pub use partition::*;
-pub use partition_statistics::PartStatistics;
-pub use projection::Projection;
-pub use pruning_statistics::PruningStatistics;
-pub use pushdown::*;
-pub use stage_file_info::StageFileInfo;
-pub use stage_file_info::StageFileStatus;
+    /// Block range pruning stats.
+    pub blocks_range_pruning_before: usize,
+    pub blocks_range_pruning_after: usize,
+
+    /// Block bloom filter pruning stats.
+    pub blocks_bloom_pruning_before: usize,
+    pub blocks_bloom_pruning_after: usize,
+}

--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -480,21 +480,26 @@ fn union_all_to_format_tree(
 }
 
 fn part_stats_info_to_format_tree(info: &PartStatistics) -> Vec<FormatTreeNode<String>> {
-    vec![
+    let mut items = vec![
         FormatTreeNode::new(format!("read rows: {}", info.read_rows)),
         FormatTreeNode::new(format!("read bytes: {}", info.read_bytes)),
         FormatTreeNode::new(format!("partitions total: {}", info.partitions_total)),
         FormatTreeNode::new(format!("partitions scanned: {}", info.partitions_scanned)),
-        FormatTreeNode::new(format!(
-            "pruning stats: segments: <range: {} -> {}>, blocks: <range: {} -> {}, bloom: {} -> {}>",
+    ];
+
+    if info.pruning_stats.segments_range_pruning_before > 0 {
+        items.push(FormatTreeNode::new(format!(
+            "pruning stats: [segments: <range pruning: {} to {}>, blocks: <range pruning: {} to {}, bloom pruning: {} to {}>]",
             info.pruning_stats.segments_range_pruning_before,
             info.pruning_stats.segments_range_pruning_after,
             info.pruning_stats.blocks_range_pruning_before,
             info.pruning_stats.blocks_range_pruning_after,
             info.pruning_stats.blocks_bloom_pruning_before,
             info.pruning_stats.blocks_bloom_pruning_after,
-        )),
-    ]
+        )))
+    }
+
+    items
 }
 
 fn plan_stats_info_to_format_tree(info: &PlanStatsInfo) -> Vec<FormatTreeNode<String>> {

--- a/src/query/storages/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/src/operations/delete.rs
@@ -18,6 +18,7 @@ use common_base::base::ProgressValues;
 use common_catalog::plan::Partitions;
 use common_catalog::plan::PartitionsShuffleKind;
 use common_catalog::plan::Projection;
+use common_catalog::plan::PruningStatistics;
 use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
@@ -271,11 +272,11 @@ impl FuseTable {
             .collect::<Vec<_>>();
 
         let (_, inner_parts) = self.read_partitions_with_metas(
-            ctx.clone(),
             self.table_info.schema(),
             None,
             &range_block_metas,
             base_snapshot.summary.block_count as usize,
+            PruningStatistics::default(),
         )?;
 
         let parts = Partitions::create(

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use common_catalog::plan::DataSourceInfo;
 use common_catalog::plan::DataSourcePlan;
+use common_catalog::plan::PruningStatistics;
 use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
@@ -113,11 +114,11 @@ impl FuseTable {
             .map(|meta| (None, meta.clone()))
             .collect();
         let (statistics, parts) = self.read_partitions_with_metas(
-            ctx.clone(),
             self.table_info.schema(),
             None,
             &block_metas,
             partitions_total,
+            PruningStatistics::default(),
         )?;
         let table_info = self.get_table_info();
         let description = statistics.get_description(&table_info.desc);

--- a/src/query/storages/fuse/src/pruning/mod.rs
+++ b/src/query/storages/fuse/src/pruning/mod.rs
@@ -15,6 +15,7 @@
 mod block_pruner;
 mod bloom_pruner;
 mod fuse_pruner;
+mod pruning_statistics;
 mod segment_pruner;
 
 pub use block_pruner::BlockPruner;
@@ -22,4 +23,5 @@ pub use bloom_pruner::BloomPruner;
 pub use bloom_pruner::BloomPrunerCreator;
 pub use fuse_pruner::FusePruner;
 pub use fuse_pruner::PruningContext;
+pub use pruning_statistics::FusePruningStatistics;
 pub use segment_pruner::SegmentPruner;

--- a/src/query/storages/fuse/src/pruning/pruning_statistics.rs
+++ b/src/query/storages/fuse/src/pruning/pruning_statistics.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Datafuse Labs.
+// Copyright 2023 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod datasource;
-mod partition;
-mod partition_statistics;
-mod projection;
-mod pruning_statistics;
-mod pushdown;
-mod stage_file_info;
+use std::sync::atomic::AtomicU64;
 
-pub use datasource::*;
-pub use partition::*;
-pub use partition_statistics::PartStatistics;
-pub use projection::Projection;
-pub use pruning_statistics::PruningStatistics;
-pub use pushdown::*;
-pub use stage_file_info::StageFileInfo;
-pub use stage_file_info::StageFileStatus;
+#[derive(Default)]
+pub struct FusePruningStatistics {
+    /// Segment range pruning stats.
+    pub segments_range_pruning_before: AtomicU64,
+    pub segments_range_pruning_after: AtomicU64,
+
+    /// Block range pruning stats.
+    pub blocks_range_pruning_before: AtomicU64,
+    pub blocks_range_pruning_after: AtomicU64,
+
+    /// Block bloom filter pruning stats.
+    pub blocks_bloom_pruning_before: AtomicU64,
+    pub blocks_bloom_pruning_after: AtomicU64,
+}

--- a/tests/sqllogictests/README.md
+++ b/tests/sqllogictests/README.md
@@ -44,7 +44,7 @@ databend-sqllogictests --help
 ### Parallel
 If you want to run test files in parallel, please add the following args:
 ```shell
-databend-sqllogictest --senable_sandbox --parallel <number>
+databend-sqllogictest --enable_sandbox --parallel <number>
 ```
 
 When start databend query, please add `--internal-enable-sandbox-tenant`, such as:

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -22,6 +22,7 @@ Filter
     ├── read bytes: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
+    ├── pruning stats: [segments: <range pruning: 1 to 0>, blocks: <range pruning: 0 to 0, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [gt(t1.a (#0), 0_u64)], limit: NONE]
     ├── output columns: [0]
     └── estimated rows: 1.00
@@ -47,6 +48,7 @@ Filter
     │       ├── read bytes: 0
     │       ├── partitions total: 1
     │       ├── partitions scanned: 0
+    │       ├── pruning stats: [segments: <range pruning: 1 to 0>, blocks: <range pruning: 0 to 0, bloom pruning: 0 to 0>]
     │       ├── push downs: [filters: [or(gt(t1.a (#0), 3_u64), gt(t1.a (#0), 1_u64))], limit: NONE]
     │       └── estimated rows: 1.00
     └── TableScan(Probe)
@@ -55,6 +57,7 @@ Filter
         ├── read bytes: 94
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 5.00
 
@@ -73,6 +76,7 @@ HashJoin
 │   ├── read bytes: 62
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -81,6 +85,7 @@ HashJoin
     ├── read bytes: 94
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 5.00
 
@@ -523,6 +528,7 @@ UnionAll
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   ├── output columns: [0]
 │   └── estimated rows: 1.00
@@ -532,6 +538,7 @@ UnionAll
     ├── read bytes: 47
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     ├── output columns: [0]
     └── estimated rows: 5.00
@@ -557,6 +564,7 @@ Filter
     │       ├── read bytes: 62
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │       ├── push downs: [filters: [or(gt(t1.a (#0), 1_u64), lt(t1.b (#1), 3_u64))], limit: NONE]
     │       └── estimated rows: 1.00
     └── Filter(Probe)
@@ -568,6 +576,7 @@ Filter
             ├── read bytes: 94
             ├── partitions total: 1
             ├── partitions scanned: 1
+            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
             ├── push downs: [filters: [or(gt(t2.a (#2), 2_u64), lt(t2.b (#3), 4_u64))], limit: NONE]
             └── estimated rows: 5.00
 
@@ -592,6 +601,7 @@ Filter
     │       ├── read bytes: 62
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
     │       ├── push downs: [filters: [or(gt(t1.a (#0), 1_u64), or(lt(t1.b (#1), 3_u64), eq(t1.a (#0), 2_u64)))], limit: NONE]
     │       └── estimated rows: 1.00
     └── TableScan(Probe)
@@ -600,6 +610,7 @@ Filter
         ├── read bytes: 94
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 5.00
 
@@ -627,6 +638,7 @@ Filter
     │   ├── read bytes: 94
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 5.00
     └── HashJoin(Probe)
@@ -641,6 +653,7 @@ Filter
         │   ├── read bytes: 62
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
+        │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         │   ├── push downs: [filters: [], limit: NONE]
         │   └── estimated rows: 1.00
         └── TableScan(Probe)
@@ -649,6 +662,7 @@ Filter
             ├── read bytes: 136
             ├── partitions total: 1
             ├── partitions scanned: 1
+            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
             ├── push downs: [filters: [], limit: NONE]
             └── estimated rows: 10.00
 
@@ -679,6 +693,7 @@ HashJoin
 │       │       ├── read bytes: 62
 │       │       ├── partitions total: 1
 │       │       ├── partitions scanned: 1
+│       │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       │       ├── push downs: [filters: [or(gt(t1.a (#0), 1_u64), lt(t1.b (#1), 3_u64))], limit: NONE]
 │       │       └── estimated rows: 1.00
 │       └── Filter(Probe)
@@ -690,6 +705,7 @@ HashJoin
 │               ├── read bytes: 94
 │               ├── partitions total: 1
 │               ├── partitions scanned: 1
+│               ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │               ├── push downs: [filters: [or(gt(t2.a (#2), 2_u64), lt(t2.b (#3), 4_u64))], limit: NONE]
 │               └── estimated rows: 5.00
 └── Filter(Probe)
@@ -701,6 +717,7 @@ HashJoin
         ├── read bytes: 136
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [gt(t3.a (#4), 1_u64)], limit: NONE]
         └── estimated rows: 10.00
 
@@ -732,6 +749,7 @@ Limit
             │       ├── read bytes: 62
             │       ├── partitions total: 1
             │       ├── partitions scanned: 1
+            │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
             │       ├── push downs: [filters: [or(or(gt(t1.a (#0), 1_u64), lt(t1.b (#1), 2_u64)), lt(t1.b (#1), 3_u64))], limit: NONE]
             │       └── estimated rows: 1.00
             └── Filter(Probe)
@@ -743,6 +761,7 @@ Limit
                     ├── read bytes: 94
                     ├── partitions total: 1
                     ├── partitions scanned: 1
+                    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
                     ├── push downs: [filters: [or(gt(t2.a (#2), 2_u64), lt(t2.b (#3), 4_u64))], limit: NONE]
                     └── estimated rows: 5.00
 
@@ -764,6 +783,7 @@ HashJoin
 │       ├── read bytes: 62
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [or(gt(t1.a (#0), 1_u64), lt(t1.b (#1), 2_u64))], limit: NONE]
 │       └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -772,6 +792,7 @@ HashJoin
     ├── read bytes: 94
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 5.00
 
@@ -803,6 +824,7 @@ EvalScalar
                     ├── read bytes: 31
                     ├── partitions total: 1
                     ├── partitions scanned: 1
+                    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
                     ├── push downs: [filters: [], limit: NONE]
                     ├── output columns: [0]
                     └── estimated rows: 1.00
@@ -835,6 +857,7 @@ EvalScalar
                     ├── read bytes: 31
                     ├── partitions total: 1
                     ├── partitions scanned: 1
+                    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
                     ├── push downs: [filters: [], limit: NONE]
                     ├── output columns: [0]
                     └── estimated rows: 1.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/fold_count.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/fold_count.test
@@ -52,6 +52,7 @@ EvalScalar
                 ├── read bytes: 4028
                 ├── partitions total: 2
                 ├── partitions scanned: 1
+                ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
                 ├── push downs: [filters: [gt(t.number (#0), 10_u64)], limit: NONE]
                 └── estimated rows: 1001.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -31,6 +31,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -39,6 +40,7 @@ HashJoin
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -57,6 +59,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -65,6 +68,7 @@ HashJoin
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -86,6 +90,7 @@ HashJoin
 │       ├── read bytes: 0
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
+│       ├── pruning stats: [segments: <range pruning: 1 to 0>, blocks: <range pruning: 0 to 0, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [gt(t.number (#0), 1_u64)], limit: NONE]
 │       └── estimated rows: 1.00
 └── Filter(Probe)
@@ -97,6 +102,7 @@ HashJoin
         ├── read bytes: 68
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [lt(1_u64, t1.number (#1))], limit: NONE]
         └── estimated rows: 10.00
 
@@ -118,6 +124,7 @@ Filter
     │   ├── read bytes: 31
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 1.00
     └── TableScan(Probe)
@@ -126,6 +133,7 @@ Filter
         ├── read bytes: 68
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 10.00
 
@@ -148,6 +156,7 @@ HashJoin
 │       ├── read bytes: 0
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
+│       ├── pruning stats: [segments: <range pruning: 1 to 0>, blocks: <range pruning: 0 to 0, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [eq(t.number (#0), 1_u64)], limit: NONE]
 │       └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -162,6 +171,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -170,6 +180,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -211,6 +222,7 @@ Filter
     │   ├── read bytes: 79
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 4.00
     └── TableScan(Probe)
@@ -219,6 +231,7 @@ Filter
         ├── read bytes: 37
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 4.00
 
@@ -240,6 +253,7 @@ Filter
     │   ├── read bytes: 79
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 4.00
     └── TableScan(Probe)
@@ -248,6 +262,7 @@ Filter
         ├── read bytes: 37
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 4.00
 
@@ -269,6 +284,7 @@ Filter
     │   ├── read bytes: 79
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 4.00
     └── TableScan(Probe)
@@ -277,6 +293,7 @@ Filter
         ├── read bytes: 37
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 4.00
 
@@ -300,6 +317,7 @@ Filter
     │   ├── read bytes: 79
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 4.00
     └── TableScan(Probe)
@@ -308,6 +326,7 @@ Filter
         ├── read bytes: 37
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 4.00
 
@@ -329,6 +348,7 @@ HashJoin
 │       ├── read bytes: 79
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [gt(b.x (#1), 42_i32), lt(b.x (#1), 45_i32)], limit: NONE]
 │       └── estimated rows: 4.00
 └── TableScan(Probe)
@@ -337,6 +357,7 @@ HashJoin
     ├── read bytes: 37
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 4.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -40,6 +40,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -54,6 +55,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -62,6 +64,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -80,6 +83,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -94,6 +98,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -102,6 +107,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -120,6 +126,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -134,6 +141,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -142,6 +150,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -160,6 +169,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -174,6 +184,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -182,6 +193,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -200,6 +212,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -214,6 +227,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -222,6 +236,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -240,6 +255,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -254,6 +270,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -262,6 +279,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -280,6 +298,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -288,6 +307,7 @@ HashJoin
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -306,6 +326,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -314,6 +335,7 @@ HashJoin
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -332,6 +354,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -340,6 +363,7 @@ HashJoin
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -358,6 +382,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -366,6 +391,7 @@ HashJoin
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -384,6 +410,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -392,6 +419,7 @@ HashJoin
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -410,6 +438,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -418,6 +447,7 @@ HashJoin
     ├── read bytes: 68
     ├── partitions total: 1
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
@@ -28,6 +28,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -42,6 +43,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -50,6 +52,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -68,6 +71,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -82,6 +86,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -90,6 +95,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -108,6 +114,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -122,6 +129,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -130,6 +138,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -148,6 +157,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -162,6 +172,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -170,6 +181,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -188,6 +200,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -202,6 +215,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -210,6 +224,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -228,6 +243,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -242,6 +258,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -250,6 +267,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
@@ -28,6 +28,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -42,6 +43,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -50,6 +52,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -68,6 +71,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -82,6 +86,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -90,6 +95,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -108,6 +114,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -122,6 +129,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -130,6 +138,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -148,6 +157,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -162,6 +172,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -170,6 +181,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -188,6 +200,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -202,6 +215,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -210,6 +224,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -228,6 +243,7 @@ HashJoin
 │   ├── read bytes: 31
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── HashJoin(Probe)
@@ -242,6 +258,7 @@ HashJoin
     │   ├── read bytes: 68
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -250,6 +267,7 @@ HashJoin
         ├── read bytes: 431
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/nullable_prune.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/nullable_prune.test
@@ -22,6 +22,7 @@ TableScan
 ├── read bytes: 62
 ├── partitions total: 2
 ├── partitions scanned: 2
+├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 0 to 0>]
 ├── push downs: [filters: [], limit: NONE]
 └── estimated rows: 6.00
 
@@ -37,6 +38,7 @@ Filter
     ├── read bytes: 37
     ├── partitions total: 2
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [is_not_null(t_nullable_prune.a (#0))], limit: NONE]
     └── estimated rows: 6.00
 
@@ -52,6 +54,7 @@ Filter
     ├── read bytes: 25
     ├── partitions total: 2
     ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [not(is_not_null(t_nullable_prune.a (#0)))], limit: NONE]
     └── estimated rows: 6.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
@@ -250,6 +250,7 @@ EvalScalar
                 ├── read bytes: 31
                 ├── partitions total: 1
                 ├── partitions scanned: 1
+                ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
                 ├── push downs: [filters: [eq(t.b (#1), 2_i32)], limit: NONE]
                 ├── output columns: [1]
                 └── estimated rows: 2.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
@@ -146,6 +146,7 @@ Limit
     │       ├── read bytes: 27
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │       ├── push downs: [filters: [], limit: 3]
     │       └── estimated rows: 1.00
     └── Limit(Probe)
@@ -158,6 +159,7 @@ Limit
             ├── read bytes: 31
             ├── partitions total: 1
             ├── partitions scanned: 1
+            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
             ├── push downs: [filters: [], limit: 3]
             └── estimated rows: 2.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -36,6 +36,7 @@ UnionAll
 │       ├── read bytes: 0
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
+│       ├── pruning stats: [segments: <range pruning: 1 to 0>, blocks: <range pruning: 0 to 0, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [gt(v.a (#0), v.b (#1))], limit: NONE]
 │       └── estimated rows: 2.00
 └── Filter
@@ -47,6 +48,7 @@ UnionAll
         ├── read bytes: 0
         ├── partitions total: 1
         ├── partitions scanned: 0
+        ├── pruning stats: [segments: <range pruning: 1 to 0>, blocks: <range pruning: 0 to 0, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [gt(a (#2), b (#3))], limit: NONE]
         └── estimated rows: 2.00
 
@@ -64,6 +66,7 @@ UnionAll
 │       ├── read bytes: 62
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [gt(v.a (#0), 1_i32)], limit: NONE]
 │       └── estimated rows: 2.00
 └── Filter
@@ -75,6 +78,7 @@ UnionAll
         ├── read bytes: 62
         ├── partitions total: 1
         ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
         ├── push downs: [filters: [gt(a (#2), 1_i32)], limit: NONE]
         └── estimated rows: 2.00
 
@@ -97,6 +101,7 @@ Limit
     │       ├── read bytes: 62
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │       ├── push downs: [filters: [], limit: 3]
     │       └── estimated rows: 2.00
     └── Limit
@@ -109,6 +114,7 @@ Limit
             ├── read bytes: 62
             ├── partitions total: 1
             ├── partitions scanned: 1
+            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
             ├── push downs: [filters: [], limit: 3]
             └── estimated rows: 2.00
 
@@ -131,6 +137,7 @@ Limit
     │       ├── read bytes: 62
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │       ├── push downs: [filters: [], limit: 4]
     │       └── estimated rows: 2.00
     └── Limit
@@ -143,6 +150,7 @@ Limit
             ├── read bytes: 62
             ├── partitions total: 1
             ├── partitions scanned: 1
+            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
             ├── push downs: [filters: [], limit: 4]
             └── estimated rows: 2.00
 
@@ -165,6 +173,7 @@ Limit
     │       ├── read bytes: 62
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │       ├── push downs: [filters: [], limit: 1]
     │       └── estimated rows: 2.00
     └── Limit
@@ -177,6 +186,7 @@ Limit
             ├── read bytes: 62
             ├── partitions total: 1
             ├── partitions scanned: 1
+            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
             ├── push downs: [filters: [], limit: 1]
             └── estimated rows: 2.00
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Only works in standalone:
```
mysql> explain SELECT URLHash, EventDate, COUNT(*) AS PageViews FROM hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 AND TraficSourceID IN (-1, 6) AND RefererHash = 3594120000172545465 GROUP BY URLHash, EventDate ORDER BY PageViews DESC LIMIT 10 OFFSET 100;
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                                                                                                                                                                                                                                                                                      |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Limit                                                                                                                                                                                                                                                                                                                                                                                        |
| ├── limit: 10                                                                                                                                                                                                                                                                                                                                                                                |
| ├── offset: 100                                                                                                                                                                                                                                                                                                                                                                              |
| ├── estimated rows: 0.00                                                                                                                                                                                                                                                                                                                                                                     |
| └── Sort                                                                                                                                                                                                                                                                                                                                                                                     |
|     ├── sort keys: [pageviews DESC NULLS LAST]                                                                                                                                                                                                                                                                                                                                               |
|     ├── estimated rows: 0.00                                                                                                                                                                                                                                                                                                                                                                 |
|     └── EvalScalar                                                                                                                                                                                                                                                                                                                                                                           |
|         ├── expressions: [COUNT(*) (#107)]                                                                                                                                                                                                                                                                                                                                                   |
|         ├── estimated rows: 0.00                                                                                                                                                                                                                                                                                                                                                             |
|         └── AggregateFinal                                                                                                                                                                                                                                                                                                                                                                   |
|             ├── group by: [urlhash, eventdate]                                                                                                                                                                                                                                                                                                                                               |
|             ├── aggregate functions: [count()]                                                                                                                                                                                                                                                                                                                                               |
|             ├── estimated rows: 0.00                                                                                                                                                                                                                                                                                                                                                         |
|             └── AggregatePartial                                                                                                                                                                                                                                                                                                                                                             |
|                 ├── group by: [urlhash, eventdate]                                                                                                                                                                                                                                                                                                                                           |
|                 ├── aggregate functions: [count()]                                                                                                                                                                                                                                                                                                                                           |
|                 ├── estimated rows: 0.00                                                                                                                                                                                                                                                                                                                                                     |
|                 └── Filter                                                                                                                                                                                                                                                                                                                                                                   |
|                     ├── filters: [eq(hits.counterid (#6), to_int32(62_u8)), gte(hits.eventdate (#5), to_date("2013-07-01")), lte(hits.eventdate (#5), to_date("2013-07-31")), eq(hits.isrefresh (#15), to_int16(0_u8)), or(eq(hits.traficsourceid (#37), minus(1_u8)), eq(hits.traficsourceid (#37), to_int16(6_u8))), eq(hits.refererhash (#102), to_int64(3594120000172545465_u64))]       |
|                     ├── estimated rows: 0.00                                                                                                                                                                                                                                                                                                                                                 |
|                     └── TableScan                                                                                                                                                                                                                                                                                                                                                            |
|                         ├── table: default.hits.hits                                                                                                                                                                                                                                                                                                                                         |
|                         ├── read rows: 6574090                                                                                                                                                                                                                                                                                                                                               |
|                         ├── read bytes: 75603278                                                                                                                                                                                                                                                                                                                                             |
|                         ├── partitions total: 751                                                                                                                                                                                                                                                                                                                                            |
|                         ├── partitions scanned: 51                                                                                                                                                                                                                                                                                                                                           |
|                         ├── pruning stats: [segments: <range pruning: 32 to 25>, blocks: <range pruning: 589 to 51, bloom pruning: 51 to 51>]                                                                                                                                                                                                                                                |
|                         ├── push downs: [filters: [eq(hits.counterid (#6), 62_i32), gte(hits.eventdate (#5), 2013-07-01), lte(hits.eventdate (#5), 2013-07-31), eq(hits.isrefresh (#15), 0_i16), or(eq(hits.traficsourceid (#37), -1_i16), eq(hits.traficsourceid (#37), 6_i16)), eq(hits.refererhash (#102), 3594120000172545465_i64)], limit: NONE]                                        |
|                         ├── output columns: [5, 6, 15, 37, 102, 103]                                                                                                                                                                                                                                                                                                                         |
|                         └── estimated rows: 99997497.00                                                                                                                                                                                                                                                                                                                                      |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

Closes #9723
