### PR TITLE
feat(compression): change the table default compression from lz4 to zstd

### DIFF
--- a/src/query/storages/common/table-meta/src/table/table_compression.rs
+++ b/src/query/storages/common/table-meta/src/table/table_compression.rs
@@ -27,9 +27,9 @@ pub enum TableCompression {
 }
 
 impl Default for TableCompression {
-    // Default is LZ4.
+    // Default is zstd.
     fn default() -> Self {
-        TableCompression::LZ4
+        TableCompression::Zstd
     }
 }
 
@@ -39,11 +39,11 @@ impl TryFrom<&str> for TableCompression {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value.to_lowercase().as_str() {
+            "" => Ok(TableCompression::default()),
             "none" => Ok(TableCompression::None),
-            // Default is LZ4.
-            "" | "lz4" => Ok(TableCompression::LZ4),
-            "snappy" => Ok(TableCompression::Snappy),
             "zstd" => Ok(TableCompression::Zstd),
+            "lz4" => Ok(TableCompression::LZ4),
+            "snappy" => Ok(TableCompression::Snappy),
             other => Err(ErrorCode::UnknownFormat(format!(
                 "unsupported table compression: {}",
                 other
@@ -69,9 +69,9 @@ impl From<TableCompression> for native::Compression {
     fn from(value: TableCompression) -> Self {
         match value {
             TableCompression::None => native::Compression::None,
+            TableCompression::LZ4 => native::Compression::LZ4,
+            TableCompression::Snappy => native::Compression::SNAPPY,
             TableCompression::Zstd => native::Compression::ZSTD,
-            // Others to LZ4.
-            _ => native::Compression::LZ4,
         }
     }
 }

--- a/tests/sqllogictests/suites/base/01_system/01_0005_system_tables_data_size
+++ b/tests/sqllogictests/suites/base/01_system/01_0005_system_tables_data_size
@@ -7,7 +7,7 @@ insert into temp values(1)
 query II
 select data_size, data_compressed_size from system.tables where name = 'temp'
 ----
-1 199
+1 207
 
 statement ok
 drop table temp

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -54,7 +54,7 @@ Filter
     └── TableScan(Probe)
         ├── table: default.default.t2
         ├── read rows: 5
-        ├── read bytes: 94
+        ├── read bytes: 108
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -73,7 +73,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.default.t1
 │   ├── read rows: 1
-│   ├── read bytes: 62
+│   ├── read bytes: 78
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -82,7 +82,7 @@ HashJoin
 └── TableScan(Probe)
     ├── table: default.default.t2
     ├── read rows: 5
-    ├── read bytes: 94
+    ├── read bytes: 108
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -525,7 +525,7 @@ UnionAll
 ├── TableScan
 │   ├── table: default.default.t1
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -535,7 +535,7 @@ UnionAll
 └── TableScan
     ├── table: default.default.t2
     ├── read rows: 5
-    ├── read bytes: 47
+    ├── read bytes: 54
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -561,7 +561,7 @@ Filter
     │   └── TableScan
     │       ├── table: default.default.t1
     │       ├── read rows: 1
-    │       ├── read bytes: 62
+    │       ├── read bytes: 78
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -573,7 +573,7 @@ Filter
         └── TableScan
             ├── table: default.default.t2
             ├── read rows: 5
-            ├── read bytes: 94
+            ├── read bytes: 108
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -598,7 +598,7 @@ Filter
     │   └── TableScan
     │       ├── table: default.default.t1
     │       ├── read rows: 1
-    │       ├── read bytes: 62
+    │       ├── read bytes: 78
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
@@ -607,7 +607,7 @@ Filter
     └── TableScan(Probe)
         ├── table: default.default.t2
         ├── read rows: 5
-        ├── read bytes: 94
+        ├── read bytes: 108
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -635,7 +635,7 @@ Filter
     ├── TableScan(Build)
     │   ├── table: default.default.t2
     │   ├── read rows: 5
-    │   ├── read bytes: 94
+    │   ├── read bytes: 108
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -650,7 +650,7 @@ Filter
         ├── TableScan(Build)
         │   ├── table: default.default.t1
         │   ├── read rows: 1
-        │   ├── read bytes: 62
+        │   ├── read bytes: 78
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
         │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -659,7 +659,7 @@ Filter
         └── TableScan(Probe)
             ├── table: default.default.t3
             ├── read rows: 10
-            ├── read bytes: 136
+            ├── read bytes: 130
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -690,7 +690,7 @@ HashJoin
 │       │   └── TableScan
 │       │       ├── table: default.default.t1
 │       │       ├── read rows: 1
-│       │       ├── read bytes: 62
+│       │       ├── read bytes: 78
 │       │       ├── partitions total: 1
 │       │       ├── partitions scanned: 1
 │       │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -702,7 +702,7 @@ HashJoin
 │           └── TableScan
 │               ├── table: default.default.t2
 │               ├── read rows: 5
-│               ├── read bytes: 94
+│               ├── read bytes: 108
 │               ├── partitions total: 1
 │               ├── partitions scanned: 1
 │               ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -714,7 +714,7 @@ HashJoin
     └── TableScan
         ├── table: default.default.t3
         ├── read rows: 10
-        ├── read bytes: 136
+        ├── read bytes: 130
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -746,7 +746,7 @@ Limit
             │   └── TableScan
             │       ├── table: default.default.t1
             │       ├── read rows: 1
-            │       ├── read bytes: 62
+            │       ├── read bytes: 78
             │       ├── partitions total: 1
             │       ├── partitions scanned: 1
             │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -758,7 +758,7 @@ Limit
                 └── TableScan
                     ├── table: default.default.t2
                     ├── read rows: 5
-                    ├── read bytes: 94
+                    ├── read bytes: 108
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -780,7 +780,7 @@ HashJoin
 │   └── TableScan
 │       ├── table: default.default.t1
 │       ├── read rows: 1
-│       ├── read bytes: 62
+│       ├── read bytes: 78
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -789,7 +789,7 @@ HashJoin
 └── TableScan(Probe)
     ├── table: default.default.t2
     ├── read rows: 5
-    ├── read bytes: 94
+    ├── read bytes: 108
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -821,7 +821,7 @@ EvalScalar
                 └── TableScan
                     ├── table: default.default.t1
                     ├── read rows: 1
-                    ├── read bytes: 31
+                    ├── read bytes: 39
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -854,7 +854,7 @@ EvalScalar
                 └── TableScan
                     ├── table: default.default.t1
                     ├── read rows: 1
-                    ├── read bytes: 31
+                    ├── read bytes: 39
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/fold_count.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/fold_count.test
@@ -49,7 +49,7 @@ EvalScalar
             └── TableScan
                 ├── table: default.default.t
                 ├── read rows: 1000
-                ├── read bytes: 4028
+                ├── read bytes: 1598
                 ├── partitions total: 2
                 ├── partitions scanned: 1
                 ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -28,7 +28,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.default.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -37,7 +37,7 @@ HashJoin
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── read rows: 10
-    ├── read bytes: 68
+    ├── read bytes: 65
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -56,7 +56,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.default.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -65,7 +65,7 @@ HashJoin
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── read rows: 10
-    ├── read bytes: 68
+    ├── read bytes: 65
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -99,7 +99,7 @@ HashJoin
     └── TableScan
         ├── table: default.default.t1
         ├── read rows: 10
-        ├── read bytes: 68
+        ├── read bytes: 65
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -121,7 +121,7 @@ Filter
     ├── TableScan(Build)
     │   ├── table: default.default.t
     │   ├── read rows: 1
-    │   ├── read bytes: 31
+    │   ├── read bytes: 39
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -130,7 +130,7 @@ Filter
     └── TableScan(Probe)
         ├── table: default.default.t1
         ├── read rows: 10
-        ├── read bytes: 68
+        ├── read bytes: 65
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -168,7 +168,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.default.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -177,7 +177,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.default.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -219,7 +219,7 @@ Filter
     ├── TableScan(Build)
     │   ├── table: default.default.twocolumn
     │   ├── read rows: 4
-    │   ├── read bytes: 79
+    │   ├── read bytes: 94
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -228,7 +228,7 @@ Filter
     └── TableScan(Probe)
         ├── table: default.default.onecolumn
         ├── read rows: 4
-        ├── read bytes: 37
+        ├── read bytes: 45
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -250,7 +250,7 @@ Filter
     ├── TableScan(Build)
     │   ├── table: default.default.twocolumn
     │   ├── read rows: 4
-    │   ├── read bytes: 79
+    │   ├── read bytes: 94
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -259,7 +259,7 @@ Filter
     └── TableScan(Probe)
         ├── table: default.default.onecolumn
         ├── read rows: 4
-        ├── read bytes: 37
+        ├── read bytes: 45
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -281,7 +281,7 @@ Filter
     ├── TableScan(Build)
     │   ├── table: default.default.twocolumn
     │   ├── read rows: 4
-    │   ├── read bytes: 79
+    │   ├── read bytes: 94
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -290,7 +290,7 @@ Filter
     └── TableScan(Probe)
         ├── table: default.default.onecolumn
         ├── read rows: 4
-        ├── read bytes: 37
+        ├── read bytes: 45
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -314,7 +314,7 @@ Filter
     ├── TableScan(Build)
     │   ├── table: default.default.twocolumn
     │   ├── read rows: 4
-    │   ├── read bytes: 79
+    │   ├── read bytes: 94
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -323,7 +323,7 @@ Filter
     └── TableScan(Probe)
         ├── table: default.default.onecolumn
         ├── read rows: 4
-        ├── read bytes: 37
+        ├── read bytes: 45
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -345,7 +345,7 @@ HashJoin
 │   └── TableScan
 │       ├── table: default.default.twocolumn
 │       ├── read rows: 4
-│       ├── read bytes: 79
+│       ├── read bytes: 94
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -354,7 +354,7 @@ HashJoin
 └── TableScan(Probe)
     ├── table: default.default.onecolumn
     ├── read rows: 4
-    ├── read bytes: 37
+    ├── read bytes: 45
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -37,7 +37,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -52,7 +52,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -61,7 +61,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -80,7 +80,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -95,7 +95,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -104,7 +104,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -123,7 +123,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -138,7 +138,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -147,7 +147,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -166,7 +166,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -181,7 +181,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -190,7 +190,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -209,7 +209,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -224,7 +224,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -233,7 +233,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -252,7 +252,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -267,7 +267,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -276,7 +276,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -295,7 +295,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -304,7 +304,7 @@ HashJoin
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 68
+    ├── read bytes: 65
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -323,7 +323,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -332,7 +332,7 @@ HashJoin
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 68
+    ├── read bytes: 65
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -351,7 +351,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -360,7 +360,7 @@ HashJoin
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 68
+    ├── read bytes: 65
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -379,7 +379,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -388,7 +388,7 @@ HashJoin
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 68
+    ├── read bytes: 65
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -407,7 +407,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -416,7 +416,7 @@ HashJoin
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 68
+    ├── read bytes: 65
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -435,7 +435,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -444,7 +444,7 @@ HashJoin
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── read rows: 10
-    ├── read bytes: 68
+    ├── read bytes: 65
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
@@ -25,7 +25,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -40,7 +40,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -49,7 +49,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -68,7 +68,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -83,7 +83,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -92,7 +92,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -111,7 +111,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -126,7 +126,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -135,7 +135,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -154,7 +154,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -169,7 +169,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -178,7 +178,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -197,7 +197,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -212,7 +212,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -221,7 +221,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -240,7 +240,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -255,7 +255,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -264,7 +264,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
@@ -25,7 +25,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -40,7 +40,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -49,7 +49,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -68,7 +68,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -83,7 +83,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -92,7 +92,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -111,7 +111,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -126,7 +126,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -135,7 +135,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -154,7 +154,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -169,7 +169,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -178,7 +178,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -197,7 +197,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -212,7 +212,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -221,7 +221,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -240,7 +240,7 @@ HashJoin
 ├── TableScan(Build)
 │   ├── table: default.join_reorder.t
 │   ├── read rows: 1
-│   ├── read bytes: 31
+│   ├── read bytes: 39
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -255,7 +255,7 @@ HashJoin
     ├── TableScan(Build)
     │   ├── table: default.join_reorder.t1
     │   ├── read rows: 10
-    │   ├── read bytes: 68
+    │   ├── read bytes: 65
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -264,7 +264,7 @@ HashJoin
     └── TableScan(Probe)
         ├── table: default.join_reorder.t2
         ├── read rows: 100
-        ├── read bytes: 431
+        ├── read bytes: 172
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/nullable_prune.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/nullable_prune.test
@@ -19,7 +19,7 @@ explain select * from t_nullable_prune
 TableScan
 ├── table: default.default.t_nullable_prune
 ├── read rows: 6
-├── read bytes: 62
+├── read bytes: 78
 ├── partitions total: 2
 ├── partitions scanned: 2
 ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 0 to 0>]
@@ -35,7 +35,7 @@ Filter
 └── TableScan
     ├── table: default.default.t_nullable_prune
     ├── read rows: 3
-    ├── read bytes: 37
+    ├── read bytes: 45
     ├── partitions total: 2
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -51,7 +51,7 @@ Filter
 └── TableScan
     ├── table: default.default.t_nullable_prune
     ├── read rows: 3
-    ├── read bytes: 25
+    ├── read bytes: 33
     ├── partitions total: 2
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
@@ -247,7 +247,7 @@ EvalScalar
             └── TableScan
                 ├── table: default.default.t
                 ├── read rows: 2
-                ├── read bytes: 31
+                ├── read bytes: 39
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
@@ -143,7 +143,7 @@ Limit
     │   └── TableScan
     │       ├── table: default.default.t
     │       ├── read rows: 1
-    │       ├── read bytes: 27
+    │       ├── read bytes: 35
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -156,7 +156,7 @@ Limit
         └── TableScan
             ├── table: default.default.t1
             ├── read rows: 2
-            ├── read bytes: 31
+            ├── read bytes: 39
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -63,7 +63,7 @@ UnionAll
 │   └── TableScan
 │       ├── table: default.default.t1
 │       ├── read rows: 2
-│       ├── read bytes: 62
+│       ├── read bytes: 78
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -75,7 +75,7 @@ UnionAll
     └── TableScan
         ├── table: default.default.t2
         ├── read rows: 2
-        ├── read bytes: 62
+        ├── read bytes: 78
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -98,7 +98,7 @@ Limit
     │   └── TableScan
     │       ├── table: default.default.t1
     │       ├── read rows: 2
-    │       ├── read bytes: 62
+    │       ├── read bytes: 78
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -111,7 +111,7 @@ Limit
         └── TableScan
             ├── table: default.default.t2
             ├── read rows: 2
-            ├── read bytes: 62
+            ├── read bytes: 78
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -134,7 +134,7 @@ Limit
     │   └── TableScan
     │       ├── table: default.default.t1
     │       ├── read rows: 2
-    │       ├── read bytes: 62
+    │       ├── read bytes: 78
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -147,7 +147,7 @@ Limit
         └── TableScan
             ├── table: default.default.t2
             ├── read rows: 2
-            ├── read bytes: 62
+            ├── read bytes: 78
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -170,7 +170,7 @@ Limit
     │   └── TableScan
     │       ├── table: default.default.t1
     │       ├── read rows: 2
-    │       ├── read bytes: 62
+    │       ├── read bytes: 78
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
@@ -183,7 +183,7 @@ Limit
         └── TableScan
             ├── table: default.default.t2
             ├── read rows: 2
-            ├── read bytes: 62
+            ├── read bytes: 78
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

As benched in #9728, zstd has a better compression ratio, it's suite for cloud object storage.

From zstd readme:

| Compressor name         | Ratio | Compression| Decompress.|
| ---------------         | ------| -----------| ---------- |
| **zstd 1.5.1 -1**       | 2.887 |   530 MB/s |  1700 MB/s |
| [zlib] 1.2.11 -1        | 2.743 |    95 MB/s |   400 MB/s |
| brotli 1.0.9 -0         | 2.702 |   395 MB/s |   450 MB/s |
| **zstd 1.5.1 --fast=1** | 2.437 |   600 MB/s |  2150 MB/s |
| **zstd 1.5.1 --fast=3** | 2.239 |   670 MB/s |  2250 MB/s |
| quicklz 1.5.0 -1        | 2.238 |   540 MB/s |   760 MB/s |
| **zstd 1.5.1 --fast=4** | 2.148 |   710 MB/s |  2300 MB/s |
| lzo1x 2.10 -1           | 2.106 |   660 MB/s |   845 MB/s |
| [lz4] 1.9.3             | 2.101 |   740 MB/s |  4500 MB/s |
| lzf 3.6 -1              | 2.077 |   410 MB/s |   830 MB/s |
| snappy 1.1.9            | 2.073 |   550 MB/s |  1750 MB/s |

Closes #9729
