### PR TITLE
chore(copy): make on_error default to abort

### DIFF
--- a/scripts/ci/ci-run-sqllogic-tests.sh
+++ b/scripts/ci/ci-run-sqllogic-tests.sh
@@ -17,4 +17,4 @@ fi
 echo "Run suites using argument: $RUN_DIR"
 
 echo "Starting databend-sqllogic tests"
-target/${BUILD_PROFILE}/databend-sqllogictests --handlers ${TEST_HANDLERS} ${RUN_DIR} --enable_sandbox --parallel 8 --debug
+target/${BUILD_PROFILE}/databend-sqllogictests --handlers ${TEST_HANDLERS} ${RUN_DIR} --skip_dir management --enable_sandbox --parallel 8 --debug

--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -111,10 +111,8 @@ impl Display for CopyStmt<'_> {
         write!(f, " SINGLE = {}", self.single)?;
         write!(f, " PURGE = {}", self.purge)?;
         write!(f, " FORCE = {}", self.force)?;
+        write!(f, " ON_ERROR = '{}'", self.on_error)?;
 
-        if !self.on_error.is_empty() {
-            write!(f, " ON_ERROR = '{}'", self.on_error)?;
-        }
         Ok(())
     }
 }

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -870,7 +870,7 @@ pub fn statement(i: Input) -> IResult<StatementMsg> {
                 single: Default::default(),
                 purge: Default::default(),
                 force: Default::default(),
-                on_error: Default::default(),
+                on_error: "abort".to_string(),
             };
             for opt in opts {
                 copy_stmt.apply_option(opt);

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -7158,7 +7158,7 @@ COPY INTO mytable
                 size_limit=10;
 ---------- Output ---------
 COPY INTO mytable FROM @~/mybucket/data.csv FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7192,7 +7192,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7209,7 +7209,7 @@ COPY INTO mytable
                 size_limit=10;
 ---------- Output ---------
 COPY INTO mytable FROM 's3://mybucket/data.csv' FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7249,7 +7249,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7269,7 +7269,7 @@ COPY INTO mytable
                 size_limit=10;
 ---------- Output ---------
 COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( endpoint_url='http://127.0.0.1:9900' ) FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7311,7 +7311,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7331,7 +7331,7 @@ COPY INTO mytable
                 );
 ---------- Output ---------
 COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( endpoint_url='http://127.0.0.1:9900' ) FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7373,7 +7373,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7382,7 +7382,7 @@ Copy(
 COPY INTO mytable
                 FROM 'https://127.0.0.1:9900';
 ---------- Output ---------
-COPY INTO mytable FROM 'https://127.0.0.1:9900/' SINGLE = false PURGE = false FORCE = false
+COPY INTO mytable FROM 'https://127.0.0.1:9900/' SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7417,7 +7417,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7426,7 +7426,7 @@ Copy(
 COPY INTO mytable
                 FROM 'https://127.0.0.1:';
 ---------- Output ---------
-COPY INTO mytable FROM 'https://127.0.0.1/' SINGLE = false PURGE = false FORCE = false
+COPY INTO mytable FROM 'https://127.0.0.1/' SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7461,7 +7461,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7478,7 +7478,7 @@ COPY INTO mytable
                 size_limit=10;
 ---------- Output ---------
 COPY INTO mytable FROM @my_stage/ FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7512,7 +7512,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7529,7 +7529,7 @@ COPY INTO 's3://mybucket/data.csv'
                 size_limit=10;
 ---------- Output ---------
 COPY INTO 's3://mybucket/data.csv' FROM mytable FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7569,7 +7569,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7586,7 +7586,7 @@ COPY INTO @my_stage
                 size_limit=10;
 ---------- Output ---------
 COPY INTO @my_stage/ FROM mytable FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7620,7 +7620,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7641,7 +7641,7 @@ COPY INTO mytable
                 size_limit=10;
 ---------- Output ---------
 COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( aws_key_id='access_key' aws_secret_key='secret_key' ) FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7684,7 +7684,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7701,7 +7701,7 @@ COPY INTO mytable
                 size_limit=10;
 ---------- Output ---------
 COPY INTO mytable FROM @external_stage/path/to/file.csv FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7735,7 +7735,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7752,7 +7752,7 @@ COPY INTO mytable
                 size_limit=10;
 ---------- Output ---------
 COPY INTO mytable FROM @external_stage/path/to/dir/ FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7786,7 +7786,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7803,7 +7803,7 @@ COPY INTO mytable
                 force=true;
 ---------- Output ---------
 COPY INTO mytable FROM @external_stage/path/to/file.csv FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SINGLE = false PURGE = false FORCE = true
+' skip_header = '1' type = 'CSV' ) SINGLE = false PURGE = false FORCE = true ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7837,7 +7837,7 @@ Copy(
         single: false,
         purge: false,
         force: true,
-        on_error: "",
+        on_error: "abort",
     },
 )
 
@@ -7854,7 +7854,7 @@ COPY INTO mytable
                 size_limit=10;
 ---------- Output ---------
 COPY INTO mytable FROM 'fs:///path/to/data.csv' FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 SINGLE = false PURGE = false FORCE = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -7894,7 +7894,7 @@ Copy(
         single: false,
         purge: false,
         force: false,
-        on_error: "",
+        on_error: "abort",
     },
 )
 

--- a/src/query/sql/src/planner/binder/copy.rs
+++ b/src/query/sql/src/planner/binder/copy.rs
@@ -498,10 +498,8 @@ impl<'a> Binder {
         // Copy options.
         {
             // on_error.
-            if !stmt.on_error.is_empty() {
-                stage.copy_options.on_error =
-                    OnErrorMode::from_str(&stmt.on_error).map_err(ErrorCode::SyntaxException)?;
-            }
+            stage.copy_options.on_error =
+                OnErrorMode::from_str(&stmt.on_error).map_err(ErrorCode::SyntaxException)?;
 
             // size_limit.
             if stmt.size_limit != 0 {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Change `ON_ERROR` default value to `abort`.

Closes #issue
