### PR TITLE
fix(metactl): when import data to meta-service dir, the specified "id" has to be one of the "initial_cluster"

### DIFF
--- a/src/binaries/metactl/main.rs
+++ b/src/binaries/metactl/main.rs
@@ -26,6 +26,8 @@ use common_meta_client::MetaGrpcClient;
 use common_meta_raft_store::config::get_default_raft_advertise_host;
 use common_tracing::init_logging;
 use common_tracing::Config as LogConfig;
+use common_tracing::FileConfig;
+use common_tracing::StderrConfig;
 use databend_meta::version::METASRV_COMMIT_VERSION;
 use serde::Deserialize;
 use serde::Serialize;
@@ -191,7 +193,17 @@ impl Default for RaftConfig {
 async fn main() -> anyhow::Result<()> {
     let config = Config::parse();
 
-    let _guards = init_logging("metactl", &LogConfig::default());
+    let log_config = LogConfig {
+        file: FileConfig {
+            on: true,
+            level: config.log_level.clone(),
+            dir: ".databend/logs".to_string(),
+            format: "text".to_string(),
+        },
+        stderr: StderrConfig::default(),
+    };
+
+    let _guards = init_logging("metactl", &log_config);
 
     eprintln!();
     eprintln!("███╗   ███╗███████╗████████╗ █████╗        ██████╗████████╗██╗     ");

--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -177,6 +177,10 @@ fn build_nodes(initial_cluster: Vec<String>, id: u64) -> anyhow::Result<BTreeMap
         nodes.insert(id, node);
     }
 
+    if nodes.is_empty() {
+        return Ok(nodes);
+    }
+
     if !nodes.contains_key(&id) {
         return Err(anyhow::anyhow!(
             "node id ({}) has to be one of cluster member({:?})",

--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -43,6 +43,7 @@ use common_meta_types::Node;
 use openraft::raft::Entry;
 use openraft::raft::EntryPayload;
 use openraft::Membership;
+use openraft::NodeId;
 use tokio::net::TcpSocket;
 use url::Url;
 
@@ -67,6 +68,8 @@ pub async fn import_data(config: &Config) -> anyhow::Result<()> {
     let raft_config = &config.raft_config;
     eprintln!("import meta dir into: {}", raft_config.raft_dir);
 
+    let nodes = build_nodes(config.initial_cluster.clone(), raft_config.id)?;
+
     init_sled_db(raft_config.raft_dir.clone());
 
     clear()?;
@@ -75,12 +78,8 @@ pub async fn import_data(config: &Config) -> anyhow::Result<()> {
     if config.initial_cluster.is_empty() {
         return Ok(());
     }
-    init_new_cluster(
-        config.initial_cluster.clone(),
-        max_log_id,
-        config.raft_config.id,
-    )
-    .await?;
+
+    init_new_cluster(nodes, max_log_id, config.raft_config.id).await?;
     Ok(())
 }
 
@@ -145,15 +144,9 @@ fn import_from(restore: String) -> anyhow::Result<Option<LogId>> {
     }
 }
 
-// initial_cluster format: node_id=endpoint,grpc_api_addr;
-async fn init_new_cluster(
-    initial_cluster: Vec<String>,
-    max_log_id: Option<LogId>,
-    id: u64,
-) -> anyhow::Result<()> {
-    eprintln!("init-cluster: {:?}", initial_cluster);
+fn build_nodes(initial_cluster: Vec<String>, id: u64) -> anyhow::Result<BTreeMap<NodeId, Node>> {
+    eprintln!("init-cluster: id={}, {:?}", id, initial_cluster);
 
-    let mut node_ids = BTreeSet::new();
     let mut nodes = BTreeMap::new();
     for peer in initial_cluster {
         eprintln!("peer:{}", peer);
@@ -162,7 +155,6 @@ async fn init_new_cluster(
             return Err(anyhow::anyhow!("invalid peer str: {}", peer));
         }
         let id = u64::from_str(node_info[0])?;
-        node_ids.insert(id);
 
         let addrs: Vec<&str> = node_info[1].split(',').collect();
         if addrs.len() != 2 {
@@ -184,6 +176,27 @@ async fn init_new_cluster(
         eprintln!("new cluster node:{}", node);
         nodes.insert(id, node);
     }
+
+    if !nodes.contains_key(&id) {
+        return Err(anyhow::anyhow!(
+            "node id ({}) has to be one of cluster member({:?})",
+            id,
+            nodes.keys().collect::<Vec<_>>()
+        ));
+    }
+
+    Ok(nodes)
+}
+
+// initial_cluster format: node_id=endpoint,grpc_api_addr;
+async fn init_new_cluster(
+    nodes: BTreeMap<NodeId, Node>,
+    max_log_id: Option<LogId>,
+    id: u64,
+) -> anyhow::Result<()> {
+    eprintln!("init-cluster: {:?}", nodes);
+
+    let node_ids = nodes.keys().copied().collect::<BTreeSet<_>>();
 
     let db = get_sled_db();
     let config = RaftConfig {

--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -255,7 +255,6 @@ pub struct MetaGrpcClient {
     /// If a background task is blocked, no meta-client will be able to proceed if meta-client is reused.
     ///
     /// Note that a thread_pool tokio runtime does not help: a scheduled tokio-task resides in `filo_slot` won't be stolen by other tokio-workers.
-    /// TODO: dead code
     #[allow(dead_code)]
     rt: Arc<Runtime>,
 }

--- a/src/meta/protos/proto/datatype.proto
+++ b/src/meta/protos/proto/datatype.proto
@@ -63,7 +63,7 @@ message DataType {
   }
 }
 
-// TODO: going to remove
+// TODO: remove when MIN_MSG_VER becomes >=24
 // A wrapper data type of another type.
 // Such a column allows to contain `null` elements
 message NullableType {
@@ -74,7 +74,7 @@ message NullableType {
   DataType inner = 1;
 }
 
-// TODO: going to remove
+// TODO: remove when MIN_MSG_VER becomes >=24
 // Timestamp data type with customizable precision and timezone: `tz`.
 message Timestamp {
   uint64 ver = 100;
@@ -85,7 +85,7 @@ message Timestamp {
   reserved 1;
 }
 
-// TODO: going to remove
+// TODO: remove when MIN_MSG_VER becomes >=24
 // Struct is similar to a `map` with fixed keys.
 message Struct {
   uint64 ver = 100;
@@ -98,7 +98,7 @@ message Struct {
   repeated DataType types = 2;
 }
 
-// TODO: going to remove
+// TODO: remove when MIN_MSG_VER becomes >=24
 // Array contains multiple elements of the same type.
 message Array {
   uint64 ver = 100;
@@ -108,19 +108,19 @@ message Array {
   DataType inner = 1;
 }
 
-// TODO: going to remove
+// TODO: remove when MIN_MSG_VER becomes >=24
 message VariantArray {
   uint64 ver = 100;
   uint64 min_reader_ver = 101;
 }
 
-// TODO: going to remove
+// TODO: remove when MIN_MSG_VER becomes >=24
 message VariantObject {
   uint64 ver = 100;
   uint64 min_reader_ver = 101;
 }
 
-// TODO: going to remove
+// TODO: remove when MIN_MSG_VER becomes >=24
 enum IntervalKind {
   Year = 0;
   Month = 1;
@@ -133,7 +133,7 @@ enum IntervalKind {
   Quarter = 8;
 }
 
-// TODO: going to remove
+// TODO: remove when MIN_MSG_VER becomes >=24
 message IntervalType {
   uint64 ver = 100;
   uint64 min_reader_ver = 101;
@@ -141,7 +141,7 @@ message IntervalType {
   IntervalKind kind = 1;
 }
 
-// TODO: going to remove
+// TODO: remove when MIN_MSG_VER becomes >=24
 // Something under developing.:)
 message Variant {
   uint64 ver = 100;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### fix(metactl): when import data to meta-service dir, the specified "id" has to be one of the "initial_cluster"

Otherwise nothing will be done and error returns, e.g., `Error: node id (0) has to be one of cluster member([1])`


##### chore(meta): adjust todos

## Changelog







## Related Issues