### PR TITLE
chore(sqllogictest): add time cost

### DIFF
--- a/tests/sqllogictests/src/client/mysql_client.rs
+++ b/tests/sqllogictests/src/client/mysql_client.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Instant;
+
 use mysql_async::prelude::Queryable;
 use mysql_async::Conn;
 use mysql_async::Pool;
@@ -36,10 +38,14 @@ impl MySQLClient {
     }
 
     pub async fn query(&mut self, sql: &str) -> Result<DBOutput> {
-        if self.debug {
-            println!("Running sql with mysql client: [{sql}]");
-        }
+        let start = Instant::now();
         let rows: Vec<Row> = self.conn.query(sql).await?;
+        if self.debug {
+            println!(
+                "Running sql with mysql client: [{sql}] ({:?})",
+                start.elapsed()
+            );
+        };
         let types = vec![ColumnType::Any; rows.len()];
         let mut parsed_rows = Vec::with_capacity(rows.len());
         for row in rows.into_iter() {

--- a/tests/sqllogictests/src/main.rs
+++ b/tests/sqllogictests/src/main.rs
@@ -99,7 +99,10 @@ pub async fn main() -> Result<()> {
 }
 
 async fn run_mysql_client() -> Result<()> {
-    println!("MySQL client starts to run...");
+    println!(
+        "MySQL client starts to run with: {:?}",
+        SqlLogicTestArgs::parse()
+    );
     let suits = SqlLogicTestArgs::parse().suites;
     let suits = std::fs::read_dir(suits).unwrap();
     run_suits(suits, ClientType::MySQL).await?;
@@ -107,7 +110,10 @@ async fn run_mysql_client() -> Result<()> {
 }
 
 async fn run_http_client() -> Result<()> {
-    println!("Http client starts to run...");
+    println!(
+        "Http client starts to run with: {:?}",
+        SqlLogicTestArgs::parse()
+    );
     let suits = SqlLogicTestArgs::parse().suites;
     let suits = std::fs::read_dir(suits).unwrap();
     run_suits(suits, ClientType::Http).await?;
@@ -115,7 +121,10 @@ async fn run_http_client() -> Result<()> {
 }
 
 async fn run_ck_http_client() -> Result<()> {
-    println!("Clickhouse http client starts to run...");
+    println!(
+        "Clickhouse http client starts to run with: {:?}",
+        SqlLogicTestArgs::parse()
+    );
     let suits = SqlLogicTestArgs::parse().suites;
     let suits = std::fs::read_dir(suits).unwrap();
     run_suits(suits, ClientType::Clickhouse).await?;
@@ -223,6 +232,8 @@ async fn run_file_async(
     client_type: &ClientType,
     filename: impl AsRef<Path>,
 ) -> std::result::Result<Vec<TestError>, TestError> {
+    let start = Instant::now();
+
     println!(
         "Running {} test for file: {} ...",
         client_type,
@@ -250,10 +261,11 @@ async fn run_file_async(
         false => "❌",
     };
     println!(
-        "Completed {} test for file: {} {}",
+        "Completed {} test for file: {} {} ({:?})",
         client_type,
         filename.as_ref().display(),
         run_file_status,
+        start.elapsed(),
     );
     Ok(error_records)
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add time cost to each query, sample:
```
MySQL client starts to run with: SqlLogicTestArgs { dir: Some("01_system"), file: None, skipped_dir: None, handlers: None, suites: "tests/sqllogictests/suites", complete: false, no_fail_fast: false, parallel: 1, enable_sandbox: true, debug: true }
Running MySQL test for file: tests/sqllogictests/suites/base/01_system/01_0001_system_tables ...
Running sql with mysql client: [SELECT * from system.tables where name = 'tables' and created_on > '2022-07-01 12:16:58.630 +0000'] (19.625208ms)
Completed MySQL test for file: tests/sqllogictests/suites/base/01_system/01_0001_system_tables ✅ (95.025083ms)
```

Closes #9718
