### PR TITLE
fix: Fix table_meta_cache can't be disabled

### DIFF
--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -212,7 +212,7 @@ impl Default for QueryConfig {
             table_engine_memory_enabled: true,
             wait_timeout_mills: 5000,
             max_query_log_size: 10000,
-            table_meta_cache_enabled: false,
+            table_meta_cache_enabled: true,
             table_cache_block_meta_count: 102400,
             table_memory_cache_mb_size: 256,
             table_disk_cache_root: "_cache".to_string(),


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: Fix table_meta_cache can't be disabled
