### PR TITLE
fix: Fix table_meta_cache can't be disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,7 @@ dependencies = [
  "databend-thrift",
  "hex",
  "once_cell",
+ "pretty_assertions",
  "semver",
  "serde",
  "serfig",

--- a/src/query/config/Cargo.toml
+++ b/src/query/config/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 doctest = false
-test = false
+test = true
 
 [features]
 default = []
@@ -35,6 +35,9 @@ serfig = "0.0.3"
 strum = "0.24.1"
 thrift = { package = "databend-thrift", version = "0.17.0", optional = true }
 tracing = "0.1.36"
+
+[dev-dependencies]
+pretty_assertions = "1.3.0"
 
 [build-dependencies]
 common-building = { path = "../../common/building" }

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -212,7 +212,7 @@ impl Default for QueryConfig {
             table_engine_memory_enabled: true,
             wait_timeout_mills: 5000,
             max_query_log_size: 10000,
-            table_meta_cache_enabled: false,
+            table_meta_cache_enabled: true,
             table_cache_block_meta_count: 102400,
             table_memory_cache_mb_size: 256,
             table_disk_cache_root: "_cache".to_string(),
@@ -273,7 +273,7 @@ impl Default for MetaConfig {
             username: "root".to_string(),
             password: "".to_string(),
             client_timeout_in_second: 10,
-            auto_sync_interval: 10,
+            auto_sync_interval: 0,
             rpc_tls_meta_server_root_ca_cert: "".to_string(),
             rpc_tls_meta_service_domain_name: "localhost".to_string(),
         }

--- a/src/query/config/src/lib.rs
+++ b/src/query/config/src/lib.rs
@@ -38,6 +38,7 @@ pub use inner::CatalogHiveConfig;
 pub use inner::Config;
 pub use inner::QueryConfig;
 pub use inner::ThriftProtocol;
+pub use outer_v0::Config as OuterConfig;
 pub use outer_v0::StorageConfig;
 pub use version::DATABEND_COMMIT_VERSION;
 pub use version::QUERY_SEMVER;

--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -1665,7 +1665,10 @@ pub struct MetaConfig {
     #[clap(long = "meta-rpc-tls-meta-server-root-ca-cert", default_value_t)]
     pub rpc_tls_meta_server_root_ca_cert: String,
 
-    #[clap(long = "meta-rpc-tls-meta-service-domain-name", default_value_t)]
+    #[clap(
+        long = "meta-rpc-tls-meta-service-domain-name",
+        default_value = "localhost"
+    )]
     pub rpc_tls_meta_service_domain_name: String,
 }
 

--- a/src/query/config/tests/main.rs
+++ b/src/query/config/tests/main.rs
@@ -1,0 +1,34 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::OsString;
+
+use clap::Parser;
+use common_config::Config;
+use common_config::OuterConfig;
+use pretty_assertions::assert_eq;
+
+/// It's required to make sure config's default value is the same with clap.
+#[test]
+fn test_config_default() {
+    let type_default = Config::default();
+    let args_default: Config = OuterConfig::parse_from(Vec::<OsString>::new())
+        .try_into()
+        .expect("parse from args must succeed");
+
+    assert_eq!(
+        type_default, args_default,
+        "inner config's default value is different from args, please check again"
+    )
+}

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -14,7 +14,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | "log"     | "stderr.format"                        | "text"                           | ""       |
 | "log"     | "stderr.level"                         | "INFO"                           | ""       |
 | "log"     | "stderr.on"                            | "true"                           | ""       |
-| "meta"    | "auto_sync_interval"                   | "10"                             | ""       |
+| "meta"    | "auto_sync_interval"                   | "0"                              | ""       |
 | "meta"    | "client_timeout_in_second"             | "10"                             | ""       |
 | "meta"    | "embedded_dir"                         | ""                               | ""       |
 | "meta"    | "endpoints"                            | ""                               | ""       |
@@ -70,7 +70,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | "query"   | "table_disk_cache_root"                | "_cache"                         | ""       |
 | "query"   | "table_engine_memory_enabled"          | "true"                           | ""       |
 | "query"   | "table_memory_cache_mb_size"           | "256"                            | ""       |
-| "query"   | "table_meta_cache_enabled"             | "false"                          | ""       |
+| "query"   | "table_meta_cache_enabled"             | "true"                           | ""       |
 | "query"   | "tenant_id"                            | "test"                           | ""       |
 | "query"   | "users"                                | ""                               | ""       |
 | "query"   | "wait_timeout_mills"                   | "5000"                           | ""       |


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: Fix table_meta_cache can't be disabled
