### PR TITLE
refactor(meta/kvapi): KVApi should have an associated error type

### DIFF
--- a/src/binaries/meta/kvapi.rs
+++ b/src/binaries/meta/kvapi.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use common_meta_api::KVApi;
+use common_meta_types::KVAppError;
 use common_meta_types::KVMeta;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKVReq;
@@ -69,7 +70,10 @@ impl KvApiCommand {
         Ok(api)
     }
 
-    pub async fn execute(&self, client: Arc<dyn KVApi>) -> anyhow::Result<String> {
+    pub async fn execute(
+        &self,
+        client: Arc<dyn KVApi<Error = KVAppError>>,
+    ) -> anyhow::Result<String> {
         let res_str = match self {
             KvApiCommand::Get(key) => {
                 let res = client.get_kv(key.as_str()).await?;

--- a/src/meta/api/src/kv_api.rs
+++ b/src/meta/api/src/kv_api.rs
@@ -69,22 +69,37 @@ pub fn get_start_and_end_of_prefix(prefix: &str) -> common_exception::Result<(St
     Ok((prefix.to_string(), prefix_of_string(prefix)?))
 }
 
+/// API of a key-value store.
 #[async_trait]
 pub trait KVApi: Send + Sync {
+    /// The Error an implementation returns.
+    ///
+    /// Depends on the implementation the error could be different.
+    /// E.g., a remove KVApi impl returns network error or remote storage error.
+    /// A local KVApi impl just returns storage error.
+    type Error: std::error::Error;
+
+    /// Update or insert a key-value record.
     async fn upsert_kv(&self, req: UpsertKVReq) -> Result<UpsertKVReply, KVAppError>;
 
+    /// Get a key-value record by key.
     async fn get_kv(&self, key: &str) -> Result<GetKVReply, KVAppError>;
 
-    // mockall complains about AsRef... so we use String here
+    // TODO: mockall complains about AsRef... so we use String here
+    /// Get several key-values by keys.
     async fn mget_kv(&self, keys: &[String]) -> Result<MGetKVReply, KVAppError>;
 
+    /// List key-value records that are starts with the specified prefix.
     async fn prefix_list_kv(&self, prefix: &str) -> Result<ListKVReply, KVAppError>;
 
+    /// Run transaction: update one or more records if specified conditions are met.
     async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, KVAppError>;
 }
 
 #[async_trait]
 impl<U: KVApi, T: Deref<Target = U> + Send + Sync> KVApi for T {
+    type Error = U::Error;
+
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         self.deref().upsert_kv(act).await
     }
@@ -107,11 +122,15 @@ impl<U: KVApi, T: Deref<Target = U> + Send + Sync> KVApi for T {
 }
 
 pub trait AsKVApi {
-    fn as_kv_api(&self) -> &dyn KVApi;
+    type Error: std::error::Error;
+
+    fn as_kv_api(&self) -> &dyn KVApi<Error = Self::Error>;
 }
 
 impl<T: KVApi> AsKVApi for T {
-    fn as_kv_api(&self) -> &dyn KVApi {
+    type Error = T::Error;
+
+    fn as_kv_api(&self) -> &dyn KVApi<Error = Self::Error> {
         self
     }
 }

--- a/src/meta/client/src/kv_api_impl.rs
+++ b/src/meta/client/src/kv_api_impl.rs
@@ -30,6 +30,7 @@ use crate::MetaGrpcClient;
 
 #[tonic::async_trait]
 impl KVApi for MetaGrpcClient {
+    type Error = KVAppError;
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         let reply = self.kv_api(act).await?;
         Ok(reply)
@@ -67,6 +68,8 @@ impl KVApi for MetaGrpcClient {
 
 #[tonic::async_trait]
 impl KVApi for ClientHandle {
+    type Error = KVAppError;
+
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         let reply = self.request(act).await?;
         Ok(reply)

--- a/src/meta/embedded/src/kv_api_impl.rs
+++ b/src/meta/embedded/src/kv_api_impl.rs
@@ -28,6 +28,7 @@ use crate::MetaEmbedded;
 
 #[async_trait]
 impl KVApi for MetaEmbedded {
+    type Error = KVAppError;
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         let sm = self.inner.lock().await;
         sm.upsert_kv(act).await

--- a/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
+++ b/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
@@ -30,6 +30,8 @@ use crate::state_machine::StateMachine;
 
 #[async_trait::async_trait]
 impl KVApi for StateMachine {
+    type Error = KVAppError;
+
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         let cmd = Cmd::UpsertKV(UpsertKV {
             key: act.key,
@@ -57,6 +59,7 @@ impl KVApi for StateMachine {
         let cmd = Cmd::Transaction(txn);
 
         let res = self.sm_tree.txn(true, |mut txn_sled_tree| {
+            // TODO(xp): unwrap???
             let r = self
                 .apply_cmd(&cmd, &mut txn_sled_tree, None, SeqV::<()>::now_ms())
                 .unwrap();

--- a/src/meta/service/src/meta_service/meta_node_kv_api_impl.rs
+++ b/src/meta/service/src/meta_service/meta_node_kv_api_impl.rs
@@ -40,6 +40,8 @@ use crate::meta_service::MetaNode;
 /// E.g. Read is not guaranteed to see a write.
 #[async_trait]
 impl KVApi for MetaNode {
+    type Error = KVAppError;
+
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         let ent = LogEntry {
             txid: None,

--- a/src/meta/store/src/lib.rs
+++ b/src/meta/store/src/lib.rs
@@ -69,6 +69,8 @@ impl MetaStore {
 
 #[async_trait::async_trait]
 impl KVApi for MetaStore {
+    type Error = KVAppError;
+
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         match self {
             MetaStore::L(x) => x.upsert_kv(act).await,

--- a/src/query/management/src/quota/quota_mgr.rs
+++ b/src/query/management/src/quota/quota_mgr.rs
@@ -19,6 +19,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_api::KVApi;
 use common_meta_types::IntoSeqV;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::Operation;
@@ -31,12 +32,12 @@ use super::quota_api::QuotaApi;
 static QUOTA_API_KEY_PREFIX: &str = "__fd_quotas";
 
 pub struct QuotaMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     key: String,
 }
 
 impl QuotaMgr {
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while quota mgr create)",

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -20,6 +20,7 @@ use common_exception::ToErrorCode;
 use common_meta_api::KVApi;
 use common_meta_types::GrantObject;
 use common_meta_types::IntoSeqV;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::Operation;
@@ -33,12 +34,12 @@ use crate::role::role_api::RoleApi;
 static ROLE_API_KEY_PREFIX: &str = "__fd_roles";
 
 pub struct RoleMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     role_prefix: String,
 }
 
 impl RoleMgr {
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while role mgr create)",

--- a/src/query/management/src/setting/setting_mgr.rs
+++ b/src/query/management/src/setting/setting_mgr.rs
@@ -18,6 +18,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_api::KVApi;
 use common_meta_types::IntoSeqV;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::Operation;
@@ -30,13 +31,13 @@ use crate::setting::SettingApi;
 static USER_SETTING_API_KEY_PREFIX: &str = "__fd_settings";
 
 pub struct SettingMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     setting_prefix: String,
 }
 
 impl SettingMgr {
     #[allow(dead_code)]
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         Ok(SettingMgr {
             kv_api,
             setting_prefix: format!("{}/{}", USER_SETTING_API_KEY_PREFIX, tenant),

--- a/src/query/management/src/stage/stage_mgr.rs
+++ b/src/query/management/src/stage/stage_mgr.rs
@@ -23,6 +23,7 @@ use common_meta_api::txn_op_put;
 use common_meta_api::KVApi;
 use common_meta_types::errors::app_error::TxnRetryMaxTimes;
 use common_meta_types::ConditionResult::Eq;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::MetaError;
@@ -43,13 +44,13 @@ static STAGE_FILE_API_KEY_PREFIX: &str = "__fd_stage_files";
 const TXN_MAX_RETRY_TIMES: u32 = 10;
 
 pub struct StageMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     stage_prefix: String,
     stage_file_prefix: String,
 }
 
 impl StageMgr {
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while role mgr create)",

--- a/src/query/management/src/udf/udf_mgr.rs
+++ b/src/query/management/src/udf/udf_mgr.rs
@@ -20,6 +20,7 @@ use common_exception::Result;
 use common_functions::is_builtin_function;
 use common_meta_api::KVApi;
 use common_meta_types::IntoSeqV;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::Operation;
@@ -32,12 +33,12 @@ use crate::udf::UdfApi;
 static UDF_API_KEY_PREFIX: &str = "__fd_udfs";
 
 pub struct UdfMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     udf_prefix: String,
 }
 
 impl UdfMgr {
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while udf mgr create)",

--- a/src/query/management/src/user/user_mgr.rs
+++ b/src/query/management/src/user/user_mgr.rs
@@ -20,6 +20,7 @@ use common_exception::Result;
 use common_meta_api::KVApi;
 use common_meta_types::AuthInfo;
 use common_meta_types::GrantObject;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::Operation;
@@ -37,12 +38,12 @@ use crate::user::user_api::UserApi;
 static USER_API_KEY_PREFIX: &str = "__fd_users";
 
 pub struct UserMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     user_prefix: String,
 }
 
 impl UserMgr {
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while user mgr create)",

--- a/src/query/management/tests/it/user.rs
+++ b/src/query/management/tests/it/user.rs
@@ -42,6 +42,8 @@ mock! {
     pub KV {}
     #[async_trait]
     impl KVApi for KV {
+        type Error = KVAppError;
+
         async fn upsert_kv(
             &self,
             act: UpsertKVReq,

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -33,13 +33,14 @@ use common_meta_api::KVApi;
 use common_meta_store::MetaStore;
 use common_meta_store::MetaStoreProvider;
 use common_meta_types::AuthInfo;
+use common_meta_types::KVAppError;
 use common_meta_types::TenantQuota;
 
 use crate::idm_config::IDMConfig;
 
 pub struct UserApiProvider {
     meta: MetaStore,
-    client: Arc<dyn KVApi>,
+    client: Arc<dyn KVApi<Error = KVAppError>>,
     idm_config: IDMConfig,
 }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/kvapi): KVApi should have an associated error type

Implementations have their own error defined to fit their needs.
E.g., a remove KVApi impl returns network error or remote storage error.
A local KVApi impl just returns storage error.

## Changelog







## Related Issues