### PR TITLE
chore(jemalloc): background_thread:true,metadata_thp:auto

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [env]
-JEMALLOC_SYS_WITH_MALLOC_CONF = "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000"
+# https://android.googlesource.com/platform/external/jemalloc_new/+/refs/heads/master/TUNING.md
+JEMALLOC_SYS_WITH_MALLOC_CONF = "percpu_arena:percpu,oversize_threshold:0,background_thread:true,metadata_thp:auto,dirty_decay_ms:5000,muzzy_decay_ms:5000"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Enable `background_thread:true,metadata_thp:auto` to purge unused memory shifted to the dedicated background threads, making the memory return to OS faster.

![image](https://user-images.githubusercontent.com/172204/215373246-8721876b-5bc8-4807-a4fd-c6b6294f2d32.png)



Closes #9775 
