### PR TITLE
refactor: remove unnecessary column data copy

### DIFF
--- a/src/query/storages/fuse/src/io/read/block/block_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_parquet.rs
@@ -63,13 +63,13 @@ impl BlockReader {
         let chunks = read_res
             .columns_chunks()?
             .into_iter()
-            .map(|(column_idx, column_chunk)| (column_idx, column_chunk.to_vec()))
+            .map(|(column_idx, column_chunk)| (column_idx, column_chunk))
             .collect::<Vec<_>>();
 
         let num_rows = meta.row_count as usize;
         let columns_chunk = chunks
             .iter()
-            .map(|(index, chunk)| (*index, chunk.as_slice()))
+            .map(|(index, chunk)| (*index, *chunk))
             .collect::<Vec<_>>();
 
         self.deserialize_parquet_chunks_with_buffer(
@@ -85,7 +85,7 @@ impl BlockReader {
     pub fn deserialize_parquet_chunks(
         &self,
         part: PartInfoPtr,
-        chunks: Vec<(usize, Vec<u8>)>,
+        chunks: Vec<(usize, &[u8])>,
     ) -> Result<DataBlock> {
         let part = FusePartInfo::from_part(&part)?;
         let start = Instant::now();
@@ -96,7 +96,7 @@ impl BlockReader {
 
         let reads = chunks
             .iter()
-            .map(|(index, chunk)| (*index, chunk.as_slice()))
+            .map(|(index, chunk)| (*index, *chunk))
             .collect::<Vec<_>>();
 
         let deserialized_res = self.deserialize_parquet_chunks_with_buffer(

--- a/src/query/storages/fuse/src/operations/mutation/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutation_source.rs
@@ -45,8 +45,7 @@ use crate::pipelines::processors::port::OutputPort;
 use crate::pipelines::processors::processor::Event;
 use crate::pipelines::processors::processor::ProcessorPtr;
 use crate::pipelines::processors::Processor;
-
-type DataChunks = Vec<(usize, Vec<u8>)>;
+use crate::MergeIOReadResult;
 
 pub enum MutationAction {
     Deletion,
@@ -55,7 +54,7 @@ pub enum MutationAction {
 
 enum State {
     ReadData(Option<PartInfoPtr>),
-    FilterData(PartInfoPtr, DataChunks),
+    FilterData(PartInfoPtr, MergeIOReadResult),
     ReadRemain {
         part: PartInfoPtr,
         data_block: DataBlock,
@@ -63,7 +62,7 @@ enum State {
     },
     MergeRemain {
         part: PartInfoPtr,
-        chunks: DataChunks,
+        chunks: MergeIOReadResult,
         data_block: DataBlock,
         filter: Value<AnyType>,
     },
@@ -170,7 +169,12 @@ impl Processor for MutationSource {
 
     fn process(&mut self) -> Result<()> {
         match std::mem::replace(&mut self.state, State::Finish) {
-            State::FilterData(part, chunks) => {
+            State::FilterData(part, read_res) => {
+                let chunks = read_res
+                    .columns_chunks()?
+                    .into_iter()
+                    .map(|(column_idx, column_chunk)| (column_idx, column_chunk))
+                    .collect::<Vec<_>>();
                 let mut data_block = self
                     .block_reader
                     .deserialize_parquet_chunks(part.clone(), chunks)?;
@@ -273,6 +277,12 @@ impl Processor for MutationSource {
                 filter,
             } => {
                 if let Some(remain_reader) = self.remain_reader.as_ref() {
+                    let chunks = chunks
+                        .columns_chunks()?
+                        .into_iter()
+                        .map(|(column_idx, column_chunk)| (column_idx, column_chunk))
+                        .collect::<Vec<_>>();
+
                     let remain_block = remain_reader.deserialize_parquet_chunks(part, chunks)?;
 
                     match self.action {
@@ -330,12 +340,7 @@ impl Processor for MutationSource {
                         &fuse_part.columns_meta,
                     )
                     .await?;
-                let chunks = read_res
-                    .columns_chunks()?
-                    .into_iter()
-                    .map(|(column_idx, column_chunk)| (column_idx, column_chunk.to_vec()))
-                    .collect::<Vec<_>>();
-                self.state = State::FilterData(inner_part, chunks);
+                self.state = State::FilterData(inner_part, read_res);
             }
             State::ReadRemain {
                 part,
@@ -353,15 +358,9 @@ impl Processor for MutationSource {
                             &fuse_part.columns_meta,
                         )
                         .await?;
-                    let chunks = read_res
-                        .columns_chunks()?
-                        .into_iter()
-                        .map(|(column_idx, column_chunk)| (column_idx, column_chunk.to_vec()))
-                        .collect::<Vec<_>>();
-
                     self.state = State::MergeRemain {
                         part,
-                        chunks,
+                        chunks: read_res,
                         data_block,
                         filter,
                     };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

remove unnecessary column data copy in

- BlockReader::read_parquet_by_meta
- MutationSource

Closes #issue
