### PR TITLE
refactor(meta/kvapi): KVApi should have an associated error type

### DIFF
--- a/src/binaries/meta/kvapi.rs
+++ b/src/binaries/meta/kvapi.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use common_meta_api::KVApi;
+use common_meta_types::KVAppError;
 use common_meta_types::KVMeta;
 use common_meta_types::SeqV;
 use common_meta_types::UpsertKVReq;
@@ -69,7 +70,10 @@ impl KvApiCommand {
         Ok(api)
     }
 
-    pub async fn execute(&self, client: Arc<dyn KVApi>) -> anyhow::Result<String> {
+    pub async fn execute(
+        &self,
+        client: Arc<dyn KVApi<Error = KVAppError>>,
+    ) -> anyhow::Result<String> {
         let res_str = match self {
             KvApiCommand::Get(key) => {
                 let res = client.get_kv(key.as_str()).await?;

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -143,7 +143,7 @@ const DEFAULT_DATA_RETENTION_SECONDS: i64 = 24 * 60 * 60;
 /// SchemaApi is implemented upon KVApi.
 /// Thus every type that impl KVApi impls SchemaApi.
 #[tonic::async_trait]
-impl<KV: KVApi> SchemaApi for KV {
+impl<KV: KVApi<Error = KVAppError>> SchemaApi for KV {
     #[tracing::instrument(level = "debug", ret, err, skip_all)]
     async fn create_database(
         &self,
@@ -2190,7 +2190,7 @@ impl<KV: KVApi> SchemaApi for KV {
 }
 
 async fn remove_table_copied_files(
-    kv_api: &impl KVApi,
+    kv_api: &impl KVApi<Error = KVAppError>,
     table_id: u64,
     condition: &mut Vec<TxnCondition>,
     if_then: &mut Vec<TxnOp>,
@@ -2220,7 +2220,7 @@ async fn remove_table_copied_files(
 }
 
 async fn gc_dropped_table(
-    kv_api: &impl KVApi,
+    kv_api: &impl KVApi<Error = KVAppError>,
     tenant: String,
     at_least: u32,
 ) -> Result<u32, KVAppError> {
@@ -2351,7 +2351,7 @@ async fn gc_dropped_table(
 }
 
 async fn remove_db_id_from_share(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     db_id: u64,
     from_share: ShareNameIdent,
     condition: &mut Vec<TxnCondition>,
@@ -2377,8 +2377,7 @@ async fn remove_db_id_from_share(
 }
 
 async fn gc_dropped_db(
-    // kv_api: &impl KVApi,
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     tenant: String,
     at_least: u32,
 ) -> Result<u32, KVAppError> {
@@ -2486,7 +2485,7 @@ fn is_drop_time_out_of_retention_time(
 
 /// Returns (db_id_seq, db_id, db_meta_seq, db_meta)
 pub(crate) async fn get_db_or_err(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     name_key: &DatabaseNameIdent,
     msg: impl Display,
 ) -> Result<(u64, u64, u64, DatabaseMeta), KVAppError> {
@@ -2549,7 +2548,10 @@ fn table_has_to_not_exist(
 ///
 /// It returns (seq, `u64` value).
 /// If the count value is not in the kv space, (0, `u64` value) is returned.
-async fn count_tables(kv_api: &impl KVApi, key: &CountTablesKey) -> Result<u64, KVAppError> {
+async fn count_tables(
+    kv_api: &impl KVApi<Error = KVAppError>,
+    key: &CountTablesKey,
+) -> Result<u64, KVAppError> {
     // For backward compatibility:
     // If the table count of a tenant is not found in kv space,,
     // we should compute the count by listing all tables of the tenant.
@@ -2571,7 +2573,7 @@ async fn count_tables(kv_api: &impl KVApi, key: &CountTablesKey) -> Result<u64, 
 }
 
 async fn get_table_id_from_share_by_name(
-    kv_api: &impl KVApi,
+    kv_api: &impl KVApi<Error = KVAppError>,
     share: &ShareNameIdent,
     db_id: u64,
     table_name: &String,
@@ -2617,7 +2619,7 @@ async fn get_table_id_from_share_by_name(
 }
 
 async fn get_table_names_by_ids(
-    kv_api: &impl KVApi,
+    kv_api: &impl KVApi<Error = KVAppError>,
     ids: &[u64],
 ) -> Result<Vec<String>, KVAppError> {
     let mut table_names = vec![];
@@ -2640,7 +2642,7 @@ async fn get_table_names_by_ids(
 }
 
 async fn get_tableinfos_by_ids(
-    kv_api: &impl KVApi,
+    kv_api: &impl KVApi<Error = KVAppError>,
     ids: &[u64],
     tenant_dbname: &DatabaseNameIdent,
     dbid_tbnames_opt: Option<Vec<DBIdTableName>>,
@@ -2697,7 +2699,7 @@ async fn get_tableinfos_by_ids(
 }
 
 async fn list_tables_from_unshare_db(
-    kv_api: &impl KVApi,
+    kv_api: &impl KVApi<Error = KVAppError>,
     db_id: u64,
     tenant_dbname: &DatabaseNameIdent,
 ) -> Result<Vec<Arc<TableInfo>>, KVAppError> {
@@ -2722,7 +2724,7 @@ async fn list_tables_from_unshare_db(
 }
 
 async fn list_tables_from_share_db(
-    kv_api: &impl KVApi,
+    kv_api: &impl KVApi<Error = KVAppError>,
     share: ShareNameIdent,
     db_id: u64,
     tenant_dbname: &DatabaseNameIdent,

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -177,7 +177,7 @@ fn calc_and_compare_drop_on_table_result(result: Vec<Arc<TableInfo>>, expected: 
 }
 
 async fn upsert_test_data(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     key: &impl KVApiKey,
     value: Vec<u8>,
 ) -> Result<u64, KVAppError> {
@@ -195,7 +195,7 @@ async fn upsert_test_data(
 }
 
 async fn delete_test_data(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     key: &impl KVApiKey,
 ) -> Result<(), KVAppError> {
     let _res = kv_api
@@ -215,7 +215,7 @@ impl SchemaApiTestSuite {
     pub async fn test_single_node<B, MT>(b: B) -> anyhow::Result<()>
     where
         B: ApiBuilder<MT>,
-        MT: ShareApi + AsKVApi + SchemaApi,
+        MT: ShareApi + AsKVApi<Error = KVAppError> + SchemaApi,
     {
         let suite = SchemaApiTestSuite {};
 
@@ -322,7 +322,7 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn database_and_table_rename<MT: SchemaApi + AsKVApi>(
+    async fn database_and_table_rename<MT: SchemaApi + AsKVApi<Error = KVAppError>>(
         &self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -637,7 +637,9 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn database_create_from_share_and_drop<MT: ShareApi + AsKVApi + SchemaApi>(
+    async fn database_create_from_share_and_drop<
+        MT: ShareApi + AsKVApi<Error = KVAppError> + SchemaApi,
+    >(
         &self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -2236,7 +2238,9 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn database_drop_out_of_retention_time_history<MT: SchemaApi + AsKVApi>(
+    async fn database_drop_out_of_retention_time_history<
+        MT: SchemaApi + AsKVApi<Error = KVAppError>,
+    >(
         self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -2298,7 +2302,7 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn create_out_of_retention_time_db<MT: SchemaApi + AsKVApi>(
+    async fn create_out_of_retention_time_db<MT: SchemaApi + AsKVApi<Error = KVAppError>>(
         self,
         mt: &MT,
         db_name: DatabaseNameIdent,
@@ -2335,7 +2339,7 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn database_gc_out_of_retention_time<MT: SchemaApi + AsKVApi>(
+    async fn database_gc_out_of_retention_time<MT: SchemaApi + AsKVApi<Error = KVAppError>>(
         self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -2418,7 +2422,7 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn create_out_of_retention_time_table<MT: SchemaApi + AsKVApi>(
+    async fn create_out_of_retention_time_table<MT: SchemaApi + AsKVApi<Error = KVAppError>>(
         self,
         mt: &MT,
         name_ident: TableNameIdent,
@@ -2470,7 +2474,7 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn table_gc_out_of_retention_time<MT: SchemaApi + AsKVApi>(
+    async fn table_gc_out_of_retention_time<MT: SchemaApi + AsKVApi<Error = KVAppError>>(
         self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -2604,7 +2608,9 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn table_drop_out_of_retention_time_history<MT: SchemaApi + AsKVApi>(
+    async fn table_drop_out_of_retention_time_history<
+        MT: SchemaApi + AsKVApi<Error = KVAppError>,
+    >(
         self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -3398,7 +3404,7 @@ impl SchemaApiTestSuite {
         Ok(())
     }
 
-    async fn get_tables_from_share<MT: ShareApi + AsKVApi + SchemaApi>(
+    async fn get_tables_from_share<MT: ShareApi + AsKVApi<Error = KVAppError> + SchemaApi>(
         &self,
         mt: &MT,
     ) -> anyhow::Result<()> {

--- a/src/meta/api/src/share_api_impl.rs
+++ b/src/meta/api/src/share_api_impl.rs
@@ -65,7 +65,7 @@ use crate::TXN_MAX_RETRY_TIMES;
 /// ShareApi is implemented upon KVApi.
 /// Thus every type that impl KVApi impls ShareApi.
 #[async_trait::async_trait]
-impl<KV: KVApi> ShareApi for KV {
+impl<KV: KVApi<Error = KVAppError>> ShareApi for KV {
     #[tracing::instrument(level = "debug", ret, err, skip_all)]
     async fn show_shares(&self, req: ShowSharesReq) -> Result<ShowSharesReply, KVAppError> {
         debug!(req = debug(&req), "ShareApi: {}", func_name!());
@@ -947,7 +947,7 @@ impl<KV: KVApi> ShareApi for KV {
 }
 
 async fn get_share_database_name(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     share_meta: &ShareMeta,
     share_name: &ShareNameIdent,
 ) -> Result<Option<String>, KVAppError> {
@@ -974,7 +974,7 @@ async fn get_share_database_name(
 }
 
 async fn get_outbound_share_tenants_by_name(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     share_name: &ShareNameIdent,
 ) -> Result<Vec<GetShareGrantTenants>, KVAppError> {
     let res = get_share_or_err(kv_api, share_name, format!("get_share: {share_name}")).await?;
@@ -1004,7 +1004,7 @@ async fn get_outbound_share_tenants_by_name(
 }
 
 async fn get_outbound_share_info_by_name(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     share_name: &ShareNameIdent,
 ) -> Result<ShareAccountReply, KVAppError> {
     let res = get_share_or_err(
@@ -1032,7 +1032,7 @@ async fn get_outbound_share_info_by_name(
 }
 
 async fn get_outbound_share_infos_by_tenant(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     tenant: &str,
 ) -> Result<Vec<ShareAccountReply>, KVAppError> {
     let mut outbound_share_accounts: Vec<ShareAccountReply> = vec![];
@@ -1054,7 +1054,7 @@ async fn get_outbound_share_infos_by_tenant(
 }
 
 async fn get_inbound_share_info_by_tenant(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     tenant: &String,
     share_account: ShareAccountNameIdent,
 ) -> Result<ShareAccountReply, KVAppError> {
@@ -1098,7 +1098,7 @@ async fn get_inbound_share_info_by_tenant(
 }
 
 async fn get_inbound_share_infos_by_tenant(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     tenant: &String,
 ) -> Result<Vec<ShareAccountReply>, KVAppError> {
     let mut inbound_share_accounts: Vec<ShareAccountReply> = vec![];
@@ -1119,7 +1119,7 @@ async fn get_inbound_share_infos_by_tenant(
 }
 
 async fn get_object_name_from_id(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     database_name: &Option<&String>,
     object: ShareGrantObject,
 ) -> Result<Option<ShareGrantObjectName>, KVAppError> {
@@ -1149,7 +1149,7 @@ async fn get_object_name_from_id(
 }
 
 async fn create_db_name_to_id_key_if_need(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     seq_and_id: &ShareGrantObjectSeqAndId,
     tenant: &str,
     obj_name: &ShareGrantObjectName,
@@ -1208,7 +1208,7 @@ fn check_share_object(
 
 /// Returns ShareGrantObjectSeqAndId by ShareGrantObjectName
 async fn get_share_object_seq_and_id(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     obj_name: &ShareGrantObjectName,
     tenant: &str,
 ) -> Result<ShareGrantObjectSeqAndId, KVAppError> {
@@ -1319,7 +1319,7 @@ fn add_grant_object_txn_if_then(
 }
 
 async fn drop_accounts_granted_from_share(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     share_id: u64,
     share_meta: &ShareMeta,
     condition: &mut Vec<TxnCondition>,
@@ -1348,7 +1348,7 @@ async fn drop_accounts_granted_from_share(
 }
 
 async fn remove_share_id_from_share_object(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     share_id: u64,
     entry: &ShareGrantEntry,
     condition: &mut Vec<TxnCondition>,
@@ -1364,7 +1364,7 @@ async fn remove_share_id_from_share_object(
 }
 
 async fn remove_share_id_from_share_objects(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     share_id: u64,
     share_meta: &ShareMeta,
     condition: &mut Vec<TxnCondition>,
@@ -1382,7 +1382,7 @@ async fn remove_share_id_from_share_objects(
 }
 
 async fn drop_all_database_from_share(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     _share_id: u64,
     share_meta: &ShareMeta,
     condition: &mut Vec<TxnCondition>,
@@ -1395,7 +1395,7 @@ async fn drop_all_database_from_share(
 }
 
 async fn get_tenant_share_spec_vec(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     tenant: String,
 ) -> Result<Vec<ShareSpec>, KVAppError> {
     let mut share_metas = vec![];
@@ -1439,7 +1439,7 @@ async fn get_tenant_share_spec_vec(
 }
 
 async fn convert_share_meta_to_spec(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     share_name: &str,
     share_id: u64,
     share_meta: ShareMeta,

--- a/src/meta/api/src/share_api_test_suite.rs
+++ b/src/meta/api/src/share_api_test_suite.rs
@@ -47,7 +47,7 @@ use crate::ShareApi;
 pub struct ShareApiTestSuite {}
 
 async fn if_share_object_data_exists(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     entry: &ShareGrantEntry,
 ) -> Result<bool, KVAppError> {
     if let Ok((_seq, _share_ids)) = get_object_shared_by_share_ids(kv_api, &entry.object).await {
@@ -58,7 +58,7 @@ async fn if_share_object_data_exists(
 
 // Return true if all the share data has been removed.
 async fn is_all_share_data_removed(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     share_name: &ShareNameIdent,
     share_id: u64,
     share_meta: &ShareMeta,
@@ -110,7 +110,7 @@ impl ShareApiTestSuite {
     pub async fn test_single_node_share<B, MT>(b: B) -> anyhow::Result<()>
     where
         B: ApiBuilder<MT>,
-        MT: ShareApi + AsKVApi + SchemaApi,
+        MT: ShareApi + AsKVApi<Error = KVAppError> + SchemaApi,
     {
         let suite = ShareApiTestSuite {};
 
@@ -126,7 +126,10 @@ impl ShareApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn share_create_show_drop<MT: ShareApi + AsKVApi>(&self, mt: &MT) -> anyhow::Result<()> {
+    async fn share_create_show_drop<MT: ShareApi + AsKVApi<Error = KVAppError>>(
+        &self,
+        mt: &MT,
+    ) -> anyhow::Result<()> {
         let tenant = "tenant1";
         let share1 = "share1";
         let share_name = ShareNameIdent {
@@ -190,7 +193,7 @@ impl ShareApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn share_add_remove_account<MT: ShareApi + AsKVApi>(
+    async fn share_add_remove_account<MT: ShareApi + AsKVApi<Error = KVAppError>>(
         &self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -483,7 +486,7 @@ impl ShareApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn share_grant_revoke_object<MT: ShareApi + AsKVApi + SchemaApi>(
+    async fn share_grant_revoke_object<MT: ShareApi + AsKVApi<Error = KVAppError> + SchemaApi>(
         &self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -824,7 +827,7 @@ impl ShareApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn get_share_grant_objects<MT: ShareApi + AsKVApi + SchemaApi>(
+    async fn get_share_grant_objects<MT: ShareApi + AsKVApi<Error = KVAppError> + SchemaApi>(
         &self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -952,7 +955,9 @@ impl ShareApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn get_grant_privileges_of_object<MT: ShareApi + AsKVApi + SchemaApi>(
+    async fn get_grant_privileges_of_object<
+        MT: ShareApi + AsKVApi<Error = KVAppError> + SchemaApi,
+    >(
         &self,
         mt: &MT,
     ) -> anyhow::Result<()> {

--- a/src/meta/api/src/testing.rs
+++ b/src/meta/api/src/testing.rs
@@ -27,7 +27,7 @@ use crate::KVApiKey;
 
 /// Get existing value by key. Panic if key is absent.
 pub(crate) async fn get_kv_data<T>(
-    kv_api: &(impl KVApi + ?Sized),
+    kv_api: &(impl KVApi<Error = KVAppError> + ?Sized),
     key: &impl KVApiKey,
 ) -> Result<T, KVAppError>
 where

--- a/src/meta/client/src/kv_api_impl.rs
+++ b/src/meta/client/src/kv_api_impl.rs
@@ -30,6 +30,7 @@ use crate::MetaGrpcClient;
 
 #[tonic::async_trait]
 impl KVApi for MetaGrpcClient {
+    type Error = KVAppError;
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         let reply = self.kv_api(act).await?;
         Ok(reply)
@@ -67,6 +68,8 @@ impl KVApi for MetaGrpcClient {
 
 #[tonic::async_trait]
 impl KVApi for ClientHandle {
+    type Error = KVAppError;
+
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         let reply = self.request(act).await?;
         Ok(reply)

--- a/src/meta/embedded/src/kv_api_impl.rs
+++ b/src/meta/embedded/src/kv_api_impl.rs
@@ -28,6 +28,7 @@ use crate::MetaEmbedded;
 
 #[async_trait]
 impl KVApi for MetaEmbedded {
+    type Error = KVAppError;
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         let sm = self.inner.lock().await;
         sm.upsert_kv(act).await

--- a/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
+++ b/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
@@ -30,6 +30,8 @@ use crate::state_machine::StateMachine;
 
 #[async_trait::async_trait]
 impl KVApi for StateMachine {
+    type Error = KVAppError;
+
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         let cmd = Cmd::UpsertKV(UpsertKV {
             key: act.key,
@@ -57,6 +59,7 @@ impl KVApi for StateMachine {
         let cmd = Cmd::Transaction(txn);
 
         let res = self.sm_tree.txn(true, |mut txn_sled_tree| {
+            // TODO(xp): unwrap???
             let r = self
                 .apply_cmd(&cmd, &mut txn_sled_tree, None, SeqV::<()>::now_ms())
                 .unwrap();

--- a/src/meta/service/src/meta_service/meta_node_kv_api_impl.rs
+++ b/src/meta/service/src/meta_service/meta_node_kv_api_impl.rs
@@ -40,6 +40,8 @@ use crate::meta_service::MetaNode;
 /// E.g. Read is not guaranteed to see a write.
 #[async_trait]
 impl KVApi for MetaNode {
+    type Error = KVAppError;
+
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         let ent = LogEntry {
             txid: None,

--- a/src/meta/store/src/lib.rs
+++ b/src/meta/store/src/lib.rs
@@ -69,6 +69,8 @@ impl MetaStore {
 
 #[async_trait::async_trait]
 impl KVApi for MetaStore {
+    type Error = KVAppError;
+
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
         match self {
             MetaStore::L(x) => x.upsert_kv(act).await,

--- a/src/query/management/src/quota/quota_mgr.rs
+++ b/src/query/management/src/quota/quota_mgr.rs
@@ -19,6 +19,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_api::KVApi;
 use common_meta_types::IntoSeqV;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::Operation;
@@ -31,12 +32,12 @@ use super::quota_api::QuotaApi;
 static QUOTA_API_KEY_PREFIX: &str = "__fd_quotas";
 
 pub struct QuotaMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     key: String,
 }
 
 impl QuotaMgr {
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while quota mgr create)",

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -20,6 +20,7 @@ use common_exception::ToErrorCode;
 use common_meta_api::KVApi;
 use common_meta_types::GrantObject;
 use common_meta_types::IntoSeqV;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::Operation;
@@ -33,12 +34,12 @@ use crate::role::role_api::RoleApi;
 static ROLE_API_KEY_PREFIX: &str = "__fd_roles";
 
 pub struct RoleMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     role_prefix: String,
 }
 
 impl RoleMgr {
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while role mgr create)",

--- a/src/query/management/src/setting/setting_mgr.rs
+++ b/src/query/management/src/setting/setting_mgr.rs
@@ -18,6 +18,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_api::KVApi;
 use common_meta_types::IntoSeqV;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::Operation;
@@ -30,13 +31,13 @@ use crate::setting::SettingApi;
 static USER_SETTING_API_KEY_PREFIX: &str = "__fd_settings";
 
 pub struct SettingMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     setting_prefix: String,
 }
 
 impl SettingMgr {
     #[allow(dead_code)]
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         Ok(SettingMgr {
             kv_api,
             setting_prefix: format!("{}/{}", USER_SETTING_API_KEY_PREFIX, tenant),

--- a/src/query/management/src/stage/stage_mgr.rs
+++ b/src/query/management/src/stage/stage_mgr.rs
@@ -23,6 +23,7 @@ use common_meta_api::txn_op_put;
 use common_meta_api::KVApi;
 use common_meta_types::errors::app_error::TxnRetryMaxTimes;
 use common_meta_types::ConditionResult::Eq;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::MetaError;
@@ -43,13 +44,13 @@ static STAGE_FILE_API_KEY_PREFIX: &str = "__fd_stage_files";
 const TXN_MAX_RETRY_TIMES: u32 = 10;
 
 pub struct StageMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     stage_prefix: String,
     stage_file_prefix: String,
 }
 
 impl StageMgr {
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while role mgr create)",

--- a/src/query/management/src/udf/udf_mgr.rs
+++ b/src/query/management/src/udf/udf_mgr.rs
@@ -20,6 +20,7 @@ use common_exception::Result;
 use common_functions::is_builtin_function;
 use common_meta_api::KVApi;
 use common_meta_types::IntoSeqV;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::Operation;
@@ -32,12 +33,12 @@ use crate::udf::UdfApi;
 static UDF_API_KEY_PREFIX: &str = "__fd_udfs";
 
 pub struct UdfMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     udf_prefix: String,
 }
 
 impl UdfMgr {
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while udf mgr create)",

--- a/src/query/management/src/user/user_mgr.rs
+++ b/src/query/management/src/user/user_mgr.rs
@@ -20,6 +20,7 @@ use common_exception::Result;
 use common_meta_api::KVApi;
 use common_meta_types::AuthInfo;
 use common_meta_types::GrantObject;
+use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::Operation;
@@ -37,12 +38,12 @@ use crate::user::user_api::UserApi;
 static USER_API_KEY_PREFIX: &str = "__fd_users";
 
 pub struct UserMgr {
-    kv_api: Arc<dyn KVApi>,
+    kv_api: Arc<dyn KVApi<Error = KVAppError>>,
     user_prefix: String,
 }
 
 impl UserMgr {
-    pub fn create(kv_api: Arc<dyn KVApi>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while user mgr create)",

--- a/src/query/management/tests/it/user.rs
+++ b/src/query/management/tests/it/user.rs
@@ -42,6 +42,8 @@ mock! {
     pub KV {}
     #[async_trait]
     impl KVApi for KV {
+        type Error = KVAppError;
+
         async fn upsert_kv(
             &self,
             act: UpsertKVReq,

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -33,13 +33,14 @@ use common_meta_api::KVApi;
 use common_meta_store::MetaStore;
 use common_meta_store::MetaStoreProvider;
 use common_meta_types::AuthInfo;
+use common_meta_types::KVAppError;
 use common_meta_types::TenantQuota;
 
 use crate::idm_config::IDMConfig;
 
 pub struct UserApiProvider {
     meta: MetaStore,
-    client: Arc<dyn KVApi>,
+    client: Arc<dyn KVApi<Error = KVAppError>>,
     idm_config: IDMConfig,
 }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/kvapi): KVApi should have an associated error type

Implementations have their own error defined to fit their needs.
E.g., a remove KVApi impl returns network error or remote storage error.
A local KVApi impl just returns storage error.

## Changelog







## Related Issues