### PR TITLE
chore(meta): rename KVApiKey::to_key/from_key to to_string/from_str

### DIFF
--- a/src/meta/api/src/id_generator.rs
+++ b/src/meta/api/src/id_generator.rs
@@ -59,11 +59,11 @@ impl IdGenerator {
 impl KVApiKey for IdGenerator {
     const PREFIX: &'static str = PREFIX_ID_GEN;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!("{}/{}", Self::PREFIX, self.resource)
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -89,30 +89,30 @@ mod t {
         // Table id generator
         {
             let g = IdGenerator::table_id();
-            let k = g.to_key();
+            let k = g.to_string_key();
             assert_eq!("__fd_id_gen/table_id", k);
 
-            let t2 = IdGenerator::from_key(&k)?;
+            let t2 = IdGenerator::from_str_key(&k)?;
             assert_eq!(g, t2);
         }
 
         // Database id generator
         {
             let g = IdGenerator::database_id();
-            let k = g.to_key();
+            let k = g.to_string_key();
             assert_eq!("__fd_id_gen/database_id", k);
 
-            let t2 = IdGenerator::from_key(&k)?;
+            let t2 = IdGenerator::from_str_key(&k)?;
             assert_eq!(g, t2);
         }
 
         // Share id generator
         {
             let g = IdGenerator::share_id();
-            let k = g.to_key();
+            let k = g.to_string_key();
             assert_eq!("__fd_id_gen/share_id", k);
 
-            let t2 = IdGenerator::from_key(&k)?;
+            let t2 = IdGenerator::from_str_key(&k)?;
             assert_eq!(g, t2);
         }
 
@@ -121,10 +121,10 @@ mod t {
 
     #[test]
     fn test_id_generator_from_key_error() -> anyhow::Result<()> {
-        assert!(IdGenerator::from_key("__fd_id_gen").is_err());
-        assert!(IdGenerator::from_key("__fd_id_gen/foo/bar").is_err());
+        assert!(IdGenerator::from_str_key("__fd_id_gen").is_err());
+        assert!(IdGenerator::from_str_key("__fd_id_gen/foo/bar").is_err());
 
-        assert!(IdGenerator::from_key("__foo/table_id").is_err());
+        assert!(IdGenerator::from_str_key("__foo/table_id").is_err());
         Ok(())
     }
 }

--- a/src/meta/api/src/kv_api_test_suite.rs
+++ b/src/meta/api/src/kv_api_test_suite.rs
@@ -16,6 +16,7 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use common_base::base::tokio;
+use common_meta_types::protobuf as pb;
 use common_meta_types::txn_condition;
 use common_meta_types::txn_op;
 use common_meta_types::txn_op_response;
@@ -23,7 +24,6 @@ use common_meta_types::ConditionResult;
 use common_meta_types::KVMeta;
 use common_meta_types::MatchSeq;
 use common_meta_types::Operation;
-use common_meta_types::PbSeqV;
 use common_meta_types::SeqV;
 use common_meta_types::TxnCondition;
 use common_meta_types::TxnDeleteByPrefixRequest;
@@ -657,7 +657,7 @@ impl KVApiTestSuite {
             let expected: Vec<TxnOpResponse> = vec![TxnOpResponse {
                 response: Some(txn_op_response::Response::Put(TxnPutResponse {
                     key: txn_key.clone(),
-                    prev_value: Some(PbSeqV::from(SeqV::new(1, val1.clone()))),
+                    prev_value: Some(pb::SeqV::from(SeqV::new(1, val1.clone()))),
                 })),
             }];
 
@@ -795,21 +795,21 @@ impl KVApiTestSuite {
                 TxnOpResponse {
                     response: Some(txn_op_response::Response::Put(TxnPutResponse {
                         key: txn_key1.clone(),
-                        prev_value: Some(PbSeqV::from(SeqV::new(4, val1.clone()))),
+                        prev_value: Some(pb::SeqV::from(SeqV::new(4, val1.clone()))),
                     })),
                 },
                 // change k2
                 TxnOpResponse {
                     response: Some(txn_op_response::Response::Put(TxnPutResponse {
                         key: txn_key2.clone(),
-                        prev_value: Some(PbSeqV::from(SeqV::new(5, val2.clone()))),
+                        prev_value: Some(pb::SeqV::from(SeqV::new(5, val2.clone()))),
                     })),
                 },
                 // get k1
                 TxnOpResponse {
                     response: Some(txn_op_response::Response::Get(TxnGetResponse {
                         key: txn_key1.clone(),
-                        value: Some(PbSeqV::from(SeqV::new(6, val1_new.clone()))),
+                        value: Some(pb::SeqV::from(SeqV::new(6, val1_new.clone()))),
                     })),
                 },
                 // delete k1
@@ -817,7 +817,7 @@ impl KVApiTestSuite {
                     response: Some(txn_op_response::Response::Delete(TxnDeleteResponse {
                         key: txn_key1.clone(),
                         success: true,
-                        prev_value: Some(PbSeqV::from(SeqV::new(6, val1_new.clone()))),
+                        prev_value: Some(pb::SeqV::from(SeqV::new(6, val1_new.clone()))),
                     })),
                 },
                 // get k1
@@ -882,14 +882,14 @@ impl KVApiTestSuite {
                 TxnOpResponse {
                     response: Some(txn_op_response::Response::Put(TxnPutResponse {
                         key: txn_key1.clone(),
-                        prev_value: Some(PbSeqV::from(SeqV::new(8, val1.clone()))),
+                        prev_value: Some(pb::SeqV::from(SeqV::new(8, val1.clone()))),
                     })),
                 },
                 // get k1
                 TxnOpResponse {
                     response: Some(txn_op_response::Response::Get(TxnGetResponse {
                         key: txn_key1.clone(),
-                        value: Some(PbSeqV::from(SeqV::new(9, val1_new.clone()))),
+                        value: Some(pb::SeqV::from(SeqV::new(9, val1_new.clone()))),
                     })),
                 },
             ];

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -163,7 +163,7 @@ impl<KV: KVApi<Error = KVAppError>> SchemaApi for KV {
         if let Some(from_share) = &req.meta.from_share {
             if from_share.tenant == req.name_ident.tenant {
                 return Err(KVAppError::AppError(AppError::WrongShare(WrongShare::new(
-                    req.name_ident.to_string(),
+                    req.name_ident.to_string_key(),
                 ))));
             }
         }
@@ -823,7 +823,7 @@ impl<KV: KVApi<Error = KVAppError>> SchemaApi for KV {
         let mut kv_keys = Vec::with_capacity(db_ids.len());
 
         for db_id in db_ids.iter() {
-            let k = DatabaseId { db_id: *db_id }.to_key();
+            let k = DatabaseId { db_id: *db_id }.to_string_key();
             kv_keys.push(k);
         }
 
@@ -1032,7 +1032,7 @@ impl<KV: KVApi<Error = KVAppError>> SchemaApi for KV {
         let mut res = vec![];
 
         for (kk, vv) in reply.into_iter() {
-            let table_id = TableId::from_key(&kk).map_err(|e| {
+            let table_id = TableId::from_str_key(&kk).map_err(|e| {
                 let inv = InvalidReply::new("list_all_tables", &e);
                 let meta_net_err = MetaNetworkError::InvalidReply(inv);
                 MetaError::NetworkError(meta_net_err)
@@ -2018,7 +2018,7 @@ impl<KV: KVApi<Error = KVAppError>> SchemaApi for KV {
                         opts.remove(k);
                     }
                     Some(v) => {
-                        opts.insert(k.to_string(), v.to_string());
+                        opts.insert(k.to_string_key(), v.to_string_key());
                     }
                 }
             }
@@ -2137,7 +2137,7 @@ impl<KV: KVApi<Error = KVAppError>> SchemaApi for KV {
         debug!(req = debug(&req), "SchemaApi: {}", func_name!());
 
         let key = CountTablesKey {
-            tenant: req.tenant.to_string(),
+            tenant: req.tenant.to_string_key(),
         };
 
         let count = loop {
@@ -2593,7 +2593,7 @@ async fn get_table_id_from_share_by_name(
     };
     if share_id_seq == 0 {
         return Err(KVAppError::AppError(AppError::WrongShare(WrongShare::new(
-            share.to_string(),
+            share.to_string_key(),
         ))));
     }
     if !share_meta.share_from_db_ids.contains(&db_id) {
@@ -2613,7 +2613,7 @@ async fn get_table_id_from_share_by_name(
     match table_names.binary_search(table_name) {
         Ok(i) => Ok(ids[i]),
         Err(_) => Err(KVAppError::AppError(AppError::WrongShareObject(
-            WrongShareObject::new(table_name.to_string()),
+            WrongShareObject::new(table_name.to_string_key()),
         ))),
     }
 }
@@ -2652,7 +2652,7 @@ async fn get_tableinfos_by_ids(
     for id in ids.iter() {
         let tbid = TableId { table_id: *id };
 
-        tb_meta_keys.push(tbid.to_key());
+        tb_meta_keys.push(tbid.to_string_key());
     }
 
     // mget() corresponding table_metas
@@ -2744,7 +2744,7 @@ async fn list_tables_from_share_db(
     };
     if share_id_seq == 0 {
         return Err(KVAppError::AppError(AppError::WrongShare(WrongShare::new(
-            share.to_string(),
+            share.to_string_key(),
         ))));
     }
     if !share_meta.share_from_db_ids.contains(&db_id) {

--- a/src/meta/api/src/schema_api_keys.rs
+++ b/src/meta/api/src/schema_api_keys.rs
@@ -55,7 +55,7 @@ pub(crate) const ID_GEN_DATABASE: &str = "database_id";
 impl KVApiKey for DatabaseNameIdent {
     const PREFIX: &'static str = PREFIX_DATABASE;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!(
             "{}/{}/{}",
             Self::PREFIX,
@@ -64,7 +64,7 @@ impl KVApiKey for DatabaseNameIdent {
         )
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -87,11 +87,11 @@ impl KVApiKey for DatabaseNameIdent {
 impl KVApiKey for DatabaseId {
     const PREFIX: &'static str = PREFIX_DATABASE_BY_ID;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!("{}/{}", Self::PREFIX, self.db_id,)
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -110,11 +110,11 @@ impl KVApiKey for DatabaseId {
 impl KVApiKey for DatabaseIdToName {
     const PREFIX: &'static str = PREFIX_DATABASE_ID_TO_NAME;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!("{}/{}", Self::PREFIX, self.db_id,)
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -133,11 +133,11 @@ impl KVApiKey for DatabaseIdToName {
 impl KVApiKey for TableIdToName {
     const PREFIX: &'static str = PREFIX_TABLE_ID_TO_NAME;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!("{}/{}", Self::PREFIX, self.table_id,)
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -156,7 +156,7 @@ impl KVApiKey for TableIdToName {
 impl KVApiKey for DbIdListKey {
     const PREFIX: &'static str = PREFIX_DB_ID_LIST;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!(
             "{}/{}/{}",
             Self::PREFIX,
@@ -165,7 +165,7 @@ impl KVApiKey for DbIdListKey {
         )
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -188,7 +188,7 @@ impl KVApiKey for DbIdListKey {
 impl KVApiKey for DBIdTableName {
     const PREFIX: &'static str = PREFIX_TABLE;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!(
             "{}/{}/{}",
             Self::PREFIX,
@@ -197,7 +197,7 @@ impl KVApiKey for DBIdTableName {
         )
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -222,11 +222,11 @@ impl KVApiKey for DBIdTableName {
 impl KVApiKey for TableId {
     const PREFIX: &'static str = PREFIX_TABLE_BY_ID;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!("{}/{}", Self::PREFIX, self.table_id,)
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -245,7 +245,7 @@ impl KVApiKey for TableId {
 impl KVApiKey for TableIdListKey {
     const PREFIX: &'static str = PREFIX_TABLE_ID_LIST;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!(
             "{}/{}/{}",
             Self::PREFIX,
@@ -254,7 +254,7 @@ impl KVApiKey for TableIdListKey {
         )
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -279,11 +279,11 @@ impl KVApiKey for TableIdListKey {
 impl KVApiKey for CountTablesKey {
     const PREFIX: &'static str = PREFIX_TABLE_COUNT;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!("{}/{}", Self::PREFIX, self.tenant)
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -303,11 +303,11 @@ impl KVApiKey for CountTablesKey {
 impl KVApiKey for TableCopiedFileNameIdent {
     const PREFIX: &'static str = PREFIX_TABLE_COPIED_FILES;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!("{}/{}/{}", Self::PREFIX, self.table_id, self.file)
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let elts: Vec<&str> = s.splitn(3, '/').collect();
         if elts.len() < 3 {
             return Err(KVApiKeyError::AtleastSegments {
@@ -329,11 +329,11 @@ impl KVApiKey for TableCopiedFileNameIdent {
 impl KVApiKey for TableCopiedFileLockKey {
     const PREFIX: &'static str = PREFIX_TABLE_COPIED_FILES_LOCK;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!("{}/{}", Self::PREFIX, self.table_id)
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -362,7 +362,7 @@ mod tests {
                 file: "/path/to/file".to_owned(),
             };
 
-            let key = name.to_key();
+            let key = name.to_string_key();
             assert_eq!(
                 key,
                 format!(
@@ -372,14 +372,14 @@ mod tests {
                     name.file,
                 )
             );
-            let from = TableCopiedFileNameIdent::from_key(&key)?;
+            let from = TableCopiedFileNameIdent::from_str_key(&key)?;
             assert_eq!(from, name);
         }
 
         // test with a key has only 2 sub-path
         {
             let key = format!("{}/{}", TableCopiedFileNameIdent::PREFIX, 2,);
-            let res = TableCopiedFileNameIdent::from_key(&key);
+            let res = TableCopiedFileNameIdent::from_str_key(&key);
             assert!(res.is_err());
             let err = res.unwrap_err();
             assert_eq!(err, KVApiKeyError::AtleastSegments {
@@ -391,7 +391,7 @@ mod tests {
         // test with a key has 5 sub-path but an empty file string
         {
             let key = format!("{}/{}/{}", TableCopiedFileNameIdent::PREFIX, 2, "");
-            let res = TableCopiedFileNameIdent::from_key(&key)?;
+            let res = TableCopiedFileNameIdent::from_str_key(&key)?;
             assert_eq!(res, TableCopiedFileNameIdent {
                 table_id: 2,
                 file: "".to_string(),

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -120,7 +120,7 @@ fn calc_and_compare_drop_on_db_result(result: Vec<Arc<DatabaseInfo>>, expected: 
 
     let mut get = BTreeMap::new();
     for item in result.iter() {
-        let name = item.name_ident.to_string();
+        let name = item.name_ident.to_string_key();
         let mut drop_on_info = match get.get_mut(&name) {
             Some(drop_on_info) => drop_on_info,
             None => {
@@ -183,7 +183,7 @@ async fn upsert_test_data(
 ) -> Result<u64, KVAppError> {
     let res = kv_api
         .upsert_kv(UpsertKVReq {
-            key: key.to_key(),
+            key: key.to_string_key(),
             seq: MatchSeq::Any,
             value: Operation::Update(value),
             value_meta: None,
@@ -200,7 +200,7 @@ async fn delete_test_data(
 ) -> Result<(), KVAppError> {
     let _res = kv_api
         .upsert_kv(UpsertKVReq {
-            key: key.to_key(),
+            key: key.to_string_key(),
             seq: MatchSeq::Any,
             value: Operation::Delete,
             value_meta: None,
@@ -1209,7 +1209,7 @@ impl SchemaApiTestSuite {
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
-                name: db_name_ident.to_string(),
+                name: db_name_ident.to_string_key(),
                 desc: "".to_string(),
                 drop_on_cnt: 0,
                 non_drop_on_cnt: 1,
@@ -1227,7 +1227,7 @@ impl SchemaApiTestSuite {
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
-                name: db_name_ident.to_string(),
+                name: db_name_ident.to_string_key(),
                 desc: "".to_string(),
                 drop_on_cnt: 1,
                 non_drop_on_cnt: 0,
@@ -1244,7 +1244,7 @@ impl SchemaApiTestSuite {
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
-                name: db_name_ident.to_string(),
+                name: db_name_ident.to_string_key(),
                 desc: "".to_string(),
                 drop_on_cnt: 0,
                 non_drop_on_cnt: 1,
@@ -1265,7 +1265,7 @@ impl SchemaApiTestSuite {
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
-                name: db_name_ident.to_string(),
+                name: db_name_ident.to_string_key(),
                 desc: "".to_string(),
                 drop_on_cnt: 1,
                 non_drop_on_cnt: 0,
@@ -1289,7 +1289,7 @@ impl SchemaApiTestSuite {
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
-                name: db_name_ident.to_string(),
+                name: db_name_ident.to_string_key(),
                 desc: "".to_string(),
                 drop_on_cnt: 1,
                 non_drop_on_cnt: 1,
@@ -1317,13 +1317,13 @@ impl SchemaApiTestSuite {
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![
                 DroponInfo {
-                    name: db_name_ident.to_string(),
+                    name: db_name_ident.to_string_key(),
                     desc: "".to_string(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 1,
                 },
                 DroponInfo {
-                    name: new_db_name_ident.to_string(),
+                    name: new_db_name_ident.to_string_key(),
                     desc: "".to_string(),
                     drop_on_cnt: 0,
                     non_drop_on_cnt: 1,
@@ -1343,13 +1343,13 @@ impl SchemaApiTestSuite {
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![
                 DroponInfo {
-                    name: db_name_ident.to_string(),
+                    name: db_name_ident.to_string_key(),
                     desc: "".to_string(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 1,
                 },
                 DroponInfo {
-                    name: new_db_name_ident.to_string(),
+                    name: new_db_name_ident.to_string_key(),
                     desc: "".to_string(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 0,
@@ -1373,13 +1373,13 @@ impl SchemaApiTestSuite {
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![
                 DroponInfo {
-                    name: db_name_ident.to_string(),
+                    name: db_name_ident.to_string_key(),
                     desc: "".to_string(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 0,
                 },
                 DroponInfo {
-                    name: new_db_name_ident.to_string(),
+                    name: new_db_name_ident.to_string_key(),
                     desc: "".to_string(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 1,

--- a/src/meta/api/src/share_api_keys.rs
+++ b/src/meta/api/src/share_api_keys.rs
@@ -42,7 +42,7 @@ pub(crate) const ID_GEN_SHARE: &str = "share_id";
 impl KVApiKey for ShareGrantObject {
     const PREFIX: &'static str = PREFIX_SHARE_BY;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         match *self {
             ShareGrantObject::Database(db_id) => {
                 format!("{}/db/{}", Self::PREFIX, db_id,)
@@ -53,7 +53,7 @@ impl KVApiKey for ShareGrantObject {
         }
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -84,7 +84,7 @@ impl KVApiKey for ShareGrantObject {
 impl KVApiKey for ShareNameIdent {
     const PREFIX: &'static str = PREFIX_SHARE;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!(
             "{}/{}/{}",
             Self::PREFIX,
@@ -93,7 +93,7 @@ impl KVApiKey for ShareNameIdent {
         )
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -116,11 +116,11 @@ impl KVApiKey for ShareNameIdent {
 impl KVApiKey for ShareId {
     const PREFIX: &'static str = PREFIX_SHARE_ID;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!("{}/{}", Self::PREFIX, self.share_id)
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -138,7 +138,7 @@ impl KVApiKey for ShareId {
 impl KVApiKey for ShareAccountNameIdent {
     const PREFIX: &'static str = PREFIX_SHARE_ACCOUNT_ID;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         if self.share_id != 0 {
             format!(
                 "{}/{}/{}",
@@ -151,7 +151,7 @@ impl KVApiKey for ShareAccountNameIdent {
         }
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;
@@ -173,11 +173,11 @@ impl KVApiKey for ShareAccountNameIdent {
 impl KVApiKey for ShareIdToName {
     const PREFIX: &'static str = PREFIX_SHARE_ID_TO_NAME;
 
-    fn to_key(&self) -> String {
+    fn to_string_key(&self) -> String {
         format!("{}/{}", Self::PREFIX, self.share_id,)
     }
 
-    fn from_key(s: &str) -> Result<Self, KVApiKeyError> {
+    fn from_str_key(s: &str) -> Result<Self, KVApiKeyError> {
         let mut elts = s.split('/');
 
         let prefix = check_segment_present(elts.next(), 0, s)?;

--- a/src/meta/api/src/testing.rs
+++ b/src/meta/api/src/testing.rs
@@ -34,7 +34,7 @@ where
     T: FromToProto,
     T::PB: common_protos::prost::Message + Default,
 {
-    let res = kv_api.get_kv(&key.to_key()).await?;
+    let res = kv_api.get_kv(&key.to_string_key()).await?;
     if let Some(res) = res {
         let s = crate::deserialize_struct(&res.data)?;
         return Ok(s);

--- a/src/meta/raft-store/src/state_machine/sm.rs
+++ b/src/meta/raft-store/src/state_machine/sm.rs
@@ -31,6 +31,7 @@ use common_meta_sled_store::SledTree;
 use common_meta_sled_store::Store;
 use common_meta_sled_store::TransactionSledTree;
 use common_meta_stoerr::MetaStorageError;
+use common_meta_types::protobuf as pb;
 use common_meta_types::txn_condition;
 use common_meta_types::txn_op;
 use common_meta_types::txn_op_response;
@@ -45,7 +46,6 @@ use common_meta_types::MatchSeqExt;
 use common_meta_types::Node;
 use common_meta_types::NodeId;
 use common_meta_types::Operation;
-use common_meta_types::PbSeqV;
 use common_meta_types::SeqV;
 use common_meta_types::TxnCondition;
 use common_meta_types::TxnDeleteByPrefixRequest;
@@ -543,7 +543,7 @@ impl StateMachine {
     ) -> Result<(), MetaStorageError> {
         let sub_tree = txn_tree.key_space::<GenericKV>();
         let sv = sub_tree.get(&get.key)?;
-        let value = sv.map(PbSeqV::from);
+        let value = sv.map(pb::SeqV::from);
         let get_resp = TxnGetResponse {
             key: get.key.clone(),
             value,
@@ -579,7 +579,7 @@ impl StateMachine {
         let put_resp = TxnPutResponse {
             key: put.key.clone(),
             prev_value: if put.prev_value {
-                prev.map(PbSeqV::from)
+                prev.map(pb::SeqV::from)
             } else {
                 None
             },
@@ -611,7 +611,7 @@ impl StateMachine {
             key: delete.key.clone(),
             success: prev.is_some(),
             prev_value: if delete.prev_value {
-                prev.map(PbSeqV::from)
+                prev.map(pb::SeqV::from)
             } else {
                 None
             },

--- a/src/meta/service/src/watcher/watcher_manager.rs
+++ b/src/meta/service/src/watcher/watcher_manager.rs
@@ -19,12 +19,12 @@ use common_base::base::tokio::sync::oneshot;
 use common_base::rangemap::RangeMap;
 use common_base::rangemap::RangeMapKey;
 use common_meta_raft_store::state_machine::StateMachineSubscriber;
+use common_meta_types::protobuf as pb;
 use common_meta_types::protobuf::watch_request::FilterType;
 use common_meta_types::protobuf::Event;
 use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::protobuf::WatchResponse;
 use common_meta_types::Change;
-use common_meta_types::PbSeqV;
 use prost::Message;
 use tonic::Status;
 use tracing::info;
@@ -161,8 +161,8 @@ impl EventDispatcher {
             let resp = WatchResponse {
                 event: Some(Event {
                     key: k.to_string(),
-                    current: current.clone().map(PbSeqV::from),
-                    prev: prev.clone().map(PbSeqV::from),
+                    current: current.clone().map(pb::SeqV::from),
+                    prev: prev.clone().map(pb::SeqV::from),
                 }),
             };
 

--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -162,7 +162,6 @@ pub use seq_errors::ConflictSeq;
 pub use seq_num::SeqNum;
 pub use seq_value::IntoSeqV;
 pub use seq_value::KVMeta;
-pub use seq_value::PbSeqV;
 pub use seq_value::SeqV;
 pub use tenant_quota::TenantQuota;
 pub use user_auth::AuthInfo;

--- a/src/meta/types/src/seq_value.rs
+++ b/src/meta/types/src/seq_value.rs
@@ -20,7 +20,7 @@ use std::time::UNIX_EPOCH;
 use serde::Deserialize;
 use serde::Serialize;
 
-pub type PbSeqV = crate::protobuf::SeqV;
+use crate::protobuf as pb;
 
 /// The meta data of a record in kv
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
@@ -121,11 +121,11 @@ impl<T> SeqV<T> {
     }
 }
 
-impl From<SeqV> for PbSeqV {
-    fn from(seqv: SeqV) -> Self {
-        PbSeqV {
-            seq: seqv.seq,
-            data: seqv.data,
+impl From<SeqV> for pb::SeqV {
+    fn from(seq_v: SeqV) -> Self {
+        pb::SeqV {
+            seq: seq_v.seq,
+            data: seq_v.data,
         }
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore(meta): rename KVApiKey::to_key/from_key to to_string/from_str

## Changelog







## Related Issues