### PR TITLE
feat(query): hold table function instances in query context.

### DIFF
--- a/src/query/catalog/src/plan/datasource.rs
+++ b/src/query/catalog/src/plan/datasource.rs
@@ -17,7 +17,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use common_expression::Scalar;
 use common_expression::TableField;
 use common_expression::TableSchema;
 use common_expression::TableSchemaRef;
@@ -29,6 +28,7 @@ use crate::plan::Partitions;
 use crate::plan::Projection;
 use crate::plan::PushDownInfo;
 use crate::plan::StageFileInfo;
+use crate::table_function::TableFunctionID;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 pub struct StageTableInfo {
@@ -101,7 +101,7 @@ pub struct DataSourcePlan {
     pub statistics: PartStatistics,
     pub description: String,
 
-    pub tbl_args: Option<Vec<Scalar>>,
+    pub table_func_id: Option<TableFunctionID>,
     pub push_downs: Option<PushDownInfo>,
 }
 

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -41,6 +41,7 @@ use crate::plan::Partitions;
 use crate::plan::PushDownInfo;
 use crate::table::column_stats_provider_impls::DummyColumnStatisticsProvider;
 use crate::table_context::TableContext;
+use crate::table_function::TableFunctionID;
 use crate::table_mutator::TableMutator;
 
 pub type ColumnId = u32;
@@ -144,7 +145,7 @@ pub trait Table: Sync + Send {
         )))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
+    fn table_function_id(&self) -> Option<TableFunctionID> {
         None
     }
 

--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -118,4 +118,6 @@ pub trait TableContext: Send + Sync {
 
     async fn get_table(&self, catalog: &str, database: &str, table: &str)
     -> Result<Arc<dyn Table>>;
+
+    fn add_table_function_instance(&self, table: Arc<dyn Table>) -> Result<()>;
 }

--- a/src/query/catalog/src/table_function.rs
+++ b/src/query/catalog/src/table_function.rs
@@ -22,3 +22,5 @@ pub trait TableFunction: Sync + Send + Table {
     fn as_table<'a>(self: Arc<Self>) -> Arc<dyn Table + 'a>
     where Self: 'a;
 }
+
+pub type TableFunctionID = String;

--- a/src/query/service/src/table_functions/sync_crash_me.rs
+++ b/src/query/service/src/table_functions/sync_crash_me.rs
@@ -25,10 +25,10 @@ use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
+use common_catalog::table_function::TableFunctionID;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::DataBlock;
-use common_expression::Scalar;
 use common_expression::TableSchema;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
@@ -46,6 +46,7 @@ use crate::table_functions::table_function_factory::TableArgs;
 use crate::table_functions::TableFunction;
 
 pub struct SyncCrashMeTable {
+    table_func_id: TableFunctionID,
     table_info: TableInfo,
     panic_message: Option<String>,
 }
@@ -55,6 +56,7 @@ impl SyncCrashMeTable {
         database_name: &str,
         _table_func_name: &str,
         table_id: u64,
+        table_func_id: TableFunctionID,
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let mut panic_message = None;
@@ -85,6 +87,7 @@ impl SyncCrashMeTable {
         };
 
         Ok(Arc::new(SyncCrashMeTable {
+            table_func_id,
             table_info,
             panic_message,
         }))
@@ -114,10 +117,8 @@ impl Table for SyncCrashMeTable {
         Ok((PartStatistics::new_exact(1, 1, 1, 1), Partitions::default()))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
-        self.panic_message
-            .clone()
-            .map(|s| vec![Scalar::String(s.as_bytes().to_vec())])
+    fn table_function_id(&self) -> Option<TableFunctionID> {
+        Some(self.table_func_id.clone())
     }
 
     fn read_data(

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -467,6 +467,10 @@ impl TableContext for CtxDelegation {
     ) -> Result<Arc<dyn Table>> {
         todo!()
     }
+
+    fn add_table_function_instance(&self, _table: Arc<dyn Table>) -> Result<()> {
+        todo!()
+    }
 }
 
 #[derive(Clone)]

--- a/src/query/service/tests/it/storages/fuse/table.rs
+++ b/src/query/service/tests/it/storages/fuse/table.rs
@@ -66,7 +66,7 @@ async fn test_fuse_table_normal_case() -> Result<()> {
                 parts,
                 statistics: Default::default(),
                 description: "".to_string(),
-                tbl_args: None,
+                table_func_id: None,
                 push_downs: None,
             })
             .await?;
@@ -126,7 +126,7 @@ async fn test_fuse_table_normal_case() -> Result<()> {
                 parts,
                 statistics: Default::default(),
                 description: "".to_string(),
-                tbl_args: None,
+                table_func_id: None,
                 push_downs: None,
             })
             .await?;

--- a/src/query/service/tests/it/storages/fuse/table_functions/clustering_information_table.rs
+++ b/src/query/service/tests/it/storages/fuse/table_functions/clustering_information_table.rs
@@ -112,7 +112,13 @@ async fn test_drive_clustering_information(
     tbl_args: TableArgs,
     ctx: Arc<QueryContext>,
 ) -> Result<SendableDataBlockStream> {
-    let func = ClusteringInformationTable::create("system", "clustering_information", 1, tbl_args)?;
+    let func = ClusteringInformationTable::create(
+        "system",
+        "clustering_information",
+        1,
+        "aaa".to_string(),
+        tbl_args,
+    )?;
     let source_plan = func
         .clone()
         .as_table()

--- a/src/query/service/tests/it/table_functions/numbers_table.rs
+++ b/src/query/service/tests/it/table_functions/numbers_table.rs
@@ -29,7 +29,7 @@ use pretty_assertions::assert_eq;
 async fn test_number_table() -> Result<()> {
     let tbl_args = Some(vec![Scalar::from(8u64)]);
     let (_guard, ctx) = crate::tests::create_query_context().await?;
-    let table = NumbersTable::create("system", "numbers_mt", 1, tbl_args)?;
+    let table = NumbersTable::create("system", "numbers_mt", 1, "aaa".to_string(), tbl_args)?;
 
     let source_plan = table
         .clone()

--- a/src/query/sql/src/executor/table_read_plan.rs
+++ b/src/query/sql/src/executor/table_read_plan.rs
@@ -81,7 +81,7 @@ impl ToReadDataSourcePlan for dyn Table {
             parts,
             statistics,
             description,
-            tbl_args: self.table_args(),
+            table_func_id: self.table_function_id(),
             push_downs,
         })
     }

--- a/src/query/sql/src/planner/binder/copy.rs
+++ b/src/query/sql/src/planner/binder/copy.rs
@@ -251,7 +251,7 @@ impl<'a> Binder {
             parts: Partitions::default(),
             statistics: Default::default(),
             description: "".to_string(),
-            tbl_args: None,
+            table_func_id: None,
             push_downs: None,
         };
 
@@ -309,7 +309,7 @@ impl<'a> Binder {
             parts: Partitions::default(),
             statistics: Default::default(),
             description: "".to_string(),
-            tbl_args: None,
+            table_func_id: None,
             push_downs: None,
         };
 

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -285,6 +285,7 @@ impl Binder {
                         table_args,
                     )?;
                 let table = table_meta.as_table();
+                self.ctx.add_table_function_instance(table.clone())?;
                 let table_alias_name = if let Some(table_alias) = alias {
                     Some(normalize_identifier(&table_alias.name, &self.name_resolution_ctx).name)
                 } else {

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -129,7 +129,7 @@ impl FuseTable {
             parts,
             statistics,
             description,
-            tbl_args: self.table_args(),
+            table_func_id: self.table_function_id(),
             push_downs: None,
         };
 

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
@@ -20,9 +20,9 @@ use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
+use common_catalog::table_function::TableFunctionID;
 use common_exception::Result;
 use common_expression::DataBlock;
-use common_expression::Scalar;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
@@ -34,7 +34,6 @@ use crate::pipelines::processors::AsyncSource;
 use crate::pipelines::processors::AsyncSourcer;
 use crate::pipelines::Pipeline;
 use crate::sessions::TableContext;
-use crate::table_functions::string_literal;
 use crate::table_functions::FuseBlock;
 use crate::table_functions::TableArgs;
 use crate::table_functions::TableFunction;
@@ -44,6 +43,7 @@ use crate::Table;
 const FUSE_FUNC_BLOCK: &str = "fuse_block";
 
 pub struct FuseBlockTable {
+    table_func_id: TableFunctionID,
     table_info: TableInfo,
     arg_database_name: String,
     arg_table_name: String,
@@ -55,6 +55,7 @@ impl FuseBlockTable {
         database_name: &str,
         table_func_name: &str,
         table_id: u64,
+        table_func_id: TableFunctionID,
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let (arg_database_name, arg_table_name, arg_snapshot_id) =
@@ -75,6 +76,7 @@ impl FuseBlockTable {
         };
 
         Ok(Arc::new(FuseBlockTable {
+            table_func_id,
             table_info,
             arg_database_name,
             arg_table_name,
@@ -101,16 +103,8 @@ impl Table for FuseBlockTable {
         Ok((PartStatistics::default(), Partitions::default()))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
-        let mut args = Vec::new();
-        args.push(string_literal(self.arg_database_name.as_str()));
-        args.push(string_literal(self.arg_table_name.as_str()));
-        if self.arg_snapshot_id.is_some() {
-            args.push(string_literal(
-                self.arg_snapshot_id.clone().unwrap().as_str(),
-            ));
-        }
-        Some(args)
+    fn table_function_id(&self) -> Option<TableFunctionID> {
+        Some(self.table_func_id.clone())
     }
 
     fn read_data(

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot_table.rs
@@ -20,9 +20,9 @@ use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
+use common_catalog::table_function::TableFunctionID;
 use common_exception::Result;
 use common_expression::DataBlock;
-use common_expression::Scalar;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
@@ -35,7 +35,6 @@ use super::table_args::parse_func_history_args;
 use crate::pipelines::processors::port::OutputPort;
 use crate::pipelines::Pipeline;
 use crate::sessions::TableContext;
-use crate::table_functions::string_literal;
 use crate::table_functions::TableArgs;
 use crate::table_functions::TableFunction;
 use crate::FuseTable;
@@ -44,6 +43,7 @@ use crate::Table;
 const FUSE_FUNC_SNAPSHOT: &str = "fuse_snapshot";
 
 pub struct FuseSnapshotTable {
+    table_func_id: TableFunctionID,
     table_info: TableInfo,
     arg_database_name: String,
     arg_table_name: String,
@@ -54,6 +54,7 @@ impl FuseSnapshotTable {
         database_name: &str,
         table_func_name: &str,
         table_id: u64,
+        table_func_id: TableFunctionID,
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let (arg_database_name, arg_table_name) = parse_func_history_args(&table_args)?;
@@ -73,6 +74,7 @@ impl FuseSnapshotTable {
         };
 
         Ok(Arc::new(FuseSnapshotTable {
+            table_func_id,
             table_info,
             arg_database_name,
             arg_table_name,
@@ -98,11 +100,8 @@ impl Table for FuseSnapshotTable {
         Ok((PartStatistics::default(), Partitions::default()))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
-        Some(vec![
-            string_literal(self.arg_database_name.as_str()),
-            string_literal(self.arg_table_name.as_str()),
-        ])
+    fn table_function_id(&self) -> Option<TableFunctionID> {
+        Some(self.table_func_id.clone())
     }
 
     fn read_data(

--- a/src/query/storages/fuse/src/table_functions/fuse_statistics/fuse_statistic_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_statistics/fuse_statistic_table.rs
@@ -20,9 +20,9 @@ use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
+use common_catalog::table_function::TableFunctionID;
 use common_exception::Result;
 use common_expression::DataBlock;
-use common_expression::Scalar;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
@@ -35,7 +35,6 @@ use crate::pipelines::processors::port::OutputPort;
 use crate::pipelines::Pipeline;
 use crate::sessions::TableContext;
 use crate::table_functions::fuse_snapshots::parse_func_history_args;
-use crate::table_functions::string_literal;
 use crate::table_functions::TableArgs;
 use crate::table_functions::TableFunction;
 use crate::FuseTable;
@@ -44,6 +43,7 @@ use crate::Table;
 const FUSE_FUNC_STATISTICS: &str = "fuse_statistics";
 
 pub struct FuseStatisticTable {
+    table_func_id: TableFunctionID,
     table_info: TableInfo,
     arg_database_name: String,
     arg_table_name: String,
@@ -54,6 +54,7 @@ impl FuseStatisticTable {
         database_name: &str,
         table_func_name: &str,
         table_id: u64,
+        table_func_id: TableFunctionID,
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let (arg_database_name, arg_table_name) = parse_func_history_args(&table_args)?;
@@ -73,6 +74,7 @@ impl FuseStatisticTable {
         };
 
         Ok(Arc::new(FuseStatisticTable {
+            table_func_id,
             table_info,
             arg_database_name,
             arg_table_name,
@@ -98,11 +100,8 @@ impl Table for FuseStatisticTable {
         Ok((PartStatistics::default(), Partitions::default()))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
-        Some(vec![
-            string_literal(self.arg_database_name.as_str()),
-            string_literal(self.arg_table_name.as_str()),
-        ])
+    fn table_function_id(&self) -> Option<TableFunctionID> {
+        Some(self.table_func_id.clone())
     }
 
     fn read_data(

--- a/src/query/storages/hive/hive/src/hive_table.rs
+++ b/src/query/storages/hive/hive/src/hive_table.rs
@@ -37,7 +37,6 @@ use common_expression::DataSchemaRef;
 use common_expression::DataSchemaRefExt;
 use common_expression::Expr;
 use common_expression::RemoteExpr;
-use common_expression::Scalar;
 use common_expression::TableSchema;
 use common_expression::TableSchemaRef;
 use common_functions::scalars::BUILTIN_FUNCTIONS;
@@ -584,10 +583,6 @@ impl Table for HiveTable {
         push_downs: Option<PushDownInfo>,
     ) -> Result<(PartStatistics, Partitions)> {
         self.do_read_partitions(ctx, push_downs).await
-    }
-
-    fn table_args(&self) -> Option<Vec<Scalar>> {
-        None
     }
 
     fn read_data(

--- a/src/query/storages/parquet/src/parquet_table/blocking.rs
+++ b/src/query/storages/parquet/src/parquet_table/blocking.rs
@@ -14,7 +14,7 @@
 
 use common_arrow::arrow::datatypes::Schema as ArrowSchema;
 use common_arrow::arrow::io::parquet::read as pread;
-use common_catalog::table_args::TableArgs;
+use common_catalog::table_function::TableFunctionID;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use glob::Pattern;
@@ -30,7 +30,7 @@ use crate::ReadOptions;
 impl ParquetTable {
     pub fn blocking_create(
         table_id: u64,
-        table_args: TableArgs,
+        table_func_id: TableFunctionID,
         operator: Operator,
         maybe_glob_locations: Vec<String>,
         read_options: ReadOptions,
@@ -41,7 +41,7 @@ impl ParquetTable {
         let table_info = create_parquet_table_info(table_id, arrow_schema.clone());
 
         Ok(ParquetTable {
-            table_args,
+            table_func_id,
             file_locations,
             table_info,
             arrow_schema,

--- a/src/query/storages/parquet/src/parquet_table/non_blocking.rs
+++ b/src/query/storages/parquet/src/parquet_table/non_blocking.rs
@@ -15,7 +15,7 @@
 use common_arrow::arrow::datatypes::Schema as ArrowSchema;
 use common_arrow::arrow::io::parquet::read as pread;
 use common_base::base::tokio;
-use common_catalog::table_args::TableArgs;
+use common_catalog::table_function::TableFunctionID;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use futures::TryStreamExt;
@@ -32,7 +32,7 @@ use crate::ReadOptions;
 impl ParquetTable {
     pub async fn create(
         table_id: u64,
-        table_args: TableArgs,
+        table_func_id: TableFunctionID,
         operator: Operator,
         maybe_glob_locations: Vec<String>,
         read_options: ReadOptions,
@@ -43,7 +43,7 @@ impl ParquetTable {
         let table_info = create_parquet_table_info(table_id, arrow_schema.clone());
 
         Ok(ParquetTable {
-            table_args,
+            table_func_id,
             file_locations,
             table_info,
             arrow_schema,

--- a/src/query/storages/parquet/src/parquet_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_table/table.rs
@@ -26,10 +26,9 @@ use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
-use common_catalog::table_args::TableArgs;
 use common_catalog::table_context::TableContext;
+use common_catalog::table_function::TableFunctionID;
 use common_exception::Result;
-use common_expression::Scalar;
 use common_expression::TableSchema;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
@@ -40,7 +39,7 @@ use opendal::Operator;
 use crate::ReadOptions;
 
 pub struct ParquetTable {
-    pub(super) table_args: TableArgs,
+    pub(super) table_func_id: TableFunctionID,
 
     pub(super) file_locations: Vec<String>,
     pub(super) table_info: TableInfo,
@@ -71,8 +70,8 @@ impl Table for ParquetTable {
         true
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
-        self.table_args.clone()
+    fn table_function_id(&self) -> Option<TableFunctionID> {
+        Some(self.table_func_id.clone())
     }
 
     /// The returned partitions only record the locations of files to read.

--- a/src/query/storages/parquet/src/table_function/table.rs
+++ b/src/query/storages/parquet/src/table_function/table.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_catalog::table::Table;
 use common_catalog::table_args::TableArgs;
 use common_catalog::table_function::TableFunction;
+use common_catalog::table_function::TableFunctionID;
 use common_config::GlobalConfig;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -40,6 +41,7 @@ impl ParquetTable {
         _database_name: &str,
         _table_func_name: &str,
         table_id: u64,
+        table_func_id: TableFunctionID,
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         if !GlobalConfig::instance().storage.allow_insecure {
@@ -53,8 +55,13 @@ impl ParquetTable {
 
         let (file_locations, read_options) = parse_parquet_table_args(&table_args)?;
 
-        let table =
-            Self::blocking_create(table_id, table_args, operator, file_locations, read_options)?;
+        let table = Self::blocking_create(
+            table_id,
+            table_func_id,
+            operator,
+            file_locations,
+            read_options,
+        )?;
 
         Ok(Arc::new(table))
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

After instantiating a table function in binding phase, store the instance in the current query context. Take the table function instance from the query context when building pipeline.

The table function instances in context are indexed by `{global-table-id}-{uuid}`.

### Implementation in the past.

In the past, table function instantialization will happen both in binding phase and pipeline building phase, which is redundant.

For table function whose creating is heavy (like `read_parquet`), it will affect the performance.