### PR TITLE
refactor(kvapi): remove dep common-base and common-exception; refine method names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,10 +1676,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "common-base",
- "common-exception",
  "common-meta-types",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,9 @@ reqwest = { version = "0.11", default-features = false, features = [
     "trust-dns",
 ] }
 
+# runtime
+tokio = { version = "1.23.1", features = ["full"] }
+
 [profile.release]
 debug = 1
 lto = "thin"

--- a/src/binaries/meta-upgrade-09/Cargo.toml
+++ b/src/binaries/meta-upgrade-09/Cargo.toml
@@ -25,7 +25,7 @@ clap = { workspace = true }
 openraft = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { version = "1.21.1", features = ["full"] }
+tokio = { workspace = true }
 
 [[bin]]
 name = "databend-meta-upgrade-09"

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -47,7 +47,7 @@ serde = { workspace = true }
 state = "0.5"
 tikv-jemalloc-ctl = { workspace = true, optional = true }
 tikv-jemalloc-sys = "0.5.2"
-tokio = { version = "1.23.1", features = ["full"] }
+tokio = { workspace = true }
 tracing = "0.1.36"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 

--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -41,7 +41,6 @@ pub use string::convert_byte_size;
 pub use string::convert_number_size;
 pub use string::escape_for_key;
 pub use string::mask_string;
-pub use string::replace_nth_char;
 pub use string::unescape_for_key;
 pub use string::unescape_string;
 pub use tokio;

--- a/src/common/base/src/base/string.rs
+++ b/src/common/base/src/base/string.rs
@@ -107,17 +107,6 @@ pub fn mask_string(s: &str, unmask_len: usize) -> String {
     }
 }
 
-/// Replace idx-th char as new char
-/// If idx is out of len(s) range, then no replacement is performed.
-/// replace_nth_char("a13", 1, '2') -> 'a23'
-/// replace_nth_char("a13", 10, '2') -> 'a13'
-pub fn replace_nth_char(s: &str, idx: usize, newchar: char) -> String {
-    s.chars()
-        .enumerate()
-        .map(|(i, c)| if i == idx { newchar } else { c })
-        .collect()
-}
-
 /// Returns string after processing escapes.
 /// This used for settings string unescape, like unescape format_field_delimiter from `\\x01` to `\x01`.
 pub fn unescape_string(escape_str: &str) -> Result<String> {

--- a/src/common/base/tests/it/string_func.rs
+++ b/src/common/base/tests/it/string_func.rs
@@ -38,12 +38,6 @@ fn mask_string_test() {
 }
 
 #[test]
-fn replace_nth_char_test() {
-    assert_eq!("a23".to_string(), replace_nth_char("a13", 1, '2'));
-    assert_eq!("a13".to_string(), replace_nth_char("a13", 10, '2'));
-}
-
-#[test]
 fn convert_test() {
     assert_eq!(convert_byte_size(0_f64), "0.00 B");
     assert_eq!(convert_byte_size(0.1_f64), "0.10 B");

--- a/src/meta/kvapi/Cargo.toml
+++ b/src/meta/kvapi/Cargo.toml
@@ -13,11 +13,10 @@ doctest = false
 test = false
 
 [dependencies]
-common-base = { path = "../../common/base" }
-common-exception = { path = "../../common/exception" }
 common-meta-types = { path = "../types" }
 
 anyhow = { workspace = true }
 async-trait = "0.1.57"
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = "0.1.36"

--- a/src/meta/kvapi/src/kvapi/api.rs
+++ b/src/meta/kvapi/src/kvapi/api.rs
@@ -15,8 +15,6 @@
 use std::ops::Deref;
 
 use async_trait::async_trait;
-use common_base::base::replace_nth_char;
-use common_exception::ErrorCode;
 use common_meta_types::GetKVReply;
 use common_meta_types::ListKVReply;
 use common_meta_types::MGetKVReply;
@@ -35,39 +33,6 @@ pub trait ApiBuilder<T>: Clone {
 
     /// Create a cluster of T
     async fn build_cluster(&self) -> Vec<T>;
-}
-
-/// Return a string that bigger than all the string prefix with input string(only support ASCII char).
-/// "a" -> "b"
-/// "1" -> "2"
-/// [96,97,127] -> [96,98,127]
-/// [127] -> [127, 127]
-/// [127,127,127, 127] -> [127,127,127, 127, 127]
-pub fn prefix_of_string(s: &str) -> common_exception::Result<String> {
-    for c in s.chars() {
-        if !c.is_ascii() {
-            return common_exception::Result::Err(ErrorCode::OnlySupportAsciiChars(format!(
-                "Only support ASCII characters: {}",
-                c
-            )));
-        }
-    }
-    let mut l = s.len();
-    while l > 0 {
-        l -= 1;
-        if let Some(c) = s.chars().nth(l) {
-            if c == 127 as char {
-                continue;
-            }
-            return Ok(replace_nth_char(s, l, (c as u8 + 1) as char));
-        }
-    }
-    Ok(format!("{}{}", s, 127 as char))
-}
-
-// return watch prefix (start, end) tuple(only support ASCII characters)
-pub fn get_start_and_end_of_prefix(prefix: &str) -> common_exception::Result<(String, String)> {
-    Ok((prefix.to_string(), prefix_of_string(prefix)?))
 }
 
 /// API of a key-value store.

--- a/src/meta/kvapi/src/kvapi/key.rs
+++ b/src/meta/kvapi/src/kvapi/key.rs
@@ -24,6 +24,9 @@ pub enum KeyError {
     #[error(transparent)]
     FromUtf8Error(#[from] FromUtf8Error),
 
+    #[error("Non-ascii char are not supported: '{non_ascii}'")]
+    AsciiError { non_ascii: String },
+
     #[error("Expect {i}-th segment to be '{expect}', but: '{got}'")]
     InvalidSegment {
         i: usize,

--- a/src/meta/kvapi/src/kvapi/mod.rs
+++ b/src/meta/kvapi/src/kvapi/mod.rs
@@ -14,10 +14,9 @@
 
 mod api;
 mod key;
+mod prefix;
 mod test_suite;
 
-pub use api::get_start_and_end_of_prefix;
-pub use api::prefix_of_string;
 pub use api::ApiBuilder;
 pub use api::AsKVApi;
 pub use api::KVApi;
@@ -29,4 +28,5 @@ pub use key::escape;
 pub use key::unescape;
 pub use key::Key;
 pub use key::KeyError;
+pub use prefix::prefix_to_range;
 pub use test_suite::TestSuite;

--- a/src/meta/kvapi/src/kvapi/prefix.rs
+++ b/src/meta/kvapi/src/kvapi/prefix.rs
@@ -1,0 +1,141 @@
+//  Copyright 2023 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Process key prefix.
+
+use crate::kvapi::KeyError;
+
+/// Convert a `prefix` to a left-close-right-open range (start, end) that includes exactly all possible string that starts with `prefix`.
+///
+/// It only supports ASCII characters.
+pub fn prefix_to_range(prefix: &str) -> Result<(String, String), KeyError> {
+    Ok((prefix.to_string(), ascii_next(prefix)?))
+}
+
+// TODO: the algo is not likely correct.
+/// Return a ascii string that bigger than all the string starts with the input `s`.
+///
+/// It only supports ASCII char.
+///
+/// "a" -> "b"
+/// "1" -> "2"
+/// [96,97,127] -> [96,98,127]
+/// [127] -> [127, 127]
+/// [127, 127, 127, 127] -> [127, 127, 127, 127, 127]
+fn ascii_next(s: &str) -> Result<String, KeyError> {
+    for c in s.chars() {
+        if !c.is_ascii() {
+            return Err(KeyError::AsciiError {
+                non_ascii: s.to_string(),
+            });
+        }
+    }
+
+    let mut l = s.len();
+    while l > 0 {
+        l -= 1;
+        if let Some(c) = s.chars().nth(l) {
+            if c == 127 as char {
+                continue;
+            }
+            return Ok(replace_nth_char(s, l, (c as u8 + 1) as char));
+        }
+    }
+
+    Ok(format!("{}{}", s, 127 as char))
+}
+
+/// Replace idx-th char as new char
+///
+/// If `idx` is out of len(s) range, then no replacement is performed.
+/// replace_nth_char("a13", 1, '2') -> 'a23'
+/// replace_nth_char("a13", 10, '2') -> 'a13'
+pub fn replace_nth_char(s: &str, idx: usize, new_char: char) -> String {
+    s.chars()
+        .enumerate()
+        .map(|(i, c)| if i == idx { new_char } else { c })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kvapi::prefix::ascii_next;
+    use crate::kvapi::prefix::replace_nth_char;
+    use crate::kvapi::prefix_to_range;
+
+    #[test]
+    fn test_ascii_next() -> anyhow::Result<()> {
+        assert_eq!("b".to_string(), ascii_next("a")?);
+        assert_eq!("2".to_string(), ascii_next("1")?);
+        assert_eq!(
+            "__fd_table_by_ie".to_string(),
+            ascii_next("__fd_table_by_id")?
+        );
+        {
+            let str = 127 as char;
+            let s = str.to_string();
+            let ret = ascii_next(&s)?;
+            for byte in ret.as_bytes() {
+                assert_eq!(*byte, 127_u8);
+            }
+        }
+        {
+            let s = format!("ab{}", 127 as char);
+            let ret = ascii_next(&s)?;
+            assert_eq!(ret, format!("ac{}", 127 as char));
+        }
+        {
+            let s = "我".to_string();
+            let ret = ascii_next(&s);
+            match ret {
+                Err(e) => {
+                    assert_eq!("Non-ascii char are not supported: '我'", e.to_string(),);
+                }
+                Ok(_) => panic!("MUST return error "),
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_prefix_to_range() -> anyhow::Result<()> {
+        assert_eq!(("aa".to_string(), "ab".to_string()), prefix_to_range("aa")?);
+        assert_eq!(("a1".to_string(), "a2".to_string()), prefix_to_range("a1")?);
+        {
+            let str = 127 as char;
+            let s = str.to_string();
+            let (_, end) = prefix_to_range(&s)?;
+            for byte in end.as_bytes() {
+                assert_eq!(*byte, 127_u8);
+            }
+        }
+        {
+            let ret = prefix_to_range("我");
+            match ret {
+                Err(e) => {
+                    assert_eq!("Non-ascii char are not supported: '我'", e.to_string(),);
+                }
+                Ok(_) => panic!("MUST return error "),
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_replace_nth_char() {
+        assert_eq!("a23".to_string(), replace_nth_char("a13", 1, '2'));
+        assert_eq!("a13".to_string(), replace_nth_char("a13", 10, '2'));
+    }
+}

--- a/src/meta/kvapi/src/kvapi/test_suite.rs
+++ b/src/meta/kvapi/src/kvapi/test_suite.rs
@@ -15,7 +15,6 @@
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
-use common_base::base::tokio;
 use common_meta_types::protobuf as pb;
 use common_meta_types::txn_condition;
 use common_meta_types::txn_op;

--- a/src/meta/kvapi/src/lib.rs
+++ b/src/meta/kvapi/src/lib.rs
@@ -22,6 +22,4 @@ pub use kvapi::check_segment_absent;
 pub use kvapi::check_segment_present;
 pub use kvapi::decode_id;
 pub use kvapi::escape;
-pub use kvapi::get_start_and_end_of_prefix;
-pub use kvapi::prefix_of_string;
 pub use kvapi::unescape;

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
@@ -21,9 +21,8 @@ use common_base::base::tokio;
 use common_base::base::tokio::time::sleep;
 use common_meta_client::ClientHandle;
 use common_meta_client::MetaGrpcClient;
-use common_meta_kvapi::get_start_and_end_of_prefix;
+use common_meta_kvapi::kvapi;
 use common_meta_kvapi::kvapi::KVApi;
-use common_meta_kvapi::prefix_of_string;
 use common_meta_types::protobuf::watch_request::FilterType;
 use common_meta_types::protobuf::Event;
 use common_meta_types::protobuf::SeqV;
@@ -115,7 +114,7 @@ async fn test_watch_txn_main(
 }
 
 #[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
-async fn test_watch() -> common_exception::Result<()> {
+async fn test_watch() -> anyhow::Result<()> {
     // - Start a metasrv server.
     // - Watch some key.
     // - Write some data.
@@ -276,7 +275,7 @@ async fn test_watch() -> common_exception::Result<()> {
         let txn_key = k1.to_string();
         let txn_val = "txn_val".as_bytes().to_vec();
 
-        let (start, end) = get_start_and_end_of_prefix(watch_prefix)?;
+        let (start, end) = kvapi::prefix_to_range(watch_prefix)?;
 
         let watch = WatchRequest {
             key: start,
@@ -428,7 +427,7 @@ async fn test_watch_expired_events() -> anyhow::Result<()> {
         client.transaction(txn).await?;
     }
 
-    let (start, end) = get_start_and_end_of_prefix(watch_prefix)?;
+    let (start, end) = kvapi::prefix_to_range(watch_prefix)?;
     let watch = WatchRequest {
         key: start,
         key_end: Some(end),
@@ -565,85 +564,6 @@ async fn test_watch_stream_count() -> common_exception::Result<()> {
         assert_eq!(1, *watcher_count.lock().unwrap());
     }
 
-    Ok(())
-}
-
-#[test]
-fn prefix_of_string_test() -> common_exception::Result<()> {
-    assert_eq!("b".to_string(), prefix_of_string("a")?);
-    assert_eq!("2".to_string(), prefix_of_string("1")?);
-    assert_eq!(
-        "__fd_table_by_ie".to_string(),
-        prefix_of_string("__fd_table_by_id")?
-    );
-    {
-        let str = 127 as char;
-        let s = str.to_string();
-        let ret = prefix_of_string(&s)?;
-        for byte in ret.as_bytes() {
-            assert_eq!(*byte, 127_u8);
-        }
-    }
-    {
-        let s = format!("ab{}", 127 as char);
-        let ret = prefix_of_string(&s)?;
-        assert_eq!(ret, format!("ac{}", 127 as char));
-    }
-    {
-        let s = "我".to_string();
-        let ret = prefix_of_string(&s);
-        match ret {
-            Err(e) => {
-                assert_eq!(
-                    e.to_string(),
-                    common_exception::ErrorCode::OnlySupportAsciiChars(format!(
-                        "Only support ASCII characters: {}",
-                        "我"
-                    ))
-                    .to_string()
-                );
-            }
-            Ok(_) => panic!("MUST return error "),
-        }
-    }
-
-    Ok(())
-}
-
-#[test]
-fn test_get_start_and_end_of_prefix() -> common_exception::Result<()> {
-    assert_eq!(
-        ("aa".to_string(), "ab".to_string()),
-        get_start_and_end_of_prefix("aa")?
-    );
-    assert_eq!(
-        ("a1".to_string(), "a2".to_string()),
-        get_start_and_end_of_prefix("a1")?
-    );
-    {
-        let str = 127 as char;
-        let s = str.to_string();
-        let (_, end) = get_start_and_end_of_prefix(&s)?;
-        for byte in end.as_bytes() {
-            assert_eq!(*byte, 127_u8);
-        }
-    }
-    {
-        let ret = get_start_and_end_of_prefix("我");
-        match ret {
-            Err(e) => {
-                assert_eq!(
-                    e.to_string(),
-                    common_exception::ErrorCode::OnlySupportAsciiChars(format!(
-                        "Only support ASCII characters: {}",
-                        "我"
-                    ))
-                    .to_string()
-                );
-            }
-            Ok(_) => panic!("MUST return error "),
-        }
-    }
     Ok(())
 }
 

--- a/src/query/pipeline/core/Cargo.toml
+++ b/src/query/pipeline/core/Cargo.toml
@@ -23,5 +23,5 @@ petgraph = "0.6.2"
 [dev-dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { version = "1.23.1", features = ["full"] }
+tokio = { workspace = true }
 typetag = "0.2.3"

--- a/tests/sqllogictests/Cargo.toml
+++ b/tests/sqllogictests/Cargo.toml
@@ -28,5 +28,5 @@ serde = "1.0.150"
 serde_json = "1.0.89"
 sqllogictest = "0.11.1"
 thiserror = "1.0.37"
-tokio = { version = "1.23.1", features = ["full"] }
+tokio = { workspace = true }
 walkdir = "2.3.2"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(kvapi): remove dep common-base and common-exception; refine method names

## Changelog







## Related Issues