### PR TITLE
feat(query): tail-array optimization in aggregate partial

### DIFF
--- a/src/common/hashtable/src/container.rs
+++ b/src/common/hashtable/src/container.rs
@@ -66,7 +66,7 @@ unsafe impl<T, A: Allocator> Container for HeapContainer<T, A> {
 
     #[inline(always)]
     fn len(&self) -> usize {
-        self.as_ref().len()
+        self.0.len()
     }
 
     fn heap_bytes(&self) -> usize {

--- a/src/common/hashtable/src/hashtable.rs
+++ b/src/common/hashtable/src/hashtable.rs
@@ -27,6 +27,9 @@ use super::table0::Table0IterMut;
 use super::traits::HashtableLike;
 use super::traits::Keyable;
 use super::utils::ZeroEntry;
+use crate::tail_array::TailArray;
+use crate::tail_array::TailArrayIter;
+use crate::tail_array::TailArrayIterMut;
 use crate::FastHash;
 
 pub struct Hashtable<K, V, A = MmapAllocator<GlobalAllocator>>
@@ -36,6 +39,7 @@ where
 {
     pub(crate) zero: ZeroEntry<K, V>,
     pub(crate) table: Table0<K, V, HeapContainer<Entry<K, V>, A>, A>,
+    pub(crate) tails: Option<TailArray<K, V, A>>,
 }
 
 unsafe impl<K: Keyable + Send, V: Send, A: Allocator + Clone + Send> Send for Hashtable<K, V, A> {}
@@ -77,6 +81,7 @@ where
         Self {
             table: Table0::with_capacity_in(capacity, allocator),
             zero: ZeroEntry(None),
+            tails: None,
         }
     }
     #[inline(always)]
@@ -145,6 +150,11 @@ where
                 return Ok(zero);
             }
         }
+
+        if let Some(tails) = &mut self.tails {
+            return Ok(tails.insert(key));
+        }
+
         self.table.check_grow();
         self.table.insert(key)
     }
@@ -159,8 +169,10 @@ where
         }
     }
     pub fn iter(&self) -> HashtableIter<'_, K, V> {
+        let tail_iter = self.tails.as_ref().map(|tails| tails.iter());
         HashtableIter {
-            inner: self.zero.iter().chain(self.table.iter()),
+            inner: Some(self.zero.iter().chain(self.table.iter())),
+            tail_iter,
         }
     }
 }
@@ -191,7 +203,8 @@ where
 }
 
 pub struct HashtableIter<'a, K, V> {
-    pub inner: std::iter::Chain<std::option::Iter<'a, Entry<K, V>>, Table0Iter<'a, K, V>>,
+    pub inner: Option<std::iter::Chain<std::option::Iter<'a, Entry<K, V>>, Table0Iter<'a, K, V>>>,
+    pub tail_iter: Option<TailArrayIter<'a, K, V>>,
 }
 
 impl<'a, K, V> Iterator for HashtableIter<'a, K, V>
@@ -200,12 +213,26 @@ where K: Keyable
     type Item = &'a Entry<K, V>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
+        if let Some(it) = self.inner.as_mut() {
+            if let Some(e) = it.next() {
+                return Some(e);
+            }
+            self.inner = None;
+        }
+
+        if let Some(it) = self.tail_iter.as_mut() {
+            if let Some(e) = it.next() {
+                return Some(e);
+            }
+            self.tail_iter = None;
+        }
+        None
     }
 }
 
 pub struct HashtableIterMut<'a, K, V> {
-    inner: std::iter::Chain<std::option::IterMut<'a, Entry<K, V>>, Table0IterMut<'a, K, V>>,
+    inner: Option<std::iter::Chain<std::option::IterMut<'a, Entry<K, V>>, Table0IterMut<'a, K, V>>>,
+    tail_iter: Option<TailArrayIterMut<'a, K, V>>,
 }
 
 impl<'a, K, V> Iterator for HashtableIterMut<'a, K, V>
@@ -214,14 +241,27 @@ where K: Keyable
     type Item = &'a mut Entry<K, V>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
+        if let Some(it) = self.inner.as_mut() {
+            if let Some(e) = it.next() {
+                return Some(e);
+            }
+            self.inner = None;
+        }
+
+        if let Some(it) = self.tail_iter.as_mut() {
+            if let Some(e) = it.next() {
+                return Some(e);
+            }
+            self.tail_iter = None;
+        }
+        None
     }
 }
 
 impl<K, V, A> HashtableLike for Hashtable<K, V, A>
 where
     K: Keyable + FastHash,
-    A: Allocator + Clone + 'static,
+    A: Allocator + Default + Clone + 'static,
 {
     type Key = K;
     type Value = V;
@@ -309,13 +349,22 @@ where
     }
 
     fn iter(&self) -> Self::Iterator<'_> {
+        let tail_iter = self.tails.as_ref().map(|tails| tails.iter());
         HashtableIter {
-            inner: self.zero.iter().chain(self.table.iter()),
+            inner: Some(self.zero.iter().chain(self.table.iter())),
+            tail_iter,
         }
     }
 
     fn clear(&mut self) {
         self.zero.0.take();
         self.table.clear();
+        let _ = self.tails.take();
+    }
+
+    fn enable_tail_array(&mut self) {
+        if self.tails.is_none() {
+            self.tails = Some(TailArray::new(Default::default()));
+        }
     }
 }

--- a/src/common/hashtable/src/lib.rs
+++ b/src/common/hashtable/src/lib.rs
@@ -30,6 +30,7 @@ mod simple_unsized_hashtable;
 #[allow(dead_code)]
 mod table1;
 mod table_empty;
+mod tail_array;
 mod traits;
 mod twolevel_hashtable;
 mod unsized_hashtable;

--- a/src/common/hashtable/src/tail_array.rs
+++ b/src/common/hashtable/src/tail_array.rs
@@ -1,0 +1,133 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::alloc::Allocator;
+
+use super::table0::Entry;
+use super::traits::Keyable;
+use crate::container::Container;
+use crate::container::StackContainer;
+
+const SIZE: usize = 8192;
+
+pub struct TailArray<K, V, A: Allocator> {
+    allocator: A,
+    pub(crate) datas: Vec<StackContainer<Entry<K, V>, SIZE, A>>,
+    pub(crate) num_items: usize,
+}
+
+impl<K, V, A> TailArray<K, V, A>
+where
+    K: Keyable,
+    A: Allocator + Clone,
+{
+    pub fn new(allocator: A) -> Self {
+        Self {
+            datas: vec![],
+            num_items: 0,
+            allocator,
+        }
+    }
+
+    pub fn insert(&mut self, key: K) -> &mut Entry<K, V> {
+        let pos = self.num_items % SIZE;
+        if pos == 0 {
+            let container = unsafe { StackContainer::new_zeroed(SIZE, self.allocator.clone()) };
+            self.datas.push(container);
+        }
+
+        let tail = self.datas.last_mut().unwrap();
+        unsafe { tail[pos].set_key(key) };
+
+        self.num_items += 1;
+        &mut tail[pos]
+    }
+
+    pub fn iter(&self) -> TailArrayIter<'_, K, V> {
+        TailArrayIter {
+            values: self.datas.iter().map(|v| v.as_ref()).collect(),
+            num_items: self.num_items,
+            i: 0,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn iter_mut(&mut self) -> TailArrayIterMut<'_, K, V> {
+        TailArrayIterMut {
+            values: self.datas.iter_mut().map(|v| v.as_mut()).collect(),
+            num_items: self.num_items,
+            i: 0,
+        }
+    }
+}
+
+pub struct TailArrayIter<'a, K, V> {
+    values: Vec<&'a [Entry<K, V>]>,
+    num_items: usize,
+    i: usize,
+}
+
+impl<'a, K, V> Iterator for TailArrayIter<'a, K, V> {
+    type Item = &'a Entry<K, V>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i >= self.num_items {
+            None
+        } else {
+            let array = self.i / SIZE;
+            let pos = self.i % SIZE;
+
+            let v = self.values[array];
+            let res = &v.as_ref()[pos];
+            self.i += 1;
+            Some(res)
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.num_items - self.i, Some(self.num_items - self.i))
+    }
+}
+
+pub struct TailArrayIterMut<'a, K, V> {
+    values: Vec<&'a mut [Entry<K, V>]>,
+    num_items: usize,
+    i: usize,
+}
+
+impl<'a, K, V> Iterator for TailArrayIterMut<'a, K, V>
+where Self: 'a
+{
+    type Item = &'a mut Entry<K, V>  where Self: 'a ;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i >= self.num_items {
+            None
+        } else {
+            let array = self.i / SIZE;
+            let pos = self.i % SIZE;
+
+            let v = &mut self.values[array];
+            let res = unsafe { &mut *(v.as_ptr().add(pos) as *mut _) };
+            self.i += 1;
+            Some(res)
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.num_items - self.i, Some(self.num_items - self.i))
+    }
+}

--- a/src/common/hashtable/src/traits.rs
+++ b/src/common/hashtable/src/traits.rs
@@ -491,5 +491,11 @@ pub trait HashtableLike {
 
     fn iter(&self) -> Self::Iterator<'_>;
 
+    /// Note: don't call this function unless you want what you are doing.
+    /// This function will make hashtable not like `hashtable` but a linked list.
+    /// If it's enabled, we will push all new keys into the tail of the linked list.
+    /// This is used in partial aggregation
+    fn enable_tail_array(&mut self) {}
+
     fn clear(&mut self);
 }

--- a/src/common/hashtable/src/twolevel_hashtable.rs
+++ b/src/common/hashtable/src/twolevel_hashtable.rs
@@ -165,6 +165,12 @@ impl<K: ?Sized + FastHash, V, Impl: HashtableLike<Key = K, Value = V>> Hashtable
             inner_table.clear();
         }
     }
+
+    fn enable_tail_array(&mut self) {
+        for inner_table in &mut self.tables {
+            inner_table.enable_tail_array();
+        }
+    }
 }
 
 pub struct TwoLevelHashtableIter<Impl> {

--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -306,11 +306,6 @@ impl DataBlock {
         self.meta.as_ref()
     }
 
-    #[inline]
-    pub fn meta(&self) -> Result<Option<BlockMetaInfoPtr>> {
-        Ok(self.meta.clone())
-    }
-
     pub fn from_arrow_chunk<A: AsRef<dyn Array>>(
         arrow_chunk: &ArrowChunk<A>,
         schema: &DataSchema,

--- a/src/query/service/src/api/rpc/exchange/exchange_sink_merge.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_sink_merge.rs
@@ -103,7 +103,7 @@ impl Processor for ExchangeMergeSink {
 
             let mut meta = vec![];
             meta.write_scalar_own(data_block.num_rows() as u32)?;
-            bincode::serialize_into(&mut meta, &data_block.meta()?)
+            bincode::serialize_into(&mut meta, &data_block.get_meta())
                 .map_err(|_| ErrorCode::BadBytes("block meta serialize error when exchange"))?;
 
             let chunks = data_block.try_into()?;

--- a/src/query/service/src/api/rpc/exchange/exchange_sink_shuffle.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_sink_shuffle.rs
@@ -124,7 +124,7 @@ impl Processor for ExchangePublisherSink {
 
                 let mut meta = vec![];
                 meta.write_scalar_own(data_block.num_rows() as u32)?;
-                bincode::serialize_into(&mut meta, &data_block.meta()?)
+                bincode::serialize_into(&mut meta, &data_block.get_meta())
                     .map_err(|_| ErrorCode::BadBytes("block meta serialize error when exchange"))?;
 
                 let chunks = data_block.try_into()?;

--- a/src/query/service/src/api/rpc/exchange/exchange_transform.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_transform.rs
@@ -232,7 +232,7 @@ impl Processor for ExchangeTransform {
                 } else {
                     let mut meta = vec![];
                     meta.write_scalar_own(data_block.num_rows() as u32)?;
-                    bincode::serialize_into(&mut meta, &data_block.meta()?).map_err(|_| {
+                    bincode::serialize_into(&mut meta, &data_block.get_meta()).map_err(|_| {
                         ErrorCode::BadBytes("block meta serialize error when exchange")
                     })?;
 

--- a/src/query/service/src/api/rpc/flight_scatter_hash.rs
+++ b/src/query/service/src/api/rpc/flight_scatter_hash.rs
@@ -124,10 +124,10 @@ impl FlightScatter for OneHashKeyFlightScatter {
         let indices = get_hash_values(&indices, num)?;
         let data_blocks = DataBlock::scatter(data_block, &indices, self.scatter_size)?;
 
-        let block_meta = data_block.meta()?;
+        let block_meta = data_block.get_meta();
         let mut res = Vec::with_capacity(data_blocks.len());
         for data_block in data_blocks {
-            res.push(data_block.add_meta(block_meta.clone())?);
+            res.push(data_block.add_meta(block_meta.cloned())?);
         }
 
         Ok(res)
@@ -150,12 +150,12 @@ impl FlightScatter for HashFlightScatter {
             Ok(vec![0; num])
         }?;
 
-        let block_meta = data_block.meta()?;
+        let block_meta = data_block.get_meta();
         let data_blocks = DataBlock::scatter(data_block, &indices, self.scatter_size)?;
 
         let mut res = Vec::with_capacity(data_blocks.len());
         for data_block in data_blocks {
-            res.push(data_block.add_meta(block_meta.clone())?);
+            res.push(data_block.add_meta(block_meta.cloned())?);
         }
 
         Ok(res)

--- a/src/query/service/src/api/rpc/packets/packet_data_precommit.rs
+++ b/src/query/service/src/api/rpc/packets/packet_data_precommit.rs
@@ -40,7 +40,7 @@ impl PrecommitBlock {
 
     pub fn write<T: Write>(self, bytes: &mut T) -> Result<()> {
         let data_block = self.0;
-        let serialized_meta = bincode::serialize(&data_block.meta()?).map_err_to_code(
+        let serialized_meta = bincode::serialize(&data_block.get_meta()).map_err_to_code(
             ErrorCode::BadBytes,
             || "precommit block serialize error when exchange",
         )?;

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_hashstate_info.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_hashstate_info.rs
@@ -1,0 +1,68 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use common_expression::BlockMetaInfo;
+use common_expression::BlockMetaInfoPtr;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+#[derive(Debug)]
+pub struct AggregateHashStateInfo {
+    pub bucket: usize,
+    // a subhashtable state
+    pub hash_state: Box<dyn Any + Send + Sync>,
+}
+
+impl AggregateHashStateInfo {
+    pub fn create(bucket: usize, hash_state: Box<dyn Any + Send + Sync>) -> BlockMetaInfoPtr {
+        Box::new(AggregateHashStateInfo { bucket, hash_state })
+    }
+}
+
+impl Serialize for AggregateHashStateInfo {
+    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        unreachable!("AggregateHashStateInfo does not support exchanging between multiple nodes")
+    }
+}
+
+impl<'de> Deserialize<'de> for AggregateHashStateInfo {
+    fn deserialize<D>(_: D) -> Result<Self, D::Error>
+    where D: Deserializer<'de> {
+        unreachable!("AggregateHashStateInfo does not support exchanging between multiple nodes")
+    }
+}
+
+#[typetag::serde(name = "aggregate_info")]
+impl BlockMetaInfo for AggregateHashStateInfo {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
+        unimplemented!("Unimplemented clone for AggregateHashStateInfo")
+    }
+
+    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
+        unimplemented!("Unimplemented equals for AggregateHashStateInfo")
+    }
+}

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_twolevel.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_twolevel.rs
@@ -114,6 +114,8 @@ where
                 method: two_level_method,
                 hash_table: two_level_hashtable,
                 generated: false,
+                should_expand_table: true,
+                input_rows: self.input_rows,
             },
         })
     }
@@ -252,6 +254,8 @@ impl<T: TwoLevelAggregatorLike> Aggregator for TwoLevelAggregator<T> {
 
     #[inline(always)]
     fn consume(&mut self, data: DataBlock) -> Result<()> {
+        // only checked in two level aggregator for high cardinality group by
+        self.inner.check_expandsion();
         self.inner.consume(data)
     }
 

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod aggregate_hashstate_info;
 mod aggregate_info;
 mod aggregator_final;
 mod aggregator_final_parallel;
@@ -21,6 +22,7 @@ mod aggregator_single_key;
 mod aggregator_twolevel;
 mod utils;
 
+pub use aggregate_hashstate_info::AggregateHashStateInfo;
 pub use aggregate_info::AggregateInfo;
 pub use aggregate_info::OverflowInfo;
 pub use aggregator_final_parallel::BucketAggregator;

--- a/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_keys_builder.rs
+++ b/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_keys_builder.rs
@@ -49,25 +49,25 @@ impl<'a, T: Number> KeysColumnBuilder for FixedKeysColumnBuilder<'a, T> {
     }
 }
 
-pub struct SerializedKeysColumnBuilder<'a> {
+pub struct StringKeysColumnBuilder<'a> {
     pub inner_builder: StringColumnBuilder,
 
-    initial: usize,
+    _initial: usize,
 
     _phantom: PhantomData<&'a ()>,
 }
 
-impl<'a> SerializedKeysColumnBuilder<'a> {
+impl<'a> StringKeysColumnBuilder<'a> {
     pub fn create(capacity: usize, value_capacity: usize) -> Self {
-        SerializedKeysColumnBuilder {
+        StringKeysColumnBuilder {
             inner_builder: StringColumnBuilder::with_capacity(capacity, value_capacity),
             _phantom: PhantomData,
-            initial: value_capacity,
+            _initial: value_capacity,
         }
     }
 }
 
-impl<'a> KeysColumnBuilder for SerializedKeysColumnBuilder<'a> {
+impl<'a> KeysColumnBuilder for StringKeysColumnBuilder<'a> {
     type T = &'a [u8];
 
     fn append_value(&mut self, v: &'a [u8]) {
@@ -76,7 +76,7 @@ impl<'a> KeysColumnBuilder for SerializedKeysColumnBuilder<'a> {
     }
 
     fn finish(self) -> Column {
-        debug_assert!(self.initial == self.inner_builder.data.len());
+        debug_assert_eq!(self._initial, self.inner_builder.data.len());
         Column::String(self.inner_builder.build())
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/group_by/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/group_by/mod.rs
@@ -26,5 +26,6 @@ pub use aggregator_keys_iter::KeysColumnIter;
 pub use aggregator_polymorphic_keys::PolymorphicKeysHelper;
 pub use aggregator_polymorphic_keys::TwoLevelHashMethod;
 pub use aggregator_state::Area;
+pub use aggregator_state::ArenaHolder;
 pub use aggregator_state_entity::StateEntityMutRef;
 pub use aggregator_state_entity::StateEntityRef;

--- a/src/query/service/src/pipelines/processors/transforms/transform_aggregator.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_aggregator.rs
@@ -103,6 +103,8 @@ impl TransformAggregator {
 pub trait Aggregator: Sized + Send {
     const NAME: &'static str;
 
+    fn check_expandsion(&mut self) {}
+
     fn consume(&mut self, data: DataBlock) -> Result<()>;
     // Generate could be called multiple times util it returns empty.
     fn generate(&mut self) -> Result<Vec<DataBlock>>;

--- a/src/query/service/src/pipelines/processors/transforms/transform_aggregator.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_aggregator.rs
@@ -20,6 +20,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::*;
 
+use super::group_by::ArenaHolder;
 use crate::pipelines::processors::port::InputPort;
 use crate::pipelines::processors::port::OutputPort;
 use crate::pipelines::processors::processor::Event;
@@ -69,6 +70,8 @@ impl TransformAggregator {
     pub fn try_create_partial(
         transform_params: AggregatorTransformParams,
         ctx: Arc<QueryContext>,
+        pass_state_to_final: bool,
+        arena_holder: ArenaHolder,
     ) -> Result<ProcessorPtr> {
         let aggregator_params = transform_params.aggregator_params.clone();
 
@@ -86,14 +89,24 @@ impl TransformAggregator {
                 HashMethodKind::T(method) => AggregatorTransform::create(
                     ctx,
                     transform_params,
-                    PartialAggregator::<false, T>::create(method, aggregator_params)?,
+                    PartialAggregator::<false, T>::create(
+                        method,
+                        aggregator_params,
+                        pass_state_to_final,
+                        arena_holder
+                    )?,
                 ),
             }),
             false => with_mappedhash_method!(|T| match transform_params.method.clone() {
                 HashMethodKind::T(method) => AggregatorTransform::create(
                     ctx,
                     transform_params,
-                    PartialAggregator::<true, T>::create(method, aggregator_params)?,
+                    PartialAggregator::<true, T>::create(
+                        method,
+                        aggregator_params,
+                        pass_state_to_final,
+                        arena_holder
+                    )?,
                 ),
             }),
         }

--- a/src/query/service/src/pipelines/processors/transforms/transform_convert_grouping.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_convert_grouping.rs
@@ -37,6 +37,8 @@ use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
 
+use super::aggregator::AggregateHashStateInfo;
+use super::group_by::ArenaHolder;
 use crate::pipelines::processors::transforms::aggregator::AggregateInfo;
 use crate::pipelines::processors::transforms::aggregator::BucketAggregator;
 use crate::pipelines::processors::transforms::group_by::KeysColumnIter;
@@ -101,6 +103,8 @@ struct InputPortState {
     bucket: isize,
 }
 
+/// A helper class that  Map
+/// AggregateInfo/AggregateHashStateInfo  --->  ConvertGroupingMetaInfo { meta: blocks with Option<AggregateHashStateInfo> }
 pub struct TransformConvertGrouping<Method: HashMethod + PolymorphicKeysHelper<Method>> {
     output: Arc<OutputPort>,
     inputs: Vec<InputPortState>,
@@ -186,11 +190,10 @@ impl<Method: HashMethod + PolymorphicKeysHelper<Method>> TransformConvertGroupin
     }
 
     fn add_bucket(&mut self, data_block: DataBlock) -> isize {
-        let data_block_meta: Option<&AggregateInfo> = data_block
+        if let Some(info) = data_block
             .get_meta()
-            .and_then(|meta| meta.as_any().downcast_ref::<AggregateInfo>());
-
-        if let Some(info) = data_block_meta {
+            .and_then(|meta| meta.as_any().downcast_ref::<AggregateInfo>())
+        {
             if info.overflow.is_none() && info.bucket > SINGLE_LEVEL_BUCKET_NUM {
                 let bucket = info.bucket;
                 match self.buckets_blocks.entry(bucket) {
@@ -204,6 +207,23 @@ impl<Method: HashMethod + PolymorphicKeysHelper<Method>> TransformConvertGroupin
 
                 return bucket;
             }
+        }
+
+        // check if it's local state
+        if let Some(info) = data_block
+            .get_meta()
+            .and_then(|meta| meta.as_any().downcast_ref::<AggregateHashStateInfo>())
+        {
+            let bucket = info.bucket as isize;
+            match self.buckets_blocks.entry(bucket) {
+                Entry::Vacant(v) => {
+                    v.insert(vec![data_block]);
+                }
+                Entry::Occupied(mut v) => {
+                    v.get_mut().push(data_block);
+                }
+            };
+            return bucket;
         }
 
         self.unsplitted_blocks.push(data_block);
@@ -389,6 +409,7 @@ fn build_convert_grouping<Method: HashMethod + PolymorphicKeysHelper<Method> + S
     method: Method,
     pipeline: &mut Pipeline,
     params: Arc<AggregatorParams>,
+    arena_holder: ArenaHolder,
 ) -> Result<()> {
     let input_nums = pipeline.output_len();
     let transform = TransformConvertGrouping::create(method.clone(), params.clone(), input_nums)?;
@@ -405,12 +426,19 @@ fn build_convert_grouping<Method: HashMethod + PolymorphicKeysHelper<Method> + S
     pipeline.resize(input_nums)?;
 
     pipeline.add_transform(|input, output| {
-        MergeBucketTransform::try_create(input, output, method.clone(), params.clone())
+        MergeBucketTransform::try_create(
+            input,
+            output,
+            method.clone(),
+            params.clone(),
+            arena_holder.clone(),
+        )
     })
 }
 
 pub fn efficiently_memory_final_aggregator(
     params: Arc<AggregatorParams>,
+    arena_holder: ArenaHolder,
     pipeline: &mut Pipeline,
 ) -> Result<()> {
     let group_cols = &params.group_columns;
@@ -419,7 +447,7 @@ pub fn efficiently_memory_final_aggregator(
     let method = DataBlock::choose_hash_method(&sample_block, group_cols)?;
 
     with_hash_method!(|T| match method {
-        HashMethodKind::T(v) => build_convert_grouping(v, pipeline, params.clone()),
+        HashMethodKind::T(v) => build_convert_grouping(v, pipeline, params.clone(), arena_holder),
     })
 }
 
@@ -432,6 +460,9 @@ struct MergeBucketTransform<Method: HashMethod + PolymorphicKeysHelper<Method> +
 
     input_block: Option<DataBlock>,
     output_blocks: Vec<DataBlock>,
+
+    // holds the state from partial group by
+    _arena_holder: ArenaHolder,
 }
 
 impl<Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static>
@@ -442,6 +473,7 @@ impl<Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static>
         output: Arc<OutputPort>,
         method: Method,
         params: Arc<AggregatorParams>,
+        arena_holder: ArenaHolder,
     ) -> Result<ProcessorPtr> {
         Ok(ProcessorPtr::create(Box::new(MergeBucketTransform {
             input,
@@ -450,6 +482,7 @@ impl<Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static>
             params,
             input_block: None,
             output_blocks: vec![],
+            _arena_holder: arena_holder,
         })))
     }
 }
@@ -505,9 +538,9 @@ impl<Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static> Proces
     fn process(&mut self) -> Result<()> {
         if let Some(mut data_block) = self.input_block.take() {
             let mut blocks = vec![];
-            if let Some(meta) = data_block.take_meta() {
-                if let Some(meta) = meta.as_any().downcast_ref::<ConvertGroupingMetaInfo>() {
-                    blocks.extend(meta.blocks.iter().cloned());
+            if let Some(mut meta) = data_block.take_meta() {
+                if let Some(meta) = meta.as_mut_any().downcast_mut::<ConvertGroupingMetaInfo>() {
+                    std::mem::swap(&mut blocks, &mut meta.blocks);
                 }
             }
 

--- a/src/query/storages/fuse/src/operations/operation_log.rs
+++ b/src/query/storages/fuse/src/operations/operation_log.rs
@@ -53,10 +53,10 @@ impl TryFrom<&DataBlock> for AppendOperationLogEntry {
     fn try_from(block: &DataBlock) -> Result<Self, Self::Error> {
         let err = ErrorCode::Internal(format!(
             "invalid data block meta of AppendOperation log, {:?}",
-            block.meta()
+            block.get_meta()
         ));
 
-        if let Some(meta) = block.meta()? {
+        if let Some(meta) = block.get_meta() {
             let cast = meta.as_any().downcast_ref::<AppendOperationLogEntry>();
             return match cast {
                 None => Err(err),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

If the reduce_factor is too low, we use tail-array in hashtable via `enable_tail_array` method.

Closes #issue
