### PR TITLE
feat(query): support array concat

### DIFF
--- a/src/query/functions/src/scalars/array.rs
+++ b/src/query/functions/src/scalars/array.rs
@@ -170,6 +170,48 @@ pub fn register(registry: &mut FunctionRegistry) {
         ),
     );
 
+    registry.register_2_arg_core::<NullableType<EmptyArrayType>, NullableType<EmptyArrayType>, EmptyArrayType, _, _>(
+        "concat",
+        FunctionProperty::default(),
+        |_, _| FunctionDomain::Full,
+        |_, _, _| Value::Scalar(()),
+    );
+
+    registry.register_combine_nullable_2_arg::<EmptyArrayType, ArrayType<NullableType<GenericType<0>>>, ArrayType<NullableType<GenericType<0>>>, _, _>(
+        "concat",
+        FunctionProperty::default(),
+        |_, _| FunctionDomain::Full,
+        vectorize_with_builder_2_arg::<EmptyArrayType, ArrayType<NullableType<GenericType<0>>>, NullableType<ArrayType<NullableType<GenericType<0>>>>>(
+            |_, arr, output, _| {
+                output.push(arr)
+            }
+        ),
+    );
+
+    registry.register_combine_nullable_2_arg::<ArrayType<NullableType<GenericType<0>>>, EmptyArrayType, ArrayType<NullableType<GenericType<0>>>, _, _>(
+        "concat",
+        FunctionProperty::default(),
+        |_, _| FunctionDomain::Full,
+        vectorize_with_builder_2_arg::<ArrayType<NullableType<GenericType<0>>>, EmptyArrayType, NullableType<ArrayType<NullableType<GenericType<0>>>>>(
+            |arr, _, output, _| {
+                output.push(arr)
+            }
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, _, _>(
+        "concat",
+        FunctionProperty::default(),
+        |_, _| FunctionDomain::Full,
+        vectorize_with_builder_2_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, ArrayType<GenericType<0>>>(
+            |lhs, rhs, output, _| {
+                output.builder.append_column(&lhs);
+                output.builder.append_column(&rhs);
+                output.commit_row()
+            }
+        ),
+    );
+
     registry.register_passthrough_nullable_3_arg::<EmptyArrayType, UInt64Type, UInt64Type, EmptyArrayType, _, _>(
         "slice",
         FunctionProperty::default(),

--- a/src/query/functions/src/scalars/array.rs
+++ b/src/query/functions/src/scalars/array.rs
@@ -177,22 +177,22 @@ pub fn register(registry: &mut FunctionRegistry) {
         |_, _, _| Value::Scalar(()),
     );
 
-    registry.register_combine_nullable_2_arg::<EmptyArrayType, ArrayType<NullableType<GenericType<0>>>, ArrayType<NullableType<GenericType<0>>>, _, _>(
+    registry.register_passthrough_nullable_2_arg::<EmptyArrayType, ArrayType<NullableType<GenericType<0>>>, ArrayType<NullableType<GenericType<0>>>, _, _>(
         "concat",
         FunctionProperty::default(),
         |_, _| FunctionDomain::Full,
-        vectorize_with_builder_2_arg::<EmptyArrayType, ArrayType<NullableType<GenericType<0>>>, NullableType<ArrayType<NullableType<GenericType<0>>>>>(
+        vectorize_with_builder_2_arg::<EmptyArrayType, ArrayType<NullableType<GenericType<0>>>, ArrayType<NullableType<GenericType<0>>>>(
             |_, arr, output, _| {
                 output.push(arr)
             }
         ),
     );
 
-    registry.register_combine_nullable_2_arg::<ArrayType<NullableType<GenericType<0>>>, EmptyArrayType, ArrayType<NullableType<GenericType<0>>>, _, _>(
+    registry.register_passthrough_nullable_2_arg::<ArrayType<NullableType<GenericType<0>>>, EmptyArrayType, ArrayType<NullableType<GenericType<0>>>, _, _>(
         "concat",
         FunctionProperty::default(),
         |_, _| FunctionDomain::Full,
-        vectorize_with_builder_2_arg::<ArrayType<NullableType<GenericType<0>>>, EmptyArrayType, NullableType<ArrayType<NullableType<GenericType<0>>>>>(
+        vectorize_with_builder_2_arg::<ArrayType<NullableType<GenericType<0>>>, EmptyArrayType, ArrayType<NullableType<GenericType<0>>>>(
             |arr, _, output, _| {
                 output.push(arr)
             }

--- a/src/query/functions/tests/it/scalars/array.rs
+++ b/src/query/functions/tests/it/scalars/array.rs
@@ -32,6 +32,7 @@ fn test_array() {
     test_remove_first(file);
     test_remove_last(file);
     test_contains(file);
+    test_concat(file);
 }
 
 fn test_create(file: &mut impl Write) {
@@ -126,4 +127,26 @@ fn test_contains(file: &mut impl Write) {
         "nullable_col in (1, '9', 3, 10, 12, true, [1,2,3])",
         &columns,
     );
+}
+
+fn test_concat(file: &mut impl Write) {
+    run_ast(file, "concat([false, true], [1,2])", &[]);
+    run_ast(file, "concat([1,2,3], ['s', null])", &[]);
+
+    let columns = [
+        ("int8_col", Int8Type::from_data(vec![1i8, 2, 7, 8])),
+        (
+            "nullable_col",
+            Int64Type::from_data_with_validity(vec![9i64, 10, 11, 12], vec![
+                true, true, false, false,
+            ]),
+        ),
+    ];
+
+    run_ast(
+        file,
+        "concat([1, 2, 3, 4, 5, null], [nullable_col])",
+        &columns,
+    );
+    run_ast(file, "concat([1,2,null], [int8_col])", &columns);
 }

--- a/src/query/functions/tests/it/scalars/testdata/array.txt
+++ b/src/query/functions/tests/it/scalars/testdata/array.txt
@@ -495,3 +495,69 @@ evaluation (internal):
 +--------------+---------------------------------------------------------------------------+
 
 
+ast            : concat([false, true], [1,2])
+raw expr       : concat(array(false, true), array(1_u8, 2_u8))
+checked expr   : concat<T0=Variant><Array(T0), Array(T0)>(CAST(array<T0=Boolean><T0, T0>(false, true) AS Array(Variant)), CAST(array<T0=UInt8><T0, T0>(1_u8, 2_u8) AS Array(Variant)))
+optimized expr : [false, true, 1, 2]
+output type    : Array(Variant)
+output domain  : [Undefined]
+output         : [false, true, 1, 2]
+
+
+ast            : concat([1,2,3], ['s', null])
+raw expr       : concat(array(1_u8, 2_u8, 3_u8), array("s", NULL))
+checked expr   : concat<T0=Variant NULL><Array(T0), Array(T0)>(CAST(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8) AS Array(Variant NULL)), CAST(array<T0=String NULL><T0, T0>(CAST("s" AS String NULL), CAST(NULL AS String NULL)) AS Array(Variant NULL)))
+optimized expr : [1, 2, 3, "s", NULL]
+output type    : Array(Variant NULL)
+output domain  : [Undefined ∪ {NULL}]
+output         : [1, 2, 3, "s", NULL]
+
+
+ast            : concat([1, 2, 3, 4, 5, null], [nullable_col])
+raw expr       : concat(array(1_u8, 2_u8, 3_u8, 4_u8, 5_u8, NULL), array(nullable_col::Int64 NULL))
+checked expr   : concat<T0=Int64 NULL><Array(T0), Array(T0)>(CAST(array<T0=UInt8 NULL><T0, T0, T0, T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL), CAST(5_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int64 NULL)), array<T0=Int64 NULL><T0>(nullable_col))
+optimized expr : concat<T0=Int64 NULL><Array(T0), Array(T0)>([1_i64, 2_i64, 3_i64, 4_i64, 5_i64, NULL], array<T0=Int64 NULL><T0>(nullable_col))
+evaluation:
++--------+-------------------+---------------------------------------------------------+
+|        | nullable_col      | Output                                                  |
++--------+-------------------+---------------------------------------------------------+
+| Type   | Int64 NULL        | Array(Int64 NULL)                                       |
+| Domain | {9..=12} ∪ {NULL} | [{-9223372036854775808..=9223372036854775807} ∪ {NULL}] |
+| Row 0  | 9_i64             | [1_i64, 2_i64, 3_i64, 4_i64, 5_i64, NULL, 9_i64]        |
+| Row 1  | 10_i64            | [1_i64, 2_i64, 3_i64, 4_i64, 5_i64, NULL, 10_i64]       |
+| Row 2  | NULL              | [1_i64, 2_i64, 3_i64, 4_i64, 5_i64, NULL, NULL]         |
+| Row 3  | NULL              | [1_i64, 2_i64, 3_i64, 4_i64, 5_i64, NULL, NULL]         |
++--------+-------------------+---------------------------------------------------------+
+evaluation (internal):
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column       | Data                                                                                                                                                                                                                                     |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| nullable_col | NullableColumn { column: Int64([9, 10, 11, 12]), validity: [0b____0011] }                                                                                                                                                                |
+| Output       | ArrayColumn { values: NullableColumn { column: Int64([1, 2, 3, 4, 5, 0, 9, 1, 2, 3, 4, 5, 0, 10, 1, 2, 3, 4, 5, 0, 0, 1, 2, 3, 4, 5, 0, 0]), validity: [0b11011111, 0b11101111, 0b11100111, 0b____0011] }, offsets: [0, 7, 14, 21, 28] } |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : concat([1,2,null], [int8_col])
+raw expr       : concat(array(1_u8, 2_u8, NULL), array(int8_col::Int8))
+checked expr   : concat<T0=Int16 NULL><Array(T0), Array(T0)>(CAST(array<T0=UInt8 NULL><T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int16 NULL)), CAST(array<T0=Int8><T0>(int8_col) AS Array(Int16 NULL)))
+optimized expr : concat<T0=Int16 NULL><Array(T0), Array(T0)>([1_i16, 2_i16, NULL], CAST(array<T0=Int8><T0>(int8_col) AS Array(Int16 NULL)))
+evaluation:
++--------+----------+-----------------------------+
+|        | int8_col | Output                      |
++--------+----------+-----------------------------+
+| Type   | Int8     | Array(Int16 NULL)           |
+| Domain | {1..=8}  | [{-32768..=32767} ∪ {NULL}] |
+| Row 0  | 1_i8     | [1_i16, 2_i16, NULL, 1_i16] |
+| Row 1  | 2_i8     | [1_i16, 2_i16, NULL, 2_i16] |
+| Row 2  | 7_i8     | [1_i16, 2_i16, NULL, 7_i16] |
+| Row 3  | 8_i8     | [1_i16, 2_i16, NULL, 8_i16] |
++--------+----------+-----------------------------+
+evaluation (internal):
++----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column   | Data                                                                                                                                                                       |
++----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| int8_col | Int8([1, 2, 7, 8])                                                                                                                                                         |
+| Output   | ArrayColumn { values: NullableColumn { column: Int16([1, 2, 0, 1, 1, 2, 0, 2, 1, 2, 0, 7, 1, 2, 0, 8]), validity: [0b10111011, 0b10111011] }, offsets: [0, 4, 8, 12, 16] } |
++----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -413,6 +413,13 @@ city64withseed(Variant, Float64) :: UInt64
 city64withseed(Variant NULL, Float64 NULL) :: UInt64 NULL
 city64withseed(Variant, Float32) :: UInt64
 city64withseed(Variant NULL, Float32 NULL) :: UInt64 NULL
+concat(Array(Nothing) NULL, Array(Nothing) NULL) :: Array(Nothing)
+concat(Array(Nothing), Array(T0 NULL)) :: Array(T0 NULL)
+concat(Array(Nothing) NULL, Array(T0 NULL) NULL) :: Array(T0 NULL) NULL
+concat(Array(T0 NULL), Array(Nothing)) :: Array(T0 NULL)
+concat(Array(T0 NULL) NULL, Array(Nothing) NULL) :: Array(T0 NULL) NULL
+concat(Array(T0), Array(T0)) :: Array(T0)
+concat(Array(T0) NULL, Array(T0) NULL) :: Array(T0) NULL
 contains(Array(UInt8), UInt8) :: Boolean
 contains(Array(UInt8) NULL, UInt8 NULL) :: Boolean NULL
 contains(Array(UInt16), UInt16) :: Boolean

--- a/tests/sqllogictests/suites/base/11_data_type/11_0005_data_type_array
+++ b/tests/sqllogictests/suites/base/11_data_type/11_0005_data_type_array
@@ -1,0 +1,40 @@
+statement ok
+DROP DATABASE IF EXISTS data_type
+
+statement ok
+CREATE DATABASE IF NOT EXISTS data_type
+
+statement ok
+USE data_type
+
+statement ok
+DROP TABLE IF EXISTS t
+
+statement ok
+create table t(col1 Array(Int Null), col2 Array(String), col3 Array(Date), col4 Array(Timestamp), col5 Array(Array(Int null)))
+
+statement ok
+insert into t values([1,2],['x','y'], ['2022-02-02'], ['2023-01-01 02:00:01'], [[1,2],[],[null]])
+
+query T
+select concat(col1, col5) from t
+----
+['1','2','[1,2]','[]','[null]']
+
+query T
+select concat(col1, col2) from t;
+----
+['1','2','"x"','"y"']
+
+query T
+select concat(col5, col2) from t;
+----
+['[1,2]','[]','[null]','"x"','"y"']
+
+query T
+select concat(col4, col3) from t;
+----
+['2023-01-01 02:00:01.000000','2022-02-02 00:00:00.000000']
+
+statement ok
+DROP DATABASE data_type


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary



concat(list1, list2) | Concatenates two lists. | concat([2, 3], [4, 5, 6]) | [2, 3, 4, 5, 6]
-- | -- | -- | --



Closes #9803
