### PR TITLE
refactor(kvapi): biuld key with KeyBuilder, instead of with raw "format!"

### DIFF
--- a/src/meta/api/src/id_generator.rs
+++ b/src/meta/api/src/id_generator.rs
@@ -57,7 +57,9 @@ impl kvapi::Key for IdGenerator {
     const PREFIX: &'static str = PREFIX_ID_GEN;
 
     fn to_string_key(&self) -> String {
-        format!("{}/{}", Self::PREFIX, self.resource)
+        kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+            .push_raw(&self.resource)
+            .done()
     }
 
     fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -329,7 +329,9 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = PREFIX_DATABASE_BY_ID;
 
         fn to_string_key(&self) -> String {
-            format!("{}/{}", Self::PREFIX, self.db_id,)
+            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                .push_u64(self.db_id)
+                .done()
         }
 
         fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
@@ -347,7 +349,9 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = PREFIX_DATABASE_ID_TO_NAME;
 
         fn to_string_key(&self) -> String {
-            format!("{}/{}", Self::PREFIX, self.db_id,)
+            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                .push_u64(self.db_id)
+                .done()
         }
 
         fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -754,7 +754,9 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = PREFIX_TABLE_ID_TO_NAME;
 
         fn to_string_key(&self) -> String {
-            format!("{}/{}", Self::PREFIX, self.table_id,)
+            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                .push_u64(self.table_id)
+                .done()
         }
 
         fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
@@ -772,7 +774,9 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = PREFIX_TABLE_BY_ID;
 
         fn to_string_key(&self) -> String {
-            format!("{}/{}", Self::PREFIX, self.table_id,)
+            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                .push_u64(self.table_id)
+                .done()
         }
 
         fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
@@ -812,7 +816,9 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = PREFIX_TABLE_COUNT;
 
         fn to_string_key(&self) -> String {
-            format!("{}/{}", Self::PREFIX, self.tenant)
+            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                .push_raw(&self.tenant)
+                .done()
         }
 
         fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
@@ -830,14 +836,20 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = PREFIX_TABLE_COPIED_FILES;
 
         fn to_string_key(&self) -> String {
-            format!("{}/{}/{}", Self::PREFIX, self.table_id, self.file)
+            // TODO: file is not escaped!!!
+            //       There already are non escaped data stored on disk.
+            //       We can not change it anymore.
+            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                .push_u64(self.table_id)
+                .push_raw(&self.file)
+                .done()
         }
 
         fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
             let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
 
             let table_id = p.next_u64()?;
-            let file = p.tail()?.to_string();
+            let file = p.tail_raw()?.to_string();
 
             Ok(TableCopiedFileNameIdent { table_id, file })
         }
@@ -848,7 +860,9 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = PREFIX_TABLE_COPIED_FILES_LOCK;
 
         fn to_string_key(&self) -> String {
-            format!("{}/{}", Self::PREFIX, self.table_id)
+            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                .push_u64(self.table_id)
+                .done()
         }
 
         fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {

--- a/src/meta/app/src/share/share.rs
+++ b/src/meta/app/src/share/share.rs
@@ -686,12 +686,14 @@ mod kvapi_key_impl {
 
         fn to_string_key(&self) -> String {
             match *self {
-                ShareGrantObject::Database(db_id) => {
-                    format!("{}/db/{}", Self::PREFIX, db_id,)
-                }
-                ShareGrantObject::Table(tbl_id) => {
-                    format!("{}/table/{}", Self::PREFIX, tbl_id,)
-                }
+                ShareGrantObject::Database(db_id) => kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                    .push_raw("db")
+                    .push_u64(db_id)
+                    .done(),
+                ShareGrantObject::Table(table_id) => kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                    .push_raw("table")
+                    .push_u64(table_id)
+                    .done(),
             }
         }
 
@@ -743,7 +745,9 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = PREFIX_SHARE_ID;
 
         fn to_string_key(&self) -> String {
-            format!("{}/{}", Self::PREFIX, self.share_id)
+            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                .push_u64(self.share_id)
+                .done()
         }
 
         fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
@@ -789,7 +793,9 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = PREFIX_SHARE_ID_TO_NAME;
 
         fn to_string_key(&self) -> String {
-            format!("{}/{}", Self::PREFIX, self.share_id,)
+            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                .push_u64(self.share_id)
+                .done()
         }
 
         fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {

--- a/src/meta/kvapi/src/kvapi/key_parser.rs
+++ b/src/meta/kvapi/src/kvapi/key_parser.rs
@@ -102,7 +102,7 @@ impl<'s> KeyParser<'s> {
     }
 
     /// Return trailing raw string that is not processed.
-    pub fn tail(&mut self) -> Result<&str, KeyError> {
+    pub fn tail_raw(&mut self) -> Result<&str, KeyError> {
         let index = self.index;
         let _ = self.next_raw()?;
 
@@ -200,25 +200,25 @@ mod tests {
 
         {
             let mut kp = KeyParser::new(s);
-            assert_eq!(Ok(s), kp.tail());
+            assert_eq!(Ok(s), kp.tail_raw());
         }
         {
             let mut kp = KeyParser::new(s);
             kp.next_raw()?;
-            assert_eq!(Ok("bar%20-/123"), kp.tail());
-        }
-        {
-            let mut kp = KeyParser::new(s);
-            kp.next_raw()?;
-            kp.next_raw()?;
-            assert_eq!(Ok("123"), kp.tail());
+            assert_eq!(Ok("bar%20-/123"), kp.tail_raw());
         }
         {
             let mut kp = KeyParser::new(s);
             kp.next_raw()?;
             kp.next_raw()?;
+            assert_eq!(Ok("123"), kp.tail_raw());
+        }
+        {
+            let mut kp = KeyParser::new(s);
             kp.next_raw()?;
-            assert!(kp.tail().is_err());
+            kp.next_raw()?;
+            kp.next_raw()?;
+            assert!(kp.tail_raw().is_err());
         }
 
         Ok(())


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(kvapi): biuld key with KeyBuilder, instead of with raw "format!"

## Changelog







## Related Issues