### PR TITLE
fix(query): shrink to fit string column for avoid large memory

### DIFF
--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -353,7 +353,9 @@ impl StringColumnBuilder {
         );
     }
 
-    pub fn build(self) -> StringColumn {
+    pub fn build(mut self) -> StringColumn {
+        self.data.shrink_to_fit();
+
         StringColumn {
             data: self.data.into(),
             offsets: self.offsets.into(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(query): shrink to fit string column for avoid large memory

Closes #issue
