### PR TITLE
refactor(query): rename some array functions add array_ prefix

### DIFF
--- a/src/query/functions/src/scalars/array.rs
+++ b/src/query/functions/src/scalars/array.rs
@@ -62,6 +62,11 @@ use siphasher::sip128::Hasher128;
 use siphasher::sip128::SipHasher24;
 
 pub fn register(registry: &mut FunctionRegistry) {
+    registry.register_aliases("contains", &["array_contains"]);
+    registry.register_aliases("get", &["array_get"]);
+    registry.register_aliases("length", &["array_length"]);
+    registry.register_aliases("slice", &["array_slice"]);
+
     registry.register_0_arg_core::<EmptyArrayType, _, _>(
         "array",
         FunctionProperty::default(),
@@ -177,14 +182,14 @@ pub fn register(registry: &mut FunctionRegistry) {
     );
 
     registry.register_2_arg_core::<NullType, NullType, NullType, _, _>(
-        "indexof",
+        "array_indexof",
         FunctionProperty::default(),
         |_, _| FunctionDomain::Full,
         |_, _, _| Value::Scalar(()),
     );
 
     registry.register_passthrough_nullable_2_arg::<ArrayType<GenericType<0>>, GenericType<0>, UInt64Type, _, _>(
-        "indexof",
+        "array_indexof",
         FunctionProperty::default(),
         |_, _| FunctionDomain::Full,
         vectorize_with_builder_2_arg::<ArrayType<GenericType<0>>, GenericType<0>, UInt64Type>(
@@ -195,14 +200,14 @@ pub fn register(registry: &mut FunctionRegistry) {
     );
 
     registry.register_2_arg_core::<NullableType<EmptyArrayType>, NullableType<EmptyArrayType>, EmptyArrayType, _, _>(
-        "concat",
+        "array_concat",
         FunctionProperty::default(),
         |_, _| FunctionDomain::Full,
         |_, _, _| Value::Scalar(()),
     );
 
     registry.register_passthrough_nullable_2_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, _, _>(
-        "concat",
+        "array_concat",
         FunctionProperty::default(),
         |_, _| FunctionDomain::Full,
         vectorize_with_builder_2_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, ArrayType<GenericType<0>>>(
@@ -254,7 +259,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     );
 
     registry.register_passthrough_nullable_1_arg::<EmptyArrayType, EmptyArrayType, _, _>(
-        "remove_first",
+        "array_remove_first",
         FunctionProperty::default(),
         |_| FunctionDomain::Full,
         vectorize_with_builder_1_arg::<EmptyArrayType, EmptyArrayType>(|_, output, _| {
@@ -263,7 +268,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     );
 
     registry.register_passthrough_nullable_1_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, _, _>(
-        "remove_first",
+        "array_remove_first",
         FunctionProperty::default(),
         |domain| FunctionDomain::Domain(domain.clone()),
         vectorize_with_builder_1_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>>(
@@ -280,7 +285,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     );
 
     registry.register_passthrough_nullable_1_arg::<EmptyArrayType, EmptyArrayType, _, _>(
-        "remove_last",
+        "array_remove_last",
         FunctionProperty::default(),
         |_| FunctionDomain::Full,
         vectorize_with_builder_1_arg::<EmptyArrayType, EmptyArrayType>(|_, output, _| {
@@ -289,7 +294,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     );
 
     registry.register_passthrough_nullable_1_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, _, _>(
-        "remove_last",
+        "array_remove_last",
         FunctionProperty::default(),
         |domain| FunctionDomain::Domain(domain.clone()),
         vectorize_with_builder_1_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>>(
@@ -306,7 +311,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     );
 
     registry.register_2_arg_core::<GenericType<0>, ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, _, _>(
-        "prepend",
+        "array_prepend",
         FunctionProperty::default(),
         |_, _| FunctionDomain::Full,
         vectorize_2_arg::<GenericType<0>, ArrayType<GenericType<0>>, ArrayType<GenericType<0>>>(|val, arr, _| {
@@ -319,7 +324,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     );
 
     registry.register_2_arg_core::<ArrayType<GenericType<0>>, GenericType<0>, ArrayType<GenericType<0>>, _, _>(
-        "append",
+        "array_append",
         FunctionProperty::default(),
         |_, _| FunctionDomain::Full,
         vectorize_2_arg::<ArrayType<GenericType<0>>, GenericType<0>, ArrayType<GenericType<0>>>(|arr, val, _| {

--- a/src/query/functions/tests/it/scalars/array.rs
+++ b/src/query/functions/tests/it/scalars/array.rs
@@ -29,15 +29,15 @@ fn test_array() {
     test_length(file);
     test_get(file);
     test_slice(file);
-    test_remove_first(file);
-    test_remove_last(file);
     test_contains(file);
-    test_concat(file);
-    test_prepend(file);
-    test_append(file);
-    test_indexof(file);
-    test_unique(file);
-    test_distinct(file);
+    test_array_remove_first(file);
+    test_array_remove_last(file);
+    test_array_concat(file);
+    test_array_prepend(file);
+    test_array_append(file);
+    test_array_indexof(file);
+    test_array_unique(file);
+    test_array_distinct(file);
 }
 
 fn test_create(file: &mut impl Write) {
@@ -93,25 +93,25 @@ fn test_slice(file: &mut impl Write) {
     ]);
 }
 
-fn test_remove_first(file: &mut impl Write) {
-    run_ast(file, "remove_first([])", &[]);
-    run_ast(file, "remove_first([1])", &[]);
-    run_ast(file, "remove_first([0, 1, 2, NULL])", &[]);
-    run_ast(file, "remove_first([0, 1, 2, 3])", &[]);
-    run_ast(file, "remove_first(['a', 'b', 'c', 'd'])", &[]);
-    run_ast(file, "remove_first([a, b])", &[
+fn test_array_remove_first(file: &mut impl Write) {
+    run_ast(file, "array_remove_first([])", &[]);
+    run_ast(file, "array_remove_first([1])", &[]);
+    run_ast(file, "array_remove_first([0, 1, 2, NULL])", &[]);
+    run_ast(file, "array_remove_first([0, 1, 2, 3])", &[]);
+    run_ast(file, "array_remove_first(['a', 'b', 'c', 'd'])", &[]);
+    run_ast(file, "array_remove_first([a, b])", &[
         ("a", Int16Type::from_data(vec![0i16, 1, 2])),
         ("b", Int16Type::from_data(vec![3i16, 4, 5])),
     ]);
 }
 
-fn test_remove_last(file: &mut impl Write) {
-    run_ast(file, "remove_last([])", &[]);
-    run_ast(file, "remove_last([1])", &[]);
-    run_ast(file, "remove_last([0, 1, 2, NULL])", &[]);
-    run_ast(file, "remove_last([0, 1, 2, 3])", &[]);
-    run_ast(file, "remove_last(['a', 'b', 'c', 'd'])", &[]);
-    run_ast(file, "remove_last([a, b])", &[
+fn test_array_remove_last(file: &mut impl Write) {
+    run_ast(file, "array_remove_last([])", &[]);
+    run_ast(file, "array_remove_last([1])", &[]);
+    run_ast(file, "array_remove_last([0, 1, 2, NULL])", &[]);
+    run_ast(file, "array_remove_last([0, 1, 2, 3])", &[]);
+    run_ast(file, "array_remove_last(['a', 'b', 'c', 'd'])", &[]);
+    run_ast(file, "array_remove_last([a, b])", &[
         ("a", Int16Type::from_data(vec![0i16, 1, 2])),
         ("b", Int16Type::from_data(vec![3i16, 4, 5])),
     ]);
@@ -147,12 +147,12 @@ fn test_contains(file: &mut impl Write) {
     );
 }
 
-fn test_concat(file: &mut impl Write) {
-    run_ast(file, "concat([], [])", &[]);
-    run_ast(file, "concat([], [1,2])", &[]);
-    run_ast(file, "concat([false, true], [])", &[]);
-    run_ast(file, "concat([false, true], [1,2])", &[]);
-    run_ast(file, "concat([1,2,3], ['s', null])", &[]);
+fn test_array_concat(file: &mut impl Write) {
+    run_ast(file, "array_concat([], [])", &[]);
+    run_ast(file, "array_concat([], [1,2])", &[]);
+    run_ast(file, "array_concat([false, true], [])", &[]);
+    run_ast(file, "array_concat([false, true], [1,2])", &[]);
+    run_ast(file, "array_concat([1,2,3], ['s', null])", &[]);
 
     let columns = [
         ("int8_col", Int8Type::from_data(vec![1i8, 2, 7, 8])),
@@ -166,43 +166,43 @@ fn test_concat(file: &mut impl Write) {
 
     run_ast(
         file,
-        "concat([1, 2, 3, 4, 5, null], [nullable_col])",
+        "array_concat([1, 2, 3, 4, 5, null], [nullable_col])",
         &columns,
     );
-    run_ast(file, "concat([1,2,null], [int8_col])", &columns);
+    run_ast(file, "array_concat([1,2,null], [int8_col])", &columns);
 }
 
-fn test_prepend(file: &mut impl Write) {
-    run_ast(file, "prepend(1, [])", &[]);
-    run_ast(file, "prepend(1, [2, 3, NULL, 4])", &[]);
-    run_ast(file, "prepend('a', ['b', NULL, NULL, 'c', 'd'])", &[]);
-    run_ast(file, "prepend(a, [b, c])", &[
+fn test_array_prepend(file: &mut impl Write) {
+    run_ast(file, "array_prepend(1, [])", &[]);
+    run_ast(file, "array_prepend(1, [2, 3, NULL, 4])", &[]);
+    run_ast(file, "array_prepend('a', ['b', NULL, NULL, 'c', 'd'])", &[]);
+    run_ast(file, "array_prepend(a, [b, c])", &[
         ("a", Int16Type::from_data(vec![0i16, 1, 2])),
         ("b", Int16Type::from_data(vec![3i16, 4, 5])),
         ("c", Int16Type::from_data(vec![6i16, 7, 8])),
     ]);
 }
 
-fn test_append(file: &mut impl Write) {
-    run_ast(file, "append([], 1)", &[]);
-    run_ast(file, "append([2, 3, NULL, 4], 5)", &[]);
-    run_ast(file, "append(['b', NULL, NULL, 'c', 'd'], 'e')", &[]);
-    run_ast(file, "append([b, c], a)", &[
+fn test_array_append(file: &mut impl Write) {
+    run_ast(file, "array_append([], 1)", &[]);
+    run_ast(file, "array_append([2, 3, NULL, 4], 5)", &[]);
+    run_ast(file, "array_append(['b', NULL, NULL, 'c', 'd'], 'e')", &[]);
+    run_ast(file, "array_append([b, c], a)", &[
         ("a", Int16Type::from_data(vec![0i16, 1, 2])),
         ("b", Int16Type::from_data(vec![3i16, 4, 5])),
         ("c", Int16Type::from_data(vec![6i16, 7, 8])),
     ]);
 }
 
-fn test_indexof(file: &mut impl Write) {
-    run_ast(file, "indexof([], NULL)", &[]);
-    run_ast(file, "indexof(NULL, NULL)", &[]);
-    run_ast(file, "indexof([false, true], false)", &[]);
-    run_ast(file, "indexof([], false)", &[]);
-    run_ast(file, "indexof([false, true], null)", &[]);
-    run_ast(file, "indexof([false, true], 0)", &[]);
-    run_ast(file, "indexof([1,2,3,'s'], 's')", &[]);
-    run_ast(file, "indexof([1,'x',null,'x'], 'x')", &[]);
+fn test_array_indexof(file: &mut impl Write) {
+    run_ast(file, "array_indexof([], NULL)", &[]);
+    run_ast(file, "array_indexof(NULL, NULL)", &[]);
+    run_ast(file, "array_indexof([false, true], false)", &[]);
+    run_ast(file, "array_indexof([], false)", &[]);
+    run_ast(file, "array_indexof([false, true], null)", &[]);
+    run_ast(file, "array_indexof([false, true], 0)", &[]);
+    run_ast(file, "array_indexof([1,2,3,'s'], 's')", &[]);
+    run_ast(file, "array_indexof([1,'x',null,'x'], 'x')", &[]);
 
     let columns = [
         ("int8_col", Int8Type::from_data(vec![1i8, 2, 7, 8])),
@@ -216,13 +216,13 @@ fn test_indexof(file: &mut impl Write) {
 
     run_ast(
         file,
-        "indexof([1, 2, 3, 4, 5, null], nullable_col)",
+        "array_indexof([1, 2, 3, 4, 5, null], nullable_col)",
         &columns,
     );
-    run_ast(file, "indexof([9,10,null], int8_col)", &columns);
+    run_ast(file, "array_indexof([9,10,null], int8_col)", &columns);
 }
 
-fn test_unique(file: &mut impl Write) {
+fn test_array_unique(file: &mut impl Write) {
     run_ast(file, "array_unique([])", &[]);
     run_ast(file, "array_unique([1, 1, 2, 2, 3, NULL])", &[]);
     run_ast(
@@ -239,7 +239,7 @@ fn test_unique(file: &mut impl Write) {
     ]);
 }
 
-fn test_distinct(file: &mut impl Write) {
+fn test_array_distinct(file: &mut impl Write) {
     run_ast(file, "array_distinct([])", &[]);
     run_ast(file, "array_distinct([1, 1, 2, 2, 3, NULL])", &[]);
     run_ast(

--- a/src/query/functions/tests/it/scalars/testdata/array.txt
+++ b/src/query/functions/tests/it/scalars/testdata/array.txt
@@ -298,142 +298,6 @@ evaluation (internal):
 +--------+--------------------------------------------------------------------------+
 
 
-ast            : remove_first([])
-raw expr       : remove_first(array())
-checked expr   : remove_first<Array(Nothing)>(array<>())
-optimized expr : [] :: Array(Nothing)
-output type    : Array(Nothing)
-output domain  : []
-output         : []
-
-
-ast            : remove_first([1])
-raw expr       : remove_first(array(1_u8))
-checked expr   : remove_first<T0=UInt8><Array(T0)>(array<T0=UInt8><T0>(1_u8))
-optimized expr : []
-output type    : Array(UInt8)
-output domain  : []
-output         : []
-
-
-ast            : remove_first([0, 1, 2, NULL])
-raw expr       : remove_first(array(0_u8, 1_u8, 2_u8, NULL))
-checked expr   : remove_first<T0=UInt8 NULL><Array(T0)>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(0_u8 AS UInt8 NULL), CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)))
-optimized expr : [1_u8, 2_u8, NULL]
-output type    : Array(UInt8 NULL)
-output domain  : [{0..=2} ∪ {NULL}]
-output         : [1_u8, 2_u8, NULL]
-
-
-ast            : remove_first([0, 1, 2, 3])
-raw expr       : remove_first(array(0_u8, 1_u8, 2_u8, 3_u8))
-checked expr   : remove_first<T0=UInt8><Array(T0)>(array<T0=UInt8><T0, T0, T0, T0>(0_u8, 1_u8, 2_u8, 3_u8))
-optimized expr : [1_u8, 2_u8, 3_u8]
-output type    : Array(UInt8)
-output domain  : [{1..=3}]
-output         : [1_u8, 2_u8, 3_u8]
-
-
-ast            : remove_first(['a', 'b', 'c', 'd'])
-raw expr       : remove_first(array("a", "b", "c", "d"))
-checked expr   : remove_first<T0=String><Array(T0)>(array<T0=String><T0, T0, T0, T0>("a", "b", "c", "d"))
-optimized expr : ["b", "c", "d"]
-output type    : Array(String)
-output domain  : [{"b"..="d"}]
-output         : ["b", "c", "d"]
-
-
-ast            : remove_first([a, b])
-raw expr       : remove_first(array(a::Int16, b::Int16))
-checked expr   : remove_first<T0=Int16><Array(T0)>(array<T0=Int16><T0, T0>(a, b))
-evaluation:
-+--------+---------+---------+--------------+
-|        | a       | b       | Output       |
-+--------+---------+---------+--------------+
-| Type   | Int16   | Int16   | Array(Int16) |
-| Domain | {0..=2} | {3..=5} | [{0..=5}]    |
-| Row 0  | 0_i16   | 3_i16   | [3_i16]      |
-| Row 1  | 1_i16   | 4_i16   | [4_i16]      |
-| Row 2  | 2_i16   | 5_i16   | [5_i16]      |
-+--------+---------+---------+--------------+
-evaluation (internal):
-+--------+-----------------------------------------------------------------+
-| Column | Data                                                            |
-+--------+-----------------------------------------------------------------+
-| a      | Int16([0, 1, 2])                                                |
-| b      | Int16([3, 4, 5])                                                |
-| Output | ArrayColumn { values: Int16([3, 4, 5]), offsets: [0, 1, 2, 3] } |
-+--------+-----------------------------------------------------------------+
-
-
-ast            : remove_last([])
-raw expr       : remove_last(array())
-checked expr   : remove_last<Array(Nothing)>(array<>())
-optimized expr : [] :: Array(Nothing)
-output type    : Array(Nothing)
-output domain  : []
-output         : []
-
-
-ast            : remove_last([1])
-raw expr       : remove_last(array(1_u8))
-checked expr   : remove_last<T0=UInt8><Array(T0)>(array<T0=UInt8><T0>(1_u8))
-optimized expr : []
-output type    : Array(UInt8)
-output domain  : []
-output         : []
-
-
-ast            : remove_last([0, 1, 2, NULL])
-raw expr       : remove_last(array(0_u8, 1_u8, 2_u8, NULL))
-checked expr   : remove_last<T0=UInt8 NULL><Array(T0)>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(0_u8 AS UInt8 NULL), CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)))
-optimized expr : [0_u8, 1_u8, 2_u8]
-output type    : Array(UInt8 NULL)
-output domain  : [{0..=2}]
-output         : [0_u8, 1_u8, 2_u8]
-
-
-ast            : remove_last([0, 1, 2, 3])
-raw expr       : remove_last(array(0_u8, 1_u8, 2_u8, 3_u8))
-checked expr   : remove_last<T0=UInt8><Array(T0)>(array<T0=UInt8><T0, T0, T0, T0>(0_u8, 1_u8, 2_u8, 3_u8))
-optimized expr : [0_u8, 1_u8, 2_u8]
-output type    : Array(UInt8)
-output domain  : [{0..=2}]
-output         : [0_u8, 1_u8, 2_u8]
-
-
-ast            : remove_last(['a', 'b', 'c', 'd'])
-raw expr       : remove_last(array("a", "b", "c", "d"))
-checked expr   : remove_last<T0=String><Array(T0)>(array<T0=String><T0, T0, T0, T0>("a", "b", "c", "d"))
-optimized expr : ["a", "b", "c"]
-output type    : Array(String)
-output domain  : [{"a"..="c"}]
-output         : ["a", "b", "c"]
-
-
-ast            : remove_last([a, b])
-raw expr       : remove_last(array(a::Int16, b::Int16))
-checked expr   : remove_last<T0=Int16><Array(T0)>(array<T0=Int16><T0, T0>(a, b))
-evaluation:
-+--------+---------+---------+--------------+
-|        | a       | b       | Output       |
-+--------+---------+---------+--------------+
-| Type   | Int16   | Int16   | Array(Int16) |
-| Domain | {0..=2} | {3..=5} | [{0..=5}]    |
-| Row 0  | 0_i16   | 3_i16   | [0_i16]      |
-| Row 1  | 1_i16   | 4_i16   | [1_i16]      |
-| Row 2  | 2_i16   | 5_i16   | [2_i16]      |
-+--------+---------+---------+--------------+
-evaluation (internal):
-+--------+-----------------------------------------------------------------+
-| Column | Data                                                            |
-+--------+-----------------------------------------------------------------+
-| a      | Int16([0, 1, 2])                                                |
-| b      | Int16([3, 4, 5])                                                |
-| Output | ArrayColumn { values: Int16([0, 1, 2]), offsets: [0, 1, 2, 3] } |
-+--------+-----------------------------------------------------------------+
-
-
 ast            : false in (false, true)
 raw expr       : or(eq(false, false), eq(false, true))
 checked expr   : or<Boolean, Boolean>(eq<Boolean, Boolean>(false, false), eq<Boolean, Boolean>(false, true))
@@ -566,55 +430,191 @@ evaluation (internal):
 +--------------+---------------------------------------------------------------------------+
 
 
-ast            : concat([], [])
-raw expr       : concat(array(), array())
-checked expr   : concat<Array(Nothing) NULL, Array(Nothing) NULL>(CAST(array<>() AS Array(Nothing) NULL), CAST(array<>() AS Array(Nothing) NULL))
+ast            : array_remove_first([])
+raw expr       : array_remove_first(array())
+checked expr   : array_remove_first<Array(Nothing)>(array<>())
 optimized expr : [] :: Array(Nothing)
 output type    : Array(Nothing)
 output domain  : []
 output         : []
 
 
-ast            : concat([], [1,2])
-raw expr       : concat(array(), array(1_u8, 2_u8))
-checked expr   : concat<T0=UInt8><Array(T0), Array(T0)>(CAST(array<>() AS Array(UInt8)), array<T0=UInt8><T0, T0>(1_u8, 2_u8))
+ast            : array_remove_first([1])
+raw expr       : array_remove_first(array(1_u8))
+checked expr   : array_remove_first<T0=UInt8><Array(T0)>(array<T0=UInt8><T0>(1_u8))
+optimized expr : []
+output type    : Array(UInt8)
+output domain  : []
+output         : []
+
+
+ast            : array_remove_first([0, 1, 2, NULL])
+raw expr       : array_remove_first(array(0_u8, 1_u8, 2_u8, NULL))
+checked expr   : array_remove_first<T0=UInt8 NULL><Array(T0)>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(0_u8 AS UInt8 NULL), CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)))
+optimized expr : [1_u8, 2_u8, NULL]
+output type    : Array(UInt8 NULL)
+output domain  : [{0..=2} ∪ {NULL}]
+output         : [1_u8, 2_u8, NULL]
+
+
+ast            : array_remove_first([0, 1, 2, 3])
+raw expr       : array_remove_first(array(0_u8, 1_u8, 2_u8, 3_u8))
+checked expr   : array_remove_first<T0=UInt8><Array(T0)>(array<T0=UInt8><T0, T0, T0, T0>(0_u8, 1_u8, 2_u8, 3_u8))
+optimized expr : [1_u8, 2_u8, 3_u8]
+output type    : Array(UInt8)
+output domain  : [{1..=3}]
+output         : [1_u8, 2_u8, 3_u8]
+
+
+ast            : array_remove_first(['a', 'b', 'c', 'd'])
+raw expr       : array_remove_first(array("a", "b", "c", "d"))
+checked expr   : array_remove_first<T0=String><Array(T0)>(array<T0=String><T0, T0, T0, T0>("a", "b", "c", "d"))
+optimized expr : ["b", "c", "d"]
+output type    : Array(String)
+output domain  : [{"b"..="d"}]
+output         : ["b", "c", "d"]
+
+
+ast            : array_remove_first([a, b])
+raw expr       : array_remove_first(array(a::Int16, b::Int16))
+checked expr   : array_remove_first<T0=Int16><Array(T0)>(array<T0=Int16><T0, T0>(a, b))
+evaluation:
++--------+---------+---------+--------------+
+|        | a       | b       | Output       |
++--------+---------+---------+--------------+
+| Type   | Int16   | Int16   | Array(Int16) |
+| Domain | {0..=2} | {3..=5} | [{0..=5}]    |
+| Row 0  | 0_i16   | 3_i16   | [3_i16]      |
+| Row 1  | 1_i16   | 4_i16   | [4_i16]      |
+| Row 2  | 2_i16   | 5_i16   | [5_i16]      |
++--------+---------+---------+--------------+
+evaluation (internal):
++--------+-----------------------------------------------------------------+
+| Column | Data                                                            |
++--------+-----------------------------------------------------------------+
+| a      | Int16([0, 1, 2])                                                |
+| b      | Int16([3, 4, 5])                                                |
+| Output | ArrayColumn { values: Int16([3, 4, 5]), offsets: [0, 1, 2, 3] } |
++--------+-----------------------------------------------------------------+
+
+
+ast            : array_remove_last([])
+raw expr       : array_remove_last(array())
+checked expr   : array_remove_last<Array(Nothing)>(array<>())
+optimized expr : [] :: Array(Nothing)
+output type    : Array(Nothing)
+output domain  : []
+output         : []
+
+
+ast            : array_remove_last([1])
+raw expr       : array_remove_last(array(1_u8))
+checked expr   : array_remove_last<T0=UInt8><Array(T0)>(array<T0=UInt8><T0>(1_u8))
+optimized expr : []
+output type    : Array(UInt8)
+output domain  : []
+output         : []
+
+
+ast            : array_remove_last([0, 1, 2, NULL])
+raw expr       : array_remove_last(array(0_u8, 1_u8, 2_u8, NULL))
+checked expr   : array_remove_last<T0=UInt8 NULL><Array(T0)>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(0_u8 AS UInt8 NULL), CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)))
+optimized expr : [0_u8, 1_u8, 2_u8]
+output type    : Array(UInt8 NULL)
+output domain  : [{0..=2}]
+output         : [0_u8, 1_u8, 2_u8]
+
+
+ast            : array_remove_last([0, 1, 2, 3])
+raw expr       : array_remove_last(array(0_u8, 1_u8, 2_u8, 3_u8))
+checked expr   : array_remove_last<T0=UInt8><Array(T0)>(array<T0=UInt8><T0, T0, T0, T0>(0_u8, 1_u8, 2_u8, 3_u8))
+optimized expr : [0_u8, 1_u8, 2_u8]
+output type    : Array(UInt8)
+output domain  : [{0..=2}]
+output         : [0_u8, 1_u8, 2_u8]
+
+
+ast            : array_remove_last(['a', 'b', 'c', 'd'])
+raw expr       : array_remove_last(array("a", "b", "c", "d"))
+checked expr   : array_remove_last<T0=String><Array(T0)>(array<T0=String><T0, T0, T0, T0>("a", "b", "c", "d"))
+optimized expr : ["a", "b", "c"]
+output type    : Array(String)
+output domain  : [{"a"..="c"}]
+output         : ["a", "b", "c"]
+
+
+ast            : array_remove_last([a, b])
+raw expr       : array_remove_last(array(a::Int16, b::Int16))
+checked expr   : array_remove_last<T0=Int16><Array(T0)>(array<T0=Int16><T0, T0>(a, b))
+evaluation:
++--------+---------+---------+--------------+
+|        | a       | b       | Output       |
++--------+---------+---------+--------------+
+| Type   | Int16   | Int16   | Array(Int16) |
+| Domain | {0..=2} | {3..=5} | [{0..=5}]    |
+| Row 0  | 0_i16   | 3_i16   | [0_i16]      |
+| Row 1  | 1_i16   | 4_i16   | [1_i16]      |
+| Row 2  | 2_i16   | 5_i16   | [2_i16]      |
++--------+---------+---------+--------------+
+evaluation (internal):
++--------+-----------------------------------------------------------------+
+| Column | Data                                                            |
++--------+-----------------------------------------------------------------+
+| a      | Int16([0, 1, 2])                                                |
+| b      | Int16([3, 4, 5])                                                |
+| Output | ArrayColumn { values: Int16([0, 1, 2]), offsets: [0, 1, 2, 3] } |
++--------+-----------------------------------------------------------------+
+
+
+ast            : array_concat([], [])
+raw expr       : array_concat(array(), array())
+checked expr   : array_concat<Array(Nothing) NULL, Array(Nothing) NULL>(CAST(array<>() AS Array(Nothing) NULL), CAST(array<>() AS Array(Nothing) NULL))
+optimized expr : [] :: Array(Nothing)
+output type    : Array(Nothing)
+output domain  : []
+output         : []
+
+
+ast            : array_concat([], [1,2])
+raw expr       : array_concat(array(), array(1_u8, 2_u8))
+checked expr   : array_concat<T0=UInt8><Array(T0), Array(T0)>(CAST(array<>() AS Array(UInt8)), array<T0=UInt8><T0, T0>(1_u8, 2_u8))
 optimized expr : [1_u8, 2_u8]
 output type    : Array(UInt8)
 output domain  : [{1..=2}]
 output         : [1_u8, 2_u8]
 
 
-ast            : concat([false, true], [])
-raw expr       : concat(array(false, true), array())
-checked expr   : concat<T0=Boolean><Array(T0), Array(T0)>(array<T0=Boolean><T0, T0>(false, true), CAST(array<>() AS Array(Boolean)))
+ast            : array_concat([false, true], [])
+raw expr       : array_concat(array(false, true), array())
+checked expr   : array_concat<T0=Boolean><Array(T0), Array(T0)>(array<T0=Boolean><T0, T0>(false, true), CAST(array<>() AS Array(Boolean)))
 optimized expr : [false, true]
 output type    : Array(Boolean)
 output domain  : [{FALSE, TRUE}]
 output         : [false, true]
 
 
-ast            : concat([false, true], [1,2])
-raw expr       : concat(array(false, true), array(1_u8, 2_u8))
-checked expr   : concat<T0=Variant><Array(T0), Array(T0)>(CAST(array<T0=Boolean><T0, T0>(false, true) AS Array(Variant)), CAST(array<T0=UInt8><T0, T0>(1_u8, 2_u8) AS Array(Variant)))
+ast            : array_concat([false, true], [1,2])
+raw expr       : array_concat(array(false, true), array(1_u8, 2_u8))
+checked expr   : array_concat<T0=Variant><Array(T0), Array(T0)>(CAST(array<T0=Boolean><T0, T0>(false, true) AS Array(Variant)), CAST(array<T0=UInt8><T0, T0>(1_u8, 2_u8) AS Array(Variant)))
 optimized expr : [false, true, 1, 2]
 output type    : Array(Variant)
 output domain  : [Undefined]
 output         : [false, true, 1, 2]
 
 
-ast            : concat([1,2,3], ['s', null])
-raw expr       : concat(array(1_u8, 2_u8, 3_u8), array("s", NULL))
-checked expr   : concat<T0=Variant NULL><Array(T0), Array(T0)>(CAST(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8) AS Array(Variant NULL)), CAST(array<T0=String NULL><T0, T0>(CAST("s" AS String NULL), CAST(NULL AS String NULL)) AS Array(Variant NULL)))
+ast            : array_concat([1,2,3], ['s', null])
+raw expr       : array_concat(array(1_u8, 2_u8, 3_u8), array("s", NULL))
+checked expr   : array_concat<T0=Variant NULL><Array(T0), Array(T0)>(CAST(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8) AS Array(Variant NULL)), CAST(array<T0=String NULL><T0, T0>(CAST("s" AS String NULL), CAST(NULL AS String NULL)) AS Array(Variant NULL)))
 optimized expr : [1, 2, 3, "s", NULL]
 output type    : Array(Variant NULL)
 output domain  : [Undefined ∪ {NULL}]
 output         : [1, 2, 3, "s", NULL]
 
 
-ast            : concat([1, 2, 3, 4, 5, null], [nullable_col])
-raw expr       : concat(array(1_u8, 2_u8, 3_u8, 4_u8, 5_u8, NULL), array(nullable_col::Int64 NULL))
-checked expr   : concat<T0=Int64 NULL><Array(T0), Array(T0)>(CAST(array<T0=UInt8 NULL><T0, T0, T0, T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL), CAST(5_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int64 NULL)), array<T0=Int64 NULL><T0>(nullable_col))
-optimized expr : concat<T0=Int64 NULL><Array(T0), Array(T0)>([1_i64, 2_i64, 3_i64, 4_i64, 5_i64, NULL], array<T0=Int64 NULL><T0>(nullable_col))
+ast            : array_concat([1, 2, 3, 4, 5, null], [nullable_col])
+raw expr       : array_concat(array(1_u8, 2_u8, 3_u8, 4_u8, 5_u8, NULL), array(nullable_col::Int64 NULL))
+checked expr   : array_concat<T0=Int64 NULL><Array(T0), Array(T0)>(CAST(array<T0=UInt8 NULL><T0, T0, T0, T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL), CAST(5_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int64 NULL)), array<T0=Int64 NULL><T0>(nullable_col))
+optimized expr : array_concat<T0=Int64 NULL><Array(T0), Array(T0)>([1_i64, 2_i64, 3_i64, 4_i64, 5_i64, NULL], array<T0=Int64 NULL><T0>(nullable_col))
 evaluation:
 +--------+-------------------+---------------------------------------------------------+
 |        | nullable_col      | Output                                                  |
@@ -635,10 +635,10 @@ evaluation (internal):
 +--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
-ast            : concat([1,2,null], [int8_col])
-raw expr       : concat(array(1_u8, 2_u8, NULL), array(int8_col::Int8))
-checked expr   : concat<T0=Int16 NULL><Array(T0), Array(T0)>(CAST(array<T0=UInt8 NULL><T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int16 NULL)), CAST(array<T0=Int8><T0>(int8_col) AS Array(Int16 NULL)))
-optimized expr : concat<T0=Int16 NULL><Array(T0), Array(T0)>([1_i16, 2_i16, NULL], CAST(array<T0=Int8><T0>(int8_col) AS Array(Int16 NULL)))
+ast            : array_concat([1,2,null], [int8_col])
+raw expr       : array_concat(array(1_u8, 2_u8, NULL), array(int8_col::Int8))
+checked expr   : array_concat<T0=Int16 NULL><Array(T0), Array(T0)>(CAST(array<T0=UInt8 NULL><T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int16 NULL)), CAST(array<T0=Int8><T0>(int8_col) AS Array(Int16 NULL)))
+optimized expr : array_concat<T0=Int16 NULL><Array(T0), Array(T0)>([1_i16, 2_i16, NULL], CAST(array<T0=Int8><T0>(int8_col) AS Array(Int16 NULL)))
 evaluation:
 +--------+----------+-----------------------------+
 |        | int8_col | Output                      |
@@ -659,36 +659,36 @@ evaluation (internal):
 +----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
-ast            : prepend(1, [])
-raw expr       : prepend(1_u8, array())
-checked expr   : prepend<T0=UInt8><T0, Array(T0)>(1_u8, CAST(array<>() AS Array(UInt8)))
+ast            : array_prepend(1, [])
+raw expr       : array_prepend(1_u8, array())
+checked expr   : array_prepend<T0=UInt8><T0, Array(T0)>(1_u8, CAST(array<>() AS Array(UInt8)))
 optimized expr : [1_u8]
 output type    : Array(UInt8)
 output domain  : [{1..=1}]
 output         : [1_u8]
 
 
-ast            : prepend(1, [2, 3, NULL, 4])
-raw expr       : prepend(1_u8, array(2_u8, 3_u8, NULL, 4_u8))
-checked expr   : prepend<T0=UInt8 NULL><T0, Array(T0)>(CAST(1_u8 AS UInt8 NULL), array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL)))
+ast            : array_prepend(1, [2, 3, NULL, 4])
+raw expr       : array_prepend(1_u8, array(2_u8, 3_u8, NULL, 4_u8))
+checked expr   : array_prepend<T0=UInt8 NULL><T0, Array(T0)>(CAST(1_u8 AS UInt8 NULL), array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL)))
 optimized expr : [1_u8, 2_u8, 3_u8, NULL, 4_u8]
 output type    : Array(UInt8 NULL)
 output domain  : [{0..=4} ∪ {NULL}]
 output         : [1_u8, 2_u8, 3_u8, NULL, 4_u8]
 
 
-ast            : prepend('a', ['b', NULL, NULL, 'c', 'd'])
-raw expr       : prepend("a", array("b", NULL, NULL, "c", "d"))
-checked expr   : prepend<T0=String NULL><T0, Array(T0)>(CAST("a" AS String NULL), array<T0=String NULL><T0, T0, T0, T0, T0>(CAST("b" AS String NULL), CAST(NULL AS String NULL), CAST(NULL AS String NULL), CAST("c" AS String NULL), CAST("d" AS String NULL)))
+ast            : array_prepend('a', ['b', NULL, NULL, 'c', 'd'])
+raw expr       : array_prepend("a", array("b", NULL, NULL, "c", "d"))
+checked expr   : array_prepend<T0=String NULL><T0, Array(T0)>(CAST("a" AS String NULL), array<T0=String NULL><T0, T0, T0, T0, T0>(CAST("b" AS String NULL), CAST(NULL AS String NULL), CAST(NULL AS String NULL), CAST("c" AS String NULL), CAST("d" AS String NULL)))
 optimized expr : ["a", "b", NULL, NULL, "c", "d"]
 output type    : Array(String NULL)
 output domain  : [{""..="d"} ∪ {NULL}]
 output         : ["a", "b", NULL, NULL, "c", "d"]
 
 
-ast            : prepend(a, [b, c])
-raw expr       : prepend(a::Int16, array(b::Int16, c::Int16))
-checked expr   : prepend<T0=Int16><T0, Array(T0)>(a, array<T0=Int16><T0, T0>(b, c))
+ast            : array_prepend(a, [b, c])
+raw expr       : array_prepend(a::Int16, array(b::Int16, c::Int16))
+checked expr   : array_prepend<T0=Int16><T0, Array(T0)>(a, array<T0=Int16><T0, T0>(b, c))
 evaluation:
 +--------+---------+---------+---------+-----------------------+
 |        | a       | b       | c       | Output                |
@@ -710,36 +710,36 @@ evaluation (internal):
 +--------+-----------------------------------------------------------------------------------+
 
 
-ast            : append([], 1)
-raw expr       : append(array(), 1_u8)
-checked expr   : append<T0=UInt8><Array(T0), T0>(CAST(array<>() AS Array(UInt8)), 1_u8)
+ast            : array_append([], 1)
+raw expr       : array_append(array(), 1_u8)
+checked expr   : array_append<T0=UInt8><Array(T0), T0>(CAST(array<>() AS Array(UInt8)), 1_u8)
 optimized expr : [1_u8]
 output type    : Array(UInt8)
 output domain  : [{1..=1}]
 output         : [1_u8]
 
 
-ast            : append([2, 3, NULL, 4], 5)
-raw expr       : append(array(2_u8, 3_u8, NULL, 4_u8), 5_u8)
-checked expr   : append<T0=UInt8 NULL><Array(T0), T0>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL)), CAST(5_u8 AS UInt8 NULL))
+ast            : array_append([2, 3, NULL, 4], 5)
+raw expr       : array_append(array(2_u8, 3_u8, NULL, 4_u8), 5_u8)
+checked expr   : array_append<T0=UInt8 NULL><Array(T0), T0>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL)), CAST(5_u8 AS UInt8 NULL))
 optimized expr : [2_u8, 3_u8, NULL, 4_u8, 5_u8]
 output type    : Array(UInt8 NULL)
 output domain  : [{0..=5} ∪ {NULL}]
 output         : [2_u8, 3_u8, NULL, 4_u8, 5_u8]
 
 
-ast            : append(['b', NULL, NULL, 'c', 'd'], 'e')
-raw expr       : append(array("b", NULL, NULL, "c", "d"), "e")
-checked expr   : append<T0=String NULL><Array(T0), T0>(array<T0=String NULL><T0, T0, T0, T0, T0>(CAST("b" AS String NULL), CAST(NULL AS String NULL), CAST(NULL AS String NULL), CAST("c" AS String NULL), CAST("d" AS String NULL)), CAST("e" AS String NULL))
+ast            : array_append(['b', NULL, NULL, 'c', 'd'], 'e')
+raw expr       : array_append(array("b", NULL, NULL, "c", "d"), "e")
+checked expr   : array_append<T0=String NULL><Array(T0), T0>(array<T0=String NULL><T0, T0, T0, T0, T0>(CAST("b" AS String NULL), CAST(NULL AS String NULL), CAST(NULL AS String NULL), CAST("c" AS String NULL), CAST("d" AS String NULL)), CAST("e" AS String NULL))
 optimized expr : ["b", NULL, NULL, "c", "d", "e"]
 output type    : Array(String NULL)
 output domain  : [{""..="e"} ∪ {NULL}]
 output         : ["b", NULL, NULL, "c", "d", "e"]
 
 
-ast            : append([b, c], a)
-raw expr       : append(array(b::Int16, c::Int16), a::Int16)
-checked expr   : append<T0=Int16><Array(T0), T0>(array<T0=Int16><T0, T0>(b, c), a)
+ast            : array_append([b, c], a)
+raw expr       : array_append(array(b::Int16, c::Int16), a::Int16)
+checked expr   : array_append<T0=Int16><Array(T0), T0>(array<T0=Int16><T0, T0>(b, c), a)
 evaluation:
 +--------+---------+---------+---------+-----------------------+
 |        | a       | b       | c       | Output                |
@@ -761,82 +761,82 @@ evaluation (internal):
 +--------+-----------------------------------------------------------------------------------+
 
 
-ast            : indexof([], NULL)
-raw expr       : indexof(array(), NULL)
-checked expr   : indexof<T0=NULL><Array(T0), T0>(CAST(array<>() AS Array(NULL)), NULL)
+ast            : array_indexof([], NULL)
+raw expr       : array_indexof(array(), NULL)
+checked expr   : array_indexof<T0=NULL><Array(T0), T0>(CAST(array<>() AS Array(NULL)), NULL)
 optimized expr : 0_u64
 output type    : UInt64
 output domain  : {0..=0}
 output         : 0_u64
 
 
-ast            : indexof(NULL, NULL)
-raw expr       : indexof(NULL, NULL)
-checked expr   : indexof<NULL, NULL>(NULL, NULL)
+ast            : array_indexof(NULL, NULL)
+raw expr       : array_indexof(NULL, NULL)
+checked expr   : array_indexof<NULL, NULL>(NULL, NULL)
 optimized expr : NULL
 output type    : NULL
 output domain  : {NULL}
 output         : NULL
 
 
-ast            : indexof([false, true], false)
-raw expr       : indexof(array(false, true), false)
-checked expr   : indexof<T0=Boolean><Array(T0), T0>(array<T0=Boolean><T0, T0>(false, true), false)
+ast            : array_indexof([false, true], false)
+raw expr       : array_indexof(array(false, true), false)
+checked expr   : array_indexof<T0=Boolean><Array(T0), T0>(array<T0=Boolean><T0, T0>(false, true), false)
 optimized expr : 1_u64
 output type    : UInt64
 output domain  : {1..=1}
 output         : 1_u64
 
 
-ast            : indexof([], false)
-raw expr       : indexof(array(), false)
-checked expr   : indexof<T0=Boolean><Array(T0), T0>(CAST(array<>() AS Array(Boolean)), false)
+ast            : array_indexof([], false)
+raw expr       : array_indexof(array(), false)
+checked expr   : array_indexof<T0=Boolean><Array(T0), T0>(CAST(array<>() AS Array(Boolean)), false)
 optimized expr : 0_u64
 output type    : UInt64
 output domain  : {0..=0}
 output         : 0_u64
 
 
-ast            : indexof([false, true], null)
-raw expr       : indexof(array(false, true), NULL)
-checked expr   : indexof<T0=Boolean NULL><Array(T0), T0>(CAST(array<T0=Boolean><T0, T0>(false, true) AS Array(Boolean NULL)), CAST(NULL AS Boolean NULL))
+ast            : array_indexof([false, true], null)
+raw expr       : array_indexof(array(false, true), NULL)
+checked expr   : array_indexof<T0=Boolean NULL><Array(T0), T0>(CAST(array<T0=Boolean><T0, T0>(false, true) AS Array(Boolean NULL)), CAST(NULL AS Boolean NULL))
 optimized expr : 0_u64
 output type    : UInt64
 output domain  : {0..=0}
 output         : 0_u64
 
 
-ast            : indexof([false, true], 0)
-raw expr       : indexof(array(false, true), 0_u8)
-checked expr   : indexof<T0=Variant><Array(T0), T0>(CAST(array<T0=Boolean><T0, T0>(false, true) AS Array(Variant)), to_variant<T0=UInt8><T0>(0_u8))
+ast            : array_indexof([false, true], 0)
+raw expr       : array_indexof(array(false, true), 0_u8)
+checked expr   : array_indexof<T0=Variant><Array(T0), T0>(CAST(array<T0=Boolean><T0, T0>(false, true) AS Array(Variant)), to_variant<T0=UInt8><T0>(0_u8))
 optimized expr : 0_u64
 output type    : UInt64
 output domain  : {0..=0}
 output         : 0_u64
 
 
-ast            : indexof([1,2,3,'s'], 's')
-raw expr       : indexof(array(1_u8, 2_u8, 3_u8, "s"), "s")
-checked expr   : indexof<T0=Variant><Array(T0), T0>(array<T0=Variant><T0, T0, T0, T0>(to_variant<T0=UInt8><T0>(1_u8), to_variant<T0=UInt8><T0>(2_u8), to_variant<T0=UInt8><T0>(3_u8), to_variant<T0=String><T0>("s")), to_variant<T0=String><T0>("s"))
+ast            : array_indexof([1,2,3,'s'], 's')
+raw expr       : array_indexof(array(1_u8, 2_u8, 3_u8, "s"), "s")
+checked expr   : array_indexof<T0=Variant><Array(T0), T0>(array<T0=Variant><T0, T0, T0, T0>(to_variant<T0=UInt8><T0>(1_u8), to_variant<T0=UInt8><T0>(2_u8), to_variant<T0=UInt8><T0>(3_u8), to_variant<T0=String><T0>("s")), to_variant<T0=String><T0>("s"))
 optimized expr : 4_u64
 output type    : UInt64
 output domain  : {4..=4}
 output         : 4_u64
 
 
-ast            : indexof([1,'x',null,'x'], 'x')
-raw expr       : indexof(array(1_u8, "x", NULL, "x"), "x")
-checked expr   : indexof<T0=Variant NULL><Array(T0), T0>(array<T0=Variant NULL><T0, T0, T0, T0>(CAST(1_u8 AS Variant NULL), CAST("x" AS Variant NULL), CAST(NULL AS Variant NULL), CAST("x" AS Variant NULL)), CAST("x" AS Variant NULL))
+ast            : array_indexof([1,'x',null,'x'], 'x')
+raw expr       : array_indexof(array(1_u8, "x", NULL, "x"), "x")
+checked expr   : array_indexof<T0=Variant NULL><Array(T0), T0>(array<T0=Variant NULL><T0, T0, T0, T0>(CAST(1_u8 AS Variant NULL), CAST("x" AS Variant NULL), CAST(NULL AS Variant NULL), CAST("x" AS Variant NULL)), CAST("x" AS Variant NULL))
 optimized expr : 2_u64
 output type    : UInt64
 output domain  : {2..=2}
 output         : 2_u64
 
 
-ast            : indexof([1, 2, 3, 4, 5, null], nullable_col)
-raw expr       : indexof(array(1_u8, 2_u8, 3_u8, 4_u8, 5_u8, NULL), nullable_col::Int64 NULL)
-checked expr   : indexof<T0=Int64 NULL><Array(T0), T0>(CAST(array<T0=UInt8 NULL><T0, T0, T0, T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL), CAST(5_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int64 NULL)), nullable_col)
-optimized expr : indexof<T0=Int64 NULL><Array(T0), T0>([1_i64, 2_i64, 3_i64, 4_i64, 5_i64, NULL], nullable_col)
+ast            : array_indexof([1, 2, 3, 4, 5, null], nullable_col)
+raw expr       : array_indexof(array(1_u8, 2_u8, 3_u8, 4_u8, 5_u8, NULL), nullable_col::Int64 NULL)
+checked expr   : array_indexof<T0=Int64 NULL><Array(T0), T0>(CAST(array<T0=UInt8 NULL><T0, T0, T0, T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL), CAST(5_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int64 NULL)), nullable_col)
+optimized expr : array_indexof<T0=Int64 NULL><Array(T0), T0>([1_i64, 2_i64, 3_i64, 4_i64, 5_i64, NULL], nullable_col)
 evaluation:
 +--------+-------------------+----------------------------+
 |        | nullable_col      | Output                     |
@@ -857,10 +857,10 @@ evaluation (internal):
 +--------------+---------------------------------------------------------------------------+
 
 
-ast            : indexof([9,10,null], int8_col)
-raw expr       : indexof(array(9_u8, 10_u8, NULL), int8_col::Int8)
-checked expr   : indexof<T0=Int16 NULL><Array(T0), T0>(CAST(array<T0=UInt8 NULL><T0, T0, T0>(CAST(9_u8 AS UInt8 NULL), CAST(10_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int16 NULL)), CAST(int8_col AS Int16 NULL))
-optimized expr : indexof<T0=Int16 NULL><Array(T0), T0>([9_i16, 10_i16, NULL], CAST(int8_col AS Int16 NULL))
+ast            : array_indexof([9,10,null], int8_col)
+raw expr       : array_indexof(array(9_u8, 10_u8, NULL), int8_col::Int8)
+checked expr   : array_indexof<T0=Int16 NULL><Array(T0), T0>(CAST(array<T0=UInt8 NULL><T0, T0, T0>(CAST(9_u8 AS UInt8 NULL), CAST(10_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int16 NULL)), CAST(int8_col AS Int16 NULL))
+optimized expr : array_indexof<T0=Int16 NULL><Array(T0), T0>([9_i16, 10_i16, NULL], CAST(int8_col AS Int16 NULL))
 evaluation:
 +--------+----------+----------------------------+
 |        | int8_col | Output                     |

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -39,12 +39,27 @@ and(Boolean, Boolean) :: Boolean
 and(Boolean NULL, Boolean NULL) :: Boolean NULL
 and_filters(Boolean, Boolean) :: Boolean
 and_filters(Boolean NULL, Boolean NULL) :: Boolean NULL
-append(Array(T0), T0) :: Array(T0)
 array() :: Array(Nothing)
+array_append(Array(T0), T0) :: Array(T0)
+array_concat(Array(Nothing) NULL, Array(Nothing) NULL) :: Array(Nothing)
+array_concat(Array(T0), Array(T0)) :: Array(T0)
+array_concat(Array(T0) NULL, Array(T0) NULL) :: Array(T0) NULL
 array_distinct(Array(Nothing)) :: Array(Nothing)
 array_distinct(Array(Nothing) NULL) :: Array(Nothing) NULL
 array_distinct(Array(T0)) :: Array(T0)
 array_distinct(Array(T0) NULL) :: Array(T0) NULL
+array_indexof(NULL, NULL) :: NULL
+array_indexof(Array(T0), T0) :: UInt64
+array_indexof(Array(T0) NULL, T0 NULL) :: UInt64 NULL
+array_prepend(T0, Array(T0)) :: Array(T0)
+array_remove_first(Array(Nothing)) :: Array(Nothing)
+array_remove_first(Array(Nothing) NULL) :: Array(Nothing) NULL
+array_remove_first(Array(T0)) :: Array(T0)
+array_remove_first(Array(T0) NULL) :: Array(T0) NULL
+array_remove_last(Array(Nothing)) :: Array(Nothing)
+array_remove_last(Array(Nothing) NULL) :: Array(Nothing) NULL
+array_remove_last(Array(T0)) :: Array(T0)
+array_remove_last(Array(T0) NULL) :: Array(T0) NULL
 array_unique(Array(Nothing)) :: UInt64
 array_unique(Array(Nothing) NULL) :: UInt64 NULL
 array_unique(Array(T0)) :: UInt64
@@ -422,9 +437,6 @@ city64withseed(Variant, Float64) :: UInt64
 city64withseed(Variant NULL, Float64 NULL) :: UInt64 NULL
 city64withseed(Variant, Float32) :: UInt64
 city64withseed(Variant NULL, Float32 NULL) :: UInt64 NULL
-concat(Array(Nothing) NULL, Array(Nothing) NULL) :: Array(Nothing)
-concat(Array(T0), Array(T0)) :: Array(T0)
-concat(Array(T0) NULL, Array(T0) NULL) :: Array(T0) NULL
 contains(Array(UInt8), UInt8) :: Boolean
 contains(Array(UInt8) NULL, UInt8 NULL) :: Boolean NULL
 contains(Array(UInt16), UInt16) :: Boolean
@@ -1020,9 +1032,6 @@ humanize_number(Float64) :: String
 humanize_number(Float64 NULL) :: String NULL
 humanize_size(Float64) :: String
 humanize_size(Float64 NULL) :: String NULL
-indexof(NULL, NULL) :: NULL
-indexof(Array(T0), T0) :: UInt64
-indexof(Array(T0) NULL, T0 NULL) :: UInt64 NULL
 inet_aton(String) :: UInt32
 inet_aton(String NULL) :: UInt32 NULL
 inet_ntoa(Int64) :: String
@@ -2135,7 +2144,6 @@ position(String, String) :: UInt64
 position(String NULL, String NULL) :: UInt64 NULL
 pow(Float64, Float64) :: Float64
 pow(Float64 NULL, Float64 NULL) :: Float64 NULL
-prepend(T0, Array(T0)) :: Array(T0)
 quote(String) :: String
 quote(String NULL) :: String NULL
 radians(Float64) :: Float64
@@ -2145,14 +2153,6 @@ rand(UInt64) :: Float64
 rand(UInt64 NULL) :: Float64 NULL
 regexp(String, String) :: Boolean
 regexp(String NULL, String NULL) :: Boolean NULL
-remove_first(Array(Nothing)) :: Array(Nothing)
-remove_first(Array(Nothing) NULL) :: Array(Nothing) NULL
-remove_first(Array(T0)) :: Array(T0)
-remove_first(Array(T0) NULL) :: Array(T0) NULL
-remove_last(Array(Nothing)) :: Array(Nothing)
-remove_last(Array(Nothing) NULL) :: Array(Nothing) NULL
-remove_last(Array(T0)) :: Array(T0)
-remove_last(Array(T0) NULL) :: Array(T0) NULL
 repeat(String, UInt64) :: String
 repeat(String NULL, UInt64 NULL) :: String NULL
 replace(String, String, String) :: String
@@ -3230,6 +3230,10 @@ tuple
 
 Function aliases (alias to origin):
 add -> plus
+array_contains -> contains
+array_get -> get
+array_length -> length
+array_slice -> slice
 ceiling -> ceil
 character_length -> char_length
 intdiv -> div

--- a/tests/sqllogictests/suites/query/02_function/02_0061_function_array
+++ b/tests/sqllogictests/suites/query/02_function/02_0061_function_array
@@ -17,52 +17,52 @@ statement ok
 insert into t values([1,2,3,3],['x','x','y','z'], ['2022-02-02'], ['2023-01-01 02:00:01'], [[1,2],[],[null]])
 
 query T
-select concat(col1, col5) from t
+select array_concat(col1, col5) from t
 ----
 ['1','2','3','3','[1,2]','[]','[null]']
 
 query T
-select concat(col1, col2) from t;
+select array_concat(col1, col2) from t;
 ----
 ['1','2','3','3','"x"','"x"','"y"','"z"']
 
 query T
-select concat(col5, col2) from t;
+select array_concat(col5, col2) from t;
 ----
 ['[1,2]','[]','[null]','"x"','"x"','"y"','"z"']
 
 query T
-select concat(col4, col3) from t;
+select array_concat(col4, col3) from t;
 ----
 ['2023-01-01 02:00:01.000000','2022-02-02 00:00:00.000000']
 
 query IIIIII
-select indexof(col1,'2'), indexof(col1,2), indexof(col2,'x'), indexof(col3,'2022-02-02'), indexof(col4,'2023-01-01 02:00:02'), indexof(col5,[NULL]) from t
+select array_indexof(col1,'2'), array_indexof(col1,2), array_indexof(col2,'x'), array_indexof(col3,'2022-02-02'), array_indexof(col4,'2023-01-01 02:00:02'), array_indexof(col5,[NULL]) from t
 ----
 0 2 1 1 0 3
 
 query I
-select indexof([1,2,null,2,null], null)
+select array_indexof([1,2,null,2,null], null)
 ----
 3
 
 query TTT
-select remove_first(col1), remove_first(col2), remove_first(col3) from t
+select array_remove_first(col1), array_remove_first(col2), array_remove_first(col3) from t
 ----
 [2,3,3] ['x','y','z'] []
 
 query TTT
-select remove_last(col1), remove_last(col2), remove_last(col3) from t
+select array_remove_last(col1), array_remove_last(col2), array_remove_last(col3) from t
 ----
 [1,2,3] ['x','x','y'] []
 
 query TTT
-select prepend(0, col1), prepend('a', col2), prepend('2022-01-01', col3) from t
+select array_prepend(0, col1), array_prepend('a', col2), array_prepend('2022-01-01', col3) from t
 ----
 [0,1,2,3,3] ['a','x','x','y','z'] ['2022-01-01','2022-02-02']
 
 query TTT
-select append(col1, 4), append(col2, 'z'), append(col3, '2022-03-03') from t
+select array_append(col1, 4), array_append(col2, 'z'), array_append(col3, '2022-03-03') from t
 ----
 [1,2,3,3,4] ['x','x','y','z','z'] ['2022-02-02','2022-03-03']
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

rename some array functions add `array_` prefix
```
remove_first -> array_remove_first
remove_last -> array_remove_last
concat -> array_concat
prepend -> array_prepend
append -> array_append
indexof -> array_indexof
```

Closes #issue
