### PR TITLE
refactor(meta): remove obsolete meta service api read_msg() and write_msg()

### DIFF
--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -41,19 +41,20 @@ pub static METACLI_COMMIT_SEMVER: Lazy<Version> = Lazy::new(|| {
 /// Oldest compatible nightly metasrv version
 ///
 /// ```text
-/// now  --.
-///        |
-/// 8.79 . |
-///      | |
-///      | '---> 8.35
-///      |    .--'
-///      |    |
-///      '-----> 8.30
-///           |  |
-///           |  |
-/// 7.59 <----+--'
-///
-/// Client       Server
+/// time
+/// ^
+/// | now  --.     now --.
+/// |        |           |
+/// |        |           '----> 8.80
+/// | 8.79 . |                  8.79
+/// |      | |
+/// |      | '---> 8.35 -.
+/// |      |             |
+/// |      '-----> 8.30 -+
+/// |                    |
+/// | 7.59               '----> 7.59
+/// |-----------------------------------
+/// | Client       Server       Client
 ///
 /// --> : pointing to min compatible version
 /// ```
@@ -62,6 +63,11 @@ pub static METACLI_COMMIT_SEMVER: Lazy<Version> = Lazy::new(|| {
 ///   Update min compatible server to 0.8.35:
 ///   Since which, meta-server adds new API kv_api() to replace write_msg() and read_msg();
 ///   Feature commit: 69a05aca41036976fec37ad7a8b447e2868ef08b 2022-09-14
+///
+/// - 2023-02-04: after 0.9.22:
+///   Remove read_msg and write_msg from service definition meta.proto
+///   Update server.min_cli_ver to 0.8.80, the min ver in which meta-client switched from
+///   `read_msg/write_msg` to `kv_api`
 pub static MIN_METASRV_SEMVER: Version = Version {
     major: 0,
     minor: 8,

--- a/src/meta/client/tests/it/grpc_server.rs
+++ b/src/meta/client/tests/it/grpc_server.rs
@@ -62,20 +62,6 @@ impl MetaService for GrpcServiceForTestImpl {
         Ok(Response::new(Box::pin(output)))
     }
 
-    async fn write_msg(
-        &self,
-        _request: Request<RaftRequest>,
-    ) -> Result<Response<RaftReply>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
-    }
-
-    async fn read_msg(
-        &self,
-        _request: Request<RaftRequest>,
-    ) -> Result<Response<RaftReply>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
-    }
-
     async fn kv_api(&self, _request: Request<RaftRequest>) -> Result<Response<RaftReply>, Status> {
         // for timeout test
         tokio::time::sleep(Duration::from_secs(60)).await;

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -164,14 +164,6 @@ impl MetaService for MetaServiceImpl {
         }
     }
 
-    async fn write_msg(&self, r: Request<RaftRequest>) -> Result<Response<RaftReply>, Status> {
-        self.kv_api(r).await
-    }
-
-    async fn read_msg(&self, r: Request<RaftRequest>) -> Result<Response<RaftReply>, Status> {
-        self.kv_api(r).await
-    }
-
     async fn kv_api(&self, r: Request<RaftRequest>) -> Result<Response<RaftReply>, Status> {
         let _guard = RequestInFlight::guard();
 

--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -63,7 +63,7 @@ impl<'a> MetaLeader<'a> {
     }
 
     #[tracing::instrument(level = "debug", skip(self, req), fields(target=%req.forward_to_leader))]
-    pub async fn handle_forwardable_req(
+    pub async fn handle_request(
         &self,
         req: ForwardRequest,
     ) -> Result<ForwardResponse, MetaOperationError> {

--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
+use common_base::base::tokio::sync::RwLockReadGuard;
 use common_meta_kvapi::kvapi::KVApi;
+use common_meta_raft_store::state_machine::StateMachine;
 use common_meta_sled_store::openraft::error::RemoveLearnerError;
+use common_meta_stoerr::MetaStorageError;
 use common_meta_types::AppliedState;
 use common_meta_types::Cmd;
 use common_meta_types::ForwardRequest;
@@ -23,6 +28,7 @@ use common_meta_types::MetaDataError;
 use common_meta_types::MetaDataReadError;
 use common_meta_types::MetaOperationError;
 use common_meta_types::Node;
+use common_meta_types::NodeId;
 use common_meta_types::RaftChangeMembershipError;
 use common_meta_types::RaftWriteError;
 use common_meta_types::SeqV;
@@ -31,23 +37,29 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 
+use crate::meta_service::raftmeta::MetaRaft;
 use crate::meta_service::ForwardRequestBody;
 use crate::meta_service::JoinRequest;
 use crate::meta_service::LeaveRequest;
 use crate::meta_service::MetaNode;
 use crate::metrics::ProposalPending;
+use crate::store::RaftStore;
 
-/// The container of APIs of a metasrv leader in a metasrv cluster.
+/// The container of APIs of the leader in a meta service cluster.
 ///
-/// A meta leader does not imply it is actually the leader granted by the cluster.
-/// It just means it believes it is the leader an have not yet perceived there is other newer leader.
+/// A leader does not imply it is actually the leader granted by the cluster.
+/// It just means it believes it is the leader and have not yet perceived there is other newer leader.
 pub struct MetaLeader<'a> {
-    meta_node: &'a MetaNode,
+    sto: &'a Arc<RaftStore>,
+    raft: &'a MetaRaft,
 }
 
 impl<'a> MetaLeader<'a> {
     pub fn new(meta_node: &'a MetaNode) -> MetaLeader {
-        MetaLeader { meta_node }
+        MetaLeader {
+            sto: &meta_node.sto,
+            raft: &meta_node.raft,
+        }
     }
 
     #[tracing::instrument(level = "debug", skip(self, req), fields(target=%req.forward_to_leader))]
@@ -74,7 +86,7 @@ impl<'a> MetaLeader<'a> {
             }
 
             ForwardRequestBody::GetKV(req) => {
-                let sm = self.meta_node.get_state_machine().await;
+                let sm = self.get_state_machine().await;
                 let res = sm
                     .get_kv(&req.key)
                     .await
@@ -82,7 +94,7 @@ impl<'a> MetaLeader<'a> {
                 Ok(ForwardResponse::GetKV(res))
             }
             ForwardRequestBody::MGetKV(req) => {
-                let sm = self.meta_node.get_state_machine().await;
+                let sm = self.get_state_machine().await;
                 let res = sm
                     .mget_kv(&req.keys)
                     .await
@@ -90,7 +102,7 @@ impl<'a> MetaLeader<'a> {
                 Ok(ForwardResponse::MGetKV(res))
             }
             ForwardRequestBody::ListKV(req) => {
-                let sm = self.meta_node.get_state_machine().await;
+                let sm = self.get_state_machine().await;
                 let res = sm
                     .prefix_list_kv(&req.prefix)
                     .await
@@ -110,7 +122,7 @@ impl<'a> MetaLeader<'a> {
     pub async fn join(&self, req: JoinRequest) -> Result<(), RaftChangeMembershipError> {
         let node_id = req.node_id;
         let endpoint = req.endpoint;
-        let metrics = self.meta_node.raft.metrics().borrow().clone();
+        let metrics = self.raft.metrics().borrow().clone();
         let membership = metrics.membership_config.membership.clone();
 
         if membership.contains(&node_id) {
@@ -132,10 +144,7 @@ impl<'a> MetaLeader<'a> {
         };
         self.write(ent).await?;
 
-        self.meta_node
-            .raft
-            .change_membership(membership, false)
-            .await?;
+        self.raft.change_membership(membership, false).await?;
         Ok(())
     }
 
@@ -150,10 +159,10 @@ impl<'a> MetaLeader<'a> {
     pub async fn leave(&self, req: LeaveRequest) -> Result<(), MetaOperationError> {
         let node_id = req.node_id;
 
-        let can_res =
-            self.meta_node.can_leave(node_id).await.map_err(|e| {
-                MetaDataError::ReadError(MetaDataReadError::new("can_leave()", "", &e))
-            })?;
+        let can_res = self
+            .can_leave(node_id)
+            .await
+            .map_err(|e| MetaDataError::ReadError(MetaDataReadError::new("can_leave()", "", &e)))?;
 
         if let Err(e) = can_res {
             info!("no need to leave: {}", e);
@@ -162,7 +171,7 @@ impl<'a> MetaLeader<'a> {
 
         // safe unwrap: if the first config is None, panic is the expected behavior here.
         let membership = {
-            let sm = self.meta_node.sto.get_state_machine().await;
+            let sm = self.get_state_machine().await;
             let m = sm.get_membership().map_err(|e| {
                 MetaDataError::ReadError(MetaDataReadError::new("get_membership()", "", &e))
             })?;
@@ -176,11 +185,11 @@ impl<'a> MetaLeader<'a> {
             let mut config0 = membership.get_ith_config(0).unwrap().clone();
             config0.remove(&node_id);
 
-            self.meta_node.raft.change_membership(config0, true).await?;
+            self.raft.change_membership(config0, true).await?;
         }
 
         // 2. Stop replication
-        let res = self.meta_node.raft.remove_learner(node_id).await;
+        let res = self.raft.remove_learner(node_id).await;
         if let Err(e) = res {
             match e {
                 RemoveLearnerError::ForwardToLeader(e) => {
@@ -221,7 +230,7 @@ impl<'a> MetaLeader<'a> {
         let _guard = ProposalPending::guard();
 
         info!("write LogEntry: {}", entry);
-        let write_res = self.meta_node.raft.client_write(entry).await;
+        let write_res = self.raft.client_write(entry).await;
         if let Ok(ok) = &write_res {
             info!(
                 "raft.client_write res ok: log_id: {}, data: {}, membership: {:?}",
@@ -236,5 +245,35 @@ impl<'a> MetaLeader<'a> {
             Ok(resp) => Ok(resp.data),
             Err(cli_write_err) => Err(RaftWriteError::from_raft_err(cli_write_err)),
         }
+    }
+
+    /// Check if a node is allowed to leave the cluster.
+    ///
+    /// A cluster must have at least one node in it.
+    async fn can_leave(&self, id: NodeId) -> Result<Result<(), String>, MetaStorageError> {
+        let m = {
+            let sm = self.get_state_machine().await;
+            sm.get_membership()?
+        };
+        info!("check can_leave: id: {}, membership: {:?}", id, m);
+
+        let membership = match m {
+            None => {
+                return Ok(Err("no membership, can not leave".to_string()));
+            }
+            Some(x) => x.membership,
+        };
+
+        let config0 = membership.get_ith_config(0).unwrap();
+
+        if config0.contains(&id) && config0.len() == 1 {
+            return Ok(Err(format!("can not remove the last node: {:?}", config0)));
+        }
+
+        Ok(Ok(()))
+    }
+
+    async fn get_state_machine(&self) -> RwLockReadGuard<'_, StateMachine> {
+        self.sto.state_machine.read().await
     }
 }

--- a/src/meta/service/src/meta_service/meta_node_kv_api_impl.rs
+++ b/src/meta/service/src/meta_service/meta_node_kv_api_impl.rs
@@ -43,16 +43,12 @@ impl kvapi::KVApi for MetaNode {
     type Error = KVAppError;
 
     async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
-        let ent = LogEntry {
-            txid: None,
-            time_ms: None,
-            cmd: Cmd::UpsertKV(UpsertKV {
-                key: act.key,
-                seq: act.seq,
-                value: act.value,
-                value_meta: act.value_meta,
-            }),
-        };
+        let ent = LogEntry::new(Cmd::UpsertKV(UpsertKV {
+            key: act.key,
+            seq: act.seq,
+            value: act.value,
+            value_meta: act.value_meta,
+        }));
         let rst = self.write(ent).await?;
 
         match rst {
@@ -99,11 +95,7 @@ impl kvapi::KVApi for MetaNode {
     #[tracing::instrument(level = "debug", skip(self, txn))]
     async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, KVAppError> {
         info!("MetaNode::transaction(): {}", txn);
-        let ent = LogEntry {
-            txid: None,
-            time_ms: None,
-            cmd: Cmd::Transaction(txn),
-        };
+        let ent = LogEntry::new(Cmd::Transaction(txn));
         let rst = self.write(ent).await?;
 
         match rst {

--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -938,7 +938,7 @@ impl MetaNode {
         // Handle the request locally or return a ForwardToLeader error
         let op_err = match assume_leader_res {
             Ok(leader) => {
-                let res = leader.handle_forwardable_req(req.clone()).await;
+                let res = leader.handle_request(req.clone()).await;
                 match res {
                     Ok(x) => return Ok(x),
                     Err(e) => e,
@@ -1001,17 +1001,12 @@ impl MetaNode {
         node: Node,
     ) -> Result<AppliedState, MetaAPIError> {
         // TODO: use txid?
-        let resp = self
-            .write(LogEntry {
-                txid: None,
-                time_ms: None,
-                cmd: Cmd::AddNode {
-                    node_id,
-                    node,
-                    overriding: false,
-                },
-            })
-            .await?;
+        let cmd = Cmd::AddNode {
+            node_id,
+            node,
+            overriding: false,
+        };
+        let resp = self.write(LogEntry::new(cmd)).await?;
 
         self.raft
             .add_learner(node_id, false)

--- a/src/meta/service/src/version.rs
+++ b/src/meta/service/src/version.rs
@@ -46,8 +46,8 @@ pub static METASRV_SEMVER: Lazy<Version> = Lazy::new(|| {
 /// Oldest compatible nightly meta-client version
 pub static MIN_METACLI_SEMVER: Version = Version {
     major: 0,
-    minor: 7,
-    patch: 59,
+    minor: 8,
+    patch: 80,
     pre: Prerelease::EMPTY,
     build: BuildMetadata::EMPTY,
 };

--- a/src/meta/service/tests/it/meta_node/meta_node_replication.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_replication.rs
@@ -70,12 +70,8 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
 
     for i in 0..n_req {
         let key = format!("test_meta_node_snapshot_replication-key-{}", i);
-        mn.write(LogEntry {
-            txid: None,
-            time_ms: None,
-            cmd: Cmd::UpsertKV(UpsertKV::update(&key, b"v")),
-        })
-        .await?;
+        mn.write(LogEntry::new(Cmd::UpsertKV(UpsertKV::update(&key, b"v"))))
+            .await?;
     }
     log_index += n_req;
 

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -166,9 +166,6 @@ service MetaService {
   // handshake
   rpc Handshake(stream HandshakeRequest) returns (stream HandshakeResponse);
 
-  rpc WriteMsg(RaftRequest) returns (RaftReply);
-  rpc ReadMsg(RaftRequest) returns (RaftReply);
-
   // General KV API for get, mget, list, and upsert;
   // It is introduced to replace `WriteMsg` and `ReadMsg`.
   //

--- a/src/meta/types/src/log_entry.rs
+++ b/src/meta/types/src/log_entry.rs
@@ -58,3 +58,17 @@ impl Display for LogEntry {
         write!(f, " cmd: {}", self.cmd)
     }
 }
+
+impl LogEntry {
+    pub fn new(cmd: Cmd) -> Self {
+        Self {
+            txid: None,
+            time_ms: None,
+            cmd,
+        }
+    }
+    pub fn with_txid(mut self, txid: Option<RaftTxId>) -> Self {
+        self.txid = txid;
+        self
+    }
+}

--- a/tests/compat/test-compat.sh
+++ b/tests/compat/test-compat.sh
@@ -231,8 +231,10 @@ run_test() {
         rm -fr suites/*
         mv 05_ddl suites/
         # FIXME:(everpcpc) sometimes old logic test fails but we can't time travel back to fix it.
-        python3 main.py
+        #       Confirm the test always pass then delete this workaround in
+        #       comment:
         # python3 main.py || true
+        python3 main.py
         cd -
     fi
 }

--- a/tests/compat/test-compat.sh
+++ b/tests/compat/test-compat.sh
@@ -227,7 +227,7 @@ run_test() {
 
         # logictest pattern argument change after v0.7.140
         # old logic test does not support pattern filter
-        mv suites/gen/05_ddl .
+        mv suites/base/05_ddl .
         rm -fr suites/*
         mv 05_ddl suites/
         # FIXME:(everpcpc) sometimes old logic test fails but we can't time travel back to fix it.

--- a/tests/compat/test-compat.sh
+++ b/tests/compat/test-compat.sh
@@ -231,7 +231,8 @@ run_test() {
         rm -fr suites/*
         mv 05_ddl suites/
         # FIXME:(everpcpc) sometimes old logic test fails but we can't time travel back to fix it.
-        python3 main.py || true
+        python3 main.py
+        # python3 main.py || true
         cd -
     fi
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta): remove obsolete meta service api read_msg() and write_msg()

The `meta-server.min_client_ver` is increased from `0.7.59` to `0.8.80`.


##### chore(meta): simplify LogEntry creating


##### chore(meta): move dependency method to MetaLeader

## Changelog







## Related Issues