### PR TITLE
chore(storage): refactor cache to moka based

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7798,6 +7798,7 @@ dependencies = [
  "common-cache",
  "common-exception",
  "metrics",
+ "moka",
  "opendal",
  "parking_lot 0.12.1",
  "serde",

--- a/src/query/storages/common/cache-manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache-manager/src/cache_manager.rs
@@ -104,7 +104,9 @@ impl CacheManager {
         self.file_meta_data_cache.clone()
     }
 
-    fn new_item_cache<T>(capacity: u64) -> Option<InMemoryItemCacheHolder<T>> {
+    fn new_item_cache<T: Send + Sync + 'static>(
+        capacity: u64,
+    ) -> Option<InMemoryItemCacheHolder<T>> {
         if capacity > 0 {
             Some(InMemoryCacheBuilder::new_item_cache(capacity))
         } else {

--- a/src/query/storages/common/cache-manager/src/caches.rs
+++ b/src/query/storages/common/cache-manager/src/caches.rs
@@ -43,7 +43,7 @@ pub type FileMetaDataCache = InMemoryItemCacheHolder<FileMetaData>;
 // - cache item s of Type `T`
 // - and implement `CacheAccessor` properly
 pub trait CachedObject<T> {
-    type Cache: CacheAccessor<String, T>;
+    type Cache: CacheAccessor<String, T> + Clone;
     fn cache() -> Option<Self::Cache>;
 }
 

--- a/src/query/storages/common/cache/Cargo.toml
+++ b/src/query/storages/common/cache/Cargo.toml
@@ -18,6 +18,7 @@ common-exception = { path = "../../../../common/exception" }
 
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
 metrics = "0.20.1"
+moka = "0.9"
 opendal = { workspace = true }
 parking_lot = "0.12.1"
 serde = { workspace = true }

--- a/src/query/storages/common/cache/src/cache.rs
+++ b/src/query/storages/common/cache/src/cache.rs
@@ -16,30 +16,29 @@ use std::borrow::Borrow;
 use std::hash::Hash;
 use std::sync::Arc;
 
-pub trait CacheAccessor<K, V> {
+pub trait CacheAccessor<K, V>: Clone {
     fn get<Q>(&self, k: &Q) -> Option<Arc<V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
 
     fn put(&self, key: K, value: Arc<V>);
-    fn evict<Q>(&self, k: &Q) -> bool
+    fn evict<Q>(&self, k: &Q)
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
 }
 
 /// The minimum interface that cache providers should implement
-pub trait StorageCache<K, V> {
-    type Meter;
-    fn put(&mut self, key: K, value: Arc<V>);
+pub trait StorageCache<K, V>: Clone {
+    fn put(&self, key: K, value: Arc<V>);
 
-    fn get<Q>(&mut self, k: &Q) -> Option<&Arc<V>>
+    fn get<Q>(&self, k: &Q) -> Option<Arc<V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
 
-    fn evict<Q>(&mut self, k: &Q) -> bool
+    fn evict<Q>(&self, k: &Q)
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
@@ -50,65 +49,30 @@ mod impls {
     use std::hash::Hash;
     use std::sync::Arc;
 
-    use parking_lot::RwLock;
-
     use crate::cache::CacheAccessor;
     use crate::cache::StorageCache;
 
-    impl<V, C> CacheAccessor<String, V> for Arc<RwLock<C>>
-    where C: StorageCache<String, V>
+    impl<V, C> CacheAccessor<String, V> for C
+    where C: StorageCache<String, V> + Clone
     {
         fn get<Q>(&self, k: &Q) -> Option<Arc<V>>
         where
             String: Borrow<Q>,
             Q: Hash + Eq + ?Sized,
         {
-            let mut guard = self.write();
-            guard.get(k).cloned()
+            StorageCache::get(self, k)
         }
 
         fn put(&self, k: String, v: Arc<V>) {
-            let mut guard = self.write();
-            guard.put(k, v);
+            StorageCache::put(self, k, v)
         }
 
-        fn evict<Q>(&self, k: &Q) -> bool
+        fn evict<Q>(&self, k: &Q)
         where
             String: Borrow<Q>,
             Q: Hash + Eq + ?Sized,
         {
-            let mut guard = self.write();
-            guard.evict(k)
-        }
-    }
-
-    impl<V, C> CacheAccessor<String, V> for Option<Arc<RwLock<C>>>
-    where C: StorageCache<String, V>
-    {
-        fn get<Q>(&self, k: &Q) -> Option<Arc<V>>
-        where
-            String: Borrow<Q>,
-            Q: Hash + Eq + ?Sized,
-        {
-            self.as_ref().and_then(|cache| cache.get(k))
-        }
-
-        fn put(&self, k: String, v: Arc<V>) {
-            if let Some(cache) = self {
-                cache.put(k, v);
-            }
-        }
-
-        fn evict<Q>(&self, k: &Q) -> bool
-        where
-            String: Borrow<Q>,
-            Q: Hash + Eq + ?Sized,
-        {
-            if let Some(cache) = self {
-                cache.evict(k)
-            } else {
-                false
-            }
+            StorageCache::evict(self, k)
         }
     }
 }

--- a/src/query/storages/common/cache/src/providers/disk_cache.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache.rs
@@ -19,16 +19,15 @@ use std::sync::Arc;
 use crate::cache::StorageCache;
 
 // TODO: local disk file based LRU/LFU/xxxx cache
+#[derive(Clone)]
 pub struct DiskCache {}
 
 impl<K, V> StorageCache<K, V> for DiskCache {
-    type Meter = ();
-
-    fn put(&mut self, _key: K, _value: Arc<V>) {
+    fn put(&self, _key: K, _value: Arc<V>) {
         todo!()
     }
 
-    fn get<Q>(&mut self, _k: &Q) -> Option<&Arc<V>>
+    fn get<Q>(&self, _k: &Q) -> Option<Arc<V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -36,7 +35,7 @@ impl<K, V> StorageCache<K, V> for DiskCache {
         todo!()
     }
 
-    fn evict<Q>(&mut self, _k: &Q) -> bool
+    fn evict<Q>(&self, _k: &Q)
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,

--- a/src/query/storages/common/cache/src/providers/memory_cache.rs
+++ b/src/query/storages/common/cache/src/providers/memory_cache.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use moka::sync::Cache as MokaCache;
 
-use crate::cache::CacheAccessor;
 use crate::cache::StorageCache;
 
 pub type ItemCache<V> = MokaCache<String, Arc<V>>;
@@ -30,8 +29,7 @@ pub type InMemoryBytesCacheHolder = BytesCache;
 pub struct InMemoryCacheBuilder;
 impl InMemoryCacheBuilder {
     pub fn new_item_cache<V: Send + Sync + 'static>(capacity: u64) -> InMemoryItemCacheHolder<V> {
-        let cache = MokaCache::<String, Arc<V>>::new(capacity);
-        cache
+        MokaCache::<String, Arc<V>>::new(capacity)
     }
 
     pub fn new_bytes_cache(capacity: u64) -> InMemoryBytesCacheHolder {

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -364,10 +364,11 @@ impl FuseTable {
                 if let Some(snapshot_statistics) = table_statistics {
                     if let Some(location) = &snapshot.table_statistics_location {
                         TableSnapshotStatistics::cache()
-                            .put(location.clone(), Arc::new(snapshot_statistics));
+                            .map(|c| c.put(location.clone(), Arc::new(snapshot_statistics)));
                     }
                 }
-                TableSnapshot::cache().put(snapshot_location.clone(), Arc::new(snapshot));
+                TableSnapshot::cache()
+                    .map(|c| c.put(snapshot_location.clone(), Arc::new(snapshot)));
                 // try keep a hit file of last snapshot
                 Self::write_last_snapshot_hint(operator, location_generator, snapshot_location)
                     .await;

--- a/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -19,7 +19,6 @@ use std::time::Instant;
 
 use common_base::base::Progress;
 use common_base::base::ProgressValues;
-use common_cache::Cache;
 use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;

--- a/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -29,6 +29,7 @@ use common_expression::TableSchemaRef;
 use common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
 use opendal::Operator;
 use storages_common_blocks::blocks_to_parquet;
+use storages_common_cache::CacheAccessor;
 use storages_common_cache_manager::CacheManager;
 use storages_common_index::BloomIndex;
 use storages_common_table_meta::meta::BlockMeta;
@@ -306,8 +307,7 @@ impl Processor for CompactTransform {
             }
             State::Output { location, segment } => {
                 if let Some(segment_cache) = CacheManager::instance().get_table_segment_cache() {
-                    let cache = &mut segment_cache.write();
-                    cache.put(location.clone(), segment.clone());
+                    segment_cache.put(location.clone(), segment.clone());
                 }
 
                 let meta = CompactSinkMeta::create(

--- a/src/query/storages/fuse/src/operations/mutation/mutation_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutation_transform.rs
@@ -25,6 +25,7 @@ use common_expression::BlockThresholds;
 use common_expression::DataBlock;
 use common_expression::TableSchemaRef;
 use opendal::Operator;
+use storages_common_cache::CacheAccessor;
 use storages_common_cache_manager::CacheManager;
 use storages_common_table_meta::meta::BlockMeta;
 use storages_common_table_meta::meta::Location;
@@ -155,8 +156,7 @@ impl MutationTransform {
             handles.push(async move {
                 op.object(&segment.location).write(segment.data).await?;
                 if let Some(segment_cache) = CacheManager::instance().get_table_segment_cache() {
-                    let cache = &mut segment_cache.write();
-                    cache.put(segment.location.clone(), segment.segment.clone());
+                    segment_cache.put(segment.location.clone(), segment.segment.clone());
                 }
                 Ok::<_, ErrorCode>(())
             });

--- a/src/query/storages/fuse/src/operations/mutation/mutation_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutation_transform.rs
@@ -17,7 +17,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use common_cache::Cache;
 use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

The original cache is using RWLock on the API level (too high), it'll acquire the write lock even in read operation(refresh the lru), this may have performance issue.

Performance:  https://github.com/moka-rs/moka/wiki#admission-and-eviction-policies

Closes #issue
