### PR TITLE
refactor(query): hashtable grow instead of grow_zero

### DIFF
--- a/src/common/hashtable/src/keys_ref.rs
+++ b/src/common/hashtable/src/keys_ref.rs
@@ -14,7 +14,6 @@
 
 use std::hash::Hash;
 use std::hash::Hasher;
-use std::mem::MaybeUninit;
 
 use super::FastHash;
 use super::HashtableKeyable;

--- a/src/common/hashtable/src/keys_ref.rs
+++ b/src/common/hashtable/src/keys_ref.rs
@@ -56,10 +56,6 @@ impl PartialEq for KeysRef {
 }
 
 unsafe impl HashtableKeyable for KeysRef {
-    fn is_zero(this: &MaybeUninit<Self>) -> bool {
-        unsafe { this.assume_init_ref().address == 0 }
-    }
-
     fn equals_zero(this: &Self) -> bool {
         this.address == 0
     }

--- a/src/common/hashtable/src/short_string_hashtable.rs
+++ b/src/common/hashtable/src/short_string_hashtable.rs
@@ -652,11 +652,6 @@ unsafe impl<const N: usize> Keyable for InlineKey<N> {
     }
 
     #[inline(always)]
-    fn is_zero(this: &MaybeUninit<Self>) -> bool {
-        unsafe { *(this as *const _ as *const u64).add(N) == 0 }
-    }
-
-    #[inline(always)]
     fn hash(&self) -> u64 {
         (self.0, self.1).fast_hash()
     }
@@ -700,11 +695,6 @@ unsafe impl Keyable for FallbackKey {
     #[inline(always)]
     fn equals_zero(_: &Self) -> bool {
         false
-    }
-
-    #[inline(always)]
-    fn is_zero(this: &MaybeUninit<Self>) -> bool {
-        unsafe { this.assume_init_ref().key.is_none() }
     }
 
     #[inline(always)]

--- a/src/common/hashtable/src/table0.rs
+++ b/src/common/hashtable/src/table0.rs
@@ -29,10 +29,6 @@ pub struct Entry<K, V> {
 }
 
 impl<K: Keyable, V> Entry<K, V> {
-    // #[inline(always)]
-    // pub(crate) fn is_zero(&self) -> bool {
-    //     K::is_zero(&self.key)
-    // }
     // this function can only be used in external crates
     #[inline(always)]
     pub fn key(&self) -> &K {
@@ -227,6 +223,7 @@ where
             }
 
             self.entries = C::new_zeroed(0, self.allocator.clone());
+            self.zeros.clear();
         }
     }
 

--- a/src/common/hashtable/src/traits.rs
+++ b/src/common/hashtable/src/traits.rs
@@ -26,8 +26,6 @@ use primitive_types::U512;
 ///
 /// All functions must be implemented correctly.
 pub unsafe trait Keyable: Sized + Copy + Eq {
-    fn is_zero(this: &MaybeUninit<Self>) -> bool;
-
     fn equals_zero(this: &Self) -> bool;
 
     fn hash(&self) -> u64;
@@ -52,11 +50,6 @@ macro_rules! impl_key_for_primitive_types {
             #[inline(always)]
             fn equals_zero(this: &Self) -> bool {
                 *this == 0
-            }
-
-            #[inline(always)]
-            fn is_zero(this: &MaybeUninit<Self>) -> bool {
-                unsafe { this.assume_init() == 0 }
             }
 
             #[inline(always)]
@@ -85,22 +78,12 @@ unsafe impl Keyable for U256 {
     }
 
     #[inline(always)]
-    fn is_zero(this: &MaybeUninit<Self>) -> bool {
-        U256::is_zero(unsafe { this.assume_init_ref() })
-    }
-
-    #[inline(always)]
     fn hash(&self) -> u64 {
         self.fast_hash()
     }
 }
 
 unsafe impl Keyable for U512 {
-    #[inline(always)]
-    fn is_zero(this: &MaybeUninit<Self>) -> bool {
-        U512::is_zero(unsafe { this.assume_init_ref() })
-    }
-
     #[inline(always)]
     fn equals_zero(this: &Self) -> bool {
         U512::is_zero(this)
@@ -114,11 +97,6 @@ unsafe impl Keyable for U512 {
 
 unsafe impl Keyable for OrderedFloat<f32> {
     #[inline(always)]
-    fn is_zero(this: &MaybeUninit<Self>) -> bool {
-        unsafe { this.assume_init() == 0.0 }
-    }
-
-    #[inline(always)]
     fn equals_zero(this: &Self) -> bool {
         *this == 0.0
     }
@@ -131,11 +109,6 @@ unsafe impl Keyable for OrderedFloat<f32> {
 
 unsafe impl Keyable for OrderedFloat<f64> {
     #[inline(always)]
-    fn is_zero(this: &MaybeUninit<Self>) -> bool {
-        unsafe { this.assume_init() == 0.0 }
-    }
-
-    #[inline(always)]
     fn equals_zero(this: &Self) -> bool {
         *this == 0.0
     }
@@ -147,11 +120,6 @@ unsafe impl Keyable for OrderedFloat<f64> {
 }
 
 unsafe impl<const N: usize> Keyable for [u8; N] {
-    #[inline(always)]
-    fn is_zero(this: &MaybeUninit<Self>) -> bool {
-        unsafe { this.assume_init() == [0; N] }
-    }
-
     #[inline(always)]
     fn equals_zero(this: &Self) -> bool {
         *this == [0; N]

--- a/src/common/hashtable/src/utils.rs
+++ b/src/common/hashtable/src/utils.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::intrinsics::assume;
-use std::mem::MaybeUninit;
 use std::ops::Deref;
 use std::ops::DerefMut;
 

--- a/src/common/hashtable/src/utils.rs
+++ b/src/common/hashtable/src/utils.rs
@@ -42,14 +42,6 @@ impl<K: Keyable> Hashed<K> {
 
 unsafe impl<K: Keyable> Keyable for Hashed<K> {
     #[inline(always)]
-    fn is_zero(this: &MaybeUninit<Self>) -> bool {
-        unsafe {
-            let addr = std::ptr::addr_of!((*this.as_ptr()).key);
-            K::is_zero(&*(addr as *const MaybeUninit<K>))
-        }
-    }
-
-    #[inline(always)]
     fn equals_zero(this: &Self) -> bool {
         K::equals_zero(&this.key)
     }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_final_parallel.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_final_parallel.rs
@@ -180,6 +180,11 @@ where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
     }
 
     fn merge_partial_hashstates(&mut self, hashtable: &mut Method::HashTable) -> Result<()> {
+        if self.hash_table.len() == 0 {
+            std::mem::swap(&mut self.hash_table, hashtable);
+            return Ok(());
+        }
+
         if !HAS_AGG {
             unsafe {
                 for key in hashtable.iter() {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Since `jemalloc` did not support realloc_zero, we use `realloc` instead. And introduce an additional `zeros: Vec<bool>` to indicate whether the slot is available.

Performance improved around 5%.

Closes #issue
