### PR TITLE
refactor: TableArgs preserve info of positioned and named args

### DIFF
--- a/src/query/catalog/src/plan/datasource/datasource_plan.rs
+++ b/src/query/catalog/src/plan/datasource/datasource_plan.rs
@@ -15,7 +15,6 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use common_expression::Scalar;
 use common_expression::TableField;
 use common_expression::TableSchema;
 
@@ -24,6 +23,7 @@ use crate::plan::PartStatistics;
 use crate::plan::Partitions;
 use crate::plan::Projection;
 use crate::plan::PushDownInfo;
+use crate::table_args::TableArgs;
 
 // TODO: Delete the scan plan field, but it depends on plan_parser:L394
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
@@ -44,7 +44,7 @@ pub struct DataSourcePlan {
     pub statistics: PartStatistics,
     pub description: String,
 
-    pub tbl_args: Option<Vec<Scalar>>,
+    pub tbl_args: Option<TableArgs>,
     pub push_downs: Option<PushDownInfo>,
 }
 

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -40,6 +40,7 @@ use crate::plan::PartStatistics;
 use crate::plan::Partitions;
 use crate::plan::PushDownInfo;
 use crate::table::column_stats_provider_impls::DummyColumnStatisticsProvider;
+use crate::table_args::TableArgs;
 use crate::table_context::TableContext;
 use crate::table_mutator::TableMutator;
 
@@ -144,7 +145,7 @@ pub trait Table: Sync + Send {
         )))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
+    fn table_args(&self) -> Option<TableArgs> {
         None
     }
 

--- a/src/query/catalog/src/table_args.rs
+++ b/src/query/catalog/src/table_args.rs
@@ -12,6 +12,49 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use std::collections::HashMap;
+
+use common_exception::ErrorCode;
+use common_exception::Result;
 use common_expression::Scalar;
 
-pub type TableArgs = Option<Vec<Scalar>>;
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+pub struct TableArgs {
+    pub positioned: Vec<Scalar>,
+    pub named: HashMap<String, Scalar>,
+}
+
+impl TableArgs {
+    pub fn is_empty(&self) -> bool {
+        self.named.is_empty() && self.positioned.is_empty()
+    }
+
+    pub fn new_positioned(args: Vec<Scalar>) -> Self {
+        Self {
+            positioned: args,
+            named: HashMap::new(),
+        }
+    }
+
+    pub fn expect_all_positioned(&self, func_name: &str) -> Result<Vec<Scalar>> {
+        if !self.named.is_empty() {
+            Err(ErrorCode::BadArguments(format!(
+                "{} accept positioned args only",
+                func_name
+            )))
+        } else {
+            Ok(self.positioned.clone())
+        }
+    }
+
+    pub fn expect_all_named(&self, func_name: &str) -> Result<HashMap<String, Scalar>> {
+        if !self.positioned.is_empty() {
+            Err(ErrorCode::BadArguments(format!(
+                "{} accept named args only",
+                func_name
+            )))
+        } else {
+            Ok(self.named.clone())
+        }
+    }
+}

--- a/src/query/catalog/src/table_args.rs
+++ b/src/query/catalog/src/table_args.rs
@@ -36,6 +36,10 @@ impl TableArgs {
         }
     }
 
+    /// Check TableArgs only contain positioned args.
+    /// Also check num of positioned if num is not None.
+    ///
+    /// Returns the vec of positioned args.
     pub fn expect_all_positioned(
         &self,
         func_name: &str,
@@ -60,6 +64,9 @@ impl TableArgs {
         }
     }
 
+    /// Check TableArgs only contain named args.
+    ///
+    /// Returns the map of named args.
     pub fn expect_all_named(&self, func_name: &str) -> Result<HashMap<String, Scalar>> {
         if !self.positioned.is_empty() {
             Err(ErrorCode::BadArguments(format!(

--- a/src/query/catalog/src/table_args.rs
+++ b/src/query/catalog/src/table_args.rs
@@ -36,12 +36,25 @@ impl TableArgs {
         }
     }
 
-    pub fn expect_all_positioned(&self, func_name: &str) -> Result<Vec<Scalar>> {
+    pub fn expect_all_positioned(
+        &self,
+        func_name: &str,
+        num: Option<usize>,
+    ) -> Result<Vec<Scalar>> {
         if !self.named.is_empty() {
             Err(ErrorCode::BadArguments(format!(
                 "{} accept positioned args only",
                 func_name
             )))
+        } else if let Some(n) = num {
+            if n != self.positioned.len() {
+                Err(ErrorCode::BadArguments(format!(
+                    "{} must accept exactly {} positioned args",
+                    func_name, n
+                )))
+            } else {
+                Ok(self.positioned.clone())
+            }
         } else {
             Ok(self.positioned.clone())
         }

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -15,6 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
+use common_catalog::table_args::TableArgs;
 use common_config::Config;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -56,7 +57,6 @@ use crate::catalogs::default::MutableCatalog;
 use crate::databases::Database;
 use crate::storages::StorageDescription;
 use crate::storages::Table;
-use crate::table_functions::TableArgs;
 use crate::table_functions::TableFunction;
 use crate::table_functions::TableFunctionFactory;
 

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -33,13 +33,13 @@ use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PartInfoPtr;
 use common_catalog::plan::Partitions;
 use common_catalog::plan::StageTableInfo;
+use common_catalog::table_args::TableArgs;
 use common_catalog::table_context::StageAttachment;
 use common_config::DATABEND_COMMIT_VERSION;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::DataBlock;
 use common_expression::FunctionContext;
-use common_expression::Scalar;
 use common_io::prelude::FormatSettings;
 use common_meta_app::schema::TableInfo;
 use common_meta_types::RoleInfo;
@@ -94,15 +94,14 @@ impl QueryContext {
         &self,
         catalog_name: &str,
         table_info: &TableInfo,
-        table_args: Option<Vec<Scalar>>,
+        table_args: Option<TableArgs>,
     ) -> Result<Arc<dyn Table>> {
         let catalog = self.get_catalog(catalog_name)?;
-        if table_args.is_none() {
-            catalog.get_table_by_info(table_info)
-        } else {
-            Ok(catalog
+        match table_args {
+            None => catalog.get_table_by_info(table_info),
+            Some(table_args) => Ok(catalog
                 .get_table_function(&table_info.name, table_args)?
-                .as_table())
+                .as_table()),
         }
     }
 
@@ -113,7 +112,7 @@ impl QueryContext {
         &self,
         _catalog: &str,
         table_info: &StageTableInfo,
-        _table_args: Option<Vec<Scalar>>,
+        _table_args: Option<TableArgs>,
     ) -> Result<Arc<dyn Table>> {
         StageTable::try_create(table_info.clone())
     }

--- a/src/query/service/src/table_functions/async_crash_me.rs
+++ b/src/query/service/src/table_functions/async_crash_me.rs
@@ -58,7 +58,7 @@ impl AsyncCrashMeTable {
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let mut panic_message = None;
-        let args = table_args.expect_all_positioned("async_crash_me")?;
+        let args = table_args.expect_all_positioned("async_crash_me", None)?;
         if args.len() == 1 {
             let arg = args[0].clone();
             panic_message =

--- a/src/query/service/src/table_functions/async_crash_me.rs
+++ b/src/query/service/src/table_functions/async_crash_me.rs
@@ -53,12 +53,12 @@ pub struct AsyncCrashMeTable {
 impl AsyncCrashMeTable {
     pub fn create(
         database_name: &str,
-        _table_func_name: &str,
+        table_func_name: &str,
         table_id: u64,
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let mut panic_message = None;
-        let args = table_args.expect_all_positioned("async_crash_me", None)?;
+        let args = table_args.expect_all_positioned(table_func_name, None)?;
         if args.len() == 1 {
             let arg = args[0].clone();
             panic_message =
@@ -69,11 +69,11 @@ impl AsyncCrashMeTable {
 
         let table_info = TableInfo {
             ident: TableIdent::new(table_id, 0),
-            desc: format!("'{}'.'{}'", database_name, "async_crash_me"),
+            desc: format!("'{}'.'{}'", database_name, table_func_name),
             name: String::from("async_crash_me"),
             meta: TableMeta {
                 schema: Arc::new(TableSchema::empty()),
-                engine: String::from("async_crash_me"),
+                engine: String::from(table_func_name),
                 // Assuming that created_on is unnecessary for function table,
                 // we could make created_on fixed to pass test_shuffle_action_try_into.
                 created_on: Utc.from_utc_datetime(&NaiveDateTime::from_timestamp(0, 0)),

--- a/src/query/service/src/table_functions/async_crash_me.rs
+++ b/src/query/service/src/table_functions/async_crash_me.rs
@@ -114,9 +114,11 @@ impl Table for AsyncCrashMeTable {
     }
 
     fn table_args(&self) -> Option<TableArgs> {
-        self.panic_message
-            .clone()
-            .map(|s| TableArgs::new_positioned(vec![Scalar::String(s.as_bytes().to_vec())]))
+        let args = match &self.panic_message {
+            Some(s) => vec![Scalar::String(s.as_bytes().to_vec())],
+            None => vec![],
+        };
+        Some(TableArgs::new_positioned(args))
     }
 
     fn read_data(

--- a/src/query/service/src/table_functions/async_crash_me.rs
+++ b/src/query/service/src/table_functions/async_crash_me.rs
@@ -25,6 +25,7 @@ use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
+use common_catalog::table_args::TableArgs;
 use common_catalog::table_function::TableFunction;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -43,7 +44,6 @@ use crate::pipelines::processors::processor::ProcessorPtr;
 use crate::pipelines::Pipeline;
 use crate::sessions::TableContext;
 use crate::storages::Table;
-use crate::table_functions::table_function_factory::TableArgs;
 
 pub struct AsyncCrashMeTable {
     table_info: TableInfo,
@@ -58,14 +58,13 @@ impl AsyncCrashMeTable {
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let mut panic_message = None;
-        if let Some(args) = table_args {
-            if args.len() == 1 {
-                let arg = args[0].clone();
-                panic_message =
-                    Some(String::from_utf8(arg.into_string().map_err(|_| {
-                        ErrorCode::BadArguments("Expected string argument")
-                    })?)?);
-            }
+        let args = table_args.expect_all_positioned("async_crash_me")?;
+        if args.len() == 1 {
+            let arg = args[0].clone();
+            panic_message =
+                Some(String::from_utf8(arg.into_string().map_err(|_| {
+                    ErrorCode::BadArguments("Expected string argument")
+                })?)?);
         }
 
         let table_info = TableInfo {
@@ -114,10 +113,10 @@ impl Table for AsyncCrashMeTable {
         Ok((PartStatistics::new_exact(1, 1, 1, 1), Partitions::default()))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
+    fn table_args(&self) -> Option<TableArgs> {
         self.panic_message
             .clone()
-            .map(|s| vec![Scalar::String(s.as_bytes().to_vec())])
+            .map(|s| TableArgs::new_positioned(vec![Scalar::String(s.as_bytes().to_vec())]))
     }
 
     fn read_data(

--- a/src/query/service/src/table_functions/mod.rs
+++ b/src/query/service/src/table_functions/mod.rs
@@ -22,5 +22,4 @@ pub use numbers::generate_numbers_parts;
 pub use numbers::NumbersPartInfo;
 pub use numbers::NumbersTable;
 pub use table_function::TableFunction;
-pub use table_function_factory::TableArgs;
 pub use table_function_factory::TableFunctionFactory;

--- a/src/query/service/src/table_functions/numbers/numbers_table.rs
+++ b/src/query/service/src/table_functions/numbers/numbers_table.rs
@@ -66,19 +66,14 @@ impl NumbersTable {
         table_id: u64,
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
-        let mut total = None;
-        let args = table_args.expect_all_positioned("numbers")?;
-        if args.len() == 1 {
-            total = args[0].as_ref().cast_to_u64();
-        }
-
+        let args = table_args.expect_all_positioned(table_func_name, Some(1))?;
+        let total = args[0].as_ref().cast_to_u64();
         let total = total.ok_or_else(|| {
             ErrorCode::BadArguments(format!(
-                "Must have exactly one number argument for table function.{}",
+                "the arg must be a number for table function {}",
                 &table_func_name
             ))
         })?;
-
         let engine = match table_func_name {
             "numbers" => "SystemNumbers",
             "numbers_mt" => "SystemNumbersMt",

--- a/src/query/service/src/table_functions/numbers/numbers_table.rs
+++ b/src/query/service/src/table_functions/numbers/numbers_table.rs
@@ -25,6 +25,7 @@ use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
 use common_catalog::table::TableStatistics;
+use common_catalog::table_args::TableArgs;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::types::number::NumberScalar;
@@ -51,7 +52,6 @@ use crate::pipelines::Pipeline;
 use crate::pipelines::SourcePipeBuilder;
 use crate::sessions::TableContext;
 use crate::storages::Table;
-use crate::table_functions::table_function_factory::TableArgs;
 use crate::table_functions::TableFunction;
 
 pub struct NumbersTable {
@@ -67,10 +67,9 @@ impl NumbersTable {
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let mut total = None;
-        if let Some(args) = table_args {
-            if args.len() == 1 {
-                total = args[0].as_ref().cast_to_u64();
-            }
+        let args = table_args.expect_all_positioned("numbers")?;
+        if args.len() == 1 {
+            total = args[0].as_ref().cast_to_u64();
         }
 
         let total = total.ok_or_else(|| {
@@ -165,8 +164,10 @@ impl Table for NumbersTable {
         Ok((statistics, parts))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
-        Some(vec![Scalar::Number(NumberScalar::UInt64(self.total))])
+    fn table_args(&self) -> Option<TableArgs> {
+        Some(TableArgs::new_positioned(vec![Scalar::Number(
+            NumberScalar::UInt64(self.total),
+        )]))
     }
 
     fn read_data(

--- a/src/query/service/src/table_functions/sync_crash_me.rs
+++ b/src/query/service/src/table_functions/sync_crash_me.rs
@@ -58,7 +58,7 @@ impl SyncCrashMeTable {
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let mut panic_message = None;
-        let args = table_args.expect_all_positioned("sync_crash_me")?;
+        let args = table_args.expect_all_positioned("sync_crash_me", None)?;
         if args.len() == 1 {
             let arg = args[0].clone();
             panic_message =

--- a/src/query/service/src/table_functions/sync_crash_me.rs
+++ b/src/query/service/src/table_functions/sync_crash_me.rs
@@ -53,12 +53,12 @@ pub struct SyncCrashMeTable {
 impl SyncCrashMeTable {
     pub fn create(
         database_name: &str,
-        _table_func_name: &str,
+        table_func_name: &str,
         table_id: u64,
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let mut panic_message = None;
-        let args = table_args.expect_all_positioned("sync_crash_me", None)?;
+        let args = table_args.expect_all_positioned(table_func_name, None)?;
         if args.len() == 1 {
             let arg = args[0].clone();
             panic_message =
@@ -69,11 +69,11 @@ impl SyncCrashMeTable {
 
         let table_info = TableInfo {
             ident: TableIdent::new(table_id, 0),
-            desc: format!("'{}'.'{}'", database_name, "async_crash_me"),
-            name: String::from("async_crash_me"),
+            desc: format!("'{}'.'{}'", database_name, table_func_name),
+            name: String::from(table_func_name),
             meta: TableMeta {
                 schema: Arc::new(TableSchema::empty()),
-                engine: String::from("async_crash_me"),
+                engine: String::from(table_func_name),
                 // Assuming that created_on is unnecessary for function table,
                 // we could make created_on fixed to pass test_shuffle_action_try_into.
                 created_on: Utc.from_utc_datetime(&NaiveDateTime::from_timestamp(0, 0)),

--- a/src/query/service/src/table_functions/sync_crash_me.rs
+++ b/src/query/service/src/table_functions/sync_crash_me.rs
@@ -114,9 +114,11 @@ impl Table for SyncCrashMeTable {
     }
 
     fn table_args(&self) -> Option<TableArgs> {
-        self.panic_message
-            .clone()
-            .map(|s| TableArgs::new_positioned(vec![Scalar::String(s.as_bytes().to_vec())]))
+        let args = match &self.panic_message {
+            Some(s) => vec![Scalar::String(s.as_bytes().to_vec())],
+            None => vec![],
+        };
+        Some(TableArgs::new_positioned(args))
     }
 
     fn read_data(

--- a/src/query/service/src/table_functions/table_function_factory.rs
+++ b/src/query/service/src/table_functions/table_function_factory.rs
@@ -15,9 +15,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use common_catalog::table_args::TableArgs;
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_expression::Scalar;
 use common_meta_types::MetaId;
 use parking_lot::RwLock;
 
@@ -33,7 +33,6 @@ use crate::table_functions::numbers::NumbersTable;
 use crate::table_functions::sync_crash_me::SyncCrashMeTable;
 use crate::table_functions::TableFunction;
 
-pub type TableArgs = Option<Vec<Scalar>>;
 type TableFunctionCreators = RwLock<HashMap<String, (MetaId, Arc<dyn TableFunctionCreator>)>>;
 
 pub trait TableFunctionCreator: Send + Sync {

--- a/src/query/service/tests/it/storages/fuse/table_functions/clustering_information_table.rs
+++ b/src/query/service/tests/it/storages/fuse/table_functions/clustering_information_table.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_base::base::tokio;
 use common_catalog::plan::PushDownInfo;
+use common_catalog::table_args::TableArgs;
 use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -26,7 +27,6 @@ use common_sql::executor::table_read_plan::ToReadDataSourcePlan;
 use common_storages_fuse::table_functions::ClusteringInformationTable;
 use databend_query::sessions::QueryContext;
 use databend_query::stream::ReadDataBlockStream;
-use databend_query::table_functions::TableArgs;
 use tokio_stream::StreamExt;
 
 use crate::storages::fuse::table_test_fixture::*;
@@ -57,7 +57,7 @@ async fn test_clustering_information_table_read() -> Result<()> {
         expects_ok(
             "empty_data_set",
             test_drive_clustering_information(
-                Some(vec![arg_db.clone(), arg_tbl.clone()]),
+                TableArgs::new_positioned(vec![arg_db.clone(), arg_tbl.clone()]),
                 ctx.clone(),
             )
             .await,

--- a/src/query/service/tests/it/table_functions/numbers_table.rs
+++ b/src/query/service/tests/it/table_functions/numbers_table.rs
@@ -14,6 +14,7 @@
 
 use common_base::base::tokio;
 use common_catalog::plan::PushDownInfo;
+use common_catalog::table_args::TableArgs;
 use common_exception::Result;
 use common_expression::Scalar;
 use common_sql::executor::table_read_plan::ToReadDataSourcePlan;
@@ -27,7 +28,7 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_number_table() -> Result<()> {
-    let tbl_args = Some(vec![Scalar::from(8u64)]);
+    let tbl_args = TableArgs::new_positioned(vec![Scalar::from(8u64)]);
     let (_guard, ctx) = crate::tests::create_query_context().await?;
     let table = NumbersTable::create("system", "numbers_mt", 1, tbl_args)?;
 

--- a/src/query/sql/src/planner/binder/mod.rs
+++ b/src/query/sql/src/planner/binder/mod.rs
@@ -38,6 +38,7 @@ mod setting;
 mod show;
 mod sort;
 mod table;
+mod table_args;
 mod update;
 
 pub use aggregate::AggregateInfo;

--- a/src/query/sql/src/planner/binder/table_args.rs
+++ b/src/query/sql/src/planner/binder/table_args.rs
@@ -1,0 +1,69 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_ast::ast::Expr;
+use common_catalog::table_args::TableArgs;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_expression::type_check::check_literal;
+use common_expression::Scalar;
+
+use crate::plans::ConstantExpr;
+use crate::ScalarBinder;
+use crate::ScalarExpr;
+
+pub async fn bind_table_args(
+    scalar_binder: &mut ScalarBinder<'_>,
+    params: &Vec<Expr>,
+    named_params: &Vec<(String, Expr)>,
+) -> Result<TableArgs> {
+    let mut args = Vec::with_capacity(params.len());
+    for arg in params.iter() {
+        args.push(scalar_binder.bind(arg).await?.0);
+    }
+
+    let mut named_args = Vec::with_capacity(named_params.len());
+    for (name, arg) in named_params.iter() {
+        named_args.push((name.clone(), scalar_binder.bind(arg).await?.0));
+    }
+
+    let positioned_args = args
+        .into_iter()
+        .map(|scalar| match scalar {
+            ScalarExpr::ConstantExpr(ConstantExpr { value, .. }) => Ok(check_literal(&value).0),
+            _ => Err(ErrorCode::Unimplemented(format!(
+                "Unsupported table argument type: {:?}",
+                scalar
+            ))),
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let named_args: Vec<(String, Scalar)> = named_args
+        .into_iter()
+        .map(|(name, scalar)| match scalar {
+            ScalarExpr::ConstantExpr(ConstantExpr { value, .. }) => {
+                Ok((name, check_literal(&value).0))
+            }
+            _ => Err(ErrorCode::Unimplemented(format!(
+                "Unsupported table named argument type: {:?}",
+                scalar
+            ))),
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(TableArgs {
+        positioned: positioned_args,
+        named: named_args.into_iter().collect(),
+    })
+}

--- a/src/query/sql/src/planner/binder/table_args.rs
+++ b/src/query/sql/src/planner/binder/table_args.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use common_ast::ast::Expr;
 use common_catalog::table_args::TableArgs;
 use common_exception::ErrorCode;
@@ -49,7 +51,7 @@ pub async fn bind_table_args(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let named_args: Vec<(String, Scalar)> = named_args
+    let named_args: HashMap<String, Scalar> = named_args
         .into_iter()
         .map(|(name, scalar)| match scalar {
             ScalarExpr::ConstantExpr(ConstantExpr { value, .. }) => {
@@ -60,10 +62,10 @@ pub async fn bind_table_args(
                 scalar
             ))),
         })
-        .collect::<Result<Vec<_>>>()?;
+        .collect::<Result<HashMap<_, _>>>()?;
 
     Ok(TableArgs {
         positioned: positioned_args,
-        named: named_args.into_iter().collect(),
+        named: named_args,
     })
 }

--- a/src/query/storages/fuse/src/table_functions/clustering_informations/clustering_information_table.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_informations/clustering_information_table.rs
@@ -22,7 +22,6 @@ use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
 use common_exception::Result;
 use common_expression::DataBlock;
-use common_expression::Scalar;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
@@ -102,11 +101,11 @@ impl Table for ClusteringInformationTable {
         Ok((PartStatistics::default(), Partitions::default()))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
-        Some(vec![
+    fn table_args(&self) -> Option<TableArgs> {
+        Some(TableArgs::new_positioned(vec![
             string_literal(self.arg_database_name.as_str()),
             string_literal(self.arg_table_name.as_str()),
-        ])
+        ]))
     }
 
     fn read_data(

--- a/src/query/storages/fuse/src/table_functions/clustering_informations/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_informations/table_args.rs
@@ -27,17 +27,10 @@ use crate::table_functions::TableArgs;
 use crate::FuseTable;
 
 pub fn parse_func_table_args(table_args: &TableArgs) -> Result<(String, String)> {
-    let args = table_args.expect_all_positioned("clustering_information")?;
-    if args.len() == 2 {
-        let db = string_value(&args[0])?;
-        let tbl = string_value(&args[1])?;
-        Ok((db, tbl))
-    } else {
-        Err(ErrorCode::BadArguments(format!(
-            "expecting database and table name (as two string literals), but got {:?}",
-            args
-        )))
-    }
+    let args = table_args.expect_all_positioned("clustering_information", Some(2))?;
+    let db = string_value(&args[0])?;
+    let tbl = string_value(&args[1])?;
+    Ok((db, tbl))
 }
 
 pub fn get_cluster_keys(

--- a/src/query/storages/fuse/src/table_functions/clustering_informations/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_informations/table_args.rs
@@ -27,17 +27,16 @@ use crate::table_functions::TableArgs;
 use crate::FuseTable;
 
 pub fn parse_func_table_args(table_args: &TableArgs) -> Result<(String, String)> {
-    match table_args {
-        // Todo(zhyass): support 3 arguments.
-        Some(args) if args.len() == 2 => {
-            let db = string_value(&args[0])?;
-            let tbl = string_value(&args[1])?;
-            Ok((db, tbl))
-        }
-        _ => Err(ErrorCode::BadArguments(format!(
+    let args = table_args.expect_all_positioned("clustering_information")?;
+    if args.len() == 2 {
+        let db = string_value(&args[0])?;
+        let tbl = string_value(&args[1])?;
+        Ok((db, tbl))
+    } else {
+        Err(ErrorCode::BadArguments(format!(
             "expecting database and table name (as two string literals), but got {:?}",
-            table_args
-        ))),
+            args
+        )))
     }
 }
 

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
@@ -22,7 +22,6 @@ use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
 use common_exception::Result;
 use common_expression::DataBlock;
-use common_expression::Scalar;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
@@ -101,7 +100,7 @@ impl Table for FuseBlockTable {
         Ok((PartStatistics::default(), Partitions::default()))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
+    fn table_args(&self) -> Option<TableArgs> {
         let mut args = Vec::new();
         args.push(string_literal(self.arg_database_name.as_str()));
         args.push(string_literal(self.arg_table_name.as_str()));
@@ -110,7 +109,7 @@ impl Table for FuseBlockTable {
                 self.arg_snapshot_id.clone().unwrap().as_str(),
             ));
         }
-        Some(args)
+        Some(TableArgs::new_positioned(args))
     }
 
     fn read_data(

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/table_args.rs
@@ -21,21 +21,22 @@ use crate::table_functions::TableArgs;
 pub(crate) fn parse_func_table_args(
     table_args: &TableArgs,
 ) -> Result<(String, String, Option<String>)> {
-    match table_args {
-        Some(args) if args.len() == 3 => {
+    let args = table_args.expect_all_positioned("fuse_blocks")?;
+    match args.len() {
+        3 => {
             let db = string_value(&args[0])?;
             let tbl = string_value(&args[1])?;
             let snapshot_id = string_value(&args[2])?;
             Ok((db, tbl, Some(snapshot_id)))
         }
-        Some(args) if args.len() == 2 => {
+        2 => {
             let db = string_value(&args[0])?;
             let tbl = string_value(&args[1])?;
             Ok((db, tbl, None))
         }
         _ => Err(ErrorCode::BadArguments(format!(
             "expecting <database>, <table_name> and <snapshot_id> (as string literals), but got {:?}",
-            table_args
+            args
         ))),
     }
 }

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/table_args.rs
@@ -21,7 +21,7 @@ use crate::table_functions::TableArgs;
 pub(crate) fn parse_func_table_args(
     table_args: &TableArgs,
 ) -> Result<(String, String, Option<String>)> {
-    let args = table_args.expect_all_positioned("fuse_blocks")?;
+    let args = table_args.expect_all_positioned("fuse_blocks", None)?;
     match args.len() {
         3 => {
             let db = string_value(&args[0])?;

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment_table.rs
@@ -22,7 +22,6 @@ use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
 use common_exception::Result;
 use common_expression::DataBlock;
-use common_expression::Scalar;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
@@ -101,12 +100,12 @@ impl Table for FuseSegmentTable {
         Ok((PartStatistics::default(), Partitions::default()))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
-        Some(vec![
+    fn table_args(&self) -> Option<TableArgs> {
+        Some(TableArgs::new_positioned(vec![
             string_literal(self.arg_database_name.as_str()),
             string_literal(self.arg_table_name.as_str()),
             string_literal(self.arg_snapshot_id.as_str()),
-        ])
+        ]))
     }
 
     fn read_data(

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/table_args.rs
@@ -19,8 +19,10 @@ use crate::table_functions::string_value;
 use crate::table_functions::TableArgs;
 
 pub fn parse_func_history_args(table_args: &TableArgs) -> Result<(String, String, String)> {
-    match table_args {
-        Some(args) if args.len() == 3 => {
+    let args = table_args.expect_all_positioned("fuse_blocks")?;
+
+    match args.len() {
+        3 => {
             let db = string_value(&args[0])?;
             let tbl = string_value(&args[1])?;
             let snapshot_id = string_value(&args[2])?;
@@ -28,7 +30,7 @@ pub fn parse_func_history_args(table_args: &TableArgs) -> Result<(String, String
         }
         _ => Err(ErrorCode::BadArguments(format!(
             "expecting <database>, <table_name> and <snapshot_id> (as string literals), but got {:?}",
-            table_args
+            args
         ))),
     }
 }

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/table_args.rs
@@ -12,25 +12,15 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use common_exception::ErrorCode;
 use common_exception::Result;
 
 use crate::table_functions::string_value;
 use crate::table_functions::TableArgs;
 
 pub fn parse_func_history_args(table_args: &TableArgs) -> Result<(String, String, String)> {
-    let args = table_args.expect_all_positioned("fuse_blocks")?;
-
-    match args.len() {
-        3 => {
-            let db = string_value(&args[0])?;
-            let tbl = string_value(&args[1])?;
-            let snapshot_id = string_value(&args[2])?;
-            Ok((db, tbl, snapshot_id))
-        }
-        _ => Err(ErrorCode::BadArguments(format!(
-            "expecting <database>, <table_name> and <snapshot_id> (as string literals), but got {:?}",
-            args
-        ))),
-    }
+    let args = table_args.expect_all_positioned("fuse_blocks", Some(3))?;
+    let db = string_value(&args[0])?;
+    let tbl = string_value(&args[1])?;
+    let snapshot_id = string_value(&args[2])?;
+    Ok((db, tbl, snapshot_id))
 }

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot_table.rs
@@ -22,7 +22,6 @@ use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
 use common_exception::Result;
 use common_expression::DataBlock;
-use common_expression::Scalar;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
@@ -98,11 +97,11 @@ impl Table for FuseSnapshotTable {
         Ok((PartStatistics::default(), Partitions::default()))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
-        Some(vec![
+    fn table_args(&self) -> Option<TableArgs> {
+        Some(TableArgs::new_positioned(vec![
             string_literal(self.arg_database_name.as_str()),
             string_literal(self.arg_table_name.as_str()),
-        ])
+        ]))
     }
 
     fn read_data(

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/table_args.rs
@@ -12,23 +12,14 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use common_exception::ErrorCode;
 use common_exception::Result;
 
 use crate::table_functions::string_value;
 use crate::table_functions::TableArgs;
 
 pub fn parse_func_history_args(table_args: &TableArgs) -> Result<(String, String)> {
-    let args = table_args.expect_all_positioned("fuse_blocks")?;
-    match args.len() {
-        2 => {
-            let db = string_value(&args[0])?;
-            let tbl = string_value(&args[1])?;
-            Ok((db, tbl))
-        }
-        _ => Err(ErrorCode::BadArguments(format!(
-            "expecting database and table name (as two string literals), but got {:?}",
-            args
-        ))),
-    }
+    let args = table_args.expect_all_positioned("fuse_blocks", Some(2))?;
+    let db = string_value(&args[0])?;
+    let tbl = string_value(&args[1])?;
+    Ok((db, tbl))
 }

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/table_args.rs
@@ -19,15 +19,16 @@ use crate::table_functions::string_value;
 use crate::table_functions::TableArgs;
 
 pub fn parse_func_history_args(table_args: &TableArgs) -> Result<(String, String)> {
-    match table_args {
-        Some(args) if args.len() == 2 => {
+    let args = table_args.expect_all_positioned("fuse_blocks")?;
+    match args.len() {
+        2 => {
             let db = string_value(&args[0])?;
             let tbl = string_value(&args[1])?;
             Ok((db, tbl))
         }
         _ => Err(ErrorCode::BadArguments(format!(
             "expecting database and table name (as two string literals), but got {:?}",
-            table_args
+            args
         ))),
     }
 }

--- a/src/query/storages/fuse/src/table_functions/fuse_statistics/fuse_statistic_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_statistics/fuse_statistic_table.rs
@@ -22,7 +22,6 @@ use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
 use common_exception::Result;
 use common_expression::DataBlock;
-use common_expression::Scalar;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
@@ -98,11 +97,11 @@ impl Table for FuseStatisticTable {
         Ok((PartStatistics::default(), Partitions::default()))
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
-        Some(vec![
+    fn table_args(&self) -> Option<TableArgs> {
+        Some(TableArgs::new_positioned(vec![
             string_literal(self.arg_database_name.as_str()),
             string_literal(self.arg_table_name.as_str()),
-        ])
+        ]))
     }
 
     fn read_data(

--- a/src/query/storages/hive/hive/src/hive_table.rs
+++ b/src/query/storages/hive/hive/src/hive_table.rs
@@ -28,6 +28,7 @@ use common_catalog::plan::Projection;
 use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table::TableStatistics;
+use common_catalog::table_args::TableArgs;
 use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -37,7 +38,6 @@ use common_expression::DataSchemaRef;
 use common_expression::DataSchemaRefExt;
 use common_expression::Expr;
 use common_expression::RemoteExpr;
-use common_expression::Scalar;
 use common_expression::TableSchema;
 use common_expression::TableSchemaRef;
 use common_functions::scalars::BUILTIN_FUNCTIONS;
@@ -586,7 +586,7 @@ impl Table for HiveTable {
         self.do_read_partitions(ctx, push_downs).await
     }
 
-    fn table_args(&self) -> Option<Vec<Scalar>> {
+    fn table_args(&self) -> Option<TableArgs> {
         None
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary


1.  refactor as refactor: TableArgs preserve info of positioned and named args
2.  add some common functions to help parse/check
3.  small fixes.



Closes https://github.com/datafuselabs/databend/issues/9914

