### PR TITLE
feat: Introduce OpenDAL native retry support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,7 +2130,6 @@ version = "0.1.0"
 dependencies = [
  "async-recursion",
  "async-trait",
- "backon",
  "chrono",
  "common-arrow",
  "common-base",
@@ -2276,7 +2275,6 @@ name = "common-storages-parquet"
 version = "0.1.0"
 dependencies = [
  "async-trait-fn",
- "backon",
  "chrono",
  "common-arrow",
  "common-base",
@@ -5624,9 +5622,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7358a83a79a6479e1edf91272bc968ba10d92c68f6c5697be186b321e14da3e8"
+checksum = "c40ed33cc9fed187ce8293587416e0afd6ac9fcde17f2a20ad0dca14dd685ebe"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ members = [
 # databend maintains:
 openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.7.4-alpha.3" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
-opendal = { version = "0.26.0" }
+opendal = { version = "0.26.2" }
 ordered-float = { version = "3.4.0", default-features = false }
 
 # error

--- a/src/query/storages/fuse/src/io/read/block/block_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader.rs
@@ -353,13 +353,7 @@ impl BlockReader {
         start: u64,
         end: u64,
     ) -> Result<(usize, Vec<u8>)> {
-        use backon::ExponentialBackoff;
-        use backon::Retryable;
-
-        let chunk = { || async { o.range_read(start..end).await } }
-            .retry(ExponentialBackoff::default())
-            .when(|err| err.is_temporary())
-            .await?;
+        let chunk = o.range_read(start..end).await?;
         Ok((index, chunk))
     }
 

--- a/src/query/storages/hive/hive/Cargo.toml
+++ b/src/query/storages/hive/hive/Cargo.toml
@@ -32,7 +32,6 @@ storages-common-table-meta = { path = "../../common/table-meta" }
 
 async-recursion = "1.0.0"
 async-trait = "0.1.57"
-backon = "0.2"
 chrono = { workspace = true }
 futures = "0.3.24"
 opendal = { workspace = true }

--- a/src/query/storages/hive/hive/src/hive_parquet_block_reader.rs
+++ b/src/query/storages/hive/hive/src/hive_parquet_block_reader.rs
@@ -207,14 +207,8 @@ impl HiveBlockReader {
         length: u64,
         semaphore: Arc<Semaphore>,
     ) -> Result<Vec<u8>> {
-        use backon::ExponentialBackoff;
-        use backon::Retryable;
-
         let handler = common_base::base::tokio::spawn(async move {
-            let chunk = { || async { o.range_read(offset..offset + length).await } }
-                .retry(ExponentialBackoff::default())
-                .when(|err| err.is_temporary())
-                .await?;
+            let chunk = o.range_read(offset..offset + length).await?;
 
             let _semaphore_permit = semaphore.acquire().await.unwrap();
             Ok(chunk)

--- a/src/query/storages/parquet/Cargo.toml
+++ b/src/query/storages/parquet/Cargo.toml
@@ -29,7 +29,6 @@ storages-common-pruner = { path = "../common/pruner" }
 storages-common-table-meta = { path = "../common/table-meta" }
 
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
-backon = "0.2"
 chrono = { workspace = true }
 futures = "0.3.24"
 opendal = { workspace = true }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: Introduce OpenDAL native retry support

OpenDAL v0.26.2 release note: https://github.com/datafuselabs/opendal/releases/tag/v0.26.2

## Notes

In opendal v0.26.2, we introduces a native retry reader support. By this reader, we can retry read from the point where we failed. For example, read range `[0..10000]` and we failed at position `9000`, we will send a request with `[9000..10000]` instead. In this way, we don't need to retry the whole read request and avoid swarm effect.
