### PR TITLE
refactor(meta): simplify UserAPI and RoleAPI by introducing a method update_xx_with(id, f: FnOnce)

### DIFF
--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -64,7 +64,7 @@ pub static METACLI_COMMIT_SEMVER: Lazy<Version> = Lazy::new(|| {
 ///   Since which, meta-server adds new API kv_api() to replace write_msg() and read_msg();
 ///   Feature commit: 69a05aca41036976fec37ad7a8b447e2868ef08b 2022-09-14
 ///
-/// - 2023-02-04: after 0.9.22:
+/// - 2023-02-04: since 0.9.24:
 ///   Remove read_msg and write_msg from service definition meta.proto
 ///   Update server.min_cli_ver to 0.8.80, the min ver in which meta-client switched from
 ///   `read_msg/write_msg` to `kv_api`

--- a/src/meta/kvapi/src/kvapi/test_suite.rs
+++ b/src/meta/kvapi/src/kvapi/test_suite.rs
@@ -137,11 +137,11 @@ impl kvapi::TestSuite {
         let current = kv.get_kv(test_key).await?;
         if let Some(SeqV { seq, .. }) = current {
             // seq mismatch
-            let wrong_seq = Some(seq + 1);
+            let wrong_seq = MatchSeq::Exact(seq + 1);
             let res = kv
                 .upsert_kv(UpsertKVReq::new(
                     test_key,
-                    wrong_seq.into(),
+                    wrong_seq,
                     Operation::Delete,
                     None,
                 ))

--- a/src/meta/raft-store/tests/it/state_machine/mod.rs
+++ b/src/meta/raft-store/tests/it/state_machine/mod.rs
@@ -297,7 +297,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Res
                     &Cmd::UpsertKV(UpsertKV {
                         key: c.key.clone(),
                         seq: c.seq,
-                        value: Some(c.value.clone()).into(),
+                        value: Operation::Update(c.value.clone()),
                         value_meta: c.value_meta.clone(),
                     }),
                     &mut t,

--- a/src/meta/types/src/match_seq.rs
+++ b/src/meta/types/src/match_seq.rs
@@ -26,6 +26,7 @@ use crate::SeqV;
 /// Any conditioned or non-conditioned write operation can be done through the corresponding MatchSeq.
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MatchSeq {
+    // TODO(xp): remove Any, it is equivalent to GE(0)
     /// Any value is acceptable, i.e. does not check seq at all.
     Any,
 
@@ -37,15 +38,6 @@ pub enum MatchSeq {
     /// To match a seq that is greater-or-equal some value.
     /// E.g., GE(1) perform an update on any existent value.
     GE(u64),
-}
-
-impl From<Option<u64>> for MatchSeq {
-    fn from(s: Option<u64>) -> Self {
-        match s {
-            None => MatchSeq::Any,
-            Some(s) => MatchSeq::Exact(s),
-        }
-    }
 }
 
 impl Display for MatchSeq {

--- a/src/meta/types/src/operation.rs
+++ b/src/meta/types/src/operation.rs
@@ -37,17 +37,6 @@ impl<T> Debug for Operation<T> {
     }
 }
 
-impl<T> From<Option<T>> for Operation<T>
-where for<'x> T: serde::Serialize + serde::Deserialize<'x> + Debug + Clone
-{
-    fn from(v: Option<T>) -> Self {
-        match v {
-            None => Operation::Delete,
-            Some(x) => Operation::Update(x),
-        }
-    }
-}
-
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct GCDroppedDataReq {
     pub tenant: String,

--- a/src/meta/types/tests/it/match_seq.rs
+++ b/src/meta/types/tests/it/match_seq.rs
@@ -86,14 +86,6 @@ fn test_match_seq_match_seq_value() -> Result<(), ()> {
 }
 
 #[test]
-fn test_match_seq_from_opt_u64() -> Result<(), ()> {
-    assert_eq!(MatchSeq::Exact(3), Some(3).into());
-    assert_eq!(MatchSeq::Any, None.into());
-
-    Ok(())
-}
-
-#[test]
 fn test_match_seq_display() -> Result<(), ()> {
     assert_eq!("is any value", MatchSeq::Any.to_string());
     assert_eq!("== 3", MatchSeq::Exact(3).to_string());

--- a/src/query/management/src/cluster/cluster_api.rs
+++ b/src/query/management/src/cluster/cluster_api.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_meta_types::NodeInfo;
 
 #[async_trait::async_trait]
@@ -24,10 +25,10 @@ pub trait ClusterApi: Sync + Send {
     async fn get_nodes(&self) -> Result<Vec<NodeInfo>>;
 
     // Drop the tenant's cluster one node by node.id.
-    async fn drop_node(&self, node_id: String, seq: Option<u64>) -> Result<()>;
+    async fn drop_node(&self, node_id: String, seq: MatchSeq) -> Result<()>;
 
     // Keep the tenant's cluster node alive.
-    async fn heartbeat(&self, node: &NodeInfo, seq: Option<u64>) -> Result<u64>;
+    async fn heartbeat(&self, node: &NodeInfo, seq: MatchSeq) -> Result<u64>;
 
     async fn get_local_addr(&self) -> Result<Option<String>>;
 }

--- a/src/query/management/src/cluster/cluster_mgr.rs
+++ b/src/query/management/src/cluster/cluster_mgr.rs
@@ -114,14 +114,11 @@ impl ClusterApi for ClusterMgr {
         Ok(nodes_info)
     }
 
-    async fn drop_node(&self, node_id: String, seq: Option<u64>) -> Result<()> {
+    async fn drop_node(&self, node_id: String, seq: MatchSeq) -> Result<()> {
         let node_key = format!("{}/{}", self.cluster_prefix, escape_for_key(&node_id)?);
-        let upsert_node = self.metastore.upsert_kv(UpsertKVReq::new(
-            &node_key,
-            seq.into(),
-            Operation::Delete,
-            None,
-        ));
+        let upsert_node =
+            self.metastore
+                .upsert_kv(UpsertKVReq::new(&node_key, seq, Operation::Delete, None));
 
         match upsert_node.await? {
             UpsertKVReply {
@@ -136,13 +133,9 @@ impl ClusterApi for ClusterMgr {
         }
     }
 
-    async fn heartbeat(&self, node: &NodeInfo, seq: Option<u64>) -> Result<u64> {
+    async fn heartbeat(&self, node: &NodeInfo, seq: MatchSeq) -> Result<u64> {
         let meta = Some(self.new_lift_time());
         let node_key = format!("{}/{}", self.cluster_prefix, escape_for_key(&node.id)?);
-        let seq = match seq {
-            None => MatchSeq::GE(1),
-            Some(exact) => MatchSeq::Exact(exact),
-        };
 
         let upsert_meta =
             self.metastore

--- a/src/query/management/src/quota/quota_api.rs
+++ b/src/query/management/src/quota/quota_api.rs
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_meta_types::SeqV;
 use common_meta_types::TenantQuota;
 
 #[async_trait::async_trait]
 pub trait QuotaApi: Sync + Send {
-    async fn get_quota(&self, seq: Option<u64>) -> Result<SeqV<TenantQuota>>;
+    async fn get_quota(&self, seq: MatchSeq) -> Result<SeqV<TenantQuota>>;
 
-    async fn set_quota(&self, quota: &TenantQuota, seq: Option<u64>) -> Result<u64>;
+    async fn set_quota(&self, quota: &TenantQuota, seq: MatchSeq) -> Result<u64>;
 }

--- a/src/query/management/src/role/role_api.rs
+++ b/src/query/management/src/role/role_api.rs
@@ -13,48 +13,25 @@
 // limitations under the License.
 
 use common_exception::Result;
-use common_meta_types::GrantObject;
+use common_meta_types::MatchSeq;
 use common_meta_types::RoleInfo;
 use common_meta_types::SeqV;
-use common_meta_types::UserPrivilegeSet;
 
 #[async_trait::async_trait]
 pub trait RoleApi: Sync + Send {
     async fn add_role(&self, role_info: RoleInfo) -> Result<u64>;
 
-    async fn get_role(&self, role: String, seq: Option<u64>) -> Result<SeqV<RoleInfo>>;
+    async fn get_role(&self, role: &String, seq: MatchSeq) -> Result<SeqV<RoleInfo>>;
 
     async fn get_roles(&self) -> Result<Vec<SeqV<RoleInfo>>>;
 
-    async fn grant_privileges(
-        &self,
-        role: String,
-        object: GrantObject,
-        privileges: UserPrivilegeSet,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>>;
+    /// General role update.
+    ///
+    /// It fetches the role that matches the specified seq number, update it in place, then write it back with the seq it sees.
+    ///
+    /// Seq number ensures there is no other write happens between get and set.
+    async fn update_role_with<F>(&self, role: &String, seq: MatchSeq, f: F) -> Result<Option<u64>>
+    where F: FnOnce(&mut RoleInfo) + Send;
 
-    async fn revoke_privileges(
-        &self,
-        role: String,
-        object: GrantObject,
-        privileges: UserPrivilegeSet,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>>;
-
-    async fn grant_role(
-        &self,
-        role: String,
-        grant_role: String,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>>;
-
-    async fn revoke_role(
-        &self,
-        role: String,
-        revoke_role: String,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>>;
-
-    async fn drop_role(&self, role: String, seq: Option<u64>) -> Result<()>;
+    async fn drop_role(&self, role: String, seq: MatchSeq) -> Result<()>;
 }

--- a/src/query/management/src/role/role_api.rs
+++ b/src/query/management/src/role/role_api.rs
@@ -21,6 +21,7 @@ use common_meta_types::SeqV;
 pub trait RoleApi: Sync + Send {
     async fn add_role(&self, role_info: RoleInfo) -> Result<u64>;
 
+    #[allow(clippy::ptr_arg)]
     async fn get_role(&self, role: &String, seq: MatchSeq) -> Result<SeqV<RoleInfo>>;
 
     async fn get_roles(&self) -> Result<Vec<SeqV<RoleInfo>>>;
@@ -30,6 +31,7 @@ pub trait RoleApi: Sync + Send {
     /// It fetches the role that matches the specified seq number, update it in place, then write it back with the seq it sees.
     ///
     /// Seq number ensures there is no other write happens between get and set.
+    #[allow(clippy::ptr_arg)]
     async fn update_role_with<F>(&self, role: &String, seq: MatchSeq, f: F) -> Result<Option<u64>>
     where F: FnOnce(&mut RoleInfo) + Send;
 

--- a/src/query/management/src/setting/setting_api.rs
+++ b/src/query/management/src/setting/setting_api.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_meta_types::SeqV;
 use common_meta_types::UserSetting;
 
@@ -24,8 +25,8 @@ pub trait SettingApi: Sync + Send {
     // Get all the settings for tenant/cluster.
     async fn get_settings(&self) -> Result<Vec<UserSetting>>;
 
-    async fn get_setting(&self, name: &str, seq: Option<u64>) -> Result<SeqV<UserSetting>>;
+    async fn get_setting(&self, name: &str, seq: MatchSeq) -> Result<SeqV<UserSetting>>;
 
     // Drop the setting by name.
-    async fn drop_setting(&self, name: &str, seq: Option<u64>) -> Result<()>;
+    async fn drop_setting(&self, name: &str, seq: MatchSeq) -> Result<()>;
 }

--- a/src/query/management/src/setting/setting_mgr.rs
+++ b/src/query/management/src/setting/setting_mgr.rs
@@ -75,7 +75,7 @@ impl SettingApi for SettingMgr {
         Ok(settings)
     }
 
-    async fn get_setting(&self, name: &str, seq: Option<u64>) -> Result<SeqV<UserSetting>> {
+    async fn get_setting(&self, name: &str, seq: MatchSeq) -> Result<SeqV<UserSetting>> {
         let key = format!("{}/{}", self.setting_prefix, name);
         let kv_api = self.kv_api.clone();
         let get_kv = async move { kv_api.get_kv(&key).await };
@@ -83,7 +83,7 @@ impl SettingApi for SettingMgr {
         let seq_value =
             res.ok_or_else(|| ErrorCode::UnknownVariable(format!("Unknown setting {}", name)))?;
 
-        match MatchSeq::from(seq).match_seq(&seq_value) {
+        match seq.match_seq(&seq_value) {
             Ok(_) => Ok(seq_value.into_seqv()?),
             Err(_) => Err(ErrorCode::UnknownVariable(format!(
                 "Unknown setting {}",
@@ -92,12 +92,12 @@ impl SettingApi for SettingMgr {
         }
     }
 
-    async fn drop_setting(&self, name: &str, seq: Option<u64>) -> Result<()> {
+    async fn drop_setting(&self, name: &str, seq: MatchSeq) -> Result<()> {
         let key = format!("{}/{}", self.setting_prefix, name);
         let kv_api = self.kv_api.clone();
         let upsert_kv = async move {
             kv_api
-                .upsert_kv(UpsertKVReq::new(&key, seq.into(), Operation::Delete, None))
+                .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Delete, None))
                 .await
         };
         let res = upsert_kv.await?;

--- a/src/query/management/src/stage/stage_api.rs
+++ b/src/query/management/src/stage/stage_api.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_meta_types::SeqV;
 use common_meta_types::StageFile;
 use common_meta_types::UserStageInfo;
@@ -22,7 +23,7 @@ pub trait StageApi: Sync + Send {
     // Add a stage info to /tenant/stage-name.
     async fn add_stage(&self, stage: UserStageInfo) -> Result<u64>;
 
-    async fn get_stage(&self, name: &str, seq: Option<u64>) -> Result<SeqV<UserStageInfo>>;
+    async fn get_stage(&self, name: &str, seq: MatchSeq) -> Result<SeqV<UserStageInfo>>;
 
     // Get all the stages for a tenant.
     async fn get_stages(&self) -> Result<Vec<UserStageInfo>>;

--- a/src/query/management/src/stage/stage_mgr.rs
+++ b/src/query/management/src/stage/stage_mgr.rs
@@ -90,7 +90,7 @@ impl StageApi for StageMgr {
         Ok(res.seq)
     }
 
-    async fn get_stage(&self, name: &str, seq: Option<u64>) -> Result<SeqV<UserStageInfo>> {
+    async fn get_stage(&self, name: &str, seq: MatchSeq) -> Result<SeqV<UserStageInfo>> {
         let key = format!("{}/{}", self.stage_prefix, escape_for_key(name)?);
         let kv_api = self.kv_api.clone();
         let get_kv = async move { kv_api.get_kv(&key).await };
@@ -98,7 +98,7 @@ impl StageApi for StageMgr {
         let seq_value =
             res.ok_or_else(|| ErrorCode::UnknownStage(format!("Unknown stage {}", name)))?;
 
-        match MatchSeq::from(seq).match_seq(&seq_value) {
+        match seq.match_seq(&seq_value) {
             Ok(_) => Ok(SeqV::new(
                 seq_value.seq,
                 deserialize_struct(&seq_value.data, ErrorCode::IllegalUserStageFormat, || "")?,

--- a/src/query/management/src/udf/udf_api.rs
+++ b/src/query/management/src/udf/udf_api.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_meta_types::SeqV;
 use common_meta_types::UserDefinedFunction;
 
@@ -22,14 +23,14 @@ pub trait UdfApi: Sync + Send {
     async fn add_udf(&self, udf: UserDefinedFunction) -> Result<u64>;
 
     // Update a UDF to /tenant/udf-name.
-    async fn update_udf(&self, udf: UserDefinedFunction, seq: Option<u64>) -> Result<u64>;
+    async fn update_udf(&self, udf: UserDefinedFunction, seq: MatchSeq) -> Result<u64>;
 
     // Get UDF by name.
-    async fn get_udf(&self, udf_name: &str, seq: Option<u64>) -> Result<SeqV<UserDefinedFunction>>;
+    async fn get_udf(&self, udf_name: &str, seq: MatchSeq) -> Result<SeqV<UserDefinedFunction>>;
 
     // Get all the UDFs for a tenant.
     async fn get_udfs(&self) -> Result<Vec<UserDefinedFunction>>;
 
     // Drop the tenant's UDF by name.
-    async fn drop_udf(&self, udf_name: &str, seq: Option<u64>) -> Result<()>;
+    async fn drop_udf(&self, udf_name: &str, seq: MatchSeq) -> Result<()>;
 }

--- a/src/query/management/src/udf/udf_mgr.rs
+++ b/src/query/management/src/udf/udf_mgr.rs
@@ -76,7 +76,7 @@ impl UdfApi for UdfMgr {
         Ok(res.seq)
     }
 
-    async fn update_udf(&self, info: UserDefinedFunction, seq: Option<u64>) -> Result<u64> {
+    async fn update_udf(&self, info: UserDefinedFunction, seq: MatchSeq) -> Result<u64> {
         if is_builtin_function(info.name.as_str()) {
             return Err(ErrorCode::UdfAlreadyExists(format!(
                 "Builtin function can not be updated: {}",
@@ -89,9 +89,9 @@ impl UdfApi for UdfMgr {
 
         let val = Operation::Update(serde_json::to_vec(&info)?);
         let key = format!("{}/{}", self.udf_prefix, escape_for_key(&info.name)?);
-        let upsert_info =
-            self.kv_api
-                .upsert_kv(UpsertKVReq::new(&key, MatchSeq::from(seq), val, None));
+        let upsert_info = self
+            .kv_api
+            .upsert_kv(UpsertKVReq::new(&key, seq, val, None));
 
         let res = upsert_info.await?;
         match res.result {
@@ -103,7 +103,7 @@ impl UdfApi for UdfMgr {
         }
     }
 
-    async fn get_udf(&self, udf_name: &str, seq: Option<u64>) -> Result<SeqV<UserDefinedFunction>> {
+    async fn get_udf(&self, udf_name: &str, seq: MatchSeq) -> Result<SeqV<UserDefinedFunction>> {
         let key = format!("{}/{}", self.udf_prefix, escape_for_key(udf_name)?);
         let kv_api = self.kv_api.clone();
         let get_kv = async move { kv_api.get_kv(&key).await };
@@ -111,7 +111,7 @@ impl UdfApi for UdfMgr {
         let seq_value =
             res.ok_or_else(|| ErrorCode::UnknownUDF(format!("Unknown Function {}", udf_name)))?;
 
-        match MatchSeq::from(seq).match_seq(&seq_value) {
+        match seq.match_seq(&seq_value) {
             Ok(_) => Ok(seq_value.into_seqv()?),
             Err(_) => Err(ErrorCode::UnknownUDF(format!(
                 "Unknown Function {}",
@@ -131,12 +131,12 @@ impl UdfApi for UdfMgr {
         Ok(udfs)
     }
 
-    async fn drop_udf(&self, udf_name: &str, seq: Option<u64>) -> Result<()> {
+    async fn drop_udf(&self, udf_name: &str, seq: MatchSeq) -> Result<()> {
         let key = format!("{}/{}", self.udf_prefix, escape_for_key(udf_name)?);
         let kv_api = self.kv_api.clone();
         let upsert_kv = async move {
             kv_api
-                .upsert_kv(UpsertKVReq::new(&key, seq.into(), Operation::Delete, None))
+                .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Delete, None))
                 .await
         };
         let res = upsert_kv.await?;

--- a/src/query/management/src/user/user_api.rs
+++ b/src/query/management/src/user/user_api.rs
@@ -14,58 +14,41 @@
 
 use common_exception::Result;
 use common_meta_types::AuthInfo;
-use common_meta_types::GrantObject;
+use common_meta_types::MatchSeq;
 use common_meta_types::SeqV;
 use common_meta_types::UserIdentity;
 use common_meta_types::UserInfo;
 use common_meta_types::UserOption;
-use common_meta_types::UserPrivilegeSet;
 
 #[async_trait::async_trait]
 pub trait UserApi: Sync + Send {
     async fn add_user(&self, user_info: UserInfo) -> Result<u64>;
 
-    async fn get_user(&self, user: UserIdentity, seq: Option<u64>) -> Result<SeqV<UserInfo>>;
+    async fn get_user(&self, user: UserIdentity, seq: MatchSeq) -> Result<SeqV<UserInfo>>;
 
     async fn get_users(&self) -> Result<Vec<SeqV<UserInfo>>>;
+
+    /// General user's grants update.
+    ///
+    /// It fetches the role that matches the specified seq number, update it in place, then write it back with the seq it sees.
+    ///
+    /// Seq number ensures there is no other write happens between get and set.
+    async fn update_user_with<F>(
+        &self,
+        user: UserIdentity,
+        seq: MatchSeq,
+        f: F,
+    ) -> Result<Option<u64>>
+    where
+        F: FnOnce(&mut UserInfo) + Send;
 
     async fn update_user(
         &self,
         user: UserIdentity,
         auth_info: Option<AuthInfo>,
         user_option: Option<UserOption>,
-        seq: Option<u64>,
+        seq: MatchSeq,
     ) -> Result<Option<u64>>;
 
-    async fn grant_privileges(
-        &self,
-        user: UserIdentity,
-        object: GrantObject,
-        privileges: UserPrivilegeSet,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>>;
-
-    async fn revoke_privileges(
-        &self,
-        user: UserIdentity,
-        object: GrantObject,
-        privileges: UserPrivilegeSet,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>>;
-
-    async fn grant_role(
-        &self,
-        user: UserIdentity,
-        grant_role: String,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>>;
-
-    async fn revoke_role(
-        &self,
-        user: UserIdentity,
-        revoke_role: String,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>>;
-
-    async fn drop_user(&self, user: UserIdentity, seq: Option<u64>) -> Result<()>;
+    async fn drop_user(&self, user: UserIdentity, seq: MatchSeq) -> Result<()>;
 }

--- a/src/query/management/src/user/user_mgr.rs
+++ b/src/query/management/src/user/user_mgr.rs
@@ -19,7 +19,6 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_kvapi::kvapi;
 use common_meta_types::AuthInfo;
-use common_meta_types::GrantObject;
 use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
@@ -29,7 +28,6 @@ use common_meta_types::UpsertKVReq;
 use common_meta_types::UserIdentity;
 use common_meta_types::UserInfo;
 use common_meta_types::UserOption;
-use common_meta_types::UserPrivilegeSet;
 
 use crate::serde::deserialize_struct;
 use crate::serde::serialize_struct;
@@ -59,26 +57,17 @@ impl UserMgr {
     async fn upsert_user_info(
         &self,
         user_info: &UserInfo,
-        seq: Option<u64>,
+        seq: MatchSeq,
     ) -> common_exception::Result<u64> {
         let user_key = format_user_key(&user_info.name, &user_info.hostname);
         let key = format!("{}/{}", self.user_prefix, escape_for_key(&user_key)?);
         let value = serialize_struct(user_info, ErrorCode::IllegalUserInfoFormat, || "")?;
 
-        let match_seq = match seq {
-            None => MatchSeq::GE(1),
-            Some(s) => MatchSeq::Exact(s),
-        };
-
         let kv_api = self.kv_api.clone();
         let res = kv_api
-            .upsert_kv(UpsertKVReq::new(
-                &key,
-                match_seq,
-                Operation::Update(value),
-                None,
-            ))
+            .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Update(value), None))
             .await?;
+
         match res.result {
             Some(SeqV { seq: s, .. }) => Ok(s),
             None => Err(ErrorCode::UnknownUser(format!(
@@ -121,14 +110,14 @@ impl UserApi for UserMgr {
         Ok(res.seq)
     }
 
-    async fn get_user(&self, user: UserIdentity, seq: Option<u64>) -> Result<SeqV<UserInfo>> {
+    async fn get_user(&self, user: UserIdentity, seq: MatchSeq) -> Result<SeqV<UserInfo>> {
         let user_key = format_user_key(&user.username, &user.hostname);
         let key = format!("{}/{}", self.user_prefix, escape_for_key(&user_key)?);
         let res = self.kv_api.get_kv(&key).await?;
         let seq_value =
             res.ok_or_else(|| ErrorCode::UnknownUser(format!("unknown user {}", user_key)))?;
 
-        match MatchSeq::from(seq).match_seq(&seq_value) {
+        match seq.match_seq(&seq_value) {
             Ok(_) => Ok(SeqV::new(
                 seq_value.seq,
                 deserialize_struct(&seq_value.data, ErrorCode::IllegalUserInfoFormat, || "")?,
@@ -151,86 +140,59 @@ impl UserApi for UserMgr {
         Ok(r)
     }
 
+    /// General user's grants update.
+    ///
+    /// It fetch the role that matches the specified seq number, update it in place, then write it back with the seq it sees.
+    ///
+    /// Seq number ensures there is no other write happens between get and set.
+    async fn update_user_with<F>(
+        &self,
+        user: UserIdentity,
+        seq: MatchSeq,
+        f: F,
+    ) -> Result<Option<u64>>
+    where
+        F: FnOnce(&mut UserInfo) + Send,
+    {
+        let SeqV {
+            seq,
+            data: mut user_info,
+            ..
+        } = self.get_user(user, seq).await?;
+
+        f(&mut user_info);
+
+        let seq = self
+            .upsert_user_info(&user_info, MatchSeq::Exact(seq))
+            .await?;
+        Ok(Some(seq))
+    }
+
+    // TODO: it deserve a better name.
     async fn update_user(
         &self,
         user: UserIdentity,
         new_auth_info: Option<AuthInfo>,
         new_user_option: Option<UserOption>,
-        seq: Option<u64>,
+        seq: MatchSeq,
     ) -> Result<Option<u64>> {
-        let user_val_seq = self.get_user(user, seq);
-        let mut user_info = user_val_seq.await?.data;
-
-        if let Some(auth_info) = new_auth_info {
-            user_info.auth_info = auth_info;
-        };
-        if let Some(user_option) = new_user_option {
-            user_info.option = user_option;
-        };
-        let seq = self.upsert_user_info(&user_info, seq).await?;
-        Ok(Some(seq))
+        self.update_user_with(user, seq, |ui: &mut UserInfo| {
+            if let Some(auth_info) = new_auth_info {
+                ui.auth_info = auth_info;
+            };
+            if let Some(user_option) = new_user_option {
+                ui.option = user_option;
+            };
+        })
+        .await
     }
 
-    async fn grant_privileges(
-        &self,
-        user: UserIdentity,
-        object: GrantObject,
-        privileges: UserPrivilegeSet,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>> {
-        let user_val_seq = self.get_user(user, seq);
-        let mut user_info = user_val_seq.await?.data;
-        user_info.grants.grant_privileges(&object, privileges);
-        let seq = self.upsert_user_info(&user_info, seq).await?;
-        Ok(Some(seq))
-    }
-
-    async fn revoke_privileges(
-        &self,
-        user: UserIdentity,
-        object: GrantObject,
-        privileges: UserPrivilegeSet,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>> {
-        let user_val_seq = self.get_user(user, seq);
-        let mut user_info = user_val_seq.await?.data;
-        user_info.grants.revoke_privileges(&object, privileges);
-        let seq = self.upsert_user_info(&user_info, seq).await?;
-        Ok(Some(seq))
-    }
-
-    async fn grant_role(
-        &self,
-        user: UserIdentity,
-        grant_role: String,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>> {
-        let user_val_seq = self.get_user(user, seq);
-        let mut user_info = user_val_seq.await?.data;
-        user_info.grants.grant_role(grant_role);
-        let seq = self.upsert_user_info(&user_info, seq).await?;
-        Ok(Some(seq))
-    }
-
-    async fn revoke_role(
-        &self,
-        user: UserIdentity,
-        revoke_role: String,
-        seq: Option<u64>,
-    ) -> Result<Option<u64>> {
-        let user_val_seq = self.get_user(user, seq);
-        let mut user_info = user_val_seq.await?.data;
-        user_info.grants.revoke_role(&revoke_role);
-        let seq = self.upsert_user_info(&user_info, seq).await?;
-        Ok(Some(seq))
-    }
-
-    async fn drop_user(&self, user: UserIdentity, seq: Option<u64>) -> Result<()> {
+    async fn drop_user(&self, user: UserIdentity, seq: MatchSeq) -> Result<()> {
         let user_key = format_user_key(&user.username, &user.hostname);
         let key = format!("{}/{}", self.user_prefix, escape_for_key(&user_key)?);
         let res = self
             .kv_api
-            .upsert_kv(UpsertKVReq::new(&key, seq.into(), Operation::Delete, None))
+            .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Delete, None))
             .await?;
         if res.prev.is_some() && res.result.is_none() {
             Ok(())

--- a/src/query/management/tests/it/cluster.rs
+++ b/src/query/management/tests/it/cluster.rs
@@ -22,6 +22,7 @@ use common_management::*;
 use common_meta_embedded::MetaEmbedded;
 use common_meta_kvapi::kvapi::KVApi;
 use common_meta_store::MetaStore;
+use common_meta_types::MatchSeq;
 use common_meta_types::NodeInfo;
 use common_meta_types::SeqV;
 
@@ -91,7 +92,7 @@ async fn test_successfully_drop_node() -> Result<()> {
     let nodes = cluster_api.get_nodes().await?;
     assert_eq!(nodes, vec![node_info.clone()]);
 
-    cluster_api.drop_node(node_info.id, None).await?;
+    cluster_api.drop_node(node_info.id, MatchSeq::GE(1)).await?;
 
     let nodes = cluster_api.get_nodes().await?;
     assert_eq!(nodes, vec![]);
@@ -103,7 +104,7 @@ async fn test_unknown_node_drop_node() -> Result<()> {
     let (_, cluster_api) = new_cluster_api().await?;
 
     match cluster_api
-        .drop_node(String::from("UNKNOWN_ID"), None)
+        .drop_node(String::from("UNKNOWN_ID"), MatchSeq::GE(1))
         .await
     {
         Ok(_) => panic!("Unknown node drop node must be return Err."),
@@ -128,7 +129,7 @@ async fn test_successfully_heartbeat_node() -> Result<()> {
     assert!(value.unwrap().meta.unwrap().expire_at.unwrap() - current_time >= 60);
 
     let current_time = current_seconds_time();
-    cluster_api.heartbeat(&node_info, None).await?;
+    cluster_api.heartbeat(&node_info, MatchSeq::GE(1)).await?;
 
     let value = kv_api
         .get_kv("__fd_clusters/test%2dtenant%2did/test%2dcluster%2did/databend_query/test_node")

--- a/src/query/management/tests/it/setting.rs
+++ b/src/query/management/tests/it/setting.rs
@@ -19,6 +19,7 @@ use common_exception::Result;
 use common_management::*;
 use common_meta_embedded::MetaEmbedded;
 use common_meta_kvapi::kvapi::KVApi;
+use common_meta_types::MatchSeq;
 use common_meta_types::SeqV;
 use common_meta_types::UserSetting;
 use common_meta_types::UserSettingValue;
@@ -79,13 +80,13 @@ async fn test_set_setting() -> Result<()> {
     // Get setting.
     {
         let expect = UserSetting::create("max_threads", UserSettingValue::UInt64(1));
-        let actual = mgr.get_setting("max_threads", None).await?;
+        let actual = mgr.get_setting("max_threads", MatchSeq::GE(0)).await?;
         assert_eq!(actual.data, expect);
     }
 
     // Drop setting.
     {
-        mgr.drop_setting("max_threads", None).await?;
+        mgr.drop_setting("max_threads", MatchSeq::GE(1)).await?;
     }
 
     // Get settings.
@@ -96,13 +97,13 @@ async fn test_set_setting() -> Result<()> {
 
     // Get setting.
     {
-        let res = mgr.get_setting("max_threads", None).await;
+        let res = mgr.get_setting("max_threads", MatchSeq::GE(0)).await;
         assert!(res.is_err());
     }
 
     // Drop setting not exists.
     {
-        let res = mgr.drop_setting("max_threads_not", None).await;
+        let res = mgr.drop_setting("max_threads_not", MatchSeq::GE(1)).await;
         assert!(res.is_err());
     }
 

--- a/src/query/management/tests/it/stage.rs
+++ b/src/query/management/tests/it/stage.rs
@@ -20,6 +20,7 @@ use common_exception::Result;
 use common_management::*;
 use common_meta_embedded::MetaEmbedded;
 use common_meta_kvapi::kvapi::KVApi;
+use common_meta_types::MatchSeq;
 use common_meta_types::SeqV;
 use common_meta_types::StageFile;
 use common_meta_types::StageParams;
@@ -136,7 +137,10 @@ async fn test_add_stage_file() -> Result<()> {
 
     let stage_info = create_test_stage_info();
     let seq = stage_api.add_stage(stage_info.clone()).await?;
-    let mystage = stage_api.get_stage("mystage", Some(seq)).await?.data;
+    let mystage = stage_api
+        .get_stage("mystage", MatchSeq::Exact(seq))
+        .await?
+        .data;
     assert_eq!(mystage.number_of_files, 0);
 
     let stage_file = StageFile {
@@ -163,7 +167,7 @@ async fn test_add_stage_file() -> Result<()> {
         catch => panic!("GetKVActionReply{:?}", catch),
     }
 
-    let new_mystage = stage_api.get_stage("mystage", None).await?.data;
+    let new_mystage = stage_api.get_stage("mystage", MatchSeq::GE(0)).await?.data;
     assert_eq!(mystage.number_of_files + 1, new_mystage.number_of_files);
     Ok(())
 }
@@ -173,7 +177,10 @@ async fn test_remove_files() -> Result<()> {
     let (_kv_api, stage_api) = new_stage_api().await?;
     let stage_info = create_test_stage_info();
     let seq = stage_api.add_stage(stage_info.clone()).await?;
-    let mystage = stage_api.get_stage("mystage", Some(seq)).await?.data;
+    let mystage = stage_api
+        .get_stage("mystage", MatchSeq::Exact(seq))
+        .await?
+        .data;
     assert_eq!(mystage.number_of_files, 0);
 
     stage_api
@@ -198,7 +205,7 @@ async fn test_remove_files() -> Result<()> {
     assert_eq!(files.len(), 1);
     assert_eq!(files[0].path, "test/books.csv".to_string());
 
-    let new_mystage = stage_api.get_stage("mystage", None).await?.data;
+    let new_mystage = stage_api.get_stage("mystage", MatchSeq::GE(0)).await?.data;
     assert_eq!(new_mystage.number_of_files, 1);
     Ok(())
 }

--- a/src/query/management/tests/it/udf.rs
+++ b/src/query/management/tests/it/udf.rs
@@ -19,6 +19,7 @@ use common_exception::Result;
 use common_management::*;
 use common_meta_embedded::MetaEmbedded;
 use common_meta_kvapi::kvapi::KVApi;
+use common_meta_types::MatchSeq;
 use common_meta_types::SeqV;
 use common_meta_types::UserDefinedFunction;
 
@@ -84,7 +85,7 @@ async fn test_successfully_drop_udf() -> Result<()> {
     let udfs = udf_api.get_udfs().await?;
     assert_eq!(udfs, vec![udf.clone()]);
 
-    udf_api.drop_udf(&udf.name, None).await?;
+    udf_api.drop_udf(&udf.name, MatchSeq::GE(1)).await?;
 
     let udfs = udf_api.get_udfs().await?;
     assert_eq!(udfs, vec![]);
@@ -95,7 +96,7 @@ async fn test_successfully_drop_udf() -> Result<()> {
 async fn test_unknown_udf_drop_udf() -> Result<()> {
     let (_, udf_api) = new_udf_api().await?;
 
-    match udf_api.drop_udf("UNKNOWN_NAME", None).await {
+    match udf_api.drop_udf("UNKNOWN_NAME", MatchSeq::GE(1)).await {
         Ok(_) => panic!("Unknown Function drop must be return Err."),
         Err(cause) => assert_eq!(cause.code(), 2602),
     }

--- a/src/query/management/tests/it/user.rs
+++ b/src/query/management/tests/it/user.rs
@@ -421,7 +421,7 @@ mod drop {
         kv.expect_upsert_kv()
             .with(predicate::eq(UpsertKVReq::new(
                 &test_key,
-                MatchSeq::Any,
+                MatchSeq::GE(1),
                 Operation::Delete,
                 None,
             )))
@@ -447,7 +447,7 @@ mod drop {
         kv.expect_upsert_kv()
             .with(predicate::eq(UpsertKVReq::new(
                 &test_key,
-                MatchSeq::Any,
+                MatchSeq::GE(1),
                 Operation::Delete,
                 None,
             )))
@@ -499,7 +499,7 @@ mod update {
             "__fd_users/tenant1/{}",
             escape_for_key(&format_user_key(test_user_name, test_hostname))?
         );
-        let test_seq = MatchSeq::GE(0);
+        let test_seq = MatchSeq::GE(1);
 
         let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
         let prev_value = serialize_struct(&user_info, ErrorCode::IllegalUserInfoFormat, || "")?;
@@ -511,7 +511,7 @@ mod update {
             kv.expect_get_kv()
                 .with(predicate::function(move |v| v == test_key.as_str()))
                 .times(1)
-                .return_once(move |_k| Ok(Some(SeqV::new(0, prev_value))));
+                .return_once(move |_k| Ok(Some(SeqV::new(1, prev_value))));
         }
 
         // and then, update_kv should be called
@@ -522,12 +522,12 @@ mod update {
         kv.expect_upsert_kv()
             .with(predicate::eq(UpsertKVReq::new(
                 &test_key,
-                MatchSeq::GE(1),
+                MatchSeq::Exact(1),
                 Operation::Update(new_value_with_old_salt.clone()),
                 None,
             )))
             .times(1)
-            .return_once(|_| Ok(UpsertKVReply::new(None, Some(SeqV::new(0, vec![])))));
+            .return_once(|_| Ok(UpsertKVReply::new(None, Some(SeqV::new(1, vec![])))));
 
         let kv = Arc::new(kv);
         let user_mgr = UserMgr::create(kv, "tenant1")?;
@@ -585,7 +585,7 @@ mod update {
             "__fd_users/tenant1/{}",
             escape_for_key(&format_user_key(test_user_name, test_hostname))?
         );
-        let test_seq = MatchSeq::GE(0);
+        let test_seq = MatchSeq::GE(1);
 
         let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
         let prev_value = serialize_struct(&user_info, ErrorCode::IllegalUserInfoFormat, || "")?;
@@ -597,13 +597,13 @@ mod update {
             kv.expect_get_kv()
                 .with(predicate::function(move |v| v == test_key.as_str()))
                 .times(1)
-                .return_once(move |_k| Ok(Some(SeqV::new(0, prev_value))));
+                .return_once(move |_k| Ok(Some(SeqV::new(2, prev_value))));
         }
 
         // upsert should be called
         kv.expect_upsert_kv()
             .with(predicate::function(move |act: &UpsertKVReq| {
-                act.key == test_key.as_str() && act.seq == MatchSeq::GE(1)
+                act.key == test_key.as_str() && act.seq == MatchSeq::Exact(2)
             }))
             .times(1)
             .returning(|_| Ok(UpsertKVReply::new(None, None)));
@@ -652,7 +652,7 @@ mod set_user_privileges {
             kv.expect_get_kv()
                 .with(predicate::function(move |v| v == test_key.as_str()))
                 .times(1)
-                .return_once(move |_k| Ok(Some(SeqV::new(0, prev_value))));
+                .return_once(move |_k| Ok(Some(SeqV::new(1, prev_value))));
         }
         // - update_kv should be called
         let mut privileges = UserPrivilegeSet::empty();
@@ -665,12 +665,12 @@ mod set_user_privileges {
         kv.expect_upsert_kv()
             .with(predicate::eq(UpsertKVReq::new(
                 &test_key,
-                MatchSeq::GE(1),
+                MatchSeq::Exact(1),
                 Operation::Update(new_value),
                 None,
             )))
             .times(1)
-            .return_once(|_| Ok(UpsertKVReply::new(None, Some(SeqV::new(0, vec![])))));
+            .return_once(|_| Ok(UpsertKVReply::new(None, Some(SeqV::new(1, vec![])))));
 
         let kv = Arc::new(kv);
         let user_mgr = UserMgr::create(kv, "tenant1")?;

--- a/src/query/management/tests/it/user.rs
+++ b/src/query/management/tests/it/user.rs
@@ -199,7 +199,7 @@ mod get {
 
         let kv = Arc::new(kv);
         let user_mgr = UserMgr::create(kv, "tenant1")?;
-        let res = user_mgr.get_user(user_info.identity(), Some(1));
+        let res = user_mgr.get_user(user_info.identity(), MatchSeq::Exact(1));
         assert!(res.await.is_ok());
 
         Ok(())
@@ -225,7 +225,7 @@ mod get {
 
         let kv = Arc::new(kv);
         let user_mgr = UserMgr::create(kv, "tenant1")?;
-        let res = user_mgr.get_user(user_info.identity(), None);
+        let res = user_mgr.get_user(user_info.identity(), MatchSeq::GE(0));
         assert!(res.await.is_ok());
         Ok(())
     }
@@ -248,7 +248,10 @@ mod get {
         let kv = Arc::new(kv);
         let user_mgr = UserMgr::create(kv, "tenant1")?;
         let res = user_mgr
-            .get_user(UserIdentity::new(test_user_name, test_hostname), None)
+            .get_user(
+                UserIdentity::new(test_user_name, test_hostname),
+                MatchSeq::GE(0),
+            )
             .await;
         assert!(res.is_err());
         assert_eq!(res.unwrap_err().code(), ErrorCode::UnknownUser("").code());
@@ -273,7 +276,10 @@ mod get {
         let kv = Arc::new(kv);
         let user_mgr = UserMgr::create(kv, "tenant1")?;
         let res = user_mgr
-            .get_user(UserIdentity::new(test_user_name, test_hostname), Some(2))
+            .get_user(
+                UserIdentity::new(test_user_name, test_hostname),
+                MatchSeq::Exact(2),
+            )
             .await;
         assert!(res.is_err());
         assert_eq!(res.unwrap_err().code(), ErrorCode::UnknownUser("").code());
@@ -297,7 +303,10 @@ mod get {
 
         let kv = Arc::new(kv);
         let user_mgr = UserMgr::create(kv, "tenant1")?;
-        let res = user_mgr.get_user(UserIdentity::new(test_user_name, test_hostname), None);
+        let res = user_mgr.get_user(
+            UserIdentity::new(test_user_name, test_hostname),
+            MatchSeq::GE(0),
+        );
         assert_eq!(
             res.await.unwrap_err().code(),
             ErrorCode::IllegalUserInfoFormat("").code()
@@ -420,7 +429,7 @@ mod drop {
             .returning(|_k| Ok(UpsertKVReply::new(Some(SeqV::new(1, vec![])), None)));
         let kv = Arc::new(kv);
         let user_mgr = UserMgr::create(kv, "tenant1")?;
-        let res = user_mgr.drop_user(UserIdentity::new(test_user, test_hostname), None);
+        let res = user_mgr.drop_user(UserIdentity::new(test_user, test_hostname), MatchSeq::GE(1));
         assert!(res.await.is_ok());
 
         Ok(())
@@ -446,7 +455,7 @@ mod drop {
             .returning(|_k| Ok(UpsertKVReply::new(None, None)));
         let kv = Arc::new(kv);
         let user_mgr = UserMgr::create(kv, "tenant1")?;
-        let res = user_mgr.drop_user(UserIdentity::new(test_user, test_hostname), None);
+        let res = user_mgr.drop_user(UserIdentity::new(test_user, test_hostname), MatchSeq::GE(1));
         assert_eq!(
             res.await.unwrap_err().code(),
             ErrorCode::UnknownUser("").code()
@@ -490,7 +499,7 @@ mod update {
             "__fd_users/tenant1/{}",
             escape_for_key(&format_user_key(test_user_name, test_hostname))?
         );
-        let test_seq = None;
+        let test_seq = MatchSeq::GE(0);
 
         let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
         let prev_value = serialize_struct(&user_info, ErrorCode::IllegalUserInfoFormat, || "")?;
@@ -542,7 +551,7 @@ mod update {
             "__fd_users/tenant1/{}",
             escape_for_key(&format_user_key(test_user_name, test_hostname))?
         );
-        let test_seq = None;
+        let test_seq = MatchSeq::GE(0);
 
         // if partial update, and get_kv returns None
         // update_kv should NOT be called
@@ -576,7 +585,7 @@ mod update {
             "__fd_users/tenant1/{}",
             escape_for_key(&format_user_key(test_user_name, test_hostname))?
         );
-        let test_seq = None;
+        let test_seq = MatchSeq::GE(0);
 
         let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
         let prev_value = serialize_struct(&user_info, ErrorCode::IllegalUserInfoFormat, || "")?;
@@ -632,7 +641,6 @@ mod set_user_privileges {
             "__fd_users/tenant1/{}",
             escape_for_key(&format_user_key(test_user_name, test_hostname))?
         );
-        let test_seq = None;
 
         let mut user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
         let prev_value = serialize_struct(&user_info, ErrorCode::IllegalUserInfoFormat, || "")?;
@@ -667,11 +675,10 @@ mod set_user_privileges {
         let kv = Arc::new(kv);
         let user_mgr = UserMgr::create(kv, "tenant1")?;
 
-        let res = user_mgr.grant_privileges(
+        let res = user_mgr.update_user_with(
             user_info.identity(),
-            GrantObject::Global,
-            privileges,
-            test_seq,
+            MatchSeq::GE(1),
+            |ui: &mut UserInfo| ui.grants.grant_privileges(&GrantObject::Global, privileges),
         );
         assert!(res.await.is_ok());
         Ok(())

--- a/src/query/service/src/interpreters/interpreter_database_create.rs
+++ b/src/query/service/src/interpreters/interpreter_database_create.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_sql::plans::CreateDatabasePlan;
 use common_users::UserApiProvider;
 
@@ -46,7 +47,7 @@ impl Interpreter for CreateDatabaseInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let tenant = self.plan.tenant.clone();
         let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
-        let quota = quota_api.get_quota(None).await?.data;
+        let quota = quota_api.get_quota(MatchSeq::GE(0)).await?.data;
         let catalog = self.ctx.get_catalog(&self.plan.catalog)?;
         let databases = catalog.list_databases(&tenant).await?;
         if quota.max_databases != 0 && databases.len() >= quota.max_databases as usize {

--- a/src/query/service/src/interpreters/interpreter_privilege_grant.rs
+++ b/src/query/service/src/interpreters/interpreter_privilege_grant.rs
@@ -65,7 +65,7 @@ impl Interpreter for GrantPrivilegeInterpreter {
             }
             PrincipalIdentity::Role(role) => {
                 user_mgr
-                    .grant_privileges_to_role(&tenant, role, plan.on, plan.priv_types)
+                    .grant_privileges_to_role(&tenant, &role, plan.on, plan.priv_types)
                     .await?;
             }
         }

--- a/src/query/service/src/interpreters/interpreter_privilege_revoke.rs
+++ b/src/query/service/src/interpreters/interpreter_privilege_revoke.rs
@@ -63,7 +63,7 @@ impl Interpreter for RevokePrivilegeInterpreter {
             }
             PrincipalIdentity::Role(role) => {
                 user_mgr
-                    .revoke_privileges_from_role(&tenant, role, plan.on, plan.priv_types)
+                    .revoke_privileges_from_role(&tenant, &role, plan.on, plan.priv_types)
                     .await?;
             }
         }

--- a/src/query/service/src/interpreters/interpreter_role_grant.rs
+++ b/src/query/service/src/interpreters/interpreter_role_grant.rs
@@ -61,7 +61,7 @@ impl Interpreter for GrantRoleInterpreter {
             }
             PrincipalIdentity::Role(role) => {
                 user_mgr
-                    .grant_role_to_role(&tenant, role, plan.role)
+                    .grant_role_to_role(&tenant, &role, plan.role)
                     .await?;
             }
         }

--- a/src/query/service/src/interpreters/interpreter_role_revoke.rs
+++ b/src/query/service/src/interpreters/interpreter_role_revoke.rs
@@ -55,7 +55,7 @@ impl Interpreter for RevokeRoleInterpreter {
             }
             PrincipalIdentity::Role(role) => {
                 UserApiProvider::instance()
-                    .revoke_role_from_role(&tenant, role.clone(), plan.role)
+                    .revoke_role_from_role(&tenant, &role, &plan.role)
                     .await?;
             }
         }

--- a/src/query/service/src/interpreters/interpreter_table_create_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create_v2.rs
@@ -21,6 +21,7 @@ use common_expression::TableSchemaRefExt;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::TableMeta;
 use common_meta_app::schema::TableNameIdent;
+use common_meta_types::MatchSeq;
 use common_sql::field_default_value;
 use common_sql::plans::CreateTablePlanV2;
 use common_users::UserApiProvider;
@@ -55,7 +56,7 @@ impl Interpreter for CreateTableInterpreterV2 {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let tenant = self.plan.tenant.clone();
         let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
-        let quota = quota_api.get_quota(None).await?.data;
+        let quota = quota_api.get_quota(MatchSeq::GE(0)).await?.data;
         let engine = self.plan.engine;
         let catalog = self.ctx.get_catalog(self.plan.catalog.as_str())?;
         let tables = catalog

--- a/src/query/service/src/interpreters/interpreter_user_create.rs
+++ b/src/query/service/src/interpreters/interpreter_user_create.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_meta_types::UserGrantSet;
 use common_meta_types::UserInfo;
 use common_meta_types::UserQuota;
@@ -55,7 +56,7 @@ impl Interpreter for CreateUserInterpreter {
         let users = user_mgr.get_users(&tenant).await?;
 
         let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
-        let quota = quota_api.get_quota(None).await?.data;
+        let quota = quota_api.get_quota(MatchSeq::GE(0)).await?.data;
         if quota.max_users != 0 && users.len() >= quota.max_users as usize {
             return Err(ErrorCode::TenantQuotaExceeded(format!(
                 "Max users quota exceeded: {}",

--- a/src/query/service/src/interpreters/interpreter_user_stage_create.rs
+++ b/src/query/service/src/interpreters/interpreter_user_stage_create.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_meta_types::StageType;
 use common_sql::plans::CreateStagePlan;
 use common_users::UserApiProvider;
@@ -57,7 +58,7 @@ impl Interpreter for CreateUserStageInterpreter {
         }
 
         let quota_api = user_mgr.get_tenant_quota_api_client(&plan.tenant)?;
-        let quota = quota_api.get_quota(None).await?.data;
+        let quota = quota_api.get_quota(MatchSeq::GE(0)).await?.data;
         let stages = user_mgr.get_stages(&plan.tenant).await?;
         if quota.max_stages != 0 && stages.len() >= quota.max_stages as usize {
             return Err(ErrorCode::TenantQuotaExceeded(format!(

--- a/src/query/service/src/procedures/admins/tenant_quota.rs
+++ b/src/query/service/src/procedures/admins/tenant_quota.rs
@@ -26,6 +26,7 @@ use common_expression::DataField;
 use common_expression::DataSchema;
 use common_expression::DataSchemaRefExt;
 use common_expression::Value;
+use common_meta_types::MatchSeq;
 use common_meta_types::TenantQuota;
 use common_meta_types::UserOptionFlag;
 use common_users::UserApiProvider;
@@ -76,7 +77,7 @@ impl OneBlockProcedure for TenantQuotaProcedure {
             tenant = args[0].clone();
         }
         let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
-        let res = quota_api.get_quota(None).await?;
+        let res = quota_api.get_quota(MatchSeq::GE(0)).await?;
         let mut quota = res.data;
 
         if args.len() <= 1 {
@@ -94,7 +95,9 @@ impl OneBlockProcedure for TenantQuotaProcedure {
             quota.max_files_per_stage = max_files_per_stage.parse::<u32>()?
         };
 
-        quota_api.set_quota(&quota, Some(res.seq)).await?;
+        quota_api
+            .set_quota(&quota, MatchSeq::Exact(res.seq))
+            .await?;
 
         self.to_block(&quota)
     }

--- a/src/query/settings/src/lib.rs
+++ b/src/query/settings/src/lib.rs
@@ -29,6 +29,7 @@ use common_config::Config;
 use common_config::GlobalConfig;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_meta_types::UserSetting;
 use common_meta_types::UserSettingValue;
 use common_users::UserApiProvider;
@@ -889,7 +890,7 @@ impl Settings {
 
         UserApiProvider::instance()
             .get_setting_api_client(&tenant)?
-            .drop_setting(key.as_str(), None)
+            .drop_setting(key.as_str(), MatchSeq::GE(1))
             .await?;
 
         setting.level = ScopeLevel::Session;

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -159,7 +159,7 @@ impl UserApiProvider {
         let client = self.get_role_api_client(tenant)?;
         client
             .update_role_with(role, MatchSeq::GE(1), |ri: &mut RoleInfo| {
-                ri.grants.revoke_role(&revoke_role)
+                ri.grants.revoke_role(revoke_role)
             })
             .await
             .map_err(|e| e.add_message_back("(while revoke role from role)"))

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -16,7 +16,9 @@ use std::collections::HashMap;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_management::RoleApi;
 use common_meta_types::GrantObject;
+use common_meta_types::MatchSeq;
 use common_meta_types::RoleInfo;
 use common_meta_types::UserPrivilegeSet;
 
@@ -30,7 +32,7 @@ impl UserApiProvider {
     // Get one role from by tenant.
     pub async fn get_role(&self, tenant: &str, role: String) -> Result<RoleInfo> {
         let client = self.get_role_api_client(tenant)?;
-        let role_data = client.get_role(role, None).await?.data;
+        let role_data = client.get_role(&role, MatchSeq::GE(0)).await?.data;
         Ok(role_data)
     }
 
@@ -92,13 +94,15 @@ impl UserApiProvider {
     pub async fn grant_privileges_to_role(
         &self,
         tenant: &str,
-        role: String,
+        role: &String,
         object: GrantObject,
         privileges: UserPrivilegeSet,
     ) -> Result<Option<u64>> {
         let client = self.get_role_api_client(tenant)?;
         client
-            .grant_privileges(role, object, privileges, None)
+            .update_role_with(role, MatchSeq::GE(1), |ri: &mut RoleInfo| {
+                ri.grants.grant_privileges(&object, privileges)
+            })
             .await
             .map_err(|e| e.add_message_back("(while set role privileges)"))
     }
@@ -106,13 +110,15 @@ impl UserApiProvider {
     pub async fn revoke_privileges_from_role(
         &self,
         tenant: &str,
-        role: String,
+        role: &String,
         object: GrantObject,
         privileges: UserPrivilegeSet,
     ) -> Result<Option<u64>> {
         let client = self.get_role_api_client(tenant)?;
         client
-            .revoke_privileges(role, object, privileges, None)
+            .update_role_with(role, MatchSeq::GE(1), |ri: &mut RoleInfo| {
+                ri.grants.revoke_privileges(&object, privileges)
+            })
             .await
             .map_err(|e| e.add_message_back("(while revoke role privileges)"))
     }
@@ -121,7 +127,7 @@ impl UserApiProvider {
     pub async fn grant_role_to_role(
         &self,
         tenant: &str,
-        target_role: String,
+        target_role: &String,
         grant_role: String,
     ) -> Result<Option<u64>> {
         let related_roles = self
@@ -137,7 +143,9 @@ impl UserApiProvider {
 
         let client = self.get_role_api_client(tenant)?;
         client
-            .grant_role(target_role, grant_role, None)
+            .update_role_with(target_role, MatchSeq::GE(1), |ri: &mut RoleInfo| {
+                ri.grants.grant_role(grant_role)
+            })
             .await
             .map_err(|e| e.add_message_back("(while grant role to role)"))
     }
@@ -145,12 +153,14 @@ impl UserApiProvider {
     pub async fn revoke_role_from_role(
         &self,
         tenant: &str,
-        role: String,
-        revoke_role: String,
+        role: &String,
+        revoke_role: &String,
     ) -> Result<Option<u64>> {
         let client = self.get_role_api_client(tenant)?;
         client
-            .revoke_role(role, revoke_role, None)
+            .update_role_with(role, MatchSeq::GE(1), |ri: &mut RoleInfo| {
+                ri.grants.revoke_role(&revoke_role)
+            })
             .await
             .map_err(|e| e.add_message_back("(while revoke role from role)"))
     }
@@ -158,7 +168,7 @@ impl UserApiProvider {
     // Drop a role by name
     pub async fn drop_role(&self, tenant: &str, role: String, if_exists: bool) -> Result<()> {
         let client = self.get_role_api_client(tenant)?;
-        let drop_role = client.drop_role(role, None);
+        let drop_role = client.drop_role(role, MatchSeq::GE(1));
         match drop_role.await {
             Ok(res) => Ok(res),
             Err(e) => {

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -34,6 +34,7 @@ use common_meta_store::MetaStore;
 use common_meta_store::MetaStoreProvider;
 use common_meta_types::AuthInfo;
 use common_meta_types::KVAppError;
+use common_meta_types::MatchSeq;
 use common_meta_types::TenantQuota;
 
 use crate::idm_config::IDMConfig;
@@ -55,8 +56,8 @@ impl UserApiProvider {
 
         if let Some(q) = quota {
             let i = UserApiProvider::instance().get_tenant_quota_api_client(tenant)?;
-            let res = i.get_quota(None).await?;
-            i.set_quota(&q, Some(res.seq)).await?;
+            let res = i.get_quota(MatchSeq::GE(0)).await?;
+            i.set_quota(&q, MatchSeq::Exact(res.seq)).await?;
         }
         Ok(())
     }
@@ -81,11 +82,11 @@ impl UserApiProvider {
         GlobalInstance::get()
     }
 
-    pub fn get_user_api_client(&self, tenant: &str) -> Result<Arc<dyn UserApi>> {
+    pub fn get_user_api_client(&self, tenant: &str) -> Result<Arc<impl UserApi>> {
         Ok(Arc::new(UserMgr::create(self.client.clone(), tenant)?))
     }
 
-    pub fn get_role_api_client(&self, tenant: &str) -> Result<Arc<dyn RoleApi>> {
+    pub fn get_role_api_client(&self, tenant: &str) -> Result<Arc<impl RoleApi>> {
         Ok(Arc::new(RoleMgr::create(self.client.clone(), tenant)?))
     }
 

--- a/src/query/users/src/user_mgr.rs
+++ b/src/query/users/src/user_mgr.rs
@@ -14,8 +14,10 @@
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_management::UserApi;
 use common_meta_types::AuthInfo;
 use common_meta_types::GrantObject;
+use common_meta_types::MatchSeq;
 use common_meta_types::UserIdentity;
 use common_meta_types::UserInfo;
 use common_meta_types::UserOption;
@@ -57,7 +59,7 @@ impl UserApiProvider {
             Ok(user_info)
         } else {
             let client = self.get_user_api_client(tenant)?;
-            let get_user = client.get_user(user, None);
+            let get_user = client.get_user(user, MatchSeq::GE(0));
             Ok(get_user.await?.data)
         }
     }
@@ -143,7 +145,9 @@ impl UserApiProvider {
     ) -> Result<Option<u64>> {
         let client = self.get_user_api_client(tenant)?;
         client
-            .grant_privileges(user, object, privileges, None)
+            .update_user_with(user, MatchSeq::GE(1), |ui: &mut UserInfo| {
+                ui.grants.grant_privileges(&object, privileges)
+            })
             .await
             .map_err(|e| e.add_message_back("(while set user privileges)"))
     }
@@ -157,7 +161,9 @@ impl UserApiProvider {
     ) -> Result<Option<u64>> {
         let client = self.get_user_api_client(tenant)?;
         client
-            .revoke_privileges(user, object, privileges, None)
+            .update_user_with(user, MatchSeq::GE(1), |ui: &mut UserInfo| {
+                ui.grants.revoke_privileges(&object, privileges)
+            })
             .await
             .map_err(|e| e.add_message_back("(while revoke user privileges)"))
     }
@@ -170,7 +176,9 @@ impl UserApiProvider {
     ) -> Result<Option<u64>> {
         let client = self.get_user_api_client(tenant)?;
         client
-            .grant_role(user, grant_role.clone(), None)
+            .update_user_with(user, MatchSeq::GE(1), |ui: &mut UserInfo| {
+                ui.grants.grant_role(grant_role)
+            })
             .await
             .map_err(|e| e.add_message_back("(while grant role to user)"))
     }
@@ -183,7 +191,9 @@ impl UserApiProvider {
     ) -> Result<Option<u64>> {
         let client = self.get_user_api_client(tenant)?;
         client
-            .revoke_role(user, revoke_role.clone(), None)
+            .update_user_with(user, MatchSeq::GE(1), |ui: &mut UserInfo| {
+                ui.grants.revoke_role(&revoke_role)
+            })
             .await
             .map_err(|e| e.add_message_back("(while revoke role from user)"))
     }
@@ -191,7 +201,7 @@ impl UserApiProvider {
     // Drop a user by name and hostname.
     pub async fn drop_user(&self, tenant: &str, user: UserIdentity, if_exists: bool) -> Result<()> {
         let client = self.get_user_api_client(tenant)?;
-        let drop_user = client.drop_user(user, None);
+        let drop_user = client.drop_user(user, MatchSeq::GE(1));
         match drop_user.await {
             Ok(res) => Ok(res),
             Err(e) => {
@@ -213,8 +223,11 @@ impl UserApiProvider {
         user_option: Option<UserOption>,
     ) -> Result<Option<u64>> {
         let client = self.get_user_api_client(tenant)?;
-        let update_user = client.update_user(user, auth_info, user_option, None);
-        match update_user.await {
+        let update_user = client
+            .update_user(user, auth_info, user_option, MatchSeq::GE(1))
+            .await;
+
+        match update_user {
             Ok(res) => Ok(res),
             Err(e) => Err(e.add_message_back("(while alter user).")),
         }

--- a/src/query/users/src/user_setting.rs
+++ b/src/query/users/src/user_setting.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_meta_types::UserSetting;
 
 use crate::UserApiProvider;
@@ -33,6 +34,8 @@ impl UserApiProvider {
     // Drop a setting by name.
     pub async fn drop_setting(&self, tenant: &str, name: &str) -> Result<()> {
         let setting_api_provider = self.get_setting_api_client(tenant)?;
-        setting_api_provider.drop_setting(name, None).await
+        setting_api_provider
+            .drop_setting(name, MatchSeq::GE(1))
+            .await
     }
 }

--- a/src/query/users/src/user_stage.rs
+++ b/src/query/users/src/user_stage.rs
@@ -14,6 +14,7 @@
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_meta_types::UserStageInfo;
 
 use crate::UserApiProvider;
@@ -44,7 +45,7 @@ impl UserApiProvider {
     // Get one stage from by tenant.
     pub async fn get_stage(&self, tenant: &str, stage_name: &str) -> Result<UserStageInfo> {
         let stage_api_provider = self.get_stage_api_client(tenant)?;
-        let get_stage = stage_api_provider.get_stage(stage_name, None);
+        let get_stage = stage_api_provider.get_stage(stage_name, MatchSeq::GE(0));
         Ok(get_stage.await?.data)
     }
 

--- a/src/query/users/src/user_udf.rs
+++ b/src/query/users/src/user_udf.rs
@@ -14,6 +14,7 @@
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::MatchSeq;
 use common_meta_types::UserDefinedFunction;
 
 use crate::UserApiProvider;
@@ -44,7 +45,7 @@ impl UserApiProvider {
     // Update a UDF.
     pub async fn update_udf(&self, tenant: &str, info: UserDefinedFunction) -> Result<u64> {
         let udf_api_client = self.get_udf_api_client(tenant)?;
-        let update_udf = udf_api_client.update_udf(info, None);
+        let update_udf = udf_api_client.update_udf(info, MatchSeq::GE(1));
         match update_udf.await {
             Ok(res) => Ok(res),
             Err(e) => Err(e.add_message_back("(while update UDF).")),
@@ -54,7 +55,7 @@ impl UserApiProvider {
     // Get a UDF by name.
     pub async fn get_udf(&self, tenant: &str, udf_name: &str) -> Result<UserDefinedFunction> {
         let udf_api_client = self.get_udf_api_client(tenant)?;
-        let get_udf = udf_api_client.get_udf(udf_name, None);
+        let get_udf = udf_api_client.get_udf(udf_name, MatchSeq::GE(0));
         Ok(get_udf.await?.data)
     }
 
@@ -72,7 +73,7 @@ impl UserApiProvider {
     // Drop a UDF by name.
     pub async fn drop_udf(&self, tenant: &str, udf_name: &str, if_exists: bool) -> Result<()> {
         let udf_api_client = self.get_udf_api_client(tenant)?;
-        let drop_udf = udf_api_client.drop_udf(udf_name, None);
+        let drop_udf = udf_api_client.drop_udf(udf_name, MatchSeq::GE(1));
         match drop_udf.await {
             Ok(res) => Ok(res),
             Err(e) => {

--- a/src/query/users/tests/it/role_mgr.rs
+++ b/src/query/users/tests/it/role_mgr.rs
@@ -69,7 +69,7 @@ async fn test_role_manager() -> Result<()> {
         role_mgr
             .grant_privileges_to_role(
                 tenant,
-                role_name.clone(),
+                &role_name,
                 GrantObject::Global,
                 UserPrivilegeSet::all_privileges(),
             )
@@ -86,7 +86,7 @@ async fn test_role_manager() -> Result<()> {
         role_mgr
             .revoke_privileges_from_role(
                 tenant,
-                role_name.clone(),
+                &role_name,
                 GrantObject::Global,
                 UserPrivilegeSet::all_privileges(),
             )


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta): simplify UserAPI and RoleAPI by introducing a method update_xx_with(id, f: FnOnce)

Remove obsolete seq number form `Option<u64>`, replace it with `MatchSeq`.


##### chore(meta): remove obsolete impl From<Option> for Operation

## Changelog







## Related Issues