### PR TITLE
refactor(cluster): use bounded channel for exchange

### DIFF
--- a/src/query/service/src/api/rpc/flight_client.rs
+++ b/src/query/service/src/api/rpc/flight_client.rs
@@ -55,7 +55,7 @@ impl FlightClient {
     }
 
     pub async fn request_server_exchange(&mut self, query_id: &str) -> Result<FlightExchange> {
-        let (tx, rx) = async_channel::unbounded();
+        let (tx, rx) = async_channel::bounded(8);
         Ok(FlightExchange::from_client(
             tx,
             self.exchange_streaming(
@@ -74,7 +74,7 @@ impl FlightClient {
         source: &str,
         fragment_id: usize,
     ) -> Result<FlightExchange> {
-        let (tx, rx) = async_channel::unbounded();
+        let (tx, rx) = async_channel::bounded(8);
         Ok(FlightExchange::from_client(
             tx,
             self.exchange_streaming(

--- a/src/query/service/src/api/rpc/flight_service.rs
+++ b/src/query/service/src/api/rpc/flight_service.rs
@@ -105,7 +105,7 @@ impl FlightService for DatabendQueryFlightService {
         match req.get_metadata("x-type")?.as_str() {
             "request_server_exchange" => {
                 let query_id = req.get_metadata("x-query-id")?;
-                let (tx, rx) = async_channel::unbounded();
+                let (tx, rx) = async_channel::bounded(8);
                 let exchange = FlightExchange::from_server(req, tx);
 
                 DataExchangeManager::instance().handle_statistics_exchange(query_id, exchange)?;
@@ -116,7 +116,7 @@ impl FlightService for DatabendQueryFlightService {
                 let query_id = req.get_metadata("x-query-id")?;
                 let fragment = req.get_metadata("x-fragment-id")?.parse::<usize>().unwrap();
 
-                let (tx, rx) = async_channel::unbounded();
+                let (tx, rx) = async_channel::bounded(8);
                 let exchange = FlightExchange::from_server(req, tx);
 
                 DataExchangeManager::instance()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor(cluster): use bounded channel for exchange

Closes #issue
