### PR TITLE
fix: enable outer join to inner join optimization

### DIFF
--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -40,7 +40,9 @@ use crate::executor::ExchangeSource;
 use crate::executor::FragmentKind;
 use crate::planner::MetadataRef;
 use crate::planner::DUMMY_TABLE_INDEX;
+use crate::BaseTableColumn;
 use crate::ColumnEntry;
+use crate::DerivedColumn;
 
 impl PhysicalPlan {
     pub fn format(&self, metadata: MetadataRef) -> Result<FormatTreeNode<String>> {
@@ -170,8 +172,9 @@ fn project_to_format_tree(
             format!(
                 "{} (#{})",
                 match metadata.read().column(*column) {
-                    ColumnEntry::BaseTableColumn { column_name, .. } => column_name,
-                    ColumnEntry::DerivedColumn { alias, .. } => alias,
+                    ColumnEntry::BaseTableColumn(BaseTableColumn { column_name, .. }) =>
+                        column_name,
+                    ColumnEntry::DerivedColumn(DerivedColumn { alias, .. }) => alias,
                 },
                 column
             )
@@ -227,8 +230,10 @@ pub fn pretty_display_agg_desc(desc: &AggregateFunctionDesc, metadata: &Metadata
             .map(|&index| {
                 let column = metadata.read().column(index).clone();
                 match column {
-                    ColumnEntry::BaseTableColumn { column_name, .. } => column_name,
-                    ColumnEntry::DerivedColumn { alias, .. } => alias,
+                    ColumnEntry::BaseTableColumn(BaseTableColumn { column_name, .. }) => {
+                        column_name
+                    }
+                    ColumnEntry::DerivedColumn(DerivedColumn { alias, .. }) => alias,
                 }
             })
             .collect::<Vec<_>>()
@@ -246,8 +251,8 @@ fn aggregate_partial_to_format_tree(
         .map(|column| {
             let column = metadata.read().column(*column).clone();
             let name = match column {
-                ColumnEntry::BaseTableColumn { column_name, .. } => column_name,
-                ColumnEntry::DerivedColumn { alias, .. } => alias,
+                ColumnEntry::BaseTableColumn(BaseTableColumn { column_name, .. }) => column_name,
+                ColumnEntry::DerivedColumn(DerivedColumn { alias, .. }) => alias,
             };
             Ok(name)
         })
@@ -288,8 +293,8 @@ fn aggregate_final_to_format_tree(
         .map(|column| {
             let column = metadata.read().column(*column).clone();
             let name = match column {
-                ColumnEntry::BaseTableColumn { column_name, .. } => column_name,
-                ColumnEntry::DerivedColumn { alias, .. } => alias,
+                ColumnEntry::BaseTableColumn(BaseTableColumn { column_name, .. }) => column_name,
+                ColumnEntry::DerivedColumn(DerivedColumn { alias, .. }) => alias,
             };
             Ok(name)
         })
@@ -336,8 +341,9 @@ fn sort_to_format_tree(plan: &Sort, metadata: &MetadataRef) -> Result<FormatTree
             Ok(format!(
                 "{} {} {}",
                 match column {
-                    ColumnEntry::BaseTableColumn { column_name, .. } => column_name,
-                    ColumnEntry::DerivedColumn { alias, .. } => alias,
+                    ColumnEntry::BaseTableColumn(BaseTableColumn { column_name, .. }) =>
+                        column_name,
+                    ColumnEntry::DerivedColumn(DerivedColumn { alias, .. }) => alias,
                 },
                 if sort_key.asc { "ASC" } else { "DESC" },
                 if sort_key.nulls_first {

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -62,8 +62,10 @@ use crate::planner::semantic::normalize_identifier;
 use crate::planner::semantic::TypeChecker;
 use crate::plans::Scan;
 use crate::plans::Statistics;
+use crate::BaseTableColumn;
 use crate::BindContext;
 use crate::ColumnEntry;
+use crate::DerivedColumn;
 use crate::IndexType;
 
 impl Binder {
@@ -396,14 +398,14 @@ impl Binder {
         let mut col_stats: HashMap<IndexType, Option<ColumnStatistics>> = HashMap::new();
         for column in columns.iter() {
             match column {
-                ColumnEntry::BaseTableColumn {
+                ColumnEntry::BaseTableColumn(BaseTableColumn {
                     column_name,
                     column_index,
                     path_indices,
                     data_type,
                     leaf_index,
                     ..
-                } => {
+                }) => {
                     let column_binding = ColumnBinding {
                         database_name: Some(database_name.to_string()),
                         table_name: Some(table.name().to_string()),
@@ -440,8 +442,12 @@ impl Binder {
                     columns: columns
                         .into_iter()
                         .map(|col| match col {
-                            ColumnEntry::BaseTableColumn { column_index, .. } => column_index,
-                            ColumnEntry::DerivedColumn { column_index, .. } => column_index,
+                            ColumnEntry::BaseTableColumn(BaseTableColumn {
+                                column_index, ..
+                            }) => column_index,
+                            ColumnEntry::DerivedColumn(DerivedColumn { column_index, .. }) => {
+                                column_index
+                            }
                         })
                         .collect(),
                     push_down_predicates: None,

--- a/src/query/sql/src/planner/expression_parser.rs
+++ b/src/query/sql/src/planner/expression_parser.rs
@@ -42,6 +42,7 @@ use parking_lot::RwLock;
 use crate::planner::binder::BindContext;
 use crate::planner::semantic::NameResolutionContext;
 use crate::planner::semantic::TypeChecker;
+use crate::BaseTableColumn;
 use crate::ColumnBinding;
 use crate::ColumnEntry;
 use crate::Metadata;
@@ -67,12 +68,12 @@ pub fn parse_exprs(
     let table = metadata.read().table(table_index).clone();
     for (index, column) in columns.iter().enumerate() {
         let column_binding = match column {
-            ColumnEntry::BaseTableColumn {
+            ColumnEntry::BaseTableColumn(BaseTableColumn {
                 column_name,
                 data_type,
                 path_indices,
                 ..
-            } => ColumnBinding {
+            }) => ColumnBinding {
                 database_name: Some("default".to_string()),
                 table_name: Some(table.name().to_string()),
                 column_name: column_name.clone(),

--- a/src/query/sql/src/planner/format/display_rel_operator.rs
+++ b/src/query/sql/src/planner/format/display_rel_operator.rs
@@ -34,7 +34,9 @@ use crate::plans::RelOperator;
 use crate::plans::ScalarExpr;
 use crate::plans::Scan;
 use crate::plans::Sort;
+use crate::BaseTableColumn;
 use crate::ColumnEntry;
+use crate::DerivedColumn;
 use crate::MetadataRef;
 
 #[derive(Clone)]
@@ -254,8 +256,12 @@ fn scan_to_format_tree(
                             .map(|item| format!(
                                 "{} (#{}) {}",
                                 match metadata.read().column(item.index) {
-                                    ColumnEntry::BaseTableColumn { column_name, .. } => column_name,
-                                    ColumnEntry::DerivedColumn { alias, .. } => alias,
+                                    ColumnEntry::BaseTableColumn(BaseTableColumn {
+                                        column_name,
+                                        ..
+                                    }) => column_name,
+                                    ColumnEntry::DerivedColumn(DerivedColumn { alias, .. }) =>
+                                        alias,
                                 },
                                 item.index,
                                 if item.asc { "ASC" } else { "DESC" }
@@ -315,8 +321,12 @@ fn logical_get_to_format_tree(
                             .map(|item| format!(
                                 "{} (#{}) {}",
                                 match metadata.read().column(item.index) {
-                                    ColumnEntry::BaseTableColumn { column_name, .. } => column_name,
-                                    ColumnEntry::DerivedColumn { alias, .. } => alias,
+                                    ColumnEntry::BaseTableColumn(BaseTableColumn {
+                                        column_name,
+                                        ..
+                                    }) => column_name,
+                                    ColumnEntry::DerivedColumn(DerivedColumn { alias, .. }) =>
+                                        alias,
                                 },
                                 item.index,
                                 if item.asc { "ASC" } else { "DESC" }
@@ -546,8 +556,8 @@ fn sort_to_format_tree(
         .map(|item| {
             let metadata = metadata.read();
             let name = match metadata.column(item.index) {
-                ColumnEntry::BaseTableColumn { column_name, .. } => column_name,
-                ColumnEntry::DerivedColumn { alias, .. } => alias,
+                ColumnEntry::BaseTableColumn(BaseTableColumn { column_name, .. }) => column_name,
+                ColumnEntry::DerivedColumn(DerivedColumn { alias, .. }) => alias,
             };
             format!(
                 "{} (#{}) {}",

--- a/src/query/sql/src/planner/metadata.rs
+++ b/src/query/sql/src/planner/metadata.rs
@@ -69,11 +69,11 @@ impl Metadata {
 
     pub fn table_index_by_column_indexes(&self, column_indexes: &ColumnSet) -> Option<IndexType> {
         self.columns.iter().find_map(|v| match v {
-            ColumnEntry::BaseTableColumn {
+            ColumnEntry::BaseTableColumn(BaseTableColumn {
                 column_index,
                 table_index,
                 ..
-            } if column_indexes.contains(column_index) => Some(*table_index),
+            }) if column_indexes.contains(column_index) => Some(*table_index),
             _ => None,
         })
     }
@@ -91,7 +91,7 @@ impl Metadata {
     pub fn columns_by_table_index(&self, index: IndexType) -> Vec<ColumnEntry> {
         self.columns
             .iter()
-            .filter(|v| matches!(v, ColumnEntry::BaseTableColumn { table_index, .. } if index == *table_index))
+            .filter(|v| matches!(v, ColumnEntry::BaseTableColumn(BaseTableColumn { table_index, .. }) if index == *table_index))
             .cloned()
             .collect()
     }
@@ -105,25 +105,25 @@ impl Metadata {
         leaf_index: Option<IndexType>,
     ) -> IndexType {
         let column_index = self.columns.len();
-        let column_entry = ColumnEntry::BaseTableColumn {
+        let column_entry = ColumnEntry::BaseTableColumn(BaseTableColumn {
             column_name: name,
             data_type,
             column_index,
             table_index,
             path_indices,
             leaf_index,
-        };
+        });
         self.columns.push(column_entry);
         column_index
     }
 
     pub fn add_derived_column(&mut self, alias: String, data_type: DataType) -> IndexType {
         let column_index = self.columns.len();
-        let column_entry = ColumnEntry::DerivedColumn {
+        let column_entry = ColumnEntry::DerivedColumn(DerivedColumn {
             column_index,
             alias,
             data_type,
-        };
+        });
         self.columns.push(column_entry);
         column_index
     }
@@ -275,34 +275,40 @@ impl TableEntry {
 }
 
 #[derive(Clone, Debug)]
+pub struct BaseTableColumn {
+    pub table_index: IndexType,
+    pub column_index: IndexType,
+    pub column_name: String,
+    pub data_type: TableDataType,
+
+    /// Path indices for inner column of struct data type.
+    pub path_indices: Option<Vec<usize>>,
+    /// Leaf index is the primitive column index in Parquet, constructed in DFS order.
+    /// None if the data type of column is struct.
+    pub leaf_index: Option<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DerivedColumn {
+    pub column_index: IndexType,
+    pub alias: String,
+    pub data_type: DataType,
+}
+
+#[derive(Clone, Debug)]
 pub enum ColumnEntry {
     /// Column from base table, for example `SELECT t.a, t.b FROM t`.
-    BaseTableColumn {
-        table_index: IndexType,
-        column_index: IndexType,
-        column_name: String,
-        data_type: TableDataType,
-
-        /// Path indices for inner column of struct data type.
-        path_indices: Option<Vec<usize>>,
-        /// Leaf index is the primitive column index in Parquet, constructed in DFS order.
-        /// None if the data type of column is struct.
-        leaf_index: Option<usize>,
-    },
+    BaseTableColumn(BaseTableColumn),
 
     /// Column synthesized from other columns, for example `SELECT t.a + t.b AS a FROM t`.
-    DerivedColumn {
-        column_index: IndexType,
-        alias: String,
-        data_type: DataType,
-    },
+    DerivedColumn(DerivedColumn),
 }
 
 impl ColumnEntry {
     pub fn index(&self) -> IndexType {
         match self {
-            ColumnEntry::BaseTableColumn { column_index, .. } => *column_index,
-            ColumnEntry::DerivedColumn { column_index, .. } => *column_index,
+            ColumnEntry::BaseTableColumn(base) => base.column_index,
+            ColumnEntry::DerivedColumn(derived) => derived.column_index,
         }
     }
 }

--- a/src/query/sql/src/planner/optimizer/cascades/tasks/apply_rule.rs
+++ b/src/query/sql/src/planner/optimizer/cascades/tasks/apply_rule.rs
@@ -58,7 +58,7 @@ impl ApplyRuleTask {
         let group = optimizer.memo.group(self.target_group_index)?;
         let m_expr = group.m_expr(self.m_expr_index)?;
         let mut state = TransformResult::new();
-        let rule = RuleFactory::create().create_rule(self.rule_id)?;
+        let rule = RuleFactory::create().create_rule(self.rule_id, None)?;
         m_expr.apply_rule(&optimizer.memo, &rule, &mut state)?;
         optimizer.insert_from_transform_state(self.target_group_index, state)?;
 

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -53,8 +53,10 @@ use crate::plans::Scan;
 use crate::plans::Statistics;
 use crate::plans::SubqueryExpr;
 use crate::plans::SubqueryType;
+use crate::BaseTableColumn;
 use crate::ColumnBinding;
 use crate::ColumnEntry;
+use crate::DerivedColumn;
 use crate::IndexType;
 use crate::MetadataRef;
 
@@ -381,14 +383,14 @@ impl SubqueryRewriter {
             for correlated_column in correlated_columns.iter() {
                 let column_entry = metadata.column(*correlated_column).clone();
                 let (name, data_type) = match &column_entry {
-                    ColumnEntry::BaseTableColumn {
+                    ColumnEntry::BaseTableColumn(BaseTableColumn {
                         column_name,
                         data_type,
                         ..
-                    } => (column_name, DataType::from(data_type)),
-                    ColumnEntry::DerivedColumn {
+                    }) => (column_name, DataType::from(data_type)),
+                    ColumnEntry::DerivedColumn(DerivedColumn {
                         alias, data_type, ..
-                    } => (alias, data_type.clone()),
+                    }) => (alias, data_type.clone()),
                 };
                 self.derived_columns.insert(
                     *correlated_column,
@@ -451,8 +453,12 @@ impl SubqueryRewriter {
                 for derived_column in self.derived_columns.values() {
                     let column_entry = metadata.column(*derived_column);
                     let data_type = match column_entry {
-                        ColumnEntry::BaseTableColumn { data_type, .. } => DataType::from(data_type),
-                        ColumnEntry::DerivedColumn { data_type, .. } => data_type.clone(),
+                        ColumnEntry::BaseTableColumn(BaseTableColumn { data_type, .. }) => {
+                            DataType::from(data_type)
+                        }
+                        ColumnEntry::DerivedColumn(DerivedColumn { data_type, .. }) => {
+                            data_type.clone()
+                        }
                     };
                     let column_binding = ColumnBinding {
                         database_name: None,
@@ -561,10 +567,12 @@ impl SubqueryRewriter {
                         let metadata = self.metadata.read();
                         let column_entry = metadata.column(*derived_column);
                         let data_type = match column_entry {
-                            ColumnEntry::BaseTableColumn { data_type, .. } => {
+                            ColumnEntry::BaseTableColumn(BaseTableColumn { data_type, .. }) => {
                                 DataType::from(data_type)
                             }
-                            ColumnEntry::DerivedColumn { data_type, .. } => data_type.clone(),
+                            ColumnEntry::DerivedColumn(DerivedColumn { data_type, .. }) => {
+                                data_type.clone()
+                            }
                         };
                         ColumnBinding {
                             database_name: None,
@@ -775,8 +783,10 @@ impl SubqueryRewriter {
             let metadata = self.metadata.read();
             let column_entry = metadata.column(*correlated_column);
             let data_type = match column_entry {
-                ColumnEntry::BaseTableColumn { data_type, .. } => DataType::from(data_type),
-                ColumnEntry::DerivedColumn { data_type, .. } => data_type.clone(),
+                ColumnEntry::BaseTableColumn(BaseTableColumn { data_type, .. }) => {
+                    DataType::from(data_type)
+                }
+                ColumnEntry::DerivedColumn(DerivedColumn { data_type, .. }) => data_type.clone(),
             };
             let right_column = ScalarExpr::BoundColumnRef(BoundColumnRef {
                 column: ColumnBinding {

--- a/src/query/sql/src/planner/optimizer/heuristic/rule_list.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/rule_list.rs
@@ -17,6 +17,7 @@ use common_exception::Result;
 use crate::optimizer::rule::RuleFactory;
 use crate::optimizer::rule::RuleID;
 use crate::optimizer::rule::RulePtr;
+use crate::MetadataRef;
 
 #[allow(dead_code)]
 // Ordered list of rules, may contain duplicated rules.
@@ -25,11 +26,11 @@ pub struct RuleList {
 }
 
 impl RuleList {
-    pub fn create(ids: Vec<RuleID>) -> Result<Self> {
+    pub fn create(ids: Vec<RuleID>, metadata: Option<MetadataRef>) -> Result<Self> {
         let factory = RuleFactory::create();
         let mut rules = vec![];
         for id in ids {
-            rules.push(factory.create_rule(id)?);
+            rules.push(factory.create_rule(id, metadata.clone())?);
         }
         Ok(RuleList { rules })
     }

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -141,7 +141,7 @@ pub fn optimize_query(
     bind_context: Box<BindContext>,
     s_expr: SExpr,
 ) -> Result<SExpr> {
-    let rules = RuleList::create(DEFAULT_REWRITE_RULES.clone())?;
+    let rules = RuleList::create(DEFAULT_REWRITE_RULES.clone(), Some(metadata.clone()))?;
 
     let contains_local_table_scan = contains_local_table_scan(&s_expr, &metadata);
 
@@ -169,7 +169,7 @@ fn get_optimized_memo(
     metadata: MetadataRef,
     bind_context: Box<BindContext>,
 ) -> Result<(Memo, HashMap<IndexType, CostContext>)> {
-    let rules = RuleList::create(DEFAULT_REWRITE_RULES.clone())?;
+    let rules = RuleList::create(DEFAULT_REWRITE_RULES.clone(), Some(metadata.clone()))?;
 
     let mut heuristic = HeuristicOptimizer::new(ctx.clone(), bind_context, metadata, rules);
     let result = heuristic.optimize(s_expr)?;

--- a/src/query/sql/src/planner/optimizer/rule/factory.rs
+++ b/src/query/sql/src/planner/optimizer/rule/factory.rs
@@ -42,6 +42,7 @@ use crate::optimizer::rule::transform::RuleLeftExchangeJoin;
 use crate::optimizer::rule::transform::RuleRightExchangeJoin;
 use crate::optimizer::rule::RuleID;
 use crate::optimizer::rule::RulePtr;
+use crate::MetadataRef;
 
 pub struct RuleFactory;
 
@@ -50,12 +51,14 @@ impl RuleFactory {
         RuleFactory {}
     }
 
-    pub fn create_rule(&self, id: RuleID) -> Result<RulePtr> {
+    pub fn create_rule(&self, id: RuleID, metadata: Option<MetadataRef>) -> Result<RulePtr> {
         match id {
             RuleID::EliminateEvalScalar => Ok(Box::new(RuleEliminateEvalScalar::new())),
             RuleID::PushDownFilterUnion => Ok(Box::new(RulePushDownFilterUnion::new())),
             RuleID::PushDownFilterEvalScalar => Ok(Box::new(RulePushDownFilterEvalScalar::new())),
-            RuleID::PushDownFilterJoin => Ok(Box::new(RulePushDownFilterJoin::new())),
+            RuleID::PushDownFilterJoin => {
+                Ok(Box::new(RulePushDownFilterJoin::new(metadata.unwrap())))
+            }
             RuleID::PushDownFilterScan => Ok(Box::new(RulePushDownFilterScan::new())),
             RuleID::PushDownLimitUnion => Ok(Box::new(RulePushDownLimitUnion::new())),
             RuleID::PushDownLimitScan => Ok(Box::new(RulePushDownLimitScan::new())),

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
@@ -290,10 +290,9 @@ impl Rule for RulePushDownFilterJoin {
 
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
         // First, try to convert outer join to inner join
-        // Todo(xudong): find a way to avoid type conflict and then open the rule
-        // let mut s_expr = self.convert_outer_to_inner_join(s_expr)?;
+        let mut s_expr = self.convert_outer_to_inner_join(s_expr)?;
         // Second, check if can convert mark join to semi join
-        let s_expr = self.convert_mark_to_semi_join(s_expr)?;
+        s_expr = self.convert_mark_to_semi_join(&s_expr)?;
         let filter: Filter = s_expr.plan().clone().try_into()?;
         if filter.predicates.is_empty() {
             state.add_result(s_expr);

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
@@ -16,21 +16,30 @@ use common_exception::Result;
 use common_expression::type_check::common_super_type;
 use itertools::Itertools;
 
+use crate::binder::satisfied_by;
 use crate::binder::JoinPredicate;
 use crate::optimizer::rule::Rule;
 use crate::optimizer::rule::TransformResult;
 use crate::optimizer::RelExpr;
+use crate::optimizer::RelationalProperty;
 use crate::optimizer::RuleID;
 use crate::optimizer::SExpr;
 use crate::planner::binder::wrap_cast;
+use crate::plans::AggregateFunction;
 use crate::plans::AndExpr;
+use crate::plans::BoundColumnRef;
+use crate::plans::CastExpr;
+use crate::plans::ComparisonExpr;
 use crate::plans::Filter;
+use crate::plans::FunctionCall;
 use crate::plans::Join;
 use crate::plans::JoinType;
+use crate::plans::NotExpr;
 use crate::plans::OrExpr;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
 use crate::plans::ScalarExpr;
+use crate::ColumnBinding;
 use crate::ColumnSet;
 use crate::IndexType;
 
@@ -89,8 +98,21 @@ impl RulePushDownFilterJoin {
             ScalarExpr::BoundColumnRef(column_binding) => {
                 nullable_columns.push(column_binding.column.index);
             }
-            ScalarExpr::AndExpr(_) => {
-                unreachable!("`Scalar::AndExpr` should have been split in binder")
+            ScalarExpr::AndExpr(expr) => {
+                let mut left_cols = vec![];
+                let mut right_cols = vec![];
+                self.find_nullable_columns(
+                    &expr.left,
+                    left_output_columns,
+                    right_output_columns,
+                    &mut left_cols,
+                )?;
+                self.find_nullable_columns(
+                    &expr.right,
+                    left_output_columns,
+                    right_output_columns,
+                    &mut right_cols,
+                )?;
             }
             ScalarExpr::OrExpr(expr) => {
                 let mut left_cols = vec![];
@@ -159,12 +181,12 @@ impl RulePushDownFilterJoin {
     }
 
     #[allow(dead_code)]
-    fn convert_outer_to_inner_join(&self, s_expr: &SExpr) -> Result<SExpr> {
+    fn convert_outer_to_inner_join(&self, s_expr: &SExpr) -> Result<(SExpr, bool)> {
         let filter: Filter = s_expr.plan().clone().try_into()?;
         let mut join: Join = s_expr.child(0)?.plan().clone().try_into()?;
         let origin_join_type = join.join_type.clone();
         if !origin_join_type.is_outer_join() {
-            return Ok(s_expr.clone());
+            return Ok((s_expr.clone(), false));
         }
         let s_join_expr = s_expr.child(0)?;
         let join_expr = RelExpr::with_s_expr(s_join_expr);
@@ -222,7 +244,7 @@ impl RulePushDownFilterJoin {
 
         let changed_join_type = join.join_type.clone();
         if origin_join_type == changed_join_type {
-            return Ok(s_expr.clone());
+            return Ok((s_expr.clone(), false));
         }
         let mut result = SExpr::create_binary(
             join.into(),
@@ -231,7 +253,7 @@ impl RulePushDownFilterJoin {
         );
         // wrap filter s_expr
         result = SExpr::create_unary(filter.into(), result);
-        Ok(result)
+        Ok((result, true))
     }
 
     fn convert_mark_to_semi_join(&self, s_expr: &SExpr) -> Result<SExpr> {
@@ -290,7 +312,20 @@ impl Rule for RulePushDownFilterJoin {
 
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
         // First, try to convert outer join to inner join
-        let mut s_expr = self.convert_outer_to_inner_join(s_expr)?;
+        let join: Join = s_expr.child(0)?.plan().clone().try_into()?;
+        let origin_join_type = join.join_type;
+        let (mut s_expr, converted) = self.convert_outer_to_inner_join(s_expr)?;
+        if converted {
+            // If outer join is converted to inner join, we need to change datatype of filter predicate
+            let mut filter: Filter = s_expr.plan().clone().try_into()?;
+            let mut new_predicates = Vec::with_capacity(filter.predicates.len());
+            for predicate in filter.predicates.iter() {
+                let new_predicate = remove_nullable(&s_expr, predicate, &origin_join_type)?;
+                new_predicates.push(new_predicate);
+            }
+            filter.predicates = new_predicates;
+            s_expr = SExpr::create_unary(filter.into(), s_expr.child(0)?.clone())
+        }
         // Second, check if can convert mark join to semi join
         s_expr = self.convert_mark_to_semi_join(&s_expr)?;
         let filter: Filter = s_expr.plan().clone().try_into()?;
@@ -546,5 +581,133 @@ fn make_or_expr(scalars: &[ScalarExpr]) -> ScalarExpr {
         left: Box::new(scalars[0].clone()),
         right: Box::new(make_or_expr(&scalars[1..])),
         return_type: Box::new(scalars[0].data_type()),
+    })
+}
+
+fn remove_nullable(
+    s_expr: &SExpr,
+    predicate: &ScalarExpr,
+    join_type: &JoinType,
+) -> Result<ScalarExpr> {
+    let join_expr = s_expr.child(0)?;
+
+    let rel_expr = RelExpr::with_s_expr(join_expr);
+    let left_prop = rel_expr.derive_relational_prop_child(0)?;
+    let right_prop = rel_expr.derive_relational_prop_child(1)?;
+
+    remove_column_nullable(predicate, &left_prop, &right_prop, join_type)
+}
+
+fn remove_column_nullable(
+    scalar_expr: &ScalarExpr,
+    left_prop: &RelationalProperty,
+    right_prop: &RelationalProperty,
+    join_type: &JoinType,
+) -> Result<ScalarExpr> {
+    Ok(match scalar_expr {
+        ScalarExpr::BoundColumnRef(column) => {
+            let mut data_type = column.column.data_type.clone();
+            match join_type {
+                JoinType::Left => {
+                    if satisfied_by(scalar_expr, right_prop) {
+                        data_type = Box::new(column.column.data_type.remove_nullable());
+                    }
+                }
+                JoinType::Right => {
+                    if satisfied_by(scalar_expr, left_prop) {
+                        data_type = Box::new(column.column.data_type.remove_nullable());
+                    }
+                }
+                JoinType::Full => data_type = Box::new(column.column.data_type.remove_nullable()),
+                _ => {}
+            };
+            ScalarExpr::BoundColumnRef(BoundColumnRef {
+                column: ColumnBinding {
+                    database_name: column.column.database_name.clone(),
+                    table_name: column.column.table_name.clone(),
+                    column_name: column.column.column_name.clone(),
+                    index: column.column.index,
+                    data_type,
+                    visibility: column.column.visibility.clone(),
+                },
+            })
+        }
+        ScalarExpr::AndExpr(expr) => {
+            let left_expr = remove_column_nullable(&expr.left, left_prop, right_prop, join_type)?;
+            let right_expr = remove_column_nullable(&expr.right, left_prop, right_prop, join_type)?;
+            ScalarExpr::AndExpr(AndExpr {
+                left: Box::new(left_expr),
+                right: Box::new(right_expr),
+                return_type: expr.return_type.clone(),
+            })
+        }
+        ScalarExpr::OrExpr(expr) => {
+            let left_expr = remove_column_nullable(&expr.left, left_prop, right_prop, join_type)?;
+            let right_expr = remove_column_nullable(&expr.right, left_prop, right_prop, join_type)?;
+            ScalarExpr::OrExpr(OrExpr {
+                left: Box::new(left_expr),
+                right: Box::new(right_expr),
+                return_type: expr.return_type.clone(),
+            })
+        }
+        ScalarExpr::NotExpr(expr) => {
+            let new_expr =
+                remove_column_nullable(&expr.argument, left_prop, right_prop, join_type)?;
+            ScalarExpr::NotExpr(NotExpr {
+                argument: Box::new(new_expr),
+                return_type: expr.return_type.clone(),
+            })
+        }
+        ScalarExpr::ComparisonExpr(expr) => {
+            let left_expr = remove_column_nullable(&expr.left, left_prop, right_prop, join_type)?;
+            let right_expr = remove_column_nullable(&expr.right, left_prop, right_prop, join_type)?;
+            ScalarExpr::ComparisonExpr(ComparisonExpr {
+                op: expr.op.clone(),
+                left: Box::new(left_expr),
+                right: Box::new(right_expr),
+                return_type: expr.return_type.clone(),
+            })
+        }
+        ScalarExpr::AggregateFunction(expr) => {
+            let mut args = Vec::with_capacity(expr.args.len());
+            for arg in expr.args.iter() {
+                args.push(remove_column_nullable(
+                    arg, left_prop, right_prop, join_type,
+                )?);
+            }
+            ScalarExpr::AggregateFunction(AggregateFunction {
+                display_name: expr.display_name.clone(),
+                func_name: expr.func_name.clone(),
+                distinct: expr.distinct,
+                params: expr.params.clone(),
+                args,
+                return_type: expr.return_type.clone(),
+            })
+        }
+        ScalarExpr::FunctionCall(expr) => {
+            let mut args = Vec::with_capacity(expr.arguments.len());
+            for arg in expr.arguments.iter() {
+                args.push(remove_column_nullable(
+                    arg, left_prop, right_prop, join_type,
+                )?);
+            }
+            ScalarExpr::FunctionCall(FunctionCall {
+                params: expr.params.clone(),
+                arguments: args,
+                func_name: expr.func_name.clone(),
+                return_type: expr.return_type.clone(),
+            })
+        }
+        ScalarExpr::CastExpr(expr) => {
+            let new_expr =
+                remove_column_nullable(&expr.argument, left_prop, right_prop, join_type)?;
+            ScalarExpr::CastExpr(CastExpr {
+                is_try: expr.is_try,
+                argument: Box::new(new_expr),
+                from_type: expr.from_type.clone(),
+                target_type: expr.target_type.clone(),
+            })
+        }
+        ScalarExpr::ConstantExpr(_) | ScalarExpr::SubqueryExpr(_) => scalar_expr.clone(),
     })
 }

--- a/src/query/sql/src/planner/optimizer/rule/rule_set.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rule_set.rs
@@ -41,7 +41,7 @@ impl RuleSet {
             if rule_set.contains(&id) {
                 return Err(ErrorCode::Internal(format!("Duplicated Rule: {id}",)));
             }
-            rule_set.insert(factory.create_rule(id)?);
+            rule_set.insert(factory.create_rule(id, None)?);
         }
 
         Ok(rule_set)

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -75,6 +75,7 @@ use crate::plans::OrExpr;
 use crate::plans::ScalarExpr;
 use crate::plans::SubqueryExpr;
 use crate::plans::SubqueryType;
+use crate::BaseTableColumn;
 use crate::BindContext;
 use crate::ColumnBinding;
 use crate::ColumnEntry;
@@ -1821,7 +1822,9 @@ impl<'a> TypeChecker<'a> {
         if let Expr::ColumnRef { column: ident, .. } = expr {
             if let ScalarExpr::BoundColumnRef(BoundColumnRef { ref column }) = scalar {
                 let column_entry = self.metadata.read().column(column.index).clone();
-                if let ColumnEntry::BaseTableColumn { data_type, .. } = column_entry {
+                if let ColumnEntry::BaseTableColumn(BaseTableColumn { data_type, .. }) =
+                    column_entry
+                {
                     table_data_type = data_type;
                     if let TableDataType::Tuple { .. } = table_data_type {
                         let box (inner_scalar, _inner_data_type) = self

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -207,95 +207,95 @@ INSERT INTO twocolumn(x, y) VALUES (44,51), (NULL,52), (42,53), (45,45)
 query T
 explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where b.x > 42
 ----
-Filter
-├── filters: [gt(b.x (#1), CAST(42 AS Int32 NULL))]
-├── estimated rows: 2.67
-└── HashJoin
-    ├── join type: LEFT OUTER
-    ├── build keys: [b.x (#1)]
-    ├── probe keys: [a.x (#0)]
-    ├── filters: []
-    ├── estimated rows: 4.00
-    ├── TableScan(Build)
-    │   ├── table: default.default.twocolumn
-    │   ├── read rows: 4
-    │   ├── read bytes: 94
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    │   ├── push downs: [filters: [], limit: NONE]
-    │   └── estimated rows: 4.00
-    └── TableScan(Probe)
-        ├── table: default.default.onecolumn
-        ├── read rows: 4
-        ├── read bytes: 45
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-        ├── push downs: [filters: [], limit: NONE]
-        └── estimated rows: 4.00
+HashJoin
+├── join type: INNER
+├── build keys: [b.x (#1)]
+├── probe keys: [a.x (#0)]
+├── filters: []
+├── estimated rows: 1.00
+├── Filter(Build)
+│   ├── filters: [gt(b.x (#1), CAST(42 AS Int32 NULL))]
+│   ├── estimated rows: 2.67
+│   └── TableScan
+│       ├── table: default.default.twocolumn
+│       ├── read rows: 4
+│       ├── read bytes: 94
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+│       ├── push downs: [filters: [gt(b.x (#1), 42)], limit: NONE]
+│       └── estimated rows: 4.00
+└── TableScan(Probe)
+    ├── table: default.default.onecolumn
+    ├── read rows: 4
+    ├── read bytes: 45
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 4.00
 
 query T
 explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where b.x > 44 or b.x < 43
 ----
-Filter
-├── filters: [or(gt(b.x (#1), CAST(44 AS Int32 NULL)), lt(b.x (#1), CAST(43 AS Int32 NULL)))]
-├── estimated rows: 2.22
-└── HashJoin
-    ├── join type: LEFT OUTER
-    ├── build keys: [b.x (#1)]
-    ├── probe keys: [a.x (#0)]
-    ├── filters: []
-    ├── estimated rows: 4.00
-    ├── TableScan(Build)
-    │   ├── table: default.default.twocolumn
-    │   ├── read rows: 4
-    │   ├── read bytes: 94
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    │   ├── push downs: [filters: [], limit: NONE]
-    │   └── estimated rows: 4.00
-    └── TableScan(Probe)
-        ├── table: default.default.onecolumn
-        ├── read rows: 4
-        ├── read bytes: 45
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-        ├── push downs: [filters: [], limit: NONE]
-        └── estimated rows: 4.00
+HashJoin
+├── join type: INNER
+├── build keys: [b.x (#1)]
+├── probe keys: [a.x (#0)]
+├── filters: []
+├── estimated rows: 1.00
+├── Filter(Build)
+│   ├── filters: [or(gt(b.x (#1), CAST(44 AS Int32 NULL)), lt(b.x (#1), CAST(43 AS Int32 NULL)))]
+│   ├── estimated rows: 2.22
+│   └── TableScan
+│       ├── table: default.default.twocolumn
+│       ├── read rows: 4
+│       ├── read bytes: 94
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+│       ├── push downs: [filters: [or(gt(b.x (#1), 44), lt(b.x (#1), 43))], limit: NONE]
+│       └── estimated rows: 4.00
+└── TableScan(Probe)
+    ├── table: default.default.onecolumn
+    ├── read rows: 4
+    ├── read bytes: 45
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 4.00
 
 query T
 explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where b.x > 42 and b.x < 45
 ----
-Filter
-├── filters: [gt(b.x (#1), CAST(42 AS Int32 NULL)), lt(b.x (#1), CAST(45 AS Int32 NULL))]
-├── estimated rows: 1.78
-└── HashJoin
-    ├── join type: LEFT OUTER
-    ├── build keys: [b.x (#1)]
-    ├── probe keys: [a.x (#0)]
-    ├── filters: []
-    ├── estimated rows: 4.00
-    ├── TableScan(Build)
-    │   ├── table: default.default.twocolumn
-    │   ├── read rows: 4
-    │   ├── read bytes: 94
-    │   ├── partitions total: 1
-    │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    │   ├── push downs: [filters: [], limit: NONE]
-    │   └── estimated rows: 4.00
-    └── TableScan(Probe)
-        ├── table: default.default.onecolumn
-        ├── read rows: 4
-        ├── read bytes: 45
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-        ├── push downs: [filters: [], limit: NONE]
-        └── estimated rows: 4.00
+HashJoin
+├── join type: INNER
+├── build keys: [b.x (#1)]
+├── probe keys: [a.x (#0)]
+├── filters: []
+├── estimated rows: 1.00
+├── Filter(Build)
+│   ├── filters: [gt(b.x (#1), CAST(42 AS Int32 NULL)), lt(b.x (#1), CAST(45 AS Int32 NULL))]
+│   ├── estimated rows: 1.78
+│   └── TableScan
+│       ├── table: default.default.twocolumn
+│       ├── read rows: 4
+│       ├── read bytes: 94
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+│       ├── push downs: [filters: [gt(b.x (#1), 42), lt(b.x (#1), 45)], limit: NONE]
+│       └── estimated rows: 4.00
+└── TableScan(Probe)
+    ├── table: default.default.onecolumn
+    ├── read rows: 4
+    ├── read bytes: 45
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 4.00
 
 # the following cases won't be converted to inner join
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

### Background

This SQL is an example: `SELECT t1.c0boolean, t0.c0varchar FROM t0 NATURAL LEFT JOIN t1 where t1.c0boolean`

Originally a left join, the column logical type of `t1` is converted to nullable at the binder stage. 

But if `outer join -> inner join`. where condition will be pushed down. However, the physical type of t1's column is not nullable. This results in a type mismatch.
  
(Note also that `t1` may have been of type `c0boolean` when the table was created)

Closes https://github.com/datafuselabs/databend/issues/9925
