### PR TITLE
feat: support multiple jwt sources in databend query

### DIFF
--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -170,6 +170,7 @@ pub struct QueryConfig {
     /// If in management mode, only can do some meta level operations(database/table/user/stage etc.) with metasrv.
     pub management_mode: bool,
     pub jwt_key_file: String,
+    pub additional_jwt_key_files: Vec<String>,
     pub async_insert_max_data_size: u64,
     pub async_insert_busy_timeout: u64,
     pub async_insert_stale_timeout: u64,
@@ -224,6 +225,7 @@ impl Default for QueryConfig {
             table_cache_bloom_index_filter_count: 1024 * 1024,
             management_mode: false,
             jwt_key_file: "".to_string(),
+            additional_jwt_key_files: Vec::new(),
             async_insert_max_data_size: 10000,
             async_insert_busy_timeout: 200,
             async_insert_stale_timeout: 0,

--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -1308,6 +1308,10 @@ pub struct QueryConfig {
     #[clap(long, default_value_t)]
     pub jwt_key_file: String,
 
+    /// If there are multiple trusted jwt provider put it into additonal_jwt_key_files configuration
+    #[clap(skip)]
+    pub additional_jwt_key_files: Vec<String>,
+
     /// The maximum memory size of the buffered data collected per insert before being inserted.
     #[clap(long, default_value = "10000")]
     pub async_insert_max_data_size: u64,
@@ -1388,6 +1392,7 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
             table_cache_bloom_index_filter_count: self.table_cache_bloom_index_filter_count,
             management_mode: self.management_mode,
             jwt_key_file: self.jwt_key_file,
+            additional_jwt_key_files: self.additional_jwt_key_files,
             async_insert_max_data_size: self.async_insert_max_data_size,
             async_insert_busy_timeout: self.async_insert_busy_timeout,
             async_insert_stale_timeout: self.async_insert_stale_timeout,
@@ -1453,6 +1458,7 @@ impl From<InnerQueryConfig> for QueryConfig {
             table_cache_bloom_index_filter_count: inner.table_cache_bloom_index_filter_count,
             management_mode: inner.management_mode,
             jwt_key_file: inner.jwt_key_file,
+            additional_jwt_key_files: inner.additional_jwt_key_files,
             async_insert_max_data_size: inner.async_insert_max_data_size,
             async_insert_busy_timeout: inner.async_insert_busy_timeout,
             async_insert_stale_timeout: inner.async_insert_stale_timeout,

--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -43,7 +43,10 @@ pub enum Credential {
 impl AuthMgr {
     pub fn create(cfg: &Config) -> Result<Arc<AuthMgr>> {
         Ok(Arc::new(AuthMgr {
-            jwt_auth: JwtAuthenticator::try_create(cfg.query.jwt_key_file.clone())?,
+            jwt_auth: JwtAuthenticator::try_create(
+                cfg.query.jwt_key_file.clone(),
+                cfg.query.additional_jwt_key_files.clone(),
+            )?,
         }))
     }
 

--- a/src/query/service/tests/it/auth.rs
+++ b/src/query/service/tests/it/auth.rs
@@ -30,6 +30,130 @@ use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::ResponseTemplate;
 
+fn get_jwks_file_rs256(kid: &str) -> (RS256KeyPair, String) {
+    let key_pair = RS256KeyPair::generate(2048).unwrap().with_key_id(kid);
+    let rsa_components = key_pair.public_key().to_components();
+    let e = encode_config(rsa_components.e, URL_SAFE_NO_PAD);
+    let n = encode_config(rsa_components.n, URL_SAFE_NO_PAD);
+    let j =
+        serde_json::json!({"keys": [ {"kty": "RSA", "kid": kid, "e": e, "n": n, } ] }).to_string();
+    (key_pair, j)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_auth_mgr_with_jwt_multi_sources() -> Result<()> {
+    let (pair1, pbkey1) = get_jwks_file_rs256("test_kid");
+    let (pair2, pbkey2) = get_jwks_file_rs256("second_kid");
+    let (pair3, _) = get_jwks_file_rs256("illegal_kid");
+
+    let template1 = ResponseTemplate::new(200).set_body_raw(pbkey1, "application/json");
+    let template2 = ResponseTemplate::new(200).set_body_raw(pbkey2, "application/json");
+    let json_path = "/jwks.json";
+    let second_path = "/plugins/jwks.json";
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(json_path))
+        .respond_with(template1)
+        .expect(1..)
+        // Mounting the mock on the mock server - it's now effective!
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(second_path))
+        .respond_with(template2)
+        .expect(1..)
+        // Mounting the mock on the mock server - it's now effective!
+        .mount(&server)
+        .await;
+    let mut conf = crate::tests::ConfigBuilder::create().config();
+    let first_url = format!("http://{}{}", server.address(), json_path);
+    let second_url = format!("http://{}{}", server.address(), second_path);
+    conf.query.jwt_key_file = first_url.clone();
+    conf.query.additional_jwt_key_files = vec![second_url];
+    let (_guard, ctx) = crate::tests::create_query_context_with_config(conf, None).await?;
+    let auth_mgr = ctx.get_auth_manager();
+    {
+        let user_name = "test-user2";
+        let role_name = "test-role";
+        let custom_claims = CustomClaims::new()
+            .with_ensure_user(EnsureUser {
+                roles: Some(vec![role_name.to_string()]),
+            })
+            .with_role("test-auth-role");
+        let claims = Claims::with_custom_claims(custom_claims, Duration::from_hours(2))
+            .with_subject(user_name.to_string());
+        let token1 = pair1.sign(claims)?;
+
+        let res = auth_mgr
+            .auth(ctx.get_current_session(), &Credential::Jwt {
+                token: token1,
+                hostname: None,
+            })
+            .await;
+        assert!(res.is_ok());
+
+        let roles: Vec<String> = ctx
+            .get_current_session()
+            .get_all_available_roles()
+            .await?
+            .into_iter()
+            .map(|r| r.name)
+            .collect();
+        assert_eq!(roles.len(), 1);
+        assert!(!roles.contains(&"test-auth-role".to_string()));
+        let claim2 = CustomClaims::new()
+            .with_ensure_user(EnsureUser {
+                roles: Some(vec![role_name.to_string()]),
+            })
+            .with_role("test-auth-role2");
+        let user2 = "candidate_by_keypair2";
+        let claims = Claims::with_custom_claims(claim2, Duration::from_hours(2))
+            .with_subject(user2.to_string());
+        let token2 = pair2.sign(claims)?;
+        let res = auth_mgr
+            .auth(ctx.get_current_session(), &Credential::Jwt {
+                token: token2,
+                hostname: None,
+            })
+            .await;
+        assert!(res.is_ok());
+
+        let roles: Vec<String> = ctx
+            .get_current_session()
+            .get_all_available_roles()
+            .await?
+            .into_iter()
+            .map(|r| r.name)
+            .collect();
+        assert_eq!(roles.len(), 1);
+        assert!(!roles.contains(&"test-auth-role2".to_string()));
+
+        let claim3 = CustomClaims::new()
+            .with_ensure_user(EnsureUser {
+                roles: Some(vec![role_name.to_string()]),
+            })
+            .with_role("test-auth-role3");
+        let user3 = "candidate_by_keypair3";
+        let claims = Claims::with_custom_claims(claim3, Duration::from_hours(2))
+            .with_subject(user3.to_string());
+        let token3 = pair3.sign(claims)?;
+        let res3 = auth_mgr
+            .auth(ctx.get_current_session(), &Credential::Jwt {
+                token: token3,
+                hostname: None,
+            })
+            .await;
+        assert!(res3.is_err());
+        assert!(
+            res3.err()
+                .unwrap()
+                .to_string()
+                .contains("could not decode token from all available jwt key stores")
+        );
+    }
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_auth_mgr_with_jwt() -> Result<()> {
     let kid = "test_kid";
@@ -72,9 +196,12 @@ async fn test_auth_mgr_with_jwt() -> Result<()> {
             })
             .await;
         assert!(res.is_err());
-        assert_eq!(
-            "Code: 1051, displayText = missing field `subject` in jwt.",
-            res.err().unwrap().to_string()
+
+        assert!(
+            res.err()
+                .unwrap()
+                .to_string()
+                .contains("missing field `subject` in jwt")
         );
     }
 
@@ -90,9 +217,12 @@ async fn test_auth_mgr_with_jwt() -> Result<()> {
             })
             .await;
         assert!(res.is_err());
-        assert_eq!(
-            "Code: 2201, displayText = unknown user 'test'@'%'.",
-            res.err().unwrap().to_string()
+
+        assert!(
+            res.err()
+                .unwrap()
+                .to_string()
+                .contains("unknown user 'test'@'%'")
         );
     }
 
@@ -110,9 +240,12 @@ async fn test_auth_mgr_with_jwt() -> Result<()> {
             })
             .await;
         assert!(res.is_err());
-        assert_eq!(
-            "Code: 2201, displayText = unknown user 'test'@'%'.",
-            res.err().unwrap().to_string()
+
+        assert!(
+            res.err()
+                .unwrap()
+                .to_string()
+                .contains("unknown user 'test'@'%'")
         );
     }
 
@@ -238,9 +371,12 @@ async fn test_auth_mgr_with_jwt() -> Result<()> {
             })
             .await;
         assert!(res.is_err());
-        assert_eq!(
-            "Code: 2201, displayText = only accept root from localhost, current: 'root'@'%'.",
-            res.err().unwrap().to_string()
+
+        assert!(
+            res.err()
+                .unwrap()
+                .to_string()
+                .contains("only accept root from localhost, current: 'root'@'%'")
         );
     }
 
@@ -291,9 +427,12 @@ async fn test_auth_mgr_with_jwt_es256() -> Result<()> {
             })
             .await;
         assert!(res.is_err());
-        assert_eq!(
-            "Code: 1051, displayText = missing field `subject` in jwt.",
-            res.err().unwrap().to_string()
+
+        assert!(
+            res.err()
+                .unwrap()
+                .to_string()
+                .contains("missing field `subject` in jwt")
         );
     }
 
@@ -309,9 +448,11 @@ async fn test_auth_mgr_with_jwt_es256() -> Result<()> {
             })
             .await;
         assert!(res.is_err());
-        assert_eq!(
-            "Code: 2201, displayText = unknown user 'test'@'%'.",
-            res.err().unwrap().to_string()
+        assert!(
+            res.err()
+                .unwrap()
+                .to_string()
+                .contains("unknown user 'test'@'%'")
         );
     }
 
@@ -329,9 +470,11 @@ async fn test_auth_mgr_with_jwt_es256() -> Result<()> {
             })
             .await;
         assert!(res.is_err());
-        assert_eq!(
-            "Code: 2201, displayText = unknown user 'test'@'%'.",
-            res.err().unwrap().to_string()
+        assert!(
+            res.err()
+                .unwrap()
+                .to_string()
+                .contains("unknown user 'test'@'%'")
         );
     }
 
@@ -457,9 +600,11 @@ async fn test_auth_mgr_with_jwt_es256() -> Result<()> {
             })
             .await;
         assert!(res.is_err());
-        assert_eq!(
-            "Code: 2201, displayText = only accept root from localhost, current: 'root'@'%'.",
-            res.err().unwrap().to_string()
+        assert!(
+            res.err()
+                .unwrap()
+                .to_string()
+                .contains("only accept root from localhost, current: 'root'@'%'")
         );
     }
 

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -22,6 +22,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | "meta"    | "rpc_tls_meta_server_root_ca_cert"     | ""                               | ""       |
 | "meta"    | "rpc_tls_meta_service_domain_name"     | "localhost"                      | ""       |
 | "meta"    | "username"                             | "root"                           | ""       |
+| "query"   | "additional_jwt_key_files"             | ""                               | ""       |
 | "query"   | "admin_api_address"                    | "127.0.0.1:8080"                 | ""       |
 | "query"   | "api_tls_server_cert"                  | ""                               | ""       |
 | "query"   | "api_tls_server_key"                   | ""                               | ""       |

--- a/src/query/users/src/jwt/authenticator.rs
+++ b/src/query/users/src/jwt/authenticator.rs
@@ -32,7 +32,7 @@ pub enum PubKey {
 
 pub struct JwtAuthenticator {
     // Todo(youngsofun): verify settings, like issuer
-    key_store: jwk::JwkKeyStore,
+    key_stores: Vec<jwk::JwkKeyStore>,
 }
 
 #[derive(Default, Deserialize, Serialize)]
@@ -73,16 +73,27 @@ impl CustomClaims {
 }
 
 impl JwtAuthenticator {
-    pub fn try_create(jwt_key_file: String) -> Result<Option<Self>> {
+    pub fn try_create(
+        jwt_key_file: String,
+        additional_jwt_key_files: Vec<String>,
+    ) -> Result<Option<Self>> {
         if jwt_key_file.is_empty() {
             return Ok(None);
         }
-        let key_store = jwk::JwkKeyStore::new(jwt_key_file);
-        Ok(Some(JwtAuthenticator { key_store }))
+        // init a vec of key store
+        let mut key_stores = vec![jwk::JwkKeyStore::new(jwt_key_file)];
+        for u in additional_jwt_key_files {
+            key_stores.push(jwk::JwkKeyStore::new(u))
+        }
+        Ok(Some(JwtAuthenticator { key_stores }))
     }
 
-    pub async fn parse_jwt_claims(&self, token: &str) -> Result<JWTClaims<CustomClaims>> {
-        let pub_key = self.key_store.get_key(None).await?;
+    pub async fn parse_jwt_claims_from_store(
+        &self,
+        token: &str,
+        key_store: &jwk::JwkKeyStore,
+    ) -> Result<JWTClaims<CustomClaims>> {
+        let pub_key = key_store.get_key(None).await?;
         let r = match &pub_key {
             PubKey::RSA256(pk) => pk.verify_token::<CustomClaims>(token, None),
             PubKey::ES256(pk) => pk.verify_token::<CustomClaims>(token, None),
@@ -94,5 +105,25 @@ impl JwtAuthenticator {
             )),
             Some(_) => Ok(c),
         }
+    }
+    pub async fn parse_jwt_claims(&self, token: &str) -> Result<JWTClaims<CustomClaims>> {
+        let mut combined_code = ErrorCode::AuthenticateFailure(
+            "could not decode token from all available jwt key stores. ",
+        );
+        for store in &self.key_stores {
+            let claim = self.parse_jwt_claims_from_store(token, store).await;
+            match claim {
+                Ok(e) => return Ok(e),
+                Err(e) => {
+                    combined_code = combined_code.add_message(format!(
+                        "message: {} , source file: {}, ",
+                        e,
+                        store.url()
+                    ));
+                    continue;
+                }
+            }
+        }
+        Err(combined_code)
     }
 }

--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -109,6 +109,9 @@ impl JwkKeyStore {
             last_refreshed_at: RwLock::new(None),
         }
     }
+    pub fn url(&self) -> String {
+        self.url.clone()
+    }
 }
 
 impl JwkKeyStore {

--- a/src/query/users/src/lib.rs
+++ b/src/query/users/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(let_chains)]
 // Copyright 2021 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +12,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #![allow(clippy::uninlined_format_args)]
+
+extern crate core;
 
 mod jwt;
 mod role_mgr;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
1. add additonal_jwt_key_files configuration
2. refactored authenticator to use multiple jwt sources instead of a single one.
3. add tests verifies the following behavior :

- [X] signed token could be verified and create user/role with additional_jwt_key_files, 
- [X] signed token could not be verified if the jwt_key_file is not in the support list

Closes #issue
