### PR TITLE
feat(query): Support `array_any` functions

### DIFF
--- a/src/query/functions/tests/it/scalars/array.rs
+++ b/src/query/functions/tests/it/scalars/array.rs
@@ -43,6 +43,7 @@ fn test_array() {
     test_array_count(file);
     test_array_max(file);
     test_array_min(file);
+    test_array_any(file);
 }
 
 fn test_create(file: &mut impl Write) {
@@ -83,6 +84,15 @@ fn test_get(file: &mut impl Write) {
 }
 
 fn test_slice(file: &mut impl Write) {
+    run_ast(file, "slice([], 1)", &[]);
+    run_ast(file, "slice([0, 1, 2, 3], 2)", &[]);
+    run_ast(file, "slice(['a', 'b', 'c', 'd'], 3)", &[]);
+    run_ast(file, "slice([a, b, c], 2)", &[
+        ("a", Int16Type::from_data(vec![0i16, 1, 2])),
+        ("b", Int16Type::from_data(vec![3i16, 4, 5])),
+        ("c", Int16Type::from_data(vec![7i16, 8, 9])),
+    ]);
+
     run_ast(file, "slice([], 1, 2)", &[]);
     run_ast(file, "slice([1], 1, 2)", &[]);
     run_ast(file, "slice([NULL, 1, 2, 3], 0, 2)", &[]);
@@ -418,6 +428,40 @@ fn test_array_min(file: &mut impl Write) {
     ]);
 
     run_ast(file, "array_min([a, b, c, d])", &[
+        (
+            "a",
+            UInt64Type::from_data_with_validity(vec![1u64, 2, 0, 4], vec![true, true, false, true]),
+        ),
+        (
+            "b",
+            UInt64Type::from_data_with_validity(vec![2u64, 0, 5, 6], vec![true, false, true, true]),
+        ),
+        (
+            "c",
+            UInt64Type::from_data_with_validity(vec![3u64, 7, 8, 9], vec![true, true, true, true]),
+        ),
+        (
+            "d",
+            UInt64Type::from_data_with_validity(vec![4u64, 6, 5, 0], vec![true, true, true, false]),
+        ),
+    ]);
+}
+
+fn test_array_any(file: &mut impl Write) {
+    run_ast(file, "array_any([])", &[]);
+    run_ast(file, "array_any([1, 2, 3])", &[]);
+    run_ast(file, "array_any([NULL, 3, 2, 1])", &[]);
+    run_ast(file, "array_any(['a', 'b', 'c'])", &[]);
+    run_ast(file, "array_any([NULL, 'x', 'y', 'z'])", &[]);
+
+    run_ast(file, "array_any([a, b, c, d])", &[
+        ("a", Int16Type::from_data(vec![1i16, 5, 8, 3])),
+        ("b", Int16Type::from_data(vec![2i16, 6, 1, 2])),
+        ("c", Int16Type::from_data(vec![3i16, 7, 7, 6])),
+        ("d", Int16Type::from_data(vec![4i16, 8, 1, 9])),
+    ]);
+
+    run_ast(file, "array_any([a, b, c, d])", &[
         (
             "a",
             UInt64Type::from_data_with_validity(vec![1u64, 2, 0, 4], vec![true, true, false, true]),

--- a/src/query/functions/tests/it/scalars/testdata/array.txt
+++ b/src/query/functions/tests/it/scalars/testdata/array.txt
@@ -201,6 +201,58 @@ evaluation (internal):
 +--------+---------------------------------------------------------------------+
 
 
+ast            : slice([], 1)
+raw expr       : slice(array(), 1_u8)
+checked expr   : slice<Array(Nothing), UInt64>(array<>(), to_uint64<UInt8>(1_u8))
+optimized expr : [] :: Array(Nothing)
+output type    : Array(Nothing)
+output domain  : []
+output         : []
+
+
+ast            : slice([0, 1, 2, 3], 2)
+raw expr       : slice(array(0_u8, 1_u8, 2_u8, 3_u8), 2_u8)
+checked expr   : slice<T0=UInt8><Array(T0), UInt64>(array<T0=UInt8><T0, T0, T0, T0>(0_u8, 1_u8, 2_u8, 3_u8), to_uint64<UInt8>(2_u8))
+optimized expr : [1, 2, 3]
+output type    : Array(UInt8)
+output domain  : [{1..=3}]
+output         : [1, 2, 3]
+
+
+ast            : slice(['a', 'b', 'c', 'd'], 3)
+raw expr       : slice(array("a", "b", "c", "d"), 3_u8)
+checked expr   : slice<T0=String><Array(T0), UInt64>(array<T0=String><T0, T0, T0, T0>("a", "b", "c", "d"), to_uint64<UInt8>(3_u8))
+optimized expr : ["c", "d"]
+output type    : Array(String)
+output domain  : [{"c"..="d"}]
+output         : ["c", "d"]
+
+
+ast            : slice([a, b, c], 2)
+raw expr       : slice(array(a::Int16, b::Int16, c::Int16), 2_u8)
+checked expr   : slice<T0=Int16><Array(T0), UInt64>(array<T0=Int16><T0, T0, T0>(a, b, c), to_uint64<UInt8>(2_u8))
+optimized expr : slice<T0=Int16><Array(T0), UInt64>(array<T0=Int16><T0, T0, T0>(a, b, c), 2_u64)
+evaluation:
++--------+---------+---------+---------+--------------+
+|        | a       | b       | c       | Output       |
++--------+---------+---------+---------+--------------+
+| Type   | Int16   | Int16   | Int16   | Array(Int16) |
+| Domain | {0..=2} | {3..=5} | {7..=9} | [{0..=9}]    |
+| Row 0  | 0       | 3       | 7       | [3, 7]       |
+| Row 1  | 1       | 4       | 8       | [4, 8]       |
+| Row 2  | 2       | 5       | 9       | [5, 9]       |
++--------+---------+---------+---------+--------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------+
+| Column | Data                                                                     |
++--------+--------------------------------------------------------------------------+
+| a      | Int16([0, 1, 2])                                                         |
+| b      | Int16([3, 4, 5])                                                         |
+| c      | Int16([7, 8, 9])                                                         |
+| Output | ArrayColumn { values: Int16([3, 7, 4, 8, 5, 9]), offsets: [0, 2, 4, 6] } |
++--------+--------------------------------------------------------------------------+
+
+
 ast            : slice([], 1, 2)
 raw expr       : slice(array(), 1_u8, 2_u8)
 checked expr   : slice<Array(Nothing), UInt64, UInt64>(array<>(), to_uint64<UInt8>(1_u8), to_uint64<UInt8>(2_u8))
@@ -1503,6 +1555,103 @@ evaluation (internal):
 ast            : array_min([a, b, c, d])
 raw expr       : array_min(array(a::UInt64 NULL, b::UInt64 NULL, c::UInt64 NULL, d::UInt64 NULL))
 checked expr   : array_min<Array(UInt64 NULL)>(array<T0=UInt64 NULL><T0, T0, T0, T0>(a, b, c, d))
+evaluation:
++--------+------------------+------------------+-------------+------------------+-------------+
+|        | a                | b                | c           | d                | Output      |
++--------+------------------+------------------+-------------+------------------+-------------+
+| Type   | UInt64 NULL      | UInt64 NULL      | UInt64 NULL | UInt64 NULL      | UInt64 NULL |
+| Domain | {0..=4} ∪ {NULL} | {0..=6} ∪ {NULL} | {3..=9}     | {0..=6} ∪ {NULL} | Unknown     |
+| Row 0  | 1                | 2                | 3           | 4                | 1           |
+| Row 1  | 2                | NULL             | 7           | 6                | 2           |
+| Row 2  | NULL             | 5                | 8           | 5                | 5           |
+| Row 3  | 4                | 6                | 9           | NULL             | 4           |
++--------+------------------+------------------+-------------+------------------+-------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------+
+| Column | Data                                                                    |
++--------+-------------------------------------------------------------------------+
+| a      | NullableColumn { column: UInt64([1, 2, 0, 4]), validity: [0b____1011] } |
+| b      | NullableColumn { column: UInt64([2, 0, 5, 6]), validity: [0b____1101] } |
+| c      | NullableColumn { column: UInt64([3, 7, 8, 9]), validity: [0b____1111] } |
+| d      | NullableColumn { column: UInt64([4, 6, 5, 0]), validity: [0b____0111] } |
+| Output | NullableColumn { column: UInt64([1, 2, 5, 4]), validity: [0b____1111] } |
++--------+-------------------------------------------------------------------------+
+
+
+ast            : array_any([])
+raw expr       : array_any(array())
+checked expr   : array_any<Array(Nothing)>(array<>())
+optimized expr : NULL
+output type    : NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : array_any([1, 2, 3])
+raw expr       : array_any(array(1_u8, 2_u8, 3_u8))
+checked expr   : array_any<Array(UInt8)>(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8))
+optimized expr : 1_u8
+output type    : UInt8 NULL
+output domain  : {1..=1}
+output         : 1
+
+
+ast            : array_any([NULL, 3, 2, 1])
+raw expr       : array_any(array(NULL, 3_u8, 2_u8, 1_u8))
+checked expr   : array_any<Array(UInt8 NULL)>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(NULL AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(1_u8 AS UInt8 NULL)))
+optimized expr : 3_u8
+output type    : UInt8 NULL
+output domain  : {3..=3}
+output         : 3
+
+
+ast            : array_any(['a', 'b', 'c'])
+raw expr       : array_any(array("a", "b", "c"))
+checked expr   : array_any<Array(String)>(array<T0=String><T0, T0, T0>("a", "b", "c"))
+optimized expr : "a"
+output type    : String NULL
+output domain  : {"a"..="a"}
+output         : "a"
+
+
+ast            : array_any([NULL, 'x', 'y', 'z'])
+raw expr       : array_any(array(NULL, "x", "y", "z"))
+checked expr   : array_any<Array(String NULL)>(array<T0=String NULL><T0, T0, T0, T0>(CAST(NULL AS String NULL), CAST("x" AS String NULL), CAST("y" AS String NULL), CAST("z" AS String NULL)))
+optimized expr : "x"
+output type    : String NULL
+output domain  : {"x"..="x"}
+output         : "x"
+
+
+ast            : array_any([a, b, c, d])
+raw expr       : array_any(array(a::Int16, b::Int16, c::Int16, d::Int16))
+checked expr   : array_any<Array(Int16)>(array<T0=Int16><T0, T0, T0, T0>(a, b, c, d))
+evaluation:
++--------+---------+---------+---------+---------+------------+
+|        | a       | b       | c       | d       | Output     |
++--------+---------+---------+---------+---------+------------+
+| Type   | Int16   | Int16   | Int16   | Int16   | Int16 NULL |
+| Domain | {1..=8} | {1..=6} | {3..=7} | {1..=9} | Unknown    |
+| Row 0  | 1       | 2       | 3       | 4       | 1          |
+| Row 1  | 5       | 6       | 7       | 8       | 5          |
+| Row 2  | 8       | 1       | 7       | 1       | 8          |
+| Row 3  | 3       | 2       | 6       | 9       | 3          |
++--------+---------+---------+---------+---------+------------+
+evaluation (internal):
++--------+------------------------------------------------------------------------+
+| Column | Data                                                                   |
++--------+------------------------------------------------------------------------+
+| a      | Int16([1, 5, 8, 3])                                                    |
+| b      | Int16([2, 6, 1, 2])                                                    |
+| c      | Int16([3, 7, 7, 6])                                                    |
+| d      | Int16([4, 8, 1, 9])                                                    |
+| Output | NullableColumn { column: Int16([1, 5, 8, 3]), validity: [0b____1111] } |
++--------+------------------------------------------------------------------------+
+
+
+ast            : array_any([a, b, c, d])
+raw expr       : array_any(array(a::UInt64 NULL, b::UInt64 NULL, c::UInt64 NULL, d::UInt64 NULL))
+checked expr   : array_any<Array(UInt64 NULL)>(array<T0=UInt64 NULL><T0, T0, T0, T0>(a, b, c, d))
 evaluation:
 +--------+------------------+------------------+-------------+------------------+-------------+
 |        | a                | b                | c           | d                | Output      |

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -2208,6 +2208,10 @@ siphash64(Boolean NULL) :: UInt64 NULL
 siphash64(Variant) :: UInt64
 siphash64(Variant NULL) :: UInt64 NULL
 sleep(Float64) :: UInt8
+slice(Array(Nothing), UInt64) :: Array(Nothing)
+slice(Array(Nothing) NULL, UInt64 NULL) :: Array(Nothing) NULL
+slice(Array(T0), UInt64) :: Array(T0)
+slice(Array(T0) NULL, UInt64 NULL) :: Array(T0) NULL
 slice(Array(Nothing), UInt64, UInt64) :: Array(Nothing)
 slice(Array(Nothing) NULL, UInt64 NULL, UInt64 NULL) :: Array(Nothing) NULL
 slice(Array(T0), UInt64, UInt64) :: Array(T0)
@@ -3145,6 +3149,7 @@ yesterday() :: Date
 
 Factory functions:
 array
+array_any
 array_avg
 array_count
 array_max

--- a/tests/sqllogictests/suites/query/02_function/02_0061_function_array
+++ b/tests/sqllogictests/suites/query/02_function/02_0061_function_array
@@ -16,6 +16,26 @@ create table t(col1 Array(Int Null), col2 Array(String), col3 Array(Date), col4 
 statement ok
 insert into t values([1,2,3,3],['x','x','y','z'], ['2022-02-02'], ['2023-01-01 02:00:01'], [[1,2],[],[null]])
 
+query IIII
+select length(col1), length(col2), length(col3), length(col4) from t
+----
+4 4 1 1
+
+query ITT
+select get(col1, 3), get(col2, 2), get(col3, 1) from t
+----
+3 x 2022-02-02
+
+query TTTT
+select slice(col1, 1), slice(col1, 2, 3), slice(col2, 2), slice(col2, 3, 3) from t
+----
+[1,2,3,3] [2,3] ['x','y','z'] ['y']
+
+query BBB
+select contains(col1, 3), contains(col2, 'x'), contains(col3, '2021-01-01') from t
+----
+1 1 0
+
 query T
 select array_concat(col1, col5) from t
 ----
@@ -98,6 +118,11 @@ select array_max(col1), array_max(col2), array_max(col3) from t
 
 query ITT
 select array_min(col1), array_min(col2), array_min(col3) from t
+----
+1 x 2022-02-02
+
+query ITT
+select array_any(col1), array_any(col2), array_any(col3) from t
 ----
 1 x 2022-02-02
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Support `array_any` function
- Support `slice` function with two arguments
- Add some logical tests for array functions

part of #7931
