### PR TITLE
docs(query): Trivial doc fix for to_start_of_week 

### DIFF
--- a/docs/doc/15-sql-functions/30-datetime-functions/tostartofweek.md
+++ b/docs/doc/15-sql-functions/30-datetime-functions/tostartofweek.md
@@ -8,7 +8,7 @@ The first day of a week can be Sunday or Monday, which is specified by the argum
 ## Syntax
 
 ```sql
-to_start_of_week(expr)
+to_start_of_week(expr[, mode])
 ```
 
 ## Arguments
@@ -38,4 +38,11 @@ SELECT to_start_of_week(to_timestamp(1630812366));
 +--------------------------------------------+
 | 2021-09-05                                 |
 +--------------------------------------------+
+
+SELECT to_start_of_week(to_timestamp(1630812366), 1);
++-----------------------------------------------+
+| to_start_of_week(to_timestamp(1630812366), 1) |
++-----------------------------------------------+
+| 2021-08-30                                    |
++-----------------------------------------------+
 ```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`mode` was not included in sql syntax

Closes #9959
