### PR TITLE
chore(metactl/test): json output map keys in arbitrary order. Do not rely on the key order

### DIFF
--- a/tests/metactl/test-metactl-restore-new-cluster.sh
+++ b/tests/metactl/test-metactl-restore-new-cluster.sh
@@ -67,9 +67,17 @@ echo " === dump new cluster state:"
 curl -sL http://127.0.0.1:28101/v1/cluster/status
 echo ""
 
-echo " === check new cluster state has the voters 4, 5, 6"
+echo " === check new cluster state has the voters 4"
 curl -sL http://127.0.0.1:28101/v1/cluster/status \
-    | grep '"voters":\[{"name":"4","endpoint":{"addr":"localhost","port":29103},"grpc_api_advertise_address":"127.0.0.1:19191"},{"name":"5","endpoint":{"addr":"localhost","port":29203},"grpc_api_advertise_address":"127.0.0.1:29191"},{"name":"6","endpoint":{"addr":"localhost","port":29303},"grpc_api_advertise_address":"127.0.0.1:39191"}\]'
+    | grep '{"name":"4","endpoint":{"addr":"localhost","port":29103},"grpc_api_advertise_address":"127.0.0.1:19191"}'
+
+echo " === check new cluster state has the voters 5"
+curl -sL http://127.0.0.1:28101/v1/cluster/status \
+    | grep '{"name":"5","endpoint":{"addr":"localhost","port":29203},"grpc_api_advertise_address":"127.0.0.1:29191"}'
+
+echo " === check new cluster state has the voters 6"
+curl -sL http://127.0.0.1:28101/v1/cluster/status \
+    | grep '{"name":"6","endpoint":{"addr":"localhost","port":29303},"grpc_api_advertise_address":"127.0.0.1:39191"}'
 echo ""
 
 killall databend-meta


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore(metactl/test): json output map keys in arbitrary order. Do not rely on the key order

- Fix: #9963 

## Changelog







## Related Issues