### PR TITLE
chore(proto-conv): fix panic unsupported type in to_pb

### DIFF
--- a/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
@@ -557,7 +557,9 @@ impl FromToProto for mt::storage::StorageParams {
             mt::storage::StorageParams::Oss(v) => Ok(pb::user_stage_info::StageStorage {
                 storage: Some(pb::user_stage_info::stage_storage::Storage::Oss(v.to_pb()?)),
             }),
-            _ => todo!("other stage storage are not supported"),
+            others => Err(Incompatible {
+                reason: format!("stage type: {} not supported", others),
+            }),
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* fix panic when unsupported type in `to_pb`

Closes #issue
