### PR TITLE
ci: disable incremental build in CI

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,6 +17,7 @@ concurrency:
 env:
   BUILD_PROFILE: release
   TARGET: x86_64-unknown-linux-gnu
+  CARGO_INCREMENTAL: 0
 
 jobs:
   build:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,7 +8,6 @@ on:
       - "docs/**"
       - "website/**"
       - "**.md"
-      - "scripts/setup/**"
       - ".devcontainer/**"
 
 concurrency:

--- a/.github/workflows/build-tool.yml
+++ b/.github/workflows/build-tool.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
     paths:
-      - "scripts/setup/**"
       - "docker/build-tool/**"
 
 permissions:

--- a/.github/workflows/dev-linux.yml
+++ b/.github/workflows/dev-linux.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   BUILD_PROFILE: debug
   RUNNER_PROVIDER: aws
-  CARGO_INCREMENTAL: 0  
+  CARGO_INCREMENTAL: 0
 
 jobs:
   check:

--- a/.github/workflows/dev-linux.yml
+++ b/.github/workflows/dev-linux.yml
@@ -18,6 +18,7 @@ concurrency:
 env:
   BUILD_PROFILE: debug
   RUNNER_PROVIDER: aws
+  CARGO_INCREMENTAL: 0  
 
 jobs:
   check:

--- a/.github/workflows/dev-linux.yml
+++ b/.github/workflows/dev-linux.yml
@@ -8,7 +8,6 @@ on:
       - "docs/**"
       - "website/**"
       - "**.md"
-      - "scripts/setup/**"
       - "docker/**"
       - ".devcontainer/**"
 

--- a/.github/workflows/dev-macos.yml
+++ b/.github/workflows/dev-macos.yml
@@ -8,7 +8,6 @@ on:
       - "docs/**"
       - "website/**"
       - "**.md"
-      - "scripts/setup/**"
       - "docker/**"
       - ".devcontainer/**"
 

--- a/.github/workflows/dev-macos.yml
+++ b/.github/workflows/dev-macos.yml
@@ -17,6 +17,7 @@ concurrency:
 
 env:
   BUILD_PROFILE: debug
+  CARGO_INCREMENTAL: 0
 
 jobs:
   build_macos:

--- a/.github/workflows/dev-perf.yml
+++ b/.github/workflows/dev-perf.yml
@@ -13,7 +13,6 @@ on:
       - "docs/**"
       - "website/**"
       - "**.md"
-      - "scripts/setup/**"
       - "docker/**"
       - ".devcontainer/**"
   # schedule:

--- a/.github/workflows/dev-perf.yml
+++ b/.github/workflows/dev-perf.yml
@@ -29,6 +29,7 @@ concurrency:
 env:
   BUILD_PROFILE: release
   RUNNER_PROVIDER: aws
+  CARGO_INCREMENTAL: 0
 
 jobs:
   build_release:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   BUILD_PROFILE: release
+  CARGO_INCREMENTAL: 0
 
 jobs:
   check:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -8,7 +8,6 @@ on:
       - "docs/**"
       - "website/**"
       - "**.md"
-      - "scripts/setup/**"
       - ".devcontainer/**"
 
 concurrency:

--- a/scripts/setup/run_build_tool.sh
+++ b/scripts/setup/run_build_tool.sh
@@ -33,7 +33,7 @@ done
 
 if [[ $ENABLE_SCCACHE == "true" ]]; then
 	env | grep -E "^SCCACHE_" >"${CARGO_HOME}/sccache.env"
-	EXTRA_ARGS="${EXTRA_ARGS} --env RUSTC_WRAPPER=/opt/rust/cargo/bin/sccache --env-file ${CARGO_HOME}/sccache.env"
+	EXTRA_ARGS="${EXTRA_ARGS} --env RUSTC_WRAPPER=/opt/rust/cargo/bin/sccach --env CARGO_INCREMENTAL=0 --env-file ${CARGO_HOME}/sccache.env"
 	COMMAND="${COMMAND} && sccache --show-stats"
 fi
 

--- a/scripts/setup/run_build_tool.sh
+++ b/scripts/setup/run_build_tool.sh
@@ -33,7 +33,7 @@ done
 
 if [[ $ENABLE_SCCACHE == "true" ]]; then
 	env | grep -E "^SCCACHE_" >"${CARGO_HOME}/sccache.env"
-	EXTRA_ARGS="${EXTRA_ARGS} --env RUSTC_WRAPPER=/opt/rust/cargo/bin/sccache --env CARGO_INCREMENTAL=0 --env-file ${CARGO_HOME}/sccache.env"
+	EXTRA_ARGS="${EXTRA_ARGS} --env RUSTC_WRAPPER=/opt/rust/cargo/bin/sccache --env-file ${CARGO_HOME}/sccache.env"
 	COMMAND="${COMMAND} && sccache --show-stats"
 fi
 

--- a/scripts/setup/run_build_tool.sh
+++ b/scripts/setup/run_build_tool.sh
@@ -33,7 +33,7 @@ done
 
 if [[ $ENABLE_SCCACHE == "true" ]]; then
 	env | grep -E "^SCCACHE_" >"${CARGO_HOME}/sccache.env"
-	EXTRA_ARGS="${EXTRA_ARGS} --env RUSTC_WRAPPER=/opt/rust/cargo/bin/sccach --env CARGO_INCREMENTAL=0 --env-file ${CARGO_HOME}/sccache.env"
+	EXTRA_ARGS="${EXTRA_ARGS} --env RUSTC_WRAPPER=/opt/rust/cargo/bin/sccache --env CARGO_INCREMENTAL=0 --env-file ${CARGO_HOME}/sccache.env"
 	COMMAND="${COMMAND} && sccache --show-stats"
 fi
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

> [Incrementally compiled crates cannot be cached.](https://github.com/mozilla/sccache#rust)

@Xuanwo 


> Disable incremental compilation. CI builds often are closer to from-scratch builds, as changes are typically much bigger than from a local edit-compile cycle. For from-scratch builds, incremental adds an extra dependency-tracking overhead. It also significantly increases the amount of IO and the size of ./target, which make caching less effective.

https://matklad.github.io/2021/09/04/fast-rust-builds.html
