### PR TITLE
feat(mmap_allocator): change the mmap allocator inner allcator from GlobalAllocator to JEAllocator

### DIFF
--- a/src/common/hashtable/src/hashtable.rs
+++ b/src/common/hashtable/src/hashtable.rs
@@ -16,7 +16,6 @@ use std::alloc::Allocator;
 use std::intrinsics::unlikely;
 use std::mem::MaybeUninit;
 
-use common_base::mem_allocator::GlobalAllocator;
 use common_base::mem_allocator::MmapAllocator;
 
 use super::container::HeapContainer;
@@ -29,7 +28,7 @@ use super::traits::Keyable;
 use super::utils::ZeroEntry;
 use crate::FastHash;
 
-pub struct Hashtable<K, V, A = MmapAllocator<GlobalAllocator>>
+pub struct Hashtable<K, V, A = MmapAllocator>
 where
     K: Keyable,
     A: Allocator + Clone,

--- a/src/common/hashtable/src/lookup_hashtable.rs
+++ b/src/common/hashtable/src/lookup_hashtable.rs
@@ -16,18 +16,13 @@ use std::alloc::Allocator;
 use std::mem;
 use std::mem::MaybeUninit;
 
-use common_base::mem_allocator::GlobalAllocator;
 use common_base::mem_allocator::MmapAllocator;
 
 use crate::table0::Entry;
 use crate::HashtableLike;
 
-pub struct LookupHashtable<
-    K: Sized,
-    const CAPACITY: usize,
-    V,
-    A: Allocator + Clone = MmapAllocator<GlobalAllocator>,
-> {
+pub struct LookupHashtable<K: Sized, const CAPACITY: usize, V, A: Allocator + Clone = MmapAllocator>
+{
     flags: Box<[bool; CAPACITY], A>,
     data: Box<[Entry<K, V>; CAPACITY], A>,
     len: usize,

--- a/src/common/hashtable/src/short_string_hashtable.rs
+++ b/src/common/hashtable/src/short_string_hashtable.rs
@@ -19,7 +19,6 @@ use std::num::NonZeroU64;
 use std::ptr::NonNull;
 
 use bumpalo::Bump;
-use common_base::mem_allocator::GlobalAllocator;
 use common_base::mem_allocator::MmapAllocator;
 
 use super::container::HeapContainer;
@@ -38,7 +37,7 @@ use crate::table_empty::TableEmpty;
 use crate::table_empty::TableEmptyIter;
 use crate::table_empty::TableEmptyIterMut;
 
-pub struct ShortStringHashtable<K, V, A = MmapAllocator<GlobalAllocator>>
+pub struct ShortStringHashtable<K, V, A = MmapAllocator>
 where
     K: UnsizedKeyable + ?Sized,
     A: Allocator + Clone,

--- a/src/common/hashtable/src/stack_hashtable.rs
+++ b/src/common/hashtable/src/stack_hashtable.rs
@@ -16,7 +16,6 @@ use std::alloc::Allocator;
 use std::intrinsics::unlikely;
 use std::mem::MaybeUninit;
 
-use common_base::mem_allocator::GlobalAllocator;
 use common_base::mem_allocator::MmapAllocator;
 
 use super::container::StackContainer;
@@ -27,7 +26,7 @@ use super::table0::Table0IterMut;
 use super::traits::Keyable;
 use super::utils::ZeroEntry;
 
-pub struct StackHashtable<K, V, const N: usize = 16, A = MmapAllocator<GlobalAllocator>>
+pub struct StackHashtable<K, V, const N: usize = 16, A = MmapAllocator>
 where
     K: Keyable,
     A: Allocator + Clone,

--- a/src/common/hashtable/src/string_hashtable.rs
+++ b/src/common/hashtable/src/string_hashtable.rs
@@ -17,7 +17,6 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 
 use bumpalo::Bump;
-use common_base::mem_allocator::GlobalAllocator;
 use common_base::mem_allocator::MmapAllocator;
 
 use super::container::HeapContainer;
@@ -37,7 +36,7 @@ use crate::table_empty::TableEmptyIterMut;
 /// Simple unsized hashtable is used for storing unsized keys in arena. It can be worked with HashMethodSerializer.
 /// Different from `ShortStringHashTable`, it doesn't use adpative sub hashtable to store key values via key size.
 /// It can be considered as a minimal hashtable implementation of ShortStringHashTable
-pub struct StringHashtable<K, V, A = MmapAllocator<GlobalAllocator>>
+pub struct StringHashtable<K, V, A = MmapAllocator>
 where
     K: UnsizedKeyable + ?Sized,
     A: Allocator + Clone,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This is the part-1:
* change the mmap allocator inner allcator from GlobalAllocator to JEAllocator
* for JEAllocator: linux use jemalloc, not linux will fallback to std allocator

Part-2 will investigate try to change the GlobalAllocator from jemalloc to std.

Closes #issue
