### PR TITLE
feat(storagte): Add drop_table_by_id api

### DIFF
--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -120,6 +120,8 @@ pub trait SchemaApi: Send + Sync {
         table_id: MetaId,
     ) -> Result<(TableIdent, Arc<TableMeta>), KVAppError>;
 
+    async fn drop_table_by_id(&self, table_id: MetaId) -> Result<DropTableReply, KVAppError>;
+
     async fn get_table_copied_file_info(
         &self,
         req: GetTableCopiedFileReq,

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -111,6 +111,7 @@ use common_meta_types::MetaNetworkError;
 use common_meta_types::TxnCondition;
 use common_meta_types::TxnOp;
 use common_meta_types::TxnRequest;
+use common_meta_types::UnknownDatabaseId;
 use common_tracing::func_name;
 use tracing::debug;
 use tracing::error;
@@ -1143,7 +1144,7 @@ impl<KV: kvapi::KVApi<Error = KVAppError>> SchemaApi for KV {
                         txn_cond_seq(&dbid_tbname, Eq, tb_id_seq),
                         // table is not changed
                         txn_cond_seq(&tbid, Eq, tb_meta_seq),
-                        // update table count atomicly
+                        // update table count atomically
                         txn_cond_seq(&tb_count_key, Eq, tb_count_seq),
                     ],
                     if_then: vec![
@@ -1781,6 +1782,147 @@ impl<KV: kvapi::KVApi<Error = KVAppError>> SchemaApi for KV {
             TableIdent::new(table_id, tb_meta_seq),
             Arc::new(table_meta.unwrap()),
         ))
+    }
+
+    #[tracing::instrument(level = "debug", ret, err, skip_all)]
+    async fn drop_table_by_id(&self, table_id: MetaId) -> Result<DropTableReply, KVAppError> {
+        debug!(req = debug(&table_id), "SchemaApi: {}", func_name!());
+
+        let mut tbcount_found = false;
+        let mut tb_count = 0;
+        let mut tb_count_seq;
+        let tbid = TableId { table_id };
+        let mut retry = 0;
+
+        while retry < TXN_MAX_RETRY_TIMES {
+            retry += 1;
+
+            // Check if table exists.
+            let (tb_meta_seq, tb_meta): (_, Option<TableMeta>) =
+                get_struct_value(self, &tbid).await?;
+            if tb_meta_seq == 0 || tb_meta.is_none() {
+                return Err(KVAppError::AppError(AppError::UnknownTableId(
+                    UnknownTableId::new(table_id, "drop_table_by_id failed to find valid tb_meta"),
+                )));
+            }
+
+            // Get db name, tenant name and related info for tx.
+            let table_id_to_name = TableIdToName { table_id };
+            let (_, table_name_opt): (_, Option<DBIdTableName>) =
+                get_struct_value(self, &table_id_to_name).await?;
+
+            let dbid_tbname = match table_name_opt {
+                Some(table_name) => table_name,
+                None => {
+                    return Err(KVAppError::AppError(AppError::UnknownTableId(
+                        UnknownTableId::new(table_id, "drop_table_by_id failed to find db_id"),
+                    )));
+                }
+            };
+
+            let tbname = dbid_tbname.table_name.clone();
+            let (tb_id_seq, _) = get_u64_value(self, &dbid_tbname).await?;
+            if tb_id_seq == 0 {
+                return Err(KVAppError::AppError(AppError::UnknownTableId(
+                    UnknownTableId::new(table_id, "drop_table_by_id failed to get valid tb_id_seq"),
+                )));
+            }
+
+            let db_id_to_name = DatabaseIdToName {
+                db_id: dbid_tbname.db_id,
+            };
+            let (_, database_name_opt): (_, Option<DatabaseNameIdent>) =
+                get_struct_value(self, &db_id_to_name).await?;
+            let tenant_dbname = match database_name_opt {
+                Some(db_name_ident) => db_name_ident,
+                None => {
+                    return Err(KVAppError::AppError(AppError::UnknownDatabaseId(
+                        UnknownDatabaseId::new(dbid_tbname.db_id, format!("drop_table_by_id")),
+                    )));
+                }
+            };
+            let tenant_dbname_tbname = TableNameIdent {
+                tenant: tenant_dbname.tenant.clone(),
+                db_name: tenant_dbname.db_name.clone(),
+                table_name: tbname,
+            };
+
+            // get current table count from _fd_table_count/tenant
+            let tb_count_key = CountTablesKey {
+                tenant: tenant_dbname.tenant.clone(),
+            };
+            (tb_count_seq, tb_count) = {
+                let (seq, count) = get_u64_value(self, &tb_count_key).await?;
+                if seq > 0 {
+                    (seq, count)
+                } else if !tbcount_found {
+                    // only count_tables for the first time.
+                    tbcount_found = true;
+                    (0, count_tables(self, &tb_count_key).await?)
+                } else {
+                    (0, tb_count)
+                }
+            };
+
+            let (_, db_id, db_meta_seq, db_meta) =
+                get_db_or_err(self, &tenant_dbname, "drop_table_by_id").await?;
+
+            debug!(
+                ident = display(&tbid),
+                name = display(&tenant_dbname_tbname),
+                "drop table by id"
+            );
+
+            {
+                let mut tb_meta = tb_meta.unwrap();
+                // drop a table with drop_on time
+                if tb_meta.drop_on.is_some() {
+                    return Err(KVAppError::AppError(AppError::DropTableWithDropTime(
+                        DropTableWithDropTime::new(&dbid_tbname.table_name),
+                    )));
+                }
+
+                tb_meta.drop_on = Some(Utc::now());
+
+                let txn_req = TxnRequest {
+                    condition: vec![
+                        // db has not to change, i.e., no new table is created.
+                        // Renaming db is OK and does not affect the seq of db_meta.
+                        txn_cond_seq(&DatabaseId { db_id }, Eq, db_meta_seq),
+                        // still this table id
+                        txn_cond_seq(&dbid_tbname, Eq, tb_id_seq),
+                        // table is not changed
+                        txn_cond_seq(&tbid, Eq, tb_meta_seq),
+                        // update table count atomically
+                        txn_cond_seq(&tb_count_key, Eq, tb_count_seq),
+                    ],
+                    if_then: vec![
+                        // Changing a table in a db has to update the seq of db_meta,
+                        // to block the batch-delete-tables when deleting a db.
+                        txn_op_put(&DatabaseId { db_id }, serialize_struct(&db_meta)?), /* (db_id) -> db_meta */
+                        txn_op_del(&dbid_tbname), // (db_id, tb_name) -> tb_id
+                        txn_op_put(&tbid, serialize_struct(&tb_meta)?), /* (tenant, db_id, tb_id) -> tb_meta */
+                        txn_op_put(&tb_count_key, serialize_u64(tb_count - 1)?), /* _fd_table_count/tenant -> tb_count */
+                    ],
+                    else_then: vec![],
+                };
+
+                let (succ, _responses) = send_txn(self, txn_req).await?;
+
+                debug!(
+                    name = display(&tenant_dbname_tbname),
+                    id = debug(&tbid),
+                    succ = display(succ),
+                    "drop_table_by_id"
+                );
+                if succ {
+                    return Ok(DropTableReply {});
+                }
+            }
+        }
+        Err(KVAppError::AppError(AppError::TxnRetryMaxTimes(
+            TxnRetryMaxTimes::new("drop_table_by_id", TXN_MAX_RETRY_TIMES),
+        )))
     }
 
     async fn get_table_copied_file_info(

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -1837,7 +1837,7 @@ impl<KV: kvapi::KVApi<Error = KVAppError>> SchemaApi for KV {
                 Some(db_name_ident) => db_name_ident,
                 None => {
                     return Err(KVAppError::AppError(AppError::UnknownDatabaseId(
-                        UnknownDatabaseId::new(dbid_tbname.db_id, format!("drop_table_by_id")),
+                        UnknownDatabaseId::new(dbid_tbname.db_id, "drop_table_by_id"),
                     )));
                 }
             };

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -253,6 +253,7 @@ impl SchemaApiTestSuite {
         suite
             .table_drop_out_of_retention_time_history(&b.build().await)
             .await?;
+        suite.drop_table_by_id(&b.build().await).await?;
         suite.get_table_by_id(&b.build().await).await?;
         suite.get_table_copied_file(&b.build().await).await?;
         suite.truncate_table(&b.build().await).await?;
@@ -3081,6 +3082,143 @@ impl SchemaApiTestSuite {
             ]);
         }
 
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn drop_table_by_id<MT: SchemaApi>(&self, mt: &MT) -> anyhow::Result<()> {
+        let tenant = "tenant1";
+        let db_name = "db1";
+        let tbl_name = "tb2";
+
+        let tbl_name_ident = TableNameIdent {
+            tenant: tenant.to_string(),
+            db_name: db_name.to_string(),
+            table_name: tbl_name.to_string(),
+        };
+
+        let schema = || {
+            Arc::new(TableSchema::new(vec![TableField::new(
+                "number",
+                TableDataType::Number(NumberDataType::UInt64),
+            )]))
+        };
+
+        let options = || maplit::btreemap! {"opt‐1".into() => "val-1".into()};
+
+        let table_meta = |created_on| TableMeta {
+            schema: schema(),
+            engine: "JSON".to_string(),
+            options: options(),
+            created_on,
+            ..TableMeta::default()
+        };
+
+        info!("--- prepare db");
+        {
+            let plan = CreateDatabaseReq {
+                if_not_exists: false,
+                name_ident: DatabaseNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: db_name.to_string(),
+                },
+                meta: DatabaseMeta {
+                    engine: "".to_string(),
+                    ..DatabaseMeta::default()
+                },
+            };
+
+            let res = mt.create_database(plan).await?;
+            info!("create database res: {:?}", res);
+
+            assert_eq!(1, res.db_id, "first database id is 1");
+        }
+
+        info!("--- create and get table");
+        {
+            let created_on = Utc::now();
+
+            let req = CreateTableReq {
+                if_not_exists: false,
+                name_ident: TableNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: db_name.to_string(),
+                    table_name: tbl_name.to_string(),
+                },
+                table_meta: table_meta(created_on),
+            };
+
+            let _tb_ident_2 = {
+                let old_db = mt.get_database(Self::req_get_db(tenant, db_name)).await?;
+                let res = mt.create_table(req.clone()).await?;
+                let cur_db = mt.get_database(Self::req_get_db(tenant, db_name)).await?;
+                assert!(old_db.ident.seq < cur_db.ident.seq);
+                assert!(res.table_id >= 1, "table id >= 1");
+                let tb_id = res.table_id;
+
+                let got = mt.get_table((tenant, db_name, tbl_name).into()).await?;
+                let seq = got.ident.seq;
+
+                let ident = TableIdent::new(tb_id, seq);
+
+                let want = TableInfo {
+                    ident,
+                    desc: format!("'{}'.'{}'.'{}'", tenant, db_name, tbl_name),
+                    name: tbl_name.into(),
+                    meta: table_meta(created_on),
+                    tenant: tenant.to_string(),
+                    ..Default::default()
+                };
+                assert_meta_eq_without_updated!(want, got.as_ref().clone(), "get created table");
+                ident
+            };
+        }
+
+        info!("--- drop_table_by_id ");
+        {
+            let table = mt.get_table((tenant, "db1", "tb2").into()).await.unwrap();
+
+            info!("--- drop_table_by_id ");
+            {
+                // Get table count.
+                info!("--- check table count of tenant1");
+                let tb_count = mt.count_tables(Self::req_count_table(tenant)).await?;
+                let mut expected_tb_count = tb_count.count;
+
+                // Check drop succeed and db_ident moves forward.
+                let old_db = mt.get_database(Self::req_get_db(tenant, db_name)).await?;
+                let got = mt.drop_table_by_id(table.ident.table_id).await;
+                assert!(got.is_ok());
+                let cur_db = mt.get_database(Self::req_get_db(tenant, db_name)).await?;
+                assert!(old_db.ident.seq < cur_db.ident.seq);
+
+                // Check table count.
+                info!("--- check table count of tenant1");
+                let tb_count = mt.count_tables(Self::req_count_table(tenant)).await?;
+                expected_tb_count -= 1;
+                assert_eq!(expected_tb_count, tb_count.count);
+
+                let res = mt
+                    .get_table_history(ListTableReq::new(tenant, db_name))
+                    .await?;
+                calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
+                    name: tbl_name.to_string(),
+                    desc: tbl_name_ident.to_string(),
+                    drop_on_cnt: 1,
+                    non_drop_on_cnt: 0,
+                }]);
+            }
+
+            info!("--- drop_table_by_id again with same table_id");
+            {
+                let got = mt.drop_table_by_id(table.ident.table_id).await;
+                assert!(got.is_err());
+                assert_eq!(
+                    ErrorCode::UnknownTableId("").code(),
+                    ErrorCode::from(got.unwrap_err()).code()
+                );
+            }
+        }
         Ok(())
     }
 

--- a/src/meta/types/src/errors/app_error.rs
+++ b/src/meta/types/src/errors/app_error.rs
@@ -229,8 +229,11 @@ pub struct UnknownDatabaseId {
 }
 
 impl UnknownDatabaseId {
-    pub fn new(db_id: u64, context: String) -> UnknownDatabaseId {
-        Self { db_id, context }
+    pub fn new(db_id: u64, context: impl Into<String>) -> UnknownDatabaseId {
+        Self {
+            db_id,
+            context: context.into(),
+        }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add `drop_table_by_id ` api for a race condition issue in `drop all`.  We were dropping table by name, which may be error prone when there's table with same name created before we actually dropped the data. This change is the part 1/2 to introduce the api, then I'll update `drop all` in a separate change.

The api is simply get tenant, database, table count and MISC info from table_id, so that we can get ready to emit the transaction. The transaction is exactly same as `drop_table`.

ref #5626
