### PR TITLE
feat(allocator): print global allocator when server start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,7 +1317,6 @@ dependencies = [
  "dashmap",
  "dyn-clone",
  "goldenfile",
- "opendal",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2955,7 +2955,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sharing-endpoint",
- "tikv-jemalloc-ctl",
  "tokio-stream",
  "tonic",
  "tracing",

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -59,7 +59,6 @@ poem = { version = "1", features = ["rustls", "multipart", "compression"] }
 sentry = { version = "0.27.0", default-features = false, features = ["backtrace", "contexts", "panic", "rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tikv-jemalloc-ctl = { workspace = true }
 tokio-stream = "0.1.10"
 tonic = "0.8.1"
 tracing = "0.1.36"

--- a/src/binaries/query/main.rs
+++ b/src/binaries/query/main.rs
@@ -237,13 +237,8 @@ async fn main_entrypoint() -> Result<()> {
             "unlimited".to_string()
         }
     });
-    println!("    allocator name: {}", GlobalAllocator::name());
-    println!("    allocator config: {}", {
-        use tikv_jemalloc_ctl::config;
-        config::malloc_conf::mib()
-            .and_then(|mib| mib.read().map(|v| v.to_owned()))
-            .unwrap_or_else(|e| format!("N/A: failed to read jemalloc config, {}", e))
-    });
+    println!("    allocator: {}", GlobalAllocator::name());
+    println!("    config: {}", GlobalAllocator::conf());
 
     println!("Cluster: {}", {
         let cluster = ClusterDiscovery::instance().discover(&conf).await?;

--- a/src/binaries/query/main.rs
+++ b/src/binaries/query/main.rs
@@ -237,7 +237,7 @@ async fn main_entrypoint() -> Result<()> {
             "unlimited".to_string()
         }
     });
-    println!("    global allocator: {}", GlobalAllocator::name());
+    println!("    allocator name: {}", GlobalAllocator::name());
     println!("    allocator config: {}", {
         use tikv_jemalloc_ctl::config;
         config::malloc_conf::mib()

--- a/src/binaries/query/main.rs
+++ b/src/binaries/query/main.rs
@@ -237,12 +237,14 @@ async fn main_entrypoint() -> Result<()> {
             "unlimited".to_string()
         }
     });
+    println!("    global allocator: {}", GlobalAllocator::name());
     println!("    allocator config: {}", {
         use tikv_jemalloc_ctl::config;
         config::malloc_conf::mib()
             .and_then(|mib| mib.read().map(|v| v.to_owned()))
             .unwrap_or_else(|e| format!("N/A: failed to read jemalloc config, {}", e))
     });
+
     println!("Cluster: {}", {
         let cluster = ClusterDiscovery::instance().discover(&conf).await?;
         let nodes = cluster.nodes.len();

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -14,7 +14,6 @@ test = false
 tracing = ["tokio/tracing"]
 jemalloc = []
 memory-profiling = [
-    "tikv-jemalloc-ctl",
     "tikv-jemalloc-sys/stats",
     "tikv-jemalloc-sys/profiling",
     "tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms",
@@ -46,7 +45,7 @@ pprof = { version = "0.10.1", features = [
 semver = "1.0.10"
 serde = { workspace = true }
 state = "0.5"
-tikv-jemalloc-ctl = { workspace = true, optional = true }
+tikv-jemalloc-ctl = { workspace = true }
 tikv-jemalloc-sys = "0.5.2"
 tokio = { workspace = true }
 tracing = "0.1.36"

--- a/src/common/base/src/mem_allocator/global.rs
+++ b/src/common/base/src/mem_allocator/global.rs
@@ -26,6 +26,12 @@ use crate::mem_allocator::DefaultAllocator;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct GlobalAllocator;
 
+impl GlobalAllocator {
+    pub fn name() -> String {
+        DefaultAllocator::name()
+    }
+}
+
 unsafe impl Allocator for GlobalAllocator {
     #[inline(always)]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {

--- a/src/common/base/src/mem_allocator/global.rs
+++ b/src/common/base/src/mem_allocator/global.rs
@@ -30,6 +30,10 @@ impl GlobalAllocator {
     pub fn name() -> String {
         DefaultAllocator::name()
     }
+
+    pub fn conf() -> String {
+        DefaultAllocator::conf()
+    }
 }
 
 unsafe impl Allocator for GlobalAllocator {

--- a/src/common/base/src/mem_allocator/jemalloc.rs
+++ b/src/common/base/src/mem_allocator/jemalloc.rs
@@ -20,6 +20,12 @@
 #[derive(Debug, Clone, Copy, Default)]
 pub struct JEAllocator;
 
+impl JEAllocator {
+    pub fn name() -> String {
+        "jemalloc".to_string()
+    }
+}
+
 #[cfg(target_os = "linux")]
 pub mod linux {
     use std::alloc::AllocError;

--- a/src/common/base/src/mem_allocator/jemalloc.rs
+++ b/src/common/base/src/mem_allocator/jemalloc.rs
@@ -24,6 +24,12 @@ impl JEAllocator {
     pub fn name() -> String {
         "jemalloc".to_string()
     }
+
+    pub fn conf() -> String {
+        tikv_jemalloc_ctl::config::malloc_conf::mib()
+            .and_then(|mib| mib.read().map(|v| v.to_owned()))
+            .unwrap_or_else(|e| format!("N/A: failed to read jemalloc config, {}", e))
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/src/common/base/src/mem_allocator/std_.rs
+++ b/src/common/base/src/mem_allocator/std_.rs
@@ -28,6 +28,10 @@ impl StdAllocator {
     pub fn name() -> String {
         "std".to_string()
     }
+
+    pub fn conf() -> String {
+        "".to_string()
+    }
 }
 
 unsafe impl Allocator for StdAllocator {

--- a/src/common/base/src/mem_allocator/std_.rs
+++ b/src/common/base/src/mem_allocator/std_.rs
@@ -24,6 +24,12 @@ use crate::runtime::ThreadTracker;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct StdAllocator;
 
+impl StdAllocator {
+    pub fn name() -> String {
+        "std".to_string()
+    }
+}
+
 unsafe impl Allocator for StdAllocator {
     #[inline(always)]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {

--- a/src/query/catalog/Cargo.toml
+++ b/src/query/catalog/Cargo.toml
@@ -19,7 +19,6 @@ common-meta-types = { path = "../../meta/types" }
 common-pipeline-core = { path = "../pipeline/core" }
 common-settings = { path = "../settings" }
 common-storage = { path = "../../common/storage" }
-opendal = { workspace = true }
 
 async-trait = "0.1.57"
 chrono = { workspace = true }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```
Databend Query

Version: v0.9.33-nightly-f831463(rust-1.68.0-nightly-2023-02-12T01:41:54.835554Z)

Logging:
    file: enabled=true, level=DEBUG, dir=./.databend/logs_meta_embedded, format=text
    stderr: enabled=false(To enable: LOG_STDERR_ON=true or RUST_LOG=info), level=INFO, format=text
Meta: embedded at ./.databend/meta_embedded
Memory:
    limit: unlimited
    allocator: jemalloc
    config: percpu_arena:percpu,oversize_threshold:0,background_thread:true,metadata_thp:auto,dirty_decay_ms:5000,muzzy_decay_ms:5000
Cluster: standalone
```

Closes #issue
