### PR TITLE
feat: infer_schema support arg 'file_format'.

### DIFF
--- a/src/query/storages/fuse/src/table_functions/infer_schema/infer_schema_table.rs
+++ b/src/query/storages/fuse/src/table_functions/infer_schema/infer_schema_table.rs
@@ -13,7 +13,6 @@
 //  limitations under the License.
 
 use std::any::Any;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use common_catalog::plan::DataSourcePlan;
@@ -47,8 +46,7 @@ use common_storage::StageFilesInfo;
 use crate::pipelines::processors::port::OutputPort;
 use crate::pipelines::Pipeline;
 use crate::sessions::TableContext;
-use crate::table_functions::infer_schema::table_args::parse_infer_schema_args;
-use crate::table_functions::string_literal;
+use crate::table_functions::infer_schema::table_args::InferSchemaArgsParsed;
 use crate::table_functions::TableArgs;
 use crate::table_functions::TableFunction;
 use crate::Table;
@@ -57,8 +55,8 @@ const INFER_SCHEMA: &str = "infer_schema";
 
 pub struct InferSchemaTable {
     table_info: TableInfo,
-    location: String,
-    files_info: StageFilesInfo,
+    args_parsed: InferSchemaArgsParsed,
+    table_args: TableArgs,
 }
 
 impl InferSchemaTable {
@@ -68,7 +66,7 @@ impl InferSchemaTable {
         table_id: u64,
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
-        let (location, files_info) = parse_infer_schema_args(&table_args)?;
+        let args_parsed = InferSchemaArgsParsed::parse(&table_args)?;
         let table_info = TableInfo {
             ident: TableIdent::new(table_id, 0),
             desc: format!("'{}'.'{}'", database_name, table_func_name),
@@ -83,8 +81,8 @@ impl InferSchemaTable {
 
         Ok(Arc::new(Self {
             table_info,
-            location,
-            files_info,
+            args_parsed,
+            table_args,
         }))
     }
 
@@ -117,12 +115,7 @@ impl Table for InferSchemaTable {
     }
 
     fn table_args(&self) -> Option<TableArgs> {
-        let mut args = HashMap::new();
-        args.insert("location".to_string(), string_literal(&self.location));
-        if let Some(pattern) = &self.files_info.pattern {
-            args.insert("pattern".to_string(), string_literal(pattern));
-        }
-        Some(TableArgs::new_named(args))
+        Some(self.table_args.clone())
     }
 
     fn read_data(
@@ -136,8 +129,8 @@ impl Table for InferSchemaTable {
                 InferSchemaSource::create(
                     ctx.clone(),
                     output,
-                    self.location.to_owned(),
-                    self.files_info.clone(),
+                    self.args_parsed.location.to_owned(),
+                    self.args_parsed.files_info.clone(),
                 )
             },
             1,

--- a/src/query/storages/fuse/src/table_functions/infer_schema/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/infer_schema/table_args.rs
@@ -19,36 +19,46 @@ use common_storage::StageFilesInfo;
 use crate::table_functions::string_value;
 use crate::table_functions::TableArgs;
 
-pub fn parse_infer_schema_args(table_args: &TableArgs) -> Result<(String, StageFilesInfo)> {
-    let args = table_args.expect_all_named("infer_schema")?;
+pub(crate) struct InferSchemaArgsParsed {
+    pub(crate) location: String,
+    pub(crate) files_info: StageFilesInfo,
+}
 
-    let mut location = None;
-    let mut files_info = StageFilesInfo {
-        path: "".to_string(),
-        files: None,
-        pattern: None,
-    };
+impl InferSchemaArgsParsed {
+    pub(crate) fn parse(table_args: &TableArgs) -> Result<Self> {
+        let args = table_args.expect_all_named("infer_schema")?;
 
-    for (k, v) in &args {
-        match k.to_lowercase().as_str() {
-            "pattern" => {
-                files_info.pattern = Some(string_value(v)?);
-            }
-            "location" => {
-                location = Some(string_value(v)?);
-            }
-            _ => {
-                return Err(ErrorCode::BadArguments(format!(
-                    "unknown param {} for infer_schema",
-                    k
-                )));
+        let mut location = None;
+        let mut files_info = StageFilesInfo {
+            path: "".to_string(),
+            files: None,
+            pattern: None,
+        };
+
+        for (k, v) in &args {
+            match k.to_lowercase().as_str() {
+                "location" => {
+                    location = Some(string_value(v)?);
+                }
+                "pattern" => {
+                    files_info.pattern = Some(string_value(v)?);
+                }
+                _ => {
+                    return Err(ErrorCode::BadArguments(format!(
+                        "unknown param {} for infer_schema",
+                        k
+                    )));
+                }
             }
         }
+
+        let location = location.ok_or(ErrorCode::BadArguments(
+            "infer_schema must specify location",
+        ))?;
+
+        Ok(Self {
+            location,
+            files_info,
+        })
     }
-
-    let location = location.ok_or(ErrorCode::BadArguments(
-        "infer_schema must specify location",
-    ))?;
-
-    Ok((location, files_info))
 }

--- a/src/query/storages/fuse/src/table_functions/infer_schema/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/infer_schema/table_args.rs
@@ -19,8 +19,10 @@ use common_storage::StageFilesInfo;
 use crate::table_functions::string_value;
 use crate::table_functions::TableArgs;
 
+#[derive(Clone)]
 pub(crate) struct InferSchemaArgsParsed {
     pub(crate) location: String,
+    pub(crate) file_format: Option<String>,
     pub(crate) files_info: StageFilesInfo,
 }
 
@@ -29,6 +31,7 @@ impl InferSchemaArgsParsed {
         let args = table_args.expect_all_named("infer_schema")?;
 
         let mut location = None;
+        let mut file_format = None;
         let mut files_info = StageFilesInfo {
             path: "".to_string(),
             files: None,
@@ -42,6 +45,9 @@ impl InferSchemaArgsParsed {
                 }
                 "pattern" => {
                     files_info.pattern = Some(string_value(v)?);
+                }
+                "file_format" => {
+                    file_format = Some(string_value(v)?);
                 }
                 _ => {
                     return Err(ErrorCode::BadArguments(format!(
@@ -58,6 +64,7 @@ impl InferSchemaArgsParsed {
 
         Ok(Self {
             location,
+            file_format,
             files_info,
         })
     }

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
@@ -29,6 +29,6 @@ echo "select * from @s2;" | $MYSQL_CLIENT_CONNECT
 echo '--- file_format'
 echo "drop stage if exists s3;" | $MYSQL_CLIENT_CONNECT
 echo "create stage s3 url = '${DATADIR}' FILE_FORMAT = (type = CSV);"  | $MYSQL_CLIENT_CONNECT
-echo "select * from @s2 (FILE_FORMAT => 'PARQUET');" | $MYSQL_CLIENT_CONNECT
+echo "select * from @s3 (FILE_FORMAT => 'PARQUET');" | $MYSQL_CLIENT_CONNECT
 
 rm -rf ${DATADIR_PATH}

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_04_infer_schema.result
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_04_infer_schema.result
@@ -4,6 +4,9 @@ t	(A INT32, B STRING)	0	1
 --- file:
 id	INT	0	0
 t	(A INT32, B STRING)	0	1
+--- file_format:
+id	INT	0	0
+t	(A INT32, B STRING)	0	1
 --- pattern:
 id	INT	0	0
 t	(A INT32, B STRING)	0	1

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_04_infer_schema.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_04_infer_schema.sh
@@ -24,6 +24,11 @@ echo "select * from infer_schema(location => '@s2/data/');" | $MYSQL_CLIENT_CONN
 echo "--- file:"
 echo "select * from infer_schema(location => '@s2/data/tuple.parquet');" | $MYSQL_CLIENT_CONNECT
 
+echo '--- file_format:'
+echo "drop stage if exists s3;" | $MYSQL_CLIENT_CONNECT
+echo "create stage s3 url = '${DATADIR}' FILE_FORMAT = (type = CSV);"  | $MYSQL_CLIENT_CONNECT
+echo "select * from infer_schema(location => '@s3', FILE_FORMAT => 'PARQUET',  pattern => '.*parquet');" | $MYSQL_CLIENT_CONNECT
+
 echo "--- pattern:"
 # should omit this file
 cp "$CURDIR"/../../../../data/sample.csv ${DATADIR_PATH}/data/00.csv
@@ -32,3 +37,4 @@ echo "select * from infer_schema(location => '@s2', pattern => '.*parquet');" | 
 echo "--- complex:"
 cp "$CURDIR"/../../../../data/complex.parquet ${DATADIR_PATH}/data/complex.parquet
 echo "select * from infer_schema(location => '@s2/data/', pattern => 'complex.*');" | $MYSQL_CLIENT_CONNECT
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

e.g.

```
select * from infer_schema(location => '@s3', FILE_FORMAT => 'PARQUET', pattern => '.*parquet');
```

same usage as https://github.com/datafuselabs/databend/pull/9983#discussion_r1103620897

Closes #issue
