### PR TITLE
feat: derive new filter and push down

### DIFF
--- a/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/derive_filter.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/derive_filter.rs
@@ -1,0 +1,154 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use common_exception::Result;
+
+use crate::optimizer::SExpr;
+use crate::plans::Filter;
+use crate::plans::Join;
+use crate::plans::JoinType;
+use crate::IndexType;
+use crate::ScalarExpr;
+
+/// Derive filter to push down
+pub fn try_derive_predicates(
+    s_expr: &SExpr,
+    join: Join,
+    mut left_push_down: Vec<ScalarExpr>,
+    mut right_push_down: Vec<ScalarExpr>,
+) -> Result<SExpr> {
+    let join_expr = s_expr.child(0)?;
+    let mut left_child = join_expr.child(0)?.clone();
+    let mut right_child = join_expr.child(1)?.clone();
+
+    if join.join_type == JoinType::Inner {
+        let mut new_left_push_down = vec![];
+        let mut new_right_push_down = vec![];
+        for predicate in left_push_down.iter() {
+            let used_columns = predicate.used_columns();
+            let mut col_to_scalar = HashMap::with_capacity(used_columns.len());
+            for column in used_columns.iter() {
+                for (idx, left_condition) in join.left_conditions.iter().enumerate() {
+                    if left_condition.used_columns().len() > 1
+                        || !left_condition.used_columns().contains(column)
+                    {
+                        continue;
+                    }
+                    col_to_scalar.insert(column, &join.right_conditions[idx]);
+                    break;
+                }
+            }
+            if col_to_scalar.len() == used_columns.len() {
+                derive_predicate(&col_to_scalar, predicate, &mut new_right_push_down)?;
+            }
+        }
+        for predicate in right_push_down.iter() {
+            let used_columns = predicate.used_columns();
+            let mut col_to_scalar = HashMap::with_capacity(used_columns.len());
+            for column in used_columns.iter() {
+                for (idx, right_condition) in join.right_conditions.iter().enumerate() {
+                    if right_condition.used_columns().len() > 1
+                        || !right_condition.used_columns().contains(column)
+                    {
+                        continue;
+                    }
+                    col_to_scalar.insert(column, &join.left_conditions[idx]);
+                    break;
+                }
+            }
+            if col_to_scalar.len() == used_columns.len() {
+                derive_predicate(&col_to_scalar, predicate, &mut new_left_push_down)?;
+            }
+        }
+        left_push_down.extend(new_left_push_down);
+        right_push_down.extend(new_right_push_down);
+    }
+
+    if !left_push_down.is_empty() {
+        left_child = SExpr::create_unary(
+            Filter {
+                predicates: left_push_down,
+                is_having: false,
+            }
+            .into(),
+            left_child,
+        );
+    }
+
+    if !right_push_down.is_empty() {
+        right_child = SExpr::create_unary(
+            Filter {
+                predicates: right_push_down,
+                is_having: false,
+            }
+            .into(),
+            right_child,
+        );
+    }
+    Ok(SExpr::create_binary(join.into(), left_child, right_child))
+}
+
+fn derive_predicate(
+    col_to_scalar: &HashMap<&IndexType, &ScalarExpr>,
+    predicate: &ScalarExpr,
+    new_push_down: &mut Vec<ScalarExpr>,
+) -> Result<()> {
+    let mut replaced_predicate = predicate.clone();
+    replace_column(&mut replaced_predicate, col_to_scalar);
+    if &replaced_predicate != predicate {
+        new_push_down.push(replaced_predicate);
+    }
+    Ok(())
+}
+
+fn replace_column(scalar: &mut ScalarExpr, col_to_scalar: &HashMap<&IndexType, &ScalarExpr>) {
+    match scalar {
+        ScalarExpr::BoundColumnRef(column) => {
+            let column_index = column.column.index;
+            // Safe to unwrap
+            *scalar = (*col_to_scalar.get(&column_index).unwrap()).clone();
+        }
+        ScalarExpr::AndExpr(expr) => {
+            replace_column(&mut expr.left, col_to_scalar);
+            replace_column(&mut expr.right, col_to_scalar);
+        }
+        ScalarExpr::OrExpr(expr) => {
+            replace_column(&mut expr.left, col_to_scalar);
+            replace_column(&mut expr.right, col_to_scalar);
+        }
+        ScalarExpr::NotExpr(expr) => {
+            replace_column(&mut expr.argument, col_to_scalar);
+        }
+        ScalarExpr::ComparisonExpr(expr) => {
+            replace_column(&mut expr.left, col_to_scalar);
+            replace_column(&mut expr.right, col_to_scalar);
+        }
+        ScalarExpr::AggregateFunction(expr) => {
+            for arg in expr.args.iter_mut() {
+                replace_column(arg, col_to_scalar)
+            }
+        }
+        ScalarExpr::FunctionCall(expr) => {
+            for arg in expr.arguments.iter_mut() {
+                replace_column(arg, col_to_scalar)
+            }
+        }
+        ScalarExpr::CastExpr(expr) => {
+            replace_column(&mut expr.argument, col_to_scalar);
+        }
+        ScalarExpr::ConstantExpr(_) | ScalarExpr::SubqueryExpr(_) => {}
+    }
+}

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/mod.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/mod.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod derive_filter;
 mod extract_or_predicates;
 mod mark_join_to_semi_join;
 mod outer_join_to_inner_join;
 
+pub use derive_filter::try_derive_predicates;
 pub use extract_or_predicates::rewrite_predicates;
 pub use mark_join_to_semi_join::convert_mark_to_semi_join;
 pub use outer_join_to_inner_join::convert_outer_to_inner_join;

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_eliminate_filter.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_eliminate_filter.rs
@@ -19,7 +19,7 @@ use crate::optimizer::rule::Rule;
 use crate::optimizer::rule::RuleID;
 use crate::optimizer::rule::TransformResult;
 use crate::optimizer::SExpr;
-use crate::plans::Filter;
+use crate::plans::{ComparisonOp, Filter};
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
 use crate::plans::ScalarExpr;
@@ -66,6 +66,29 @@ impl Rule for RuleEliminateFilter {
             .into_iter()
             .unique()
             .collect::<Vec<ScalarExpr>>();
+        // Delete identically equal predicate
+        // After constant fold is ready, we can delete the following code
+        let predicates = predicates
+            .into_iter()
+            .filter(|predicate| {
+                match predicate {
+                    ScalarExpr::ComparisonExpr(comparison_expr) => {
+                        let left_column = match &*comparison_expr.left {
+                            ScalarExpr::BoundColumnRef(left_col) => left_col,
+                            _ => return true,
+                        };
+                        let right_column = match &*comparison_expr.right {
+                            ScalarExpr::BoundColumnRef(right_col) => right_col,
+                            _ => return true,
+                        };
+                        !(comparison_expr.op == ComparisonOp::Equal
+                            && left_column.column.index == right_column.column.index)
+                    }
+                    _ => true,
+                }
+            })
+            .collect::<Vec<ScalarExpr>>();
+
         if predicates.is_empty() {
             state.add_result(s_expr.child(0)?.clone());
         } else if origin_predicates.len() != predicates.len() {

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
@@ -20,6 +20,7 @@ use crate::optimizer::rule::rewrite::filter_join::convert_mark_to_semi_join;
 use crate::optimizer::rule::rewrite::filter_join::convert_outer_to_inner_join;
 use crate::optimizer::rule::rewrite::filter_join::remove_nullable;
 use crate::optimizer::rule::rewrite::filter_join::rewrite_predicates;
+use crate::optimizer::rule::rewrite::filter_join::try_derive_predicates;
 use crate::optimizer::rule::Rule;
 use crate::optimizer::rule::TransformResult;
 use crate::optimizer::RelExpr;
@@ -201,32 +202,8 @@ pub fn try_push_down_filter_join(
         return Ok((false, s_expr.clone()));
     }
 
-    let mut left_child = join_expr.child(0)?.clone();
-    let mut right_child = join_expr.child(1)?.clone();
-
-    if !left_push_down.is_empty() {
-        left_child = SExpr::create_unary(
-            Filter {
-                predicates: left_push_down,
-                is_having: false,
-            }
-            .into(),
-            left_child,
-        );
-    }
-
-    if !right_push_down.is_empty() {
-        right_child = SExpr::create_unary(
-            Filter {
-                predicates: right_push_down,
-                is_having: false,
-            }
-            .into(),
-            right_child,
-        );
-    }
-
-    let mut result = SExpr::create_binary(join.into(), left_child, right_child);
+    // try to derive new predicate and push down filter
+    let mut result = try_derive_predicates(s_expr, join, left_push_down, right_push_down)?;
 
     if !original_predicates.is_empty() {
         result = SExpr::create_unary(

--- a/tests/sqllogictests/suites/mode/cluster/04_0002_explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/04_0002_explain_v2.test
@@ -47,14 +47,17 @@ Exchange
         ├── estimated rows: 0.00
         ├── Exchange(Build)
         │   ├── exchange type: Hash(t2.a (#2))
-        │   └── TableScan
-        │       ├── table: default.default.t2
-        │       ├── read rows: 0
-        │       ├── read bytes: 0
-        │       ├── partitions total: 0
-        │       ├── partitions scanned: 0
-        │       ├── push downs: [filters: [], limit: NONE]
-        │       └── estimated rows: 0.00
+        │   └── Filter
+        │       ├── filters: [or(gt(t2.a (#2), to_int32(3)), gt(t2.a (#2), to_int32(1)))]
+        │       ├── estimated rows: 0.00
+        │       └── TableScan
+        │           ├── table: default.default.t2
+        │           ├── read rows: 0
+        │           ├── read bytes: 0
+        │           ├── partitions total: 0
+        │           ├── partitions scanned: 0
+        │           ├── push downs: [filters: [or(gt(t2.a (#2), 3), gt(t2.a (#2), 1))], limit: NONE]
+        │           └── estimated rows: 0.00
         └── Exchange(Probe)
             ├── exchange type: Hash(t1.a (#0))
             └── Filter

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -32,13 +32,13 @@ explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a an
 ----
 Filter
 ├── filters: [or(gt(t1.a (#0), to_uint64(3)), and(gt(t2.a (#2), to_uint64(5)), gt(t1.a (#0), to_uint64(1))))]
-├── estimated rows: 0.19
+├── estimated rows: 0.14
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [t1.a (#0)]
     ├── probe keys: [t2.a (#2)]
     ├── filters: []
-    ├── estimated rows: 0.56
+    ├── estimated rows: 0.43
     ├── Filter(Build)
     │   ├── filters: [or(gt(t1.a (#0), to_uint64(3)), gt(t1.a (#0), to_uint64(1)))]
     │   ├── estimated rows: 0.56
@@ -51,15 +51,18 @@ Filter
     │       ├── pruning stats: [segments: <range pruning: 1 to 0>, blocks: <range pruning: 0 to 0, bloom pruning: 0 to 0>]
     │       ├── push downs: [filters: [or(gt(t1.a (#0), 3), gt(t1.a (#0), 1))], limit: NONE]
     │       └── estimated rows: 1.00
-    └── TableScan(Probe)
-        ├── table: default.default.t2
-        ├── read rows: 5
-        ├── read bytes: 108
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-        ├── push downs: [filters: [], limit: NONE]
-        └── estimated rows: 5.00
+    └── Filter(Probe)
+        ├── filters: [or(gt(t2.a (#2), to_uint64(3)), gt(t2.a (#2), to_uint64(1)))]
+        ├── estimated rows: 3.12
+        └── TableScan
+            ├── table: default.default.t2
+            ├── read rows: 5
+            ├── read bytes: 108
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+            ├── push downs: [filters: [or(gt(t2.a (#2), 3), gt(t2.a (#2), 1))], limit: NONE]
+            └── estimated rows: 5.00
 
 query T
 explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -209,31 +209,34 @@ explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where
 ----
 HashJoin
 ├── join type: INNER
-├── build keys: [b.x (#1)]
-├── probe keys: [a.x (#0)]
+├── build keys: [a.x (#0)]
+├── probe keys: [b.x (#1)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── Filter(Build)
-│   ├── filters: [gt(b.x (#1), CAST(42 AS Int32 NULL))]
-│   ├── estimated rows: 2.67
+│   ├── filters: [gt(a.x (#0), CAST(42 AS Int32 NULL))]
+│   ├── estimated rows: 1.33
 │   └── TableScan
-│       ├── table: default.default.twocolumn
+│       ├── table: default.default.onecolumn
 │       ├── read rows: 4
-│       ├── read bytes: 94
+│       ├── read bytes: 45
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [gt(b.x (#1), 42)], limit: NONE]
+│       ├── push downs: [filters: [gt(a.x (#0), 42)], limit: NONE]
 │       └── estimated rows: 4.00
-└── TableScan(Probe)
-    ├── table: default.default.onecolumn
-    ├── read rows: 4
-    ├── read bytes: 45
-    ├── partitions total: 1
-    ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 4.00
+└── Filter(Probe)
+    ├── filters: [gt(b.x (#1), CAST(42 AS Int32 NULL))]
+    ├── estimated rows: 2.67
+    └── TableScan
+        ├── table: default.default.twocolumn
+        ├── read rows: 4
+        ├── read bytes: 94
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [gt(b.x (#1), 42)], limit: NONE]
+        └── estimated rows: 4.00
 
 query T
 explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where b.x > 44 or b.x < 43
@@ -256,46 +259,52 @@ HashJoin
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [or(gt(b.x (#1), 44), lt(b.x (#1), 43))], limit: NONE]
 │       └── estimated rows: 4.00
-└── TableScan(Probe)
-    ├── table: default.default.onecolumn
-    ├── read rows: 4
-    ├── read bytes: 45
-    ├── partitions total: 1
-    ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 4.00
+└── Filter(Probe)
+    ├── filters: [or(gt(a.x (#0), CAST(44 AS Int32 NULL)), lt(a.x (#0), CAST(43 AS Int32 NULL)))]
+    ├── estimated rows: 2.67
+    └── TableScan
+        ├── table: default.default.onecolumn
+        ├── read rows: 4
+        ├── read bytes: 45
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [or(gt(a.x (#0), 44), lt(a.x (#0), 43))], limit: NONE]
+        └── estimated rows: 4.00
 
 query T
 explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where b.x > 42 and b.x < 45
 ----
 HashJoin
 ├── join type: INNER
-├── build keys: [b.x (#1)]
-├── probe keys: [a.x (#0)]
+├── build keys: [a.x (#0)]
+├── probe keys: [b.x (#1)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── Filter(Build)
-│   ├── filters: [gt(b.x (#1), CAST(42 AS Int32 NULL)), lt(b.x (#1), CAST(45 AS Int32 NULL))]
-│   ├── estimated rows: 1.78
+│   ├── filters: [gt(a.x (#0), CAST(42 AS Int32 NULL)), lt(a.x (#0), CAST(45 AS Int32 NULL))]
+│   ├── estimated rows: 1.33
 │   └── TableScan
-│       ├── table: default.default.twocolumn
+│       ├── table: default.default.onecolumn
 │       ├── read rows: 4
-│       ├── read bytes: 94
+│       ├── read bytes: 45
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [gt(b.x (#1), 42), lt(b.x (#1), 45)], limit: NONE]
+│       ├── push downs: [filters: [gt(a.x (#0), 42), lt(a.x (#0), 45)], limit: NONE]
 │       └── estimated rows: 4.00
-└── TableScan(Probe)
-    ├── table: default.default.onecolumn
-    ├── read rows: 4
-    ├── read bytes: 45
-    ├── partitions total: 1
-    ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 4.00
+└── Filter(Probe)
+    ├── filters: [gt(b.x (#1), CAST(42 AS Int32 NULL)), lt(b.x (#1), CAST(45 AS Int32 NULL))]
+    ├── estimated rows: 1.78
+    └── TableScan
+        ├── table: default.default.twocolumn
+        ├── read rows: 4
+        ├── read bytes: 94
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [gt(b.x (#1), 42), lt(b.x (#1), 45)], limit: NONE]
+        └── estimated rows: 4.00
 
 # the following cases won't be converted to inner join
 
@@ -363,6 +372,175 @@ HashJoin
 
 statement ok
 drop table t
+
+statement ok
+drop table t1
+
+statement ok
+drop table t2
+
+statement ok
+create table t1 (a int, b int)
+
+statement ok
+create table t2 (a int, b int)
+
+query T
+explain select * from t1 inner join t2 on t1.a = t2.a where t1.a > 10
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t2.a (#2)]
+├── probe keys: [t1.a (#0)]
+├── filters: []
+├── estimated rows: 0.00
+├── Filter(Build)
+│   ├── filters: [gt(t2.a (#2), to_int32(10))]
+│   ├── estimated rows: 0.00
+│   └── TableScan
+│       ├── table: default.default.t2
+│       ├── read rows: 0
+│       ├── read bytes: 0
+│       ├── partitions total: 0
+│       ├── partitions scanned: 0
+│       ├── push downs: [filters: [gt(t2.a (#2), 10)], limit: NONE]
+│       └── estimated rows: 0.00
+└── Filter(Probe)
+    ├── filters: [gt(t1.a (#0), to_int32(10))]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: default.default.t1
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [gt(t1.a (#0), 10)], limit: NONE]
+        └── estimated rows: 0.00
+
+query T
+explain select * from t1 inner join t2 on t1.a = t2.a where t1.a + t1.b> 10
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t2.a (#2)]
+├── probe keys: [t1.a (#0)]
+├── filters: []
+├── estimated rows: 0.00
+├── TableScan(Build)
+│   ├── table: default.default.t2
+│   ├── read rows: 0
+│   ├── read bytes: 0
+│   ├── partitions total: 0
+│   ├── partitions scanned: 0
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 0.00
+└── Filter(Probe)
+    ├── filters: [gt(plus(t1.a (#0), t1.b (#1)), to_int64(10))]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: default.default.t1
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [gt(plus(t1.a (#0), t1.b (#1)), 10)], limit: NONE]
+        └── estimated rows: 0.00
+
+query T
+explain select * from t1 inner join t2 on t1.a = t2.a and t1.b = t2.b  where t2.a > 10
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t2.a (#2), t2.b (#3)]
+├── probe keys: [t1.a (#0), t1.b (#1)]
+├── filters: []
+├── estimated rows: 0.00
+├── Filter(Build)
+│   ├── filters: [gt(t2.a (#2), to_int32(10))]
+│   ├── estimated rows: 0.00
+│   └── TableScan
+│       ├── table: default.default.t2
+│       ├── read rows: 0
+│       ├── read bytes: 0
+│       ├── partitions total: 0
+│       ├── partitions scanned: 0
+│       ├── push downs: [filters: [gt(t2.a (#2), 10)], limit: NONE]
+│       └── estimated rows: 0.00
+└── Filter(Probe)
+    ├── filters: [gt(t1.a (#0), to_int32(10))]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: default.default.t1
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [gt(t1.a (#0), 10)], limit: NONE]
+        └── estimated rows: 0.00
+
+query T
+explain select * from t1 inner join t2 on t1.a = t2.a and t1.b = t2.b  where t2.a + t2.b> 10
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t2.a (#2), t2.b (#3)]
+├── probe keys: [t1.a (#0), t1.b (#1)]
+├── filters: []
+├── estimated rows: 0.00
+├── Filter(Build)
+│   ├── filters: [gt(plus(t2.a (#2), t2.b (#3)), to_int64(10))]
+│   ├── estimated rows: 0.00
+│   └── TableScan
+│       ├── table: default.default.t2
+│       ├── read rows: 0
+│       ├── read bytes: 0
+│       ├── partitions total: 0
+│       ├── partitions scanned: 0
+│       ├── push downs: [filters: [gt(plus(t2.a (#2), t2.b (#3)), 10)], limit: NONE]
+│       └── estimated rows: 0.00
+└── Filter(Probe)
+    ├── filters: [gt(plus(t1.a (#0), t1.b (#1)), to_int64(10))]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: default.default.t1
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [gt(plus(t1.a (#0), t1.b (#1)), 10)], limit: NONE]
+        └── estimated rows: 0.00
+
+query T
+explain select * from t1 inner join t2 on t1.a = t2.a and t1.b = t2.b  where t1.b + t1.a> 10
+----
+HashJoin
+├── join type: INNER
+├── build keys: [t2.a (#2), t2.b (#3)]
+├── probe keys: [t1.a (#0), t1.b (#1)]
+├── filters: []
+├── estimated rows: 0.00
+├── Filter(Build)
+│   ├── filters: [gt(plus(t2.b (#3), t2.a (#2)), to_int64(10))]
+│   ├── estimated rows: 0.00
+│   └── TableScan
+│       ├── table: default.default.t2
+│       ├── read rows: 0
+│       ├── read bytes: 0
+│       ├── partitions total: 0
+│       ├── partitions scanned: 0
+│       ├── push downs: [filters: [gt(plus(t2.b (#3), t2.a (#2)), 10)], limit: NONE]
+│       └── estimated rows: 0.00
+└── Filter(Probe)
+    ├── filters: [gt(plus(t1.b (#1), t1.a (#0)), to_int64(10))]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: default.default.t1
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [gt(plus(t1.b (#1), t1.a (#0)), 10)], limit: NONE]
+        └── estimated rows: 0.00
 
 statement ok
 drop table t1

--- a/tests/sqllogictests/suites/mode/standalone/explain/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/limit.test
@@ -91,32 +91,29 @@ Limit
                     ├── estimated rows: 1.00
                     ├── EvalScalar(Build)
                     │   ├── expressions: [COUNT(*) (#5)]
-                    │   ├── estimated rows: 0.33
+                    │   ├── estimated rows: 1.00
                     │   └── AggregateFinal
                     │       ├── group by: [number]
                     │       ├── aggregate functions: [count()]
-                    │       ├── estimated rows: 0.33
+                    │       ├── estimated rows: 1.00
                     │       └── AggregatePartial
                     │           ├── group by: [number]
                     │           ├── aggregate functions: [count()]
-                    │           ├── estimated rows: 0.33
+                    │           ├── estimated rows: 1.00
                     │           └── HashJoin
                     │               ├── join type: CROSS
                     │               ├── build keys: []
                     │               ├── probe keys: []
                     │               ├── filters: []
-                    │               ├── estimated rows: 0.33
-                    │               ├── Filter(Build)
-                    │               │   ├── filters: [eq(subquery_2 (#2), t2.number (#2))]
-                    │               │   ├── estimated rows: 0.33
-                    │               │   └── TableScan
-                    │               │       ├── table: default.system.numbers
-                    │               │       ├── read rows: 1
-                    │               │       ├── read bytes: 8
-                    │               │       ├── partitions total: 1
-                    │               │       ├── partitions scanned: 1
-                    │               │       ├── push downs: [filters: [eq(subquery_2 (#2), t2.number (#2))], limit: NONE]
-                    │               │       └── estimated rows: 1.00
+                    │               ├── estimated rows: 1.00
+                    │               ├── TableScan(Build)
+                    │               │   ├── table: default.system.numbers
+                    │               │   ├── read rows: 1
+                    │               │   ├── read bytes: 8
+                    │               │   ├── partitions total: 1
+                    │               │   ├── partitions scanned: 1
+                    │               │   ├── push downs: [filters: [], limit: NONE]
+                    │               │   └── estimated rows: 1.00
                     │               └── TableScan(Probe)
                     │                   ├── table: default.system.numbers
                     │                   ├── read rows: 1

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -12,32 +12,29 @@ Filter
     ├── estimated rows: 1.00
     ├── EvalScalar(Build)
     │   ├── expressions: [COUNT(*) (#5)]
-    │   ├── estimated rows: 0.33
+    │   ├── estimated rows: 1.00
     │   └── AggregateFinal
     │       ├── group by: [number]
     │       ├── aggregate functions: [count()]
-    │       ├── estimated rows: 0.33
+    │       ├── estimated rows: 1.00
     │       └── AggregatePartial
     │           ├── group by: [number]
     │           ├── aggregate functions: [count()]
-    │           ├── estimated rows: 0.33
+    │           ├── estimated rows: 1.00
     │           └── HashJoin
     │               ├── join type: CROSS
     │               ├── build keys: []
     │               ├── probe keys: []
     │               ├── filters: []
-    │               ├── estimated rows: 0.33
-    │               ├── Filter(Build)
-    │               │   ├── filters: [eq(subquery_2 (#2), t2.number (#2))]
-    │               │   ├── estimated rows: 0.33
-    │               │   └── TableScan
-    │               │       ├── table: default.system.numbers
-    │               │       ├── read rows: 1
-    │               │       ├── read bytes: 8
-    │               │       ├── partitions total: 1
-    │               │       ├── partitions scanned: 1
-    │               │       ├── push downs: [filters: [eq(subquery_2 (#2), t2.number (#2))], limit: NONE]
-    │               │       └── estimated rows: 1.00
+    │               ├── estimated rows: 1.00
+    │               ├── TableScan(Build)
+    │               │   ├── table: default.system.numbers
+    │               │   ├── read rows: 1
+    │               │   ├── read bytes: 8
+    │               │   ├── partitions total: 1
+    │               │   ├── partitions scanned: 1
+    │               │   ├── push downs: [filters: [], limit: NONE]
+    │               │   └── estimated rows: 1.00
     │               └── TableScan(Probe)
     │                   ├── table: default.system.numbers
     │                   ├── read rows: 1
@@ -74,24 +71,21 @@ explain select t.number from numbers(1) as t where exists (select t1.number from
 ----
 Filter
 ├── filters: [or(2 (#2), CAST(gt(t.number (#0), to_uint64(1)) AS Boolean NULL))]
-├── estimated rows: 0.33
+├── estimated rows: 1.00
 └── HashJoin
     ├── join type: RIGHT MARK
     ├── build keys: [subquery_1 (#1)]
     ├── probe keys: [subquery_0 (#0)]
     ├── filters: []
-    ├── estimated rows: 0.33
-    ├── Filter(Build)
-    │   ├── filters: [eq(subquery_1 (#1), t1.number (#1))]
-    │   ├── estimated rows: 0.33
-    │   └── TableScan
-    │       ├── table: default.system.numbers
-    │       ├── read rows: 1
-    │       ├── read bytes: 8
-    │       ├── partitions total: 1
-    │       ├── partitions scanned: 1
-    │       ├── push downs: [filters: [eq(subquery_1 (#1), t1.number (#1))], limit: NONE]
-    │       └── estimated rows: 1.00
+    ├── estimated rows: 1.00
+    ├── TableScan(Build)
+    │   ├── table: default.system.numbers
+    │   ├── read rows: 1
+    │   ├── read bytes: 8
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.system.numbers
         ├── read rows: 1
@@ -353,26 +347,23 @@ Filter
     ├── estimated rows: 1.00
     ├── EvalScalar(Build)
     │   ├── expressions: [eq(COUNT(*) (#4), to_uint64(1))]
-    │   ├── estimated rows: 0.33
+    │   ├── estimated rows: 1.00
     │   └── AggregateFinal
     │       ├── group by: [number]
     │       ├── aggregate functions: [count()]
-    │       ├── estimated rows: 0.33
+    │       ├── estimated rows: 1.00
     │       └── AggregatePartial
     │           ├── group by: [number]
     │           ├── aggregate functions: [count()]
-    │           ├── estimated rows: 0.33
-    │           └── Filter
-    │               ├── filters: [eq(subquery_2 (#2), numbers.number (#2))]
-    │               ├── estimated rows: 0.33
-    │               └── TableScan
-    │                   ├── table: default.system.numbers
-    │                   ├── read rows: 1
-    │                   ├── read bytes: 8
-    │                   ├── partitions total: 1
-    │                   ├── partitions scanned: 1
-    │                   ├── push downs: [filters: [eq(subquery_2 (#2), numbers.number (#2))], limit: NONE]
-    │                   └── estimated rows: 1.00
+    │           ├── estimated rows: 1.00
+    │           └── TableScan
+    │               ├── table: default.system.numbers
+    │               ├── read rows: 1
+    │               ├── read bytes: 8
+    │               ├── partitions total: 1
+    │               ├── partitions scanned: 1
+    │               ├── push downs: [filters: [], limit: NONE]
+    │               └── estimated rows: 1.00
     └── HashJoin(Probe)
         ├── join type: INNER
         ├── build keys: [t1.number (#1)]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```sql 
mysql> explain select nodm.locno,
    ->        sum(nodd.qty + 10)                    as d_boxes,
    ->        sum(nodd.qty * nodd.packing_qty + 100 ) as d_qty,
    ->        count(distinct nodd.article_no)  as skues,
    ->        count(distinct nodm.deliver_no)  as sheets
    -> from ods_nwms.nwms_om_deliver_m nodm
    ->          inner join ods_nwms.nwms_om_deliver_d nodd on nodm.locno = nodd.locno and nodm.deliver_no = nodd.deliver_no
    ->   where nodm.locno = 'C52'
    -> group by
    ->     nodm.locno
    -> order by d_qty
    ->    ;
```
`nodm.locno = nodd.locno  + nodm.locno = 'C52' ⇒ nodd.locno = 'C52'`

For more cases, please see `join.test`.

Closes #9988 
