### PR TITLE
feat(planner): Support `EXPLAIN ANALYZE` statement to profile query execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,6 +1896,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-profile"
+version = "0.1.0"
+
+[[package]]
 name = "common-proto-conv"
 version = "0.1.0"
 dependencies = [
@@ -2003,6 +2007,7 @@ dependencies = [
  "common-pipeline-core",
  "common-pipeline-sources",
  "common-pipeline-transforms",
+ "common-profile",
  "common-settings",
  "common-storage",
  "common-storages-parquet",
@@ -3080,6 +3085,7 @@ dependencies = [
  "common-pipeline-sinks",
  "common-pipeline-sources",
  "common-pipeline-transforms",
+ "common-profile",
  "common-settings",
  "common-sql",
  "common-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "src/common/metrics",
     "src/common/tracing",
     "src/common/storage",
+    "src/common/profile",
     # Query
     "src/query/ast",
     "src/query/codegen",

--- a/src/common/profile/Cargo.toml
+++ b/src/common/profile/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "common-profile"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
+
+[lib]
+doctest = false
+test = false

--- a/src/common/profile/src/lib.rs
+++ b/src/common/profile/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Datafuse Labs.
+// Copyright 2023 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ExplainKind {
-    Ast(String),
-    Syntax(String),
-    // The display string will be filled by optimizer, as we
-    // don't want to expose `Memo` to other crates.
-    Memo(String),
-    Graph,
-    Pipeline,
-    Fragments,
-    Raw,
-    Plan,
-
-    // Explain analyze plan
-    AnalyzePlan,
-}
+mod span;
+pub use span::*;

--- a/src/common/profile/src/span.rs
+++ b/src/common/profile/src/span.rs
@@ -1,0 +1,70 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+pub type ProfSpanSetRef<K = u32> = Arc<Mutex<ProfSpanSet<K>>>;
+
+#[derive(Default)]
+pub struct ProfSpan {
+    /// The time spent to process in nanoseconds
+    pub process_time: u64,
+}
+
+impl ProfSpan {
+    pub fn add(&mut self, other: &Self) {
+        self.process_time += other.process_time;
+    }
+}
+
+#[derive(Default)]
+pub struct ProfSpanSet<K = u32> {
+    spans: HashMap<K, ProfSpan>,
+}
+
+impl<K> ProfSpanSet<K>
+where K: std::hash::Hash + Eq
+{
+    pub fn update(&mut self, key: K, span: ProfSpan) {
+        let entry = self.spans.entry(key).or_insert_with(ProfSpan::default);
+        entry.add(&span);
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &ProfSpan)> {
+        self.spans.iter()
+    }
+
+    pub fn get(&self, k: &K) -> Option<&ProfSpan> {
+        self.spans.get(k)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct ProfSpanBuilder {
+    process_time: u64,
+}
+
+impl ProfSpanBuilder {
+    pub fn accumulate_process_time(&mut self, nanos: u64) {
+        self.process_time += nanos;
+    }
+
+    pub fn finish(self) -> ProfSpan {
+        ProfSpan {
+            process_time: self.process_time,
+        }
+    }
+}

--- a/src/query/ast/src/ast/format/ast_format.rs
+++ b/src/query/ast/src/ast/format/ast_format.rs
@@ -677,6 +677,7 @@ impl<'ast> Visitor<'ast> for AstFormatVisitor {
             ExplainKind::Raw => "Raw",
             ExplainKind::Plan => "Plan",
             ExplainKind::Memo(_) => "Memo",
+            ExplainKind::AnalyzePlan => "Analyze",
         });
         let format_ctx = AstFormatContext::with_children(name, 1);
         let node = FormatTreeNode::with_children(format_ctx, vec![child]);

--- a/src/query/ast/src/ast/statements/statement.rs
+++ b/src/query/ast/src/ast/statements/statement.rs
@@ -34,6 +34,9 @@ pub enum Statement {
         kind: ExplainKind,
         query: Box<Statement>,
     },
+    ExplainAnalyze {
+        query: Box<Statement>,
+    },
 
     Copy(CopyStmt),
     Call(CallStmt),
@@ -206,9 +209,13 @@ impl Display for Statement {
                     ExplainKind::Fragments => write!(f, " FRAGMENTS")?,
                     ExplainKind::Raw => write!(f, " RAW")?,
                     ExplainKind::Plan => (),
+                    ExplainKind::AnalyzePlan => write!(f, " ANALYZE")?,
                     ExplainKind::Memo(_) => write!(f, "MEMO")?,
                 }
                 write!(f, " {query}")?;
+            }
+            Statement::ExplainAnalyze { query } => {
+                write!(f, "EXPLAIN ANALYZE {query}")?;
             }
             Statement::Query(query) => write!(f, "{query}")?,
             Statement::Insert(insert) => write!(f, "{insert}")?,

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -82,6 +82,14 @@ pub fn statement(i: Input) -> IResult<StatementMsg> {
             })
         },
     );
+    let explain_analyze = map(
+        rule! {
+            EXPLAIN ~ ANALYZE ~ #statement
+        },
+        |(_, _, statement)| Statement::ExplainAnalyze {
+            query: Box::new(statement.stmt),
+        },
+    );
     let insert = map(
         rule! {
             INSERT ~ ( INTO | OVERWRITE ) ~ TABLE?
@@ -992,6 +1000,7 @@ pub fn statement(i: Input) -> IResult<StatementMsg> {
         rule!(
             #map(query, |query| Statement::Query(Box::new(query)))
             | #explain : "`EXPLAIN [PIPELINE | GRAPH] <statement>`"
+            | #explain_analyze : "`EXPLAIN ANALYZE <statement>`"
             | #insert : "`INSERT INTO [TABLE] <table> [(<column>, ...)] (FORMAT <format> | VALUES <values> | <query>)`"
             | #delete : "`DELETE FROM <table> [WHERE ...]`"
             | #update : "`UPDATE <table> SET <column> = <expr> [, <column> = <expr> , ... ] [WHERE ...]`"

--- a/src/query/ast/src/visitors/walk.rs
+++ b/src/query/ast/src/visitors/walk.rs
@@ -299,6 +299,7 @@ pub fn walk_cte<'a, V: Visitor<'a>>(visitor: &mut V, cte: &'a CTE) {
 pub fn walk_statement<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Statement) {
     match statement {
         Statement::Explain { kind, query } => visitor.visit_explain(kind, query),
+        Statement::ExplainAnalyze { query } => visitor.visit_statement(query),
         Statement::Query(query) => visitor.visit_query(query),
         Statement::Insert(insert) => visitor.visit_insert(insert),
         Statement::Delete {

--- a/src/query/ast/src/visitors/walk_mut.rs
+++ b/src/query/ast/src/visitors/walk_mut.rs
@@ -299,6 +299,7 @@ pub fn walk_cte_mut<V: VisitorMut>(visitor: &mut V, cte: &mut CTE) {
 pub fn walk_statement_mut<V: VisitorMut>(visitor: &mut V, statement: &mut Statement) {
     match statement {
         Statement::Explain { kind, query } => visitor.visit_explain(kind, &mut *query),
+        Statement::ExplainAnalyze { query } => visitor.visit_statement(&mut *query),
         Statement::Query(query) => visitor.visit_query(&mut *query),
         Statement::Insert(insert) => visitor.visit_insert(insert),
         Statement::Delete {

--- a/src/query/pipeline/core/src/processors/processor.rs
+++ b/src/query/pipeline/core/src/processors/processor.rs
@@ -114,3 +114,30 @@ impl ProcessorPtr {
         (*self.inner.get()).async_process().boxed()
     }
 }
+
+#[async_trait::async_trait]
+impl<T: Processor + ?Sized> Processor for Box<T> {
+    fn name(&self) -> String {
+        (**self).name()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        (**self).as_any()
+    }
+
+    fn event(&mut self) -> Result<Event> {
+        (**self).event()
+    }
+
+    fn interrupt(&self) {
+        (**self).interrupt()
+    }
+
+    fn process(&mut self) -> Result<()> {
+        (**self).process()
+    }
+
+    async fn async_process(&mut self) -> Result<()> {
+        (**self).async_process().await
+    }
+}

--- a/src/query/pipeline/sinks/src/async_sink.rs
+++ b/src/query/pipeline/sinks/src/async_sink.rs
@@ -21,7 +21,6 @@ use common_exception::Result;
 use common_expression::DataBlock;
 use common_pipeline_core::processors::port::InputPort;
 use common_pipeline_core::processors::processor::Event;
-use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_core::processors::Processor;
 
 #[async_trait]
@@ -49,14 +48,14 @@ pub struct AsyncSinker<T: AsyncSink + 'static> {
 }
 
 impl<T: AsyncSink + 'static> AsyncSinker<T> {
-    pub fn create(input: Arc<InputPort>, inner: T) -> ProcessorPtr {
-        ProcessorPtr::create(Box::new(AsyncSinker {
+    pub fn create(input: Arc<InputPort>, inner: T) -> Box<dyn Processor> {
+        Box::new(AsyncSinker {
             inner,
             input,
             input_data: None,
             called_on_start: false,
             called_on_finish: false,
-        }))
+        })
     }
 }
 

--- a/src/query/pipeline/sinks/src/context_sink.rs
+++ b/src/query/pipeline/sinks/src/context_sink.rs
@@ -18,7 +18,7 @@ use common_catalog::table_context::TableContext;
 use common_exception::Result;
 use common_expression::DataBlock;
 use common_pipeline_core::processors::port::InputPort;
-use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_core::processors::Processor;
 
 use crate::Sink;
 use crate::Sinker;
@@ -28,7 +28,7 @@ pub struct ContextSink {
 }
 
 impl ContextSink {
-    pub fn create(input: Arc<InputPort>, ctx: Arc<dyn TableContext>) -> ProcessorPtr {
+    pub fn create(input: Arc<InputPort>, ctx: Arc<dyn TableContext>) -> Box<dyn Processor> {
         Sinker::create(input, ContextSink { ctx })
     }
 }

--- a/src/query/pipeline/sinks/src/empty_sink.rs
+++ b/src/query/pipeline/sinks/src/empty_sink.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_expression::DataBlock;
 use common_pipeline_core::processors::port::InputPort;
-use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_core::processors::Processor;
 
 use super::Sink;
 use super::Sinker;
@@ -25,7 +25,7 @@ use super::Sinker;
 pub struct EmptySink;
 
 impl EmptySink {
-    pub fn create(input: Arc<InputPort>) -> ProcessorPtr {
+    pub fn create(input: Arc<InputPort>) -> Box<dyn Processor> {
         Sinker::create(input, EmptySink {})
     }
 }

--- a/src/query/pipeline/sinks/src/sync_sink.rs
+++ b/src/query/pipeline/sinks/src/sync_sink.rs
@@ -19,7 +19,6 @@ use common_exception::Result;
 use common_expression::DataBlock;
 use common_pipeline_core::processors::port::InputPort;
 use common_pipeline_core::processors::processor::Event;
-use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_core::processors::Processor;
 
 pub trait Sink: Send {
@@ -47,14 +46,14 @@ pub struct Sinker<T: Sink + 'static> {
 }
 
 impl<T: Sink + 'static> Sinker<T> {
-    pub fn create(input: Arc<InputPort>, inner: T) -> ProcessorPtr {
-        ProcessorPtr::create(Box::new(Sinker {
+    pub fn create(input: Arc<InputPort>, inner: T) -> Box<dyn Processor> {
+        Box::new(Sinker {
             inner,
             input,
             input_data: None,
             called_on_start: false,
             called_on_finish: false,
-        }))
+        })
     }
 }
 

--- a/src/query/pipeline/sinks/src/sync_sink_sender.rs
+++ b/src/query/pipeline/sinks/src/sync_sink_sender.rs
@@ -18,7 +18,7 @@ use common_base::base::tokio::sync::mpsc::Sender;
 use common_exception::Result;
 use common_expression::DataBlock;
 use common_pipeline_core::processors::port::InputPort;
-use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_core::processors::Processor;
 
 use crate::Sink;
 use crate::Sinker;
@@ -28,7 +28,7 @@ pub struct SyncSenderSink {
 }
 
 impl SyncSenderSink {
-    pub fn create(sender: Sender<Result<DataBlock>>, input: Arc<InputPort>) -> ProcessorPtr {
+    pub fn create(sender: Sender<Result<DataBlock>>, input: Arc<InputPort>) -> Box<dyn Processor> {
         Sinker::create(input, SyncSenderSink { sender })
     }
 }

--- a/src/query/pipeline/sinks/src/union_receive_sink.rs
+++ b/src/query/pipeline/sinks/src/union_receive_sink.rs
@@ -21,7 +21,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::DataBlock;
 use common_pipeline_core::processors::port::InputPort;
-use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_core::processors::Processor;
 
 use crate::AsyncSink;
 use crate::AsyncSinker;
@@ -31,7 +31,7 @@ pub struct UnionReceiveSink {
 }
 
 impl UnionReceiveSink {
-    pub fn create(sender: Option<Sender<DataBlock>>, input: Arc<InputPort>) -> ProcessorPtr {
+    pub fn create(sender: Option<Sender<DataBlock>>, input: Arc<InputPort>) -> Box<dyn Processor> {
         AsyncSinker::create(input, UnionReceiveSink { sender })
     }
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/transform.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform.rs
@@ -20,7 +20,6 @@ use common_expression::DataBlock;
 use common_pipeline_core::processors::port::InputPort;
 use common_pipeline_core::processors::port::OutputPort;
 use common_pipeline_core::processors::processor::Event;
-use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_core::processors::Processor;
 
 // TODO: maybe we also need async transform for `SELECT sleep(1)`?
@@ -55,8 +54,8 @@ pub struct Transformer<T: Transform + 'static> {
 }
 
 impl<T: Transform + 'static> Transformer<T> {
-    pub fn create(input: Arc<InputPort>, output: Arc<OutputPort>, inner: T) -> ProcessorPtr {
-        ProcessorPtr::create(Box::new(Transformer {
+    pub fn create(input: Arc<InputPort>, output: Arc<OutputPort>, inner: T) -> Box<dyn Processor> {
+        Box::new(Self {
             input,
             output,
             transform: inner,
@@ -64,7 +63,7 @@ impl<T: Transform + 'static> Transformer<T> {
             output_data: None,
             called_on_start: false,
             called_on_finish: false,
-        }))
+        })
     }
 }
 

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact.rs
@@ -22,7 +22,6 @@ use common_expression::DataBlock;
 use common_pipeline_core::processors::port::InputPort;
 use common_pipeline_core::processors::port::OutputPort;
 use common_pipeline_core::processors::processor::Event;
-use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_core::processors::Processor;
 
 pub type Aborting = Arc<Box<dyn Fn() -> bool + Send + Sync + 'static>>;
@@ -57,7 +56,7 @@ impl<T: Compactor + Send + 'static> TransformCompact<T> {
         input_port: Arc<InputPort>,
         output_port: Arc<OutputPort>,
         compactor: T,
-    ) -> Result<ProcessorPtr> {
+    ) -> Result<Box<dyn Processor>> {
         let state = ProcessorState::Consume(ConsumeState {
             input_port,
             output_port,
@@ -65,7 +64,7 @@ impl<T: Compactor + Send + 'static> TransformCompact<T> {
             output_data_blocks: VecDeque::new(),
         });
 
-        Ok(ProcessorPtr::create(Box::new(Self { state, compactor })))
+        Ok(Box::new(Self { state, compactor }))
     }
 
     #[inline(always)]

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_sort_partial.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_sort_partial.rs
@@ -19,7 +19,7 @@ use common_expression::DataBlock;
 use common_expression::SortColumnDescription;
 use common_pipeline_core::processors::port::InputPort;
 use common_pipeline_core::processors::port::OutputPort;
-use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_core::processors::Processor;
 
 use crate::processors::transforms::Transform;
 use crate::processors::transforms::Transformer;
@@ -35,7 +35,7 @@ impl TransformSortPartial {
         output: Arc<OutputPort>,
         limit: Option<usize>,
         sort_columns_descriptions: Vec<SortColumnDescription>,
-    ) -> Result<ProcessorPtr> {
+    ) -> Result<Box<dyn Processor>> {
         Ok(Transformer::create(input, output, TransformSortPartial {
             limit,
             sort_columns_descriptions,

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -61,6 +61,7 @@ common-pipeline-core = { path = "../pipeline/core" }
 common-pipeline-sinks = { path = "../pipeline/sinks" }
 common-pipeline-sources = { path = "../pipeline/sources" }
 common-pipeline-transforms = { path = "../pipeline/transforms" }
+common-profile = { path = "../../common/profile" }
 common-settings = { path = "../settings" }
 common-sql = { path = "../sql" }
 common-storage = { path = "../../common/storage" }
@@ -78,7 +79,6 @@ common-storages-system = { path = "../storages/system" }
 common-storages-view = { path = "../storages/view" }
 common-tracing = { path = "../../common/tracing" }
 common-users = { path = "../users" }
-common-profile = { path = "../../common/profile" }
 storages-common-cache = { path = "../storages/common/cache" }
 
 storages-common-blocks = { path = "../storages/common/blocks" }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -78,6 +78,7 @@ common-storages-system = { path = "../storages/system" }
 common-storages-view = { path = "../storages/view" }
 common-tracing = { path = "../../common/tracing" }
 common-users = { path = "../users" }
+common-profile = { path = "../../common/profile" }
 storages-common-cache = { path = "../storages/common/cache" }
 
 storages-common-blocks = { path = "../storages/common/blocks" }

--- a/src/query/service/src/api/rpc/exchange/exchange_manager.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_manager.rs
@@ -27,6 +27,7 @@ use common_config::GlobalConfig;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_grpc::ConnectionFactory;
+use common_profile::ProfSpanSetRef;
 use parking_lot::Mutex;
 use parking_lot::ReentrantMutex;
 
@@ -652,7 +653,8 @@ impl FragmentCoordinator {
             match &self.payload {
                 FragmentPayload::Plan(plan) => {
                     let pipeline_ctx = QueryContext::create_from(ctx);
-                    let pipeline_builder = PipelineBuilder::create(pipeline_ctx);
+                    let pipeline_builder =
+                        PipelineBuilder::create(pipeline_ctx, false, ProfSpanSetRef::default());
                     self.pipeline_build_res = Some(pipeline_builder.finalize(plan)?);
                 }
             };

--- a/src/query/service/src/api/rpc/exchange/exchange_sink.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_sink.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_pipeline_core::pipe::Pipe;
+use common_pipeline_core::processors::processor::ProcessorPtr;
 
 use crate::api::rpc::exchange::exchange_params::ExchangeParams;
 use crate::api::rpc::exchange::exchange_sink_writer::create_writer_items;
@@ -61,10 +62,10 @@ impl ExchangeSink {
 
                 assert_eq!(flight_exchange.len(), 1);
                 pipeline.add_sink(|input| {
-                    Ok(ExchangeWriterSink::create(
+                    Ok(ProcessorPtr::create(ExchangeWriterSink::create(
                         input,
                         flight_exchange[0].clone(),
-                    ))
+                    )))
                 })
             }
             ExchangeParams::ShuffleExchange(params) => {

--- a/src/query/service/src/api/rpc/exchange/exchange_sink_writer.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_sink_writer.rs
@@ -20,6 +20,7 @@ use common_expression::DataBlock;
 use common_pipeline_core::pipe::PipeItem;
 use common_pipeline_core::processors::port::InputPort;
 use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_core::processors::Processor;
 use common_pipeline_sinks::AsyncSink;
 use common_pipeline_sinks::AsyncSinker;
 
@@ -31,7 +32,7 @@ pub struct ExchangeWriterSink {
 }
 
 impl ExchangeWriterSink {
-    pub fn create(input: Arc<InputPort>, flight_exchange: FlightExchange) -> ProcessorPtr {
+    pub fn create(input: Arc<InputPort>, flight_exchange: FlightExchange) -> Box<dyn Processor> {
         AsyncSinker::create(input, ExchangeWriterSink {
             exchange: flight_exchange,
         })
@@ -72,7 +73,7 @@ impl AsyncSink for ExchangeWriterSink {
 pub fn create_writer_item(exchange: FlightExchange) -> PipeItem {
     let input = InputPort::create();
     PipeItem::create(
-        ExchangeWriterSink::create(input.clone(), exchange),
+        ProcessorPtr::create(ExchangeWriterSink::create(input.clone(), exchange)),
         vec![input],
         vec![],
     )

--- a/src/query/service/src/api/rpc/exchange/exchange_transform_scatter.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_transform_scatter.rs
@@ -34,7 +34,9 @@ impl ScatterTransform {
         output: Arc<OutputPort>,
         scatter: Arc<Box<dyn FlightScatter>>,
     ) -> ProcessorPtr {
-        Transformer::create(input, output, ScatterTransform { scatter })
+        ProcessorPtr::create(Transformer::create(input, output, ScatterTransform {
+            scatter,
+        }))
     }
 }
 

--- a/src/query/service/src/api/rpc/exchange/serde/exchange_deserializer.rs
+++ b/src/query/service/src/api/rpc/exchange/serde/exchange_deserializer.rs
@@ -59,11 +59,15 @@ impl TransformExchangeDeserializer {
             is_little_endian: true,
         };
 
-        Transformer::create(input, output, TransformExchangeDeserializer {
-            ipc_schema,
-            arrow_schema,
-            schema: schema.clone(),
-        })
+        ProcessorPtr::create(Transformer::create(
+            input,
+            output,
+            TransformExchangeDeserializer {
+                ipc_schema,
+                arrow_schema,
+                schema: schema.clone(),
+            },
+        ))
     }
 
     fn recv_data(&self, fragment_data: FragmentData) -> Result<DataBlock> {

--- a/src/query/service/src/api/rpc/exchange/serde/exchange_serializer.rs
+++ b/src/query/service/src/api/rpc/exchange/serde/exchange_serializer.rs
@@ -104,10 +104,14 @@ impl TransformExchangeSerializer {
     ) -> ProcessorPtr {
         let arrow_schema = schema.to_arrow();
         let ipc_fields = default_ipc_fields(&arrow_schema.fields);
-        Transformer::create(input, output, TransformExchangeSerializer {
-            ipc_fields,
-            options: WriteOptions { compression: None },
-        })
+        ProcessorPtr::create(Transformer::create(
+            input,
+            output,
+            TransformExchangeSerializer {
+                ipc_fields,
+                options: WriteOptions { compression: None },
+            },
+        ))
     }
 }
 

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -57,6 +57,7 @@ impl AccessChecker for PrivilegeAccess {
                 }
             }
             Plan::Explain { .. } => {}
+            Plan::ExplainAnalyze { .. } => {}
             Plan::Copy(_) => {}
             Plan::Call(_) => {}
             // Catalog

--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -98,6 +98,11 @@ impl InterpreterFactory {
                 plan.clone(),
                 ExplainKind::Syntax(formatted_sql.clone()),
             )?)),
+            Plan::ExplainAnalyze { plan } => Ok(Arc::new(ExplainInterpreter::try_create(
+                ctx,
+                *plan.clone(),
+                ExplainKind::AnalyzePlan,
+            )?)),
 
             Plan::Call(plan) => Ok(Arc::new(CallInterpreter::try_create(ctx, *plan.clone())?)),
 

--- a/src/query/service/src/interpreters/interpreter_insert_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_insert_v2.rs
@@ -416,7 +416,7 @@ impl Interpreter for InsertInterpreterV2 {
                             bind_context,
                             ..
                         } => {
-                            let builder1 =
+                            let mut builder1 =
                                 PhysicalPlanBuilder::new(metadata.clone(), self.ctx.clone());
                             (builder1.build(s_expr).await?, bind_context.columns.clone())
                         }
@@ -459,7 +459,8 @@ impl Interpreter for InsertInterpreterV2 {
                     };
 
                     let mut build_res =
-                        build_query_pipeline(&self.ctx, &[], &insert_select_plan, false).await?;
+                        build_query_pipeline(&self.ctx, &[], &insert_select_plan, false, false)
+                            .await?;
 
                     let ctx = self.ctx.clone();
                     let overwrite = self.plan.overwrite;

--- a/src/query/service/src/interpreters/interpreter_select_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_select_v2.rs
@@ -54,13 +54,14 @@ impl SelectInterpreterV2 {
     }
 
     pub async fn build_pipeline(&self) -> Result<PipelineBuildResult> {
-        let builder = PhysicalPlanBuilder::new(self.metadata.clone(), self.ctx.clone());
+        let mut builder = PhysicalPlanBuilder::new(self.metadata.clone(), self.ctx.clone());
         let physical_plan = builder.build(&self.s_expr).await?;
         build_query_pipeline(
             &self.ctx,
             &self.bind_context.columns,
             &physical_plan,
             self.ignore_result,
+            false,
         )
         .await
     }

--- a/src/query/service/src/pipelines/executor/pipeline_pulling_executor.rs
+++ b/src/query/service/src/pipelines/executor/pipeline_pulling_executor.rs
@@ -24,6 +24,7 @@ use common_base::runtime::Thread;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::DataBlock;
+use common_pipeline_core::processors::Processor;
 use common_pipeline_sinks::Sink;
 use common_pipeline_sinks::Sinker;
 use parking_lot::Condvar;
@@ -103,7 +104,7 @@ impl PipelinePullingExecutor {
             ));
         }
 
-        pipeline.add_sink(|input| Ok(PullingSink::create(tx.clone(), input)))
+        pipeline.add_sink(|input| Ok(ProcessorPtr::create(PullingSink::create(tx.clone(), input))))
     }
 
     pub fn try_create(
@@ -215,7 +216,7 @@ struct PullingSink {
 }
 
 impl PullingSink {
-    pub fn create(tx: SyncSender<DataBlock>, input: Arc<InputPort>) -> ProcessorPtr {
+    pub fn create(tx: SyncSender<DataBlock>, input: Arc<InputPort>) -> Box<dyn Processor> {
         Sinker::create(input, PullingSink { sender: Some(tx) })
     }
 }

--- a/src/query/service/src/pipelines/pipeline_build_res.rs
+++ b/src/query/service/src/pipelines/pipeline_build_res.rs
@@ -18,11 +18,16 @@ use common_pipeline_core::processors::port::OutputPort;
 use common_pipeline_core::Pipeline;
 use common_pipeline_core::SourcePipeBuilder;
 use common_pipeline_sources::OneBlockSource;
+use common_profile::ProfSpanSetRef;
 
 pub struct PipelineBuildResult {
     pub main_pipeline: Pipeline,
     // Containing some sub queries pipelines, must be complete pipeline
     pub sources_pipelines: Vec<Pipeline>,
+
+    /// Set of profiling spans for the query.
+    /// Will be empty if profiling is disabled.
+    pub prof_span_set: ProfSpanSetRef,
 }
 
 impl PipelineBuildResult {
@@ -30,6 +35,7 @@ impl PipelineBuildResult {
         PipelineBuildResult {
             main_pipeline: Pipeline::create(),
             sources_pipelines: vec![],
+            prof_span_set: ProfSpanSetRef::default(),
         }
     }
 
@@ -47,6 +53,7 @@ impl PipelineBuildResult {
         Ok(PipelineBuildResult {
             main_pipeline,
             sources_pipelines: vec![],
+            prof_span_set: ProfSpanSetRef::default(),
         })
     }
 

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -27,10 +27,12 @@ use common_expression::SortColumnDescription;
 use common_functions::aggregates::AggregateFunctionFactory;
 use common_functions::aggregates::AggregateFunctionRef;
 use common_functions::scalars::BUILTIN_FUNCTIONS;
+use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_sinks::EmptySink;
 use common_pipeline_sinks::Sinker;
 use common_pipeline_sinks::UnionReceiveSink;
 use common_pipeline_transforms::processors::transforms::try_add_multi_sort_merge;
+use common_profile::ProfSpanSetRef;
 use common_sql::evaluator::BlockOperator;
 use common_sql::evaluator::CompoundBlockOperator;
 use common_sql::executor::AggregateFinal;
@@ -52,6 +54,7 @@ use common_sql::plans::JoinType;
 use common_sql::ColumnBinding;
 use common_sql::IndexType;
 
+use super::processors::ProfileWrapper;
 use crate::pipelines::processors::transforms::efficiently_memory_final_aggregator;
 use crate::pipelines::processors::transforms::HashJoinDesc;
 use crate::pipelines::processors::transforms::RightSemiAntiJoinCompactor;
@@ -82,16 +85,26 @@ use crate::sessions::TableContext;
 
 pub struct PipelineBuilder {
     ctx: Arc<QueryContext>,
+
     main_pipeline: Pipeline,
     pub pipelines: Vec<Pipeline>,
+
+    enable_profiling: bool,
+    prof_span_set: ProfSpanSetRef,
 }
 
 impl PipelineBuilder {
-    pub fn create(ctx: Arc<QueryContext>) -> PipelineBuilder {
+    pub fn create(
+        ctx: Arc<QueryContext>,
+        enable_profiling: bool,
+        prof_span_set: ProfSpanSetRef,
+    ) -> PipelineBuilder {
         PipelineBuilder {
+            enable_profiling,
             ctx,
             pipelines: vec![],
             main_pipeline: Pipeline::create(),
+            prof_span_set,
         }
     }
 
@@ -109,6 +122,7 @@ impl PipelineBuilder {
         Ok(PipelineBuildResult {
             main_pipeline: self.main_pipeline,
             sources_pipelines: self.pipelines,
+            prof_span_set: self.prof_span_set,
         })
     }
 
@@ -137,7 +151,7 @@ impl PipelineBuilder {
 
     fn build_join(&mut self, join: &HashJoin) -> Result<()> {
         let state = self.build_join_state(join)?;
-        self.expand_build_side_pipeline(&join.build, state.clone())?;
+        self.expand_build_side_pipeline(&join.build, join, state.clone())?;
         self.build_join_probe(join, state)
     }
 
@@ -154,18 +168,33 @@ impl PipelineBuilder {
     fn expand_build_side_pipeline(
         &mut self,
         build: &PhysicalPlan,
+        hash_join_plan: &HashJoin,
         join_state: Arc<JoinHashTable>,
     ) -> Result<()> {
         let build_side_context = QueryContext::create_from(self.ctx.clone());
-        let build_side_builder = PipelineBuilder::create(build_side_context);
+        let build_side_builder = PipelineBuilder::create(
+            build_side_context,
+            self.enable_profiling,
+            self.prof_span_set.clone(),
+        );
         let mut build_res = build_side_builder.finalize(build)?;
 
         assert!(build_res.main_pipeline.is_pulling_pipeline()?);
         build_res.main_pipeline.add_sink(|input| {
-            Ok(Sinker::<SinkBuildHashTable>::create(
+            let transform = Sinker::<SinkBuildHashTable>::create(
                 input,
                 SinkBuildHashTable::try_create(join_state.clone())?,
-            ))
+            );
+
+            if self.enable_profiling {
+                Ok(ProcessorPtr::create(ProfileWrapper::create(
+                    transform,
+                    hash_join_plan.plan_id,
+                    self.prof_span_set.clone(),
+                )))
+            } else {
+                Ok(ProcessorPtr::create(transform))
+            }
         })?;
 
         self.pipelines.push(build_res.main_pipeline);
@@ -182,7 +211,7 @@ impl PipelineBuilder {
         ignore_result: bool,
     ) -> Result<()> {
         if ignore_result {
-            return pipeline.add_sink(|input| Ok(EmptySink::create(input)));
+            return pipeline.add_sink(|input| Ok(ProcessorPtr::create(EmptySink::create(input))));
         }
 
         let mut projections = Vec::with_capacity(result_columns.len());
@@ -199,14 +228,14 @@ impl PipelineBuilder {
             result_fields.push(DataField::new(name.as_str(), data_type.clone()));
         }
         pipeline.add_transform(|input, output| {
-            Ok(CompoundBlockOperator::create(
+            Ok(ProcessorPtr::create(CompoundBlockOperator::create(
                 input,
                 output,
                 *func_ctx,
                 vec![BlockOperator::Project {
                     projection: projections.clone(),
                 }],
-            ))
+            )))
         })?;
 
         Ok(())
@@ -229,12 +258,12 @@ impl PipelineBuilder {
             let ops = vec![BlockOperator::Project { projection }];
             let func_ctx = self.ctx.get_function_context()?;
             self.main_pipeline.add_transform(|input, output| {
-                Ok(CompoundBlockOperator::create(
+                Ok(ProcessorPtr::create(CompoundBlockOperator::create(
                     input,
                     output,
                     func_ctx,
                     ops.clone(),
-                ))
+                )))
             })?;
         }
         Ok(())
@@ -258,14 +287,24 @@ impl PipelineBuilder {
             })?;
 
         self.main_pipeline.add_transform(|input, output| {
-            Ok(CompoundBlockOperator::create(
+            let transform = CompoundBlockOperator::create(
                 input,
                 output,
                 self.ctx.get_function_context()?,
                 vec![BlockOperator::Filter {
                     expr: predicate.clone(),
                 }],
-            ))
+            );
+
+            if self.enable_profiling {
+                Ok(ProcessorPtr::create(ProfileWrapper::create(
+                    transform,
+                    filter.plan_id,
+                    self.prof_span_set.clone(),
+                )))
+            } else {
+                Ok(ProcessorPtr::create(transform))
+            }
         })?;
 
         Ok(())
@@ -276,14 +315,14 @@ impl PipelineBuilder {
         let func_ctx = self.ctx.get_function_context()?;
 
         self.main_pipeline.add_transform(|input, output| {
-            Ok(CompoundBlockOperator::create(
+            Ok(ProcessorPtr::create(CompoundBlockOperator::create(
                 input,
                 output,
                 func_ctx,
                 vec![BlockOperator::Project {
                     projection: project.projections.clone(),
                 }],
-            ))
+            )))
         })
     }
 
@@ -302,12 +341,18 @@ impl PipelineBuilder {
         let func_ctx = self.ctx.get_function_context()?;
 
         self.main_pipeline.add_transform(|input, output| {
-            Ok(CompoundBlockOperator::create(
-                input,
-                output,
-                func_ctx,
-                operators.clone(),
-            ))
+            let transform =
+                CompoundBlockOperator::create(input, output, func_ctx, operators.clone());
+
+            if self.enable_profiling {
+                Ok(ProcessorPtr::create(ProfileWrapper::create(
+                    transform,
+                    eval_scalar.plan_id,
+                    self.prof_span_set.clone(),
+                )))
+            } else {
+                Ok(ProcessorPtr::create(transform))
+            }
         })?;
 
         Ok(())
@@ -326,11 +371,21 @@ impl PipelineBuilder {
         let pass_state_to_final = self.enable_memory_efficient_aggregator(&params);
 
         self.main_pipeline.add_transform(|input, output| {
-            TransformAggregator::try_create_partial(
+            let transform = TransformAggregator::try_create_partial(
                 AggregatorTransformParams::try_create(input, output, &params)?,
                 self.ctx.clone(),
                 pass_state_to_final,
-            )
+            )?;
+
+            if self.enable_profiling {
+                Ok(ProcessorPtr::create(ProfileWrapper::create(
+                    transform,
+                    aggregate.plan_id,
+                    self.prof_span_set.clone(),
+                )))
+            } else {
+                Ok(ProcessorPtr::create(transform))
+            }
         })?;
 
         Ok(())
@@ -359,10 +414,20 @@ impl PipelineBuilder {
 
         self.main_pipeline.resize(1)?;
         self.main_pipeline.add_transform(|input, output| {
-            TransformAggregator::try_create_final(
+            let transform = TransformAggregator::try_create_final(
                 self.ctx.clone(),
                 AggregatorTransformParams::try_create(input, output, &params)?,
-            )
+            )?;
+
+            if self.enable_profiling {
+                Ok(ProcessorPtr::create(ProfileWrapper::create(
+                    transform,
+                    aggregate.plan_id,
+                    self.prof_span_set.clone(),
+                )))
+            } else {
+                Ok(ProcessorPtr::create(transform))
+            }
         })?;
 
         Ok(())
@@ -443,16 +508,37 @@ impl PipelineBuilder {
 
         // Sort
         self.main_pipeline.add_transform(|input, output| {
-            TransformSortPartial::try_create(input, output, sort.limit, sort_desc.clone())
+            let transform =
+                TransformSortPartial::try_create(input, output, sort.limit, sort_desc.clone())?;
+
+            if self.enable_profiling {
+                Ok(ProcessorPtr::create(ProfileWrapper::create(
+                    transform,
+                    sort.plan_id,
+                    self.prof_span_set.clone(),
+                )))
+            } else {
+                Ok(ProcessorPtr::create(transform))
+            }
         })?;
 
         // Merge
         self.main_pipeline.add_transform(|input, output| {
-            TransformSortMerge::try_create(
+            let transform = TransformSortMerge::try_create(
                 input,
                 output,
                 SortMergeCompactor::new(block_size, sort.limit, sort_desc.clone()),
-            )
+            )?;
+
+            if self.enable_profiling {
+                Ok(ProcessorPtr::create(ProfileWrapper::create(
+                    transform,
+                    sort.plan_id,
+                    self.prof_span_set.clone(),
+                )))
+            } else {
+                Ok(ProcessorPtr::create(transform))
+            }
         })?;
 
         // Concat merge in single thread
@@ -470,7 +556,17 @@ impl PipelineBuilder {
 
         self.main_pipeline.resize(1)?;
         self.main_pipeline.add_transform(|input, output| {
-            TransformLimit::try_create(limit.limit, limit.offset, input, output)
+            let transform = TransformLimit::try_create(limit.limit, limit.offset, input, output)?;
+
+            if self.enable_profiling {
+                Ok(ProcessorPtr::create(ProfileWrapper::create(
+                    transform,
+                    limit.plan_id,
+                    self.prof_span_set.clone(),
+                )))
+            } else {
+                Ok(ProcessorPtr::create(transform))
+            }
         })
     }
 
@@ -478,13 +574,23 @@ impl PipelineBuilder {
         self.build_pipeline(&join.probe)?;
 
         self.main_pipeline.add_transform(|input, output| {
-            TransformHashJoinProbe::create(
+            let transform = TransformHashJoinProbe::create(
                 self.ctx.clone(),
                 input,
                 output,
                 state.clone(),
                 join.output_schema()?,
-            )
+            )?;
+
+            if self.enable_profiling {
+                Ok(ProcessorPtr::create(ProfileWrapper::create(
+                    transform,
+                    join.plan_id,
+                    self.prof_span_set.clone(),
+                )))
+            } else {
+                Ok(ProcessorPtr::create(transform))
+            }
         })?;
 
         if (join.join_type == JoinType::Left
@@ -494,44 +600,84 @@ impl PipelineBuilder {
         {
             self.main_pipeline.resize(1)?;
             self.main_pipeline.add_transform(|input, output| {
-                TransformLeftJoin::try_create(
+                let transform = TransformLeftJoin::try_create(
                     input,
                     output,
                     LeftJoinCompactor::create(state.clone()),
-                )
+                )?;
+
+                if self.enable_profiling {
+                    Ok(ProcessorPtr::create(ProfileWrapper::create(
+                        transform,
+                        join.plan_id,
+                        self.prof_span_set.clone(),
+                    )))
+                } else {
+                    Ok(ProcessorPtr::create(transform))
+                }
             })?;
         }
 
         if join.join_type == JoinType::LeftMark {
             self.main_pipeline.resize(1)?;
             self.main_pipeline.add_transform(|input, output| {
-                TransformMarkJoin::try_create(
+                let transform = TransformMarkJoin::try_create(
                     input,
                     output,
                     MarkJoinCompactor::create(state.clone()),
-                )
+                )?;
+
+                if self.enable_profiling {
+                    Ok(ProcessorPtr::create(ProfileWrapper::create(
+                        transform,
+                        join.plan_id,
+                        self.prof_span_set.clone(),
+                    )))
+                } else {
+                    Ok(ProcessorPtr::create(transform))
+                }
             })?;
         }
 
         if join.join_type == JoinType::Right || join.join_type == JoinType::Full {
             self.main_pipeline.resize(1)?;
             self.main_pipeline.add_transform(|input, output| {
-                TransformRightJoin::try_create(
+                let transform = TransformRightJoin::try_create(
                     input,
                     output,
                     RightJoinCompactor::create(state.clone()),
-                )
+                )?;
+
+                if self.enable_profiling {
+                    Ok(ProcessorPtr::create(ProfileWrapper::create(
+                        transform,
+                        join.plan_id,
+                        self.prof_span_set.clone(),
+                    )))
+                } else {
+                    Ok(ProcessorPtr::create(transform))
+                }
             })?;
         }
 
         if join.join_type == JoinType::RightAnti || join.join_type == JoinType::RightSemi {
             self.main_pipeline.resize(1)?;
             self.main_pipeline.add_transform(|input, output| {
-                TransformRightSemiAntiJoin::try_create(
+                let transform = TransformRightSemiAntiJoin::try_create(
                     input,
                     output,
                     RightSemiAntiJoinCompactor::create(state.clone()),
-                )
+                )?;
+
+                if self.enable_profiling {
+                    Ok(ProcessorPtr::create(ProfileWrapper::create(
+                        transform,
+                        join.plan_id,
+                        self.prof_span_set.clone(),
+                    )))
+                } else {
+                    Ok(ProcessorPtr::create(transform))
+                }
             })?;
         }
 
@@ -555,18 +701,33 @@ impl PipelineBuilder {
         self.build_pipeline(&exchange_sink.input)
     }
 
-    fn expand_union_all(&mut self, plan: &PhysicalPlan) -> Result<Receiver<DataBlock>> {
+    fn expand_union_all(
+        &mut self,
+        input: &PhysicalPlan,
+        union_plan: &UnionAll,
+    ) -> Result<Receiver<DataBlock>> {
         let union_ctx = QueryContext::create_from(self.ctx.clone());
-        let pipeline_builder = PipelineBuilder::create(union_ctx);
-        let mut build_res = pipeline_builder.finalize(plan)?;
+        let pipeline_builder =
+            PipelineBuilder::create(union_ctx, self.enable_profiling, self.prof_span_set.clone());
+        let mut build_res = pipeline_builder.finalize(input)?;
 
         assert!(build_res.main_pipeline.is_pulling_pipeline()?);
 
         let (tx, rx) = async_channel::unbounded();
 
-        build_res
-            .main_pipeline
-            .add_sink(|input_port| Ok(UnionReceiveSink::create(Some(tx.clone()), input_port)))?;
+        build_res.main_pipeline.add_sink(|input_port| {
+            let transform = UnionReceiveSink::create(Some(tx.clone()), input_port);
+
+            if self.enable_profiling {
+                Ok(ProcessorPtr::create(ProfileWrapper::create(
+                    transform,
+                    union_plan.plan_id,
+                    self.prof_span_set.clone(),
+                )))
+            } else {
+                Ok(ProcessorPtr::create(transform))
+            }
+        })?;
 
         self.pipelines.push(build_res.main_pipeline);
         self.pipelines
@@ -576,17 +737,27 @@ impl PipelineBuilder {
 
     pub fn build_union_all(&mut self, union_all: &UnionAll) -> Result<()> {
         self.build_pipeline(&union_all.left)?;
-        let union_all_receiver = self.expand_union_all(&union_all.right)?;
+        let union_all_receiver = self.expand_union_all(&union_all.right, union_all)?;
         self.main_pipeline
             .add_transform(|transform_input_port, transform_output_port| {
-                TransformMergeBlock::try_create(
+                let transform = TransformMergeBlock::try_create(
                     transform_input_port,
                     transform_output_port,
                     union_all.left.output_schema()?,
                     union_all.right.output_schema()?,
                     union_all.pairs.clone(),
                     union_all_receiver.clone(),
-                )
+                )?;
+
+                if self.enable_profiling {
+                    Ok(ProcessorPtr::create(ProfileWrapper::create(
+                        transform,
+                        union_all.plan_id,
+                        self.prof_span_set.clone(),
+                    )))
+                } else {
+                    Ok(ProcessorPtr::create(transform))
+                }
             })?;
         Ok(())
     }

--- a/src/query/service/src/pipelines/processors/mod.rs
+++ b/src/query/service/src/pipelines/processors/mod.rs
@@ -26,6 +26,7 @@ pub use transforms::HashTable;
 pub use transforms::JoinHashTable;
 pub use transforms::LeftJoinCompactor;
 pub use transforms::MarkJoinCompactor;
+pub use transforms::ProfileWrapper;
 pub use transforms::RightJoinCompactor;
 pub use transforms::SerializerHashTable;
 pub use transforms::SinkBuildHashTable;

--- a/src/query/service/src/pipelines/processors/transforms/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/mod.rs
@@ -24,6 +24,7 @@ mod transform_left_join;
 mod transform_limit;
 mod transform_mark_join;
 
+mod profile_wrapper;
 mod transform_add_const_columns;
 mod transform_convert_grouping;
 mod transform_merge_block;
@@ -44,6 +45,7 @@ pub use hash_join::HashJoinState;
 pub use hash_join::HashTable;
 pub use hash_join::JoinHashTable;
 pub use hash_join::SerializerHashTable;
+pub use profile_wrapper::ProfileWrapper;
 pub use transform_add_const_columns::TransformAddConstColumns;
 pub use transform_aggregator::TransformAggregator;
 pub use transform_block_compact::BlockCompactor;

--- a/src/query/service/src/pipelines/processors/transforms/profile_wrapper.rs
+++ b/src/query/service/src/pipelines/processors/transforms/profile_wrapper.rs
@@ -1,0 +1,85 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Instant;
+
+use common_exception::Result;
+use common_pipeline_core::processors::processor::Event;
+use common_pipeline_core::processors::Processor;
+use common_profile::ProfSpanBuilder;
+use common_profile::ProfSpanSetRef;
+
+pub struct ProfileWrapper<T> {
+    inner: T,
+    prof_span_id: u32,
+    prof_span_set: ProfSpanSetRef,
+    prof_span_builder: ProfSpanBuilder,
+}
+
+impl<T> ProfileWrapper<T>
+where T: Processor + 'static
+{
+    pub fn create(
+        inner: T,
+        prof_span_id: u32,
+        prof_span_set: ProfSpanSetRef,
+    ) -> Box<dyn Processor> {
+        Box::new(Self {
+            inner,
+            prof_span_id,
+            prof_span_set,
+            prof_span_builder: ProfSpanBuilder::default(),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl<T> Processor for ProfileWrapper<T>
+where T: Processor + 'static
+{
+    fn name(&self) -> String {
+        self.inner.name()
+    }
+
+    fn as_any(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn event(&mut self) -> Result<Event> {
+        match self.inner.event()? {
+            Event::Finished => {
+                self.prof_span_set
+                    .lock()
+                    .unwrap()
+                    .update(self.prof_span_id, self.prof_span_builder.clone().finish());
+                Ok(Event::Finished)
+            }
+            v => Ok(v),
+        }
+    }
+
+    fn process(&mut self) -> Result<()> {
+        let instant = Instant::now();
+        self.inner.process()?;
+        let elapsed = instant.elapsed();
+        self.prof_span_builder
+            .accumulate_process_time(elapsed.as_nanos() as u64);
+        Ok(())
+    }
+
+    async fn async_process(&mut self) -> Result<()> {
+        // TODO: record profile information for async process
+        self.inner.async_process().await
+    }
+}

--- a/src/query/service/src/pipelines/processors/transforms/transform_add_const_columns.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_add_const_columns.rs
@@ -79,10 +79,14 @@ where Self: Transform
             operators: ops,
         };
 
-        Ok(Transformer::create(input, output, Self {
-            expression_transform,
-            input_len: input_schema.num_fields(),
-        }))
+        Ok(ProcessorPtr::create(Transformer::create(
+            input,
+            output,
+            Self {
+                expression_transform,
+                input_len: input_schema.num_fields(),
+            },
+        )))
     }
 }
 

--- a/src/query/service/src/pipelines/processors/transforms/transform_aggregator.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_aggregator.rs
@@ -23,7 +23,6 @@ use common_expression::*;
 use crate::pipelines::processors::port::InputPort;
 use crate::pipelines::processors::port::OutputPort;
 use crate::pipelines::processors::processor::Event;
-use crate::pipelines::processors::processor::ProcessorPtr;
 use crate::pipelines::processors::transforms::aggregator::*;
 use crate::pipelines::processors::AggregatorTransformParams;
 use crate::pipelines::processors::Processor;
@@ -35,7 +34,7 @@ impl TransformAggregator {
     pub fn try_create_final(
         ctx: Arc<QueryContext>,
         transform_params: AggregatorTransformParams,
-    ) -> Result<ProcessorPtr> {
+    ) -> Result<Box<dyn Processor>> {
         let aggregator_params = transform_params.aggregator_params.clone();
 
         let max_threads = ctx.get_settings().get_max_threads()? as usize;
@@ -70,7 +69,7 @@ impl TransformAggregator {
         transform_params: AggregatorTransformParams,
         ctx: Arc<QueryContext>,
         pass_state_to_final: bool,
-    ) -> Result<ProcessorPtr> {
+    ) -> Result<Box<dyn Processor>> {
         let aggregator_params = transform_params.aggregator_params.clone();
 
         let max_threads = ctx.get_settings().get_max_threads()? as usize;
@@ -132,7 +131,7 @@ impl<TAggregator: Aggregator + PartitionedAggregatorLike + 'static>
         ctx: Arc<QueryContext>,
         transform_params: AggregatorTransformParams,
         inner: TAggregator,
-    ) -> Result<ProcessorPtr> {
+    ) -> Result<Box<dyn Processor>> {
         let settings = ctx.get_settings();
         let two_level_threshold = settings.get_group_by_two_level_threshold()? as usize;
 
@@ -147,11 +146,9 @@ impl<TAggregator: Aggregator + PartitionedAggregatorLike + 'static>
         if TAggregator::SUPPORT_TWO_LEVEL
             && transform_params.aggregator_params.has_distinct_combinator()
         {
-            Ok(ProcessorPtr::create(Box::new(
-                transformer.convert_to_two_level_consume()?,
-            )))
+            Ok(Box::new(transformer.convert_to_two_level_consume()?))
         } else {
-            Ok(ProcessorPtr::create(Box::new(transformer)))
+            Ok(Box::new(transformer))
         }
     }
 

--- a/src/query/service/src/pipelines/processors/transforms/transform_cast_schema.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_cast_schema.rs
@@ -68,11 +68,15 @@ where Self: Transform
                 }
             })
             .collect();
-        Ok(Transformer::create(input_port, output_port, Self {
-            func_ctx,
-            insert_schema,
-            exprs,
-        }))
+        Ok(ProcessorPtr::create(Transformer::create(
+            input_port,
+            output_port,
+            Self {
+                func_ctx,
+                insert_schema,
+                exprs,
+            },
+        )))
     }
 }
 

--- a/src/query/service/src/pipelines/processors/transforms/transform_dummy.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_dummy.rs
@@ -29,7 +29,7 @@ pub struct TransformDummy;
 impl TransformDummy {
     #[allow(dead_code)]
     pub fn create(input: Arc<InputPort>, output: Arc<OutputPort>) -> ProcessorPtr {
-        Transformer::create(input, output, TransformDummy {})
+        ProcessorPtr::create(Transformer::create(input, output, TransformDummy {}))
     }
 }
 

--- a/src/query/service/src/pipelines/processors/transforms/transform_hash_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_hash_join.rs
@@ -25,7 +25,6 @@ use super::hash_join::ProbeState;
 use crate::pipelines::processors::port::InputPort;
 use crate::pipelines::processors::port::OutputPort;
 use crate::pipelines::processors::processor::Event;
-use crate::pipelines::processors::processor::ProcessorPtr;
 use crate::pipelines::processors::transforms::hash_join::HashJoinState;
 use crate::pipelines::processors::Processor;
 use crate::sessions::QueryContext;
@@ -81,9 +80,9 @@ impl TransformHashJoinProbe {
         output_port: Arc<OutputPort>,
         join_state: Arc<dyn HashJoinState>,
         _output_schema: DataSchemaRef,
-    ) -> Result<ProcessorPtr> {
+    ) -> Result<Box<dyn Processor>> {
         let default_block_size = ctx.get_settings().get_max_block_size()?;
-        Ok(ProcessorPtr::create(Box::new(TransformHashJoinProbe {
+        Ok(Box::new(TransformHashJoinProbe {
             input_data: None,
             output_data_blocks: VecDeque::new(),
             input_port,
@@ -91,7 +90,7 @@ impl TransformHashJoinProbe {
             step: HashJoinStep::Build,
             join_state,
             probe_state: ProbeState::with_capacity(default_block_size as usize),
-        })))
+        }))
     }
 
     fn probe(&mut self, block: &DataBlock) -> Result<()> {

--- a/src/query/service/src/pipelines/processors/transforms/transform_limit.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_limit.rs
@@ -22,7 +22,6 @@ use common_expression::DataBlock;
 use crate::pipelines::processors::port::InputPort;
 use crate::pipelines::processors::port::OutputPort;
 use crate::pipelines::processors::processor::Event;
-use crate::pipelines::processors::processor::ProcessorPtr;
 use crate::pipelines::processors::Processor;
 
 pub struct TransformLimit;
@@ -33,7 +32,7 @@ impl TransformLimit {
         offset: usize,
         input: Arc<InputPort>,
         output: Arc<OutputPort>,
-    ) -> Result<ProcessorPtr> {
+    ) -> Result<Box<dyn Processor>> {
         match (limit, offset) {
             (None, 0) => Err(ErrorCode::Internal("It's a bug")),
             (Some(_), 0) => OnlyLimitTransform::create(input, output, limit, offset),
@@ -68,15 +67,15 @@ impl<const MODE: usize> TransformLimitImpl<MODE> {
         output: Arc<OutputPort>,
         limit: Option<usize>,
         offset: usize,
-    ) -> Result<ProcessorPtr> {
-        Ok(ProcessorPtr::create(Box::new(Self {
+    ) -> Result<Box<dyn Processor>> {
+        Ok(Box::new(Self {
             input,
             output,
             input_data_block: None,
             output_data_block: None,
             skip_remaining: offset,
             take_remaining: limit.unwrap_or(0),
-        })))
+        }))
     }
 
     pub fn take_rows(&mut self, data_block: DataBlock) -> DataBlock {

--- a/src/query/service/src/pipelines/processors/transforms/transform_merge_block.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_merge_block.rs
@@ -27,7 +27,6 @@ use common_io::prelude::FormatSettings;
 use common_pipeline_core::processors::port::InputPort;
 use common_pipeline_core::processors::port::OutputPort;
 use common_pipeline_core::processors::processor::Event;
-use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_core::processors::Processor;
 
 pub struct TransformMergeBlock {
@@ -53,8 +52,8 @@ impl TransformMergeBlock {
         right_schema: DataSchemaRef,
         pairs: Vec<(String, String)>,
         receiver: Receiver<DataBlock>,
-    ) -> Result<ProcessorPtr> {
-        Ok(ProcessorPtr::create(Box::new(TransformMergeBlock {
+    ) -> Result<Box<dyn Processor>> {
+        Ok(Box::new(TransformMergeBlock {
             finished: false,
             input,
             output,
@@ -65,7 +64,7 @@ impl TransformMergeBlock {
             pairs,
             receiver,
             receiver_result: None,
-        })))
+        }))
     }
 
     fn project_block(&self, block: DataBlock, is_left: bool) -> Result<DataBlock> {

--- a/src/query/service/src/pipelines/processors/transforms/transform_resort_addon.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_resort_addon.rs
@@ -96,10 +96,14 @@ where Self: Transform
             operators: ops,
         };
 
-        Ok(Transformer::create(input, output, Self {
-            expression_transform,
-            input_len: input_schema.num_fields(),
-        }))
+        Ok(ProcessorPtr::create(Transformer::create(
+            input,
+            output,
+            Self {
+                expression_transform,
+                input_len: input_schema.num_fields(),
+            },
+        )))
     }
 }
 

--- a/src/query/service/src/schedulers/fragments/fragmenter.rs
+++ b/src/query/service/src/schedulers/fragments/fragmenter.rs
@@ -141,6 +141,7 @@ impl PhysicalPlanReplacer for Fragmenter {
         self.fragments = fragments;
 
         Ok(PhysicalPlan::HashJoin(HashJoin {
+            plan_id: plan.plan_id,
             build: Box::new(build_input),
             probe: Box::new(probe_input),
             build_keys: plan.build_keys.clone(),

--- a/src/query/service/src/schedulers/fragments/plan_fragment.rs
+++ b/src/query/service/src/schedulers/fragments/plan_fragment.rs
@@ -191,6 +191,7 @@ struct ReplaceReadSource {
 impl PhysicalPlanReplacer for ReplaceReadSource {
     fn replace_table_scan(&mut self, plan: &TableScan) -> Result<PhysicalPlan> {
         Ok(PhysicalPlan::TableScan(TableScan {
+            plan_id: plan.plan_id,
             source: Box::new(self.source.clone()),
             name_mapping: plan.name_mapping.clone(),
             table_index: plan.table_index,

--- a/src/query/service/src/schedulers/fragments/query_fragment_actions_display.rs
+++ b/src/query/service/src/schedulers/fragments/query_fragment_actions_display.rs
@@ -15,6 +15,7 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
 
+use common_profile::ProfSpanSetRef;
 use common_sql::MetadataRef;
 
 use crate::api::DataExchange;
@@ -81,7 +82,7 @@ impl<'a> Display for QueryFragmentActionsWrap<'a> {
             match &fragment_action.payload {
                 FragmentPayload::Plan(node) => {
                     let plan_display_string = node
-                        .format(self.metadata.clone())
+                        .format(self.metadata.clone(), ProfSpanSetRef::default())
                         .and_then(|node| node.format_pretty_with_prefix("    "))
                         .unwrap();
                     write!(f, "{}", plan_display_string)?;

--- a/src/query/service/src/schedulers/scheduler.rs
+++ b/src/query/service/src/schedulers/scheduler.rs
@@ -14,7 +14,9 @@
 
 use std::sync::Arc;
 
+use common_exception::ErrorCode;
 use common_exception::Result;
+use common_profile::ProfSpanSetRef;
 
 use crate::pipelines::PipelineBuildResult;
 use crate::pipelines::PipelineBuilder;
@@ -33,10 +35,16 @@ pub async fn build_query_pipeline(
     result_columns: &[ColumnBinding],
     plan: &PhysicalPlan,
     ignore_result: bool,
+    enable_profiling: bool,
 ) -> Result<PipelineBuildResult> {
     let mut build_res = if !plan.is_distributed_plan() {
-        build_local_pipeline(ctx, plan).await
+        build_local_pipeline(ctx, plan, enable_profiling).await
     } else {
+        if enable_profiling {
+            return Err(ErrorCode::Unimplemented(
+                "Query profiling is not supported in distributed mode",
+            ));
+        }
         build_distributed_pipeline(ctx, plan).await
     }?;
 
@@ -55,8 +63,10 @@ pub async fn build_query_pipeline(
 pub async fn build_local_pipeline(
     ctx: &Arc<QueryContext>,
     plan: &PhysicalPlan,
+    enable_profiling: bool,
 ) -> Result<PipelineBuildResult> {
-    let pipeline = PipelineBuilder::create(ctx.clone());
+    let pipeline =
+        PipelineBuilder::create(ctx.clone(), enable_profiling, ProfSpanSetRef::default());
     let mut build_res = pipeline.finalize(plan)?;
 
     let settings = ctx.get_settings();

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -65,6 +65,7 @@ fn has_result_set_by_plan(plan: &Plan) -> bool {
             | Plan::Explain { .. }
             | Plan::ExplainAst { .. }
             | Plan::ExplainSyntax { .. }
+            | Plan::ExplainAnalyze { .. }
             | Plan::Call(_)
             | Plan::ShowCreateDatabase(_)
             | Plan::ShowCreateTable(_)

--- a/src/query/service/tests/it/pipelines/executor/executor_graph.rs
+++ b/src/query/service/tests/it/pipelines/executor/executor_graph.rs
@@ -22,6 +22,7 @@ use common_exception::Result;
 use common_expression::DataBlock;
 use common_pipeline_core::pipe::Pipe;
 use common_pipeline_core::pipe::PipeItem;
+use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_sinks::SyncSenderSink;
 use common_pipeline_sources::SyncReceiverSource;
 use databend_query::pipelines::executor::RunningGraph;
@@ -244,7 +245,7 @@ fn create_sink_pipe(size: usize) -> Result<(Vec<Receiver<Result<DataBlock>>>, Pi
         let (tx, rx) = channel(1);
         rxs.push(rx);
         items.push(PipeItem::create(
-            SyncSenderSink::create(tx, input.clone()),
+            ProcessorPtr::create(SyncSenderSink::create(tx, input.clone())),
             vec![input],
             vec![],
         ));

--- a/src/query/sql/Cargo.toml
+++ b/src/query/sql/Cargo.toml
@@ -31,6 +31,7 @@ common-meta-app = { path = "../../meta/app" }
 common-meta-store = { path = "../../meta/store" }
 common-meta-types = { path = "../../meta/types" }
 common-metrics = { path = "../../common/metrics" }
+common-profile = { path = "../../common/profile" }
 
 common-pipeline-core = { path = "../pipeline/core" }
 common-pipeline-sources = { path = "../pipeline/sources" }

--- a/src/query/sql/src/evaluator/block_operator.rs
+++ b/src/query/sql/src/evaluator/block_operator.rs
@@ -23,7 +23,7 @@ use common_expression::FunctionContext;
 use common_functions::scalars::BUILTIN_FUNCTIONS;
 use common_pipeline_core::processors::port::InputPort;
 use common_pipeline_core::processors::port::OutputPort;
-use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_core::processors::Processor;
 use common_pipeline_transforms::processors::transforms::Transform;
 use common_pipeline_transforms::processors::transforms::Transformer;
 
@@ -84,7 +84,7 @@ impl CompoundBlockOperator {
         output_port: Arc<OutputPort>,
         ctx: FunctionContext,
         operators: Vec<BlockOperator>,
-    ) -> ProcessorPtr {
+    ) -> Box<dyn Processor> {
         Transformer::<Self>::create(input_port, output_port, Self { operators, ctx })
     }
 

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -36,6 +36,10 @@ pub type ColumnID = String;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct TableScan {
+    /// A unique id of operator in a `PhysicalPlan` tree.
+    /// Only used for display.
+    pub plan_id: u32,
+
     pub name_mapping: BTreeMap<String, IndexType>,
     pub source: Box<DataSourcePlan>,
 
@@ -59,6 +63,10 @@ impl TableScan {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Filter {
+    /// A unique id of operator in a `PhysicalPlan` tree.
+    /// Only used for display.
+    pub plan_id: u32,
+
     pub input: Box<PhysicalPlan>,
     pub predicates: Vec<RemoteExpr>,
 
@@ -74,6 +82,10 @@ impl Filter {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Project {
+    /// A unique id of operator in a `PhysicalPlan` tree.
+    /// Only used for display.
+    pub plan_id: u32,
+
     pub input: Box<PhysicalPlan>,
     pub projections: Vec<usize>,
 
@@ -95,6 +107,10 @@ impl Project {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct EvalScalar {
+    /// A unique id of operator in a `PhysicalPlan` tree.
+    /// Only used for display.
+    pub plan_id: u32,
+
     pub input: Box<PhysicalPlan>,
     pub exprs: Vec<(RemoteExpr, IndexType)>,
 
@@ -117,6 +133,10 @@ impl EvalScalar {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct AggregatePartial {
+    /// A unique id of operator in a `PhysicalPlan` tree.
+    /// Only used for display.
+    pub plan_id: u32,
+
     pub input: Box<PhysicalPlan>,
     pub group_by: Vec<IndexType>,
     pub agg_funcs: Vec<AggregateFunctionDesc>,
@@ -155,6 +175,10 @@ impl AggregatePartial {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct AggregateFinal {
+    /// A unique id of operator in a `PhysicalPlan` tree.
+    /// Only used for display.
+    pub plan_id: u32,
+
     pub input: Box<PhysicalPlan>,
     pub group_by: Vec<IndexType>,
     pub agg_funcs: Vec<AggregateFunctionDesc>,
@@ -186,6 +210,10 @@ impl AggregateFinal {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Sort {
+    /// A unique id of operator in a `PhysicalPlan` tree.
+    /// Only used for display.
+    pub plan_id: u32,
+
     pub input: Box<PhysicalPlan>,
     pub order_by: Vec<SortDesc>,
     // limit = Limit.limit + Limit.offset
@@ -203,6 +231,10 @@ impl Sort {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Limit {
+    /// A unique id of operator in a `PhysicalPlan` tree.
+    /// Only used for display.
+    pub plan_id: u32,
+
     pub input: Box<PhysicalPlan>,
     pub limit: Option<usize>,
     pub offset: usize,
@@ -219,6 +251,10 @@ impl Limit {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct HashJoin {
+    /// A unique id of operator in a `PhysicalPlan` tree.
+    /// Only used for display.
+    pub plan_id: u32,
+
     pub build: Box<PhysicalPlan>,
     pub probe: Box<PhysicalPlan>,
     pub build_keys: Vec<RemoteExpr>,
@@ -376,6 +412,10 @@ impl ExchangeSink {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct UnionAll {
+    /// A unique id of operator in a `PhysicalPlan` tree.
+    /// Only used for display.
+    pub plan_id: u32,
+
     pub left: Box<PhysicalPlan>,
     pub right: Box<PhysicalPlan>,
     pub pairs: Vec<(String, String)>,

--- a/src/query/sql/src/executor/physical_plan_visitor.rs
+++ b/src/query/sql/src/executor/physical_plan_visitor.rs
@@ -58,6 +58,7 @@ pub trait PhysicalPlanReplacer {
         let input = self.replace(&plan.input)?;
 
         Ok(PhysicalPlan::Filter(Filter {
+            plan_id: plan.plan_id,
             input: Box::new(input),
             predicates: plan.predicates.clone(),
             stat_info: plan.stat_info.clone(),
@@ -68,6 +69,7 @@ pub trait PhysicalPlanReplacer {
         let input = self.replace(&plan.input)?;
 
         Ok(PhysicalPlan::Project(Project {
+            plan_id: plan.plan_id,
             input: Box::new(input),
             projections: plan.projections.clone(),
             columns: plan.columns.clone(),
@@ -79,6 +81,7 @@ pub trait PhysicalPlanReplacer {
         let input = self.replace(&plan.input)?;
 
         Ok(PhysicalPlan::EvalScalar(EvalScalar {
+            plan_id: plan.plan_id,
             input: Box::new(input),
             exprs: plan.exprs.clone(),
             stat_info: plan.stat_info.clone(),
@@ -89,6 +92,7 @@ pub trait PhysicalPlanReplacer {
         let input = self.replace(&plan.input)?;
 
         Ok(PhysicalPlan::AggregatePartial(AggregatePartial {
+            plan_id: plan.plan_id,
             input: Box::new(input),
             group_by: plan.group_by.clone(),
             agg_funcs: plan.agg_funcs.clone(),
@@ -100,6 +104,7 @@ pub trait PhysicalPlanReplacer {
         let input = self.replace(&plan.input)?;
 
         Ok(PhysicalPlan::AggregateFinal(AggregateFinal {
+            plan_id: plan.plan_id,
             input: Box::new(input),
             before_group_by_schema: plan.before_group_by_schema.clone(),
             group_by: plan.group_by.clone(),
@@ -114,6 +119,7 @@ pub trait PhysicalPlanReplacer {
         let probe = self.replace(&plan.probe)?;
 
         Ok(PhysicalPlan::HashJoin(HashJoin {
+            plan_id: plan.plan_id,
             build: Box::new(build),
             probe: Box::new(probe),
             build_keys: plan.build_keys.clone(),
@@ -130,6 +136,7 @@ pub trait PhysicalPlanReplacer {
         let input = self.replace(&plan.input)?;
 
         Ok(PhysicalPlan::Sort(Sort {
+            plan_id: plan.plan_id,
             input: Box::new(input),
             order_by: plan.order_by.clone(),
             limit: plan.limit,
@@ -141,6 +148,7 @@ pub trait PhysicalPlanReplacer {
         let input = self.replace(&plan.input)?;
 
         Ok(PhysicalPlan::Limit(Limit {
+            plan_id: plan.plan_id,
             input: Box::new(input),
             limit: plan.limit,
             offset: plan.offset,
@@ -180,6 +188,7 @@ pub trait PhysicalPlanReplacer {
         let left = self.replace(&plan.left)?;
         let right = self.replace(&plan.right)?;
         Ok(PhysicalPlan::UnionAll(UnionAll {
+            plan_id: plan.plan_id,
             left: Box::new(left),
             right: Box::new(right),
             schema: plan.schema.clone(),

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -106,6 +106,11 @@ impl<'a> Binder {
                 }
             }
 
+            Statement::ExplainAnalyze { query } => {
+                let plan = self.bind_statement(bind_context, query).await?;
+                Plan::ExplainAnalyze { plan: Box::new(plan) }
+            }
+
             Statement::ShowFunctions { limit } => {
                 self.bind_show_functions(bind_context, limit).await?
             }

--- a/src/query/sql/src/planner/format/display_plan.rs
+++ b/src/query/sql/src/planner/format/display_plan.rs
@@ -28,6 +28,7 @@ impl Plan {
             }
             Plan::ExplainAst { .. } => Ok("ExplainAst".to_string()),
             Plan::ExplainSyntax { .. } => Ok("ExplainSyntax".to_string()),
+            Plan::ExplainAnalyze { .. } => Ok("ExplainAnalyze".to_string()),
 
             Plan::Copy(plan) => Ok(format!("{:?}", plan)),
 

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -110,6 +110,9 @@ pub fn optimize(
                 plan: Box::new(optimize(ctx, opt_ctx, *plan)?),
             }),
         },
+        Plan::ExplainAnalyze { plan } => Ok(Plan::ExplainAnalyze {
+            plan: Box::new(optimize(ctx, opt_ctx, *plan)?),
+        }),
         Plan::Copy(v) => {
             Ok(Plan::Copy(Box::new(match *v {
                 CopyPlanV2::IntoStage {

--- a/src/query/sql/src/planner/plans/plan.rs
+++ b/src/query/sql/src/planner/plans/plan.rs
@@ -112,6 +112,9 @@ pub enum Plan {
     ExplainSyntax {
         formatted_sql: String,
     },
+    ExplainAnalyze {
+        plan: Box<Plan>,
+    },
 
     // Copy
     Copy(Box<CopyPlanV2>),
@@ -233,6 +236,7 @@ impl Display for Plan {
             Plan::Query { .. } => write!(f, "Query"),
             Plan::Copy(_) => write!(f, "Copy"),
             Plan::Explain { .. } => write!(f, "Explain"),
+            Plan::ExplainAnalyze { .. } => write!(f, "ExplainAnalyze"),
             Plan::ShowCreateCatalog(_) => write!(f, "ShowCreateCatalog"),
             Plan::CreateCatalog(_) => write!(f, "CreateCatalog"),
             Plan::DropCatalog(_) => write!(f, "DropCatalog"),
@@ -315,6 +319,9 @@ impl Plan {
                 ..
             } => bind_context.output_schema(),
             Plan::Explain { .. } | Plan::ExplainAst { .. } | Plan::ExplainSyntax { .. } => {
+                DataSchemaRefExt::create(vec![DataField::new("explain", DataType::String)])
+            }
+            Plan::ExplainAnalyze { .. } => {
                 DataSchemaRefExt::create(vec![DataField::new("explain", DataType::String)])
             }
             Plan::Copy(_) => Arc::new(DataSchema::empty()),

--- a/src/query/storages/memory/src/memory_table.rs
+++ b/src/query/storages/memory/src/memory_table.rs
@@ -233,7 +233,12 @@ impl Table for MemoryTable {
         _: AppendMode,
         _: bool,
     ) -> Result<()> {
-        pipeline.add_sink(|input| Ok(ContextSink::create(input, ctx.clone())))
+        pipeline.add_sink(|input| {
+            Ok(ProcessorPtr::create(ContextSink::create(
+                input,
+                ctx.clone(),
+            )))
+        })
     }
 
     async fn commit_insertion(

--- a/src/query/storages/null/src/null_table.rs
+++ b/src/query/storages/null/src/null_table.rs
@@ -92,7 +92,7 @@ impl Table for NullTable {
         _: AppendMode,
         _: bool,
     ) -> Result<()> {
-        pipeline.add_sink(|input| Ok(EmptySink::create(input)))?;
+        pipeline.add_sink(|input| Ok(ProcessorPtr::create(EmptySink::create(input))))?;
         Ok(())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

A naive implementation of `EXPLAIN ANALYZE` statement.

In this PR, we introduced a framework to help us profile queries.

The processing time of processors is collected and accumulated and will be displayed along with the corresponding SQL operator.

For example:
<img width="604" alt="image" src="https://user-images.githubusercontent.com/22445410/218460768-1ab13171-3e79-4cc6-9b7b-2e46f0850b3d.png">
<img width="1238" alt="image" src="https://user-images.githubusercontent.com/22445410/218463992-c3b429cd-348d-476f-82e2-5f2d648f2837.png">


This metric is helpful in figuring out which SQL operator is critical in most scenarios.

More metrics will be added later.

Closes #9927 
