### PR TITLE
chore(query): remove extra hashtable iter

### DIFF
--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -1285,6 +1285,7 @@ impl From<&DataType> for ArrowDataType {
                     .iter()
                     .enumerate()
                     .map(|(index, ty)| {
+                        let index = index + 1;
                         let name = format!("{index}");
                         ArrowField::new(name.as_str(), ty.into(), ty.is_nullable())
                     })
@@ -1396,7 +1397,7 @@ pub fn infer_schema_type(data_type: &DataType) -> Result<TableDataType> {
             let fields_name = fields
                 .iter()
                 .enumerate()
-                .map(|(idx, _)| idx.to_string())
+                .map(|(idx, _)| (idx + 1).to_string())
                 .collect::<Vec<_>>();
             Ok(TableDataType::Tuple {
                 fields_name,

--- a/src/query/functions/src/aggregates/aggregate_count.rs
+++ b/src/query/functions/src/aggregates/aggregate_count.rs
@@ -165,6 +165,19 @@ impl AggregateFunction for AggregateCountFunction {
         Ok(())
     }
 
+    fn batch_merge_result(&self, places: &[StateAddr], builder: &mut ColumnBuilder) -> Result<()> {
+        match builder {
+            ColumnBuilder::Number(NumberColumnBuilder::UInt64(builder)) => {
+                for place in places {
+                    let state = place.get::<AggregateCountState>();
+                    builder.push(state.count);
+                }
+            }
+            _ => unreachable!(),
+        }
+        Ok(())
+    }
+
     fn merge_result(&self, place: StateAddr, builder: &mut ColumnBuilder) -> Result<()> {
         match builder {
             ColumnBuilder::Number(NumberColumnBuilder::UInt64(builder)) => {

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -2352,7 +2352,7 @@ impl<'a> TypeChecker<'a> {
                 fields_name: match fields_name {
                     None => (0..fields_type.len())
                         .into_iter()
-                        .map(|i| i.to_string())
+                        .map(|i| (i + 1).to_string())
                         .collect(),
                     Some(names) => names.clone(),
                 },

--- a/tests/sqllogictests/suites/base/03_dml/03_0026_insert_into_tuple
+++ b/tests/sqllogictests/suites/base/03_dml/03_0026_insert_into_tuple
@@ -76,5 +76,14 @@ select t:a:m, t:a:n, t:a, t:b:x, t:b:y, t:b from v
 10 11 (10,11) 20 21 (20,21)
 30 31 (30,31) 40 41 (40,41)
 
+
+statement ok
+create table t4 (a Tuple(Int, Int) )
+
+query TTTT
+desc t4
+----
+a (1 INT32, 2 INT32) NO (0, 0) (empty)
+
 statement ok
 DROP DATABASE db1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

1. remove extra hashtable iter
2. fix tuple name index

Closes #issue
