### PR TITLE
chore(ci): trigger benchmark on release manually

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,9 +15,12 @@ on:
       - "**.md"
       - "docker/**"
       - ".devcontainer/**"
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The tag to run benchmark
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -30,12 +33,13 @@ env:
 
 jobs:
   build_release:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci-benchmark')
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci-benchmark')
     timeout-minutes: 30
     runs-on: [self-hosted, X64, Linux, perf]
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-depth: 0
       - uses: ./.github/actions/build_linux
         with:
@@ -86,10 +90,10 @@ jobs:
               BENCHMARK_TYPE="PR"
               jq ".extra.pr = \"${{ github.event.number }}\"" <result.json >result.json.tmp && mv result.json.tmp result.json
               ;;
-            push)
-              BENCHMARK_SYSTEM="Databend(Release@${{ github.ref_name }})"
+            workflow_dispatch)
+              BENCHMARK_SYSTEM="Databend(Release@${{ github.event.inputs.tag }})"
               BENCHMARK_TYPE="Release"
-              jq ".extra.release = \"${{ github.ref_name }}\"" <result.json >result.json.tmp && mv result.json.tmp result.json
+              jq ".extra.release = \"${{ github.event.inputs.tag }}\"" <result.json >result.json.tmp && mv result.json.tmp result.json
               ;;
             *)
               echo "Unspported event"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,14 @@ jobs:
           gh release create ${{ steps.generated-tag.outputs.tag }} --generate-notes -p
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Trigger benchmark
+        continue-on-error: true
+        run: |
+          echo "Trigger benchmark for ${{ steps.generated-tag.outputs.tag }}"
+          gh workflow run benchmark.yml -f tag=${{ steps.generated-tag.outputs.tag }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
   publish_macos:
     name: macos assets

--- a/.github/workflows/trusted-benchmark.yml
+++ b/.github/workflows/trusted-benchmark.yml
@@ -49,7 +49,7 @@ jobs:
   archive_for_release:
     runs-on: [self-hosted, X64, Linux, dev]
     if: >
-      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Releases are created by `github-actions` using `GITHUB_TOKEN`, which would trigger no other GitHub event, thus benchmark not running on release before.

Closes #issue
