### PR TITLE
fix(privilege): add privileges on system.one to PUBLIC by default

### DIFF
--- a/src/meta/app/src/principal/user_privilege.rs
+++ b/src/meta/app/src/principal/user_privilege.rs
@@ -212,3 +212,11 @@ impl From<Vec<UserPrivilegeType>> for UserPrivilegeSet {
         result
     }
 }
+
+impl From<UserPrivilegeType> for UserPrivilegeSet {
+    fn from(value: UserPrivilegeType) -> Self {
+        let mut privileges = UserPrivilegeSet::empty();
+        privileges.set_privilege(value);
+        privileges
+    }
+}

--- a/src/query/service/src/interpreters/interpreter_role_create.rs
+++ b/src/query/service/src/interpreters/interpreter_role_create.rs
@@ -48,7 +48,9 @@ impl Interpreter for CreateRoleInterpreter {
         // TODO: add privilege check about CREATE ROLE
         let plan = self.plan.clone();
         let tenant = self.ctx.get_tenant();
-        UserApiProvider::instance()
+        let user_mgr = UserApiProvider::instance();
+        user_mgr.ensure_builtin_roles(&tenant).await?;
+        user_mgr
             .add_role(&tenant, RoleInfo::new(&plan.role_name), plan.if_not_exists)
             .await?;
         RoleCacheManager::instance().force_reload(&tenant).await?;

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -81,14 +81,23 @@ impl UserApiProvider {
     // 2. PUBLIC, which have no any privilege by default, but every role contains the PUBLIC role.
     //    The data objects which owned by PUBLIC can be accessed by any role.
     pub async fn ensure_builtin_roles(&self, tenant: &str) -> Result<u64> {
-        let mut role_info = RoleInfo::new(BUILTIN_ROLE_ACCOUNT_ADMIN);
-        role_info.grants.grant_privileges(
+        let mut account_admin = RoleInfo::new(BUILTIN_ROLE_ACCOUNT_ADMIN);
+        account_admin.grants.grant_privileges(
             &GrantObject::Global,
             UserPrivilegeSet::available_privileges_on_global(),
         );
-        self.add_role(tenant, role_info, true).await?;
-        let role_info = RoleInfo::new(BUILTIN_ROLE_PUBLIC);
-        self.add_role(tenant, role_info, true).await
+        self.add_role(tenant, account_admin, true).await?;
+
+        let mut public = RoleInfo::new(BUILTIN_ROLE_PUBLIC);
+        public.grants.grant_privileges(
+            &GrantObject::Table(
+                "default".to_string(),
+                "system".to_string(),
+                "one".to_string(),
+            ),
+            UserPrivilegeSet::available_privileges_on_global(),
+        );
+        self.add_role(tenant, public, true).await
     }
 
     pub async fn grant_privileges_to_role(

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -20,6 +20,7 @@ use common_management::RoleApi;
 use common_meta_app::principal::GrantObject;
 use common_meta_app::principal::RoleInfo;
 use common_meta_app::principal::UserPrivilegeSet;
+use common_meta_app::principal::UserPrivilegeType;
 use common_meta_types::MatchSeq;
 
 use crate::role_util::find_all_related_roles;
@@ -95,7 +96,7 @@ impl UserApiProvider {
                 "system".to_string(),
                 "one".to_string(),
             ),
-            UserPrivilegeSet::available_privileges_on_global(),
+            UserPrivilegeType::Select.into(),
         );
         self.add_role(tenant, public, true).await
     }

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -78,8 +78,8 @@ impl UserApiProvider {
     // Ensure the builtin roles inside a tenant. Currently we have two builtin roles:
     // 1. ACCOUNT_ADMIN, which has the equivalent privileges of `GRANT ALL ON *.* TO ROLE account_admin`,
     //    it also contains all roles. ACCOUNT_ADMIN can access the data objects which owned by any role.
-    // 2. PUBLIC, which have no any privilege by default, but every role contains the PUBLIC role.
-    //    The data objects which owned by PUBLIC can be accessed by any role.
+    // 2. PUBLIC, on the other side only includes the public accessible privileges, but every role
+    //    contains the PUBLIC role. The data objects which owned by PUBLIC can be accessed by any role.
     pub async fn ensure_builtin_roles(&self, tenant: &str) -> Result<u64> {
         let mut account_admin = RoleInfo::new(BUILTIN_ROLE_ACCOUNT_ADMIN);
         account_admin.grants.grant_privileges(

--- a/tests/sqllogictests/suites/base/05_ddl/05_0006_ddl_grant_privilege
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0006_ddl_grant_privilege
@@ -52,6 +52,7 @@ SHOW GRANTS FOR 'test-grant'@'localhost'
 GRANT ALL ON 'default'.'default'.* TO 'test-grant'@'localhost'
 GRANT SELECT ON 'default'.'db01'.* TO 'test-grant'@'localhost'
 GRANT SELECT ON 'default'.'db01'.'tb1' TO 'test-grant'@'localhost'
+GRANT ALL ON 'default'.'system'.'one' TO 'test-grant'@'localhost'
 
 statement ok
 REVOKE SELECT ON db01.* FROM 'test-grant'@'localhost'
@@ -61,6 +62,7 @@ SHOW GRANTS FOR 'test-grant'@'localhost'
 ----
 GRANT ALL ON 'default'.'default'.* TO 'test-grant'@'localhost'
 GRANT SELECT ON 'default'.'db01'.'tb1' TO 'test-grant'@'localhost'
+GRANT ALL ON 'default'.'system'.'one' TO 'test-grant'@'localhost'
 
 statement ok
 REVOKE ALL PRIVILEGES ON * FROM 'test-grant'@'localhost'

--- a/tests/sqllogictests/suites/base/05_ddl/05_0006_ddl_grant_privilege
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0006_ddl_grant_privilege
@@ -52,7 +52,7 @@ SHOW GRANTS FOR 'test-grant'@'localhost'
 GRANT ALL ON 'default'.'default'.* TO 'test-grant'@'localhost'
 GRANT SELECT ON 'default'.'db01'.* TO 'test-grant'@'localhost'
 GRANT SELECT ON 'default'.'db01'.'tb1' TO 'test-grant'@'localhost'
-GRANT ALL ON 'default'.'system'.'one' TO 'test-grant'@'localhost'
+GRANT SELECT ON 'default'.'system'.'one' TO 'test-grant'@'localhost'
 
 statement ok
 REVOKE SELECT ON db01.* FROM 'test-grant'@'localhost'
@@ -62,7 +62,7 @@ SHOW GRANTS FOR 'test-grant'@'localhost'
 ----
 GRANT ALL ON 'default'.'default'.* TO 'test-grant'@'localhost'
 GRANT SELECT ON 'default'.'db01'.'tb1' TO 'test-grant'@'localhost'
-GRANT ALL ON 'default'.'system'.'one' TO 'test-grant'@'localhost'
+GRANT SELECT ON 'default'.'system'.'one' TO 'test-grant'@'localhost'
 
 statement ok
 REVOKE ALL PRIVILEGES ON * FROM 'test-grant'@'localhost'
@@ -71,6 +71,7 @@ query T
 SHOW GRANTS FOR 'test-grant'@'localhost'
 ----
 GRANT SELECT ON 'default'.'db01'.'tb1' TO 'test-grant'@'localhost'
+GRANT SELECT ON 'default'.'system'.'one' TO 'test-grant'@'localhost'
 
 statement ok
 CREATE ROLE 'test-grant-role'
@@ -85,6 +86,7 @@ query T
 SHOW GRANTS FOR ROLE 'test-grant-role'
 ----
 GRANT SELECT ON 'default'.'default'.* TO 'test-grant-role'
+GRANT SELECT ON 'default'.'system'.'one' TO 'test-grant-role'
 
 statement ok
 DROP ROLE 'test-grant-role'

--- a/tests/sqllogictests/suites/base/05_ddl/05_0018_ddl_revoke
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0018_ddl_revoke
@@ -59,7 +59,7 @@ query T
 SHOW GRANTS FOR 'test-priv'
 ----
 GRANT SELECT ON 'default'.'b'.* TO 'test-priv'@'%'
-GRANT ALL ON 'default'.'system'.'one' TO 'test-priv'@'%'
+GRANT SELECT ON 'default'.'system'.'one' TO 'test-priv'@'%'
 
 statement ok
 REVOKE SELECT ON a.* FROM 'test-priv'
@@ -68,7 +68,7 @@ query T
 SHOW GRANTS FOR 'test-priv'
 ----
 GRANT SELECT ON 'default'.'b'.* TO 'test-priv'@'%'
-GRANT ALL ON 'default'.'system'.'one' TO 'test-priv'@'%'
+GRANT SELECT ON 'default'.'system'.'one' TO 'test-priv'@'%'
 
 statement ok
 REVOKE SELECT ON b.* FROM 'test-priv'

--- a/tests/sqllogictests/suites/base/05_ddl/05_0018_ddl_revoke
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0018_ddl_revoke
@@ -59,6 +59,7 @@ query T
 SHOW GRANTS FOR 'test-priv'
 ----
 GRANT SELECT ON 'default'.'b'.* TO 'test-priv'@'%'
+GRANT ALL ON 'default'.'system'.'one' TO 'test-priv'@'%'
 
 statement ok
 REVOKE SELECT ON a.* FROM 'test-priv'
@@ -67,6 +68,7 @@ query T
 SHOW GRANTS FOR 'test-priv'
 ----
 GRANT SELECT ON 'default'.'b'.* TO 'test-priv'@'%'
+GRANT ALL ON 'default'.'system'.'one' TO 'test-priv'@'%'
 
 statement ok
 REVOKE SELECT ON b.* FROM 'test-priv'

--- a/tests/sqllogictests/suites/base/05_ddl/05_0022_ddl_revoke
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0022_ddl_revoke
@@ -59,6 +59,7 @@ query T
 SHOW GRANTS FOR 'test-priv'
 ----
 GRANT SELECT ON 'default'.'b'.* TO 'test-priv'@'%'
+GRANT SELECT ON 'default'.'system'.'one' TO 'test-priv'@'%'
 
 statement ok
 REVOKE SELECT ON a.* FROM 'test-priv'
@@ -67,7 +68,7 @@ query T
 SHOW GRANTS FOR 'test-priv'
 ----
 GRANT SELECT ON 'default'.'b'.* TO 'test-priv'@'%'
-GRANT ALL ON 'default'.'system'.'one' TO 'test-priv'@'%'
+GRANT SELECT ON 'default'.'system'.'one' TO 'test-priv'@'%'
 
 statement ok
 REVOKE SELECT ON b.* FROM 'test-priv'

--- a/tests/sqllogictests/suites/base/05_ddl/05_0022_ddl_revoke
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0022_ddl_revoke
@@ -67,6 +67,7 @@ query T
 SHOW GRANTS FOR 'test-priv'
 ----
 GRANT SELECT ON 'default'.'b'.* TO 'test-priv'@'%'
+GRANT ALL ON 'default'.'system'.'one' TO 'test-priv'@'%'
 
 statement ok
 REVOKE SELECT ON b.* FROM 'test-priv'

--- a/tests/sqllogictests/suites/base/05_ddl/05_0024_ddl_set_role
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0024_ddl_set_role
@@ -17,3 +17,11 @@ SET ROLE 'test-role-not-exists'
 
 statement ok
 DROP ROLE IF EXISTS 'test-s'
+
+onlyif mysql
+statement ok
+SET ROLE 'public'
+
+onlyif mysql
+statement ok
+SELECT 1

--- a/tests/sqllogictests/suites/base/06_show/06_0007_show_roles
+++ b/tests/sqllogictests/suites/base/06_show/06_0007_show_roles
@@ -4,6 +4,8 @@ CREATE ROLE IF NOT EXISTS 'test'
 query T
 select name from system.roles;
 ----
+account_admin
+public
 test
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR adds a SELECT privilege on system.one to the PUBLIC role, so the normal users can execute `SELECT 1` without hitting permission denied error.

Closes #10036
