### PR TITLE
fix: fix limit pushdown outer join

### DIFF
--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_limit_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_limit_join.rs
@@ -87,10 +87,7 @@ impl Rule for RulePushDownLimitOuterJoin {
             match join.join_type {
                 JoinType::Left => {
                     let mut result = s_expr.replace_children(vec![child.replace_children(vec![
-                        SExpr::create_unary(
-                            RelOperator::Limit(limit.clone()),
-                            child.child(0)?.clone(),
-                        ),
+                        SExpr::create_unary(RelOperator::Limit(limit), child.child(0)?.clone()),
                         child.child(1)?.clone(),
                     ])]);
                     result.set_applied_rule(&self.id);
@@ -99,10 +96,7 @@ impl Rule for RulePushDownLimitOuterJoin {
                 JoinType::Right => {
                     let mut result = s_expr.replace_children(vec![child.replace_children(vec![
                         child.child(0)?.clone(),
-                        SExpr::create_unary(
-                            RelOperator::Limit(limit.clone()),
-                            child.child(1)?.clone(),
-                        ),
+                        SExpr::create_unary(RelOperator::Limit(limit), child.child(1)?.clone()),
                     ])]);
                     result.set_applied_rule(&self.id);
                     state.add_result(result)

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_limit_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_limit_join.rs
@@ -34,9 +34,9 @@ use crate::plans::RelOperator;
 ///               |
 ///        Left Outer Join
 ///             /     \
-///           Limit   Limit
-///           /         \
-///          *           *
+///           Limit    *
+///           /
+///          *
 pub struct RulePushDownLimitOuterJoin {
     id: RuleID,
     pattern: SExpr,
@@ -85,13 +85,24 @@ impl Rule for RulePushDownLimitOuterJoin {
             let child = s_expr.child(0)?;
             let join: Join = child.plan().clone().try_into()?;
             match join.join_type {
-                JoinType::Left | JoinType::Full => {
+                JoinType::Left => {
                     let mut result = s_expr.replace_children(vec![child.replace_children(vec![
                         SExpr::create_unary(
                             RelOperator::Limit(limit.clone()),
                             child.child(0)?.clone(),
                         ),
-                        SExpr::create_unary(RelOperator::Limit(limit), child.child(1)?.clone()),
+                        child.child(1)?.clone(),
+                    ])]);
+                    result.set_applied_rule(&self.id);
+                    state.add_result(result)
+                }
+                JoinType::Right => {
+                    let mut result = s_expr.replace_children(vec![child.replace_children(vec![
+                        child.child(0)?.clone(),
+                        SExpr::create_unary(
+                            RelOperator::Limit(limit.clone()),
+                            child.child(1)?.clone(),
+                        ),
                     ])]);
                     result.set_applied_rule(&self.id);
                     state.add_result(result)

--- a/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
@@ -149,22 +149,59 @@ Limit
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     │       ├── push downs: [filters: [], limit: 3]
     │       └── estimated rows: 1.00
-    └── Limit(Probe)
-        ├── limit: 2
-        ├── offset: 1
-        ├── estimated rows: 2.00
-        └── TableScan
-            ├── table: default.default.t1
-            ├── read rows: 2
-            ├── read bytes: 39
-            ├── partitions total: 1
-            ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-            ├── push downs: [filters: [], limit: 3]
-            └── estimated rows: 2.00
+    └── TableScan(Probe)
+        ├── table: default.default.t1
+        ├── read rows: 2
+        ├── read bytes: 39
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 2.00
+
+query T
+explain select * from t1 right join t on t.a = t1.a limit 1,2
+----
+Limit
+├── limit: 2
+├── offset: 1
+├── estimated rows: 2.00
+└── HashJoin
+    ├── join type: RIGHT OUTER
+    ├── build keys: [TRY_CAST(t.a (#1) AS Int32 NULL)]
+    ├── probe keys: [t1.a (#0)]
+    ├── filters: []
+    ├── estimated rows: 2.00
+    ├── Limit(Build)
+    │   ├── limit: 2
+    │   ├── offset: 1
+    │   ├── estimated rows: 1.00
+    │   └── TableScan
+    │       ├── table: default.default.t
+    │       ├── read rows: 1
+    │       ├── read bytes: 35
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+    │       ├── push downs: [filters: [], limit: 3]
+    │       └── estimated rows: 1.00
+    └── TableScan(Probe)
+        ├── table: default.default.t1
+        ├── read rows: 2
+        ├── read bytes: 39
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 2.00
 
 query II
 select * from t left join t1 on t.a = t1.a limit 1
+----
+1 1
+
+query II
+select * from t1 right join t on t.a = t1.a limit 1
 ----
 1 1
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. Limit shouldn't push down full outer join
2. Support push down limit right join
3. fix limit push down left join

Closes https://github.com/datafuselabs/databend/issues/10012
