### PR TITLE
fix: ignore dropped column statistics by column id when reducing block statistics

### DIFF
--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -15,6 +15,7 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use common_arrow::arrow::bitmap::Bitmap;
@@ -382,6 +383,10 @@ impl TableSchema {
         self.fields.remove(i);
 
         Ok(())
+    }
+
+    pub fn to_column_id_set(&self) -> HashSet<ColumnId> {
+        HashSet::from_iter(self.to_column_ids().iter().cloned())
     }
 
     pub fn to_column_ids(&self) -> Vec<ColumnId> {

--- a/src/query/service/src/interpreters/interpreter_table_add_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_add_column.rs
@@ -58,7 +58,6 @@ impl Interpreter for AddTableColumnInterpreter {
 
         if let Some(table) = &tbl {
             let table_info = table.get_table_info();
-            println!("add column table info: {:?}", table_info);
             if table_info.engine() == VIEW_ENGINE {
                 return Err(ErrorCode::TableEngineNotSupported(format!(
                     "{}.{} engine is VIEW that doesn't support alter",

--- a/src/query/service/src/interpreters/interpreter_table_add_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_add_column.rs
@@ -48,14 +48,17 @@ impl Interpreter for AddTableColumnInterpreter {
         let catalog_name = self.plan.catalog.as_str();
         let db_name = self.plan.database.as_str();
         let tbl_name = self.plan.table.as_str();
+
         let tbl = self
             .ctx
-            .get_table(catalog_name, db_name, tbl_name)
+            .get_catalog(catalog_name)?
+            .get_table(self.ctx.get_tenant().as_str(), db_name, tbl_name)
             .await
             .ok();
 
         if let Some(table) = &tbl {
             let table_info = table.get_table_info();
+            println!("add column table info: {:?}", table_info);
             if table_info.engine() == VIEW_ENGINE {
                 return Err(ErrorCode::TableEngineNotSupported(format!(
                     "{}.{} engine is VIEW that doesn't support alter",

--- a/src/query/service/src/interpreters/interpreter_table_drop_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_drop_column.rs
@@ -50,7 +50,8 @@ impl Interpreter for DropTableColumnInterpreter {
         let tbl_name = self.plan.table.as_str();
         let tbl = self
             .ctx
-            .get_table(catalog_name, db_name, tbl_name)
+            .get_catalog(catalog_name)?
+            .get_table(self.ctx.get_tenant().as_str(), db_name, tbl_name)
             .await
             .ok();
 

--- a/src/query/service/tests/it/storages/fuse/operations/alter_table.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/alter_table.rs
@@ -1,0 +1,155 @@
+//  Copyright 2023 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use common_base::base::tokio;
+use common_exception::Result;
+use common_expression::types::Int32Type;
+use common_expression::types::NumberDataType;
+use common_expression::types::UInt64Type;
+use common_expression::ColumnId;
+use common_expression::DataBlock;
+use common_expression::FromData;
+use common_expression::TableDataType;
+use common_expression::TableField;
+use common_expression::TableSchemaRefExt;
+use common_sql::plans::AddTableColumnPlan;
+use common_sql::plans::DropTableColumnPlan;
+use common_sql::Planner;
+use common_storages_fuse::io::MetaReaders;
+use common_storages_fuse::FuseTable;
+use common_storages_fuse::TableContext;
+use databend_query::interpreters::AddTableColumnInterpreter;
+use databend_query::interpreters::DropTableColumnInterpreter;
+use databend_query::interpreters::Interpreter;
+use databend_query::interpreters::InterpreterFactory;
+use futures_util::TryStreamExt;
+use storages_common_cache::LoadParams;
+use storages_common_table_meta::meta::TableSnapshot;
+use storages_common_table_meta::meta::Versioned;
+use storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
+
+use crate::storages::fuse::table_test_fixture::TestFixture;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fuse_table_optimize_alter_table() -> Result<()> {
+    let fixture = TestFixture::new().await;
+    let ctx = fixture.ctx();
+    let tbl_name = fixture.default_table_name();
+    let db_name = fixture.default_db_name();
+
+    fixture.create_normal_table().await?;
+
+    let table = fixture.latest_default_table().await?;
+    let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+
+    // insert values
+    let table = fixture.latest_default_table().await?;
+    let num_blocks = 1;
+    let stream = TestFixture::gen_sample_blocks_stream(num_blocks, 1);
+
+    let blocks = stream.try_collect().await?;
+    fixture
+        .append_commit_blocks(table.clone(), blocks, false, true)
+        .await?;
+
+    // get statistics
+    let snapshot_loc = table
+        .get_table_info()
+        .options()
+        .get(OPT_KEY_SNAPSHOT_LOCATION)
+        .unwrap();
+    let reader = MetaReaders::segment_info_reader(
+        fuse_table.get_operator(),
+        TestFixture::default_table_schema(),
+    );
+    let expected_column_ids = vec![0, 1];
+    let params = LoadParams {
+        location: snapshot_loc.clone(),
+        len_hint: None,
+        ver: TableSnapshot::VERSION,
+    };
+
+    let segment_info = reader.read(&params).await?;
+    assert_eq!(
+        segment_info.blocks[0]
+            .col_stats
+            .keys()
+            .cloned()
+            .collect::<Vec<ColumnId>>(),
+        expected_column_ids,
+    );
+
+    // drop a column
+    let drop_table_column_plan = DropTableColumnPlan {
+        catalog: fixture.default_catalog_name(),
+        database: fixture.default_db_name(),
+        table: fixture.default_table_name(),
+        column: "t".to_string(),
+    };
+    let interpreter = DropTableColumnInterpreter::try_create(ctx.clone(), drop_table_column_plan)?;
+    interpreter.execute(ctx.clone()).await?;
+
+    // add a column
+    let fields = vec![
+        TestFixture::default_table_schema().fields()[0].clone(),
+        TableField::new("b", TableDataType::Number(NumberDataType::UInt64)),
+    ];
+    let schema = TableSchemaRefExt::create(fields);
+
+    let add_table_column_plan = AddTableColumnPlan {
+        catalog: fixture.default_catalog_name(),
+        database: fixture.default_db_name(),
+        table: fixture.default_table_name(),
+        schema,
+        field_default_exprs: vec![],
+        field_comments: vec![],
+    };
+    let interpreter = AddTableColumnInterpreter::try_create(ctx.clone(), add_table_column_plan)?;
+    interpreter.execute(ctx.clone()).await?;
+
+    // insert values
+    let block = {
+        let column0 = Int32Type::from_data(vec![1, 2]);
+        let column1 = UInt64Type::from_data(vec![3, 4]);
+
+        DataBlock::new_from_columns(vec![column0, column1])
+    };
+
+    fixture
+        .append_commit_blocks(table.clone(), vec![block], false, true)
+        .await?;
+
+    // do compact
+    let query = format!("optimize table {db_name}.{tbl_name} compact");
+    let mut planner = Planner::new(ctx.clone());
+    let (plan, _, _) = planner.plan_sql(&query).await?;
+    let interpreter = InterpreterFactory::get(ctx.clone(), &plan).await?;
+    ctx.get_settings().set_max_threads(1)?;
+    let data_stream = interpreter.execute(ctx.clone()).await?;
+    let _ = data_stream.try_collect::<Vec<_>>().await;
+
+    // verify statistics
+    let expected_column_ids = vec![0, 2];
+    let segment_info = reader.read(&params).await?;
+    assert_eq!(
+        segment_info.blocks[0]
+            .col_stats
+            .keys()
+            .cloned()
+            .collect::<Vec<ColumnId>>(),
+        expected_column_ids,
+    );
+
+    Ok(())
+}

--- a/src/query/service/tests/it/storages/fuse/operations/alter_table.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/alter_table.rs
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use std::collections::HashSet;
+
 use common_base::base::tokio;
 use common_exception::Result;
 use common_expression::types::Int32Type;
@@ -35,11 +37,73 @@ use databend_query::interpreters::Interpreter;
 use databend_query::interpreters::InterpreterFactory;
 use futures_util::TryStreamExt;
 use storages_common_cache::LoadParams;
+use storages_common_table_meta::meta::SegmentInfo;
 use storages_common_table_meta::meta::TableSnapshot;
 use storages_common_table_meta::meta::Versioned;
 use storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 
 use crate::storages::fuse::table_test_fixture::TestFixture;
+
+async fn check_segment_column_ids(
+    fixture: &TestFixture,
+    expected_column_ids: Vec<ColumnId>,
+) -> Result<()> {
+    let catalog = fixture.ctx().get_catalog("default")?;
+    // get the latest tbl
+    let table = catalog
+        .get_table(
+            fixture.default_tenant().as_str(),
+            fixture.default_db_name().as_str(),
+            fixture.default_table_name().as_str(),
+        )
+        .await?;
+
+    let snapshot_loc = table
+        .get_table_info()
+        .options()
+        .get(OPT_KEY_SNAPSHOT_LOCATION)
+        .unwrap();
+    let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+
+    let snapshot_reader = MetaReaders::table_snapshot_reader(fuse_table.get_operator());
+    let params = LoadParams {
+        location: snapshot_loc.clone(),
+        len_hint: None,
+        ver: TableSnapshot::VERSION,
+    };
+
+    let snapshot = snapshot_reader.read(&params).await?;
+    let expected_column_ids =
+        HashSet::<ColumnId>::from_iter(expected_column_ids.clone().iter().cloned());
+    for (seg_loc, _) in &snapshot.segments {
+        let segment_reader = MetaReaders::segment_info_reader(
+            fuse_table.get_operator(),
+            TestFixture::default_table_schema(),
+        );
+        let params = LoadParams {
+            location: seg_loc.clone(),
+            len_hint: None,
+            ver: SegmentInfo::VERSION,
+        };
+        let segment_info = segment_reader.read(&params).await?;
+        segment_info.blocks.iter().for_each(|block_meta| {
+            assert_eq!(
+                HashSet::from_iter(
+                    block_meta
+                        .col_stats
+                        .keys()
+                        .cloned()
+                        .collect::<Vec<ColumnId>>()
+                        .iter()
+                        .cloned()
+                ),
+                expected_column_ids,
+            );
+        });
+    }
+
+    Ok(())
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fuse_table_optimize_alter_table() -> Result<()> {
@@ -47,11 +111,9 @@ async fn test_fuse_table_optimize_alter_table() -> Result<()> {
     let ctx = fixture.ctx();
     let tbl_name = fixture.default_table_name();
     let db_name = fixture.default_db_name();
+    let catalog_name = fixture.default_catalog_name();
 
     fixture.create_normal_table().await?;
-
-    let table = fixture.latest_default_table().await?;
-    let fuse_table = FuseTable::try_from_table(table.as_ref())?;
 
     // insert values
     let table = fixture.latest_default_table().await?;
@@ -63,32 +125,9 @@ async fn test_fuse_table_optimize_alter_table() -> Result<()> {
         .append_commit_blocks(table.clone(), blocks, false, true)
         .await?;
 
-    // get statistics
-    let snapshot_loc = table
-        .get_table_info()
-        .options()
-        .get(OPT_KEY_SNAPSHOT_LOCATION)
-        .unwrap();
-    let reader = MetaReaders::segment_info_reader(
-        fuse_table.get_operator(),
-        TestFixture::default_table_schema(),
-    );
+    // check column ids
     let expected_column_ids = vec![0, 1];
-    let params = LoadParams {
-        location: snapshot_loc.clone(),
-        len_hint: None,
-        ver: TableSnapshot::VERSION,
-    };
-
-    let segment_info = reader.read(&params).await?;
-    assert_eq!(
-        segment_info.blocks[0]
-            .col_stats
-            .keys()
-            .cloned()
-            .collect::<Vec<ColumnId>>(),
-        expected_column_ids,
-    );
+    check_segment_column_ids(&fixture, expected_column_ids).await?;
 
     // drop a column
     let drop_table_column_plan = DropTableColumnPlan {
@@ -101,10 +140,10 @@ async fn test_fuse_table_optimize_alter_table() -> Result<()> {
     interpreter.execute(ctx.clone()).await?;
 
     // add a column
-    let fields = vec![
-        TestFixture::default_table_schema().fields()[0].clone(),
-        TableField::new("b", TableDataType::Number(NumberDataType::UInt64)),
-    ];
+    let fields = vec![TableField::new(
+        "b",
+        TableDataType::Number(NumberDataType::UInt64),
+    )];
     let schema = TableSchemaRefExt::create(fields);
 
     let add_table_column_plan = AddTableColumnPlan {
@@ -118,13 +157,24 @@ async fn test_fuse_table_optimize_alter_table() -> Result<()> {
     let interpreter = AddTableColumnInterpreter::try_create(ctx.clone(), add_table_column_plan)?;
     interpreter.execute(ctx.clone()).await?;
 
-    // insert values
+    // insert values for new schema
     let block = {
         let column0 = Int32Type::from_data(vec![1, 2]);
-        let column1 = UInt64Type::from_data(vec![3, 4]);
+        let column2 = UInt64Type::from_data(vec![3, 4]);
 
-        DataBlock::new_from_columns(vec![column0, column1])
+        DataBlock::new_from_columns(vec![column0, column2])
     };
+
+    // get the latest tbl
+    let table = fixture
+        .ctx()
+        .get_catalog(&catalog_name)?
+        .get_table(
+            fixture.default_tenant().as_str(),
+            fixture.default_db_name().as_str(),
+            fixture.default_table_name().as_str(),
+        )
+        .await?;
 
     fixture
         .append_commit_blocks(table.clone(), vec![block], false, true)
@@ -139,17 +189,9 @@ async fn test_fuse_table_optimize_alter_table() -> Result<()> {
     let data_stream = interpreter.execute(ctx.clone()).await?;
     let _ = data_stream.try_collect::<Vec<_>>().await;
 
-    // verify statistics
-    let expected_column_ids = vec![0, 2];
-    let segment_info = reader.read(&params).await?;
-    assert_eq!(
-        segment_info.blocks[0]
-            .col_stats
-            .keys()
-            .cloned()
-            .collect::<Vec<ColumnId>>(),
-        expected_column_ids,
-    );
+    // verify statistics has only [0,3]
+    let expected_column_ids = vec![0, 3];
+    check_segment_column_ids(&fixture, expected_column_ids).await?;
 
     Ok(())
 }

--- a/src/query/service/tests/it/storages/fuse/operations/mod.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mod.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 #![allow(clippy::too_many_arguments)]
+mod alter_table;
 mod analyze;
 mod clustering;
 mod commit;

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -136,7 +136,7 @@ fn test_ft_stats_col_stats_reduce() -> common_exception::Result<()> {
         .iter()
         .map(|b| gen_columns_statistics(&b.clone().unwrap(), None, None))
         .collect::<common_exception::Result<Vec<_>>>()?;
-    let r = reducers::reduce_block_statistics(&col_stats, None);
+    let r = reducers::reduce_block_statistics(&col_stats, None, None);
     assert!(r.is_ok());
     let r = r.unwrap();
     assert_eq!(3, r.len());
@@ -191,7 +191,7 @@ fn test_reduce_block_statistics_in_memory_size() -> common_exception::Result<()>
     // combine two statistics
     let col_stats_left = HashMap::from_iter(iter(0).take(num_of_cols));
     let col_stats_right = HashMap::from_iter(iter(0).take(num_of_cols));
-    let r = reducers::reduce_block_statistics(&[col_stats_left, col_stats_right], None)?;
+    let r = reducers::reduce_block_statistics(&[col_stats_left, col_stats_right], None, None)?;
     assert_eq!(num_of_cols, r.len());
     // there should be 100 columns in the result
     for idx in 1..=100 {

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -425,7 +425,11 @@ impl FuseTable {
                 acc.col_stats = if acc.col_stats.is_empty() {
                     stats.col_stats.clone()
                 } else {
-                    statistics::reduce_block_statistics(&[&acc.col_stats, &stats.col_stats], None)?
+                    statistics::reduce_block_statistics(
+                        &[&acc.col_stats, &stats.col_stats],
+                        None,
+                        None,
+                    )?
                 };
                 seg_acc.push(location.clone());
                 Ok::<_, ErrorCode>((acc, seg_acc))

--- a/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/compact_transform.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Instant;
@@ -24,6 +25,7 @@ use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::BlockThresholds;
+use common_expression::ColumnId;
 use common_expression::DataBlock;
 use common_expression::TableSchemaRef;
 use common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
@@ -90,6 +92,7 @@ pub struct CompactTransform {
     location_gen: TableMetaLocationGenerator,
     dal: Operator,
     schema: TableSchemaRef,
+    column_id_set: HashSet<ColumnId>,
 
     // Limit the memory size of the block read.
     max_memory: u64,
@@ -121,6 +124,7 @@ impl CompactTransform {
         let max_threads = settings.get_max_threads()?;
         let max_memory = max_memory_usage / max_threads;
         let max_io_requests = settings.get_max_storage_io_requests()? as usize;
+        let column_id_set = schema.to_column_id_set();
         Ok(ProcessorPtr::create(Box::new(CompactTransform {
             ctx,
             state: State::Consume,
@@ -132,6 +136,7 @@ impl CompactTransform {
             location_gen,
             dal,
             schema,
+            column_id_set,
             max_memory,
             max_io_requests,
             compact_tasks: VecDeque::new(),
@@ -226,7 +231,11 @@ impl Processor for CompactTransform {
                     let new_block = DataBlock::concat(&compact_blocks)?;
 
                     // generate block statistics.
-                    let col_stats = reduce_block_statistics(&stats, Some(&new_block))?;
+                    let col_stats = reduce_block_statistics(
+                        &stats,
+                        Some(&new_block),
+                        Some(&self.column_id_set),
+                    )?;
                     let row_count = new_block.num_rows() as u64;
                     let block_size = new_block.memory_size() as u64;
                     let (block_location, block_id) = self.location_gen.gen_block_location();

--- a/src/query/storages/fuse/src/statistics/accumulator.rs
+++ b/src/query/storages/fuse/src/statistics/accumulator.rs
@@ -91,13 +91,13 @@ impl StatisticsAccumulator {
     }
 
     pub fn summary(&self) -> Result<StatisticsOfColumns> {
-        super::reduce_block_statistics(&self.blocks_statistics, None)
+        super::reduce_block_statistics(&self.blocks_statistics, None, None)
     }
 
     fn add(
         &mut self,
         file_size: u64,
-        column_meta: HashMap<u32, ColumnMeta>,
+        column_meta: HashMap<ColumnId, ColumnMeta>,
         block_statistics: BlockStatistics,
         bloom_filter_index_location: Option<Location>,
         bloom_filter_index_size: u64,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. fix: ignore dropped column statistics by column id when reducing block statistics
2. add test case.

Closes https://github.com/datafuselabs/databend/issues/10020
