### PR TITLE
refactor: fix abuse of ErrorCode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,6 +1252,7 @@ dependencies = [
 name = "common-base"
 version = "0.1.0"
 dependencies = [
+ "anyerror",
  "anyhow",
  "async-channel",
  "async-trait",
@@ -1535,6 +1536,7 @@ dependencies = [
 name = "common-http"
 version = "0.1.0"
 dependencies = [
+ "anyerror",
  "common-base",
  "common-exception",
  "futures",
@@ -1542,6 +1544,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "tempfile",
+ "thiserror",
  "tracing",
 ]
 
@@ -2932,6 +2935,7 @@ checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 name = "databend-binaries"
 version = "0.1.0"
 dependencies = [
+ "anyerror",
  "anyhow",
  "clap 3.2.23",
  "comfy-table",

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -50,6 +50,7 @@ databend-query = { path = "../query/service" }
 sharing-endpoint = { path = "../query/sharing-endpoint" }
 
 # Crates.io dependencies
+anyerror = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 comfy-table = "6.1.3"

--- a/src/binaries/meta/main.rs
+++ b/src/binaries/meta/main.rs
@@ -19,6 +19,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyerror::AnyError;
 use common_base::base::tokio;
 use common_base::base::StopHandle;
 use common_base::base::Stoppable;
@@ -103,8 +104,8 @@ async fn main() -> anyhow::Result<()> {
 
     let meta_node = MetaNode::start(&conf).await?;
 
-    let mut stop_handler = StopHandle::create();
-    let stop_tx = StopHandle::install_termination_handle();
+    let mut stop_handler = StopHandle::<AnyError>::create();
+    let stop_tx = StopHandle::<AnyError>::install_termination_handle();
 
     // HTTP API service.
     {

--- a/src/binaries/query/main.rs
+++ b/src/binaries/query/main.rs
@@ -145,7 +145,7 @@ async fn main_entrypoint() -> Result<()> {
         let hostname = conf.query.clickhouse_http_handler_host.clone();
         let listening = format!("{}:{}", hostname, conf.query.clickhouse_http_handler_port);
 
-        let mut srv = HttpHandler::create(HttpHandlerKind::Clickhouse)?;
+        let mut srv = HttpHandler::create(HttpHandlerKind::Clickhouse);
         let listening = srv.start(listening.parse()?).await?;
         shutdown_handle.add_service(srv);
 
@@ -161,7 +161,7 @@ async fn main_entrypoint() -> Result<()> {
         let hostname = conf.query.http_handler_host.clone();
         let listening = format!("{}:{}", hostname, conf.query.http_handler_port);
 
-        let mut srv = HttpHandler::create(HttpHandlerKind::Query)?;
+        let mut srv = HttpHandler::create(HttpHandlerKind::Query);
         let listening = srv.start(listening.parse()?).await?;
         shutdown_handle.add_service(srv);
 
@@ -175,7 +175,7 @@ async fn main_entrypoint() -> Result<()> {
     // Metric API service.
     {
         let address = conf.query.metric_api_address.clone();
-        let mut srv = MetricService::create()?;
+        let mut srv = MetricService::create();
         let listening = srv.start(address.parse()?).await?;
         shutdown_handle.add_service(srv);
         info!("Listening for Metric API: {}/metrics", listening);
@@ -184,7 +184,7 @@ async fn main_entrypoint() -> Result<()> {
     // Admin HTTP API service.
     {
         let address = conf.query.admin_api_address.clone();
-        let mut srv = HttpService::create(&conf)?;
+        let mut srv = HttpService::create(&conf);
         let listening = srv.start(address.parse()?).await?;
         shutdown_handle.add_service(srv);
         info!("Listening for Admin HTTP API: {}", listening);

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -52,5 +52,6 @@ tracing = "0.1.36"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 
 [dev-dependencies]
+anyerror = { workspace = true }
 anyhow = { workspace = true }
 rand = "0.8.3"

--- a/src/common/base/src/base/stoppable.rs
+++ b/src/common/base/src/base/stoppable.rs
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_exception::ErrorCode;
 use tokio::sync::broadcast;
 
 /// A task that can be started and stopped.
 #[async_trait::async_trait]
 pub trait Stoppable {
+    type Error;
+
     /// Start working without blocking the calling thread.
     /// When returned, it should have been successfully started.
     /// Otherwise an Err() should be returned.
     ///
     /// Calling `start()` on a started task should get an error.
-    async fn start(&mut self) -> Result<(), ErrorCode>;
+    async fn start(&mut self) -> Result<(), Self::Error>;
 
     /// Blocking stop. It should not return until everything is cleaned up.
     ///
@@ -32,5 +33,6 @@ pub trait Stoppable {
     /// An impl should either close everything at once, or just ignore the `force` signal if it does not support force stop.
     ///
     /// Calling `stop()` twice should get an error.
-    async fn stop(&mut self, mut force: Option<broadcast::Receiver<()>>) -> Result<(), ErrorCode>;
+    async fn stop(&mut self, mut force: Option<broadcast::Receiver<()>>)
+    -> Result<(), Self::Error>;
 }

--- a/src/common/base/tests/it/stoppable.rs
+++ b/src/common/base/tests/it/stoppable.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyerror::AnyError;
 use common_base::base::*;
-use common_exception::Result;
 use tokio::sync::broadcast;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::TryRecvError;
@@ -26,11 +26,13 @@ struct FooTask {}
 
 #[async_trait::async_trait]
 impl Stoppable for FooTask {
-    async fn start(&mut self) -> Result<()> {
+    type Error = AnyError;
+
+    async fn start(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    async fn stop(&mut self, force: Option<broadcast::Receiver<()>>) -> Result<()> {
+    async fn stop(&mut self, force: Option<broadcast::Receiver<()>>) -> Result<(), Self::Error> {
         info!("--- FooTask stop, force: {:?}", force);
 
         // block the stop until force stop.
@@ -44,7 +46,7 @@ impl Stoppable for FooTask {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_stoppable() -> Result<()> {
+async fn test_stoppable() -> anyhow::Result<()> {
     // - Create a task and start it.
     // - Stop but the task would block.
     // - Signal the task to force stop.
@@ -87,7 +89,7 @@ async fn test_stoppable() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_stop_handle() -> Result<()> {
+async fn test_stop_handle() -> anyhow::Result<()> {
     // - Create 2 tasks and start them.
     // - Stop but the task would block.
     // - Signal the task to force stop.
@@ -140,7 +142,7 @@ async fn test_stop_handle() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_stop_handle_drop() -> Result<()> {
+async fn test_stop_handle_drop() -> anyhow::Result<()> {
     // - Create a task and start it.
     // - Then quit and the Drop should forcibly stop it and the test should not block.
     let mut t1 = FooTask::default();

--- a/src/common/http/Cargo.toml
+++ b/src/common/http/Cargo.toml
@@ -23,10 +23,12 @@ common-exception = { path = "../exception" }
 # Github dependencies
 
 # Crates.io dependencies
+anyerror = { workspace = true }
 futures = "0.3.24"
 poem = { version = "1", features = ["rustls"] }
 serde = { workspace = true }
 tempfile = { version = "3.3.0", optional = true }
+thiserror = { workspace = true }
 tracing = "0.1.36"
 
 [dev-dependencies]

--- a/src/common/http/src/errors.rs
+++ b/src/common/http/src/errors.rs
@@ -1,0 +1,36 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyerror::AnyError;
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum HttpError {
+    #[error(transparent)]
+    BadAddressFormat(AnyError),
+
+    #[error("can not listen {listening}: {message}")]
+    ListenError { message: String, listening: String },
+
+    #[error(transparent)]
+    TlsConfigError(AnyError),
+}
+
+impl HttpError {
+    pub fn listen_error(listening: impl ToString, message: impl ToString) -> Self {
+        Self::ListenError {
+            message: message.to_string(),
+            listening: listening.to_string(),
+        }
+    }
+}

--- a/src/common/http/src/lib.rs
+++ b/src/common/http/src/lib.rs
@@ -15,9 +15,11 @@
 #![allow(clippy::uninlined_format_args)]
 
 mod debug;
+mod errors;
 mod health;
 mod http_shutdown_handlers;
 
 pub use debug::*;
+pub use errors::HttpError;
 pub use health::*;
 pub use http_shutdown_handlers::HttpShutdownHandler;

--- a/src/meta/app/src/tenant/mod.rs
+++ b/src/meta/app/src/tenant/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2023 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This crate defines meta data types used by meta-client application, e.g. Schema, User, Share etc.
-//! Such as Database, Table and User etc.
-//!
-//! Types in this crate will not be used directly by databend-meta.
-//! But instead, they are used by the caller of meta-client, e.g, databend-query.
+mod quota;
 
-#![allow(clippy::uninlined_format_args)]
-#![deny(unused_crate_dependencies)]
-#![feature(no_sanitize)]
-
-pub mod principal;
-pub mod schema;
-pub mod share;
-pub mod storage;
-pub mod tenant;
+pub use quota::TenantQuota;

--- a/src/meta/app/src/tenant/quota.rs
+++ b/src/meta/app/src/tenant/quota.rs
@@ -13,11 +13,8 @@
 // limitations under the License.
 
 use common_exception::ErrorCode;
-use common_exception::Result;
-use serde::Deserialize;
-use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 #[serde(default)]
 pub struct TenantQuota {
     // The max databases can be created in the tenant.
@@ -39,7 +36,7 @@ pub struct TenantQuota {
 impl TryFrom<Vec<u8>> for TenantQuota {
     type Error = ErrorCode;
 
-    fn try_from(value: Vec<u8>) -> Result<Self> {
+    fn try_from(value: Vec<u8>) -> common_exception::Result<Self> {
         match serde_json::from_slice(&value) {
             Ok(quota) => Ok(quota),
             Err(err) => Err(ErrorCode::IllegalTenantQuotaFormat(format!(

--- a/src/meta/service/tests/it/api/http/config.rs
+++ b/src/meta/service/tests/it/api/http/config.rs
@@ -26,7 +26,7 @@ use poem::Route;
 use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_config() -> common_exception::Result<()> {
+async fn test_config() -> anyhow::Result<()> {
     let conf = Config::default();
     let cluster_router = Route::new()
         .at("/v1/config", get(config_handler))

--- a/src/meta/service/tests/it/api/http_service.rs
+++ b/src/meta/service/tests/it/api/http_service.rs
@@ -17,7 +17,6 @@ use std::io::Read;
 
 use common_base::base::tokio;
 use common_base::base::Stoppable;
-use common_exception::Result;
 use databend_meta::api::HttpService;
 use databend_meta::configs::Config;
 use databend_meta::init_meta_ut;
@@ -31,7 +30,7 @@ use crate::tests::tls_constants::TEST_SERVER_KEY;
 
 // TODO(zhihanz) add tls fail case
 #[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
-async fn test_http_service_tls_server() -> Result<()> {
+async fn test_http_service_tls_server() -> anyhow::Result<()> {
     let mut conf = Config::default();
     let addr_str = "127.0.0.1:30002";
 

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_tls.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_tls.rs
@@ -15,13 +15,15 @@
 use std::time::Duration;
 
 use common_base::base::tokio;
-use common_exception::ErrorCode;
 use common_grpc::RpcClientTlsConfig;
 use common_meta_api::SchemaApi;
 use common_meta_client::MetaGrpcClient;
 use common_meta_kvapi::kvapi::KVApi;
+use common_meta_types::KVAppError;
+use common_meta_types::MetaClientError;
+use common_meta_types::MetaError;
+use common_meta_types::MetaNetworkError;
 use databend_meta::init_meta_ut;
-use pretty_assertions::assert_eq;
 
 use crate::tests::service::MetaSrvTestContext;
 use crate::tests::start_metasrv_with_context;
@@ -94,11 +96,18 @@ async fn test_tls_client_config_failure() -> anyhow::Result<()> {
     .unwrap();
 
     let c = r.get_kv("foo").await;
-    assert!(c.is_err());
+    assert!(c.is_err(), "expect error: {:?}", c);
 
-    if let Err(e) = c {
-        let e = ErrorCode::from(e);
-        assert_eq!(e.code(), ErrorCode::TLSConfigurationFailure("").code());
+    let e = c.unwrap_err();
+
+    if let KVAppError::MetaError(MetaError::ClientError(MetaClientError::NetworkError(
+        MetaNetworkError::TLSConfigError(any_err),
+    ))) = e
+    {
+        let _ = any_err;
+    } else {
+        unreachable!("expect tls error but: {:?}", e);
     }
+
     Ok(())
 }

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
@@ -501,7 +501,7 @@ async fn test_watch_expired_events() -> anyhow::Result<()> {
 }
 
 #[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
-async fn test_watch_stream_count() -> common_exception::Result<()> {
+async fn test_watch_stream_count() -> anyhow::Result<()> {
     // When the client drops the stream, databend-meta should reclaim the resources.
 
     let (tc, addr) = crate::tests::start_metasrv().await?;

--- a/src/meta/types/src/errors/meta_startup_errors.rs
+++ b/src/meta/types/src/errors/meta_startup_errors.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use anyerror::AnyError;
-use common_exception::ErrorCode;
 use common_meta_stoerr::MetaStorageError;
 use openraft::error::InitializeError;
 
@@ -45,23 +44,4 @@ pub enum MetaStartupError {
 
     #[error("{0}")]
     MetaServiceError(String),
-}
-
-impl From<MetaStartupError> for ErrorCode {
-    fn from(e: MetaStartupError) -> Self {
-        match e {
-            MetaStartupError::InvalidConfig(err_str) => ErrorCode::MetaServiceError(err_str),
-            MetaStartupError::MetaStoreAlreadyExists(node_id) => {
-                ErrorCode::MetaServiceError(format!("meta store already exists: {}", node_id))
-            }
-            MetaStartupError::MetaStoreNotFound => ErrorCode::MetaServiceError("MetaStoreNotFound"),
-            MetaStartupError::MetaServiceError(err_str) => ErrorCode::MetaServiceError(err_str),
-            MetaStartupError::InitializeError(e) => ErrorCode::MetaServiceError(e.to_string()),
-            MetaStartupError::StoreOpenError(e) => e.into(),
-            MetaStartupError::ServiceStartupError(e) => e.into(),
-            MetaStartupError::AddNodeError { source } => {
-                ErrorCode::MetaServiceError(source.to_string())
-            }
-        }
-    }
 }

--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -33,7 +33,6 @@ mod raft_types;
 mod seq_errors;
 mod seq_num;
 mod seq_value;
-mod tenant_quota;
 mod with;
 
 mod proto_display;
@@ -131,5 +130,4 @@ pub use seq_num::SeqNum;
 pub use seq_value::IntoSeqV;
 pub use seq_value::KVMeta;
 pub use seq_value::SeqV;
-pub use tenant_quota::TenantQuota;
 pub use with::With;

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -25,7 +25,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_grpc::RpcClientConf;
 use common_grpc::RpcClientTlsConfig;
-use common_meta_types::TenantQuota;
+use common_meta_app::tenant::TenantQuota;
 use common_storage::StorageConfig;
 use common_tracing::Config as LogConfig;
 use common_users::idm_config::IDMConfig;

--- a/src/query/config/src/outer_v0.rs
+++ b/src/query/config/src/outer_v0.rs
@@ -36,7 +36,7 @@ use common_meta_app::storage::StorageOssConfig as InnerStorageOssConfig;
 use common_meta_app::storage::StorageParams;
 use common_meta_app::storage::StorageRedisConfig as InnerStorageRedisConfig;
 use common_meta_app::storage::StorageS3Config as InnerStorageS3Config;
-use common_meta_types::TenantQuota;
+use common_meta_app::tenant::TenantQuota;
 use common_storage::CacheConfig as InnerCacheConfig;
 use common_storage::StorageConfig as InnerStorageConfig;
 use common_tracing::Config as InnerLogConfig;

--- a/src/query/management/src/quota/quota_api.rs
+++ b/src/query/management/src/quota/quota_api.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use common_exception::Result;
+use common_meta_app::tenant::TenantQuota;
 use common_meta_types::MatchSeq;
 use common_meta_types::SeqV;
-use common_meta_types::TenantQuota;
 
 #[async_trait::async_trait]
 pub trait QuotaApi: Sync + Send {

--- a/src/query/management/src/quota/quota_mgr.rs
+++ b/src/query/management/src/quota/quota_mgr.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_base::base::escape_for_key;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_app::tenant::TenantQuota;
 use common_meta_kvapi::kvapi;
 use common_meta_kvapi::kvapi::UpsertKVReq;
 use common_meta_types::IntoSeqV;
@@ -25,7 +26,6 @@ use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
-use common_meta_types::TenantQuota;
 
 use super::quota_api::QuotaApi;
 

--- a/src/query/service/src/api/http_service.rs
+++ b/src/query/service/src/api/http_service.rs
@@ -16,13 +16,15 @@ use std::net::SocketAddr;
 use std::path::Path;
 
 use common_config::Config;
-use common_exception::Result;
+use common_exception::ErrorCode;
 use common_http::health_handler;
 use common_http::home::debug_home_handler;
 #[cfg(feature = "memory-profiling")]
 use common_http::jeprof::debug_jeprof_dump_handler;
 use common_http::pprof::debug_pprof_handler;
+use common_http::HttpError;
 use common_http::HttpShutdownHandler;
+use common_meta_types::anyerror::AnyError;
 use poem::get;
 use poem::listener::RustlsCertificate;
 use poem::listener::RustlsConfig;
@@ -39,11 +41,11 @@ pub struct HttpService {
 }
 
 impl HttpService {
-    pub fn create(config: &Config) -> Result<Box<HttpService>> {
-        Ok(Box::new(HttpService {
+    pub fn create(config: &Config) -> Box<HttpService> {
+        Box::new(HttpService {
             config: config.clone(),
             shutdown_handler: HttpShutdownHandler::create("http api".to_string()),
-        }))
+        })
     }
 
     fn build_router(&self) -> impl Endpoint {
@@ -90,11 +92,13 @@ impl HttpService {
         route
     }
 
-    fn build_tls(config: &Config) -> Result<RustlsConfig> {
+    fn build_tls(config: &Config) -> Result<RustlsConfig, std::io::Error> {
         let certificate = RustlsCertificate::new()
             .cert(std::fs::read(config.query.api_tls_server_cert.as_str())?)
             .key(std::fs::read(config.query.api_tls_server_key.as_str())?);
+
         let mut cfg = RustlsConfig::new().fallback(certificate);
+
         if Path::new(&config.query.api_tls_server_root_ca_cert).exists() {
             cfg = cfg.client_auth_required(std::fs::read(
                 config.query.api_tls_server_root_ca_cert.as_str(),
@@ -103,10 +107,12 @@ impl HttpService {
         Ok(cfg)
     }
 
-    async fn start_with_tls(&mut self, listening: SocketAddr) -> Result<SocketAddr> {
+    async fn start_with_tls(&mut self, listening: SocketAddr) -> Result<SocketAddr, HttpError> {
         info!("Http API TLS enabled");
 
-        let tls_config = Self::build_tls(&self.config)?;
+        let tls_config = Self::build_tls(&self.config)
+            .map_err(|e| HttpError::TlsConfigError(AnyError::new(&e)))?;
+
         let addr = self
             .shutdown_handler
             .start_service(listening, Some(tls_config), self.build_router(), None)
@@ -114,7 +120,7 @@ impl HttpService {
         Ok(addr)
     }
 
-    async fn start_without_tls(&mut self, listening: SocketAddr) -> Result<SocketAddr> {
+    async fn start_without_tls(&mut self, listening: SocketAddr) -> Result<SocketAddr, HttpError> {
         warn!("Http API TLS not set");
 
         let addr = self
@@ -131,11 +137,22 @@ impl Server for HttpService {
         self.shutdown_handler.shutdown(graceful).await;
     }
 
-    async fn start(&mut self, listening: SocketAddr) -> Result<SocketAddr> {
+    async fn start(&mut self, listening: SocketAddr) -> Result<SocketAddr, ErrorCode> {
         let config = &self.config.query;
-        match config.api_tls_server_key.is_empty() || config.api_tls_server_cert.is_empty() {
-            true => self.start_without_tls(listening).await,
-            false => self.start_with_tls(listening).await,
-        }
+        let res =
+            match config.api_tls_server_key.is_empty() || config.api_tls_server_cert.is_empty() {
+                true => self.start_without_tls(listening).await,
+                false => self.start_with_tls(listening).await,
+            };
+
+        res.map_err(|e: HttpError| match e {
+            HttpError::BadAddressFormat(any_err) => {
+                ErrorCode::BadAddressFormat(any_err.to_string())
+            }
+            le @ HttpError::ListenError { .. } => ErrorCode::CannotListenerPort(le.to_string()),
+            HttpError::TlsConfigError(any_err) => {
+                ErrorCode::TLSConfigurationFailure(any_err.to_string())
+            }
+        })
     }
 }

--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -41,13 +41,13 @@ pub enum Credential {
 }
 
 impl AuthMgr {
-    pub fn create(cfg: &Config) -> Result<Arc<AuthMgr>> {
-        Ok(Arc::new(AuthMgr {
-            jwt_auth: JwtAuthenticator::try_create(
+    pub fn create(cfg: &Config) -> Arc<AuthMgr> {
+        Arc::new(AuthMgr {
+            jwt_auth: JwtAuthenticator::create(
                 cfg.query.jwt_key_file.clone(),
                 cfg.query.jwt_key_files.clone(),
-            )?,
-        }))
+            ),
+        })
     }
 
     pub async fn auth(&self, session: Arc<Session>, credential: &Credential) -> Result<()> {

--- a/src/query/service/src/procedures/admins/tenant_quota.rs
+++ b/src/query/service/src/procedures/admins/tenant_quota.rs
@@ -27,8 +27,8 @@ use common_expression::DataSchema;
 use common_expression::DataSchemaRefExt;
 use common_expression::Value;
 use common_meta_app::principal::UserOptionFlag;
+use common_meta_app::tenant::TenantQuota;
 use common_meta_types::MatchSeq;
-use common_meta_types::TenantQuota;
 use common_users::UserApiProvider;
 
 use crate::procedures::OneBlockProcedure;

--- a/src/query/service/src/servers/http/http_services.rs
+++ b/src/query/service/src/servers/http/http_services.rs
@@ -17,8 +17,10 @@ use std::path::Path;
 
 use common_config::Config;
 use common_config::GlobalConfig;
-use common_exception::Result;
+use common_exception::ErrorCode;
+use common_http::HttpError;
 use common_http::HttpShutdownHandler;
+use common_meta_types::anyerror::AnyError;
 use poem::get;
 use poem::listener::RustlsCertificate;
 use poem::listener::RustlsConfig;
@@ -73,14 +75,14 @@ pub struct HttpHandler {
 }
 
 impl HttpHandler {
-    pub fn create(kind: HttpHandlerKind) -> Result<Box<dyn Server>> {
-        Ok(Box::new(HttpHandler {
+    pub fn create(kind: HttpHandlerKind) -> Box<dyn Server> {
+        Box::new(HttpHandler {
             kind,
             shutdown_handler: HttpShutdownHandler::create("http handler".to_string()),
-        }))
+        })
     }
 
-    async fn build_router(&self, config: &Config, sock: SocketAddr) -> Result<impl Endpoint> {
+    async fn build_router(&self, config: &Config, sock: SocketAddr) -> impl Endpoint {
         let ep = match self.kind {
             HttpHandlerKind::Query => Route::new()
                 .at(
@@ -96,16 +98,16 @@ impl HttpHandler {
             HttpHandlerKind::Clickhouse => Route::new().nest("/", clickhouse_router()),
         };
 
-        let auth_manager = AuthMgr::create(config)?;
+        let auth_manager = AuthMgr::create(config);
         let session_middleware = HTTPSessionMiddleware::create(self.kind, auth_manager);
-        Ok(ep
-            .with(session_middleware)
+
+        ep.with(session_middleware)
             .with(NormalizePath::new(TrailingSlash::Trim))
             .with(CatchPanic::new())
-            .boxed())
+            .boxed()
     }
 
-    fn build_tls(config: &Config) -> Result<RustlsConfig> {
+    fn build_tls(config: &Config) -> Result<RustlsConfig, std::io::Error> {
         let certificate = RustlsCertificate::new()
             .cert(std::fs::read(
                 config.query.http_handler_tls_server_cert.as_str(),
@@ -122,22 +124,24 @@ impl HttpHandler {
         Ok(cfg)
     }
 
-    async fn start_with_tls(&mut self, listening: SocketAddr) -> Result<SocketAddr> {
+    async fn start_with_tls(&mut self, listening: SocketAddr) -> Result<SocketAddr, HttpError> {
         info!("Http Handler TLS enabled");
 
         let config = GlobalConfig::instance();
 
-        let tls_config = Self::build_tls(config.as_ref())?;
-        let router = self.build_router(config.as_ref(), listening).await?;
+        let tls_config = Self::build_tls(config.as_ref())
+            .map_err(|e: std::io::Error| HttpError::TlsConfigError(AnyError::new(&e)))?;
+
+        let router = self.build_router(config.as_ref(), listening).await;
         self.shutdown_handler
             .start_service(listening, Some(tls_config), router, None)
             .await
     }
 
-    async fn start_without_tls(&mut self, listening: SocketAddr) -> Result<SocketAddr> {
+    async fn start_without_tls(&mut self, listening: SocketAddr) -> Result<SocketAddr, HttpError> {
         let router = self
             .build_router(GlobalConfig::instance().as_ref(), listening)
-            .await?;
+            .await;
         self.shutdown_handler
             .start_service(listening, None, router, None)
             .await
@@ -150,13 +154,24 @@ impl Server for HttpHandler {
         self.shutdown_handler.shutdown(graceful).await;
     }
 
-    async fn start(&mut self, listening: SocketAddr) -> Result<SocketAddr> {
+    async fn start(&mut self, listening: SocketAddr) -> Result<SocketAddr, ErrorCode> {
         let config = GlobalConfig::instance();
-        match config.query.http_handler_tls_server_key.is_empty()
+
+        let res = match config.query.http_handler_tls_server_key.is_empty()
             || config.query.http_handler_tls_server_cert.is_empty()
         {
             true => self.start_without_tls(listening).await,
             false => self.start_with_tls(listening).await,
-        }
+        };
+
+        res.map_err(|e: HttpError| match e {
+            HttpError::BadAddressFormat(any_err) => {
+                ErrorCode::BadAddressFormat(any_err.to_string())
+            }
+            le @ HttpError::ListenError { .. } => ErrorCode::CannotListenerPort(le.to_string()),
+            HttpError::TlsConfigError(any_err) => {
+                ErrorCode::TLSConfigurationFailure(any_err.to_string())
+            }
+        })
     }
 }

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -103,7 +103,7 @@ impl QueryContextShared {
             running_query_kind: Arc::new(RwLock::new(None)),
             aborting: Arc::new(AtomicBool::new(false)),
             tables_refs: Arc::new(Mutex::new(HashMap::new())),
-            auth_manager: AuthMgr::create(config)?,
+            auth_manager: AuthMgr::create(config),
             affect: Arc::new(Mutex::new(None)),
             executor: Arc::new(RwLock::new(Weak::new())),
             precommit_blocks: Arc::new(RwLock::new(vec![])),

--- a/src/query/service/tests/it/api/http_service.rs
+++ b/src/query/service/tests/it/api/http_service.rs
@@ -33,7 +33,7 @@ async fn test_http_service_tls_server() -> Result<()> {
             .api_tls_server_key(TEST_SERVER_KEY)
             .api_tls_server_cert(TEST_SERVER_CERT)
             .build(),
-    )?;
+    );
 
     let listening = srv.start(address_str.parse()?).await?;
 
@@ -69,7 +69,7 @@ async fn test_http_service_tls_server_failed_case_1() -> Result<()> {
             .api_tls_server_key(TEST_SERVER_KEY)
             .api_tls_server_cert(TEST_SERVER_CERT)
             .build(),
-    )?;
+    );
     let listening = http_service.start(address_str.parse()?).await?;
 
     // test cert is issued for "localhost"
@@ -91,7 +91,7 @@ async fn test_http_service_tls_server_mutual_tls() -> Result<()> {
             .api_tls_server_cert(TEST_TLS_SERVER_CERT)
             .api_tls_server_root_ca_cert(TEST_TLS_CA_CERT)
             .build(),
-    )?;
+    );
     let listening = srv.start(addr_str.parse()?).await?;
 
     // test cert is issued for "localhost"
@@ -129,7 +129,7 @@ async fn test_http_service_tls_server_mutual_tls_failed() -> Result<()> {
             .api_tls_server_cert(TEST_TLS_SERVER_CERT)
             .api_tls_server_root_ca_cert(TEST_TLS_CA_CERT)
             .build(),
-    )?;
+    );
     let listening = srv.start(address_str.parse()?).await?;
 
     // test cert is issued for "localhost"

--- a/src/query/service/tests/it/metrics.rs
+++ b/src/query/service/tests/it/metrics.rs
@@ -25,7 +25,7 @@ pub static METRIC_TEST: &str = "metrics.test";
 #[tokio::test(flavor = "multi_thread")]
 async fn test_metric_server() -> common_exception::Result<()> {
     init_default_metrics_recorder();
-    let mut service = MetricService::create()?;
+    let mut service = MetricService::create();
     let listening = "127.0.0.1:0".parse::<SocketAddr>()?;
     let listening = service.start(listening).await?;
     let client = reqwest::Client::builder().build().unwrap();

--- a/src/query/service/tests/it/servers/http/clickhouse_handler.rs
+++ b/src/query/service/tests/it/servers/http/clickhouse_handler.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 
 use common_base::base::tokio;
 use common_config::Config;
-use common_exception::Result;
 use databend_query::auth::AuthMgr;
 use databend_query::servers::http::middleware::HTTPSessionEndpoint;
 use databend_query::servers::http::middleware::HTTPSessionMiddleware;
@@ -53,7 +52,7 @@ macro_rules! assert_ok {
 async fn test_select() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await.unwrap();
+    let server = Server::new(&config).await;
 
     {
         let (status, body) = server.get("bad sql").await;
@@ -100,7 +99,7 @@ async fn test_select() -> PoemResult<()> {
 async fn test_insert_values() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await.unwrap();
+    let server = Server::new(&config).await;
     {
         let (status, body) = server.post("create table t1(a int, b string)", "").await;
         assert_eq!(status, StatusCode::OK);
@@ -128,7 +127,7 @@ async fn test_insert_values() -> PoemResult<()> {
 async fn test_output_formats() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await.unwrap();
+    let server = Server::new(&config).await;
     {
         let (status, body) = server
             .post("create table t1(a int, b string null)", "")
@@ -170,7 +169,7 @@ async fn test_output_formats() -> PoemResult<()> {
 async fn test_output_format_compress() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await.unwrap();
+    let server = Server::new(&config).await;
     let sql = "select 1 format TabSeparated";
     let (status, body) = server
         .get_response_bytes(
@@ -191,7 +190,7 @@ async fn test_output_format_compress() -> PoemResult<()> {
 async fn test_insert_format_values() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await.unwrap();
+    let server = Server::new(&config).await;
     {
         let (status, body) = server.post("create table t1(a int, b string)", "").await;
         assert_eq!(status, StatusCode::OK);
@@ -220,7 +219,7 @@ async fn test_insert_format_ndjson() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
 
-    let server = Server::new(&config).await.unwrap();
+    let server = Server::new(&config).await;
     {
         let (status, body) = server
             .post("create table t1(a int, b string null)", "")
@@ -274,7 +273,7 @@ async fn test_insert_format_ndjson() -> PoemResult<()> {
 async fn test_settings() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await.unwrap();
+    let server = Server::new(&config).await;
 
     // unknown setting
     {
@@ -329,7 +328,7 @@ async fn test_settings() -> PoemResult<()> {
 async fn test_multi_partition() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await.unwrap();
+    let server = Server::new(&config).await;
     {
         let sql = "create table tb2(id int, c1 varchar) Engine=Fuse;";
         let (status, body) = server.get(sql).await;
@@ -422,13 +421,13 @@ struct Server {
 }
 
 impl Server {
-    pub async fn new(config: &Config) -> Result<Self> {
+    pub async fn new(config: &Config) -> Self {
         let session_middleware =
-            HTTPSessionMiddleware::create(HttpHandlerKind::Clickhouse, AuthMgr::create(config)?);
+            HTTPSessionMiddleware::create(HttpHandlerKind::Clickhouse, AuthMgr::create(config));
         let endpoint = Route::new()
             .nest("/", clickhouse_router())
             .with(session_middleware);
-        Ok(Server { endpoint })
+        Server { endpoint }
     }
 
     pub async fn get_response_bytes(&self, req: Request) -> (StatusCode, Vec<u8>) {

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -442,7 +442,7 @@ async fn test_result_timeout() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -466,7 +466,7 @@ async fn test_system_tables() -> Result<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await?;
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
     let ep = Route::new()
         .nest("/v1/query", query_route())
         .with(session_middleware);
@@ -548,7 +548,7 @@ async fn test_query_log() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -603,7 +603,7 @@ async fn test_query_log() -> Result<()> {
     );
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -684,7 +684,7 @@ async fn post_sql(sql: &str, wait_time_secs: u64) -> Result<(StatusCode, QueryRe
 pub async fn create_endpoint() -> Result<EndpointType> {
     let config = ConfigBuilder::create().build();
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
 
     Ok(Route::new()
         .nest("/v1/query", query_route())
@@ -767,7 +767,7 @@ async fn test_auth_jwt() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -896,7 +896,7 @@ async fn test_auth_jwt_with_create_user() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
     let ep = Route::new()
         .nest("/v1/query", query_route())
         .with(session_middleware);
@@ -936,7 +936,7 @@ async fn test_http_handler_tls_server() -> Result<()> {
     )
     .await?;
     let address_str = format!("127.0.0.1:{}", get_free_tcp_port());
-    let mut srv = HttpHandler::create(HttpHandlerKind::Query)?;
+    let mut srv = HttpHandler::create(HttpHandlerKind::Query);
 
     let listening = srv.start(address_str.parse()?).await?;
 
@@ -978,7 +978,7 @@ async fn test_http_handler_tls_server_failed_case_1() -> Result<()> {
         .build();
     let _guard = TestGlobalServices::setup(config).await?;
     let address_str = format!("127.0.0.1:{}", get_free_tcp_port());
-    let mut srv = HttpHandler::create(HttpHandlerKind::Query)?;
+    let mut srv = HttpHandler::create(HttpHandlerKind::Query);
 
     let listening = srv.start(address_str.parse()?).await?;
 
@@ -1004,7 +1004,7 @@ async fn test_http_service_tls_server_mutual_tls() -> Result<()> {
 
     let _guard = TestGlobalServices::setup(config.clone()).await?;
     let address_str = format!("127.0.0.1:{}", get_free_tcp_port());
-    let mut srv = HttpHandler::create(HttpHandlerKind::Query)?;
+    let mut srv = HttpHandler::create(HttpHandlerKind::Query);
     let listening = srv.start(address_str.parse()?).await?;
 
     // test cert is issued for "localhost"
@@ -1055,7 +1055,7 @@ async fn test_http_service_tls_server_mutual_tls_failed() -> Result<()> {
     .await?;
     let address_str = format!("127.0.0.1:{}", get_free_tcp_port());
 
-    let mut srv = HttpHandler::create(HttpHandlerKind::Query)?;
+    let mut srv = HttpHandler::create(HttpHandlerKind::Query);
     let listening = srv.start(address_str.parse()?).await?;
 
     // test cert is issued for "localhost"
@@ -1212,7 +1212,7 @@ async fn test_auth_configured_user() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config)?);
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
 
     let ep = Route::new()
         .nest("/v1/query", query_route())

--- a/src/query/users/src/jwt/authenticator.rs
+++ b/src/query/users/src/jwt/authenticator.rs
@@ -78,16 +78,16 @@ impl CustomClaims {
 }
 
 impl JwtAuthenticator {
-    pub fn try_create(jwt_key_file: String, jwt_key_files: Vec<String>) -> Result<Option<Self>> {
+    pub fn create(jwt_key_file: String, jwt_key_files: Vec<String>) -> Option<Self> {
         if jwt_key_file.is_empty() && jwt_key_files.is_empty() {
-            return Ok(None);
+            return None;
         }
         // init a vec of key store
         let mut key_stores = vec![jwk::JwkKeyStore::new(jwt_key_file)];
         for u in jwt_key_files {
             key_stores.push(jwk::JwkKeyStore::new(u))
         }
-        Ok(Some(JwtAuthenticator { key_stores }))
+        Some(JwtAuthenticator { key_stores })
     }
 
     // parse jwt claims from single source, if custom claim is not matching on desired, claim parsed would be empty

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -32,12 +32,12 @@ use common_management::UdfMgr;
 use common_management::UserApi;
 use common_management::UserMgr;
 use common_meta_app::principal::AuthInfo;
+use common_meta_app::tenant::TenantQuota;
 use common_meta_kvapi::kvapi;
 use common_meta_store::MetaStore;
 use common_meta_store::MetaStoreProvider;
 use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
-use common_meta_types::TenantQuota;
 
 use crate::idm_config::IDMConfig;
 

--- a/src/query/users/tests/it/jwt/authenticator.rs
+++ b/src/query/users/tests/it/jwt/authenticator.rs
@@ -53,9 +53,7 @@ async fn test_parse_non_custom_claim() -> Result<()> {
         .mount(&server)
         .await;
     let first_url = format!("http://{}{}", server.address(), json_path);
-    let auth = JwtAuthenticator::try_create(first_url, vec![])
-        .unwrap()
-        .unwrap();
+    let auth = JwtAuthenticator::create(first_url, vec![]).unwrap();
     let user_name = "test-user2";
     let my_additional_data = MyAdditionalData {
         user_is_admin: false,


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### Refactor: fix abuse of ErrorCode

`trait Stoppable`: add associated Error so that let an implementation
define its own error type.

- Replace unnecessary `Result<T, E>` with T.
- Use specific Error instead of ErrorCode if possible. E.g., HttpSerivce defines its own Error type.
- Use a generic error type such as anyhow for test return type.


##### chore(meta): move TenantQuota to crate meta-app

## Changelog







## Related Issues