### PR TITLE
fix(storage): wrong column statistics when contain tuple type

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/alter_table.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/alter_table.rs
@@ -126,8 +126,9 @@ async fn test_fuse_table_optimize_alter_table() -> Result<()> {
         .await?;
 
     // check column ids
-    let expected_column_ids = vec![0, 1];
-    check_segment_column_ids(&fixture, expected_column_ids).await?;
+    // the table contains two fields: id int32, t tuple(int, int)
+    let expected_leaf_column_ids = vec![0, 1, 2];
+    check_segment_column_ids(&fixture, expected_leaf_column_ids).await?;
 
     // drop a column
     let drop_table_column_plan = DropTableColumnPlan {

--- a/src/query/service/tests/it/storages/fuse/operations/alter_table.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/alter_table.rs
@@ -126,7 +126,7 @@ async fn test_fuse_table_optimize_alter_table() -> Result<()> {
         .await?;
 
     // check column ids
-    // the table contains two fields: id int32, t tuple(int, int)
+    // the table contains two fields: id int32, t tuple(int32, int32)
     let expected_leaf_column_ids = vec![0, 1, 2];
     check_segment_column_ids(&fixture, expected_leaf_column_ids).await?;
 

--- a/src/query/service/tests/it/storages/fuse/operations/gc.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/gc.rs
@@ -308,7 +308,7 @@ mod utils {
 
         let blocks: std::vec::Vec<DataBlock> = stream.try_collect().await?;
         for block in blocks {
-            let stats = gen_columns_statistics(&block, None, Some(&schema))?;
+            let stats = gen_columns_statistics(&block, None, &schema)?;
             let block_meta = block_writer
                 .write(FuseStorageFormat::Parquet, &schema, block, stats, None)
                 .await?;

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -678,7 +678,7 @@ impl CompactSegmentTestFixture {
             let mut stats_acc = StatisticsAccumulator::default();
             for block in blocks {
                 let block = block?;
-                let col_stats = gen_columns_statistics(&block, None, Some(&schema))?;
+                let col_stats = gen_columns_statistics(&block, None, &schema)?;
 
                 let mut block_statistics =
                     BlockStatistics::from(&block, "".to_owned(), None, None, &schema)?;

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_base::base::tokio;
 use common_expression::type_check::check;
@@ -31,6 +32,9 @@ use common_expression::FunctionContext;
 use common_expression::Literal;
 use common_expression::RawExpr;
 use common_expression::Scalar;
+use common_expression::TableDataType;
+use common_expression::TableField;
+use common_expression::TableSchema;
 use common_functions::aggregates::eval_aggr;
 use common_functions::scalars::BUILTIN_FUNCTIONS;
 use common_sql::evaluator::BlockOperator;
@@ -59,12 +63,16 @@ use crate::storages::fuse::table_test_fixture::TestFixture;
 
 #[test]
 fn test_ft_stats_block_stats() -> common_exception::Result<()> {
+    let schema = Arc::new(TableSchema::new(vec![
+        TableField::new("a", TableDataType::Number(NumberDataType::Int32)),
+        TableField::new("b", TableDataType::String),
+    ]));
     let block = DataBlock::new_from_columns(vec![
         Int32Type::from_data(vec![1, 2, 3]),
         StringType::from_data(vec!["aa", "aa", "bb"]),
     ]);
 
-    let r = gen_columns_statistics(&block, None, None)?;
+    let r = gen_columns_statistics(&block, None, &schema)?;
     assert_eq!(2, r.len());
     let col_stats = r.get(&0).unwrap();
     assert_eq!(col_stats.min, Scalar::Number(NumberScalar::Int32(1)));
@@ -79,6 +87,11 @@ fn test_ft_stats_block_stats() -> common_exception::Result<()> {
 
 #[test]
 fn test_ft_stats_block_stats_with_column_distinct_count() -> common_exception::Result<()> {
+    let schema = Arc::new(TableSchema::new(vec![
+        TableField::new("a", TableDataType::Number(NumberDataType::Int32)),
+        TableField::new("b", TableDataType::String),
+    ]));
+
     let block = DataBlock::new_from_columns(vec![
         Int32Type::from_data(vec![1, 2, 3]),
         StringType::from_data(vec!["aa", "aa", "bb"]),
@@ -86,7 +99,7 @@ fn test_ft_stats_block_stats_with_column_distinct_count() -> common_exception::R
     let mut column_distinct_count = HashMap::new();
     column_distinct_count.insert(0, 3);
     column_distinct_count.insert(1, 2);
-    let r = gen_columns_statistics(&block, Some(column_distinct_count), None)?;
+    let r = gen_columns_statistics(&block, Some(column_distinct_count), &schema)?;
     assert_eq!(2, r.len());
     let col_stats = r.get(&0).unwrap();
     assert_eq!(col_stats.min, Scalar::Number(NumberScalar::Int32(1)));
@@ -101,6 +114,17 @@ fn test_ft_stats_block_stats_with_column_distinct_count() -> common_exception::R
 
 #[test]
 fn test_ft_tuple_stats_block_stats() -> common_exception::Result<()> {
+    let schema = Arc::new(TableSchema::new(vec![TableField::new(
+        "a",
+        TableDataType::Tuple {
+            fields_name: vec!["a11".to_string(), "a12".to_string()],
+            fields_type: vec![
+                TableDataType::Number(NumberDataType::Int32),
+                TableDataType::Number(NumberDataType::Int32),
+            ],
+        },
+    )]));
+
     let inner_columns = vec![
         Int32Type::from_data(vec![1, 2, 3]),
         Int32Type::from_data(vec![4, 5, 6]),
@@ -112,7 +136,7 @@ fn test_ft_tuple_stats_block_stats() -> common_exception::Result<()> {
 
     let block = DataBlock::new_from_columns(vec![column]);
 
-    let r = gen_columns_statistics(&block, None, None)?;
+    let r = gen_columns_statistics(&block, None, &schema)?;
     assert_eq!(2, r.len());
     let col0_stats = r.get(&0).unwrap();
     assert_eq!(col0_stats.min, Scalar::Number(NumberScalar::Int32(1)));
@@ -130,11 +154,11 @@ fn test_ft_stats_col_stats_reduce() -> common_exception::Result<()> {
     let rows_per_block = 3;
     let val_start_with = 1;
 
-    let (_, blocks) =
+    let (schema, blocks) =
         TestFixture::gen_sample_blocks_ex(num_of_blocks, rows_per_block, val_start_with);
     let col_stats = blocks
         .iter()
-        .map(|b| gen_columns_statistics(&b.clone().unwrap(), None, None))
+        .map(|b| gen_columns_statistics(&b.clone().unwrap(), None, &schema))
         .collect::<common_exception::Result<Vec<_>>>()?;
     let r = reducers::reduce_block_statistics(&col_stats, None, None);
     assert!(r.is_ok());
@@ -215,7 +239,7 @@ async fn test_accumulator() -> common_exception::Result<()> {
     let loc_generator = TableMetaLocationGenerator::with_prefix("/".to_owned());
     for item in blocks {
         let block = item?;
-        let col_stats = gen_columns_statistics(&block, None, Some(&schema))?;
+        let col_stats = gen_columns_statistics(&block, None, &schema)?;
         let block_statistics =
             BlockStatistics::from(&block, "does_not_matter".to_owned(), None, None, &schema)?;
         let block_writer = BlockWriter::new(&operator, &loc_generator);
@@ -401,6 +425,11 @@ fn test_ft_stats_block_stats_string_columns_trimming_using_eval() -> common_exce
             rand_strings.push(rand_string);
         }
 
+        let schema = Arc::new(TableSchema::new(vec![TableField::new(
+            "a",
+            TableDataType::String,
+        )]));
+
         // build test data block, which has only on column, of String type
         let data_col = StringType::from_data(
             rand_strings
@@ -417,7 +446,7 @@ fn test_ft_stats_block_stats_string_columns_trimming_using_eval() -> common_exce
         let max_expr = max_col.0.index(0).unwrap();
 
         // generate the statistics of column
-        let stats_of_columns = gen_columns_statistics(&block, None, None).unwrap();
+        let stats_of_columns = gen_columns_statistics(&block, None, &schema).unwrap();
 
         // check if the max value (untrimmed) is in degenerated condition:
         // - the length of string value is larger or equal than STRING_PREFIX_LEN

--- a/src/query/service/tests/it/storages/statistics/column_statistics.rs
+++ b/src/query/service/tests/it/storages/statistics/column_statistics.rs
@@ -12,16 +12,23 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_expression::types::number::Float64Type;
 use common_expression::types::number::Int64Type;
+use common_expression::types::NumberDataType;
 use common_expression::Column;
 use common_expression::DataBlock;
 use common_expression::FromData;
 use common_expression::Scalar;
+use common_expression::TableDataType;
+use common_expression::TableField;
+use common_expression::TableSchema;
+use common_expression::TableSchemaRef;
 use databend_query::storages::fuse::statistics::gen_columns_statistics;
 
-fn gen_sample_block() -> (DataBlock, Vec<Column>) {
+fn gen_sample_block() -> (DataBlock, Vec<Column>, TableSchemaRef) {
     //   sample message
     //
     //   struct {
@@ -35,6 +42,24 @@ fn gen_sample_block() -> (DataBlock, Vec<Column>) {
     //      f : i64,
     //      g: f64,
     //   }
+
+    let schema = Arc::new(TableSchema::new(vec![
+        TableField::new("a", TableDataType::Tuple {
+            fields_name: vec!["b".to_string(), "e".to_string()],
+            fields_type: vec![
+                TableDataType::Tuple {
+                    fields_name: vec!["c".to_string(), "d".to_string()],
+                    fields_type: vec![
+                        TableDataType::Number(NumberDataType::Int64),
+                        TableDataType::Number(NumberDataType::Float64),
+                    ],
+                },
+                TableDataType::Number(NumberDataType::Float64),
+            ],
+        }),
+        TableField::new("f", TableDataType::Number(NumberDataType::Int64)),
+        TableField::new("g", TableDataType::Number(NumberDataType::Float64)),
+    ]));
 
     // prepare leaves
     let col_c = Int64Type::from_data(vec![1i64, 2, 3]);
@@ -54,15 +79,17 @@ fn gen_sample_block() -> (DataBlock, Vec<Column>) {
     };
 
     let columns = vec![col_a, col_f.clone(), col_g.clone()];
-    (DataBlock::new_from_columns(columns), vec![
-        col_c, col_d, col_e, col_f, col_g,
-    ])
+    (
+        DataBlock::new_from_columns(columns),
+        vec![col_c, col_d, col_e, col_f, col_g],
+        schema,
+    )
 }
 
 #[test]
 fn test_column_statistic() -> Result<()> {
-    let (sample_block, sample_cols) = gen_sample_block();
-    let col_stats = gen_columns_statistics(&sample_block, None, None)?;
+    let (sample_block, sample_cols, schema) = gen_sample_block();
+    let col_stats = gen_columns_statistics(&sample_block, None, &schema)?;
 
     assert_eq!(5, col_stats.len());
 

--- a/src/query/storages/fuse/src/operations/mutation/serialize_data_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/serialize_data_transform.rs
@@ -183,7 +183,7 @@ impl Processor for SerializeDataTransform {
                     .as_ref()
                     .map(|i| i.column_distinct_count.clone());
                 let col_stats =
-                    gen_columns_statistics(&block, column_distinct_count, Some(&self.schema))?;
+                    gen_columns_statistics(&block, column_distinct_count, &self.schema)?;
 
                 // serialize data block.
                 let mut block_data = Vec::with_capacity(DEFAULT_BLOCK_BUFFER_SIZE);

--- a/src/query/storages/fuse/src/statistics/block_statistics.rs
+++ b/src/query/storages/fuse/src/statistics/block_statistics.rs
@@ -45,7 +45,7 @@ impl BlockStatistics {
             block_column_statistics: column_statistic::gen_columns_statistics(
                 data_block,
                 column_distinct_count,
-                Some(schema),
+                schema,
             )?,
             block_cluster_statistics: cluster_stats,
         })

--- a/src/query/storages/fuse/src/statistics/column_statistic.rs
+++ b/src/query/storages/fuse/src/statistics/column_statistic.rs
@@ -41,15 +41,15 @@ pub fn get_traverse_columns_dfs(data_block: &DataBlock) -> traverse::TraverseRes
 pub fn gen_columns_statistics(
     data_block: &DataBlock,
     column_distinct_count: Option<HashMap<FieldIndex, usize>>,
-    schema: Option<&TableSchemaRef>,
+    schema: &TableSchemaRef,
 ) -> Result<StatisticsOfColumns> {
     let mut statistics = StatisticsOfColumns::new();
     let data_block = data_block.convert_to_full();
     let rows = data_block.num_rows();
 
     let leaves = get_traverse_columns_dfs(&data_block)?;
-    let column_ids = schema.map(|schema| schema.to_column_ids());
-    for (idx, (col_idx, col, data_type)) in leaves.iter().enumerate() {
+    let leaf_column_ids = schema.to_leaf_column_ids();
+    for ((col_idx, col, data_type), column_id) in leaves.iter().zip(leaf_column_ids) {
         if col.is_none() {
             continue;
         }
@@ -124,11 +124,6 @@ pub fn gen_columns_statistics(
             distinct_of_values: Some(distinct_of_values),
         };
 
-        // use column id as key instead of index
-        let column_id = match column_ids {
-            Some(ref column_ids) => column_ids[idx],
-            None => idx as u32,
-        };
         statistics.insert(column_id, col_stats);
     }
     Ok(statistics)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Use `to_leaf_column_ids` instead of `to_column_ids` when generate column statistics

Closes #10067 
