### PR TITLE
chore(ci): generate report for nightly on release

### DIFF
--- a/.github/workflows/trusted-benchmark.yml
+++ b/.github/workflows/trusted-benchmark.yml
@@ -86,3 +86,14 @@ jobs:
           RESULT_PEFIX="$(date -u +%Y)/$(date -u +%m)/$(date -u +%Y-%m-%d)/${{ env.RELEASE_TAG }}"
           aws s3 cp ./results/result-fs.json "s3://repo.databend.rs/benchmark/clickbench/release/${RESULT_PEFIX}-fs.json"
           aws s3 cp ./results/result-s3.json "s3://repo.databend.rs/benchmark/clickbench/release/${RESULT_PEFIX}-s3.json"
+          rm -f ./results/result-fs.json
+          rm -f ./results/result-s3.json
+      - name: Generate report
+        working-directory: benchmark/clickbench
+        run: |
+          aws s3 sync "s3://repo.databend.rs/benchmark/clickbench/release/$(date -u +%Y)/$(date -u +%m)/" ./results/
+          ./update-results.sh
+      - name: Upload PR clickbench report to repo.databend.rs
+        working-directory: benchmark/clickbench
+        run: |
+          aws s3 cp ./results/index.html s3://repo.databend.rs/benchmark/clickbench/release/index.html


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Report for nightly release will be avaiable at https://repo.databend.rs/benchmark/clickbench/release/index.html on next release.


Closes #issue
