### PR TITLE
refactor(meta/client): add compatible layer for upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,7 +1618,9 @@ dependencies = [
  "common-tracing",
  "enumflags2",
  "maplit",
+ "serde",
  "serde_json",
+ "thiserror",
  "tonic",
  "tracing",
 ]
@@ -1653,6 +1655,7 @@ dependencies = [
 name = "common-meta-client"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "common-arrow",
  "common-base",
  "common-building",
@@ -1673,6 +1676,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "thiserror",
  "tonic",
  "tracing",
 ]

--- a/src/binaries/meta/kvapi.rs
+++ b/src/binaries/meta/kvapi.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 
 use common_meta_kvapi::kvapi;
 use common_meta_kvapi::kvapi::UpsertKVReq;
-use common_meta_types::KVAppError;
 use common_meta_types::KVMeta;
+use common_meta_types::MetaError;
 use common_meta_types::SeqV;
 use common_meta_types::With;
 use databend_meta::configs::Config;
@@ -72,7 +72,7 @@ impl KvApiCommand {
 
     pub async fn execute(
         &self,
-        client: Arc<dyn kvapi::KVApi<Error = KVAppError>>,
+        client: Arc<dyn kvapi::KVApi<Error = MetaError>>,
     ) -> anyhow::Result<String> {
         let res_str = match self {
             KvApiCommand::Get(key) => {

--- a/src/meta/api/Cargo.toml
+++ b/src/meta/api/Cargo.toml
@@ -27,6 +27,8 @@ async-trait = "0.1.57"
 chrono = { workspace = true }
 enumflags2 = { version = "0.7.5", features = ["serde"] }
 maplit = "1.0.2"
+serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tonic = { version = "0.8.1", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
 tracing = "0.1.36"

--- a/src/meta/api/src/errors.rs
+++ b/src/meta/api/src/errors.rs
@@ -1,0 +1,96 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(xp): update these comment when merged. And client/meta plot picture.
+// Before 2023-02-15(<= v0.9.38-nightly) meta-service returns KVAppError
+//
+// Since 2023-02-15(> v0.9.38-nightly) meta-service returns just MetaError
+// ---
+/// Compatible layer to receive different types of errors from meta-service.
+///
+/// It allows the server side to switch to return a smaller error type, e.g., from KVAppError to MetaAPIError.
+///
+/// Currently:
+/// - Meta service kv_api returns KVAppError, while the client only consume the MetaApiError variants
+#[derive(thiserror::Error, serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum Compatible<Outer, Inner>
+where
+    Outer: From<Inner>,
+    Outer: TryInto<Inner>,
+{
+    Outer(Outer),
+    Inner(Inner),
+}
+
+impl<Outer, Inner> Compatible<Outer, Inner>
+where
+    Outer: From<Inner>,
+    Outer: TryInto<Inner>,
+{
+    pub fn into_inner(self) -> Inner
+    where Inner: From<<Outer as TryInto<Inner>>::Error> {
+        match self {
+            Compatible::Outer(o) => {
+                let i: Inner = o.try_into().unwrap_or_else(|e| Inner::from(e));
+                i
+            }
+            Compatible::Inner(i) => i,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common_meta_types::ForwardToLeader;
+    use common_meta_types::KVAppError;
+    use common_meta_types::MetaAPIError;
+    use common_meta_types::MetaError;
+
+    use crate::errors::Compatible;
+
+    #[test]
+    fn test_read_api_err_from_api_err() -> anyhow::Result<()> {
+        let me = MetaAPIError::ForwardToLeader(ForwardToLeader { leader_id: Some(1) });
+        let s = serde_json::to_string(&me)?;
+
+        let ge: Compatible<KVAppError, MetaAPIError> = serde_json::from_str(&s)?;
+
+        if let MetaAPIError::ForwardToLeader(f) = ge.clone().into_inner() {
+            assert_eq!(Some(1), f.leader_id);
+        } else {
+            unreachable!("expect ForwardToLeader but: {:?}", ge);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_api_err_from_kv_app_err() -> anyhow::Result<()> {
+        let me = KVAppError::MetaError(MetaError::APIError(MetaAPIError::ForwardToLeader(
+            ForwardToLeader { leader_id: Some(1) },
+        )));
+        let s = serde_json::to_string(&me)?;
+
+        let ge: Compatible<KVAppError, MetaAPIError> = serde_json::from_str(&s)?;
+
+        if let MetaAPIError::ForwardToLeader(f) = ge.clone().into_inner() {
+            assert_eq!(Some(1), f.leader_id);
+        } else {
+            unreachable!("expect ForwardToLeader but: {:?}", ge);
+        }
+
+        Ok(())
+    }
+}

--- a/src/meta/api/src/lib.rs
+++ b/src/meta/api/src/lib.rs
@@ -16,8 +16,10 @@
 #![deny(unused_crate_dependencies)]
 extern crate common_meta_types;
 
+pub mod errors;
 mod id;
 mod id_generator;
+pub mod reply;
 mod schema_api;
 mod schema_api_impl;
 mod schema_api_keys;

--- a/src/meta/api/src/reply.rs
+++ b/src/meta/api/src/reply.rs
@@ -1,0 +1,137 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_meta_types::protobuf::RaftReply;
+use common_meta_types::InvalidReply;
+use common_meta_types::KVAppError;
+use common_meta_types::MetaAPIError;
+use common_meta_types::MetaError;
+use common_meta_types::MetaNetworkError;
+use common_meta_types::TxnOpResponse;
+use common_meta_types::TxnReply;
+use serde::de::DeserializeOwned;
+
+use crate::errors::Compatible;
+
+/// Compatible layer:
+/// Convert either KVAppError or MetaAPIError to MetaAPIError
+pub fn reply_to_api_result<T>(msg: RaftReply) -> Result<T, MetaAPIError>
+where T: DeserializeOwned {
+    if !msg.data.is_empty() {
+        let res: T = serde_json::from_str(&msg.data)
+            .map_err(|e| InvalidReply::new("can not decode RaftReply.data", &e))?;
+        Ok(res)
+    } else {
+        let err: Compatible<KVAppError, MetaAPIError> = serde_json::from_str(&msg.error)
+            .map_err(|e| InvalidReply::new("can not decode RaftReply.error", &e))?;
+
+        let err = err.into_inner();
+        Err(err)
+    }
+}
+
+/// Compatible layer:
+/// Convert either KVAppError or MetaError to MetaError
+pub fn reply_to_meta_result<T>(raft_reply: RaftReply) -> Result<T, MetaError>
+where T: DeserializeOwned {
+    if !raft_reply.data.is_empty() {
+        let res: T = serde_json::from_str(&raft_reply.data)
+            .map_err(|e| InvalidReply::new("can not decode RaftReply.data", &e))?;
+        Ok(res)
+    } else {
+        let err: Compatible<KVAppError, MetaError> = serde_json::from_str(&raft_reply.error)
+            .map_err(|e| InvalidReply::new("can not decode RaftReply.error", &e))?;
+
+        let err = err.into_inner();
+
+        Err(err)
+    }
+}
+
+/// Compatible layer:
+/// Convert txn response to `success` and a series of `TxnOpResponse`.
+pub fn txn_reply_to_api_result(
+    txn_reply: TxnReply,
+) -> Result<(bool, Vec<TxnOpResponse>), MetaAPIError> {
+    if txn_reply.error.is_empty() {
+        Ok((txn_reply.success, txn_reply.responses))
+    } else {
+        let err: Compatible<KVAppError, MetaAPIError> = serde_json::from_str(&txn_reply.error)
+            .map_err(|e| {
+                MetaNetworkError::InvalidReply(InvalidReply::new("invalid TxnReply.error", &e))
+            })?;
+        let err = err.into_inner();
+        Err(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Foo {
+        i: i32,
+    }
+
+    use common_meta_types::protobuf::RaftReply;
+    use common_meta_types::MetaAPIError;
+    use common_meta_types::MetaNetworkError;
+
+    use crate::reply::reply_to_api_result;
+
+    #[test]
+    fn test_valid_reply() -> anyhow::Result<()> {
+        // Unable to decode `.data`
+
+        let msg = RaftReply {
+            data: "foo".to_string(),
+            error: "".to_string(),
+        };
+        let res: Result<Foo, MetaAPIError> = reply_to_api_result(msg);
+        match res {
+            Err(MetaAPIError::NetworkError(MetaNetworkError::InvalidReply(inv_reply))) => {
+                assert!(
+                    inv_reply
+                        .to_string()
+                        .starts_with("InvalidReply: can not decode RaftReply.data")
+                );
+            }
+            _ => {
+                unreachable!("expect InvalidReply")
+            }
+        }
+
+        // Unable to decode `.error`
+
+        let msg = RaftReply {
+            data: "".to_string(),
+            error: "foo".to_string(),
+        };
+        let res: Result<Foo, MetaAPIError> = reply_to_api_result(msg);
+        match res {
+            Err(MetaAPIError::NetworkError(MetaNetworkError::InvalidReply(inv_reply))) => {
+                assert!(
+                    inv_reply
+                        .to_string()
+                        .starts_with("InvalidReply: can not decode RaftReply.error")
+                );
+            }
+            _ => {
+                unreachable!("expect InvalidReply")
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -76,6 +76,7 @@ use common_meta_kvapi::kvapi::UpsertKVReq;
 use common_meta_types::GCDroppedDataReq;
 use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
+use common_meta_types::MetaError;
 use common_meta_types::Operation;
 use tracing::debug;
 use tracing::info;
@@ -175,7 +176,7 @@ fn calc_and_compare_drop_on_table_result(result: Vec<Arc<TableInfo>>, expected: 
 }
 
 async fn upsert_test_data(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     key: &impl kvapi::Key,
     value: Vec<u8>,
 ) -> Result<u64, KVAppError> {
@@ -193,7 +194,7 @@ async fn upsert_test_data(
 }
 
 async fn delete_test_data(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     key: &impl kvapi::Key,
 ) -> Result<(), KVAppError> {
     let _res = kv_api
@@ -213,7 +214,7 @@ impl SchemaApiTestSuite {
     pub async fn test_single_node<B, MT>(b: B) -> anyhow::Result<()>
     where
         B: kvapi::ApiBuilder<MT>,
-        MT: ShareApi + kvapi::AsKVApi<Error = KVAppError> + SchemaApi,
+        MT: ShareApi + kvapi::AsKVApi<Error = MetaError> + SchemaApi,
     {
         let suite = SchemaApiTestSuite {};
 
@@ -321,7 +322,7 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn database_and_table_rename<MT: SchemaApi + kvapi::AsKVApi<Error = KVAppError>>(
+    async fn database_and_table_rename<MT: SchemaApi + kvapi::AsKVApi<Error = MetaError>>(
         &self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -637,7 +638,7 @@ impl SchemaApiTestSuite {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn database_create_from_share_and_drop<
-        MT: ShareApi + kvapi::AsKVApi<Error = KVAppError> + SchemaApi,
+        MT: ShareApi + kvapi::AsKVApi<Error = MetaError> + SchemaApi,
     >(
         &self,
         mt: &MT,
@@ -2238,7 +2239,7 @@ impl SchemaApiTestSuite {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn database_drop_out_of_retention_time_history<
-        MT: SchemaApi + kvapi::AsKVApi<Error = KVAppError>,
+        MT: SchemaApi + kvapi::AsKVApi<Error = MetaError>,
     >(
         self,
         mt: &MT,
@@ -2301,7 +2302,7 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn create_out_of_retention_time_db<MT: SchemaApi + kvapi::AsKVApi<Error = KVAppError>>(
+    async fn create_out_of_retention_time_db<MT: SchemaApi + kvapi::AsKVApi<Error = MetaError>>(
         self,
         mt: &MT,
         db_name: DatabaseNameIdent,
@@ -2339,7 +2340,7 @@ impl SchemaApiTestSuite {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn database_gc_out_of_retention_time<
-        MT: SchemaApi + kvapi::AsKVApi<Error = KVAppError>,
+        MT: SchemaApi + kvapi::AsKVApi<Error = MetaError>,
     >(
         self,
         mt: &MT,
@@ -2424,7 +2425,7 @@ impl SchemaApiTestSuite {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn create_out_of_retention_time_table<
-        MT: SchemaApi + kvapi::AsKVApi<Error = KVAppError>,
+        MT: SchemaApi + kvapi::AsKVApi<Error = MetaError>,
     >(
         self,
         mt: &MT,
@@ -2477,7 +2478,7 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn table_gc_out_of_retention_time<MT: SchemaApi + kvapi::AsKVApi<Error = KVAppError>>(
+    async fn table_gc_out_of_retention_time<MT: SchemaApi + kvapi::AsKVApi<Error = MetaError>>(
         self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -2612,7 +2613,7 @@ impl SchemaApiTestSuite {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn table_drop_out_of_retention_time_history<
-        MT: SchemaApi + kvapi::AsKVApi<Error = KVAppError>,
+        MT: SchemaApi + kvapi::AsKVApi<Error = MetaError>,
     >(
         self,
         mt: &MT,
@@ -3544,9 +3545,7 @@ impl SchemaApiTestSuite {
         Ok(())
     }
 
-    async fn get_tables_from_share<
-        MT: ShareApi + kvapi::AsKVApi<Error = KVAppError> + SchemaApi,
-    >(
+    async fn get_tables_from_share<MT: ShareApi + kvapi::AsKVApi<Error = MetaError> + SchemaApi>(
         &self,
         mt: &MT,
     ) -> anyhow::Result<()> {

--- a/src/meta/api/src/share_api_impl.rs
+++ b/src/meta/api/src/share_api_impl.rs
@@ -33,6 +33,7 @@ use common_meta_types::errors::app_error::WrongShare;
 use common_meta_types::errors::app_error::WrongShareObject;
 use common_meta_types::ConditionResult::Eq;
 use common_meta_types::KVAppError;
+use common_meta_types::MetaError;
 use common_meta_types::TxnCondition;
 use common_meta_types::TxnOp;
 use common_meta_types::TxnRequest;
@@ -65,7 +66,7 @@ use crate::TXN_MAX_RETRY_TIMES;
 /// ShareApi is implemented upon kvapi::KVApi.
 /// Thus every type that impl kvapi::KVApi impls ShareApi.
 #[async_trait::async_trait]
-impl<KV: kvapi::KVApi<Error = KVAppError>> ShareApi for KV {
+impl<KV: kvapi::KVApi<Error = MetaError>> ShareApi for KV {
     #[tracing::instrument(level = "debug", ret, err, skip_all)]
     async fn show_shares(&self, req: ShowSharesReq) -> Result<ShowSharesReply, KVAppError> {
         debug!(req = debug(&req), "ShareApi: {}", func_name!());
@@ -947,7 +948,7 @@ impl<KV: kvapi::KVApi<Error = KVAppError>> ShareApi for KV {
 }
 
 async fn get_share_database_name(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     share_meta: &ShareMeta,
     share_name: &ShareNameIdent,
 ) -> Result<Option<String>, KVAppError> {
@@ -974,7 +975,7 @@ async fn get_share_database_name(
 }
 
 async fn get_outbound_share_tenants_by_name(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     share_name: &ShareNameIdent,
 ) -> Result<Vec<GetShareGrantTenants>, KVAppError> {
     let res = get_share_or_err(kv_api, share_name, format!("get_share: {share_name}")).await?;
@@ -1004,7 +1005,7 @@ async fn get_outbound_share_tenants_by_name(
 }
 
 async fn get_outbound_share_info_by_name(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     share_name: &ShareNameIdent,
 ) -> Result<ShareAccountReply, KVAppError> {
     let res = get_share_or_err(
@@ -1032,7 +1033,7 @@ async fn get_outbound_share_info_by_name(
 }
 
 async fn get_outbound_share_infos_by_tenant(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     tenant: &str,
 ) -> Result<Vec<ShareAccountReply>, KVAppError> {
     let mut outbound_share_accounts: Vec<ShareAccountReply> = vec![];
@@ -1054,7 +1055,7 @@ async fn get_outbound_share_infos_by_tenant(
 }
 
 async fn get_inbound_share_info_by_tenant(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     tenant: &String,
     share_account: ShareAccountNameIdent,
 ) -> Result<ShareAccountReply, KVAppError> {
@@ -1098,7 +1099,7 @@ async fn get_inbound_share_info_by_tenant(
 }
 
 async fn get_inbound_share_infos_by_tenant(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     tenant: &String,
 ) -> Result<Vec<ShareAccountReply>, KVAppError> {
     let mut inbound_share_accounts: Vec<ShareAccountReply> = vec![];
@@ -1119,7 +1120,7 @@ async fn get_inbound_share_infos_by_tenant(
 }
 
 async fn get_object_name_from_id(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     database_name: &Option<&String>,
     object: ShareGrantObject,
 ) -> Result<Option<ShareGrantObjectName>, KVAppError> {
@@ -1149,7 +1150,7 @@ async fn get_object_name_from_id(
 }
 
 async fn create_db_name_to_id_key_if_need(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     seq_and_id: &ShareGrantObjectSeqAndId,
     tenant: &str,
     obj_name: &ShareGrantObjectName,
@@ -1208,7 +1209,7 @@ fn check_share_object(
 
 /// Returns ShareGrantObjectSeqAndId by ShareGrantObjectName
 async fn get_share_object_seq_and_id(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     obj_name: &ShareGrantObjectName,
     tenant: &str,
 ) -> Result<ShareGrantObjectSeqAndId, KVAppError> {
@@ -1319,7 +1320,7 @@ fn add_grant_object_txn_if_then(
 }
 
 async fn drop_accounts_granted_from_share(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     share_id: u64,
     share_meta: &ShareMeta,
     condition: &mut Vec<TxnCondition>,
@@ -1348,7 +1349,7 @@ async fn drop_accounts_granted_from_share(
 }
 
 async fn remove_share_id_from_share_object(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     share_id: u64,
     entry: &ShareGrantEntry,
     condition: &mut Vec<TxnCondition>,
@@ -1364,7 +1365,7 @@ async fn remove_share_id_from_share_object(
 }
 
 async fn remove_share_id_from_share_objects(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     share_id: u64,
     share_meta: &ShareMeta,
     condition: &mut Vec<TxnCondition>,
@@ -1382,7 +1383,7 @@ async fn remove_share_id_from_share_objects(
 }
 
 async fn drop_all_database_from_share(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     _share_id: u64,
     share_meta: &ShareMeta,
     condition: &mut Vec<TxnCondition>,
@@ -1395,7 +1396,7 @@ async fn drop_all_database_from_share(
 }
 
 async fn get_tenant_share_spec_vec(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     tenant: String,
 ) -> Result<Vec<ShareSpec>, KVAppError> {
     let mut share_metas = vec![];
@@ -1439,7 +1440,7 @@ async fn get_tenant_share_spec_vec(
 }
 
 async fn convert_share_meta_to_spec(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     share_name: &str,
     share_id: u64,
     share_meta: ShareMeta,

--- a/src/meta/api/src/share_api_test_suite.rs
+++ b/src/meta/api/src/share_api_test_suite.rs
@@ -23,6 +23,7 @@ use common_meta_app::schema::TableNameIdent;
 use common_meta_app::share::*;
 use common_meta_kvapi::kvapi;
 use common_meta_types::KVAppError;
+use common_meta_types::MetaError;
 use enumflags2::BitFlags;
 use tracing::info;
 
@@ -45,7 +46,7 @@ use crate::ShareApi;
 pub struct ShareApiTestSuite {}
 
 async fn if_share_object_data_exists(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     entry: &ShareGrantEntry,
 ) -> Result<bool, KVAppError> {
     if let Ok((_seq, _share_ids)) = get_object_shared_by_share_ids(kv_api, &entry.object).await {
@@ -56,7 +57,7 @@ async fn if_share_object_data_exists(
 
 // Return true if all the share data has been removed.
 async fn is_all_share_data_removed(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     share_name: &ShareNameIdent,
     share_id: u64,
     share_meta: &ShareMeta,
@@ -108,7 +109,7 @@ impl ShareApiTestSuite {
     pub async fn test_single_node_share<B, MT>(b: B) -> anyhow::Result<()>
     where
         B: kvapi::ApiBuilder<MT>,
-        MT: ShareApi + kvapi::AsKVApi<Error = KVAppError> + SchemaApi,
+        MT: ShareApi + kvapi::AsKVApi<Error = MetaError> + SchemaApi,
     {
         let suite = ShareApiTestSuite {};
 
@@ -124,7 +125,7 @@ impl ShareApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn share_create_show_drop<MT: ShareApi + kvapi::AsKVApi<Error = KVAppError>>(
+    async fn share_create_show_drop<MT: ShareApi + kvapi::AsKVApi<Error = MetaError>>(
         &self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -191,7 +192,7 @@ impl ShareApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn share_add_remove_account<MT: ShareApi + kvapi::AsKVApi<Error = KVAppError>>(
+    async fn share_add_remove_account<MT: ShareApi + kvapi::AsKVApi<Error = MetaError>>(
         &self,
         mt: &MT,
     ) -> anyhow::Result<()> {
@@ -485,7 +486,7 @@ impl ShareApiTestSuite {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn share_grant_revoke_object<
-        MT: ShareApi + kvapi::AsKVApi<Error = KVAppError> + SchemaApi,
+        MT: ShareApi + kvapi::AsKVApi<Error = MetaError> + SchemaApi,
     >(
         &self,
         mt: &MT,
@@ -828,7 +829,7 @@ impl ShareApiTestSuite {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn get_share_grant_objects<
-        MT: ShareApi + kvapi::AsKVApi<Error = KVAppError> + SchemaApi,
+        MT: ShareApi + kvapi::AsKVApi<Error = MetaError> + SchemaApi,
     >(
         &self,
         mt: &MT,
@@ -958,7 +959,7 @@ impl ShareApiTestSuite {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn get_grant_privileges_of_object<
-        MT: ShareApi + kvapi::AsKVApi<Error = KVAppError> + SchemaApi,
+        MT: ShareApi + kvapi::AsKVApi<Error = MetaError> + SchemaApi,
     >(
         &self,
         mt: &MT,

--- a/src/meta/api/src/testing.rs
+++ b/src/meta/api/src/testing.rs
@@ -25,7 +25,7 @@ use common_proto_conv::FromToProto;
 
 /// Get existing value by key. Panic if key is absent.
 pub(crate) async fn get_kv_data<T>(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     key: &impl kvapi::Key,
 ) -> Result<T, KVAppError>
 where

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -36,6 +36,7 @@ use common_meta_types::InvalidArgument;
 use common_meta_types::InvalidReply;
 use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
+use common_meta_types::MetaError;
 use common_meta_types::MetaNetworkError;
 use common_meta_types::Operation;
 use common_meta_types::TxnCondition;
@@ -49,6 +50,7 @@ use enumflags2::BitFlags;
 use tracing::debug;
 use ConditionResult::Eq;
 
+use crate::reply::txn_reply_to_api_result;
 use crate::Id;
 
 pub const TXN_MAX_RETRY_TIMES: u32 = 10;
@@ -62,7 +64,7 @@ pub const TXN_MAX_RETRY_TIMES: u32 = 10;
 /// It returns (seq, `u64` value).
 /// If not found, (0,0) is returned.
 pub async fn get_u64_value<T: kvapi::Key>(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     key: &T,
 ) -> Result<(u64, u64), KVAppError> {
     let res = kv_api.get_kv(&key.to_string_key()).await?;
@@ -78,7 +80,7 @@ pub async fn get_u64_value<T: kvapi::Key>(
 ///
 /// It returns seq number and the data.
 pub async fn get_struct_value<K, T>(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     k: &K,
 ) -> Result<(u64, Option<T>), KVAppError>
 where
@@ -98,7 +100,7 @@ where
 /// It returns a vec of structured key(such as DatabaseNameIdent), such as:
 /// all the `db_name` with prefix `__fd_database/<tenant>/`.
 pub async fn list_keys<K: kvapi::Key>(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     key: &K,
 ) -> Result<Vec<K>, KVAppError> {
     let res = kv_api.prefix_list_kv(&key.to_string_key()).await?;
@@ -126,9 +128,9 @@ pub async fn list_keys<K: kvapi::Key>(
 ///
 /// It returns a vec of structured key(such as DatabaseNameIdent) and a vec of `u64`.
 pub async fn list_u64_value<K: kvapi::Key>(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     key: &K,
-) -> Result<(Vec<K>, Vec<u64>), KVAppError> {
+) -> Result<(Vec<K>, Vec<u64>), MetaError> {
     let res = kv_api.prefix_list_kv(&key.to_string_key()).await?;
 
     let n = res.len();
@@ -172,7 +174,7 @@ pub fn deserialize_u64(v: &[u8]) -> Result<Id, MetaNetworkError> {
 /// Ids are categorized by generators.
 /// Ids may not be consecutive.
 pub async fn fetch_id<T: kvapi::Key>(
-    kv_api: &impl kvapi::KVApi<Error = KVAppError>,
+    kv_api: &impl kvapi::KVApi<Error = MetaError>,
     generator: T,
 ) -> Result<u64, KVAppError> {
     let res = kv_api
@@ -224,12 +226,11 @@ where
 }
 
 pub async fn send_txn(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     txn_req: TxnRequest,
 ) -> Result<(bool, Vec<TxnOpResponse>), KVAppError> {
     let tx_reply = kv_api.transaction(txn_req).await?;
-    let res: Result<_, KVAppError> = tx_reply.into();
-    let (succ, responses) = res?;
+    let (succ, responses) = txn_reply_to_api_result(tx_reply)?;
     Ok((succ, responses))
 }
 
@@ -319,7 +320,7 @@ pub fn table_has_to_exist(
 
 // Return (share_id_seq, share_id, share_meta_seq, share_meta)
 pub async fn get_share_or_err(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     name_key: &ShareNameIdent,
     msg: impl Display,
 ) -> Result<(u64, u64, u64, ShareMeta), KVAppError> {
@@ -333,7 +334,7 @@ pub async fn get_share_or_err(
 
 /// Returns (share_meta_seq, share_meta)
 pub async fn get_share_meta_by_id_or_err(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     share_id: u64,
     msg: impl Display,
 ) -> Result<(u64, ShareMeta), KVAppError> {
@@ -381,7 +382,7 @@ fn share_has_to_exist(
 
 /// Returns (share_account_meta_seq, share_account_meta)
 pub async fn get_share_account_meta_or_err(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     name_key: &ShareAccountNameIdent,
     msg: impl Display,
 ) -> Result<(u64, ShareAccountMeta), KVAppError> {
@@ -421,7 +422,7 @@ fn share_account_meta_has_to_exist(
 
 /// Returns (share_meta_seq, share_meta)
 pub async fn get_share_id_to_name_or_err(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     share_id: u64,
     msg: impl Display,
 ) -> Result<(u64, ShareNameIdent), KVAppError> {
@@ -458,7 +459,7 @@ pub fn get_share_database_id_and_privilege(
 
 // Return true if all the database data has been removed.
 pub async fn is_all_db_data_removed(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     db_id: u64,
 ) -> Result<bool, KVAppError> {
     let dbid = DatabaseId { db_id };
@@ -486,7 +487,7 @@ pub async fn is_all_db_data_removed(
 // When the database needs to be removed, add `TxnCondition` into `condition`
 //    and `TxnOp` into the `if_then`.
 pub async fn is_db_need_to_be_remove<F>(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     db_id: u64,
     mut f: F,
     condition: &mut Vec<TxnCondition>,
@@ -523,7 +524,7 @@ where
 }
 
 pub async fn get_object_shared_by_share_ids(
-    kv_api: &(impl kvapi::KVApi<Error = KVAppError> + ?Sized),
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     object: &ShareGrantObject,
 ) -> Result<(u64, ObjectSharedByShareIds), KVAppError> {
     let (seq, share_ids): (u64, Option<ObjectSharedByShareIds>) =

--- a/src/meta/client/Cargo.toml
+++ b/src/meta/client/Cargo.toml
@@ -31,6 +31,7 @@ prost = { workspace = true }
 semver = "1.0.14"
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tonic = { version = "0.8.1", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
 tracing = "0.1.36"
 
@@ -38,6 +39,7 @@ tracing = "0.1.36"
 common-exception = { path = "../../common/exception" }
 common-meta-app = { path = "../app" }
 
+anyhow = { workspace = true }
 rand = "0.8.5"
 
 [build-dependencies]

--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -37,7 +37,6 @@ use common_grpc::ConnectionFactory;
 use common_grpc::GrpcConnectionError;
 use common_grpc::RpcClientConf;
 use common_grpc::RpcClientTlsConfig;
-use common_meta_kvapi::kvapi::KVApi;
 use common_meta_types::anyerror::AnyError;
 use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use common_meta_types::protobuf::ClientInfo;

--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -37,6 +37,7 @@ use common_grpc::ConnectionFactory;
 use common_grpc::GrpcConnectionError;
 use common_grpc::RpcClientConf;
 use common_grpc::RpcClientTlsConfig;
+use common_meta_api::reply::reply_to_api_result;
 use common_meta_types::anyerror::AnyError;
 use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use common_meta_types::protobuf::ClientInfo;
@@ -51,7 +52,6 @@ use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::protobuf::WatchResponse;
 use common_meta_types::ConnectionError;
 use common_meta_types::InvalidArgument;
-use common_meta_types::KVAppError;
 use common_meta_types::MetaClientError;
 use common_meta_types::MetaError;
 use common_meta_types::MetaHandshakeError;
@@ -813,7 +813,7 @@ impl MetaGrpcClient {
     }
 
     #[tracing::instrument(level = "debug", skip(self, v))]
-    pub(crate) async fn kv_api<T, R>(&self, v: T) -> Result<R, KVAppError>
+    pub(crate) async fn kv_api<T, R>(&self, v: T) -> Result<R, MetaError>
     where
         T: RequestFor<Reply = R>,
         T: Into<MetaGrpcReq>,
@@ -860,12 +860,12 @@ impl MetaGrpcClient {
         };
         let raft_reply = rpc_res?;
 
-        let res: Result<R, KVAppError> = raft_reply.into();
-        res
+        let resp: R = reply_to_api_result(raft_reply)?;
+        Ok(resp)
     }
 
     #[tracing::instrument(level = "debug", skip(self, req))]
-    pub(crate) async fn transaction(&self, req: TxnRequest) -> Result<TxnReply, KVAppError> {
+    pub(crate) async fn transaction(&self, req: TxnRequest) -> Result<TxnReply, MetaError> {
         let txn: TxnRequest = req;
 
         debug!(req = display(&txn), "MetaGrpcClient::transaction request");

--- a/src/meta/client/src/kv_api_impl.rs
+++ b/src/meta/client/src/kv_api_impl.rs
@@ -26,45 +26,6 @@ use common_meta_types::TxnReply;
 use common_meta_types::TxnRequest;
 
 use crate::ClientHandle;
-use crate::MetaGrpcClient;
-
-#[tonic::async_trait]
-impl kvapi::KVApi for MetaGrpcClient {
-    type Error = KVAppError;
-    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
-        let reply = self.kv_api(act).await?;
-        Ok(reply)
-    }
-
-    async fn get_kv(&self, key: &str) -> Result<GetKVReply, KVAppError> {
-        let reply = self
-            .kv_api(GetKVReq {
-                key: key.to_string(),
-            })
-            .await?;
-        Ok(reply)
-    }
-
-    async fn mget_kv(&self, keys: &[String]) -> Result<MGetKVReply, KVAppError> {
-        let keys = keys.to_vec();
-        let reply = self.kv_api(MGetKVReq { keys }).await?;
-        Ok(reply)
-    }
-
-    async fn prefix_list_kv(&self, prefix: &str) -> Result<ListKVReply, KVAppError> {
-        let reply = self
-            .kv_api(ListKVReq {
-                prefix: prefix.to_string(),
-            })
-            .await?;
-        Ok(reply)
-    }
-
-    async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, KVAppError> {
-        let reply = self.transaction(txn).await?;
-        Ok(reply)
-    }
-}
 
 #[tonic::async_trait]
 impl kvapi::KVApi for ClientHandle {

--- a/src/meta/client/src/kv_api_impl.rs
+++ b/src/meta/client/src/kv_api_impl.rs
@@ -21,7 +21,7 @@ use common_meta_kvapi::kvapi::MGetKVReply;
 use common_meta_kvapi::kvapi::MGetKVReq;
 use common_meta_kvapi::kvapi::UpsertKVReply;
 use common_meta_kvapi::kvapi::UpsertKVReq;
-use common_meta_types::KVAppError;
+use common_meta_types::MetaError;
 use common_meta_types::TxnReply;
 use common_meta_types::TxnRequest;
 
@@ -29,14 +29,14 @@ use crate::ClientHandle;
 
 #[tonic::async_trait]
 impl kvapi::KVApi for ClientHandle {
-    type Error = KVAppError;
+    type Error = MetaError;
 
-    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
+    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, Self::Error> {
         let reply = self.request(act).await?;
         Ok(reply)
     }
 
-    async fn get_kv(&self, key: &str) -> Result<GetKVReply, KVAppError> {
+    async fn get_kv(&self, key: &str) -> Result<GetKVReply, Self::Error> {
         let reply = self
             .request(GetKVReq {
                 key: key.to_string(),
@@ -45,13 +45,13 @@ impl kvapi::KVApi for ClientHandle {
         Ok(reply)
     }
 
-    async fn mget_kv(&self, keys: &[String]) -> Result<MGetKVReply, KVAppError> {
+    async fn mget_kv(&self, keys: &[String]) -> Result<MGetKVReply, Self::Error> {
         let keys = keys.to_vec();
         let reply = self.request(MGetKVReq { keys }).await?;
         Ok(reply)
     }
 
-    async fn prefix_list_kv(&self, prefix: &str) -> Result<ListKVReply, KVAppError> {
+    async fn prefix_list_kv(&self, prefix: &str) -> Result<ListKVReply, Self::Error> {
         let reply = self
             .request(ListKVReq {
                 prefix: prefix.to_string(),
@@ -60,7 +60,7 @@ impl kvapi::KVApi for ClientHandle {
         Ok(reply)
     }
 
-    async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, KVAppError> {
+    async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, Self::Error> {
         let reply = self.request(txn).await?;
         Ok(reply)
     }

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -19,6 +19,8 @@ mod grpc_client;
 mod kv_api_impl;
 mod message;
 
+pub use common_meta_api::reply::reply_to_api_result;
+pub use common_meta_api::reply::reply_to_meta_result;
 pub use grpc_action::MetaGrpcReq;
 pub use grpc_action::RequestFor;
 pub use grpc_client::ClientHandle;

--- a/src/meta/client/src/message.rs
+++ b/src/meta/client/src/message.rs
@@ -26,7 +26,6 @@ use common_meta_types::protobuf::ClientInfo;
 use common_meta_types::protobuf::ExportedChunk;
 use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::protobuf::WatchResponse;
-use common_meta_types::KVAppError;
 use common_meta_types::MetaClientError;
 use common_meta_types::MetaError;
 use common_meta_types::TxnReply;
@@ -100,11 +99,11 @@ impl Request {
 /// Meta-client worker-to-handle response body
 #[derive(Debug, derive_more::TryInto)]
 pub enum Response {
-    Get(Result<GetKVReply, KVAppError>),
-    MGet(Result<MGetKVReply, KVAppError>),
-    PrefixList(Result<ListKVReply, KVAppError>),
-    Upsert(Result<UpsertKVReply, KVAppError>),
-    Txn(Result<TxnReply, KVAppError>),
+    Get(Result<GetKVReply, MetaError>),
+    MGet(Result<MGetKVReply, MetaError>),
+    PrefixList(Result<ListKVReply, MetaError>),
+    Upsert(Result<UpsertKVReply, MetaError>),
+    Txn(Result<TxnReply, MetaError>),
     Watch(Result<tonic::codec::Streaming<WatchResponse>, MetaError>),
     Export(Result<tonic::codec::Streaming<ExportedChunk>, MetaError>),
     MakeClient(

--- a/src/meta/embedded/src/kv_api_impl.rs
+++ b/src/meta/embedded/src/kv_api_impl.rs
@@ -20,7 +20,7 @@ use common_meta_kvapi::kvapi::MGetKVReply;
 use common_meta_kvapi::kvapi::UpsertKVReply;
 use common_meta_kvapi::kvapi::UpsertKVReq;
 pub use common_meta_sled_store::init_temp_sled_db;
-use common_meta_types::KVAppError;
+use common_meta_types::MetaError;
 use common_meta_types::TxnReply;
 use common_meta_types::TxnRequest;
 
@@ -28,28 +28,28 @@ use crate::MetaEmbedded;
 
 #[async_trait]
 impl kvapi::KVApi for MetaEmbedded {
-    type Error = KVAppError;
-    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
+    type Error = MetaError;
+    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, Self::Error> {
         let sm = self.inner.lock().await;
         sm.upsert_kv(act).await
     }
 
-    async fn get_kv(&self, key: &str) -> Result<GetKVReply, KVAppError> {
+    async fn get_kv(&self, key: &str) -> Result<GetKVReply, Self::Error> {
         let sm = self.inner.lock().await;
         sm.get_kv(key).await
     }
 
-    async fn mget_kv(&self, key: &[String]) -> Result<MGetKVReply, KVAppError> {
+    async fn mget_kv(&self, key: &[String]) -> Result<MGetKVReply, Self::Error> {
         let sm = self.inner.lock().await;
         sm.mget_kv(key).await
     }
 
-    async fn prefix_list_kv(&self, prefix: &str) -> Result<ListKVReply, KVAppError> {
+    async fn prefix_list_kv(&self, prefix: &str) -> Result<ListKVReply, Self::Error> {
         let sm = self.inner.lock().await;
         sm.prefix_list_kv(prefix).await
     }
 
-    async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, KVAppError> {
+    async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, Self::Error> {
         let sm = self.inner.lock().await;
         sm.transaction(txn).await
     }

--- a/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
+++ b/src/meta/raft-store/src/state_machine/sm_kv_api_impl.rs
@@ -18,7 +18,7 @@ use common_meta_kvapi::kvapi::MGetKVReply;
 use common_meta_kvapi::kvapi::UpsertKVReply;
 use common_meta_kvapi::kvapi::UpsertKVReq;
 use common_meta_types::Cmd;
-use common_meta_types::KVAppError;
+use common_meta_types::MetaError;
 use common_meta_types::SeqV;
 use common_meta_types::TxnReply;
 use common_meta_types::TxnRequest;
@@ -30,9 +30,9 @@ use crate::state_machine::StateMachine;
 
 #[async_trait::async_trait]
 impl kvapi::KVApi for StateMachine {
-    type Error = KVAppError;
+    type Error = MetaError;
 
-    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
+    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, Self::Error> {
         let cmd = Cmd::UpsertKV(UpsertKV {
             key: act.key,
             seq: act.seq,
@@ -55,7 +55,7 @@ impl kvapi::KVApi for StateMachine {
         }
     }
 
-    async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, KVAppError> {
+    async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, Self::Error> {
         let cmd = Cmd::Transaction(txn);
 
         let res = self.sm_tree.txn(true, |mut txn_sled_tree| {
@@ -69,12 +69,12 @@ impl kvapi::KVApi for StateMachine {
         match res {
             AppliedState::TxnReply(x) => Ok(x),
             _ => {
-                panic!("expect AppliedState::TxnReply");
+                unreachable!("expect AppliedState::TxnReply");
             }
         }
     }
 
-    async fn get_kv(&self, key: &str) -> Result<GetKVReply, KVAppError> {
+    async fn get_kv(&self, key: &str) -> Result<GetKVReply, Self::Error> {
         // TODO(xp) refine get(): a &str is enough for key
         let sv = self.kvs().get(&key.to_string())?;
         debug!("get_kv sv:{:?}", sv);
@@ -84,7 +84,7 @@ impl kvapi::KVApi for StateMachine {
         Ok(res)
     }
 
-    async fn mget_kv(&self, keys: &[String]) -> Result<MGetKVReply, KVAppError> {
+    async fn mget_kv(&self, keys: &[String]) -> Result<MGetKVReply, Self::Error> {
         let kvs = self.kvs();
         let mut res = vec![];
 
@@ -102,7 +102,7 @@ impl kvapi::KVApi for StateMachine {
     async fn prefix_list_kv(
         &self,
         prefix: &str,
-    ) -> Result<Vec<(String, SeqV<Vec<u8>>)>, KVAppError> {
+    ) -> Result<Vec<(String, SeqV<Vec<u8>>)>, Self::Error> {
         let kvs = self.kvs();
         let kv_pairs = kvs.scan_prefix(&prefix.to_string())?;
 

--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -28,6 +28,7 @@ use common_base::base::tokio::task::JoinHandle;
 use common_base::base::tokio::time::Instant;
 use common_grpc::ConnectionFactory;
 use common_grpc::DNSResolver;
+use common_meta_client::reply_to_api_result;
 use common_meta_raft_store::applied_state::AppliedState;
 use common_meta_raft_store::config::RaftConfig;
 use common_meta_raft_store::key_spaces::GenericKV;
@@ -665,7 +666,7 @@ impl MetaNode {
                 Ok(r) => {
                     let reply = r.into_inner();
 
-                    let res: Result<ForwardResponse, MetaAPIError> = reply.into();
+                    let res: Result<ForwardResponse, MetaAPIError> = reply_to_api_result(reply);
                     match res {
                         Ok(v) => {
                             info!("join cluster via {} success: {:?}", addr, v);
@@ -1091,7 +1092,7 @@ impl MetaNode {
         })?;
         let raft_mes = resp.into_inner();
 
-        let res: Result<ForwardResponse, MetaAPIError> = raft_mes.into();
+        let res: Result<ForwardResponse, MetaAPIError> = reply_to_api_result(raft_mes);
         let resp = res?;
         Ok(resp)
     }

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_tls.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_tls.rs
@@ -19,7 +19,6 @@ use common_grpc::RpcClientTlsConfig;
 use common_meta_api::SchemaApi;
 use common_meta_client::MetaGrpcClient;
 use common_meta_kvapi::kvapi::KVApi;
-use common_meta_types::KVAppError;
 use common_meta_types::MetaClientError;
 use common_meta_types::MetaError;
 use common_meta_types::MetaNetworkError;
@@ -100,9 +99,9 @@ async fn test_tls_client_config_failure() -> anyhow::Result<()> {
 
     let e = c.unwrap_err();
 
-    if let KVAppError::MetaError(MetaError::ClientError(MetaClientError::NetworkError(
+    if let MetaError::ClientError(MetaClientError::NetworkError(
         MetaNetworkError::TLSConfigError(any_err),
-    ))) = e
+    )) = e
     {
         let _ = any_err;
     } else {

--- a/src/meta/service/tests/it/meta_node/meta_node_seq_api.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_seq_api.rs
@@ -16,6 +16,7 @@
 //! It can also be used by apps to generate mono incremental seq numbers.
 
 use common_base::base::tokio;
+use common_meta_client::reply_to_meta_result;
 use common_meta_raft_store::applied_state::AppliedState;
 use common_meta_types::protobuf::raft_service_client::RaftServiceClient;
 use common_meta_types::Cmd;
@@ -46,7 +47,7 @@ async fn test_meta_node_incr_seq() -> anyhow::Result<()> {
         };
         let raft_reply = client.write(req).await?.into_inner();
 
-        let res: Result<AppliedState, MetaError> = raft_reply.into();
+        let res: Result<AppliedState, MetaError> = reply_to_meta_result(raft_reply);
         let resp: AppliedState = res?;
         match resp {
             AppliedState::Seq { seq } => {

--- a/src/meta/store/src/lib.rs
+++ b/src/meta/store/src/lib.rs
@@ -26,7 +26,6 @@ use common_meta_kvapi::kvapi::ListKVReply;
 use common_meta_kvapi::kvapi::MGetKVReply;
 use common_meta_kvapi::kvapi::UpsertKVReply;
 use common_meta_kvapi::kvapi::UpsertKVReq;
-use common_meta_types::KVAppError;
 use common_meta_types::MetaError;
 use common_meta_types::TxnReply;
 use common_meta_types::TxnRequest;
@@ -69,37 +68,37 @@ impl MetaStore {
 
 #[async_trait::async_trait]
 impl kvapi::KVApi for MetaStore {
-    type Error = KVAppError;
+    type Error = MetaError;
 
-    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, KVAppError> {
+    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, MetaError> {
         match self {
             MetaStore::L(x) => x.upsert_kv(act).await,
             MetaStore::R(x) => x.upsert_kv(act).await,
         }
     }
 
-    async fn get_kv(&self, key: &str) -> Result<GetKVReply, KVAppError> {
+    async fn get_kv(&self, key: &str) -> Result<GetKVReply, MetaError> {
         match self {
             MetaStore::L(x) => x.get_kv(key).await,
             MetaStore::R(x) => x.get_kv(key).await,
         }
     }
 
-    async fn mget_kv(&self, key: &[String]) -> Result<MGetKVReply, KVAppError> {
+    async fn mget_kv(&self, key: &[String]) -> Result<MGetKVReply, MetaError> {
         match self {
             MetaStore::L(x) => x.mget_kv(key).await,
             MetaStore::R(x) => x.mget_kv(key).await,
         }
     }
 
-    async fn prefix_list_kv(&self, prefix: &str) -> Result<ListKVReply, KVAppError> {
+    async fn prefix_list_kv(&self, prefix: &str) -> Result<ListKVReply, MetaError> {
         match self {
             MetaStore::L(x) => x.prefix_list_kv(prefix).await,
             MetaStore::R(x) => x.prefix_list_kv(prefix).await,
         }
     }
 
-    async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, KVAppError> {
+    async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, MetaError> {
         match self {
             MetaStore::L(x) => x.transaction(txn).await,
             MetaStore::R(x) => x.transaction(txn).await,
@@ -112,7 +111,7 @@ impl MetaStoreProvider {
         MetaStoreProvider { rpc_conf }
     }
 
-    pub async fn create_meta_store(&self) -> Result<MetaStore, KVAppError> {
+    pub async fn create_meta_store(&self) -> Result<MetaStore, MetaError> {
         if self.rpc_conf.local_mode() {
             info!(
                 conf = debug(&self.rpc_conf),

--- a/src/query/management/src/file_format/file_format_mgr.rs
+++ b/src/query/management/src/file_format/file_format_mgr.rs
@@ -20,9 +20,9 @@ use common_exception::Result;
 use common_meta_app::principal::UserDefinedFileFormat;
 use common_meta_kvapi::kvapi;
 use common_meta_kvapi::kvapi::UpsertKVReq;
-use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
+use common_meta_types::MetaError;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 
@@ -33,12 +33,12 @@ use crate::FileFormatApi;
 static USER_FILE_FORMAT_API_KEY_PREFIX: &str = "__fd_file_formats";
 
 pub struct FileFormatMgr {
-    kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>,
+    kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>,
     file_format_prefix: String,
 }
 
 impl FileFormatMgr {
-    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while role mgr create)",

--- a/src/query/management/src/quota/quota_mgr.rs
+++ b/src/query/management/src/quota/quota_mgr.rs
@@ -21,9 +21,9 @@ use common_meta_app::tenant::TenantQuota;
 use common_meta_kvapi::kvapi;
 use common_meta_kvapi::kvapi::UpsertKVReq;
 use common_meta_types::IntoSeqV;
-use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
+use common_meta_types::MetaError;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 
@@ -32,12 +32,12 @@ use super::quota_api::QuotaApi;
 static QUOTA_API_KEY_PREFIX: &str = "__fd_quotas";
 
 pub struct QuotaMgr {
-    kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>,
+    kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>,
     key: String,
 }
 
 impl QuotaMgr {
-    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while quota mgr create)",

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -21,9 +21,9 @@ use common_meta_app::principal::RoleInfo;
 use common_meta_kvapi::kvapi;
 use common_meta_kvapi::kvapi::UpsertKVReq;
 use common_meta_types::IntoSeqV;
-use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
+use common_meta_types::MetaError;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 
@@ -32,12 +32,12 @@ use crate::role::role_api::RoleApi;
 static ROLE_API_KEY_PREFIX: &str = "__fd_roles";
 
 pub struct RoleMgr {
-    kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>,
+    kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>,
     role_prefix: String,
 }
 
 impl RoleMgr {
-    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while role mgr create)",

--- a/src/query/management/src/setting/setting_mgr.rs
+++ b/src/query/management/src/setting/setting_mgr.rs
@@ -20,9 +20,9 @@ use common_meta_app::principal::UserSetting;
 use common_meta_kvapi::kvapi;
 use common_meta_kvapi::kvapi::UpsertKVReq;
 use common_meta_types::IntoSeqV;
-use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
+use common_meta_types::MetaError;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 
@@ -31,13 +31,13 @@ use crate::setting::SettingApi;
 static USER_SETTING_API_KEY_PREFIX: &str = "__fd_settings";
 
 pub struct SettingMgr {
-    kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>,
+    kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>,
     setting_prefix: String,
 }
 
 impl SettingMgr {
     #[allow(dead_code)]
-    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>, tenant: &str) -> Result<Self> {
         Ok(SettingMgr {
             kv_api,
             setting_prefix: format!("{}/{}", USER_SETTING_API_KEY_PREFIX, tenant),

--- a/src/query/management/src/stage/stage_mgr.rs
+++ b/src/query/management/src/stage/stage_mgr.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_base::base::escape_for_key;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_api::reply::txn_reply_to_api_result;
 use common_meta_api::txn_cond_seq;
 use common_meta_api::txn_op_del;
 use common_meta_api::txn_op_put;
@@ -26,7 +27,6 @@ use common_meta_kvapi::kvapi;
 use common_meta_kvapi::kvapi::UpsertKVReq;
 use common_meta_types::errors::app_error::TxnRetryMaxTimes;
 use common_meta_types::ConditionResult::Eq;
-use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
 use common_meta_types::MetaError;
@@ -44,13 +44,13 @@ static STAGE_FILE_API_KEY_PREFIX: &str = "__fd_stage_files";
 const TXN_MAX_RETRY_TIMES: u32 = 10;
 
 pub struct StageMgr {
-    kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>,
+    kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>,
     stage_prefix: String,
     stage_file_prefix: String,
 }
 
 impl StageMgr {
-    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while role mgr create)",
@@ -146,8 +146,7 @@ impl StageApi for StageMgr {
                 else_then: vec![],
             };
             let tx_reply = self.kv_api.transaction(txn_req).await?;
-            let res: Result<_, MetaError> = tx_reply.into();
-            let (succ, _) = res?;
+            let (succ, _) = txn_reply_to_api_result(tx_reply)?;
 
             if succ {
                 return Ok(());
@@ -208,9 +207,9 @@ impl StageApi for StageMgr {
                 ],
                 else_then: vec![],
             };
+
             let tx_reply = self.kv_api.transaction(txn_req).await?;
-            let res: Result<_, MetaError> = tx_reply.into();
-            let (succ, _) = res?;
+            let (succ, _) = txn_reply_to_api_result(tx_reply)?;
 
             if succ {
                 return Ok(0);
@@ -275,8 +274,7 @@ impl StageApi for StageMgr {
                 else_then: vec![],
             };
             let tx_reply = self.kv_api.transaction(txn_req).await?;
-            let res: Result<_, MetaError> = tx_reply.into();
-            let (succ, _) = res?;
+            let (succ, _) = txn_reply_to_api_result(tx_reply)?;
 
             if succ {
                 return Ok(());

--- a/src/query/management/src/udf/udf_mgr.rs
+++ b/src/query/management/src/udf/udf_mgr.rs
@@ -22,9 +22,9 @@ use common_meta_app::principal::UserDefinedFunction;
 use common_meta_kvapi::kvapi;
 use common_meta_kvapi::kvapi::UpsertKVReq;
 use common_meta_types::IntoSeqV;
-use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
+use common_meta_types::MetaError;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 
@@ -33,12 +33,12 @@ use crate::udf::UdfApi;
 static UDF_API_KEY_PREFIX: &str = "__fd_udfs";
 
 pub struct UdfMgr {
-    kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>,
+    kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>,
     udf_prefix: String,
 }
 
 impl UdfMgr {
-    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while udf mgr create)",

--- a/src/query/management/src/user/user_mgr.rs
+++ b/src/query/management/src/user/user_mgr.rs
@@ -21,9 +21,9 @@ use common_meta_app::principal::UserIdentity;
 use common_meta_app::principal::UserInfo;
 use common_meta_kvapi::kvapi;
 use common_meta_kvapi::kvapi::UpsertKVReq;
-use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
 use common_meta_types::MatchSeqExt;
+use common_meta_types::MetaError;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 
@@ -34,12 +34,12 @@ use crate::user::user_api::UserApi;
 static USER_API_KEY_PREFIX: &str = "__fd_users";
 
 pub struct UserMgr {
-    kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>,
+    kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>,
     user_prefix: String,
 }
 
 impl UserMgr {
-    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = KVAppError>>, tenant: &str) -> Result<Self> {
+    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>, tenant: &str) -> Result<Self> {
         if tenant.is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while user mgr create)",

--- a/src/query/management/tests/it/user.rs
+++ b/src/query/management/tests/it/user.rs
@@ -28,8 +28,8 @@ use common_meta_kvapi::kvapi::ListKVReply;
 use common_meta_kvapi::kvapi::MGetKVReply;
 use common_meta_kvapi::kvapi::UpsertKVReply;
 use common_meta_kvapi::kvapi::UpsertKVReq;
-use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
+use common_meta_types::MetaError;
 use common_meta_types::Operation;
 use common_meta_types::SeqV;
 use common_meta_types::TxnReply;
@@ -42,23 +42,23 @@ mock! {
     pub KV {}
     #[async_trait]
     impl kvapi::KVApi for KV {
-        type Error = KVAppError;
+        type Error = MetaError;
 
         async fn upsert_kv(
             &self,
             act: UpsertKVReq,
-        ) -> Result<UpsertKVReply, KVAppError>;
+        ) -> Result<UpsertKVReply, MetaError>;
 
-        async fn get_kv(&self, key: &str) -> Result<GetKVReply,KVAppError>;
+        async fn get_kv(&self, key: &str) -> Result<GetKVReply,MetaError>;
 
         async fn mget_kv(
             &self,
             key: &[String],
-        ) -> Result<MGetKVReply,KVAppError>;
+        ) -> Result<MGetKVReply,MetaError>;
 
-        async fn prefix_list_kv(&self, prefix: &str) -> Result<ListKVReply, KVAppError>;
+        async fn prefix_list_kv(&self, prefix: &str) -> Result<ListKVReply, MetaError>;
 
-        async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, KVAppError>;
+        async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, MetaError>;
 
         }
 }

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -36,14 +36,14 @@ use common_meta_app::tenant::TenantQuota;
 use common_meta_kvapi::kvapi;
 use common_meta_store::MetaStore;
 use common_meta_store::MetaStoreProvider;
-use common_meta_types::KVAppError;
 use common_meta_types::MatchSeq;
+use common_meta_types::MetaError;
 
 use crate::idm_config::IDMConfig;
 
 pub struct UserApiProvider {
     meta: MetaStore,
-    client: Arc<dyn kvapi::KVApi<Error = KVAppError>>,
+    client: Arc<dyn kvapi::KVApi<Error = MetaError>>,
     idm_config: IDMConfig,
 }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/client): add compatible layer for upgrade

Currently meta-service responds `KVAppError` for kv-api, which is too big.
`MetaAPIError`, which is a sub error of `KVAppError`,  would be enough.

This is the first step of this change: let the client be able to parse
both `KVAppError` and `MetaAPIError`. When this patch is merged, the
server side can upgrade to produce just `MetaAPIError`.

Changes on client side:

Add type `Compatible<Outer, Inner>` as a compatbile enum for both
`KVAppError` and `MetaAPIError`.

Try to parse a responded error into `Compatible` then extract
`MetaAPIError` for use.

It no longer uses `KVAppError`, e.g., SchemaApi or ShareApi just relies
on a KVApi implementation that just returns MetaError.

Changes on server side:

The meta sercie still responds `KVAppError`. But some of the error types
used internally are adjusted.


##### chore(meta/kvapi): MetaGrpcClient does not need to impl KVApi

## Changelog







## Related Issues