### PR TITLE
fix(cluster): fix wrong error message 'abort query'

### DIFF
--- a/src/query/service/src/api/rpc/exchange/statistics_receiver.rs
+++ b/src/query/service/src/api/rpc/exchange/statistics_receiver.rs
@@ -145,6 +145,7 @@ impl StatisticsReceiver {
             .send(DataPacket::FetchProgressAndPrecommit)
             .await
         {
+            // The query is done(in remote).
             return match error.code() == ErrorCode::ABORTED_QUERY {
                 true => Ok(true),
                 false => Err(error),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(cluster): fix wrong error message 'abort query'

#10070 https://github.com/datafuselabs/databend/actions/runs/4191538507/jobs/7266220445

Closes #issue
