### PR TITLE
feat(query): type decimal support agg func min/max

### DIFF
--- a/src/query/expression/src/types/decimal.rs
+++ b/src/query/expression/src/types/decimal.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::fmt::Debug;
+use std::marker::PhantomData;
 use std::ops::Range;
 
 use common_arrow::arrow::buffer::Buffer;
@@ -26,8 +27,124 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use super::SimpleDomain;
+use crate::types::ValueType;
 use crate::utils::arrow::buffer_into_mut;
 use crate::Column;
+use crate::ColumnBuilder;
+use crate::Domain;
+use crate::Scalar;
+use crate::ScalarRef;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecimalType<T: Decimal>(PhantomData<T>);
+
+impl<Num: Decimal> ValueType for DecimalType<Num> {
+    type Scalar = Num;
+    type ScalarRef<'a> = Num;
+    type Column = Buffer<Num>;
+    type Domain = SimpleDomain<Num>;
+    type ColumnIterator<'a> = std::iter::Cloned<std::slice::Iter<'a, Num>>;
+    type ColumnBuilder = Vec<Num>;
+
+    fn upcast_gat<'short, 'long: 'short>(long: Self::ScalarRef<'long>) -> Self::ScalarRef<'short> {
+        long
+    }
+
+    fn to_owned_scalar<'a>(scalar: Self::ScalarRef<'a>) -> Self::Scalar {
+        scalar
+    }
+
+    fn to_scalar_ref<'a>(scalar: &'a Self::Scalar) -> Self::ScalarRef<'a> {
+        *scalar
+    }
+
+    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+        Num::try_downcast_scalar(scalar.as_decimal()?)
+    }
+
+    fn try_downcast_column<'a>(col: &'a Column) -> Option<Self::Column> {
+        let down_col = Num::try_downcast_column(col);
+        if let Some(col) = down_col {
+            Some(col.0)
+        } else {
+            None
+        }
+    }
+
+    fn try_downcast_domain(domain: &Domain) -> Option<Self::Domain> {
+        Num::try_downcast_domain(domain.as_decimal()?)
+    }
+
+    fn try_downcast_builder<'a>(
+        builder: &'a mut ColumnBuilder,
+    ) -> Option<&'a mut Self::ColumnBuilder> {
+        Num::try_downcast_builder(builder)
+    }
+
+    fn upcast_scalar(scalar: Self::Scalar) -> Scalar {
+        Num::upcast_scalar(scalar)
+    }
+
+    fn upcast_column(col: Self::Column) -> Column {
+        Num::upcast_column(col)
+    }
+
+    fn upcast_domain(domain: Self::Domain) -> Domain {
+        Num::upcast_domain(domain)
+    }
+
+    fn column_len<'a>(col: &'a Self::Column) -> usize {
+        col.len()
+    }
+
+    fn index_column<'a>(col: &'a Self::Column, index: usize) -> Option<Self::ScalarRef<'a>> {
+        col.get(index).cloned()
+    }
+
+    unsafe fn index_column_unchecked<'a>(
+        col: &'a Self::Column,
+        index: usize,
+    ) -> Self::ScalarRef<'a> {
+        *col.get_unchecked(index)
+    }
+
+    fn slice_column<'a>(col: &'a Self::Column, range: Range<usize>) -> Self::Column {
+        col.clone().slice(range.start, range.end - range.start)
+    }
+
+    fn iter_column<'a>(col: &'a Self::Column) -> Self::ColumnIterator<'a> {
+        col.iter().cloned()
+    }
+
+    fn column_to_builder(col: Self::Column) -> Self::ColumnBuilder {
+        buffer_into_mut(col)
+    }
+
+    fn builder_len(builder: &Self::ColumnBuilder) -> usize {
+        builder.len()
+    }
+
+    fn push_item(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>) {
+        builder.push(item)
+    }
+
+    fn push_default(builder: &mut Self::ColumnBuilder) {
+        builder.push(Num::default())
+    }
+
+    fn append_column(builder: &mut Self::ColumnBuilder, other: &Self::Column) {
+        builder.extend_from_slice(other);
+    }
+
+    fn build_column(builder: Self::ColumnBuilder) -> Self::Column {
+        builder.into()
+    }
+
+    fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
+        assert_eq!(builder.len(), 1);
+        builder[0]
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, EnumAsInner)]
 pub enum DecimalDataType {
@@ -65,10 +182,14 @@ pub struct DecimalSize {
     pub scale: u8,
 }
 
-pub trait Decimal: Sized {
+pub trait Decimal:
+    Copy + Debug + Default + Clone + Copy + PartialEq + Eq + PartialOrd + Ord + Sync + Send + 'static
+{
     fn one() -> Self;
     // 10**scale
     fn e(n: u32) -> Self;
+
+    fn max_of_max_precision() -> Self;
 
     fn min_for_precision(precision: u8) -> Self;
     fn max_for_precision(precision: u8) -> Self;
@@ -76,6 +197,13 @@ pub trait Decimal: Sized {
     fn from_float(value: f64) -> Self;
 
     fn try_downcast_column(column: &Column) -> Option<(Buffer<Self>, DecimalSize)>;
+    fn try_downcast_builder<'a>(builder: &'a mut ColumnBuilder) -> Option<&'a mut Vec<Self>>;
+
+    fn try_downcast_scalar(scalar: &DecimalScalar) -> Option<Self>;
+    fn try_downcast_domain(domain: &DecimalDomain) -> Option<SimpleDomain<Self>>;
+    fn upcast_scalar(scalar: Self) -> Scalar;
+    fn upcast_column(col: Buffer<Self>) -> Column;
+    fn upcast_domain(domain: SimpleDomain<Self>) -> Domain;
 
     fn to_column_from_buffer(value: Buffer<Self>, size: DecimalSize) -> DecimalColumn;
 
@@ -92,6 +220,10 @@ impl Decimal for i128 {
         10_i128.pow(n)
     }
 
+    fn max_of_max_precision() -> Self {
+        Self::max_for_precision(MAX_DECIMAL128_PRECISION)
+    }
+
     fn min_for_precision(to_precision: u8) -> Self {
         9_i128
             .saturating_pow(1 + to_precision as u32)
@@ -100,10 +232,6 @@ impl Decimal for i128 {
 
     fn max_for_precision(to_precision: u8) -> Self {
         9_i128.saturating_pow(1 + to_precision as u32)
-    }
-
-    fn to_column_from_buffer(value: Buffer<Self>, size: DecimalSize) -> DecimalColumn {
-        DecimalColumn::Decimal128(value, size)
     }
 
     fn from_float(value: f64) -> Self {
@@ -117,6 +245,53 @@ impl Decimal for i128 {
             DecimalColumn::Decimal256(_, _) => None,
         }
     }
+
+    fn try_downcast_builder<'a>(builder: &'a mut ColumnBuilder) -> Option<&'a mut Vec<Self>> {
+        match builder {
+            ColumnBuilder::Decimal(DecimalColumnBuilder::Decimal128(s, _)) => Some(s),
+            _ => None,
+        }
+    }
+
+    fn try_downcast_scalar<'a>(scalar: &DecimalScalar) -> Option<Self> {
+        match scalar {
+            DecimalScalar::Decimal128(val, _) => Some(*val),
+            _ => None,
+        }
+    }
+
+    fn try_downcast_domain(domain: &DecimalDomain) -> Option<SimpleDomain<Self>> {
+        match domain {
+            DecimalDomain::Decimal128(val, _) => Some(*val),
+            _ => None,
+        }
+    }
+
+    // will mock DecimalSize need modify when use it
+    fn upcast_scalar(scalar: Self) -> Scalar {
+        Scalar::Decimal(DecimalScalar::Decimal128(scalar, DecimalSize {
+            precision: MAX_DECIMAL128_PRECISION,
+            scale: 0,
+        }))
+    }
+
+    fn upcast_column(col: Buffer<Self>) -> Column {
+        Column::Decimal(DecimalColumn::Decimal128(col, DecimalSize {
+            precision: MAX_DECIMAL128_PRECISION,
+            scale: 0,
+        }))
+    }
+
+    fn upcast_domain(domain: SimpleDomain<Self>) -> Domain {
+        Domain::Decimal(DecimalDomain::Decimal128(domain, DecimalSize {
+            precision: MAX_DECIMAL128_PRECISION,
+            scale: 0,
+        }))
+    }
+
+    fn to_column_from_buffer(value: Buffer<Self>, size: DecimalSize) -> DecimalColumn {
+        DecimalColumn::Decimal128(value, size)
+    }
 }
 
 impl Decimal for i256 {
@@ -126,6 +301,10 @@ impl Decimal for i256 {
 
     fn e(n: u32) -> Self {
         (i256::ONE * 10).pow(n)
+    }
+
+    fn max_of_max_precision() -> Self {
+        Self::max_for_precision(MAX_DECIMAL256_PRECISION)
     }
 
     fn min_for_precision(to_precision: u8) -> Self {
@@ -142,21 +321,63 @@ impl Decimal for i256 {
         i256::from(value.to_i128().unwrap())
     }
 
-    fn to_column_from_buffer(value: Buffer<Self>, size: DecimalSize) -> DecimalColumn {
-        DecimalColumn::Decimal256(value, size)
-    }
-
     fn try_downcast_column(column: &Column) -> Option<(Buffer<Self>, DecimalSize)> {
         let column = column.as_decimal()?;
         match column {
-            DecimalColumn::Decimal128(_, _) => None,
             DecimalColumn::Decimal256(c, size) => Some((c.clone(), *size)),
+            _ => None,
         }
+    }
+
+    fn try_downcast_builder<'a>(builder: &'a mut ColumnBuilder) -> Option<&'a mut Vec<Self>> {
+        match builder {
+            ColumnBuilder::Decimal(DecimalColumnBuilder::Decimal256(s, _)) => Some(s),
+            _ => None,
+        }
+    }
+
+    fn try_downcast_scalar<'a>(scalar: &DecimalScalar) -> Option<Self> {
+        match scalar {
+            DecimalScalar::Decimal256(val, _) => Some(*val),
+            _ => None,
+        }
+    }
+
+    fn try_downcast_domain(domain: &DecimalDomain) -> Option<SimpleDomain<Self>> {
+        match domain {
+            DecimalDomain::Decimal256(val, _) => Some(*val),
+            _ => None,
+        }
+    }
+
+    fn upcast_scalar(scalar: Self) -> Scalar {
+        Scalar::Decimal(DecimalScalar::Decimal256(scalar, DecimalSize {
+            precision: MAX_DECIMAL256_PRECISION,
+            scale: 0,
+        }))
+    }
+
+    fn upcast_column(col: Buffer<Self>) -> Column {
+        Column::Decimal(DecimalColumn::Decimal256(col, DecimalSize {
+            precision: MAX_DECIMAL256_PRECISION,
+            scale: 0,
+        }))
+    }
+
+    fn upcast_domain(domain: SimpleDomain<Self>) -> Domain {
+        Domain::Decimal(DecimalDomain::Decimal256(domain, DecimalSize {
+            precision: MAX_DECIMAL256_PRECISION,
+            scale: 0,
+        }))
+    }
+
+    fn to_column_from_buffer(value: Buffer<Self>, size: DecimalSize) -> DecimalColumn {
+        DecimalColumn::Decimal256(value, size)
     }
 }
 
-static MAX_DECIMAL128_PRECISION: u8 = 38;
-static MAX_DECIMAL256_PRECISION: u8 = 76;
+pub static MAX_DECIMAL128_PRECISION: u8 = 38;
+pub static MAX_DECIMAL256_PRECISION: u8 = 76;
 
 impl DecimalDataType {
     pub fn from_size(size: DecimalSize) -> Result<DecimalDataType> {

--- a/src/query/functions/src/aggregates/aggregate_min_max_any.rs
+++ b/src/query/functions/src/aggregates/aggregate_min_max_any.rs
@@ -20,12 +20,14 @@ use std::sync::Arc;
 use common_arrow::arrow::bitmap::Bitmap;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_expression::types::decimal::*;
 use common_expression::types::number::*;
 use common_expression::types::*;
 use common_expression::with_number_mapped_type;
 use common_expression::Column;
 use common_expression::ColumnBuilder;
 use common_expression::Scalar;
+use ethnum::i256;
 
 use super::aggregate_function_factory::AggregateFunctionDescription;
 use super::aggregate_scalar_state::need_manual_drop_state;
@@ -210,6 +212,30 @@ pub fn try_create_aggregate_min_max_any_function<const CMP_TYPE: u8>(
                             )
                         }
                     })
+                }
+                DataType::Decimal(DecimalDataType::Decimal128(s)) => {
+                    let decimal_size = DecimalSize {
+                        precision: s.precision,
+                        scale: s.scale,
+                    };
+                    type State = ScalarState<DecimalType<i128>, CMP>;
+                    AggregateMinMaxAnyFunction::<DecimalType<i128>, CMP, State>::try_create(
+                        display_name,
+                        DataType::Decimal(DecimalDataType::from_size(decimal_size)?),
+                        need_drop,
+                    )
+                }
+                DataType::Decimal(DecimalDataType::Decimal256(s)) => {
+                    let decimal_size = DecimalSize {
+                        precision: s.precision,
+                        scale: s.scale,
+                    };
+                    type State = ScalarState<DecimalType<i256>, CMP>;
+                    AggregateMinMaxAnyFunction::<DecimalType<i256>, CMP, State>::try_create(
+                        display_name,
+                        DataType::Decimal(DecimalDataType::from_size(decimal_size)?),
+                        need_drop,
+                    )
                 }
                 _ => {
                     type State = ScalarState<AnyType, CMP>;

--- a/tests/sqllogictests/suites/base/11_data_type/11_0006_data_type_decimal
+++ b/tests/sqllogictests/suites/base/11_data_type/11_0006_data_type_decimal
@@ -124,6 +124,16 @@ SELECT MAX(CAST(4.26 AS DECIMAL(6, 2)))
 4.26
 
 query I
+select max(number::Decimal(6,2)) as result from numbers(10);
+----
+9.00
+
+query I
+select min(number::Decimal(6,2)) as result from numbers(10);
+----
+0.00
+
+query I
 SELECT ANY(CAST(2.34 AS DECIMAL(6, 2)))
 ----
 2.34

--- a/tests/sqllogictests/suites/base/11_data_type/11_0006_data_type_decimal
+++ b/tests/sqllogictests/suites/base/11_data_type/11_0006_data_type_decimal
@@ -112,3 +112,18 @@ query I
 SELECT CAST(-4.56 AS DECIMAL(6, 2)) / CAST(-1.23 AS DECIMAL(6, 2)) AS result;
 ----
 3.69
+
+query I
+SELECT MIN(CAST(-4.56 AS DECIMAL(6, 2)))
+----
+-4.55
+
+query I
+SELECT MAX(CAST(4.26 AS DECIMAL(6, 2)))
+----
+4.26
+
+query I
+SELECT ANY(CAST(2.34 AS DECIMAL(6, 2)))
+----
+2.34


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

type decimal support agg func min/max

Closes #part of #10005
