### PR TITLE
fix: implementation of  `Default` for config::CacheConfig should use values from `inner::CacheConfig`

### DIFF
--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -1817,7 +1817,7 @@ impl TryInto<InnerLocalConfig> for LocalConfig {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Args, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Args)]
 #[serde(default, deny_unknown_fields)]
 pub struct CacheConfig {
     /// Enable table meta cache. Default is enabled. Set it to false to disable all the table meta caches
@@ -1891,6 +1891,13 @@ pub struct CacheConfig {
     /// and the access pattern will benefit from caching, consider enabled this cache.
     #[clap(long = "cache-table-data-deserialized-data-bytes", default_value = "0")]
     pub table_data_deserialized_data_bytes: u64,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        // Here we should (have to) convert self from the default value of  inner::CacheConfig :(
+        super::inner::CacheConfig::default().into()
+    }
 }
 
 #[inline]

--- a/src/query/service/tests/it/configs.rs
+++ b/src/query/service/tests/it/configs.rs
@@ -17,6 +17,7 @@ use std::env::temp_dir;
 use std::fs;
 use std::io::Write;
 
+use common_config::CacheConfig;
 use common_config::CacheStorageTypeConfig;
 use common_config::CatalogConfig;
 use common_config::CatalogHiveConfig;
@@ -808,5 +809,29 @@ fn test_env_config_obsoleted() -> Result<()> {
         });
     }
 
+    Ok(())
+}
+
+#[test]
+fn test_env_config_and_defaults() -> Result<()> {
+    temp_env::with_vars(
+        vec![("CACHE_ENABLE_TABLE_META_CACHE", Some("true"))],
+        || {
+            let configured = InnerConfig::load_for_test()
+                .expect("must success")
+                .into_config();
+
+            let default = CacheConfig::default();
+            assert!(configured.cache.enable_table_meta_cache);
+            assert_eq!(
+                default.table_meta_segment_count,
+                configured.cache.table_meta_segment_count
+            );
+            assert_eq!(
+                default.table_meta_snapshot_count,
+                configured.cache.table_meta_snapshot_count
+            );
+        },
+    );
     Ok(())
 }

--- a/src/query/service/tests/it/configs.rs
+++ b/src/query/service/tests/it/configs.rs
@@ -813,7 +813,11 @@ fn test_env_config_obsoleted() -> Result<()> {
 }
 
 #[test]
-fn test_env_config_and_defaults() -> Result<()> {
+fn test_env_cache_config_and_defaults() -> Result<()> {
+    // test if one of the cache config option is overridden by environment variable
+    // default values of other cache config options are correct
+    //
+    // @see issue https://github.com/datafuselabs/databend/issues/10088
     temp_env::with_vars(
         vec![("CACHE_ENABLE_TABLE_META_CACHE", Some("true"))],
         || {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

implementation of  `Default` for config::CacheConfig should use values from `inner::CacheConfig`

after fix:

`CACHE_ENABLE_TABLE_META_CACHE=true ./target/debug/databend-query  --meta-embedded-dir .databend/meta`

default values of cache configs are as expected
~~~
mysql> select * from system.configs where "group" = 'cache';
+-------+----------------------------------------+--------------------+-------------+
| group | name                                   | value              | description |
+-------+----------------------------------------+--------------------+-------------+
| cache | enable_table_meta_cache                | true               |             |
| cache | table_meta_snapshot_count              | 256                |             |
| cache | table_meta_segment_count               | 10240              |             |
| cache | table_meta_statistic_count             | 256                |             |
| cache | enable_table_bloom_index_cache         | true               |             |
| cache | table_bloom_index_meta_count           | 3000               |             |
| cache | table_bloom_index_filter_count         | 1048576            |             |
| cache | data_cache_storage                     | none               |             |
| cache | table_data_cache_population_queue_size | 65536              |             |
| cache | disk.max_bytes                         | 21474836480        |             |
| cache | disk.path                              | ./.databend/_cache |             |
| cache | table_data_deserialized_data_bytes     | 0                  |             |
+-------+----------------------------------------+--------------------+-------------+
~~~

Closes #10088
