### PR TITLE
refactor: save default values in FuseTable instead of BlockReader

### DIFF
--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -305,13 +305,17 @@ impl FuseTable {
     }
 
     pub fn try_get_default_values(&self, ctx: Arc<dyn TableContext>) -> Result<Vec<Scalar>> {
-        let schema_seq_default_vals = self.schema_seq_default_vals.read().unwrap();
-
-        if schema_seq_default_vals.0 == self.table_info.ident.seq
-            && !schema_seq_default_vals.1.is_empty()
+        // Get read lock to check if default values exist
         {
-            return Ok(schema_seq_default_vals.1.clone());
+            let schema_seq_default_vals = self.schema_seq_default_vals.read().unwrap();
+
+            if schema_seq_default_vals.0 == self.table_info.ident.seq
+                && !schema_seq_default_vals.1.is_empty()
+            {
+                return Ok(schema_seq_default_vals.1.clone());
+            }
         }
+        // Get write lock to write default values
         let mut schema_seq_default_vals = self.schema_seq_default_vals.write().unwrap();
         let schema = self.table_info.meta.schema.as_ref();
         let mut field_default_vals = Vec::with_capacity(schema.fields().len());

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -18,6 +18,7 @@ use std::convert::TryFrom;
 use std::str;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use common_catalog::catalog::StorageDescription;
 use common_catalog::plan::DataSourcePlan;
@@ -38,11 +39,13 @@ use common_expression::ColumnId;
 use common_expression::DataBlock;
 use common_expression::FieldIndex;
 use common_expression::RemoteExpr;
+use common_expression::Scalar;
 use common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
 use common_io::constants::DEFAULT_BLOCK_MAX_ROWS;
 use common_meta_app::schema::DatabaseType;
 use common_meta_app::schema::TableInfo;
 use common_sharing::create_share_table_operator;
+use common_sql::field_default_value;
 use common_sql::parse_exprs;
 use common_storage::init_operator;
 use common_storage::DataOperator;
@@ -94,6 +97,8 @@ pub struct FuseTable {
 
     pub(crate) operator: Operator,
     pub(crate) data_metrics: Arc<StorageMetrics>,
+
+    schema_seq_default_vals: Arc<Mutex<(u64, Vec<Scalar>)>>,
 }
 
 impl FuseTable {
@@ -150,6 +155,7 @@ impl FuseTable {
             data_metrics,
             storage_format: FuseStorageFormat::from_str(storage_format.as_str())?,
             table_compression: table_compression.as_str().try_into()?,
+            schema_seq_default_vals: Default::default(),
         }))
     }
 
@@ -296,6 +302,23 @@ impl FuseTable {
 
     pub fn transient(&self) -> bool {
         self.table_info.meta.options.contains_key("TRANSIENT")
+    }
+
+    pub fn try_get_default_values(&self, ctx: Arc<dyn TableContext>) -> Result<Vec<Scalar>> {
+        let mut schema_seq_default_vals = self.schema_seq_default_vals.lock().unwrap().to_owned();
+        let (seq, default_vals) = schema_seq_default_vals;
+
+        if seq == self.table_info.ident.seq && !default_vals.is_empty() {
+            return Ok(default_vals);
+        }
+        let schema = self.table_info.meta.schema.as_ref();
+        let mut field_default_vals = Vec::with_capacity(schema.fields().len());
+        for field in schema.fields() {
+            field_default_vals.push(field_default_value(ctx.clone(), field)?);
+        }
+        schema_seq_default_vals.0 = self.table_info.ident.seq;
+        schema_seq_default_vals.1 = field_default_vals.clone();
+        Ok(field_default_vals)
     }
 }
 

--- a/src/query/storages/fuse/src/io/read/block/block_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader.rs
@@ -19,7 +19,6 @@ use common_arrow::arrow::datatypes::Field;
 use common_arrow::arrow::io::parquet::write::to_parquet_schema;
 use common_arrow::parquet::metadata::SchemaDescriptor;
 use common_catalog::plan::Projection;
-use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::types::DataType;
@@ -30,7 +29,6 @@ use common_expression::FieldIndex;
 use common_expression::Scalar;
 use common_expression::TableField;
 use common_expression::TableSchemaRef;
-use common_sql::field_default_value;
 use common_storage::ColumnNode;
 use common_storage::ColumnNodes;
 use opendal::Operator;
@@ -76,7 +74,7 @@ impl BlockReader {
         operator: Operator,
         schema: TableSchemaRef,
         projection: Projection,
-        ctx: Arc<dyn TableContext>,
+        field_default_vals: Vec<Scalar>,
     ) -> Result<Arc<BlockReader>> {
         // init projected_schema and default_vals of schema.fields
         let (projected_schema, default_vals) = match projection {
@@ -84,23 +82,14 @@ impl BlockReader {
                 let projected_schema = TableSchemaRef::new(schema.project(indices));
                 // If projection by Columns, just calc default values by projected fields.
                 let mut default_vals = Vec::with_capacity(projected_schema.fields().len());
-                for field in projected_schema.fields() {
-                    let default_val = field_default_value(ctx.clone(), field)?;
-                    default_vals.push(default_val);
-                }
+                indices.iter().for_each(|index| {
+                    default_vals.push(field_default_vals[*index].clone());
+                });
 
                 (projected_schema, default_vals)
             }
             Projection::InnerColumns(ref path_indices) => {
                 let projected_schema = TableSchemaRef::new(schema.inner_project(path_indices));
-                let mut field_default_vals = Vec::with_capacity(schema.fields().len());
-
-                // If projection by InnerColumns, first calc default value of all schema fields.
-                for field in schema.fields() {
-                    field_default_vals.push(field_default_value(ctx.clone(), field)?);
-                }
-
-                // Then calc project scalars by path_indices
                 let mut default_vals = Vec::with_capacity(schema.fields().len());
                 path_indices.values().for_each(|path| {
                     default_vals.push(

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -35,7 +35,12 @@ impl FuseTable {
         ctx: Arc<dyn TableContext>,
     ) -> Result<Arc<BlockReader>> {
         let table_schema = self.table_info.schema();
-        BlockReader::create(self.operator.clone(), table_schema, projection, ctx)
+        BlockReader::create(
+            self.operator.clone(),
+            table_schema,
+            projection,
+            self.try_get_default_values(ctx)?,
+        )
     }
 
     // Build the block reader.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor: save default values in FuseTable instead of BlockReader

Closes #issue
