### PR TITLE
chore(query): check meta set twice for data block

### DIFF
--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -297,6 +297,12 @@ impl DataBlock {
 
     #[inline]
     pub fn add_meta(self, meta: Option<BlockMetaInfoPtr>) -> Result<Self> {
+        if self.meta.is_some() {
+            return Err(ErrorCode::Internal(
+                "Internal error, block meta data is set twice.",
+            ));
+        }
+
         Ok(Self {
             columns: self.columns.clone(),
             num_rows: self.num_rows,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore(query): check meta set twice for data block

Closes #issue
