### PR TITLE
chore(config): make obsolete check from QueryConfig to Config

### DIFF
--- a/docs/doc/13-sql-reference/70-system-tables/system-configs.md
+++ b/docs/doc/13-sql-reference/70-system-tables/system-configs.md
@@ -38,7 +38,6 @@ mysql> SELECT * FROM system.configs;
 | query   | rpc_tls_query_server_root_ca_cert      |                                |             |
 | query   | rpc_tls_query_service_domain_name      | localhost                      |             |
 | query   | table_engine_memory_enabled            | true                           |             |
-| query   | database_engine_github_enabled         | true                           |             |
 | query   | wait_timeout_mills                     | 5000                           |             |
 | query   | max_query_log_size                     | 10000                          |             |
 | query   | management_mode                        | false                          |             |

--- a/scripts/ci/deploy/config/databend-query-embedded-meta-hive.toml
+++ b/scripts/ci/deploy/config/databend-query-embedded-meta-hive.toml
@@ -31,7 +31,6 @@ tenant_id = "test_tenant"
 cluster_id = "test_cluster"
 
 table_engine_memory_enabled = true
-database_engine_github_enabled = true
 
 [log]
 

--- a/scripts/ci/deploy/config/databend-query-embedded-meta.toml
+++ b/scripts/ci/deploy/config/databend-query-embedded-meta.toml
@@ -31,7 +31,6 @@ tenant_id = "test_tenant"
 cluster_id = "test_cluster"
 
 table_engine_memory_enabled = true
-database_engine_github_enabled = true
 
 [log]
 

--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -31,7 +31,6 @@ tenant_id = "test_tenant"
 cluster_id = "test_cluster"
 
 table_engine_memory_enabled = true
-database_engine_github_enabled = true
 
 # [[query.users]]
 # name = "admin"

--- a/scripts/ci/deploy/config/databend-query-node-2.toml
+++ b/scripts/ci/deploy/config/databend-query-node-2.toml
@@ -31,7 +31,6 @@ tenant_id = "test_tenant"
 cluster_id = "test_cluster"
 
 table_engine_memory_enabled = true
-database_engine_github_enabled = true
 
 [log]
 

--- a/scripts/ci/deploy/config/databend-query-node-3.toml
+++ b/scripts/ci/deploy/config/databend-query-node-3.toml
@@ -32,7 +32,6 @@ tenant_id = "test_tenant"
 cluster_id = "test_cluster"
 
 table_engine_memory_enabled = true
-database_engine_github_enabled = true
 
 [log]
 

--- a/scripts/ci/deploy/config/databend-query-node-shared.toml
+++ b/scripts/ci/deploy/config/databend-query-node-shared.toml
@@ -31,7 +31,6 @@ tenant_id = "shared_tenant"
 cluster_id = "test_cluster"
 
 table_engine_memory_enabled = true
-database_engine_github_enabled = true
 
 share_endpoint_address = "127.0.0.1:33003" # receive shared information from open sharing
 # [[query.users]]

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -1124,10 +1124,6 @@ pub struct QueryConfig {
     #[clap(long, parse(try_from_str), default_value = "true")]
     pub table_engine_memory_enabled: bool,
 
-    /// Deprecated: Database engine github enabled
-    #[clap(long, parse(try_from_str), default_value = "true")]
-    pub database_engine_github_enabled: bool,
-
     #[clap(long, default_value = "5000")]
     pub wait_timeout_mills: u64,
 
@@ -1319,7 +1315,6 @@ impl From<InnerQueryConfig> for QueryConfig {
             rpc_tls_query_server_root_ca_cert: inner.rpc_tls_query_server_root_ca_cert,
             rpc_tls_query_service_domain_name: inner.rpc_tls_query_service_domain_name,
             table_engine_memory_enabled: inner.table_engine_memory_enabled,
-            database_engine_github_enabled: true,
             wait_timeout_mills: inner.wait_timeout_mills,
             max_query_log_size: inner.max_query_log_size,
             management_mode: inner.management_mode,

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -181,7 +181,11 @@ impl Config {
             builder = builder.collect(from_self(arg_conf));
         }
 
-        Ok(builder.build()?)
+        // Check obsoleted.
+        let conf = builder.build()?;
+        conf.check_obsoleted()?;
+
+        Ok(conf)
     }
 }
 
@@ -1219,7 +1223,7 @@ pub struct QueryConfig {
     /// OBSOLETED: (cache of raw bloom filter data is no longer supported)
     /// Max bytes of cached bloom filter bytes.
     #[clap(long)]
-    table_cache_bloom_index_data_bytes: Option<u64>,
+    pub(crate) table_cache_bloom_index_data_bytes: Option<u64>,
 }
 
 impl Default for QueryConfig {
@@ -1232,7 +1236,6 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
     type Error = ErrorCode;
 
     fn try_into(self) -> Result<InnerQueryConfig> {
-        self.check_obsoleted()?;
         Ok(InnerQueryConfig {
             tenant_id: self.tenant_id,
             cluster_id: self.cluster_id,
@@ -1981,172 +1984,5 @@ mod cache_config_converters {
                 inner::CacheStorageTypeConfig::Disk => CacheStorageTypeConfig::Disk,
             }
         }
-    }
-}
-
-// Obsoleted configuration entries checking
-//
-// The following code should be removed from the release after the next release.
-// Just give user errors without any detail explanation and migration suggestions.
-impl QueryConfig {
-    fn check<T>(
-        target: &Option<T>,
-        cli_arg_name: &str,
-        alternative_cli_arg: &str,
-        alternative_toml_config: &str,
-        alternative_env_var: &str,
-    ) -> Option<String> {
-        target.as_ref().map(|_| {
-            format!(
-                "
- --------------------------------------------------------------
- *** {cli_arg_name} *** is obsoleted : 
- --------------------------------------------------------------
-   alternative command-line options : {alternative_cli_arg}
-   alternative environment variable : {alternative_env_var}
-            alternative toml config : {alternative_toml_config}
- --------------------------------------------------------------
-"
-            )
-        })
-    }
-    fn check_obsoleted(&self) -> Result<()> {
-        let check_results = vec![
-            Self::check(
-                &self.table_disk_cache_mb_size,
-                "table-disk-cache-mb-size",
-                "cache-disk-max-bytes",
-                r#"
-                    [cache]
-                    ...
-                    data_cache_storage = "disk"
-                    ...
-                    [cache.disk]
-                    max_bytes = [MAX_BYTES]  
-                    ...
-                  "#,
-                "CACHE_DISK_MAX_BYTES",
-            ),
-            Self::check(
-                &self.table_meta_cache_enabled,
-                "table-meta-cache-enabled",
-                "cache-enable-table-meta-cache",
-                r#"
-                    [cache]
-                    enable_table_meta_cache=[true|false]
-                  "#,
-                "CACHE_ENABLE_TABLE_META_CACHE",
-            ),
-            Self::check(
-                &self.table_cache_block_meta_count,
-                "table-cache-block-meta-count",
-                "N/A",
-                "N/A",
-                "N/A",
-            ),
-            Self::check(
-                &self.table_memory_cache_mb_size,
-                "table-memory-cache-mb-size",
-                "N/A",
-                "N/A",
-                "N/A",
-            ),
-            Self::check(
-                &self.table_disk_cache_root,
-                "table-disk-cache-root",
-                "cache-disk-path",
-                r#"
-                    [cache]
-                    ...
-                    data_cache_storage = "disk"
-                    ...
-                    [cache.disk]
-                    max_bytes = [MAX_BYTES]  
-                    path = [PATH]
-                    ...
-                    "#,
-                "CACHE_DISK_PATH",
-            ),
-            Self::check(
-                &self.table_cache_snapshot_count,
-                "table-cache-snapshot-count",
-                "cache-table-meta-snapshot-count",
-                r#"
-                    [cache]
-                    table_meta_snapshot_count = [COUNT]
-                    "#,
-                "CACHE_TABLE_META_SNAPSHOT_COUNT",
-            ),
-            Self::check(
-                &self.table_cache_statistic_count,
-                "table-cache-statistic-count",
-                "cache-table-meta-statistic-count",
-                r#"
-                    [cache]
-                    table_meta_statistic_count = [COUNT]
-                    "#,
-                "CACHE_TABLE_META_STATISTIC_COUNT",
-            ),
-            Self::check(
-                &self.table_cache_segment_count,
-                "table-cache-segment-count",
-                "cache-table-meta-segment-count",
-                r#"
-                    [cache]
-                    table_meta_segment_count = [COUNT]
-                    "#,
-                "CACHE_TABLE_META_SEGMENT_COUNT",
-            ),
-            Self::check(
-                &self.table_cache_bloom_index_meta_count,
-                "table-cache-bloom-index-meta-count",
-                "cache-table-bloom-index-meta-count",
-                r#"
-                    [cache]
-                    table_bloom_index_meta_count = [COUNT]
-                    "#,
-                "CACHE_TABLE_BLOOM_INDEX_META_COUNT",
-            ),
-            Self::check(
-                &self.table_cache_bloom_index_filter_count,
-                "table-cache-bloom-index-filter-count",
-                "cache-table-bloom-index-filter-count",
-                r#"
-                    [cache]
-                    table_bloom_index_filter_count = [COUNT]
-                    "#,
-                "CACHE_TABLE_BLOOM_INDEX_FILTER_COUNT",
-            ),
-            Self::check(
-                &self.table_cache_bloom_index_data_bytes,
-                "table-cache-bloom-index-data-bytes",
-                "N/A",
-                "N/A",
-                "N/A",
-            ),
-        ];
-        let messages = check_results.into_iter().flatten().collect::<Vec<_>>();
-        if !messages.is_empty() {
-            let errors = messages.join("\n");
-            Err(ErrorCode::InvalidConfig(format!("\n{errors}")))
-        } else {
-            Ok(())
-        }
-    }
-
-    pub const fn obsoleted_option_keys() -> &'static [&'static str; 11] {
-        &[
-            "table_disk_cache_mb_size",
-            "table_meta_cache_enabled",
-            "table_cache_block_meta_count",
-            "table_memory_cache_mb_size",
-            "table_disk_cache_root",
-            "table_cache_snapshot_count",
-            "table_cache_statistic_count",
-            "table_cache_segment_count",
-            "table_cache_bloom_index_meta_count",
-            "table_cache_bloom_index_filter_count",
-            "table_cache_bloom_index_data_bytes",
-        ]
     }
 }

--- a/src/query/config/src/lib.rs
+++ b/src/query/config/src/lib.rs
@@ -30,6 +30,7 @@
 mod config;
 mod global;
 mod inner;
+mod obsolete;
 mod version;
 
 pub use config::CacheStorageTypeConfig;

--- a/src/query/config/src/obsolete.rs
+++ b/src/query/config/src/obsolete.rs
@@ -1,0 +1,187 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::Config;
+
+// Obsoleted configuration entries checking
+//
+// The following code should be removed from the release after the next release.
+// Just give user errors without any detail explanation and migration suggestions.
+impl Config {
+    pub const fn obsoleted_option_keys() -> &'static [&'static str; 11] {
+        &[
+            "table_disk_cache_mb_size",
+            "table_meta_cache_enabled",
+            "table_cache_block_meta_count",
+            "table_memory_cache_mb_size",
+            "table_disk_cache_root",
+            "table_cache_snapshot_count",
+            "table_cache_statistic_count",
+            "table_cache_segment_count",
+            "table_cache_bloom_index_meta_count",
+            "table_cache_bloom_index_filter_count",
+            "table_cache_bloom_index_data_bytes",
+        ]
+    }
+
+    pub(crate) fn check_obsoleted(&self) -> Result<()> {
+        let check_results = vec![
+            Self::check(
+                &self.query.table_disk_cache_mb_size,
+                "table-disk-cache-mb-size",
+                "cache-disk-max-bytes",
+                r#"
+                    [cache]
+                    ...
+                    data_cache_storage = "disk"
+                    ...
+                    [cache.disk]
+                    max_bytes = [MAX_BYTES]  
+                    ...
+                  "#,
+                "CACHE_DISK_MAX_BYTES",
+            ),
+            Self::check(
+                &self.query.table_meta_cache_enabled,
+                "table-meta-cache-enabled",
+                "cache-enable-table-meta-cache",
+                r#"
+                    [cache]
+                    enable_table_meta_cache=[true|false]
+                  "#,
+                "CACHE_ENABLE_TABLE_META_CACHE",
+            ),
+            Self::check(
+                &self.query.table_cache_block_meta_count,
+                "table-cache-block-meta-count",
+                "N/A",
+                "N/A",
+                "N/A",
+            ),
+            Self::check(
+                &self.query.table_memory_cache_mb_size,
+                "table-memory-cache-mb-size",
+                "N/A",
+                "N/A",
+                "N/A",
+            ),
+            Self::check(
+                &self.query.table_disk_cache_root,
+                "table-disk-cache-root",
+                "cache-disk-path",
+                r#"
+                    [cache]
+                    ...
+                    data_cache_storage = "disk"
+                    ...
+                    [cache.disk]
+                    max_bytes = [MAX_BYTES]  
+                    path = [PATH]
+                    ...
+                    "#,
+                "CACHE_DISK_PATH",
+            ),
+            Self::check(
+                &self.query.table_cache_snapshot_count,
+                "table-cache-snapshot-count",
+                "cache-table-meta-snapshot-count",
+                r#"
+                    [cache]
+                    table_meta_snapshot_count = [COUNT]
+                    "#,
+                "CACHE_TABLE_META_SNAPSHOT_COUNT",
+            ),
+            Self::check(
+                &self.query.table_cache_statistic_count,
+                "table-cache-statistic-count",
+                "cache-table-meta-statistic-count",
+                r#"
+                    [cache]
+                    table_meta_statistic_count = [COUNT]
+                    "#,
+                "CACHE_TABLE_META_STATISTIC_COUNT",
+            ),
+            Self::check(
+                &self.query.table_cache_segment_count,
+                "table-cache-segment-count",
+                "cache-table-meta-segment-count",
+                r#"
+                    [cache]
+                    table_meta_segment_count = [COUNT]
+                    "#,
+                "CACHE_TABLE_META_SEGMENT_COUNT",
+            ),
+            Self::check(
+                &self.query.table_cache_bloom_index_meta_count,
+                "table-cache-bloom-index-meta-count",
+                "cache-table-bloom-index-meta-count",
+                r#"
+                    [cache]
+                    table_bloom_index_meta_count = [COUNT]
+                    "#,
+                "CACHE_TABLE_BLOOM_INDEX_META_COUNT",
+            ),
+            Self::check(
+                &self.query.table_cache_bloom_index_filter_count,
+                "table-cache-bloom-index-filter-count",
+                "cache-table-bloom-index-filter-count",
+                r#"
+                    [cache]
+                    table_bloom_index_filter_count = [COUNT]
+                    "#,
+                "CACHE_TABLE_BLOOM_INDEX_FILTER_COUNT",
+            ),
+            Self::check(
+                &self.query.table_cache_bloom_index_data_bytes,
+                "table-cache-bloom-index-data-bytes",
+                "N/A",
+                "N/A",
+                "N/A",
+            ),
+        ];
+
+        let messages = check_results.into_iter().flatten().collect::<Vec<_>>();
+        if !messages.is_empty() {
+            let errors = messages.join("\n");
+            Err(ErrorCode::InvalidConfig(format!("\n{errors}")))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn check<T>(
+        target: &Option<T>,
+        cli_arg_name: &str,
+        alternative_cli_arg: &str,
+        alternative_toml_config: &str,
+        alternative_env_var: &str,
+    ) -> Option<String> {
+        target.as_ref().map(|_| {
+            format!(
+                "
+ --------------------------------------------------------------
+ *** {cli_arg_name} *** is obsoleted : 
+ --------------------------------------------------------------
+   alternative command-line options : {alternative_cli_arg}
+   alternative environment variable : {alternative_env_var}
+            alternative toml config : {alternative_toml_config}
+ --------------------------------------------------------------
+"
+            )
+        })
+    }
+}

--- a/src/query/service/tests/it/configs.rs
+++ b/src/query/service/tests/it/configs.rs
@@ -559,7 +559,6 @@ rpc_tls_server_key = ""
 rpc_tls_query_server_root_ca_cert = ""
 rpc_tls_query_service_domain_name = "localhost"
 table_engine_memory_enabled = true
-database_engine_github_enabled = true
 wait_timeout_mills = 5000
 max_query_log_size = 10000
 management_mode = false

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -46,7 +46,6 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | "query"   | "clickhouse_http_handler_host"           | "127.0.0.1"                      | ""       |
 | "query"   | "clickhouse_http_handler_port"           | "8124"                           | ""       |
 | "query"   | "cluster_id"                             | ""                               | ""       |
-| "query"   | "database_engine_github_enabled"         | "true"                           | ""       |
 | "query"   | "flight_api_address"                     | "127.0.0.1:9090"                 | ""       |
 | "query"   | "http_handler_host"                      | "127.0.0.1"                      | ""       |
 | "query"   | "http_handler_port"                      | "8000"                           | ""       |

--- a/src/query/storages/system/src/configs_table.rs
+++ b/src/query/storages/system/src/configs_table.rs
@@ -55,8 +55,7 @@ impl SyncSystemTable for ConfigsTable {
         let mut descs: Vec<String> = vec![];
 
         let query_config = config.query;
-        let query_config_value =
-            Self::remove_obsolete_query_configs(serde_json::to_value(query_config)?);
+        let query_config_value = Self::remove_obsolete_configs(serde_json::to_value(query_config)?);
 
         ConfigsTable::extract_config(
             &mut names,
@@ -282,7 +281,7 @@ impl ConfigsTable {
         descs.push(desc);
     }
 
-    fn remove_obsolete_query_configs(config_json: JsonValue) -> JsonValue {
+    fn remove_obsolete_configs(config_json: JsonValue) -> JsonValue {
         match config_json {
             Value::Object(mut config_json_obj) => {
                 for key in Config::obsoleted_option_keys().iter() {

--- a/src/query/storages/system/src/configs_table.rs
+++ b/src/query/storages/system/src/configs_table.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use common_base::base::mask_string;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
+use common_config::Config;
 use common_config::GlobalConfig;
-use common_config::QueryConfig;
 use common_exception::Result;
 use common_expression::types::StringType;
 use common_expression::utils::FromData;
@@ -285,7 +285,7 @@ impl ConfigsTable {
     fn remove_obsolete_query_configs(config_json: JsonValue) -> JsonValue {
         match config_json {
             Value::Object(mut config_json_obj) => {
-                for key in QueryConfig::obsoleted_option_keys().iter() {
+                for key in Config::obsoleted_option_keys().iter() {
                     config_json_obj.remove(*key);
                 }
                 JsonValue::Object(config_json_obj)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* If we have some obsoleted configs in `Meta/Cache` or others, now we can add them to `check_obsoleted`
* removed unused `database_engine_github_enabled`

Closes #issue
