### PR TITLE
fix: fix json parse timestamp when input is an integer

### DIFF
--- a/src/query/formats/src/field_decoder/json_ast.rs
+++ b/src/query/formats/src/field_decoder/json_ast.rs
@@ -194,6 +194,16 @@ impl FieldJsonAstDecoder {
                 column.builder.push(micros.as_());
                 Ok(())
             }
+            Value::Number(number) => match number.as_i64() {
+                Some(n) => {
+                    check_timestamp(n)?;
+                    column.builder.push(n);
+                    Ok(())
+                }
+                None => Err(ErrorCode::BadArguments(
+                    "Incorrect timestamp value, must be i64",
+                )),
+            },
             _ => Err(ErrorCode::BadBytes("Incorrect boolean value")),
         }
     }

--- a/tests/sqllogictests/suites/base/03_dml/03_0016_insert_into_values
+++ b/tests/sqllogictests/suites/base/03_dml/03_0016_insert_into_values
@@ -56,6 +56,20 @@ statement error 1303
 insert into st1 values ('a', 'b')
 
 statement ok
+create table if not exists ts1(a timestamp)
+
+statement ok
+insert into ts1 values (1676620596564)
+
+query T
+select * from ts1
+----
+2023-02-17 07:56:36.564000
+
+statement ok
+drop table ts1
+
+statement ok
 drop table st1
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix json parse timestamp when input is an integer

Closes #10103 
