### PR TITLE
refactor(executor): destroy pull sink after pipeline finished

### DIFF
--- a/src/query/service/src/pipelines/executor/pipeline_executor.rs
+++ b/src/query/service/src/pipelines/executor/pipeline_executor.rs
@@ -36,10 +36,10 @@ use crate::pipelines::executor::executor_worker_context::ExecutorWorkerContext;
 use crate::pipelines::executor::ExecutorSettings;
 use crate::pipelines::pipeline::Pipeline;
 
-pub type InitCallback = Arc<Box<dyn Fn() -> Result<()> + Send + Sync + 'static>>;
+pub type InitCallback = Box<dyn FnOnce() -> Result<()> + Send + Sync + 'static>;
 
 pub type FinishedCallback =
-Box<dyn FnOnce(&Option<ErrorCode>) -> Result<()> + Send + Sync + 'static>;
+    Box<dyn FnOnce(&Option<ErrorCode>) -> Result<()> + Send + Sync + 'static>;
 
 pub struct PipelineExecutor {
     threads_num: usize,
@@ -47,7 +47,7 @@ pub struct PipelineExecutor {
     workers_condvar: Arc<WorkersCondvar>,
     pub async_runtime: Arc<Runtime>,
     pub global_tasks_queue: Arc<ExecutorTasksQueue>,
-    on_init_callback: InitCallback,
+    on_init_callback: Mutex<Option<InitCallback>>,
     on_finished_callback: Mutex<Option<FinishedCallback>>,
     settings: ExecutorSettings,
     finished_notify: Notify,
@@ -67,8 +67,8 @@ impl PipelineExecutor {
         Self::try_create(
             RunningGraph::create(pipeline)?,
             threads_num,
-            on_init_callback,
-            on_finished_callback,
+            Mutex::new(Some(on_init_callback)),
+            Mutex::new(Some(on_finished_callback)),
             settings,
         )
     }
@@ -87,34 +87,40 @@ impl PipelineExecutor {
             .max()
             .unwrap_or(0);
 
-        let on_init_callbacks = pipelines
-            .iter_mut()
-            .map(|x| x.take_on_init())
-            .collect::<Vec<_>>();
+        let on_init_callback = {
+            let pipelines_callback = pipelines
+                .iter_mut()
+                .map(|x| x.take_on_init())
+                .collect::<Vec<_>>();
 
-        let on_finished_callbacks = pipelines
-            .iter_mut()
-            .map(|x| x.take_on_finished())
-            .collect::<Vec<_>>();
+            pipelines_callback.into_iter().reduce(|left, right| {
+                Box::new(move || {
+                    left()?;
+                    right()
+                })
+            })
+        };
+
+        let on_finished_callback = {
+            let pipelines_callback = pipelines
+                .iter_mut()
+                .map(|x| x.take_on_finished())
+                .collect::<Vec<_>>();
+
+            pipelines_callback.into_iter().reduce(|left, right| {
+                Box::new(move |arg| {
+                    left(arg)?;
+                    right(arg)
+                })
+            })
+        };
 
         assert_ne!(threads_num, 0, "Pipeline max threads cannot equals zero.");
         Self::try_create(
             RunningGraph::from_pipelines(pipelines)?,
             threads_num,
-            Arc::new(Box::new(move || {
-                for on_init_callback in &on_init_callbacks {
-                    on_init_callback()?;
-                }
-
-                Ok(())
-            })),
-            Box::new(move |may_error| {
-                for on_finished_callback in on_finished_callbacks {
-                    on_finished_callback(may_error)?;
-                }
-
-                Ok(())
-            }),
+            Mutex::new(on_init_callback),
+            Mutex::new(on_finished_callback),
             settings,
         )
     }
@@ -122,8 +128,8 @@ impl PipelineExecutor {
     fn try_create(
         graph: RunningGraph,
         threads_num: usize,
-        on_init_callback: InitCallback,
-        on_finished_callback: FinishedCallback,
+        on_init_callback: Mutex<Option<InitCallback>>,
+        on_finished_callback: Mutex<Option<FinishedCallback>>,
         settings: ExecutorSettings,
     ) -> Result<Arc<PipelineExecutor>> {
         let workers_condvar = WorkersCondvar::create(threads_num);
@@ -135,12 +141,22 @@ impl PipelineExecutor {
             workers_condvar,
             global_tasks_queue,
             on_init_callback,
-            on_finished_callback: Mutex::new(Some(on_finished_callback)),
+            on_finished_callback,
             async_runtime: GlobalIORuntime::instance(),
             settings,
             finished_notify: Notify::new(),
             finished_error: Mutex::new(None),
         }))
+    }
+
+    fn on_finished(&self, error: &Option<ErrorCode>) -> Result<()> {
+        let mut guard = self.on_finished_callback.lock();
+        if let Some(on_finished_callback) = guard.take() {
+            drop(guard);
+            (on_finished_callback)(error)?;
+        }
+
+        Ok(())
     }
 
     pub fn finish(&self, cause: Option<ErrorCode>) {
@@ -178,11 +194,7 @@ impl PipelineExecutor {
                     let may_error = Some(error.clone());
                     drop(finished_error_guard);
 
-                    let mut on_finished_callback = self.on_finished_callback.lock();
-                    if let Some(on_finished_callback) = on_finished_callback.take() {
-                        (on_finished_callback)(&may_error)?;
-                    }
-
+                    self.on_finished(&may_error)?;
                     return Err(may_error.unwrap());
                 }
             }
@@ -190,27 +202,26 @@ impl PipelineExecutor {
             // We will ignore the abort query error, because returned by finished_error if abort query.
             if matches!(&thread_res, Err(error) if error.code() != ErrorCode::ABORTED_QUERY) {
                 let may_error = Some(thread_res.unwrap_err());
-                let mut on_finished_callback = self.on_finished_callback.lock();
-                if let Some(on_finished_callback) = on_finished_callback.take() {
-                    (on_finished_callback)(&may_error)?;
-                }
+                self.on_finished(&may_error)?;
                 return Err(may_error.unwrap());
             }
         }
 
-        let mut on_finished_callback = self.on_finished_callback.lock();
-        if let Some(on_finished_callback) = on_finished_callback.take() {
-            (on_finished_callback)(&None)?;
-        }
-        // (self.on_finished_callback)(&None)?;
+        self.on_finished(&None)?;
         Ok(())
     }
 
     fn init(self: &Arc<Self>) -> Result<()> {
         unsafe {
             // TODO: the on init callback cannot be killed.
-            if let Err(cause) = (self.on_init_callback)() {
-                return Err(cause.add_message_back("(while in query pipeline init)"));
+            {
+                let mut guard = self.on_init_callback.lock();
+                if let Some(callback) = guard.take() {
+                    drop(guard);
+                    if let Err(cause) = callback() {
+                        return Err(cause.add_message_back("(while in query pipeline init)"));
+                    }
+                }
             }
 
             let mut init_schedule_queue = self.graph.init_schedule_queue()?;
@@ -263,7 +274,7 @@ impl PipelineExecutor {
         for thread_num in 0..threads {
             let this = self.clone();
             #[allow(unused_mut)]
-                let mut name = Some(format!("PipelineExecutor-{}", thread_num));
+            let mut name = Some(format!("PipelineExecutor-{}", thread_num));
 
             #[cfg(debug_assertions)]
             {

--- a/src/query/service/src/pipelines/executor/pipeline_pulling_executor.rs
+++ b/src/query/service/src/pipelines/executor/pipeline_pulling_executor.rs
@@ -97,14 +97,15 @@ pub struct PipelinePullingExecutor {
 }
 
 impl PipelinePullingExecutor {
-    fn wrap_pipeline(pipeline: &mut Pipeline, mut tx: SyncSender<DataBlock>) -> Result<()> {
+    fn wrap_pipeline(pipeline: &mut Pipeline, tx: SyncSender<DataBlock>) -> Result<()> {
         if pipeline.is_pushing_pipeline()? || !pipeline.is_pulling_pipeline()? {
             return Err(ErrorCode::Internal(
                 "Logical error, PipelinePullingExecutor can only work on pulling pipeline.",
             ));
         }
 
-        pipeline.add_sink(|input| Ok(ProcessorPtr::create(PullingSink::create(tx.clone(), input))))?;
+        pipeline
+            .add_sink(|input| Ok(ProcessorPtr::create(PullingSink::create(tx.clone(), input))))?;
 
         pipeline.set_on_finished(move |_may_error| {
             drop(tx);
@@ -153,7 +154,7 @@ impl PipelinePullingExecutor {
         let threads_executor = self.executor.clone();
         let thread_function = Self::thread_function(state, threads_executor);
         #[allow(unused_mut)]
-            let mut thread_name = Some(String::from("PullingExecutor"));
+        let mut thread_name = Some(String::from("PullingExecutor"));
 
         #[cfg(debug_assertions)]
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor(executor): destroy pull sink after pipeline finished

Closes #issue
