### PR TITLE
feat: add internal_merge_on_read_mutation config option

### DIFF
--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -1169,6 +1169,10 @@ pub struct QueryConfig {
     #[clap(long)]
     pub internal_enable_sandbox_tenant: bool,
 
+    /// Experiment config options, DO NOT USE IT IN PRODUCTION ENV
+    #[clap(long)]
+    pub internal_merge_on_read_mutation: bool,
+
     // ----- the following options/args are all deprecated               ----
     // ----- and turned into Option<T>, to help user migrate the configs ----
     /// OBSOLETED: Table disk cache size (mb).
@@ -1275,6 +1279,7 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
             share_endpoint_auth_token_file: self.share_endpoint_auth_token_file,
             tenant_quota: self.quota,
             internal_enable_sandbox_tenant: self.internal_enable_sandbox_tenant,
+            internal_merge_on_read_mutation: self.internal_merge_on_read_mutation,
         })
     }
 }
@@ -1328,6 +1333,7 @@ impl From<InnerQueryConfig> for QueryConfig {
             share_endpoint_auth_token_file: inner.share_endpoint_auth_token_file,
             quota: inner.tenant_quota,
             internal_enable_sandbox_tenant: inner.internal_enable_sandbox_tenant,
+            internal_merge_on_read_mutation: false,
             // obsoleted config entries
             table_disk_cache_mb_size: None,
             table_meta_cache_enabled: None,

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -162,6 +162,7 @@ pub struct QueryConfig {
     pub share_endpoint_auth_token_file: String,
     pub tenant_quota: Option<TenantQuota>,
     pub internal_enable_sandbox_tenant: bool,
+    pub internal_merge_on_read_mutation: bool,
 }
 
 impl Default for QueryConfig {
@@ -207,6 +208,7 @@ impl Default for QueryConfig {
             share_endpoint_auth_token_file: "".to_string(),
             tenant_quota: None,
             internal_enable_sandbox_tenant: false,
+            internal_merge_on_read_mutation: false,
         }
     }
 }

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -54,6 +54,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | "query"   | "http_handler_tls_server_key"            | ""                               | ""       |
 | "query"   | "http_handler_tls_server_root_ca_cert"   | ""                               | ""       |
 | "query"   | "internal_enable_sandbox_tenant"         | "false"                          | ""       |
+| "query"   | "internal_merge_on_read_mutation"        | "false"                          | ""       |
 | "query"   | "jwt_key_file"                           | ""                               | ""       |
 | "query"   | "jwt_key_files"                          | ""                               | ""       |
 | "query"   | "management_mode"                        | "false"                          | ""       |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add new internal config option `internal_merge_on_read_mutation`,  by default `false`, disable the merge_on_read behaviors (read & mutation)

Closes #issue
