### PR TITLE
refactor(query): use HashMethodBounds to simplify generics bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,6 +1395,7 @@ dependencies = [
  "common-ast",
  "common-datavalues",
  "common-exception",
+ "common-hashtable",
  "common-io",
  "common-jsonb",
  "dashmap",

--- a/src/query/expression/Cargo.toml
+++ b/src/query/expression/Cargo.toml
@@ -15,6 +15,7 @@ common-arrow = { path = "../../common/arrow" }
 common-datavalues = { path = "../datavalues" }
 common-exception = { path = "../../common/exception" }
 common-io = { path = "../../common/io" }
+common-hashtable = { path = "../../common/hashtable" }
 
 # Github dependencies
 

--- a/src/query/expression/Cargo.toml
+++ b/src/query/expression/Cargo.toml
@@ -14,8 +14,8 @@ test = false
 common-arrow = { path = "../../common/arrow" }
 common-datavalues = { path = "../datavalues" }
 common-exception = { path = "../../common/exception" }
-common-io = { path = "../../common/io" }
 common-hashtable = { path = "../../common/hashtable" }
+common-io = { path = "../../common/io" }
 
 # Github dependencies
 

--- a/src/query/expression/src/kernels/group_by_hash.rs
+++ b/src/query/expression/src/kernels/group_by_hash.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::fmt::Debug;
-use std::hash::Hash;
 use std::iter::TrustedLen;
 use std::marker::PhantomData;
 use std::ops::Not;
@@ -27,6 +26,7 @@ use common_io::prelude::FormatSettings;
 use micromarshal::Marshal;
 use primitive_types::U256;
 use primitive_types::U512;
+use common_hashtable::FastHash;
 
 use crate::types::boolean::BooleanType;
 use crate::types::nullable::NullableColumn;
@@ -52,7 +52,7 @@ pub enum KeysState {
 }
 
 pub trait HashMethod: Clone {
-    type HashKey: ?Sized + Eq + Hash + Debug;
+    type HashKey: ?Sized + Eq + FastHash + Debug;
 
     type HashKeyIter<'a>: Iterator<Item = &'a Self::HashKey> + TrustedLen
     where Self: 'a;

--- a/src/query/expression/src/kernels/group_by_hash.rs
+++ b/src/query/expression/src/kernels/group_by_hash.rs
@@ -21,12 +21,12 @@ use common_arrow::arrow::bitmap::Bitmap;
 use common_arrow::arrow::buffer::Buffer;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_hashtable::FastHash;
 use common_io::prelude::BinaryWrite;
 use common_io::prelude::FormatSettings;
 use micromarshal::Marshal;
 use primitive_types::U256;
 use primitive_types::U512;
-use common_hashtable::FastHash;
 
 use crate::types::boolean::BooleanType;
 use crate::types::nullable::NullableColumn;
@@ -51,7 +51,7 @@ pub enum KeysState {
     U512(Vec<U512>),
 }
 
-pub trait HashMethod: Clone {
+pub trait HashMethod: Clone + Sync + Send + 'static {
     type HashKey: ?Sized + Eq + FastHash + Debug;
 
     type HashKeyIter<'a>: Iterator<Item = &'a Self::HashKey> + TrustedLen

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_final_parallel.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_final_parallel.rs
@@ -24,7 +24,6 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::ColumnBuilder;
 use common_expression::DataBlock;
-use common_expression::HashMethod;
 use common_functions::aggregates::StateAddr;
 use common_hashtable::HashtableEntryMutRefLike;
 use common_hashtable::HashtableEntryRefLike;
@@ -37,15 +36,13 @@ use crate::pipelines::processors::transforms::aggregator::aggregate_info::Aggreg
 use crate::pipelines::processors::transforms::group_by::Area;
 use crate::pipelines::processors::transforms::group_by::ArenaHolder;
 use crate::pipelines::processors::transforms::group_by::GroupColumnsBuilder;
+use crate::pipelines::processors::transforms::group_by::HashMethodBounds;
 use crate::pipelines::processors::transforms::group_by::KeysColumnIter;
-use crate::pipelines::processors::transforms::group_by::PolymorphicKeysHelper;
 use crate::pipelines::processors::transforms::transform_aggregator::Aggregator;
 use crate::pipelines::processors::AggregatorParams;
 use crate::sessions::QueryContext;
 
-pub struct ParallelFinalAggregator<const HAS_AGG: bool, Method>
-where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
-{
+pub struct ParallelFinalAggregator<const HAS_AGG: bool, Method: HashMethodBounds> {
     method: Method,
     query_ctx: Arc<QueryContext>,
     params: Arc<AggregatorParams>,
@@ -53,9 +50,7 @@ where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
     generated: bool,
 }
 
-impl<Method, const HAS_AGG: bool> ParallelFinalAggregator<HAS_AGG, Method>
-where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
-{
+impl<Method: HashMethodBounds, const HAS_AGG: bool> ParallelFinalAggregator<HAS_AGG, Method> {
     pub fn create(
         ctx: Arc<QueryContext>,
         method: Method,
@@ -71,8 +66,8 @@ where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
     }
 }
 
-impl<Method, const HAS_AGG: bool> Aggregator for ParallelFinalAggregator<HAS_AGG, Method>
-where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
+impl<Method: HashMethodBounds, const HAS_AGG: bool> Aggregator
+    for ParallelFinalAggregator<HAS_AGG, Method>
 {
     const NAME: &'static str = "GroupByFinalTransform";
 
@@ -143,9 +138,7 @@ where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
     }
 }
 
-pub struct BucketAggregator<const HAS_AGG: bool, Method>
-where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
-{
+pub struct BucketAggregator<const HAS_AGG: bool, Method: HashMethodBounds> {
     area: Area,
     method: Method,
     params: Arc<AggregatorParams>,
@@ -157,9 +150,7 @@ where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
     temp_place: StateAddr,
 }
 
-impl<const HAS_AGG: bool, Method> BucketAggregator<HAS_AGG, Method>
-where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
-{
+impl<const HAS_AGG: bool, Method: HashMethodBounds> BucketAggregator<HAS_AGG, Method> {
     pub fn create(method: Method, params: Arc<AggregatorParams>) -> Result<Self> {
         let mut area = Area::create();
         let hash_table = method.create_hash_table()?;
@@ -449,9 +440,7 @@ where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
     }
 }
 
-impl<const HAS_AGG: bool, Method> Drop for BucketAggregator<HAS_AGG, Method>
-where Method: HashMethod + PolymorphicKeysHelper<Method> + Send + 'static
-{
+impl<const HAS_AGG: bool, Method: HashMethodBounds> Drop for BucketAggregator<HAS_AGG, Method> {
     fn drop(&mut self) {
         self.drop_states();
     }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_partial.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_partial.rs
@@ -19,7 +19,6 @@ use common_expression::types::string::StringColumnBuilder;
 use common_expression::BlockEntry;
 use common_expression::Column;
 use common_expression::DataBlock;
-use common_expression::HashMethod;
 use common_functions::aggregates::StateAddr;
 use common_functions::aggregates::StateAddrs;
 use common_hashtable::HashtableEntryMutRefLike;
@@ -29,14 +28,12 @@ use common_hashtable::HashtableLike;
 use super::estimated_key_size;
 use crate::pipelines::processors::transforms::group_by::Area;
 use crate::pipelines::processors::transforms::group_by::ArenaHolder;
+use crate::pipelines::processors::transforms::group_by::HashMethodBounds;
 use crate::pipelines::processors::transforms::group_by::KeysColumnBuilder;
-use crate::pipelines::processors::transforms::group_by::PolymorphicKeysHelper;
 use crate::pipelines::processors::transforms::transform_aggregator::Aggregator;
 use crate::pipelines::processors::AggregatorParams;
 
-pub struct PartialAggregator<const HAS_AGG: bool, Method>
-where Method: HashMethod + PolymorphicKeysHelper<Method>
-{
+pub struct PartialAggregator<const HAS_AGG: bool, Method: HashMethodBounds> {
     pub states_dropped: bool,
 
     pub area: Option<Area>,
@@ -50,9 +47,7 @@ where Method: HashMethod + PolymorphicKeysHelper<Method>
     pub two_level_mode: bool,
 }
 
-impl<const HAS_AGG: bool, Method: HashMethod + PolymorphicKeysHelper<Method> + Send>
-    PartialAggregator<HAS_AGG, Method>
-{
+impl<const HAS_AGG: bool, Method: HashMethodBounds> PartialAggregator<HAS_AGG, Method> {
     pub fn create(
         method: Method,
         params: Arc<AggregatorParams>,
@@ -231,7 +226,7 @@ impl<const HAS_AGG: bool, Method: HashMethod + PolymorphicKeysHelper<Method> + S
     }
 }
 
-impl<const HAS_AGG: bool, Method: HashMethod + PolymorphicKeysHelper<Method> + Send> Aggregator
+impl<const HAS_AGG: bool, Method: HashMethodBounds> Aggregator
     for PartialAggregator<HAS_AGG, Method>
 {
     const NAME: &'static str = "GroupByPartialTransform";
@@ -267,9 +262,7 @@ impl<const HAS_AGG: bool, Method: HashMethod + PolymorphicKeysHelper<Method> + S
     }
 }
 
-impl<const HAS_AGG: bool, Method: HashMethod + PolymorphicKeysHelper<Method>>
-    PartialAggregator<HAS_AGG, Method>
-{
+impl<const HAS_AGG: bool, Method: HashMethodBounds> PartialAggregator<HAS_AGG, Method> {
     pub fn drop_states(&mut self) {
         if !self.states_dropped {
             let aggregator_params = self.params.as_ref();
@@ -305,9 +298,7 @@ impl<const HAS_AGG: bool, Method: HashMethod + PolymorphicKeysHelper<Method>>
     }
 }
 
-impl<const HAS_AGG: bool, Method: HashMethod + PolymorphicKeysHelper<Method>> Drop
-    for PartialAggregator<HAS_AGG, Method>
-{
+impl<const HAS_AGG: bool, Method: HashMethodBounds> Drop for PartialAggregator<HAS_AGG, Method> {
     fn drop(&mut self) {
         self.drop_states();
     }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_partitioned.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_partitioned.rs
@@ -21,10 +21,8 @@ use common_expression::types::DataType;
 use common_expression::BlockEntry;
 use common_expression::Column;
 use common_expression::DataBlock;
-use common_expression::HashMethod;
 use common_expression::Value;
 use common_functions::aggregates::StateAddr;
-use common_hashtable::FastHash;
 use common_hashtable::HashtableEntryMutRefLike;
 use common_hashtable::HashtableEntryRefLike;
 use common_hashtable::HashtableLike;
@@ -35,6 +33,7 @@ use crate::pipelines::processors::transforms::aggregator::aggregate_info::Aggreg
 use crate::pipelines::processors::transforms::aggregator::aggregator_final_parallel::ParallelFinalAggregator;
 use crate::pipelines::processors::transforms::aggregator::AggregateHashStateInfo;
 use crate::pipelines::processors::transforms::aggregator::PartialAggregator;
+use crate::pipelines::processors::transforms::group_by::HashMethodBounds;
 use crate::pipelines::processors::transforms::group_by::KeysColumnBuilder;
 use crate::pipelines::processors::transforms::group_by::PartitionedHashMethod;
 use crate::pipelines::processors::transforms::group_by::PolymorphicKeysHelper;
@@ -67,10 +66,8 @@ where Self: Aggregator + Send
     }
 }
 
-impl<Method, const HAS_AGG: bool> PartitionedAggregatorLike for PartialAggregator<HAS_AGG, Method>
-where
-    Method: HashMethod + PolymorphicKeysHelper<Method> + Send,
-    Method::HashKey: FastHash,
+impl<Method: HashMethodBounds, const HAS_AGG: bool> PartitionedAggregatorLike
+    for PartialAggregator<HAS_AGG, Method>
 {
     const SUPPORT_PARTITION: bool = Method::SUPPORT_PARTITIONED;
 
@@ -239,11 +236,8 @@ where
     }
 }
 
-impl<Method, const HAS_AGG: bool> PartitionedAggregatorLike
+impl<Method: HashMethodBounds, const HAS_AGG: bool> PartitionedAggregatorLike
     for ParallelFinalAggregator<HAS_AGG, Method>
-where
-    Method: HashMethod + PolymorphicKeysHelper<Method> + Send,
-    Method::HashKey: FastHash,
 {
     const SUPPORT_PARTITION: bool = false;
     type PartitionedAggregator = ParallelFinalAggregator<HAS_AGG, PartitionedHashMethod<Method>>;

--- a/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_polymorphic_keys.rs
+++ b/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_polymorphic_keys.rs
@@ -513,7 +513,6 @@ impl<Method> PolymorphicKeysHelper<PartitionedHashMethod<Method>> for Partitione
 where
     Self: HashMethod<HashKey = Method::HashKey>,
     Method: HashMethod + PolymorphicKeysHelper<Method> + Send,
-    Method::HashKey: FastHash,
 {
     // Partitioned cannot be recursive
     const SUPPORT_PARTITIONED: bool = false;

--- a/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_polymorphic_keys.rs
+++ b/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_polymorphic_keys.rs
@@ -87,7 +87,7 @@ use crate::pipelines::processors::AggregatorParams;
 //     }
 // }
 //
-pub trait PolymorphicKeysHelper<Method: HashMethod> {
+pub trait PolymorphicKeysHelper<Method: HashMethod>: Send + Sync + 'static {
     const SUPPORT_PARTITIONED: bool;
 
     type HashTable<T: Send + Sync + 'static>: HashtableLike<Key = Method::HashKey, Value = T>
@@ -512,7 +512,7 @@ impl<Method: HashMethod + Send> HashMethod for PartitionedHashMethod<Method> {
 impl<Method> PolymorphicKeysHelper<PartitionedHashMethod<Method>> for PartitionedHashMethod<Method>
 where
     Self: HashMethod<HashKey = Method::HashKey>,
-    Method: HashMethod + PolymorphicKeysHelper<Method> + Send,
+    Method: HashMethod + PolymorphicKeysHelper<Method>,
 {
     // Partitioned cannot be recursive
     const SUPPORT_PARTITIONED: bool = false;
@@ -563,3 +563,7 @@ where
         self.method.get_hash(v)
     }
 }
+
+pub trait HashMethodBounds: HashMethod + PolymorphicKeysHelper<Self> {}
+
+impl<T: HashMethod + PolymorphicKeysHelper<T>> HashMethodBounds for T {}

--- a/src/query/service/src/pipelines/processors/transforms/group_by/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/group_by/mod.rs
@@ -23,6 +23,7 @@ mod large_number;
 pub use aggregator_groups_builder::GroupColumnsBuilder;
 pub use aggregator_keys_builder::KeysColumnBuilder;
 pub use aggregator_keys_iter::KeysColumnIter;
+pub use aggregator_polymorphic_keys::HashMethodBounds;
 pub use aggregator_polymorphic_keys::PartitionedHashMethod;
 pub use aggregator_polymorphic_keys::PolymorphicKeysHelper;
 pub use aggregator_state::Area;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor(query): use HashMethodBounds to simplify generics bounds

Closes #issue
