### PR TITLE
chore(storage): introduce a reusable runtime pool to prune the blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,6 +1259,7 @@ dependencies = [
  "async-trait",
  "bytesize",
  "common-exception",
+ "ctor",
  "ctrlc",
  "enquote",
  "futures",

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -29,6 +29,7 @@ common-exception = { path = "../exception" }
 async-channel = "1.7.1"
 async-trait = "0.1.57"
 bytesize = "1.1.0"
+ctor = "0.1.26"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 enquote = "1.1.0"
 futures = "0.3.24"

--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod net;
+mod object_pool;
 mod profiling;
 mod progress;
 mod select;
@@ -25,6 +26,8 @@ mod uniq_id;
 
 pub use net::get_free_tcp_port;
 pub use net::get_free_udp_port;
+pub use object_pool::Pool;
+pub use object_pool::Reusable;
 pub use profiling::Profiling;
 pub use progress::Progress;
 pub use progress::ProgressValues;

--- a/src/common/base/src/base/object_pool.rs
+++ b/src/common/base/src/base/object_pool.rs
@@ -1,0 +1,201 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A thread-safe object pool with automatic return and attach/detach semantics
+// Forked from: https://github.com/CJP10/object-pool/ with capacity limit
+
+use std::collections::VecDeque;
+use std::iter::FromIterator;
+use std::mem::forget;
+use std::mem::ManuallyDrop;
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+use parking_lot::Mutex;
+
+pub type Stack<T> = VecDeque<T>;
+
+pub struct Pool<T> {
+    objects: Mutex<Stack<T>>,
+    cap: usize,
+}
+
+impl<T> Pool<T> {
+    #[inline]
+    pub fn new<F>(cap: usize, init: F) -> Pool<T>
+    where F: Fn() -> T {
+        Pool {
+            objects: Mutex::new((0..cap).into_iter().map(|_| init()).collect()),
+            cap,
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.objects.lock().len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.objects.lock().is_empty()
+    }
+
+    #[inline]
+    pub fn try_pull(&self) -> Option<Reusable<T>> {
+        self.objects
+            .lock()
+            .pop_back()
+            .map(|data| Reusable::new(self, data))
+    }
+
+    #[inline]
+    pub fn pull<F: Fn() -> T>(&self, fallback: F) -> Reusable<T> {
+        self.try_pull()
+            .unwrap_or_else(|| Reusable::new(self, fallback()))
+    }
+
+    #[inline]
+    pub fn attach(&self, t: T) {
+        let mut objects = self.objects.lock();
+        if objects.len() < self.cap {
+            objects.push_back(t);
+        }
+    }
+}
+
+impl<T> FromIterator<T> for Pool<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let objects = iter.into_iter().collect::<VecDeque<_>>();
+        let cap = objects.len();
+        Self {
+            objects: Mutex::new(objects),
+            cap,
+        }
+    }
+}
+
+pub struct Reusable<'a, T> {
+    pool: &'a Pool<T>,
+    data: ManuallyDrop<T>,
+}
+
+impl<'a, T> Reusable<'a, T> {
+    #[inline]
+    pub fn new(pool: &'a Pool<T>, t: T) -> Self {
+        Self {
+            pool,
+            data: ManuallyDrop::new(t),
+        }
+    }
+
+    #[inline]
+    pub fn detach(mut self) -> (&'a Pool<T>, T) {
+        let ret = unsafe { (self.pool, self.take()) };
+        forget(self);
+        ret
+    }
+
+    unsafe fn take(&mut self) -> T {
+        ManuallyDrop::take(&mut self.data)
+    }
+}
+
+impl<'a, T> Deref for Reusable<'a, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl<'a, T> DerefMut for Reusable<'a, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
+impl<'a, T> Drop for Reusable<'a, T> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { self.pool.attach(self.take()) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::mem::drop;
+
+    use crate::base::Pool;
+    use crate::Pool;
+    use crate::Reusable;
+
+    #[test]
+    fn detach() {
+        let pool = Pool::new(1, || Vec::new());
+        let (pool, mut object) = pool.try_pull().unwrap().detach();
+        object.push(1);
+        Reusable::new(&pool, object);
+        assert_eq!(pool.try_pull().unwrap()[0], 1);
+    }
+
+    #[test]
+    fn detach_then_attach() {
+        let pool = Pool::new(1, || Vec::new());
+        let (pool, mut object) = pool.try_pull().unwrap().detach();
+        object.push(1);
+        pool.attach(object);
+        assert_eq!(pool.try_pull().unwrap()[0], 1);
+    }
+
+    #[test]
+    fn pull() {
+        let pool = Pool::<Vec<u8>>::new(1, || Vec::new());
+
+        let object1 = pool.try_pull();
+        let object2 = pool.try_pull();
+        let object3 = pool.pull(|| Vec::new());
+
+        assert!(object1.is_some());
+        assert!(object2.is_none());
+        drop(object1);
+        drop(object2);
+        drop(object3);
+        assert_eq!(pool.len(), 2);
+    }
+
+    #[test]
+    fn e2e() {
+        let pool = Pool::new(10, || Vec::new());
+        let mut objects = VecDeque::new();
+
+        for i in 0..10 {
+            let mut object = pool.try_pull().unwrap();
+            object.push(i);
+
+            objects.push_back(object);
+        }
+
+        assert!(pool.try_pull().is_none());
+        drop(objects);
+        assert!(pool.try_pull().is_some());
+
+        for i in (10..0).rev() {
+            let mut object = pool.objects.lock().pop_back().unwrap();
+            assert_eq!(object.pop(), Some(i));
+        }
+    }
+}

--- a/src/common/base/src/runtime/global_runtime.rs
+++ b/src/common/base/src/runtime/global_runtime.rs
@@ -15,8 +15,11 @@
 use std::sync::Arc;
 
 use common_exception::Result;
+use ctor::ctor;
 
 use crate::base::GlobalInstance;
+use crate::base::Pool;
+use crate::base::Reusable;
 use crate::runtime::Runtime;
 
 pub struct GlobalIORuntime;
@@ -26,14 +29,51 @@ impl GlobalIORuntime {
         let thread_num = std::cmp::max(num_cpus, num_cpus::get() / 2);
         let thread_num = std::cmp::max(2, thread_num);
 
-        GlobalInstance::set(Arc::new(Runtime::with_worker_threads(
+        let runtime = Arc::new(Runtime::with_worker_threads(
             thread_num,
             Some("IO-worker".to_owned()),
-        )?));
+        )?);
+
+        GlobalInstance::set((thread_num as i32, runtime));
         Ok(())
     }
 
     pub fn instance() -> Arc<Runtime> {
-        GlobalInstance::get()
+        let (_, runtime): (i32, Arc<Runtime>) = GlobalInstance::get();
+        runtime
+    }
+}
+
+pub struct ReusableRuntimePool {
+    thread_num: usize,
+    pool: Pool<Arc<Runtime>>,
+}
+
+#[ctor]
+pub static RESUE_RUNTIME: ReusableRuntimePool = reuse_runtime_pool();
+
+fn reuse_runtime_pool() -> ReusableRuntimePool {
+    let thread_num = std::cmp::max(2, num_cpus::get() / 2);
+    let pool = Pool::new(4, || {
+        Arc::new(
+            Runtime::with_worker_threads(thread_num, Some("ReusableRuntime-Worker".to_owned()))
+                .unwrap(),
+        )
+    });
+
+    ReusableRuntimePool { thread_num, pool }
+}
+
+impl ReusableRuntimePool {
+    pub fn pull(&self) -> Reusable<Arc<Runtime>> {
+        self.pool.pull(|| {
+            Arc::new(
+                Runtime::with_worker_threads(
+                    self.thread_num,
+                    Some("ReusableRuntime-Worker".to_owned()),
+                )
+                .unwrap(),
+            )
+        })
     }
 }

--- a/src/common/base/src/runtime/mod.rs
+++ b/src/common/base/src/runtime/mod.rs
@@ -23,6 +23,7 @@ mod thread_pool;
 pub use catch_unwind::catch_unwind;
 pub use catch_unwind::CatchUnwindFuture;
 pub use global_runtime::GlobalIORuntime;
+pub use global_runtime::RESUE_RUNTIME;
 pub use runtime::Dropper;
 pub use runtime::Runtime;
 pub use runtime::TrySpawn;

--- a/src/query/sharing-endpoint/src/services.rs
+++ b/src/query/sharing-endpoint/src/services.rs
@@ -28,6 +28,7 @@ impl SharingServices {
         GlobalInstance::init_production();
 
         GlobalIORuntime::init(config.storage.num_cpus as usize)?;
+
         SharingAccessor::init(&config).await
     }
 }

--- a/src/query/storages/fuse/src/pruning/segment_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/segment_pruner.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use common_base::base::tokio::sync::OwnedSemaphorePermit;
+use common_base::runtime::RESUE_RUNTIME;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::TableSchemaRef;
@@ -80,9 +81,9 @@ impl SegmentPruner {
         });
 
         // Run tasks and collect the results.
-        let pruning_runtime = self.pruning_ctx.pruning_runtime.clone();
         let pruning_semaphore = self.pruning_ctx.pruning_semaphore.clone();
-        let handlers = pruning_runtime
+        let runtime = RESUE_RUNTIME.pull();
+        let handlers = runtime
             .try_spawn_batch_with_owned_semaphore(pruning_semaphore, pruning_tasks)
             .await?;
         let joint = future::try_join_all(handlers)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

We don't need to new runtime in each query in low qps. This pr adds a reusable pool to cache the runtime.

Performance of:

```
SELECT UserID FROM hits WHERE UserID = 435090932899640449;
```

will not degression in hot query.

Closes #issue
