### PR TITLE
feat(query): support multi-table query result cache.

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -84,8 +84,8 @@ pub trait TableContext: Send + Sync {
     fn get_partition(&self) -> Option<PartInfoPtr>;
     fn get_partitions(&self, num: usize) -> Vec<PartInfoPtr>;
     fn set_partitions(&self, partitions: Partitions) -> Result<()>;
-    fn set_paritions_sha(&self, sha: String);
-    fn get_partitions_sha(&self) -> Option<String>;
+    fn add_partitions_sha(&self, sha: String);
+    fn get_partitions_shas(&self) -> Vec<String>;
 
     fn attach_query_str(&self, kind: String, query: &str);
     fn get_query_str(&self) -> String;

--- a/src/query/service/src/interpreters/interpreter_select_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_select_v2.rs
@@ -151,10 +151,7 @@ impl Interpreter for SelectInterpreterV2 {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         // 0. Need to build pipeline first to get the partitions.
         let mut build_res = self.build_pipeline().await?;
-        // Only single table query can use result cache now. Multi-tables query will be supported later.
-        if self.ctx.get_settings().get_enable_query_result_cache()?
-            && self.metadata.read().tables().len() == 1
-        {
+        if self.ctx.get_settings().get_enable_query_result_cache()? {
             // 1. Try to get result from cache.
             let kv_store = UserApiProvider::instance().get_meta_store_client();
             let cache_reader = ResultCacheReader::create(

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -73,7 +73,6 @@ use crate::storages::Table;
 pub struct QueryContext {
     version: String,
     partition_queue: Arc<RwLock<VecDeque<PartInfoPtr>>>,
-    partitions_sha: Arc<RwLock<Option<String>>>,
     shared: Arc<QueryContextShared>,
     fragment_id: Arc<AtomicUsize>,
 }
@@ -88,7 +87,6 @@ impl QueryContext {
 
         Arc::new(QueryContext {
             partition_queue: Arc::new(RwLock::new(VecDeque::new())),
-            partitions_sha: Arc::new(RwLock::new(None)),
             version: format!("DatabendQuery {}", *DATABEND_COMMIT_VERSION),
             shared,
             fragment_id: Arc::new(AtomicUsize::new(0)),
@@ -279,13 +277,13 @@ impl TableContext for QueryContext {
         Ok(())
     }
 
-    fn set_paritions_sha(&self, s: String) {
-        let mut sha = self.partitions_sha.write();
-        *sha = Some(s);
+    fn add_partitions_sha(&self, s: String) {
+        let mut shas = self.shared.partitions_shas.write();
+        shas.push(s);
     }
 
-    fn get_partitions_sha(&self) -> Option<String> {
-        let sha = self.partitions_sha.read();
+    fn get_partitions_shas(&self) -> Vec<String> {
+        let sha = self.shared.partitions_shas.read();
         sha.clone()
     }
 

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -80,6 +80,8 @@ pub struct QueryContextShared {
     pub(in crate::sessions) stage_attachment: Arc<RwLock<Option<StageAttachment>>>,
     pub(in crate::sessions) created_time: SystemTime,
     pub(in crate::sessions) on_error_map: Arc<RwLock<Option<HashMap<String, ErrorCode>>>>,
+    /// partitions_sha for each table in the query. Not empty only when enabling query result cache.
+    pub(in crate::sessions) partitions_shas: Arc<RwLock<Vec<String>>>,
 }
 
 impl QueryContextShared {
@@ -110,6 +112,7 @@ impl QueryContextShared {
             stage_attachment: Arc::new(RwLock::new(None)),
             created_time: SystemTime::now(),
             on_error_map: Arc::new(RwLock::new(None)),
+            partitions_shas: Arc::new(RwLock::new(vec![])),
         }))
     }
 

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -356,11 +356,11 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
-    fn set_paritions_sha(&self, _sha: String) {
+    fn add_partitions_sha(&self, _sha: String) {
         todo!()
     }
 
-    fn get_partitions_sha(&self) -> Option<String> {
+    fn get_partitions_shas(&self) -> Vec<String> {
         todo!()
     }
 

--- a/src/query/sql/src/executor/table_read_plan.rs
+++ b/src/query/sql/src/executor/table_read_plan.rs
@@ -55,7 +55,7 @@ impl ToReadDataSourcePlan for dyn Table {
         // We need the partition sha256 to specify the result cache.
         if ctx.get_settings().get_enable_query_result_cache()? {
             let sha = parts.compute_sha256()?;
-            ctx.set_paritions_sha(sha);
+            ctx.add_partitions_sha(sha);
         }
 
         let source_info = self.get_data_source_info();

--- a/src/query/storages/result_cache/src/common.rs
+++ b/src/query/storages/result_cache/src/common.rs
@@ -39,7 +39,7 @@ pub(crate) fn gen_result_cache_dir(key: &str) -> String {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(crate) struct ResultCacheValue {
-    /// The query SQL.
+    /// The original query SQL.
     pub sql: String,
     /// The query time.
     pub query_time: u64,
@@ -49,8 +49,8 @@ pub(crate) struct ResultCacheValue {
     pub result_size: usize,
     /// The number of rows in the result cache.
     pub num_rows: usize,
-    /// The sha256 of the partitions.
-    pub partitions_sha: String,
+    /// The sha256 of the partitions for each table in the query.
+    pub partitions_shas: Vec<String>,
     /// The location of the result cache file.
     pub location: String,
 }

--- a/src/query/storages/result_cache/src/write/sink.rs
+++ b/src/query/storages/result_cache/src/write/sink.rs
@@ -35,7 +35,7 @@ use crate::meta_manager::ResultCacheMetaManager;
 
 pub struct WriteResultCacheSink {
     sql: String,
-    partitions_sha: String,
+    partitions_shas: Vec<String>,
 
     meta_mgr: ResultCacheMetaManager,
     cache_writer: ResultCacheWriter,
@@ -73,7 +73,7 @@ impl AsyncMpscSink for WriteResultCacheSink {
             sql: self.sql.clone(),
             query_time: now,
             ttl,
-            partitions_sha: self.partitions_sha.clone(),
+            partitions_shas: self.partitions_shas.clone(),
             result_size: self.cache_writer.current_bytes(),
             num_rows: self.cache_writer.num_rows(),
             location,
@@ -94,7 +94,7 @@ impl WriteResultCacheSink {
         let ttl = settings.get_result_cache_ttl()?;
         let tenant = ctx.get_tenant();
         let sql = ctx.get_query_str();
-        let partitions_sha = ctx.get_partitions_sha().unwrap();
+        let partitions_shas = ctx.get_partitions_shas();
 
         let key = gen_common_key(&sql);
         let meta_key = gen_result_cache_meta_key(&tenant, &key);
@@ -107,7 +107,7 @@ impl WriteResultCacheSink {
             inputs,
             WriteResultCacheSink {
                 sql,
-                partitions_sha,
+                partitions_shas,
                 meta_mgr: ResultCacheMetaManager::create(kv_store, meta_key, ttl),
                 cache_writer,
             },

--- a/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache
+++ b/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache
@@ -1,43 +1,95 @@
 statement ok
-DROP DATABASE IF EXISTS db20;
+DROP DATABASE IF EXISTS db20_13;
 
 statement ok
-CREATE DATABASE db20;
+CREATE DATABASE db20_13;
 
 statement ok
-USE db20;
+USE db20_13;
 
 statement ok
-CREATE TABLE IF NOT EXISTS t13 (a INT);
+CREATE TABLE IF NOT EXISTS t1 (a INT);
 
 statement ok
-INSERT INTO t13 VALUES (1), (2), (3);
+INSERT INTO t1 VALUES (1), (2), (3);
 
 query I
-SELECT * FROM t13 ORDER BY a;
+SELECT * FROM t1 ORDER BY a;
 ----
 1
 2
 3
+
+statement ok
+CREATE TABLE IF NOT EXISTS t2 (b VARCHAR);
+
+statement ok
+INSERT INTO t2 VALUES ('a'), ('b'), ('c');
+
+query I
+SELECT * FROM t2 ORDER BY b;
+----
+a
+b
+c
 
 statement ok
 SET enable_query_result_cache = 1;
 
+# Write cache
+
 query I
-SELECT * FROM t13 ORDER BY a;
+SELECT * FROM t1 ORDER BY a;
 ----
 1
 2
 3
 
+query IT
+SELECT * FROM t1, t2 ORDER BY a, b;
+----
+1 a
+1 b
+1 c
+2 a
+2 b
+2 c
+3 a
+3 b
+3 c
+
+# Read cache
+
+query I
+SELECT * FROM t1 ORDER BY a;
+----
+1
+2
+3
+
+query IT
+SELECT * FROM t1, t2 ORDER BY a, b;
+----
+1 a
+1 b
+1 c
+2 a
+2 b
+2 c
+3 a
+3 b
+3 c
+
+# Insert new data
+
 statement ok
-INSERT INTO t13 VALUES (4), (5), (6);
+INSERT INTO t1 VALUES (4), (5), (6);
 
 statement ok
 SET enable_query_result_cache = 0;
 
 query I
-SELECT * FROM t13 ORDER BY a;
+SELECT * FROM t1 ORDER BY a;
 ----
 1
 2
@@ -45,6 +97,30 @@ SELECT * FROM t13 ORDER BY a;
 4
 5
 6
+
+query IT
+SELECT * FROM t1, t2 ORDER BY a, b;
+----
+1 a
+1 b
+1 c
+2 a
+2 b
+2 c
+3 a
+3 b
+3 c
+4 a
+4 b
+4 c
+5 a
+5 b
+5 c
+6 a
+6 b
+6 c
+
+# tolerate inconsistent result cache
 
 statement ok
 SET enable_query_result_cache = 1;
@@ -53,17 +129,30 @@ statement ok
 SET tolerate_inconsistent_result_cache = 1;
 
 query I
-SELECT * FROM t13 ORDER BY a;
+SELECT * FROM t1 ORDER BY a;
 ----
 1
 2
 3
 
+query IT
+SELECT * FROM t1, t2 ORDER BY a, b;
+----
+1 a
+1 b
+1 c
+2 a
+2 b
+2 c
+3 a
+3 b
+3 c
+
 statement ok
 SET tolerate_inconsistent_result_cache = 0;
 
 query I
-SELECT * FROM t13 ORDER BY a;
+SELECT * FROM t1 ORDER BY a;
 ----
 1
 2
@@ -72,8 +161,33 @@ SELECT * FROM t13 ORDER BY a;
 5
 6
 
-statement ok
-DROP TABLE t13;
+query IT
+SELECT * FROM t1, t2 ORDER BY a, b;
+----
+1 a
+1 b
+1 c
+2 a
+2 b
+2 c
+3 a
+3 b
+3 c
+4 a
+4 b
+4 c
+5 a
+5 b
+5 c
+6 a
+6 b
+6 c
 
 statement ok
-DROP DATABASE db20;
+DROP TABLE t1;
+
+statement ok
+DROP TABLE t2;
+
+statement ok
+DROP DATABASE db20_13;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Store the SHA-256 values of partitions of each `TableScan` of the query in the query context.

Use these SHA-256 values to check if the query result cache is valid.

Tracking in #10010 .