### PR TITLE
chore(query): use formatted AST to generate the result cache key.

### DIFF
--- a/src/query/service/src/interpreters/interpreter_copy_v2.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_v2.rs
@@ -68,13 +68,14 @@ impl CopyInterpreterV2 {
         path: &str,
         query: &Plan,
     ) -> Result<PipelineBuildResult> {
-        let (s_expr, metadata, bind_context) = match query {
+        let (s_expr, metadata, bind_context, formatted_ast) = match query {
             Plan::Query {
                 s_expr,
                 metadata,
                 bind_context,
+                formatted_ast,
                 ..
-            } => (s_expr, metadata, bind_context),
+            } => (s_expr, metadata, bind_context, formatted_ast),
             v => unreachable!("Input plan must be Query, but it's {}", v),
         };
 
@@ -83,6 +84,7 @@ impl CopyInterpreterV2 {
             *(bind_context.clone()),
             *s_expr.clone(),
             metadata.clone(),
+            formatted_ast.clone(),
             false,
         )?;
 

--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -78,12 +78,14 @@ impl InterpreterFactory {
                 bind_context,
                 metadata,
                 ignore_result,
+                formatted_ast,
                 ..
             } => Ok(Arc::new(SelectInterpreterV2::try_create(
                 ctx,
                 *bind_context.clone(),
                 *s_expr.clone(),
                 metadata.clone(),
+                formatted_ast.clone(),
                 *ignore_result,
             )?)),
             Plan::Explain { kind, plan } => Ok(Arc::new(ExplainInterpreter::try_create(

--- a/src/query/service/src/procedures/systems/search_tables.rs
+++ b/src/query/service/src/procedures/systems/search_tables.rs
@@ -70,6 +70,7 @@ impl OneBlockProcedure for SearchTablesProcedure {
                 *bind_context,
                 *s_expr,
                 metadata,
+                None,
                 false,
             )?;
             interpreter.execute(ctx.clone()).await

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -283,8 +283,10 @@ impl TableContext for QueryContext {
     }
 
     fn get_partitions_shas(&self) -> Vec<String> {
-        let sha = self.shared.partitions_shas.read();
-        sha.clone()
+        let mut sha = self.shared.partitions_shas.read().clone();
+        // Sort to make sure the SHAs are stable for the same query.
+        sha.sort();
+        sha
     }
 
     fn attach_query_str(&self, kind: String, query: &str) {

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_ast::ast::format_statement;
 use common_ast::ast::ExplainKind;
 use common_ast::ast::Statement;
 use common_ast::parser::parse_sql;
@@ -92,12 +93,18 @@ impl<'a> Binder {
         let plan = match stmt {
             Statement::Query(query) => {
                 let (s_expr, bind_context) = self.bind_query(bind_context, query).await?;
+                let formatted_ast = if self.ctx.get_settings().get_enable_query_result_cache()? {
+                    Some(format_statement(stmt.clone())?)
+                } else {
+                    None
+                };
                 Plan::Query {
                     s_expr: Box::new(s_expr),
                     metadata: self.metadata.clone(),
                     bind_context: Box::new(bind_context),
                     rewrite_kind: None,
                     ignore_result: query.ignore_result,
+                    formatted_ast,
                 }
             }
 

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -63,6 +63,7 @@ pub fn optimize(
             bind_context,
             metadata,
             rewrite_kind,
+            formatted_ast,
             ignore_result,
         } => Ok(Plan::Query {
             s_expr: Box::new(optimize_query(
@@ -75,6 +76,7 @@ pub fn optimize(
             bind_context,
             metadata,
             rewrite_kind,
+            formatted_ast,
             ignore_result,
         }),
         Plan::Explain { kind, plan } => match kind {

--- a/src/query/sql/src/planner/plans/plan.rs
+++ b/src/query/sql/src/planner/plans/plan.rs
@@ -102,6 +102,8 @@ pub enum Plan {
         metadata: MetadataRef,
         bind_context: Box<BindContext>,
         rewrite_kind: Option<RewriteKind>,
+        // Use for generate query result cache key.
+        formatted_ast: Option<String>,
         ignore_result: bool,
     },
 

--- a/src/query/storages/result_cache/src/common.rs
+++ b/src/query/storages/result_cache/src/common.rs
@@ -23,7 +23,7 @@ use sha2::Sha256;
 const RESULT_CACHE_PREFIX: &str = "_result_cache";
 
 #[inline(always)]
-pub(crate) fn gen_common_key(raw: &str) -> String {
+pub fn gen_result_cache_key(raw: &str) -> String {
     format!("{:x}", Sha256::digest(raw))
 }
 

--- a/src/query/storages/result_cache/src/lib.rs
+++ b/src/query/storages/result_cache/src/lib.rs
@@ -19,5 +19,6 @@ mod meta_manager;
 mod read;
 mod write;
 
+pub use common::gen_result_cache_key;
 pub use read::ResultCacheReader;
 pub use write::WriteResultCacheSink;

--- a/src/query/storages/result_cache/src/read/reader.rs
+++ b/src/query/storages/result_cache/src/read/reader.rs
@@ -21,7 +21,6 @@ use common_meta_store::MetaStore;
 use common_storage::DataOperator;
 use opendal::Operator;
 
-use crate::common::gen_common_key;
 use crate::common::gen_result_cache_meta_key;
 use crate::common::read_blocks_from_buffer;
 use crate::meta_manager::ResultCacheMetaManager;
@@ -41,13 +40,12 @@ pub struct ResultCacheReader {
 impl ResultCacheReader {
     pub fn create(
         ctx: Arc<dyn TableContext>,
+        key: &str,
         kv_store: Arc<MetaStore>,
         tolerate_inconsistent: bool,
     ) -> Self {
-        let sql = ctx.get_query_str();
         let tenant = ctx.get_tenant();
-        let key = gen_common_key(&sql);
-        let meta_key = gen_result_cache_meta_key(&tenant, &key);
+        let meta_key = gen_result_cache_meta_key(&tenant, key);
         let partitions_shas = ctx.get_partitions_shas();
 
         Self {

--- a/src/query/storages/result_cache/src/write/sink.rs
+++ b/src/query/storages/result_cache/src/write/sink.rs
@@ -27,7 +27,6 @@ use common_pipeline_sinks::AsyncMpscSinker;
 use common_storage::DataOperator;
 
 use super::writer::ResultCacheWriter;
-use crate::common::gen_common_key;
 use crate::common::gen_result_cache_dir;
 use crate::common::gen_result_cache_meta_key;
 use crate::common::ResultCacheValue;
@@ -86,6 +85,7 @@ impl AsyncMpscSink for WriteResultCacheSink {
 impl WriteResultCacheSink {
     pub fn try_create(
         ctx: Arc<dyn TableContext>,
+        key: &str,
         inputs: Vec<Arc<InputPort>>,
         kv_store: Arc<MetaStore>,
     ) -> Result<ProcessorPtr> {
@@ -96,9 +96,8 @@ impl WriteResultCacheSink {
         let sql = ctx.get_query_str();
         let partitions_shas = ctx.get_partitions_shas();
 
-        let key = gen_common_key(&sql);
-        let meta_key = gen_result_cache_meta_key(&tenant, &key);
-        let location = gen_result_cache_dir(&key);
+        let meta_key = gen_result_cache_meta_key(&tenant, key);
+        let location = gen_result_cache_dir(key);
 
         let operator = DataOperator::instance().operator();
         let cache_writer = ResultCacheWriter::create(location, operator, max_bytes);

--- a/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache
+++ b/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache
@@ -135,6 +135,16 @@ SELECT * FROM t1 ORDER BY a;
 2
 3
 
+# The cache can also be used even if the case of the SQL statement is different.
+# Because the cache key is generated from AST.
+
+query I
+select * FRoM t1 OrDER bY a; 
+----
+1
+2
+3
+
 query IT
 SELECT * FROM t1, t2 ORDER BY a, b;
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Use formatted AST to generate the result cache key. This make SQLs with different cases can use the same cache.

For example:

```sql
select * from t;
SELECT * FROM t;
```

These two SQLs can use the same cache.

Tacking in #10010
