### PR TITLE
ci: Fix typos-cli is not installed correctly

### DIFF
--- a/scripts/setup/rust-tools.txt
+++ b/scripts/setup/rust-tools.txt
@@ -1,4 +1,4 @@
-cargo-audit@0.17.3
-cargo-machete@0.4.0
+cargo-audit@0.17.4
+cargo-machete@0.5.0
 taplo-cli@0.8.0
-typos-cli@0.10.8
+typos-cli@1.13.10


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Fix typos-cli is not installed correctly
