### PR TITLE
fix: fix parse timestamp for row based format

### DIFF
--- a/src/common/io/src/cursor_ext/cursor_read_number_ext.rs
+++ b/src/common/io/src/cursor_ext/cursor_read_number_ext.rs
@@ -22,7 +22,6 @@ use lexical_core::FromLexical;
 pub trait ReadNumberExt {
     fn read_int_text<T: FromLexical>(&mut self) -> Result<T>;
     fn read_float_text<T: FromLexical>(&mut self) -> Result<T>;
-
     fn read_num_text_exact<T: FromLexical>(&mut self) -> Result<T>;
 }
 

--- a/src/query/formats/src/field_decoder/row_based.rs
+++ b/src/query/formats/src/field_decoder/row_based.rs
@@ -244,8 +244,7 @@ pub trait FieldDecoderRowBased: FieldDecoder {
                     );
                     return Err(ErrorCode::BadBytes(msg));
                 }
-                let micros = t.timestamp_micros();
-                micros
+                t.timestamp_micros()
             }
             Err(_) => {
                 buffer_readr

--- a/tests/sqllogictests/suites/base/issues/issue_10103.test
+++ b/tests/sqllogictests/suites/base/issues/issue_10103.test
@@ -1,0 +1,43 @@
+statement ok
+DROP DATABASE IF EXISTS db1
+
+statement ok
+CREATE DATABASE db1
+
+statement ok
+USE db1
+
+statement ok
+CREATE TABLE test_table(id BIGINT, name VARCHAR, age INT)
+
+statement ok
+CREATE TABLE test_ts_table(ts TIMESTAMP, name VARCHAR, age INT)
+
+statement ok
+insert into test_table (id,name,age) values (1676805481000000,'2',3), (1676805481000000, '5', 6)
+
+statement ok
+CREATE STAGE IF NOT EXISTS test
+
+statement ok
+copy into @test from test_table FILE_FORMAT = (type = CSV)
+
+statement ok
+copy into test_ts_table from @test FILE_FORMAT = (type = CSV)
+
+query A
+SELECT ts FROM test_ts_table LIMIT 1
+----
+2023-02-19 11:18:01.000000
+
+statement ok
+drop table test_table all
+
+statement ok
+drop table test_ts_table all
+
+statement ok
+drop stage test
+
+statement ok
+DROP DATABASE db1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix timestamp parsing for row-based formats.

Closes #10103 
