### PR TITLE
chore: fix select from `system.columns` if there is a view from stage.

### DIFF
--- a/src/query/ast/src/ast/query.rs
+++ b/src/query/ast/src/ast/query.rs
@@ -371,7 +371,7 @@ impl Display for TableReference {
                 options,
                 alias,
             } => {
-                write!(f, "({location})")?;
+                write!(f, "{location}")?;
                 if let Some(files) = &options.files {
                     let files = files.join(",");
                     write!(f, " FILES {files}")?;

--- a/src/query/service/src/interpreters/interpreter_view_create.rs
+++ b/src/query/service/src/interpreters/interpreter_view_create.rs
@@ -22,6 +22,7 @@ use common_meta_app::schema::TableMeta;
 use common_meta_app::schema::TableNameIdent;
 use common_sql::plans::CreateViewPlan;
 use common_sql::Planner;
+use common_storages_view::view_table::QUERY;
 use common_storages_view::view_table::VIEW_ENGINE;
 
 use crate::interpreters::Interpreter;
@@ -90,7 +91,7 @@ impl CreateViewInterpreter {
                 self.plan.column_names.join(", ")
             )
         };
-        options.insert("query".to_string(), subquery);
+        options.insert(QUERY.to_string(), subquery);
 
         let plan = CreateTableReq {
             if_not_exists: self.plan.if_not_exists,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

In the past:

```sql
create view v as select * from @stage;
```

the inner SQL will be stored as 

```
select * from (@stage/);
```

This will let selecting from `system.columns` failed because the SQL text cannot be parsed by the planner.

In this PR, the SQL text stored will be changed to:

```
select * from @stage/;
```
