### PR TITLE
refactor(meta): upgrade openraft to 0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5550,8 +5550,8 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.7.3"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.7.4-alpha.3#c6fe29d4a53b47f6c43d83a24e1610788a4c0166"
+version = "0.7.4"
+source = "git+https://github.com/datafuselabs/openraft?tag=v0.7.4#959636885e2069c685b1bdb9ebc5a875565f4a8a"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ members = [
 
 [workspace.dependencies]
 # databend maintains:
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.7.4-alpha.3" }
+openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.7.4" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 opendal = { version = "0.28.0" }
 ordered-float = { version = "3.4.0", default-features = false }

--- a/src/meta/raft-store/src/applied_state.rs
+++ b/src/meta/raft-store/src/applied_state.rs
@@ -19,7 +19,6 @@ use common_meta_types::protobuf::RaftReply;
 use common_meta_types::Change;
 use common_meta_types::Node;
 use common_meta_types::TxnReply;
-use openraft::AppDataResponse;
 
 /// The state of an applied raft log.
 /// Normally it includes two fields: the state before applying and the state after applying the log.
@@ -46,8 +45,6 @@ pub enum AppliedState {
     #[try_into(ignore)]
     None,
 }
-
-impl AppDataResponse for AppliedState {}
 
 impl fmt::Display for AppliedState {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/src/meta/types/src/log_entry.rs
+++ b/src/meta/types/src/log_entry.rs
@@ -15,7 +15,6 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
 
-use openraft::AppData;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -43,8 +42,6 @@ pub struct LogEntry {
     /// The action a client want to take.
     pub cmd: Cmd,
 }
-
-impl AppData for LogEntry {}
 
 impl Display for LogEntry {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta): upgrade openraft to 0.7.4

openraft released 0.7.4; Nothing really changed since 0.7.4-alpha.3

## Changelog







## Related Issues