### PR TITLE
docs: lift the decimal type under the number type

### DIFF
--- a/docs/doc/13-sql-reference/10-data-types/10-data-type-numeric-types.md
+++ b/docs/doc/13-sql-reference/10-data-types/10-data-type-numeric-types.md
@@ -7,12 +7,12 @@ description: Basic Numeric data type.
 
 Basic Integer Numbers data types.
 
-| Name      |  Aliases     | Storage Size | Min Value                   | Max Value                       | Description
-|-----------|--------------| -------------| --------------------------- | ------------------------------- | -------
-| TINYINT   |  INT8        | 1 byte       |  -128                       |  127                            |
-| SMALLINT  |  INT16       | 2 bytes      |  -32768                     |  32767                          |
-| INT       |  INT32       | 4 bytes      |  -2147483648                |  2147483647                     |
-| BIGINT    |  INT64       | 8 bytes      |  -9223372036854775808       |  9223372036854775807            |
+| Name     | Aliases | Storage Size | Min Value            | Max Value           | Description |
+|----------|---------|--------------|----------------------|---------------------|-------------|
+| TINYINT  | INT8    | 1 byte       | -128                 | 127                 |             |
+| SMALLINT | INT16   | 2 bytes      | -32768               | 32767               |             |
+| INT      | INT32   | 4 bytes      | -2147483648          | 2147483647          |             |
+| BIGINT   | INT64   | 8 bytes      | -9223372036854775808 | 9223372036854775807 |             |
 
 :::tip
 If you want unsigned integer, please use `UNSIGNED` constraint, this is compatible with MySQL, for example:
@@ -26,10 +26,10 @@ CREATE TABLE test_numeric(tiny TINYINT, tiny_unsigned TINYINT UNSIGNED)
 
 Basic Float32/Float64 data types.
 
-| Name      |  Aliases     | Storage Size | Min Value                   | Max Value                       | Description
-|-----------|--------------| -------------| --------------------------- | ------------------------------- | -------
-| FLOAT     |              | 4 bytes      |  -3.40282347e+38            | 3.40282347e+38                  |
-| DOUBLE    |              | 8 bytes      |  -1.7976931348623157E+308   | 1.7976931348623157E+308         |
+| Name   | Aliases | Storage Size | Min Value                | Max Value               | Description |
+|--------|---------|--------------|--------------------------|-------------------------|-------------|
+| FLOAT  |         | 4 bytes      | -3.40282347e+38          | 3.40282347e+38          |             |
+| DOUBLE |         | 8 bytes      | -1.7976931348623157E+308 | 1.7976931348623157E+308 |             |
 
 ## Functions
 

--- a/docs/doc/13-sql-reference/10-data-types/11-data-type-decimal-types.md
+++ b/docs/doc/13-sql-reference/10-data-types/11-data-type-decimal-types.md
@@ -14,11 +14,29 @@ We can use `DECIMAL(P, S)` to indicate decimal types.
 
 If `P` is less than 38, the physical datatype of decimal is `Decimal128`, otherwise it's `Decimal256`.
 
+For a DECIMAL(P, S) data type:
+* The minimum value is `-10^P + 1` divided by `10^S`.
+* The maximum value is `10^P - 1` divided by `10^S`.
+ 
+If you have a `DECIMAL(10, 2)` , you can store values with up to `10 digits`, with `2 digits` to the right of the decimal point. The minimum value is `-9999999.99`, and the maximum value is `9999999.99`.
+
 ## Example
 
 ```sql
 
-select 3::Decimal(19, 1); -- 3.0
+-- Create a table with decimal data type.
+create table decimal(value decimal(36, 18));
+
+-- Insert two values.
+insert into decimal values(0.152587668674722117), (0.017820781941443176);
+
+select * from decimal;
++----------------------+
+| value                |
++----------------------+
+| 0.152587668674722117 |
+| 0.017820781941443176 |
++----------------------+
 ```
 
 ## Precision Inference

--- a/docs/doc/13-sql-reference/10-data-types/index.md
+++ b/docs/doc/13-sql-reference/10-data-types/index.md
@@ -7,36 +7,37 @@ slug: ./
 Databend supports SQL data types in several categories:
 * [Boolean Data Types](00-data-type-logical-types.md)
 * [Numeric Data Types](10-data-type-numeric-types.md)
+* [Decimal Data Types](11-data-type-decimal-types.md)
 * [Date & Time Data Types](20-data-type-time-date-types.md)
 * [String Data Types](30-data-type-string-types.md)
-* [Decimal Data Types](43-data-type-decimal-types.md)
 * [Array(T) Data Types](40-data-type-array-types.md)
 * [Tuple Data Types](41-data-type-tuple-types.md)
 * [Semi-structured Data Types](42-data-type-semi-structured-types.md)
 
 ## General-Purpose Data Types
 
-| Name      |  Aliases     | Storage Size | Min Value                   | Max Value                      | Description 
-|-----------|--------------| -------------| --------------------------- | -------------------------------| -------
-| BOOLEAN   |  BOOL        | 1 byte       |                             |                                | Logical boolean (true/false)
-| TINYINT   |  INT8        | 1 byte       |  -128                       |  127                           | 
-| SMALLINT  |  INT16       | 2 bytes      |  -32768                     |  32767                         |
-| INT       |  INT32       | 4 bytes      |  -2147483648                |  2147483647                    |
-| BIGINT    |  INT64       | 8 bytes      |  -9223372036854775808       |  9223372036854775807           |
-| FLOAT     |              | 4 bytes      |  -3.40282347e+38            | 3.40282347e+38                 |
-| DOUBLE    |              | 8 bytes      |  -1.7976931348623157E+308   | 1.7976931348623157E+308        |
-| DATE      |              | 4 bytes      |  1000-01-01                 | 9999-12-31                     | YYYY-MM-DD             
-| TIMESTAMP |              | 8 bytes      |  0001-01-01 00:00:00        | 9999-12-31 23:59:59.999999 UTC | YYYY-MM-DD hh:mm:ss[.fraction], up to microseconds (6 digits) precision
-| VARCHAR   |  STRING      | variable     |                             |                                |
 
+| Name      | Aliases | Storage Size | Min Value                | Max Value                      | Description                                                             |
+|-----------|---------|--------------|--------------------------|--------------------------------|-------------------------------------------------------------------------|
+| BOOLEAN   | BOOL    | 1 byte       |                          |                                | Logical boolean (true/false)                                            |
+| TINYINT   | INT8    | 1 byte       | -128                     | 127                            |                                                                         |
+| SMALLINT  | INT16   | 2 bytes      | -32768                   | 32767                          |                                                                         |
+| INT       | INT32   | 4 bytes      | -2147483648              | 2147483647                     |                                                                         |
+| BIGINT    | INT64   | 8 bytes      | -9223372036854775808     | 9223372036854775807            |                                                                         |
+| FLOAT     |         | 4 bytes      | -3.40282347e+38          | 3.40282347e+38                 |                                                                         |
+| DOUBLE    |         | 8 bytes      | -1.7976931348623157E+308 | 1.7976931348623157E+308        |                                                                         |
+| DECIMAL   |         | 16 bytes     |                          |                                |                                                                         |
+| DATE      |         | 4 bytes      | 1000-01-01               | 9999-12-31                     | YYYY-MM-DD                                                              |
+| TIMESTAMP |         | 8 bytes      | 0001-01-01 00:00:00      | 9999-12-31 23:59:59.999999 UTC | YYYY-MM-DD hh:mm:ss[.fraction], up to microseconds (6 digits) precision |
+| VARCHAR   | STRING  | variable     |                          |                                |                                                                         |
 
 ## Semi-structured Data Types
 
 Databend supports three Semi-structured types: ARRAY, OBJECT and VARIANT.
 
-| Name    |    Aliases   | Build From Values       | Description
-|---------|--------------|-------------------------|----------------
-| ARRAY   |              | [1,2,3]                 | Zero-based indexed list, each value can have difference data type.
-| TUPLE   |              | ('2023-02-14 08:00:00','Valentine's Day') | Collection of ordered,immmutable, which requires the type of each element to be declared before being used.
-| VARIANT |  JSON        | [1,{"a":1,"b":{"c":2}}] | Collection of elements of different data types., including ARRAY and OBJECT.
+| Name    | Aliases | Build From Values                         | Description                                                                                                 |
+|---------|---------|-------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| ARRAY   |         | [1,2,3]                                   | Zero-based indexed list, each value can have difference data type.                                          |
+| TUPLE   |         | ('2023-02-14 08:00:00','Valentine's Day') | Collection of ordered,immmutable, which requires the type of each element to be declared before being used. |
+| VARIANT | JSON    | [1,{"a":1,"b":{"c":2}}]                   | Collection of elements of different data types., including ARRAY and OBJECT.                                |
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Add more examples for decimal data type, including min and max
* Lift the decimal order

Closes #issue
