### PR TITLE
fix(query): fix query result cache system table

### DIFF
--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -338,6 +338,9 @@ impl QueryContextShared {
 
 impl Drop for QueryContextShared {
     fn drop(&mut self) {
+        // last_query_id() should return the query_id of the last executed statement,
+        // so we set it when the current context drops
+        // to avoid returning the query_id of the current statement.
         self.session
             .session_ctx
             .update_query_ids_results(self.init_query_id.read().clone(), None)

--- a/tests/sqllogictests/suites/base/01_system/01_0011_system_query_cache
+++ b/tests/sqllogictests/suites/base/01_system/01_0011_system_query_cache
@@ -24,8 +24,17 @@ SELECT num_rows FROM system.query_cache;
 ----
 3
 
+# tables under system db should not be cached
+query I
+SELECT num_rows FROM system.query_cache;
+----
+3
+
 statement ok
 SET enable_query_result_cache = 0;
+
+statement ok
+truncate table system.query_cache;
 
 statement ok
 DROP TABLE t1;

--- a/tests/sqllogictests/suites/base/01_system/01_0011_system_query_cache
+++ b/tests/sqllogictests/suites/base/01_system/01_0011_system_query_cache
@@ -24,11 +24,23 @@ SELECT num_rows FROM system.query_cache;
 ----
 3
 
+statement ok
+INSERT INTO t1 VALUES (4);
+
+statement ok
+SELECT * FROM t1;
+
 # tables under system db should not be cached
+statement ok
+SET query_result_cache_allow_inconsistent = 1;
+
 query I
 SELECT num_rows FROM system.query_cache;
 ----
-3
+4
+
+statement ok
+SET query_result_cache_allow_inconsistent = 0;
 
 statement ok
 SET enable_query_result_cache = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

system tables usually contain statistical information and should not be cached.

Closes #issue
