### PR TITLE
fix: UnaryOp +/- should have high Precedence in PrattParser.

### DIFF
--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -326,8 +326,8 @@ impl<'a, I: Iterator<Item = WithSpan<'a, ExprElement>>> PrattParser<I> for ExprP
             ExprElement::UnaryOp { op } => match op {
                 UnaryOperator::Not => Affix::Prefix(Precedence(NOT_PREC)),
 
-                UnaryOperator::Plus => Affix::Prefix(Precedence(30)),
-                UnaryOperator::Minus => Affix::Prefix(Precedence(30)),
+                UnaryOperator::Plus => Affix::Prefix(Precedence(50)),
+                UnaryOperator::Minus => Affix::Prefix(Precedence(50)),
             },
             ExprElement::BinaryOp { op } => match op {
                 BinaryOperator::Or => Affix::Infix(Precedence(5), Associativity::Left),
@@ -362,7 +362,7 @@ impl<'a, I: Iterator<Item = WithSpan<'a, ExprElement>>> PrattParser<I> for ExprP
                 BinaryOperator::Modulo => Affix::Infix(Precedence(40), Associativity::Left),
                 BinaryOperator::StringConcat => Affix::Infix(Precedence(40), Associativity::Left),
             },
-            ExprElement::PgCast { .. } => Affix::Postfix(Precedence(50)),
+            ExprElement::PgCast { .. } => Affix::Postfix(Precedence(60)),
             _ => Affix::Nilfix,
         };
         Ok(affix)

--- a/src/query/ast/tests/it/testdata/expr.txt
+++ b/src/query/ast/tests/it/testdata/expr.txt
@@ -730,39 +730,39 @@ FunctionCall {
 ---------- Input ----------
 - - + + - 1 + + - 2
 ---------- Output ---------
-(- (- (+ (+ (- (1 + (+ (- 2))))))))
+((- (- (+ (+ (- 1))))) + (+ (- 2)))
 ---------- AST ------------
-UnaryOp {
+BinaryOp {
     span: Some(
-        0..1,
+        12..13,
     ),
-    op: Minus,
-    expr: UnaryOp {
+    op: Plus,
+    left: UnaryOp {
         span: Some(
-            2..3,
+            0..1,
         ),
         op: Minus,
         expr: UnaryOp {
             span: Some(
-                4..5,
+                2..3,
             ),
-            op: Plus,
+            op: Minus,
             expr: UnaryOp {
                 span: Some(
-                    6..7,
+                    4..5,
                 ),
                 op: Plus,
                 expr: UnaryOp {
                     span: Some(
-                        8..9,
+                        6..7,
                     ),
-                    op: Minus,
-                    expr: BinaryOp {
+                    op: Plus,
+                    expr: UnaryOp {
                         span: Some(
-                            12..13,
+                            8..9,
                         ),
-                        op: Plus,
-                        left: Literal {
+                        op: Minus,
+                        expr: Literal {
                             span: Some(
                                 10..11,
                             ),
@@ -770,28 +770,28 @@ UnaryOp {
                                 1,
                             ),
                         },
-                        right: UnaryOp {
-                            span: Some(
-                                14..15,
-                            ),
-                            op: Plus,
-                            expr: UnaryOp {
-                                span: Some(
-                                    16..17,
-                                ),
-                                op: Minus,
-                                expr: Literal {
-                                    span: Some(
-                                        18..19,
-                                    ),
-                                    lit: Integer(
-                                        2,
-                                    ),
-                                },
-                            },
-                        },
                     },
                 },
+            },
+        },
+    },
+    right: UnaryOp {
+        span: Some(
+            14..15,
+        ),
+        op: Plus,
+        expr: UnaryOp {
+            span: Some(
+                16..17,
+            ),
+            op: Minus,
+            expr: Literal {
+                span: Some(
+                    18..19,
+                ),
+                lit: Integer(
+                    2,
+                ),
             },
         },
     },


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

before this pr, we got  `-1 + - 1 = -(1 + (- 1) )= 0`

Summary about this PR

see https://github.com/segeljakt/pratt/blob/master/examples/lalrpop-pratt/src/main.rs#L58

Closes #issue
