### PR TITLE
fix: result_scan not set query_id when meta_key is none

### DIFF
--- a/src/query/service/src/interpreters/interpreter_select.rs
+++ b/src/query/service/src/interpreters/interpreter_select.rs
@@ -221,8 +221,10 @@ impl Interpreter for SelectInterpreter {
             if let Some(t) = self.result_scan_table()? {
                 let arg_query_id = parse_result_scan_args(&t.table_args().unwrap())?;
                 let meta_key = self.ctx.get_result_cache_key(&arg_query_id);
-                self.ctx
-                    .set_query_id_result_cache(self.ctx.get_id(), meta_key.unwrap());
+                if let Some(meta_key) = meta_key {
+                    self.ctx
+                        .set_query_id_result_cache(self.ctx.get_id(), meta_key);
+                }
                 return Ok(build_res);
             }
 

--- a/tests/sqllogictests/suites/query/select.test
+++ b/tests/sqllogictests/suites/query/select.test
@@ -30,7 +30,7 @@ select t1.a from db.t as t1
 2
 
 onlyif http
-statement error column doesn't exist
+statement error column a doesn't exist
 select db.t1.a from db.t as t1
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

meta_key may not always have a value

Closes #issue
