### PR TITLE
docs: fix installing docs typo

### DIFF
--- a/docs/doc/10-deploy/01-installing-databend.md
+++ b/docs/doc/10-deploy/01-installing-databend.md
@@ -7,7 +7,7 @@ description:
 
 Databend offers you these options for downloading the installation packages:
 
-- [Manual download](#manual-download): You can download the installation package for your platfom directly from the Databend website.
+- [Manual download](#manual-download): You can download the installation package for your platform directly from the Databend website.
 - [APT Package Manager](#apt-package-manager): You can use the APT package manager to download and install Databend on Ubuntu or Debian.
 - [Docker](#docker): You can use Docker to download and run Databend in a containerized environment.
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix installing docs typo

Closes #issue
