### PR TITLE
feat(query): support multiple unnest columns.

### DIFF
--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -1362,6 +1362,20 @@ impl Column {
         }
     }
 
+    pub fn wrap_nullable(self) -> Self {
+        match self {
+            col @ Column::Nullable(_) => col,
+            col => {
+                let mut validity = MutableBitmap::with_capacity(col.len());
+                validity.extend_constant(col.len(), true);
+                Column::Nullable(Box::new(NullableColumn {
+                    column: col,
+                    validity: validity.into(),
+                }))
+            }
+        }
+    }
+
     pub fn memory_size(&self) -> usize {
         match self {
             Column::Null { .. } => std::mem::size_of::<usize>(),

--- a/src/query/sql/src/evaluator/block_operator.rs
+++ b/src/query/sql/src/evaluator/block_operator.rs
@@ -157,9 +157,13 @@ impl BlockOperator {
         }
 
         let (unnest_columns, unnest_offsets) = if unnest_columns.len() == 1 {
+            // Short path: only one unnest column.
             let (index, col) = unnest_columns.into_iter().next().unwrap();
-            let unnest_columns = HashMap::from([(index, col.values)]);
+            let range =
+                *col.offsets.first().unwrap() as usize..*col.offsets.last().unwrap() as usize;
             let offsets = col.offsets.to_vec();
+            let new_col = col.values.slice(range).wrap_nullable();
+            let unnest_columns = HashMap::from([(index, new_col)]);
             (unnest_columns, offsets)
         } else {
             Self::unify_unnest_columns(unnest_columns)

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -154,7 +154,7 @@ impl Unnest {
         for offset in &self.offsets {
             let f = &mut fields[*offset];
             let inner_type = f.data_type().as_array().unwrap();
-            *f = DataField::new(f.name(), *inner_type.clone());
+            *f = DataField::new(f.name(), inner_type.wrap_nullable());
         }
         Ok(DataSchemaRefExt::create(fields))
     }

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1713,7 +1713,7 @@ impl<'a> TypeChecker<'a> {
                 let box (inner_expr, inner_type) = inner_res.unwrap();
                 Some(match inner_type {
                     DataType::Array(inner) => {
-                        let return_type = inner.clone();
+                        let return_type = Box::new(inner.wrap_nullable());
                         Ok(Box::new((
                             ScalarExpr::Unnest(Unnest {
                                 return_type,

--- a/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
+++ b/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
@@ -59,6 +59,40 @@ select unnest(a), a from t;
 4 [3,4,5]
 5 [3,4,5]
 
+query II
+select unnest([1,2,3]), unnest([3,4,5]);
+----
+1 3
+2 4
+3 5
+
+query IT
+select unnest([1,2,3]), unnest([3]);
+----
+1 3
+2 NULL
+3 NULL
+
+query IIT
+select unnest([1,2,3]), number, unnest([3]) from numbers(2);
+----
+1 0 3
+2 0 NULL
+3 0 NULL
+1 1 3
+2 1 NULL
+3 1 NULL
+
+query ITT
+select unnest(a), a, unnest([1,2,3]) from t;
+----
+1 [1,2] 1
+2 [1,2] 2
+NULL [1,2] 3
+3 [3,4,5] 1
+4 [3,4,5] 2
+5 [3,4,5] 3
+
 statement ok
 drop table t;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

If the original length of each column is different, the shorter ones will be padded with NULLs.

For example:

```
+---------+---------+
| origin1 | origin2 |
+---------+---------+
| [1,2]   | [1,2,3] |
| [3,4,5] | [4,5]   |
+---------+---------+
 ```

will be unnested to:

```
+---------+---------+
| unnest1 | unnest2 |
+------ --+---------+
| 1       | 1       |  -- From original row 1
| 2       | 2       |  -- From original row 1
| NULL    | 3       |  -- From original row 1
| 3       | 4       |  -- From original row 2
| 4       | 5       |  -- From original row 2
| 5       | NULL    |  -- From original row 2
+---------+---------+
```

Tracking in #10295
