### PR TITLE
chore(query): refine result_scan error messages

### DIFF
--- a/tests/sqllogictests/suites/base/20+_others/20_0014_result_scan
+++ b/tests/sqllogictests/suites/base/20+_others/20_0014_result_scan
@@ -13,8 +13,18 @@ CREATE TABLE IF NOT EXISTS t1 (a INT);
 statement ok
 INSERT INTO t1 VALUES (1), (2), (3);
 
+query I
+SELECT * FROM t1 ORDER BY a;
+----
+1
+2
+3
+
 statement ok
 SET enable_query_result_cache = 1;
+
+statement error `RESULT_SCAN` could not find related cache key in current session for this query id
+SELECT * FROM RESULT_SCAN(last_query_id()) ORDER BY a;
 
 query I
 SELECT * FROM t1 ORDER BY a;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refine result_scan error messages, before this patch, if we do:
```sql
SELECT * FROM t1 ORDER BY a;

SET enable_query_result_cache = 1;

SELECT * FROM RESULT_SCAN(last_query_id()) ORDER BY a;
```
will get "column a doesn't exist". 

After this patch, we got "`RESULT_SCAN` could not find related cache key in current session for this query id: xxx"

Closes #issue
