### PR TITLE
feat(query): support more advanced `unnest` operations.

### DIFF
--- a/src/query/expression/src/expression.rs
+++ b/src/query/expression/src/expression.rs
@@ -425,6 +425,75 @@ impl<Index: ColumnIndex> Expr<Index> {
     }
 }
 
+impl Expr<usize> {
+    pub fn project_column_ref_with_unnest_offset(
+        &self,
+        f: impl Fn(&usize) -> usize + Copy,
+        offset: &mut usize,
+    ) -> Expr<usize> {
+        match self {
+            Expr::Constant {
+                span,
+                scalar,
+                data_type,
+            } => Expr::Constant {
+                span: *span,
+                scalar: scalar.clone(),
+                data_type: data_type.clone(),
+            },
+            Expr::ColumnRef {
+                span,
+                id,
+                data_type,
+                display_name,
+            } => {
+                let id = if *id == usize::MAX {
+                    let id = *offset;
+                    *offset += 1;
+                    id
+                } else {
+                    f(id)
+                };
+                Expr::ColumnRef {
+                    span: *span,
+                    id,
+                    data_type: data_type.clone(),
+                    display_name: display_name.clone(),
+                }
+            }
+            Expr::Cast {
+                span,
+                is_try,
+                expr,
+                dest_type,
+            } => Expr::Cast {
+                span: *span,
+                is_try: *is_try,
+                expr: Box::new(expr.project_column_ref_with_unnest_offset(f, offset)),
+                dest_type: dest_type.clone(),
+            },
+            Expr::FunctionCall {
+                span,
+                id,
+                function,
+                generics,
+                args,
+                return_type,
+            } => Expr::FunctionCall {
+                span: *span,
+                id: id.clone(),
+                function: function.clone(),
+                generics: generics.clone(),
+                args: args
+                    .iter()
+                    .map(|expr| expr.project_column_ref_with_unnest_offset(f, offset))
+                    .collect(),
+                return_type: return_type.clone(),
+            },
+        }
+    }
+}
+
 impl<Index: ColumnIndex> RemoteExpr<Index> {
     pub fn as_expr(&self, fn_registry: &FunctionRegistry) -> Expr<Index> {
         match self {

--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -195,7 +195,9 @@ impl DataSchema {
 
     /// Find the index of the column with the given name.
     pub fn index_of(&self, name: &str) -> Result<FieldIndex> {
-        for i in 0..self.fields.len() {
+        for i in (0..self.fields.len()).rev() {
+            // Use `rev` is because unnest columns will be attached to end of schema,
+            // but their names are the same as the original column.
             if self.fields[i].name() == name {
                 return Ok(i);
             }

--- a/src/query/expression/src/types.rs
+++ b/src/query/expression/src/types.rs
@@ -120,6 +120,13 @@ impl DataType {
         }
     }
 
+    pub fn unnest(&self) -> Self {
+        match self {
+            DataType::Array(ty) => ty.unnest(),
+            _ => self.clone(),
+        }
+    }
+
     pub fn has_generic(&self) -> bool {
         match self {
             DataType::Generic(_) => true,

--- a/src/query/expression/src/types/array.rs
+++ b/src/query/expression/src/types/array.rs
@@ -221,6 +221,12 @@ impl<T: ValueType> ArrayColumn<T> {
     pub fn memory_size(&self) -> usize {
         T::column_memory_size(&self.values) + self.offsets.len() * 8
     }
+
+    pub fn underlying_column(&self) -> T::Column {
+        debug_assert!(!self.offsets.is_empty());
+        let range = *self.offsets.first().unwrap() as usize..*self.offsets.last().unwrap() as usize;
+        T::slice_column(&self.values, range)
+    }
 }
 
 impl ArrayColumn<AnyType> {

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -376,7 +376,7 @@ impl PipelineBuilder {
         self.build_pipeline(&unnest.input)?;
 
         let op = BlockOperator::Unnest {
-            fields: unnest.offsets.clone(),
+            num_columns: unnest.num_columns,
         };
 
         let func_ctx = self.ctx.get_function_context()?;

--- a/src/query/sql/src/evaluator/block_operator.rs
+++ b/src/query/sql/src/evaluator/block_operator.rs
@@ -165,7 +165,7 @@ impl BlockOperator {
         }
 
         let (unnest_columns, unnest_offsets) = Self::unify_unnest_columns(unnest_columns);
-        let num_rows = *unnest_offsets.last().unwrap() as usize;
+        let num_rows = *unnest_offsets.last().unwrap();
 
         // Convert unnest_offsets to take indices.
         let mut take_indices = Vec::with_capacity(num_rows);
@@ -240,10 +240,7 @@ impl BlockOperator {
             .into_iter()
             .map(|(i, col)| {
                 let typ = col.values.data_type().unnest();
-                let arrays = col
-                    .iter()
-                    .map(|arr| Self::unnest_column(arr))
-                    .collect::<Vec<_>>();
+                let arrays = col.iter().map(Self::unnest_column).collect::<Vec<_>>();
                 (i, typ, arrays)
             })
             .collect::<Vec<_>>();
@@ -281,11 +278,11 @@ impl BlockOperator {
                 let inner_col = unsafe { cols.get_unchecked(row) };
                 let inner_len = inner_col.len();
                 debug_assert!(inner_len <= len);
-                builder.builder.append_column(&inner_col);
+                builder.builder.append_column(inner_col);
                 builder.validity.extend_constant(inner_len, true);
                 // Avoid using `if branch`.
                 let d = typ.default_value();
-                let defaults = ColumnBuilder::repeat(&d.as_ref(), len - inner_len, &typ).build();
+                let defaults = ColumnBuilder::repeat(&d.as_ref(), len - inner_len, typ).build();
                 builder.builder.append_column(&defaults);
                 builder.validity.extend_constant(len - inner_len, false);
             }

--- a/src/query/sql/src/evaluator/block_operator.rs
+++ b/src/query/sql/src/evaluator/block_operator.rs
@@ -98,9 +98,9 @@ impl BlockOperator {
                 {
                     let array_col = match &col.value {
                         Value::Scalar(Scalar::Array(col)) => {
-                            Box::new(ArrayColumnBuilder::<AnyType>::repeat(col, num_rows).build())
+                            ArrayColumnBuilder::<AnyType>::repeat(col, num_rows).build()
                         }
-                        Value::Column(Column::Array(col)) => col.clone(),
+                        Value::Column(Column::Array(col)) => *col.clone(),
                         _ => {
                             return Err(ErrorCode::Internal(
                                 "Unnest can only be applied to array types.",
@@ -160,7 +160,7 @@ impl BlockOperator {
     /// The array scalar `[1,2,3]` will be replicated first (See the logic in `BlockOperator::execute`).
     fn fit_unnest(
         input: DataBlock,
-        unnest_columns: Vec<Box<ArrayColumn<AnyType>>>,
+        unnest_columns: Vec<ArrayColumn<AnyType>>,
     ) -> Result<DataBlock> {
         if unnest_columns.is_empty() {
             return Ok(input);
@@ -233,7 +233,7 @@ impl BlockOperator {
     /// +---------+---------+
     /// ```
     fn unify_unnest_columns(
-        unnest_columns: Vec<Box<ArrayColumn<AnyType>>>,
+        unnest_columns: Vec<ArrayColumn<AnyType>>,
     ) -> (Vec<Column>, Vec<usize>) {
         debug_assert!(!unnest_columns.is_empty());
         let num_rows = unnest_columns[0].len(); // Rows of the original `ArrayColumn`s.

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -154,7 +154,7 @@ impl Unnest {
         for offset in &self.offsets {
             let f = &mut fields[*offset];
             let inner_type = f.data_type().as_array().unwrap();
-            *f = DataField::new(f.name(), inner_type.wrap_nullable());
+            *f = DataField::new(f.name(), inner_type.unnest().wrap_nullable());
         }
         Ok(DataSchemaRefExt::create(fields))
     }

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -327,7 +327,7 @@ impl PhysicalPlanBuilder {
                         let mut before_scalars = vec![];
                         item.scalar
                             .collect_before_unnest_scalars(&mut before_scalars);
-                        let befores =
+                        let before =
                             before_scalars
                                 .iter()
                                 .map(|scalar| {
@@ -342,7 +342,7 @@ impl PhysicalPlanBuilder {
                                     Ok((expr.as_remote_expr(), item.index))
                                 })
                                 .collect::<Result<Vec<_>>>()?;
-                        before_exprs.extend(befores);
+                        before_exprs.extend(before);
 
                         // 1.2 Collect the after unnest scalars, and build into `RemoteExpr`.
                         let expr = item

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -303,56 +303,94 @@ impl PhysicalPlanBuilder {
             }
 
             RelOperator::EvalScalar(eval_scalar) => {
+                // If there is `unnest` in `eval_scalar`, we should split the physical plan into three parts:
+                // 3. Eval After Unnest Scalar
+                // |_______2. Unnest
+                //         |_______1. Eval Before Unnest Scalar
+                // The input fields and the output fields of each part will be like:
+                // 1. [i1, i2, .., in] -> [i1, i2, .. in, b1, b2, .., bm] (m == before_unnest.len() == unnest.len())
+                // 2. [i1, i2, .. in, b1, b2, .., bm] -> [i1, i2, .. in, u1, u2, .., um] (`unnest` will replace the columns in place)
+                // 3. [i1, i2, .. in, u1, u2, .., un] -> [i1, i2, .. in, u1, u2, .., um, o1, o2, .., op] (p == after_unnest.len())
+
                 let input = Box::new(self.build(s_expr.child(0)?).await?);
                 let input_schema = input.output_schema()?;
-                // The begin offset of the eval scalar columns.
-                let offset = input_schema.fields().len();
 
-                // 1. Collect unnest scalars.
-                let mut unnest_scalars = vec![];
-                let exprs = eval_scalar
+                let mut before_exprs = vec![];
+                let mut unnest_offset = input_schema.fields().len();
+
+                // 1. Collect the before unnest scalars, unnest, and after unnest scalars.
+                let after_exprs = eval_scalar
                     .items
                     .iter()
-                    .enumerate()
-                    .map(|(i, item)| {
-                        let scalar = match &item.scalar {
-                            ScalarExpr::Unnest(crate::plans::Unnest { argument, .. }) => {
-                                unnest_scalars.push(i + offset);
-                                argument
-                            }
-                            _ => &item.scalar,
-                        };
+                    .map(|item| {
+                        // 1.1 Collect the before unnest scalars, and build into `RemoteExpr`.
+                        let mut before_scalars = vec![];
+                        item.scalar
+                            .collect_before_unnest_scalars(&mut before_scalars);
+                        let befores =
+                            before_scalars
+                                .iter()
+                                .map(|scalar| {
+                                    let expr = scalar.as_expr_with_col_index()?.project_column_ref(
+                                        |index| input_schema.index_of(&index.to_string()).unwrap(),
+                                    );
+                                    let (expr, _) = ConstantFolder::fold(
+                                        &expr,
+                                        self.ctx.get_function_context()?,
+                                        &BUILTIN_FUNCTIONS,
+                                    );
+                                    Ok((expr.as_remote_expr(), item.index))
+                                })
+                                .collect::<Result<Vec<_>>>()?;
+                        before_exprs.extend(befores);
 
-                        let expr = scalar
+                        // 1.2 Collect the after unnest scalars, and build into `RemoteExpr`.
+                        let expr = item
+                            .scalar
                             .as_expr_with_col_index()?
-                            .project_column_ref(|index| {
-                                input_schema.index_of(&index.to_string()).unwrap()
-                            });
+                            .project_column_ref_with_unnest_offset(
+                                |index| input_schema.index_of(&index.to_string()).unwrap(),
+                                &mut unnest_offset,
+                            );
                         let (expr, _) = ConstantFolder::fold(
                             &expr,
                             self.ctx.get_function_context()?,
                             &BUILTIN_FUNCTIONS,
                         );
+
+                        debug_assert!(
+                            unnest_offset == before_exprs.len() + input_schema.fields().len()
+                        );
                         Ok((expr.as_remote_expr(), item.index))
                     })
                     .collect::<Result<_>>()?;
 
-                // 2. There are unnest scalars,
-                // add Unnest operator after EvalScalar operator.
-                let eval_scalar_plan = PhysicalPlan::EvalScalar(EvalScalar {
-                    plan_id: self.next_plan_id(),
-                    input,
-                    exprs,
-                    stat_info: Some(stat_info.clone()),
-                });
-
-                Ok(if unnest_scalars.is_empty() {
-                    eval_scalar_plan
-                } else {
-                    PhysicalPlan::Unnest(Unnest {
+                // 2. Construct the physical plan.
+                Ok(if before_exprs.is_empty() {
+                    PhysicalPlan::EvalScalar(EvalScalar {
                         plan_id: self.next_plan_id(),
-                        input: Box::new(eval_scalar_plan),
-                        offsets: unnest_scalars,
+                        input,
+                        exprs: after_exprs,
+                        stat_info: Some(stat_info.clone()),
+                    })
+                } else {
+                    let num_unnest_columns = before_exprs.len();
+                    let before_plan = PhysicalPlan::EvalScalar(EvalScalar {
+                        plan_id: self.next_plan_id(),
+                        input,
+                        exprs: before_exprs,
+                        stat_info: Some(stat_info.clone()),
+                    });
+                    let unnest_plan = PhysicalPlan::Unnest(Unnest {
+                        plan_id: self.next_plan_id(),
+                        input: Box::new(before_plan),
+                        num_columns: num_unnest_columns,
+                        stat_info: Some(stat_info.clone()),
+                    });
+                    PhysicalPlan::EvalScalar(EvalScalar {
+                        plan_id: self.next_plan_id(),
+                        input: Box::new(unnest_plan),
+                        exprs: after_exprs,
                         stat_info: Some(stat_info),
                     })
                 })

--- a/src/query/sql/src/executor/physical_plan_display.rs
+++ b/src/query/sql/src/executor/physical_plan_display.rs
@@ -301,12 +301,6 @@ impl Display for DistributedInsertSelect {
 
 impl Display for Unnest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let columns = self
-            .offsets
-            .iter()
-            .map(|v| v.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-        write!(f, "Unnest: column: [{}]", columns)
+        write!(f, "Unnest: unnset num : {}", self.num_columns)
     }
 }

--- a/src/query/sql/src/executor/physical_plan_visitor.rs
+++ b/src/query/sql/src/executor/physical_plan_visitor.rs
@@ -220,7 +220,7 @@ pub trait PhysicalPlanReplacer {
         Ok(PhysicalPlan::Unnest(Unnest {
             plan_id: plan.plan_id,
             input: Box::new(input),
-            offsets: plan.offsets.clone(),
+            num_columns: plan.num_columns,
             stat_info: plan.stat_info.clone(),
         }))
     }

--- a/src/query/sql/src/planner/semantic/lowering.rs
+++ b/src/query/sql/src/planner/semantic/lowering.rs
@@ -108,7 +108,13 @@ impl ScalarExpr {
                 data_type: subquery.data_type(),
                 display_name: DUMMY_NAME.to_string(),
             },
-            ScalarExpr::Unnest(_) => unreachable!("Unnest cannot be lowered to RawExpr"),
+            ScalarExpr::Unnest(unnest) => RawExpr::ColumnRef {
+                // Rewrite to a ColumnRef
+                span: None,
+                id: DUMMY_NAME.to_string(),
+                data_type: *unnest.return_type.clone(),
+                display_name: DUMMY_NAME.to_string(),
+            },
         }
     }
 
@@ -200,9 +206,13 @@ impl ScalarExpr {
                 data_type: subquery.data_type(),
                 display_name: DUMMY_NAME.to_string(),
             },
-            ScalarExpr::Unnest(_) => {
-                unreachable!("Unnest cannot be converted to RawExpr")
-            }
+            ScalarExpr::Unnest(unnest) => RawExpr::ColumnRef {
+                // Rewrite to a ColumnRef
+                span: None,
+                id: DUMMY_INDEX,
+                data_type: *unnest.return_type.clone(),
+                display_name: format!("_unnest"),
+            },
         }
     }
 

--- a/src/query/sql/src/planner/semantic/lowering.rs
+++ b/src/query/sql/src/planner/semantic/lowering.rs
@@ -211,7 +211,7 @@ impl ScalarExpr {
                 span: None,
                 id: DUMMY_INDEX,
                 data_type: *unnest.return_type.clone(),
-                display_name: format!("_unnest"),
+                display_name: DUMMY_NAME.to_string(),
             },
         }
     }

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1715,7 +1715,7 @@ impl<'a> TypeChecker<'a> {
                 let box (inner_expr, inner_type) = inner_res.unwrap();
                 Some(match inner_type {
                     DataType::Array(inner) => {
-                        let return_type = Box::new(inner.wrap_nullable());
+                        let return_type = Box::new(inner.unnest().wrap_nullable());
                         Ok(Box::new((
                             ScalarExpr::Unnest(Unnest {
                                 return_type,

--- a/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
+++ b/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
@@ -9,6 +9,13 @@ select unnest([1,2,3]);
 2
 3
 
+query I
+select unnest([1,2,3]) + 1;
+----
+2
+3
+4
+
 query II
 select unnest([1,2,3]), number from numbers(1);
 ----
@@ -25,6 +32,16 @@ select unnest([1,2,3]), number from numbers(2);
 1 1
 2 1
 3 1
+
+query II
+select unnest([1,2,3]), number, unnest([1,2,3]) + number from numbers(2);
+----
+1 0 1
+2 0 2
+3 0 3
+1 1 2
+2 1 3
+3 1 4
 
 statement ok
 DROP DATABASE IF EXISTS db_02_0062;
@@ -66,12 +83,26 @@ select unnest([1,2,3]), unnest([3,4,5]);
 2 4
 3 5
 
+query I
+select unnest([1,2,3]) + unnest([3,4,5]);
+----
+4
+6
+8
+
 query IT
 select unnest([1,2,3]), unnest([3]);
 ----
 1 3
 2 NULL
 3 NULL
+
+query T
+select unnest([1,2,3]) + unnest([3]);
+----
+4
+NULL
+NULL
 
 query IIT
 select unnest([1,2,3]), number, unnest([3]) from numbers(2);
@@ -122,6 +153,15 @@ select unnest(a) as ua, a from t order by ua;
 3 [3,4,5]
 4 [3,4,5]
 5 [3,4,5]
+
+query ITI
+select unnest(a) + 1 as ua, a from t order by ua;
+----
+2 [1,2]
+3 [1,2]
+4 [3,4,5]
+5 [3,4,5]
+6 [3,4,5]
 
 statement ok
 drop table t;
@@ -182,6 +222,19 @@ select unnest(a) from t;
 7
 8
 9
+
+query I
+select 1 + unnest(a) from t;
+----
+2
+3
+4
+5
+6
+7
+8
+9
+10
 
 query IT
 select unnest(a), a from t;

--- a/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
+++ b/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
@@ -126,6 +126,79 @@ select unnest(a) as ua, a from t order by ua;
 statement ok
 drop table t;
 
+# Unnest deeply nested arrays.
+
+query I
+select unnest([[1,2], [3,4,5]]);
+----
+1
+2
+3
+4
+5
+
+query I
+select unnest([[[1,2], [3,4]], [[5,6], [7,8,9]]]);
+----
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+query II
+select unnest([[1,2], [3,4,5]]), number from numbers(2);
+----
+1 0
+2 0
+3 0
+4 0
+5 0
+1 1
+2 1
+3 1
+4 1
+5 1
+
+statement ok
+create table t (a array(array(int))) ENGINE=Memory;
+
+statement ok
+insert into t values([[1,2], [3,4]]), ([[5,6], [7,8,9]]);
+
+query I
+select unnest(a) from t;
+----
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+query IT
+select unnest(a), a from t;
+----
+1 [[1,2],[3,4]]
+2 [[1,2],[3,4]]
+3 [[1,2],[3,4]]
+4 [[1,2],[3,4]]
+5 [[5,6],[7,8,9]]
+6 [[5,6],[7,8,9]]
+7 [[5,6],[7,8,9]]
+8 [[5,6],[7,8,9]]
+9 [[5,6],[7,8,9]]
+
+statement ok
+drop table t;
+
 statement ok
 DROP DATABASE db_02_0062;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- [x] 1. Be able to wrap `unnest` in other expressions.
- [x] 2. `unnest` will unnest to the end. 

Examples:

For 1.

```sql
explain select unnest([1,2]) + 1;
+--------------------------------------------------------------+
| explain                                                      |
+--------------------------------------------------------------+
| EvalScalar                                                   |
| ├── expressions: [plus(_unnest, 1)]                          |
| ├── estimated rows: 0.00                                     |
| └── Unnest                                                   |
|     └── EvalScalar                                           |
|         ├── expressions: [[1, 2]]                            |
|         ├── estimated rows: 0.00                             |
|         └── TableScan                                        |
|             ├── table: default.system.one                    |
|             ├── read rows: 1                                 |
|             ├── read bytes: 1                                |
|             ├── partitions total: 1                          |
|             ├── partitions scanned: 1                        |
|             ├── push downs: [filters: [], limit: NONE]       |
|             └── estimated rows: 0.00                         |
+--------------------------------------------------------------+

select unnest([1,2]) + 1;
+--------------------+
| unnest([1, 2]) + 1 |
+--------------------+
|                  2 |
|                  3 |
+--------------------+


```

For 2.

```sql
select unnest([[[1,2], [3,4]], [[5,6], [7,8,9]]]);
+-------------------------------------------------+
| unnest([[[1, 2], [3, 4]], [[5, 6], [7, 8, 9]]]) |
+-------------------------------------------------+
| 1                                               |
| 2                                               |
| 3                                               |
| 4                                               |
| 5                                               |
| 6                                               |
| 7                                               |
| 8                                               |
| 9                                               |
+-------------------------------------------------+
```


Tracking in #10295
