### PR TITLE
feat(function): Support Map type get function

### DIFF
--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -899,7 +899,7 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
     );
 
     let map_expr = map(
-        rule! { "{" ~ #comma_separated_list1(map_element) ~ "}" },
+        rule! { "{" ~ #comma_separated_list0(map_element) ~ "}" },
         |(_, kvs, _)| ExprElement::Map { kvs },
     );
 

--- a/src/query/expression/src/property.rs
+++ b/src/query/expression/src/property.rs
@@ -78,6 +78,8 @@ pub enum Domain {
     Nullable(NullableDomain<AnyType>),
     /// `Array(None)` means that the array is empty, thus there is no inner domain information.
     Array(Option<Box<Domain>>),
+    /// `Map(None)` means that the map is empty, thus there is no inner domain information.
+    Map(Option<(Box<Domain>, Box<Domain>)>),
     Tuple(Vec<Domain>),
     /// For certain types, like `Variant`, the domain is useless therefore is not defined.
     Undefined,
@@ -177,7 +179,19 @@ impl Domain {
             }
             DataType::EmptyArray => Domain::Array(None),
             DataType::Array(ty) => Domain::Array(Some(Box::new(Domain::full(ty)))),
-            DataType::EmptyMap | DataType::Map(_) | DataType::Variant => Domain::Undefined,
+            DataType::EmptyMap => Domain::Map(None),
+            DataType::Map(box ty) => {
+                let inner_domain = match ty {
+                    DataType::Tuple(inner_tys) => {
+                        let key_domain = Box::new(Domain::full(&inner_tys[0]));
+                        let val_domain = Box::new(Domain::full(&inner_tys[1]));
+                        (key_domain, val_domain)
+                    }
+                    _ => unreachable!(),
+                };
+                Domain::Map(Some(inner_domain))
+            }
+            DataType::Variant => Domain::Undefined,
             DataType::Generic(_) => unreachable!(),
         }
     }
@@ -287,6 +301,16 @@ impl Domain {
             (Domain::Array(Some(self_arr)), Domain::Array(Some(other_arr))) => {
                 Domain::Array(Some(Box::new(self_arr.merge(other_arr))))
             }
+            (Domain::Map(None), Domain::Map(None)) => Domain::Map(None),
+            (Domain::Map(Some(_)), Domain::Map(None)) => self.clone(),
+            (Domain::Map(None), Domain::Map(Some(_))) => other.clone(),
+            (
+                Domain::Map(Some((self_key, self_val))),
+                Domain::Map(Some((other_key, other_val))),
+            ) => Domain::Map(Some((
+                Box::new(self_key.merge(other_key)),
+                Box::new(self_val.merge(other_val)),
+            ))),
             (Domain::Tuple(self_tup), Domain::Tuple(other_tup)) => Domain::Tuple(
                 self_tup
                     .iter()

--- a/src/query/expression/src/types/empty_map.rs
+++ b/src/query/expression/src/types/empty_map.rs
@@ -62,7 +62,7 @@ impl ValueType for EmptyMapType {
 
     fn try_downcast_domain(domain: &Domain) -> Option<Self::Domain> {
         match domain {
-            Domain::Array(None) => Some(()),
+            Domain::Map(None) => Some(()),
             _ => None,
         }
     }
@@ -85,7 +85,7 @@ impl ValueType for EmptyMapType {
     }
 
     fn upcast_domain(_: Self::Domain) -> Domain {
-        Domain::Array(None)
+        Domain::Map(None)
     }
 
     fn column_len<'a>(len: &'a Self::Column) -> usize {

--- a/src/query/expression/src/utils/display.rs
+++ b/src/query/expression/src/utils/display.rs
@@ -757,6 +757,10 @@ impl Display for Domain {
                 }
                 write!(f, ")")
             }
+            Domain::Map(None) => write!(f, "{{}}"),
+            Domain::Map(Some((key_domain, val_domain))) => {
+                write!(f, "{{[{key_domain}], [{val_domain}]}}")
+            }
             Domain::Undefined => write!(f, "Undefined"),
         }
     }

--- a/src/query/functions/tests/it/scalars/map.rs
+++ b/src/query/functions/tests/it/scalars/map.rs
@@ -26,6 +26,7 @@ fn test_map() {
     let file = &mut mint.new_goldenfile("map.txt").unwrap();
 
     test_create(file);
+    test_get(file);
 }
 
 fn test_create(file: &mut impl Write) {
@@ -60,4 +61,23 @@ fn test_create(file: &mut impl Write) {
         &columns,
     );
     run_ast(file, "map(['k1', 'k2'], [a_col, b_col])", &columns);
+}
+
+fn test_get(file: &mut impl Write) {
+    run_ast(file, "map([],[])[1]", &[]);
+    run_ast(file, "map([1,2],['a','b'])[1]", &[]);
+    run_ast(file, "map([1,2],['a','b'])[10]", &[]);
+    run_ast(file, "map(['a','b'],[1,2])['a']", &[]);
+    run_ast(file, "map(['a','b'],[1,2])['x']", &[]);
+
+    run_ast(file, "{}['k']", &[]);
+    run_ast(file, "{'k1':'v1','k2':'v2'}['k1']", &[]);
+    run_ast(file, "{'k1':'v1','k2':'v2'}['k3']", &[]);
+
+    run_ast(file, "map([k1,k2],[v1,v2])[1]", &[
+        ("k1", Int16Type::from_data(vec![1i16, 2])),
+        ("k2", Int16Type::from_data(vec![3i16, 4])),
+        ("v1", StringType::from_data(vec!["v1", "v2"])),
+        ("v2", StringType::from_data(vec!["v3", "v4"])),
+    ]);
 }

--- a/src/query/functions/tests/it/scalars/parser.rs
+++ b/src/query/functions/tests/it/scalars/parser.rs
@@ -298,6 +298,33 @@ pub fn transform_expr(ast: AExpr, columns: &[(&str, DataType)]) -> RawExpr {
                 args: vec![transform_expr(*expr, columns)],
             }
         }
+        AExpr::Map { span, kvs } => {
+            let mut keys = Vec::with_capacity(kvs.len());
+            let mut vals = Vec::with_capacity(kvs.len());
+            for (key, val) in kvs {
+                keys.push(transform_expr(key, columns));
+                vals.push(transform_expr(val, columns));
+            }
+            let keys = RawExpr::FunctionCall {
+                span,
+                name: "array".to_string(),
+                params: vec![],
+                args: keys,
+            };
+            let vals = RawExpr::FunctionCall {
+                span,
+                name: "array".to_string(),
+                params: vec![],
+                args: vals,
+            };
+            let args = vec![keys, vals];
+            RawExpr::FunctionCall {
+                span,
+                name: "map".to_string(),
+                params: vec![],
+                args,
+            }
+        }
         AExpr::Tuple { span, exprs } => RawExpr::FunctionCall {
             span,
             name: "tuple".to_string(),

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -982,6 +982,9 @@ get(Variant NULL, UInt64 NULL) :: Variant NULL
 get(Array(Nothing) NULL, UInt64 NULL) :: NULL
 get(Array(T0 NULL), UInt64) :: T0 NULL
 get(Array(T0 NULL) NULL, UInt64 NULL) :: T0 NULL
+get(Map(Nothing) NULL, T0 NULL) :: NULL
+get(Map(T0, T1), T0) :: T1 NULL
+get(Map(T0, T1) NULL, T0 NULL) :: T1 NULL
 get_ignore_case(Variant NULL, String NULL) :: Variant NULL
 get_path(Variant NULL, String NULL) :: Variant NULL
 great_circle_angle(Float64, Float64, Float64, Float64) :: Float32

--- a/src/query/functions/tests/it/scalars/testdata/map.txt
+++ b/src/query/functions/tests/it/scalars/testdata/map.txt
@@ -3,7 +3,7 @@ raw expr       : map(array(), array())
 checked expr   : map<Array(Nothing), Array(Nothing)>(array<>(), array<>())
 optimized expr : {} :: Map(Nothing)
 output type    : Map(Nothing)
-output domain  : Undefined
+output domain  : {}
 output         : {}
 
 
@@ -12,7 +12,7 @@ raw expr       : map(array(1_u8, 2_u8), array("a", "b"))
 checked expr   : map<T0=UInt8, T1=String><Array(T0), Array(T1)>(array<T0=UInt8><T0, T0>(1_u8, 2_u8), array<T0=String><T0, T0>("a", "b"))
 optimized expr : {1_u8:"a", 2_u8:"b"}
 output type    : Map(UInt8, String)
-output domain  : Undefined
+output domain  : {[{1..=2}], [{"a"..="b"}]}
 output         : {1:"a", 2:"b"}
 
 
@@ -21,7 +21,7 @@ raw expr       : map(array("k1", "k2", "k3"), array("v1", "v2", "v3"))
 checked expr   : map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0, T0, T0>("k1", "k2", "k3"), array<T0=String><T0, T0, T0>("v1", "v2", "v3"))
 optimized expr : {"k1":"v1", "k2":"v2", "k3":"v3"}
 output type    : Map(String, String)
-output domain  : Undefined
+output domain  : {[{"k1"..="k3"}], [{"v1"..="v3"}]}
 output         : {"k1":"v1", "k2":"v2", "k3":"v3"}
 
 
@@ -104,5 +104,102 @@ evaluation (internal):
 | b_col  | Int8([4, 5, 6])                                                                                                                                                                          |
 | Output | ArrayColumn { values: Tuple { fields: [StringColumn { data: 0x6b316b326b316b326b316b32, offsets: [0, 2, 4, 6, 8, 10, 12] }, Int8([1, 4, 2, 5, 3, 6])], len: 6 }, offsets: [0, 2, 4, 6] } |
 +--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : map([],[])[1]
+raw expr       : get(map(array(), array()), 1_u8)
+checked expr   : get<T0=UInt8><Map(Nothing) NULL, T0 NULL>(CAST(map<Array(Nothing), Array(Nothing)>(array<>(), array<>()) AS Map(Nothing) NULL), CAST(1_u8 AS UInt8 NULL))
+optimized expr : NULL
+output type    : NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : map([1,2],['a','b'])[1]
+raw expr       : get(map(array(1_u8, 2_u8), array("a", "b")), 1_u8)
+checked expr   : get<T0=UInt8, T1=String><Map(T0, T1), T0>(map<T0=UInt8, T1=String><Array(T0), Array(T1)>(array<T0=UInt8><T0, T0>(1_u8, 2_u8), array<T0=String><T0, T0>("a", "b")), 1_u8)
+optimized expr : "a"
+output type    : String NULL
+output domain  : {"a"..="a"}
+output         : "a"
+
+
+ast            : map([1,2],['a','b'])[10]
+raw expr       : get(map(array(1_u8, 2_u8), array("a", "b")), 10_u8)
+checked expr   : get<T0=UInt8, T1=String><Map(T0, T1), T0>(map<T0=UInt8, T1=String><Array(T0), Array(T1)>(array<T0=UInt8><T0, T0>(1_u8, 2_u8), array<T0=String><T0, T0>("a", "b")), 10_u8)
+optimized expr : NULL
+output type    : String NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : map(['a','b'],[1,2])['a']
+raw expr       : get(map(array("a", "b"), array(1_u8, 2_u8)), "a")
+checked expr   : get<T0=String, T1=UInt8><Map(T0, T1), T0>(map<T0=String, T1=UInt8><Array(T0), Array(T1)>(array<T0=String><T0, T0>("a", "b"), array<T0=UInt8><T0, T0>(1_u8, 2_u8)), "a")
+optimized expr : 1_u8
+output type    : UInt8 NULL
+output domain  : {1..=1}
+output         : 1
+
+
+ast            : map(['a','b'],[1,2])['x']
+raw expr       : get(map(array("a", "b"), array(1_u8, 2_u8)), "x")
+checked expr   : get<T0=String, T1=UInt8><Map(T0, T1), T0>(map<T0=String, T1=UInt8><Array(T0), Array(T1)>(array<T0=String><T0, T0>("a", "b"), array<T0=UInt8><T0, T0>(1_u8, 2_u8)), "x")
+optimized expr : NULL
+output type    : UInt8 NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : {}['k']
+raw expr       : get(map(array(), array()), "k")
+checked expr   : get<T0=String><Map(Nothing) NULL, T0 NULL>(CAST(map<Array(Nothing), Array(Nothing)>(array<>(), array<>()) AS Map(Nothing) NULL), CAST("k" AS String NULL))
+optimized expr : NULL
+output type    : NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : {'k1':'v1','k2':'v2'}['k1']
+raw expr       : get(map(array("k1", "k2"), array("v1", "v2")), "k1")
+checked expr   : get<T0=String, T1=String><Map(T0, T1), T0>(map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0, T0>("k1", "k2"), array<T0=String><T0, T0>("v1", "v2")), "k1")
+optimized expr : "v1"
+output type    : String NULL
+output domain  : {"v1"..="v1"}
+output         : "v1"
+
+
+ast            : {'k1':'v1','k2':'v2'}['k3']
+raw expr       : get(map(array("k1", "k2"), array("v1", "v2")), "k3")
+checked expr   : get<T0=String, T1=String><Map(T0, T1), T0>(map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0, T0>("k1", "k2"), array<T0=String><T0, T0>("v1", "v2")), "k3")
+optimized expr : NULL
+output type    : String NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : map([k1,k2],[v1,v2])[1]
+raw expr       : get(map(array(k1::Int16, k2::Int16), array(v1::String, v2::String)), 1_u8)
+checked expr   : get<T0=Int16, T1=String><Map(T0, T1), T0>(map<T0=Int16, T1=String><Array(T0), Array(T1)>(array<T0=Int16><T0, T0>(k1, k2), array<T0=String><T0, T0>(v1, v2)), to_int16<UInt8>(1_u8))
+optimized expr : get<T0=Int16, T1=String><Map(T0, T1), T0>(map<T0=Int16, T1=String><Array(T0), Array(T1)>(array<T0=Int16><T0, T0>(k1, k2), array<T0=String><T0, T0>(v1, v2)), 1_i16)
+evaluation:
++--------+---------+---------+---------------+---------------+-------------+
+|        | k1      | k2      | v1            | v2            | Output      |
++--------+---------+---------+---------------+---------------+-------------+
+| Type   | Int16   | Int16   | String        | String        | String NULL |
+| Domain | {1..=2} | {3..=4} | {"v1"..="v2"} | {"v3"..="v4"} | Unknown     |
+| Row 0  | 1       | 3       | "v1"          | "v3"          | "v1"        |
+| Row 1  | 2       | 4       | "v2"          | "v4"          | NULL        |
++--------+---------+---------+---------------+---------------+-------------+
+evaluation (internal):
++--------+------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                 |
++--------+------------------------------------------------------------------------------------------------------+
+| k1     | Int16([1, 2])                                                                                        |
+| k2     | Int16([3, 4])                                                                                        |
+| v1     | StringColumn { data: 0x76317632, offsets: [0, 2, 4] }                                                |
+| v2     | StringColumn { data: 0x76337634, offsets: [0, 2, 4] }                                                |
+| Output | NullableColumn { column: StringColumn { data: 0x7631, offsets: [0, 2, 2] }, validity: [0b______01] } |
++--------+------------------------------------------------------------------------------------------------------+
 
 

--- a/tests/sqllogictests/suites/base/03_common/03_0037_insert_into_map
+++ b/tests/sqllogictests/suites/base/03_common/03_0037_insert_into_map
@@ -20,6 +20,13 @@ select * from t1
 2 {300:'mn'}
 3 {}
 
+query TTTT
+select m[100], m[200], m[300], m[400] from t1
+----
+abc def NULL NULL
+NULL NULL mn NULL
+NULL NULL NULL NULL
+
 statement error 1001
 INSERT INTO t1 (id, m) VALUES(1, {100:'k1',100:'k2'})
 
@@ -34,6 +41,12 @@ select * from t2
 ----
 1 {'k1':['2020-01-01','2021-01-02'],'k2':['2022-01-01']}
 2 {'k3':['2023-01-01']}
+
+query TTTT
+select m['k1'], m['k2'], m['k3'], m['k4'] from t2
+----
+['2020-01-01','2021-01-02'] ['2022-01-01'] NULL NULL
+NULL NULL ['2023-01-01'] NULL
 
 statement error 1001
 CREATE TABLE IF NOT EXISTS t3(id Int, m Map(Array(Date), String)) Engine = Fuse


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Support Map type `get` function.
- Add `Domain::Map` for the `Map` type.
- Upgrade `Strawboat` to fix read native format nested `Array` failed.

Part of #10062 
