### PR TITLE
refactor: add query_id and active_result_scan to system.query_cache

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -14,6 +14,7 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -110,6 +111,7 @@ pub trait TableContext: Send + Sync {
     fn get_processes_info(&self) -> Vec<ProcessInfo>;
     fn get_stage_attachment(&self) -> Option<StageAttachment>;
     fn get_last_query_id(&self, index: i32) -> String;
+    fn get_query_id_history(&self) -> HashSet<String>;
     fn get_result_cache_key(&self, query_id: &str) -> Option<String>;
     fn set_query_id_result_cache(&self, query_id: String, result_cache_key: String);
     fn set_on_error_map(&self, map: Option<HashMap<String, ErrorCode>>);

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -380,6 +381,10 @@ impl TableContext for QueryContext {
 
     fn get_last_query_id(&self, index: i32) -> String {
         self.shared.session.session_ctx.get_last_query_id(index)
+    }
+
+    fn get_query_id_history(&self) -> HashSet<String> {
+        self.shared.session.session_ctx.get_query_id_history()
     }
 
     fn get_result_cache_key(&self, query_id: &str) -> Option<String> {

--- a/src/query/service/src/sessions/session_ctx.rs
+++ b/src/query/service/src/sessions/session_ctx.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -256,5 +257,10 @@ impl SessionContext {
         }
 
         (*lock)[idx as usize].0.clone()
+    }
+
+    pub fn get_query_id_history(&self) -> HashSet<String> {
+        let lock = self.query_ids_results.read();
+        HashSet::from_iter(lock.iter().map(|result| result.clone().0))
     }
 }

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 use std::any::Any;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
@@ -445,6 +446,9 @@ impl TableContext for CtxDelegation {
     }
 
     fn get_last_query_id(&self, _index: i32) -> String {
+        todo!()
+    }
+    fn get_query_id_history(&self) -> HashSet<String> {
         todo!()
     }
     fn get_result_cache_key(&self, _query_id: &str) -> Option<String> {

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -6,6 +6,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 +---------------------------------+----------------------+-----------------------+--------------------+---------------------+----------+----------+----------+----------+
 | "Comment"                       | "system"             | "engines"             | "String"           | "VARCHAR"           | ""       | ""       | "NO"     | ""       |
 | "Engine"                        | "system"             | "engines"             | "String"           | "VARCHAR"           | ""       | ""       | "NO"     | ""       |
+| "active_result_scan"            | "system"             | "query_cache"         | "Boolean"          | "BOOLEAN"           | ""       | ""       | "NO"     | ""       |
 | "auth_string"                   | "system"             | "users"               | "String"           | "VARCHAR"           | ""       | ""       | "NO"     | ""       |
 | "auth_type"                     | "system"             | "users"               | "String"           | "VARCHAR"           | ""       | ""       | "NO"     | ""       |
 | "cardinality"                   | "information_schema" | "statistics"          | "NULL"             | "NULL"              | ""       | ""       | "NO"     | ""       |
@@ -167,6 +168,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | "position_in_unique_constraint" | "information_schema" | "key_column_usage"    | "NULL"             | "NULL"              | ""       | ""       | "NO"     | ""       |
 | "projections"                   | "system"             | "query_log"           | "String"           | "VARCHAR"           | ""       | ""       | "NO"     | ""       |
 | "query_duration_ms"             | "system"             | "query_log"           | "Int64"            | "BIGINT"            | ""       | ""       | "NO"     | ""       |
+| "query_id"                      | "system"             | "query_cache"         | "String"           | "VARCHAR"           | ""       | ""       | "NO"     | ""       |
 | "query_id"                      | "system"             | "query_log"           | "String"           | "VARCHAR"           | ""       | ""       | "NO"     | ""       |
 | "query_kind"                    | "system"             | "query_log"           | "String"           | "VARCHAR"           | ""       | ""       | "NO"     | ""       |
 | "query_start_time"              | "system"             | "query_log"           | "Timestamp"        | "TIMESTAMP"         | ""       | ""       | "NO"     | ""       |

--- a/src/query/storages/result_cache/src/common.rs
+++ b/src/query/storages/result_cache/src/common.rs
@@ -41,6 +41,8 @@ pub(crate) fn gen_result_cache_dir(key: &str) -> String {
 pub struct ResultCacheValue {
     /// The original query SQL.
     pub sql: String,
+    /// Associated query id
+    pub query_id: String,
     /// The query time.
     pub query_time: u64,
     /// Time-to-live of this query.

--- a/src/query/storages/result_cache/src/write/sink.rs
+++ b/src/query/storages/result_cache/src/write/sink.rs
@@ -73,6 +73,7 @@ impl AsyncMpscSink for WriteResultCacheSink {
 
         let value = ResultCacheValue {
             sql: self.sql.clone(),
+            query_id: self.ctx.get_id(),
             query_time: now,
             ttl,
             partitions_shas: self.partitions_shas.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add `query_id` and `active_result_scan` to `system.query_cache`.

`active_result_scan`is true to indicate that the associated query_id can be used by result_scan.

Closes #issue
