### PR TITLE
fix: make `PushDownPrewhere` as a rule.

### DIFF
--- a/src/query/sql/src/planner/optimizer/heuristic/heuristic.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/heuristic.rs
@@ -20,7 +20,6 @@ use once_cell::sync::Lazy;
 
 use super::prune_unused_columns::UnusedColumnPruner;
 use crate::optimizer::heuristic::decorrelate::decorrelate_subquery;
-use crate::optimizer::heuristic::prewhere_optimization::PrewhereOptimizer;
 use crate::optimizer::rule::RulePtr;
 use crate::optimizer::rule::TransformResult;
 use crate::optimizer::ColumnSet;
@@ -54,7 +53,8 @@ pub static DEFAULT_REWRITE_RULES: Lazy<Vec<RuleID>> = Lazy::new(|| {
         RuleID::FoldCountAggregate,
         RuleID::SplitAggregate,
         RuleID::PushDownFilterScan,
-        RuleID::PushDownSortScan,
+        RuleID::PushDownPrewhere, /* PushDownPrwhere should be after all rules except PushDownFilterScan */
+        RuleID::PushDownSortScan, // PushDownFilterScan should be after PushDownPrewhere
     ]
 });
 
@@ -93,9 +93,6 @@ impl HeuristicOptimizer {
     }
 
     fn post_optimize(&mut self, s_expr: SExpr) -> Result<SExpr> {
-        let prewhere_optimizer = PrewhereOptimizer::new(self.metadata.clone());
-        let s_expr = prewhere_optimizer.prewhere_optimize(s_expr)?;
-
         let pruner = UnusedColumnPruner::new(self.metadata.clone());
         let require_columns: ColumnSet =
             self.bind_context.columns.iter().map(|c| c.index).collect();
@@ -105,12 +102,6 @@ impl HeuristicOptimizer {
     pub fn optimize(&mut self, s_expr: SExpr) -> Result<SExpr> {
         let pre_optimized = self.pre_optimize(s_expr)?;
         let optimized = self.optimize_expression(&pre_optimized)?;
-        let post_optimized = self.post_optimize(optimized)?;
-
-        // do it again, some rules may be missed after the post_optimized
-        // for example: push down sort + limit (topn) to scan
-        // TODO: if we push down the filter to scan, we need to remove the filter plan
-        let optimized = self.optimize_expression(&post_optimized)?;
         let post_optimized = self.post_optimize(optimized)?;
 
         Ok(post_optimized)

--- a/src/query/sql/src/planner/optimizer/heuristic/mod.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/mod.rs
@@ -15,7 +15,6 @@
 mod decorrelate;
 #[allow(clippy::module_inception)]
 mod heuristic;
-mod prewhere_optimization;
 mod prune_unused_columns;
 mod rule_list;
 mod subquery_rewriter;

--- a/src/query/sql/src/planner/optimizer/rule/factory.rs
+++ b/src/query/sql/src/planner/optimizer/rule/factory.rs
@@ -25,6 +25,7 @@ use super::rewrite::RulePushDownFilterEvalScalar;
 use super::rewrite::RulePushDownFilterJoin;
 use super::rewrite::RulePushDownLimitAggregate;
 use super::rewrite::RulePushDownLimitExpression;
+use super::rewrite::RulePushDownPrewhere;
 use super::transform::RuleCommuteJoin;
 use super::transform::RuleLeftAssociateJoin;
 use super::transform::RuleRightAssociateJoin;
@@ -103,6 +104,7 @@ impl RuleFactory {
             RuleID::LeftExchangeJoin => Ok(Box::new(RuleLeftExchangeJoin::new())),
             RuleID::RightExchangeJoin => Ok(Box::new(RuleRightExchangeJoin::new())),
             RuleID::ExchangeJoin => Ok(Box::new(RuleExchangeJoin::new())),
+            RuleID::PushDownPrewhere => Ok(Box::new(RulePushDownPrewhere::new(metadata.unwrap()))),
         }
     }
 }

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/mod.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/mod.rs
@@ -32,6 +32,7 @@ mod rule_push_down_limit_join;
 mod rule_push_down_limit_scan;
 mod rule_push_down_limit_sort;
 mod rule_push_down_limit_union;
+mod rule_push_down_prewhere;
 mod rule_push_down_sort_scan;
 mod rule_split_aggregate;
 
@@ -55,5 +56,6 @@ pub use rule_push_down_limit_join::RulePushDownLimitOuterJoin;
 pub use rule_push_down_limit_scan::RulePushDownLimitScan;
 pub use rule_push_down_limit_sort::RulePushDownLimitSort;
 pub use rule_push_down_limit_union::RulePushDownLimitUnion;
+pub use rule_push_down_prewhere::RulePushDownPrewhere;
 pub use rule_push_down_sort_scan::RulePushDownSortScan;
 pub use rule_split_aggregate::RuleSplitAggregate;

--- a/src/query/sql/src/planner/optimizer/rule/rule.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rule.rs
@@ -60,6 +60,7 @@ pub enum RuleID {
     MergeFilter,
     SplitAggregate,
     FoldCountAggregate,
+    PushDownPrewhere,
 
     // Exploration rules
     CommuteJoin,
@@ -95,6 +96,7 @@ impl Display for RuleID {
             RuleID::SplitAggregate => write!(f, "SplitAggregate"),
             RuleID::NormalizeDisjunctiveFilter => write!(f, "NormalizeDisjunctiveFilter"),
             RuleID::FoldCountAggregate => write!(f, "FoldCountAggregate"),
+            RuleID::PushDownPrewhere => write!(f, "PushDownPrewhere"),
 
             RuleID::CommuteJoin => write!(f, "CommuteJoin"),
             RuleID::CommuteJoinBaseTable => write!(f, "CommuteJoinBaseTable"),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`PrewhereOptimizer` is no longer existing. Instead, it will become a rule.

Notice that `PushDownPrewhere` should be after all other rules except `PushDownSortScan`.

After this modification, we don't need to do optimization twice any more. This will also fix the failure of TPC-H Q19 for native format.
