### PR TITLE
refactor: the panic hook should output error to stderr, not only to log, in case there is a panic when initializing logging

### DIFF
--- a/src/common/tracing/src/panic_hook.rs
+++ b/src/common/tracing/src/panic_hook.rs
@@ -41,12 +41,12 @@ pub fn log_panic(panic: &PanicInfo) {
     if let Some(location) = panic.location() {
         error!(
             message = %panic,
-            backtrace = %backtrace,
+            backtrace = %backtrace_str,
             panic.file = location.file(),
             panic.line = location.line(),
             panic.column = location.column(),
         );
     } else {
-        error!(message = %panic, backtrace = %backtrace);
+        error!(message = %panic, backtrace = %backtrace_str);
     }
 }

--- a/src/common/tracing/src/panic_hook.rs
+++ b/src/common/tracing/src/panic_hook.rs
@@ -33,7 +33,11 @@ pub fn set_panic_hook() {
 
 pub fn log_panic(panic: &PanicInfo) {
     let backtrace = Backtrace::force_capture();
-    let backtrace = format!("{:?}", backtrace);
+    let backtrace_str = format!("{:?}", backtrace);
+
+    eprintln!("{}", panic);
+    eprintln!("{}", backtrace);
+
     if let Some(location) = panic.location() {
         error!(
             message = %panic,


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: the panic hook should output error to stderr, not only to log, in case there is a panic when initializing logging

- Fix: #10355

## Changelog




- Improvement


## Related Issues