### PR TITLE
refactor(executor): always call sink on_finish

### DIFF
--- a/src/query/pipeline/sinks/src/async_sink.rs
+++ b/src/query/pipeline/sinks/src/async_sink.rs
@@ -69,7 +69,7 @@ impl<T: AsyncSink + 'static> Drop for AsyncSinker<T> {
             self.called_on_finish = true;
             if let Some(mut inner) = self.inner.take() {
                 GlobalIORuntime::instance().spawn(async move {
-                    let _ = inner.on_finish();
+                    let _ = inner.on_finish().await;
                 });
             }
         }

--- a/src/query/pipeline/sinks/src/async_sink.rs
+++ b/src/query/pipeline/sinks/src/async_sink.rs
@@ -17,6 +17,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use async_trait::unboxed_simple;
+use common_base::runtime::GlobalIORuntime;
+use common_base::runtime::TrySpawn;
 use common_exception::Result;
 use common_expression::DataBlock;
 use common_pipeline_core::processors::port::InputPort;
@@ -40,7 +42,7 @@ pub trait AsyncSink: Send {
 }
 
 pub struct AsyncSinker<T: AsyncSink + 'static> {
-    inner: T,
+    inner: Option<T>,
     finished: bool,
     input: Arc<InputPort>,
     input_data: Option<DataBlock>,
@@ -51,13 +53,26 @@ pub struct AsyncSinker<T: AsyncSink + 'static> {
 impl<T: AsyncSink + 'static> AsyncSinker<T> {
     pub fn create(input: Arc<InputPort>, inner: T) -> Box<dyn Processor> {
         Box::new(AsyncSinker {
-            inner,
             input,
             finished: false,
             input_data: None,
+            inner: Some(inner),
             called_on_start: false,
             called_on_finish: false,
         })
+    }
+}
+
+impl<T: AsyncSink + 'static> Drop for AsyncSinker<T> {
+    fn drop(&mut self) {
+        if !self.called_on_finish {
+            self.called_on_finish = true;
+            if let Some(mut inner) = self.inner.take() {
+                GlobalIORuntime::instance().spawn(async move {
+                    let _ = inner.on_finish();
+                });
+            }
+        }
     }
 }
 
@@ -111,12 +126,12 @@ impl<T: AsyncSink + 'static> Processor for AsyncSinker<T> {
     async fn async_process(&mut self) -> Result<()> {
         if !self.called_on_start {
             self.called_on_start = true;
-            self.inner.on_start().await?;
+            self.inner.as_mut().unwrap().on_start().await?;
         } else if let Some(data_block) = self.input_data.take() {
-            self.finished = self.inner.consume(data_block).await?;
+            self.finished = self.inner.as_mut().unwrap().consume(data_block).await?;
         } else if !self.called_on_finish {
             self.called_on_finish = true;
-            self.inner.on_finish().await?;
+            self.inner.as_mut().unwrap().on_finish().await?;
         }
 
         Ok(())

--- a/src/query/pipeline/sinks/src/sync_sink.rs
+++ b/src/query/pipeline/sinks/src/sync_sink.rs
@@ -45,6 +45,15 @@ pub struct Sinker<T: Sink + 'static> {
     called_on_finish: bool,
 }
 
+impl<T: Sink + 'static> Drop for Sinker<T> {
+    fn drop(&mut self) {
+        if !self.called_on_finish {
+            self.called_on_finish = true;
+            let _ = self.inner.on_finish();
+        }
+    }
+}
+
 impl<T: Sink + 'static> Sinker<T> {
     pub fn create(input: Arc<InputPort>, inner: T) -> Box<dyn Processor> {
         Box::new(Sinker {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor(executor): always call sink on_finish

```
2023-03-04T18:44:31.819763Z  WARN databend_query::pipelines::executor::processor_async_task: src/query/service/src/pipelines/executor/processor_async_task.rs:77: Very slow processor async task, query_id:"b087d3f2-5516-4abd-896d-a395ec85d091", processor id: NodeIndex(106), name: "HashJoin", elapsed: 1620.419467644s
2023-03-04T18:44:36.821102Z  WARN databend_query::pipelines::executor::processor_async_task: src/query/service/src/pipelines/executor/processor_async_task.rs:77: Very slow processor async task, query_id:"b087d3f2-5516-4abd-896d-a395ec85d091", processor id: NodeIndex(106), name: "HashJoin", elapsed: 1625.420808724s
2023-03-04T18:44:41.822417Z  WARN databend_query::pipelines::executor::processor_async_task: src/query/service/src/pipelines/executor/processor_async_task.rs:77: Very slow processor async task, query_id:"b087d3f2-5516-4abd-896d-a395ec85d091", processor id: NodeIndex(106), name: "HashJoin", elapsed: 1630.422122969s
2023-03-04T18:44:46.823769Z  WARN databend_query::pipelines::executor::processor_async_task: src/query/service/src/pipelines/executor/processor_async_task.rs:77: Very slow processor async task, query_id:"b087d3f2-5516-4abd-896d-a395ec85d091", processor id: NodeIndex(106), name: "HashJoin", elapsed: 1635.423473711s
2023-03-04T18:44:51.825158Z  WARN databend_query::pipelines::executor::processor_async_task: src/query/service/src/pipelines/executor/processor_async_task.rs:77: Very slow processor async task, query_id:"b087d3f2-5516-4abd-896d-a395ec85d091", processor id: NodeIndex(106), name: "HashJoin", elapsed: 1640.424862588s
2023-03-04T18:44:56.826527Z  WARN databend_query::pipelines::executor::processor_async_task: src/query/service/src/pipelines/executor/processor_async_task.rs:77: Very slow processor async task, query_id:"b087d3f2-5516-4abd-896d-a395ec85d091", processor id: NodeIndex(106), name: "HashJoin", elapsed: 1645.426232664s
2023-03-04T18:45:01.826915Z  WARN databend_query::pipelines::executor::processor_async_task: src/query/service/src/pipelines/executor/processor_async_task.rs:77: Very slow processor async task, query_id:"b087d3f2-5516-4abd-896d-a395ec85d091", processor id: NodeIndex(106), name: "HashJoin", elapsed: 1650.426618576s
2023-03-04T18:45:06.828305Z  WARN databend_query::pipelines::executor::processor_async_task: src/query/service/src/pipelines/executor/processor_async_task.rs:77: Very slow processor async task, query_id:"b087d3f2-5516-4abd-896d-a395ec85d091", processor id: NodeIndex(106), name: "HashJoin", elapsed: 1655.428007849s
```

Closes #issue
