### PR TITLE
feat(function): Support Variant function object_construct

### DIFF
--- a/src/query/functions/src/scalars/variant.rs
+++ b/src/query/functions/src/scalars/variant.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use std::borrow::Cow;
+use std::collections::HashSet;
+use std::sync::Arc;
 
 use bstr::ByteSlice;
 use chrono::Datelike;
@@ -21,11 +23,14 @@ use common_expression::types::date::string_to_date;
 use common_expression::types::nullable::NullableColumn;
 use common_expression::types::nullable::NullableDomain;
 use common_expression::types::number::*;
+use common_expression::types::string::StringColumnBuilder;
 use common_expression::types::timestamp::string_to_timestamp;
 use common_expression::types::variant::cast_scalar_to_variant;
 use common_expression::types::variant::cast_scalars_to_variants;
 use common_expression::types::variant::JSONB_NULL;
+use common_expression::types::AnyType;
 use common_expression::types::BooleanType;
+use common_expression::types::DataType;
 use common_expression::types::DateType;
 use common_expression::types::GenericType;
 use common_expression::types::NullableType;
@@ -41,9 +46,16 @@ use common_expression::vectorize_2_arg;
 use common_expression::vectorize_with_builder_1_arg;
 use common_expression::vectorize_with_builder_2_arg;
 use common_expression::with_number_mapped_type;
+use common_expression::Column;
+use common_expression::ColumnBuilder;
+use common_expression::EvalContext;
+use common_expression::Function;
 use common_expression::FunctionDomain;
 use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
+use common_expression::FunctionSignature;
+use common_expression::Scalar;
+use common_expression::ScalarRef;
 use common_expression::Value;
 use common_expression::ValueRef;
 use jsonb::array_length;
@@ -51,6 +63,7 @@ use jsonb::as_bool;
 use jsonb::as_f64;
 use jsonb::as_i64;
 use jsonb::as_str;
+use jsonb::build_object;
 use jsonb::get_by_name_ignore_case;
 use jsonb::get_by_path;
 use jsonb::is_array;
@@ -111,7 +124,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.register_combine_nullable_1_arg::<StringType, StringType, _, _>(
         "check_json",
         FunctionProperty::default(),
-        |_| FunctionDomain::MayThrow,
+        |_| FunctionDomain::Full,
         vectorize_with_builder_1_arg::<StringType, NullableType<StringType>>(|s, output, _| {
             if s.trim().is_empty() {
                 output.push_null();
@@ -404,13 +417,17 @@ pub fn register(registry: &mut FunctionRegistry) {
         "to_boolean",
         FunctionProperty::default(),
         |_| FunctionDomain::MayThrow,
-        vectorize_with_builder_1_arg::<VariantType, BooleanType>(|val, output, ctx| match to_bool(
-            val,
-        ) {
-            Ok(value) => output.push(value),
-            Err(err) => {
-                ctx.set_error(output.len(), err.to_string());
+        vectorize_with_builder_1_arg::<VariantType, BooleanType>(|val, output, ctx| {
+            if val.is_empty() {
                 output.push(false);
+            } else {
+                match to_bool(val) {
+                    Ok(value) => output.push(value),
+                    Err(err) => {
+                        ctx.set_error(output.len(), err.to_string());
+                        output.push(false);
+                    }
+                }
             }
         }),
     );
@@ -420,12 +437,16 @@ pub fn register(registry: &mut FunctionRegistry) {
         FunctionProperty::default(),
         |_| FunctionDomain::Full,
         vectorize_with_builder_1_arg::<VariantType, NullableType<BooleanType>>(|val, output, _| {
-            match to_bool(val) {
-                Ok(value) => {
-                    output.validity.push(true);
-                    output.builder.push(value);
+            if val.is_empty() {
+                output.push_null();
+            } else {
+                match to_bool(val) {
+                    Ok(value) => {
+                        output.validity.push(true);
+                        output.builder.push(value);
+                    }
+                    Err(_) => output.push_null(),
                 }
-                Err(_) => output.push_null(),
             }
         }),
     );
@@ -435,13 +456,17 @@ pub fn register(registry: &mut FunctionRegistry) {
         FunctionProperty::default(),
         |_| FunctionDomain::MayThrow,
         vectorize_with_builder_1_arg::<VariantType, StringType>(|val, output, ctx| {
-            match to_str(val) {
-                Ok(value) => output.put_slice(value.as_bytes()),
-                Err(err) => {
-                    ctx.set_error(output.len(), err.to_string());
+            if val.is_empty() {
+                output.commit_row();
+            } else {
+                match to_str(val) {
+                    Ok(value) => output.put_slice(value.as_bytes()),
+                    Err(err) => {
+                        ctx.set_error(output.len(), err.to_string());
+                    }
                 }
+                output.commit_row();
             }
-            output.commit_row();
         }),
     );
 
@@ -450,13 +475,17 @@ pub fn register(registry: &mut FunctionRegistry) {
         FunctionProperty::default(),
         |_| FunctionDomain::Full,
         vectorize_with_builder_1_arg::<VariantType, NullableType<StringType>>(|val, output, _| {
-            match to_str(val) {
-                Ok(value) => {
-                    output.validity.push(true);
-                    output.builder.put_slice(value.as_bytes());
-                    output.builder.commit_row();
+            if val.is_empty() {
+                output.push_null();
+            } else {
+                match to_str(val) {
+                    Ok(value) => {
+                        output.validity.push(true);
+                        output.builder.put_slice(value.as_bytes());
+                        output.builder.commit_row();
+                    }
+                    Err(_) => output.push_null(),
                 }
-                Err(_) => output.push_null(),
             }
         }),
     );
@@ -466,11 +495,15 @@ pub fn register(registry: &mut FunctionRegistry) {
         FunctionProperty::default(),
         |_| FunctionDomain::MayThrow,
         vectorize_with_builder_1_arg::<VariantType, DateType>(|val, output, ctx| {
-            match as_str(val).and_then(|val| string_to_date(val.as_bytes(), ctx.tz.tz)) {
-                Some(d) => output.push(d.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
-                None => {
-                    ctx.set_error(output.len(), "unable to cast to type `DATE`");
-                    output.push(0);
+            if val.is_empty() {
+                output.push(0);
+            } else {
+                match as_str(val).and_then(|val| string_to_date(val.as_bytes(), ctx.tz.tz)) {
+                    Some(d) => output.push(d.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
+                    None => {
+                        ctx.set_error(output.len(), "unable to cast to type `DATE`");
+                        output.push(0);
+                    }
                 }
             }
         }),
@@ -481,10 +514,15 @@ pub fn register(registry: &mut FunctionRegistry) {
         FunctionProperty::default(),
         |_| FunctionDomain::Full,
         vectorize_with_builder_1_arg::<VariantType, NullableType<DateType>>(|val, output, ctx| {
-            match as_str(val).and_then(|str_value| string_to_date(str_value.as_bytes(), ctx.tz.tz))
-            {
-                Some(date) => output.push(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
-                None => output.push_null(),
+            if val.is_empty() {
+                output.push_null();
+            } else {
+                match as_str(val)
+                    .and_then(|str_value| string_to_date(str_value.as_bytes(), ctx.tz.tz))
+                {
+                    Some(date) => output.push(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
+                    None => output.push_null(),
+                }
             }
         }),
     );
@@ -493,17 +531,19 @@ pub fn register(registry: &mut FunctionRegistry) {
         "to_timestamp",
         FunctionProperty::default(),
         |_| FunctionDomain::MayThrow,
-        vectorize_with_builder_1_arg::<VariantType, TimestampType>(
-            |val, output, ctx| match as_str(val)
-                .and_then(|val| string_to_timestamp(val.as_bytes(), ctx.tz.tz))
-            {
-                Some(ts) => output.push(ts.timestamp_micros()),
-                None => {
-                    ctx.set_error(output.len(), "unable to cast to type `TIMESTAMP`");
-                    output.push(0);
+        vectorize_with_builder_1_arg::<VariantType, TimestampType>(|val, output, ctx| {
+            if val.is_empty() {
+                output.push(0);
+            } else {
+                match as_str(val).and_then(|val| string_to_timestamp(val.as_bytes(), ctx.tz.tz)) {
+                    Some(ts) => output.push(ts.timestamp_micros()),
+                    None => {
+                        ctx.set_error(output.len(), "unable to cast to type `TIMESTAMP`");
+                        output.push(0);
+                    }
                 }
-            },
-        ),
+            }
+        }),
     );
 
     registry.register_combine_nullable_1_arg::<VariantType, TimestampType, _, _>(
@@ -511,16 +551,22 @@ pub fn register(registry: &mut FunctionRegistry) {
         FunctionProperty::default(),
         |_| FunctionDomain::Full,
         vectorize_with_builder_1_arg::<VariantType, NullableType<TimestampType>>(
-            |val, output, ctx| match as_str(val) {
-                Some(str_val) => {
-                    let timestamp = string_to_timestamp(str_val.as_bytes(), ctx.tz.tz)
-                        .map(|ts| ts.timestamp_micros());
-                    match timestamp {
-                        Some(timestamp) => output.push(timestamp),
+            |val, output, ctx| {
+                if val.is_empty() {
+                    output.push_null();
+                } else {
+                    match as_str(val) {
+                        Some(str_val) => {
+                            let timestamp = string_to_timestamp(str_val.as_bytes(), ctx.tz.tz)
+                                .map(|ts| ts.timestamp_micros());
+                            match timestamp {
+                                Some(timestamp) => output.push(timestamp),
+                                None => output.push_null(),
+                            }
+                        }
                         None => output.push_null(),
                     }
                 }
-                None => output.push_null(),
             },
         ),
     );
@@ -536,23 +582,27 @@ pub fn register(registry: &mut FunctionRegistry) {
                         |_| FunctionDomain::MayThrow,
                         vectorize_with_builder_1_arg::<VariantType, NumberType<NUM_TYPE>>(
                             move |val, output, ctx| {
-                                type Native = <NUM_TYPE as Number>::Native;
-
-                                let value: Option<Native> = if dest_type.is_float() {
-                                    to_f64(val).ok().and_then(num_traits::cast::cast)
-                                } else if dest_type.is_signed() {
-                                    to_i64(val).ok().and_then(num_traits::cast::cast)
+                                if val.is_empty() {
+                                    output.push(NUM_TYPE::default());
                                 } else {
-                                    to_u64(val).ok().and_then(num_traits::cast::cast)
-                                };
-                                match value {
-                                    Some(value) => output.push(value.into()),
-                                    None => {
-                                        ctx.set_error(
-                                            output.len(),
-                                            format!("unable to cast to type {dest_type}",),
-                                        );
-                                        output.push(NUM_TYPE::default());
+                                    type Native = <NUM_TYPE as Number>::Native;
+
+                                    let value: Option<Native> = if dest_type.is_float() {
+                                        to_f64(val).ok().and_then(num_traits::cast::cast)
+                                    } else if dest_type.is_signed() {
+                                        to_i64(val).ok().and_then(num_traits::cast::cast)
+                                    } else {
+                                        to_u64(val).ok().and_then(num_traits::cast::cast)
+                                    };
+                                    match value {
+                                        Some(value) => output.push(value.into()),
+                                        None => {
+                                            ctx.set_error(
+                                                output.len(),
+                                                format!("unable to cast to type {dest_type}",),
+                                            );
+                                            output.push(NUM_TYPE::default());
+                                        }
                                     }
                                 }
                             },
@@ -569,7 +619,9 @@ pub fn register(registry: &mut FunctionRegistry) {
                             VariantType,
                             NullableType<NumberType<NUM_TYPE>>,
                         >(move |val, output, _| {
-                            if dest_type.is_float() {
+                            if val.is_empty() {
+                                output.push_null();
+                            } else if dest_type.is_float() {
                                 if let Ok(value) = to_f64(val) {
                                     if let Some(new_value) = num_traits::cast::cast(value) {
                                         output.push(new_value);
@@ -604,5 +656,103 @@ pub fn register(registry: &mut FunctionRegistry) {
                     );
             }
         });
+    }
+
+    registry.register_function_factory("object_construct", |_, args_type| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "object_construct".to_string(),
+                args_type: (0..args_type.len()).map(DataType::Generic).collect(),
+                return_type: DataType::Variant,
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| FunctionDomain::MayThrow),
+            eval: Box::new(move |args, ctx| object_construct_fn(args, ctx, false)),
+        }))
+    });
+
+    registry.register_function_factory("object_construct_keep_null", |_, args_type| {
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "object_construct_keep_null".to_string(),
+                args_type: (0..args_type.len()).map(DataType::Generic).collect(),
+                return_type: DataType::Variant,
+                property: FunctionProperty::default(),
+            },
+            calc_domain: Box::new(|_| FunctionDomain::MayThrow),
+            eval: Box::new(move |args, ctx| object_construct_fn(args, ctx, true)),
+        }))
+    });
+}
+
+fn object_construct_fn(
+    args: &[ValueRef<AnyType>],
+    ctx: &mut EvalContext,
+    keep_null: bool,
+) -> Value<AnyType> {
+    let len = args.iter().find_map(|arg| match arg {
+        ValueRef::Column(col) => Some(col.len()),
+        _ => None,
+    });
+
+    let mut columns = Vec::with_capacity(args.len());
+    for (i, arg) in args.iter().enumerate() {
+        let column = match arg {
+            ValueRef::Column(column) => column.clone(),
+            ValueRef::Scalar(s) => {
+                let column_builder = ColumnBuilder::repeat(s, 1, &ctx.generics[i]);
+                column_builder.build()
+            }
+        };
+        columns.push(column);
+    }
+
+    let cap = len.unwrap_or(1);
+    let mut builder = StringColumnBuilder::with_capacity(cap, cap * 50);
+    if columns.len() % 2 != 0 {
+        ctx.set_error(0, "The number of keys and values must be equal");
+        for _ in 0..(len.unwrap_or(1)) {
+            builder.commit_row();
+        }
+    } else {
+        let mut set = HashSet::new();
+        for idx in 0..(len.unwrap_or(1)) {
+            set.clear();
+            let mut kvs = Vec::with_capacity(columns.len() / 2);
+            for i in (0..columns.len()).step_by(2) {
+                let k = unsafe { columns[i].index_unchecked(idx) };
+                if k == ScalarRef::Null {
+                    continue;
+                }
+                let v = unsafe { columns[i + 1].index_unchecked(idx) };
+                if v == ScalarRef::Null && !keep_null {
+                    continue;
+                }
+                let key = match k {
+                    ScalarRef::String(v) => unsafe { String::from_utf8_unchecked(v.to_vec()) },
+                    _ => {
+                        ctx.set_error(builder.len(), "Key must be a string value");
+                        break;
+                    }
+                };
+                if set.contains(&key) {
+                    ctx.set_error(builder.len(), "Keys have to be unique");
+                    break;
+                }
+                set.insert(key.clone());
+                let mut val = vec![];
+                cast_scalar_to_variant(v, ctx.tz, &mut val);
+                kvs.push((key, val));
+            }
+            if let Err(err) = build_object(kvs.iter().map(|(k, v)| (k, &v[..])), &mut builder.data)
+            {
+                ctx.set_error(builder.len(), err.to_string());
+            }
+            builder.commit_row();
+        }
+    }
+    match len {
+        Some(_) => Value::Column(Column::Variant(builder.build())),
+        None => Value::Scalar(Scalar::Variant(builder.build_scalar())),
     }
 }

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -2210,6 +2210,8 @@ Functions overloads:
 33 noteq(Array(T0) NULL, Array(T0) NULL) :: Boolean NULL
 34 noteq FACTORY
 0 now() :: Timestamp
+0 object_construct FACTORY
+0 object_construct_keep_null FACTORY
 0 object_keys(Variant NULL) :: Variant NULL
 0 oct(Int64) :: String
 1 oct(Int64 NULL) :: String NULL

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -307,7 +307,7 @@ evaluation:
 |        | s                | Output                  |
 +--------+------------------+-------------------------+
 | Type   | String           | String NULL             |
-| Domain | {"abc"..="true"} | Unknown                 |
+| Domain | {"abc"..="true"} | {""..} ∪ {NULL}         |
 | Row 0  | "null"           | NULL                    |
 | Row 1  | "abc"            | "expected value, pos 1" |
 | Row 2  | "true"           | NULL                    |
@@ -329,7 +329,7 @@ evaluation:
 |        | s                     | Output                  |
 +--------+-----------------------+-------------------------+
 | Type   | String NULL           | String NULL             |
-| Domain | {""..="ttt"} ∪ {NULL} | Unknown                 |
+| Domain | {""..="ttt"} ∪ {NULL} | {""..} ∪ {NULL}         |
 | Row 0  | "true"                | NULL                    |
 | Row 1  | "ttt"                 | "expected ident, pos 2" |
 | Row 2  | NULL                  | NULL                    |
@@ -1354,5 +1354,800 @@ evaluation (internal):
 | s      | StringColumn { data: 0x7472756531323331322e3334226162225b312c322c335d7b2261223a2262227d, offsets: [0, 4, 7, 12, 16, 23, 32] }             |
 | Output | NullableColumn { column: StringColumn { data: 0x4000000110000001100000016162, offsets: [0, 0, 0, 0, 0, 0, 14] }, validity: [0b__100000] } |
 +--------+-------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : to_boolean(parse_json('true'))
+raw expr       : to_boolean(parse_json("true"))
+checked expr   : to_boolean<Variant>(parse_json<String>("true"))
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | to_boolean(parse_json('123'))
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ InvalidCast while evaluating function `to_boolean(123)`
+
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | to_boolean(parse_json('"abc"'))
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ InvalidCast while evaluating function `to_boolean("abc")`
+
+
+
+ast            : to_uint64(parse_json('123'))
+raw expr       : to_uint64(parse_json("123"))
+checked expr   : to_uint64<Variant>(parse_json<String>("123"))
+optimized expr : 123_u64
+output type    : UInt64
+output domain  : {123..=123}
+output         : 123
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | to_uint64(parse_json('-123'))
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type UInt64 while evaluating function `to_uint64(-123)`
+
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | to_uint64(parse_json('"abc"'))
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type UInt64 while evaluating function `to_uint64("abc")`
+
+
+
+ast            : to_int64(parse_json('123'))
+raw expr       : to_int64(parse_json("123"))
+checked expr   : to_int64<Variant>(parse_json<String>("123"))
+optimized expr : 123_i64
+output type    : Int64
+output domain  : {123..=123}
+output         : 123
+
+
+ast            : to_int64(parse_json('-123'))
+raw expr       : to_int64(parse_json("-123"))
+checked expr   : to_int64<Variant>(parse_json<String>("-123"))
+optimized expr : -123_i64
+output type    : Int64
+output domain  : {-123..=-123}
+output         : -123
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | to_int64(parse_json('"abc"'))
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type Int64 while evaluating function `to_int64("abc")`
+
+
+
+ast            : to_float64(parse_json('12.34'))
+raw expr       : to_float64(parse_json("12.34"))
+checked expr   : to_float64<Variant>(parse_json<String>("12.34"))
+optimized expr : 12.34_f64
+output type    : Float64
+output domain  : {12.34..=12.34}
+output         : 12.34
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | to_float64(parse_json('"abc"'))
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type Float64 while evaluating function `to_float64("abc")`
+
+
+
+ast            : to_date(parse_json('"2023-01-01"'))
+raw expr       : to_date(parse_json("\"2023-01-01\""))
+checked expr   : to_date<Variant>(parse_json<String>("\"2023-01-01\""))
+optimized expr : 19358
+output type    : Date
+output domain  : {19358..=19358}
+output         : 2023-01-01
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | to_date(parse_json('"abc"'))
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `DATE` while evaluating function `to_date("abc")`
+
+
+
+ast            : to_timestamp(parse_json('"2023-01-01 00:00:00"'))
+raw expr       : to_timestamp(parse_json("\"2023-01-01 00:00:00\""))
+checked expr   : to_timestamp<Variant>(parse_json<String>("\"2023-01-01 00:00:00\""))
+optimized expr : 1672531200000000
+output type    : Timestamp
+output domain  : {1672531200000000..=1672531200000000}
+output         : 2023-01-01 00:00:00.000000
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | to_timestamp(parse_json('"abc"'))
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `TIMESTAMP` while evaluating function `to_timestamp("abc")`
+
+
+
+ast            : to_string(parse_json('12.34'))
+raw expr       : to_string(parse_json("12.34"))
+checked expr   : to_string<Variant>(parse_json<String>("12.34"))
+optimized expr : "12.34"
+output type    : String
+output domain  : {"12.34"..="12.34"}
+output         : "12.34"
+
+
+ast            : to_string(parse_json('"abc"'))
+raw expr       : to_string(parse_json("\"abc\""))
+checked expr   : to_string<Variant>(parse_json<String>("\"abc\""))
+optimized expr : "abc"
+output type    : String
+output domain  : {"abc"..="abc"}
+output         : "abc"
+
+
+ast            : to_boolean(parse_json(s))
+raw expr       : to_boolean(parse_json(s::String NULL))
+checked expr   : to_boolean<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+------------------------+--------------+
+|        | s                      | Output       |
++--------+------------------------+--------------+
+| Type   | String NULL            | Boolean NULL |
+| Domain | {""..="true"} ∪ {NULL} | Unknown      |
+| Row 0  | "true"                 | true         |
+| Row 1  | NULL                   | NULL         |
+| Row 2  | "true"                 | true         |
++--------+------------------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                |
++--------+---------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x7472756574727565, offsets: [0, 4, 4, 8] }, validity: [0b_____101] } |
+| Output | NullableColumn { column: Boolean([0b_____101]), validity: [0b_____101] }                                            |
++--------+---------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : to_int64(parse_json(s))
+raw expr       : to_int64(parse_json(s::String NULL))
+checked expr   : to_int64<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+---------------------+------------+
+|        | s                   | Output     |
++--------+---------------------+------------+
+| Type   | String NULL         | Int64 NULL |
+| Domain | {""..="1"} ∪ {NULL} | Unknown    |
+| Row 0  | "1"                 | 1          |
+| Row 1  | NULL                | NULL       |
+| Row 2  | "-10"               | -10        |
++--------+---------------------+------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                        |
++--------+-------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x312d3130, offsets: [0, 1, 1, 4] }, validity: [0b_____101] } |
+| Output | NullableColumn { column: Int64([1, 0, -10]), validity: [0b_____101] }                                       |
++--------+-------------------------------------------------------------------------------------------------------------+
+
+
+ast            : to_uint64(parse_json(s))
+raw expr       : to_uint64(parse_json(s::String NULL))
+checked expr   : to_uint64<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+----------------------+-------------+
+|        | s                    | Output      |
++--------+----------------------+-------------+
+| Type   | String NULL          | UInt64 NULL |
+| Domain | {""..="20"} ∪ {NULL} | Unknown     |
+| Row 0  | "1"                  | 1           |
+| Row 1  | NULL                 | NULL        |
+| Row 2  | "20"                 | 20          |
++--------+----------------------+-------------+
+evaluation (internal):
++--------+-----------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                      |
++--------+-----------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x313230, offsets: [0, 1, 1, 3] }, validity: [0b_____101] } |
+| Output | NullableColumn { column: UInt64([1, 0, 20]), validity: [0b_____101] }                                     |
++--------+-----------------------------------------------------------------------------------------------------------+
+
+
+ast            : to_float64(parse_json(s))
+raw expr       : to_float64(parse_json(s::String NULL))
+checked expr   : to_float64<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+-------------------------+--------------+
+|        | s                       | Output       |
++--------+-------------------------+--------------+
+| Type   | String NULL             | Float64 NULL |
+| Domain | {""..="100.2"} ∪ {NULL} | Unknown      |
+| Row 0  | "1.2"                   | 1.2          |
+| Row 1  | NULL                    | NULL         |
+| Row 2  | "100.2"                 | 100.2        |
++--------+-------------------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                |
++--------+---------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x312e323130302e32, offsets: [0, 3, 3, 8] }, validity: [0b_____101] } |
+| Output | NullableColumn { column: Float64([1.2, 0, 100.2]), validity: [0b_____101] }                                         |
++--------+---------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : to_date(parse_json(s))
+raw expr       : to_date(parse_json(s::String NULL))
+checked expr   : to_date<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+----------------------------------+------------+
+|        | s                                | Output     |
++--------+----------------------------------+------------+
+| Type   | String NULL                      | Date NULL  |
+| Domain | {""..="\"2023-10-01\""} ∪ {NULL} | Unknown    |
+| Row 0  | "\"2020-01-01\""                 | 2020-01-01 |
+| Row 1  | NULL                             | NULL       |
+| Row 2  | "\"2023-10-01\""                 | 2023-10-01 |
++--------+----------------------------------+------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                   |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x22323032302d30312d30312222323032332d31302d303122, offsets: [0, 12, 12, 24] }, validity: [0b_____101] } |
+| Output | NullableColumn { column: [18262, 0, 19631], validity: [0b_____101] }                                                                                   |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : to_timestamp(parse_json(s))
+raw expr       : to_timestamp(parse_json(s::String NULL))
+checked expr   : to_timestamp<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+-------------------------------------------+----------------------------+
+|        | s                                         | Output                     |
++--------+-------------------------------------------+----------------------------+
+| Type   | String NULL                               | Timestamp NULL             |
+| Domain | {""..="\"2023-10-01 10:11:12\""} ∪ {NULL} | Unknown                    |
+| Row 0  | "\"2020-01-01 00:00:00\""                 | 2020-01-01 00:00:00.000000 |
+| Row 1  | NULL                                      | NULL                       |
+| Row 2  | "\"2023-10-01 10:11:12\""                 | 2023-10-01 10:11:12.000000 |
++--------+-------------------------------------------+----------------------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                       |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x22323032302d30312d30312030303a30303a30302222323032332d31302d30312031303a31313a313222, offsets: [0, 21, 21, 42] }, validity: [0b_____101] } |
+| Output | NullableColumn { column: [1577836800000000, 0, 1696155072000000], validity: [0b_____101] }                                                                                                 |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : to_string(parse_json(s))
+raw expr       : to_string(parse_json(s::String NULL))
+checked expr   : to_string<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+-----------------------+-------------+
+|        | s                     | Output      |
++--------+-----------------------+-------------+
+| Type   | String NULL           | String NULL |
+| Domain | {""..="123"} ∪ {NULL} | Unknown     |
+| Row 0  | "\"abc\""             | "abc"       |
+| Row 1  | NULL                  | NULL        |
+| Row 2  | "123"                 | "123"       |
++--------+-----------------------+-------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                |
++--------+---------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x2261626322313233, offsets: [0, 5, 5, 8] }, validity: [0b_____101] } |
+| Output | NullableColumn { column: StringColumn { data: 0x616263313233, offsets: [0, 3, 3, 6] }, validity: [0b_____101] }     |
++--------+---------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : try_to_boolean(parse_json('true'))
+raw expr       : try_to_boolean(parse_json("true"))
+checked expr   : try_to_boolean<Variant>(parse_json<String>("true"))
+optimized expr : true
+output type    : Boolean NULL
+output domain  : {TRUE}
+output         : true
+
+
+ast            : try_to_boolean(parse_json('123'))
+raw expr       : try_to_boolean(parse_json("123"))
+checked expr   : try_to_boolean<Variant>(parse_json<String>("123"))
+optimized expr : NULL
+output type    : Boolean NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_to_boolean(parse_json('"abc"'))
+raw expr       : try_to_boolean(parse_json("\"abc\""))
+checked expr   : try_to_boolean<Variant>(parse_json<String>("\"abc\""))
+optimized expr : NULL
+output type    : Boolean NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_to_uint64(parse_json('123'))
+raw expr       : try_to_uint64(parse_json("123"))
+checked expr   : try_to_uint64<Variant>(parse_json<String>("123"))
+optimized expr : 123_u64
+output type    : UInt64 NULL
+output domain  : {123..=123}
+output         : 123
+
+
+ast            : try_to_uint64(parse_json('-123'))
+raw expr       : try_to_uint64(parse_json("-123"))
+checked expr   : try_to_uint64<Variant>(parse_json<String>("-123"))
+optimized expr : NULL
+output type    : UInt64 NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_to_uint64(parse_json('"abc"'))
+raw expr       : try_to_uint64(parse_json("\"abc\""))
+checked expr   : try_to_uint64<Variant>(parse_json<String>("\"abc\""))
+optimized expr : NULL
+output type    : UInt64 NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_to_int64(parse_json('123'))
+raw expr       : try_to_int64(parse_json("123"))
+checked expr   : try_to_int64<Variant>(parse_json<String>("123"))
+optimized expr : 123_i64
+output type    : Int64 NULL
+output domain  : {123..=123}
+output         : 123
+
+
+ast            : try_to_int64(parse_json('-123'))
+raw expr       : try_to_int64(parse_json("-123"))
+checked expr   : try_to_int64<Variant>(parse_json<String>("-123"))
+optimized expr : -123_i64
+output type    : Int64 NULL
+output domain  : {-123..=-123}
+output         : -123
+
+
+ast            : try_to_int64(parse_json('"abc"'))
+raw expr       : try_to_int64(parse_json("\"abc\""))
+checked expr   : try_to_int64<Variant>(parse_json<String>("\"abc\""))
+optimized expr : NULL
+output type    : Int64 NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_to_float64(parse_json('12.34'))
+raw expr       : try_to_float64(parse_json("12.34"))
+checked expr   : try_to_float64<Variant>(parse_json<String>("12.34"))
+optimized expr : 12.34_f64
+output type    : Float64 NULL
+output domain  : {12.34..=12.34}
+output         : 12.34
+
+
+ast            : try_to_float64(parse_json('"abc"'))
+raw expr       : try_to_float64(parse_json("\"abc\""))
+checked expr   : try_to_float64<Variant>(parse_json<String>("\"abc\""))
+optimized expr : NULL
+output type    : Float64 NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_to_date(parse_json('"2023-01-01"'))
+raw expr       : try_to_date(parse_json("\"2023-01-01\""))
+checked expr   : try_to_date<Variant>(parse_json<String>("\"2023-01-01\""))
+optimized expr : 19358
+output type    : Date NULL
+output domain  : {19358..=19358}
+output         : 2023-01-01
+
+
+ast            : try_to_date(parse_json('"abc"'))
+raw expr       : try_to_date(parse_json("\"abc\""))
+checked expr   : try_to_date<Variant>(parse_json<String>("\"abc\""))
+optimized expr : NULL
+output type    : Date NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_to_timestamp(parse_json('"2023-01-01 00:00:00"'))
+raw expr       : try_to_timestamp(parse_json("\"2023-01-01 00:00:00\""))
+checked expr   : try_to_timestamp<Variant>(parse_json<String>("\"2023-01-01 00:00:00\""))
+optimized expr : 1672531200000000
+output type    : Timestamp NULL
+output domain  : {1672531200000000..=1672531200000000}
+output         : 2023-01-01 00:00:00.000000
+
+
+ast            : try_to_timestamp(parse_json('"abc"'))
+raw expr       : try_to_timestamp(parse_json("\"abc\""))
+checked expr   : try_to_timestamp<Variant>(parse_json<String>("\"abc\""))
+optimized expr : NULL
+output type    : Timestamp NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_to_string(parse_json('12.34'))
+raw expr       : try_to_string(parse_json("12.34"))
+checked expr   : try_to_string<Variant>(parse_json<String>("12.34"))
+optimized expr : "12.34"
+output type    : String NULL
+output domain  : {"12.34"..="12.34"}
+output         : "12.34"
+
+
+ast            : try_to_string(parse_json('"abc"'))
+raw expr       : try_to_string(parse_json("\"abc\""))
+checked expr   : try_to_string<Variant>(parse_json<String>("\"abc\""))
+optimized expr : "abc"
+output type    : String NULL
+output domain  : {"abc"..="abc"}
+output         : "abc"
+
+
+ast            : try_to_boolean(parse_json(s))
+raw expr       : try_to_boolean(parse_json(s::String NULL))
+checked expr   : try_to_boolean<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+---------------------------+--------------+
+|        | s                         | Output       |
++--------+---------------------------+--------------+
+| Type   | String NULL               | Boolean NULL |
+| Domain | {""..="true"} ∪ {NULL}    | Unknown      |
+| Row 0  | "true"                    | true         |
+| Row 1  | "123"                     | NULL         |
+| Row 2  | "-100"                    | NULL         |
+| Row 3  | "12.34"                   | NULL         |
+| Row 4  | NULL                      | NULL         |
+| Row 5  | "\"2020-01-01\""          | NULL         |
+| Row 6  | "\"2021-01-01 20:00:00\"" | NULL         |
+| Row 7  | "\"abc\""                 | NULL         |
++--------+---------------------------+--------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                 |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275653132332d31303031322e333422323032302d30312d30312222323032312d30312d30312032303a30303a3030222261626322, offsets: [0, 4, 7, 11, 16, 16, 28, 49, 54] }, validity: [0b11101111] } |
+| Output | NullableColumn { column: Boolean([0b00000001]), validity: [0b00000001] }                                                                                                                                                             |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : try_to_int64(parse_json(s))
+raw expr       : try_to_int64(parse_json(s::String NULL))
+checked expr   : try_to_int64<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+---------------------------+------------+
+|        | s                         | Output     |
++--------+---------------------------+------------+
+| Type   | String NULL               | Int64 NULL |
+| Domain | {""..="true"} ∪ {NULL}    | Unknown    |
+| Row 0  | "true"                    | 1          |
+| Row 1  | "123"                     | 123        |
+| Row 2  | "-100"                    | -100       |
+| Row 3  | "12.34"                   | NULL       |
+| Row 4  | NULL                      | NULL       |
+| Row 5  | "\"2020-01-01\""          | NULL       |
+| Row 6  | "\"2021-01-01 20:00:00\"" | NULL       |
+| Row 7  | "\"abc\""                 | NULL       |
++--------+---------------------------+------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                 |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275653132332d31303031322e333422323032302d30312d30312222323032312d30312d30312032303a30303a3030222261626322, offsets: [0, 4, 7, 11, 16, 16, 28, 49, 54] }, validity: [0b11101111] } |
+| Output | NullableColumn { column: Int64([1, 123, -100, 0, 0, 0, 0, 0]), validity: [0b00000111] }                                                                                                                                              |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : try_to_uint64(parse_json(s))
+raw expr       : try_to_uint64(parse_json(s::String NULL))
+checked expr   : try_to_uint64<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+---------------------------+-------------+
+|        | s                         | Output      |
++--------+---------------------------+-------------+
+| Type   | String NULL               | UInt64 NULL |
+| Domain | {""..="true"} ∪ {NULL}    | Unknown     |
+| Row 0  | "true"                    | 1           |
+| Row 1  | "123"                     | 123         |
+| Row 2  | "-100"                    | NULL        |
+| Row 3  | "12.34"                   | NULL        |
+| Row 4  | NULL                      | NULL        |
+| Row 5  | "\"2020-01-01\""          | NULL        |
+| Row 6  | "\"2021-01-01 20:00:00\"" | NULL        |
+| Row 7  | "\"abc\""                 | NULL        |
++--------+---------------------------+-------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                 |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275653132332d31303031322e333422323032302d30312d30312222323032312d30312d30312032303a30303a3030222261626322, offsets: [0, 4, 7, 11, 16, 16, 28, 49, 54] }, validity: [0b11101111] } |
+| Output | NullableColumn { column: UInt64([1, 123, 0, 0, 0, 0, 0, 0]), validity: [0b00000011] }                                                                                                                                                |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : try_to_float64(parse_json(s))
+raw expr       : try_to_float64(parse_json(s::String NULL))
+checked expr   : try_to_float64<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+---------------------------+--------------+
+|        | s                         | Output       |
++--------+---------------------------+--------------+
+| Type   | String NULL               | Float64 NULL |
+| Domain | {""..="true"} ∪ {NULL}    | Unknown      |
+| Row 0  | "true"                    | 1            |
+| Row 1  | "123"                     | 123          |
+| Row 2  | "-100"                    | -100         |
+| Row 3  | "12.34"                   | 12.34        |
+| Row 4  | NULL                      | NULL         |
+| Row 5  | "\"2020-01-01\""          | NULL         |
+| Row 6  | "\"2021-01-01 20:00:00\"" | NULL         |
+| Row 7  | "\"abc\""                 | NULL         |
++--------+---------------------------+--------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                 |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275653132332d31303031322e333422323032302d30312d30312222323032312d30312d30312032303a30303a3030222261626322, offsets: [0, 4, 7, 11, 16, 16, 28, 49, 54] }, validity: [0b11101111] } |
+| Output | NullableColumn { column: Float64([1, 123, -100, 12.34, 0, 0, 0, 0]), validity: [0b00001111] }                                                                                                                                        |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : try_to_date(parse_json(s))
+raw expr       : try_to_date(parse_json(s::String NULL))
+checked expr   : try_to_date<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+---------------------------+------------+
+|        | s                         | Output     |
++--------+---------------------------+------------+
+| Type   | String NULL               | Date NULL  |
+| Domain | {""..="true"} ∪ {NULL}    | Unknown    |
+| Row 0  | "true"                    | NULL       |
+| Row 1  | "123"                     | NULL       |
+| Row 2  | "-100"                    | NULL       |
+| Row 3  | "12.34"                   | NULL       |
+| Row 4  | NULL                      | NULL       |
+| Row 5  | "\"2020-01-01\""          | 2020-01-01 |
+| Row 6  | "\"2021-01-01 20:00:00\"" | 2021-01-01 |
+| Row 7  | "\"abc\""                 | NULL       |
++--------+---------------------------+------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                 |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275653132332d31303031322e333422323032302d30312d30312222323032312d30312d30312032303a30303a3030222261626322, offsets: [0, 4, 7, 11, 16, 16, 28, 49, 54] }, validity: [0b11101111] } |
+| Output | NullableColumn { column: [0, 0, 0, 0, 0, 18262, 18628, 0], validity: [0b01100000] }                                                                                                                                                  |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : try_to_timestamp(parse_json(s))
+raw expr       : try_to_timestamp(parse_json(s::String NULL))
+checked expr   : try_to_timestamp<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+---------------------------+----------------------------+
+|        | s                         | Output                     |
++--------+---------------------------+----------------------------+
+| Type   | String NULL               | Timestamp NULL             |
+| Domain | {""..="true"} ∪ {NULL}    | Unknown                    |
+| Row 0  | "true"                    | NULL                       |
+| Row 1  | "123"                     | NULL                       |
+| Row 2  | "-100"                    | NULL                       |
+| Row 3  | "12.34"                   | NULL                       |
+| Row 4  | NULL                      | NULL                       |
+| Row 5  | "\"2020-01-01\""          | 2020-01-01 00:00:00.000000 |
+| Row 6  | "\"2021-01-01 20:00:00\"" | 2021-01-01 20:00:00.000000 |
+| Row 7  | "\"abc\""                 | NULL                       |
++--------+---------------------------+----------------------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                 |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275653132332d31303031322e333422323032302d30312d30312222323032312d30312d30312032303a30303a3030222261626322, offsets: [0, 4, 7, 11, 16, 16, 28, 49, 54] }, validity: [0b11101111] } |
+| Output | NullableColumn { column: [0, 0, 0, 0, 0, 1577836800000000, 1609531200000000, 0], validity: [0b01100000] }                                                                                                                            |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : try_to_string(parse_json(s))
+raw expr       : try_to_string(parse_json(s::String NULL))
+checked expr   : try_to_string<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+---------------------------+-----------------------+
+|        | s                         | Output                |
++--------+---------------------------+-----------------------+
+| Type   | String NULL               | String NULL           |
+| Domain | {""..="true"} ∪ {NULL}    | Unknown               |
+| Row 0  | "true"                    | "true"                |
+| Row 1  | "123"                     | "123"                 |
+| Row 2  | "-100"                    | "-100"                |
+| Row 3  | "12.34"                   | "12.34"               |
+| Row 4  | NULL                      | NULL                  |
+| Row 5  | "\"2020-01-01\""          | "2020-01-01"          |
+| Row 6  | "\"2021-01-01 20:00:00\"" | "2021-01-01 20:00:00" |
+| Row 7  | "\"abc\""                 | "abc"                 |
++--------+---------------------------+-----------------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                 |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn { data: 0x747275653132332d31303031322e333422323032302d30312d30312222323032312d30312d30312032303a30303a3030222261626322, offsets: [0, 4, 7, 11, 16, 16, 28, 49, 54] }, validity: [0b11101111] } |
+| Output | NullableColumn { column: StringColumn { data: 0x747275653132332d31303031322e3334323032302d30312d3031323032312d30312d30312032303a30303a3030616263, offsets: [0, 4, 7, 11, 16, 16, 26, 45, 48] }, validity: [0b11101111] }             |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : object_construct()
+raw expr       : object_construct()
+checked expr   : object_construct<>()
+optimized expr : 0x40000000
+output type    : Variant
+output domain  : Undefined
+output         : {}
+
+
+ast            : object_construct('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})
+raw expr       : object_construct("a", true, "b", 1_u8, "c", "str", "d", array(1_u8, 2_u8), "e", map(array("k"), array("v")))
+checked expr   : object_construct<T0=String, T1=Boolean, T2=String, T3=UInt8, T4=String, T5=String, T6=String, T7=Array(UInt8), T8=String, T9=Map(String, String)><T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>("a", true, "b", 1_u8, "c", "str", "d", array<T0=UInt8><T0, T0>(1_u8, 2_u8), "e", map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0>("k"), array<T0=String><T0>("v")))
+optimized expr : 0x400000051000000110000001100000011000000110000001400000002000000210000003500000105000000e61626364655001737472800000022000000220000002500150024000000110000001100000016b76
+output type    : Variant
+output domain  : Undefined
+output         : {"a":true,"b":1,"c":"str","d":[1,2],"e":{"k":"v"}}
+
+
+ast            : object_construct('k1', 1, 'k2', null, 'k3', 2, null, 3)
+raw expr       : object_construct("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
+checked expr   : object_construct<T0=String, T1=UInt8, T2=String, T3=NULL, T4=String, T5=UInt8, T6=NULL, T7=UInt8><T0, T1, T2, T3, T4, T5, T6, T7>("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
+optimized expr : 0x40000002100000021000000220000002200000026b316b3350015002
+output type    : Variant
+output domain  : Undefined
+output         : {"k1":1,"k3":2}
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | object_construct('k1', 1, 'k1')
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The number of keys and values must be equal while evaluating function `object_construct("k1", 1, "k1")`
+
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | object_construct('k1', 1, 'k1', 2)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Keys have to be unique while evaluating function `object_construct("k1", 1, "k1", 2)`
+
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | object_construct(1, 'k1', 2, 'k2')
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Key must be a string value while evaluating function `object_construct(1, "k1", 2, "k2")`
+
+
+
+ast            : object_construct(k1, v1, k2, v2)
+raw expr       : object_construct(k1::String NULL, v1::String NULL, k2::String NULL, v2::String NULL)
+checked expr   : object_construct<T0=String NULL, T1=String NULL, T2=String NULL, T3=String NULL><T0, T1, T2, T3>(k1, v1, k2, v2)
+evaluation:
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+|        | k1                   | v1                   | k2                   | v2            | Output                |
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+| Type   | String NULL          | String NULL          | String NULL          | String NULL   | Variant               |
+| Domain | {""..="d1"} ∪ {NULL} | {""..="l1"} ∪ {NULL} | {""..="d2"} ∪ {NULL} | {"j2"..="m2"} | Unknown               |
+| Row 0  | "a1"                 | "j1"                 | "a2"                 | "j2"          | {"a1":"j1","a2":"j2"} |
+| Row 1  | "b1"                 | "k1"                 | NULL                 | "k2"          | {"b1":"k1"}           |
+| Row 2  | NULL                 | "l1"                 | "c2"                 | "l2"          | {"c2":"l2"}           |
+| Row 3  | "d1"                 | NULL                 | "d2"                 | "m2"          | {"d2":"m2"}           |
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+evaluation (internal):
++--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                            |
++--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| k1     | NullableColumn { column: StringColumn { data: 0x613162316431, offsets: [0, 2, 4, 4, 6] }, validity: [0b____1011] }                                                                                              |
+| v1     | NullableColumn { column: StringColumn { data: 0x6a316b316c31, offsets: [0, 2, 4, 6, 6] }, validity: [0b____0111] }                                                                                              |
+| k2     | NullableColumn { column: StringColumn { data: 0x613263326432, offsets: [0, 2, 2, 4, 6] }, validity: [0b____1101] }                                                                                              |
+| v2     | NullableColumn { column: StringColumn { data: 0x6a326b326c326d32, offsets: [0, 2, 4, 6, 8] }, validity: [0b____1111] }                                                                                          |
+| Output | StringColumn { data: 0x4000000210000002100000021000000210000002613161326a316a3240000001100000021000000262316b3140000001100000021000000263326c3240000001100000021000000264326d32, offsets: [0, 28, 44, 60, 76] } |
++--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : object_construct_keep_null()
+raw expr       : object_construct_keep_null()
+checked expr   : object_construct_keep_null<>()
+optimized expr : 0x40000000
+output type    : Variant
+output domain  : Undefined
+output         : {}
+
+
+ast            : object_construct_keep_null('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})
+raw expr       : object_construct_keep_null("a", true, "b", 1_u8, "c", "str", "d", array(1_u8, 2_u8), "e", map(array("k"), array("v")))
+checked expr   : object_construct_keep_null<T0=String, T1=Boolean, T2=String, T3=UInt8, T4=String, T5=String, T6=String, T7=Array(UInt8), T8=String, T9=Map(String, String)><T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>("a", true, "b", 1_u8, "c", "str", "d", array<T0=UInt8><T0, T0>(1_u8, 2_u8), "e", map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0>("k"), array<T0=String><T0>("v")))
+optimized expr : 0x400000051000000110000001100000011000000110000001400000002000000210000003500000105000000e61626364655001737472800000022000000220000002500150024000000110000001100000016b76
+output type    : Variant
+output domain  : Undefined
+output         : {"a":true,"b":1,"c":"str","d":[1,2],"e":{"k":"v"}}
+
+
+ast            : object_construct_keep_null('k1', 1, 'k2', null, 'k3', 2, null, 3)
+raw expr       : object_construct_keep_null("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
+checked expr   : object_construct_keep_null<T0=String, T1=UInt8, T2=String, T3=NULL, T4=String, T5=UInt8, T6=NULL, T7=UInt8><T0, T1, T2, T3, T4, T5, T6, T7>("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
+optimized expr : 0x400000031000000210000002100000022000000200000000200000026b316b326b3350015002
+output type    : Variant
+output domain  : Undefined
+output         : {"k1":1,"k2":null,"k3":2}
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | object_construct_keep_null('k1', 1, 'k1')
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The number of keys and values must be equal while evaluating function `object_construct_keep_null("k1", 1, "k1")`
+
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | object_construct_keep_null('k1', 1, 'k1', 2)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Keys have to be unique while evaluating function `object_construct_keep_null("k1", 1, "k1", 2)`
+
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | object_construct_keep_null(1, 'k1', 2, 'k2')
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Key must be a string value while evaluating function `object_construct_keep_null(1, "k1", 2, "k2")`
+
+
+
+ast            : object_construct_keep_null(k1, v1, k2, v2)
+raw expr       : object_construct_keep_null(k1::String NULL, v1::String NULL, k2::String NULL, v2::String NULL)
+checked expr   : object_construct_keep_null<T0=String NULL, T1=String NULL, T2=String NULL, T3=String NULL><T0, T1, T2, T3>(k1, v1, k2, v2)
+evaluation:
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+|        | k1                   | v1                   | k2                   | v2            | Output                |
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+| Type   | String NULL          | String NULL          | String NULL          | String NULL   | Variant               |
+| Domain | {""..="d1"} ∪ {NULL} | {""..="l1"} ∪ {NULL} | {""..="d2"} ∪ {NULL} | {"j2"..="m2"} | Unknown               |
+| Row 0  | "a1"                 | "j1"                 | "a2"                 | "j2"          | {"a1":"j1","a2":"j2"} |
+| Row 1  | "b1"                 | "k1"                 | NULL                 | "k2"          | {"b1":"k1"}           |
+| Row 2  | NULL                 | "l1"                 | "c2"                 | "l2"          | {"c2":"l2"}           |
+| Row 3  | "d1"                 | NULL                 | "d2"                 | "m2"          | {"d1":null,"d2":"m2"} |
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| k1     | NullableColumn { column: StringColumn { data: 0x613162316431, offsets: [0, 2, 4, 4, 6] }, validity: [0b____1011] }                                                                                                                  |
+| v1     | NullableColumn { column: StringColumn { data: 0x6a316b316c31, offsets: [0, 2, 4, 6, 6] }, validity: [0b____0111] }                                                                                                                  |
+| k2     | NullableColumn { column: StringColumn { data: 0x613263326432, offsets: [0, 2, 2, 4, 6] }, validity: [0b____1101] }                                                                                                                  |
+| v2     | NullableColumn { column: StringColumn { data: 0x6a326b326c326d32, offsets: [0, 2, 4, 6, 8] }, validity: [0b____1111] }                                                                                                              |
+| Output | StringColumn { data: 0x4000000210000002100000021000000210000002613161326a316a3240000001100000021000000262316b3140000001100000021000000263326c324000000210000002100000020000000010000002643164326d32, offsets: [0, 28, 44, 60, 86] } |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 

--- a/src/query/functions/tests/it/scalars/variant.rs
+++ b/src/query/functions/tests/it/scalars/variant.rs
@@ -35,6 +35,10 @@ fn test_variant() {
     test_get_path(file);
     test_json_extract_path_text(file);
     test_as_type(file);
+    test_to_type(file);
+    test_try_to_type(file);
+    test_object_construct(file);
+    test_object_construct_keep_null(file);
 }
 
 fn test_parse_json(file: &mut impl Write) {
@@ -384,4 +388,198 @@ fn test_as_type(file: &mut impl Write) {
     run_ast(file, "as_array(try_parse_json(s))", columns);
     run_ast(file, "as_object(parse_json(s))", columns);
     run_ast(file, "as_object(try_parse_json(s))", columns);
+}
+
+fn test_to_type(file: &mut impl Write) {
+    run_ast(file, "to_boolean(parse_json('true'))", &[]);
+    run_ast(file, "to_boolean(parse_json('123'))", &[]);
+    run_ast(file, "to_boolean(parse_json('\"abc\"'))", &[]);
+    run_ast(file, "to_uint64(parse_json('123'))", &[]);
+    run_ast(file, "to_uint64(parse_json('-123'))", &[]);
+    run_ast(file, "to_uint64(parse_json('\"abc\"'))", &[]);
+    run_ast(file, "to_int64(parse_json('123'))", &[]);
+    run_ast(file, "to_int64(parse_json('-123'))", &[]);
+    run_ast(file, "to_int64(parse_json('\"abc\"'))", &[]);
+    run_ast(file, "to_float64(parse_json('12.34'))", &[]);
+    run_ast(file, "to_float64(parse_json('\"abc\"'))", &[]);
+    run_ast(file, "to_date(parse_json('\"2023-01-01\"'))", &[]);
+    run_ast(file, "to_date(parse_json('\"abc\"'))", &[]);
+    run_ast(
+        file,
+        "to_timestamp(parse_json('\"2023-01-01 00:00:00\"'))",
+        &[],
+    );
+    run_ast(file, "to_timestamp(parse_json('\"abc\"'))", &[]);
+    run_ast(file, "to_string(parse_json('12.34'))", &[]);
+    run_ast(file, "to_string(parse_json('\"abc\"'))", &[]);
+
+    run_ast(file, "to_boolean(parse_json(s))", &[(
+        "s",
+        StringType::from_data_with_validity(&["true", "", "true"], vec![true, false, true]),
+    )]);
+    run_ast(file, "to_int64(parse_json(s))", &[(
+        "s",
+        StringType::from_data_with_validity(&["1", "", "-10"], vec![true, false, true]),
+    )]);
+    run_ast(file, "to_uint64(parse_json(s))", &[(
+        "s",
+        StringType::from_data_with_validity(&["1", "", "20"], vec![true, false, true]),
+    )]);
+    run_ast(file, "to_float64(parse_json(s))", &[(
+        "s",
+        StringType::from_data_with_validity(&["1.2", "", "100.2"], vec![true, false, true]),
+    )]);
+    run_ast(file, "to_date(parse_json(s))", &[(
+        "s",
+        StringType::from_data_with_validity(&["\"2020-01-01\"", "", "\"2023-10-01\""], vec![
+            true, false, true,
+        ]),
+    )]);
+    run_ast(file, "to_timestamp(parse_json(s))", &[(
+        "s",
+        StringType::from_data_with_validity(
+            &["\"2020-01-01 00:00:00\"", "", "\"2023-10-01 10:11:12\""],
+            vec![true, false, true],
+        ),
+    )]);
+    run_ast(file, "to_string(parse_json(s))", &[(
+        "s",
+        StringType::from_data_with_validity(&["\"abc\"", "", "123"], vec![true, false, true]),
+    )]);
+}
+
+fn test_try_to_type(file: &mut impl Write) {
+    run_ast(file, "try_to_boolean(parse_json('true'))", &[]);
+    run_ast(file, "try_to_boolean(parse_json('123'))", &[]);
+    run_ast(file, "try_to_boolean(parse_json('\"abc\"'))", &[]);
+    run_ast(file, "try_to_uint64(parse_json('123'))", &[]);
+    run_ast(file, "try_to_uint64(parse_json('-123'))", &[]);
+    run_ast(file, "try_to_uint64(parse_json('\"abc\"'))", &[]);
+    run_ast(file, "try_to_int64(parse_json('123'))", &[]);
+    run_ast(file, "try_to_int64(parse_json('-123'))", &[]);
+    run_ast(file, "try_to_int64(parse_json('\"abc\"'))", &[]);
+    run_ast(file, "try_to_float64(parse_json('12.34'))", &[]);
+    run_ast(file, "try_to_float64(parse_json('\"abc\"'))", &[]);
+    run_ast(file, "try_to_date(parse_json('\"2023-01-01\"'))", &[]);
+    run_ast(file, "try_to_date(parse_json('\"abc\"'))", &[]);
+    run_ast(
+        file,
+        "try_to_timestamp(parse_json('\"2023-01-01 00:00:00\"'))",
+        &[],
+    );
+    run_ast(file, "try_to_timestamp(parse_json('\"abc\"'))", &[]);
+    run_ast(file, "try_to_string(parse_json('12.34'))", &[]);
+    run_ast(file, "try_to_string(parse_json('\"abc\"'))", &[]);
+
+    let columns = &[(
+        "s",
+        StringType::from_data_with_validity(
+            &[
+                "true",
+                "123",
+                "-100",
+                "12.34",
+                "",
+                "\"2020-01-01\"",
+                "\"2021-01-01 20:00:00\"",
+                "\"abc\"",
+            ],
+            vec![true, true, true, true, false, true, true, true],
+        ),
+    )];
+    run_ast(file, "try_to_boolean(parse_json(s))", columns);
+    run_ast(file, "try_to_int64(parse_json(s))", columns);
+    run_ast(file, "try_to_uint64(parse_json(s))", columns);
+    run_ast(file, "try_to_float64(parse_json(s))", columns);
+    run_ast(file, "try_to_date(parse_json(s))", columns);
+    run_ast(file, "try_to_timestamp(parse_json(s))", columns);
+    run_ast(file, "try_to_string(parse_json(s))", columns);
+}
+
+fn test_object_construct(file: &mut impl Write) {
+    run_ast(file, "object_construct()", &[]);
+    run_ast(
+        file,
+        "object_construct('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})",
+        &[],
+    );
+    run_ast(
+        file,
+        "object_construct('k1', 1, 'k2', null, 'k3', 2, null, 3)",
+        &[],
+    );
+    run_ast(file, "object_construct('k1', 1, 'k1')", &[]);
+    run_ast(file, "object_construct('k1', 1, 'k1', 2)", &[]);
+    run_ast(file, "object_construct(1, 'k1', 2, 'k2')", &[]);
+
+    run_ast(file, "object_construct(k1, v1, k2, v2)", &[
+        (
+            "k1",
+            StringType::from_data_with_validity(&["a1", "b1", "", "d1"], vec![
+                true, true, false, true,
+            ]),
+        ),
+        (
+            "v1",
+            StringType::from_data_with_validity(&["j1", "k1", "l1", ""], vec![
+                true, true, true, false,
+            ]),
+        ),
+        (
+            "k2",
+            StringType::from_data_with_validity(&["a2", "", "c2", "d2"], vec![
+                true, false, true, true,
+            ]),
+        ),
+        (
+            "v2",
+            StringType::from_data_with_validity(&["j2", "k2", "l2", "m2"], vec![
+                true, true, true, true,
+            ]),
+        ),
+    ]);
+}
+
+fn test_object_construct_keep_null(file: &mut impl Write) {
+    run_ast(file, "object_construct_keep_null()", &[]);
+    run_ast(
+        file,
+        "object_construct_keep_null('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})",
+        &[],
+    );
+    run_ast(
+        file,
+        "object_construct_keep_null('k1', 1, 'k2', null, 'k3', 2, null, 3)",
+        &[],
+    );
+    run_ast(file, "object_construct_keep_null('k1', 1, 'k1')", &[]);
+    run_ast(file, "object_construct_keep_null('k1', 1, 'k1', 2)", &[]);
+    run_ast(file, "object_construct_keep_null(1, 'k1', 2, 'k2')", &[]);
+
+    run_ast(file, "object_construct_keep_null(k1, v1, k2, v2)", &[
+        (
+            "k1",
+            StringType::from_data_with_validity(&["a1", "b1", "", "d1"], vec![
+                true, true, false, true,
+            ]),
+        ),
+        (
+            "v1",
+            StringType::from_data_with_validity(&["j1", "k1", "l1", ""], vec![
+                true, true, true, false,
+            ]),
+        ),
+        (
+            "k2",
+            StringType::from_data_with_validity(&["a2", "", "c2", "d2"], vec![
+                true, false, true, true,
+            ]),
+        ),
+        (
+            "v2",
+            StringType::from_data_with_validity(&["j2", "k2", "l2", "m2"], vec![
+                true, true, true, true,
+            ]),
+        ),
+    ]);
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Support Variant function `object_construct` and `object_construct_keep_null`
- Add unit tests for variant `to_<type>` and `try_to_<type>` functions
- Fix `to_<type>` and `try_to_<type>` with null value 

Closes #4724
Closes #5425
