### PR TITLE
chore(planner): Refactor data type of `ScalarExpr`

### DIFF
--- a/src/query/service/src/interpreters/interpreter_insert.rs
+++ b/src/query/service/src/interpreters/interpreter_insert.rs
@@ -785,16 +785,12 @@ async fn fill_default_value(
         let tokens = tokenize_sql(default_expr)?;
         let backtrace = Backtrace::new();
         let ast = parse_expr(&tokens, Dialect::PostgreSQL, &backtrace)?;
-        let (mut scalar, ty) = binder.bind(&ast).await?;
-
-        if !field.data_type().eq(&ty) {
-            scalar = ScalarExpr::CastExpr(CastExpr {
-                is_try: false,
-                argument: Box::new(scalar),
-                from_type: Box::new(ty),
-                target_type: Box::new(field.data_type().clone()),
-            })
-        }
+        let (mut scalar, _) = binder.bind(&ast).await?;
+        scalar = ScalarExpr::CastExpr(CastExpr {
+            is_try: false,
+            argument: Box::new(scalar),
+            target_type: Box::new(field.data_type().clone()),
+        });
 
         let expr = scalar
             .as_expr_with_col_index()?
@@ -858,16 +854,13 @@ async fn exprs_to_scalar(
             }
         }
 
-        let (mut scalar, data_type) = scalar_binder.bind(expr).await?;
+        let (mut scalar, _) = scalar_binder.bind(expr).await?;
         let field_data_type = schema.field(i).data_type();
-        if &data_type != field_data_type {
-            scalar = ScalarExpr::CastExpr(CastExpr {
-                is_try: false,
-                argument: Box::new(scalar),
-                from_type: Box::new(data_type),
-                target_type: Box::new(field_data_type.clone()),
-            })
-        }
+        scalar = ScalarExpr::CastExpr(CastExpr {
+            is_try: false,
+            argument: Box::new(scalar),
+            target_type: Box::new(field_data_type.clone()),
+        });
         let expr = scalar
             .as_expr_with_col_index()?
             .project_column_ref(|index| schema.index_of(&index.to_string()).unwrap());

--- a/src/query/service/src/interpreters/interpreter_update.rs
+++ b/src/query/service/src/interpreters/interpreter_update.rs
@@ -97,7 +97,6 @@ impl Interpreter for UpdateInterpreter {
                 let left = ScalarExpr::CastExpr(CastExpr {
                     is_try: false,
                     argument: Box::new(scalar.clone()),
-                    from_type: Box::new(scalar.data_type()),
                     target_type: Box::new(field.data_type().clone()),
                 });
                 let scalar = if col_indices.is_empty() {
@@ -123,12 +122,10 @@ impl Interpreter for UpdateInterpreter {
                         }
                     }
                     let right = right.ok_or_else(|| ErrorCode::Internal("It's a bug"))?;
-                    let return_type = right.data_type();
                     ScalarExpr::FunctionCall(FunctionCall {
                         params: vec![],
                         arguments: vec![predicate.clone(), left, right],
                         func_name: "if".to_string(),
-                        return_type: Box::new(return_type),
                     })
                 };
                 acc.push((*index, scalar.as_expr_with_col_name()?.as_remote_expr()));

--- a/src/query/service/tests/it/sql/planner/format/mod.rs
+++ b/src/query/service/tests/it/sql/planner/format/mod.rs
@@ -116,7 +116,6 @@ fn test_format() {
                         }
                         .into(),
                     ],
-                    return_type: Box::new(DataType::Boolean),
                 }
                 .into(),
             ],

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -441,7 +441,7 @@ impl PhysicalPlanBuilder {
                                         name: agg.func_name.clone(),
                                         args: agg.args.iter().map(|s| {
                                             s.data_type()
-                                        }).collect(),
+                                        }).collect::<Result<_>>()?,
                                         params: agg.params.clone(),
                                         return_type: *agg.return_type.clone(),
                                     },
@@ -488,7 +488,7 @@ impl PhysicalPlanBuilder {
                                         &agg.group_items
                                             .iter()
                                             .map(|v| v.scalar.data_type())
-                                            .collect::<Vec<_>>(),
+                                            .collect::<Result<Vec<_>>>()?,
                                     )?
                                     .data_type();
 
@@ -541,7 +541,7 @@ impl PhysicalPlanBuilder {
                                         name: agg.func_name.clone(),
                                         args: agg.args.iter().map(|s| {
                                             s.data_type()
-                                        }).collect(),
+                                        }).collect::<Result<_>>()?,
                                         params: agg.params.clone(),
                                         return_type: *agg.return_type.clone(),
                                     },
@@ -822,7 +822,6 @@ impl PhysicalPlanBuilder {
                         ScalarExpr::AndExpr(AndExpr {
                             left: Box::new(lhs),
                             right: Box::new(rhs),
-                            return_type: Box::new(DataType::Boolean),
                         })
                     })
                     .expect("there should be at least one predicate in prewhere");

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -964,7 +964,6 @@ impl Binder {
                     let is_try = schema_data_type.is_nullable();
                     let cast_expr_to_field_type = ScalarExpr::CastExpr(CastExpr {
                         is_try,
-                        from_type: Box::new(expr.data_type()),
                         target_type: Box::new(DataType::from(&schema_data_type)),
                         argument: Box::new(expr),
                     })

--- a/src/query/sql/src/planner/binder/join.rs
+++ b/src/query/sql/src/planner/binder/join.rs
@@ -608,8 +608,8 @@ impl<'a> JoinConditionResolver<'a> {
         let (left_columns, right_columns) = self.left_right_columns()?;
 
         // Bump types of left conditions and right conditions
-        let left_type = left.data_type();
-        let right_type = right.data_type();
+        let left_type = left.data_type()?;
+        let right_type = right.data_type()?;
         if left_type.ne(&right_type) {
             let least_super_type = common_super_type(
                 left_type.clone(),

--- a/src/query/sql/src/planner/binder/project.rs
+++ b/src/query/sql/src/planner/binder/project.rs
@@ -55,7 +55,7 @@ impl Binder {
                 column_binding.column_name = item.alias.clone();
                 column_binding
             } else {
-                self.create_column_binding(None, None, item.alias.clone(), item.scalar.data_type())
+                self.create_column_binding(None, None, item.alias.clone(), item.scalar.data_type()?)
             };
             let scalar = if let ScalarExpr::SubqueryExpr(SubqueryExpr {
                 typ,

--- a/src/query/sql/src/planner/binder/scalar_common.rs
+++ b/src/query/sql/src/planner/binder/scalar_common.rs
@@ -213,16 +213,6 @@ pub fn wrap_cast(scalar: &ScalarExpr, target_type: &DataType) -> ScalarExpr {
     ScalarExpr::CastExpr(CastExpr {
         is_try: false,
         argument: Box::new(scalar.clone()),
-        from_type: Box::new(scalar.data_type()),
         target_type: Box::new(target_type.clone()),
     })
-}
-
-/// Wrap a cast expression with given target type if the scalar is not of the target type
-pub fn wrap_cast_if_needed(scalar: &ScalarExpr, target_type: &DataType) -> ScalarExpr {
-    if &scalar.data_type() == target_type {
-        scalar.clone()
-    } else {
-        wrap_cast(scalar, target_type)
-    }
 }

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -488,7 +488,6 @@ impl Binder {
                         }
                         .into(),
                     ),
-                    from_type: Box::new(*left_col.data_type.clone()),
                     target_type: Box::new(coercion_types[idx].clone()),
                 };
                 left_scalar_items.push(ScalarItem {
@@ -514,7 +513,6 @@ impl Binder {
                         }
                         .into(),
                     ),
-                    from_type: Box::new(*right_col.data_type.clone()),
                     target_type: Box::new(coercion_types[idx].clone()),
                 };
                 right_scalar_items.push(ScalarItem {

--- a/src/query/sql/src/planner/binder/setting.rs
+++ b/src/query/sql/src/planner/binder/setting.rs
@@ -49,11 +49,10 @@ impl Binder {
         );
         let variable = variable.name.clone();
 
-        let (scalar, data_type) = *type_checker.resolve(value, None).await?;
+        let (scalar, _) = *type_checker.resolve(value, None).await?;
         let scalar = ScalarExpr::CastExpr(CastExpr {
             is_try: false,
             argument: Box::new(scalar),
-            from_type: Box::new(data_type),
             target_type: Box::new(DataType::String),
         });
         let expr = scalar.as_expr_with_col_index()?;

--- a/src/query/sql/src/planner/binder/sort.rs
+++ b/src/query/sql/src/planner/binder/sort.rs
@@ -201,7 +201,7 @@ impl Binder {
                         None,
                         None,
                         format!("{:#}", order.expr),
-                        rewrite_scalar.data_type(),
+                        rewrite_scalar.data_type()?,
                     );
                     order_items.push(OrderItem {
                         expr: order.clone(),
@@ -368,53 +368,26 @@ impl Binder {
         match replacement_opt {
             Some(replacement) => Ok(replacement),
             None => match original_scalar {
-                ScalarExpr::AndExpr(AndExpr {
-                    left,
-                    right,
-                    return_type,
-                }) => {
+                ScalarExpr::AndExpr(AndExpr { left, right }) => {
                     let left =
                         Box::new(self.rewrite_scalar_with_replacement(left, replacement_fn)?);
                     let right =
                         Box::new(self.rewrite_scalar_with_replacement(right, replacement_fn)?);
-                    Ok(ScalarExpr::AndExpr(AndExpr {
-                        left,
-                        right,
-                        return_type: return_type.clone(),
-                    }))
+                    Ok(ScalarExpr::AndExpr(AndExpr { left, right }))
                 }
-                ScalarExpr::OrExpr(OrExpr {
-                    left,
-                    right,
-                    return_type,
-                }) => {
+                ScalarExpr::OrExpr(OrExpr { left, right }) => {
                     let left =
                         Box::new(self.rewrite_scalar_with_replacement(left, replacement_fn)?);
                     let right =
                         Box::new(self.rewrite_scalar_with_replacement(right, replacement_fn)?);
-                    Ok(ScalarExpr::OrExpr(OrExpr {
-                        left,
-                        right,
-                        return_type: return_type.clone(),
-                    }))
+                    Ok(ScalarExpr::OrExpr(OrExpr { left, right }))
                 }
-                ScalarExpr::NotExpr(NotExpr {
-                    argument,
-                    return_type,
-                }) => {
+                ScalarExpr::NotExpr(NotExpr { argument }) => {
                     let argument =
                         Box::new(self.rewrite_scalar_with_replacement(argument, replacement_fn)?);
-                    Ok(ScalarExpr::NotExpr(NotExpr {
-                        argument,
-                        return_type: return_type.clone(),
-                    }))
+                    Ok(ScalarExpr::NotExpr(NotExpr { argument }))
                 }
-                ScalarExpr::ComparisonExpr(ComparisonExpr {
-                    op,
-                    left,
-                    right,
-                    return_type,
-                }) => {
+                ScalarExpr::ComparisonExpr(ComparisonExpr { op, left, right }) => {
                     let left =
                         Box::new(self.rewrite_scalar_with_replacement(left, replacement_fn)?);
                     let right =
@@ -423,7 +396,6 @@ impl Binder {
                         op: op.clone(),
                         left,
                         right,
-                        return_type: return_type.clone(),
                     }))
                 }
                 ScalarExpr::AggregateFunction(AggregateFunction {
@@ -451,7 +423,6 @@ impl Binder {
                     params,
                     arguments,
                     func_name,
-                    return_type,
                 }) => {
                     let arguments = arguments
                         .iter()
@@ -461,13 +432,11 @@ impl Binder {
                         params: params.clone(),
                         arguments,
                         func_name: func_name.clone(),
-                        return_type: return_type.clone(),
                     }))
                 }
                 ScalarExpr::CastExpr(CastExpr {
                     is_try,
                     argument,
-                    from_type,
                     target_type,
                 }) => {
                     let argument =
@@ -475,7 +444,6 @@ impl Binder {
                     Ok(ScalarExpr::CastExpr(CastExpr {
                         is_try: *is_try,
                         argument,
-                        from_type: from_type.clone(),
                         target_type: target_type.clone(),
                     }))
                 }

--- a/src/query/sql/src/planner/format/display_rel_operator.rs
+++ b/src/query/sql/src/planner/format/display_rel_operator.rs
@@ -15,7 +15,6 @@
 use std::fmt::Display;
 
 use common_ast::ast::FormatTreeNode;
-use common_expression::types::DataType;
 use itertools::Itertools;
 
 use crate::optimizer::SExpr;
@@ -364,7 +363,6 @@ pub fn logical_join_to_format_tree(
                 op: ComparisonOp::Equal,
                 left: Box::new(left.clone()),
                 right: Box::new(right.clone()),
-                return_type: Box::new(DataType::Boolean),
             }
             .into()
         })
@@ -380,7 +378,6 @@ pub fn logical_join_to_format_tree(
             ScalarExpr::AndExpr(AndExpr {
                 left: Box::new(prev),
                 right: Box::new(next.clone()),
-                return_type: Box::new(DataType::Boolean),
             })
         });
         format_scalar(&metadata, &pred)

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -164,14 +164,14 @@ impl SubqueryRewriter {
                 }
 
                 JoinPredicate::Both { left, right } => {
-                    if left.data_type().eq(&right.data_type()) {
+                    if left.data_type()?.eq(&right.data_type()?) {
                         left_conditions.push(left.clone());
                         right_conditions.push(right.clone());
                         continue;
                     }
                     let join_type = common_super_type(
-                        left.data_type(),
-                        right.data_type(),
+                        left.data_type()?,
+                        right.data_type()?,
                         &BUILTIN_FUNCTIONS.default_cast_rules,
                     )
                     .ok_or_else(|| ErrorCode::Internal("Cannot find common type"))?;
@@ -340,7 +340,6 @@ impl SubqueryRewriter {
                     op,
                     left: Box::new(child_expr),
                     right: Box::new(right_condition),
-                    return_type: Box::new(DataType::Nullable(Box::new(DataType::Boolean))),
                 })];
                 let marker_index = if let Some(idx) = subquery.projection_index {
                     idx
@@ -715,7 +714,6 @@ impl SubqueryRewriter {
                 Ok(ScalarExpr::AndExpr(AndExpr {
                     left: Box::new(left),
                     right: Box::new(right),
-                    return_type: and_expr.return_type.clone(),
                 }))
             }
             ScalarExpr::OrExpr(or_expr) => {
@@ -724,14 +722,12 @@ impl SubqueryRewriter {
                 Ok(ScalarExpr::OrExpr(OrExpr {
                     left: Box::new(left),
                     right: Box::new(right),
-                    return_type: or_expr.return_type.clone(),
                 }))
             }
             ScalarExpr::NotExpr(not_expr) => {
                 let argument = self.flatten_scalar(&not_expr.argument, correlated_columns)?;
                 Ok(ScalarExpr::NotExpr(NotExpr {
                     argument: Box::new(argument),
-                    return_type: not_expr.return_type.clone(),
                 }))
             }
             ScalarExpr::ComparisonExpr(comparison_expr) => {
@@ -741,7 +737,6 @@ impl SubqueryRewriter {
                     op: comparison_expr.op.clone(),
                     left: Box::new(left),
                     right: Box::new(right),
-                    return_type: comparison_expr.return_type.clone(),
                 }))
             }
             ScalarExpr::AggregateFunction(agg) => {
@@ -767,7 +762,6 @@ impl SubqueryRewriter {
                     params: fun_call.params.clone(),
                     arguments,
                     func_name: fun_call.func_name.clone(),
-                    return_type: fun_call.return_type.clone(),
                 }))
             }
             ScalarExpr::CastExpr(cast_expr) => {
@@ -775,7 +769,6 @@ impl SubqueryRewriter {
                 Ok(ScalarExpr::CastExpr(CastExpr {
                     is_try: cast_expr.is_try,
                     argument: Box::new(scalar),
-                    from_type: cast_expr.from_type.clone(),
                     target_type: cast_expr.target_type.clone(),
                 }))
             }

--- a/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
@@ -159,7 +159,6 @@ impl SubqueryRewriter {
                     AndExpr {
                         left: Box::new(left),
                         right: Box::new(right),
-                        return_type: expr.return_type.clone(),
                     }
                     .into(),
                     s_expr,
@@ -173,7 +172,6 @@ impl SubqueryRewriter {
                     OrExpr {
                         left: Box::new(left),
                         right: Box::new(right),
-                        return_type: expr.return_type.clone(),
                     }
                     .into(),
                     s_expr,
@@ -186,7 +184,6 @@ impl SubqueryRewriter {
                 Ok((
                     NotExpr {
                         argument: Box::new(argument),
-                        return_type: expr.return_type.clone(),
                     }
                     .into(),
                     s_expr,
@@ -201,7 +198,6 @@ impl SubqueryRewriter {
                         op: expr.op.clone(),
                         left: Box::new(left),
                         right: Box::new(right),
-                        return_type: expr.return_type.clone(),
                     }
                     .into(),
                     s_expr,
@@ -223,7 +219,6 @@ impl SubqueryRewriter {
                     params: func.params.clone(),
                     arguments: args,
                     func_name: func.func_name.clone(),
-                    return_type: func.return_type.clone(),
                 }
                 .into();
 
@@ -236,7 +231,6 @@ impl SubqueryRewriter {
                     CastExpr {
                         is_try: cast.is_try,
                         argument: Box::new(scalar),
-                        from_type: cast.from_type.clone(),
                         target_type: cast.target_type.clone(),
                     }
                     .into(),
@@ -332,12 +326,10 @@ impl SubqueryRewriter {
                         params: vec![],
                         arguments: vec![column_ref.clone()],
                         func_name: "is_not_null".to_string(),
-                        return_type: Box::new(DataType::Boolean),
                     });
                     let cast_column_ref_to_uint64 = ScalarExpr::CastExpr(CastExpr {
                         is_try: true,
-                        argument: Box::new(column_ref.clone()),
-                        from_type: Box::new(column_ref.data_type()),
+                        argument: Box::new(column_ref),
                         target_type: Box::new(
                             DataType::Number(NumberDataType::UInt64).wrap_nullable(),
                         ),
@@ -354,11 +346,7 @@ impl SubqueryRewriter {
                             params: vec![],
                             arguments: vec![is_not_null, cast_column_ref_to_uint64, zero],
                             func_name: "if".to_string(),
-                            return_type: Box::new(
-                                DataType::Number(NumberDataType::UInt64).wrap_nullable(),
-                            ),
                         })),
-                        from_type: Box::new(column_ref.data_type()),
                         target_type: Box::new(
                             DataType::Number(NumberDataType::UInt64).wrap_nullable(),
                         ),
@@ -366,7 +354,6 @@ impl SubqueryRewriter {
                 } else if subquery.typ == SubqueryType::NotExists {
                     ScalarExpr::NotExpr(NotExpr {
                         argument: Box::new(column_ref),
-                        return_type: Box::new(DataType::Nullable(Box::new(DataType::Boolean))),
                     })
                 } else {
                     column_ref
@@ -461,7 +448,6 @@ impl SubqueryRewriter {
                         }
                         .into(),
                     ),
-                    return_type: Box::new(DataType::Boolean.wrap_nullable()),
                 };
                 let filter = Filter {
                     predicates: vec![compare.into()],
@@ -517,7 +503,6 @@ impl SubqueryRewriter {
                             op,
                             left: Box::new(right_condition),
                             right: Box::new(left_condition),
-                            return_type: Box::new(DataType::Nullable(Box::new(DataType::Boolean))),
                         });
                         (vec![], vec![], vec![other_condition])
                     };

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/extract_or_predicates.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/extract_or_predicates.rs
@@ -125,7 +125,6 @@ fn make_and_expr(scalars: &[ScalarExpr]) -> ScalarExpr {
     ScalarExpr::AndExpr(AndExpr {
         left: Box::new(scalars[0].clone()),
         right: Box::new(make_and_expr(&scalars[1..])),
-        return_type: Box::new(scalars[0].data_type()),
     })
 }
 
@@ -137,6 +136,5 @@ fn make_or_expr(scalars: &[ScalarExpr]) -> ScalarExpr {
     ScalarExpr::OrExpr(OrExpr {
         left: Box::new(scalars[0].clone()),
         right: Box::new(make_or_expr(&scalars[1..])),
-        return_type: Box::new(scalars[0].data_type()),
     })
 }

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/outer_join_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/outer_join_to_inner_join.rs
@@ -292,7 +292,6 @@ fn remove_column_nullable(
             ScalarExpr::AndExpr(AndExpr {
                 left: Box::new(left_expr),
                 right: Box::new(right_expr),
-                return_type: expr.return_type.clone(),
             })
         }
         ScalarExpr::OrExpr(expr) => {
@@ -308,7 +307,6 @@ fn remove_column_nullable(
             ScalarExpr::OrExpr(OrExpr {
                 left: Box::new(left_expr),
                 right: Box::new(right_expr),
-                return_type: expr.return_type.clone(),
             })
         }
         ScalarExpr::NotExpr(expr) => {
@@ -316,7 +314,6 @@ fn remove_column_nullable(
                 remove_column_nullable(&expr.argument, left_prop, right_prop, join_type, metadata)?;
             ScalarExpr::NotExpr(NotExpr {
                 argument: Box::new(new_expr),
-                return_type: expr.return_type.clone(),
             })
         }
         ScalarExpr::ComparisonExpr(expr) => {
@@ -333,7 +330,6 @@ fn remove_column_nullable(
                 op: expr.op.clone(),
                 left: Box::new(left_expr),
                 right: Box::new(right_expr),
-                return_type: expr.return_type.clone(),
             })
         }
         ScalarExpr::AggregateFunction(expr) => {
@@ -371,7 +367,6 @@ fn remove_column_nullable(
                 params: expr.params.clone(),
                 arguments: args,
                 func_name: expr.func_name.clone(),
-                return_type: expr.return_type.clone(),
             })
         }
         ScalarExpr::CastExpr(expr) => {
@@ -380,7 +375,6 @@ fn remove_column_nullable(
             ScalarExpr::CastExpr(CastExpr {
                 is_try: expr.is_try,
                 argument: Box::new(new_expr),
-                from_type: expr.from_type.clone(),
                 target_type: expr.target_type.clone(),
             })
         }

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
@@ -81,7 +81,7 @@ impl Rule for RuleFoldCountAggregate {
                         && (agg_func.args.is_empty()
                             || !matches!(
                                 agg_func.args[0].data_type(),
-                                DataType::Nullable(_) | DataType::Null
+                                Ok(DataType::Nullable(_)) | Ok(DataType::Null)
                             ))
                         && !agg_func.distinct
                 }
@@ -93,7 +93,7 @@ impl Rule for RuleFoldCountAggregate {
                 ScalarExpr::AggregateFunction(agg_func) => {
                     agg_func.func_name == "count"
                         && (agg_func.args.is_empty()
-                            || matches!(agg_func.args[0].data_type(), DataType::Nullable(_)))
+                            || matches!(agg_func.args[0].data_type(), Ok(DataType::Nullable(_))))
                         && !agg_func.distinct
                 }
                 _ => false,
@@ -104,7 +104,7 @@ impl Rule for RuleFoldCountAggregate {
             for item in scalars.iter_mut() {
                 item.scalar = ScalarExpr::ConstantExpr(ConstantExpr {
                     value: Literal::UInt64(card),
-                    data_type: Box::new(item.scalar.data_type()),
+                    data_type: Box::new(item.scalar.data_type()?),
                 });
             }
             let eval_scalar = EvalScalar { items: scalars };
@@ -125,7 +125,7 @@ impl Rule for RuleFoldCountAggregate {
                     if agg_func.args.is_empty() {
                         item.scalar = ScalarExpr::ConstantExpr(ConstantExpr {
                             value: Literal::UInt64(table_card),
-                            data_type: Box::new(item.scalar.data_type()),
+                            data_type: Box::new(item.scalar.data_type()?),
                         });
                         return Ok(());
                     } else {
@@ -135,7 +135,7 @@ impl Rule for RuleFoldCountAggregate {
                             if let Some(card) = col_stat {
                                 item.scalar = ScalarExpr::ConstantExpr(ConstantExpr {
                                     value: Literal::UInt64(table_card - card.null_count),
-                                    data_type: Box::new(item.scalar.data_type()),
+                                    data_type: Box::new(item.scalar.data_type()?),
                                 });
                             } else {
                                 return Ok(());

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_normalize_disjunctive_filter.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_normalize_disjunctive_filter.rs
@@ -71,7 +71,6 @@ fn normalize_predicate_scalar(
                     ScalarExpr::AndExpr(AndExpr {
                         left: Box::from(lhs),
                         right: Box::from(rhs),
-                        return_type: Box::new(return_type.clone()),
                     })
                 })
                 .expect("has at least two args")
@@ -84,7 +83,6 @@ fn normalize_predicate_scalar(
                     ScalarExpr::OrExpr(OrExpr {
                         left: Box::from(lhs),
                         right: Box::from(rhs),
-                        return_type: Box::new(return_type.clone()),
                     })
                 })
                 .expect("has at least two args")
@@ -143,7 +141,7 @@ impl Rule for RuleNormalizeDisjunctiveFilter {
             }
             rewritten_predicates.push(normalize_predicate_scalar(
                 rewritten_predicate_scalar,
-                predicate.data_type(),
+                predicate.data_type()?,
             ));
         }
         let mut split_predicates: Vec<ScalarExpr> = Vec::with_capacity(rewritten_predicates.len());

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
@@ -169,8 +169,8 @@ pub fn try_push_down_filter_join(
             JoinPredicate::Other(_) => original_predicates.push(predicate),
 
             JoinPredicate::Both { left, right } => {
-                let left_type = left.data_type();
-                let right_type = right.data_type();
+                let left_type = left.data_type()?;
+                let right_type = right.data_type()?;
                 let join_key_type =
                     common_super_type(left_type, right_type, &BUILTIN_FUNCTIONS.default_cast_rules);
 
@@ -182,7 +182,7 @@ pub fn try_push_down_filter_join(
                         join.join_type = JoinType::Inner;
                     }
                     if join.join_type == JoinType::Inner {
-                        if left.data_type().ne(&right.data_type()) {
+                        if left.data_type()? != right.data_type()? {
                             let left = wrap_cast(left, &join_key_type);
                             let right = wrap_cast(right, &join_key_type);
                             join.left_conditions.push(left);

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_union.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_union.rs
@@ -153,22 +153,18 @@ fn replace_column_binding(
         ScalarExpr::AndExpr(expr) => Ok(ScalarExpr::AndExpr(AndExpr {
             left: Box::new(replace_column_binding(index_pairs, *expr.left)?),
             right: Box::new(replace_column_binding(index_pairs, *expr.right)?),
-            return_type: expr.return_type,
         })),
         ScalarExpr::OrExpr(expr) => Ok(ScalarExpr::OrExpr(OrExpr {
             left: Box::new(replace_column_binding(index_pairs, *expr.left)?),
             right: Box::new(replace_column_binding(index_pairs, *expr.right)?),
-            return_type: expr.return_type,
         })),
         ScalarExpr::NotExpr(expr) => Ok(ScalarExpr::NotExpr(NotExpr {
             argument: Box::new(replace_column_binding(index_pairs, *expr.argument)?),
-            return_type: expr.return_type,
         })),
         ScalarExpr::ComparisonExpr(expr) => Ok(ScalarExpr::ComparisonExpr(ComparisonExpr {
             op: expr.op,
             left: Box::new(replace_column_binding(index_pairs, *expr.left)?),
             right: Box::new(replace_column_binding(index_pairs, *expr.right)?),
-            return_type: expr.return_type,
         })),
         ScalarExpr::AggregateFunction(expr) => {
             Ok(ScalarExpr::AggregateFunction(AggregateFunction {
@@ -192,12 +188,10 @@ fn replace_column_binding(
                 .map(|arg| replace_column_binding(index_pairs, arg))
                 .collect::<Result<Vec<_>>>()?,
             func_name: expr.func_name,
-            return_type: expr.return_type,
         })),
         ScalarExpr::CastExpr(expr) => Ok(ScalarExpr::CastExpr(CastExpr {
             is_try: expr.is_try,
             argument: Box::new(replace_column_binding(index_pairs, *(expr.argument))?),
-            from_type: expr.from_type,
             target_type: expr.target_type,
         })),
         ScalarExpr::SubqueryExpr(_) => Err(ErrorCode::Unimplemented(

--- a/src/query/sql/src/planner/optimizer/rule/transform/util.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/util.rs
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 use common_exception::Result;
-use common_expression::type_check;
-use common_expression::RawExpr;
-use common_functions::scalars::BUILTIN_FUNCTIONS;
 
 use crate::plans::ComparisonExpr;
 use crate::plans::ComparisonOp;
@@ -28,22 +25,10 @@ pub fn get_join_predicates(join: &Join) -> Result<Vec<ScalarExpr>> {
         .iter()
         .zip(join.right_conditions.iter())
         .map(|(left_cond, right_cond)| {
-            let registry = &BUILTIN_FUNCTIONS;
-            let raw_expr = RawExpr::FunctionCall {
-                span: None,
-                name: "eq".to_string(),
-                params: vec![],
-                args: vec![
-                    left_cond.as_raw_expr_with_col_name(),
-                    right_cond.as_raw_expr_with_col_name(),
-                ],
-            };
-            let expr = type_check::check(&raw_expr, registry)?;
             Ok(ScalarExpr::ComparisonExpr(ComparisonExpr {
                 left: Box::new(left_cond.clone()),
                 right: Box::new(right_cond.clone()),
                 op: ComparisonOp::Equal,
-                return_type: Box::new(expr.data_type().clone()),
             }))
         })
         .collect::<Result<Vec<_>>>()?

--- a/src/query/sql/src/planner/plans/scalar_expr.rs
+++ b/src/query/sql/src/planner/plans/scalar_expr.rs
@@ -43,20 +43,8 @@ pub enum ScalarExpr {
 }
 
 impl ScalarExpr {
-    pub fn data_type(&self) -> DataType {
-        match self {
-            ScalarExpr::BoundColumnRef(scalar) => (*scalar.column.data_type).clone(),
-            ScalarExpr::ConstantExpr(scalar) => (*scalar.data_type).clone(),
-            ScalarExpr::AndExpr(scalar) => (*scalar.return_type).clone(),
-            ScalarExpr::OrExpr(scalar) => (*scalar.return_type).clone(),
-            ScalarExpr::NotExpr(scalar) => (*scalar.return_type).clone(),
-            ScalarExpr::ComparisonExpr(scalar) => (*scalar.return_type).clone(),
-            ScalarExpr::AggregateFunction(scalar) => (*scalar.return_type).clone(),
-            ScalarExpr::FunctionCall(scalar) => (*scalar.return_type).clone(),
-            ScalarExpr::CastExpr(scalar) => (*scalar.target_type).clone(),
-            ScalarExpr::SubqueryExpr(scalar) => scalar.data_type(),
-            ScalarExpr::Unnest(scalar) => (*scalar.return_type).clone(),
-        }
+    pub fn data_type(&self) -> Result<DataType> {
+        Ok(self.as_expr_with_col_index()?.data_type().clone())
     }
 
     pub fn used_columns(&self) -> ColumnSet {
@@ -347,20 +335,17 @@ pub struct ConstantExpr {
 pub struct AndExpr {
     pub left: Box<ScalarExpr>,
     pub right: Box<ScalarExpr>,
-    pub return_type: Box<DataType>,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct OrExpr {
     pub left: Box<ScalarExpr>,
     pub right: Box<ScalarExpr>,
-    pub return_type: Box<DataType>,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct NotExpr {
     pub argument: Box<ScalarExpr>,
-    pub return_type: Box<DataType>,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -417,7 +402,6 @@ pub struct ComparisonExpr {
     pub op: ComparisonOp,
     pub left: Box<ScalarExpr>,
     pub right: Box<ScalarExpr>,
-    pub return_type: Box<DataType>,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -437,7 +421,6 @@ pub struct FunctionCall {
     pub arguments: Vec<ScalarExpr>,
 
     pub func_name: String,
-    pub return_type: Box<DataType>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -450,7 +433,6 @@ pub struct Unnest {
 pub struct CastExpr {
     pub is_try: bool,
     pub argument: Box<ScalarExpr>,
-    pub from_type: Box<DataType>,
     pub target_type: Box<DataType>,
 }
 

--- a/src/query/sql/src/planner/semantic/grouping_check.rs
+++ b/src/query/sql/src/planner/semantic/grouping_check.rs
@@ -54,7 +54,7 @@ impl<'a> GroupingChecker<'a> {
                 table_name: None,
                 column_name: "group_item".to_string(),
                 index: column.index,
-                data_type: Box::new(column.scalar.data_type()),
+                data_type: Box::new(column.scalar.data_type()?),
                 visibility: Visibility::Visible,
             };
             return Ok(BoundColumnRef {
@@ -75,25 +75,21 @@ impl<'a> GroupingChecker<'a> {
             ScalarExpr::AndExpr(scalar) => Ok(AndExpr {
                 left: Box::new(self.resolve(&scalar.left, span)?),
                 right: Box::new(self.resolve(&scalar.right, span)?),
-                return_type: scalar.return_type.clone(),
             }
             .into()),
             ScalarExpr::OrExpr(scalar) => Ok(OrExpr {
                 left: Box::new(self.resolve(&scalar.left, span)?),
                 right: Box::new(self.resolve(&scalar.right, span)?),
-                return_type: scalar.return_type.clone(),
             }
             .into()),
             ScalarExpr::NotExpr(scalar) => Ok(NotExpr {
                 argument: Box::new(self.resolve(&scalar.argument, span)?),
-                return_type: scalar.return_type.clone(),
             }
             .into()),
             ScalarExpr::ComparisonExpr(scalar) => Ok(ComparisonExpr {
                 op: scalar.op.clone(),
                 left: Box::new(self.resolve(&scalar.left, span)?),
                 right: Box::new(self.resolve(&scalar.right, span)?),
-                return_type: scalar.return_type.clone(),
             }
             .into()),
             ScalarExpr::FunctionCall(func) => {
@@ -106,14 +102,12 @@ impl<'a> GroupingChecker<'a> {
                     params: func.params.clone(),
                     arguments: args,
                     func_name: func.func_name.clone(),
-                    return_type: func.return_type.clone(),
                 }
                 .into())
             }
             ScalarExpr::CastExpr(cast) => Ok(CastExpr {
                 is_try: cast.is_try,
                 argument: Box::new(self.resolve(&cast.argument, span)?),
-                from_type: cast.from_type.clone(),
                 target_type: cast.target_type.clone(),
             }
             .into()),
@@ -140,7 +134,7 @@ impl<'a> GroupingChecker<'a> {
                         table_name: None,
                         column_name: agg.display_name.clone(),
                         index: agg_func.index,
-                        data_type: Box::new(agg_func.scalar.data_type()),
+                        data_type: Box::new(agg_func.scalar.data_type()?),
                         visibility: Visibility::Visible,
                     };
                     return Ok(BoundColumnRef {

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -2077,9 +2077,9 @@ impl<'a> TypeChecker<'a> {
                 func_name: "get".to_string(),
             }
             .into();
-            scalar = wrap_cast(&scalar, &DataType::from(&table_data_type));
         }
-        Ok(Box::new((scalar, DataType::from(&table_data_type))))
+        let return_type = scalar.data_type()?;
+        Ok(Box::new((scalar, return_type)))
     }
 
     #[async_recursion::async_recursion]

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -2059,7 +2059,6 @@ impl<'a> TypeChecker<'a> {
                     func_name: "get".to_string(),
                 }
                 .into();
-                scalar = wrap_cast(&scalar, &DataType::from(&table_data_type));
                 continue;
             }
             let box (path_value, path_data_type) = self.resolve_literal(&path_lit, None)?;

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -57,10 +57,10 @@ use common_users::UserApiProvider;
 
 use super::name_resolution::NameResolutionContext;
 use super::normalize_identifier;
+use crate::binder::wrap_cast;
 use crate::binder::Binder;
 use crate::binder::NameResolutionResult;
 use crate::optimizer::RelExpr;
-use crate::planner::binder::wrap_cast_if_needed;
 use crate::planner::metadata::optimize_remove_count_args;
 use crate::plans::AggregateFunction;
 use crate::plans::AndExpr;
@@ -188,7 +188,7 @@ impl<'a> TypeChecker<'a> {
                         (BoundColumnRef { column }.into(), data_type)
                     }
                     NameResolutionResult::Alias { scalar, .. } => {
-                        (scalar.clone(), scalar.data_type())
+                        (scalar.clone(), scalar.data_type()?)
                     }
                 };
 
@@ -396,7 +396,6 @@ impl<'a> TypeChecker<'a> {
                         AndExpr {
                             left: Box::new(ge_func),
                             right: Box::new(le_func),
-                            return_type: Box::new(data_type.clone()),
                         }
                         .into(),
                         data_type,
@@ -437,7 +436,6 @@ impl<'a> TypeChecker<'a> {
                         OrExpr {
                             left: Box::new(lt_func),
                             right: Box::new(gt_func),
-                            return_type: Box::new(data_type.clone()),
                         }
                         .into(),
                         data_type,
@@ -514,7 +512,7 @@ impl<'a> TypeChecker<'a> {
             Expr::Cast {
                 expr, target_type, ..
             } => {
-                let box (scalar, data_type) = self.resolve(expr, required_type).await?;
+                let box (scalar, _) = self.resolve(expr, required_type).await?;
                 let raw_expr = RawExpr::Cast {
                     span: None,
                     is_try: false,
@@ -527,7 +525,6 @@ impl<'a> TypeChecker<'a> {
                     CastExpr {
                         is_try: false,
                         argument: Box::new(scalar),
-                        from_type: Box::new(data_type),
                         target_type: Box::new(expr.data_type().clone()),
                     }
                     .into(),
@@ -538,7 +535,7 @@ impl<'a> TypeChecker<'a> {
             Expr::TryCast {
                 expr, target_type, ..
             } => {
-                let box (scalar, data_type) = self.resolve(expr, required_type).await?;
+                let box (scalar, _) = self.resolve(expr, required_type).await?;
                 let raw_expr = RawExpr::Cast {
                     span: None,
                     is_try: true,
@@ -551,7 +548,6 @@ impl<'a> TypeChecker<'a> {
                     CastExpr {
                         is_try: true,
                         argument: Box::new(scalar),
-                        from_type: Box::new(data_type),
                         target_type: Box::new(expr.data_type().clone()),
                     }
                     .into(),
@@ -979,7 +975,7 @@ impl<'a> TypeChecker<'a> {
         for argument in arguments {
             let box (arg, mut arg_type) = self.resolve(argument, None).await?;
             if let ScalarExpr::SubqueryExpr(subquery) = &arg {
-                if subquery.typ == SubqueryType::Scalar && !arg.data_type().is_nullable() {
+                if subquery.typ == SubqueryType::Scalar && !arg.data_type()?.is_nullable() {
                     arg_type = arg_type.wrap_nullable();
                 }
             }
@@ -1000,7 +996,7 @@ impl<'a> TypeChecker<'a> {
         }
 
         // rewrite_collation
-        let func_name = if self.function_need_collation(func_name, &args)
+        let func_name = if self.function_need_collation(func_name, &args)?
             && self.ctx.get_settings().get_collation()? == "utf8"
         {
             format!("{func_name}_utf8")
@@ -1044,7 +1040,6 @@ impl<'a> TypeChecker<'a> {
                 params,
                 arguments: args,
                 func_name: func_name.to_string(),
-                return_type: Box::new(expr.data_type().clone()),
             }
             .into(),
             expr.data_type().clone(),
@@ -1074,10 +1069,8 @@ impl<'a> TypeChecker<'a> {
                 let (positive, data_type) = *self
                     .resolve_binary_op(span, &positive_op, left, right, required_type)
                     .await?;
-                let return_type = Box::new(data_type.clone());
                 let scalar = ScalarExpr::NotExpr(NotExpr {
                     argument: Box::new(positive),
-                    return_type,
                 });
                 Ok(Box::new((scalar, data_type)))
             }
@@ -1106,7 +1099,6 @@ impl<'a> TypeChecker<'a> {
                         op,
                         left: Box::new(left),
                         right: Box::new(right),
-                        return_type: Box::new(data_type.clone()),
                     }
                     .into(),
                     data_type,
@@ -1130,7 +1122,6 @@ impl<'a> TypeChecker<'a> {
                     AndExpr {
                         left: Box::new(left),
                         right: Box::new(right),
-                        return_type: Box::new(data_type.clone()),
                     }
                     .into(),
                     data_type,
@@ -1154,7 +1145,6 @@ impl<'a> TypeChecker<'a> {
                     OrExpr {
                         left: Box::new(left),
                         right: Box::new(right),
-                        return_type: Box::new(data_type.clone()),
                     }
                     .into(),
                     data_type,
@@ -1204,7 +1194,6 @@ impl<'a> TypeChecker<'a> {
                 Ok(Box::new((
                     NotExpr {
                         argument: Box::new(argument),
-                        return_type: Box::new(data_type.clone()),
                     }
                     .into(),
                     data_type,
@@ -1300,7 +1289,7 @@ impl<'a> TypeChecker<'a> {
             ASTIntervalKind::Year => {
                 self.resolve_function(
                     span,
-                    "to_start_of_year",vec![], 
+                    "to_start_of_year", vec![],
                     &[date],
                     None,
                 )
@@ -1309,7 +1298,7 @@ impl<'a> TypeChecker<'a> {
             ASTIntervalKind::Quarter => {
                 self.resolve_function(
                     span,
-                    "to_start_of_quarter",vec![], 
+                    "to_start_of_quarter", vec![],
                     &[date],
                     None,
                 )
@@ -1318,7 +1307,7 @@ impl<'a> TypeChecker<'a> {
             ASTIntervalKind::Month => {
                 self.resolve_function(
                     span,
-                    "to_start_of_month",vec![], 
+                    "to_start_of_month", vec![],
                     &[date],
                     None,
                 )
@@ -1327,7 +1316,7 @@ impl<'a> TypeChecker<'a> {
             ASTIntervalKind::Day => {
                 self.resolve_function(
                     span,
-                    "to_start_of_day",vec![], 
+                    "to_start_of_day", vec![],
                     &[date],
                     None,
                 )
@@ -1336,7 +1325,7 @@ impl<'a> TypeChecker<'a> {
             ASTIntervalKind::Hour => {
                 self.resolve_function(
                     span,
-                    "to_start_of_hour",vec![], 
+                    "to_start_of_hour", vec![],
                     &[date],
                     None,
                 )
@@ -1345,7 +1334,7 @@ impl<'a> TypeChecker<'a> {
             ASTIntervalKind::Minute => {
                 self.resolve_function(
                     span,
-                    "to_start_of_minute",vec![], 
+                    "to_start_of_minute", vec![],
                     &[date],
                     None,
                 )
@@ -1354,7 +1343,7 @@ impl<'a> TypeChecker<'a> {
             ASTIntervalKind::Second => {
                 self.resolve_function(
                     span,
-                    "to_start_of_second",vec![], 
+                    "to_start_of_second", vec![],
                     &[date],
                     None,
                 )
@@ -1408,12 +1397,12 @@ impl<'a> TypeChecker<'a> {
                     *data_type.clone(),
                     &BUILTIN_FUNCTIONS.default_cast_rules,
                 )
-                .ok_or_else(|| {
-                    ErrorCode::Internal(format!(
-                        "Subquery type {scalar_data_type} and expression {data_type} cannot be matched"
-                    ))
-                })?;
-                scalar = wrap_cast_if_needed(&scalar, &coercion_type);
+                    .ok_or_else(|| {
+                        ErrorCode::Internal(format!(
+                            "Subquery type {scalar_data_type} and expression {data_type} cannot be matched"
+                        ))
+                    })?;
+                scalar = wrap_cast(&scalar, &coercion_type);
                 data_type = Box::new(coercion_type);
             }
             child_scalar = Some(Box::new(scalar));
@@ -1666,14 +1655,14 @@ impl<'a> TypeChecker<'a> {
                         Expr::BinaryOp {
                             op, left, right, ..
                         } => {
-                            if let Expr::Literal {span:_, lit:Literal::UInt64(l)} = **left
-                                && let Expr::Literal {span:_, lit:Literal::UInt64(r)} = **right {
+                            if let Expr::Literal { span: _, lit: Literal::UInt64(l) } = **left
+                                && let Expr::Literal { span: _, lit: Literal::UInt64(r) } = **right {
                                 match op {
                                     BinaryOperator::Plus => (l + r) as i32,
                                     BinaryOperator::Minus => (l - r) as i32,
                                     _ => -1,
                                 }
-                            } else {-1}
+                            } else { -1 }
                         }
                         Expr::UnaryOp { op, expr, .. } => {
                             if let Expr::Literal {
@@ -2068,7 +2057,6 @@ impl<'a> TypeChecker<'a> {
                     params: vec![idx],
                     arguments: vec![scalar.clone()],
                     func_name: "get".to_string(),
-                    return_type: Box::new(DataType::from(&table_data_type)),
                 }
                 .into();
                 continue;
@@ -2079,19 +2067,15 @@ impl<'a> TypeChecker<'a> {
                 data_type: Box::new(path_data_type.clone()),
             }
             .into();
-            if let TableDataType::Array(inner_type) = table_data_type {
-                table_data_type = *inner_type;
-            }
-            table_data_type = TableDataType::wrap_nullable(&table_data_type);
             scalar = FunctionCall {
                 params: vec![],
                 arguments: vec![scalar.clone(), path_scalar],
                 func_name: "get".to_string(),
-                return_type: Box::new(DataType::from(&table_data_type)),
             }
             .into();
         }
-        Ok(Box::new((scalar, DataType::from(&table_data_type))))
+        let return_type = scalar.data_type()?;
+        Ok(Box::new((scalar, return_type)))
     }
 
     #[async_recursion::async_recursion]
@@ -2170,7 +2154,7 @@ impl<'a> TypeChecker<'a> {
                         (BoundColumnRef { column }.into(), data_type)
                     }
                     NameResolutionResult::Alias { scalar, .. } => {
-                        (scalar.clone(), scalar.data_type())
+                        (scalar.clone(), scalar.data_type()?)
                     }
                 };
                 Ok(Box::new((scalar, data_type)))
@@ -2183,11 +2167,11 @@ impl<'a> TypeChecker<'a> {
                         params: vec![idx],
                         arguments: vec![scalar.clone()],
                         func_name: "get".to_string(),
-                        return_type: Box::new(DataType::from(&table_data_type)),
                     }
                     .into();
+                    scalar = wrap_cast(&scalar, &DataType::from(&table_data_type));
                 }
-                let return_type = scalar.data_type();
+                let return_type = scalar.data_type()?;
                 Ok(Box::new((scalar, return_type)))
             }
         }
@@ -2473,12 +2457,13 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
-    fn function_need_collation(&self, name: &str, args: &[ScalarExpr]) -> bool {
+    fn function_need_collation(&self, name: &str, args: &[ScalarExpr]) -> Result<bool> {
         let names = vec!["substr", "substring", "length"];
-        !args.is_empty()
-            && matches!(args[0].data_type().remove_nullable(), DataType::String)
+        let result = !args.is_empty()
+            && matches!(args[0].data_type()?.remove_nullable(), DataType::String)
             && self.ctx.get_settings().get_collation().unwrap() != "binary"
-            && names.contains(&name)
+            && names.contains(&name);
+        Ok(result)
     }
 
     pub fn resolve_type_name(type_name: &TypeName) -> Result<TableDataType> {

--- a/src/query/storages/parquet/src/pruning.rs
+++ b/src/query/storages/parquet/src/pruning.rs
@@ -708,7 +708,6 @@ mod tests {
                     }),
                 ],
                 func_name: "gt".to_string(),
-                return_type: Box::new(DataType::Boolean),
             });
             let filter = filter.as_expr_with_col_name()?;
             let pruner =
@@ -737,7 +736,6 @@ mod tests {
                     }),
                 ],
                 func_name: "lt".to_string(),
-                return_type: Box::new(DataType::Boolean),
             });
             let filter = filter.as_expr_with_col_name()?;
             let pruner =
@@ -766,7 +764,6 @@ mod tests {
                     }),
                 ],
                 func_name: "lte".to_string(),
-                return_type: Box::new(DataType::Boolean),
             });
             let filter = filter.as_expr_with_col_name()?;
             let pruner =
@@ -805,7 +802,6 @@ mod tests {
                     }),
                 ],
                 func_name: "gt".to_string(),
-                return_type: Box::new(DataType::Boolean),
             });
             let filter = filter.as_expr_with_col_name()?;
             let pruners = build_column_page_pruners(FunctionContext::default(), &schema, &filter)?;
@@ -835,7 +831,6 @@ mod tests {
                     }),
                 ],
                 func_name: "lte".to_string(),
-                return_type: Box::new(DataType::Boolean),
             });
             let filter = filter.as_expr_with_col_name()?;
             let pruners = build_column_page_pruners(FunctionContext::default(), &schema, &filter)?;
@@ -865,7 +860,6 @@ mod tests {
                     }),
                 ],
                 func_name: "gt".to_string(),
-                return_type: Box::new(DataType::Boolean),
             });
             let filter = filter.as_expr_with_col_name()?;
             let pruners = build_column_page_pruners(FunctionContext::default(), &schema, &filter)?;
@@ -895,7 +889,6 @@ mod tests {
                     }),
                 ],
                 func_name: "lte".to_string(),
-                return_type: Box::new(DataType::Boolean),
             });
             let filter = filter.as_expr_with_col_name()?;
             let pruners = build_column_page_pruners(FunctionContext::default(), &schema, &filter)?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Get data type of `ScalarExpr` with type checking to prevent unmatched data type.
