### PR TITLE
ci: larger wait time for http handler long polling.

### DIFF
--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -1116,18 +1116,23 @@ async fn test_multi_partition() -> Result<()> {
 
     let sqls = vec![
         ("create table tb2(id int, c1 varchar) Engine=Fuse;", 0),
-        ("insert into tb2 values(1, 'mysql'),(2,'databend')", 0),
-        ("insert into tb2 values(1, 'mysql'),(2,'databend')", 0),
-        ("insert into tb2 values(1, 'mysql'),(2,'databend')", 0),
+        ("insert into tb2 values(1, 'mysql'),(1, 'databend')", 0),
+        ("insert into tb2 values(2, 'mysql'),(2, 'databend')", 0),
+        ("insert into tb2 values(3, 'mysql'),(3, 'databend')", 0),
         ("select * from tb2;", 6),
     ];
 
+    let wait_time_secs = 5;
     for (sql, data_len) in sqls {
-        let json = serde_json::json!({"sql": sql.to_string(), "pagination": {"wait_time_secs": 2}});
+        let json = serde_json::json!({"sql": sql.to_string(), "pagination": {"wait_time_secs": wait_time_secs}});
         let (status, result) = post_json_to_endpoint(&route, &json).await?;
         assert_eq!(status, StatusCode::OK);
         assert!(result.error.is_none(), "{:?}", result.error);
-        assert_eq!(result.state, ExecuteStateKind::Succeeded);
+        assert_eq!(
+            result.state,
+            ExecuteStateKind::Succeeded,
+            "SQL '{sql}' not finish after {wait_time_secs} secs"
+        );
         assert_eq!(result.data.len(), data_len);
     }
     Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix ci failure to slow `create table` https://github.com/datafuselabs/databend/actions/runs/4362596845/jobs/7627675766

I will refactor tests like this later.

Closes #issue
