### PR TITLE
feat: new feature `enable-histogram-metrics`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4984,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.20.1"
-source = "git+https://github.com/datafuse-extras/metrics.git?rev=bc49d03#bc49d0364bc53499cb43fa418b2c474ef3ef24f1"
+source = "git+https://github.com/datafuse-extras/metrics.git?rev=fc2ecd1#fc2ecd143dc0461166081f80bc76f0b38381f3a1"
 dependencies = [
  "ahash 0.7.6",
  "metrics-macros",
@@ -5009,7 +5009,7 @@ dependencies = [
 [[package]]
 name = "metrics-macros"
 version = "0.6.0"
-source = "git+https://github.com/datafuse-extras/metrics.git?rev=bc49d03#bc49d0364bc53499cb43fa418b2c474ef3ef24f1"
+source = "git+https://github.com/datafuse-extras/metrics.git?rev=fc2ecd1#fc2ecd143dc0461166081f80bc76f0b38381f3a1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,4 +180,4 @@ rpath = false
 arrow2 = { git = "https://github.com/jorgecarleitao/arrow2", rev = "9749aee" }
 parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", rev = "ed0e1ff" }
 limits-rs = { git = "https://github.com/datafuse-extras/limits-rs", rev = "abfcf7b" }
-metrics = { git = "https://github.com/datafuse-extras/metrics.git", rev = "bc49d03" }
+metrics = { git = "https://github.com/datafuse-extras/metrics.git", rev = "fc2ecd1" }

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -26,6 +26,12 @@ io-uring = [
     "common-meta-raft-store/io-uring",
 ]
 
+enable-histogram-metrics = [
+    "default",
+    "common-metrics/enable-histogram",
+    "databend-query/enable-histogram-metrics",
+]
+
 [dependencies]
 # Workspace dependencies
 common-base = { path = "../common/base" }

--- a/src/common/metrics/Cargo.toml
+++ b/src/common/metrics/Cargo.toml
@@ -10,6 +10,9 @@ edition = { workspace = true }
 doctest = false
 test = false
 
+[features]
+enable-histogram = ["metrics/enable-histogram"]
+
 [dependencies]
 # Workspace dependencies
 common-exception = { path = "../exception" }

--- a/src/meta/client/Cargo.toml
+++ b/src/meta/client/Cargo.toml
@@ -13,6 +13,9 @@ edition = { workspace = true }
 doctest = false
 test = false
 
+[features]
+enable-histogram = ["common-metrics/enable-histogram"]
+
 [dependencies]
 common-arrow = { path = "../../common/arrow" }
 common-base = { path = "../../common/base" }

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -22,6 +22,8 @@ io-uring = [
     "common-meta-raft-store/io-uring",
 ]
 
+enable-histogram = ["common-metrics/enable-histogram"]
+
 [dependencies]
 # Workspace dependencies
 common-arrow = { path = "../../common/arrow" }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -31,6 +31,15 @@ io-uring = [
     # "common-meta-raft-store/io-uring",
 ]
 
+enable-histogram-metrics = [
+    "default",
+    "common-metrics/enable-histogram",
+    "common-storages-fuse/enable-histogram-metrics",
+    "common-storages-system/enable-histogram-metrics",
+    "metrics/enable-histogram",
+    "storages-common-cache/enable-histogram-metrics",
+]
+
 [dependencies]
 # Workspace dependencies
 common-arrow = { path = "../../common/arrow" }

--- a/src/query/storages/common/cache/Cargo.toml
+++ b/src/query/storages/common/cache/Cargo.toml
@@ -11,6 +11,9 @@ edition = { workspace = true }
 doctest = false
 test = false
 
+[features]
+enable-histogram-metrics = ["metrics/enable-histogram"]
+
 [dependencies]
 common-cache = { path = "../../../../common/cache" }
 common-exception = { path = "../../../../common/exception" }

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -11,6 +11,9 @@ edition = { workspace = true }
 doctest = false
 test = false
 
+[features]
+enable-histogram-metrics = ["metrics/enable-histogram", "storages-common-cache/enable-histogram-metrics"]
+
 [dependencies]
 common-arrow = { path = "../../../common/arrow" }
 common-base = { path = "../../../common/base" }

--- a/src/query/storages/system/Cargo.toml
+++ b/src/query/storages/system/Cargo.toml
@@ -11,6 +11,9 @@ edition = { workspace = true }
 doctest = false
 test = false
 
+[features]
+enable-histogram-metrics = ["common-metrics/enable-histogram"]
+
 [dependencies]
 common-base = { path = "../../../common/base" }
 common-catalog = { path = "../../catalog" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

introduce a new cargo feature `enable-histogram-metrics`,  which can enable the histogram metrics

- by default, it is disabled, metrics of histogram will be no-op 
- if enabled,  metrics of histogram will be "generated"
   e.g.  `cargo b --features enable-histogram-metrics`
   
   
the "reason" of disabling histogram by default : https://github.com/metrics-rs/metrics/issues/245   

Closes #10428
