### PR TITLE
feat(storage): Map data type support bloom filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8314,6 +8314,7 @@ version = "0.1.0"
 dependencies = [
  "anyerror",
  "cbordata",
+ "common-arrow",
  "common-exception",
  "common-expression",
  "common-functions",

--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -399,6 +399,13 @@ impl FunctionID {
             FunctionID::Factory { id, .. } => *id,
         }
     }
+
+    pub fn name(&self) -> &String {
+        match self {
+            FunctionID::Builtin { name, .. } => name,
+            FunctionID::Factory { name, .. } => name,
+        }
+    }
 }
 
 pub fn wrap_nullable<F>(f: F) -> impl Fn(&[ValueRef<AnyType>], &mut EvalContext) -> Value<AnyType>

--- a/src/query/expression/src/kernels/concat.rs
+++ b/src/query/expression/src/kernels/concat.rs
@@ -18,6 +18,7 @@ use itertools::Itertools;
 
 use crate::types::array::ArrayColumnBuilder;
 use crate::types::decimal::DecimalColumn;
+use crate::types::map::KvColumnBuilder;
 use crate::types::nullable::NullableColumn;
 use crate::types::number::NumberColumn;
 use crate::types::string::StringColumnBuilder;
@@ -28,6 +29,7 @@ use crate::types::BooleanType;
 use crate::types::DateType;
 use crate::types::EmptyArrayType;
 use crate::types::EmptyMapType;
+use crate::types::MapType;
 use crate::types::NullType;
 use crate::types::NullableType;
 use crate::types::NumberType;
@@ -138,7 +140,7 @@ impl Column {
                 let builder = Vec::with_capacity(capacity);
                 Self::concat_value_types::<DateType>(builder, columns)
             }
-            Column::Array(col) | Column::Map(col) => {
+            Column::Array(col) => {
                 let mut offsets = Vec::with_capacity(capacity + 1);
                 offsets.push(0);
                 let builder = ColumnBuilder::from_column(
@@ -147,6 +149,24 @@ impl Column {
                 );
                 let builder = ArrayColumnBuilder { builder, offsets };
                 Self::concat_value_types::<ArrayType<AnyType>>(builder, columns)
+            }
+            Column::Map(col) => {
+                let mut offsets = Vec::with_capacity(capacity + 1);
+                offsets.push(0);
+                let builder = ColumnBuilder::from_column(
+                    TypeDeserializerImpl::with_capacity(&col.values.data_type(), capacity)
+                        .finish_to_column(),
+                );
+                let (key_builder, val_builder) = match builder {
+                    ColumnBuilder::Tuple { fields, .. } => (fields[0].clone(), fields[1].clone()),
+                    _ => unreachable!(),
+                };
+                let builder = KvColumnBuilder {
+                    keys: key_builder,
+                    values: val_builder,
+                };
+                let builder = ArrayColumnBuilder { builder, offsets };
+                Self::concat_value_types::<MapType<AnyType, AnyType>>(builder, columns)
             }
             Column::Nullable(_) => {
                 let mut bitmaps = Vec::with_capacity(columns.len());

--- a/src/query/expression/src/kernels/filter.rs
+++ b/src/query/expression/src/kernels/filter.rs
@@ -19,8 +19,10 @@ use common_arrow::arrow::bitmap::MutableBitmap;
 use common_arrow::arrow::buffer::Buffer;
 use common_exception::Result;
 
+use crate::types::array::ArrayColumn;
 use crate::types::array::ArrayColumnBuilder;
 use crate::types::decimal::DecimalColumn;
+use crate::types::map::KvColumnBuilder;
 use crate::types::nullable::NullableColumn;
 use crate::types::number::NumberColumn;
 use crate::types::string::StringColumn;
@@ -28,6 +30,7 @@ use crate::types::string::StringColumnBuilder;
 use crate::types::AnyType;
 use crate::types::ArrayType;
 use crate::types::BooleanType;
+use crate::types::MapType;
 use crate::types::ValueType;
 use crate::types::VariantType;
 use crate::with_decimal_type;
@@ -133,7 +136,7 @@ impl Column {
                 let d = Self::filter_primitive_types(column, filter);
                 Column::Date(d)
             }
-            Column::Array(column) | Column::Map(column) => {
+            Column::Array(column) => {
                 let mut offsets = Vec::with_capacity(length + 1);
                 offsets.push(0);
                 let builder = ColumnBuilder::from_column(
@@ -142,6 +145,25 @@ impl Column {
                 );
                 let builder = ArrayColumnBuilder { builder, offsets };
                 Self::filter_scalar_types::<ArrayType<AnyType>>(column, builder, filter)
+            }
+            Column::Map(column) => {
+                let mut offsets = Vec::with_capacity(length + 1);
+                offsets.push(0);
+                let builder = ColumnBuilder::from_column(
+                    TypeDeserializerImpl::with_capacity(&column.values.data_type(), length)
+                        .finish_to_column(),
+                );
+                let (key_builder, val_builder) = match builder {
+                    ColumnBuilder::Tuple { fields, .. } => (fields[0].clone(), fields[1].clone()),
+                    _ => unreachable!(),
+                };
+                let builder = KvColumnBuilder {
+                    keys: key_builder,
+                    values: val_builder,
+                };
+                let builder = ArrayColumnBuilder { builder, offsets };
+                let column = ArrayColumn::try_downcast(column).unwrap();
+                Self::filter_scalar_types::<MapType<AnyType, AnyType>>(&column, builder, filter)
             }
             Column::Nullable(c) => {
                 let column = Self::filter(&c.column, filter);

--- a/src/query/expression/src/kernels/scatter.rs
+++ b/src/query/expression/src/kernels/scatter.rs
@@ -16,8 +16,10 @@ use common_arrow::arrow::bitmap::MutableBitmap;
 use common_exception::Result;
 use itertools::Itertools;
 
+use crate::types::array::ArrayColumn;
 use crate::types::array::ArrayColumnBuilder;
 use crate::types::decimal::DecimalColumn;
+use crate::types::map::KvColumnBuilder;
 use crate::types::nullable::NullableColumn;
 use crate::types::number::NumberColumn;
 use crate::types::string::StringColumnBuilder;
@@ -26,6 +28,7 @@ use crate::types::ArrayType;
 use crate::types::BooleanType;
 use crate::types::DataType;
 use crate::types::DateType;
+use crate::types::MapType;
 use crate::types::NumberType;
 use crate::types::StringType;
 use crate::types::TimestampType;
@@ -191,7 +194,7 @@ impl Column {
                 indices,
                 scatter_size,
             ),
-            Column::Array(column) | Column::Map(column) => {
+            Column::Array(column) => {
                 let mut offsets = Vec::with_capacity(length + 1);
                 offsets.push(0);
                 let builder = ColumnBuilder::from_column(
@@ -201,6 +204,30 @@ impl Column {
                 let builder = ArrayColumnBuilder { builder, offsets };
                 Self::scatter_scalars::<ArrayType<AnyType>, _>(
                     column,
+                    builder,
+                    indices,
+                    scatter_size,
+                )
+            }
+            Column::Map(column) => {
+                let mut offsets = Vec::with_capacity(length + 1);
+                offsets.push(0);
+                let builder = ColumnBuilder::from_column(
+                    TypeDeserializerImpl::with_capacity(&column.values.data_type(), length)
+                        .finish_to_column(),
+                );
+                let (key_builder, val_builder) = match builder {
+                    ColumnBuilder::Tuple { fields, .. } => (fields[0].clone(), fields[1].clone()),
+                    _ => unreachable!(),
+                };
+                let builder = KvColumnBuilder {
+                    keys: key_builder,
+                    values: val_builder,
+                };
+                let builder = ArrayColumnBuilder { builder, offsets };
+                let column = ArrayColumn::try_downcast(column).unwrap();
+                Self::scatter_scalars::<MapType<AnyType, AnyType>, _>(
+                    &column,
                     builder,
                     indices,
                     scatter_size,

--- a/src/query/storages/common/index/Cargo.toml
+++ b/src/query/storages/common/index/Cargo.toml
@@ -32,6 +32,7 @@ xorfilter-rs = { git = "https://github.com/datafuse-extras/xorfilter", features 
 ], tag = "databend-alpha.4" }
 
 [dev-dependencies]
+common-arrow = { path = "../../../../common/arrow" }
 criterion = "0.4"
 rand = "0.8.5"
 

--- a/src/query/storages/common/index/src/lib.rs
+++ b/src/query/storages/common/index/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #![allow(clippy::uninlined_format_args)]
+#![feature(box_patterns)]
 
 mod bloom_index;
 pub mod filters;

--- a/src/query/storages/common/index/tests/it/filters/bloom_filter.rs
+++ b/src/query/storages/common/index/tests/it/filters/bloom_filter.rs
@@ -16,14 +16,20 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use common_arrow::arrow::buffer::Buffer;
 use common_exception::Result;
 use common_expression::type_check::check_function;
+use common_expression::types::array::ArrayColumn;
+use common_expression::types::map::KvColumn;
+use common_expression::types::map::KvPair;
 use common_expression::types::number::NumberScalar;
 use common_expression::types::number::UInt8Type;
+use common_expression::types::AnyType;
 use common_expression::types::DataType;
 use common_expression::types::NumberDataType;
 use common_expression::types::StringType;
 use common_expression::BlockEntry;
+use common_expression::Column;
 use common_expression::DataBlock;
 use common_expression::Expr;
 use common_expression::FromData;
@@ -44,7 +50,24 @@ fn test_bloom_filter() -> Result<()> {
     let schema = Arc::new(TableSchema::new(vec![
         TableField::new("0", TableDataType::Number(NumberDataType::UInt8)),
         TableField::new("1", TableDataType::String),
+        TableField::new(
+            "2",
+            TableDataType::Map(Box::new(TableDataType::Tuple {
+                fields_name: vec!["key".to_string(), "value".to_string()],
+                fields_type: vec![
+                    TableDataType::Number(NumberDataType::UInt8),
+                    TableDataType::String,
+                ],
+            })),
+        ),
     ]));
+
+    let kv_ty = DataType::Tuple(vec![
+        DataType::Number(NumberDataType::UInt8),
+        DataType::String,
+    ]);
+    let map_ty = DataType::Map(Box::new(kv_ty));
+
     let blocks = vec![
         DataBlock::new(
             vec![
@@ -56,12 +79,32 @@ fn test_bloom_filter() -> Result<()> {
                     data_type: DataType::String,
                     value: Value::Scalar(Scalar::String(b"a".to_vec())),
                 },
+                BlockEntry {
+                    data_type: map_ty.clone(),
+                    value: Value::Scalar(Scalar::Map(Column::Tuple {
+                        fields: vec![
+                            UInt8Type::from_data(vec![1, 2]),
+                            StringType::from_data(vec!["a", "b"]),
+                        ],
+                        len: 2,
+                    })),
+                },
             ],
             2,
         ),
         DataBlock::new_from_columns(vec![
             UInt8Type::from_data(vec![2, 3]),
             StringType::from_data(vec!["b", "c"]),
+            Column::Map(Box::new(
+                ArrayColumn::<KvPair<AnyType, AnyType>> {
+                    values: KvColumn {
+                        keys: UInt8Type::from_data(vec![1, 2, 3]),
+                        values: StringType::from_data(vec!["b", "c", "d"]),
+                    },
+                    offsets: Buffer::<u64>::from(vec![0, 2, 3]),
+                }
+                .upcast(),
+            )),
         ]),
     ];
     let blocks_ref = blocks.iter().collect::<Vec<_>>();
@@ -114,6 +157,42 @@ fn test_bloom_filter() -> Result<()> {
         eval_index(&index, "1", Scalar::String(b"d".to_vec()), DataType::String)
     );
 
+    assert_eq!(
+        FilterEvalResult::Uncertain,
+        eval_map_index(
+            &index,
+            "2",
+            map_ty.clone(),
+            Scalar::Number(NumberScalar::UInt8(1)),
+            DataType::Number(NumberDataType::UInt8),
+            Scalar::String(b"a".to_vec()),
+            DataType::String
+        )
+    );
+    assert_eq!(
+        FilterEvalResult::Uncertain,
+        eval_map_index(
+            &index,
+            "2",
+            map_ty.clone(),
+            Scalar::Number(NumberScalar::UInt8(2)),
+            DataType::Number(NumberDataType::UInt8),
+            Scalar::String(b"b".to_vec()),
+            DataType::String
+        )
+    );
+    assert_eq!(
+        FilterEvalResult::MustFalse,
+        eval_map_index(
+            &index,
+            "2",
+            map_ty,
+            Scalar::Number(NumberScalar::UInt8(3)),
+            DataType::Number(NumberDataType::UInt8),
+            Scalar::String(b"x".to_vec()),
+            DataType::String
+        )
+    );
     Ok(())
 }
 
@@ -135,6 +214,62 @@ fn eval_index(index: &BloomIndex, col_name: &str, val: Scalar, ty: DataType) -> 
                 data_type: ty,
             },
         ],
+        &BUILTIN_FUNCTIONS,
+    )
+    .unwrap();
+
+    let point_query_cols = BloomIndex::find_eq_columns(&expr).unwrap();
+
+    let mut scalar_map = HashMap::<Scalar, u64>::new();
+    let func_ctx = FunctionContext::default();
+    for (_, scalar, ty) in point_query_cols.iter() {
+        if !scalar_map.contains_key(scalar) {
+            let digest = BloomIndex::calculate_scalar_digest(func_ctx, scalar, ty).unwrap();
+            scalar_map.insert(scalar.clone(), digest);
+        }
+    }
+
+    index.apply(expr, &scalar_map).unwrap()
+}
+
+fn eval_map_index(
+    index: &BloomIndex,
+    col_name: &str,
+    map_ty: DataType,
+    key: Scalar,
+    key_ty: DataType,
+    val: Scalar,
+    ty: DataType,
+) -> FilterEvalResult {
+    let get_expr = check_function(
+        None,
+        "get",
+        &[],
+        &[
+            Expr::ColumnRef {
+                span: None,
+                id: col_name.to_string(),
+                data_type: map_ty,
+                display_name: col_name.to_string(),
+            },
+            Expr::Constant {
+                span: None,
+                scalar: key,
+                data_type: key_ty,
+            },
+        ],
+        &BUILTIN_FUNCTIONS,
+    )
+    .unwrap();
+    let expr = check_function(
+        None,
+        "eq",
+        &[],
+        &[get_expr, Expr::Constant {
+            span: None,
+            scalar: val,
+            data_type: ty,
+        }],
         &BUILTIN_FUNCTIONS,
     )
     .unwrap();

--- a/tests/sqllogictests/suites/base/03_common/03_0037_insert_into_map
+++ b/tests/sqllogictests/suites/base/03_common/03_0037_insert_into_map
@@ -27,6 +27,11 @@ abc def NULL NULL
 NULL NULL mn NULL
 NULL NULL NULL NULL
 
+query IT
+select * from t1 where m[300] = 'mn'
+----
+2 {300:'mn'}
+
 statement error 1001
 INSERT INTO t1 (id, m) VALUES(1, {100:'k1',100:'k2'})
 
@@ -47,6 +52,11 @@ select m['k1'], m['k2'], m['k3'], m['k4'] from t2
 ----
 ['2020-01-01','2021-01-02'] ['2022-01-01'] NULL NULL
 NULL NULL ['2023-01-01'] NULL
+
+query IT
+select * from t2 where m['k3'] = ['2023-01-01'::date]
+----
+2 {'k3':['2023-01-01']}
 
 statement error 1001
 CREATE TABLE IF NOT EXISTS t3(id Int, m Map(Array(Date), String)) Engine = Fuse


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Map data type support bloom filter

Part of #10062

From the test data example, we can see that the bloom filter is effective in reducing the query time if the value of the query does not exist.

```sql
MySQL root@127.0.0.1:default> select count(*) from test;
+----------+
| count(*) |
+----------+
| 100000   |
+----------+
1 row in set
Time: 0.153s
MySQL root@127.0.0.1:default> select * from test where log['ip'] = '205.91.162.148';
+----+----------------------------------------+
| id | log                                    |
+----+----------------------------------------+
| 1  | {'ip':'205.91.162.148','url':'test-1'} |
+----+----------------------------------------+
1 row in set
Time: 1.733s
MySQL root@127.0.0.1:default> select * from test where log['ip'] = '205.91.162.141';
+----+-----+
| id | log |
+----+-----+
+----+-----+
0 rows in set
Time: 0.129s
```
