### PR TITLE
fix(query): make sort respect index

### DIFF
--- a/src/query/sql/src/planner/binder/sort.rs
+++ b/src/query/sql/src/planner/binder/sort.rs
@@ -156,11 +156,12 @@ impl Binder {
                         ))
                         .set_span(order.expr.span()));
                     }
+
                     order_items.push(OrderItem {
                         expr: order.clone(),
                         name: projections[index].column_name.clone(),
                         index: projections[index].index,
-                        need_eval_scalar: false,
+                        need_eval_scalar: true,
                     });
                 }
                 _ => {

--- a/src/query/sql/src/planner/binder/sort.rs
+++ b/src/query/sql/src/planner/binder/sort.rs
@@ -161,7 +161,7 @@ impl Binder {
                         expr: order.clone(),
                         name: projections[index].column_name.clone(),
                         index: projections[index].index,
-                        need_eval_scalar: scalar_items.get(&item.index).map_or(
+                        need_eval_scalar: scalar_items.get(&projections[index].index).map_or(
                             false,
                             |scalar_item| {
                                 !matches!(&scalar_item.scalar, ScalarExpr::BoundColumnRef(_))

--- a/src/query/sql/src/planner/binder/sort.rs
+++ b/src/query/sql/src/planner/binder/sort.rs
@@ -161,7 +161,12 @@ impl Binder {
                         expr: order.clone(),
                         name: projections[index].column_name.clone(),
                         index: projections[index].index,
-                        need_eval_scalar: true,
+                        need_eval_scalar: scalar_items.get(&item.index).map_or(
+                            false,
+                            |scalar_item| {
+                                !matches!(&scalar_item.scalar, ScalarExpr::BoundColumnRef(_))
+                            },
+                        ),
                     });
                 }
                 _ => {

--- a/tests/sqllogictests/suites/query/order.test
+++ b/tests/sqllogictests/suites/query/order.test
@@ -28,6 +28,15 @@ NULL
 1
 2
 
+query II
+select number  d , max(1-number) c from numbers(4) group by 1  order by 2;
+----
+3 -2
+2 -1
+1 0
+0 1
+
+
 statement ok
 drop table order_test
 
@@ -36,4 +45,3 @@ select number from numbers(10) as a order by b.number
 
 statement error
 select number from (select * from numbers(10) as b) as a order by b.number
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

make sort respect index

```
MySQL [(none)]> select number  d , max(1-number) c from numbers(4) group by 1  order by 2;
+------+------+
| d    | c    |
+------+------+
|    3 |   -2 |
|    2 |   -1 |
|    1 |    0 |
|    0 |    1 |
+------+------+
4 rows in set (0.044 sec)
```

Closes #10453 
