### PR TITLE
docs(query): add access control doc about privilege 

### DIFF
--- a/docs/doc/04-security/00-access-control/10-access-control-privileges.md
+++ b/docs/doc/04-security/00-access-control/10-access-control-privileges.md
@@ -1,0 +1,78 @@
+---
+title: Access Control Privileges
+sidebar_label: Privileges
+description:
+  Databend Access Control Privileges
+---
+
+This topic describes the privileges that are available in the Databend access control model.
+
+## All Privileges
+
+| Privilege | Object Type | Description |
+| :--                 | :--                  | :--                  |
+| ALL   |  All    | Grants all the privileges for the specified object type. |
+| Alter   |    Database, Table, View   | Privilege to alter databases or tables. |
+| Create   |     Database, Table    | Privilege to create databases or tables. |
+| Delete   |  Table   | Privilege to delete or truncate rows in a table. |
+| Drop       |    Database, Table, View    | Privilege to drop databases or tables or views and undrop databases or tables. |
+| Insert       |   Table       | Privilege to insert rows into tables. |
+| Select       |    Table      | Privilege to select rows from tables . |
+| Update       |      Table    | Privilege to update rows in a table |
+| Grant       |     Global    | Privilege to Grant/Revoke privileges to users or roles |
+| Super       |      Global   | Privilege to Kill query, Set global configs, OptimizeTable. |
+| Usage       |    Global     | UsagePrivilege is a synonym for “no privileges” |
+| Create Role   |      Global    | Not used |
+| Create Stage   |    Not used     | Not used |
+| Create User   |     Global     | Not used |
+
+## Global Privileges
+
+| Privilege | Usage |
+| :--                 | :--                  |
+| ALL   |  Grants all the privileges for the specified object type. |
+| Grant   |    Add/Drop table Column, Alter table cluster key, Re-cluster table |
+| CreateRole   |     Create table    |
+| CreateUser   |  Delete rows in a table, Truncate table |
+| Super       |    Kill query, Set configs |
+| Usage       |   Only can connect to databend query, but no privileges |
+
+
+## Table Privileges
+
+| Privilege | Usage |
+| :--                 | :--                  |
+| ALL   |  Grants all the privileges for the specified object type. |
+| Alter   |    Add/Drop table Column, Alter table cluster key, Re-cluster table |
+| Create   |     Create table    |
+| Delete   |  Delete rows in a table, Truncate table |
+| Drop       |    Drop table, Undrop table(restores the recent version of a dropped table) |
+| Insert       |   Insert rows into table |
+| Select       |    Select rows from tables |
+| Update       |      Update rows in a table |
+| Super       |    Optimize table need super privilege |
+
+## View Privileges
+
+| Privilege | Usage |
+| :--                 | :--                  |
+| ALL   |  Grants all the privileges for the specified object type |
+| Alter   |    Create/Drop view, Alter the existing view by using another `QUERY` |
+| Drop       |    Drop view |
+
+## Database Privileges
+
+| Privilege | Usage |
+| :--                 | :--                  |
+| Alter   |    Rename database |
+| Create   |     Create database    |
+| Drop       |    Drop database, Undrop database((restores the recent version of a dropped database)) |
+
+
+## Session Policy Privileges
+
+
+| Privilege | Usage |
+| :--                 | :--                  |
+| Super       |    Kill query, Set configs |
+| ALL   |  Grants all the privileges for the specified object type. |

--- a/docs/doc/04-security/00-access-control/_category_.json
+++ b/docs/doc/04-security/00-access-control/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Access Control",
+  "link": {
+    "type": "generated-index",
+    "slug": "/operations/access"
+  }
+}

--- a/docs/doc/04-security/_category_.json
+++ b/docs/doc/04-security/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Security",
+  "link": {
+    "type": "generated-index",
+    "slug": "/security"
+  }
+}

--- a/src/meta/app/src/principal/user_privilege.rs
+++ b/src/meta/app/src/principal/user_privilege.rs
@@ -46,7 +46,7 @@ pub enum UserPrivilegeType {
     Create = 1 << 1,
     // Privilege to drop databases or tables.
     Drop = 1 << 7,
-    // Privilege to delete rows in a table
+    // Privilege to alter databases or tables.
     Alter = 1 << 8,
     // Privilege to Kill query, Set global configs, etc.
     Super = 1 << 9,

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -1359,7 +1359,6 @@ pub fn priv_type(i: Input) -> IResult<UserPrivilegeType> {
         value(UserPrivilegeType::Insert, rule! { INSERT }),
         value(UserPrivilegeType::Update, rule! { UPDATE }),
         value(UserPrivilegeType::Delete, rule! { DELETE }),
-        value(UserPrivilegeType::Create, rule! { CREATE }),
         value(UserPrivilegeType::Drop, rule! { DROP }),
         value(UserPrivilegeType::Alter, rule! { ALTER }),
         value(UserPrivilegeType::Super, rule! { SUPER }),
@@ -1367,6 +1366,7 @@ pub fn priv_type(i: Input) -> IResult<UserPrivilegeType> {
         value(UserPrivilegeType::CreateRole, rule! { CREATE ~ ROLE }),
         value(UserPrivilegeType::Grant, rule! { GRANT }),
         value(UserPrivilegeType::CreateStage, rule! { CREATE ~ STAGE }),
+        value(UserPrivilegeType::Create, rule! { CREATE }),
         value(UserPrivilegeType::Set, rule! { SET }),
     ))(i)
 }

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -167,6 +167,7 @@ fn test_statement() {
         r#"ALTER DATABASE c RENAME TO a;"#,
         r#"ALTER DATABASE ctl.c RENAME TO a;"#,
         r#"CREATE TABLE t (a INT COMMENT 'col comment') COMMENT='table comment';"#,
+        r#"GRANT CREATE, CREATE USER ON * TO 'test-grant'@'localhost';"#,
         r#"GRANT SELECT, CREATE ON * TO 'test-grant'@'localhost';"#,
         r#"GRANT SELECT, CREATE ON *.* TO 'test-grant'@'localhost';"#,
         r#"GRANT SELECT, CREATE ON * TO USER 'test-grant'@'localhost';"#,
@@ -593,3 +594,4 @@ fn test_expr_error() {
         run_parser!(file, expr, case);
     }
 }
+

--- a/src/query/ast/tests/it/testdata/statement-error.txt
+++ b/src/query/ast/tests/it/testdata/statement-error.txt
@@ -233,7 +233,7 @@ error:
   --> SQL:1:15
   |
 1 | GRANT SELECT, ALL PRIVILEGES, CREATE ON * TO 'test-grant'@'localhost';
-  | ----- ------  ^^^ expected `USAGE`, `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `CREATE`, or 5 more ...
+  | ----- ------  ^^^ expected `USAGE`, `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `DROP`, or 5 more ...
   | |     |        
   | |     while parsing <privileges> ON <privileges_level>
   | while parsing `GRANT { ROLE <role_name> | schemaObjectPrivileges | ALL [ PRIVILEGES ] ON <privileges_level> } TO { [ROLE <role_name>] | [USER] <user> }`
@@ -268,7 +268,7 @@ error:
   --> SQL:1:24
   |
 1 | REVOKE SELECT, CREATE, ALL PRIVILEGES ON * FROM 'test-grant'@'localhost';
-  | ------ ------          ^^^ expected `USAGE`, `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `CREATE`, or 5 more ...
+  | ------ ------          ^^^ expected `USAGE`, `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `DROP`, or 5 more ...
   | |      |                
   | |      while parsing <privileges> ON <privileges_level>
   | while parsing `REVOKE { ROLE <role_name> | schemaObjectPrivileges | ALL [ PRIVILEGES ] ON <privileges_level> } FROM { [ROLE <role_name>] | [USER] <user> }`

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -6167,6 +6167,32 @@ CreateTable(
 
 
 ---------- Input ----------
+GRANT CREATE, CREATE USER ON * TO 'test-grant'@'localhost';
+---------- Output ---------
+GRANT CREATE, CREATE USER ON * TO USER 'test-grant'@'localhost'
+---------- AST ------------
+Grant(
+    GrantStmt {
+        source: Privs {
+            privileges: [
+                Create,
+                CreateUser,
+            ],
+            level: Database(
+                None,
+            ),
+        },
+        principal: User(
+            UserIdentity {
+                username: "test-grant",
+                hostname: "localhost",
+            },
+        ),
+    },
+)
+
+
+---------- Input ----------
 GRANT SELECT, CREATE ON * TO 'test-grant'@'localhost';
 ---------- Output ---------
 GRANT SELECT, CREATE ON * TO USER 'test-grant'@'localhost'


### PR DESCRIPTION
## Summary

1. add doc: priv

2. fix grant create user/stage/role err

## Questions

1. I try to add priv doc. But I find in [privilege_access.rs
](https://github.com/datafuselabs/databend/blob/main/src/query/service/src/interpreters/access/privilege_access.rs) more plan does not check privilege. 

2. And I think this is unreasonable? Why create view need alter priv?
cc @BohuTANG 
```rust
Plan::CreateView(plan) => {
    session
        .validate_privilege(
            &GrantObject::Database(plan.catalog.clone(), plan.database.clone()),
            UserPrivilegeType::Alter,
        )
        .await?;
}
```

```sql
mysql> show grants;
+-----------------------------------------------------+
| Grants                                              |
+-----------------------------------------------------+
| GRANT CREATE,CREATE ROLE ON *.* TO 'b'@'%'          |
| GRANT SELECT ON 'default'.'system'.'one' TO 'b'@'%' |
+-----------------------------------------------------+
2 rows in set (0.03 sec)
Read 0 rows, 0.00 B in 0.004 sec., 0 rows/sec., 0.00 B/sec.

mysql> create view v_t2 as select * from t;
ERROR 1105 (HY000): Code: 1063, displayText = Permission denied, user 'b'@'%' requires ALTER privilege on 'default'.'default'.*.

```

Closes #10385
