### PR TITLE
docs: Fix Typo in Header

### DIFF
--- a/docs/doc/00-overview/index.md
+++ b/docs/doc/00-overview/index.md
@@ -50,7 +50,7 @@ import TabItem from '@theme/TabItem';
 </TabItem>
 </Tabs>
 
-## Databend Architucture
+## Databend Architecture
 
 Databend's high-level architecture is composed of a meta-service layer, a compute layer, and a storage layer.
 


### PR DESCRIPTION
Architucture -> Architecture

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Just a simple typo fix - since it's in a header it is pretty glaring. 

Closes #issue

None, just fixing a typo.