### PR TITLE
chore: rename json function `object_construct` as `json_object`

### DIFF
--- a/src/query/functions/src/scalars/variant.rs
+++ b/src/query/functions/src/scalars/variant.rs
@@ -79,6 +79,8 @@ use jsonb::to_u64;
 use jsonb::JsonPathRef;
 
 pub fn register(registry: &mut FunctionRegistry) {
+    registry.register_aliases("json_object_keys", &["object_keys"]);
+
     registry.register_passthrough_nullable_1_arg::<StringType, VariantType, _, _>(
         "parse_json",
         FunctionProperty::default(),
@@ -147,7 +149,7 @@ pub fn register(registry: &mut FunctionRegistry) {
     );
 
     registry.register_1_arg_core::<NullableType<VariantType>, NullableType<VariantType>, _, _>(
-        "object_keys",
+        "json_object_keys",
         FunctionProperty::default(),
         |_| FunctionDomain::Full,
         vectorize_1_arg::<NullableType<VariantType>, NullableType<VariantType>>(|val, _| {
@@ -658,34 +660,34 @@ pub fn register(registry: &mut FunctionRegistry) {
         });
     }
 
-    registry.register_function_factory("object_construct", |_, args_type| {
+    registry.register_function_factory("json_object", |_, args_type| {
         Some(Arc::new(Function {
             signature: FunctionSignature {
-                name: "object_construct".to_string(),
+                name: "json_object".to_string(),
                 args_type: (0..args_type.len()).map(DataType::Generic).collect(),
                 return_type: DataType::Variant,
                 property: FunctionProperty::default(),
             },
             calc_domain: Box::new(|_| FunctionDomain::MayThrow),
-            eval: Box::new(move |args, ctx| object_construct_fn(args, ctx, false)),
+            eval: Box::new(move |args, ctx| json_object_fn(args, ctx, false)),
         }))
     });
 
-    registry.register_function_factory("object_construct_keep_null", |_, args_type| {
+    registry.register_function_factory("json_object_keep_null", |_, args_type| {
         Some(Arc::new(Function {
             signature: FunctionSignature {
-                name: "object_construct_keep_null".to_string(),
+                name: "json_object_keep_null".to_string(),
                 args_type: (0..args_type.len()).map(DataType::Generic).collect(),
                 return_type: DataType::Variant,
                 property: FunctionProperty::default(),
             },
             calc_domain: Box::new(|_| FunctionDomain::MayThrow),
-            eval: Box::new(move |args, ctx| object_construct_fn(args, ctx, true)),
+            eval: Box::new(move |args, ctx| json_object_fn(args, ctx, true)),
         }))
     });
 }
 
-fn object_construct_fn(
+fn json_object_fn(
     args: &[ValueRef<AnyType>],
     ctx: &mut EvalContext,
     keep_null: bool,

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -16,6 +16,7 @@ mid -> substr
 mod -> modulo
 neg -> minus
 negate -> minus
+object_keys -> json_object_keys
 octet_length -> length
 remove_nullable -> assume_not_null
 rlike -> regexp
@@ -1340,6 +1341,9 @@ Functions overloads:
 1 is_true(Boolean NULL) :: Boolean
 0 json_extract_path_text(String, String) :: String NULL
 1 json_extract_path_text(String NULL, String NULL) :: String NULL
+0 json_object FACTORY
+0 json_object_keep_null FACTORY
+0 json_object_keys(Variant NULL) :: Variant NULL
 0 left(String, UInt64) :: String
 1 left(String NULL, UInt64 NULL) :: String NULL
 0 length(Variant NULL) :: UInt32 NULL
@@ -2210,9 +2214,6 @@ Functions overloads:
 33 noteq(Array(T0) NULL, Array(T0) NULL) :: Boolean NULL
 34 noteq FACTORY
 0 now() :: Timestamp
-0 object_construct FACTORY
-0 object_construct_keep_null FACTORY
-0 object_keys(Variant NULL) :: Variant NULL
 0 oct(Int64) :: String
 1 oct(Int64 NULL) :: String NULL
 0 or(Boolean, Boolean) :: Boolean

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -416,27 +416,27 @@ evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
-ast            : object_keys(parse_json('[1,2,3,4]'))
-raw expr       : object_keys(parse_json("[1,2,3,4]"))
-checked expr   : object_keys<Variant NULL>(CAST(parse_json<String>("[1,2,3,4]") AS Variant NULL))
+ast            : json_object_keys(parse_json('[1,2,3,4]'))
+raw expr       : json_object_keys(parse_json("[1,2,3,4]"))
+checked expr   : json_object_keys<Variant NULL>(CAST(parse_json<String>("[1,2,3,4]") AS Variant NULL))
 optimized expr : NULL
 output type    : Variant NULL
 output domain  : {NULL}
 output         : NULL
 
 
-ast            : object_keys(parse_json('{"k1":"v1","k2":"v2"}'))
-raw expr       : object_keys(parse_json("{\"k1\":\"v1\",\"k2\":\"v2\"}"))
-checked expr   : object_keys<Variant NULL>(CAST(parse_json<String>("{\"k1\":\"v1\",\"k2\":\"v2\"}") AS Variant NULL))
+ast            : json_object_keys(parse_json('{"k1":"v1","k2":"v2"}'))
+raw expr       : json_object_keys(parse_json("{\"k1\":\"v1\",\"k2\":\"v2\"}"))
+checked expr   : json_object_keys<Variant NULL>(CAST(parse_json<String>("{\"k1\":\"v1\",\"k2\":\"v2\"}") AS Variant NULL))
 optimized expr : 0x8000000210000002100000026b316b32
 output type    : Variant NULL
 output domain  : Undefined
 output         : ["k1","k2"]
 
 
-ast            : object_keys(parse_json(s))
-raw expr       : object_keys(parse_json(s::String))
-checked expr   : object_keys<Variant NULL>(CAST(parse_json<String>(s) AS Variant NULL))
+ast            : json_object_keys(parse_json(s))
+raw expr       : json_object_keys(parse_json(s::String))
+checked expr   : json_object_keys<Variant NULL>(CAST(parse_json<String>(s) AS Variant NULL))
 evaluation:
 +--------+-------------------------------------------------+--------------+
 |        | s                                               | Output       |
@@ -456,9 +456,9 @@ evaluation (internal):
 +--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
-ast            : object_keys(parse_json(s))
-raw expr       : object_keys(parse_json(s::String NULL))
-checked expr   : object_keys<Variant NULL>(parse_json<String NULL>(s))
+ast            : json_object_keys(parse_json(s))
+raw expr       : json_object_keys(parse_json(s::String NULL))
+checked expr   : json_object_keys<Variant NULL>(parse_json<String NULL>(s))
 evaluation:
 +--------+-------------------------------------------------+--------------+
 |        | s                                               | Output       |
@@ -1997,27 +1997,27 @@ evaluation (internal):
 +--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
-ast            : object_construct()
-raw expr       : object_construct()
-checked expr   : object_construct<>()
+ast            : json_object()
+raw expr       : json_object()
+checked expr   : json_object<>()
 optimized expr : 0x40000000
 output type    : Variant
 output domain  : Undefined
 output         : {}
 
 
-ast            : object_construct('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})
-raw expr       : object_construct("a", true, "b", 1_u8, "c", "str", "d", array(1_u8, 2_u8), "e", map(array("k"), array("v")))
-checked expr   : object_construct<T0=String, T1=Boolean, T2=String, T3=UInt8, T4=String, T5=String, T6=String, T7=Array(UInt8), T8=String, T9=Map(String, String)><T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>("a", true, "b", 1_u8, "c", "str", "d", array<T0=UInt8><T0, T0>(1_u8, 2_u8), "e", map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0>("k"), array<T0=String><T0>("v")))
+ast            : json_object('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})
+raw expr       : json_object("a", true, "b", 1_u8, "c", "str", "d", array(1_u8, 2_u8), "e", map(array("k"), array("v")))
+checked expr   : json_object<T0=String, T1=Boolean, T2=String, T3=UInt8, T4=String, T5=String, T6=String, T7=Array(UInt8), T8=String, T9=Map(String, String)><T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>("a", true, "b", 1_u8, "c", "str", "d", array<T0=UInt8><T0, T0>(1_u8, 2_u8), "e", map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0>("k"), array<T0=String><T0>("v")))
 optimized expr : 0x400000051000000110000001100000011000000110000001400000002000000210000003500000105000000e61626364655001737472800000022000000220000002500150024000000110000001100000016b76
 output type    : Variant
 output domain  : Undefined
 output         : {"a":true,"b":1,"c":"str","d":[1,2],"e":{"k":"v"}}
 
 
-ast            : object_construct('k1', 1, 'k2', null, 'k3', 2, null, 3)
-raw expr       : object_construct("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
-checked expr   : object_construct<T0=String, T1=UInt8, T2=String, T3=NULL, T4=String, T5=UInt8, T6=NULL, T7=UInt8><T0, T1, T2, T3, T4, T5, T6, T7>("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
+ast            : json_object('k1', 1, 'k2', null, 'k3', 2, null, 3)
+raw expr       : json_object("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
+checked expr   : json_object<T0=String, T1=UInt8, T2=String, T3=NULL, T4=String, T5=UInt8, T6=NULL, T7=UInt8><T0, T1, T2, T3, T4, T5, T6, T7>("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
 optimized expr : 0x40000002100000021000000220000002200000026b316b3350015002
 output type    : Variant
 output domain  : Undefined
@@ -2027,30 +2027,30 @@ output         : {"k1":1,"k3":2}
 error: 
   --> SQL:1:1
   |
-1 | object_construct('k1', 1, 'k1')
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The number of keys and values must be equal while evaluating function `object_construct("k1", 1, "k1")`
+1 | json_object('k1', 1, 'k1')
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ The number of keys and values must be equal while evaluating function `json_object("k1", 1, "k1")`
 
 
 
 error: 
   --> SQL:1:1
   |
-1 | object_construct('k1', 1, 'k1', 2)
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Keys have to be unique while evaluating function `object_construct("k1", 1, "k1", 2)`
+1 | json_object('k1', 1, 'k1', 2)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Keys have to be unique while evaluating function `json_object("k1", 1, "k1", 2)`
 
 
 
 error: 
   --> SQL:1:1
   |
-1 | object_construct(1, 'k1', 2, 'k2')
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Key must be a string value while evaluating function `object_construct(1, "k1", 2, "k2")`
+1 | json_object(1, 'k1', 2, 'k2')
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Key must be a string value while evaluating function `json_object(1, "k1", 2, "k2")`
 
 
 
-ast            : object_construct(k1, v1, k2, v2)
-raw expr       : object_construct(k1::String NULL, v1::String NULL, k2::String NULL, v2::String NULL)
-checked expr   : object_construct<T0=String NULL, T1=String NULL, T2=String NULL, T3=String NULL><T0, T1, T2, T3>(k1, v1, k2, v2)
+ast            : json_object(k1, v1, k2, v2)
+raw expr       : json_object(k1::String NULL, v1::String NULL, k2::String NULL, v2::String NULL)
+checked expr   : json_object<T0=String NULL, T1=String NULL, T2=String NULL, T3=String NULL><T0, T1, T2, T3>(k1, v1, k2, v2)
 evaluation:
 +--------+----------------------+----------------------+----------------------+---------------+-----------------------+
 |        | k1                   | v1                   | k2                   | v2            | Output                |
@@ -2074,27 +2074,27 @@ evaluation (internal):
 +--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
-ast            : object_construct_keep_null()
-raw expr       : object_construct_keep_null()
-checked expr   : object_construct_keep_null<>()
+ast            : json_object_keep_null()
+raw expr       : json_object_keep_null()
+checked expr   : json_object_keep_null<>()
 optimized expr : 0x40000000
 output type    : Variant
 output domain  : Undefined
 output         : {}
 
 
-ast            : object_construct_keep_null('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})
-raw expr       : object_construct_keep_null("a", true, "b", 1_u8, "c", "str", "d", array(1_u8, 2_u8), "e", map(array("k"), array("v")))
-checked expr   : object_construct_keep_null<T0=String, T1=Boolean, T2=String, T3=UInt8, T4=String, T5=String, T6=String, T7=Array(UInt8), T8=String, T9=Map(String, String)><T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>("a", true, "b", 1_u8, "c", "str", "d", array<T0=UInt8><T0, T0>(1_u8, 2_u8), "e", map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0>("k"), array<T0=String><T0>("v")))
+ast            : json_object_keep_null('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})
+raw expr       : json_object_keep_null("a", true, "b", 1_u8, "c", "str", "d", array(1_u8, 2_u8), "e", map(array("k"), array("v")))
+checked expr   : json_object_keep_null<T0=String, T1=Boolean, T2=String, T3=UInt8, T4=String, T5=String, T6=String, T7=Array(UInt8), T8=String, T9=Map(String, String)><T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>("a", true, "b", 1_u8, "c", "str", "d", array<T0=UInt8><T0, T0>(1_u8, 2_u8), "e", map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0>("k"), array<T0=String><T0>("v")))
 optimized expr : 0x400000051000000110000001100000011000000110000001400000002000000210000003500000105000000e61626364655001737472800000022000000220000002500150024000000110000001100000016b76
 output type    : Variant
 output domain  : Undefined
 output         : {"a":true,"b":1,"c":"str","d":[1,2],"e":{"k":"v"}}
 
 
-ast            : object_construct_keep_null('k1', 1, 'k2', null, 'k3', 2, null, 3)
-raw expr       : object_construct_keep_null("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
-checked expr   : object_construct_keep_null<T0=String, T1=UInt8, T2=String, T3=NULL, T4=String, T5=UInt8, T6=NULL, T7=UInt8><T0, T1, T2, T3, T4, T5, T6, T7>("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
+ast            : json_object_keep_null('k1', 1, 'k2', null, 'k3', 2, null, 3)
+raw expr       : json_object_keep_null("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
+checked expr   : json_object_keep_null<T0=String, T1=UInt8, T2=String, T3=NULL, T4=String, T5=UInt8, T6=NULL, T7=UInt8><T0, T1, T2, T3, T4, T5, T6, T7>("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
 optimized expr : 0x400000031000000210000002100000022000000200000000200000026b316b326b3350015002
 output type    : Variant
 output domain  : Undefined
@@ -2104,30 +2104,30 @@ output         : {"k1":1,"k2":null,"k3":2}
 error: 
   --> SQL:1:1
   |
-1 | object_construct_keep_null('k1', 1, 'k1')
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The number of keys and values must be equal while evaluating function `object_construct_keep_null("k1", 1, "k1")`
+1 | json_object_keep_null('k1', 1, 'k1')
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The number of keys and values must be equal while evaluating function `json_object_keep_null("k1", 1, "k1")`
 
 
 
 error: 
   --> SQL:1:1
   |
-1 | object_construct_keep_null('k1', 1, 'k1', 2)
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Keys have to be unique while evaluating function `object_construct_keep_null("k1", 1, "k1", 2)`
+1 | json_object_keep_null('k1', 1, 'k1', 2)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Keys have to be unique while evaluating function `json_object_keep_null("k1", 1, "k1", 2)`
 
 
 
 error: 
   --> SQL:1:1
   |
-1 | object_construct_keep_null(1, 'k1', 2, 'k2')
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Key must be a string value while evaluating function `object_construct_keep_null(1, "k1", 2, "k2")`
+1 | json_object_keep_null(1, 'k1', 2, 'k2')
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Key must be a string value while evaluating function `json_object_keep_null(1, "k1", 2, "k2")`
 
 
 
-ast            : object_construct_keep_null(k1, v1, k2, v2)
-raw expr       : object_construct_keep_null(k1::String NULL, v1::String NULL, k2::String NULL, v2::String NULL)
-checked expr   : object_construct_keep_null<T0=String NULL, T1=String NULL, T2=String NULL, T3=String NULL><T0, T1, T2, T3>(k1, v1, k2, v2)
+ast            : json_object_keep_null(k1, v1, k2, v2)
+raw expr       : json_object_keep_null(k1::String NULL, v1::String NULL, k2::String NULL, v2::String NULL)
+checked expr   : json_object_keep_null<T0=String NULL, T1=String NULL, T2=String NULL, T3=String NULL><T0, T1, T2, T3>(k1, v1, k2, v2)
 evaluation:
 +--------+----------------------+----------------------+----------------------+---------------+-----------------------+
 |        | k1                   | v1                   | k2                   | v2            | Output                |

--- a/src/query/functions/tests/it/scalars/variant.rs
+++ b/src/query/functions/tests/it/scalars/variant.rs
@@ -29,7 +29,7 @@ fn test_variant() {
     test_try_parse_json(file);
     test_check_json(file);
     test_length(file);
-    test_object_keys(file);
+    test_json_object_keys(file);
     test_get(file);
     test_get_ignore_case(file);
     test_get_path(file);
@@ -37,8 +37,8 @@ fn test_variant() {
     test_as_type(file);
     test_to_type(file);
     test_try_to_type(file);
-    test_object_construct(file);
-    test_object_construct_keep_null(file);
+    test_json_object(file);
+    test_json_object_keep_null(file);
 }
 
 fn test_parse_json(file: &mut impl Write) {
@@ -149,15 +149,15 @@ fn test_length(file: &mut impl Write) {
     )]);
 }
 
-fn test_object_keys(file: &mut impl Write) {
-    run_ast(file, "object_keys(parse_json('[1,2,3,4]'))", &[]);
+fn test_json_object_keys(file: &mut impl Write) {
+    run_ast(file, "json_object_keys(parse_json('[1,2,3,4]'))", &[]);
     run_ast(
         file,
-        "object_keys(parse_json('{\"k1\":\"v1\",\"k2\":\"v2\"}'))",
+        "json_object_keys(parse_json('{\"k1\":\"v1\",\"k2\":\"v2\"}'))",
         &[],
     );
 
-    run_ast(file, "object_keys(parse_json(s))", &[(
+    run_ast(file, "json_object_keys(parse_json(s))", &[(
         "s",
         StringType::from_data(vec![
             "[1,2,3,4]",
@@ -166,7 +166,7 @@ fn test_object_keys(file: &mut impl Write) {
         ]),
     )]);
 
-    run_ast(file, "object_keys(parse_json(s))", &[(
+    run_ast(file, "json_object_keys(parse_json(s))", &[(
         "s",
         StringType::from_data_with_validity(
             &[
@@ -496,23 +496,23 @@ fn test_try_to_type(file: &mut impl Write) {
     run_ast(file, "try_to_string(parse_json(s))", columns);
 }
 
-fn test_object_construct(file: &mut impl Write) {
-    run_ast(file, "object_construct()", &[]);
+fn test_json_object(file: &mut impl Write) {
+    run_ast(file, "json_object()", &[]);
     run_ast(
         file,
-        "object_construct('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})",
+        "json_object('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})",
         &[],
     );
     run_ast(
         file,
-        "object_construct('k1', 1, 'k2', null, 'k3', 2, null, 3)",
+        "json_object('k1', 1, 'k2', null, 'k3', 2, null, 3)",
         &[],
     );
-    run_ast(file, "object_construct('k1', 1, 'k1')", &[]);
-    run_ast(file, "object_construct('k1', 1, 'k1', 2)", &[]);
-    run_ast(file, "object_construct(1, 'k1', 2, 'k2')", &[]);
+    run_ast(file, "json_object('k1', 1, 'k1')", &[]);
+    run_ast(file, "json_object('k1', 1, 'k1', 2)", &[]);
+    run_ast(file, "json_object(1, 'k1', 2, 'k2')", &[]);
 
-    run_ast(file, "object_construct(k1, v1, k2, v2)", &[
+    run_ast(file, "json_object(k1, v1, k2, v2)", &[
         (
             "k1",
             StringType::from_data_with_validity(&["a1", "b1", "", "d1"], vec![
@@ -540,23 +540,23 @@ fn test_object_construct(file: &mut impl Write) {
     ]);
 }
 
-fn test_object_construct_keep_null(file: &mut impl Write) {
-    run_ast(file, "object_construct_keep_null()", &[]);
+fn test_json_object_keep_null(file: &mut impl Write) {
+    run_ast(file, "json_object_keep_null()", &[]);
     run_ast(
         file,
-        "object_construct_keep_null('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})",
+        "json_object_keep_null('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})",
         &[],
     );
     run_ast(
         file,
-        "object_construct_keep_null('k1', 1, 'k2', null, 'k3', 2, null, 3)",
+        "json_object_keep_null('k1', 1, 'k2', null, 'k3', 2, null, 3)",
         &[],
     );
-    run_ast(file, "object_construct_keep_null('k1', 1, 'k1')", &[]);
-    run_ast(file, "object_construct_keep_null('k1', 1, 'k1', 2)", &[]);
-    run_ast(file, "object_construct_keep_null(1, 'k1', 2, 'k2')", &[]);
+    run_ast(file, "json_object_keep_null('k1', 1, 'k1')", &[]);
+    run_ast(file, "json_object_keep_null('k1', 1, 'k1', 2)", &[]);
+    run_ast(file, "json_object_keep_null(1, 'k1', 2, 'k2')", &[]);
 
-    run_ast(file, "object_construct_keep_null(k1, v1, k2, v2)", &[
+    run_ast(file, "json_object_keep_null(k1, v1, k2, v2)", &[
         (
             "k1",
             StringType::from_data_with_validity(&["a1", "b1", "", "d1"], vec![


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The `JSON` functions `object_construct` and `object_construct_keep_null` are too long and easily confused with other types of functions, so renamed them as follows:

- rename `object_keys` as `json_object_keys`, and use `object_keys` as alias for compatible
- rename `object_construct` as `json_object`
- rename `object_construct_keep_null` as `json_object_keep_null`

In order to distinguish `JSON` functions from the `Array` and `Map` related functions. New `JSON` functions added in the future will be named starting with `json_`, for example:

- `json_array` creates a `JSON` type `Array`
- `json_array_append` adds elements to a `JSON` type `Array`
- `json_array_contains` checks for the existence of an element in a `JSON` type `Array`
- `json_object_insert` inserts an element into a `JSON` type `Object`
- `json_object_delete` deletes an element in a `JSON` type `Object`
-  ...

Closes #issue
