### PR TITLE
chore: make delete file in batch to parallel

### DIFF
--- a/src/query/storages/fuse/src/io/files.rs
+++ b/src/query/storages/fuse/src/io/files.rs
@@ -12,44 +12,53 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use std::mem;
 use std::sync::Arc;
 
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
 use opendal::Operator;
 
+use crate::io::try_join_futures;
+
 // File related operations.
 pub struct Files {
+    ctx: Arc<dyn TableContext>,
     operator: Operator,
 }
 
 impl Files {
-    pub fn create(_: Arc<dyn TableContext>, operator: Operator) -> Self {
-        Self { operator }
+    pub fn create(ctx: Arc<dyn TableContext>, operator: Operator) -> Self {
+        Self { ctx, operator }
     }
 
+    /// Removes a batch of files asynchronously by splitting a list of file locations into smaller groups of size 1000,
+    /// and then deleting each group of files using the delete_files function.
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn remove_file_in_batch(
         &self,
         file_locations: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Result<()> {
-        let iter = file_locations.into_iter().map(|v| v.as_ref().to_string());
+        let batch_size = 1000;
+        let locations = Vec::from_iter(file_locations.into_iter().map(|v| v.as_ref().to_string()));
+        let mut chunks = locations.chunks(batch_size);
 
-        // OpenDAL support delete via a stream. But it will cause higher
-        // ranked problems. So let's write them by hand.
-        let mut paths = Vec::with_capacity(1000);
-        for path in iter {
-            paths.push(path);
-            if paths.len() >= 1000 {
-                self.operator.remove(mem::take(&mut paths)).await?;
-            }
-        }
+        let tasks = std::iter::from_fn(move || {
+            chunks
+                .next()
+                .map(|location| Self::delete_files(self.operator.clone(), location.to_vec()))
+        });
 
-        if !paths.is_empty() {
-            self.operator.remove(mem::take(&mut paths)).await?;
-        }
+        try_join_futures(
+            self.ctx.clone(),
+            tasks,
+            "batch-remove-files-worker".to_owned(),
+        )
+        .await?;
+        Ok(())
+    }
 
+    async fn delete_files(op: Operator, locations: Vec<String>) -> Result<()> {
+        op.remove(locations).await?;
         Ok(())
     }
 }

--- a/src/query/storages/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/src/io/mod.rs
@@ -14,6 +14,7 @@
 
 mod files;
 mod locations;
+mod parallel;
 mod read;
 mod segments;
 mod snapshots;
@@ -21,6 +22,8 @@ mod write;
 
 pub use files::Files;
 pub use locations::TableMetaLocationGenerator;
+pub use parallel::try_join_futures;
+pub use parallel::try_join_futures_with_vec;
 pub use read::BlockReader;
 pub use read::BloomBlockFilterReader;
 pub use read::MergeIOReadResult;
@@ -31,8 +34,6 @@ pub use read::SegmentInfoReader;
 pub use read::SnapshotHistoryReader;
 pub use read::TableSnapshotReader;
 pub use read::UncompressedBuffer;
-pub use segments::try_join_futures;
-pub use segments::try_join_futures_with_vec;
 pub use segments::SegmentsIO;
 pub use snapshots::ListSnapshotLiteOption;
 pub use snapshots::SnapshotLiteListExtended;

--- a/src/query/storages/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/src/io/mod.rs
@@ -22,8 +22,7 @@ mod write;
 
 pub use files::Files;
 pub use locations::TableMetaLocationGenerator;
-pub use parallel::try_join_futures;
-pub use parallel::try_join_futures_with_vec;
+pub use parallel::execute_futures_in_parallel;
 pub use read::BlockReader;
 pub use read::BloomBlockFilterReader;
 pub use read::MergeIOReadResult;

--- a/src/query/storages/fuse/src/io/parallel.rs
+++ b/src/query/storages/fuse/src/io/parallel.rs
@@ -1,0 +1,71 @@
+//  Copyright 2022 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use common_base::base::tokio::sync::Semaphore;
+use common_base::runtime::Runtime;
+use common_catalog::table_context::TableContext;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use futures_util::future;
+use tracing::Instrument;
+
+/// Run multiple futures parallel
+/// using a semaphore to limit the parallelism number, and a specified thread pool to run the futures.
+/// It waits for all futures to complete and returns their results.
+pub async fn try_join_futures<Fut>(
+    ctx: Arc<dyn TableContext>,
+    futures: impl IntoIterator<Item = Fut>,
+    thread_name: String,
+) -> Result<Vec<Fut::Output>>
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    let max_runtime_threads = ctx.get_settings().get_max_threads()? as usize;
+    let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
+
+    // 1. build the runtime.
+    let semaphore = Semaphore::new(max_io_requests);
+    let runtime = Arc::new(Runtime::with_worker_threads(
+        max_runtime_threads,
+        Some(thread_name),
+    )?);
+
+    // 2. spawn all the tasks to the runtime.
+    let join_handlers = runtime.try_spawn_batch(semaphore, futures).await?;
+
+    // 3. get all the result.
+    future::try_join_all(join_handlers)
+        .instrument(tracing::debug_span!("try_join_futures_all"))
+        .await
+        .map_err(|e| ErrorCode::StorageOther(format!("try join futures failure, {}", e)))
+}
+
+/// This is a workaround to address `higher-ranked lifetime error` from rustc
+///
+/// TODO: remove me after rustc works with try_join_futures directly.
+pub async fn try_join_futures_with_vec<Fut>(
+    ctx: Arc<dyn TableContext>,
+    futures: Vec<Fut>,
+    thread_name: String,
+) -> Result<Vec<Fut::Output>>
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    try_join_futures(ctx, futures, thread_name).await
+}

--- a/src/query/storages/fuse/src/io/segments.rs
+++ b/src/query/storages/fuse/src/io/segments.rs
@@ -23,7 +23,7 @@ use storages_common_table_meta::meta::Location;
 use storages_common_table_meta::meta::SegmentInfo;
 use tracing::Instrument;
 
-use crate::io::try_join_futures;
+use crate::io::execute_futures_in_parallel;
 use crate::io::MetaReaders;
 
 // Read segment related operations.
@@ -88,7 +88,7 @@ impl SegmentsIO {
             }
         });
 
-        try_join_futures(
+        execute_futures_in_parallel(
             self.ctx.clone(),
             tasks,
             "fuse-req-segments-worker".to_owned(),
@@ -143,7 +143,7 @@ impl SegmentsIO {
             })
         });
 
-        try_join_futures(
+        execute_futures_in_parallel(
             self.ctx.clone(),
             tasks,
             "fuse-req-segments-worker".to_owned(),

--- a/src/query/storages/fuse/src/io/snapshots.rs
+++ b/src/query/storages/fuse/src/io/snapshots.rs
@@ -37,7 +37,7 @@ use tracing::info;
 use tracing::warn;
 use tracing::Instrument;
 
-use crate::io::try_join_futures;
+use crate::io::execute_futures_in_parallel;
 use crate::io::MetaReaders;
 use crate::io::SnapshotHistoryReader;
 use crate::io::TableMetaLocationGenerator;
@@ -168,7 +168,7 @@ impl SnapshotsIO {
             })
         });
 
-        try_join_futures(
+        execute_futures_in_parallel(
             self.ctx.clone(),
             tasks,
             "fuse-req-snapshots-worker".to_owned(),

--- a/src/query/storages/fuse/src/operations/merge_into/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/processors/transform_mutation_aggregator.rs
@@ -30,7 +30,7 @@ use storages_common_table_meta::meta::Location;
 use storages_common_table_meta::meta::SegmentInfo;
 use tracing::debug;
 
-use crate::io::try_join_futures_with_vec;
+use crate::io::execute_futures_in_parallel;
 use crate::io::SegmentsIO;
 use crate::io::TableMetaLocationGenerator;
 use crate::operations::merge_into::mutation_meta::mutation_log::CommitMeta;
@@ -160,7 +160,7 @@ impl TableMutationAggregator {
             });
         }
 
-        try_join_futures_with_vec(
+        execute_futures_in_parallel(
             self.ctx.clone(),
             handles,
             "mutation-write-segments-worker".to_owned(),

--- a/src/query/storages/fuse/src/operations/mutation/mutation_transform.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutation_transform.rs
@@ -31,7 +31,7 @@ use storages_common_table_meta::meta::Location;
 use storages_common_table_meta::meta::SegmentInfo;
 use storages_common_table_meta::meta::Statistics;
 
-use crate::io::try_join_futures_with_vec;
+use crate::io::execute_futures_in_parallel;
 use crate::io::SegmentsIO;
 use crate::io::TableMetaLocationGenerator;
 use crate::operations::mutation::AbortOperation;
@@ -161,7 +161,7 @@ impl MutationTransform {
             });
         }
 
-        try_join_futures_with_vec(
+        execute_futures_in_parallel(
             self.ctx.clone(),
             handles,
             "mutation-write-segments-worker".to_owned(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Old:
```
list @bomb;
292992 rows in set (18.23 sec)

mysql> remove @bomb;
Query OK, 0 rows affected (1 min 38.22 sec)
```

This PR:
```
list @bomb;
292992 rows in set (15.63 sec)

mysql> remove @bomb;
Query OK, 0 rows affected (16.99 sec)
```

How to test:
```
create stage bomb;
copy into @bomb from (select * from numbers(300000000)) file_format=(type=parquet) max_file_size=32;
remove @bomb;
```

Closes #issue
