### PR TITLE
fix(query): fix grant create user err

### DIFF
--- a/src/meta/app/src/principal/user_privilege.rs
+++ b/src/meta/app/src/principal/user_privilege.rs
@@ -46,7 +46,7 @@ pub enum UserPrivilegeType {
     Create = 1 << 1,
     // Privilege to drop databases or tables.
     Drop = 1 << 7,
-    // Privilege to delete rows in a table
+    // Privilege to alter databases or tables.
     Alter = 1 << 8,
     // Privilege to Kill query, Set global configs, etc.
     Super = 1 << 9,

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -1359,7 +1359,6 @@ pub fn priv_type(i: Input) -> IResult<UserPrivilegeType> {
         value(UserPrivilegeType::Insert, rule! { INSERT }),
         value(UserPrivilegeType::Update, rule! { UPDATE }),
         value(UserPrivilegeType::Delete, rule! { DELETE }),
-        value(UserPrivilegeType::Create, rule! { CREATE }),
         value(UserPrivilegeType::Drop, rule! { DROP }),
         value(UserPrivilegeType::Alter, rule! { ALTER }),
         value(UserPrivilegeType::Super, rule! { SUPER }),
@@ -1368,6 +1367,7 @@ pub fn priv_type(i: Input) -> IResult<UserPrivilegeType> {
         value(UserPrivilegeType::Grant, rule! { GRANT }),
         value(UserPrivilegeType::CreateStage, rule! { CREATE ~ STAGE }),
         value(UserPrivilegeType::Set, rule! { SET }),
+        value(UserPrivilegeType::Create, rule! { CREATE }),
     ))(i)
 }
 

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -167,6 +167,7 @@ fn test_statement() {
         r#"ALTER DATABASE c RENAME TO a;"#,
         r#"ALTER DATABASE ctl.c RENAME TO a;"#,
         r#"CREATE TABLE t (a INT COMMENT 'col comment') COMMENT='table comment';"#,
+        r#"GRANT CREATE, CREATE USER ON * TO 'test-grant'@'localhost';"#,
         r#"GRANT SELECT, CREATE ON * TO 'test-grant'@'localhost';"#,
         r#"GRANT SELECT, CREATE ON *.* TO 'test-grant'@'localhost';"#,
         r#"GRANT SELECT, CREATE ON * TO USER 'test-grant'@'localhost';"#,

--- a/src/query/ast/tests/it/testdata/statement-error.txt
+++ b/src/query/ast/tests/it/testdata/statement-error.txt
@@ -233,7 +233,7 @@ error:
   --> SQL:1:15
   |
 1 | GRANT SELECT, ALL PRIVILEGES, CREATE ON * TO 'test-grant'@'localhost';
-  | ----- ------  ^^^ expected `USAGE`, `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `CREATE`, or 5 more ...
+  | ----- ------  ^^^ expected `USAGE`, `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `DROP`, or 5 more ...
   | |     |        
   | |     while parsing <privileges> ON <privileges_level>
   | while parsing `GRANT { ROLE <role_name> | schemaObjectPrivileges | ALL [ PRIVILEGES ] ON <privileges_level> } TO { [ROLE <role_name>] | [USER] <user> }`
@@ -268,7 +268,7 @@ error:
   --> SQL:1:24
   |
 1 | REVOKE SELECT, CREATE, ALL PRIVILEGES ON * FROM 'test-grant'@'localhost';
-  | ------ ------          ^^^ expected `USAGE`, `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `CREATE`, or 5 more ...
+  | ------ ------          ^^^ expected `USAGE`, `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `DROP`, or 5 more ...
   | |      |                
   | |      while parsing <privileges> ON <privileges_level>
   | while parsing `REVOKE { ROLE <role_name> | schemaObjectPrivileges | ALL [ PRIVILEGES ] ON <privileges_level> } FROM { [ROLE <role_name>] | [USER] <user> }`

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -6168,6 +6168,32 @@ CreateTable(
 
 
 ---------- Input ----------
+GRANT CREATE, CREATE USER ON * TO 'test-grant'@'localhost';
+---------- Output ---------
+GRANT CREATE, CREATE USER ON * TO USER 'test-grant'@'localhost'
+---------- AST ------------
+Grant(
+    GrantStmt {
+        source: Privs {
+            privileges: [
+                Create,
+                CreateUser,
+            ],
+            level: Database(
+                None,
+            ),
+        },
+        principal: User(
+            UserIdentity {
+                username: "test-grant",
+                hostname: "localhost",
+            },
+        ),
+    },
+)
+
+
+---------- Input ----------
 GRANT SELECT, CREATE ON * TO 'test-grant'@'localhost';
 ---------- Output ---------
 GRANT SELECT, CREATE ON * TO USER 'test-grant'@'localhost'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```sql
dd:root@localhost/default=> grant create stage on *.* to 'a'@'%';
error: databend: query has error: code: 1005, message: error: 
  --> SQL:1:14
  |
1 | grant create stage on *.* to 'a'@'%';
  | ----- ------ ^^^^^ expected `ON` or `,`
  | |     |       
  | |     while parsing <privileges> ON <privileges_level>
  | while parsing `GRANT { ROLE <role_name> | schemaObjectPrivileges | ALL [ PRIVILEGES ] ON <privileges_level> } TO { [ROLE <role_name>] | [USER] <user> }`

```

Closes #issue
