### PR TITLE
fix: show process status info

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -57,6 +57,7 @@ pub struct ProcessInfo {
     pub scan_progress_value: Option<ProgressValues>,
     pub mysql_connection_id: Option<u32>,
     pub created_time: SystemTime,
+    pub status_info: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -233,6 +233,7 @@ impl QueryContextShared {
         }
     }
 
+    // TODO to_cache?
     async fn get_table_to_cache(
         &self,
         catalog: &str,
@@ -338,6 +339,11 @@ impl QueryContextShared {
 
     pub fn get_created_time(&self) -> SystemTime {
         self.created_time
+    }
+
+    pub fn get_status_info(&self) -> String {
+        let status = self.status.read();
+        status.clone()
     }
 }
 

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -233,7 +233,6 @@ impl QueryContextShared {
         }
     }
 
-    // TODO to_cache?
     async fn get_table_to_cache(
         &self,
         catalog: &str,

--- a/src/query/service/src/sessions/session_info.rs
+++ b/src/query/service/src/sessions/session_info.rs
@@ -29,10 +29,11 @@ impl Session {
         self.to_process_info(&session_ctx)
     }
 
-    fn to_process_info(self: &Arc<Self>, status: &SessionContext) -> ProcessInfo {
+    fn to_process_info(self: &Arc<Self>, session_ctx: &SessionContext) -> ProcessInfo {
         let mut memory_usage = 0;
 
-        if let Some(shared) = status.get_query_context_shared() {
+        let shared_query_context = &session_ctx.get_query_context_shared();
+        if let Some(shared) = shared_query_context {
             if let Ok(runtime) = shared.try_get_runtime() {
                 let mem_stat = runtime.get_tracker();
                 memory_usage = mem_stat.get_memory_usage();
@@ -42,17 +43,20 @@ impl Session {
         ProcessInfo {
             id: self.id.clone(),
             typ: self.get_type().to_string(),
-            state: self.process_state(status),
-            database: status.get_current_database(),
-            user: status.get_current_user(),
+            state: self.process_state(session_ctx),
+            database: session_ctx.get_current_database(),
+            user: session_ctx.get_current_user(),
             settings: self.get_settings(),
-            client_address: status.get_client_host(),
-            session_extra_info: self.process_extra_info(status),
+            client_address: session_ctx.get_client_host(),
+            session_extra_info: self.process_extra_info(session_ctx),
             memory_usage,
-            data_metrics: Self::query_data_metrics(status),
-            scan_progress_value: Self::query_scan_progress_value(status),
+            data_metrics: Self::query_data_metrics(session_ctx),
+            scan_progress_value: Self::query_scan_progress_value(session_ctx),
             mysql_connection_id: self.mysql_connection_id,
-            created_time: Self::query_created_time(status),
+            created_time: Self::query_created_time(session_ctx),
+            status_info: shared_query_context
+                .as_ref()
+                .map(|qry_ctx| qry_ctx.get_status_info()),
         }
     }
 

--- a/src/query/storages/system/src/processes_table.rs
+++ b/src/query/storages/system/src/processes_table.rs
@@ -106,7 +106,13 @@ impl SyncSystemTable for ProcessesTable {
             }
 
             // Status info.
-            processes_status.push(ctx.get_status_info().clone().into_bytes());
+            processes_status.push(
+                process_info
+                    .status_info
+                    .clone()
+                    .unwrap_or("".to_owned())
+                    .into_bytes(),
+            );
         }
 
         Ok(DataBlock::new_from_columns(vec![


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

show process status info should use the status info of the process/query context being shown, not the query context of statement `show processlist`

Closes #issue
