### PR TITLE
ci: Remove pull-requests: write which is not allowed

### DIFF
--- a/.github/workflows/trusted-benchmark.yml
+++ b/.github/workflows/trusted-benchmark.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   id-token: write
-  pull-requests: write
   contents: read
 
 env:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```txt
The workflow is not valid. .github/workflows/release.yml (Line: 516, Col: 3): Error calling workflow 'datafuselabs/databend/.github/workflows/trusted-benchmark.yml@200bb85fb199265b5fce5a02ef219ea26101e7b0'. The workflow 'datafuselabs/databend/.github/workflows/trusted-benchmark.yml@200bb85fb199265b5fce5a02ef219ea26101e7b0' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.
```

Our CI process is failing because of this error. I believe the solution would be to remove it.