### PR TITLE
feat(storage): Support domain for nested data types

### DIFF
--- a/src/query/expression/src/types.rs
+++ b/src/query/expression/src/types.rs
@@ -236,6 +236,20 @@ impl DataType {
             _ => self.to_string().to_uppercase(),
         }
     }
+
+    // Returns the number of leaf columns of the DataType
+    pub fn num_leaf_columns(&self) -> usize {
+        match self {
+            DataType::Nullable(box inner_ty)
+            | DataType::Array(box inner_ty)
+            | DataType::Map(box inner_ty) => inner_ty.num_leaf_columns(),
+            DataType::Tuple(inner_tys) => inner_tys
+                .iter()
+                .map(|inner_ty| inner_ty.num_leaf_columns())
+                .sum(),
+            _ => 1,
+        }
+    }
 }
 
 pub trait ValueType: Debug + Clone + PartialEq + Sized + 'static {

--- a/src/query/expression/tests/it/schema.rs
+++ b/src/query/expression/tests/it/schema.rs
@@ -526,3 +526,43 @@ fn test_schema_modify_field() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_leaf_columns_of() -> Result<()> {
+    let fields = vec![
+        TableField::new("a", TableDataType::Number(NumberDataType::UInt64)),
+        TableField::new("b", TableDataType::Tuple {
+            fields_name: vec!["b1".to_string(), "b2".to_string()],
+            fields_type: vec![
+                TableDataType::Tuple {
+                    fields_name: vec!["b11".to_string(), "b12".to_string()],
+                    fields_type: vec![TableDataType::Boolean, TableDataType::String],
+                }
+                TableDataType::Number(NumberDataType::UInt64),
+            ],
+        }
+        TableField::new("c", TableDataType::Array(Box::new(TableDataType::Number(NumberDataType::UInt64)))),
+        TableField::new("d", TableDataType::Map(Box::new(
+            TableDataType::Tuple {
+                fields_name: vec!["key".to_string(), "value".to_string()],
+                fields_type: vec![TableDataType::String, TableDataType::String],
+            }
+        )),
+        TableField::new("e", TableDataType::String),
+    ];
+    let mut schema = TableSchema::new(fields);
+
+    assert_eq!(schema.leaf_columns_of("a"), vec![0]);
+    assert_eq!(schema.leaf_columns_of("b"), vec![1,2,3]);
+    assert_eq!(schema.leaf_columns_of("b:b1"), vec![1,2]);
+    assert_eq!(schema.leaf_columns_of("b:1"), vec![1,2]);
+    assert_eq!(schema.leaf_columns_of("b:b1:b11"), vec![1]);
+    assert_eq!(schema.leaf_columns_of("b:1:1"), vec![1]);
+    assert_eq!(schema.leaf_columns_of("b:b1:b12"), vec![2]);
+    assert_eq!(schema.leaf_columns_of("b:1:2"), vec![2]);
+    assert_eq!(schema.leaf_columns_of("b:b2"), vec![3]);
+    assert_eq!(schema.leaf_columns_of("b:2"), vec![3]);
+    assert_eq!(schema.leaf_columns_of("c"), vec![4]);
+    assert_eq!(schema.leaf_columns_of("d"), vec![5,6]);
+    assert_eq!(schema.leaf_columns_of("e"), vec![7]);
+}

--- a/src/query/storages/common/index/src/page_index.rs
+++ b/src/query/storages/common/index/src/page_index.rs
@@ -162,14 +162,14 @@ impl PageIndex {
             {
                 let f = &self.cluster_key_fields[idx];
 
-                let stats = ColumnStatistics {
+                let stat = ColumnStatistics {
                     min: min.clone(),
                     max: max.clone(),
                     null_count: 1,
                     in_memory_size: 0,
                     distinct_of_values: None,
                 };
-                let domain = statistics_to_domain(Some(&stats), f.data_type());
+                let domain = statistics_to_domain(vec![&stat], f.data_type());
                 input_domains.insert(f.name().clone(), domain);
             }
 

--- a/src/query/storages/fuse/src/statistics/column_statistic.rs
+++ b/src/query/storages/fuse/src/statistics/column_statistic.rs
@@ -50,15 +50,10 @@ pub fn gen_columns_statistics(
     let leaves = get_traverse_columns_dfs(&data_block)?;
     let leaf_column_ids = schema.to_leaf_column_ids();
     for ((col_idx, col, data_type), column_id) in leaves.iter().zip(leaf_column_ids) {
-        if col.is_none() {
-            continue;
-        }
-
         // Ignore the range index does not supported type.
         if !RangeIndex::supported_type(data_type) {
             continue;
         }
-        let col = col.as_ref().unwrap();
 
         // later, during the evaluation of expressions, name of field does not matter
         let mut min = Scalar::Null;
@@ -130,13 +125,15 @@ pub fn gen_columns_statistics(
 }
 
 pub mod traverse {
+    use common_expression::types::map::KvPair;
+    use common_expression::types::AnyType;
     use common_expression::types::DataType;
     use common_expression::BlockEntry;
     use common_expression::Column;
 
     use super::*;
 
-    pub type TraverseResult = Result<Vec<(Option<usize>, Option<Column>, DataType)>>;
+    pub type TraverseResult = Result<Vec<(Option<usize>, Column, DataType)>>;
 
     // traverses columns and collects the leaves in depth first manner
     pub fn traverse_columns_dfs(columns: &[BlockEntry]) -> TraverseResult {
@@ -144,7 +141,7 @@ pub mod traverse {
         for (idx, entry) in columns.iter().enumerate() {
             let data_type = &entry.data_type;
             let column = entry.value.as_column().unwrap();
-            traverse_recursive(Some(idx), Some(column), data_type, &mut leaves)?;
+            traverse_recursive(Some(idx), column, data_type, &mut leaves)?;
         }
         Ok(leaves)
     }
@@ -152,56 +149,52 @@ pub mod traverse {
     /// Traverse the columns in DFS order, convert them to a flatten columns array sorted by leaf_index.
     /// We must ensure that each leaf node is traversed, otherwise we may get an incorrect leaf_index.
     ///
-    /// For the `Tuple` type, we should expand its inner columns.
-    /// For the `Array` type, if there is a nested `Tuple` type inside, it also needs to be found and expanded.
+    /// For the `Array, `Map` and `Tuple` types, we should expand its inner columns.
     fn traverse_recursive(
         idx: Option<usize>,
-        column: Option<&Column>,
+        column: &Column,
         data_type: &DataType,
-        leaves: &mut Vec<(Option<usize>, Option<Column>, DataType)>,
+        leaves: &mut Vec<(Option<usize>, Column, DataType)>,
     ) -> Result<()> {
         match data_type.remove_nullable() {
-            DataType::Tuple(inner_types) => match (data_type.is_nullable(), column) {
-                (false, Some(column)) => {
-                    let inner_columns = column.as_tuple().unwrap();
-                    for (inner_column, inner_type) in inner_columns.iter().zip(inner_types.iter()) {
-                        traverse_recursive(None, Some(inner_column), inner_type, leaves)?;
-                    }
-                }
-                (_, _) => {
-                    for inner_type in inner_types.iter() {
-                        traverse_recursive(None, None, inner_type, leaves)?;
-                    }
-                }
-            },
-            DataType::Array(inner_type) => {
-                let mut inner_type = inner_type;
-                loop {
-                    match inner_type.remove_nullable() {
-                        DataType::Tuple(tuple_inner_types) => {
-                            for tuple_inner_type in tuple_inner_types.iter() {
-                                traverse_recursive(None, None, tuple_inner_type, leaves)?;
-                            }
-                        }
-                        DataType::Array(array_inner_type) => {
-                            inner_type = array_inner_type;
-                            continue;
-                        }
-                        _ => leaves.push((idx, column.cloned(), data_type.clone())),
-                    }
-                    break;
+            DataType::Tuple(inner_types) => {
+                let inner_columns = if data_type.is_nullable() {
+                    let nullable_column = column.as_nullable().unwrap();
+                    nullable_column.column.as_tuple().unwrap()
+                } else {
+                    column.as_tuple().unwrap()
+                };
+                for (inner_column, inner_type) in inner_columns.iter().zip(inner_types.iter()) {
+                    traverse_recursive(None, inner_column, inner_type, leaves)?;
                 }
             }
+            DataType::Array(inner_type) => {
+                let array_column = if data_type.is_nullable() {
+                    let nullable_column = column.as_nullable().unwrap();
+                    nullable_column.column.as_array().unwrap()
+                } else {
+                    column.as_array().unwrap()
+                };
+                traverse_recursive(None, &array_column.values, &inner_type, leaves)?;
+            }
             DataType::Map(inner_type) => match *inner_type {
-                DataType::Tuple(tuple_inner_types) => {
-                    for tuple_inner_type in tuple_inner_types.iter() {
-                        traverse_recursive(None, None, tuple_inner_type, leaves)?;
-                    }
+                DataType::Tuple(inner_types) => {
+                    let map_column = if data_type.is_nullable() {
+                        let nullable_column = column.as_nullable().unwrap();
+                        nullable_column.column.as_map().unwrap()
+                    } else {
+                        column.as_map().unwrap()
+                    };
+                    let kv_column =
+                        KvPair::<AnyType, AnyType>::try_downcast_column(&map_column.values)
+                            .unwrap();
+                    traverse_recursive(None, &kv_column.keys, &inner_types[0], leaves)?;
+                    traverse_recursive(None, &kv_column.values, &inner_types[1], leaves)?;
                 }
                 _ => unreachable!(),
             },
             _ => {
-                leaves.push((idx, column.cloned(), data_type.clone()));
+                leaves.push((idx, column.clone(), data_type.clone()));
             }
         }
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Store max/min values for all the leaf columns of nested data types
- Generate domain for nested data types and skip the block if the filter range does not match the domain 

From local test data, it can effectively reduce the query time when the filter ranges do not match

```sql

MySQL root@127.0.0.1:default> create table tt (a array(int), b map(string, int), c tuple(int, string));
Query OK, 0 rows affected
Time: 0.223s
MySQL root@127.0.0.1:default> select count(*) from tt;
+----------+
| count(*) |
+----------+
| 100000   |
+----------+
1 row in set
Time: 0.087s
MySQL root@127.0.0.1:default> select * from tt where a[1] >= 100;
+-------------------+---------------+----------------+
| a                 | b             | c              |
+-------------------+---------------+----------------+
| [100,101,102,103] | {'ip':99999}  | (100009,'abc') |
| [100,101,102,103] | {'ip':100000} | (100010,'abc') |
+-------------------+---------------+----------------+
2 rows in set
Time: 0.705s
MySQL root@127.0.0.1:default> select * from tt where a[1] >= 200;
+---+---+---+
| a | b | c |
+---+---+---+
+---+---+---+
0 rows in set
Time: 0.118s
MySQL root@127.0.0.1:default> select * from tt where b['ip'] >= 99999;
+-------------------+---------------+----------------+
| a                 | b             | c              |
+-------------------+---------------+----------------+
| [100,101,102,103] | {'ip':99999}  | (100009,'abc') |
| [100,101,102,103] | {'ip':100000} | (100010,'abc') |
+-------------------+---------------+----------------+
2 rows in set
Time: 0.792s
MySQL root@127.0.0.1:default> select * from tt where b['ip'] > 100000;
+---+---+---+
| a | b | c |
+---+---+---+
+---+---+---+
0 rows in set
Time: 0.108s
MySQL root@127.0.0.1:default> select * from tt where c.1 >= 100009;
+-------------------+---------------+----------------+
| a                 | b             | c              |
+-------------------+---------------+----------------+
| [100,101,102,103] | {'ip':99999}  | (100009,'abc') |
| [100,101,102,103] | {'ip':100000} | (100010,'abc') |
+-------------------+---------------+----------------+
2 rows in set
Time: 0.763s
MySQL root@127.0.0.1:default> select * from tt where c.1 >= 200009;
+---+---+---+
| a | b | c |
+---+---+---+
+---+---+---+
0 rows in set
Time: 0.116s
```
Closes #10487 
