### PR TITLE
feat(query): Add the NULLABLE field to information_schema.columns

### DIFF
--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -153,6 +153,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | "name"                          | "system"             | "tables_with_history" | "String"           | "VARCHAR"           | ""       | ""       | "NO"     | ""       |
 | "name"                          | "system"             | "users"               | "String"           | "VARCHAR"           | ""       | ""       | "NO"     | ""       |
 | "non_unique"                    | "information_schema" | "statistics"          | "NULL"             | "NULL"              | ""       | ""       | "NO"     | ""       |
+| "nullable"                      | "information_schema" | "columns"             | "Nullable(UInt8)"  | "TINYINT UNSIGNED"  | ""       | ""       | "YES"    | ""       |
 | "nullable"                      | "information_schema" | "statistics"          | "NULL"             | "NULL"              | ""       | ""       | "NO"     | ""       |
 | "num_rows"                      | "system"             | "query_cache"         | "UInt64"           | "BIGINT UNSIGNED"   | ""       | ""       | "NO"     | ""       |
 | "num_rows"                      | "system"             | "tables"              | "Nullable(UInt64)" | "BIGINT UNSIGNED"   | ""       | ""       | "YES"    | ""       |

--- a/src/query/storages/information-schema/src/columns_table.rs
+++ b/src/query/storages/information-schema/src/columns_table.rs
@@ -35,6 +35,9 @@ impl ColumnsTable {
             NULL AS column_default,
             NULL AS column_comment,
             NULL AS column_key,
+            case when is_nullable='NO' then 0
+            when is_nullable='YES' then 1
+            end as nullable,
             is_nullable AS is_nullable,
             data_type AS data_type,
             data_type AS column_type,

--- a/tests/sqllogictests/suites/base/20+_others/20_0000_describe_table
+++ b/tests/sqllogictests/suites/base/20+_others/20_0000_describe_table
@@ -62,6 +62,7 @@ ordinal_position TINYINT UNSIGNED NO 0 (empty)
 column_default NULL NO NULL (empty)
 column_comment NULL NO NULL (empty)
 column_key NULL NO NULL (empty)
+nullable TINYINT UNSIGNED YES NULL (empty)
 is_nullable VARCHAR NO "" (empty)
 data_type VARCHAR NO "" (empty)
 column_type VARCHAR NO "" (empty)
@@ -81,6 +82,12 @@ domain_catalog NULL NO NULL (empty)
 domain_schema NULL NO NULL (empty)
 domain_name NULL NO NULL (empty)
 extra NULL NO NULL (empty)
+
+query TTT
+select column_name, nullable, is_nullable from INFORMATION_SCHEMA.COLUMNS where table_name='tables_with_history' and column_name in ('num_rows', 'dropped_on') order by column_name
+----
+dropped_on 0 NO
+num_rows 1 YES
 
 statement ok
 DROP TABLE IF EXISTS t


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add the NULLABLE field to information_schema.columns

1 means is_nullable = 'YES'.

0 means is_nullable = 'NO'.

Closes #10557
