### PR TITLE
chore(storage): const predication returns empty partitions

### DIFF
--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -27,6 +27,8 @@ use common_catalog::plan::TopK;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
+use common_expression::RemoteExpr;
+use common_expression::Scalar;
 use common_expression::TableSchemaRef;
 use common_meta_app::schema::TableInfo;
 use common_storage::ColumnNodes;
@@ -56,6 +58,18 @@ impl FuseTable {
         push_downs: Option<PushDownInfo>,
     ) -> Result<(PartStatistics, Partitions)> {
         debug!("fuse table do read partitions, push downs:{:?}", push_downs);
+
+        if let Some(PushDownInfo {
+            filter:
+                Some(RemoteExpr::Constant {
+                    scalar: Scalar::Boolean(false),
+                    ..
+                }),
+            ..
+        }) = &push_downs
+        {
+            return Ok((PartStatistics::default(), Partitions::default()));
+        }
 
         let snapshot = self.read_table_snapshot().await?;
         match snapshot {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

```
select * from table where 1 = 2 
```

will not read segments anymore.


Closes #issue
