### PR TITLE
docs(compact): refine the compact

### DIFF
--- a/docs/doc/14-sql-commands/00-ddl/20-table/60-optimize-table.md
+++ b/docs/doc/14-sql-commands/00-ddl/20-table/60-optimize-table.md
@@ -2,19 +2,19 @@
 title: OPTIMIZE TABLE
 ---
 
-Optimizing a table in Databend is about compacting or purging its historical data to save storage space and improve query efficiency.
+Optimizing a table in Databend involves compacting or purging historical data to save storage space and enhance query performance.
 
-:::caution
-**Time Travel Requires Historical Data**. Purging historical data from storage might break the Time Travel feature. Take this into consideration before you do so.
-:::
 
-## What are Snapshot, Segment, and Block?
+## Databend Data Storage: Snapshot, Segment, and Block
 
 Snapshot, segment, and block are the concepts Databend uses for data storage. Databend uses them to construct a hierarchical structure for storing table data.
 
+
 ![](/img/sql/storage-structure.PNG)
 
-Databend automatically creates snapshots of a table when data updates occur, so a snapshot represents a version of the table's data. When working with Databend, you're most likely to access a snapshot with the snapshot ID when you retrieve and query a previous version of the table' data with the [AT](../../20-query-syntax/dml-at.md) clause.
+Databend automatically creates table snapshots upon data updates. A snapshot represents a version of the table's segment metadata.
+
+When working with Databend, you're most likely to access a snapshot with the snapshot ID when you retrieve and query a previous version of the table's data with the [AT](../../20-query-syntax/dml-at.md) clause.
 
 A snapshot is a JSON file that does not save the table's data but indicate the segments the snapshot links to. If you run [FUSE_SNAPSHOT](../../../15-sql-functions/111-system-functions/fuse_snapshot.md) against a table, you can find the saved snapshots for the table.
 
@@ -22,94 +22,118 @@ A segment is a JSON file that organizes the storage blocks (at least 1, at most 
 
 Databends saves actual table data in parquet files and considers each parquet file as a block. If you run [FUSE_BLOCK](../../../15-sql-functions/111-system-functions/fuse_block.md) against a snapshot with the snapshot ID, you can find which blocks are referenced by the snapshot.
 
-Databend creates a unique ID for each database and table for storing the snapshot, segment, and block files and saves them to your object storage in the path `<bucket_name>/[root]/<db_id>/<table_id>/`. Each snapshot, segment, and block file is named with a UUID (32-character lowercase hexadecimal string).
+Databend creates a unique ID for each database and table for storing the snapshot, segment, and block files and saves them to your object storage in the path `<bucket_name>/<tenant_id>/<db_id>/<table_id>/`. Each snapshot, segment, and block file is named with a UUID (32-character lowercase hexadecimal string).
 
-| File     | Format  | Filename                        | Storage Folder                                                               |
-|----------|---------|---------------------------------|----------------------------------------------------------------------------|
-| Snapshot | JSON    | `<32bitUUID>_<version>.json`    | `<bucket_name>/[root]/<db_id>/<table_id>/_ss/`   |
-| Segment  | JSON    | `<32bitUUID>_<version>.json`    | `<bucket_name>/[root]/<db_id>/<table_id>/_sg/`   |
-| Block    | parquet | `<32bitUUID>_<version>.parquet` | `<bucket_name>/[root]/<db_id>/<table_id>/_b/` |
+| File     | Format  | Filename                        | Storage Folder                                      |
+|----------|---------|---------------------------------|-----------------------------------------------------|
+| Snapshot | JSON    | `<32bitUUID>_<version>.json`    | `<bucket_name>/<tenant_id>/<db_id>/<table_id>/_ss/` |
+| Segment  | JSON    | `<32bitUUID>_<version>.json`    | `<bucket_name>/<tenant_id>/<db_id>/<table_id>/_sg/` |
+| Block    | parquet | `<32bitUUID>_<version>.parquet` | `<bucket_name>/<tenant_id>/<db_id>/<table_id>/_b/`  |
 
 ## Table Optimization Considerations
 
-Consider optimizing a table regularly if the table receives frequent updates. Databend recommends these best practices to help decide on an optimization for a table:
+For effective table optimization, understand when and how to apply various optimization techniques, including segment compaction, block compaction, and purging.
 
-### When to Optimize a Table
+In Databend, the perfect block size is `100MB` (uncompressed size) or `1,000,000` rows, and each segment has `1,000` blocks.
 
-A table requires optimization if more than 100 blocks of it meet the following conditions:
+## Segment Compaction
 
-- The block size is less than 100M.
-- The number of the rows in the block is less than 800,000.
-
+Compact segments when a table has too many small segments (less than `100 blocks` per segment).
 ```sql
-select if(count(*)>100,'The table needs compact now','The table does not need compact now') from fuse_block('<your_database>','<your_table>') where file_size <100*1024*1024 and row_count<800000;
+SELECT block_count, segment_count, IF(block_count/segment_count < 100, 'The table needs segment compact now', 'The table does not need segment compact now') AS advice 
+FROM fuse_snapshot('your-database', 'your-table') LIMIT 1;
 ```
 
-### Compacting Segments Only
-
-The optimization merges both segments and blocks of a table by default. However, you can choose to compact the segments only when a table has too many segments.
-
-Databend recommends optimizing the segments only for a table when the table has more than 1,000 segments and the average number of blocks per segment is less than 500.
-
+**Syntax**
 ```sql
-select count(*),avg(block_count),if(avg(block_count)<500,'The table needs segment compact now','The table does not need segment compact now') from fuse_segment('<your_database>','<your_table>');
+OPTIMIZE TABLE [database.]table_name COMPACT SEGMENT [LIMIT <segment_count>]
 ```
 
-### When NOT to Optimize a Table
+Compacts the table data by merging small segments into larger ones.
+- The option LIMIT sets the maximum number of segments to be compacted. In this case, Databend will select and compact the latest segments.
 
-Optimizing a table could be time-consuming, especially for large ones. Databend does not recommend optimizing a table too frequently. Before you optimize a table, make sure the table fully satisfies the conditions described in [When to Optimize a Table](#when-to-optimize-a-table).
+**Example**
+```sql
+-- Check whether need segment compact
+select block_count, segment_count,  if(block_count/segment_count < 100, 'The table needs segment compact now', 'The table does not need segment compact now') as advice from fuse_snapshot('hits', 'hits');
++-------------+---------------+-------------------------------------+
+| block_count | segment_count | advice                              |
++-------------+---------------+-------------------------------------+
+|         751 |            32 | The table needs segment compact now |
++-------------+---------------+-------------------------------------+
+    
+-- Compact segment
+optimize table hits compact segment;
+    
+-- Check again
+select block_count, segment_count,  if(block_count/segment_count < 100, 'The table needs segment compact now', 'The table does not need segment compact now') as advice from fuse_snapshot('hits', 'hits') limit 1;
++-------------+---------------+---------------------------------------------+
+| block_count | segment_count | advice                                      |
++-------------+---------------+---------------------------------------------+
+|         751 |             1 | The table does not need segment compact now |
++-------------+---------------+---------------------------------------------+
+```
 
-## Syntax
+## Block Compaction
 
+Compact blocks when a table has a large number of small blocks or when the table has a high percentage of inserted, deleted, or updated rows.
+
+You can check it with if the uncompressed size of each block is close to the perfect size of `100MB`. 
+
+If the size is less than `50MB`, we suggest doing block compaction, as it indicates too many small blocks:
+
+```sql
+SELECT block_count, humanize_size(bytes_uncompressed/block_count) AS per_block_uncompressed_size,  IF(bytes_uncompressed/block_count/1024/1024<50, 'The table needs block compact now', 'The table does not need block compact now') as advice 
+FROM fuse_snapshot('your-database', 'your-table') LIMIT 1;
+```
+
+:::note
+We recommend performing segment compaction first, followed by block compaction.
+:::
+
+**Syntax**
+```sql
+OPTIMIZE TABLE [database.]table_name COMPACT [LIMIT <segment_count>]
+```
+Compacts the table data by merging small blocks and segments into larger ones.
+- This command creates a new snapshot (along with compacted segments and blocks) of the most recent table data without affecting the existing storage files, so the storage space won't be released until you purge the historical data.
+- Depending on the size of the given table, it may take quite a while to complete the execution.
+- The option LIMIT sets the maximum number of segments to be compacted. In this case, Databend will select and compact the latest segments.
+
+**Example**
+```sql
+OPTIMIZE TABLE my_database.my_table COMPACT LIMIT 50;
+```
+
+## Purging
+
+Purging permanently removes historical data, including unused snapshots, segments, and blocks, from your storage. 
+It can save storage space but may affect the Time Travel feature. Consider purging when:
+- The storage cost is a major concern, and you don't require historical data for Time Travel or other purposes.
+- You've compacted your table and want to remove older, unused data.
+
+**Syntax**
 ```sql
 -- Purge historical data
 OPTIMIZE TABLE [database.]table_name PURGE
 -- Purge historical data generated before a snapshot or a timestamp was created
 OPTIMIZE TABLE [database.]table_name PURGE BEFORE (SNAPSHOT => '<SNAPSHOT_ID>')
 OPTIMIZE TABLE [database.]table_name PURGE BEFORE (TIMESTAMP => '<TIMESTAMP>'::TIMESTAMP)
-
--- Compact historical data
-OPTIMIZE TABLE [database.]table_name COMPACT [LIMIT <segment_count>]
--- Compact historical data by merging segments ONLY
-OPTIMIZE TABLE [database.]table_name COMPACT SEGMENT [LIMIT <segment_count>]
-
--- Compact and purge historical data
-OPTIMIZE TABLE [database.]table_name ALL
 ```
 
 - `OPTIMIZE TABLE <table_name> PURGE`
 
-    Purges historical data from the table. Only the latest snapshot (including the segments and blocks referenced by this snapshot) will be kept.
+  Purges historical data from the table. Only the latest snapshot (including the segments and blocks referenced by this snapshot) will be kept.
 
 - `OPTIMIZE TABLE <table_name> PURGE BEFORE (SNAPSHOT => '<SNAPSHOT_ID>')`
 
-    Purges the historical data that was generated before the specified snapshot was created. This erases related snapshots, segments, and blocks from storage.
+  Purges the historical data that was generated before the specified snapshot was created. This erases related snapshots, segments, and blocks from storage.
 
 - `OPTIMIZE TABLE <table_name> PURGE BEFORE (TIMESTAMP => '<TIMESTAMP>'::TIMESTAMP)`
 
-    Purges the historical data that was generated before the specified timestamp was created. This erases related snapshots, segments, and blocks from storage.
+  Purges the historical data that was generated before the specified timestamp was created. This erases related snapshots, segments, and blocks from storage.
 
-- `OPTIMIZE TABLE <table_name> COMPACT [LIMIT <segment_count>]`
-
-    Compacts the table data by merging small blocks and segments into larger ones.
-
-    - This command creates a new snapshot (along with compacted segments and blocks) of the most recent table data without affecting the existing storage files, so the storage space won't be released until you purge the historical data.
-    - Depending on the size of the given table, it may take quite a while to complete the execution.
-    - The option LIMIT sets the maximum number of segments to be compacted. In this case, Databend will select and compact the latest segments.
-
--  `OPTIMIZE TABLE <table_name> COMPACT SEGMENT [LIMIT <segment_count>]`
-
-    Compacts the table data by merging small segments into larger ones.
-
-    - See [Compacting Segments Only](#compacting-segments-only) for when you need this command.
-    - The option LIMIT sets the maximum number of segments to be compacted. In this case, Databend will select and compact the latest segments.
-
--   `OPTIMIZE TABLE <table_name> ALL`
-
-    Equals to `OPTIMIZE TABLE <table_name> COMPACT` + `OPTIMIZE TABLE <table_name> PURGE`.
-
-## Examples
-
+**Example**
 ```sql
 -- Create a table and insert data using three INSERT statements
 create table t(x int);
@@ -131,19 +155,6 @@ select snapshot_id, segment_count, block_count, timestamp from fuse_snapshot('de
 
 snapshot_id                     |segment_count|block_count|timestamp            |
 --------------------------------+-------------+-----------+---------------------+
-edc9477b62c24f299c05a4d189030772|            3|          3|2022-12-26 19:33:49.0|
-256f1fe2e3974ee595474b2a8cad7a39|            2|          2|2022-12-26 19:33:42.0|
-1e060f7d145747578963b5a7e3b14742|            1|          1|2022-12-26 19:32:57.0|
-
--- Compact the table table
-optimize table t compact;
-
--- Notice that a new snapshot was added
-select snapshot_id, segment_count, block_count, timestamp from fuse_snapshot('default', 't');
-
-snapshot_id                     |segment_count|block_count|timestamp            |
---------------------------------+-------------+-----------+---------------------+
-9828b23f74664ff3806f44bbc1925ea5|            1|          1|2022-12-26 19:39:27.0|
 edc9477b62c24f299c05a4d189030772|            3|          3|2022-12-26 19:33:49.0|
 256f1fe2e3974ee595474b2a8cad7a39|            2|          2|2022-12-26 19:33:42.0|
 1e060f7d145747578963b5a7e3b14742|            1|          1|2022-12-26 19:32:57.0|


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This pr suggests user to check whether
compact segments(less than 100blocks per segment):
```
SELECT block_count, segment_count, 
IF(block_count/segment_count < 100, 'The table needs segment compact now', 'The table does not need segment compact now') AS advice 
FROM fuse_snapshot('your-database', 'your-table') LIMIT 1;
```

compact blocks(the uncompress size less than 50MB per block):
```
SELECT block_count, humanize_size(bytes_uncompressed/block_count) AS per_block_uncompressed_size,
IF(bytes_uncompressed/block_count/1024/1024<50, 'The table needs block compact now', 'The table does not need block compact now') as advice 
FROM fuse_snapshot('your-database', 'your-table') LIMIT 1;
```

Closes #issue
