### PR TITLE
feat: support `CUBE` and `ROLLUP`.

### DIFF
--- a/src/query/ast/src/ast/format/ast_format.rs
+++ b/src/query/ast/src/ast/format/ast_format.rs
@@ -2074,45 +2074,76 @@ impl<'ast> Visitor<'ast> for AstFormatVisitor {
                 FormatTreeNode::with_children(selection_format_ctx, vec![selection_child]);
             children.push(selection_node);
         }
-        match &stmt.group_by {
-            Some(GroupBy::Normal(exprs)) => {
-                let mut group_by_list_children = Vec::with_capacity(exprs.len());
-                for group_by in exprs.iter() {
-                    self.visit_expr(group_by);
-                    group_by_list_children.push(self.children.pop().unwrap());
-                }
-                let group_by_list_name = "GroupByList".to_string();
-                let group_by_list_format_ctx = AstFormatContext::with_children(
-                    group_by_list_name,
-                    group_by_list_children.len(),
-                );
-                let group_by_list_node =
-                    FormatTreeNode::with_children(group_by_list_format_ctx, group_by_list_children);
-                children.push(group_by_list_node);
-            }
-            Some(GroupBy::GroupingSets(sets)) => {
-                let mut grouping_sets = Vec::with_capacity(sets.len());
-                for set in sets.iter() {
-                    let mut grouping_set = Vec::with_capacity(set.len());
-                    for expr in set.iter() {
-                        self.visit_expr(expr);
-                        grouping_set.push(self.children.pop().unwrap());
+        if let Some(group_by) = &stmt.group_by {
+            match group_by {
+                GroupBy::Normal(exprs) => {
+                    let mut group_by_list_children = Vec::with_capacity(exprs.len());
+                    for group_by in exprs.iter() {
+                        self.visit_expr(group_by);
+                        group_by_list_children.push(self.children.pop().unwrap());
                     }
-                    let name = "GroupingSet".to_string();
-                    let grouping_set_format_ctx =
-                        AstFormatContext::with_children(name, grouping_set.len());
-                    let grouping_set_node =
-                        FormatTreeNode::with_children(grouping_set_format_ctx, grouping_set);
-                    grouping_sets.push(grouping_set_node);
+                    let group_by_list_name = "GroupByList".to_string();
+                    let group_by_list_format_ctx = AstFormatContext::with_children(
+                        group_by_list_name,
+                        group_by_list_children.len(),
+                    );
+                    let group_by_list_node = FormatTreeNode::with_children(
+                        group_by_list_format_ctx,
+                        group_by_list_children,
+                    );
+                    children.push(group_by_list_node);
                 }
-                let group_by_list_name = "GroupByList".to_string();
-                let group_by_list_format_ctx =
-                    AstFormatContext::with_children(group_by_list_name, grouping_sets.len());
-                let group_by_list_node =
-                    FormatTreeNode::with_children(group_by_list_format_ctx, grouping_sets);
-                children.push(group_by_list_node);
+                GroupBy::GroupingSets(sets) => {
+                    let mut grouping_sets = Vec::with_capacity(sets.len());
+                    for set in sets.iter() {
+                        let mut grouping_set = Vec::with_capacity(set.len());
+                        for expr in set.iter() {
+                            self.visit_expr(expr);
+                            grouping_set.push(self.children.pop().unwrap());
+                        }
+                        let name = "GroupingSet".to_string();
+                        let grouping_set_format_ctx =
+                            AstFormatContext::with_children(name, grouping_set.len());
+                        let grouping_set_node =
+                            FormatTreeNode::with_children(grouping_set_format_ctx, grouping_set);
+                        grouping_sets.push(grouping_set_node);
+                    }
+                    let group_by_list_name = "GroupByList".to_string();
+                    let group_by_list_format_ctx =
+                        AstFormatContext::with_children(group_by_list_name, grouping_sets.len());
+                    let group_by_list_node =
+                        FormatTreeNode::with_children(group_by_list_format_ctx, grouping_sets);
+                    children.push(group_by_list_node);
+                }
+                GroupBy::Rollup(exprs) => {
+                    let mut rollup_list_children = Vec::with_capacity(exprs.len());
+                    for group_by in exprs.iter() {
+                        self.visit_expr(group_by);
+                        rollup_list_children.push(self.children.pop().unwrap());
+                    }
+                    let rollup_list_name = "GroupByRollUpList".to_string();
+                    let rollup_list_format_ctx = AstFormatContext::with_children(
+                        rollup_list_name,
+                        rollup_list_children.len(),
+                    );
+                    let rollup_list_node =
+                        FormatTreeNode::with_children(rollup_list_format_ctx, rollup_list_children);
+                    children.push(rollup_list_node);
+                }
+                GroupBy::Cube(exprs) => {
+                    let mut cube_list_children = Vec::with_capacity(exprs.len());
+                    for group_by in exprs.iter() {
+                        self.visit_expr(group_by);
+                        cube_list_children.push(self.children.pop().unwrap());
+                    }
+                    let cube_list_name = "GroupByCubeList".to_string();
+                    let cube_list_format_ctx =
+                        AstFormatContext::with_children(cube_list_name, cube_list_children.len());
+                    let cube_list_node =
+                        FormatTreeNode::with_children(cube_list_format_ctx, cube_list_children);
+                    children.push(cube_list_node);
+                }
             }
-            _ => {}
         }
 
         if let Some(having) = &stmt.having {

--- a/src/query/ast/src/ast/format/syntax/query.rs
+++ b/src/query/ast/src/ast/format/syntax/query.rs
@@ -203,33 +203,56 @@ fn pretty_group_set(set: Vec<Expr>) -> RcDoc<'static> {
 }
 
 fn pretty_group_by(group_by: Option<GroupBy>) -> RcDoc<'static> {
-    match group_by {
-        Some(GroupBy::Normal(exprs)) => RcDoc::line()
-            .append(
-                RcDoc::text("GROUP BY").append(
-                    if exprs.len() > 1 {
-                        RcDoc::line()
-                    } else {
-                        RcDoc::space()
-                    }
-                    .nest(NEST_FACTOR),
+    if let Some(group_by) = group_by {
+        match group_by {
+            GroupBy::Normal(exprs) => RcDoc::line()
+                .append(
+                    RcDoc::text("GROUP BY").append(
+                        if exprs.len() > 1 {
+                            RcDoc::line()
+                        } else {
+                            RcDoc::space()
+                        }
+                        .nest(NEST_FACTOR),
+                    ),
+                )
+                .append(
+                    interweave_comma(exprs.into_iter().map(pretty_expr))
+                        .nest(NEST_FACTOR)
+                        .group(),
                 ),
-            )
-            .append(
-                interweave_comma(exprs.into_iter().map(pretty_expr))
-                    .nest(NEST_FACTOR)
-                    .group(),
-            ),
-        Some(GroupBy::GroupingSets(sets)) => RcDoc::line()
-            .append(RcDoc::text("GROUP BY GROUPING SETS (").append(RcDoc::line().nest(NEST_FACTOR)))
-            .append(
-                interweave_comma(sets.into_iter().map(pretty_group_set))
-                    .nest(NEST_FACTOR)
-                    .group(),
-            )
-            .append(RcDoc::line())
-            .append(RcDoc::text(")")),
-        _ => RcDoc::nil(),
+            GroupBy::GroupingSets(sets) => RcDoc::line()
+                .append(
+                    RcDoc::text("GROUP BY GROUPING SETS (").append(RcDoc::line().nest(NEST_FACTOR)),
+                )
+                .append(
+                    interweave_comma(sets.into_iter().map(pretty_group_set))
+                        .nest(NEST_FACTOR)
+                        .group(),
+                )
+                .append(RcDoc::line())
+                .append(RcDoc::text(")")),
+            GroupBy::Rollup(exprs) => RcDoc::line()
+                .append(RcDoc::text("GROUP BY ROLLUP (").append(RcDoc::line().nest(NEST_FACTOR)))
+                .append(
+                    interweave_comma(exprs.into_iter().map(pretty_expr))
+                        .nest(NEST_FACTOR)
+                        .group(),
+                )
+                .append(RcDoc::line())
+                .append(RcDoc::text(")")),
+            GroupBy::Cube(exprs) => RcDoc::line()
+                .append(RcDoc::text("GROUP BY CUBE (").append(RcDoc::line().nest(NEST_FACTOR)))
+                .append(
+                    interweave_comma(exprs.into_iter().map(pretty_expr))
+                        .nest(NEST_FACTOR)
+                        .group(),
+                )
+                .append(RcDoc::line())
+                .append(RcDoc::text(")")),
+        }
+    } else {
+        RcDoc::nil()
     }
 }
 

--- a/src/query/ast/src/ast/query.rs
+++ b/src/query/ast/src/ast/query.rs
@@ -96,6 +96,10 @@ pub enum GroupBy {
     ///
     /// GroupSet := (expr [, expr]*) | expr
     GroupingSets(Vec<Vec<Expr>>),
+    /// GROUP BY CUBE ( expr [, expr]* )
+    Cube(Vec<Expr>),
+    /// GROUP BY ROLLUP ( expr [, expr]* )
+    Rollup(Vec<Expr>),
 }
 
 /// A relational set expression, like `SELECT ... FROM ... {UNION|EXCEPT|INTERSECT} SELECT ... FROM ...`
@@ -469,6 +473,16 @@ impl Display for SelectStmt {
                         write_comma_separated_list(f, set)?;
                         write!(f, ")")?;
                     }
+                    write!(f, ")")?;
+                }
+                GroupBy::Cube(exprs) => {
+                    write!(f, "CUBE (")?;
+                    write_comma_separated_list(f, exprs)?;
+                    write!(f, ")")?;
+                }
+                GroupBy::Rollup(exprs) => {
+                    write!(f, "ROLLUP (")?;
+                    write_comma_separated_list(f, exprs)?;
                     write!(f, ")")?;
                 }
             }

--- a/src/query/ast/src/parser/query.rs
+++ b/src/query/ast/src/parser/query.rs
@@ -569,6 +569,14 @@ pub fn group_by_items(i: Input) -> IResult<GroupBy> {
     let normal = map(rule! { ^#comma_separated_list1(expr) }, |groups| {
         GroupBy::Normal(groups)
     });
+    let cube = map(
+        rule! { CUBE ~ "(" ~ ^#comma_separated_list1(expr) ~ ")" },
+        |(_, _, groups, _)| GroupBy::Cube(groups),
+    );
+    let rollup = map(
+        rule! { ROLLUP ~ "(" ~ ^#comma_separated_list1(expr) ~ ")" },
+        |(_, _, groups, _)| GroupBy::Rollup(groups),
+    );
     let group_set = alt((
         map(rule! {"(" ~ ")"}, |(_, _)| vec![]), // empty grouping set
         map(
@@ -581,7 +589,7 @@ pub fn group_by_items(i: Input) -> IResult<GroupBy> {
         rule! { GROUPING ~ SETS ~ "(" ~ ^#comma_separated_list1(group_set) ~ ")"  },
         |(_, _, _, sets, _)| GroupBy::GroupingSets(sets),
     );
-    rule!(#group_sets | #normal)(i)
+    rule!(#group_sets | #cube | #rollup | #normal)(i)
 }
 
 pub fn set_operation_element(i: Input) -> IResult<WithSpan<SetOperationElement>> {

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -985,7 +985,7 @@ impl TokenKind {
             | TokenKind::FLOAT
             // | TokenKind::FOREIGN
             // | TokenKind::GREATEST
-            | TokenKind::GROUPING
+            // | TokenKind::GROUPING
             | TokenKind::CUBE
             | TokenKind::ROLLUP
             // | TokenKind::IFNULL

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -879,6 +879,10 @@ pub enum TokenKind {
     GROUPING,
     #[token("SETS", ignore(ascii_case))]
     SETS,
+    #[token("CUBE", ignore(ascii_case))]
+    CUBE,
+    #[token("ROLLUP", ignore(ascii_case))]
+    ROLLUP,
 }
 
 // Reference: https://www.postgresql.org/docs/current/sql-keywords-appendix.html
@@ -981,7 +985,9 @@ impl TokenKind {
             | TokenKind::FLOAT
             // | TokenKind::FOREIGN
             // | TokenKind::GREATEST
-            // | TokenKind::GROUPING
+            | TokenKind::GROUPING
+            | TokenKind::CUBE
+            | TokenKind::ROLLUP
             // | TokenKind::IFNULL
             | TokenKind::IN
             // | TokenKind::INITIALLY

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -372,6 +372,8 @@ fn test_statement() {
         r#"SELECT * FROM t GROUP BY GROUPING SETS (a, b, (c, d))"#,
         r#"SELECT * FROM t GROUP BY GROUPING SETS ((a, b), (c), (d, e))"#,
         r#"SELECT * FROM t GROUP BY GROUPING SETS ((a, b), (), (d, e))"#,
+        r#"SELECT * FROM t GROUP BY CUBE (a, b, c)"#,
+        r#"SELECT * FROM t GROUP BY ROLLUP (a, b, c)"#,
     ];
 
     for case in cases {

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -9206,3 +9206,209 @@ Query(
 )
 
 
+---------- Input ----------
+SELECT * FROM t GROUP BY CUBE (a, b, c)
+---------- Output ---------
+SELECT * FROM t GROUP BY CUBE (a, b, c)
+---------- AST ------------
+Query(
+    Query {
+        span: Some(
+            0..39,
+        ),
+        with: None,
+        body: Select(
+            SelectStmt {
+                span: Some(
+                    0..39,
+                ),
+                distinct: false,
+                select_list: [
+                    QualifiedName {
+                        qualified: [
+                            Star,
+                        ],
+                        exclude: None,
+                    },
+                ],
+                from: [
+                    Table {
+                        span: Some(
+                            14..15,
+                        ),
+                        catalog: None,
+                        database: None,
+                        table: Identifier {
+                            name: "t",
+                            quote: None,
+                            span: Some(
+                                14..15,
+                            ),
+                        },
+                        alias: None,
+                        travel_point: None,
+                    },
+                ],
+                selection: None,
+                group_by: Some(
+                    Cube(
+                        [
+                            ColumnRef {
+                                span: Some(
+                                    31..32,
+                                ),
+                                database: None,
+                                table: None,
+                                column: Identifier {
+                                    name: "a",
+                                    quote: None,
+                                    span: Some(
+                                        31..32,
+                                    ),
+                                },
+                            },
+                            ColumnRef {
+                                span: Some(
+                                    34..35,
+                                ),
+                                database: None,
+                                table: None,
+                                column: Identifier {
+                                    name: "b",
+                                    quote: None,
+                                    span: Some(
+                                        34..35,
+                                    ),
+                                },
+                            },
+                            ColumnRef {
+                                span: Some(
+                                    37..38,
+                                ),
+                                database: None,
+                                table: None,
+                                column: Identifier {
+                                    name: "c",
+                                    quote: None,
+                                    span: Some(
+                                        37..38,
+                                    ),
+                                },
+                            },
+                        ],
+                    ),
+                ),
+                having: None,
+            },
+        ),
+        order_by: [],
+        limit: [],
+        offset: None,
+        ignore_result: false,
+    },
+)
+
+
+---------- Input ----------
+SELECT * FROM t GROUP BY ROLLUP (a, b, c)
+---------- Output ---------
+SELECT * FROM t GROUP BY ROLLUP (a, b, c)
+---------- AST ------------
+Query(
+    Query {
+        span: Some(
+            0..41,
+        ),
+        with: None,
+        body: Select(
+            SelectStmt {
+                span: Some(
+                    0..41,
+                ),
+                distinct: false,
+                select_list: [
+                    QualifiedName {
+                        qualified: [
+                            Star,
+                        ],
+                        exclude: None,
+                    },
+                ],
+                from: [
+                    Table {
+                        span: Some(
+                            14..15,
+                        ),
+                        catalog: None,
+                        database: None,
+                        table: Identifier {
+                            name: "t",
+                            quote: None,
+                            span: Some(
+                                14..15,
+                            ),
+                        },
+                        alias: None,
+                        travel_point: None,
+                    },
+                ],
+                selection: None,
+                group_by: Some(
+                    Rollup(
+                        [
+                            ColumnRef {
+                                span: Some(
+                                    33..34,
+                                ),
+                                database: None,
+                                table: None,
+                                column: Identifier {
+                                    name: "a",
+                                    quote: None,
+                                    span: Some(
+                                        33..34,
+                                    ),
+                                },
+                            },
+                            ColumnRef {
+                                span: Some(
+                                    36..37,
+                                ),
+                                database: None,
+                                table: None,
+                                column: Identifier {
+                                    name: "b",
+                                    quote: None,
+                                    span: Some(
+                                        36..37,
+                                    ),
+                                },
+                            },
+                            ColumnRef {
+                                span: Some(
+                                    39..40,
+                                ),
+                                database: None,
+                                table: None,
+                                column: Identifier {
+                                    name: "c",
+                                    quote: None,
+                                    span: Some(
+                                        39..40,
+                                    ),
+                                },
+                            },
+                        ],
+                    ),
+                ),
+                having: None,
+            },
+        ),
+        order_by: [],
+        limit: [],
+        offset: None,
+        ignore_result: false,
+    },
+)
+
+

--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -338,6 +338,24 @@ impl Binder {
                 self.resolve_grouping_sets(bind_context, select_list, sets, &available_aliases)
                     .await
             }
+            // TODO: avoid too many clones.
+            GroupBy::Rollup(exprs) => {
+                // ROLLUP (a,b,c) => GROUPING SETS ((a,b,c), (a,b), (a), ())
+                let mut sets = Vec::with_capacity(exprs.len() + 1);
+                for i in (0..=exprs.len()).rev() {
+                    sets.push(exprs[0..i].to_vec());
+                }
+                self.resolve_grouping_sets(bind_context, select_list, &sets, &available_aliases)
+                    .await
+            }
+            GroupBy::Cube(exprs) => {
+                // CUBE (a,b) => GROUPING SETS ((a,b),(a),(b),()) // All subsets
+                let sets = (0..=exprs.len())
+                    .flat_map(|count| exprs.clone().into_iter().combinations(count))
+                    .collect::<Vec<_>>();
+                self.resolve_grouping_sets(bind_context, select_list, &sets, &available_aliases)
+                    .await
+            }
         }
     }
 

--- a/tests/sqllogictests/suites/duckdb/sql/aggregate/group/group_by_grouping_sets.test
+++ b/tests/sqllogictests/suites/duckdb/sql/aggregate/group/group_by_grouping_sets.test
@@ -55,5 +55,41 @@ NULL B 10 0 1 2 1
 b NULL 11 1 0 1 2
 NULL NULL 18 1 1 3 3
 
+query TTIIIII
+select a, b, sum(c) as sc, grouping(b), grouping(a), grouping(a,b), grouping(b,a) from t group by grouping sets ((a,b),(a),()) order by sc;
+----
+a A 3 0 0 0 0
+a B 4 0 0 0 0
+b A 5 0 0 0 0
+b B 6 0 0 0 0
+a NULL 7 1 0 1 2
+b NULL 11 1 0 1 2
+NULL NULL 18 1 1 3 3
+
+
+query TTIIIII
+select a, b, sum(c) as sc, grouping(b), grouping(a), grouping(a,b), grouping(b,a) from t group by cube (a,b) order by sc;
+----
+a A 3 0 0 0 0
+a B 4 0 0 0 0
+b A 5 0 0 0 0
+b B 6 0 0 0 0
+a NULL 7 1 0 1 2
+NULL A 8 0 1 2 1
+NULL B 10 0 1 2 1
+b NULL 11 1 0 1 2
+NULL NULL 18 1 1 3 3
+
+query TTIIIII
+select a, b, sum(c) as sc, grouping(b), grouping(a), grouping(a,b), grouping(b,a) from t group by rollup (a,b) order by sc;
+----
+a A 3 0 0 0 0
+a B 4 0 0 0 0
+b A 5 0 0 0 0
+b B 6 0 0 0 0
+a NULL 7 1 0 1 2
+b NULL 11 1 0 1 2
+NULL NULL 18 1 1 3 3
+
 statement ok
 drop table t all;

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_grouping_sets.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_grouping_sets.test
@@ -1,0 +1,57 @@
+query T
+explain select number % 2 as a, number % 3 as b, number % 5 as c from numbers(1) group by rollup(a, b, c);
+----
+EvalScalar
+├── expressions: [group_item (#1), group_item (#2), group_item (#3)]
+├── estimated rows: 1.00
+└── AggregateFinal
+    ├── group by: [a, b, c, _grouping_id]
+    ├── aggregate functions: []
+    ├── estimated rows: 1.00
+    └── AggregatePartial
+        ├── group by: [a, b, c, _grouping_id]
+        ├── aggregate functions: []
+        ├── estimated rows: 1.00
+        └── AggregateExpand
+            ├── grouping sets: [(a, b, c), (a, b), (a), ()]
+            ├── estimated rows: 1.00
+            └── EvalScalar
+                ├── expressions: [numbers.number (#0) % 2, numbers.number (#0) % 3, numbers.number (#0) % 5]
+                ├── estimated rows: 1.00
+                └── TableScan
+                    ├── table: default.system.numbers
+                    ├── read rows: 1
+                    ├── read bytes: 8
+                    ├── partitions total: 1
+                    ├── partitions scanned: 1
+                    ├── push downs: [filters: [], limit: NONE]
+                    └── estimated rows: 1.00
+
+query T
+explain select number % 2 as a, number % 3 as b, number % 5 as c from numbers(1) group by cube(a, b, c);
+----
+EvalScalar
+├── expressions: [group_item (#1), group_item (#2), group_item (#3)]
+├── estimated rows: 1.00
+└── AggregateFinal
+    ├── group by: [a, b, c, _grouping_id]
+    ├── aggregate functions: []
+    ├── estimated rows: 1.00
+    └── AggregatePartial
+        ├── group by: [a, b, c, _grouping_id]
+        ├── aggregate functions: []
+        ├── estimated rows: 1.00
+        └── AggregateExpand
+            ├── grouping sets: [(), (a), (b), (c), (a, b), (a, c), (b, c), (a, b, c)]
+            ├── estimated rows: 1.00
+            └── EvalScalar
+                ├── expressions: [numbers.number (#0) % 2, numbers.number (#0) % 3, numbers.number (#0) % 5]
+                ├── estimated rows: 1.00
+                └── TableScan
+                    ├── table: default.system.numbers
+                    ├── read rows: 1
+                    ├── read bytes: 8
+                    ├── partitions total: 1
+                    ├── partitions scanned: 1
+                    ├── push downs: [filters: [], limit: NONE]
+                    └── estimated rows: 1.00


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`ROLLUP` and `CUBE` are two syntactic sugars of `GROUPING SETS`.

We can just desugar them into `GROUPING SETS` when binding.

`ROLLUP(a,b,c)` => `GROUPING SETS ((a,b,c), (a,b), (a), ())` ；

`CUBE(a,b)` => `GROUPING SETS ((a,b),(a),(b),())` (subset combinations)

Tracking in #10492.
