### PR TITLE
feat: add `ai_to_sql` transalte natual lanauge to SQL based on your table schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,8 +311,7 @@ dependencies = [
 [[package]]
 name = "async-openai"
 version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9d82d5f5c687492134fd6f8bde81c996a7f7d1350d4326caecc797f9b3b6a8"
+source = "git+https://github.com/Xuanwo/async-openai?rev=22fd9ca0c9c86a2c57462c5fd32aaff407d6b000#22fd9ca0c9c86a2c57462c5fd32aaff407d6b000"
 dependencies = [
  "backoff",
  "base64 0.21.0",
@@ -3704,21 +3703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "foreign_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5370,19 +5354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6353,24 +6324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce7b49e1e6d8aa67232ef1c4c936c0af58756eb2db6f65c40bacb39035e7f42"
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6682,49 +6635,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176be2629957c157240f68f61f2d0053ad3a4ecfdd9ebf1e6521d18d9635cf67"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -7936,13 +7850,11 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7953,7 +7865,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -9453,16 +9364,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-openai"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9d82d5f5c687492134fd6f8bde81c996a7f7d1350d4326caecc797f9b3b6a8"
+dependencies = [
+ "backoff",
+ "base64 0.21.0",
+ "derive_builder",
+ "futures",
+ "rand 0.8.5",
+ "reqwest",
+ "reqwest-eventsource",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,6 +3017,7 @@ version = "0.1.0"
 dependencies = [
  "aho-corasick",
  "async-channel",
+ "async-openai",
  "async-stream",
  "async-trait-fn",
  "base64 0.21.0",
@@ -3190,6 +3213,37 @@ checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -3524,6 +3578,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3637,6 +3702,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign_vec"
@@ -5290,6 +5370,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6260,6 +6353,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce7b49e1e6d8aa67232ef1c4c936c0af58756eb2db6f65c40bacb39035e7f42"
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6571,10 +6682,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176be2629957c157240f68f61f2d0053ad3a4ecfdd9ebf1e6521d18d9635cf67"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -7786,11 +7936,13 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7801,6 +7953,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -7812,6 +7965,22 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f03f570355882dd8d15acc3a313841e6e90eddbc76a93c748fd82cc13ba9f51"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror",
 ]
 
 [[package]]
@@ -9284,6 +9453,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/docs/doc/14-sql-commands/20-query-syntax/02-dml-with.md
+++ b/docs/doc/14-sql-commands/20-query-syntax/02-dml-with.md
@@ -35,9 +35,10 @@ ORDER  BY customername;
 ## Syntax
 
 ```sql    
-WITH cte_name1 [(col_name [, col_name] ...)] AS (subquery1)
-[, cte_name2 [(col_name [, col_name] ...)] AS (subquery2)]
-[...]
+WITH
+        <cte_name1> [ ( <cte_column_list> ) ] AS ( SELECT ...  )
+    [ , <cte_name2> [ ( <cte_column_list> ) ] AS ( SELECT ...  ) ]
+    [ , <cte_nameN> [ ( <cte_column_list> ) ] AS ( SELECT ...  ) ]
 SELECT ...
 ```
 
@@ -45,11 +46,9 @@ Where:
 
 `WITH`: Initiates the WITH clause.
 
-`cte_name1`: Specifies the name of the first result set. 
+`<cte_name1>, <cte_nameN>`: The CTE name.
 
-`subquery1`: Defines the first result set.
-
-`cte_name2 AS (subquery2)`: You can define multiple CTEs in a WITH clause.
+`<cte_column_list>`: The names of the columns in the CTE.
 
 - A CTE can refer to any CTEs in the same WITH clause that are defined before.
 

--- a/docs/doc/15-sql-functions/61-ai-functions/_category_.json
+++ b/docs/doc/15-sql-functions/61-ai-functions/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "AI Functions"
+}

--- a/docs/doc/15-sql-functions/61-ai-functions/index.md
+++ b/docs/doc/15-sql-functions/61-ai-functions/index.md
@@ -1,0 +1,43 @@
+---
+title: 'AI Functions'
+---
+
+Databend can utilize the OpenAI `Code-Davinci-002` engine to translate natural language into SQL queries.
+
+By integrating OLAP and AI, Databend simplifies the process of writing SQL queries based on your table schema.
+
+The `ai_to_sql` function allows us to effortlessly generate SQL queries using natural language.
+
+## Syntax
+
+```sql
+USE <your-database>;
+SELECT * FROM ai_to_sql('<prompt>', '<openai-api-key>');
+```
+
+## Example
+
+:::note
+Please note that the generated SQL query may need to be adapted to match Databend's syntax and functionality, as it might be based on PostgreSQL-standard SQL.
+:::
+
+
+```sql
+CREATE DATABASE openai;
+USE openai;
+
+CREATE TABLE users(
+    id INT,
+    name VARCHAR,
+    age INT
+);
+
+SELECT * FROM ai_to_sql('List all users older than 30 years', '<openai-api-key>');
+```
+
+Output:
+```sql
+*************************** 1. row ***************************
+     database: simple_example
+generated_sql:  SELECT * FROM users WHERE age > 30;
+```

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -98,7 +98,8 @@ storages-common-table-meta = { path = "../storages/common/table-meta" }
 # Crates.io dependencies
 aho-corasick = { version = "0.7.20" }
 async-channel = "1.7.1"
-async-openai = "0.9.5"
+# Wait for https://github.com/64bit/async-openai/pull/60
+async-openai = { version = "0.9.5", git = "https://github.com/Xuanwo/async-openai", rev = "22fd9ca0c9c86a2c57462c5fd32aaff407d6b000" }
 async-stream = "0.3.3"
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
 base64 = "0.21.0"

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -129,7 +129,7 @@ pin-project-lite = "0.2.9"
 poem = { version = "1", features = ["rustls", "multipart", "compression"] }
 rand = "0.8.5"
 regex = "1.6.0"
-reqwest = "0.11.14"
+reqwest = { version = "0.11.14", features = ['__rustls'] }
 scopeguard = "1.1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -129,7 +129,7 @@ pin-project-lite = "0.2.9"
 poem = { version = "1", features = ["rustls", "multipart", "compression"] }
 rand = "0.8.5"
 regex = "1.6.0"
-reqwest = { version = "0.11.14", features = ['__rustls'] }
+reqwest = { workspace = true }
 scopeguard = "1.1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -98,6 +98,7 @@ storages-common-table-meta = { path = "../storages/common/table-meta" }
 # Crates.io dependencies
 aho-corasick = { version = "0.7.20" }
 async-channel = "1.7.1"
+async-openai = "0.9.5"
 async-stream = "0.3.3"
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
 base64 = "0.21.0"
@@ -128,6 +129,7 @@ pin-project-lite = "0.2.9"
 poem = { version = "1", features = ["rustls", "multipart", "compression"] }
 rand = "0.8.5"
 regex = "1.6.0"
+reqwest = "0.11.14"
 scopeguard = "1.1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/service/src/table_functions/openai/gpt_to_sql.rs
+++ b/src/query/service/src/table_functions/openai/gpt_to_sql.rs
@@ -1,0 +1,286 @@
+//  Copyright 2023 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::any::Any;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_openai::types::CreateCompletionRequestArgs;
+use async_openai::Client;
+use chrono::NaiveDateTime;
+use chrono::TimeZone;
+use chrono::Utc;
+use common_catalog::catalog::CATALOG_DEFAULT;
+use common_catalog::plan::DataSourcePlan;
+use common_catalog::plan::PartStatistics;
+use common_catalog::plan::Partitions;
+use common_catalog::plan::PushDownInfo;
+use common_catalog::table_args::TableArgs;
+use common_catalog::table_function::TableFunction;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_expression::types::StringType;
+use common_expression::DataBlock;
+use common_expression::FromData;
+use common_expression::TableDataType;
+use common_expression::TableField;
+use common_expression::TableSchema;
+use common_meta_app::schema::TableIdent;
+use common_meta_app::schema::TableInfo;
+use common_meta_app::schema::TableMeta;
+use common_pipeline_core::processors::port::OutputPort;
+use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_core::Pipeline;
+use common_pipeline_sources::AsyncSource;
+use common_pipeline_sources::AsyncSourcer;
+use common_storages_factory::Table;
+use common_storages_fuse::table_functions::string_literal;
+use common_storages_fuse::TableContext;
+use common_storages_view::view_table::VIEW_ENGINE;
+use tracing::info;
+
+pub struct GPT2SQLTable {
+    prompt: String,
+    api_key: String,
+    table_info: TableInfo,
+}
+
+impl GPT2SQLTable {
+    pub fn create(
+        database_name: &str,
+        table_func_name: &str,
+        table_id: u64,
+        table_args: TableArgs,
+    ) -> Result<Arc<dyn TableFunction>> {
+        // Check args.
+        let args = table_args.expect_all_positioned(table_func_name, Some(2))?;
+        let prompt = String::from_utf8(
+            args[0]
+                .clone()
+                .into_string()
+                .map_err(|_| ErrorCode::BadArguments("Expected string argument."))?,
+        )?;
+        let api_key = String::from_utf8(
+            args[1]
+                .clone()
+                .into_string()
+                .map_err(|_| ErrorCode::BadArguments("Expected string argument."))?,
+        )?;
+
+        let schema = TableSchema::new(vec![
+            TableField::new("database", TableDataType::String),
+            TableField::new("generated_sql", TableDataType::String),
+        ]);
+        let table_info = TableInfo {
+            ident: TableIdent::new(table_id, 0),
+            desc: format!("'{}'.'{}'", database_name, table_func_name),
+            name: String::from(table_func_name),
+            meta: TableMeta {
+                schema: Arc::new(schema),
+                engine: String::from(table_func_name),
+                // Assuming that created_on is unnecessary for function table,
+                // we could make created_on fixed to pass test_shuffle_action_try_into.
+                created_on: Utc
+                    .from_utc_datetime(&NaiveDateTime::from_timestamp_opt(0, 0).unwrap()),
+                updated_on: Utc
+                    .from_utc_datetime(&NaiveDateTime::from_timestamp_opt(0, 0).unwrap()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        Ok(Arc::new(GPT2SQLTable {
+            prompt,
+            api_key,
+            table_info,
+        }))
+    }
+}
+
+impl TableFunction for GPT2SQLTable {
+    fn function_name(&self) -> &str {
+        self.name()
+    }
+
+    fn as_table<'a>(self: Arc<Self>) -> Arc<dyn Table + 'a>
+    where Self: 'a {
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl Table for GPT2SQLTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn get_table_info(&self) -> &TableInfo {
+        &self.table_info
+    }
+
+    async fn read_partitions(
+        &self,
+        _: Arc<dyn TableContext>,
+        _: Option<PushDownInfo>,
+    ) -> Result<(PartStatistics, Partitions)> {
+        // dummy statistics
+        Ok((PartStatistics::default_exact(), Partitions::default()))
+    }
+
+    fn table_args(&self) -> Option<TableArgs> {
+        Some(TableArgs::new_positioned(vec![
+            string_literal(self.prompt.as_str()),
+            string_literal(self.api_key.as_str()),
+        ]))
+    }
+
+    fn read_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _plan: &DataSourcePlan,
+        pipeline: &mut Pipeline,
+    ) -> Result<()> {
+        pipeline.add_source(
+            |output| {
+                GPT2SQLSource::create(
+                    ctx.clone(),
+                    output,
+                    self.prompt.clone(),
+                    self.api_key.clone(),
+                )
+            },
+            1,
+        )?;
+        Ok(())
+    }
+}
+
+struct GPT2SQLSource {
+    ctx: Arc<dyn TableContext>,
+    prompt: String,
+    api_key: String,
+    finished: bool,
+}
+
+impl GPT2SQLSource {
+    pub fn create(
+        ctx: Arc<dyn TableContext>,
+        output: Arc<OutputPort>,
+        prompt: String,
+        api_key: String,
+    ) -> Result<ProcessorPtr> {
+        AsyncSourcer::create(ctx.clone(), output, GPT2SQLSource {
+            prompt,
+            api_key,
+            ctx,
+            finished: false,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncSource for GPT2SQLSource {
+    const NAME: &'static str = "gpt_to_sql";
+
+    #[async_trait::unboxed_simple]
+    async fn generate(&mut self) -> Result<Option<DataBlock>> {
+        if self.finished {
+            return Ok(None);
+        }
+
+        // ### Postgres SQL tables, with their properties:
+        // #
+        // # Employee(id, name, department_id)
+        // # Department(id, name, address)
+        // # Salary_Payments(id, employee_id, amount, date)
+        // #
+        // ### A query to list the names of the departments which employed more than 10 employees in the last 3 months
+        // SELECT
+        let database = self.ctx.get_current_database();
+        let tenant = self.ctx.get_tenant();
+        let catalog = self.ctx.get_catalog(CATALOG_DEFAULT)?;
+
+        let mut template = vec![];
+        template.push("### Postgres SQL tables, with their properties:".to_string());
+        template.push("#".to_string());
+
+        for table in catalog.list_tables(tenant.as_str(), &database).await? {
+            let fields = if table.engine() == VIEW_ENGINE {
+                continue;
+            } else {
+                table.schema().fields().clone()
+            };
+
+            let columns_name = fields
+                .iter()
+                .map(|f| f.name().to_string())
+                .collect::<Vec<_>>();
+            template.push(format!("{}({})", table.name(), columns_name.join(",")));
+        }
+        template.push("#".to_string());
+        template.push(format!("### {}", self.prompt.clone()));
+        template.push("#".to_string());
+        template.push("SELECT".to_string());
+
+        let model = "code-davinci-002";
+        let timeout = Duration::from_secs(30);
+        let prompt = template.join("");
+        let api_key = self.api_key.clone();
+        info!("openai request prompt: {}", prompt);
+
+        // Client
+        let http_client = reqwest::ClientBuilder::new()
+            .user_agent("databend")
+            .timeout(timeout)
+            .build()
+            .map_err(|e| ErrorCode::Internal(format!("openai http error: {:?}", e)))?;
+        let client = Client::new()
+            .with_api_key(api_key)
+            .with_http_client(http_client);
+
+        // Request
+        let request = CreateCompletionRequestArgs::default()
+            .model(model)
+            .prompt(prompt)
+            .temperature(0.0)
+            .max_tokens(150_u16)
+            .top_p(1.0)
+            .frequency_penalty(0.0)
+            .presence_penalty(0.0)
+            .stop(["#", ";"])
+            .build()
+            .map_err(|e| ErrorCode::Internal(format!("openai request error: {:?}", e)))?;
+
+        // Response.
+        let response = client
+            .completions()
+            .create(request)
+            .await
+            .map_err(|e| ErrorCode::Internal(format!("openai response error: {:?}", e)))?;
+
+        let database = self.ctx.get_current_database();
+        let sql = format!("SELECT{}", response.choices.first().unwrap().text.clone());
+        info!("openai response sql: {}", sql);
+        let database: Vec<Vec<u8>> = vec![database.into_bytes()];
+        let sql: Vec<Vec<u8>> = vec![sql.into_bytes()];
+
+        // Mark done.
+        self.finished = true;
+
+        Ok(Some(DataBlock::new_from_columns(vec![
+            StringType::from_data(database),
+            StringType::from_data(sql),
+        ])))
+    }
+}

--- a/src/query/service/src/table_functions/openai/mod.rs
+++ b/src/query/service/src/table_functions/openai/mod.rs
@@ -1,4 +1,4 @@
-//  Copyright 2021 Datafuse Labs.
+//  Copyright 2023 Datafuse Labs.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -12,18 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-mod async_crash_me;
-mod numbers;
-mod openai;
-mod sync_crash_me;
-mod table_function;
-mod table_function_factory;
-mod unnest;
+mod gpt_to_sql;
 
-pub use numbers::generate_numbers_parts;
-pub use numbers::NumbersPartInfo;
-pub use numbers::NumbersTable;
-pub use openai::GPT2SQLTable;
-pub use table_function::TableFunction;
-pub use table_function_factory::TableFunctionFactory;
-pub use unnest::UnnestTable;
+pub use gpt_to_sql::GPT2SQLTable;

--- a/src/query/service/src/table_functions/table_function_factory.rs
+++ b/src/query/service/src/table_functions/table_function_factory.rs
@@ -34,6 +34,7 @@ use crate::storages::fuse::table_functions::FuseStatisticTable;
 use crate::table_functions::async_crash_me::AsyncCrashMeTable;
 use crate::table_functions::numbers::NumbersTable;
 use crate::table_functions::sync_crash_me::SyncCrashMeTable;
+use crate::table_functions::GPT2SQLTable;
 use crate::table_functions::TableFunction;
 
 type TableFunctionCreators = RwLock<HashMap<String, (MetaId, Arc<dyn TableFunctionCreator>)>>;
@@ -141,6 +142,11 @@ impl TableFunctionFactory {
         creators.insert(
             "unnest".to_string(),
             (next_id(), Arc::new(UnnestTable::create)),
+        );
+
+        creators.insert(
+            "ai_to_sql".to_string(),
+            (next_id(), Arc::new(GPT2SQLTable::create)),
         );
 
         TableFunctionFactory {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```
CREATE DATABASE openai;
USE openai;

CREATE TABLE users(
    id INT,
    name VARCHAR,
    age INT
);

SELECT * FROM ai_to_sql('List all users older than 30 years', '<openai-api-key>');
```

Output:
```
*************************** 1. row ***************************
     database: simple_example
generated_sql:  SELECT * FROM users WHERE age > 30;
```

Closes #issue
