### PR TITLE
chore(async-openai): Come back to upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,8 +310,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.9.5"
-source = "git+https://github.com/Xuanwo/async-openai?rev=22fd9ca0c9c86a2c57462c5fd32aaff407d6b000#22fd9ca0c9c86a2c57462c5fd32aaff407d6b000"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc62bea0dc0376372c6cb0e450168b7805d6655b88a3dfd340036743a3d91fca"
 dependencies = [
  "backoff",
  "base64 0.21.0",

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -98,8 +98,7 @@ storages-common-table-meta = { path = "../storages/common/table-meta" }
 # Crates.io dependencies
 aho-corasick = { version = "0.7.20" }
 async-channel = "1.7.1"
-# Wait for https://github.com/64bit/async-openai/pull/60
-async-openai = { version = "0.9.5", git = "https://github.com/Xuanwo/async-openai", rev = "22fd9ca0c9c86a2c57462c5fd32aaff407d6b000" }
+async-openai = "0.10.0"
 async-stream = "0.3.3"
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
 base64 = "0.21.0"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore(async-openai): Come back to upstream