### PR TITLE
refactor: AST check is not needed after static runtime check added

### DIFF
--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -229,8 +229,13 @@ impl Connection {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
                 format!(
-                    "Unknown params [{}], please check the documents for supported params",
-                    diffs.join(","),
+                    "connection params invalid: expected [{}], got [{}]",
+                    self.visited_keys
+                        .iter()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(","),
+                    diffs.join(",")
                 ),
             ));
         }

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -47,20 +47,9 @@ fn connection_opt(sep: &'static str) -> impl FnMut(Input) -> IResult<(String, St
         let sep2 = match_text(sep);
         let string_options = map(
             rule! {
-                (AWS_KEY_ID
-                    | AWS_SECRET_KEY
-                    | ACCESS_KEY_ID
-                    | ACCESS_KEY_SECRET
-                    | ENDPOINT_URL
-                    | SECRET_ACCESS_KEY
-                    | SESSION_TOKEN
-                    | REGION
-                    | HTTPS
-                    | DELEGATION
-                    | ENABLE_VIRTUAL_HOST_STYLE)
-                ~ #sep1 ~ #literal_string
+                ( #ident ) ~ #sep1 ~ #literal_string
             },
-            |(k, _, v)| (k.text().to_string().to_lowercase(), v),
+            |(k, _, v)| (k.to_string().to_lowercase(), v),
         );
 
         let bool_options = map(

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -243,10 +243,6 @@ pub enum TokenKind {
     //    reserved list.
     #[token("ALL", ignore(ascii_case))]
     ALL,
-    #[token("ACCESS_KEY_ID", ignore(ascii_case))]
-    ACCESS_KEY_ID,
-    #[token("ACCESS_KEY_SECRET", ignore(ascii_case))]
-    ACCESS_KEY_SECRET,
     #[token("ADD", ignore(ascii_case))]
     ADD,
     #[token("ANY", ignore(ascii_case))]
@@ -271,10 +267,6 @@ pub enum TokenKind {
     AT,
     #[token("ASC", ignore(ascii_case))]
     ASC,
-    #[token("AWS_KEY_ID", ignore(ascii_case))]
-    AWS_KEY_ID,
-    #[token("AWS_SECRET_KEY", ignore(ascii_case))]
-    AWS_SECRET_KEY,
     #[token("ANTI", ignore(ascii_case))]
     ANTI,
     #[token("BEFORE", ignore(ascii_case))]
@@ -371,8 +363,6 @@ pub enum TokenKind {
     DEFAULT,
     #[token("DEFLATE", ignore(ascii_case))]
     DEFLATE,
-    #[token("DELEGATION", ignore(ascii_case))]
-    DELEGATION, // delegation token, used in webhdfs
     #[token("DELETE", ignore(ascii_case))]
     DELETE,
     #[token("DESC", ignore(ascii_case))]
@@ -405,8 +395,6 @@ pub enum TokenKind {
     ENABLE_VIRTUAL_HOST_STYLE,
     #[token("END", ignore(ascii_case))]
     END,
-    #[token("ENDPOINT_URL", ignore(ascii_case))]
-    ENDPOINT_URL,
     #[token("ENGINE", ignore(ascii_case))]
     ENGINE,
     #[token("ENGINES", ignore(ascii_case))]
@@ -489,8 +477,6 @@ pub enum TokenKind {
     HIVE,
     #[token("HOUR", ignore(ascii_case))]
     HOUR,
-    #[token("HTTPS", ignore(ascii_case))]
-    HTTPS,
     #[token("ICEBERG", ignore(ascii_case))]
     ICEBERG,
     #[token("INTERSECT", ignore(ascii_case))]
@@ -673,8 +659,6 @@ pub enum TokenKind {
     PRESIGN,
     #[token("PRIVILEGES", ignore(ascii_case))]
     PRIVILEGES,
-    #[token("REGION", ignore(ascii_case))]
-    REGION,
     #[token("REMOVE", ignore(ascii_case))]
     REMOVE,
     #[token("REVOKE", ignore(ascii_case))]
@@ -695,14 +679,10 @@ pub enum TokenKind {
     SCHEMAS,
     #[token("SECOND", ignore(ascii_case))]
     SECOND,
-    #[token("SECRET_ACCESS_KEY", ignore(ascii_case))]
-    SECRET_ACCESS_KEY,
     #[token("SELECT", ignore(ascii_case))]
     SELECT,
     #[token("SEGMENT", ignore(ascii_case))]
     SEGMENT,
-    #[token("SESSION_TOKEN", ignore(ascii_case))]
-    SESSION_TOKEN,
     #[token("SET", ignore(ascii_case))]
     SET,
     #[token("UNSET", ignore(ascii_case))]

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -149,6 +149,7 @@ fn test_statement() {
         r#"select parse_json('{"k1": [0, 1, 2]}').k1[0];"#,
         r#"CREATE STAGE ~"#,
         r#"CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c' aws_secret_key='4x5y6z') file_format=(type = CSV compression = GZIP record_delimiter=',')"#,
+        r#"CREATE STAGE IF NOT EXISTS test_stage url='azblob://load/files/' connection=(account_name='1a2b3c' account_key='4x5y6z') file_format=(type = CSV compression = GZIP record_delimiter=',')"#,
         r#"DROP STAGE abc"#,
         r#"DROP STAGE ~"#,
         r#"list @stage_a;"#,

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -5769,6 +5769,43 @@ CreateStage(
 
 
 ---------- Input ----------
+CREATE STAGE IF NOT EXISTS test_stage url='azblob://load/files/' connection=(account_name='1a2b3c' account_key='4x5y6z') file_format=(type = CSV compression = GZIP record_delimiter=',')
+---------- Output ---------
+CREATE STAGE IF NOT EXISTS test_stage URL = 'azblob://load/files/' CONNECTION = ( account_key='4x5y6z' account_name='1a2b3c' ) FILE_FORMAT = ( compression = 'GZIP' record_delimiter = ',' type = 'CSV' )
+---------- AST ------------
+CreateStage(
+    CreateStageStmt {
+        if_not_exists: true,
+        stage_name: "test_stage",
+        location: Some(
+            UriLocation {
+                protocol: "azblob",
+                name: "load",
+                path: "/files/",
+                part_prefix: "",
+                connection: Connection {
+                    visited_keys: {},
+                    conns: {
+                        "account_key": "4x5y6z",
+                        "account_name": "1a2b3c",
+                    },
+                },
+            },
+        ),
+        file_format_options: {
+            "compression": "GZIP",
+            "record_delimiter": ",",
+            "type": "CSV",
+        },
+        on_error: "",
+        size_limit: 0,
+        validation_mode: "",
+        comments: "",
+    },
+)
+
+
+---------- Input ----------
 DROP STAGE abc
 ---------- Output ---------
 DROP STAGES abc

--- a/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables
@@ -227,7 +227,7 @@ create table t(a int, A int)
 statement error Duplicated column name
 create table t as select number, number from numbers(1)
 
-statement error 1105
+statement error 4000
 create table tb101 (id int ,c1 datetime) 's3://wubx/tb101' connection=(aws_key_id='minioadmin' aws_ssecret_key='minioadmin' endpoint_url='http://127.0.0.1:9900');
 
 statement ok

--- a/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables
@@ -227,7 +227,7 @@ create table t(a int, A int)
 statement error Duplicated column name
 create table t as select number, number from numbers(1)
 
-statement error 1005
+statement error 1105
 create table tb101 (id int ,c1 datetime) 's3://wubx/tb101' connection=(aws_key_id='minioadmin' aws_ssecret_key='minioadmin' endpoint_url='http://127.0.0.1:9900');
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix https://github.com/datafuselabs/databend/issues/10653

We already have a runtime check here:

https://github.com/datafuselabs/databend/blob/048b72ac8c179f38e985d9370d44a70b586766dd/src/query/ast/src/ast/statements/copy.rs#L221-L239

For example:

![image](https://user-images.githubusercontent.com/5351546/226177347-62f4215f-6a32-4eb9-86a0-da006a1c7776.png)
