### PR TITLE
chore(planner): support multi filter pushdown into scan

### DIFF
--- a/src/query/functions/src/scalars/other.rs
+++ b/src/query/functions/src/scalars/other.rs
@@ -100,8 +100,9 @@ pub fn register(registry: &mut FunctionRegistry) {
         FunctionProperty::default(),
         |_| FunctionDomain::MayThrow,
         |a, ctx| {
-            if let Some(s) = a.as_scalar() {
-                let duration = Duration::try_from_secs_f64(val.into()).map_err(|x| x.to_string());
+            if let Some(val) = a.as_scalar() {
+                let duration =
+                    Duration::try_from_secs_f64((*val).into()).map_err(|x| x.to_string());
                 match duration {
                     Ok(duration) => {
                         if duration.gt(&Duration::from_secs(300)) {
@@ -110,20 +111,18 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 duration
                             );
                             ctx.set_error(0, err);
-                            Ok(Value::Scalar(Scalar::Null(NullType::UInt8)))
                         } else {
                             std::thread::sleep(duration);
-                            Ok(Value::Scalar(Scalar::Value(UInt8Type::from(1))))
                         }
                     }
                     Err(e) => {
                         ctx.set_error(0, e);
-                        Ok(Value::Scalar(Scalar::Null(NullType::UInt8)))
                     }
                 }
             } else {
                 ctx.set_error(0, "Must be constant value");
             }
+            Value::Scalar(0_u8)
         },
     );
 

--- a/src/query/functions/tests/it/scalars/testdata/other.txt
+++ b/src/query/functions/tests/it/scalars/testdata/other.txt
@@ -134,10 +134,10 @@ output         : "DOUBLE"
 ast            : sleep(2)
 raw expr       : sleep(2_u8)
 checked expr   : sleep<Float64>(to_float64<UInt8>(2_u8))
-optimized expr : 1_u8
+optimized expr : 0_u8
 output type    : UInt8
-output domain  : {1..=1}
-output         : 1
+output domain  : {0..=0}
+output         : 0
 
 
 error: 

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
@@ -94,8 +94,6 @@ impl Rule for RulePushDownFilterScan {
         let filter: Filter = s_expr.plan().clone().try_into()?;
         let mut get: Scan = s_expr.child(0)?.plan().clone().try_into()?;
 
-        if get.push_down_predicates.is_some() {}
-
         let add_filters = self.find_push_down_predicates(&filter.predicates)?;
 
         match get.push_down_predicates.as_mut() {

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
@@ -94,15 +94,18 @@ impl Rule for RulePushDownFilterScan {
         let filter: Filter = s_expr.plan().clone().try_into()?;
         let mut get: Scan = s_expr.child(0)?.plan().clone().try_into()?;
 
-        if get.push_down_predicates.is_some() {
-            return Ok(());
+        if get.push_down_predicates.is_some() {}
+
+        let add_filters = self.find_push_down_predicates(&filter.predicates)?;
+
+        match get.push_down_predicates.as_mut() {
+            Some(vs) => vs.extend(add_filters),
+            None => get.push_down_predicates = Some(add_filters),
         }
 
-        get.push_down_predicates = Some(self.find_push_down_predicates(&filter.predicates)?);
-
-        let result = SExpr::create_unary(filter.into(), SExpr::create_leaf(get.into()));
+        let mut result = SExpr::create_unary(filter.into(), SExpr::create_leaf(get.into()));
+        result.set_applied_rule(&self.id);
         state.add_result(result);
-
         Ok(())
     }
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/select.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select.test
@@ -159,3 +159,21 @@ TableScan
 ├── partitions scanned: 1
 ├── push downs: [filters: [], limit: NONE]
 └── estimated rows: 1.00
+
+
+
+query T
+explain select * from (select * from numbers(100)  where  number> 33 ) where 1=2;
+---
+----
+Filter
+├── filters: [false, numbers.number (#0) > 33]
+├── estimated rows: 11.11
+└── TableScan
+    ├── table: default.system.numbers
+    ├── read rows: 0
+    ├── read bytes: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    ├── push downs: [filters: [false], limit: NONE]
+    └── estimated rows: 100.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/sort.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/sort.test
@@ -58,5 +58,6 @@ Sort
         ├── output columns: [a]
         └── estimated rows: 0.00
 
+
 statement ok
 drop table if exists t1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

1. make sleep only accept scalar arg 
2. support multi filter pushdown into scan

Closes #10644 #10663 
