### PR TITLE
chore(system): add disable_system_table_load to allow disable load some system tables

### DIFF
--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -1291,6 +1291,10 @@ pub struct QueryConfig {
     /// Max bytes of cached bloom filter bytes.
     #[clap(long)]
     pub(crate) table_cache_bloom_index_data_bytes: Option<u64>,
+
+    /// Disable some system load(For example system.configs) for cloud security.
+    #[clap(long)]
+    pub disable_system_table_load: bool,
 }
 
 impl Default for QueryConfig {
@@ -1347,6 +1351,7 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
             tenant_quota: self.quota,
             internal_enable_sandbox_tenant: self.internal_enable_sandbox_tenant,
             internal_merge_on_read_mutation: self.internal_merge_on_read_mutation,
+            disable_system_table_load: self.disable_system_table_load,
         })
     }
 }
@@ -1415,6 +1420,7 @@ impl From<InnerQueryConfig> for QueryConfig {
             table_cache_bloom_index_meta_count: None,
             table_cache_bloom_index_filter_count: None,
             table_cache_bloom_index_data_bytes: None,
+            disable_system_table_load: inner.disable_system_table_load,
         }
     }
 }

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -163,6 +163,8 @@ pub struct QueryConfig {
     pub tenant_quota: Option<TenantQuota>,
     pub internal_enable_sandbox_tenant: bool,
     pub internal_merge_on_read_mutation: bool,
+    /// Disable some system load(For example system.configs) for cloud security.
+    pub disable_system_table_load: bool,
 }
 
 impl Default for QueryConfig {
@@ -209,6 +211,7 @@ impl Default for QueryConfig {
             tenant_quota: None,
             internal_enable_sandbox_tenant: false,
             internal_merge_on_read_mutation: false,
+            disable_system_table_load: false,
         }
     }
 }

--- a/src/query/service/src/databases/system/system_database.rs
+++ b/src/query/service/src/databases/system/system_database.rs
@@ -60,8 +60,8 @@ impl SystemDatabase {
     /// These tables may disabled to the sql users.
     fn disable_system_tables() -> HashMap<String, bool> {
         let mut map = HashMap::new();
-        map.insert("system.config".to_string(), true);
-        map.insert("system.cluster".to_string(), true);
+        map.insert("configs".to_string(), true);
+        map.insert("clusters".to_string(), true);
         map
     }
 

--- a/src/query/service/src/databases/system/system_database.rs
+++ b/src/query/service/src/databases/system/system_database.rs
@@ -101,11 +101,12 @@ impl SystemDatabase {
             TableFunctionsTable::create(sys_db_meta.next_table_id()),
         ];
 
+        let disable_tables = Self::disable_system_tables();
         for tbl in table_list.into_iter() {
             // Not load the disable system tables.
             if config.query.disable_system_table_load {
                 let name = tbl.name();
-                if !Self::disable_system_tables()[name] {
+                if disable_tables.get(name).is_none() {
                     sys_db_meta.insert("system", tbl);
                 }
             } else {

--- a/src/query/service/tests/it/databases/mod.rs
+++ b/src/query/service/tests/it/databases/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2023 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(clippy::uninlined_format_args)]
-#![feature(thread_local)]
-
-mod api;
-mod auth;
-mod catalogs;
-mod clusters;
-mod configs;
-mod databases;
-mod metrics;
-mod pipelines;
-mod servers;
-mod sessions;
-mod sql;
-mod storages;
-mod table_functions;
-mod tests;
+mod system;

--- a/src/query/service/tests/it/databases/system/mod.rs
+++ b/src/query/service/tests/it/databases/system/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2023 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(clippy::uninlined_format_args)]
-#![feature(thread_local)]
-
-mod api;
-mod auth;
-mod catalogs;
-mod clusters;
-mod configs;
-mod databases;
-mod metrics;
-mod pipelines;
-mod servers;
-mod sessions;
-mod sql;
-mod storages;
-mod table_functions;
-mod tests;
+mod system_database;

--- a/src/query/service/tests/it/databases/system/system_database.rs
+++ b/src/query/service/tests/it/databases/system/system_database.rs
@@ -1,0 +1,48 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::Result;
+use databend_query::catalogs::InMemoryMetas;
+use databend_query::catalogs::SYS_DB_ID_BEGIN;
+use databend_query::catalogs::SYS_TBL_ID_BEGIN;
+use databend_query::databases::SystemDatabase;
+
+use crate::tests::ConfigBuilder;
+
+#[test]
+fn test_disable_system_table() -> Result<()> {
+    let mut conf = ConfigBuilder::create().build();
+
+    // Normal.
+    {
+        let mut sys_db_meta = InMemoryMetas::create(SYS_DB_ID_BEGIN, SYS_TBL_ID_BEGIN);
+        sys_db_meta.init_db("system");
+        let _ = SystemDatabase::create(&mut sys_db_meta, &conf);
+        let t1 = sys_db_meta.get_by_name("system", "clusters");
+        assert!(t1.is_ok());
+    }
+
+    // Disable.
+    {
+        conf.query.disable_system_table_load = true;
+
+        let mut sys_db_meta = InMemoryMetas::create(SYS_DB_ID_BEGIN, SYS_TBL_ID_BEGIN);
+        sys_db_meta.init_db("system");
+        let _ = SystemDatabase::create(&mut sys_db_meta, &conf);
+        let t1 = sys_db_meta.get_by_name("system", "clusters");
+        assert!(t1.is_err());
+    }
+
+    Ok(())
+}

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -46,6 +46,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | "query"   | "cluster_id"                               | ""                               | ""       |
 | "query"   | "default_compression"                      | "auto"                           | ""       |
 | "query"   | "default_storage_format"                   | "auto"                           | ""       |
+| "query"   | "disable_system_table_load"                | "false"                          | ""       |
 | "query"   | "flight_api_address"                       | "127.0.0.1:9090"                 | ""       |
 | "query"   | "http_handler_host"                        | "127.0.0.1"                      | ""       |
 | "query"   | "http_handler_port"                        | "8000"                           | ""       |


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

For security, some system tables like `config/cluster` is no need to the SQL user query.
In this PR we introduce a new query.config:`disable_system_table_load` to control them.

Closes #issue
