### PR TITLE
fix(query): warn about reserved built-in user

### DIFF
--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -38,6 +38,7 @@ use common_meta_store::MetaStore;
 use common_meta_store::MetaStoreProvider;
 use common_meta_types::MatchSeq;
 use common_meta_types::MetaError;
+use tracing::warn;
 
 use crate::idm_config::IDMConfig;
 
@@ -69,6 +70,14 @@ impl UserApiProvider {
         idm_config: IDMConfig,
     ) -> Result<Arc<UserApiProvider>> {
         let client = MetaStoreProvider::new(conf).create_meta_store().await?;
+        for user in idm_config.users.keys() {
+            match user.as_str() {
+                "root" | "default" => {
+                    warn!("Reserved built-in user `{}` will be ignored", user);
+                }
+                _ => {}
+            }
+        }
         Ok(Arc::new(UserApiProvider {
             meta: client.clone(),
             client: client.arc(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```
WARN common_users::user_api: src/query/users/src/user_api.rs:76: Reserved built-in user `root` will be ignored
```

Closes #issue
