### PR TITLE
fix: in copy force mode, files should be insert unconditionally

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -2927,8 +2927,6 @@ fn build_upsert_table_copied_file_info_conditions(
         if fail_if_duplicated {
             // "fail_if_duplicated" mode, assumes files are absent
             condition.push(txn_cond_seq(&key, Eq, 0));
-        } else {
-            condition.push(txn_cond_seq(&key, Ge, 0));
         }
         set_update_expire_operation(&key, &file_info, &req.expire_at, &mut if_then)?;
     }

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -104,7 +104,6 @@ use common_meta_kvapi::kvapi::Key;
 use common_meta_types::txn_op::Request;
 use common_meta_types::txn_op_response::Response;
 use common_meta_types::ConditionResult;
-use common_meta_types::ConditionResult::Ge;
 use common_meta_types::GCDroppedDataReply;
 use common_meta_types::GCDroppedDataReq;
 use common_meta_types::InvalidReply;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

patch of PR https://github.com/datafuselabs/databend/pull/10427

in copy force mode, files could be inserted unconditionally (no related conditions needed to be put in the `if condition`) .

that hurts the performance.


Closes #issue
