### PR TITLE
feat(openai): add openai_api_key to config

### DIFF
--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -1296,8 +1296,7 @@ pub struct QueryConfig {
     #[clap(long)]
     pub disable_system_table_load: bool,
 
-    // Ignore show in the config table.
-    #[serde(skip_serializing)]
+    // This will not show in system.configs, put it to mask.rs.
     #[clap(long, default_value = "")]
     pub openai_api_key: String,
 }

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -1295,6 +1295,11 @@ pub struct QueryConfig {
     /// Disable some system load(For example system.configs) for cloud security.
     #[clap(long)]
     pub disable_system_table_load: bool,
+
+    // Ignore show in the config table.
+    #[serde(skip_serializing)]
+    #[clap(long, default_value = "")]
+    pub openai_api_key: String,
 }
 
 impl Default for QueryConfig {
@@ -1352,6 +1357,7 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
             internal_enable_sandbox_tenant: self.internal_enable_sandbox_tenant,
             internal_merge_on_read_mutation: self.internal_merge_on_read_mutation,
             disable_system_table_load: self.disable_system_table_load,
+            openai_api_key: self.openai_api_key,
         })
     }
 }
@@ -1421,6 +1427,7 @@ impl From<InnerQueryConfig> for QueryConfig {
             table_cache_bloom_index_filter_count: None,
             table_cache_bloom_index_data_bytes: None,
             disable_system_table_load: inner.disable_system_table_load,
+            openai_api_key: inner.openai_api_key,
         }
     }
 }

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -165,6 +165,7 @@ pub struct QueryConfig {
     pub internal_merge_on_read_mutation: bool,
     /// Disable some system load(For example system.configs) for cloud security.
     pub disable_system_table_load: bool,
+    pub openai_api_key: String,
 }
 
 impl Default for QueryConfig {
@@ -212,6 +213,7 @@ impl Default for QueryConfig {
             internal_enable_sandbox_tenant: false,
             internal_merge_on_read_mutation: false,
             disable_system_table_load: false,
+            openai_api_key: "".to_string(),
         }
     }
 }

--- a/src/query/config/src/lib.rs
+++ b/src/query/config/src/lib.rs
@@ -30,6 +30,7 @@
 mod config;
 mod global;
 mod inner;
+mod mask;
 mod obsolete;
 mod version;
 

--- a/src/query/config/src/mask.rs
+++ b/src/query/config/src/mask.rs
@@ -1,0 +1,22 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Config;
+
+// Mask the config value to ******
+impl Config {
+    pub const fn mask_option_keys() -> &'static [&'static str; 1] {
+        &["openai_api_key"]
+    }
+}

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -68,6 +68,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | "query"   | "mysql_handler_port"                       | "3307"                           | ""       |
 | "query"   | "mysql_handler_tcp_keepalive_timeout_secs" | "120"                            | ""       |
 | "query"   | "num_cpus"                                 | "0"                              | ""       |
+| "query"   | "openai_api_key"                           | "******"                         | ""       |
 | "query"   | "quota"                                    | "null"                           | ""       |
 | "query"   | "rpc_tls_query_server_root_ca_cert"        | ""                               | ""       |
 | "query"   | "rpc_tls_query_service_domain_name"        | "localhost"                      | ""       |

--- a/src/query/service/tests/it/table_functions/mod.rs
+++ b/src/query/service/tests/it/table_functions/mod.rs
@@ -13,3 +13,4 @@
 //  limitations under the License.W
 
 mod numbers_table;
+mod openai;

--- a/src/query/service/tests/it/table_functions/openai.rs
+++ b/src/query/service/tests/it/table_functions/openai.rs
@@ -1,0 +1,50 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use common_catalog::table_args::TableArgs;
+use common_exception::Result;
+use common_expression::Scalar;
+use databend_query::table_functions::GPT2SQLTable;
+
+#[test]
+fn test_ai_to_sql_args() -> Result<()> {
+    // 1 arg.
+    {
+        let tbl_args =
+            TableArgs::new_positioned(vec![Scalar::String("prompt".to_string().into_bytes())]);
+        let _ = GPT2SQLTable::create("system", "ai_to_sql", 1, tbl_args)?;
+    }
+
+    // 2 args.
+    {
+        let tbl_args = TableArgs::new_positioned(vec![
+            Scalar::String("prompt".to_string().into_bytes()),
+            Scalar::String("api-key".to_string().into_bytes()),
+        ]);
+        let _ = GPT2SQLTable::create("system", "ai_to_sql", 1, tbl_args)?;
+    }
+
+    // 3 args.
+    {
+        let tbl_args = TableArgs::new_positioned(vec![
+            Scalar::String("prompt".to_string().into_bytes()),
+            Scalar::String("api-key".to_string().into_bytes()),
+            Scalar::String("3rd".to_string().into_bytes()),
+        ]);
+        let result = GPT2SQLTable::create("system", "ai_to_sql", 1, tbl_args);
+        assert!(result.is_err());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Introduce a new query config: `openai_api_key`:
```
mysql> select * from ai_to_sql('how many hits');
+----------+---------------------------+
| database | generated_sql             |
+----------+---------------------------+
| hits     | SELECT count(*) FROM hits |
+----------+---------------------------+
```

In the system.configs:
```
 query   | openai_api_key                           | ******                                   |             |
```

Closes #10654
