### PR TITLE
fix(query): fix view select filter can not push down to scan

### DIFF
--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_eval_scalar.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_eval_scalar.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_exception::ErrorCode;
 use common_exception::Result;
 
 use crate::optimizer::rule::Rule;
@@ -20,10 +21,21 @@ use crate::optimizer::rule::TransformResult;
 use crate::optimizer::ColumnSet;
 use crate::optimizer::RelExpr;
 use crate::optimizer::SExpr;
+use crate::plans::AggregateFunction;
+use crate::plans::AndExpr;
+use crate::plans::CastExpr;
+use crate::plans::ComparisonExpr;
 use crate::plans::EvalScalar;
 use crate::plans::Filter;
+use crate::plans::FunctionCall;
+use crate::plans::NotExpr;
+use crate::plans::OrExpr;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
+use crate::plans::ScalarExpr;
+use crate::plans::ScalarItem;
+use crate::plans::Unnest;
+use crate::plans::WindowFunc;
 
 pub struct RulePushDownFilterEvalScalar {
     id: RuleID,
@@ -59,6 +71,216 @@ impl RulePushDownFilterEvalScalar {
             ),
         }
     }
+
+    // Replace predicate with children scalar items
+    fn replace_predicate(
+        predicate: &ScalarExpr,
+        items: &[ScalarItem],
+        eval_scalar_columns: &ColumnSet,
+        eval_scalar_child_columns: &ColumnSet,
+    ) -> Result<ScalarExpr> {
+        if !predicate
+            .used_columns()
+            .is_subset(eval_scalar_child_columns)
+            && predicate.used_columns().is_subset(eval_scalar_columns)
+        {
+            match predicate {
+                ScalarExpr::BoundColumnRef(column) => {
+                    for item in items {
+                        if item.index == column.column.index {
+                            return Ok(item.scalar.clone());
+                        }
+                    }
+                    Err(ErrorCode::UnknownColumn(format!(
+                        "Cannot find column to replace `{}`(#{})",
+                        column.column.column_name, column.column.index
+                    )))
+                }
+                ScalarExpr::AndExpr(scalar) => {
+                    let left = Self::replace_predicate(
+                        &scalar.left,
+                        items,
+                        eval_scalar_columns,
+                        eval_scalar_child_columns,
+                    )?;
+                    let right = Self::replace_predicate(
+                        &scalar.right,
+                        items,
+                        eval_scalar_columns,
+                        eval_scalar_child_columns,
+                    )?;
+                    Ok(ScalarExpr::AndExpr(AndExpr {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    }))
+                }
+                ScalarExpr::OrExpr(scalar) => {
+                    let left = Self::replace_predicate(
+                        &scalar.left,
+                        items,
+                        eval_scalar_columns,
+                        eval_scalar_child_columns,
+                    )?;
+                    let right = Self::replace_predicate(
+                        &scalar.right,
+                        items,
+                        eval_scalar_columns,
+                        eval_scalar_child_columns,
+                    )?;
+                    Ok(ScalarExpr::OrExpr(OrExpr {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    }))
+                }
+                ScalarExpr::NotExpr(scalar) => {
+                    let argument = Self::replace_predicate(
+                        &scalar.argument,
+                        items,
+                        eval_scalar_columns,
+                        eval_scalar_child_columns,
+                    )?;
+                    Ok(ScalarExpr::NotExpr(NotExpr {
+                        argument: Box::new(argument),
+                    }))
+                }
+                ScalarExpr::ComparisonExpr(scalar) => {
+                    let left = Self::replace_predicate(
+                        &scalar.left,
+                        items,
+                        eval_scalar_columns,
+                        eval_scalar_child_columns,
+                    )?;
+                    let right = Self::replace_predicate(
+                        &scalar.right,
+                        items,
+                        eval_scalar_columns,
+                        eval_scalar_child_columns,
+                    )?;
+                    Ok(ScalarExpr::ComparisonExpr(ComparisonExpr {
+                        op: scalar.op.clone(),
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    }))
+                }
+                ScalarExpr::WindowFunction(window) => {
+                    let args = window
+                        .agg_func
+                        .args
+                        .iter()
+                        .map(|arg| {
+                            Self::replace_predicate(
+                                arg,
+                                items,
+                                eval_scalar_columns,
+                                eval_scalar_child_columns,
+                            )
+                        })
+                        .collect::<Result<Vec<ScalarExpr>>>()?;
+
+                    let agg_func = AggregateFunction {
+                        func_name: window.agg_func.func_name.clone(),
+                        distinct: window.agg_func.distinct,
+                        params: window.agg_func.params.clone(),
+                        args,
+                        return_type: window.agg_func.return_type.clone(),
+                        display_name: window.agg_func.display_name.clone(),
+                    };
+
+                    let partition_by = window
+                        .partition_by
+                        .iter()
+                        .map(|arg| {
+                            Self::replace_predicate(
+                                arg,
+                                items,
+                                eval_scalar_columns,
+                                eval_scalar_child_columns,
+                            )
+                        })
+                        .collect::<Result<Vec<ScalarExpr>>>()?;
+
+                    Ok(ScalarExpr::WindowFunction(WindowFunc {
+                        agg_func,
+                        partition_by,
+                        frame: window.frame.clone(),
+                    }))
+                }
+                ScalarExpr::AggregateFunction(agg_func) => {
+                    let args = agg_func
+                        .args
+                        .iter()
+                        .map(|arg| {
+                            Self::replace_predicate(
+                                arg,
+                                items,
+                                eval_scalar_columns,
+                                eval_scalar_child_columns,
+                            )
+                        })
+                        .collect::<Result<Vec<ScalarExpr>>>()?;
+
+                    Ok(ScalarExpr::AggregateFunction(AggregateFunction {
+                        func_name: agg_func.func_name.clone(),
+                        distinct: agg_func.distinct,
+                        params: agg_func.params.clone(),
+                        args,
+                        return_type: agg_func.return_type.clone(),
+                        display_name: agg_func.display_name.clone(),
+                    }))
+                }
+                ScalarExpr::FunctionCall(func) => {
+                    let arguments = func
+                        .arguments
+                        .iter()
+                        .map(|arg| {
+                            Self::replace_predicate(
+                                arg,
+                                items,
+                                eval_scalar_columns,
+                                eval_scalar_child_columns,
+                            )
+                        })
+                        .collect::<Result<Vec<ScalarExpr>>>()?;
+
+                    Ok(ScalarExpr::FunctionCall(FunctionCall {
+                        span: func.span,
+                        params: func.params.clone(),
+                        arguments,
+                        func_name: func.func_name.clone(),
+                    }))
+                }
+                ScalarExpr::Unnest(unnest) => {
+                    let arg = Self::replace_predicate(
+                        &unnest.argument,
+                        items,
+                        eval_scalar_columns,
+                        eval_scalar_child_columns,
+                    )?;
+                    Ok(ScalarExpr::Unnest(Unnest {
+                        argument: Box::new(arg),
+                        return_type: unnest.return_type.clone(),
+                    }))
+                }
+                ScalarExpr::CastExpr(cast) => {
+                    let arg = Self::replace_predicate(
+                        &cast.argument,
+                        items,
+                        eval_scalar_columns,
+                        eval_scalar_child_columns,
+                    )?;
+                    Ok(ScalarExpr::CastExpr(CastExpr {
+                        span: cast.span,
+                        is_try: cast.is_try,
+                        argument: Box::new(arg),
+                        target_type: cast.target_type.clone(),
+                    }))
+                }
+                _ => Ok(predicate.clone()),
+            }
+        } else {
+            Ok(predicate.clone())
+        }
+    }
 }
 
 impl Rule for RulePushDownFilterEvalScalar {
@@ -67,16 +289,46 @@ impl Rule for RulePushDownFilterEvalScalar {
     }
 
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
-        let filter: Filter = s_expr.plan().clone().try_into()?;
+        let mut filter: Filter = s_expr.plan().clone().try_into()?;
+
+        let mut used_columns = ColumnSet::new();
+        for pred in filter.predicates.iter() {
+            used_columns = used_columns.union(&pred.used_columns()).cloned().collect();
+        }
+
         let input = s_expr.child(0)?;
         let eval_scalar: EvalScalar = s_expr.child(0)?.plan().clone().try_into()?;
 
         let rel_expr = RelExpr::with_s_expr(input);
         let eval_scalar_child_prop = rel_expr.derive_relational_prop_child(0)?;
 
-        let mut used_columns = ColumnSet::new();
-        for pred in filter.predicates.iter() {
-            used_columns = used_columns.union(&pred.used_columns()).cloned().collect();
+        let scalar_rel_expr = RelExpr::with_s_expr(s_expr);
+        let eval_scalar_prop = scalar_rel_expr.derive_relational_prop_child(0)?;
+
+        // Replacing `DerivedColumn` in `Filter` with the column expression defined in the view.
+        // This allows us to eliminate the `EvalScalar` and push the filter down to the `Scan`.
+        if used_columns.is_subset(&eval_scalar_prop.output_columns)
+            && !used_columns.is_subset(&eval_scalar_child_prop.output_columns)
+        {
+            let new_predicates = &filter
+                .predicates
+                .iter()
+                .map(|predicate| {
+                    Self::replace_predicate(
+                        predicate,
+                        &eval_scalar.items,
+                        &eval_scalar_prop.output_columns,
+                        &eval_scalar_child_prop.output_columns,
+                    )
+                })
+                .collect::<Result<Vec<ScalarExpr>>>()?;
+
+            filter.predicates = new_predicates.to_vec();
+
+            used_columns.clear();
+            for pred in filter.predicates.iter() {
+                used_columns = used_columns.union(&pred.used_columns()).cloned().collect();
+            }
         }
 
         // Check if `Filter` can be satisfied by children of `EvalScalar`

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
@@ -56,11 +56,11 @@ impl RulePushDownFilterScan {
     }
 
     fn find_push_down_predicates(&self, predicates: &[ScalarExpr]) -> Result<Vec<ScalarExpr>> {
+        let metadata = self.metadata.read();
+        let column_entries = metadata.columns();
         let mut filtered_predicates = vec![];
         for predicate in predicates {
             let used_columns = predicate.used_columns();
-            let metadata = self.metadata.read();
-            let column_entries = metadata.columns();
             let mut contain_derived_column = false;
             for column_entry in column_entries {
                 match column_entry {

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -907,3 +907,42 @@ Query (children 1)
                 ├── Literal String("p3")
                 ├── prune_page=>Literal Boolean(true)
                 └── refresh_meta_cache=>Literal Boolean(true)
+
+statement ok
+create table t4(a int, b string);
+
+query T
+explain select * from t4 where a = 1 and try_cast(get(try_parse_json(b),'bb') as varchar) = 'xx';
+----
+Filter
+├── filters: [t4.a (#0) = 1, is_true(TRY_CAST(get(try_parse_json(t4.b (#1)), "bb") AS String NULL) = "xx")]
+├── estimated rows: 0.00
+└── TableScan
+    ├── table: default.default.t4
+    ├── read rows: 0
+    ├── read bytes: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    ├── push downs: [filters: [is_true(CAST(t4.a (#0) = 1 AS Boolean NULL) AND TRY_CAST(get(try_parse_json(t4.b (#1)), "bb") AS String NULL) = "xx")], limit: NONE]
+    └── estimated rows: 0.00
+
+statement ok
+create view v4 as select a as a, try_cast(get(try_parse_json(b), 'bb') as varchar) as b from t4;
+
+query T
+explain select * from v4 where b = 'xx';
+----
+EvalScalar
+├── expressions: [TRY_CAST(get(try_parse_json(t4.b (#1)), "bb") AS String NULL)]
+├── estimated rows: 0.00
+└── Filter
+    ├── filters: [is_true(TRY_CAST(get(try_parse_json(t4.b (#1)), "bb") AS String NULL) = "xx")]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: default.default.t4
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [is_true(TRY_CAST(get(try_parse_json(t4.b (#1)), "bb") AS String NULL) = "xx")], limit: NONE]
+        └── estimated rows: 0.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
@@ -124,19 +124,19 @@ Filter
     │               ├── probe keys: [t3.b (#10)]
     │               ├── filters: []
     │               ├── estimated rows: 0.33
-    │               ├── Filter(Build)
-    │               │   ├── filters: [t2.c (#6) = 1]
+    │               ├── EvalScalar(Build)
+    │               │   ├── expressions: [numbers.number (#3) + 1]
     │               │   ├── estimated rows: 0.33
-    │               │   └── EvalScalar
-    │               │       ├── expressions: [numbers.number (#3) + 1, numbers.number (#3) + 1]
-    │               │       ├── estimated rows: 1.00
+    │               │   └── Filter
+    │               │       ├── filters: [numbers.number (#3) + 1 = 1]
+    │               │       ├── estimated rows: 0.33
     │               │       └── TableScan
     │               │           ├── table: default.system.numbers
     │               │           ├── read rows: 1
     │               │           ├── read bytes: 8
     │               │           ├── partitions total: 1
     │               │           ├── partitions scanned: 1
-    │               │           ├── push downs: [filters: [], limit: NONE]
+    │               │           ├── push downs: [filters: [numbers.number (#3) + 1 = 1], limit: NONE]
     │               │           └── estimated rows: 1.00
     │               └── EvalScalar(Probe)
     │                   ├── expressions: [numbers.number (#8) + 1]

--- a/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
@@ -69,19 +69,19 @@ HashJoin
 ├── probe keys: [t2.b (#7)]
 ├── filters: []
 ├── estimated rows: 0.33
-├── Filter(Build)
-│   ├── filters: [t1.c (#3) = 1]
+├── EvalScalar(Build)
+│   ├── expressions: [numbers.number (#0) + 1, numbers.number (#0) + 1]
 │   ├── estimated rows: 0.33
-│   └── EvalScalar
-│       ├── expressions: [numbers.number (#0) + 1, numbers.number (#0) + 1, numbers.number (#0) + 1]
-│       ├── estimated rows: 1.00
+│   └── Filter
+│       ├── filters: [numbers.number (#0) + 1 = 1]
+│       ├── estimated rows: 0.33
 │       └── TableScan
 │           ├── table: default.system.numbers
 │           ├── read rows: 1
 │           ├── read bytes: 8
 │           ├── partitions total: 1
 │           ├── partitions scanned: 1
-│           ├── push downs: [filters: [], limit: NONE]
+│           ├── push downs: [filters: [numbers.number (#0) + 1 = 1], limit: NONE]
 │           └── estimated rows: 1.00
 └── EvalScalar(Probe)
     ├── expressions: [numbers.number (#5) + 1]

--- a/tests/sqllogictests/suites/mode/standalone/explain/select.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select.test
@@ -28,19 +28,19 @@ Filter
 query T
 explain select * from (select number as a, number + 1 as b from numbers(1)) as t1 where a = 1 and b = 1
 ----
-Filter
-├── filters: [t1.a (#0) = 1, t1.b (#1) = 1]
+EvalScalar
+├── expressions: [numbers.number (#0) + 1]
 ├── estimated rows: 0.11
-└── EvalScalar
-    ├── expressions: [numbers.number (#0) + 1]
-    ├── estimated rows: 1.00
+└── Filter
+    ├── filters: [t1.a (#0) = 1, numbers.number (#0) + 1 = 1]
+    ├── estimated rows: 0.11
     └── TableScan
         ├── table: default.system.numbers
         ├── read rows: 1
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── push downs: [filters: [], limit: NONE]
+        ├── push downs: [filters: [t1.a (#0) = 1 AND numbers.number (#0) + 1 = 1], limit: NONE]
         └── estimated rows: 1.00
 
 query T


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Replacing `DerivedColumn` in `Filter` with the column expression defined in the view, so that we can push down the `Filter` to the `Scan`.

Closes #9882
