### PR TITLE
fix: manual drop state to prevent memory leak

### DIFF
--- a/src/query/functions/src/aggregates/aggregate_quantile_cont.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_cont.rs
@@ -230,6 +230,15 @@ where T: Number + AsPrimitive<f64>
         let state = place.get::<QuantileState>();
         state.merge_result(builder, self.levels.clone())
     }
+
+    fn need_manual_drop_state(&self) -> bool {
+        true
+    }
+
+    unsafe fn drop_state(&self, place: StateAddr) {
+        let state = place.get::<QuantileState>();
+        std::ptr::drop_in_place(state);
+    }
 }
 
 impl<T> AggregateQuantileContFunction<T>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Manual drop state to prevent memory leak

Closes #issue
