### PR TITLE
chore(query): make flush returns empty builder

### DIFF
--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -330,8 +330,11 @@ impl StringColumnBuilder {
             let bytes_per_row = self.data.len() / 64 + 1;
             let bytes_estimate = bytes_per_row * self.offsets.capacity();
 
+            static MAX_HINT_SIZE: usize = 1000000000;
             // if we are more than 10% over the capacity, we reserve more
-            if bytes_estimate as f64 > self.data.capacity() as f64 * 1.10f64 {
+            if bytes_estimate < MAX_HINT_SIZE
+                && bytes_estimate as f64 > self.data.capacity() as f64 * 1.10f64
+            {
                 self.data.reserve(bytes_estimate - self.data.capacity());
             }
         }

--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -330,7 +330,7 @@ impl StringColumnBuilder {
             let bytes_per_row = self.data.len() / 64 + 1;
             let bytes_estimate = bytes_per_row * self.offsets.capacity();
 
-            static MAX_HINT_SIZE: usize = 1000000000;
+            const MAX_HINT_SIZE: usize = 1000000000;
             // if we are more than 10% over the capacity, we reserve more
             if bytes_estimate < MAX_HINT_SIZE
                 && bytes_estimate as f64 > self.data.capacity() as f64 * 1.10f64

--- a/src/query/pipeline/sources/src/input_formats/input_format_text.rs
+++ b/src/query/pipeline/sources/src/input_formats/input_format_text.rs
@@ -463,10 +463,7 @@ impl<T: InputFormatTextBase> BlockBuilder<T> {
             .mutable_columns
             .iter_mut()
             .map(|col| {
-                let empty_builder = ColumnBuilder::with_capacity(
-                    &col.data_type(),
-                    self.ctx.block_compact_thresholds.min_rows_per_block,
-                );
+                let empty_builder = ColumnBuilder::with_capacity(&col.data_type(), 0);
                 std::mem::replace(col, empty_builder).build()
             })
             .collect();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Test #10483 is leaked or not.

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/3325189/226981730-acd081e5-3e9c-4155-baba-07b16c060f23.png">



If the processor is leaked (unsafe codes in pipeline processor), object `BlockBuilder` will be memory leaked thus the builder will be memory leaked.

Closes #issue
