### PR TITLE
chore(query): add compare domain for string types

### DIFF
--- a/src/query/expression/src/property.rs
+++ b/src/query/expression/src/property.rs
@@ -380,3 +380,112 @@ impl Domain {
         }
     }
 }
+
+pub trait SimpleDomainCmp {
+    fn domain_eq(&self, other: &Self) -> FunctionDomain<BooleanType>;
+    fn domain_noteq(&self, other: &Self) -> FunctionDomain<BooleanType>;
+    fn domain_gt(&self, other: &Self) -> FunctionDomain<BooleanType>;
+    fn domain_gte(&self, other: &Self) -> FunctionDomain<BooleanType>;
+    fn domain_lt(&self, other: &Self) -> FunctionDomain<BooleanType>;
+    fn domain_lte(&self, other: &Self) -> FunctionDomain<BooleanType>;
+}
+
+const ALL_TRUE_DOMAIN: BooleanDomain = BooleanDomain {
+    has_true: true,
+    has_false: false,
+};
+
+const ALL_FALSE_DOMAIN: BooleanDomain = BooleanDomain {
+    has_true: false,
+    has_false: true,
+};
+
+impl<T: Ord + PartialOrd> SimpleDomainCmp for SimpleDomain<T> {
+    fn domain_eq(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        if self.min > other.max || self.max < other.min {
+            FunctionDomain::Domain(ALL_FALSE_DOMAIN)
+        } else {
+            FunctionDomain::Full
+        }
+    }
+
+    fn domain_noteq(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        if self.min > other.max || self.max < other.min {
+            FunctionDomain::Domain(ALL_TRUE_DOMAIN)
+        } else {
+            FunctionDomain::Full
+        }
+    }
+
+    fn domain_gt(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        if self.min > other.max {
+            FunctionDomain::Domain(ALL_TRUE_DOMAIN)
+        } else if self.max <= other.min {
+            FunctionDomain::Domain(ALL_FALSE_DOMAIN)
+        } else {
+            FunctionDomain::Full
+        }
+    }
+
+    fn domain_gte(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        if self.min >= other.max {
+            FunctionDomain::Domain(ALL_TRUE_DOMAIN)
+        } else if self.max < other.min {
+            FunctionDomain::Domain(ALL_FALSE_DOMAIN)
+        } else {
+            FunctionDomain::Full
+        }
+    }
+
+    fn domain_lt(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        if self.max < other.min {
+            FunctionDomain::Domain(ALL_TRUE_DOMAIN)
+        } else if self.min >= other.max {
+            FunctionDomain::Domain(ALL_FALSE_DOMAIN)
+        } else {
+            FunctionDomain::Full
+        }
+    }
+
+    fn domain_lte(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        if self.max <= other.min {
+            FunctionDomain::Domain(ALL_TRUE_DOMAIN)
+        } else if self.min > other.max {
+            FunctionDomain::Domain(ALL_FALSE_DOMAIN)
+        } else {
+            FunctionDomain::Full
+        }
+    }
+}
+
+impl SimpleDomainCmp for StringDomain {
+    fn domain_eq(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        let (d1, d2) = self.unify(other);
+        d1.domain_eq(&d2)
+    }
+
+    fn domain_noteq(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        let (d1, d2) = self.unify(other);
+        d1.domain_noteq(&d2)
+    }
+
+    fn domain_gt(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        let (d1, d2) = self.unify(other);
+        d1.domain_gt(&d2)
+    }
+
+    fn domain_gte(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        let (d1, d2) = self.unify(other);
+        d1.domain_gte(&d2)
+    }
+
+    fn domain_lt(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        let (d1, d2) = self.unify(other);
+        d1.domain_lt(&d2)
+    }
+
+    fn domain_lte(&self, other: &Self) -> FunctionDomain<BooleanType> {
+        let (d1, d2) = self.unify(other);
+        d1.domain_lte(&d2)
+    }
+}

--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -20,6 +20,7 @@ use common_arrow::arrow::trusted_len::TrustedLen;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::SimpleDomain;
 use crate::property::Domain;
 use crate::types::ArgType;
 use crate::types::DataType;
@@ -411,5 +412,37 @@ impl<'a> FromIterator<&'a [u8]> for StringColumnBuilder {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StringDomain {
     pub min: Vec<u8>,
+    // None is max value for full domain
     pub max: Option<Vec<u8>>,
+}
+
+pub struct UnifyStringDomain {
+    pub min: Vec<u8>,
+    // None is max value for full domain
+    pub max: Vec<u8>,
+}
+
+impl StringDomain {
+    pub fn unify(&self, other: &Self) -> (SimpleDomain<Vec<u8>>, SimpleDomain<Vec<u8>>) {
+        let mut max_size = self.min.len().max(other.min.len());
+        if let Some(max) = &self.max {
+            max_size = max_size.max(max.len());
+        }
+        if let Some(max) = &other.max {
+            max_size = max_size.max(max.len());
+        }
+
+        let max_value = vec![255; max_size];
+
+        (
+            SimpleDomain {
+                min: self.min.clone(),
+                max: self.max.clone().unwrap_or_else(|| max_value.clone()),
+            },
+            SimpleDomain {
+                min: other.min.clone(),
+                max: other.max.clone().unwrap_or_else(|| max_value.clone()),
+            },
+        )
+    }
 }

--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -432,7 +432,7 @@ impl StringDomain {
             max_size = max_size.max(max.len());
         }
 
-        let max_value = vec![255; max_size];
+        let max_value = vec![255; max_size + 1];
 
         (
             SimpleDomain {

--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -412,14 +412,8 @@ impl<'a> FromIterator<&'a [u8]> for StringColumnBuilder {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StringDomain {
     pub min: Vec<u8>,
-    // None is max value for full domain
+    // max value is None for full domain
     pub max: Option<Vec<u8>>,
-}
-
-pub struct UnifyStringDomain {
-    pub min: Vec<u8>,
-    // None is max value for full domain
-    pub max: Vec<u8>,
 }
 
 impl StringDomain {

--- a/src/query/functions/src/scalars/comparison.rs
+++ b/src/query/functions/src/scalars/comparison.rs
@@ -43,6 +43,7 @@ use common_expression::FunctionProperty;
 use common_expression::FunctionRegistry;
 use common_expression::FunctionSignature;
 use common_expression::ScalarRef;
+use common_expression::SimpleDomainCmp;
 use common_expression::ValueRef;
 use memchr::memmem;
 use regex::bytes::Regex;
@@ -125,128 +126,49 @@ fn register_variant_cmp(registry: &mut FunctionRegistry) {
     );
 }
 
-fn register_string_cmp(registry: &mut FunctionRegistry) {
-    registry.register_2_arg::<StringType, StringType, BooleanType, _, _>(
-        "eq",
-        FunctionProperty::default(),
-        |_, _| FunctionDomain::Full,
-        |lhs, rhs, _| lhs == rhs,
-    );
-    registry.register_2_arg::<StringType, StringType, BooleanType, _, _>(
-        "noteq",
-        FunctionProperty::default(),
-        |_, _| FunctionDomain::Full,
-        |lhs, rhs, _| lhs != rhs,
-    );
-    registry.register_2_arg::<StringType, StringType, BooleanType, _, _>(
-        "gt",
-        FunctionProperty::default(),
-        |_, _| FunctionDomain::Full,
-        |lhs, rhs, _| lhs > rhs,
-    );
-    registry.register_2_arg::<StringType, StringType, BooleanType, _, _>(
-        "gte",
-        FunctionProperty::default(),
-        |_, _| FunctionDomain::Full,
-        |lhs, rhs, _| lhs >= rhs,
-    );
-    registry.register_2_arg::<StringType, StringType, BooleanType, _, _>(
-        "lt",
-        FunctionProperty::default(),
-        |_, _| FunctionDomain::Full,
-        |lhs, rhs, _| lhs < rhs,
-    );
-    registry.register_2_arg::<StringType, StringType, BooleanType, _, _>(
-        "lte",
-        FunctionProperty::default(),
-        |_, _| FunctionDomain::Full,
-        |lhs, rhs, _| lhs <= rhs,
-    );
-}
-
 macro_rules! register_simple_domain_type_cmp {
     ($registry:ident, $T:ty) => {
         $registry.register_2_arg::<$T, $T, BooleanType, _, _>(
             "eq",
             FunctionProperty::default(),
-            |d1, d2| {
-                if d1.min > d2.max || d1.max < d2.min {
-                    FunctionDomain::Domain(ALL_FALSE_DOMAIN)
-                } else {
-                    FunctionDomain::Full
-                }
-            },
+            |d1, d2| d1.domain_eq(d2),
             |lhs, rhs, _| lhs == rhs,
         );
         $registry.register_2_arg::<$T, $T, BooleanType, _, _>(
             "noteq",
             FunctionProperty::default(),
-            |d1, d2| {
-                if d1.min > d2.max || d1.max < d2.min {
-                    FunctionDomain::Domain(ALL_TRUE_DOMAIN)
-                } else {
-                    FunctionDomain::Full
-                }
-            },
+            |d1, d2| d1.domain_noteq(d2),
             |lhs, rhs, _| lhs != rhs,
         );
         $registry.register_2_arg::<$T, $T, BooleanType, _, _>(
             "gt",
             FunctionProperty::default(),
-            |d1, d2| {
-                if d1.min > d2.max {
-                    FunctionDomain::Domain(ALL_TRUE_DOMAIN)
-                } else if d1.max <= d2.min {
-                    FunctionDomain::Domain(ALL_FALSE_DOMAIN)
-                } else {
-                    FunctionDomain::Full
-                }
-            },
+            |d1, d2| d1.domain_gt(d2),
             |lhs, rhs, _| lhs > rhs,
         );
         $registry.register_2_arg::<$T, $T, BooleanType, _, _>(
             "gte",
             FunctionProperty::default(),
-            |d1, d2| {
-                if d1.min >= d2.max {
-                    FunctionDomain::Domain(ALL_TRUE_DOMAIN)
-                } else if d1.max < d2.min {
-                    FunctionDomain::Domain(ALL_FALSE_DOMAIN)
-                } else {
-                    FunctionDomain::Full
-                }
-            },
+            |d1, d2| d1.domain_gte(d2),
             |lhs, rhs, _| lhs >= rhs,
         );
         $registry.register_2_arg::<$T, $T, BooleanType, _, _>(
             "lt",
             FunctionProperty::default(),
-            |d1, d2| {
-                if d1.max < d2.min {
-                    FunctionDomain::Domain(ALL_TRUE_DOMAIN)
-                } else if d1.min >= d2.max {
-                    FunctionDomain::Domain(ALL_FALSE_DOMAIN)
-                } else {
-                    FunctionDomain::Full
-                }
-            },
+            |d1, d2| d1.domain_lt(d2),
             |lhs, rhs, _| lhs < rhs,
         );
         $registry.register_2_arg::<$T, $T, BooleanType, _, _>(
             "lte",
             FunctionProperty::default(),
-            |d1, d2| {
-                if d1.max <= d2.min {
-                    FunctionDomain::Domain(ALL_TRUE_DOMAIN)
-                } else if d1.min > d2.max {
-                    FunctionDomain::Domain(ALL_FALSE_DOMAIN)
-                } else {
-                    FunctionDomain::Full
-                }
-            },
+            |d1, d2| d1.domain_lte(d2),
             |lhs, rhs, _| lhs <= rhs,
         );
     };
+}
+
+fn register_string_cmp(registry: &mut FunctionRegistry) {
+    register_simple_domain_type_cmp!(registry, StringType);
 }
 
 fn register_date_cmp(registry: &mut FunctionRegistry) {

--- a/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
@@ -1,0 +1,49 @@
+statement ok
+create table range_t(c varchar, i int)
+
+statement ok
+insert into range_t values ('bcd', 1), ('efg', 10)
+
+query T
+explain select 1 from range_t where c > 'efg'
+----
+EvalScalar
+├── expressions: [1]
+├── estimated rows: 0.67
+└── Filter
+    ├── filters: [range_t.c (#0) > "efg"]
+    ├── estimated rows: 0.67
+    └── TableScan
+        ├── table: default.default.range_t
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 1
+        ├── partitions scanned: 0
+        ├── pruning stats: [segments: <range pruning: 1 to 0>, blocks: <range pruning: 0 to 0, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [range_t.c (#0) > "efg"], limit: NONE]
+        ├── output columns: [c]
+        └── estimated rows: 2.00
+
+
+query T
+explain select 1 from range_t where i > 20
+----
+EvalScalar
+├── expressions: [1]
+├── estimated rows: 0.67
+└── Filter
+    ├── filters: [range_t.i (#1) > 20]
+    ├── estimated rows: 0.67
+    └── TableScan
+        ├── table: default.default.range_t
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 1
+        ├── partitions scanned: 0
+        ├── pruning stats: [segments: <range pruning: 1 to 0>, blocks: <range pruning: 0 to 0, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [range_t.i (#1) > 20], limit: NONE]
+        ├── output columns: [i]
+        └── estimated rows: 2.00
+
+statement ok
+drop table range_t


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

1.  add compare domain for string types
2. add `SimpleDomainCmp` trait to used codes.

Closes #10735
