### PR TITLE
fix(query): create a virtual JWT user instead of ensuring on metasrv

### DIFF
--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -71,6 +71,11 @@ impl AuthMgr {
                 // create a virtual JWT user only available in current session
                 let auth_role = jwt.custom.role.clone();
                 let mut user_info = UserInfo::new(&user_name, "%", AuthInfo::JWT);
+                if user_info.identity().is_root() {
+                    return Err(ErrorCode::AuthenticateFailure(
+                        "root user is not allowed in jwt auth.",
+                    ));
+                }
                 if let Some(ref role) = auth_role {
                     user_info.grants.grant_role(role.clone());
                 }

--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -100,7 +100,6 @@ fn auth_by_header(
         match Bearer::decode(value) {
             Some(bearer) => Ok(Credential::Jwt {
                 token: bearer.token().to_string(),
-                hostname: client_ip,
             }),
             None => Err(ErrorCode::AuthenticateFailure("bad Bearer auth header")),
         }

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -738,7 +738,7 @@ async fn post_json_to_endpoint(
 
 #[tokio::test(flavor = "current_thread")]
 async fn test_auth_jwt() -> Result<()> {
-    let user_name = "root";
+    let user_name = "test_user";
 
     let kid = "test_kid";
     let key_pair = RS256KeyPair::generate(2048)?.with_key_id(kid);
@@ -788,8 +788,7 @@ async fn test_auth_jwt() -> Result<()> {
 
     let token = key_pair.sign(claims)?;
     let bear = headers::Authorization::bearer(&token).unwrap();
-    // root user can only login in localhost
-    assert_auth_current_user(&ep, user_name, bear, "127.0.0.1").await?;
+    assert_auth_current_user(&ep, user_name, bear, "%").await?;
     Ok(())
 }
 

--- a/src/query/service/tests/it/storages/testdata/roles_table.txt
+++ b/src/query/service/tests/it/storages/testdata/roles_table.txt
@@ -1,11 +1,13 @@
 ---------- TABLE INFO ------------
 DB.Table: 'system'.'roles', Table: roles-table_id:1, ver:0, Engine: SystemRoles
 -------- TABLE CONTENTS ----------
-+----------+----------+
-| Column 0 | Column 1 |
-+----------+----------+
-| "test"   | 0        |
-| "test1"  | 1        |
-+----------+----------+
++-----------------+----------+
+| Column 0        | Column 1 |
++-----------------+----------+
+| "account_admin" | 0        |
+| "public"        | 0        |
+| "test"          | 0        |
+| "test1"         | 1        |
++-----------------+----------+
 
 

--- a/src/query/users/src/jwt/authenticator.rs
+++ b/src/query/users/src/jwt/authenticator.rs
@@ -36,12 +36,12 @@ pub struct JwtAuthenticator {
     key_stores: Vec<jwk::JwkKeyStore>,
 }
 
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct EnsureUser {
     pub roles: Option<Vec<String>>,
 }
 
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct CustomClaims {
     pub tenant_id: Option<String>,
     pub role: Option<String>,

--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -93,10 +93,10 @@ pub struct JwkKeys {
 }
 
 pub struct JwkKeyStore {
-    url: String,
+    pub(crate) url: String,
     keys: Arc<RwLock<HashMap<String, PubKey>>>,
-    last_refreshed_at: RwLock<Option<Instant>>,
-    refresh_interval: Duration,
+    pub(crate) last_refreshed_at: RwLock<Option<Instant>>,
+    pub(crate) refresh_interval: Duration,
 }
 
 impl JwkKeyStore {

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -56,7 +56,9 @@ impl UserApiProvider {
         quota: Option<TenantQuota>,
     ) -> Result<()> {
         GlobalInstance::set(Self::try_create(conf, idm_config).await?);
-
+        UserApiProvider::instance()
+            .ensure_builtin_roles(tenant)
+            .await?;
         if let Some(q) = quota {
             let i = UserApiProvider::instance().get_tenant_quota_api_client(tenant)?;
             let res = i.get_quota(MatchSeq::GE(0)).await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Ensuring a user to MetaSrv is a painful cost, which make our JWT auth take up to 1s+ on every request.
Since we do not really need a user on MetaSrv with JWT auth, this PR

* create a virtual JWT user instead of ensuring on metasrv
* remove hostname for JWT auth & deny root user
* ensure_builtin_roles on GlobalService init for UserApiProvider

Closes #issue
