### PR TITLE
fix(functions): fix unnest with null argument

### DIFF
--- a/src/query/functions/src/srfs/mod.rs
+++ b/src/query/functions/src/srfs/mod.rs
@@ -407,10 +407,10 @@ pub fn register(registry: &mut FunctionRegistry) {
             eval: FunctionEval::SRF {
                 eval: Box::new(|_, num_rows| {
                     let mut columns = Vec::with_capacity(num_rows);
-                    for _ in 0..num_rows {
+                    (0..num_rows).for_each(|_| {
                         let column = ColumnBuilder::with_capacity(&DataType::Null, 0).build();
                         columns.push((Value::Column(Column::Tuple(vec![column])), 0));
-                    }
+                    });
                     columns
                 }),
             },

--- a/src/query/functions/src/srfs/mod.rs
+++ b/src/query/functions/src/srfs/mod.rs
@@ -16,6 +16,7 @@ use common_expression::types::array::ArrayColumnBuilder;
 use common_expression::types::AnyType;
 use common_expression::types::DataType;
 use common_expression::Column;
+use common_expression::ColumnBuilder;
 use common_expression::Function;
 use common_expression::FunctionEval;
 use common_expression::FunctionKind;
@@ -39,6 +40,10 @@ pub fn register(registry: &mut FunctionRegistry) {
                 ArrayColumnBuilder::<AnyType>::repeat(&col, num_rows).build()
             }
             Value::Column(Column::Array(col)) => *col,
+            Value::Column(Column::Nullable(box nullable_column)) => match nullable_column.column {
+                Column::Array(col) => *col,
+                _ => unreachable!(),
+            },
             _ => unreachable!(),
         };
         debug_assert_eq!(unnest_array.len(), num_rows);
@@ -63,6 +68,18 @@ pub fn register(registry: &mut FunctionRegistry) {
                 ))))),
             ))))),
         ))))];
+        registry.register_function(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
+                args_type: vec![args_type[0].wrap_nullable()],
+                return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
+                    DataType::Generic(0),
+                ))]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(unnest_impl),
+            },
+        });
         registry.register_function(Function {
             signature: FunctionSignature {
                 name: "unnest".to_string(),
@@ -91,6 +108,18 @@ pub fn register(registry: &mut FunctionRegistry) {
         registry.register_function(Function {
             signature: FunctionSignature {
                 name: "unnest".to_string(),
+                args_type: vec![args_type[0].wrap_nullable()],
+                return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
+                    DataType::Generic(0),
+                ))]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(unnest_impl),
+            },
+        });
+        registry.register_function(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
                 args_type,
                 return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
                     DataType::Generic(0),
@@ -111,6 +140,18 @@ pub fn register(registry: &mut FunctionRegistry) {
                 ))))),
             ))))),
         ))))];
+        registry.register_function(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
+                args_type: vec![args_type[0].wrap_nullable()],
+                return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
+                    DataType::Generic(0),
+                ))]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(unnest_impl),
+            },
+        });
         registry.register_function(Function {
             signature: FunctionSignature {
                 name: "unnest".to_string(),
@@ -137,6 +178,18 @@ pub fn register(registry: &mut FunctionRegistry) {
         registry.register_function(Function {
             signature: FunctionSignature {
                 name: "unnest".to_string(),
+                args_type: vec![args_type[0].wrap_nullable()],
+                return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
+                    DataType::Generic(0),
+                ))]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(unnest_impl),
+            },
+        });
+        registry.register_function(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
                 args_type,
                 return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
                     DataType::Generic(0),
@@ -157,6 +210,18 @@ pub fn register(registry: &mut FunctionRegistry) {
                 ))))),
             ))))),
         ))))];
+        registry.register_function(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
+                args_type: vec![args_type[0].wrap_nullable()],
+                return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
+                    DataType::Generic(0),
+                ))]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(unnest_impl),
+            },
+        });
         registry.register_function(Function {
             signature: FunctionSignature {
                 name: "unnest".to_string(),
@@ -181,6 +246,18 @@ pub fn register(registry: &mut FunctionRegistry) {
         registry.register_function(Function {
             signature: FunctionSignature {
                 name: "unnest".to_string(),
+                args_type: vec![args_type[0].wrap_nullable()],
+                return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
+                    DataType::Generic(0),
+                ))]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(unnest_impl),
+            },
+        });
+        registry.register_function(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
                 args_type,
                 return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
                     DataType::Generic(0),
@@ -199,6 +276,18 @@ pub fn register(registry: &mut FunctionRegistry) {
                 Box::new(DataType::Generic(0)),
             ))))),
         ))))];
+        registry.register_function(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
+                args_type: vec![args_type[0].wrap_nullable()],
+                return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
+                    DataType::Generic(0),
+                ))]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(unnest_impl),
+            },
+        });
         registry.register_function(Function {
             signature: FunctionSignature {
                 name: "unnest".to_string(),
@@ -221,6 +310,18 @@ pub fn register(registry: &mut FunctionRegistry) {
         registry.register_function(Function {
             signature: FunctionSignature {
                 name: "unnest".to_string(),
+                args_type: vec![args_type[0].wrap_nullable()],
+                return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
+                    DataType::Generic(0),
+                ))]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(unnest_impl),
+            },
+        });
+        registry.register_function(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
                 args_type,
                 return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
                     DataType::Generic(0),
@@ -237,6 +338,18 @@ pub fn register(registry: &mut FunctionRegistry) {
         let args_type = vec![DataType::Array(Box::new(DataType::Array(Box::new(
             DataType::Nullable(Box::new(DataType::Generic(0))),
         ))))];
+        registry.register_function(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
+                args_type: vec![args_type[0].wrap_nullable()],
+                return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
+                    DataType::Generic(0),
+                ))]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(unnest_impl),
+            },
+        });
         registry.register_function(Function {
             signature: FunctionSignature {
                 name: "unnest".to_string(),
@@ -259,6 +372,18 @@ pub fn register(registry: &mut FunctionRegistry) {
         registry.register_function(Function {
             signature: FunctionSignature {
                 name: "unnest".to_string(),
+                args_type: vec![args_type[0].wrap_nullable()],
+                return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
+                    DataType::Generic(0),
+                ))]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(unnest_impl),
+            },
+        });
+        registry.register_function(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
                 args_type,
                 return_type: DataType::Tuple(vec![DataType::Nullable(Box::new(
                     DataType::Generic(0),
@@ -266,6 +391,28 @@ pub fn register(registry: &mut FunctionRegistry) {
             },
             eval: FunctionEval::SRF {
                 eval: Box::new(unnest_impl),
+            },
+        });
+    }
+
+    {
+        // Unnest NULL
+        let args_type = vec![DataType::Null];
+        registry.register_function(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
+                args_type,
+                return_type: DataType::Tuple(vec![DataType::Null]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(|_, num_rows| {
+                    let mut columns = Vec::with_capacity(num_rows);
+                    for _ in 0..num_rows {
+                        let column = ColumnBuilder::with_capacity(&DataType::Null, 0).build();
+                        columns.push((Value::Column(Column::Tuple(vec![column])), 0));
+                    }
+                    columns
+                }),
             },
         });
     }

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -3755,16 +3755,27 @@ Functions overloads:
 0 typeof(T0) :: String
 0 unhex(String) :: String
 1 unhex(String NULL) :: String NULL
-0 unnest(Array(Array(Array(Array(Array(Array(Array(Array(Array(Array(T0 NULL))))))))))) :: Tuple(T0 NULL,)
-1 unnest(Array(Array(Array(Array(Array(Array(Array(Array(Array(T0 NULL)))))))))) :: Tuple(T0 NULL,)
-2 unnest(Array(Array(Array(Array(Array(Array(Array(Array(T0 NULL))))))))) :: Tuple(T0 NULL,)
-3 unnest(Array(Array(Array(Array(Array(Array(Array(T0 NULL)))))))) :: Tuple(T0 NULL,)
-4 unnest(Array(Array(Array(Array(Array(Array(T0 NULL))))))) :: Tuple(T0 NULL,)
-5 unnest(Array(Array(Array(Array(Array(T0 NULL)))))) :: Tuple(T0 NULL,)
-6 unnest(Array(Array(Array(Array(T0 NULL))))) :: Tuple(T0 NULL,)
-7 unnest(Array(Array(Array(T0 NULL)))) :: Tuple(T0 NULL,)
-8 unnest(Array(Array(T0 NULL))) :: Tuple(T0 NULL,)
-9 unnest(Array(T0 NULL)) :: Tuple(T0 NULL,)
+0 unnest(Array(Array(Array(Array(Array(Array(Array(Array(Array(Array(T0 NULL)))))))))) NULL) :: Tuple(T0 NULL,)
+1 unnest(Array(Array(Array(Array(Array(Array(Array(Array(Array(Array(T0 NULL))))))))))) :: Tuple(T0 NULL,)
+2 unnest(Array(Array(Array(Array(Array(Array(Array(Array(Array(T0 NULL))))))))) NULL) :: Tuple(T0 NULL,)
+3 unnest(Array(Array(Array(Array(Array(Array(Array(Array(Array(T0 NULL)))))))))) :: Tuple(T0 NULL,)
+4 unnest(Array(Array(Array(Array(Array(Array(Array(Array(T0 NULL)))))))) NULL) :: Tuple(T0 NULL,)
+5 unnest(Array(Array(Array(Array(Array(Array(Array(Array(T0 NULL))))))))) :: Tuple(T0 NULL,)
+6 unnest(Array(Array(Array(Array(Array(Array(Array(T0 NULL))))))) NULL) :: Tuple(T0 NULL,)
+7 unnest(Array(Array(Array(Array(Array(Array(Array(T0 NULL)))))))) :: Tuple(T0 NULL,)
+8 unnest(Array(Array(Array(Array(Array(Array(T0 NULL)))))) NULL) :: Tuple(T0 NULL,)
+9 unnest(Array(Array(Array(Array(Array(Array(T0 NULL))))))) :: Tuple(T0 NULL,)
+10 unnest(Array(Array(Array(Array(Array(T0 NULL))))) NULL) :: Tuple(T0 NULL,)
+11 unnest(Array(Array(Array(Array(Array(T0 NULL)))))) :: Tuple(T0 NULL,)
+12 unnest(Array(Array(Array(Array(T0 NULL)))) NULL) :: Tuple(T0 NULL,)
+13 unnest(Array(Array(Array(Array(T0 NULL))))) :: Tuple(T0 NULL,)
+14 unnest(Array(Array(Array(T0 NULL))) NULL) :: Tuple(T0 NULL,)
+15 unnest(Array(Array(Array(T0 NULL)))) :: Tuple(T0 NULL,)
+16 unnest(Array(Array(T0 NULL)) NULL) :: Tuple(T0 NULL,)
+17 unnest(Array(Array(T0 NULL))) :: Tuple(T0 NULL,)
+18 unnest(Array(T0 NULL) NULL) :: Tuple(T0 NULL,)
+19 unnest(Array(T0 NULL)) :: Tuple(T0 NULL,)
+20 unnest(NULL) :: Tuple(NULL,)
 0 upper(String) :: String
 1 upper(String NULL) :: String NULL
 0 xor(Boolean, Boolean) :: Boolean

--- a/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
+++ b/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
@@ -3,6 +3,10 @@ select unnest([]::array(int));
 ----
 
 query I
+select unnest(null);
+----
+
+query I
 select unnest([1,2,3]);
 ----
 1
@@ -248,6 +252,33 @@ select unnest(a), a from t;
 7 [[5,6],[7,8,9]]
 8 [[5,6],[7,8,9]]
 9 [[5,6],[7,8,9]]
+
+statement ok
+drop table t;
+
+statement ok
+create table t (a array(int) null);
+
+statement ok
+insert into t values ([1,2]), (null), ([3,4,5]);
+
+query I
+select unnest(a) from t;
+----
+1
+2
+3
+4
+5
+
+query IT
+select unnest(a), unnest(null) from t;
+----
+1 NULL
+2 NULL
+3 NULL
+4 NULL
+5 NULL
 
 statement ok
 drop table t;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

unnest function support `NULL` value and `Nullable Array Column`

Closes #10758
