### PR TITLE
feat: FlightSQL support update (DDL and insert)

### DIFF
--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -29,7 +29,7 @@ http_handler_port = 8000
 
 # Databend Query FlightSQL Handler.
 flight_sql_handler_host = "0.0.0.0"
-flight_sql_handler_port = 50050
+flight_sql_handler_port = 8900
 
 tenant_id = "test_tenant"
 cluster_id = "test_cluster"

--- a/scripts/ci/deploy/config/databend-query-node-2.toml
+++ b/scripts/ci/deploy/config/databend-query-node-2.toml
@@ -29,7 +29,7 @@ http_handler_port = 8002
 
 # Databend Query FlightSQL Handler.
 flight_sql_handler_host = "0.0.0.0"
-flight_sql_handler_port = 7002
+flight_sql_handler_port = 8902
 
 tenant_id = "test_tenant"
 cluster_id = "test_cluster"

--- a/scripts/ci/deploy/config/databend-query-node-3.toml
+++ b/scripts/ci/deploy/config/databend-query-node-3.toml
@@ -30,7 +30,7 @@ http_handler_port = 8003
 
 # Databend Query FlightSQL Handler.
 flight_sql_handler_host = "0.0.0.0"
-flight_sql_handler_port = 7003
+flight_sql_handler_port = 8903
 
 tenant_id = "test_tenant"
 cluster_id = "test_cluster"

--- a/scripts/ci/deploy/config/databend-query-node-shared.toml
+++ b/scripts/ci/deploy/config/databend-query-node-shared.toml
@@ -27,6 +27,9 @@ clickhouse_http_handler_port = 58124
 http_handler_host = "0.0.0.0"
 http_handler_port = 58000
 
+flight_sql_handler_host = "0.0.0.0"
+flight_sql_handler_port = 58900
+
 tenant_id = "shared_tenant"
 cluster_id = "test_cluster"
 

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -1154,7 +1154,7 @@ pub struct QueryConfig {
     #[clap(long, default_value = "127.0.0.1")]
     pub flight_sql_handler_host: String,
 
-    #[clap(long, default_value = "7000")]
+    #[clap(long, default_value = "8900")]
     pub flight_sql_handler_port: u16,
 
     #[clap(long, default_value = "127.0.0.1:9090")]

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -196,7 +196,7 @@ impl Default for QueryConfig {
             http_handler_result_timeout_secs: 60,
             flight_api_address: "127.0.0.1:9090".to_string(),
             flight_sql_handler_host: "127.0.0.1".to_string(),
-            flight_sql_handler_port: 7000,
+            flight_sql_handler_port: 8900,
             admin_api_address: "127.0.0.1:8080".to_string(),
             metric_api_address: "127.0.0.1:7070".to_string(),
             api_tls_server_cert: "".to_string(),

--- a/src/query/expression/src/convert_arrow_rs/array.rs
+++ b/src/query/expression/src/convert_arrow_rs/array.rs
@@ -18,10 +18,18 @@ use arrow_array::make_array;
 use arrow_array::Array;
 use arrow_array::ArrowPrimitiveType;
 use arrow_array::BooleanArray;
+use arrow_array::Int16Array;
+use arrow_array::Int32Array;
+use arrow_array::Int64Array;
+use arrow_array::Int8Array;
 use arrow_array::LargeStringArray;
 use arrow_array::NullArray;
 use arrow_array::PrimitiveArray;
 use arrow_array::StringArray;
+use arrow_array::UInt16Array;
+use arrow_array::UInt32Array;
+use arrow_array::UInt64Array;
+use arrow_array::UInt8Array;
 use arrow_buffer::i256;
 use arrow_buffer::ArrowNativeType;
 use arrow_buffer::Buffer;
@@ -205,6 +213,61 @@ impl Column {
                     data: array.value_data().to_vec().into(),
                 })
             }
+            DataType::Boolean => {
+                let array = array.as_any().downcast_ref::<BooleanArray>().unwrap();
+                let bytes = array.values().clone().into_vec().map_err(|_| {
+                    ArrowError::CastError(
+                        "can not covert Buffer of BooleanArray to Vec".to_string(),
+                    )
+                })?;
+                let bitmap = Bitmap::try_new(bytes, array.len()).map_err(|e| {
+                    ArrowError::CastError(format!(
+                        "can not covert  BooleanArray to Column::Boolean: {e:?}"
+                    ))
+                })?;
+                Column::Boolean(bitmap)
+            }
+            DataType::Int8 => {
+                let array = array.as_any().downcast_ref::<Int8Array>().unwrap();
+                let buffer2: Buffer2<i8> = array.values().to_vec().into();
+                Column::Number(NumberColumn::Int8(buffer2))
+            }
+            DataType::UInt8 => {
+                let array = array.as_any().downcast_ref::<UInt8Array>().unwrap();
+                let buffer2: Buffer2<u8> = array.values().to_vec().into();
+                Column::Number(NumberColumn::UInt8(buffer2))
+            }
+            DataType::Int16 => {
+                let array = array.as_any().downcast_ref::<Int16Array>().unwrap();
+                let buffer2: Buffer2<i16> = array.values().to_vec().into();
+                Column::Number(NumberColumn::Int16(buffer2))
+            }
+            DataType::UInt16 => {
+                let array = array.as_any().downcast_ref::<UInt16Array>().unwrap();
+                let buffer2: Buffer2<u16> = array.values().to_vec().into();
+                Column::Number(NumberColumn::UInt16(buffer2))
+            }
+            DataType::Int32 => {
+                let array = array.as_any().downcast_ref::<Int32Array>().unwrap();
+                let buffer2: Buffer2<i32> = array.values().to_vec().into();
+                Column::Number(NumberColumn::Int32(buffer2))
+            }
+            DataType::UInt32 => {
+                let array = array.as_any().downcast_ref::<UInt32Array>().unwrap();
+                let buffer2: Buffer2<u32> = array.values().to_vec().into();
+                Column::Number(NumberColumn::UInt32(buffer2))
+            }
+            DataType::Int64 => {
+                let array = array.as_any().downcast_ref::<Int64Array>().unwrap();
+                let buffer2: Buffer2<i64> = array.values().to_vec().into();
+                Column::Number(NumberColumn::Int64(buffer2))
+            }
+            DataType::UInt64 => {
+                let array = array.as_any().downcast_ref::<UInt64Array>().unwrap();
+                let buffer2: Buffer2<u64> = array.values().to_vec().into();
+                Column::Number(NumberColumn::UInt64(buffer2))
+            }
+
             _ => Err(ArrowError::NotYetImplemented(format!(
                 "Column::from_arrow_rs() for {data_type} not implemented yet"
             )))?,

--- a/src/query/expression/src/convert_arrow_rs/record_batch.rs
+++ b/src/query/expression/src/convert_arrow_rs/record_batch.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use arrow_array::RecordBatch;
 use arrow_schema::ArrowError;
 
+use crate::Column;
 use crate::DataBlock;
 use crate::DataSchema;
 
@@ -29,5 +30,14 @@ impl DataBlock {
         }
         let schema = Arc::new(data_schema.into());
         RecordBatch::try_new(schema, arrays)
+    }
+
+    pub fn from_record_batch(batch: &RecordBatch) -> Result<(Self, DataSchema), ArrowError> {
+        let mut columns = Vec::with_capacity(batch.columns().len());
+        for array in batch.columns() {
+            columns.push(Column::from_arrow_rs(array.clone())?)
+        }
+        let schema = DataSchema::try_from(&(*batch.schema()))?;
+        Ok((DataBlock::new_from_columns(columns), schema))
     }
 }

--- a/src/query/service/src/servers/flight_sql/flight_sql_service/service.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_service/service.rs
@@ -436,22 +436,22 @@ impl FlightSqlService for FlightSqlServiceImpl {
         query: ActionClosePreparedStatementRequest,
         request: Request<Action>,
     ) {
-        tracing::info!(
-            "do_action_close_prepared_statement with handle {:?}",
-            query.prepared_statement_handle
-        );
-        if self.get_session(&request).is_ok() {
-            let handle = query.prepared_statement_handle.as_ref();
-            if let Ok(handle) = std::str::from_utf8(handle) {
-                match Uuid::try_parse(handle) {
-                    Ok(handle) => {
+        let handle = query.prepared_statement_handle.as_ref();
+        if let Ok(handle) = std::str::from_utf8(handle) {
+            tracing::info!(
+                "do_action_close_prepared_statement with handle {:?}",
+                handle
+            );
+            match Uuid::try_parse(handle) {
+                Ok(handle) => {
+                    if self.get_session(&request).is_ok() {
                         self.statements.remove(&handle);
                     }
-                    Err(e) => {
-                        Status::internal(format!(
-                            "do_get_fallback Error decoding handle: {e} {handle:?}"
-                        ));
-                    }
+                }
+                Err(e) => {
+                    Status::internal(format!(
+                        "do_action_close_prepared_statement Error decoding handle: {e} {handle:?}"
+                    ));
                 }
             }
         }

--- a/src/query/service/src/servers/flight_sql/flight_sql_service/session.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_service/session.rs
@@ -31,7 +31,6 @@ use crate::sessions::SessionType;
 
 impl FlightSqlServiceImpl {
     pub(super) fn get_session<T>(&self, req: &Request<T>) -> Result<Arc<Session>, Status> {
-        println!("{:?}", req.metadata());
         let auth = req
             .metadata()
             .get("authorization")

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -27,7 +27,6 @@ use common_exception::ToErrorCode;
 use common_expression::DataBlock;
 use common_expression::DataSchemaRef;
 use common_expression::SendableDataBlockStream;
-use common_sql::plans::Plan;
 use common_sql::Planner;
 use common_users::CertifiedInfo;
 use common_users::UserApiProvider;
@@ -57,30 +56,6 @@ use crate::sessions::QueryContext;
 use crate::sessions::Session;
 use crate::sessions::TableContext;
 use crate::stream::DataBlockStream;
-
-fn has_result_set_by_plan(plan: &Plan) -> bool {
-    matches!(
-        plan,
-        Plan::Query { .. }
-            | Plan::Explain { .. }
-            | Plan::ExplainAst { .. }
-            | Plan::ExplainSyntax { .. }
-            | Plan::ExplainAnalyze { .. }
-            | Plan::Call(_)
-            | Plan::ShowCreateDatabase(_)
-            | Plan::ShowCreateTable(_)
-            | Plan::ShowFileFormats(_)
-            | Plan::ShowRoles(_)
-            | Plan::DescShare(_)
-            | Plan::ShowShares(_)
-            | Plan::ShowShareEndpoint(_)
-            | Plan::ShowObjectGrantPrivileges(_)
-            | Plan::ShowGrantTenantsOfShare(_)
-            | Plan::DescribeTable(_)
-            | Plan::ShowGrants(_)
-            | Plan::Presign(_)
-    )
-}
 
 struct InteractiveWorkerBase<W: AsyncWrite + Send + Unpin> {
     session: Arc<Session>,
@@ -348,7 +323,7 @@ impl<W: AsyncWrite + Send + Unpin> InteractiveWorkerBase<W> {
 
                 context.attach_query_str(plan.to_string(), extras.stament.to_mask_sql());
                 let interpreter = InterpreterFactory::get(context.clone(), &plan).await;
-                let has_result_set = has_result_set_by_plan(&plan);
+                let has_result_set = plan.has_result_set();
 
                 match interpreter {
                     Ok(interpreter) => {

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -49,7 +49,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | "query"   | "disable_system_table_load"                | "false"                          | ""       |
 | "query"   | "flight_api_address"                       | "127.0.0.1:9090"                 | ""       |
 | "query"   | "flight_sql_handler_host"                  | "127.0.0.1"                      | ""       |
-| "query"   | "flight_sql_handler_port"                  | "7000"                           | ""       |
+| "query"   | "flight_sql_handler_port"                  | "8900"                           | ""       |
 | "query"   | "flight_sql_tls_server_cert"               | ""                               | ""       |
 | "query"   | "flight_sql_tls_server_key"                | ""                               | ""       |
 | "query"   | "http_handler_host"                        | "127.0.0.1"                      | ""       |

--- a/src/query/sql/src/planner/plans/plan.rs
+++ b/src/query/sql/src/planner/plans/plan.rs
@@ -422,4 +422,28 @@ impl Plan {
             Plan::RevertTable(plan) => plan.schema(),
         }
     }
+
+    pub fn has_result_set(&self) -> bool {
+        matches!(
+            self,
+            Plan::Query { .. }
+                | Plan::Explain { .. }
+                | Plan::ExplainAst { .. }
+                | Plan::ExplainSyntax { .. }
+                | Plan::ExplainAnalyze { .. }
+                | Plan::Call(_)
+                | Plan::ShowCreateDatabase(_)
+                | Plan::ShowCreateTable(_)
+                | Plan::ShowFileFormats(_)
+                | Plan::ShowRoles(_)
+                | Plan::DescShare(_)
+                | Plan::ShowShares(_)
+                | Plan::ShowShareEndpoint(_)
+                | Plan::ShowObjectGrantPrivileges(_)
+                | Plan::ShowGrantTenantsOfShare(_)
+                | Plan::DescribeTable(_)
+                | Plan::ShowGrants(_)
+                | Plan::Presign(_)
+        )
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

part of https://github.com/datafuselabs/databend/issues/10745.

-  ddl/insert work well with JDBC, see https://github.com/youngsofun/test_flight_sql/blob/main/src/main/java/Test.java.
    - but the official rs client has a bug (which is not used in production AFAIK),  so new unit test cases is commented out for now. however,  it uses a different interface of FlightSQL from JDBC(in JDBC, all statement is implemented as preparedStatement internally ).
- port change from 7000 to 8900 due to https://github.com/datafuselabs/databend/discussions/10741

- still only basic types are supported, I will go back to it after  impl meta related API  https://github.com/datafuselabs/databend/issues/10745.



Closes #issue
