### PR TITLE
fix(query): init AuthMgr with GlobalInstance

### DIFF
--- a/scripts/ci/ci-run-stateful-tests-standalone-minio.sh
+++ b/scripts/ci/ci-run-stateful-tests-standalone-minio.sh
@@ -39,5 +39,5 @@ echo "Starting databend-test"
 
 # only expected to get adopted in stateful tests
 if [[ "$ALLOW_SHARING" == "true" ]]; then
-  ./databend-test $1 --mode 'standalone' --run-dir 3_stateful_sharing
+	./databend-test $1 --mode 'standalone' --run-dir 3_stateful_sharing
 fi

--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -14,7 +14,8 @@
 
 use std::sync::Arc;
 
-pub use common_config::InnerConfig;
+use common_base::base::GlobalInstance;
+use common_config::InnerConfig;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_app::principal::AuthInfo;
@@ -40,7 +41,16 @@ pub enum Credential {
 }
 
 impl AuthMgr {
-    pub fn create(cfg: &InnerConfig) -> Arc<AuthMgr> {
+    pub fn init(cfg: &InnerConfig) -> Result<()> {
+        GlobalInstance::set(AuthMgr::create(cfg));
+        Ok(())
+    }
+
+    pub fn instance() -> Arc<AuthMgr> {
+        GlobalInstance::get()
+    }
+
+    fn create(cfg: &InnerConfig) -> Arc<AuthMgr> {
         Arc::new(AuthMgr {
             jwt_auth: JwtAuthenticator::create(
                 cfg.query.jwt_key_file.clone(),

--- a/src/query/service/src/global_services.rs
+++ b/src/query/service/src/global_services.rs
@@ -27,6 +27,7 @@ use common_users::UserApiProvider;
 use storages_common_cache_manager::CacheManager;
 
 use crate::api::DataExchangeManager;
+use crate::auth::AuthMgr;
 use crate::catalogs::CatalogManagerHelper;
 use crate::clusters::ClusterDiscovery;
 use crate::servers::http::v1::HttpQueryManager;
@@ -66,6 +67,7 @@ impl GlobalServices {
         HttpQueryManager::init(&config).await?;
         DataExchangeManager::init()?;
         SessionManager::init(&config)?;
+        AuthMgr::init(&config)?;
         UserApiProvider::init(
             config.meta.to_meta_grpc_client_conf(),
             config.query.idm,

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -64,7 +64,6 @@ use parking_lot::RwLock;
 use tracing::debug;
 
 use crate::api::DataExchangeManager;
-use crate::auth::AuthMgr;
 use crate::catalogs::Catalog;
 use crate::clusters::Cluster;
 use crate::pipelines::executor::PipelineExecutor;
@@ -157,10 +156,6 @@ impl QueryContext {
 
     pub fn get_exchange_manager(&self) -> Arc<DataExchangeManager> {
         DataExchangeManager::instance()
-    }
-
-    pub fn get_auth_manager(&self) -> Arc<AuthMgr> {
-        self.shared.get_auth_manager()
     }
 
     // Get the current session.

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -124,7 +124,7 @@ impl Session {
         let config = GlobalConfig::instance();
         let session = self.clone();
         let cluster = ClusterDiscovery::instance().discover(&config).await?;
-        let shared = QueryContextShared::try_create(&config, session, cluster)?;
+        let shared = QueryContextShared::try_create(session, cluster)?;
 
         self.session_ctx
             .set_query_context_shared(Arc::downgrade(&shared));

--- a/src/query/service/tests/it/auth.rs
+++ b/src/query/service/tests/it/auth.rs
@@ -21,6 +21,7 @@ use common_meta_app::principal::UserInfo;
 use common_users::CustomClaims;
 use common_users::EnsureUser;
 use common_users::UserApiProvider;
+use databend_query::auth::AuthMgr;
 use databend_query::auth::Credential;
 use databend_query::sessions::TableContext;
 use jwt_simple::prelude::*;
@@ -79,7 +80,7 @@ async fn test_auth_mgr_with_jwt_multi_sources() -> Result<()> {
     conf.query.jwt_key_file = first_url.clone();
     conf.query.jwt_key_files = vec![second_url];
     let (_guard, ctx) = crate::tests::create_query_context_with_config(conf, None).await?;
-    let auth_mgr = ctx.get_auth_manager();
+    let auth_mgr = AuthMgr::instance();
     {
         let user_name = "test-user2";
         let role_name = "test-role";
@@ -210,7 +211,7 @@ async fn test_auth_mgr_with_jwt() -> Result<()> {
     let mut conf = crate::tests::ConfigBuilder::create().config();
     conf.query.jwt_key_file = jwks_url.clone();
     let (_guard, ctx) = crate::tests::create_query_context_with_config(conf, None).await?;
-    let auth_mgr = ctx.get_auth_manager();
+    let auth_mgr = AuthMgr::instance();
     let user_name = "test";
 
     // without subject
@@ -387,7 +388,7 @@ async fn test_auth_mgr_with_jwt_es256() -> Result<()> {
     let mut conf = crate::tests::ConfigBuilder::create().config();
     conf.query.jwt_key_file = jwks_url.clone();
     let (_guard, ctx) = crate::tests::create_query_context_with_config(conf, None).await?;
-    let auth_mgr = ctx.get_auth_manager();
+    let auth_mgr = AuthMgr::instance();
     let user_name = "test";
 
     // without subject
@@ -560,7 +561,7 @@ async fn test_jwt_auth_mgr_with_management() -> Result<()> {
         .config();
     conf.query.jwt_key_file = format!("http://{}{}", server.address(), json_path);
     let (_guard, ctx) = crate::tests::create_query_context_with_config(conf, None).await?;
-    let auth_mgr = ctx.get_auth_manager();
+    let auth_mgr = AuthMgr::instance();
 
     // with create user in other tenant
     {

--- a/src/query/service/tests/it/servers/http/clickhouse_handler.rs
+++ b/src/query/service/tests/it/servers/http/clickhouse_handler.rs
@@ -15,7 +15,6 @@
 use std::collections::HashMap;
 
 use common_base::base::tokio;
-use common_config::InnerConfig;
 use databend_query::auth::AuthMgr;
 use databend_query::servers::http::middleware::HTTPSessionEndpoint;
 use databend_query::servers::http::middleware::HTTPSessionMiddleware;
@@ -53,7 +52,7 @@ macro_rules! assert_ok {
 async fn test_select() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await;
+    let server = Server::new().await;
 
     {
         let (status, body) = server.get("bad sql").await;
@@ -100,7 +99,7 @@ async fn test_select() -> PoemResult<()> {
 async fn test_insert_values() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await;
+    let server = Server::new().await;
     {
         let (status, body) = server.post("create table t1(a int, b string)", "").await;
         assert_eq!(status, StatusCode::OK);
@@ -128,7 +127,7 @@ async fn test_insert_values() -> PoemResult<()> {
 async fn test_output_formats() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await;
+    let server = Server::new().await;
     {
         let (status, body) = server
             .post("create table t1(a int, b string null)", "")
@@ -170,7 +169,7 @@ async fn test_output_formats() -> PoemResult<()> {
 async fn test_output_format_compress() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await;
+    let server = Server::new().await;
     let sql = "select 1 format TabSeparated";
     let (status, body) = server
         .get_response_bytes(
@@ -191,7 +190,7 @@ async fn test_output_format_compress() -> PoemResult<()> {
 async fn test_insert_format_values() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await;
+    let server = Server::new().await;
     {
         let (status, body) = server.post("create table t1(a int, b string)", "").await;
         assert_eq!(status, StatusCode::OK);
@@ -220,7 +219,7 @@ async fn test_insert_format_ndjson() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
 
-    let server = Server::new(&config).await;
+    let server = Server::new().await;
     {
         let (status, body) = server
             .post("create table t1(a int, b string null)", "")
@@ -274,7 +273,7 @@ async fn test_insert_format_ndjson() -> PoemResult<()> {
 async fn test_settings() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await;
+    let server = Server::new().await;
 
     // unknown setting
     {
@@ -329,7 +328,7 @@ async fn test_settings() -> PoemResult<()> {
 async fn test_multi_partition() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await;
+    let server = Server::new().await;
     {
         let sql = "create table tb2(id int, c1 varchar) Engine=Fuse;";
         let (status, body) = server.get(sql).await;
@@ -362,7 +361,7 @@ async fn test_multi_partition() -> PoemResult<()> {
 async fn test_federated() -> PoemResult<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await.unwrap();
-    let server = Server::new(&config).await;
+    let server = Server::new().await;
     {
         let sql = "select version();";
         let (status, body) = server.get(sql).await;
@@ -437,9 +436,9 @@ struct Server {
 }
 
 impl Server {
-    pub async fn new(config: &InnerConfig) -> Self {
+    pub async fn new() -> Self {
         let session_middleware =
-            HTTPSessionMiddleware::create(HttpHandlerKind::Clickhouse, AuthMgr::create(config));
+            HTTPSessionMiddleware::create(HttpHandlerKind::Clickhouse, AuthMgr::instance());
         let endpoint = Route::new()
             .nest("/", clickhouse_router())
             .with(session_middleware);

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -442,7 +442,7 @@ async fn test_result_timeout() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::instance());
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -466,7 +466,7 @@ async fn test_system_tables() -> Result<()> {
     let config = ConfigBuilder::create().build();
     let _guard = TestGlobalServices::setup(config.clone()).await?;
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::instance());
     let ep = Route::new()
         .nest("/v1/query", query_route())
         .with(session_middleware);
@@ -548,7 +548,7 @@ async fn test_query_log() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::instance());
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -603,7 +603,7 @@ async fn test_query_log() -> Result<()> {
     );
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::instance());
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -682,9 +682,8 @@ async fn post_sql(sql: &str, wait_time_secs: u64) -> Result<(StatusCode, QueryRe
 }
 
 pub async fn create_endpoint() -> Result<EndpointType> {
-    let config = ConfigBuilder::create().build();
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::instance());
 
     Ok(Route::new()
         .nest("/v1/query", query_route())
@@ -767,7 +766,7 @@ async fn test_auth_jwt() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::instance());
 
     let ep = Route::new()
         .nest("/v1/query", query_route())
@@ -895,7 +894,7 @@ async fn test_auth_jwt_with_create_user() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::instance());
     let ep = Route::new()
         .nest("/v1/query", query_route())
         .with(session_middleware);
@@ -1216,7 +1215,7 @@ async fn test_auth_configured_user() -> Result<()> {
     let _guard = TestGlobalServices::setup(config.clone()).await?;
 
     let session_middleware =
-        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::create(&config));
+        HTTPSessionMiddleware::create(HttpHandlerKind::Query, AuthMgr::instance());
 
     let ep = Route::new()
         .nest("/v1/query", query_route())

--- a/src/query/service/tests/it/tests/context.rs
+++ b/src/query/service/tests/it/tests/context.rs
@@ -157,7 +157,6 @@ pub async fn create_query_context_with_cluster(
     let nodes = desc.cluster_nodes_list;
 
     let dummy_query_context = QueryContext::create_from_shared(QueryContextShared::try_create(
-        &config,
         dummy_session,
         Cluster::create(nodes, local_id),
     )?);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Avoid creating an `AuthMgr` instance on every session.
* Remove `auth_manager` from query ctx.
* Then `InnerConfig` is no longer needed by query ctx.

Closes #issue
