### PR TITLE
feat: basic implementation of `TransformWindow`.

### DIFF
--- a/src/query/service/src/pipelines/processors/mod.rs
+++ b/src/query/service/src/pipelines/processors/mod.rs
@@ -39,3 +39,4 @@ pub use transforms::TransformLimit;
 pub use transforms::TransformResortAddOn;
 pub use transforms::TransformRuntimeFilter;
 pub use transforms::TransformSortPartial;
+pub use transforms::TransformWindow;

--- a/src/query/service/src/pipelines/processors/mod.rs
+++ b/src/query/service/src/pipelines/processors/mod.rs
@@ -40,3 +40,5 @@ pub use transforms::TransformResortAddOn;
 pub use transforms::TransformRuntimeFilter;
 pub use transforms::TransformSortPartial;
 pub use transforms::TransformWindow;
+pub use transforms::WindowFrame;
+pub use transforms::WindowFrameBound;

--- a/src/query/service/src/pipelines/processors/transforms/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/mod.rs
@@ -21,6 +21,7 @@ mod transform_hash_join;
 mod transform_left_join;
 mod transform_limit;
 mod transform_mark_join;
+mod window;
 
 mod profile_wrapper;
 mod runtime_filter;
@@ -90,3 +91,6 @@ pub use transform_runtime_filter::SinkRuntimeFilterSource;
 pub use transform_runtime_filter::TransformRuntimeFilter;
 pub use transform_sort_merge::SortMergeCompactor;
 pub use transform_sort_partial::TransformSortPartial;
+pub use window::TransformWindow;
+pub use window::WindowFrame;
+pub use window::WindowFrameBound;

--- a/src/query/service/src/pipelines/processors/transforms/window/frame.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/frame.rs
@@ -1,0 +1,30 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Clone)]
+pub enum WindowFrameBound {
+    /// `CURRENT ROW`
+    CurrentRow,
+    /// `<N> PRECEDING` or `UNBOUNDED PRECEDING`.
+    Preceding(Option<usize>),
+    /// `<N> FOLLOWING` or `UNBOUNDED FOLLOWING`.
+    Following(Option<usize>),
+}
+
+#[derive(Clone)]
+pub struct WindowFrame {
+    // TODO: support RANGE frame, only support Rows frame now.
+    pub start_bound: WindowFrameBound,
+    pub end_bound: WindowFrameBound,
+}

--- a/src/query/service/src/pipelines/processors/transforms/window/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/mod.rs
@@ -1,0 +1,20 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod frame;
+mod transform_window;
+
+pub use frame::WindowFrame;
+pub use frame::WindowFrameBound;
+pub use transform_window::TransformWindow;

--- a/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
@@ -1,0 +1,691 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use common_exception::Result;
+use common_expression::BlockEntry;
+use common_expression::Column;
+use common_expression::ColumnBuilder;
+use common_expression::DataBlock;
+use common_expression::Value;
+use common_functions::aggregates::get_layout_offsets;
+use common_functions::aggregates::AggregateFunction;
+use common_functions::aggregates::StateAddr;
+use common_pipeline_core::processors::processor::Event;
+use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_core::processors::Processor;
+
+use super::frame::WindowFrame;
+use super::WindowFrameBound;
+use crate::pipelines::processors::transforms::group_by::Area;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
+struct RowPtr {
+    pub block: usize,
+    pub row: usize,
+}
+
+impl RowPtr {
+    #[inline(always)]
+    pub fn new(block: usize, row: usize) -> Self {
+        Self { block, row }
+    }
+}
+
+#[derive(Clone)]
+pub struct WindowBlock {
+    pub block: DataBlock,
+    pub builder: ColumnBuilder,
+}
+
+/// The input [`DataBlock`] of [`TransformWindow`] should be sorted by partition and order by columns.
+///
+/// Window function will not change the rows count of the original data.
+pub struct TransformWindow {
+    function: Arc<dyn AggregateFunction>,
+    arguments: Vec<usize>,
+
+    state_place: StateAddr,
+    arena: Area,
+
+    partition_indices: Vec<usize>,
+    order_by_indices: Vec<usize>,
+
+    /// A queue of data blocks that we need to process.
+    /// If partition is ended, we may free the data block from front of the queue.
+    blocks: VecDeque<WindowBlock>,
+    /// A queue of data blocks that can be output.
+    outputs: VecDeque<DataBlock>,
+
+    /// monotonically increasing index of the current block in the queue.
+    first_block: usize,
+    current_block: usize,
+
+    // Partition: [`partition_start`, `partition_end`). `partition_end` is excluded.
+    partition_start: RowPtr,
+    partition_end: RowPtr,
+    partition_ended: bool,
+
+    // Frame: [`frame_start`, `frame_end`]. `frame_end` is included.
+    frame_kind: WindowFrame,
+    prev_frame_start: RowPtr,
+    prev_frame_end: RowPtr,
+    frame_start: RowPtr,
+    frame_end: RowPtr,
+    frame_started: bool,
+    frame_ended: bool,
+
+    current_row: RowPtr,
+
+    // Used for rank
+    current_row_in_partition: usize,
+    input_is_finished: bool,
+}
+
+impl TransformWindow {
+    pub fn try_create_processor(
+        function: Arc<dyn AggregateFunction>,
+        arguments: Vec<usize>,
+        partition_indices: Vec<usize>,
+        order_by_indices: Vec<usize>,
+        frame_kind: WindowFrame,
+    ) -> Result<ProcessorPtr> {
+        let transform = Self::try_create(
+            function,
+            arguments,
+            partition_indices,
+            order_by_indices,
+            frame_kind,
+        )?;
+        Ok(ProcessorPtr::create(Box::new(transform)))
+    }
+
+    fn try_create(
+        function: Arc<dyn AggregateFunction>,
+        arguments: Vec<usize>,
+        partition_indices: Vec<usize>,
+        order_by_indices: Vec<usize>,
+        frame_kind: WindowFrame,
+    ) -> Result<Self> {
+        let mut arena = Area::create();
+        let mut state_offset = Vec::with_capacity(1);
+        let layout = get_layout_offsets(&[function.clone()], &mut state_offset)?;
+        let state_place: StateAddr = arena.alloc_layout(layout).into();
+        let state_place = state_place.next(state_offset[0]);
+
+        Ok(Self {
+            function,
+            arguments,
+            partition_indices,
+            order_by_indices,
+            state_place,
+            arena,
+            blocks: VecDeque::new(),
+            outputs: VecDeque::new(),
+            first_block: 0,
+            current_block: 0,
+            partition_start: RowPtr::default(),
+            partition_end: RowPtr::default(),
+            partition_ended: false,
+            frame_kind,
+            frame_start: RowPtr::default(),
+            frame_end: RowPtr::default(),
+            prev_frame_start: RowPtr::default(),
+            prev_frame_end: RowPtr::default(),
+            frame_started: false,
+            frame_ended: false,
+            current_row: RowPtr::default(),
+            current_row_in_partition: 1,
+            input_is_finished: false,
+        })
+    }
+
+    #[inline(always)]
+    fn blocks_start(&self) -> RowPtr {
+        RowPtr::new(self.first_block, 0)
+    }
+
+    #[inline(always)]
+    fn blocks_end(&self) -> RowPtr {
+        RowPtr::new(self.first_block + self.blocks.len(), 0)
+    }
+
+    #[inline(always)]
+    fn block_rows(&self, index: RowPtr) -> usize {
+        self.block_at(index).num_rows()
+    }
+
+    #[inline(always)]
+    fn block_at(&self, index: RowPtr) -> &DataBlock {
+        &self.blocks[index.block - self.first_block].block
+    }
+
+    #[inline(always)]
+    fn builder_at(&mut self, index: RowPtr) -> &mut ColumnBuilder {
+        &mut self.blocks[index.block - self.first_block].builder
+    }
+
+    #[inline(always)]
+    fn column_at(&self, index: RowPtr, column_index: usize) -> &Column {
+        self.block_at(index)
+            .get_by_offset(column_index)
+            .value
+            .as_column()
+            .unwrap()
+    }
+
+    fn current_row_sub_within_partition(&self, mut n: usize) -> RowPtr {
+        let RowPtr { mut block, mut row } = self.current_row;
+        let start = &self.partition_start;
+        // Use '>' to avoid overflow.
+        while block > start.block {
+            if row >= n {
+                return RowPtr::new(block, row - n);
+            }
+            n -= row;
+            block -= 1;
+            row = self.block_rows(RowPtr::new(block, 0));
+        }
+        // block == paritition_start.block
+        // row == block.num_rows();
+        row = row - (row - start.row).min(n);
+        RowPtr::new(block, row)
+    }
+
+    fn current_row_add_within_partition(&self, mut n: usize) -> RowPtr {
+        let RowPtr { mut block, mut row } = self.current_row;
+        let end = &self.partition_end;
+        while block < end.block {
+            let rows = self.block_rows(RowPtr::new(block, 0));
+            if row + n < rows {
+                return RowPtr::new(block, row + n);
+            }
+            n -= rows - row;
+            block += 1;
+            row = 0;
+        }
+        // block == partition_end.block
+        // row == 0
+        RowPtr::new(block, end.row.min(n))
+    }
+
+    #[inline(always)]
+    fn aggregate_arguments(block: &DataBlock, arguments: &[usize]) -> Vec<Column> {
+        arguments
+            .iter()
+            .map(|index| {
+                block
+                    .get_by_offset(*index)
+                    .value
+                    .as_column()
+                    .cloned()
+                    .unwrap()
+            })
+            .collect()
+    }
+
+    /// Advance the partition end to the next partition or the end of the data.
+    fn advance_partition(&mut self) {
+        if self.partition_ended {
+            return;
+        }
+
+        let end = self.blocks_end();
+
+        if self.input_is_finished {
+            self.partition_ended = true;
+            assert_eq!(self.partition_end, end);
+            return;
+        }
+
+        if self.partition_end == end {
+            return;
+        }
+
+        let partition_by_columns = self.partition_indices.len();
+        if partition_by_columns == 0 {
+            self.partition_end = end;
+            return;
+        }
+
+        let block_rows = self.block_rows(self.partition_end);
+
+        while self.partition_end.row < block_rows {
+            let mut i = 0;
+            while i < partition_by_columns {
+                let prev_column = self.column_at(self.prev_frame_start, self.partition_indices[i]);
+                let compare_column = self.column_at(self.partition_end, self.partition_indices[i]);
+
+                if prev_column.index(self.prev_frame_start.row)
+                    != compare_column.index(self.partition_end.row)
+                {
+                    break;
+                }
+                i += 1;
+            }
+
+            if i < partition_by_columns {
+                self.partition_ended = true;
+                return;
+            }
+            self.partition_end.row += 1;
+        }
+
+        assert_eq!(self.partition_end.row, block_rows);
+        self.partition_end.block += 1;
+        self.partition_end.row = 0;
+
+        assert!(!self.partition_ended && self.partition_end == end);
+    }
+
+    fn advance_frame_start(&mut self) {
+        if self.frame_started {
+            return;
+        }
+        match &self.frame_kind.start_bound {
+            WindowFrameBound::CurrentRow => {
+                self.frame_started = true;
+                self.frame_start = self.current_row;
+            }
+            WindowFrameBound::Preceding(Some(n)) => {
+                self.frame_started = true;
+                self.frame_start = self.current_row_sub_within_partition(*n);
+            }
+            WindowFrameBound::Preceding(_) => {
+                self.frame_started = true;
+                self.frame_start = self.partition_start;
+            }
+            WindowFrameBound::Following(Some(n)) => {
+                self.frame_start = self.current_row_add_within_partition(*n);
+                self.frame_started = self.partition_ended || self.frame_start != self.partition_end
+            }
+            WindowFrameBound::Following(_) => {
+                unreachable!()
+            }
+        }
+    }
+
+    fn advance_frame_end(&mut self) {
+        match &self.frame_kind.end_bound {
+            WindowFrameBound::CurrentRow => {
+                self.frame_ended = true;
+                self.frame_end = self.current_row;
+            }
+            WindowFrameBound::Preceding(Some(n)) => {
+                self.frame_ended = true;
+                self.frame_end = self.current_row_sub_within_partition(*n);
+            }
+            WindowFrameBound::Preceding(_) => {
+                unreachable!()
+            }
+            WindowFrameBound::Following(Some(n)) => {
+                self.frame_end = self.current_row_add_within_partition(*n);
+                self.frame_ended = self.partition_ended || self.frame_end != self.partition_end
+            }
+            WindowFrameBound::Following(_) => {
+                self.frame_ended = self.partition_ended;
+                self.frame_end = self.partition_end;
+                if self.partition_end.row == 0 {
+                    self.frame_end.block -= 1;
+                    self.frame_end.row = self.block_rows(self.frame_end) - 1;
+                } else {
+                    self.frame_end.row -= 1;
+                }
+            }
+        }
+    }
+
+    // Advance the current row to the next row
+    // if the current row is the last row of the current block, advance the current block and row = 0
+    fn advance_row(&mut self, mut row: RowPtr) -> RowPtr {
+        if row.row < self.block_rows(row) - 1 {
+            row.row += 1;
+        } else {
+            row.block += 1;
+            row.row = 0;
+        }
+        row
+    }
+
+    /// When adding a [`DataBlock`], we compute the aggregations to the end.
+    ///
+    /// For each row in the input block,
+    /// compute the aggregation result of its window frame and add it intp result column buffer.
+    ///
+    /// If not reach the end bound of the window frame, hold the temporary aggregation value in `state_place`.
+    ///
+    /// Once collect all the results of one input [`DataBlock`], attach the corresponding result column to the input as output.
+    fn add_block(&mut self, data: Option<DataBlock>) -> Result<()> {
+        if let Some(data) = data {
+            let num_rows = data.num_rows();
+            self.blocks.push_back(WindowBlock {
+                block: data.convert_to_full(),
+                builder: ColumnBuilder::with_capacity(&self.function.return_type()?, num_rows),
+            });
+        }
+
+        // Each loop will do:
+        // 1. Try to advance the partition.
+        // 2. Try to advance the frame (if the frame is not started or ended, break the loop and end the process).
+        // 3. Compute the aggregation for current frame.
+        // 4. If the partition is not ended, break the loop;
+        //    else start next partition.
+        loop {
+            // 1.
+            self.advance_partition();
+
+            while self.current_row < self.partition_end {
+                // 2.
+                self.advance_frame_start();
+                if !self.frame_started {
+                    break;
+                }
+                if self.frame_end < self.partition_end {
+                    self.frame_end = self.partition_end;
+                }
+                self.advance_frame_end();
+                if !self.frame_ended {
+                    break;
+                }
+
+                // 3.
+                self.apply_aggregate()?;
+
+                self.prev_frame_start = self.frame_start;
+                self.prev_frame_end = self.frame_end;
+
+                self.current_row = self.advance_row(self.current_row);
+
+                self.current_row_in_partition += 1;
+                self.frame_started = false;
+                self.frame_ended = false;
+            }
+
+            if self.input_is_finished {
+                return Ok(());
+            }
+
+            // 4.
+            if !self.partition_ended {
+                break;
+            }
+
+            // start to new partition
+            self.partition_start = self.partition_end;
+            self.current_row = self.advance_row(self.current_row);
+            self.partition_ended = false;
+
+            // reset frames
+            self.prev_frame_start = self.frame_start;
+            self.prev_frame_end = self.frame_end;
+            self.frame_start = self.partition_start;
+            self.frame_end = self.partition_start;
+
+            self.current_row_in_partition = 1;
+        }
+
+        self.check_outputs();
+
+        Ok(())
+    }
+
+    fn check_outputs(&mut self) {
+        while let Some(WindowBlock { block, builder }) = self.blocks.front() {
+            if block.num_rows() == builder.len() {
+                let WindowBlock { mut block, builder } = self.blocks.pop_front().unwrap();
+                let new_column = builder.build();
+                block.add_column(BlockEntry {
+                    data_type: new_column.data_type(),
+                    value: Value::Column(new_column),
+                });
+                self.outputs.push_back(block);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn apply_aggregate(&mut self) -> Result<()> {
+        let row_start = self.frame_start;
+        let row_end = self.frame_end;
+
+        // TODO: for some case, current frame can continue to use the previous frame's state
+        // Reset state
+        self.function.init_state(self.state_place);
+
+        for block in row_start.block..=row_end.block {
+            let block_row_start = if block == row_start.block {
+                row_start.row
+            } else {
+                0
+            };
+            let block_row_end = if block == row_end.block {
+                row_end.row
+            } else {
+                self.block_rows(RowPtr { block, row: 0 }) - 1
+            };
+
+            let data = self.block_at(RowPtr { block, row: 0 });
+            let columns = Self::aggregate_arguments(data, &self.arguments);
+
+            for row in block_row_start..=block_row_end {
+                self.function
+                    .accumulate_row(self.state_place, &columns, row)?;
+            }
+        }
+
+        let function = self.function.clone();
+        let place = self.state_place;
+        let builder = self.builder_at(self.current_row);
+        function.merge_result(place, builder)?;
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl Processor for TransformWindow {
+    fn name(&self) -> String {
+        "Transform Window".to_string()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn event(&mut self) -> Result<Event> {
+        todo!()
+    }
+
+    fn process(&mut self) -> Result<()> {
+        todo!()
+    }
+}
+
+mod tests {
+    use common_exception::Result;
+    use common_expression::types::DataType;
+    use common_expression::types::Int32Type;
+    use common_expression::Column;
+    use common_expression::ColumnBuilder;
+    use common_expression::DataBlock;
+    use common_expression::FromData;
+    use common_functions::aggregates::AggregateFunctionFactory;
+
+    use super::TransformWindow;
+    use super::WindowBlock;
+    use crate::pipelines::processors::transforms::window::transform_window::RowPtr;
+    use crate::pipelines::processors::transforms::WindowFrame;
+    use crate::pipelines::processors::transforms::WindowFrameBound;
+
+    fn get_transform_window(
+        window_frame: WindowFrame,
+        arg_type: DataType,
+    ) -> Result<TransformWindow> {
+        let function = AggregateFunctionFactory::instance().get("sum", vec![], vec![arg_type])?;
+        let mut transform =
+            TransformWindow::try_create(function, vec![0], vec![0], vec![0], window_frame)?;
+        Ok(transform)
+    }
+
+    fn get_transform_window_with_data(
+        window_frame: WindowFrame,
+        column: Column,
+    ) -> Result<TransformWindow> {
+        let data_type = column.data_type();
+        let num_rows = column.len();
+        let mut transform = get_transform_window(window_frame, data_type.clone())?;
+        transform.blocks.push_back(WindowBlock {
+            block: DataBlock::new_from_columns(vec![column]),
+            builder: ColumnBuilder::with_capacity(&data_type, num_rows),
+        });
+        Ok(transform)
+    }
+
+    #[test]
+    fn test_partition_advance() -> Result<()> {
+        {
+            let mut transform = get_transform_window_with_data(
+                WindowFrame {
+                    start_bound: WindowFrameBound::CurrentRow,
+                    end_bound: WindowFrameBound::CurrentRow,
+                },
+                Int32Type::from_data(vec![1, 1, 1]),
+            )?;
+
+            transform.advance_partition();
+
+            assert!(!transform.partition_ended);
+            assert_eq!(transform.partition_end, RowPtr::new(1, 0));
+        }
+
+        {
+            let mut transform = get_transform_window_with_data(
+                WindowFrame {
+                    start_bound: WindowFrameBound::CurrentRow,
+                    end_bound: WindowFrameBound::CurrentRow,
+                },
+                Int32Type::from_data(vec![1, 1, 2]),
+            )?;
+
+            transform.advance_partition();
+
+            assert!(transform.partition_ended);
+            assert_eq!(transform.partition_end, RowPtr::new(0, 2));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_frame_advance() -> Result<()> {
+        {
+            let mut transform = get_transform_window_with_data(
+                WindowFrame {
+                    start_bound: WindowFrameBound::Following(Some(4)),
+                    end_bound: WindowFrameBound::Following(Some(5)),
+                },
+                Int32Type::from_data(vec![1, 1, 1]),
+            )?;
+
+            transform.advance_partition();
+
+            assert!(!transform.partition_ended);
+            assert_eq!(transform.partition_end, RowPtr::new(1, 0));
+
+            transform.advance_frame_start();
+            assert!(!transform.frame_started)
+        }
+
+        {
+            let mut transform = get_transform_window_with_data(
+                WindowFrame {
+                    start_bound: WindowFrameBound::Preceding(Some(2)),
+                    end_bound: WindowFrameBound::Following(Some(5)),
+                },
+                Int32Type::from_data(vec![1, 1, 1]),
+            )?;
+
+            transform.advance_partition();
+            transform.current_row = RowPtr::new(0, 1);
+
+            assert!(!transform.partition_ended);
+            assert_eq!(transform.partition_end, RowPtr::new(1, 0));
+
+            transform.advance_frame_start();
+            assert!(transform.frame_started);
+            assert_eq!(transform.frame_start, RowPtr::new(0, 0));
+
+            transform.advance_frame_end();
+            assert!(!transform.frame_ended);
+        }
+
+        {
+            let mut transform = get_transform_window_with_data(
+                WindowFrame {
+                    start_bound: WindowFrameBound::Preceding(Some(2)),
+                    end_bound: WindowFrameBound::Following(Some(1)),
+                },
+                Int32Type::from_data(vec![1, 1, 1]),
+            )?;
+
+            transform.advance_partition();
+            transform.current_row = RowPtr::new(0, 1);
+
+            assert!(!transform.partition_ended);
+            assert_eq!(transform.partition_end, RowPtr::new(1, 0));
+
+            transform.advance_frame_start();
+            assert!(transform.frame_started);
+            assert_eq!(transform.frame_start, RowPtr::new(0, 0));
+
+            transform.advance_frame_end();
+            assert!(transform.frame_ended);
+            assert_eq!(transform.frame_end, RowPtr::new(0, 2));
+        }
+
+        {
+            let mut transform = get_transform_window_with_data(
+                WindowFrame {
+                    start_bound: WindowFrameBound::Preceding(None),
+                    end_bound: WindowFrameBound::Following(None),
+                },
+                Int32Type::from_data(vec![1, 1, 1, 2]),
+            )?;
+
+            transform.advance_partition();
+            transform.current_row = RowPtr::new(0, 1);
+
+            assert!(transform.partition_ended);
+            assert_eq!(transform.partition_end, RowPtr::new(0, 3));
+
+            transform.advance_frame_start();
+            assert!(transform.frame_started);
+            assert_eq!(transform.frame_start, RowPtr::new(0, 0));
+
+            transform.advance_frame_end();
+            assert!(transform.frame_ended);
+            assert_eq!(transform.frame_end, RowPtr::new(0, 2));
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_block() -> Result<()> {
+        Ok(())
+    }
+}

--- a/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Some variables and functions are named and designed with reference to ClickHouse.
+// - https://github.com/ClickHouse/ClickHouse/blob/master/src/Processors/Transforms/WindowTransform.h
+// - https://github.com/ClickHouse/ClickHouse/blob/master/src/Processors/Transforms/WindowTransform.cpp
+
 use std::any::Any;
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -559,7 +563,7 @@ impl Processor for TransformWindow {
     }
 }
 
-#[test]
+#[cfg(test)]
 mod tests {
     use common_exception::Result;
     use common_expression::block_debug::assert_blocks_eq;
@@ -569,11 +573,14 @@ mod tests {
     use common_expression::Column;
     use common_expression::ColumnBuilder;
     use common_expression::DataBlock;
+    use common_expression::FromData;
     use common_functions::aggregates::AggregateFunctionFactory;
 
     use super::TransformWindow;
     use super::WindowBlock;
+    use crate::pipelines::processors::transforms::window::transform_window::RowPtr;
     use crate::pipelines::processors::transforms::WindowFrame;
+    use crate::pipelines::processors::transforms::WindowFrameBound;
 
     fn get_transform_window(
         window_frame: WindowFrame,

--- a/src/query/service/tests/it/pipelines/processors/mod.rs
+++ b/src/query/service/tests/it/pipelines/processors/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2023 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,5 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod executor;
-mod processors;
+mod transforms;

--- a/src/query/service/tests/it/pipelines/processors/transforms/mod.rs
+++ b/src/query/service/tests/it/pipelines/processors/transforms/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2023 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,5 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod executor;
-mod processors;
+mod transform_window;

--- a/src/query/service/tests/it/pipelines/processors/transforms/transform_window.rs
+++ b/src/query/service/tests/it/pipelines/processors/transforms/transform_window.rs
@@ -1,0 +1,227 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_base::base::tokio;
+use common_exception::Result;
+use common_expression::block_debug::assert_blocks_eq;
+use common_expression::types::DataType;
+use common_expression::types::Int32Type;
+use common_expression::types::NumberDataType;
+use common_expression::DataBlock;
+use common_expression::FromData;
+use common_functions::aggregates::AggregateFunctionFactory;
+use common_pipeline_core::processors::connect;
+use common_pipeline_core::processors::port::InputPort;
+use common_pipeline_core::processors::port::OutputPort;
+use common_pipeline_core::processors::processor::Event;
+use common_pipeline_core::processors::Processor;
+use databend_query::pipelines::processors::TransformWindow;
+use databend_query::pipelines::processors::WindowFrame;
+use databend_query::pipelines::processors::WindowFrameBound;
+
+#[allow(clippy::type_complexity)]
+fn get_transform_window(
+    window_frame: WindowFrame,
+) -> Result<(Box<dyn Processor>, Arc<InputPort>, Arc<OutputPort>)> {
+    let function = AggregateFunctionFactory::instance()
+        .get("sum", vec![], vec![DataType::Number(NumberDataType::Int32)])?;
+    let input = InputPort::create();
+    let output = OutputPort::create();
+    let transform = TransformWindow::try_create(
+        input.clone(),
+        output.clone(),
+        function,
+        vec![0],
+        vec![0],
+        window_frame,
+    )?;
+
+    Ok((Box::new(transform), input, output))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_transform_window() -> Result<()> {
+    {
+        let upstream_output = OutputPort::create();
+        let downstream_input = InputPort::create();
+        let (mut transform, input, output) = get_transform_window(WindowFrame {
+            start_bound: WindowFrameBound::Preceding(Some(1)),
+            end_bound: WindowFrameBound::Following(Some(1)),
+        })?;
+
+        unsafe {
+            connect(&input, &upstream_output);
+            connect(&downstream_input, &output);
+        }
+
+        downstream_input.set_need_data();
+
+        assert!(matches!(transform.event()?, Event::NeedData));
+        upstream_output.push_data(Ok(DataBlock::new_from_columns(vec![Int32Type::from_data(
+            vec![1, 1, 1, 2, 2, 3, 3, 3],
+        )])));
+
+        assert!(matches!(transform.event()?, Event::Sync));
+        transform.process()?;
+
+        assert!(matches!(transform.event()?, Event::NeedData));
+        upstream_output.push_data(Ok(DataBlock::new_from_columns(vec![Int32Type::from_data(
+            vec![3, 4, 4],
+        )])));
+        upstream_output.finish();
+
+        assert!(matches!(transform.event()?, Event::Sync));
+        transform.process()?;
+
+        assert!(matches!(transform.event()?, Event::NeedConsume));
+        let block = downstream_input.pull_data().unwrap()?;
+        assert_blocks_eq(
+            vec![
+                "+----------+----------+",
+                "| Column 0 | Column 1 |",
+                "+----------+----------+",
+                "| 1        | 2        |",
+                "| 1        | 3        |",
+                "| 1        | 2        |",
+                "| 2        | 4        |",
+                "| 2        | 4        |",
+                "| 3        | 6        |",
+                "| 3        | 9        |",
+                "| 3        | 9        |",
+                "+----------+----------+",
+            ],
+            &[block],
+        );
+        downstream_input.set_need_data();
+
+        assert!(matches!(transform.event()?, Event::Sync));
+        transform.process()?;
+
+        assert!(matches!(transform.event()?, Event::NeedConsume));
+        let block = downstream_input.pull_data().unwrap()?;
+        assert_blocks_eq(
+            vec![
+                "+----------+----------+",
+                "| Column 0 | Column 1 |",
+                "+----------+----------+",
+                "| 3        | 6        |",
+                "| 4        | 8        |",
+                "| 4        | 8        |",
+                "+----------+----------+",
+            ],
+            &[block],
+        );
+        downstream_input.set_need_data();
+
+        assert!(matches!(transform.event()?, Event::Finished));
+    }
+
+    {
+        let upstream_output = OutputPort::create();
+        let downstream_input = InputPort::create();
+        let (mut transform, input, output) = get_transform_window(WindowFrame {
+            start_bound: WindowFrameBound::Preceding(None),
+            end_bound: WindowFrameBound::Following(None),
+        })?;
+
+        unsafe {
+            connect(&input, &upstream_output);
+            connect(&downstream_input, &output);
+        }
+
+        downstream_input.set_need_data();
+
+        assert!(matches!(transform.event()?, Event::NeedData));
+        upstream_output.push_data(Ok(DataBlock::new_from_columns(vec![Int32Type::from_data(
+            vec![1, 1, 1],
+        )])));
+
+        assert!(matches!(transform.event()?, Event::Sync));
+        transform.process()?;
+
+        assert!(matches!(transform.event()?, Event::NeedData));
+        upstream_output.push_data(Ok(DataBlock::new_from_columns(vec![Int32Type::from_data(
+            vec![1, 1, 1],
+        )])));
+
+        assert!(matches!(transform.event()?, Event::Sync));
+        transform.process()?;
+
+        assert!(matches!(transform.event()?, Event::NeedData));
+        upstream_output.push_data(Ok(DataBlock::new_from_columns(vec![Int32Type::from_data(
+            vec![1, 1, 1],
+        )])));
+        upstream_output.finish();
+
+        assert!(matches!(transform.event()?, Event::Sync));
+        transform.process()?;
+
+        assert!(matches!(transform.event()?, Event::Sync));
+        transform.process()?;
+
+        assert!(matches!(transform.event()?, Event::NeedConsume));
+        let block = downstream_input.pull_data().unwrap()?;
+        assert_blocks_eq(
+            vec![
+                "+----------+----------+",
+                "| Column 0 | Column 1 |",
+                "+----------+----------+",
+                "| 1        | 9        |",
+                "| 1        | 9        |",
+                "| 1        | 9        |",
+                "+----------+----------+",
+            ],
+            &[block],
+        );
+        downstream_input.set_need_data();
+
+        assert!(matches!(transform.event()?, Event::NeedConsume));
+        let block = downstream_input.pull_data().unwrap()?;
+        assert_blocks_eq(
+            vec![
+                "+----------+----------+",
+                "| Column 0 | Column 1 |",
+                "+----------+----------+",
+                "| 1        | 9        |",
+                "| 1        | 9        |",
+                "| 1        | 9        |",
+                "+----------+----------+",
+            ],
+            &[block],
+        );
+        downstream_input.set_need_data();
+
+        assert!(matches!(transform.event()?, Event::NeedConsume));
+        let block = downstream_input.pull_data().unwrap()?;
+        assert_blocks_eq(
+            vec![
+                "+----------+----------+",
+                "| Column 0 | Column 1 |",
+                "+----------+----------+",
+                "| 1        | 9        |",
+                "| 1        | 9        |",
+                "| 1        | 9        |",
+                "+----------+----------+",
+            ],
+            &[block],
+        );
+        downstream_input.set_need_data();
+
+        assert!(matches!(transform.event()?, Event::Finished));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Basic implementation of `TransformWindow`.

For each row, compute its window frame and apply aggregation.

Time complexity: O(n^2).

Window sliding logic will be improved in later PRs.
