### PR TITLE
feat(planner): Try add optimizer test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,6 +3320,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "databend-sqlunittests"
+version = "0.1.0"
+dependencies = [
+ "common-config",
+]
+
+[[package]]
 name = "databend-thrift"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,8 @@ members = [
     "src/meta/service",
     # sqllogictest
     "tests/sqllogictests",
+    # sqlunittest
+    "tests/sqlunittests/optimizer",
 ]
 
 [workspace.dependencies]

--- a/src/query/service/tests/it/sql/planner/mod.rs
+++ b/src/query/service/tests/it/sql/planner/mod.rs
@@ -15,3 +15,4 @@
 mod builders;
 mod format;
 mod semantic;
+mod optimizer;

--- a/src/query/service/tests/it/sql/planner/optimizer/mod.rs
+++ b/src/query/service/tests/it/sql/planner/optimizer/mod.rs
@@ -1,0 +1,112 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use common_base::base::tokio;
+use common_exception::Result;
+use common_sql::Planner;
+use common_storages_fuse::TableContext;
+use databend_query::interpreters::InterpreterFactory;
+use futures_util::TryStreamExt;
+
+use crate::storages::fuse::table_test_fixture::TestFixture;
+use crate::storages::fuse::utils::do_purge_test;
+use crate::storages::fuse::utils::TestTableOperation;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fuse_snapshot_optimize_purge() -> Result<()> {
+    do_purge_test(
+        "explicit purge",
+        TestTableOperation::Optimize("purge".to_string()),
+        1,
+        0,
+        1,
+        1,
+        1,
+        None,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fuse_snapshot_optimize_all() -> Result<()> {
+    do_purge_test(
+        "explicit purge",
+        TestTableOperation::Optimize("all".to_string()),
+        1,
+        0,
+        1,
+        1,
+        1,
+        None,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fuse_table_optimize() -> Result<()> {
+    let fixture = TestFixture::new().await;
+    let ctx = fixture.ctx();
+    let tbl_name = fixture.default_table_name();
+    let db_name = fixture.default_db_name();
+
+    fixture.create_normal_table().await?;
+
+    // insert 5 times
+    let n = 5;
+    for _ in 0..n {
+        let table = fixture.latest_default_table().await?;
+        let num_blocks = 1;
+        let stream = TestFixture::gen_sample_blocks_stream(num_blocks, 1);
+
+        let blocks = stream.try_collect().await?;
+        fixture
+            .append_commit_blocks(table.clone(), blocks, false, true)
+            .await?;
+    }
+
+    // there will be 5 blocks
+    let table = fixture.latest_default_table().await?;
+    let (_, parts) = table.read_partitions(ctx.clone(), None).await?;
+    assert_eq!(parts.len(), n);
+
+    // do compact
+    let query = format!("optimize table {db_name}.{tbl_name} compact");
+
+    let mut planner = Planner::new(ctx.clone());
+    let (plan, _) = planner.plan_sql(&query).await?;
+    let interpreter = InterpreterFactory::get(ctx.clone(), &plan).await?;
+
+    // `PipelineBuilder` will parallelize the table reading according to value of setting `max_threads`,
+    // and `Table::read` will also try to de-queue read jobs preemptively. thus, the number of blocks
+    // that `Table::append` takes are not deterministic (`append` is also executed in parallel in this case),
+    // therefore, the final number of blocks varies.
+    // To avoid flaky test, the value of setting `max_threads` is set to be 1, so that pipeline_builder will
+    // only arrange one worker for the `ReadDataSourcePlan`.
+    ctx.get_settings().set_max_threads(1)?;
+    let data_stream = interpreter.execute(ctx.clone()).await?;
+    let _ = data_stream.try_collect::<Vec<_>>().await;
+
+    // verify compaction
+    let table = fixture.latest_default_table().await?;
+    let (_, parts) = table.read_partitions(ctx.clone(), None).await?;
+    // blocks are so tiny, they should be compacted into one
+    assert_eq!(parts.len(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn test() {
+    let _n = 5;
+}

--- a/src/query/service/tests/it/storages/fuse/mod.rs
+++ b/src/query/service/tests/it/storages/fuse/mod.rs
@@ -22,5 +22,5 @@ mod pruning;
 mod statistics;
 mod table;
 mod table_functions;
-mod table_test_fixture;
-mod utils;
+pub(crate) mod table_test_fixture;
+pub(crate) mod utils;

--- a/src/query/service/tests/it/storages/mod.rs
+++ b/src/query/service/tests/it/storages/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod fuse;
+pub(crate) mod fuse;
 mod null;
 mod statistics;
 mod system;

--- a/tests/sqlunittests/optimizer/Cargo.toml
+++ b/tests/sqlunittests/optimizer/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "databend-sqlunittests"
+version = "0.1.0"
+
+[dependencies]
+common-config = { path = "../../../src/query/config" }

--- a/tests/sqlunittests/optimizer/src/context.rs
+++ b/tests/sqlunittests/optimizer/src/context.rs
@@ -1,0 +1,7 @@
+extern crate common_config;
+use self::common_config::InnerConfig;
+
+#[test]
+fn test() {
+    
+}

--- a/tests/sqlunittests/optimizer/src/main.rs
+++ b/tests/sqlunittests/optimizer/src/main.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let _n = 6;
+}
+
+mod context;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

As subsequent optimization rules become more and more complex, testing becomes difficult without a single-point debugging framework.
From my current understanding, there is no framework for unit testing the optimizer. I'm trying to add this framework.
Three places were chosen as follow-up paths:

> - **src/query/sql/tests:** The optimization process requires QueryContext data, and the creation of QueryContext depends on the relevant logic of Session. If you add test logic here, you need to rely on the Service module, which will cause circular dependency
> - **src/query/service/tests/it/sql/planner/optimizer:** The example code is copied from src/query/service/tests/it/storages/fuse/operations/optimize.rs, not the real test logic. But because I'm a newcomer to Rust, I don't know why I can't enter debugging after setting a breakpoint.
> - **tests/sqlunittests:** The path corresponding to tests/sqllogictests, the path for unit testing, in which a subpath for unit testing of the optimizer is created: tests/sqlunittests/optimizer. From the current point of view, there is no problem with this path.

Closes #issue
