### PR TITLE
fix: Allow PUBLIC role show databases / tables / columns

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -19,6 +19,7 @@ use common_exception::Result;
 use common_meta_app::principal::GrantObject;
 use common_meta_app::principal::UserPrivilegeType;
 use common_sql::plans::CopyPlan;
+use common_sql::plans::RewriteKind;
 
 use crate::interpreters::access::AccessChecker;
 use crate::sessions::QueryContext;
@@ -40,7 +41,22 @@ impl AccessChecker for PrivilegeAccess {
         let session = self.ctx.get_current_session();
 
         match plan {
-            Plan::Query { metadata, .. } => {
+            Plan::Query {
+                metadata,
+                rewrite_kind,
+                ..
+            } => {
+                match rewrite_kind {
+                    Some(RewriteKind::ShowDatabases)
+                    | Some(RewriteKind::ShowTables)
+                    | Some(RewriteKind::ShowColumns)
+                    | Some(RewriteKind::ShowEngines)
+                    | Some(RewriteKind::ShowFunctions)
+                    | Some(RewriteKind::ShowTableFunctions) => {
+                        return Ok(());
+                    }
+                    _ => {}
+                };
                 let metadata = metadata.read().clone();
                 for table in metadata.tables() {
                     if table.is_source_of_view() {

--- a/tests/suites/0_stateless/20+_others/20_0012_privilege_access.result
+++ b/tests/suites/0_stateless/20+_others/20_0012_privilege_access.result
@@ -1,3 +1,6 @@
+default
+information_schema
+system
 ERROR 1105 (HY000) at line 1: Code: 1063, displayText = Permission denied, user 'test-user'@'127.0.0.1' requires [Insert] privilege on 'default'.'default'.'t20_0012'.
 1
 2

--- a/tests/suites/0_stateless/20+_others/20_0012_privilege_access.sh
+++ b/tests/suites/0_stateless/20+_others/20_0012_privilege_access.sh
@@ -12,6 +12,9 @@ echo "create user 'test-user'@'$QUERY_MYSQL_HANDLER_HOST' IDENTIFIED BY '$TEST_U
 ## create table
 echo "create table t20_0012(c int)" | $MYSQL_CLIENT_CONNECT
 
+## show tables
+echo "show databases" | $TEST_USER_CONNECT
+
 ## insert data
 echo "insert into t20_0012 values(1),(2)" | $TEST_USER_CONNECT
 ## grant user privilege


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR is a quick fix about the users with PUBLIC role can not view the databases / tables / columns.

We can later add more checks among the privileges about the target databases, likewise an user can not SHOW TABLES on a databases which she don't have the SELECT privilege.

Closes #issue
