### PR TITLE
feat: add metrics for openai invoke

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,7 @@ name = "common-openai"
 version = "0.1.0"
 dependencies = [
  "common-exception",
+ "metrics",
  "openai_api_rust",
 ]
 

--- a/src/common/openai/Cargo.toml
+++ b/src/common/openai/Cargo.toml
@@ -19,6 +19,7 @@ common-exception = { path = "../exception" }
 # Github dependencies
 
 # Crates.io dependencies
+metrics = "0.20.1"
 openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "36c7c1b" }
 
 [dev-dependencies]

--- a/src/common/openai/src/completion.rs
+++ b/src/common/openai/src/completion.rs
@@ -18,6 +18,8 @@ use openai_api_rust::completions::CompletionsApi;
 use openai_api_rust::completions::CompletionsBody;
 use openai_api_rust::Auth;
 
+use crate::metrics::metrics_completion_count;
+use crate::metrics::metrics_completion_token;
 use crate::OpenAI;
 
 impl OpenAI {
@@ -57,6 +59,12 @@ impl OpenAI {
         } else {
             resp.choices[0].text.clone().unwrap_or("".to_string())
         };
+
+        // perf.
+        {
+            metrics_completion_count(1);
+            metrics_completion_token(usage.unwrap_or(0));
+        }
 
         Ok((sql, usage))
     }

--- a/src/common/openai/src/embedding.rs
+++ b/src/common/openai/src/embedding.rs
@@ -18,6 +18,8 @@ use openai_api_rust::embeddings::EmbeddingsApi;
 use openai_api_rust::embeddings::EmbeddingsBody;
 use openai_api_rust::Auth;
 
+use crate::metrics::metrics_embedding_count;
+use crate::metrics::metrics_embedding_token;
 use crate::OpenAI;
 
 impl OpenAI {
@@ -49,6 +51,12 @@ impl OpenAI {
             } else {
                 res.push(vec![]);
             }
+        }
+
+        // perf.
+        {
+            metrics_embedding_count(1);
+            metrics_embedding_token(usage.unwrap_or(0));
         }
 
         Ok((res, usage))

--- a/src/common/openai/src/metrics.rs
+++ b/src/common/openai/src/metrics.rs
@@ -11,13 +11,22 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
-mod completion;
-mod embedding;
-#[allow(clippy::module_inception)]
-mod openai;
+use metrics::increment_gauge;
 
-pub(crate) mod metrics;
+pub fn metrics_completion_count(c: u32) {
+    increment_gauge!("openai_completion_count", c as f64);
+}
 
-pub use openai::AIModel;
-pub use openai::OpenAI;
+pub fn metrics_completion_token(c: u32) {
+    increment_gauge!("openai_completion_token", c as f64);
+}
+
+pub fn metrics_embedding_count(c: u32) {
+    increment_gauge!("openai_embedding_count", c as f64);
+}
+
+pub fn metrics_embedding_token(c: u32) {
+    increment_gauge!("openai_embedding_token", c as f64);
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```
pub fn metrics_completion_count(c: u32) {
    increment_gauge!("openai_completion_count", c as f64);
}

pub fn metrics_completion_token(c: u32) {
    increment_gauge!("openai_completion_token", c as f64);
}

pub fn metrics_embedding_count(c: u32) {
    increment_gauge!("openai_embedding_count", c as f64);
}

pub fn metrics_embedding_token(c: u32) {
    increment_gauge!("openai_embedding_token", c as f64);
}
```

openai pricing:
```
completion $0.0200 / 1K tokens
embedding $0.0004 / 1K tokens
```

Closes #issue
