### PR TITLE
feat(FlightSQL): support basic SqlInfo.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,7 @@ name = "databend-query"
 version = "0.1.0"
 dependencies = [
  "aho-corasick",
+ "arrow-array",
  "arrow-cast",
  "arrow-flight",
  "arrow-ipc",

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -100,6 +100,7 @@ storages-common-table-meta = { path = "../storages/common/table-meta" }
 
 # Crates.io dependencies
 aho-corasick = { version = "0.7.20" }
+arrow-array = { version = "35.0.0" }
 arrow-flight = { version = "35.0.0", features = ["flight-sql-experimental"] }
 arrow-ipc = { version = "35.0.0" }
 arrow-schema = { version = "35.0.0" }

--- a/src/query/service/src/servers/flight_sql/flight_sql_service/mod.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_service/mod.rs
@@ -17,6 +17,7 @@
 mod query;
 mod service;
 mod session;
+mod sql_info;
 
 use std::pin::Pin;
 use std::sync::Arc;
@@ -26,6 +27,7 @@ use common_sql::plans::Plan;
 use common_sql::PlanExtras;
 use dashmap::DashMap;
 use futures::Stream;
+use sql_info::SqlInfoProvider;
 use tonic::Status;
 use uuid::Uuid;
 

--- a/src/query/service/src/servers/flight_sql/flight_sql_service/service.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_service/service.rs
@@ -79,6 +79,34 @@ fn try_unpack_any<T: ProstMessageExt>(message: Any) -> std::result::Result<T, St
         })
 }
 
+fn simple_flight_info<T: ProstMessageExt>(message: T) -> Response<FlightInfo> {
+    let loc = Location {
+        uri: "location_not_used".to_string(),
+    };
+
+    let buf = message.as_any().encode_to_vec().into();
+    let ticket = Ticket { ticket: buf };
+    let endpoint = FlightEndpoint {
+        ticket: Some(ticket),
+        location: vec![loc],
+    };
+    let endpoints = vec![endpoint];
+
+    let flight_desc = FlightDescriptor {
+        r#type: DescriptorType::Cmd.into(),
+        cmd: Default::default(),
+        path: vec![],
+    };
+    let info = FlightInfo {
+        schema: Default::default(),
+        flight_descriptor: Some(flight_desc),
+        endpoint: endpoints,
+        total_records: -1,
+        total_bytes: -1,
+    };
+    Response::new(info)
+}
+
 #[tonic::async_trait]
 impl FlightSqlService for FlightSqlServiceImpl {
     type FlightService = FlightSqlServiceImpl;
@@ -246,9 +274,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
         tracing::info!("get_flight_info_sql_info({query:?})");
-        Err(Status::unimplemented(
-            "get_flight_info_sql_info not implemented",
-        ))
+        Ok(simple_flight_info(query))
     }
 
     async fn get_flight_info_primary_keys(
@@ -358,7 +384,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
         tracing::info!("do_get_sql_info({query:?})");
-        Err(Status::unimplemented("do_get_sql_info not implemented"))
+        Ok(Response::new(super::SqlInfoProvider::all_info()?))
     }
 
     async fn do_get_primary_keys(

--- a/src/query/service/src/servers/flight_sql/flight_sql_service/sql_info.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_service/sql_info.rs
@@ -1,0 +1,81 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use arrow_array::builder::Int32Builder;
+use arrow_array::builder::StringBuilder;
+use arrow_array::ArrayRef;
+use arrow_array::RecordBatch;
+use arrow_flight::sql::SqlInfo;
+use arrow_flight::utils::batches_to_flight_data;
+use arrow_flight::FlightData;
+use arrow_schema::ArrowError;
+use arrow_schema::DataType;
+use arrow_schema::Field;
+use arrow_schema::Schema;
+use futures_util::stream;
+use tonic::Status;
+
+use crate::servers::flight_sql::flight_sql_service::DoGetStream;
+
+pub(super) struct SqlInfoProvider {}
+
+impl SqlInfoProvider {
+    fn key_field() -> Field {
+        Field::new("info_name", DataType::Int32, false)
+    }
+
+    fn string_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Self::key_field(),
+            Field::new("value", DataType::Utf8, false),
+        ]))
+    }
+
+    fn key_array(info: SqlInfo) -> ArrayRef {
+        let mut builder = Int32Builder::new();
+        builder.append_value(info as i32);
+        Arc::new(builder.finish())
+    }
+
+    fn string_array(value: &str) -> ArrayRef {
+        let mut builder = StringBuilder::new();
+        builder.append_value(value);
+        Arc::new(builder.finish())
+    }
+
+    fn server_name() -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(Self::string_schema(), vec![
+            Self::key_array(SqlInfo::FlightSqlServerName),
+            Self::string_array("Databend"),
+        ])
+    }
+
+    fn all_info_flight_data() -> Result<Vec<FlightData>, ArrowError> {
+        let batch = Self::server_name()?;
+        let schema = (*batch.schema()).clone();
+        let batches = vec![batch];
+        batches_to_flight_data(schema, batches)
+    }
+
+    pub fn all_info() -> Result<DoGetStream, Status> {
+        let flight_data = Self::all_info_flight_data()
+            .map_err(|e| Status::internal(format!("{e:?}")))?
+            .into_iter()
+            .map(Ok);
+        let stream = stream::iter(flight_data);
+        Ok(Box::pin(stream))
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

we can now call 

```
  String name = connection.getMetaData().getDatabaseProductName();
```

there are many a lot more  SqlInfos to add later.

the implement detail not found in spec but in the code or JAVA JDBC

Closes #issue
