### PR TITLE
feat(expression): support Vector data type

### DIFF
--- a/src/meta/proto-conv/src/schema_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/schema_from_to_protobuf_impl.rs
@@ -210,6 +210,7 @@ impl FromToProto for ex::TableDataType {
                         ex::TableDataType::Decimal(ex::types::decimal::DecimalDataType::from_pb(x)?)
                     }
                     Dt24::EmptyMapT(_) => ex::TableDataType::EmptyMap,
+                    Dt24::VectorT(_) => ex::TableDataType::Vector,
                 };
                 Ok(x)
             }
@@ -269,6 +270,7 @@ impl FromToProto for ex::TableDataType {
                 new_pb_dt24(Dt24::TupleT(x))
             }
             TableDataType::Variant => new_pb_dt24(Dt24::VariantT(pb::Empty {})),
+            TableDataType::Vector => new_pb_dt24(Dt24::VectorT(pb::Empty {})),
         };
         Ok(x)
     }

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -61,6 +61,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (29, "2023-02-23: Add: metadata.proto/DataType EmptyMap types", ),
     (30, "2023-02-21: Add: config.proto/WebhdfsStorageConfig; Modify: user.proto/UserStageInfo::StageStorage", ),
     (31, "2023-02-21: Add: CopyOptions::max_files", ),
+    (32, "2023-03-28: Add: metadata.proto/DataType Vector types", ),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -38,3 +38,4 @@ mod v028_schema;
 mod v029_schema;
 mod v030_user_stage;
 mod v031_copy_max_file;
+mod v032_schema;

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -226,6 +226,7 @@ pub(crate) fn new_latest_schema() -> TableSchema {
             })),
         ),
         TableField::new("empty_map", TableDataType::EmptyMap),
+        TableField::new("vector", TableDataType::Vector),
     ];
     TableSchema::new(fields)
 }

--- a/src/meta/proto-conv/tests/it/v032_schema.rs
+++ b/src/meta/proto-conv/tests/it/v032_schema.rs
@@ -1,0 +1,87 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_expression::types::decimal::DecimalSize;
+use common_expression::types::DecimalDataType;
+use common_expression::types::NumberDataType;
+use common_expression::TableDataType;
+use common_expression::TableField;
+use common_expression::TableSchema;
+
+use crate::common;
+
+// These bytes are built when a new version in introduced,
+// and are kept for backward compatibility test.
+//
+// *************************************************************
+// * These messages should never be updated,                   *
+// * only be added when a new version is added,                *
+// * or be removed when an old version is no longer supported. *
+// *************************************************************
+//
+// The message bytes are built from the output of `test_build_pb_buf()`
+#[test]
+fn test_decode_v32_schema() -> anyhow::Result<()> {
+    let schema_v32 = [
+        10, 28, 10, 1, 97, 26, 17, 154, 2, 8, 34, 0, 160, 6, 32, 168, 6, 24, 160, 6, 32, 168, 6,
+        24, 160, 6, 32, 168, 6, 24, 10, 104, 10, 1, 98, 26, 91, 202, 2, 82, 10, 2, 98, 49, 10, 2,
+        98, 50, 18, 47, 202, 2, 38, 10, 3, 98, 49, 49, 10, 3, 98, 49, 50, 18, 9, 138, 2, 0, 160, 6,
+        32, 168, 6, 24, 18, 9, 146, 2, 0, 160, 6, 32, 168, 6, 24, 160, 6, 32, 168, 6, 24, 160, 6,
+        32, 168, 6, 24, 18, 17, 154, 2, 8, 66, 0, 160, 6, 32, 168, 6, 24, 160, 6, 32, 168, 6, 24,
+        160, 6, 32, 168, 6, 24, 160, 6, 32, 168, 6, 24, 32, 1, 160, 6, 32, 168, 6, 24, 10, 30, 10,
+        1, 99, 26, 17, 154, 2, 8, 34, 0, 160, 6, 32, 168, 6, 24, 160, 6, 32, 168, 6, 24, 32, 4,
+        160, 6, 32, 168, 6, 24, 10, 49, 10, 10, 100, 101, 99, 105, 109, 97, 108, 49, 50, 56, 26,
+        27, 218, 2, 18, 10, 10, 8, 18, 16, 3, 160, 6, 32, 168, 6, 24, 160, 6, 32, 168, 6, 24, 160,
+        6, 32, 168, 6, 24, 32, 5, 160, 6, 32, 168, 6, 24, 10, 49, 10, 10, 100, 101, 99, 105, 109,
+        97, 108, 50, 53, 54, 26, 27, 218, 2, 18, 18, 10, 8, 46, 16, 6, 160, 6, 32, 168, 6, 24, 160,
+        6, 32, 168, 6, 24, 160, 6, 32, 168, 6, 24, 32, 6, 160, 6, 32, 168, 6, 24, 10, 30, 10, 9,
+        101, 109, 112, 116, 121, 95, 109, 97, 112, 26, 9, 226, 2, 0, 160, 6, 32, 168, 6, 24, 32, 7,
+        160, 6, 32, 168, 6, 24, 10, 27, 10, 6, 118, 101, 99, 116, 111, 114, 26, 9, 234, 2, 0, 160,
+        6, 32, 168, 6, 24, 32, 8, 160, 6, 32, 168, 6, 24, 24, 9, 160, 6, 32, 168, 6, 24,
+    ];
+
+    let b1 = TableDataType::Tuple {
+        fields_name: vec!["b11".to_string(), "b12".to_string()],
+        fields_type: vec![TableDataType::Boolean, TableDataType::String],
+    };
+    let b = TableDataType::Tuple {
+        fields_name: vec!["b1".to_string(), "b2".to_string()],
+        fields_type: vec![b1, TableDataType::Number(NumberDataType::Int64)],
+    };
+    let fields = vec![
+        TableField::new("a", TableDataType::Number(NumberDataType::UInt64)),
+        TableField::new("b", b),
+        TableField::new("c", TableDataType::Number(NumberDataType::UInt64)),
+        TableField::new(
+            "decimal128",
+            TableDataType::Decimal(DecimalDataType::Decimal128(DecimalSize {
+                precision: 18,
+                scale: 3,
+            })),
+        ),
+        TableField::new(
+            "decimal256",
+            TableDataType::Decimal(DecimalDataType::Decimal256(DecimalSize {
+                precision: 46,
+                scale: 6,
+            })),
+        ),
+        TableField::new("empty_map", TableDataType::EmptyMap),
+        TableField::new("vector", TableDataType::Vector),
+    ];
+    let want = || TableSchema::new(fields.clone());
+    common::test_load_old(func_name!(), schema_v32.as_slice(), 32, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}

--- a/src/meta/protos/proto/datatype.proto
+++ b/src/meta/protos/proto/datatype.proto
@@ -62,6 +62,7 @@ message DataType {
     Empty    variant_t     = 42;
     Decimal  decimal_t     = 43;
     Empty    empty_map_t   = 44;
+    Empty    vector_t      = 45;
   }
 }
 

--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -178,7 +178,7 @@ pub enum Expr {
         modifier: Option<SubqueryModifier>,
         subquery: Box<Query>,
     },
-    /// Access elements of `Array`, `Object` and `Variant` by index or key, like `arr[0]`, or `obj:k1`
+    /// Access elements of `Array`, `Map` and `Variant` by index or key, like `arr[0]`, or `obj:k1`
     MapAccess {
         span: Span,
         expr: Box<Expr>,
@@ -429,6 +429,7 @@ pub enum TypeName {
     Timestamp,
     String,
     Array(Box<TypeName>),
+    Vector,
     Map {
         key_type: Box<TypeName>,
         val_type: Box<TypeName>,
@@ -821,6 +822,9 @@ impl Display for TypeName {
             }
             TypeName::Array(ty) => {
                 write!(f, "ARRAY({})", ty)?;
+            }
+            TypeName::Vector => {
+                write!(f, "VECTOR")?;
             }
             TypeName::Map { key_type, val_type } => {
                 write!(f, "MAP({}, {})", key_type, val_type)?;

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -833,6 +833,8 @@ pub enum TokenKind {
     VARCHAR,
     #[token("VARIANT", ignore(ascii_case))]
     VARIANT,
+    #[token("VECTOR", ignore(ascii_case))]
+    VECTOR,
     #[token("VIEW", ignore(ascii_case))]
     VIEW,
     #[token("WEEK", ignore(ascii_case))]

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -410,7 +410,6 @@ fn test_statement_error() {
         r#"create table a (c varch)"#,
         r#"create table a (c tuple())"#,
         r#"create table a (c decimal)"#,
-        r#"create table a (b tuple(c int, uint64));"#,
         r#"drop table if a.b"#,
         r#"truncate table a.b.c.d"#,
         r#"truncate a"#,

--- a/src/query/ast/tests/it/testdata/expr-error.txt
+++ b/src/query/ast/tests/it/testdata/expr-error.txt
@@ -32,7 +32,7 @@ error:
 1 | CAST(col1 AS foo)
   | ----         ^^^
   | |            |
-  | |            expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 31 more ...
+  | |            expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 32 more ...
   | |            while parsing type name
   | while parsing `CAST(... AS ...)`
   | while parsing expression

--- a/src/query/ast/tests/it/testdata/statement-error.txt
+++ b/src/query/ast/tests/it/testdata/statement-error.txt
@@ -31,7 +31,7 @@ error:
 1 | create table a (c varch)
   | ------          - ^^^^^
   | |               | |
-  | |               | expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 30 more ...
+  | |               | expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 31 more ...
   | |               | while parsing type name
   | |               while parsing `<column name> <type> [DEFAULT <default value>] [COMMENT '<comment>']`
   | while parsing `CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
@@ -44,8 +44,9 @@ error:
   --> SQL:1:25
   |
 1 | create table a (c tuple())
-  | ------          - ----- ^ expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 32 more ...
+  | ------          - ----- ^ expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 33 more ...
   | |               | |      
+  | |               | while parsing TUPLE(<type>, ...)
   | |               | while parsing type name
   | |               while parsing `<column name> <type> [DEFAULT <default value>] [COMMENT '<comment>']`
   | while parsing `CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
@@ -60,23 +61,6 @@ error:
 1 | create table a (c decimal)
   | ------          - -------^ expected `(`
   | |               | |       
-  | |               | while parsing type name
-  | |               while parsing `<column name> <type> [DEFAULT <default value>] [COMMENT '<comment>']`
-  | while parsing `CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
-
-
----------- Input ----------
-create table a (b tuple(c int, uint64));
----------- Output ---------
-error: 
-  --> SQL:1:38
-  |
-1 | create table a (b tuple(c int, uint64));
-  | ------          - -----              ^
-  | |               | |                  |
-  | |               | |                  expected `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, or 30 more ...
-  | |               | |                  while parsing type name
-  | |               | while parsing TUPLE(<name> <type>, ...)
   | |               | while parsing type name
   | |               while parsing `<column name> <type> [DEFAULT <default value>] [COMMENT '<comment>']`
   | while parsing `CREATE TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`

--- a/src/query/expression/src/converts/to.rs
+++ b/src/query/expression/src/converts/to.rs
@@ -50,6 +50,6 @@ pub fn scalar_to_datavalue(scalar: &Scalar) -> DataValue {
             let values = x.iter().map(scalar_to_datavalue).collect();
             DataValue::Struct(values)
         }
-        Scalar::EmptyMap | Scalar::Map(_) => unimplemented!(),
+        Scalar::EmptyMap | Scalar::Map(_) | Scalar::Vector(_) => unimplemented!(),
     }
 }

--- a/src/query/expression/src/kernels/concat.rs
+++ b/src/query/expression/src/kernels/concat.rs
@@ -37,6 +37,7 @@ use crate::types::StringType;
 use crate::types::TimestampType;
 use crate::types::ValueType;
 use crate::types::VariantType;
+use crate::types::VectorType;
 use crate::with_decimal_type;
 use crate::with_number_mapped_type;
 use crate::BlockEntry;
@@ -144,6 +145,13 @@ impl Column {
                 let builder = ColumnBuilder::with_capacity(&col.values.data_type(), capacity);
                 let builder = ArrayColumnBuilder { builder, offsets };
                 Self::concat_value_types::<ArrayType<AnyType>>(builder, columns)
+            }
+            Column::Vector(_) => {
+                let mut offsets = Vec::with_capacity(capacity + 1);
+                offsets.push(0);
+                let builder = Vec::with_capacity(capacity);
+                let builder = ArrayColumnBuilder { builder, offsets };
+                Self::concat_value_types::<VectorType>(builder, columns)
             }
             Column::Map(col) => {
                 let mut offsets = Vec::with_capacity(capacity + 1);

--- a/src/query/expression/src/kernels/filter.rs
+++ b/src/query/expression/src/kernels/filter.rs
@@ -33,6 +33,7 @@ use crate::types::BooleanType;
 use crate::types::MapType;
 use crate::types::ValueType;
 use crate::types::VariantType;
+use crate::types::VectorType;
 use crate::with_decimal_type;
 use crate::with_number_type;
 use crate::BlockEntry;
@@ -140,6 +141,13 @@ impl Column {
                 let builder = ColumnBuilder::with_capacity(&column.values.data_type(), length);
                 let builder = ArrayColumnBuilder { builder, offsets };
                 Self::filter_scalar_types::<ArrayType<AnyType>>(column, builder, filter)
+            }
+            Column::Vector(column) => {
+                let mut offsets = Vec::with_capacity(length + 1);
+                offsets.push(0);
+                let builder = Vec::with_capacity(length);
+                let builder = ArrayColumnBuilder { builder, offsets };
+                Self::filter_scalar_types::<VectorType>(column, builder, filter)
             }
             Column::Map(column) => {
                 let mut offsets = Vec::with_capacity(length + 1);

--- a/src/query/expression/src/kernels/group_by_hash.rs
+++ b/src/query/expression/src/kernels/group_by_hash.rs
@@ -545,6 +545,13 @@ pub fn serialize_column_binary(column: &Column, row: usize, vec: &mut Vec<u8>) {
                 serialize_column_binary(&data, i, vec);
             }
         }
+        Column::Vector(array) => {
+            let data = array.index(row).unwrap();
+            BinaryWrite::write_uvarint(vec, data.len() as u64).unwrap();
+            for i in 0..data.len() {
+                vec.extend_from_slice(data[i].to_le_bytes().as_ref());
+            }
+        }
         Column::Nullable(c) => {
             let valid = c.validity.get_bit(row);
             vec.push(valid as u8);

--- a/src/query/expression/src/kernels/scatter.rs
+++ b/src/query/expression/src/kernels/scatter.rs
@@ -34,6 +34,7 @@ use crate::types::StringType;
 use crate::types::TimestampType;
 use crate::types::ValueType;
 use crate::types::VariantType;
+use crate::types::VectorType;
 use crate::with_decimal_type;
 use crate::with_number_mapped_type;
 use crate::BlockEntry;
@@ -203,6 +204,13 @@ impl Column {
                     indices,
                     scatter_size,
                 )
+            }
+            Column::Vector(column) => {
+                let mut offsets = Vec::with_capacity(length + 1);
+                offsets.push(0);
+                let builder = Vec::with_capacity(length);
+                let builder = ArrayColumnBuilder { builder, offsets };
+                Self::scatter_scalars::<VectorType, _>(column, builder, indices, scatter_size)
             }
             Column::Map(column) => {
                 let mut offsets = Vec::with_capacity(length + 1);

--- a/src/query/expression/src/kernels/take.rs
+++ b/src/query/expression/src/kernels/take.rs
@@ -30,6 +30,7 @@ use crate::types::NumberType;
 use crate::types::StringType;
 use crate::types::ValueType;
 use crate::types::VariantType;
+use crate::types::VectorType;
 use crate::with_decimal_type;
 use crate::with_number_mapped_type;
 use crate::BlockEntry;
@@ -109,6 +110,13 @@ impl Column {
                 let builder = ColumnBuilder::with_capacity(&column.values.data_type(), self.len());
                 let builder = ArrayColumnBuilder { builder, offsets };
                 Self::take_value_types::<ArrayType<AnyType>, _>(column, builder, indices)
+            }
+            Column::Vector(column) => {
+                let mut offsets = Vec::with_capacity(length + 1);
+                offsets.push(0);
+                let builder = Vec::with_capacity(self.len());
+                let builder = ArrayColumnBuilder { builder, offsets };
+                Self::take_value_types::<VectorType, _>(column, builder, indices)
             }
             Column::Map(column) => {
                 let mut offsets = Vec::with_capacity(length + 1);

--- a/src/query/expression/src/kernels/take_chunks.rs
+++ b/src/query/expression/src/kernels/take_chunks.rs
@@ -32,6 +32,7 @@ use crate::types::StringType;
 use crate::types::TimestampType;
 use crate::types::ValueType;
 use crate::types::VariantType;
+use crate::types::VectorType;
 use crate::with_decimal_type;
 use crate::with_number_mapped_type;
 use crate::BlockEntry;
@@ -243,6 +244,13 @@ impl Column {
                 let builder = ColumnBuilder::with_capacity(&column.values.data_type(), result_size);
                 let builder = ArrayColumnBuilder { builder, offsets };
                 Self::take_block_value_types::<ArrayType<AnyType>>(columns, builder, indices)
+            }
+            Column::Vector(_) => {
+                let mut offsets = Vec::with_capacity(result_size + 1);
+                offsets.push(0);
+                let builder = Vec::with_capacity(result_size);
+                let builder = ArrayColumnBuilder { builder, offsets };
+                Self::take_block_value_types::<VectorType>(columns, builder, indices)
             }
             Column::Map(column) => {
                 let mut offsets = Vec::with_capacity(result_size + 1);

--- a/src/query/expression/src/property.rs
+++ b/src/query/expression/src/property.rs
@@ -189,6 +189,9 @@ impl Domain {
             }
             DataType::EmptyArray => Domain::Array(None),
             DataType::Array(ty) => Domain::Array(Some(Box::new(Domain::full(ty)))),
+            DataType::Vector => Domain::Array(Some(Box::new(Domain::full(&DataType::Number(
+                NumberDataType::Float32,
+            ))))),
             DataType::EmptyMap => Domain::Map(None),
             DataType::Map(box ty) => {
                 let inner_domain = match ty {

--- a/src/query/expression/src/types.rs
+++ b/src/query/expression/src/types.rs
@@ -28,6 +28,7 @@ pub mod number_class;
 pub mod string;
 pub mod timestamp;
 pub mod variant;
+pub mod vector;
 
 use std::fmt::Debug;
 use std::ops::Range;
@@ -53,6 +54,7 @@ pub use self::number_class::*;
 pub use self::string::StringType;
 pub use self::timestamp::TimestampType;
 pub use self::variant::VariantType;
+pub use self::vector::VectorType;
 use crate::property::Domain;
 use crate::values::Column;
 use crate::values::Scalar;
@@ -74,6 +76,7 @@ pub enum DataType {
     Date,
     Nullable(Box<DataType>),
     Array(Box<DataType>),
+    Vector,
     Map(Box<DataType>),
     Tuple(Vec<DataType>),
     Variant,

--- a/src/query/expression/src/types/array.rs
+++ b/src/query/expression/src/types/array.rs
@@ -358,7 +358,7 @@ impl<T: ArgType> ArrayColumnBuilder<T> {
 
 impl ArrayColumnBuilder<AnyType> {
     pub fn pop(&mut self) -> Option<Column> {
-        if self.len() > 1 {
+        if self.len() > 0 {
             let pop_count = self.offsets[self.offsets.len() - 1] as usize
                 - self.offsets[self.offsets.len() - 2] as usize;
             self.offsets.pop();

--- a/src/query/expression/src/types/array.rs
+++ b/src/query/expression/src/types/array.rs
@@ -358,7 +358,7 @@ impl<T: ArgType> ArrayColumnBuilder<T> {
 
 impl ArrayColumnBuilder<AnyType> {
     pub fn pop(&mut self) -> Option<Column> {
-        if self.len() > 0 {
+        if self.len() > 1 {
             let pop_count = self.offsets[self.offsets.len() - 1] as usize
                 - self.offsets[self.offsets.len() - 2] as usize;
             self.offsets.pop();

--- a/src/query/expression/src/types/variant.rs
+++ b/src/query/expression/src/types/variant.rs
@@ -199,6 +199,17 @@ pub fn cast_scalar_to_variant(scalar: ScalarRef, tz: TzLUT, buf: &mut Vec<u8>) {
             jsonb::build_array(items.iter(), buf).expect("failed to build jsonb array");
             return;
         }
+        ScalarRef::Vector(col) => {
+            let mut builder = StringColumnBuilder::with_capacity(col.len(), col.len() * 16);
+            for v in col.iter() {
+                let value: jsonb::Value = v.0.into();
+                value.write_to_vec(&mut builder.data);
+                builder.commit_row();
+            }
+            let items = builder.build();
+            jsonb::build_array(items.iter(), buf).expect("failed to build jsonb array");
+            return;
+        }
         ScalarRef::Map(col) => {
             let kv_col = KvPair::<AnyType, AnyType>::try_downcast_column(&col).unwrap();
             let kvs = kv_col

--- a/src/query/expression/src/types/vector.rs
+++ b/src/query/expression/src/types/vector.rs
@@ -1,0 +1,196 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Range;
+
+use common_arrow::arrow::buffer::Buffer;
+use common_arrow::arrow::trusted_len::TrustedLen;
+
+use crate::property::Domain;
+use crate::types::array::ArrayColumn;
+use crate::types::array::ArrayColumnBuilder;
+use crate::types::number::F32;
+use crate::types::ArgType;
+use crate::types::DataType;
+use crate::types::Float32Type;
+use crate::types::GenericMap;
+use crate::types::NumberDomain;
+use crate::types::SimpleDomain;
+use crate::types::ValueType;
+use crate::values::Column;
+use crate::values::Scalar;
+use crate::ColumnBuilder;
+use crate::ScalarRef;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VectorType;
+
+impl ValueType for VectorType {
+    type Scalar = Vec<F32>;
+    type ScalarRef<'a> = Vec<F32>;
+    type Column = ArrayColumn<Float32Type>;
+    type Domain = SimpleDomain<F32>;
+    type ColumnIterator<'a> = VectorIterator<'a>;
+    type ColumnBuilder = ArrayColumnBuilder<Float32Type>;
+
+    #[inline]
+    fn upcast_gat<'short, 'long: 'short>(long: Vec<F32>) -> Vec<F32> {
+        long
+    }
+
+    fn to_owned_scalar<'a>(scalar: Self::ScalarRef<'a>) -> Self::Scalar {
+        scalar.to_vec()
+    }
+
+    fn to_scalar_ref<'a>(scalar: &'a Self::Scalar) -> Self::ScalarRef<'a> {
+        scalar.to_vec()
+    }
+
+    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+        scalar.as_vector().cloned()
+    }
+
+    fn try_downcast_column<'a>(col: &'a Column) -> Option<Self::Column> {
+        Some(*col.as_vector()?.clone())
+    }
+
+    fn try_downcast_domain(domain: &Domain) -> Option<Self::Domain> {
+        match domain {
+            Domain::Array(Some(domain)) => Some(Float32Type::try_downcast_domain(domain)?),
+            Domain::Array(None) => Some(Float32Type::full_domain()),
+            _ => None,
+        }
+    }
+
+    fn try_downcast_builder<'a>(
+        _builder: &'a mut ColumnBuilder,
+    ) -> Option<&'a mut Self::ColumnBuilder> {
+        None
+    }
+
+    fn upcast_scalar(scalar: Self::Scalar) -> Scalar {
+        Scalar::Vector(scalar)
+    }
+
+    fn upcast_column(col: Self::Column) -> Column {
+        Column::Vector(Box::new(col))
+    }
+
+    fn upcast_domain(domain: Self::Domain) -> Domain {
+        Domain::Array(Some(Box::new(Domain::Number(NumberDomain::Float32(
+            domain,
+        )))))
+    }
+
+    fn column_len<'a>(col: &'a Self::Column) -> usize {
+        col.len()
+    }
+
+    fn index_column<'a>(col: &'a Self::Column, index: usize) -> Option<Self::ScalarRef<'a>> {
+        Some(col.index(index).unwrap().as_slice().to_vec())
+    }
+
+    unsafe fn index_column_unchecked<'a>(
+        col: &'a Self::Column,
+        index: usize,
+    ) -> Self::ScalarRef<'a> {
+        col.index_unchecked(index).as_slice().to_vec()
+    }
+
+    fn slice_column<'a>(col: &'a Self::Column, range: Range<usize>) -> Self::Column {
+        col.slice(range)
+    }
+
+    fn iter_column<'a>(col: &'a Self::Column) -> Self::ColumnIterator<'a> {
+        VectorIterator {
+            values: &col.values,
+            offsets: col.offsets.windows(2),
+        }
+    }
+
+    fn column_to_builder(col: Self::Column) -> Self::ColumnBuilder {
+        ArrayColumnBuilder::from_column(col)
+    }
+
+    fn builder_len(builder: &Self::ColumnBuilder) -> usize {
+        builder.len()
+    }
+
+    fn push_item(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>) {
+        let value = Buffer::<F32>::from(item);
+        builder.push(value);
+    }
+
+    fn push_default(builder: &mut Self::ColumnBuilder) {
+        builder.push_default();
+    }
+
+    fn append_column(builder: &mut Self::ColumnBuilder, other_builder: &Self::Column) {
+        builder.append_column(other_builder);
+    }
+
+    fn build_column(builder: Self::ColumnBuilder) -> Self::Column {
+        builder.build()
+    }
+
+    fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
+        builder.build_scalar().as_slice().to_vec()
+    }
+
+    fn scalar_memory_size<'a>(scalar: &Self::ScalarRef<'a>) -> usize {
+        4 * scalar.len()
+    }
+
+    fn column_memory_size(col: &Self::Column) -> usize {
+        col.memory_size()
+    }
+}
+
+impl ArgType for VectorType {
+    fn data_type() -> DataType {
+        DataType::Vector
+    }
+
+    fn full_domain() -> Self::Domain {
+        Float32Type::full_domain()
+    }
+
+    fn create_builder(capacity: usize, generics: &GenericMap) -> Self::ColumnBuilder {
+        ArrayColumnBuilder::<Float32Type>::with_capacity(capacity, 0, generics)
+    }
+}
+
+pub struct VectorIterator<'a> {
+    values: &'a Buffer<F32>,
+    offsets: std::slice::Windows<'a, u64>,
+}
+
+impl<'a> Iterator for VectorIterator<'a> {
+    type Item = Vec<F32>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.offsets.next().map(|range| {
+            Float32Type::slice_column(self.values, (range[0] as usize)..(range[1] as usize))
+                .as_slice()
+                .to_vec()
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.offsets.size_hint()
+    }
+}
+
+unsafe impl<'a> TrustedLen for VectorIterator<'a> {}
+unsafe impl<'a> std::iter::TrustedLen for VectorIterator<'a> {}

--- a/src/query/expression/src/utils/display.rs
+++ b/src/query/expression/src/utils/display.rs
@@ -124,7 +124,12 @@ impl<'a> Debug for ScalarRef<'a> {
             },
             ScalarRef::Timestamp(t) => write!(f, "{t:?}"),
             ScalarRef::Date(d) => write!(f, "{d:?}"),
-            ScalarRef::Array(col) => write!(f, "[{}]", col.iter().join(", ")),
+            ScalarRef::Array(col) => {
+                write!(f, "[{}]", col.iter().join(", "))
+            }
+            ScalarRef::Vector(col) => {
+                write!(f, "[{}]", col.iter().join(", "))
+            }
             ScalarRef::Map(col) => {
                 write!(f, "{{")?;
                 let kv_col = KvPair::<AnyType, AnyType>::try_downcast_column(col).unwrap();
@@ -169,6 +174,7 @@ impl Debug for Column {
             Column::Timestamp(col) => write!(f, "{col:?}"),
             Column::Date(col) => write!(f, "{col:?}"),
             Column::Array(col) => write!(f, "{col:?}"),
+            Column::Vector(col) => write!(f, "{col:?}"),
             Column::Map(col) => write!(f, "{col:?}"),
             Column::Nullable(col) => write!(f, "{col:?}"),
             Column::Tuple(fields) => f.debug_tuple("Tuple").field(fields).finish(),
@@ -198,7 +204,12 @@ impl<'a> Display for ScalarRef<'a> {
             },
             ScalarRef::Timestamp(t) => write!(f, "{}", timestamp_to_string(*t, Tz::UTC)),
             ScalarRef::Date(d) => write!(f, "{}", date_to_string(*d as i64, Tz::UTC)),
-            ScalarRef::Array(col) => write!(f, "[{}]", col.iter().join(", ")),
+            ScalarRef::Array(col) => {
+                write!(f, "[{}]", col.iter().join(", "))
+            }
+            ScalarRef::Vector(col) => {
+                write!(f, "[{}]", col.iter().join(", "))
+            }
             ScalarRef::Map(col) => {
                 write!(f, "{{")?;
                 let kv_col = KvPair::<AnyType, AnyType>::try_downcast_column(col).unwrap();
@@ -437,6 +448,7 @@ impl Display for DataType {
             DataType::Nullable(inner) => write!(f, "{inner} NULL"),
             DataType::EmptyArray => write!(f, "Array(Nothing)"),
             DataType::Array(inner) => write!(f, "Array({inner})"),
+            DataType::Vector => write!(f, "Vector"),
             DataType::EmptyMap => write!(f, "Map(Nothing)"),
             DataType::Map(inner) => match *inner.clone() {
                 DataType::Tuple(fields) => {
@@ -476,6 +488,7 @@ impl Display for TableDataType {
             TableDataType::Nullable(inner) => write!(f, "{inner} NULL"),
             TableDataType::EmptyArray => write!(f, "Array(Nothing)"),
             TableDataType::Array(inner) => write!(f, "Array({inner})"),
+            TableDataType::Vector => write!(f, "Vector"),
             TableDataType::EmptyMap => write!(f, "Map(Nothing)"),
             TableDataType::Map(inner) => match *inner.clone() {
                 TableDataType::Tuple {

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -2407,7 +2407,7 @@ impl ColumnBuilder {
             ColumnBuilder::Date(builder) => builder.pop().map(Scalar::Date),
             ColumnBuilder::Array(builder) => builder.pop().map(Scalar::Array),
             ColumnBuilder::Vector(builder) => {
-                if builder.len() > 1 {
+                if builder.len() > 0 {
                     builder.offsets.pop();
                     let idx = *builder.offsets.last().unwrap() as usize;
                     let vals = builder.builder.drain(idx..).collect();

--- a/src/query/formats/src/field_decoder/json_ast.rs
+++ b/src/query/formats/src/field_decoder/json_ast.rs
@@ -31,6 +31,7 @@ use common_expression::types::number::Number;
 use common_expression::types::string::StringColumnBuilder;
 use common_expression::types::timestamp::check_timestamp;
 use common_expression::types::AnyType;
+use common_expression::types::Float32Type;
 use common_expression::types::NumberColumnBuilder;
 use common_expression::with_decimal_type;
 use common_expression::with_number_mapped_type;
@@ -84,6 +85,7 @@ impl FieldJsonAstDecoder {
             ColumnBuilder::Timestamp(c) => self.read_timestamp(c, value),
             ColumnBuilder::String(c) => self.read_string(c, value),
             ColumnBuilder::Array(c) => self.read_array(c, value),
+            ColumnBuilder::Vector(c) => self.read_vector(c, value),
             ColumnBuilder::Map(c) => self.read_map(c, value),
             ColumnBuilder::Tuple(fields) => self.read_tuple(fields, value),
             ColumnBuilder::Variant(c) => self.read_variant(c, value),
@@ -246,6 +248,23 @@ impl FieldJsonAstDecoder {
             Value::Array(vals) => {
                 for val in vals {
                     self.read_field(&mut column.builder, val)?;
+                }
+                column.commit_row();
+                Ok(())
+            }
+            _ => Err(ErrorCode::BadBytes("Incorrect json value, must be array")),
+        }
+    }
+
+    fn read_vector(
+        &self,
+        column: &mut ArrayColumnBuilder<Float32Type>,
+        value: &Value,
+    ) -> Result<()> {
+        match value {
+            Value::Array(vals) => {
+                for val in vals {
+                    self.read_float(&mut column.builder, val)?;
                 }
                 column.commit_row();
                 Ok(())

--- a/src/query/formats/src/field_encoder/row_based.rs
+++ b/src/query/formats/src/field_encoder/row_based.rs
@@ -62,6 +62,7 @@ pub trait FieldEncoderRowBased {
             Column::String(c) => self.write_string(c, row_index, out_buf, raw),
             Column::Nullable(box c) => self.write_nullable(c, row_index, out_buf, raw),
             Column::Array(box c) => self.write_array(c, row_index, out_buf, raw),
+            Column::Vector(box c) => self.write_array(c, row_index, out_buf, raw),
             Column::Map(box c) => self.write_map(c, row_index, out_buf, raw),
             Column::Tuple(fields) => self.write_tuple(fields, row_index, out_buf, raw),
             Column::Variant(c) => self.write_variant(c, row_index, out_buf, raw),

--- a/src/query/formats/src/output_format/json.rs
+++ b/src/query/formats/src/output_format/json.rs
@@ -105,6 +105,13 @@ fn scalar_to_json(s: ScalarRef<'_>, format: &FormatSettings) -> JsonValue {
                 .collect();
             JsonValue::Array(vals)
         }
+        ScalarRef::Vector(x) => {
+            let vals = x
+                .iter()
+                .map(|v| JsonValue::Number(serde_json::Number::from_f64(v.0 as f64).unwrap()))
+                .collect();
+            JsonValue::Array(vals)
+        }
         ScalarRef::Map(x) => {
             let vals = x
                 .iter()

--- a/src/query/functions/tests/it/scalars/parser.rs
+++ b/src/query/functions/tests/it/scalars/parser.rs
@@ -541,6 +541,7 @@ fn transform_data_type(target_type: common_ast::ast::TypeName) -> DataType {
             DataType::Nullable(Box::new(transform_data_type(*inner_type)))
         }
         common_ast::ast::TypeName::Variant => DataType::Variant,
+        common_ast::ast::TypeName::Vector => DataType::Vector,
     }
 }
 

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -1097,8 +1097,8 @@ Functions overloads:
 28 contains(Array(T0), T0) :: Boolean
 0 cos(Float64) :: Float64
 1 cos(Float64 NULL) :: Float64 NULL
-0 cosine_distance(Array(Float32), Array(Float32)) :: Float32
-1 cosine_distance(Array(Float32) NULL, Array(Float32) NULL) :: Float32 NULL
+0 cosine_distance(Vector, Vector) :: Float32
+1 cosine_distance(Vector NULL, Vector NULL) :: Float32 NULL
 0 cot(Float64) :: Float64
 1 cot(Float64 NULL) :: Float64 NULL
 0 crc32(String) :: UInt32
@@ -1506,8 +1506,8 @@ Functions overloads:
 198 divide(Float64 NULL, Float32 NULL) :: Float64 NULL
 199 divide(Float64, Float64) :: Float64
 200 divide(Float64 NULL, Float64 NULL) :: Float64 NULL
-0 embedding_vector(String, String) :: Array(Float32)
-1 embedding_vector(String NULL, String NULL) :: Array(Float32) NULL
+0 embedding_vector(String, String) :: Vector
+1 embedding_vector(String NULL, String NULL) :: Vector NULL
 0 eq(Variant, Variant) :: Boolean
 1 eq(Variant NULL, Variant NULL) :: Boolean NULL
 2 eq(String, String) :: Boolean
@@ -1607,6 +1607,8 @@ Functions overloads:
 9 get FACTORY
 10 get FACTORY
 11 get FACTORY
+12 get(Vector, UInt64) :: Float32 NULL
+13 get(Vector NULL, UInt64 NULL) :: Float32 NULL
 0 get_ignore_case(Variant NULL, String NULL) :: Variant NULL
 0 get_path(Variant NULL, String NULL) :: Variant NULL
 0 great_circle_angle(Float64, Float64, Float64, Float64) :: Float32
@@ -1722,6 +1724,8 @@ Functions overloads:
 4 length(Array(T0) NULL) :: UInt64 NULL
 5 length(String) :: UInt64
 6 length(String NULL) :: UInt64 NULL
+7 length(Vector) :: UInt64
+8 length(Vector NULL) :: UInt64 NULL
 0 like(String, String) :: Boolean
 1 like(String NULL, String NULL) :: Boolean NULL
 0 ln(UInt8) :: Float64

--- a/src/query/functions/tests/it/scalars/testdata/vector.txt
+++ b/src/query/functions/tests/it/scalars/testdata/vector.txt
@@ -1,6 +1,6 @@
 ast            : cosine_distance([a], [b])
 raw expr       : cosine_distance(array(a::Float32), array(b::Float32))
-checked expr   : cosine_distance<Array(Float32), Array(Float32)>(array<T0=Float32><T0>(a), array<T0=Float32><T0>(b))
+checked expr   : cosine_distance<Vector, Vector>(CAST(array<T0=Float32><T0>(a) AS Vector), CAST(array<T0=Float32><T0>(b) AS Vector))
 evaluation:
 +--------+---------+---------+---------+
 |        | a       | b       | Output  |

--- a/src/query/service/src/servers/mysql/writers/query_result_writer.rs
+++ b/src/query/service/src/servers/mysql/writers/query_result_writer.rs
@@ -164,6 +164,7 @@ impl<'a, W: AsyncWrite + Send + Unpin> DFQueryResultWriter<'a, W> {
                 DataType::Date => Ok(ColumnType::MYSQL_TYPE_DATE),
                 DataType::Timestamp => Ok(ColumnType::MYSQL_TYPE_DATETIME),
                 DataType::Array(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+                DataType::Vector => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
                 DataType::Map(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
                 DataType::Tuple(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
                 DataType::Variant => Ok(ColumnType::MYSQL_TYPE_VARCHAR),

--- a/tests/sqllogictests/suites/base/03_common/03_0026_insert_into_tuple
+++ b/tests/sqllogictests/suites/base/03_common/03_0026_insert_into_tuple
@@ -25,7 +25,7 @@ select t.1, t.2, t.3, t.4, t.5, t.6 from t1
 1 100 12.34 abc 2020-01-01 2020-01-01 00:00:00.000000
 0 200 -25.73 xyz 2022-06-01 2022-06-01 12:00:00.000000
 
-statement error 1005
+statement error 1001
 CREATE TABLE IF NOT EXISTS t2(t Tuple(a Bool, Int64)) Engine = Fuse
 
 statement ok

--- a/tests/sqllogictests/suites/base/03_common/03_0038_insert_into_vector
+++ b/tests/sqllogictests/suites/base/03_common/03_0038_insert_into_vector
@@ -8,27 +8,27 @@ statement ok
 USE db1
 
 statement ok
-CREATE TABLE IF NOT EXISTS t1(id Int, v Vector) Engine = Fuse
+CREATE TABLE IF NOT EXISTS tv1(id Int, v Vector) Engine = Fuse
 
 statement ok
-INSERT INTO t1 (id, v) VALUES(1, [1.1, 1.2, 1.3]),(2, [2.1, 2.2, 2.3]),(3, [3.1, 3.2, 3.3]);
+INSERT INTO tv1 (id, v) VALUES(1, [1.1, 1.2, 1.3]),(2, [2.1, 2.2, 2.3]),(3, [3.1, 3.2, 3.3])
 
 query IT
-select * from t1
+select * from tv1
 ----
 1 [1.1,1.2,1.3]
 2 [2.1,2.2,2.3]
 3 [3.1,3.2,3.3]
 
 query II
-select v[1], v[2] from t1
+select v[1], v[2] from tv1
 ----
 1.1 1.2
 2.1 2.2
 3.1 3.2
 
 query I
-select cosine_distance(v, [10.1,11.2,12.3]) from t1;
+select cosine_distance(v, [10.1,11.2,12.3]) from tv1
 ----
 0.99992687
 0.9990788

--- a/tests/sqllogictests/suites/base/03_common/03_0038_insert_into_vector
+++ b/tests/sqllogictests/suites/base/03_common/03_0038_insert_into_vector
@@ -1,0 +1,38 @@
+statement ok
+DROP DATABASE IF EXISTS db1
+
+statement ok
+CREATE DATABASE db1
+
+statement ok
+USE db1
+
+statement ok
+CREATE TABLE IF NOT EXISTS t1(id Int, v Vector) Engine = Fuse
+
+statement ok
+INSERT INTO t1 (id, v) VALUES(1, [1.1, 1.2, 1.3]),(2, [2.1, 2.2, 2.3]),(3, [3.1, 3.2, 3.3]);
+
+query IT
+select * from t1
+----
+1 [1.1,1.2,1.3]
+2 [2.1,2.2,2.3]
+3 [3.1,3.2,3.3]
+
+query II
+select v[1], v[2] from t1
+----
+1.1 1.2
+2.1 2.2
+3.1 3.2
+
+query I
+select cosine_distance(v, [10.1,11.2,12.3]) from t1;
+----
+0.99992687
+0.9990788
+0.9985147
+
+statement ok
+DROP DATABASE db1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support the `Vector` data type, as alias of `Array<Float32>`

Closes #10769
