### PR TITLE
Update 10-put-to-stage.md

### DIFF
--- a/docs/doc/11-integrations/00-api/10-put-to-stage.md
+++ b/docs/doc/11-integrations/00-api/10-put-to-stage.md
@@ -69,7 +69,7 @@ CREATE STAGE my_external_stage url = 's3://testbucket/admin/data/' credentials=(
 Download [books.parquet](https://datafuse-1253727613.cos.ap-hongkong.myqcloud.com/data/books.parquet)
 
 ```shell title='Put books.parquet to stage'
-curl  -H "stage_name:my_external_stage" -F "upload=@books.parquet" -XPUT "http://localhost:8000/v1/upload_to_stage"
+curl  -H "stage_name:my_external_stage" -F "upload=@books.parquet" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root:
 ```
 
 ```shell title='Response'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

```sheel
[qijun@arch ~]$ curl  -H "stage_name:my_internal_stage" -F "upload=@books.parquet" -XPUT "http://localhost:8004/v1/upload_to_stage"
{"error":{"code":"401","message":"No authorization header detected"}}
```

If `-u root:` is missing, authorization failure will be displayed.
Closes #issue
