### PR TITLE
fix: EmptyShareEndpointConfig  error on any SHOW TABLES

### DIFF
--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -18,6 +18,7 @@ use common_catalog::catalog::Catalog;
 use common_catalog::catalog::CatalogManager;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
+use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::types::number::UInt64Type;
 use common_expression::types::NumberDataType;
@@ -106,7 +107,11 @@ where TablesTable<T>: HistoryAware
             for db in dbs {
                 let name = db.name().to_string().into_boxed_str();
                 let name: &str = Box::leak(name);
-                let tables = Self::list_tables(&ctl, tenant.as_str(), name).await?;
+                let tables = match Self::list_tables(&ctl, tenant.as_str(), name).await {
+                    Ok(tables) => tables,
+                    Err(err) if err.code() == ErrorCode::EMPTY_SHARE_ENDPOINT_CONFIG => continue,
+                    Err(err) => return Err(err),
+                };
                 for table in tables {
                     catalogs.push(ctl_name.as_bytes().to_vec());
                     databases.push(name.as_bytes().to_vec());

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -109,7 +109,10 @@ where TablesTable<T>: HistoryAware
                 let name: &str = Box::leak(name);
                 let tables = match Self::list_tables(&ctl, tenant.as_str(), name).await {
                     Ok(tables) => tables,
-                    Err(err) if err.code() == ErrorCode::EMPTY_SHARE_ENDPOINT_CONFIG => continue,
+                    Err(err) if err.code() == ErrorCode::EMPTY_SHARE_ENDPOINT_CONFIG => {
+                        tracing::warn!("list tables failed on db {}: {}", db.name(), err);
+                        continue;
+                    }
                     Err(err) => return Err(err),
                 };
                 for table in tables {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently SHOW TABLES is a rewrite to selecting `system.tables`.

However in `system.tables`, it tries to list all the tables from every databases. If any databases raises EmptyShareEndpointConfig, all SHOW TABLES to any database will met this error.

This PR tries to swallow the EmptyShareEndpointConfig on SHOW TABLES statement.