### PR TITLE
fix:  processors used in the impl of `replace into` may lose data

### DIFF
--- a/src/query/storages/fuse/src/operations/merge_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/merge_into_mutator.rs
@@ -32,7 +32,7 @@ use storages_common_cache::LoadParams;
 use storages_common_table_meta::meta::BlockMeta;
 use storages_common_table_meta::meta::ColumnStatistics;
 use storages_common_table_meta::meta::Location;
-use tracing::debug;
+use tracing::info;
 
 use crate::io::write_data;
 use crate::io::BlockBuilder;
@@ -189,7 +189,10 @@ impl MergeIntoOperationAggregator {
         block_meta: &BlockMeta,
         deleted_key_hashes: &HashSet<UniqueKeyDigest>,
     ) -> Result<Option<ReplacementLogEntry>> {
-        debug!("apply delete to segment {}", segment_index);
+        info!(
+            "apply delete to segment idx {}, block idx {}",
+            segment_index, block_index
+        );
         if block_meta.row_count == 0 {
             return Ok(None);
         }
@@ -243,13 +246,13 @@ impl MergeIntoOperationAggregator {
 
         // shortcuts
         if bitmap.unset_bits() == 0 {
-            debug!("nothing deleted");
+            info!("nothing deleted");
             // nothing to be deleted
             return Ok(None);
         }
 
         if bitmap.unset_bits() == block_meta.row_count as usize {
-            debug!("whole block deletion");
+            info!("whole block deletion");
             // whole block deletion
             // NOTE that if deletion marker is enabled, check the real meaning of `row_count`
             let mutation = ReplacementLogEntry {
@@ -266,7 +269,7 @@ impl MergeIntoOperationAggregator {
 
         let bitmap = bitmap.into();
         let new_block = data_block.filter_with_bitmap(&bitmap)?;
-        debug!("number of row deleted: {}", bitmap.unset_bits());
+        info!("number of row deleted: {}", bitmap.unset_bits());
 
         // serialization and compression is cpu intensive, send them to dedicated thread pool
         // and wait (asyncly, which will NOT block the executor thread)

--- a/src/query/storages/fuse/src/operations/merge_into/processors/processor_broadcast.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/processors/processor_broadcast.rs
@@ -77,6 +77,8 @@ impl Processor for BroadcastProcessor {
 
         if self.input_port.has_data() && self.input_data.is_none() {
             self.input_data = Some(self.input_port.pull_data().unwrap());
+            // reset output index
+            self.output_index = 0;
         }
 
         if let Some(data) = &self.input_data {

--- a/src/query/storages/fuse/src/operations/merge_into/processors/transform_append.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/processors/transform_append.rs
@@ -159,6 +159,12 @@ impl AsyncAccumulatingTransform for AppendTransform {
     const NAME: &'static str = "AppendTransform";
 
     async fn transform(&mut self, data_block: DataBlock) -> Result<Option<DataBlock>> {
+        if data_block.is_empty() {
+            // data source like
+            //  `select number from numbers(3000000) where number >=2000000 and number < 3000000`
+            // may generate empty data blocks
+            return Ok(None);
+        }
         // 1. serialize block and index
         let block_builder = self.block_builder.clone();
         let serialized_block_state =

--- a/src/query/storages/fuse/src/operations/replace_into/processor_replace_into.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/processor_replace_into.rs
@@ -123,8 +123,15 @@ impl Processor for ReplaceIntoProcessor {
             }
 
             if self.input_port.has_data() {
-                self.input_data = Some(self.input_port.pull_data().unwrap()?);
-                Ok(Event::Sync)
+                if self.output_data_append.is_none() && self.output_data_merge_into_action.is_none()
+                {
+                    // no pending data (being sent to down streams)
+                    self.input_data = Some(self.input_port.pull_data().unwrap()?);
+                    Ok(Event::Sync)
+                } else {
+                    // data pending
+                    Ok(Event::NeedConsume)
+                }
             } else {
                 self.input_port.set_need_data();
                 Ok(Event::NeedData)

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0024_replace_into_issue_10861
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0024_replace_into_issue_10861
@@ -1,0 +1,55 @@
+statement ok
+DROP DATABASE IF EXISTS issue_10861
+
+statement ok
+CREATE DATABASE issue_10861
+
+statement ok
+USE issue_10861
+
+statement ok
+create table s(id int);
+
+statement ok
+insert into s values(1);
+
+statement ok
+insert into s values(2);
+
+statement ok
+insert into s values(3);
+
+statement ok
+create table t(id int);
+
+statement ok
+replace into t on(id) select * from s;
+
+query I
+select * from t order by id;
+----
+1
+2
+3
+
+# replace into again, with the same source data set, multiple blocks
+statement ok
+replace into t on(id) select * from s;
+
+# expect no lost or duplications
+query I
+select * from t order by id;
+----
+1
+2
+3
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP TABLE s;
+
+statement ok
+DROP DATABASE issue_10861;
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

_broadcast processor_ and _replace_into processor_ used in the impl of `replace into` may lose data blocks,

and if that happened, data may be partially replaced into the target table.

- [x] fix
- [x] sqllogic test

Closes #10861
