### PR TITLE
feat: add feature "raft-store-defensive" to enable defensive check

### DIFF
--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -26,6 +26,9 @@ io-uring = [
     "common-meta-raft-store/io-uring",
 ]
 
+# Enable defensive check when accessing raft store.
+raft-store-defensive = ["databend-meta/raft-store-defensive"]
+
 enable-histogram-metrics = [
     "default",
     "common-metrics/enable-histogram",

--- a/src/binaries/metabench/main.rs
+++ b/src/binaries/metabench/main.rs
@@ -41,6 +41,10 @@ use serde::Serialize;
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Parser)]
 #[clap(about, version = &**METASRV_COMMIT_VERSION, author)]
 struct Config {
+    /// The prefix of keys to write.
+    #[clap(long, default_value = "0")]
+    pub prefix: u64,
+
     #[clap(long, default_value = "10")]
     pub client: u32,
 
@@ -75,20 +79,25 @@ async fn main() {
         client_num += 1;
         let addr = config.grpc_api_address.clone();
         let typ = config.rpc.clone();
+        let prefix = config.prefix;
 
         let handle = tokio::spawn(async move {
             let client =
                 MetaGrpcClient::try_create(vec![addr.to_string()], "root", "xxx", None, None, None);
-            if client.is_err() {
-                return;
-            }
-            let client = client.unwrap();
+
+            let client = match client {
+                Ok(client) => client,
+                Err(e) => {
+                    eprintln!("Failed to create client: {}", e);
+                    return;
+                }
+            };
 
             for i in 0..config.number {
                 if typ == "upsert_kv" {
-                    benchmark_upsert(&client, client_num, i).await;
+                    benchmark_upsert(&client, prefix, client_num, i).await;
                 } else if typ == "table" {
-                    benchmark_table(&client, client_num, i).await;
+                    benchmark_table(&client, prefix, client_num, i).await;
                 } else {
                     unreachable!("Invalid config.rpc: {}", typ);
                 }
@@ -109,25 +118,30 @@ async fn main() {
     );
 }
 
-async fn benchmark_upsert(client: &Arc<ClientHandle>, client_num: u32, i: u32) {
-    let node_key = format!("{}-{}", client_num, i);
+async fn benchmark_upsert(client: &Arc<ClientHandle>, prefix: u64, client_num: u32, i: u32) {
+    let node_key = || format!("{}-{}-{}", prefix, client_num, i);
+
     let seq = MatchSeq::Any;
-    let value = Operation::Update(b"v3".to_vec());
+    let value = Operation::Update(node_key().as_bytes().to_vec());
 
     let res = client
-        .upsert_kv(UpsertKVReq::new(&node_key, seq, value, None))
+        .upsert_kv(UpsertKVReq::new(&node_key(), seq, value, None))
         .await;
 
     print_res(i, "upsert_kv", &res);
 }
 
-async fn benchmark_table(client: &Arc<ClientHandle>, client_num: u32, i: u32) {
+async fn benchmark_table(client: &Arc<ClientHandle>, prefix: u64, client_num: u32, i: u32) {
+    let tenant = || format!("tenant-{}-{}", prefix, client_num);
+    let db_name = || format!("db-{}-{}", prefix, client_num);
+    let table_name = || format!("table-{}-{}", prefix, client_num);
+
     let res = client
         .create_database(CreateDatabaseReq {
             if_not_exists: false,
             name_ident: DatabaseNameIdent {
-                tenant: format!("tenant-{}", client_num),
-                db_name: format!("db-{}", client_num),
+                tenant: tenant(),
+                db_name: db_name(),
             },
             meta: Default::default(),
         })
@@ -139,9 +153,9 @@ async fn benchmark_table(client: &Arc<ClientHandle>, client_num: u32, i: u32) {
         .create_table(CreateTableReq {
             if_not_exists: true,
             name_ident: TableNameIdent {
-                tenant: format!("tenant-{}", client_num),
-                db_name: format!("db-{}", client_num),
-                table_name: format!("table-{}", client_num),
+                tenant: tenant(),
+                db_name: db_name(),
+                table_name: table_name(),
             },
             table_meta: Default::default(),
         })
@@ -150,11 +164,7 @@ async fn benchmark_table(client: &Arc<ClientHandle>, client_num: u32, i: u32) {
     print_res(i, "create_table", &res);
 
     let res = client
-        .get_table(GetTableReq::new(
-            format!("tenant-{}", client_num),
-            format!("db-{}", client_num),
-            format!("table-{}", client_num),
-        ))
+        .get_table(GetTableReq::new(tenant(), db_name(), table_name()))
         .await;
 
     print_res(i, "get_table", &res);

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -24,6 +24,9 @@ io-uring = [
 
 enable-histogram = ["common-metrics/enable-histogram"]
 
+# Enable defensive check when accessing raft store.
+raft-store-defensive = []
+
 [dependencies]
 # Workspace dependencies
 common-arrow = { path = "../../common/arrow" }

--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -34,7 +34,9 @@ use common_meta_raft_store::config::RaftConfig;
 use common_meta_raft_store::key_spaces::GenericKV;
 use common_meta_sled_store::openraft;
 use common_meta_sled_store::openraft::ChangeMembers;
+#[cfg(feature = "raft-store-defensive")]
 use common_meta_sled_store::openraft::DefensiveCheckBase;
+#[cfg(feature = "raft-store-defensive")]
 use common_meta_sled_store::openraft::StoreExt;
 use common_meta_sled_store::SledKeySpace;
 use common_meta_stoerr::MetaStorageError;
@@ -367,8 +369,13 @@ impl MetaNode {
         }
 
         let sto = RaftStoreBare::open_create(&config, open, create).await?;
-        let sto = StoreExt::new(sto);
-        sto.set_defensive(true);
+
+        #[cfg(feature = "raft-store-defensive")]
+        let sto = {
+            let sto_ext = StoreExt::new(sto);
+            sto_ext.set_defensive(true);
+            sto_ext
+        };
 
         // config.id only used for the first time
         let self_node_id = if sto.is_opened() { sto.id } else { config.id };

--- a/src/meta/service/src/store/mod.rs
+++ b/src/meta/service/src/store/mod.rs
@@ -16,7 +16,9 @@ mod store_bare;
 mod store_inner;
 mod to_storage_error;
 
+#[cfg(feature = "raft-store-defensive")]
 use common_meta_sled_store::openraft::StoreExt;
+#[cfg(feature = "raft-store-defensive")]
 use common_meta_types::TypeConfig;
 pub use store_bare::RaftStoreBare;
 pub use store_inner::StoreInner;
@@ -25,7 +27,8 @@ pub use to_storage_error::ToStorageError;
 /// Implements `RaftStorage` and provides defensive check.
 ///
 /// It is used to discover unexpected invalid data read or write, which is potentially a bug.
+#[cfg(feature = "raft-store-defensive")]
 pub type RaftStore = StoreExt<TypeConfig, RaftStoreBare>;
 
-// Uncomment this to disable defensive check
-// pub(crate) type RaftStore = raft_store_impl::RaftStore;
+#[cfg(not(feature = "raft-store-defensive"))]
+pub(crate) type RaftStore = RaftStoreBare;

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -158,6 +158,8 @@ impl StoreInner {
     pub(crate) async fn do_build_snapshot(&self) -> Result<Snapshot, StorageError> {
         // NOTE: building snapshot is guaranteed to be serialized called by RaftCore.
 
+        info!("log compaction start");
+
         // 1. Take a serialized snapshot
 
         let (snap, last_applied_log, last_membership, snapshot_id) = match self
@@ -173,6 +175,8 @@ impl StoreInner {
             }
             Ok(r) => r,
         };
+
+        info!("log compaction serialization start");
 
         let data = serde_json::to_vec(&snap)
             .map_err(MetaStorageError::from)


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feat: add feature "raft-store-defensive" to enable defensive check

This feature enables defensive check when accessing the raft store, e.g,
it check if the next log is at index of last index plus one, when
appending logs.

For optimal performance, this feature is disabled by default.


##### chore(meta-bench): key prefix can be specified


##### chore(meta): add log about snapshot building

## Changelog

- New Feature





## Related Issues