### PR TITLE
refactor: do not upsert copied-files set if both purge and force are enabled

### DIFF
--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -287,7 +287,14 @@ impl Catalog for MutableCatalog {
         req: UpdateTableMetaReq,
     ) -> Result<UpdateTableMetaReply> {
         match table_info.db_type.clone() {
-            DatabaseType::NormalDB => Ok(self.ctx.meta.update_table_meta(req).await?),
+            DatabaseType::NormalDB => {
+                info!(
+                    "updating table meta. table desc: [{}], has copied files: [{}]",
+                    table_info.desc,
+                    req.copied_files.is_some()
+                );
+                Ok(self.ctx.meta.update_table_meta(req).await?)
+            }
             DatabaseType::ShareDB(share_ident) => {
                 let db = self
                     .get_database(&share_ident.tenant, &share_ident.share_name)

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -289,7 +289,7 @@ impl Catalog for MutableCatalog {
         match table_info.db_type.clone() {
             DatabaseType::NormalDB => {
                 info!(
-                    "updating table meta. table desc: [{}], has copied files: [{}]",
+                    "updating table meta. table desc: [{}], has copied files: [{}]?",
                     table_info.desc,
                     req.copied_files.is_some()
                 );

--- a/src/query/service/src/interpreters/interpreter_copy.rs
+++ b/src/query/service/src/interpreters/interpreter_copy.rs
@@ -433,12 +433,11 @@ impl CopyInterpreter {
             let table_id = to_table.get_id();
             let expire_hours = ctx.get_settings().get_load_file_metadata_expire_hours()?;
 
-            let table_info = to_table.get_table_info();
             let upsert_copied_files_request = {
                 if stage_info.copy_options.purge && force {
                     // if `purge-after-copy` is enabled, and in `force` copy mode,
                     // we do not need to upsert copied files into meta server
-                    info!("[purge] and [force] are both enabled,  will not update copied-files set. ({})", &table_info.desc);
+                    info!("[purge] and [force] are both enabled,  will not update copied-files set. ({})", &to_table.get_table_info().desc);
                     None
                 } else {
                     let fail_if_duplicated = !force;

--- a/src/query/service/src/interpreters/interpreter_copy.rs
+++ b/src/query/service/src/interpreters/interpreter_copy.rs
@@ -260,6 +260,7 @@ impl CopyInterpreter {
         info!("end to list files: got {} files", num_all_files);
 
         let need_copy_file_infos = if force {
+            info!("force mode, ignore file filtering");
             all_source_file_infos
         } else {
             // Status.
@@ -429,13 +430,22 @@ impl CopyInterpreter {
             let table_id = to_table.get_id();
             let expire_hours = ctx.get_settings().get_load_file_metadata_expire_hours()?;
 
-            let fail_if_duplicated = !force;
-            let upsert_copied_files_request = Self::upsert_copied_files_request(
-                table_id,
-                expire_hours,
-                copied_file_tree,
-                fail_if_duplicated,
-            );
+            let upsert_copied_files_request = {
+                if stage_info.copy_options.purge && force {
+                    // if `purge-after-copy` is enabled, and in `force` copy mode,
+                    // we do not need to upsert copied files into meta server
+                    info!("[purge-after-copy] and [force-copy] are both enabled,  will not update copied-files set");
+                    None
+                } else {
+                    let fail_if_duplicated = !force;
+                    Self::upsert_copied_files_request(
+                        table_id,
+                        expire_hours,
+                        copied_file_tree,
+                        fail_if_duplicated,
+                    )
+                }
+            };
 
             {
                 let status = format!("begin commit, number of copied files:{}", num_copied_files);

--- a/src/query/service/src/interpreters/interpreter_copy.rs
+++ b/src/query/service/src/interpreters/interpreter_copy.rs
@@ -260,7 +260,10 @@ impl CopyInterpreter {
         info!("end to list files: got {} files", num_all_files);
 
         let need_copy_file_infos = if force {
-            info!("force mode, ignore file filtering");
+            info!(
+                "force mode, ignore file filtering. ({}.{})",
+                database_name, table_name
+            );
             all_source_file_infos
         } else {
             // Status.
@@ -430,11 +433,12 @@ impl CopyInterpreter {
             let table_id = to_table.get_id();
             let expire_hours = ctx.get_settings().get_load_file_metadata_expire_hours()?;
 
+            let table_info = to_table.get_table_info();
             let upsert_copied_files_request = {
                 if stage_info.copy_options.purge && force {
                     // if `purge-after-copy` is enabled, and in `force` copy mode,
                     // we do not need to upsert copied files into meta server
-                    info!("[purge-after-copy] and [force-copy] are both enabled,  will not update copied-files set");
+                    info!("[purge] and [force] are both enabled,  will not update copied-files set. ({})", &table_info.desc);
                     None
                 } else {
                     let fail_if_duplicated = !force;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

during the execution of `copy-into`, if both purge and force are enabled, do not upsert the table's copied-files set in meta server.

NOTE:

since the table's copied-files set will NOT be upsert in meta service, if both `purge` and `force` are enabled.

later/parallel executions of `copy-into`  are taking the risk of data duplication.

Closes #10854
