### PR TITLE
refactor(meta): upgrade openraft from 0.8.3-alpha.2 to 0.8.4-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "anyerror"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e12e6ab32fef5c165c118177ad96b5b056bdcbb154658e30750cbe80380481"
+checksum = "eef94a982ad4ebc3036bb072f45fcbb63a6b1b91932a6f5d982a166d8d529916"
 dependencies = [
  "anyhow",
  "serde",
@@ -1970,7 +1970,7 @@ dependencies = [
  "maplit",
  "num",
  "once_cell",
- "openraft 0.8.3",
+ "openraft 0.8.4",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -1990,7 +1990,7 @@ dependencies = [
  "common-meta-types",
  "common-tracing",
  "once_cell",
- "openraft 0.8.3",
+ "openraft 0.8.4",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -2038,7 +2038,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "once_cell",
- "openraft 0.8.3",
+ "openraft 0.8.4",
  "prost",
  "prost-build",
  "regex",
@@ -3268,7 +3268,7 @@ dependencies = [
  "common-proto-conv",
  "common-protos",
  "common-tracing",
- "openraft 0.8.3",
+ "openraft 0.8.4",
  "serde",
  "serde_json",
  "tokio",
@@ -7066,8 +7066,8 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.8.3"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.3-alpha.2#ae28352a303d14dddbb20cd351d2c93d0b8db3a4"
+version = "0.8.4"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.1#8f83d590a5b417dcfa4133a268ba31fa52c6d4c5"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,14 +105,14 @@ jsonb = { version = "0.1.1" }
 
 # openraft = { version = "0.8.2", features = ["compat-07"] }
 # For debugging
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.8.3-alpha.2", features = ["compat-07"] }
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.8.4-alpha.1", features = ["compat-07"] }
 
 # type helper
 derive_more = "0.99.17"
 
 # error
 anyhow = { version = "1.0.65" }
-anyerror = { version = "=0.1.7" }
+anyerror = { version = "=0.1.8" }
 thiserror = { version = "1" }
 
 # CLI

--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -245,7 +245,7 @@ async fn init_new_cluster(
             payload: EntryPayload::Membership(membership),
         };
 
-        log.append(&[entry]).await?;
+        log.append([entry]).await?;
     }
 
     // construct AddNode log entries
@@ -271,7 +271,7 @@ async fn init_new_cluster(
                 }),
             };
 
-            log.append(&[entry]).await?;
+            log.append([entry]).await?;
         }
     }
 

--- a/src/meta/raft-store/src/log/raft_log.rs
+++ b/src/meta/raft-store/src/log/raft_log.rs
@@ -96,7 +96,10 @@ impl RaftLog {
     /// There is no overriding check either. It always overrides the existent ones.
     ///
     /// When this function returns the logs are guaranteed to be fsync-ed.
-    pub async fn append(&self, logs: &[Entry]) -> Result<(), MetaStorageError> {
+    pub async fn append<I: IntoIterator<Item = Entry>>(
+        &self,
+        logs: I,
+    ) -> Result<(), MetaStorageError> {
         self.logs().append(logs).await
     }
 

--- a/src/meta/raft-store/tests/it/log.rs
+++ b/src/meta/raft-store/tests/it/log.rs
@@ -70,7 +70,7 @@ async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
         },
     ];
 
-    rl.append(&logs).await?;
+    rl.append(logs.clone()).await?;
 
     let got = rl.range_values(0..)?;
     assert_eq!(logs, got);
@@ -131,7 +131,7 @@ async fn test_raft_log_insert() -> anyhow::Result<()> {
         },
     ];
 
-    rl.append(&logs).await?;
+    rl.append(logs.clone()).await?;
 
     assert_eq!(logs, rl.range_values(..)?);
 
@@ -165,7 +165,7 @@ async fn test_raft_log_get() -> anyhow::Result<()> {
         },
     ];
 
-    rl.append(&logs).await?;
+    rl.append(logs.clone()).await?;
 
     assert_eq!(None, rl.logs().get(&1)?);
     assert_eq!(Some(logs[0].clone()), rl.logs().get(&2)?);
@@ -203,7 +203,7 @@ async fn test_raft_log_last() -> anyhow::Result<()> {
         },
     ];
 
-    rl.append(&logs).await?;
+    rl.append(logs.clone()).await?;
     assert_eq!(Some((4, logs[1].clone())), rl.logs().last()?);
 
     Ok(())
@@ -246,19 +246,19 @@ async fn test_raft_log_range_remove() -> anyhow::Result<()> {
         },
     ];
 
-    rl.append(&logs).await?;
+    rl.append(logs.clone()).await?;
     rl.range_remove(0..).await?;
     assert_eq!(logs[5..], rl.range_values(0..)?);
 
-    rl.append(&logs).await?;
+    rl.append(logs.clone()).await?;
     rl.range_remove(1..).await?;
     assert_eq!(logs[5..], rl.range_values(0..)?);
 
-    rl.append(&logs).await?;
+    rl.append(logs.clone()).await?;
     rl.range_remove(3..).await?;
     assert_eq!(logs[0..1], rl.range_values(0..)?);
 
-    rl.append(&logs).await?;
+    rl.append(logs.clone()).await?;
     rl.range_remove(3..10).await?;
     assert_eq!(logs[0..1], rl.range_values(0..5)?);
     assert_eq!(logs[3..], rl.range_values(5..)?);

--- a/src/meta/sled-store/src/sled_tree.rs
+++ b/src/meta/sled-store/src/sled_tree.rs
@@ -292,14 +292,15 @@ impl SledTree {
     }
 
     /// Append many key-values into SledTree.
-    pub(crate) async fn append<KV, T>(&self, kvs: &[T]) -> Result<(), MetaStorageError>
+    pub(crate) async fn append<KV, T, I>(&self, kvs: I) -> Result<(), MetaStorageError>
     where
         KV: SledKeySpace,
         T: SledAsRef<KV::K, KV::V>,
+        I: IntoIterator<Item = T>,
     {
         let mut batch = sled::Batch::default();
 
-        for t in kvs.iter() {
+        for t in kvs.into_iter() {
             let key = t.as_key();
             let value = t.as_value();
 
@@ -522,9 +523,12 @@ impl<'a, KV: SledKeySpace> AsKeySpace<'a, KV> {
         Ok(res)
     }
 
-    pub async fn append<T>(&self, kvs: &[T]) -> Result<(), MetaStorageError>
-    where T: SledAsRef<KV::K, KV::V> {
-        self.inner.append::<KV, _>(kvs).await
+    pub async fn append<T, I>(&self, kvs: I) -> Result<(), MetaStorageError>
+    where
+        T: SledAsRef<KV::K, KV::V>,
+        I: IntoIterator<Item = T>,
+    {
+        self.inner.append::<KV, _, _>(kvs).await
     }
 
     pub async fn insert(

--- a/src/meta/sled-store/tests/it/sled_iter.rs
+++ b/src/meta/sled-store/tests/it/sled_iter.rs
@@ -58,7 +58,7 @@ async fn test_sled_iter() -> anyhow::Result<()> {
         let tree = SledTree::open(&tc.db, tc.tree_name.clone(), true)?;
         let log_tree = tree.key_space::<Logs>();
 
-        log_tree.append(&logs).await?;
+        log_tree.append(logs.clone()).await?;
         tc.tree_name
     };
 
@@ -68,7 +68,7 @@ async fn test_sled_iter() -> anyhow::Result<()> {
         let tree = SledTree::open(&tc.db, tc.tree_name.clone(), true)?;
         let log_tree = tree.key_space::<Logs>();
 
-        log_tree.append(&logs).await?;
+        log_tree.append(logs.clone()).await?;
         tc.tree_name
     };
 
@@ -100,8 +100,8 @@ async fn test_sled_iter() -> anyhow::Result<()> {
         }
 
         let want = vec![
-            "2, Entry { log_id: LogId { leader_id: LeaderId { term: 1, node_id: 0 }, index: 2 }, payload: Blank }".to_string(),
-            "4, Entry { log_id: LogId { leader_id: LeaderId { term: 3, node_id: 0 }, index: 4 }, payload: Normal(LogEntry { txid: None, time_ms: None, cmd: UpsertKV(UpsertKV { key: \"foo\", seq: Exact(0), value: Update(\"[binary]\"), value_meta: None }) }) }".to_string(),
+            "2, Entry { log_id: LogId { leader_id: LeaderId { term: 1, node_id: 0 }, index: 2 }, payload: blank }".to_string(),
+            "4, Entry { log_id: LogId { leader_id: LeaderId { term: 3, node_id: 0 }, index: 4 }, payload: normal }".to_string(),
         ];
 
         assert_eq!(want, got);

--- a/src/meta/sled-store/tests/it/sled_tree.rs
+++ b/src/meta/sled-store/tests/it/sled_tree.rs
@@ -78,7 +78,7 @@ async fn test_as_range() -> anyhow::Result<()> {
         },
     ];
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
 
     let metas = vec![
         (
@@ -88,7 +88,7 @@ async fn test_as_range() -> anyhow::Result<()> {
         (Initialized, StateMachineMetaValue::Bool(true)),
     ];
 
-    meta_tree.append(metas.as_slice()).await?;
+    meta_tree.append(metas.clone()).await?;
 
     // key space Logs
 
@@ -152,7 +152,7 @@ async fn test_key_space_last() -> anyhow::Result<()> {
         },
     ];
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
     assert_eq!(Some((4, logs[1].clone())), log_tree.last()?);
     assert_eq!(None, tree.key_space::<StateMachineMeta>().last()?);
 
@@ -165,7 +165,7 @@ async fn test_key_space_last() -> anyhow::Result<()> {
     ];
 
     tree.key_space::<StateMachineMeta>()
-        .append(metas.as_slice())
+        .append(metas.clone())
         .await?;
 
     assert_eq!(Some((4, logs[1].clone())), log_tree.last()?);
@@ -203,7 +203,7 @@ async fn test_key_space_append() -> anyhow::Result<()> {
         }),
     ];
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
 
     let want: Vec<Entry> = vec![
         Entry {
@@ -271,7 +271,7 @@ async fn test_key_space_append_and_range_get() -> anyhow::Result<()> {
         },
     ];
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
 
     let got = log_tree.range_values(0..)?;
     assert_eq!(logs, got);
@@ -330,7 +330,7 @@ async fn test_key_space_range_kvs() -> anyhow::Result<()> {
         },
     ];
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
 
     let got = log_tree
         .range(9..)?
@@ -361,7 +361,7 @@ async fn test_key_space_scan_prefix() -> anyhow::Result<()> {
         ("b".to_string(), "y".to_string()),
     ];
 
-    file_tree.append(&files).await?;
+    file_tree.append(files.clone()).await?;
 
     let kvs = vec![
         ("a".to_string(), SeqV::new(1, vec![])),
@@ -369,7 +369,7 @@ async fn test_key_space_scan_prefix() -> anyhow::Result<()> {
         ("b".to_string(), SeqV::new(3, vec![])),
     ];
 
-    kv_tree.append(&kvs).await?;
+    kv_tree.append(kvs.clone()).await?;
 
     let got = file_tree.scan_prefix(&"".to_string())?;
     assert_eq!(files, got);
@@ -414,7 +414,7 @@ async fn test_key_space_insert() -> anyhow::Result<()> {
         },
     ];
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
 
     assert_eq!(logs, log_tree.range_values(..)?);
 
@@ -473,7 +473,7 @@ async fn test_key_space_get() -> anyhow::Result<()> {
         },
     ];
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
 
     assert_eq!(None, log_tree.get(&1)?);
     assert_eq!(Some(logs[0].clone()), log_tree.get(&2)?);
@@ -522,19 +522,19 @@ async fn test_key_space_range_remove() -> anyhow::Result<()> {
         },
     ];
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
     log_tree.range_remove(0.., false).await?;
     assert_eq!(logs[5..], log_tree.range_values(0..)?);
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
     log_tree.range_remove(1.., false).await?;
     assert_eq!(logs[5..], log_tree.range_values(0..)?);
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
     log_tree.range_remove(3.., true).await?;
     assert_eq!(logs[0..1], log_tree.range_values(0..)?);
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
     log_tree.range_remove(3..10, true).await?;
     assert_eq!(logs[0..1], log_tree.range_values(0..5)?);
     assert_eq!(logs[3..], log_tree.range_values(5..)?);
@@ -569,7 +569,7 @@ async fn test_key_space_multi_types() -> anyhow::Result<()> {
         },
     ];
 
-    log_tree.append(&logs).await?;
+    log_tree.append(logs.clone()).await?;
 
     let metas = vec![
         (
@@ -578,7 +578,7 @@ async fn test_key_space_multi_types() -> anyhow::Result<()> {
         ),
         (Initialized, StateMachineMetaValue::Bool(true)),
     ];
-    sm_meta.append(&metas).await?;
+    sm_meta.append(metas.clone()).await?;
 
     // range get/keys are limited to its own namespace.
     {
@@ -634,7 +634,7 @@ async fn test_export() -> anyhow::Result<()> {
             },
         ];
 
-        log_tree.append(&logs).await?;
+        log_tree.append(logs.clone()).await?;
 
         let data = tree.export()?;
 

--- a/src/meta/types/src/raft_types.rs
+++ b/src/meta/types/src/raft_types.rs
@@ -25,7 +25,7 @@ pub type LogIndex = u64;
 pub type Term = u64;
 
 openraft::declare_raft_types!(
-    pub TypeConfig: D = LogEntry, R = AppliedState, NodeId = NodeId, Node = MembershipNode
+    pub TypeConfig: D = LogEntry, R = AppliedState, NodeId = NodeId, Node = MembershipNode, Entry = openraft::entry::Entry<TypeConfig>
 );
 
 pub type CommittedLeaderId = openraft::CommittedLeaderId<NodeId>;

--- a/tests/meta-data-compat-openraft-07/test-meta-data-compat-openraft-08.sh
+++ b/tests/meta-data-compat-openraft-07/test-meta-data-compat-openraft-08.sh
@@ -23,8 +23,8 @@ echo " === start a single node databend-meta"
 chmod +x ./target/${BUILD_PROFILE}/databend-meta
 ./target/${BUILD_PROFILE}/databend-meta --single --raft-dir "$meta_dir" &
 METASRV_PID=$!
-echo $METASRV_PID
-sleep 3
+echo "meta-service pid:" $METASRV_PID
+sleep 10
 
 echo " === export data from a running databend-meta to $exported"
 ./target/${BUILD_PROFILE}/databend-metactl --export --grpc-api-address "localhost:9191" >$exported

--- a/tests/meta-data-compat-openraft-07/test-meta-data-compat-openraft-08.sh
+++ b/tests/meta-data-compat-openraft-07/test-meta-data-compat-openraft-08.sh
@@ -21,7 +21,11 @@ sleep 1
 echo " === start a single node databend-meta"
 # test export from grpc
 chmod +x ./target/${BUILD_PROFILE}/databend-meta
-./target/${BUILD_PROFILE}/databend-meta --single --raft-dir "$meta_dir" &
+
+# Give it a very big heartbeat interval to prevent election.
+# Election will change the `vote` in storage and thus fail the following `diff`
+# in this test.
+./target/${BUILD_PROFILE}/databend-meta --heartbeat-interval 100000 --single --raft-dir "$meta_dir" &
 METASRV_PID=$!
 echo "meta-service pid:" $METASRV_PID
 sleep 10


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta) upgrade openraft from 0.8.3-alpha.2 to 0.8.4-alpha.1

### Changed:

-   Changed: [9ddb5715](https://github.com/datafuselabs/openraft/commit/9ddb5715a33902a83124f48ee33d75d490fcffa5) RaftState: make vote private. Accesses vote via 2 new public methods: `vote_ref()` and `vote_last_modified()`.; by 张炎泼; 2023-03-12

-   Changed: [3b4f4e18](https://github.com/datafuselabs/openraft/commit/3b4f4e186bca5404744d2940571974500d52734d) move log id related traits to mod `openraft::log_id`; by 张炎泼; 2023-03-14

-   Changed: [a92499f2](https://github.com/datafuselabs/openraft/commit/a92499f20360f0f6eba3452e6944702d6a50f56d) StoreBuilder does not need to run a test, it only needs to build a store; by 张炎泼; 2023-03-21

-   Changed: [6e9d3573](https://github.com/datafuselabs/openraft/commit/6e9d35736a0967f06d9e334a0286208e7d6fe123) remove `Clone` from trait `AppData`; by 张炎泼; 2023-03-26

-   Changed: [285e6225](https://github.com/datafuselabs/openraft/commit/285e6225d3e0e8363d8b194e09a113f4e9750b81) instead of a slice, `RaftStorage::append_to_log()` now accepts an `IntoIterator`; by 张炎泼; 2023-03-27

### Improved:

-   Improved: [54aea8a2](https://github.com/datafuselabs/openraft/commit/54aea8a267741ca458c86ef1885041d244817c86) fix: delay election if a greater last log id is seen; by 张炎泼; 2023-03-14

-   Improved: [16adf89b](https://github.com/datafuselabs/openraft/commit/16adf89b0009d3a1be93a90ac964b60d33175b6f) add trait OptionalSerde as a global containing trait of optional serde traits; by 张炎泼; 2023-03-18

-   Improved: [dc6b52d7](https://github.com/datafuselabs/openraft/commit/dc6b52d7b1b88386065068e470c1b49352a174d5) add const parameter to DisplaySlice to specify the max number of elements to display; by 张炎泼; 2023-03-19

### Added:

-   Added: [e39da9f0](https://github.com/datafuselabs/openraft/commit/e39da9f022f5411b8828fac096cd8bcd118d6426) define custom Entry type for raft log; by 张炎泼; 2023-03-16

-   Added: [fc0bfd54](https://github.com/datafuselabs/openraft/commit/fc0bfd544e0fc683468482c94f0165af0bce1528) add methods to StorageIOError to simplify error creation; by 张炎泼; 2023-03-26

## Changelog







## Related Issues