### PR TITLE
feat: support aggregation function in window clause.

### DIFF
--- a/src/query/expression/src/type_check.rs
+++ b/src/query/expression/src/type_check.rs
@@ -195,6 +195,21 @@ pub fn check_function<Index: ColumnIndex>(
         );
     }
 
+    // Do not check grouping
+    if name == "grouping" {
+        debug_assert!(candidates.len() == 1);
+        let (id, function) = candidates.into_iter().next().unwrap();
+        let return_type = function.signature.return_type.clone();
+        return Ok(Expr::FunctionCall {
+            span,
+            id,
+            function,
+            generics: vec![],
+            args: args.to_vec(),
+            return_type,
+        });
+    }
+
     let auto_cast_rules = fn_registry.get_auto_cast_rules(name);
 
     let mut fail_resaons = Vec::with_capacity(candidates.len());

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -735,9 +735,8 @@ impl PipelineBuilder {
             })
             .collect::<Result<Vec<_>>>()?;
 
+        let old_output_len = self.main_pipeline.output_len();
         if !partition_by.is_empty() || !order_by.is_empty() {
-            let old_output_len = self.main_pipeline.output_len();
-
             let mut sort_desc = Vec::with_capacity(partition_by.len() + order_by.len());
 
             for offset in &partition_by {
@@ -757,10 +756,9 @@ impl PipelineBuilder {
             }
 
             self.build_sort_pipeline(input_schema.clone(), sort_desc, window.plan_id, None)?;
-
-            self.main_pipeline.resize(old_output_len)?;
         }
-
+        // `TransformWindow` is a pipeline breaker.
+        self.main_pipeline.resize(1)?;
         let func = WindowFunctionInfo::try_create(&window.func, &input_schema)?;
         // Window
         self.main_pipeline.add_transform(|input, output| {
@@ -773,7 +771,9 @@ impl PipelineBuilder {
                 window.window_frame.clone(),
             )?;
             Ok(ProcessorPtr::create(transform))
-        })
+        })?;
+
+        self.main_pipeline.resize(old_output_len)
     }
 
     fn build_sort(&mut self, sort: &Sort) -> Result<()> {

--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -154,14 +154,7 @@ impl<'a> AggregateRewriter<'a> {
             // TODO(leiysky): should we recursively process subquery here?
             ScalarExpr::SubqueryExpr(_) => Ok(scalar.clone()),
 
-            ScalarExpr::AggregateFunction(agg_func) => {
-                if self.in_window {
-                    // This will be processed later when analyzing window.
-                    Ok(scalar.clone())
-                } else {
-                    self.replace_aggregate_function(agg_func)
-                }
-            }
+            ScalarExpr::AggregateFunction(agg_func) => self.replace_aggregate_function(agg_func),
 
             ScalarExpr::WindowFunction(window) => {
                 self.in_window = true;

--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -29,11 +29,9 @@ use itertools::Itertools;
 use super::prune_by_children;
 use crate::binder::scalar::ScalarBinder;
 use crate::binder::select::SelectList;
-use crate::binder::window::WindowFunctionInfo;
 use crate::binder::Binder;
 use crate::binder::ColumnBinding;
 use crate::binder::Visibility;
-use crate::binder::WindowOrderByInfo;
 use crate::optimizer::SExpr;
 use crate::plans::Aggregate;
 use crate::plans::AggregateFunction;
@@ -86,16 +84,20 @@ pub struct AggregateInfo {
     pub grouping_sets: Vec<Vec<IndexType>>,
 }
 
-pub(super) struct AggregateAndWindowRewriter<'a> {
+pub(super) struct AggregateRewriter<'a> {
     pub bind_context: &'a mut BindContext,
     pub metadata: MetadataRef,
+    // If the aggregate function is in the arguments of window function,
+    // ignore it here, it will be processed later when analyzing window.
+    in_window: bool,
 }
 
-impl<'a> AggregateAndWindowRewriter<'a> {
+impl<'a> AggregateRewriter<'a> {
     pub fn new(bind_context: &'a mut BindContext, metadata: MetadataRef) -> Self {
         Self {
             bind_context,
             metadata,
+            in_window: false,
         }
     }
 
@@ -152,10 +154,64 @@ impl<'a> AggregateAndWindowRewriter<'a> {
             // TODO(leiysky): should we recursively process subquery here?
             ScalarExpr::SubqueryExpr(_) => Ok(scalar.clone()),
 
-            ScalarExpr::AggregateFunction(agg_func) => self.replace_aggregate_function(agg_func),
+            ScalarExpr::AggregateFunction(agg_func) => {
+                if self.in_window {
+                    // This will be processed later when analyzing window.
+                    Ok(scalar.clone())
+                } else {
+                    self.replace_aggregate_function(agg_func)
+                }
+            }
 
-            // already resolved in `analyze_window_select`
-            ScalarExpr::WindowFunction(window) => self.replace_window_function(window),
+            ScalarExpr::WindowFunction(window) => {
+                self.in_window = true;
+
+                let partition_by = window
+                    .partition_by
+                    .iter()
+                    .map(|part| self.visit(part))
+                    .collect::<Result<Vec<_>>>()?;
+                let order_by = window
+                    .order_by
+                    .iter()
+                    .map(|order| {
+                        Ok(WindowOrderBy {
+                            expr: self.visit(&order.expr)?,
+                            asc: order.asc,
+                            nulls_first: order.nulls_first,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let func = match &window.func {
+                    WindowFuncType::Aggregate(agg) => {
+                        let new_args = agg
+                            .args
+                            .iter()
+                            .map(|arg| self.visit(arg))
+                            .collect::<Result<Vec<_>>>()?;
+                        WindowFuncType::Aggregate(AggregateFunction {
+                            func_name: agg.func_name.clone(),
+                            args: new_args,
+                            display_name: agg.display_name.clone(),
+                            distinct: agg.distinct,
+                            params: agg.params.clone(),
+                            return_type: agg.return_type.clone(),
+                        })
+                    }
+                    func => func.clone(),
+                };
+
+                self.in_window = false;
+
+                Ok(WindowFunc {
+                    display_name: window.display_name.clone(),
+                    func,
+                    partition_by,
+                    order_by,
+                    frame: window.frame.clone(),
+                }
+                .into())
+            }
         }
     }
 
@@ -272,205 +328,17 @@ impl<'a> AggregateAndWindowRewriter<'a> {
 
         Ok(replaced_func.into())
     }
-
-    fn replace_window_function(&mut self, window: &WindowFunc) -> Result<ScalarExpr> {
-        let window_infos = &mut self.bind_context.windows;
-
-        let mut replaced_partition_items: Vec<ScalarExpr> =
-            Vec::with_capacity(window.partition_by.len());
-        let mut replaced_order_by_items: Vec<WindowOrderBy> =
-            Vec::with_capacity(window.order_by.len());
-        let mut agg_args = vec![];
-
-        let window_func_name = window.func.func_name();
-        let func = match &window.func {
-            WindowFuncType::Aggregate(agg) => {
-                // resolve aggregate function args in window function.
-                let mut replaced_args: Vec<ScalarExpr> = Vec::with_capacity(agg.args.len());
-                for (i, arg) in agg.args.iter().enumerate() {
-                    let name = format!("{}_arg_{}", &window_func_name, i);
-                    if let ScalarExpr::BoundColumnRef(column_ref) = arg {
-                        replaced_args.push(column_ref.clone().into());
-                        agg_args.push(ScalarItem {
-                            index: column_ref.column.index,
-                            scalar: arg.clone(),
-                        });
-                    } else {
-                        let index = self
-                            .metadata
-                            .write()
-                            .add_derived_column(name.clone(), arg.data_type()?);
-
-                        // Generate a ColumnBinding for each argument of aggregates
-                        let column_binding = ColumnBinding {
-                            database_name: None,
-                            table_name: None,
-                            column_name: name,
-                            index,
-                            data_type: Box::new(arg.data_type()?),
-                            visibility: Visibility::Visible,
-                        };
-                        replaced_args.push(
-                            BoundColumnRef {
-                                span: arg.span(),
-                                column: column_binding.clone(),
-                            }
-                            .into(),
-                        );
-                        agg_args.push(ScalarItem {
-                            index,
-                            scalar: arg.clone(),
-                        });
-                    }
-                }
-                WindowFuncType::Aggregate(AggregateFunction {
-                    display_name: agg.display_name.clone(),
-                    func_name: agg.func_name.clone(),
-                    distinct: agg.distinct,
-                    params: agg.params.clone(),
-                    args: replaced_args,
-                    return_type: agg.return_type.clone(),
-                })
-            }
-            func => func.clone(),
-        };
-
-        // resolve partition by
-        let mut partition_by_items = vec![];
-        for (i, part) in window.partition_by.iter().enumerate() {
-            let name = format!("{}_part_{}", &window_func_name, i);
-            if let ScalarExpr::BoundColumnRef(column_ref) = part {
-                replaced_partition_items.push(column_ref.clone().into());
-                partition_by_items.push(ScalarItem {
-                    index: column_ref.column.index,
-                    scalar: part.clone(),
-                });
-            } else {
-                let index = self
-                    .metadata
-                    .write()
-                    .add_derived_column(name.clone(), part.data_type()?);
-
-                // Generate a ColumnBinding for each argument of aggregates
-                let column_binding = ColumnBinding {
-                    database_name: None,
-                    table_name: None,
-                    column_name: name,
-                    index,
-                    data_type: Box::new(part.data_type()?),
-                    visibility: Visibility::Visible,
-                };
-                replaced_partition_items.push(
-                    BoundColumnRef {
-                        span: part.span(),
-                        column: column_binding.clone(),
-                    }
-                    .into(),
-                );
-                partition_by_items.push(ScalarItem {
-                    index,
-                    scalar: part.clone(),
-                });
-            }
-        }
-
-        // resolve order by
-        let mut order_by_items = vec![];
-        for (i, order) in window.order_by.iter().enumerate() {
-            let name = format!("{}_order_{}", &window_func_name, i);
-            if let ScalarExpr::BoundColumnRef(column_ref) = &order.expr {
-                replaced_order_by_items.push(WindowOrderBy {
-                    expr: column_ref.clone().into(),
-                    asc: order.asc,
-                    nulls_first: order.nulls_first,
-                });
-                order_by_items.push(WindowOrderByInfo {
-                    order_by_item: ScalarItem {
-                        index: column_ref.column.index,
-                        scalar: order.expr.clone(),
-                    },
-                    asc: order.asc,
-                    nulls_first: order.nulls_first,
-                })
-            } else {
-                let index = self
-                    .metadata
-                    .write()
-                    .add_derived_column(name.clone(), order.expr.data_type()?);
-
-                // Generate a ColumnBinding for each argument of aggregates
-                let column_binding = ColumnBinding {
-                    database_name: None,
-                    table_name: None,
-                    column_name: name,
-                    index,
-                    data_type: Box::new(order.expr.data_type()?),
-                    visibility: Visibility::Visible,
-                };
-                replaced_order_by_items.push(WindowOrderBy {
-                    expr: BoundColumnRef {
-                        span: order.expr.span(),
-                        column: column_binding,
-                    }
-                    .into(),
-                    asc: order.asc,
-                    nulls_first: order.nulls_first,
-                });
-                order_by_items.push(WindowOrderByInfo {
-                    order_by_item: ScalarItem {
-                        index,
-                        scalar: order.expr.clone(),
-                    },
-                    asc: order.asc,
-                    nulls_first: order.nulls_first,
-                })
-            }
-        }
-
-        let index = self
-            .metadata
-            .write()
-            .add_derived_column(window.display_name.clone(), window.func.return_type());
-
-        // create window info
-        let window_info = WindowFunctionInfo {
-            index,
-            func: func.clone(),
-            arguments: agg_args,
-            partition_by_items,
-            order_by_items,
-            frame: window.frame.clone(),
-        };
-
-        // push window info to BindContext
-        window_infos.window_functions.push(window_info);
-        window_infos.window_functions_map.insert(
-            window.display_name.clone(),
-            window_infos.window_functions.len() - 1,
-        );
-
-        let replaced_window = WindowFunc {
-            display_name: window.display_name.clone(),
-            func,
-            partition_by: replaced_partition_items,
-            order_by: replaced_order_by_items,
-            frame: window.frame.clone(),
-        };
-
-        Ok(replaced_window.into())
-    }
 }
-
 impl Binder {
-    /// Analyze aggregates and windows in select clause, this will rewrite aggregate and window functions.
-    /// See `AggregateRewriter` for more details.
-    pub(crate) fn analyze_aggregate_and_window_select(
+    /// Analyze aggregates in select clause, this will rewrite aggregate functions.
+    /// See [`AggregateRewriter`] for more details.
+    pub(crate) fn analyze_aggregate_select(
         &mut self,
         bind_context: &mut BindContext,
         select_list: &mut SelectList,
     ) -> Result<()> {
         for item in select_list.items.iter_mut() {
-            let mut rewriter = AggregateAndWindowRewriter::new(bind_context, self.metadata.clone());
+            let mut rewriter = AggregateRewriter::new(bind_context, self.metadata.clone());
             let new_scalar = rewriter.visit(&item.scalar)?;
             item.scalar = new_scalar;
         }

--- a/src/query/sql/src/planner/binder/distinct.rs
+++ b/src/query/sql/src/planner/binder/distinct.rs
@@ -43,7 +43,7 @@ impl Binder {
             .drain()
             .map(|(_, item)| {
                 if bind_context.in_grouping {
-                    let mut group_checker = GroupingChecker::new(bind_context);
+                    let group_checker = GroupingChecker::new(bind_context);
                     let scalar = group_checker.resolve(&item.scalar, None)?;
                     Ok(ScalarItem {
                         scalar,

--- a/src/query/sql/src/planner/binder/having.rs
+++ b/src/query/sql/src/planner/binder/having.rs
@@ -17,7 +17,7 @@ use common_exception::Result;
 use common_exception::Span;
 
 use super::select::SelectList;
-use crate::binder::aggregate::AggregateAndWindowRewriter;
+use crate::binder::aggregate::AggregateRewriter;
 use crate::binder::split_conjunctions;
 use crate::binder::ExprContext;
 use crate::binder::ScalarBinder;
@@ -51,7 +51,7 @@ impl Binder {
             &aliases,
         );
         let (scalar, _) = scalar_binder.bind(having).await?;
-        let mut rewriter = AggregateAndWindowRewriter::new(bind_context, self.metadata.clone());
+        let mut rewriter = AggregateRewriter::new(bind_context, self.metadata.clone());
         Ok((rewriter.visit(&scalar)?, having.span()))
     }
 
@@ -67,7 +67,7 @@ impl Binder {
 
         let scalar = if bind_context.in_grouping {
             // If we are in grouping context, we will perform the grouping check
-            let mut grouping_checker = GroupingChecker::new(bind_context);
+            let grouping_checker = GroupingChecker::new(bind_context);
             grouping_checker.resolve(&having, span)?
         } else {
             // Otherwise we just fallback to a normal selection as `WHERE` clause.

--- a/src/query/sql/src/planner/binder/project.rs
+++ b/src/query/sql/src/planner/binder/project.rs
@@ -112,14 +112,14 @@ impl Binder {
             .iter()
             .map(|(_, item)| {
                 if bind_context.in_grouping {
-                    let mut grouping_checker = GroupingChecker::new(bind_context);
+                    let grouping_checker = GroupingChecker::new(bind_context);
                     let scalar = grouping_checker.resolve(&item.scalar, None)?;
                     Ok(ScalarItem {
                         scalar,
                         index: item.index,
                     })
                 } else {
-                    let mut window_checker = WindowChecker::new(bind_context);
+                    let window_checker = WindowChecker::new(bind_context);
                     let scalar = window_checker.resolve(&item.scalar)?;
                     Ok(ScalarItem {
                         scalar,

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -139,7 +139,11 @@ impl Binder {
                 .await?;
         }
 
-        self.analyze_aggregate_and_window_select(&mut from_context, &mut select_list)?;
+        self.analyze_aggregate_select(&mut from_context, &mut select_list)?;
+
+        // `analyze_window` should behind `analyze_aggregate_select`,
+        // because `analyze_window` will rewrite the aggregate functions in the window function's arguments.
+        self.analyze_window(&mut from_context, &mut select_list)?;
 
         // `analyze_projection` should behind `analyze_aggregate_select` because `analyze_aggregate_select` will rewrite `grouping`.
         let (mut scalar_items, projections) = self.analyze_projection(&select_list)?;

--- a/src/query/sql/src/planner/binder/sort.rs
+++ b/src/query/sql/src/planner/binder/sort.rs
@@ -245,7 +245,7 @@ impl Binder {
 
         for order in order_by.items {
             if from_context.in_grouping {
-                let mut group_checker = GroupingChecker::new(from_context);
+                let group_checker = GroupingChecker::new(from_context);
                 // Perform grouping check on original scalar expression if order item is alias.
                 if let Some(scalar_item) = select_list
                     .items
@@ -282,10 +282,10 @@ impl Binder {
                         need_group_check = true;
                     }
                     if from_context.in_grouping || need_group_check {
-                        let mut group_checker = GroupingChecker::new(from_context);
+                        let group_checker = GroupingChecker::new(from_context);
                         scalar = group_checker.resolve(&scalar, None)?;
                     } else if !from_context.windows.window_functions.is_empty() {
-                        let mut window_checker = WindowChecker::new(from_context);
+                        let window_checker = WindowChecker::new(from_context);
                         scalar = window_checker.resolve(&scalar)?;
                     }
                     scalars.push(ScalarItem { scalar, index });

--- a/src/query/sql/src/planner/binder/window.rs
+++ b/src/query/sql/src/planner/binder/window.rs
@@ -14,16 +14,33 @@
 
 use std::collections::HashMap;
 
+use common_exception::ErrorCode;
 use common_exception::Result;
 
+use super::select::SelectList;
 use crate::optimizer::SExpr;
+use crate::plans::AggregateFunction;
+use crate::plans::AndExpr;
+use crate::plans::BoundColumnRef;
+use crate::plans::CastExpr;
+use crate::plans::ComparisonExpr;
 use crate::plans::EvalScalar;
+use crate::plans::FunctionCall;
+use crate::plans::NotExpr;
+use crate::plans::OrExpr;
+use crate::plans::ScalarExpr;
 use crate::plans::ScalarItem;
 use crate::plans::Window;
+use crate::plans::WindowFunc;
 use crate::plans::WindowFuncFrame;
 use crate::plans::WindowFuncType;
+use crate::plans::WindowOrderBy;
+use crate::BindContext;
 use crate::Binder;
+use crate::ColumnBinding;
 use crate::IndexType;
+use crate::MetadataRef;
+use crate::Visibility;
 
 impl Binder {
     #[async_backtrace::framed]
@@ -89,4 +106,330 @@ pub struct WindowOrderByInfo {
     pub order_by_item: ScalarItem,
     pub asc: Option<bool>,
     pub nulls_first: Option<bool>,
+}
+
+pub(super) struct WindowRewriter<'a> {
+    pub bind_context: &'a mut BindContext,
+    pub metadata: MetadataRef,
+    // While analyzing in-window aggregate function, we can repalce it with a BoundColumnRef
+    in_window: bool,
+}
+
+impl<'a> WindowRewriter<'a> {
+    pub fn new(bind_context: &'a mut BindContext, metadata: MetadataRef) -> Self {
+        Self {
+            bind_context,
+            metadata,
+            in_window: false,
+        }
+    }
+
+    pub fn visit(&mut self, scalar: &ScalarExpr) -> Result<ScalarExpr> {
+        match scalar {
+            ScalarExpr::BoundColumnRef(_) => Ok(scalar.clone()),
+            ScalarExpr::BoundInternalColumnRef(_) => Ok(scalar.clone()),
+            ScalarExpr::ConstantExpr(_) => Ok(scalar.clone()),
+            ScalarExpr::AndExpr(scalar) => Ok(AndExpr {
+                left: Box::new(self.visit(&scalar.left)?),
+                right: Box::new(self.visit(&scalar.right)?),
+            }
+            .into()),
+            ScalarExpr::OrExpr(scalar) => Ok(OrExpr {
+                left: Box::new(self.visit(&scalar.left)?),
+                right: Box::new(self.visit(&scalar.right)?),
+            }
+            .into()),
+            ScalarExpr::NotExpr(scalar) => Ok(NotExpr {
+                argument: Box::new(self.visit(&scalar.argument)?),
+            }
+            .into()),
+            ScalarExpr::ComparisonExpr(scalar) => Ok(ComparisonExpr {
+                op: scalar.op.clone(),
+                left: Box::new(self.visit(&scalar.left)?),
+                right: Box::new(self.visit(&scalar.right)?),
+            }
+            .into()),
+            ScalarExpr::FunctionCall(func) => {
+                let new_args = func
+                    .arguments
+                    .iter()
+                    .map(|arg| self.visit(arg))
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(FunctionCall {
+                    span: func.span,
+                    func_name: func.func_name.clone(),
+                    params: func.params.clone(),
+                    arguments: new_args,
+                }
+                .into())
+            }
+            ScalarExpr::CastExpr(cast) => Ok(CastExpr {
+                span: cast.span,
+                is_try: cast.is_try,
+                argument: Box::new(self.visit(&cast.argument)?),
+                target_type: cast.target_type.clone(),
+            }
+            .into()),
+
+            // TODO(leiysky): should we recursively process subquery here?
+            ScalarExpr::SubqueryExpr(_) => Ok(scalar.clone()),
+
+            ScalarExpr::AggregateFunction(agg_func) => {
+                if self.in_window {
+                    if let Some(index) = self
+                        .bind_context
+                        .aggregate_info
+                        .aggregate_functions_map
+                        .get(&agg_func.display_name)
+                    {
+                        let agg = &self.bind_context.aggregate_info.aggregate_functions[*index];
+                        let column_binding = ColumnBinding {
+                            database_name: None,
+                            table_name: None,
+                            column_name: agg_func.display_name.clone(),
+                            index: agg.index,
+                            data_type: agg_func.return_type.clone(),
+                            visibility: Visibility::Visible,
+                        };
+                        Ok(BoundColumnRef {
+                            span: None,
+                            column: column_binding,
+                        }
+                        .into())
+                    } else {
+                        Err(ErrorCode::BadArguments("Invalid window function argument"))
+                    }
+                } else {
+                    let new_args = agg_func
+                        .args
+                        .iter()
+                        .map(|arg| self.visit(arg))
+                        .collect::<Result<Vec<_>>>()?;
+                    Ok(AggregateFunction {
+                        func_name: agg_func.func_name.clone(),
+                        distinct: agg_func.distinct,
+                        params: agg_func.params.clone(),
+                        args: new_args,
+                        return_type: agg_func.return_type.clone(),
+                        display_name: agg_func.display_name.clone(),
+                    }
+                    .into())
+                }
+            }
+
+            ScalarExpr::WindowFunction(window) => {
+                self.in_window = true;
+                let scalar = self.replace_window_function(window)?;
+                self.in_window = false;
+                Ok(scalar)
+            }
+        }
+    }
+
+    fn replace_window_function(&mut self, window: &WindowFunc) -> Result<ScalarExpr> {
+        let mut replaced_partition_items: Vec<ScalarExpr> =
+            Vec::with_capacity(window.partition_by.len());
+        let mut replaced_order_by_items: Vec<WindowOrderBy> =
+            Vec::with_capacity(window.order_by.len());
+        let mut agg_args = vec![];
+
+        let window_func_name = window.func.func_name();
+        let func = match &window.func {
+            WindowFuncType::Aggregate(agg) => {
+                // resolve aggregate function args in window function.
+                let mut replaced_args: Vec<ScalarExpr> = Vec::with_capacity(agg.args.len());
+                for (i, arg) in agg.args.iter().enumerate() {
+                    let arg = self.visit(arg)?;
+                    let name = format!("{}_arg_{}", &window_func_name, i);
+                    if let ScalarExpr::BoundColumnRef(column_ref) = &arg {
+                        replaced_args.push(column_ref.clone().into());
+                        agg_args.push(ScalarItem {
+                            index: column_ref.column.index,
+                            scalar: arg.clone(),
+                        });
+                    } else {
+                        let index = self
+                            .metadata
+                            .write()
+                            .add_derived_column(name.clone(), arg.data_type()?);
+
+                        // Generate a ColumnBinding for each argument of aggregates
+                        let column_binding = ColumnBinding {
+                            database_name: None,
+                            table_name: None,
+                            column_name: name,
+                            index,
+                            data_type: Box::new(arg.data_type()?),
+                            visibility: Visibility::Visible,
+                        };
+                        replaced_args.push(
+                            BoundColumnRef {
+                                span: arg.span(),
+                                column: column_binding.clone(),
+                            }
+                            .into(),
+                        );
+                        agg_args.push(ScalarItem {
+                            index,
+                            scalar: arg.clone(),
+                        });
+                    }
+                }
+                WindowFuncType::Aggregate(AggregateFunction {
+                    display_name: agg.display_name.clone(),
+                    func_name: agg.func_name.clone(),
+                    distinct: agg.distinct,
+                    params: agg.params.clone(),
+                    args: replaced_args,
+                    return_type: agg.return_type.clone(),
+                })
+            }
+            func => func.clone(),
+        };
+
+        // resolve partition by
+        let mut partition_by_items = vec![];
+        for (i, part) in window.partition_by.iter().enumerate() {
+            let part = self.visit(part)?;
+            let name = format!("{}_part_{}", &window_func_name, i);
+            if let ScalarExpr::BoundColumnRef(column_ref) = &part {
+                replaced_partition_items.push(column_ref.clone().into());
+                partition_by_items.push(ScalarItem {
+                    index: column_ref.column.index,
+                    scalar: part.clone(),
+                });
+            } else {
+                let index = self
+                    .metadata
+                    .write()
+                    .add_derived_column(name.clone(), part.data_type()?);
+
+                // Generate a ColumnBinding for each argument of aggregates
+                let column_binding = ColumnBinding {
+                    database_name: None,
+                    table_name: None,
+                    column_name: name,
+                    index,
+                    data_type: Box::new(part.data_type()?),
+                    visibility: Visibility::Visible,
+                };
+                replaced_partition_items.push(
+                    BoundColumnRef {
+                        span: part.span(),
+                        column: column_binding.clone(),
+                    }
+                    .into(),
+                );
+                partition_by_items.push(ScalarItem {
+                    index,
+                    scalar: part.clone(),
+                });
+            }
+        }
+
+        // resolve order by
+        let mut order_by_items = vec![];
+        for (i, order) in window.order_by.iter().enumerate() {
+            let order_expr = self.visit(&order.expr)?;
+            let name = format!("{}_order_{}", &window_func_name, i);
+            if let ScalarExpr::BoundColumnRef(column_ref) = &order_expr {
+                replaced_order_by_items.push(WindowOrderBy {
+                    expr: column_ref.clone().into(),
+                    asc: order.asc,
+                    nulls_first: order.nulls_first,
+                });
+                order_by_items.push(WindowOrderByInfo {
+                    order_by_item: ScalarItem {
+                        index: column_ref.column.index,
+                        scalar: order_expr.clone(),
+                    },
+                    asc: order.asc,
+                    nulls_first: order.nulls_first,
+                })
+            } else {
+                let index = self
+                    .metadata
+                    .write()
+                    .add_derived_column(name.clone(), order_expr.data_type()?);
+
+                // Generate a ColumnBinding for each argument of aggregates
+                let column_binding = ColumnBinding {
+                    database_name: None,
+                    table_name: None,
+                    column_name: name,
+                    index,
+                    data_type: Box::new(order_expr.data_type()?),
+                    visibility: Visibility::Visible,
+                };
+                replaced_order_by_items.push(WindowOrderBy {
+                    expr: BoundColumnRef {
+                        span: order_expr.span(),
+                        column: column_binding,
+                    }
+                    .into(),
+                    asc: order.asc,
+                    nulls_first: order.nulls_first,
+                });
+                order_by_items.push(WindowOrderByInfo {
+                    order_by_item: ScalarItem {
+                        index,
+                        scalar: order_expr,
+                    },
+                    asc: order.asc,
+                    nulls_first: order.nulls_first,
+                })
+            }
+        }
+
+        let index = self
+            .metadata
+            .write()
+            .add_derived_column(window.display_name.clone(), window.func.return_type());
+
+        // create window info
+        let window_info = WindowFunctionInfo {
+            index,
+            func: func.clone(),
+            arguments: agg_args,
+            partition_by_items,
+            order_by_items,
+            frame: window.frame.clone(),
+        };
+
+        let window_infos = &mut self.bind_context.windows;
+        // push window info to BindContext
+        window_infos.window_functions.push(window_info);
+        window_infos.window_functions_map.insert(
+            window.display_name.clone(),
+            window_infos.window_functions.len() - 1,
+        );
+
+        let replaced_window = WindowFunc {
+            display_name: window.display_name.clone(),
+            func,
+            partition_by: replaced_partition_items,
+            order_by: replaced_order_by_items,
+            frame: window.frame.clone(),
+        };
+
+        Ok(replaced_window.into())
+    }
+}
+
+impl Binder {
+    /// Analyze =windows in select clause, this will rewrite window functions.
+    /// See [`WindowRewriter`] for more details.
+    pub(crate) fn analyze_window(
+        &mut self,
+        bind_context: &mut BindContext,
+        select_list: &mut SelectList,
+    ) -> Result<()> {
+        for item in select_list.items.iter_mut() {
+            let mut rewriter = WindowRewriter::new(bind_context, self.metadata.clone());
+            let new_scalar = rewriter.visit(&item.scalar)?;
+            item.scalar = new_scalar;
+        }
+
+        Ok(())
+    }
 }

--- a/src/query/sql/src/planner/semantic/window_check.rs
+++ b/src/query/sql/src/planner/semantic/window_check.rs
@@ -36,7 +36,7 @@ impl<'a> WindowChecker<'a> {
         Self { bind_context }
     }
 
-    pub fn resolve(&mut self, scalar: &ScalarExpr) -> Result<ScalarExpr> {
+    pub fn resolve(&self, scalar: &ScalarExpr) -> Result<ScalarExpr> {
         match scalar {
             ScalarExpr::BoundColumnRef(_)
             | ScalarExpr::BoundInternalColumnRef(_)

--- a/tests/sqllogictests/suites/query/window_function/window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/window_basic.test
@@ -183,12 +183,29 @@ sales -111.11111111111086
 sales 0.0
 sales 0.0
 
-statement ok
-DROP DATABASE test_window
-
-# aggregate functions in window functions
+# aggregate functions in window clause
 query TII
 select depname, sum(sum(salary)) over (), sum(salary) from empsalary group by depname;
+----
 develop 25100 25100
 sales 39700 14600
 personnel 47100 7400
+
+query III
+select grouping(salary), grouping(depname), sum(grouping(salary)) over (partition by grouping(salary) + grouping(depname) order by grouping(depname) desc) from empsalary group by rollup (depname, salary);
+----
+0 0 0
+0 0 0
+0 0 0
+0 0 0
+0 0 0
+0 0 0
+0 0 0
+0 0 0
+1 0 1
+1 0 2
+1 0 3
+1 1 1
+
+statement ok
+DROP DATABASE test_window

--- a/tests/sqllogictests/suites/query/window_function/window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/window_basic.test
@@ -185,18 +185,18 @@ sales 0.0
 
 # aggregate functions in window clause
 query TII
-select depname, sum(sum(salary)) over (), sum(salary) from empsalary group by depname;
+select depname, sum(sum(salary)) over (partition by 1 order by sum(salary)), sum(salary) from empsalary group by depname;
 ----
-develop 25100 25100
-sales 39700 14600
-personnel 47100 7400
+personnel 7400 7400
+sales 22000 14600
+develop 47100 25100
 
 query TI
-select depname, sum(sum(salary)) over () from empsalary group by depname;
+select depname, sum(sum(salary)) over (partition by 1 order by sum(salary)) from empsalary group by depname;
 ----
-develop 25100
-sales 39700
-personnel 47100
+personnel 7400
+sales 22000
+develop 47100
 
 query III
 select grouping(salary), grouping(depname), sum(grouping(salary)) over (partition by grouping(salary) + grouping(depname) order by grouping(depname) desc) from empsalary group by rollup (depname, salary);

--- a/tests/sqllogictests/suites/query/window_function/window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/window_basic.test
@@ -191,6 +191,13 @@ develop 25100 25100
 sales 39700 14600
 personnel 47100 7400
 
+query TI
+select depname, sum(sum(salary)) over () from empsalary group by depname;
+----
+develop 25100
+sales 39700
+personnel 47100
+
 query III
 select grouping(salary), grouping(depname), sum(grouping(salary)) over (partition by grouping(salary) + grouping(depname) order by grouping(depname) desc) from empsalary group by rollup (depname, salary);
 ----
@@ -206,6 +213,21 @@ select grouping(salary), grouping(depname), sum(grouping(salary)) over (partitio
 1 0 2
 1 0 3
 1 1 1
+
+# Winodw func in subquery
+query I
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY depname ORDER BY salary) rn FROM empsalary ORDER BY depname, rn)
+----
+1
+2
+3
+4
+5
+1
+2
+1
+2
+3
 
 statement ok
 DROP DATABASE test_window

--- a/tests/sqllogictests/suites/query/window_function/window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/window_basic.test
@@ -185,3 +185,10 @@ sales 0.0
 
 statement ok
 DROP DATABASE test_window
+
+# aggregate functions in window functions
+query TII
+select depname, sum(sum(salary)) over (), sum(salary) from empsalary group by depname;
+develop 25100 25100
+sales 39700 14600
+personnel 47100 7400


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Support such SQLs:

```sql
select a, sum(a), sum(sum(a)) over (partition by sum(a) order by sum(a)) from t group by b;
select grouping(salary), grouping(depname), sum(grouping(salary)) over (partition by grouping(salary) + grouping(depname) order by grouping(depname) desc) from empsalary group by rollup (depname, salary);
```

- Fix checking function `grouping`, allow `grouping` appearing in nested exprs.
- Allow window function appearing in subquery.
- Fix window pipeline. `TransformWindow` should be a pipeline breaker, which means we should `pipeline.resize(1)` before concat `TransformWindow`.

Tracking in #10810
