### PR TITLE
chore: add completion mode for SQL or Text

### DIFF
--- a/src/common/openai/src/completion.rs
+++ b/src/common/openai/src/completion.rs
@@ -22,8 +22,21 @@ use crate::metrics::metrics_completion_count;
 use crate::metrics::metrics_completion_token;
 use crate::OpenAI;
 
+pub enum CompletionMode {
+    // SQL translate:
+    // max_tokens: 150, stop: ['#', ';']
+    SQL,
+    // Text completion:
+    // max_tokens: 250, stop: none
+    Text,
+}
+
 impl OpenAI {
-    pub fn completion_request(&self, prompt: String) -> Result<(String, Option<u32>)> {
+    pub fn completion_request(
+        &self,
+        prompt: String,
+        mode: CompletionMode,
+    ) -> Result<(String, Option<u32>)> {
         let openai = openai_api_rust::OpenAI::new(
             Auth {
                 api_key: self.api_key.clone(),
@@ -31,18 +44,24 @@ impl OpenAI {
             },
             &self.api_base,
         );
+
+        let (max_tokens, stop) = match mode {
+            CompletionMode::SQL => (Some(150), Some(vec!["#".to_string(), ";".to_string()])),
+            CompletionMode::Text => (Some(250), None),
+        };
+
         let body = CompletionsBody {
             model: self.model.to_string(),
             prompt: Some(vec![prompt]),
             suffix: None,
-            max_tokens: Some(150),
+            max_tokens,
             temperature: Some(0_f32),
             top_p: Some(1_f32),
             n: Some(2),
             stream: Some(false),
             logprobs: None,
             echo: None,
-            stop: Some(vec!["#".to_string(), ";".to_string()]),
+            stop,
             presence_penalty: None,
             frequency_penalty: None,
             best_of: None,

--- a/src/common/openai/src/lib.rs
+++ b/src/common/openai/src/lib.rs
@@ -19,5 +19,6 @@ mod openai;
 
 pub(crate) mod metrics;
 
+pub use completion::CompletionMode;
 pub use openai::AIModel;
 pub use openai::OpenAI;

--- a/src/query/functions/src/scalars/vector.rs
+++ b/src/query/functions/src/scalars/vector.rs
@@ -21,6 +21,7 @@ use common_expression::vectorize_with_builder_2_arg;
 use common_expression::FunctionDomain;
 use common_expression::FunctionRegistry;
 use common_openai::AIModel;
+use common_openai::CompletionMode;
 use common_openai::OpenAI;
 use common_vector::cosine_distance;
 
@@ -87,7 +88,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 let data = std::str::from_utf8(data).unwrap();
                 let api_key = std::str::from_utf8(api_key).unwrap();
                 let openai = OpenAI::create(api_key.to_string(), AIModel::TextDavinci003);
-                let result = openai.completion_request(data.to_string());
+                let result = openai.completion_request(data.to_string(), CompletionMode::Text);
                 match result {
                     Ok((resp, _)) => {
                         output.put_str(&resp);

--- a/src/query/service/src/table_functions/openai/ai_to_sql.rs
+++ b/src/query/service/src/table_functions/openai/ai_to_sql.rs
@@ -38,6 +38,7 @@ use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
 use common_openai::AIModel;
+use common_openai::CompletionMode;
 use common_openai::OpenAI;
 use common_pipeline_core::processors::port::OutputPort;
 use common_pipeline_core::processors::processor::ProcessorPtr;
@@ -219,7 +220,7 @@ impl AsyncSource for GPT2SQLSource {
         // Response.
         let api_key = GlobalConfig::instance().query.openai_api_key.clone();
         let openai = OpenAI::create(api_key, AIModel::TextDavinci003);
-        let (sql, _) = openai.completion_request(prompt)?;
+        let (sql, _) = openai.completion_request(prompt, CompletionMode::SQL)?;
 
         let sql = format!("SELECT{}", sql);
         info!("openai response sql: {}", sql);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```
pub enum CompletionMode {
    // SQL translate:
    // max_tokens: 150, stop: ['#', ';']
    SQL,
    // Text completion:
    // max_tokens: 250, stop: none
    Text,
}
```

Closes #issue
