### PR TITLE
chore: make the completion more larger response

### DIFF
--- a/src/common/openai/src/completion.rs
+++ b/src/common/openai/src/completion.rs
@@ -27,7 +27,7 @@ pub enum CompletionMode {
     // max_tokens: 150, stop: ['#', ';']
     SQL,
     // Text completion:
-    // max_tokens: 250, stop: none
+    // max_tokens: 512, stop: none
     Text,
 }
 
@@ -47,7 +47,7 @@ impl OpenAI {
 
         let (max_tokens, stop) = match mode {
             CompletionMode::SQL => (Some(150), Some(vec!["#".to_string(), ";".to_string()])),
-            CompletionMode::Text => (Some(250), None),
+            CompletionMode::Text => (Some(512), None),
         };
 
         let body = CompletionsBody {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

max_token from 250 to 512, make the openai response more contents.

Closes #issue
