### PR TITLE
refactor(format): add FileFormatParams.

### DIFF
--- a/src/meta/app/src/principal/file_format.rs
+++ b/src/meta/app/src/principal/file_format.rs
@@ -1,0 +1,203 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::str::FromStr;
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::principal::StageFileCompression;
+use crate::principal::StageFileFormatType;
+
+const OPT_FILED_DELIMITER: &str = "field_delimiter";
+const OPT_RECORDE_DELIMITER: &str = "record_delimiter";
+const OPT_SKIP_HEADER: &str = "skip_header";
+const OPT_NAN_DISPLAY: &str = "nan_display";
+const OPT_ESCAPE: &str = "escape";
+const OPT_QUOTE: &str = "quote";
+const OPT_ROW_TAG: &str = "row_tag";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileFormatOptionsAst {
+    pub options: BTreeMap<String, String>,
+}
+
+impl FileFormatOptionsAst {
+    fn take_string(&mut self, key: &str, default: &str) -> String {
+        self.options
+            .remove(key)
+            .unwrap_or_else(|| default.to_string())
+    }
+
+    fn take_type(&mut self) -> Result<StageFileFormatType> {
+        let typ = self.options.remove("type").ok_or_else(|| {
+            ErrorCode::IllegalFileFormat("Missing type in file format options".to_string())
+        })?;
+        StageFileFormatType::from_str(&typ).map_err(ErrorCode::IllegalFileFormat)
+    }
+
+    fn take_compression(&mut self) -> Result<StageFileCompression> {
+        let compression = self.options.remove("compression").ok_or_else(|| {
+            ErrorCode::IllegalFileFormat("Missing compression in file format options".to_string())
+        })?;
+        StageFileCompression::from_str(&compression).map_err(ErrorCode::IllegalFileFormat)
+    }
+
+    fn take_u64(&mut self, key: &str, default: u64) -> Result<u64> {
+        match self.options.remove(key) {
+            Some(v) => Ok(u64::from_str(&v)?),
+            None => Ok(default),
+        }
+    }
+}
+
+/// File format parameters after checking and parsing.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum FileFormatParams {
+    Csv(CsvFileFormatParams),
+    Tsv(TsvFileFormatParams),
+    NdJson(NdJsonFileFormatParams),
+    Json(JsonFileFormatParams),
+    Xml(XmlFileFormatParams),
+    Parquet(ParquetFileFormatParams),
+}
+
+impl Default for FileFormatParams {
+    fn default() -> Self {
+        FileFormatParams::Parquet(ParquetFileFormatParams {})
+    }
+}
+
+impl TryFrom<FileFormatOptionsAst> for FileFormatParams {
+    type Error = ErrorCode;
+    fn try_from(ast: FileFormatOptionsAst) -> Result<Self> {
+        let mut ast = ast;
+        let typ = ast.take_type()?;
+        let params = match typ {
+            StageFileFormatType::Xml => {
+                let row_tag = ast.take_string(OPT_ROW_TAG, "row");
+                let compression = ast.take_compression()?;
+                FileFormatParams::Xml(XmlFileFormatParams {
+                    compression,
+                    row_tag,
+                })
+            }
+            StageFileFormatType::Json => {
+                let compression = ast.take_compression()?;
+                FileFormatParams::Json(JsonFileFormatParams { compression })
+            }
+            StageFileFormatType::NdJson => {
+                let compression = ast.take_compression()?;
+                FileFormatParams::NdJson(NdJsonFileFormatParams { compression })
+            }
+            StageFileFormatType::Parquet => FileFormatParams::Parquet(ParquetFileFormatParams {}),
+            StageFileFormatType::Csv => {
+                let compression = ast.take_compression()?;
+                let headers = ast.take_u64(OPT_SKIP_HEADER, 0)?;
+                let field_delimiter = ast.take_string(OPT_FILED_DELIMITER, ",");
+                let record_delimiter = ast.take_string(OPT_RECORDE_DELIMITER, "\n");
+                let nan_display = ast.take_string(OPT_NAN_DISPLAY, "NaN");
+                let escape = ast.take_string(OPT_ESCAPE, "");
+                let quote = ast.take_string(OPT_QUOTE, "\"");
+                FileFormatParams::Csv(CsvFileFormatParams {
+                    compression,
+                    headers,
+                    field_delimiter,
+                    record_delimiter,
+                    nan_display,
+                    escape,
+                    quote,
+                })
+            }
+            StageFileFormatType::Tsv => {
+                let compression = ast.take_compression()?;
+                let headers = ast.take_u64(OPT_SKIP_HEADER, 0)?;
+                let field_delimiter = ast.take_string(OPT_FILED_DELIMITER, "\t");
+                let record_delimiter = ast.take_string(OPT_RECORDE_DELIMITER, "\n");
+                let nan_display = ast.take_string(OPT_NAN_DISPLAY, "nan");
+                let escape = ast.take_string(OPT_ESCAPE, "\\");
+                let quote = ast.take_string(OPT_QUOTE, "\'");
+                FileFormatParams::Tsv(TsvFileFormatParams {
+                    compression,
+                    headers,
+                    field_delimiter,
+                    record_delimiter,
+                    nan_display,
+                    quote,
+                    escape,
+                })
+            }
+            _ => {
+                return Err(ErrorCode::IllegalFileFormat(format!(
+                    "Unsupported file format {typ:?}"
+                )));
+            }
+        };
+
+        if ast.options.is_empty() {
+            Ok(params)
+        } else {
+            Err(ErrorCode::IllegalFileFormat(format!(
+                "Unsupported options for {:?} {:?}",
+                typ, ast.options
+            )))
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CsvFileFormatParams {
+    pub compression: StageFileCompression,
+    pub headers: u64,
+    pub field_delimiter: String,
+    pub record_delimiter: String,
+    pub nan_display: String,
+    pub escape: String,
+    pub quote: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TsvFileFormatParams {
+    pub compression: StageFileCompression,
+    pub headers: u64,
+    pub field_delimiter: String,
+    pub record_delimiter: String,
+    pub nan_display: String,
+    pub escape: String,
+    pub quote: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct XmlFileFormatParams {
+    pub compression: StageFileCompression,
+    pub row_tag: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct JsonFileFormatParams {
+    pub compression: StageFileCompression,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct NdJsonFileFormatParams {
+    pub compression: StageFileCompression,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ParquetFileFormatParams {}

--- a/src/meta/app/src/principal/mod.rs
+++ b/src/meta/app/src/principal/mod.rs
@@ -14,6 +14,7 @@
 
 //! Principal is a user or role that accesses an entity.
 
+mod file_format;
 mod principal_identity;
 mod role_info;
 mod user_auth;
@@ -27,6 +28,7 @@ mod user_quota;
 mod user_setting;
 mod user_stage;
 
+pub use file_format::*;
 pub use principal_identity::PrincipalIdentity;
 pub use role_info::RoleInfo;
 pub use role_info::RoleInfoSerdeError;

--- a/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
@@ -208,7 +208,7 @@ impl FromToProto for mt::principal::UserDefinedFileFormat {
 impl FromToProto for mt::principal::FileFormatParams {
     type PB = pb::FileFormatParams;
     fn get_pb_ver(_p: &Self::PB) -> u64 {
-        0
+        VER
     }
 
     fn from_pb(p: Self::PB) -> Result<Self, Incompatible>

--- a/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
@@ -204,3 +204,271 @@ impl FromToProto for mt::principal::UserDefinedFileFormat {
         })
     }
 }
+
+impl FromToProto for mt::principal::FileFormatParams {
+    type PB = pb::FileFormatParams;
+    fn get_pb_ver(_p: &Self::PB) -> u64 {
+        0
+    }
+
+    fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
+    where Self: Sized {
+        match p.format {
+            Some(pb::file_format_params::Format::Parquet(p)) => {
+                Ok(mt::principal::FileFormatParams::Parquet(
+                    mt::principal::ParquetFileFormatParams::from_pb(p)?,
+                ))
+            }
+            Some(pb::file_format_params::Format::NdJson(p)) => {
+                Ok(mt::principal::FileFormatParams::NdJson(
+                    mt::principal::NdJsonFileFormatParams::from_pb(p)?,
+                ))
+            }
+            Some(pb::file_format_params::Format::Csv(p)) => {
+                Ok(mt::principal::FileFormatParams::Csv(
+                    mt::principal::CsvFileFormatParams::from_pb(p)?,
+                ))
+            }
+            Some(pb::file_format_params::Format::Json(p)) => {
+                Ok(mt::principal::FileFormatParams::Json(
+                    mt::principal::JsonFileFormatParams::from_pb(p)?,
+                ))
+            }
+            Some(pb::file_format_params::Format::Tsv(p)) => {
+                Ok(mt::principal::FileFormatParams::Tsv(
+                    mt::principal::TsvFileFormatParams::from_pb(p)?,
+                ))
+            }
+            Some(pb::file_format_params::Format::Xml(p)) => {
+                Ok(mt::principal::FileFormatParams::Xml(
+                    mt::principal::XmlFileFormatParams::from_pb(p)?,
+                ))
+            }
+            None => Err(Incompatible {
+                reason: "FileFormatParams.format cannot be None".to_string(),
+            }),
+        }
+    }
+
+    fn to_pb(&self) -> Result<Self::PB, Incompatible> {
+        match self {
+            Self::Parquet(p) => Ok(Self::PB {
+                format: Some(pb::file_format_params::Format::Parquet(
+                    mt::principal::ParquetFileFormatParams::to_pb(p)?,
+                )),
+            }),
+            Self::NdJson(p) => Ok(Self::PB {
+                format: Some(pb::file_format_params::Format::NdJson(
+                    mt::principal::NdJsonFileFormatParams::to_pb(p)?,
+                )),
+            }),
+            Self::Csv(p) => Ok(Self::PB {
+                format: Some(pb::file_format_params::Format::Csv(
+                    mt::principal::CsvFileFormatParams::to_pb(p)?,
+                )),
+            }),
+            Self::Json(p) => Ok(Self::PB {
+                format: Some(pb::file_format_params::Format::Json(
+                    mt::principal::JsonFileFormatParams::to_pb(p)?,
+                )),
+            }),
+            Self::Tsv(p) => Ok(Self::PB {
+                format: Some(pb::file_format_params::Format::Tsv(
+                    mt::principal::TsvFileFormatParams::to_pb(p)?,
+                )),
+            }),
+            Self::Xml(p) => Ok(Self::PB {
+                format: Some(pb::file_format_params::Format::Xml(
+                    mt::principal::XmlFileFormatParams::to_pb(p)?,
+                )),
+            }),
+        }
+    }
+}
+
+impl FromToProto for mt::principal::ParquetFileFormatParams {
+    type PB = pb::ParquetFileFormatParams;
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.ver
+    }
+
+    fn from_pb(p: pb::ParquetFileFormatParams) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.ver, p.min_reader_ver)?;
+        Ok(mt::principal::ParquetFileFormatParams {})
+    }
+
+    fn to_pb(&self) -> Result<pb::ParquetFileFormatParams, Incompatible> {
+        Ok(pb::ParquetFileFormatParams {
+            ver: VER,
+            min_reader_ver: MIN_READER_VER,
+        })
+    }
+}
+
+impl FromToProto for mt::principal::NdJsonFileFormatParams {
+    type PB = pb::NdJsonFileFormatParams;
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.ver
+    }
+
+    fn from_pb(p: pb::NdJsonFileFormatParams) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.ver, p.min_reader_ver)?;
+        let compression = mt::principal::StageFileCompression::from_pb(
+            FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
+                reason: format!("invalid StageFileCompression: {}", p.compression),
+            })?,
+        )?;
+        Ok(mt::principal::NdJsonFileFormatParams { compression })
+    }
+
+    fn to_pb(&self) -> Result<pb::NdJsonFileFormatParams, Incompatible> {
+        let compression = mt::principal::StageFileCompression::to_pb(&self.compression)? as i32;
+        Ok(pb::NdJsonFileFormatParams {
+            ver: VER,
+            min_reader_ver: MIN_READER_VER,
+            compression,
+        })
+    }
+}
+
+impl FromToProto for mt::principal::JsonFileFormatParams {
+    type PB = pb::JsonFileFormatParams;
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.ver
+    }
+
+    fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.ver, p.min_reader_ver)?;
+        let compression = mt::principal::StageFileCompression::from_pb(
+            FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
+                reason: format!("invalid StageFileCompression: {}", p.compression),
+            })?,
+        )?;
+        Ok(Self { compression })
+    }
+
+    fn to_pb(&self) -> Result<Self::PB, Incompatible> {
+        let compression = mt::principal::StageFileCompression::to_pb(&self.compression)? as i32;
+        Ok(Self::PB {
+            ver: VER,
+            min_reader_ver: MIN_READER_VER,
+            compression,
+        })
+    }
+}
+
+impl FromToProto for mt::principal::XmlFileFormatParams {
+    type PB = pb::XmlFileFormatParams;
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.ver
+    }
+
+    fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.ver, p.min_reader_ver)?;
+        let compression = mt::principal::StageFileCompression::from_pb(
+            FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
+                reason: format!("invalid StageFileCompression: {}", p.compression),
+            })?,
+        )?;
+        Ok(Self {
+            compression,
+            row_tag: p.row_tag,
+        })
+    }
+
+    fn to_pb(&self) -> Result<Self::PB, Incompatible> {
+        let compression = mt::principal::StageFileCompression::to_pb(&self.compression)? as i32;
+        Ok(Self::PB {
+            ver: VER,
+            min_reader_ver: MIN_READER_VER,
+            compression,
+            row_tag: self.row_tag.clone(),
+        })
+    }
+}
+
+impl FromToProto for mt::principal::CsvFileFormatParams {
+    type PB = pb::CsvFileFormatParams;
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.ver
+    }
+
+    fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.ver, p.min_reader_ver)?;
+        let compression = mt::principal::StageFileCompression::from_pb(
+            FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
+                reason: format!("invalid StageFileCompression: {}", p.compression),
+            })?,
+        )?;
+        Ok(Self {
+            compression,
+            headers: p.headers,
+            field_delimiter: p.field_delimiter,
+            record_delimiter: p.record_delimiter,
+            quote: p.quote,
+            escape: p.escape,
+            nan_display: p.nan_display,
+        })
+    }
+
+    fn to_pb(&self) -> Result<Self::PB, Incompatible> {
+        let compression = mt::principal::StageFileCompression::to_pb(&self.compression)? as i32;
+        Ok(Self::PB {
+            ver: VER,
+            min_reader_ver: MIN_READER_VER,
+            compression,
+            headers: self.headers,
+            field_delimiter: self.field_delimiter.clone(),
+            record_delimiter: self.record_delimiter.clone(),
+            quote: self.quote.clone(),
+            escape: self.escape.clone(),
+            nan_display: self.nan_display.clone(),
+        })
+    }
+}
+
+impl FromToProto for mt::principal::TsvFileFormatParams {
+    type PB = pb::TsvFileFormatParams;
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.ver
+    }
+
+    fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.ver, p.min_reader_ver)?;
+        let compression = mt::principal::StageFileCompression::from_pb(
+            FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
+                reason: format!("invalid StageFileCompression: {}", p.compression),
+            })?,
+        )?;
+        Ok(Self {
+            compression,
+            headers: p.headers,
+            field_delimiter: p.field_delimiter,
+            record_delimiter: p.record_delimiter,
+            escape: p.escape,
+            nan_display: p.nan_display,
+            quote: p.quote,
+        })
+    }
+
+    fn to_pb(&self) -> Result<Self::PB, Incompatible> {
+        let compression = mt::principal::StageFileCompression::to_pb(&self.compression)? as i32;
+        Ok(Self::PB {
+            ver: VER,
+            min_reader_ver: MIN_READER_VER,
+            compression,
+            headers: self.headers,
+            field_delimiter: self.field_delimiter.clone(),
+            record_delimiter: self.record_delimiter.clone(),
+            escape: self.escape.clone(),
+            quote: self.quote.clone(),
+            nan_display: self.nan_display.clone(),
+        })
+    }
+}

--- a/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
@@ -333,32 +333,3 @@ impl FromToProto for mt::principal::UserIdentity {
         })
     }
 }
-
-impl FromToProto for mt::principal::StageType {
-    type PB = pb::stage_info::StageType;
-    fn get_pb_ver(_p: &Self::PB) -> u64 {
-        0
-    }
-    fn from_pb(p: pb::stage_info::StageType) -> Result<Self, Incompatible>
-    where Self: Sized {
-        match p {
-            pb::stage_info::StageType::LegacyInternal => {
-                Ok(mt::principal::StageType::LegacyInternal)
-            }
-            pb::stage_info::StageType::External => Ok(mt::principal::StageType::External),
-            pb::stage_info::StageType::Internal => Ok(mt::principal::StageType::Internal),
-            pb::stage_info::StageType::User => Ok(mt::principal::StageType::User),
-        }
-    }
-
-    fn to_pb(&self) -> Result<pb::stage_info::StageType, Incompatible> {
-        match *self {
-            mt::principal::StageType::LegacyInternal => {
-                Ok(pb::stage_info::StageType::LegacyInternal)
-            }
-            mt::principal::StageType::External => Ok(pb::stage_info::StageType::External),
-            mt::principal::StageType::Internal => Ok(pb::stage_info::StageType::Internal),
-            mt::principal::StageType::User => Ok(pb::stage_info::StageType::User),
-        }
-    }
-}

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -61,6 +61,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (29, "2023-02-23: Add: metadata.proto/DataType EmptyMap types", ),
     (30, "2023-02-21: Add: config.proto/WebhdfsStorageConfig; Modify: user.proto/UserStageInfo::StageStorage", ),
     (31, "2023-02-21: Add: CopyOptions::max_files", ),
+    (32, "2023-04-05: Add: file_format.proto/FileFormatParams", ),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -38,3 +38,4 @@ mod v028_schema;
 mod v029_schema;
 mod v030_user_stage;
 mod v031_copy_max_file;
+mod v032_file_format_params;

--- a/src/meta/proto-conv/tests/it/v032_file_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v032_file_format_params.rs
@@ -1,0 +1,132 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_meta_app as mt;
+use common_meta_app::principal::CsvFileFormatParams;
+use common_meta_app::principal::StageFileCompression;
+use common_meta_app::principal::TsvFileFormatParams;
+
+use crate::common;
+use crate::v032_file_format_params::mt::principal::JsonFileFormatParams;
+use crate::v032_file_format_params::mt::principal::NdJsonFileFormatParams;
+use crate::v032_file_format_params::mt::principal::ParquetFileFormatParams;
+use crate::v032_file_format_params::mt::principal::XmlFileFormatParams;
+
+// These bytes are built when a new version in introduced,
+// and are kept for backward compatibility test.
+//
+// *************************************************************
+// * These messages should never be updated,                   *
+// * only be added when a new version is added,                *
+// * or be removed when an old version is no longer supported. *
+// *************************************************************
+//
+#[test]
+fn test_decode_v32_csv_file_format_params() -> anyhow::Result<()> {
+    let file_format_params_v32 = vec![
+        18, 29, 8, 1, 16, 1, 26, 2, 102, 100, 34, 2, 114, 100, 42, 3, 110, 97, 110, 50, 1, 92, 58,
+        1, 39, 160, 6, 32, 168, 6, 24,
+    ];
+    let want = || {
+        mt::principal::FileFormatParams::Csv(CsvFileFormatParams {
+            compression: StageFileCompression::Gzip,
+            headers: 1,
+            field_delimiter: "fd".to_string(),
+            record_delimiter: "rd".to_string(),
+            nan_display: "nan".to_string(),
+            escape: "\\".to_string(),
+            quote: "\'".to_string(),
+        })
+    };
+    common::test_load_old(func_name!(), file_format_params_v32.as_slice(), 32, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}
+
+#[test]
+fn test_decode_v32_tsv_file_format_params() -> anyhow::Result<()> {
+    let file_format_params_v32 = vec![
+        26, 29, 8, 1, 16, 1, 26, 2, 102, 100, 34, 2, 114, 100, 42, 3, 110, 97, 110, 50, 1, 92, 58,
+        1, 39, 160, 6, 32, 168, 6, 24,
+    ];
+
+    let want = || {
+        mt::principal::FileFormatParams::Tsv(TsvFileFormatParams {
+            compression: StageFileCompression::Gzip,
+            headers: 1,
+            field_delimiter: "fd".to_string(),
+            record_delimiter: "rd".to_string(),
+            nan_display: "nan".to_string(),
+            escape: "\\".to_string(),
+            quote: "\'".to_string(),
+        })
+    };
+    common::test_pb_from_to(func_name!(), want())?;
+    common::test_load_old(func_name!(), file_format_params_v32.as_slice(), 32, want())?;
+    Ok(())
+}
+
+#[test]
+fn test_decode_v32_ndjson_file_format_params() -> anyhow::Result<()> {
+    let file_format_params_v32 = vec![42, 8, 8, 1, 160, 6, 32, 168, 6, 24];
+
+    let want = || {
+        mt::principal::FileFormatParams::NdJson(NdJsonFileFormatParams {
+            compression: StageFileCompression::Gzip,
+        })
+    };
+    common::test_pb_from_to(func_name!(), want())?;
+    common::test_load_old(func_name!(), file_format_params_v32.as_slice(), 32, want())?;
+    Ok(())
+}
+
+#[test]
+fn test_decode_v32_json_file_format_params() -> anyhow::Result<()> {
+    let file_format_params_v32 = vec![34, 8, 8, 1, 160, 6, 32, 168, 6, 24];
+    let want = || {
+        mt::principal::FileFormatParams::Json(JsonFileFormatParams {
+            compression: StageFileCompression::Gzip,
+        })
+    };
+    common::test_load_old(func_name!(), file_format_params_v32.as_slice(), 32, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}
+
+#[test]
+fn test_decode_v32_xml_file_format_params() -> anyhow::Result<()> {
+    let file_format_params_v32 = vec![
+        50, 17, 8, 1, 18, 7, 114, 111, 119, 95, 116, 97, 103, 160, 6, 32, 168, 6, 24,
+    ];
+
+    let want = || {
+        mt::principal::FileFormatParams::Xml(XmlFileFormatParams {
+            compression: StageFileCompression::Gzip,
+            row_tag: "row_tag".to_string(),
+        })
+    };
+    common::test_load_old(func_name!(), file_format_params_v32.as_slice(), 32, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}
+
+#[test]
+fn test_decode_v32_parquet_file_format_params() -> anyhow::Result<()> {
+    let file_format_params_v32 = vec![10, 6, 160, 6, 32, 168, 6, 24];
+
+    let want = || mt::principal::FileFormatParams::Parquet(ParquetFileFormatParams {});
+    common::test_load_old(func_name!(), file_format_params_v32.as_slice(), 32, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}

--- a/src/meta/protos/proto/file_format.proto
+++ b/src/meta/protos/proto/file_format.proto
@@ -75,3 +75,65 @@ message FileFormatOptions {
 
   string quote = 9;
 }
+
+message FileFormatParams {
+  oneof format {
+    ParquetFileFormatParams parquet = 1;
+    CsvFileFormatParams csv = 2;
+    TsvFileFormatParams tsv = 3;
+    JsonFileFormatParams json = 4;
+    NdJsonFileFormatParams nd_json = 5;
+    XmlFileFormatParams xml = 6;
+  }
+}
+
+message ParquetFileFormatParams {
+  uint64 ver = 100;
+  uint64 min_reader_ver = 101;
+}
+
+message CsvFileFormatParams {
+  uint64 ver = 100;
+  uint64 min_reader_ver = 101;
+
+  StageFileCompression compression =1;
+  uint64 headers = 2;
+  string field_delimiter = 3;
+  string record_delimiter = 4;
+  string nan_display = 5;
+  string escape = 6;
+  string quote = 7;
+}
+
+message TsvFileFormatParams {
+  uint64 ver = 100;
+  uint64 min_reader_ver = 101;
+
+  StageFileCompression compression = 1;
+  uint64 headers = 2;
+  string field_delimiter = 3;
+  string record_delimiter = 4;
+  string nan_display = 5;
+  string escape = 6;
+  string quote = 7;
+}
+
+message XmlFileFormatParams {
+  uint64 ver = 100;
+  uint64 min_reader_ver = 101;
+  StageFileCompression compression = 1;
+  string row_tag = 2;
+}
+
+message NdJsonFileFormatParams {
+  uint64 ver = 100;
+  uint64 min_reader_ver = 101;
+  StageFileCompression compression = 1;
+}
+
+message JsonFileFormatParams {
+  uint64 ver = 100;
+  uint64 min_reader_ver = 101;
+  StageFileCompression compression = 1;
+
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

step 2  of  https://github.com/datafuselabs/databend/issues/10376

1. add enum FileFormatParams which is going to replace FileFormatOptions,  it`s corresponding PB def in meta, and the convs
2. func to trans FileFormatAst to FileFormatParams.
3. rename `skip_header` to `headers`, since it will be also used for OutputFormat later.

FileFormatParams is not really used, so this pr is safe.

There may be changes to  FileFormatParams in the following pr, but they won't be significant.


