### PR TITLE
feat(query): Add toUnixTimestamp function

### DIFF
--- a/src/query/expression/src/utils/date_helper.rs
+++ b/src/query/expression/src/utils/date_helper.rs
@@ -423,6 +423,7 @@ pub struct ToDayOfWeek;
 pub struct ToHour;
 pub struct ToMinute;
 pub struct ToSecond;
+pub struct ToUnixTimestamp;
 
 impl ToNumber<u32> for ToYYYYMM {
     fn to_number(dt: &DateTime<Tz>) -> u32 {
@@ -474,6 +475,12 @@ impl ToNumber<u8> for ToDayOfMonth {
 impl ToNumber<u8> for ToDayOfWeek {
     fn to_number(dt: &DateTime<Tz>) -> u8 {
         dt.weekday().number_from_monday() as u8
+    }
+}
+
+impl ToNumber<i64> for ToUnixTimestamp {
+    fn to_number(dt: &DateTime<Tz>) -> i64 {
+        dt.timestamp()
     }
 }
 

--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -870,6 +870,13 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
             ToNumberImpl::eval_timestamp::<ToDayOfWeek, _>(val, ctx.tz)
         }),
     );
+    registry.register_passthrough_nullable_1_arg::<TimestampType, Int64Type, _, _>(
+        "to_unix_timestamp",
+        |_| FunctionDomain::Full,
+        vectorize_1_arg::<TimestampType, Int64Type>(|val, ctx| {
+            ToNumberImpl::eval_timestamp::<ToUnixTimestamp, _>(val, ctx.tz)
+        }),
+    );
 
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt8Type, _, _>(
         "to_hour",

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -3376,8 +3376,8 @@ Functions overloads:
 21 to_uint8(Float64 NULL) :: UInt8 NULL
 22 to_uint8(Boolean) :: UInt8
 23 to_uint8(Boolean NULL) :: UInt8 NULL
-24 to_unix_timestamp(Timestamp) :: Int64
-25 to_unix_timestamp(Timestamp NULL) :: Int64 NULL
+0 to_unix_timestamp(Timestamp) :: Int64
+1 to_unix_timestamp(Timestamp NULL) :: Int64 NULL
 0 to_variant(T0) :: Variant
 1 to_variant(T0 NULL) :: Variant NULL
 0 to_year(Date) :: UInt16

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -3376,6 +3376,8 @@ Functions overloads:
 21 to_uint8(Float64 NULL) :: UInt8 NULL
 22 to_uint8(Boolean) :: UInt8
 23 to_uint8(Boolean NULL) :: UInt8 NULL
+24 to_unix_timestamp(Timestamp) :: Int64
+25 to_unix_timestamp(Timestamp NULL) :: Int64 NULL
 0 to_variant(T0) :: Variant
 1 to_variant(T0 NULL) :: Variant NULL
 0 to_year(Date) :: UInt16

--- a/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes
+++ b/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes
@@ -117,9 +117,15 @@ select to_datetime('9999-12-31 23:59:')
 9999-12-31 23:59:00.000000
 
 query T
-select to_unix_timestamp('2023-04-06 04:06:23.231808')
+select to_unix_timestamp('2022-12-31T23:59:59+00:00')
 ----
-1680753983
+1672531199
+
+query T
+select to_unix_timestamp('2022-12-31T23:59:59-08:00')
+----
+1672559999
+
 
 statement error 1001
 select to_datetime('9999-01-01 00x')

--- a/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes
+++ b/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes
@@ -16,6 +16,10 @@ SELECT now() >= 1630295616::TIMESTAMP
 ----
 1
 
+query B
+SELECT to_unix_timestamp(now()) >= 1680753801;
+----
+1
 
 
 query TB
@@ -112,6 +116,11 @@ select to_datetime('9999-12-31 23:59:')
 ----
 9999-12-31 23:59:00.000000
 
+query T
+select to_unix_timestamp('2023-04-06 04:06:23.231808')
+----
+1680753983
+
 statement error 1001
 select to_datetime('9999-01-01 00x')
 
@@ -169,6 +178,11 @@ select typeof(today() - today()) = 'INT'
 
 query B
 select typeof(now() - now()) = 'BIGINT'
+----
+1
+
+query B
+select typeof(to_unix_timestamp('2023-04-06 04:06:23.231808')) = 'BIGINT'
 ----
 1
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
Summary about this PR
Feature:
Now users can use `to_unix_timestamp()` function to convert Databend timestamp to unix timestamp.
```
mysql> select to_unix_timestamp(now());
+--------------------------+
| to_unix_timestamp(now()) |
+--------------------------+
|           unix_timestamp |
+--------------------------+
```

Closes #10902 
