### PR TITLE
fix(query): mysql affected_rows should use write process value

### DIFF
--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -468,7 +468,7 @@ impl ProgressReporter for ContextProgressReporter {
     }
 
     fn affected_rows(&self) -> u64 {
-        let progress = self.context.get_scan_progress_value();
+        let progress = self.context.get_write_progress_value();
         progress.rows as u64
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

mysql affected_rows should use write process value

Closes #10748
