### PR TITLE
fix: skip errors on listing tables in admin api

### DIFF
--- a/src/query/service/src/api/http/v1/tenant_tables.rs
+++ b/src/query/service/src/api/http/v1/tenant_tables.rs
@@ -27,6 +27,7 @@ use serde::Serialize;
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Default)]
 pub struct TenantTablesResponse {
     pub tables: Vec<TenantTableInfo>,
+    pub warnings: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Default)]
@@ -42,13 +43,25 @@ pub struct TenantTableInfo {
     pub index_bytes: u64,
 }
 
-async fn load_tenant_tables(tenant: &str) -> Result<Vec<TenantTableInfo>> {
+async fn load_tenant_tables(tenant: &str) -> Result<TenantTablesResponse> {
     let catalog = CatalogManager::instance().get_catalog(CATALOG_DEFAULT)?;
     let databases = catalog.list_databases(tenant).await?;
 
     let mut table_infos: Vec<TenantTableInfo> = vec![];
+    let mut warnings: Vec<String> = vec![];
     for database in databases {
-        let tables = catalog.list_tables(tenant, database.name()).await?;
+        let tables = match catalog.list_tables(tenant, database.name()).await {
+            Ok(v) => v,
+            Err(err) => {
+                warnings.push(format!(
+                    "failed to list tables of database {}.{}: {}",
+                    tenant,
+                    database.name(),
+                    err
+                ));
+                continue;
+            }
+        };
         for table in tables {
             let stats = &table.get_table_info().meta.statistics;
             table_infos.push(TenantTableInfo {
@@ -64,7 +77,10 @@ async fn load_tenant_tables(tenant: &str) -> Result<Vec<TenantTableInfo>> {
             });
         }
     }
-    Ok(table_infos)
+    Ok(TenantTablesResponse {
+        tables: table_infos,
+        warnings,
+    })
 }
 
 // This handler returns the statistics about the tables of a tenant. It's only enabled in management mode.
@@ -73,10 +89,10 @@ async fn load_tenant_tables(tenant: &str) -> Result<Vec<TenantTableInfo>> {
 pub async fn list_tenant_tables_handler(
     Path(tenant): Path<String>,
 ) -> poem::Result<impl IntoResponse> {
-    let tables = load_tenant_tables(&tenant)
+    let resp = load_tenant_tables(&tenant)
         .await
         .map_err(poem::error::InternalServerError)?;
-    Ok(Json(TenantTablesResponse { tables }))
+    Ok(Json(resp))
 }
 
 // This handler returns the statistics about the tables of the current tenant.
@@ -85,11 +101,14 @@ pub async fn list_tenant_tables_handler(
 pub async fn list_tables_handler() -> poem::Result<impl IntoResponse> {
     let tenant = &GlobalConfig::instance().query.tenant_id;
     if tenant.is_empty() {
-        return Ok(Json(TenantTablesResponse { tables: vec![] }));
+        return Ok(Json(TenantTablesResponse {
+            tables: vec![],
+            warnings: vec![],
+        }));
     }
 
-    let tables = load_tenant_tables(tenant)
+    let resp = load_tenant_tables(tenant)
         .await
         .map_err(poem::error::InternalServerError)?;
-    Ok(Json(TenantTablesResponse { tables }))
+    Ok(Json(resp))
 }

--- a/src/query/sharing/src/share_endpoint.rs
+++ b/src/query/sharing/src/share_endpoint.rs
@@ -100,7 +100,7 @@ impl ShareEndpointManager {
                 },
                 None => {
                     return Err(ErrorCode::UnknownShareEndpoint(format!(
-                        "UnknownShareEndpoint from {:?} to {:?}",
+                        "Unknown share endpoint on accessing shared database from tenant {:?} to target tenant {:?}",
                         from_tenant, to_tenant
                     )));
                 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

On accessing the tables info by admin api, I got a UnknownShareEndpoint error like this:

```
curl localhost:8080/v1/tenants/tnh2xmxsf/tables
Code: 2715, Text = UnknownShareEndpoint from "default" to "tncy3exa1".
```

Afeter investigation, I found that "default" tenant tries to access a shared database from tenant tncy3exa1, but the share endpoint endpoint is not set. A bad config on one database made all the databases infomation can not be shown at all.

This PR added a `warnings` field in the list_tenant_tables_handler, to swallow the errors but display them in the warnings field. So users can still get the most of table infomations and warning message without lose all the things by one bad config.
