### PR TITLE
refactor: Revert switch to global IO runtime for pruning

### DIFF
--- a/src/query/storages/fuse/src/pruning/fuse_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/fuse_pruner.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use common_base::base::tokio::sync::Semaphore;
-use common_base::runtime::GlobalIORuntime;
 use common_base::runtime::Runtime;
 use common_catalog::plan::PushDownInfo;
 use common_catalog::table_context::TableContext;
@@ -119,7 +118,7 @@ impl FusePruner {
         )?;
 
         // Constraint the degree of parallelism
-        // let max_threads = ctx.get_settings().get_max_threads()? as usize;
+        let max_threads = ctx.get_settings().get_max_threads()? as usize;
         let max_concurrency = {
             let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
             // Prevent us from miss-configured max_storage_io_requests setting, e.g. 0
@@ -134,18 +133,17 @@ impl FusePruner {
         };
 
         // Pruning runtime.
-        // let pruning_runtime = Arc::new(Runtime::with_worker_threads(
-        //     max_threads,
-        //     Some("pruning-worker".to_owned()),
-        // )?);
+        let pruning_runtime = Arc::new(Runtime::with_worker_threads(
+            max_threads,
+            Some("pruning-worker".to_owned()),
+        )?);
         let pruning_semaphore = Arc::new(Semaphore::new(max_concurrency));
         let pruning_stats = Arc::new(FusePruningStatistics::default());
 
         let pruning_ctx = Arc::new(PruningContext {
             ctx: ctx.clone(),
             dal,
-            // TODO: we should switch back to pruning_runtime after we figure out the root cause of hang.
-            pruning_runtime: GlobalIORuntime::instance(),
+            pruning_runtime,
             pruning_semaphore,
             limit_pruner,
             range_pruner,


### PR DESCRIPTION
This reverts commit 537c9f295dc28212e5c22fa3dc4094ab45bbce8c.

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Revert #10941
