### PR TITLE
chore: fix ai_to_sql response miss blank

### DIFF
--- a/src/query/service/src/table_functions/openai/ai_to_sql.rs
+++ b/src/query/service/src/table_functions/openai/ai_to_sql.rs
@@ -229,7 +229,7 @@ impl AsyncSource for GPT2SQLSource {
         let openai = OpenAI::create(api_base, api_key, api_embedding_model, api_completion_model);
         let (sql, _) = openai.completion_sql_request(prompt)?;
 
-        let sql = format!("SELECT{}", sql);
+        let sql = format!("SELECT {}", sql);
         info!("openai response sql: {}", sql);
         let database = self.ctx.get_current_database();
         let database: Vec<Vec<u8>> = vec![database.into_bytes()];


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```
mysql> select * from ai_to_sql('how many visits');
+----------+--------------------------+
| database | generated_sql            |
+----------+--------------------------+
| hits     | SELECTCOUNT(*) FROM hits |
+----------+--------------------------+
```

Closes #issue
