### PR TITLE
fix: ensure builtin roles on JWT check

### DIFF
--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -83,6 +83,11 @@ impl AuthMgr {
 
                 let tenant = session.get_current_tenant();
                 let identity = UserIdentity::new(&user_name, "%");
+
+                // ensure the builtin roles like ACCOUNT_ADMIN, PUBLIC exists
+                user_api.ensure_builtin_roles(&tenant).await?;
+
+                // create a new user for this identity if not exists
                 let user = match user_api.get_user(&tenant, identity.clone()).await {
                     Ok(user_info) => match user_info.auth_info {
                         AuthInfo::JWT => user_info,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently we're initializing the builtin roles on start up. However there're also cases we want to read the multi-tenant metadata before any warehouse get started. When you try access the metadata with a JWT token but without builtin roles initialized, you will get several permission denied error.

This PR tries to fix this issue via ensure builtin roles on every JWT check, and to avoid degrading the performance, it check the existence of the role before any write operation, which avoids most of the write operations.
