### PR TITLE
fix: join condition should push down

### DIFF
--- a/src/query/sql/src/planner/binder/join.rs
+++ b/src/query/sql/src/planner/binder/join.rs
@@ -641,18 +641,20 @@ impl<'a> JoinConditionResolver<'a> {
             right = wrap_cast(&right, &least_super_type);
         }
 
-        if left_used_columns.is_subset(&left_columns)
-            && right_used_columns.is_subset(&right_columns)
-        {
-            left_join_conditions.push(left);
-            right_join_conditions.push(right);
-            return Ok(true);
-        } else if left_used_columns.is_subset(&right_columns)
-            && right_used_columns.is_subset(&left_columns)
-        {
-            left_join_conditions.push(right);
-            right_join_conditions.push(left);
-            return Ok(true);
+        if !left_used_columns.is_empty() && !right_used_columns.is_empty() {
+            if left_used_columns.is_subset(&left_columns)
+                && right_used_columns.is_subset(&right_columns)
+            {
+                left_join_conditions.push(left);
+                right_join_conditions.push(right);
+                return Ok(true);
+            } else if left_used_columns.is_subset(&right_columns)
+                && right_used_columns.is_subset(&left_columns)
+            {
+                left_join_conditions.push(right);
+                right_join_conditions.push(left);
+                return Ok(true);
+            }
         }
         Ok(false)
     }

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -689,3 +689,56 @@ set enable_cbo = 1
 
 statement ok
 drop table t1
+
+statement ok
+CREATE TABLE IF NOT EXISTS onecolumn (x INT NULL);
+
+statement ok
+INSERT INTO onecolumn(x) VALUES (44), (NULL), (42);
+
+statement ok
+CREATE TABLE IF NOT EXISTS twocolumn (x INT NULL, y INT NULL);
+
+statement ok
+INSERT INTO twocolumn(x, y) VALUES (44,51), (NULL,52), (42,53), (45,45);
+
+query T
+explain SELECT o.x, t.y FROM onecolumn o INNER JOIN twocolumn t ON (o.x=t.x AND t.y=53);
+----
+EvalScalar
+├── expressions: [o.x (#0), t.y (#2)]
+├── estimated rows: 8.00
+└── HashJoin
+    ├── join type: INNER
+    ├── build keys: [t.x (#1)]
+    ├── probe keys: [o.x (#0)]
+    ├── filters: []
+    ├── estimated rows: 8.00
+    ├── Filter(Build)
+    │   ├── filters: [is_true(t.y (#2) = 53)]
+    │   ├── estimated rows: 1.14
+    │   └── TableScan
+    │       ├── table: default.default.twocolumn
+    │       ├── read rows: 8
+    │       ├── read bytes: 188
+    │       ├── partitions total: 2
+    │       ├── partitions scanned: 2
+    │       ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 2 to 2>]
+    │       ├── push downs: [filters: [is_true(t.y (#2) = 53)], limit: NONE]
+    │       └── estimated rows: 8.00
+    └── TableScan(Probe)
+        ├── table: default.default.onecolumn
+        ├── read rows: 7
+        ├── read bytes: 86
+        ├── partitions total: 2
+        ├── partitions scanned: 2
+        ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 7.00
+
+
+statement ok
+drop table onecolumn;
+
+statement ok
+drop table twocolumn;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
```sql
explain SELECT o.x, t.y FROM onecolumn o INNER JOIN twocolumn t ON (o.x=t.x AND t.y=53);
```

Before
```
+--------------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                        |
+--------------------------------------------------------------------------------------------------------------------------------+
| EvalScalar                                                                                                                     |
| ├── expressions: [o.x (#0), t.y (#2)]                                                                                          |
| ├── estimated rows: 1.00                                                                                                       |
| └── HashJoin                                                                                                                   |
|     ├── join type: INNER                                                                                                       |
|     ├── build keys: [o.x (#0), 53]                                                                                             |
|     ├── probe keys: [t.x (#1), t.y (#2)]                                                                                       |
|     ├── filters: []                                                                                                            |
|     ├── estimated rows: 1.00                                                                                                   |
|     ├── TableScan(Build)                                                                                                       |
|     │   ├── table: default.default.onecolumn                                                                                   |
|     │   ├── read rows: 3                                                                                                       |
|     │   ├── read bytes: 41                                                                                                     |
|     │   ├── partitions total: 1                                                                                                |
|     │   ├── partitions scanned: 1                                                                                              |
|     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]         |
|     │   ├── push downs: [filters: [], limit: NONE]                                                                             |
|     │   └── estimated rows: 3.00                                                                                               |
|     └── TableScan(Probe)                                                                                                       |
|         ├── table: default.default.twocolumn                                                                                   |
|         ├── read rows: 4                                                                                                       |
|         ├── read bytes: 94                                                                                                     |
|         ├── partitions total: 1                                                                                                |
|         ├── partitions scanned: 1                                                                                              |
|         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]         |
|         ├── push downs: [filters: [], limit: NONE]                                                                             |
|         └── estimated rows: 4.00                                                                                               |
+--------------------------------------------------------------------------------------------------------------------------------+
```

Now
```
+------------------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                            |
+------------------------------------------------------------------------------------------------------------------------------------+
| EvalScalar                                                                                                                         |
| ├── expressions: [o.x (#0), t.y (#2)]                                                                                              |
| ├── estimated rows: 1.00                                                                                                           |
| └── HashJoin                                                                                                                       |
|     ├── join type: INNER                                                                                                           |
|     ├── build keys: [t.x (#1)]                                                                                                     |
|     ├── probe keys: [o.x (#0)]                                                                                                     |
|     ├── filters: []                                                                                                                |
|     ├── estimated rows: 1.00                                                                                                       |
|     ├── Filter(Build)                                                                                                              |
|     │   ├── filters: [is_true(t.y (#2) = 53)]                                                                                      |
|     │   ├── estimated rows: 1.33                                                                                                   |
|     │   └── TableScan                                                                                                              |
|     │       ├── table: default.default.twocolumn                                                                                   |
|     │       ├── read rows: 4                                                                                                       |
|     │       ├── read bytes: 94                                                                                                     |
|     │       ├── partitions total: 1                                                                                                |
|     │       ├── partitions scanned: 1                                                                                              |
|     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]         |
|     │       ├── push downs: [filters: [is_true(t.y (#2) = 53)], limit: NONE]                                                       |
|     │       └── estimated rows: 4.00                                                                                               |
|     └── TableScan(Probe)                                                                                                           |
|         ├── table: default.default.onecolumn                                                                                       |
|         ├── read rows: 3                                                                                                           |
|         ├── read bytes: 41                                                                                                         |
|         ├── partitions total: 1                                                                                                    |
|         ├── partitions scanned: 1                                                                                                  |
|         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]             |
|         ├── push downs: [filters: [], limit: NONE]                                                                                 |
|         └── estimated rows: 3.00                                                                                                   |
+------------------------------------------------------------------------------------------------------------------------------------+
```

Closes #issue
