### PR TITLE
refactor: Bump OpenDAL to v0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ checksum = "3659ebaa5387be8848f768e72a2f967c471fa6225c6b1506a1f3acfdaf25ed17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -417,7 +417,7 @@ checksum = "c54fb3976c0d3c2730a4c0904061fb6b3d255e7e67a56939955ef8ce6aa4175f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -457,7 +457,7 @@ checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -479,7 +479,7 @@ checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -490,13 +490,13 @@ checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.66"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -507,7 +507,7 @@ checksum = "e50b5d93114c4fe54a90adba208ea9fc5e4e6a26d7048b4df11ddaaec3635b31"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -856,7 +856,7 @@ dependencies = [
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -867,7 +867,7 @@ checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -878,7 +878,7 @@ checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -969,7 +969,7 @@ checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -995,7 +995,7 @@ checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1139,7 +1139,7 @@ dependencies = [
  "proc-macro-error 0.4.12",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1308,7 +1308,7 @@ dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1321,7 +1321,7 @@ dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1998,7 +1998,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
- "sled",
+ "sled 0.34.6",
  "tempfile",
  "thiserror",
  "tracing",
@@ -2012,7 +2012,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "sled",
+ "sled 0.34.6",
  "thiserror",
 ]
 
@@ -3064,7 +3064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3101,7 +3101,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3118,7 +3118,7 @@ checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3142,7 +3142,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3153,7 +3153,7 @@ checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serfig",
- "sled",
+ "sled 0.34.6",
  "temp-env",
  "tempfile",
  "tokio-stream",
@@ -3511,7 +3511,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3544,7 +3544,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
+dependencies = [
+ "dirs-sys 0.4.0",
 ]
 
 [[package]]
@@ -3556,6 +3565,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+dependencies = [
+ "libc",
+ "redox_users",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3626,7 +3646,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3709,7 +3729,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3723,7 +3743,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3735,7 +3755,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3756,7 +3776,7 @@ checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4028,7 +4048,7 @@ checksum = "b83164912bb4c97cfe0772913c7af7387ee2e00cb6d4636fb65a35b3d0c8f173"
 dependencies = [
  "frunk_proc_macro_helpers",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4040,7 +4060,7 @@ dependencies = [
  "frunk_core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4064,7 +4084,7 @@ dependencies = [
  "frunk_proc_macro_helpers",
  "proc-macro-hack",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4160,7 +4180,7 @@ checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4197,6 +4217,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -4310,7 +4339,7 @@ checksum = "69e0cd8a998937e25c6ba7cc276b96ec5cc3f4dc4ab5de9ede4fb152bdd5c5eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5056,7 +5085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ffa5bf0772f9b01de501c035b6b084cf9b8bb07dec41e3afc6a17336a65f47"
 dependencies = [
  "bitflags 1.3.2",
- "dirs",
+ "dirs 4.0.0",
  "gix-path",
  "libc",
  "windows 0.43.0",
@@ -6185,7 +6214,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6284,7 +6313,7 @@ checksum = "c334ac67725febd94c067736ac46ef1c7cacf1c743ca14b9f917c2df2c20acd8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6388,7 +6417,7 @@ source = "git+https://github.com/datafuse-extras/metrics.git?rev=fc2ecd1#fc2ecd1
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6484,7 +6513,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6556,7 +6585,7 @@ checksum = "1af1abf82261d780d114014eff4b555e47d823f3b84f893c4388572b40e089fb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "target-features",
 ]
 
@@ -6696,7 +6725,7 @@ dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6784,7 +6813,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6893,9 +6922,9 @@ dependencies = [
 
 [[package]]
 name = "opendal"
-version = "0.30.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89d32f1761175aff31cb233330e206c2a8d9c3e96b0af3e74d0e7eff978b46a"
+checksum = "cf96af8fd158be23ee9c3a6adb3383a665424cc50b0c68774fe6d1a18892077f"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -6903,6 +6932,7 @@ dependencies = [
  "backon",
  "base64 0.21.0",
  "bytes",
+ "chrono",
  "flagset",
  "futures",
  "hdrs",
@@ -6923,11 +6953,9 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "time 0.3.20",
+ "sled 0.34.7",
  "tokio",
  "tracing",
- "trust-dns-resolver",
- "ureq",
  "uuid",
 ]
 
@@ -7381,7 +7409,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7513,7 +7541,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7640,7 +7668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7699,7 +7727,7 @@ dependencies = [
  "proc-macro-error-attr 0.4.12",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -7712,7 +7740,7 @@ dependencies = [
  "proc-macro-error-attr 1.0.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -7724,7 +7752,7 @@ checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "syn-mid",
  "version_check",
 ]
@@ -7748,9 +7776,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -7820,7 +7848,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 1.0.109",
  "tempfile",
  "which 4.4.0",
 ]
@@ -7835,7 +7863,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7889,7 +7917,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7978,9 +8006,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -8206,15 +8234,16 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.8.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db6d8d2cd7fa61403d14de670f98d7cedac38143681c124943d7bb69258b3a"
+checksum = "3875de6d7d0468315194cb8332913aae0d6803cfd5c7f089dc174ff5350f7b29"
 dependencies = [
  "anyhow",
- "backon",
+ "async-trait",
  "base64 0.21.0",
  "bytes",
- "dirs",
+ "chrono",
+ "dirs 5.0.0",
  "form_urlencoded",
  "hex",
  "hmac",
@@ -8225,14 +8254,14 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.28.1",
  "rand 0.8.5",
+ "reqwest",
  "rsa 0.8.2",
  "rust-ini",
  "serde",
  "serde_json",
  "sha1",
  "sha2",
- "time 0.3.20",
- "ureq",
+ "tokio",
 ]
 
 [[package]]
@@ -8391,7 +8420,7 @@ checksum = "ac1c672430eb41556291981f45ca900a0239ad007242d1cb4b4167af842db666"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8853,7 +8882,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8887,7 +8916,7 @@ checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8936,7 +8965,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9177,6 +9206,22 @@ dependencies = [
  "log",
  "parking_lot 0.11.2",
  "rio",
+]
+
+[[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -9462,7 +9507,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9516,6 +9561,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn-mid"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9523,7 +9579,7 @@ checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9644,7 +9700,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9776,14 +9832,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -9807,13 +9862,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -9940,7 +9995,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -10021,7 +10076,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -10211,7 +10266,7 @@ checksum = "bf9f5f225956dc2254c6c27500deac9390a066b2e8a1a571300627a7c4400a33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -10312,7 +10367,6 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs",
  "serde",
  "serde_json",
  "url",
@@ -10466,7 +10520,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -10500,7 +10554,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,7 +2312,6 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
- "ureq",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ members = [
 [workspace.dependencies]
 # databend maintains:
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
-opendal = { version = "0.30", features = [
+opendal = { version = "0.31", features = [
     "layers-tracing",
     "layers-metrics",
     "services-ipfs",

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -28,6 +28,5 @@ opendal = { workspace = true }
 regex = "1.6.0"
 reqwest = { workspace = true }
 serde = { workspace = true }
-ureq = { version = "2", default-features = false }
 
 [dev-dependencies]

--- a/src/common/storage/src/stage.rs
+++ b/src/common/storage/src/stage.rs
@@ -15,7 +15,6 @@
 use std::path::Path;
 
 use chrono::DateTime;
-use chrono::TimeZone;
 use chrono::Utc;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -56,10 +55,7 @@ impl StageFileInfo {
             path,
             size: meta.content_length(),
             md5: meta.content_md5().map(str::to_string),
-            last_modified: meta
-                .last_modified()
-                .map(|v| Utc.timestamp_nanos(v.unix_timestamp_nanos() as i64))
-                .unwrap_or_default(),
+            last_modified: meta.last_modified().unwrap_or_default(),
             etag: meta.etag().map(str::to_string),
             status: StageFileStatus::NeedCopy,
             creator: None,

--- a/src/query/service/src/interpreters/interpreter_presign.rs
+++ b/src/query/service/src/interpreters/interpreter_presign.rs
@@ -66,13 +66,14 @@ impl Interpreter for PresignInterpreter {
         }
 
         let presigned_req = match self.plan.action {
-            PresignAction::Download => op.presign_read(&self.plan.path, self.plan.expire)?,
+            PresignAction::Download => op.presign_read(&self.plan.path, self.plan.expire).await?,
             PresignAction::Upload => {
                 let mut presign_args = OpWrite::new();
                 if let Some(content_type) = &self.plan.content_type {
                     presign_args = presign_args.with_content_type(content_type);
                 }
-                op.presign_write_with(&self.plan.path, presign_args, self.plan.expire)?
+                op.presign_write_with(&self.plan.path, presign_args, self.plan.expire)
+                    .await?
             }
         };
 

--- a/src/query/sharing-endpoint/src/accessor/share_table_accessor.rs
+++ b/src/query/sharing-endpoint/src/accessor/share_table_accessor.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use common_exception::Result;
 use common_storages_share::SHARE_CONFIG_PREFIX;
-use time::Duration;
 
 use crate::accessor::truncate_root;
 use crate::accessor::SharingAccessor;
@@ -53,11 +54,15 @@ impl SharingAccessor {
         let obj_path = format!("{}/{}", loc_prefix, file_path);
         let op = self.op.clone();
         if input.method == "HEAD" {
-            let s = op.presign_stat(obj_path.as_str(), Duration::hours(1))?;
+            let s = op
+                .presign_stat(obj_path.as_str(), Duration::from_secs(1))
+                .await?;
             return Ok(PresignFileResponse::new(&s, input.file_name.clone()));
         }
 
-        let s = op.presign_read(obj_path.as_str(), Duration::hours(1))?;
+        let s = op
+            .presign_read(obj_path.as_str(), Duration::from_secs(1))
+            .await?;
         Ok(PresignFileResponse::new(&s, input.file_name.clone()))
     }
 

--- a/src/query/sharing/src/layer.rs
+++ b/src/query/sharing/src/layer.rs
@@ -154,7 +154,7 @@ impl Accessor for SharedAccessor {
             })?,
         );
 
-        let resp = self.client.send_async(req).await?;
+        let resp = self.client.send(req).await?;
 
         if resp.status().is_success() {
             let content_length = parse_content_length(resp.headers())
@@ -185,7 +185,7 @@ impl Accessor for SharedAccessor {
         let req = req
             .body(AsyncBody::Empty)
             .map_err(new_request_build_error)?;
-        let resp = self.client.send_async(req).await?;
+        let resp = self.client.send(req).await?;
         let status = resp.status();
         match status {
             StatusCode::OK => {

--- a/src/query/sharing/src/share_endpoint.rs
+++ b/src/query/sharing/src/share_endpoint.rs
@@ -137,7 +137,7 @@ impl ShareEndpointManager {
             .header(CONTENT_LENGTH, bs.len())
             .header(TENANT_HEADER, requester)
             .body(AsyncBody::Bytes(bs))?;
-        let resp = self.client.send_async(req).await;
+        let resp = self.client.send(req).await;
         match resp {
             Ok(resp) => {
                 let bs = resp.into_body().bytes().await?;
@@ -173,7 +173,7 @@ impl ShareEndpointManager {
                         .header(CONTENT_LENGTH, bs.len())
                         .header(TENANT_HEADER, requester)
                         .body(AsyncBody::Bytes(bs))?;
-                    let resp = self.client.send_async(req).await;
+                    let resp = self.client.send(req).await;
                     match resp {
                         Ok(resp) => {
                             let bs = resp.into_body().bytes().await?;

--- a/src/query/sharing/src/signer.rs
+++ b/src/query/sharing/src/signer.rs
@@ -164,7 +164,7 @@ impl SharedSigner {
             .header(CONTENT_LENGTH, bs.len())
             .header(TENANT_HEADER, requester)
             .body(AsyncBody::Bytes(bs))?;
-        let resp = self.client.send_async(req).await?;
+        let resp = self.client.send(req).await?;
         let bs = resp.into_body().bytes().await?;
         let items: Vec<PresignResponseItem> = serde_json::from_slice(&bs)?;
 

--- a/src/query/sql/src/planner/binder/presign.rs
+++ b/src/query/sql/src/planner/binder/presign.rs
@@ -16,7 +16,6 @@ use common_ast::ast::PresignAction as AstPresignAction;
 use common_ast::ast::PresignLocation;
 use common_ast::ast::PresignStmt;
 use common_exception::Result;
-use time::Duration;
 
 use super::copy::parse_stage_location_v2;
 use crate::binder::Binder;
@@ -45,7 +44,7 @@ impl Binder {
                         AstPresignAction::Download => PresignAction::Download,
                         AstPresignAction::Upload => PresignAction::Upload,
                     },
-                    expire: Duration::seconds(stmt.expire.as_secs() as i64),
+                    expire: stmt.expire,
                     content_type: stmt.content_type.clone(),
                 })))
             }

--- a/src/query/sql/src/planner/plans/presign.rs
+++ b/src/query/sql/src/planner/plans/presign.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use common_expression::types::DataType;
 use common_expression::DataField;
 use common_expression::DataSchemaRef;
 use common_expression::DataSchemaRefExt;
 use common_meta_app::principal::StageInfo;
-use time::Duration;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PresignAction {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR will bump OpenDAL to 0.31.

In this upgrade, opendal adopt async reqsign which removes all the block operations during auth.
