### PR TITLE
feat: accelerate dphyp algo

### DIFF
--- a/scripts/ci/ci-run-stateless-tests-standalone.sh
+++ b/scripts/ci/ci-run-stateless-tests-standalone.sh
@@ -11,4 +11,4 @@ SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 cd "$SCRIPT_PATH/../../tests" || exit
 
 echo "Starting databend-test"
-./databend-test --mode 'standalone' --run-dir 0_stateless
+./databend-test --mode 'standalone' --run-dir 0_stateless --skip '18_0064_q64'

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -1141,10 +1141,10 @@ impl PhysicalPlanBuilder {
 
     fn build_plan_stat_info(&self, s_expr: &SExpr) -> Result<PlanStatsInfo> {
         let rel_expr = RelExpr::with_s_expr(s_expr);
-        let prop = rel_expr.derive_relational_prop()?;
+        let stat_info = rel_expr.derive_cardinality()?;
 
         Ok(PlanStatsInfo {
-            estimated_rows: prop.cardinality,
+            estimated_rows: stat_info.cardinality,
         })
     }
 }

--- a/src/query/sql/src/planner/optimizer/cascades/cascade.rs
+++ b/src/query/sql/src/planner/optimizer/cascades/cascade.rs
@@ -123,7 +123,7 @@ impl CascadesOptimizer {
             .map(|index| self.find_optimal_plan(*index))
             .collect::<Result<Vec<_>>>()?;
 
-        let result = SExpr::create(m_expr.plan.clone(), children, None, None);
+        let result = SExpr::create(m_expr.plan.clone(), children, None, None, None);
 
         Ok(result)
     }

--- a/src/query/sql/src/planner/optimizer/group.rs
+++ b/src/query/sql/src/planner/optimizer/group.rs
@@ -17,6 +17,7 @@ use common_exception::Result;
 
 use crate::optimizer::m_expr::MExpr;
 use crate::optimizer::property::RelationalProperty;
+use crate::optimizer::StatInfo;
 use crate::IndexType;
 
 /// State of a `Group`
@@ -46,15 +47,23 @@ pub struct Group {
     /// Relational property shared by expressions in a same `Group`
     pub relational_prop: RelationalProperty,
 
+    /// Stat info shared by expressions in a same `Group`
+    pub stat_info: StatInfo,
+
     pub state: GroupState,
 }
 
 impl Group {
-    pub fn create(index: IndexType, relational_prop: RelationalProperty) -> Self {
+    pub fn create(
+        index: IndexType,
+        relational_prop: RelationalProperty,
+        stat_info: StatInfo,
+    ) -> Self {
         Group {
             group_index: index,
             m_exprs: vec![],
             relational_prop,
+            stat_info,
             state: GroupState::Init,
         }
     }

--- a/src/query/sql/src/planner/optimizer/hyper_dp/dphyp.rs
+++ b/src/query/sql/src/planner/optimizer/hyper_dp/dphyp.rs
@@ -29,7 +29,6 @@ use crate::optimizer::RuleFactory;
 use crate::optimizer::RuleID;
 use crate::optimizer::SExpr;
 use crate::plans::Filter;
-use crate::plans::Join;
 use crate::plans::JoinType;
 use crate::plans::RelOperator;
 use crate::IndexType;

--- a/src/query/sql/src/planner/optimizer/hyper_dp/join_node.rs
+++ b/src/query/sql/src/planner/optimizer/hyper_dp/join_node.rs
@@ -15,15 +15,12 @@
 use std::sync::Arc;
 
 use common_exception::Result;
-use parking_lot::Mutex;
 
 use crate::optimizer::hyper_dp::join_relation::JoinRelation;
-use crate::optimizer::hyper_dp::DPhpy;
 use crate::optimizer::RelExpr;
 use crate::optimizer::SExpr;
 use crate::plans::Join;
 use crate::plans::JoinType;
-use crate::plans::Operator;
 use crate::plans::RelOperator;
 use crate::IndexType;
 use crate::ScalarExpr;
@@ -52,7 +49,7 @@ impl JoinNode {
             self.s_expr.as_ref().unwrap()
         };
         let rel_expr = RelExpr::with_s_expr(s_expr);
-        let card = rel_expr.derive_cardinality()?.0;
+        let card = rel_expr.derive_cardinality()?.cardinality;
         self.cardinality = Some(card);
         Ok(card)
     }

--- a/src/query/sql/src/planner/optimizer/hyper_dp/join_relation.rs
+++ b/src/query/sql/src/planner/optimizer/hyper_dp/join_relation.rs
@@ -38,7 +38,7 @@ impl JoinRelation {
 
     pub fn cardinality(&self) -> Result<f64> {
         let rel_expr = RelExpr::with_s_expr(&self.s_expr);
-        Ok(rel_expr.derive_relational_prop()?.cardinality)
+        Ok(rel_expr.derive_cardinality()?.cardinality)
     }
 }
 

--- a/src/query/sql/src/planner/optimizer/hyper_dp/query_graph.rs
+++ b/src/query/sql/src/planner/optimizer/hyper_dp/query_graph.rs
@@ -47,12 +47,15 @@ impl QueryEdge {
 #[derive(Clone, Debug)]
 pub struct QueryGraph {
     root_edge: QueryEdge,
+    // cache neighbors
+    cached_neighbors: HashMap<Vec<IndexType>, Vec<IndexType>>,
 }
 
 impl QueryGraph {
     pub fn new() -> Self {
         Self {
             root_edge: QueryEdge::new(),
+            cached_neighbors: Default::default(),
         }
     }
 
@@ -70,10 +73,10 @@ impl QueryGraph {
                     break;
                 }
                 edge = edge.children.get(node).unwrap();
-            }
-            for neighbor_info in edge.neighbors.iter() {
-                if is_subset(&neighbor_info.neighbors, neighbor) {
-                    return Ok((true, neighbor_info.join_conditions.clone()));
+                for neighbor_info in edge.neighbors.iter() {
+                    if is_subset(&neighbor_info.neighbors, neighbor) {
+                        return Ok((true, neighbor_info.join_conditions.clone()));
+                    }
                 }
             }
         }
@@ -82,29 +85,42 @@ impl QueryGraph {
 
     // Get all neighbors of `nodes` which are not in `forbidden_nodes`
     pub fn neighbors(
-        &self,
+        &mut self,
         nodes: &[IndexType],
         forbidden_nodes: &HashSet<IndexType>,
     ) -> Result<Vec<IndexType>> {
+        if let Some(neighbor) = self.cached_neighbors.get(nodes) {
+            let mut neighbors = neighbor.clone();
+            neighbors.retain(|node| !forbidden_nodes.contains(node));
+            neighbors.sort();
+            return Ok(neighbors);
+        }
+        let mut cached_neighbors = vec![];
         let mut neighbors = vec![];
         // Find neighbors for nodes that aren't in `forbidden_nodes`
         let nodes_size = nodes.len();
         for i in 0..nodes_size {
             let mut edge = &self.root_edge;
             for node in nodes.iter().take(nodes_size).skip(i) {
-                if !edge.children.contains_key(node) {
+                if let Some(child) = edge.children.get(node) {
+                    edge = child;
+                } else {
                     break;
                 }
-                edge = edge.children.get(node).unwrap();
-            }
-            for neighbor_info in edge.neighbors.iter() {
-                if !forbidden_nodes.contains(&neighbor_info.neighbors[0]) {
-                    neighbors.push(neighbor_info.neighbors[0]);
-                    return Ok(neighbors);
+                for neighbor_info in edge.neighbors.iter() {
+                    cached_neighbors.push(neighbor_info.neighbors[0]);
+                    if !forbidden_nodes.contains(&neighbor_info.neighbors[0])
+                        && !nodes.contains(&neighbor_info.neighbors[0])
+                    {
+                        neighbors.push(neighbor_info.neighbors[0]);
+                    }
                 }
             }
         }
+        self.cached_neighbors
+            .insert(nodes.to_vec(), cached_neighbors);
         neighbors.dedup();
+        neighbors.sort();
         Ok(neighbors)
     }
 
@@ -143,6 +159,14 @@ impl QueryGraph {
             join_conditions: vec![join_condition],
         };
         left_edge.neighbors.push(neighbor_info);
+        self.cached_neighbors
+            .entry(left_set.to_vec())
+            .and_modify(|val| val.push(right_set[0]))
+            .or_insert(vec![right_set[0]]);
+        self.cached_neighbors
+            .entry(right_set.to_vec())
+            .and_modify(|val| val.push(left_set[0]))
+            .or_insert(vec![left_set[0]]);
         Ok(())
     }
 }

--- a/src/query/sql/src/planner/optimizer/hyper_dp/query_graph.rs
+++ b/src/query/sql/src/planner/optimizer/hyper_dp/query_graph.rs
@@ -69,10 +69,11 @@ impl QueryGraph {
         for i in 0..nodes_size {
             let mut edge = &self.root_edge;
             for node in nodes.iter().take(nodes_size).skip(i) {
-                if !edge.children.contains_key(node) {
+                if let Some(child) = edge.children.get(node) {
+                    edge = child;
+                } else {
                     break;
                 }
-                edge = edge.children.get(node).unwrap();
                 for neighbor_info in edge.neighbors.iter() {
                     if is_subset(&neighbor_info.neighbors, neighbor) {
                         return Ok((true, neighbor_info.join_conditions.clone()));

--- a/src/query/sql/src/planner/optimizer/memo.rs
+++ b/src/query/sql/src/planner/optimizer/memo.rs
@@ -23,6 +23,7 @@ use super::RelationalProperty;
 use crate::optimizer::group::Group;
 use crate::optimizer::m_expr::MExpr;
 use crate::optimizer::s_expr::SExpr;
+use crate::optimizer::StatInfo;
 use crate::plans::RelOperator;
 use crate::IndexType;
 
@@ -100,7 +101,8 @@ impl Memo {
             _ => {
                 let rel_expr = RelExpr::with_s_expr(&s_expr);
                 let relational_prop = rel_expr.derive_relational_prop()?;
-                self.add_group(relational_prop)
+                let stat_info = rel_expr.derive_cardinality()?;
+                self.add_group(relational_prop, stat_info)
             }
         };
 
@@ -136,9 +138,9 @@ impl Memo {
             .ok_or_else(|| ErrorCode::Internal(format!("Group index {} not found", index)))
     }
 
-    fn add_group(&mut self, relational_prop: RelationalProperty) -> IndexType {
+    fn add_group(&mut self, relational_prop: RelationalProperty, stat_info: StatInfo) -> IndexType {
         let group_index = self.groups.len();
-        let group = Group::create(group_index, relational_prop);
+        let group = Group::create(group_index, relational_prop, stat_info);
         self.groups.push(group);
         group_index
     }

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -153,6 +153,7 @@ pub fn optimize_query(
     if ctx.get_settings().get_enable_dphyp()? {
         let (dp_res, optimized) = DPhpy::new(metadata.clone()).optimize(result.clone())?;
         result = dp_res;
+        dbg!(optimized);
         if !optimized {
             // Callback to CascadesOptimizer
             let mut cascades = CascadesOptimizer::create(ctx.clone(), metadata)?;

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -153,7 +153,6 @@ pub fn optimize_query(
     if ctx.get_settings().get_enable_dphyp()? {
         let (dp_res, optimized) = DPhpy::new(metadata.clone()).optimize(result.clone())?;
         result = dp_res;
-        dbg!(optimized);
         if !optimized {
             // Callback to CascadesOptimizer
             let mut cascades = CascadesOptimizer::create(ctx.clone(), metadata)?;

--- a/src/query/sql/src/planner/optimizer/pattern_extractor.rs
+++ b/src/query/sql/src/planner/optimizer/pattern_extractor.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use common_exception::Result;
 
 use crate::optimizer::group::Group;
@@ -41,7 +39,7 @@ impl PatternExtractor {
                 vec![],
                 Some(m_expr.group_index),
                 Some(memo.group(m_expr.group_index)?.relational_prop.clone()),
-                None,
+                Some(memo.group(m_expr.group_index)?.stat_info.clone()),
             )]);
         }
 
@@ -95,7 +93,7 @@ impl PatternExtractor {
                 vec![],
                 Some(m_expr.group_index),
                 Some(memo.group(m_expr.group_index)?.relational_prop.clone()),
-                None,
+                Some(memo.group(m_expr.group_index)?.stat_info.clone()),
             ));
             return Ok(results);
         }
@@ -110,7 +108,7 @@ impl PatternExtractor {
                 children,
                 Some(m_expr.group_index),
                 Some(memo.group(m_expr.group_index)?.relational_prop.clone()),
-                None,
+                Some(memo.group(m_expr.group_index)?.stat_info.clone()),
             ));
 
             let mut shifted = false;

--- a/src/query/sql/src/planner/optimizer/pattern_extractor.rs
+++ b/src/query/sql/src/planner/optimizer/pattern_extractor.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 
 use crate::optimizer::group::Group;
@@ -39,6 +41,7 @@ impl PatternExtractor {
                 vec![],
                 Some(m_expr.group_index),
                 Some(memo.group(m_expr.group_index)?.relational_prop.clone()),
+                None,
             )]);
         }
 
@@ -92,6 +95,7 @@ impl PatternExtractor {
                 vec![],
                 Some(m_expr.group_index),
                 Some(memo.group(m_expr.group_index)?.relational_prop.clone()),
+                None,
             ));
             return Ok(results);
         }
@@ -106,6 +110,7 @@ impl PatternExtractor {
                 children,
                 Some(m_expr.group_index),
                 Some(memo.group(m_expr.group_index)?.relational_prop.clone()),
+                None,
             ));
 
             let mut shifted = false;

--- a/src/query/sql/src/planner/optimizer/property/enforcer.rs
+++ b/src/query/sql/src/planner/optimizer/property/enforcer.rs
@@ -36,7 +36,7 @@ pub fn require_property(
         .iter()
         .map(|child| require_property(ctx.clone(), required, child))
         .collect::<Result<Vec<SExpr>>>()?;
-    let optimized_expr = SExpr::create(s_expr.plan().clone(), optimized_children, None, None);
+    let optimized_expr = SExpr::create(s_expr.plan().clone(), optimized_children, None, None, None);
 
     let rel_expr = RelExpr::with_s_expr(&optimized_expr);
     let mut children = Vec::with_capacity(s_expr.arity());
@@ -85,6 +85,7 @@ pub fn require_property(
     Ok(SExpr::create(
         optimized_expr.plan().clone(),
         children,
+        None,
         None,
         None,
     ))

--- a/src/query/sql/src/planner/optimizer/property/mod.rs
+++ b/src/query/sql/src/planner/optimizer/property/mod.rs
@@ -40,6 +40,7 @@ pub use property::Distribution;
 pub use property::PhysicalProperty;
 pub use property::RelationalProperty;
 pub use property::RequiredProperty;
+pub use property::StatInfo;
 pub use property::Statistics;
 pub use property::TableSet;
 pub use selectivity::SelectivityEstimator;

--- a/src/query/sql/src/planner/optimizer/property/property.rs
+++ b/src/query/sql/src/planner/optimizer/property/property.rs
@@ -42,6 +42,14 @@ pub struct Statistics {
 }
 
 #[derive(Default, Clone, Debug)]
+pub struct StatInfo {
+    // TODO(leiysky): introduce upper bound of cardinality to
+    // reduce error in estimation.
+    pub cardinality: f64,
+    pub statistics: Statistics,
+}
+
+#[derive(Default, Clone, Debug)]
 pub struct RelationalProperty {
     /// Output columns of a relational expression
     pub output_columns: ColumnSet,
@@ -51,11 +59,6 @@ pub struct RelationalProperty {
 
     /// Used columns of a relational expression
     pub used_columns: ColumnSet,
-
-    // TODO(leiysky): introduce upper bound of cardinality to
-    // reduce error in estimation.
-    pub cardinality: f64,
-    pub statistics: Statistics,
 }
 
 #[derive(Default, Clone)]

--- a/src/query/sql/src/planner/optimizer/property/selectivity.rs
+++ b/src/query/sql/src/planner/optimizer/property/selectivity.rs
@@ -31,7 +31,7 @@ use crate::plans::ScalarExpr;
 /// that we cannot estimate the selectivity for it.
 /// This factor comes from the paper
 /// "Access Path Selection in a Relational Database Management System"
-pub const DEFAULT_SELECTIVITY: f64 = 1f64 / 3f64;
+pub const DEFAULT_SELECTIVITY: f64 = 0.4;
 pub const MAX_SELECTIVITY: f64 = 1f64;
 
 pub struct SelectivityEstimator<'a> {

--- a/src/query/sql/src/planner/optimizer/property/selectivity.rs
+++ b/src/query/sql/src/planner/optimizer/property/selectivity.rs
@@ -31,7 +31,7 @@ use crate::plans::ScalarExpr;
 /// that we cannot estimate the selectivity for it.
 /// This factor comes from the paper
 /// "Access Path Selection in a Relational Database Management System"
-pub const DEFAULT_SELECTIVITY: f64 = 0.4;
+pub const DEFAULT_SELECTIVITY: f64 = 1f64 / 3f64;
 pub const MAX_SELECTIVITY: f64 = 1f64;
 
 pub struct SelectivityEstimator<'a> {

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_exchange_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_exchange_join.rs
@@ -254,6 +254,7 @@ impl Rule for RuleExchangeJoin {
             ],
             None,
             None,
+            None,
         );
 
         // Disable the following rules for join 4

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_left_associate_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_left_associate_join.rs
@@ -203,6 +203,7 @@ impl Rule for RuleLeftAssociateJoin {
             ],
             None,
             None,
+            None,
         );
 
         // Disable the following rules for join 3

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_left_exchange_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_left_exchange_join.rs
@@ -201,6 +201,7 @@ impl Rule for RuleLeftExchangeJoin {
             ],
             None,
             None,
+            None,
         );
 
         // Disable the following rules for join 3

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_right_associate_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_right_associate_join.rs
@@ -199,6 +199,7 @@ impl Rule for RuleRightAssociateJoin {
             ],
             None,
             None,
+            None,
         );
 
         // Disable the following rules for join 3

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_right_exchange_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_right_exchange_join.rs
@@ -195,6 +195,7 @@ impl Rule for RuleRightExchangeJoin {
             ],
             None,
             None,
+            None,
         );
 
         // Disable the following rules for join 3

--- a/src/query/sql/src/planner/optimizer/s_expr.rs
+++ b/src/query/sql/src/planner/optimizer/s_expr.rs
@@ -22,6 +22,7 @@ use educe::Educe;
 use super::RelationalProperty;
 use crate::optimizer::rule::AppliedRules;
 use crate::optimizer::rule::RuleID;
+use crate::optimizer::Statistics;
 use crate::plans::Operator;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
@@ -48,6 +49,9 @@ pub struct SExpr {
     #[educe(Hash(ignore), PartialEq(ignore), Eq(ignore))]
     pub(crate) rel_prop: Arc<Mutex<Option<RelationalProperty>>>,
 
+    #[educe(Hash(ignore), PartialEq(ignore), Eq(ignore))]
+    pub(crate) stat_info: Arc<Mutex<Option<(f64, Statistics)>>>,
+
     /// A bitmap to record applied rules on current SExpr, to prevent
     /// redundant transformations.
     pub(crate) applied_rules: AppliedRules,
@@ -59,27 +63,28 @@ impl SExpr {
         children: Vec<SExpr>,
         original_group: Option<IndexType>,
         rel_prop: Option<RelationalProperty>,
+        stat_info: Option<(f64, Statistics)>,
     ) -> Self {
         SExpr {
             plan,
             children: Arc::new(children),
             original_group,
             rel_prop: Arc::new(Mutex::new(rel_prop)),
-
+            stat_info: Arc::new(Mutex::new(stat_info)),
             applied_rules: AppliedRules::default(),
         }
     }
 
     pub fn create_unary(plan: RelOperator, child: SExpr) -> Self {
-        Self::create(plan, vec![child], None, None)
+        Self::create(plan, vec![child], None, None, None)
     }
 
     pub fn create_binary(plan: RelOperator, left_child: SExpr, right_child: SExpr) -> Self {
-        Self::create(plan, vec![left_child, right_child], None, None)
+        Self::create(plan, vec![left_child, right_child], None, None, None)
     }
 
     pub fn create_leaf(plan: RelOperator) -> Self {
-        Self::create(plan, vec![], None, None)
+        Self::create(plan, vec![], None, None, None)
     }
 
     pub fn create_pattern_leaf() -> Self {
@@ -89,6 +94,7 @@ impl SExpr {
             }
             .into(),
             vec![],
+            None,
             None,
             None,
         )
@@ -151,6 +157,7 @@ impl SExpr {
             plan: self.plan.clone(),
             original_group: None,
             rel_prop: Arc::new(Mutex::new(None)),
+            stat_info: Arc::new(Mutex::new(None)),
             applied_rules: self.applied_rules.clone(),
             children: Arc::new(children),
         }
@@ -161,6 +168,7 @@ impl SExpr {
             plan,
             original_group: self.original_group,
             rel_prop: self.rel_prop.clone(),
+            stat_info: self.stat_info.clone(),
             applied_rules: self.applied_rules.clone(),
             children: self.children.clone(),
         }

--- a/src/query/sql/src/planner/optimizer/s_expr.rs
+++ b/src/query/sql/src/planner/optimizer/s_expr.rs
@@ -22,7 +22,7 @@ use educe::Educe;
 use super::RelationalProperty;
 use crate::optimizer::rule::AppliedRules;
 use crate::optimizer::rule::RuleID;
-use crate::optimizer::Statistics;
+use crate::optimizer::StatInfo;
 use crate::plans::Operator;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
@@ -50,7 +50,7 @@ pub struct SExpr {
     pub(crate) rel_prop: Arc<Mutex<Option<RelationalProperty>>>,
 
     #[educe(Hash(ignore), PartialEq(ignore), Eq(ignore))]
-    pub(crate) stat_info: Arc<Mutex<Option<(f64, Statistics)>>>,
+    pub(crate) stat_info: Arc<Mutex<Option<StatInfo>>>,
 
     /// A bitmap to record applied rules on current SExpr, to prevent
     /// redundant transformations.
@@ -63,7 +63,7 @@ impl SExpr {
         children: Vec<SExpr>,
         original_group: Option<IndexType>,
         rel_prop: Option<RelationalProperty>,
-        stat_info: Option<(f64, Statistics)>,
+        stat_info: Option<StatInfo>,
     ) -> Self {
         SExpr {
             plan,

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -24,7 +24,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
-use crate::optimizer::SExpr;
+use crate::optimizer::StatInfo;
 use crate::optimizer::Statistics;
 use crate::plans::Operator;
 use crate::plans::RelOp;
@@ -147,7 +147,7 @@ impl Operator for Aggregate {
     }
 
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty> {
-        let mut input_prop = rel_expr.derive_relational_prop_child(0)?;
+        let input_prop = rel_expr.derive_relational_prop_child(0)?;
 
         // Derive output columns
         let mut output_columns = ColumnSet::new();
@@ -165,74 +165,20 @@ impl Operator for Aggregate {
             .cloned()
             .collect();
 
-        let cardinality = if self.group_items.is_empty() {
-            // Scalar aggregation
-            1.0
-        } else if self.group_items.iter().any(|item| {
-            input_prop
-                .statistics
-                .column_stats
-                .get(&item.index)
-                .is_none()
-        }) {
-            input_prop.cardinality
-        } else {
-            // A upper bound
-            let res = self.group_items.iter().fold(1.0, |acc, item| {
-                let item_stat = input_prop.statistics.column_stats.get(&item.index).unwrap();
-                acc * item_stat.ndv
-            });
-            for item in self.group_items.iter() {
-                let item_stat = input_prop
-                    .statistics
-                    .column_stats
-                    .get_mut(&item.index)
-                    .unwrap();
-                if let Some(histogram) = &mut item_stat.histogram {
-                    let mut num_values = 0.0;
-                    let mut num_distinct = 0.0;
-                    for bucket in histogram.buckets.iter() {
-                        num_distinct += bucket.num_distinct();
-                        num_values += bucket.num_values();
-                    }
-                    // When there is a high probability that eager aggregation
-                    // is better, we will update the histogram.
-                    if num_values / num_distinct >= 10.0 {
-                        for bucket in histogram.buckets.iter_mut() {
-                            bucket.aggregate_values();
-                        }
-                    }
-                }
-            }
-            // To avoid res is very large
-            f64::min(res, input_prop.cardinality)
-        };
-
-        let precise_cardinality = if self.group_items.is_empty() {
-            Some(1)
-        } else {
-            None
-        };
-
         // Derive used columns
         let mut used_columns = self.used_columns()?;
         used_columns.extend(input_prop.used_columns);
-        let column_stats = input_prop.statistics.column_stats;
 
         Ok(RelationalProperty {
             output_columns,
             outer_columns,
             used_columns,
-            cardinality,
-            statistics: Statistics {
-                precise_cardinality,
-                column_stats,
-            },
         })
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
-        let (cardinality, mut statistics) = rel_expr.derive_cardinality_child(0)?;
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
+        let stat_info = rel_expr.derive_cardinality_child(0)?;
+        let (cardinality, mut statistics) = (stat_info.cardinality, stat_info.statistics);
         let cardinality = if self.group_items.is_empty() {
             // Scalar aggregation
             1.0
@@ -275,9 +221,12 @@ impl Operator for Aggregate {
         } else {
             None
         };
-        Ok((cardinality, Statistics {
-            precise_cardinality,
-            column_stats: statistics.column_stats,
-        }))
+        Ok(StatInfo {
+            cardinality,
+            statistics: Statistics {
+                precise_cardinality,
+                column_stats: statistics.column_stats,
+            },
+        })
     }
 }

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -24,6 +24,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
+use crate::optimizer::SExpr;
 use crate::optimizer::Statistics;
 use crate::plans::Operator;
 use crate::plans::RelOp;
@@ -228,5 +229,55 @@ impl Operator for Aggregate {
                 column_stats,
             },
         })
+    }
+
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+        let (cardinality, mut statistics) = rel_expr.derive_cardinality_child(0)?;
+        let cardinality = if self.group_items.is_empty() {
+            // Scalar aggregation
+            1.0
+        } else if self
+            .group_items
+            .iter()
+            .any(|item| statistics.column_stats.get(&item.index).is_none())
+        {
+            cardinality
+        } else {
+            // A upper bound
+            let res = self.group_items.iter().fold(1.0, |acc, item| {
+                let item_stat = statistics.column_stats.get(&item.index).unwrap();
+                acc * item_stat.ndv
+            });
+            for item in self.group_items.iter() {
+                let item_stat = statistics.column_stats.get_mut(&item.index).unwrap();
+                if let Some(histogram) = &mut item_stat.histogram {
+                    let mut num_values = 0.0;
+                    let mut num_distinct = 0.0;
+                    for bucket in histogram.buckets.iter() {
+                        num_distinct += bucket.num_distinct();
+                        num_values += bucket.num_values();
+                    }
+                    // When there is a high probability that eager aggregation
+                    // is better, we will update the histogram.
+                    if num_values / num_distinct >= 10.0 {
+                        for bucket in histogram.buckets.iter_mut() {
+                            bucket.aggregate_values();
+                        }
+                    }
+                }
+            }
+            // To avoid res is very large
+            f64::min(res, cardinality)
+        };
+
+        let precise_cardinality = if self.group_items.is_empty() {
+            Some(1)
+        } else {
+            None
+        };
+        Ok((cardinality, Statistics {
+            precise_cardinality,
+            column_stats: statistics.column_stats,
+        }))
     }
 }

--- a/src/query/sql/src/planner/plans/dummy_table_scan.rs
+++ b/src/query/sql/src/planner/plans/dummy_table_scan.rs
@@ -20,6 +20,7 @@ use common_exception::Result;
 use super::Operator;
 use crate::optimizer::ColumnSet;
 use crate::optimizer::PhysicalProperty;
+use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::Statistics;
 
@@ -60,6 +61,13 @@ impl Operator for DummyTableScan {
         Ok(PhysicalProperty {
             distribution: crate::optimizer::Distribution::Serial,
         })
+    }
+
+    fn derive_cardinality(&self, _rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+        Ok((1.0, Statistics {
+            precise_cardinality: Some(1),
+            column_stats: Default::default(),
+        }))
     }
 
     fn compute_required_prop_child(

--- a/src/query/sql/src/planner/plans/dummy_table_scan.rs
+++ b/src/query/sql/src/planner/plans/dummy_table_scan.rs
@@ -22,6 +22,7 @@ use crate::optimizer::ColumnSet;
 use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
+use crate::optimizer::StatInfo;
 use crate::optimizer::Statistics;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -46,11 +47,6 @@ impl Operator for DummyTableScan {
             output_columns: ColumnSet::new(),
             outer_columns: ColumnSet::new(),
             used_columns: ColumnSet::new(),
-            cardinality: 1.0,
-            statistics: Statistics {
-                precise_cardinality: Some(1),
-                column_stats: Default::default(),
-            },
         })
     }
 
@@ -63,11 +59,14 @@ impl Operator for DummyTableScan {
         })
     }
 
-    fn derive_cardinality(&self, _rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
-        Ok((1.0, Statistics {
-            precise_cardinality: Some(1),
-            column_stats: Default::default(),
-        }))
+    fn derive_cardinality(&self, _rel_expr: &RelExpr) -> Result<StatInfo> {
+        Ok(StatInfo {
+            cardinality: 1.0,
+            statistics: Statistics {
+                precise_cardinality: Some(1),
+                column_stats: Default::default(),
+            },
+        })
     }
 
     fn compute_required_prop_child(

--- a/src/query/sql/src/planner/plans/eval_scalar.rs
+++ b/src/query/sql/src/planner/plans/eval_scalar.rs
@@ -118,4 +118,8 @@ impl Operator for EvalScalar {
             },
         })
     }
+
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+        rel_expr.derive_cardinality_child(0)
+    }
 }

--- a/src/query/sql/src/planner/plans/exchange.rs
+++ b/src/query/sql/src/planner/plans/exchange.rs
@@ -22,7 +22,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
-use crate::optimizer::Statistics;
+use crate::optimizer::StatInfo;
 use crate::plans::Operator;
 use crate::plans::RelOp;
 use crate::plans::ScalarExpr;
@@ -55,7 +55,7 @@ impl Operator for Exchange {
         })
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
         rel_expr.derive_cardinality_child(0)
     }
 

--- a/src/query/sql/src/planner/plans/exchange.rs
+++ b/src/query/sql/src/planner/plans/exchange.rs
@@ -22,6 +22,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
+use crate::optimizer::Statistics;
 use crate::plans::Operator;
 use crate::plans::RelOp;
 use crate::plans::ScalarExpr;
@@ -52,6 +53,10 @@ impl Operator for Exchange {
                 Exchange::Merge => Distribution::Serial,
             },
         })
+    }
+
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+        rel_expr.derive_cardinality_child(0)
     }
 
     fn compute_required_prop_child(

--- a/src/query/sql/src/planner/plans/filter.rs
+++ b/src/query/sql/src/planner/plans/filter.rs
@@ -24,6 +24,7 @@ use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
 use crate::optimizer::SelectivityEstimator;
+use crate::optimizer::StatInfo;
 use crate::optimizer::Statistics;
 use crate::optimizer::MAX_SELECTIVITY;
 use crate::plans::Operator;
@@ -67,7 +68,7 @@ impl Operator for Filter {
     }
 
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty> {
-        let mut input_prop = rel_expr.derive_relational_prop_child(0)?;
+        let input_prop = rel_expr.derive_relational_prop_child(0)?;
         let output_columns = input_prop.output_columns;
 
         // Derive outer columns
@@ -82,47 +83,20 @@ impl Operator for Filter {
         }
         outer_columns = outer_columns.difference(&output_columns).cloned().collect();
 
-        // Derive cardinality
-        let sb = SelectivityEstimator::new(&input_prop.statistics);
-        let mut selectivity = MAX_SELECTIVITY;
-        for pred in self.predicates.iter() {
-            // Compute selectivity for each conjunction
-            selectivity *= sb.compute_selectivity(pred);
-        }
-        let cardinality = input_prop.cardinality * selectivity;
         // Derive used columns
         let mut used_columns = self.used_columns()?;
         used_columns.extend(input_prop.used_columns);
-
-        // Derive column statistics
-        let column_stats = if cardinality == 0.0 {
-            HashMap::new()
-        } else {
-            for (_, column_stat) in input_prop.statistics.column_stats.iter_mut() {
-                if cardinality < input_prop.cardinality {
-                    column_stat.ndv =
-                        (column_stat.ndv * cardinality / input_prop.cardinality).ceil();
-                }
-            }
-            input_prop.statistics.column_stats
-        };
 
         Ok(RelationalProperty {
             output_columns,
             outer_columns,
             used_columns,
-            cardinality,
-            // TODO(leiysky): if the predicate is always true, then we can pass through
-            // precise cardinality
-            statistics: Statistics {
-                precise_cardinality: None,
-                column_stats,
-            },
         })
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
-        let (cardinality, mut statistics) = rel_expr.derive_cardinality_child(0)?;
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
+        let stat_info = rel_expr.derive_cardinality_child(0)?;
+        let (input_cardinality, mut statistics) = (stat_info.cardinality, stat_info.statistics);
         // Derive cardinality
         let sb = SelectivityEstimator::new(&statistics);
         let mut selectivity = MAX_SELECTIVITY;
@@ -130,22 +104,25 @@ impl Operator for Filter {
             // Compute selectivity for each conjunction
             selectivity *= sb.compute_selectivity(pred);
         }
-        let cardinality = cardinality * selectivity;
+        let cardinality = input_cardinality * selectivity;
 
         // Derive column statistics
         let column_stats = if cardinality == 0.0 {
             HashMap::new()
         } else {
             for (_, column_stat) in statistics.column_stats.iter_mut() {
-                if cardinality < cardinality {
+                if cardinality < input_cardinality {
                     column_stat.ndv = (column_stat.ndv * cardinality / cardinality).ceil();
                 }
             }
             statistics.column_stats
         };
-        Ok((cardinality, Statistics {
-            precise_cardinality: statistics.precise_cardinality,
-            column_stats,
-        }))
+        Ok(StatInfo {
+            cardinality,
+            statistics: Statistics {
+                precise_cardinality: None,
+                column_stats,
+            },
+        })
     }
 }

--- a/src/query/sql/src/planner/plans/filter.rs
+++ b/src/query/sql/src/planner/plans/filter.rs
@@ -112,7 +112,7 @@ impl Operator for Filter {
         } else {
             for (_, column_stat) in statistics.column_stats.iter_mut() {
                 if cardinality < input_cardinality {
-                    column_stat.ndv = (column_stat.ndv * cardinality / cardinality).ceil();
+                    column_stat.ndv = (column_stat.ndv * cardinality / input_cardinality).ceil();
                 }
             }
             statistics.column_stats

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -243,13 +243,10 @@ impl Join {
                         continue;
                     }
                     let card = match (&left_col_stat.histogram, &right_col_stat.histogram) {
-                        /*
                         (Some(left_hist), Some(right_hist)) => {
                             // Evaluate join cardinality by histogram.
                             evaluate_by_histogram(left_hist, right_hist, &mut new_ndv)?
                         }
-
-                         */
                         _ => evaluate_by_ndv(
                             left_col_stat,
                             right_col_stat,

--- a/src/query/sql/src/planner/plans/limit.rs
+++ b/src/query/sql/src/planner/plans/limit.rs
@@ -70,4 +70,16 @@ impl Operator for Limit {
             },
         })
     }
+
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+        let (cardinality, _statistics) = rel_expr.derive_cardinality_child(0)?;
+        let cardinality = match self.limit {
+            Some(limit) if (limit as f64) < cardinality => limit as f64,
+            _ => cardinality,
+        };
+        Ok((cardinality, Statistics {
+            precise_cardinality: None,
+            column_stats: Default::default(),
+        }))
+    }
 }

--- a/src/query/sql/src/planner/plans/operator.rs
+++ b/src/query/sql/src/planner/plans/operator.rs
@@ -32,8 +32,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
-use crate::optimizer::SExpr;
-use crate::optimizer::Statistics;
+use crate::optimizer::StatInfo;
 use crate::plans::runtime_filter_source::RuntimeFilterSource;
 use crate::plans::Exchange;
 use crate::plans::ProjectSet;
@@ -50,7 +49,7 @@ pub trait Operator {
 
     fn derive_physical_prop(&self, rel_expr: &RelExpr) -> Result<PhysicalProperty>;
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)>;
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo>;
 
     fn compute_required_prop_child(
         &self,
@@ -160,7 +159,7 @@ impl Operator for RelOperator {
         }
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
         match self {
             RelOperator::Scan(rel_op) => rel_op.derive_cardinality(rel_expr),
             RelOperator::Join(rel_op) => rel_op.derive_cardinality(rel_expr),

--- a/src/query/sql/src/planner/plans/operator.rs
+++ b/src/query/sql/src/planner/plans/operator.rs
@@ -32,6 +32,8 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
+use crate::optimizer::SExpr;
+use crate::optimizer::Statistics;
 use crate::plans::runtime_filter_source::RuntimeFilterSource;
 use crate::plans::Exchange;
 use crate::plans::ProjectSet;
@@ -47,6 +49,8 @@ pub trait Operator {
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty>;
 
     fn derive_physical_prop(&self, rel_expr: &RelExpr) -> Result<PhysicalProperty>;
+
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)>;
 
     fn compute_required_prop_child(
         &self,
@@ -153,6 +157,25 @@ impl Operator for RelOperator {
             RelOperator::RuntimeFilterSource(rel_op) => rel_op.derive_physical_prop(rel_expr),
             RelOperator::ProjectSet(rel_op) => rel_op.derive_physical_prop(rel_expr),
             RelOperator::Window(rel_op) => rel_op.derive_physical_prop(rel_expr),
+        }
+    }
+
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+        match self {
+            RelOperator::Scan(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::Join(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::EvalScalar(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::Filter(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::Aggregate(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::Sort(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::Limit(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::Pattern(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::Exchange(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::UnionAll(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::DummyTableScan(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::RuntimeFilterSource(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::ProjectSet(rel_op) => rel_op.derive_cardinality(rel_expr),
+            RelOperator::Window(rel_op) => rel_op.derive_cardinality(rel_expr),
         }
     }
 

--- a/src/query/sql/src/planner/plans/pattern.rs
+++ b/src/query/sql/src/planner/plans/pattern.rs
@@ -21,7 +21,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
-use crate::optimizer::Statistics;
+use crate::optimizer::StatInfo;
 use crate::plans::Operator;
 use crate::plans::RelOp;
 
@@ -57,10 +57,7 @@ impl Operator for PatternPlan {
         ))
     }
 
-    fn derive_cardinality(
-        &self,
-        _rel_expr: &RelExpr,
-    ) -> common_exception::Result<(f64, Statistics)> {
+    fn derive_cardinality(&self, _rel_expr: &RelExpr) -> common_exception::Result<StatInfo> {
         Err(ErrorCode::Internal(
             "Cannot derive cardinality for pattern plan",
         ))

--- a/src/query/sql/src/planner/plans/pattern.rs
+++ b/src/query/sql/src/planner/plans/pattern.rs
@@ -21,6 +21,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
+use crate::optimizer::Statistics;
 use crate::plans::Operator;
 use crate::plans::RelOp;
 
@@ -53,6 +54,15 @@ impl Operator for PatternPlan {
     ) -> common_exception::Result<PhysicalProperty> {
         Err(ErrorCode::Internal(
             "Cannot derive physical property for pattern plan",
+        ))
+    }
+
+    fn derive_cardinality(
+        &self,
+        _rel_expr: &RelExpr,
+    ) -> common_exception::Result<(f64, Statistics)> {
+        Err(ErrorCode::Internal(
+            "Cannot derive cardinality for pattern plan",
         ))
     }
 

--- a/src/query/sql/src/planner/plans/project_set.rs
+++ b/src/query/sql/src/planner/plans/project_set.rs
@@ -20,6 +20,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
+use crate::optimizer::Statistics;
 use crate::plans::Operator;
 use crate::plans::RelOp;
 use crate::IndexType;
@@ -67,6 +68,13 @@ impl Operator for ProjectSet {
         rel_expr: &RelExpr,
     ) -> common_exception::Result<PhysicalProperty> {
         rel_expr.derive_physical_prop_child(0)
+    }
+
+    fn derive_cardinality(
+        &self,
+        rel_expr: &RelExpr,
+    ) -> common_exception::Result<(f64, Statistics)> {
+        rel_expr.derive_cardinality_child(0)
     }
 
     fn compute_required_prop_child(

--- a/src/query/sql/src/planner/plans/project_set.rs
+++ b/src/query/sql/src/planner/plans/project_set.rs
@@ -20,7 +20,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
-use crate::optimizer::Statistics;
+use crate::optimizer::StatInfo;
 use crate::plans::Operator;
 use crate::plans::RelOp;
 use crate::IndexType;
@@ -57,9 +57,6 @@ impl Operator for ProjectSet {
         for srf in &self.srfs {
             child_prop.output_columns.insert(srf.index);
         }
-
-        // ProjectSet is set-returning functions, precise_cardinality set None
-        child_prop.statistics.precise_cardinality = None;
         Ok(child_prop)
     }
 
@@ -70,10 +67,7 @@ impl Operator for ProjectSet {
         rel_expr.derive_physical_prop_child(0)
     }
 
-    fn derive_cardinality(
-        &self,
-        rel_expr: &RelExpr,
-    ) -> common_exception::Result<(f64, Statistics)> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> common_exception::Result<StatInfo> {
         rel_expr.derive_cardinality_child(0)
     }
 

--- a/src/query/sql/src/planner/plans/project_set.rs
+++ b/src/query/sql/src/planner/plans/project_set.rs
@@ -68,7 +68,10 @@ impl Operator for ProjectSet {
     }
 
     fn derive_cardinality(&self, rel_expr: &RelExpr) -> common_exception::Result<StatInfo> {
-        rel_expr.derive_cardinality_child(0)
+        let mut input_stat = rel_expr.derive_cardinality_child(0)?;
+        // ProjectSet is set-returning functions, precise_cardinality set None
+        input_stat.statistics.precise_cardinality = None;
+        Ok(input_stat)
     }
 
     fn compute_required_prop_child(

--- a/src/query/sql/src/planner/plans/runtime_filter_source.rs
+++ b/src/query/sql/src/planner/plans/runtime_filter_source.rs
@@ -92,6 +92,14 @@ impl Operator for RuntimeFilterSource {
         todo!()
     }
 
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+        let (cardinality, mut statistics) = rel_expr.derive_cardinality_child(0)?;
+        Ok((cardinality, Statistics {
+            precise_cardinality: None,
+            column_stats: statistics.column_stats,
+        }))
+    }
+
     fn compute_required_prop_child(
         &self,
         _ctx: Arc<dyn TableContext>,

--- a/src/query/sql/src/planner/plans/scan.rs
+++ b/src/query/sql/src/planner/plans/scan.rs
@@ -223,6 +223,11 @@ impl Operator for Scan {
         })
     }
 
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, OpStatistics)> {
+        let rel_prop = self.derive_relational_prop(rel_expr)?;
+        Ok((rel_prop.cardinality, rel_prop.statistics))
+    }
+
     // Won't be invoked at all, since `PhysicalScan` is leaf node
     fn compute_required_prop_child(
         &self,

--- a/src/query/sql/src/planner/plans/scan.rs
+++ b/src/query/sql/src/planner/plans/scan.rs
@@ -32,6 +32,7 @@ use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
 use crate::optimizer::SelectivityEstimator;
+use crate::optimizer::StatInfo;
 use crate::optimizer::Statistics as OpStatistics;
 use crate::optimizer::DEFAULT_HISTOGRAM_BUCKETS;
 use crate::optimizer::MAX_SELECTIVITY;
@@ -94,6 +95,21 @@ impl Scan {
             prewhere,
         }
     }
+
+    fn used_columns(&self) -> ColumnSet {
+        let mut used_columns = ColumnSet::new();
+        if let Some(preds) = &self.push_down_predicates {
+            for pred in preds.iter() {
+                used_columns.extend(pred.used_columns());
+            }
+        }
+        if let Some(prewhere) = &self.prewhere {
+            used_columns.extend(prewhere.prewhere_columns.iter());
+        }
+
+        used_columns.extend(self.columns.iter());
+        used_columns
+    }
 }
 
 impl PartialEq for Scan {
@@ -122,17 +138,21 @@ impl Operator for Scan {
     }
 
     fn derive_relational_prop(&self, _rel_expr: &RelExpr) -> Result<RelationalProperty> {
-        let mut used_columns = ColumnSet::new();
-        if let Some(preds) = &self.push_down_predicates {
-            for pred in preds.iter() {
-                used_columns.extend(pred.used_columns());
-            }
-        }
-        if let Some(prewhere) = &self.prewhere {
-            used_columns.extend(prewhere.prewhere_columns.iter());
-        }
+        Ok(RelationalProperty {
+            output_columns: self.columns.clone(),
+            outer_columns: Default::default(),
+            used_columns: self.used_columns(),
+        })
+    }
 
-        used_columns.extend(self.columns.iter());
+    fn derive_physical_prop(&self, _rel_expr: &RelExpr) -> Result<PhysicalProperty> {
+        Ok(PhysicalProperty {
+            distribution: Distribution::Random,
+        })
+    }
+
+    fn derive_cardinality(&self, _rel_expr: &RelExpr) -> Result<StatInfo> {
+        let used_columns = self.used_columns();
 
         let num_rows = self
             .statistics
@@ -204,28 +224,13 @@ impl Operator for Scan {
         } else {
             None
         };
-
-        Ok(RelationalProperty {
-            output_columns: self.columns.clone(),
-            outer_columns: Default::default(),
-            used_columns,
+        Ok(StatInfo {
             cardinality,
             statistics: OpStatistics {
                 precise_cardinality,
                 column_stats,
             },
         })
-    }
-
-    fn derive_physical_prop(&self, _rel_expr: &RelExpr) -> Result<PhysicalProperty> {
-        Ok(PhysicalProperty {
-            distribution: Distribution::Random,
-        })
-    }
-
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, OpStatistics)> {
-        let rel_prop = self.derive_relational_prop(rel_expr)?;
-        Ok((rel_prop.cardinality, rel_prop.statistics))
     }
 
     // Won't be invoked at all, since `PhysicalScan` is leaf node

--- a/src/query/sql/src/planner/plans/sort.rs
+++ b/src/query/sql/src/planner/plans/sort.rs
@@ -22,6 +22,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
+use crate::optimizer::Statistics;
 use crate::plans::Operator;
 use crate::plans::RelOp;
 use crate::IndexType;
@@ -62,5 +63,9 @@ impl Operator for Sort {
 
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty> {
         rel_expr.derive_relational_prop_child(0)
+    }
+
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+        rel_expr.derive_cardinality_child(0)
     }
 }

--- a/src/query/sql/src/planner/plans/sort.rs
+++ b/src/query/sql/src/planner/plans/sort.rs
@@ -22,7 +22,7 @@ use crate::optimizer::PhysicalProperty;
 use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::RequiredProperty;
-use crate::optimizer::Statistics;
+use crate::optimizer::StatInfo;
 use crate::plans::Operator;
 use crate::plans::RelOp;
 use crate::IndexType;
@@ -65,7 +65,7 @@ impl Operator for Sort {
         rel_expr.derive_relational_prop_child(0)
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
         rel_expr.derive_cardinality_child(0)
     }
 }

--- a/src/query/sql/src/planner/plans/union_all.rs
+++ b/src/query/sql/src/planner/plans/union_all.rs
@@ -105,6 +105,10 @@ impl Operator for UnionAll {
         })
     }
 
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+        todo!()
+    }
+
     fn compute_required_prop_child(
         &self,
         _ctx: Arc<dyn TableContext>,

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -213,6 +213,7 @@ pub enum WindowFuncType {
     RowNumber,
     Rank,
     DenseRank,
+    PercentRank,
 }
 
 impl WindowFuncType {
@@ -221,6 +222,7 @@ impl WindowFuncType {
             "row_number" => Ok(WindowFuncType::RowNumber),
             "rank" => Ok(WindowFuncType::Rank),
             "dense_rank" => Ok(WindowFuncType::DenseRank),
+            "percent_rank" => Ok(WindowFuncType::PercentRank),
             _ => Err(ErrorCode::UnknownFunction(format!(
                 "Unknown window function: {}",
                 name
@@ -233,6 +235,7 @@ impl WindowFuncType {
             WindowFuncType::RowNumber => "row_number".to_string(),
             WindowFuncType::Rank => "rank".to_string(),
             WindowFuncType::DenseRank => "dense_rank".to_string(),
+            WindowFuncType::PercentRank => "percent_rank".to_string(),
         }
     }
 
@@ -251,6 +254,7 @@ impl WindowFuncType {
             WindowFuncType::RowNumber | WindowFuncType::Rank | WindowFuncType::DenseRank => {
                 DataType::Number(NumberDataType::UInt64)
             }
+            WindowFuncType::PercentRank => DataType::Number(NumberDataType::Float64),
         }
     }
 }

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -161,6 +161,10 @@ impl Operator for Window {
             },
         })
     }
+
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<(f64, Statistics)> {
+        todo!()
+    }
 }
 
 #[derive(Default, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -646,7 +646,7 @@ if __name__ == '__main__':
     parser.add_argument('-t',
                         '--timeout',
                         type=int,
-                        default=60,
+                        default=120,
                         help='Timeout for each test case in seconds')
     parser.add_argument('--record',
                         type=int,

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -646,7 +646,7 @@ if __name__ == '__main__':
     parser.add_argument('-t',
                         '--timeout',
                         type=int,
-                        default=180,
+                        default=60,
                         help='Timeout for each test case in seconds')
     parser.add_argument('--record',
                         type=int,

--- a/tests/databend-test
+++ b/tests/databend-test
@@ -646,7 +646,7 @@ if __name__ == '__main__':
     parser.add_argument('-t',
                         '--timeout',
                         type=int,
-                        default=120,
+                        default=180,
                         help='Timeout for each test case in seconds')
     parser.add_argument('--record',
                         type=int,

--- a/tests/suites/0_stateless/18_tpcds/18_0000_prepare.sh
+++ b/tests/suites/0_stateless/18_tpcds/18_0000_prepare.sh
@@ -58,5 +58,6 @@ do
     echo $t
     insert_sql="insert into ${db}.$t file_format = (type = CSV skip_header = 0 field_delimiter = '|' record_delimiter = '\n')"
     curl -s -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load" -H "insert_sql: ${insert_sql}" -F 'upload=@"'${CURDIR}'/data/data/'$t'.csv"' > /dev/null 2>&1
+    echo "analyze table $db.$t" | $MYSQL_CLIENT_CONNECT
 done
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. fix bugs in dphyp: enumeration space is insufficient
2. accelerate dphyp
    1. add some caches to save intermediate state
    2. split `RelationalProperty` to two parts
    3. spawn new threads to process subquery in dphyp
  

Closes #issue
