### PR TITLE
ci: use larger runner for hive release build [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
           repo_role_arn: ${{ secrets.REPO_ROLE_ARN }}
 
   hive:
-    runs-on: [self-hosted, X64, Linux, 8c16g]
+    runs-on: [self-hosted, X64, Linux, 16c32g]
     needs: [create_release]
     env:
       RUNNER_PROVIDER: aws


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Closes #issue
