### PR TITLE
feat(function): support window function percent_rank.

### DIFF
--- a/src/query/functions/src/lib.rs
+++ b/src/query/functions/src/lib.rs
@@ -35,7 +35,8 @@ pub fn is_builtin_function(name: &str) -> bool {
 #[ctor]
 pub static BUILTIN_FUNCTIONS: FunctionRegistry = builtin_functions();
 
-pub const GENERAL_WINDOW_FUNCTIONS: [&str; 3] = ["row_number", "rank", "dense_rank"];
+pub const GENERAL_WINDOW_FUNCTIONS: [&str; 4] =
+    ["row_number", "rank", "dense_rank", "percent_rank"];
 
 fn builtin_functions() -> FunctionRegistry {
     let mut registry = FunctionRegistry::empty();

--- a/src/query/service/src/pipelines/processors/transforms/window/window_function.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/window_function.rs
@@ -35,6 +35,7 @@ pub enum WindowFunctionInfo {
     RowNumber,
     Rank,
     DenseRank,
+    PercentRank,
 }
 
 pub struct WindowFuncAggImpl {
@@ -91,6 +92,7 @@ pub enum WindowFunctionImpl {
     RowNumber,
     Rank,
     DenseRank,
+    PercentRank,
 }
 
 impl WindowFunctionInfo {
@@ -115,6 +117,7 @@ impl WindowFunctionInfo {
             WindowFunction::RowNumber => Self::RowNumber,
             WindowFunction::Rank => Self::Rank,
             WindowFunction::DenseRank => Self::DenseRank,
+            WindowFunction::PercentRank => Self::PercentRank,
         })
     }
 }
@@ -140,6 +143,7 @@ impl WindowFunctionImpl {
             WindowFunctionInfo::RowNumber => Self::RowNumber,
             WindowFunctionInfo::Rank => Self::Rank,
             WindowFunctionInfo::DenseRank => Self::DenseRank,
+            WindowFunctionInfo::PercentRank => Self::PercentRank,
         })
     }
 
@@ -149,6 +153,7 @@ impl WindowFunctionImpl {
             Self::RowNumber | Self::Rank | Self::DenseRank => {
                 DataType::Number(NumberDataType::UInt64)
             }
+            Self::PercentRank => DataType::Number(NumberDataType::Float64),
         })
     }
 

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -295,6 +295,7 @@ pub enum WindowFunction {
     RowNumber,
     Rank,
     DenseRank,
+    PercentRank,
 }
 
 impl WindowFunction {
@@ -304,6 +305,7 @@ impl WindowFunction {
             WindowFunction::RowNumber | WindowFunction::Rank | WindowFunction::DenseRank => {
                 DataType::Number(NumberDataType::UInt64)
             }
+            WindowFunction::PercentRank => DataType::Number(NumberDataType::Float64),
         }
     }
 }
@@ -315,6 +317,7 @@ impl Display for WindowFunction {
             WindowFunction::RowNumber => write!(f, "row_number"),
             WindowFunction::Rank => write!(f, "rank"),
             WindowFunction::DenseRank => write!(f, "dense_rank"),
+            WindowFunction::PercentRank => write!(f, "percent_rank"),
         }
     }
 }

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -773,6 +773,7 @@ impl PhysicalPlanBuilder {
                     WindowFuncType::RowNumber => WindowFunction::RowNumber,
                     WindowFuncType::Rank => WindowFunction::Rank,
                     WindowFuncType::DenseRank => WindowFunction::DenseRank,
+                    WindowFuncType::PercentRank => WindowFunction::PercentRank,
                 };
 
                 Ok(PhysicalPlan::Window(Window {

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -204,6 +204,7 @@ pub enum WindowFuncType {
     RowNumber,
     Rank,
     DenseRank,
+    PercentRank,
 }
 
 impl WindowFuncType {
@@ -212,6 +213,7 @@ impl WindowFuncType {
             "row_number" => Ok(WindowFuncType::RowNumber),
             "rank" => Ok(WindowFuncType::Rank),
             "dense_rank" => Ok(WindowFuncType::DenseRank),
+            "percent_rank" => Ok(WindowFuncType::PercentRank),
             _ => Err(ErrorCode::UnknownFunction(format!(
                 "Unknown window function: {}",
                 name
@@ -224,6 +226,7 @@ impl WindowFuncType {
             WindowFuncType::RowNumber => "row_number".to_string(),
             WindowFuncType::Rank => "rank".to_string(),
             WindowFuncType::DenseRank => "dense_rank".to_string(),
+            WindowFuncType::PercentRank => "percent_rank".to_string(),
         }
     }
 
@@ -242,6 +245,7 @@ impl WindowFuncType {
             WindowFuncType::RowNumber | WindowFuncType::Rank | WindowFuncType::DenseRank => {
                 DataType::Number(NumberDataType::UInt64)
             }
+            WindowFuncType::PercentRank => DataType::Number(NumberDataType::Float64),
         }
     }
 }

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -906,7 +906,7 @@ impl<'a> TypeChecker<'a> {
             })
         }
         let frame = self
-            .resolve_window_frame(span, &mut order_by, window.window_frame.clone())
+            .resolve_window_frame(span, &func, &mut order_by, window.window_frame.clone())
             .await?;
         let data_type = func.return_type();
         let window_func = WindowFunc {
@@ -1127,9 +1127,17 @@ impl<'a> TypeChecker<'a> {
     async fn resolve_window_frame(
         &mut self,
         span: Span,
+        func: &WindowFuncType,
         order_by: &mut [WindowOrderBy],
         window_frame: Option<WindowFrame>,
     ) -> Result<WindowFuncFrame> {
+        if matches!(func, WindowFuncType::PercentRank) {
+            return Ok(WindowFuncFrame {
+                units: WindowFuncFrameUnits::Rows,
+                start_bound: WindowFuncFrameBound::Preceding(None),
+                end_bound: WindowFuncFrameBound::Following(None),
+            });
+        }
         if let Some(frame) = window_frame {
             if frame.units.is_range() {
                 if order_by.len() != 1 {

--- a/tests/sqllogictests/suites/query/window_function/named_window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/named_window_basic.test
@@ -170,6 +170,21 @@ sales 4800 1
 sales 4800 1
 sales 5000 3
 
+# percent_rank
+query TII
+SELECT depname, salary, percent_rank() OVER w FROM empsalary WINDOW w AS (PARTITION BY depname ORDER BY salary) order by depname, salary
+----
+develop 4200 0.0
+develop 4500 0.25
+develop 5200 0.5
+develop 5200 0.5
+develop 6000 1.0
+personnel 3500 0.0
+personnel 3900 1.0
+sales 4800 0.0
+sales 4800 0.0
+sales 5000 1.0
+
 # min/max/avg
 query TIIR
 SELECT depname, min(salary) OVER w m1, max(salary) OVER w m2, AVG(salary) OVER w m3 FROM empsalary WINDOW w AS (PARTITION BY depname ORDER BY salary, empno) ORDER BY depname, empno

--- a/tests/sqllogictests/suites/query/window_function/window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/window_basic.test
@@ -89,6 +89,20 @@ sales 4800 1
 sales 4800 1
 sales 5000 3
 
+# percent_rank
+query TII
+SELECT depname, salary, percent_rank() OVER (PARTITION BY depname ORDER BY salary) FROM empsalary order by depname, salary
+----
+develop 4200 0.0
+develop 4500 0.25
+develop 5200 0.5
+develop 5200 0.5
+develop 6000 1.0
+personnel 3500 0.0
+personnel 3900 1.0
+sales 4800 0.0
+sales 4800 0.0
+sales 5000 1.0
 
 # row_number
 query I


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary


percent_rank operate on the entire partition.




>>> Standard SQL specifies that window functions that operate on the entire partition should have no frame clause. MySQL permits a frame clause for such functions but ignores it. These functions use the entire partition even if a frame is specified

see https://dev.mysql.com/doc/refman/8.0/en/window-functions-frames.html

Postgres do exactly the same.

Tracking in https://github.com/datafuselabs/databend/issues/10810
