### PR TITLE
chore: Bump to reqsign 0.9.2 for helping debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8234,9 +8234,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3875de6d7d0468315194cb8332913aae0d6803cfd5c7f089dc174ff5350f7b29"
+checksum = "d560bb549fe31e484c89a0fff9815d34b147f4d7bf8b0dbd77f2f923f0026687"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10289,7 +10289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore: Bump to reqsign 0.9.2 for helping debug
