### PR TITLE
feat(meta-service): Split log store and state-machine store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6976,7 +6976,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.8.4"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.1#8f83d590a5b417dcfa4133a268ba31fa52c6d4c5"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.2#dbdaf0a2c2f225754a20bf9fc06fc7137013dcdc"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ jsonb = { version = "0.1.1" }
 
 # openraft = { version = "0.8.2", features = ["compat-07"] }
 # For debugging
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.8.4-alpha.1", features = ["compat-07"] }
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.8.4-alpha.2", features = ["compat-07"] }
 
 # type helper
 derive_more = "0.99.17"

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -26,9 +26,6 @@ io-uring = [
     "common-meta-raft-store/io-uring",
 ]
 
-# Enable defensive check when accessing raft store.
-raft-store-defensive = ["databend-meta/raft-store-defensive"]
-
 enable-histogram-metrics = [
     "default",
     "common-metrics/enable-histogram",

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -24,9 +24,6 @@ io-uring = [
 
 enable-histogram = ["common-metrics/enable-histogram"]
 
-# Enable defensive check when accessing raft store.
-raft-store-defensive = []
-
 [dependencies]
 # Workspace dependencies
 common-arrow = { path = "../../common/arrow" }

--- a/src/meta/service/src/api/http/v1/ctrl.rs
+++ b/src/meta/service/src/api/http/v1/ctrl.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use poem::http::StatusCode;
 use poem::web::Data;
@@ -31,5 +32,23 @@ pub async fn trigger_snapshot(meta_node: Data<&Arc<MetaNode>>) -> poem::Result<i
         .trigger_snapshot()
         .await
         .map_err(|e| poem::Error::from_string(e.to_string(), StatusCode::INTERNAL_SERVER_ERROR))?;
+    Ok(Json(()))
+}
+
+#[poem::handler]
+pub async fn block_dump_snapshot(
+    meta_node: Data<&Arc<MetaNode>>,
+) -> poem::Result<impl IntoResponse> {
+    let mut sm = meta_node.sto.get_state_machine().await;
+    sm.blocking_config_mut().dump_snapshot = Duration::from_millis(1_000_000);
+    Ok(Json(()))
+}
+
+#[poem::handler]
+pub async fn block_serde_snapshot(
+    meta_node: Data<&Arc<MetaNode>>,
+) -> poem::Result<impl IntoResponse> {
+    let mut sm = meta_node.sto.get_state_machine().await;
+    sm.blocking_config_mut().serde_snapshot = Duration::from_millis(1_000_000);
     Ok(Json(()))
 }

--- a/src/meta/service/src/api/http_service.rs
+++ b/src/meta/service/src/api/http_service.rs
@@ -63,6 +63,14 @@ impl HttpService {
                 get(super::http::v1::ctrl::trigger_snapshot),
             )
             .at(
+                "/v1/ctrl/block_dump_snapshot",
+                get(super::http::v1::ctrl::block_dump_snapshot),
+            )
+            .at(
+                "/v1/ctrl/block_serde_snapshot",
+                get(super::http::v1::ctrl::block_serde_snapshot),
+            )
+            .at(
                 "/v1/cluster/nodes",
                 get(super::http::v1::cluster_state::nodes_handler),
             )

--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -33,11 +33,8 @@ use common_meta_client::reply_to_api_result;
 use common_meta_raft_store::config::RaftConfig;
 use common_meta_raft_store::key_spaces::GenericKV;
 use common_meta_sled_store::openraft;
+use common_meta_sled_store::openraft::storage::Adaptor;
 use common_meta_sled_store::openraft::ChangeMembers;
-#[cfg(feature = "raft-store-defensive")]
-use common_meta_sled_store::openraft::DefensiveCheckBase;
-#[cfg(feature = "raft-store-defensive")]
-use common_meta_sled_store::openraft::StoreExt;
 use common_meta_sled_store::SledKeySpace;
 use common_meta_stoerr::MetaStorageError;
 use common_meta_types::protobuf::raft_service_client::RaftServiceClient;
@@ -89,7 +86,6 @@ use crate::meta_service::RaftServiceImpl;
 use crate::metrics::server_metrics;
 use crate::network::Network;
 use crate::store::RaftStore;
-use crate::store::RaftStoreBare;
 use crate::watcher::DispatcherSender;
 use crate::watcher::EventDispatcher;
 use crate::watcher::EventDispatcherHandle;
@@ -127,8 +123,11 @@ pub struct MetaNodeStatus {
     pub last_seq: u64,
 }
 
+pub type LogStore = Adaptor<TypeConfig, RaftStore>;
+pub type SMStore = Adaptor<TypeConfig, RaftStore>;
+
 /// MetaRaft is a implementation of the generic Raft handling meta data R/W.
-pub type MetaRaft = Raft<TypeConfig, Network, RaftStore>;
+pub type MetaRaft = Raft<TypeConfig, Network, LogStore, SMStore>;
 
 /// MetaNode is the container of meta data related components and threads, such as storage, the raft node and a raft-state monitor.
 pub struct MetaNode {
@@ -173,7 +172,9 @@ impl MetaNodeBuilder {
 
         let net = Network::new(sto.clone());
 
-        let raft = MetaRaft::new(node_id, Arc::new(config), net, sto.clone())
+        let (log_store, sm_store) = Adaptor::new(sto.clone());
+
+        let raft = MetaRaft::new(node_id, Arc::new(config), net, log_store, sm_store)
             .await
             .map_err(|e| MetaStartupError::MetaServiceError(e.to_string()))?;
         let metrics_rx = raft.metrics();
@@ -368,14 +369,7 @@ impl MetaNode {
             config.no_sync = true;
         }
 
-        let sto = RaftStoreBare::open_create(&config, open, create).await?;
-
-        #[cfg(feature = "raft-store-defensive")]
-        let sto = {
-            let sto_ext = StoreExt::new(sto);
-            sto_ext.set_defensive(true);
-            sto_ext
-        };
+        let sto = RaftStore::open_create(&config, open, create).await?;
 
         // config.id only used for the first time
         let self_node_id = if sto.is_opened() { sto.id } else { config.id };

--- a/src/meta/service/src/store/mod.rs
+++ b/src/meta/service/src/store/mod.rs
@@ -12,23 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod store_bare;
+#[allow(clippy::module_inception)]
+mod store;
 mod store_inner;
 mod to_storage_error;
 
-#[cfg(feature = "raft-store-defensive")]
-use common_meta_sled_store::openraft::StoreExt;
-#[cfg(feature = "raft-store-defensive")]
-use common_meta_types::TypeConfig;
-pub use store_bare::RaftStoreBare;
+pub use store::RaftStore;
 pub use store_inner::StoreInner;
 pub use to_storage_error::ToStorageError;
-
-/// Implements `RaftStorage` and provides defensive check.
-///
-/// It is used to discover unexpected invalid data read or write, which is potentially a bug.
-#[cfg(feature = "raft-store-defensive")]
-pub type RaftStore = StoreExt<TypeConfig, RaftStoreBare>;
-
-#[cfg(not(feature = "raft-store-defensive"))]
-pub(crate) type RaftStore = RaftStoreBare;

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -14,8 +14,11 @@
 
 use std::io::Cursor;
 use std::io::ErrorKind;
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyerror::AnyError;
+use common_base::base::tokio;
 use common_base::base::tokio::sync::RwLock;
 use common_base::base::tokio::sync::RwLockWriteGuard;
 use common_meta_raft_store::config::RaftConfig;
@@ -38,6 +41,7 @@ use common_meta_types::NodeId;
 use common_meta_types::Snapshot;
 use common_meta_types::SnapshotMeta;
 use common_meta_types::StorageError;
+use common_meta_types::StorageIOError;
 use tracing::info;
 
 use crate::export::vec_kv_to_json;
@@ -85,7 +89,7 @@ pub struct StoreInner {
     ///
     /// - Acquire a read lock to WRITE or READ. Transactional RW relies on sled concurrency control.
     /// - Acquire a write lock before installing a snapshot, to prevent any write to the db.
-    pub state_machine: RwLock<StateMachine>,
+    pub state_machine: Arc<RwLock<StateMachine>>,
 
     /// The current snapshot.
     pub current_snapshot: RwLock<Option<StoredSnapshot>>,
@@ -134,7 +138,8 @@ impl StoreInner {
             raft_state.write_state_machine_id(&(sm_id, sm_id)).await?;
         }
 
-        let sm = RwLock::new(StateMachine::open(config, sm_id).await?);
+        let sm = StateMachine::open(config, sm_id).await?;
+        let sm = Arc::new(RwLock::new(sm));
         let current_snapshot = RwLock::new(None);
 
         Ok(Self {
@@ -162,23 +167,48 @@ impl StoreInner {
 
         // 1. Take a serialized snapshot
 
-        let (snap, last_applied_log, last_membership, snapshot_id) = match self
-            .state_machine
-            .write()
-            .await
-            .build_snapshot()
-            .map_to_sto_err(ErrorSubject::StateMachine, ErrorVerb::Read)
-        {
-            Err(err) => {
-                raft_metrics::storage::incr_raft_storage_fail("build_snapshot", false);
-                return Err(err);
+        let (snap, last_applied_log, last_membership, snapshot_id) = {
+            let sm = self.state_machine.clone();
+
+            // An exclusive lock is required, because sled does not provide snapshot isolation.
+            let s = sm.write().await;
+
+            // Move heavy load task to a blocking thread pool.
+            let res = tokio::task::block_in_place(move || s.build_snapshot());
+
+            // build_snapshot error
+            match res {
+                Ok(res) => res,
+                Err(e) => {
+                    raft_metrics::storage::incr_raft_storage_fail("build_snapshot", false);
+                    return Err(StorageIOError::read_snapshot(None, AnyError::new(&e)).into());
+                }
             }
-            Ok(r) => r,
         };
 
         info!("log compaction serialization start");
 
-        let data = serde_json::to_vec(&snap)
+        let sl = if cfg!(debug_assertions) {
+            let sm = self.get_state_machine().await;
+            sm.blocking_config().serde_snapshot
+        } else {
+            Duration::from_secs(0)
+        };
+
+        // Move heavy load to a blocking thread pool.
+        let res = tokio::task::block_in_place(move || {
+            #[allow(clippy::collapsible_if)]
+            if cfg!(debug_assertions) {
+                if !sl.is_zero() {
+                    tracing::warn!("start    serializing snapshot sleep 1000s");
+                    std::thread::sleep(sl);
+                    tracing::warn!("finished serializing snapshot sleep 1000s");
+                }
+            }
+            serde_json::to_vec(&snap)
+        });
+
+        let data = res
             .map_err(MetaStorageError::from)
             .map_to_sto_err(ErrorSubject::StateMachine, ErrorVerb::Read)?;
 

--- a/src/meta/service/tests/it/meta_node/meta_node_raft_api.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_raft_api.rs
@@ -1,0 +1,117 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test raft protocol behaviors
+
+use std::time::Duration;
+
+use common_base::base::tokio;
+use common_meta_types::Cmd;
+use common_meta_types::LogEntry;
+use common_meta_types::UpsertKV;
+use databend_meta::init_meta_ut;
+use maplit::btreeset;
+use tracing::info;
+
+use crate::tests::meta_node::start_meta_node_cluster;
+
+/// When a follower is dumping a snapshot, it should not block append entries request.
+/// Thus heartbeat should still be processed, and logs can be committed by leader(but not by followers).
+///
+/// Building a snapshot includes two steps:
+/// 1. Dumping the state machine to a in-memory struct.
+/// 2. Serialize the dumped data.
+#[async_entry::test(worker_threads = 5, init = "init_meta_ut!()", tracing_span = "debug")]
+async fn test_meta_node_dumping_snapshot_does_not_block_append_entries() -> anyhow::Result<()> {
+    info!("--- initialize cluster 2 voters");
+    let (mut _log_index, mut tcs) = start_meta_node_cluster(btreeset![0, 1], btreeset![]).await?;
+
+    let tc0 = tcs.remove(0);
+    let tc1 = tcs.remove(0);
+
+    let mn0 = tc0.meta_node.clone().unwrap();
+    let mn1 = tc1.meta_node.clone().unwrap();
+
+    info!("--- block dumping snapshot from state machine for 5 seconds");
+    {
+        let mut sm = mn1.sto.get_state_machine().await;
+        let mut blocking_config = sm.blocking_config_mut();
+        blocking_config.dump_snapshot = Duration::from_secs(5);
+    }
+
+    info!("--- trigger building snapshot");
+    mn1.raft.trigger_snapshot().await?;
+
+    info!("--- Wait 500 ms for snapshot to be begin building");
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    info!("--- With snapshot being blocked, leader can still write");
+    let key = "foo";
+    mn0.assume_leader()
+        .await?
+        .write(LogEntry {
+            txid: None,
+            time_ms: None,
+            cmd: Cmd::UpsertKV(UpsertKV::update(key, key.as_bytes())),
+        })
+        .await?;
+    info!("--- Write done");
+
+    Ok(())
+}
+
+/// When a follower is serializing a snapshot, it should not block append entries request.
+/// Thus heartbeat should still be processed, and logs can be committed by leader(but not by followers).
+///
+/// Building a snapshot includes two steps:
+/// 1. Dumping the state machine to a in-memory struct.
+/// 2. Serialize the dumped data.
+#[async_entry::test(worker_threads = 5, init = "init_meta_ut!()", tracing_span = "debug")]
+async fn test_meta_node_serializing_snapshot_does_not_block_append_entries() -> anyhow::Result<()> {
+    info!("--- initialize cluster 2 voters");
+    let (mut _log_index, mut tcs) = start_meta_node_cluster(btreeset![0, 1], btreeset![]).await?;
+
+    let tc0 = tcs.remove(0);
+    let tc1 = tcs.remove(0);
+
+    let mn0 = tc0.meta_node.clone().unwrap();
+    let mn1 = tc1.meta_node.clone().unwrap();
+
+    info!("--- block dumping snapshot from state machine for 5 seconds");
+    {
+        let mut sm = mn1.sto.get_state_machine().await;
+        let mut blocking_config = sm.blocking_config_mut();
+        blocking_config.serde_snapshot = Duration::from_secs(5);
+    }
+
+    info!("--- trigger building snapshot");
+    mn1.raft.trigger_snapshot().await?;
+
+    info!("--- Wait 500 ms for snapshot to be begin building");
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    info!("--- With snapshot being blocked, leader can still write");
+    let key = "foo";
+    mn0.assume_leader()
+        .await?
+        .write(LogEntry {
+            txid: None,
+            time_ms: None,
+            cmd: Cmd::UpsertKV(UpsertKV::update(key, key.as_bytes())),
+        })
+        .await?;
+    info!("--- Write done");
+
+    Ok(())
+}

--- a/src/meta/service/tests/it/meta_node/mod.rs
+++ b/src/meta/service/tests/it/meta_node/mod.rs
@@ -15,5 +15,6 @@
 pub(crate) mod meta_node_kv_api;
 pub(crate) mod meta_node_kv_api_expire;
 pub(crate) mod meta_node_lifecycle;
+pub(crate) mod meta_node_raft_api;
 pub(crate) mod meta_node_replication;
 pub(crate) mod meta_node_request_forwarding;

--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -122,6 +122,7 @@ pub use crate::raft_types::LogId;
 pub use crate::raft_types::LogIndex;
 pub use crate::raft_types::Membership;
 pub use crate::raft_types::MembershipNode;
+pub use crate::raft_types::NetworkError;
 pub use crate::raft_types::NodeId;
 pub use crate::raft_types::RPCError;
 pub use crate::raft_types::RaftError;

--- a/src/meta/types/src/raft_types.rs
+++ b/src/meta/types/src/raft_types.rs
@@ -48,6 +48,7 @@ pub type ErrorSubject = openraft::ErrorSubject<NodeId>;
 
 pub type RPCError<E> = openraft::error::RPCError<NodeId, MembershipNode, E>;
 pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<NodeId, E>;
+pub type NetworkError = openraft::error::NetworkError;
 
 pub type StorageError = openraft::StorageError<NodeId>;
 pub type StorageIOError = openraft::StorageIOError<NodeId>;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

## feat(meta-service): Split log store and state-machine store

Separate the log store and state-machine store, in order to prevent
blocking of append-entries (heartbeat) when creating a snapshot.

## refactor(meta-service): test building snapshot not block append-entries

Add a config for debugging that temporarily blocks snapshot building,
for testing purposes.

Add two tests that verify the leader's ability to write log entries
while a follower's snapshot building is blocked, in a 2-voter cluster.

[Openraft](https://github.com/datafuselabs/openraft/tree/release-0.8) changes since v0.8.4-alpha.1 to v0.8.4-alpha.2 :

### Feature: add feature flag storage-v2 to enable RaftLogStorage and RaftStateMachine

`storage-v2`: enables `RaftLogStorage` and `RaftStateMachine` as the v2 storage
This is a temporary feature flag, and will be removed in the future, when v2 storage is stable.
This feature disables `Adapter`, which is for v1 storage to be used as v2.
V2 storage separates log store and state machine store so that log IO and state machine IO can be parallelized naturally.

### Improve: getting a snapshot does not block RaftCore task

`RaftCore` no longer blocks on receiving a snapshot from the state-machine
worker while replicating a snapshot. Instead, it sends the `Receiver` to
the replication task and the replication task blocks on receiving the
snapshot.

### Fix: compat07::SnapshotMeta should decode v08 SnapshotMeta

### Fix: if the application does not persist snapshot, build a snapshot when starting up

### Improve: move state machine operations to another task

State machine operations, such as applying log entries, building/installing/getting snapshot are moved to `core::sm::Worker`, which is run in a standalone task other than the one running `RaftCore`.
In this way, log io operation(mostly appending log entries) and state machine io operations(mostly applying log entries) can be paralleled.

- Log io are sitll running in `RaftCore` task.

- Snapshot receiving/streaming are removed from `RaftCore`.

- Add `IOState` to `RaftState` to track the applied log id.

  This field is used to determine whether a certain command, such as
  sending a response, can be executed after a specific log has been
  applied.

- Refactor: `leader_step_down()` can only be run when the response of the second change-membership is sent.
  Before this commit, updating the `committed` is done atomically with
  sending back response. Since thie commit, these two steps are done
  separately, because applying log entries are moved to another task.
  Therefore `leader_step_down()` must wait for these two steps to be
  finished.

### Change: move `RaftStateMachine` out of `RaftStorage`

In Raft, the state machine is an independent storage component that
operates separately from the log store. As a result, accessing the log
store and accessing the state machine can be naturally parallelized.

This commit replaces the type parameter `RaftStorage` in
`Raft<.., S: RaftStorage>` with two type parameters: `RaftLogStorage` and
`RaftStateMachine`.

- Add: `RaftLogReaderExt` to provide additional log access methods based
  on a `RaftLogReader` implementation. Some of the methods are moved
  from `StorageHelper` to this trait.

- Add: `Adapter` to let application use the seperated log state machine
  framework without rewriting `RaftStorage` implementation.

### Fix: ProgressEntry::is_log_range_inflight() checks a log range, not a log entry This bug causes replication tries to send pruged log.

### Change: remove defensive check utilities

Most defensive checks are replaced with `debug_assert!` embedded in Engine.
`StoreExt` as a `RaftStorage` wrapper that implements defensive checks
are no longer needed. `StoreExt` are mainly used for testing and it is
very slow so that can not be used in production.

- Remove structs: `StoreExt`, `DefensiveStoreBuilder`
- Remove traits: `Wrapper`, `DefensiveCheckBase`, `DefensiveCheck`,

### Change: remove unused trait RaftStorageDebug

`RaftStorageDebug` has only one method `get_state_machine()`,
and state machine is entirely a user defined struct. Obtaining a state
machine does not imply anything about the struct or behavior of it.

### Refactor: allow snapshot buillding and streaming at the same time

Although enabling snapshot building and streaming at the same time may
lead to inefficiencies, it enhances the clarity of the system's overall
structure. For instance, when processing a stream, there is
no need to handle any building state.

In this commit, a new `snapshot_state::State` is introduced that includes
both a building state and a streaming state.

### Improve: send AppendEntries response before committing entries

When a follower receives an append-entries request that includes a
series of log entries to append and the log id that the leader
has committed, it responds with an append-entries response after
committing and applying the entries.

However, this is not strictly necessary. The follower could simply send
the response as soon as the log entries have been appended and flushed
to disk, without waiting for them to be committed.

### Improve: follower stores the accepted log id

A follower stores the ID of the latest log that has been synchronized by
the leader, represented as `(LeaderId, Option<LogId>)`.
This information is only kept in memory and is not taken into account
when processing vote requests or determining the commit condition.

The reason for storing this information is to allow followers to commit
only those logs that have been replicated by their current leader.

## Changelog







## Related Issues


- Fix: #10873

