### PR TITLE
feat(storage): replace support cluster stats generator

### DIFF
--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -295,7 +295,7 @@ pub trait Table: Sync + Send {
         )))
     }
 
-    fn get_block_compact_thresholds(&self) -> BlockThresholds {
+    fn get_block_thresholds(&self) -> BlockThresholds {
         BlockThresholds {
             max_rows_per_block: DEFAULT_BLOCK_MAX_ROWS,
             min_rows_per_block: DEFAULT_BLOCK_MIN_ROWS,

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -303,7 +303,7 @@ pub trait Table: Sync + Send {
         }
     }
 
-    fn set_block_compact_thresholds(&self, _thresholds: BlockThresholds) {
+    fn set_block_thresholds(&self, _thresholds: BlockThresholds) {
         unimplemented!()
     }
 

--- a/src/query/service/src/interpreters/interpreter_copy.rs
+++ b/src/query/service/src/interpreters/interpreter_copy.rs
@@ -340,7 +340,7 @@ impl CopyInterpreter {
         let to_table = ctx
             .get_table(catalog_name, database_name, table_name)
             .await?;
-        stage_table.set_block_compact_thresholds(to_table.get_block_thresholds());
+        stage_table.set_block_thresholds(to_table.get_block_thresholds());
         stage_table.read_data(table_ctx, &read_source_plan, &mut build_res.main_pipeline)?;
 
         // Build Limit pipeline.

--- a/src/query/service/src/interpreters/interpreter_copy.rs
+++ b/src/query/service/src/interpreters/interpreter_copy.rs
@@ -340,7 +340,7 @@ impl CopyInterpreter {
         let to_table = ctx
             .get_table(catalog_name, database_name, table_name)
             .await?;
-        stage_table.set_block_compact_thresholds(to_table.get_block_compact_thresholds());
+        stage_table.set_block_compact_thresholds(to_table.get_block_thresholds());
         stage_table.read_data(table_ctx, &read_source_plan, &mut build_res.main_pipeline)?;
 
         // Build Limit pipeline.

--- a/src/query/service/src/interpreters/interpreter_replace.rs
+++ b/src/query/service/src/interpreters/interpreter_replace.rs
@@ -62,12 +62,6 @@ impl Interpreter for ReplaceInterpreter {
             .get_table(&plan.catalog, &plan.database, &plan.table)
             .await?;
 
-        if table.get_table_info().meta.default_cluster_key_id.is_some() {
-            return Err(ErrorCode::StorageOther(
-                "replace into table with cluster key definition is not supported yet",
-            ));
-        }
-
         let mut pipeline = self
             .connect_input_source(self.ctx.clone(), &self.plan.source, self.plan.schema())
             .await?;

--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -328,7 +328,7 @@ pub async fn clickhouse_handler_post(
                     ctx.get_settings(),
                     table_schema,
                     ctx.get_scan_progress(),
-                    to_table.get_block_compact_thresholds(),
+                    to_table.get_block_thresholds(),
                 )
                 .await
                 .map_err(InternalServerError)?,
@@ -377,7 +377,7 @@ pub async fn clickhouse_handler_post(
                     table_schema,
                     ctx.get_scan_progress(),
                     false,
-                    to_table.get_block_compact_thresholds(),
+                    to_table.get_block_thresholds(),
                 )
                 .await
                 .map_err(|err| err.display_with_sql(&sql))

--- a/src/query/service/src/servers/http/v1/load.rs
+++ b/src/query/service/src/servers/http/v1/load.rs
@@ -155,7 +155,7 @@ pub async fn streaming_load(
                         table_schema,
                         context.get_scan_progress(),
                         false,
-                        to_table.get_block_compact_thresholds(),
+                        to_table.get_block_thresholds(),
                     )
                     .await
                     .map_err(|err| err.display_with_sql(insert_sql))

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -628,7 +628,7 @@ impl Table for FuseTable {
             .await
     }
 
-    fn get_block_compact_thresholds(&self) -> BlockThresholds {
+    fn get_block_thresholds(&self) -> BlockThresholds {
         let max_rows_per_block =
             self.get_option(FUSE_OPT_KEY_ROW_PER_BLOCK, DEFAULT_BLOCK_MAX_ROWS);
         let min_rows_per_block = (max_rows_per_block as f64 * 0.8) as usize;

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -114,7 +114,7 @@ impl FuseTable {
     ) -> Result<ClusterStatsGenerator> {
         let cluster_stats_gen = self.get_cluster_stats_gen(ctx.clone(), 0, block_thresholds)?;
 
-        let operators =  cluster_stats_gen.operators.clone();
+        let operators = cluster_stats_gen.operators.clone();
         if !operators.is_empty() {
             let num_input_columns = self.table_info.schema().fields().len();
             let func_ctx2 = cluster_stats_gen.func_ctx.clone();

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -45,7 +45,7 @@ impl FuseTable {
         append_mode: AppendMode,
         need_output: bool,
     ) -> Result<()> {
-        let block_compact_thresholds = self.get_block_compact_thresholds();
+        let block_thresholds = self.get_block_thresholds();
         let write_settings = self.get_write_settings();
 
         match append_mode {
@@ -54,7 +54,7 @@ impl FuseTable {
                     Ok(ProcessorPtr::create(TransformCompact::try_create(
                         transform_input_port,
                         transform_output_port,
-                        BlockCompactor::new(block_compact_thresholds, true),
+                        BlockCompactor::new(block_thresholds, true),
                     )?))
                 })?;
             }
@@ -65,21 +65,69 @@ impl FuseTable {
                     Ok(ProcessorPtr::create(TransformCompact::try_create(
                         transform_input_port,
                         transform_output_port,
-                        BlockCompactorForCopy::new(block_compact_thresholds),
+                        BlockCompactorForCopy::new(block_thresholds),
                     )?))
                 })?;
                 pipeline.resize(size)?;
             }
         }
 
-        let max_page_size = self.get_max_page_size();
-        let cluster_stats_gen = self.get_cluster_stats_gen(
-            ctx.clone(),
-            max_page_size,
-            pipeline,
-            0,
-            block_compact_thresholds,
-        )?;
+        let cluster_stats_gen =
+            self.cluster_gen_for_append(ctx.clone(), pipeline, block_thresholds)?;
+        if need_output {
+            pipeline.add_transform(|transform_input_port, transform_output_port| {
+                FuseTableSink::try_create(
+                    transform_input_port,
+                    ctx.clone(),
+                    write_settings.clone(),
+                    self.operator.clone(),
+                    self.meta_location_generator().clone(),
+                    cluster_stats_gen.clone(),
+                    block_thresholds,
+                    self.table_info.schema(),
+                    Some(transform_output_port),
+                )
+            })?;
+        } else {
+            pipeline.add_sink(|input| {
+                FuseTableSink::try_create(
+                    input,
+                    ctx.clone(),
+                    write_settings.clone(),
+                    self.operator.clone(),
+                    self.meta_location_generator().clone(),
+                    cluster_stats_gen.clone(),
+                    block_thresholds,
+                    self.table_info.schema(),
+                    None,
+                )
+            })?;
+        }
+        Ok(())
+    }
+
+    pub fn cluster_gen_for_append(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        pipeline: &mut Pipeline,
+        block_thresholds: BlockThresholds,
+    ) -> Result<ClusterStatsGenerator> {
+        let cluster_stats_gen = self.get_cluster_stats_gen(ctx.clone(), 0, block_thresholds)?;
+
+        let operators =  cluster_stats_gen.operators.clone();
+        if !operators.is_empty() {
+            let num_input_columns = self.table_info.schema().fields().len();
+            let func_ctx2 = cluster_stats_gen.func_ctx.clone();
+            pipeline.add_transform(move |input, output| {
+                Ok(ProcessorPtr::create(CompoundBlockOperator::create(
+                    input,
+                    output,
+                    num_input_columns,
+                    func_ctx2.clone(),
+                    operators.clone(),
+                )))
+            })?;
+        }
 
         let cluster_keys = &cluster_stats_gen.cluster_key_index;
         if !cluster_keys.is_empty() {
@@ -102,46 +150,14 @@ impl FuseTable {
                 )?))
             })?;
         }
-
-        if need_output {
-            pipeline.add_transform(|transform_input_port, transform_output_port| {
-                FuseTableSink::try_create(
-                    transform_input_port,
-                    ctx.clone(),
-                    write_settings.clone(),
-                    self.operator.clone(),
-                    self.meta_location_generator().clone(),
-                    cluster_stats_gen.clone(),
-                    block_compact_thresholds,
-                    self.table_info.schema(),
-                    Some(transform_output_port),
-                )
-            })?;
-        } else {
-            pipeline.add_sink(|input| {
-                FuseTableSink::try_create(
-                    input,
-                    ctx.clone(),
-                    write_settings.clone(),
-                    self.operator.clone(),
-                    self.meta_location_generator().clone(),
-                    cluster_stats_gen.clone(),
-                    block_compact_thresholds,
-                    self.table_info.schema(),
-                    None,
-                )
-            })?;
-        }
-        Ok(())
+        Ok(cluster_stats_gen)
     }
 
     pub fn get_cluster_stats_gen(
         &self,
         ctx: Arc<dyn TableContext>,
-        max_page_size: Option<usize>,
-        pipeline: &mut Pipeline,
         level: i32,
-        block_compactor: BlockThresholds,
+        block_thresholds: BlockThresholds,
     ) -> Result<ClusterStatsGenerator> {
         let cluster_keys = self.cluster_keys(ctx.clone());
         if cluster_keys.is_empty() {
@@ -158,14 +174,13 @@ impl FuseTable {
         let mut exprs = Vec::with_capacity(cluster_keys.len());
 
         for remote_expr in &cluster_keys {
-            let expr = remote_expr
+            let expr: Expr = remote_expr
                 .as_expr(&BUILTIN_FUNCTIONS)
                 .project_column_ref(|name| input_schema.index_of(name).unwrap());
-            let offset = match &expr {
+            let index = match &expr {
                 Expr::ColumnRef { id, .. } => *id,
                 _ => {
                     let cname = format!("{}", expr);
-
                     merged.push(DataField::new(cname.as_str(), expr.data_type().clone()));
                     exprs.push(expr);
 
@@ -174,36 +189,25 @@ impl FuseTable {
                     offset
                 }
             };
-            cluster_key_index.push(offset);
+            cluster_key_index.push(index);
         }
 
-        let func_ctx = ctx.get_function_context()?;
-        if !exprs.is_empty() {
-            let num_input_columns = input_schema.fields().len();
-            let func_ctx2 = func_ctx.clone();
-            pipeline.add_transform(move |input, output| {
-                Ok(ProcessorPtr::create(CompoundBlockOperator::create(
-                    input,
-                    output,
-                    num_input_columns,
-                    func_ctx2.clone(),
-                    vec![BlockOperator::Map {
-                        exprs: exprs.clone(),
-                    }],
-                )))
-            })?;
-        }
+        let operators = if exprs.is_empty() {
+            vec![]
+        } else {
+            vec![BlockOperator::Map { exprs }]
+        };
 
         Ok(ClusterStatsGenerator::new(
             self.cluster_key_meta.as_ref().unwrap().0,
             cluster_key_index,
             extra_key_num,
-            max_page_size,
+            self.get_max_page_size(),
             level,
-            block_compactor,
-            vec![],
+            block_thresholds,
+            operators,
             merged,
-            func_ctx,
+            ctx.get_function_context()?,
         ))
     }
 

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -122,7 +122,7 @@ impl FuseTable {
             return Ok(());
         }
 
-        let thresholds = self.get_block_compact_thresholds();
+        let thresholds = self.get_block_thresholds();
         let schema = self.schema();
         let write_settings = self.get_write_settings();
 

--- a/src/query/storages/fuse/src/operations/fuse_sink.rs
+++ b/src/query/storages/fuse/src/operations/fuse_sink.rs
@@ -217,7 +217,7 @@ impl Processor for FuseTableSink {
         match std::mem::replace(&mut self.state, State::None) {
             State::NeedSerialize(data_block) => {
                 let (cluster_stats, block) =
-                    self.cluster_stats_gen.gen_stats_for_append(&data_block)?;
+                    self.cluster_stats_gen.gen_stats_for_append(data_block)?;
 
                 let (block_location, block_id) = self.meta_locations.gen_block_location();
 

--- a/src/query/storages/fuse/src/operations/merge_into/processors/transform_append.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/processors/transform_append.rs
@@ -47,6 +47,7 @@ use crate::metrics::metrics_inc_block_write_milliseconds;
 use crate::metrics::metrics_inc_block_write_nums;
 use crate::operations::merge_into::mutation_meta::mutation_log::AppendOperationLogEntry;
 use crate::operations::merge_into::mutation_meta::mutation_log::MutationLogs;
+use crate::statistics::ClusterStatsGenerator;
 use crate::statistics::StatisticsAccumulator;
 
 // Write down data blocks, generate indexes, emits append log entries
@@ -66,12 +67,14 @@ impl AppendTransform {
         meta_locations: TableMetaLocationGenerator,
         source_schema: Arc<TableSchema>,
         thresholds: BlockThresholds,
+        cluster_stats_gen: ClusterStatsGenerator,
     ) -> AppendTransform {
         let block_builder = BlockBuilder {
             ctx,
             meta_locations: meta_locations.clone(),
             source_schema,
             write_settings: write_settings.clone(),
+            cluster_stats_gen,
         };
         AppendTransform {
             data_accessor,
@@ -173,7 +176,11 @@ impl AsyncAccumulatingTransform for AppendTransform {
         // 1. serialize block and index
         let block_builder = self.block_builder.clone();
         let serialized_block_state = GlobalIORuntime::instance()
-            .spawn_blocking(move || block_builder.build(data_block))
+            .spawn_blocking(move || {
+                block_builder.build(data_block, |block, generator| {
+                    generator.gen_stats_for_append(block)
+                })
+            })
             .await?;
 
         let progress_values = ProgressValues {

--- a/src/query/storages/fuse/src/operations/mutation/compact/compact_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/compact_source.rs
@@ -37,6 +37,7 @@ use crate::operations::mutation::CompactPartInfo;
 use crate::pipelines::processors::port::OutputPort;
 use crate::pipelines::processors::processor::Event;
 use crate::pipelines::processors::Processor;
+use crate::statistics::ClusterStatsGenerator;
 
 pub struct CompactSource {
     ctx: Arc<dyn TableContext>,
@@ -65,6 +66,7 @@ impl CompactSource {
             meta_locations,
             source_schema,
             write_settings,
+            cluster_stats_gen: ClusterStatsGenerator::default(),
         };
         Ok(ProcessorPtr::create(Box::new(CompactSource {
             ctx,
@@ -158,7 +160,9 @@ impl Processor for CompactSource {
                 };
                 // build block serialization.
                 let serialized = GlobalIORuntime::instance()
-                    .spawn_blocking(move || block_builder.build(new_block))
+                    .spawn_blocking(move || {
+                        block_builder.build(new_block, |block, _| Ok((None, block)))
+                    })
                     .await?;
 
                 let start = Instant::now();

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -31,6 +31,7 @@ use common_pipeline_transforms::processors::transforms::try_create_transform_sor
 use common_pipeline_transforms::processors::transforms::BlockCompactor;
 use common_pipeline_transforms::processors::transforms::TransformCompact;
 use common_pipeline_transforms::processors::transforms::TransformSortPartial;
+use common_sql::evaluator::CompoundBlockOperator;
 use storages_common_table_meta::meta::BlockMeta;
 
 use crate::operations::FuseTableSink;
@@ -80,7 +81,7 @@ impl FuseTable {
             }
         });
 
-        let block_compact_thresholds = self.get_block_compact_thresholds();
+        let block_thresholds = self.get_block_thresholds();
         let avg_depth_threshold = self.get_option(
             FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD,
             DEFAULT_AVG_DEPTH_THRESHOLD,
@@ -97,7 +98,7 @@ impl FuseTable {
             self.meta_location_generator.clone(),
             snapshot,
             threshold,
-            block_compact_thresholds,
+            block_thresholds,
             blocks_map,
             self.operator.clone(),
         )?;
@@ -140,17 +141,23 @@ impl FuseTable {
         // ReadDataKind to avoid OOM.
         self.do_read_data(ctx.clone(), &plan, pipeline)?;
 
-        let max_page_size = self.get_max_page_size();
+        let cluster_stats_gen =
+            self.get_cluster_stats_gen(ctx.clone(), mutator.level() + 1, block_thresholds)?;
+        let operators = cluster_stats_gen.operators.clone();
+        if !operators.is_empty() {
+            let num_input_columns = self.table_info.schema().fields().len();
+            let func_ctx2 = cluster_stats_gen.func_ctx.clone();
+            pipeline.add_transform(move |input, output| {
+                Ok(ProcessorPtr::create(CompoundBlockOperator::create(
+                    input,
+                    output,
+                    num_input_columns,
+                    func_ctx2.clone(),
+                    operators.clone(),
+                )))
+            })?;
+        }
 
-        let cluster_stats_gen = self.get_cluster_stats_gen(
-            ctx.clone(),
-            max_page_size,
-            pipeline,
-            mutator.level() + 1,
-            block_compact_thresholds,
-        )?;
-
-        let _schema = table_info.schema();
         // sort
         let sort_descs: Vec<SortColumnDescription> = cluster_stats_gen
             .cluster_key_index
@@ -171,6 +178,7 @@ impl FuseTable {
                 sort_descs.clone(),
             )?))
         })?;
+
         let block_size = ctx.get_settings().get_max_block_size()? as usize;
         // construct output fields
         let output_fields: Vec<DataField> = cluster_stats_gen.out_fields.clone();
@@ -193,7 +201,7 @@ impl FuseTable {
             Ok(ProcessorPtr::create(TransformCompact::try_create(
                 transform_input_port,
                 transform_output_port,
-                BlockCompactor::new(block_compact_thresholds, true),
+                BlockCompactor::new(block_thresholds, true),
             )?))
         })?;
 
@@ -205,7 +213,7 @@ impl FuseTable {
                 self.operator.clone(),
                 self.meta_location_generator().clone(),
                 cluster_stats_gen.clone(),
-                block_compact_thresholds,
+                block_thresholds,
                 self.table_info.schema(),
                 None,
             )

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -265,7 +265,7 @@ impl Table for StageTable {
         ))
     }
 
-    fn get_block_compact_thresholds(&self) -> BlockThresholds {
+    fn get_block_thresholds(&self) -> BlockThresholds {
         let guard = self.block_compact_threshold.lock();
         (*guard).expect("must success")
     }

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -270,7 +270,7 @@ impl Table for StageTable {
         (*guard).expect("must success")
     }
 
-    fn set_block_compact_thresholds(&self, thresholds: BlockThresholds) {
+    fn set_block_thresholds(&self, thresholds: BlockThresholds) {
         let mut guard = self.block_compact_threshold.lock();
         (*guard) = Some(thresholds)
     }

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into
@@ -262,19 +262,6 @@ statement ok
 DROP TABLE test;
 
 
-#####################################
-# clustered table not supported yet #
-#####################################
-
-statement ok
-create table t_clustered(a int,b int) CLUSTER BY(a);
-
-statement error 4000
-replace into t_clustered(a, b) on(a) values(1,2);
-
-statement ok
-DROP TABLE t_clustered;
-
 ##############
 # from stage #
 ##############

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into
@@ -361,6 +361,34 @@ drop table test
 
 #####################
 
+statement ok
+CREATE TABLE test(a int, b int) cluster by(a+1, b)
+
+statement ok
+insert into test values(1, 1)
+
+statement ok
+insert into test values(2, 2), (3, 2)
+
+statement ok
+replace into test on(a) values(3, 3), (4, 4)
+
+query II
+select a, b FROM test order by a
+----
+1 1
+2 2
+3 3
+4 4
+
+query TIIFFT
+select * FROM clustering_information('db_09_0023','test')
+----
+((a + 1), b) 3 2 0.0 1.0 {"00001":3}
+
+statement ok
+DROP TABLE test
+
 
 statement ok
 DROP DATABASE db_09_0023


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support table with cluster key definition for Replace into statement

```
mysql> CREATE TABLE test(a int, b int) cluster by(a+1, b);
Query OK, 0 rows affected (0.05 sec)

mysql> insert into test values(1, 1);
Query OK, 1 row affected (0.05 sec)

mysql> insert into test values(2, 2), (3, 2);
Query OK, 2 rows affected (0.04 sec)

mysql> replace into test on(a) values(3, 3), (4, 4);
Query OK, 3 rows affected (0.05 sec)

mysql> select a, b FROM test order by a;
+------+------+
| a    | b    |
+------+------+
|    1 |    1 |
|    2 |    2 |
|    3 |    3 |
|    4 |    4 |
+------+------+
4 rows in set (0.03 sec)
Read 4 rows, 32.00 B in 0.008 sec., 503.64 rows/sec., 3.93 KiB/sec.

mysql> select * FROM clustering_information('default','test') ;
+-----------------+-------------------+----------------------------+------------------+---------------+-----------------------+
| cluster_by_keys | total_block_count | total_constant_block_count | average_overlaps | average_depth | block_depth_histogram |
+-----------------+-------------------+----------------------------+------------------+---------------+-----------------------+
| ((a + 1), b)    |                 3 |                          2 |              0.0 |           1.0 | {"00001":3}           |
+-----------------+-------------------+----------------------------+------------------+---------------+-----------------------+
1 row in set (0.04 sec)
Read 1 rows, 384.00 B in 0.028 sec., 36.32 rows/sec., 13.62 KiB/sec.
```

Closes #10371 
