### PR TITLE
refactor(meta-service): handle every error when joining into a cluster

### DIFF
--- a/src/binaries/meta/main.rs
+++ b/src/binaries/meta/main.rs
@@ -172,6 +172,7 @@ async fn main() -> anyhow::Result<()> {
 /// The meta service GRPC API address can be changed by administrator in the config file.
 ///
 /// Thus every time a meta server starts up, re-register the node info to broadcast its latest grpc address
+#[tracing::instrument(level = "info", skip_all)]
 async fn register_node(meta_node: &Arc<MetaNode>, conf: &Config) -> Result<(), anyhow::Error> {
     info!(
         "Register node to update raft_api_advertise_host_endpoint and grpc_api_advertise_address"

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -49,9 +49,8 @@ use crate::metrics::raft_metrics;
 use crate::store::ToStorageError;
 use crate::Opened;
 
-/// An storage implementing the `async_raft::RaftStorage` trait.
+/// This is the inner store that provides support utilities for implementing the raft storage API.
 ///
-/// It is the stateful part in a raft implementation.
 /// This store is backed by a sled db, contents are stored in 3 trees:
 ///   state:
 ///       id
@@ -165,8 +164,7 @@ impl StoreInner {
 
         info!("log compaction start");
 
-        // 1. Take a serialized snapshot
-
+        // Dump the data of a snapshot
         let (snap, last_applied_log, last_membership, snapshot_id) = {
             let sm = self.state_machine.clone();
 

--- a/src/meta/stoerr/src/meta_storage_errors.rs
+++ b/src/meta/stoerr/src/meta_storage_errors.rs
@@ -19,6 +19,7 @@ use sled::transaction::UnabortableTransactionError;
 
 use crate::MetaBytesError;
 
+/// Storage level error that is raised by meta service.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
 pub enum MetaStorageError {
     /// An error raised when encode/decode data to/from underlying storage.


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta-service): handle every error when joining into a cluster

Just do not give up too quickly, retry when leader is not ready or when
there are concurrent membership changes on going.

## Changelog







## Related Issues