### PR TITLE
chore: add openai http request timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6872,7 +6872,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 [[package]]
 name = "openai_api_rust"
 version = "0.1.4"
-source = "git+https://github.com/datafuse-extras/openai-api?rev=5f977a4#5f977a4382499758188db2982cc790cbde1190f4"
+source = "git+https://github.com/datafuse-extras/openai-api?rev=87a140c#87a140cb32a08f2a65c230d29d5e0f085f3ade4c"
 dependencies = [
  "log",
  "serde",

--- a/src/common/openai/Cargo.toml
+++ b/src/common/openai/Cargo.toml
@@ -21,6 +21,6 @@ common-exception = { path = "../exception" }
 # Crates.io dependencies
 log = "0.4"
 metrics = "0.20.1"
-openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "5f977a4" }
+openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "87a140c" }
 
 [dev-dependencies]

--- a/src/common/openai/src/completion.rs
+++ b/src/common/openai/src/completion.rs
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use std::time::Duration;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 use log::trace;
@@ -51,11 +53,12 @@ impl OpenAI {
                 organization: None,
             },
             &self.api_base,
+            Duration::from_secs(120),
         );
 
         let (max_tokens, stop) = match mode {
             CompletionMode::Sql => (Some(150), Some(vec!["#".to_string(), ";".to_string()])),
-            CompletionMode::Text => (Some(1024), None),
+            CompletionMode::Text => (Some(800), None),
         };
 
         let body = ChatBody {

--- a/src/common/openai/src/embedding.rs
+++ b/src/common/openai/src/embedding.rs
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use std::time::Duration;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 use openai_api_rust::embeddings::EmbeddingsApi;
@@ -31,6 +33,7 @@ impl OpenAI {
                 organization: None,
             },
             &self.api_base,
+            Duration::from_secs(120),
         );
         let body = EmbeddingsBody {
             model: self.embedding_model.to_string(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* add openai request timeout from 30s to 120s
* reduce the completion max token length from 1024 to 800

Closes #issue
