### PR TITLE
fix: fix purge test bugs

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/optimize.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/optimize.rs
@@ -24,12 +24,12 @@ use crate::storages::fuse::utils::do_purge_test;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fuse_snapshot_optimize_purge() -> Result<()> {
-    do_purge_test("explicit purge", "purge", 2, 0, 2, 2, 2).await
+    do_purge_test("test_fuse_snapshot_optimize_purge", 1, 0, 1, 1, 1).await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fuse_snapshot_optimize_all() -> Result<()> {
-    do_purge_test("explicit purge", "all", 2, 0, 2, 2, 2).await
+    do_purge_test("test_fuse_snapshot_optimize_all", 1, 0, 1, 1, 1).await
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/query/service/tests/it/storages/fuse/utils.rs
+++ b/src/query/service/tests/it/storages/fuse/utils.rs
@@ -13,14 +13,15 @@
 //  limitations under the License.
 
 use std::str;
+use std::sync::Arc;
 
 use common_exception::Result;
+use common_storages_fuse::FuseTable;
 use common_storages_fuse::TableContext;
 
 use super::table_test_fixture::append_sample_data;
 use super::table_test_fixture::append_sample_data_overwrite;
 use super::table_test_fixture::check_data_dir;
-use super::table_test_fixture::execute_command;
 use super::table_test_fixture::history_should_have_item;
 use super::table_test_fixture::TestFixture;
 
@@ -35,7 +36,6 @@ pub async fn do_insertions(fixture: &TestFixture) -> Result<()> {
 
 pub async fn do_purge_test(
     case_name: &str,
-    op: &str,
     snapshot_count: u32,
     table_statistic_count: u32,
     segment_count: u32,
@@ -43,9 +43,6 @@ pub async fn do_purge_test(
     index_count: u32,
 ) -> Result<()> {
     let fixture = TestFixture::new().await;
-    let db = fixture.default_db_name();
-    let tbl = fixture.default_table_name();
-    let qry = format!("optimize table {}.{} {}", db, tbl, op);
 
     // insert, and then insert overwrite (1 snapshot, 1 segment, 1 data block, 1 index block for each insertion);
     do_insertions(&fixture).await?;
@@ -54,9 +51,13 @@ pub async fn do_purge_test(
     append_sample_data_overwrite(1, true, &fixture).await?;
 
     // execute the query
-    let ctx = fixture.ctx();
-    ctx.get_settings().set_retention_period(0)?;
-    execute_command(ctx, &qry).await?;
+    let table = fixture.latest_default_table().await?;
+    let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+    let snapshot_files = fuse_table.list_snapshot_files().await?;
+    let table_ctx: Arc<dyn TableContext> = fixture.ctx();
+    fuse_table
+        .do_purge(&table_ctx, snapshot_files, true)
+        .await?;
 
     check_data_dir(
         &fixture,

--- a/src/query/storages/fuse/src/operations/navigate.rs
+++ b/src/query/storages/fuse/src/operations/navigate.rs
@@ -28,7 +28,6 @@ use opendal::Metakey;
 use storages_common_cache::LoadParams;
 use storages_common_table_meta::meta::TableSnapshot;
 use storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
-use tracing::error;
 use tracing::warn;
 
 use crate::io::MetaReaders;
@@ -143,43 +142,16 @@ impl FuseTable {
         instant: Option<NavigationPoint>,
     ) -> Result<(Arc<FuseTable>, Vec<String>)> {
         let retention = Duration::hours(ctx.get_settings().get_retention_period()? as i64);
-
-        let root_snapshot_location = match self.snapshot_loc().await? {
-            Some(root_snapshot_location) => root_snapshot_location,
-            None => {
-                return Err(ErrorCode::TableHistoricalDataNotFound(
-                    "No historical data found at given point",
-                ));
-            }
+        let root_snapshot = if let Some(snapshot) = self.read_table_snapshot().await? {
+            snapshot
+        } else {
+            return Err(ErrorCode::TableHistoricalDataNotFound(
+                "No historical data found at given point",
+            ));
         };
 
-        let op = self.operator.clone();
-        let meta = op.stat(&root_snapshot_location).await?;
-        let timestamp = match meta.mode() {
-            EntryMode::FILE => {
-                let modified = if let Some(modified) = meta.last_modified() {
-                    modified
-                } else {
-                    // since opendal cannot get last_modified time, use snapshot metadata instead
-                    if let Some(snapshot) = self.read_table_snapshot().await? {
-                        snapshot.timestamp.unwrap()
-                    } else {
-                        return Err(ErrorCode::TableHistoricalDataNotFound(
-                            "No historical data found at given point",
-                        ));
-                    }
-                };
-                modified
-            }
-            _ => {
-                error!("found not snapshot file in {:}", root_snapshot_location);
-                return Err(ErrorCode::TableHistoricalDataNotFound(
-                    "found not snapshot file",
-                ));
-            }
-        };
-
-        let mut time_point = timestamp - retention;
+        assert!(root_snapshot.timestamp.is_some());
+        let mut time_point = root_snapshot.timestamp.unwrap() - retention;
 
         let (location, files) = match instant {
             Some(NavigationPoint::TimePoint(point)) => {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: fix purge test bugs

bug reason: in function `navigate_for_purge` use `snapshot.timestamp` as purge timestamp, but in `list_files` use `last_modified` time to get file list, `last_modified` sometimes may bigger than `snapshot.timestamp`, so some files be ignored.

use `do_purge`  instead of sql.

Closes #issue
