### PR TITLE
refactor: table meta format_version

### DIFF
--- a/src/query/storages/common/table-meta/src/meta/v1/segment.rs
+++ b/src/query/storages/common/table-meta/src/meta/v1/segment.rs
@@ -32,7 +32,7 @@ use crate::meta::Versioned;
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SegmentInfo {
     /// format version
-    format_version: FormatVersion,
+    pub format_version: FormatVersion,
     /// blocks belong to this segment
     pub blocks: Vec<Arc<BlockMeta>>,
     /// summary statistics
@@ -107,10 +107,6 @@ impl SegmentInfo {
             summary,
         }
     }
-
-    pub fn format_version(&self) -> u64 {
-        self.format_version
-    }
 }
 
 use super::super::v0;
@@ -118,7 +114,8 @@ use super::super::v0;
 impl From<v0::SegmentInfo> for SegmentInfo {
     fn from(s: v0::SegmentInfo) -> Self {
         Self {
-            format_version: SegmentInfo::VERSION,
+            // the is no version before v0, and no versions other then 0 can be converted into v0
+            format_version: v0::SegmentInfo::VERSION,
             blocks: s
                 .blocks
                 .into_iter()

--- a/src/query/storages/common/table-meta/src/meta/v1/snapshot.rs
+++ b/src/query/storages/common/table-meta/src/meta/v1/snapshot.rs
@@ -31,7 +31,7 @@ use crate::meta::Versioned;
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TableSnapshot {
     /// format version of snapshot
-    format_version: FormatVersion,
+    pub format_version: FormatVersion,
 
     /// id of snapshot
     pub snapshot_id: SnapshotId,
@@ -118,7 +118,8 @@ use super::super::v0;
 impl From<v0::TableSnapshot> for TableSnapshot {
     fn from(s: v0::TableSnapshot) -> Self {
         Self {
-            format_version: TableSnapshot::VERSION,
+            // the is no version before v0, and no versions other then 0 can be converted into v0
+            format_version: v0::TableSnapshot::VERSION,
             snapshot_id: s.snapshot_id,
             timestamp: None,
             prev_snapshot_id: s.prev_snapshot_id.map(|id| (id, 0)),
@@ -150,6 +151,8 @@ pub struct TableSnapshotLite {
 impl From<&TableSnapshot> for TableSnapshotLite {
     fn from(value: &TableSnapshot) -> Self {
         TableSnapshotLite {
+            // NOTE: it is important to let the format_version return from here
+            // carries the format_version of snapshot being converted.
             format_version: value.format_version(),
             snapshot_id: value.snapshot_id,
             timestamp: value.timestamp,

--- a/src/query/storages/common/table-meta/src/meta/v1/table_snapshot_statistics.rs
+++ b/src/query/storages/common/table-meta/src/meta/v1/table_snapshot_statistics.rs
@@ -25,7 +25,7 @@ use crate::meta::Versioned;
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TableSnapshotStatistics {
     /// format version of snapshot
-    format_version: FormatVersion,
+    pub format_version: FormatVersion,
 
     /// id of snapshot
     pub snapshot_id: SnapshotId,

--- a/src/query/storages/common/table-meta/src/meta/v2/segment.rs
+++ b/src/query/storages/common/table-meta/src/meta/v2/segment.rs
@@ -37,7 +37,7 @@ use crate::meta::Versioned;
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SegmentInfo {
     /// format version
-    format_version: FormatVersion,
+    pub format_version: FormatVersion,
     /// blocks belong to this segment
     pub blocks: Vec<Arc<BlockMeta>>,
     /// summary statistics
@@ -52,11 +52,6 @@ impl SegmentInfo {
             blocks,
             summary,
         }
-    }
-
-    #[inline]
-    pub fn version(&self) -> FormatVersion {
-        self.format_version
     }
 }
 
@@ -117,7 +112,8 @@ impl SegmentInfo {
     pub fn from_v0(s: v0::SegmentInfo, fields: &[TableField]) -> Self {
         let summary = Statistics::from_v0(s.summary, fields);
         Self {
-            format_version: SegmentInfo::VERSION,
+            // the is no version before v0, and no versions other then 0 can be converted into v0
+            format_version: v0::SegmentInfo::VERSION,
             blocks: s
                 .blocks
                 .into_iter()
@@ -130,7 +126,9 @@ impl SegmentInfo {
     pub fn from_v1(s: v1::SegmentInfo, fields: &[TableField]) -> Self {
         let summary = Statistics::from_v0(s.summary, fields);
         Self {
-            format_version: SegmentInfo::VERSION,
+            // NOTE: it is important to let the format_version return from here
+            // carries the format_version of segment info being converted.
+            format_version: s.format_version,
             blocks: s
                 .blocks
                 .into_iter()

--- a/src/query/storages/common/table-meta/src/meta/v2/snapshot.rs
+++ b/src/query/storages/common/table-meta/src/meta/v2/snapshot.rs
@@ -33,7 +33,7 @@ use crate::meta::Versioned;
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TableSnapshot {
     /// format version of snapshot
-    format_version: FormatVersion,
+    pub format_version: FormatVersion,
 
     /// id of snapshot
     pub snapshot_id: SnapshotId,
@@ -103,7 +103,8 @@ impl From<v0::TableSnapshot> for TableSnapshot {
         let leaf_fields = schema.leaf_fields();
         let summary = Statistics::from_v0(s.summary, &leaf_fields);
         Self {
-            format_version: TableSnapshot::VERSION,
+            // the is no version before v0, and no versions other then 0 can be converted into v0
+            format_version: v0::TableSnapshot::VERSION,
             snapshot_id: s.snapshot_id,
             timestamp: None,
             prev_snapshot_id: s.prev_snapshot_id.map(|id| (id, 0)),
@@ -123,7 +124,9 @@ impl From<v1::TableSnapshot> for TableSnapshot {
         let leaf_fields = schema.leaf_fields();
         let summary = Statistics::from_v0(s.summary, &leaf_fields);
         Self {
-            format_version: TableSnapshot::VERSION,
+            // NOTE: it is important to let the format_version return from here
+            // carries the format_version of snapshot being converted.
+            format_version: s.format_version,
             snapshot_id: s.snapshot_id,
             timestamp: None,
             prev_snapshot_id: s.prev_snapshot_id,

--- a/src/query/storages/common/table-meta/src/meta/v3/snapshot.rs
+++ b/src/query/storages/common/table-meta/src/meta/v3/snapshot.rs
@@ -39,8 +39,21 @@ use crate::meta::Versioned;
 /// The structure of the segment is the same as that of v2, but the serialization and deserialization methods are different
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TableSnapshot {
-    /// format version of snapshot
-    format_version: FormatVersion,
+    /// format version of TableSnapshot meta data
+    ///
+    /// Note that:
+    ///
+    /// - A instance of v3::TableSnapshot may have a value of v2/v1::TableSnapshot::VERSION for this field.
+    ///
+    ///   That indicates this instance is converted from a v2/v1::TableSnapshot.
+    ///
+    /// - The meta writers are responsible for only writing down the latest version of TableSnapshot, and
+    /// the format_version being written is of the latest version.
+    ///
+    ///   e.g. if the current version of TableSnapshot is v3::TableSnapshot, then the format_version
+    ///   that will be written down to object storage as part of TableSnapshot table meta data,
+    ///   should always be v3::TableSnapshot::VERSION (which is 3)
+    pub format_version: FormatVersion,
 
     /// id of snapshot
     pub snapshot_id: SnapshotId,
@@ -154,10 +167,6 @@ impl TableSnapshot {
         Encoding::default()
     }
 
-    pub fn format_version(&self) -> u64 {
-        self.format_version
-    }
-
     pub fn build_segment_id_map(&self) -> HashMap<String, usize> {
         let segment_count = self.segments.len();
         let mut segment_id_map = HashMap::new();
@@ -171,7 +180,9 @@ impl TableSnapshot {
 impl From<v2::TableSnapshot> for TableSnapshot {
     fn from(s: v2::TableSnapshot) -> Self {
         Self {
-            format_version: TableSnapshot::VERSION,
+            // NOTE: it is important to let the format_version return from here
+            // carries the format_version of snapshot being converted.
+            format_version: s.format_version,
             snapshot_id: s.snapshot_id,
             timestamp: s.timestamp,
             prev_snapshot_id: s.prev_snapshot_id,

--- a/src/query/storages/fuse/src/io/write/meta_writer.rs
+++ b/src/query/storages/fuse/src/io/write/meta_writer.rs
@@ -21,6 +21,7 @@ use storages_common_cache_manager::CachedObject;
 use storages_common_table_meta::meta::SegmentInfo;
 use storages_common_table_meta::meta::TableSnapshot;
 use storages_common_table_meta::meta::TableSnapshotStatistics;
+use storages_common_table_meta::meta::Versioned;
 
 #[async_trait::async_trait]
 pub trait MetaWriter<T> {
@@ -75,19 +76,102 @@ trait Marshal {
 
 impl Marshal for SegmentInfo {
     fn marshal(&self) -> Result<Vec<u8>> {
+        // make sure the table meta we write down to object store always has the current version
+        // can we expressed as type constraint?
+        assert_eq!(self.format_version, SegmentInfo::VERSION);
         self.to_bytes()
     }
 }
 
 impl Marshal for TableSnapshot {
     fn marshal(&self) -> Result<Vec<u8>> {
+        // make sure the table meta we write down to object store always has the current version
+        // can not by expressed as type constraint yet.
+        assert_eq!(self.format_version, TableSnapshot::VERSION);
         self.to_bytes()
     }
 }
 
 impl Marshal for TableSnapshotStatistics {
     fn marshal(&self) -> Result<Vec<u8>> {
+        // make sure the table meta we write down to object store always has the current version
+        // can we expressed as type constraint?
+        assert_eq!(self.format_version, TableSnapshotStatistics::VERSION);
         let bytes = serde_json::to_vec(self)?;
         Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::panic::catch_unwind;
+
+    use common_expression::TableSchema;
+    use storages_common_table_meta::meta::SnapshotId;
+    use storages_common_table_meta::meta::Statistics;
+
+    use super::*;
+
+    #[test]
+    fn test_segment_format_version_validation() {
+        // old versions are not allowed (runtime panics)
+        for v in 0..SegmentInfo::VERSION {
+            let r = catch_unwind(|| {
+                let mut segment = SegmentInfo::new(vec![], Statistics::default());
+                segment.format_version = v;
+                let _ = segment.marshal();
+            });
+            assert!(r.is_err())
+        }
+
+        // current version allowed
+        let segment = SegmentInfo::new(vec![], Statistics::default());
+        segment.marshal().unwrap();
+    }
+
+    #[test]
+    fn test_snapshot_format_version_validation() {
+        // old versions are not allowed (runtime panics)
+        for v in 0..TableSnapshot::VERSION {
+            let r = catch_unwind(|| {
+                let mut snapshot = TableSnapshot::new(
+                    SnapshotId::new_v4(),
+                    &None,
+                    None,
+                    TableSchema::default(),
+                    Statistics::default(),
+                    vec![],
+                    None,
+                    None,
+                );
+                snapshot.format_version = v;
+                let _ = snapshot.marshal();
+            });
+            assert!(r.is_err())
+        }
+
+        // current version allowed
+        let snapshot = TableSnapshot::new(
+            SnapshotId::new_v4(),
+            &None,
+            None,
+            TableSchema::default(),
+            Statistics::default(),
+            vec![],
+            None,
+            None,
+        );
+        snapshot.marshal().unwrap();
+    }
+
+    #[test]
+    fn test_table_snapshot_statistics_format_version_validation() {
+        // since there is only one version for TableSnapshotStatistics,
+        // we omit the checking of invalid format versions, otherwise clippy will complain about empty_ranges
+
+        // current version allowed
+        let snapshot_stats = TableSnapshotStatistics::new(HashMap::new());
+        snapshot_stats.marshal().unwrap();
     }
 }

--- a/src/query/storages/fuse/src/operations/read/fuse_row_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_row_fetcher.rs
@@ -178,7 +178,7 @@ where F: RowFetcher + Send + Sync + 'static
                 .read(&LoadParams {
                     location: location.clone(),
                     len_hint: None,
-                    ver: snapshot.format_version(),
+                    ver: snapshot.format_version, // TODO this is buggy, should use segment version
                     put_cache: true,
                 })
                 .await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

as suggest by @zhyass (and @sundy-li @jun0315 )

https://github.com/datafuselabs/databend/pull/11015#discussion_r1171167453

we should consider allowing the value of `format_version` to be different from the Version number of the given table meta type.

let's take the current version of SegmentInfo for example:
~~~
impl Versioned<3> for v3::SegmentInfo {}
~~~

we allow that  a instance of  v3::SegementInfo `v3_seg: v3::SegmentInfo`,  has a value 2  `format_version` field. which indicates that this instance is converted from `v2::SegmentInfo`.

for the writing part, to ensure that only the current version of table meta are used:

or put it more specific way,  if `vn::SegemntInfo` is being persistent to object storage, the `format_version` that being put into the object, must be `n`

- The table meta writer only accepts the concrete types of table meta, and only the current versions of table meta types.
- At runtime, before the table meta is persistent to object storage, we check(assert) that, the value `format_version` field is as expected, i.e. for v3 table meta types, the format_version should always be 3

(if we could express these constraints by the rust's type systems, that will be better)


also this PR fixes issue #11204 (test cases will be submit in another PR)

Closes #11204
