### PR TITLE
chore: more  test cases of fuse compat

### DIFF
--- a/tests/fuse-compat/compat-logictest/01_meta_compression/fuse_compat_write
+++ b/tests/fuse-compat/compat-logictest/01_meta_compression/fuse_compat_write
@@ -1,4 +1,7 @@
-# prepare the data for logic test
+###################################
+# prepare the data for logic test #
+###################################
+
 
 statement ok
 DROP TABLE IF EXISTS fuse_test_snapshots;
@@ -16,8 +19,9 @@ INSERT INTO fuse_test_snapshots VALUES(2);
 statement ok
 INSERT INTO fuse_test_snapshots VALUES(3);
 
-
-# prepare the data for stateless test
+#######################################
+# prepare the data for stateless test #
+#######################################
 #
 # TODO (refine compat test)
 #
@@ -48,3 +52,22 @@ INSERT INTO fuse_test_flashback VALUES(2);
 
 statement ok
 INSERT INTO fuse_test_flashback VALUES(3);
+
+########################################
+# prepare the data for compaction test #
+#  issue 11204                         #
+########################################
+
+statement ok
+DROP TABLE IF EXISTS fuse_test_compaction;
+
+statement ok
+CREATE TABLE fuse_test_compaction( c int);
+
+# prepare 3 blocks and segments
+statement ok
+INSERT INTO fuse_test_compaction VALUES(1);
+
+statement ok
+INSERT INTO fuse_test_compaction VALUES(2);
+

--- a/tests/fuse-compat/compat-stateless/01_flashback/01_0001_across_versions.result
+++ b/tests/fuse-compat/compat-stateless/01_flashback/01_0001_across_versions.result
@@ -1,4 +1,5 @@
-checking that 3 snapshots exit
+suite: flashback across version boundary
+checking that 3 snapshots exist
 3
 checking that 5 snapshot exist
 5
@@ -16,3 +17,20 @@ checking that after flashback to the 4th last snapshot s2 which is of version 2,
 2
 checking that after flashback to the 5th last snapshot s1 which is of version 2, the table contains {1}
 1
+suite: test compaction & fuse_snapshot across version boundary
+checking that 2 snapshots of version 2 exist
+2	2
+doing compact
+checking that after compaction the table still contains {1,2}
+1
+2
+checking that after compaction, 2 snapshots of version 2, and 1 snapshot of version 3 exist
+1	3
+2	2
+checking the version and location of snapshots s2 is correct
+1	1
+checking that flashback works as expected (to s2)
+1	1
+checking that after flashback to s2,  the table contains {1,2}
+1
+2

--- a/tests/fuse-compat/compat-stateless/01_flashback/01_0001_across_versions.sh
+++ b/tests/fuse-compat/compat-stateless/01_flashback/01_0001_across_versions.sh
@@ -6,11 +6,17 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # this case is supposed to run with the current version of query,
 # after fuse-compat/compat-logictest/01_meta_compression/ been run with the old version of query
 
+##########################################
+# test flashback across version boundary #
+##########################################
+
+echo "suite: flashback across version boundary"
 # current situation:
 # - we have inserted 3 rows into fuse_test_flashback, which produced 3 snapshots
 # - and the content of the table is {1,2,3}
 
-echo "checking that 3 snapshots exit"
+
+echo "checking that 3 snapshots exist"
 echo "select count(*)  from fuse_snapshot('default', 'fuse_test_flashback')" | $MYSQL_CLIENT_CONNECT
 
 # write down 2 new rows using current version
@@ -50,3 +56,49 @@ echo "alter table fuse_test_flashback flashback to (snapshot => '$FST_SNAPSHOT_I
 
 echo "checking that after flashback to the 5th last snapshot s1 which is of version 2, the table contains {1}"
 echo "select c  from fuse_test_flashback order by c" | $MYSQL_CLIENT_CONNECT
+
+###########################################################
+# test compaction & fuse_snapshot across version boundary #
+# issue 11204                                             #
+###########################################################
+
+echo "suite: test compaction & fuse_snapshot across version boundary"
+
+# current situation:
+# - we have inserted 2 rows into fuse_test_compaction, which produced 2 snapshots
+# - the content of the table is {1,2}
+# - the snapshots are s1 {1}, s2 {1,2}
+
+
+echo "checking that 2 snapshots of version 2 exist"
+echo "select count() c, format_version v from fuse_snapshot('default', 'fuse_test_compaction') group by v order by c" | $MYSQL_CLIENT_CONNECT
+
+# grab the current last snapshot (s2)
+FST_SNAPSHOT_S2_ID=$(echo "select snapshot_id from fuse_snapshot('default','fuse_test_compaction') limit 1" | $MYSQL_CLIENT_CONNECT)
+# grab s2's location
+FST_SNAPSHOT_S2_ID_LOC=$(echo "select snapshot_location from fuse_snapshot('default','fuse_test_compaction') limit 1" | $MYSQL_CLIENT_CONNECT)
+
+# compact the table
+echo "doing compact"
+echo "optimize table fuse_test_compaction compact" | $MYSQL_CLIENT_CONNECT
+
+# verify the following cases:
+
+echo "checking that after compaction the table still contains {1,2}"
+echo "select c from fuse_test_compaction order by c" | $MYSQL_CLIENT_CONNECT
+
+echo "checking that after compaction, 2 snapshots of version 2, and 1 snapshot of version 3 exist"
+echo "select count() c, format_version v from fuse_snapshot('default', 'fuse_test_compaction') group by v order by c " | $MYSQL_CLIENT_CONNECT
+
+echo "checking the version and location of snapshots s2 is correct"
+echo "select snapshot_location='${FST_SNAPSHOT_S2_ID_LOC}', format_version=2 from fuse_snapshot('default', 'fuse_test_compaction') where snapshot_id='$FST_SNAPSHOT_S2_ID'" | $MYSQL_CLIENT_CONNECT
+
+# flash back to s2
+echo "alter table fuse_test_compaction flashback to (snapshot => '$FST_SNAPSHOT_S2_ID')" | $MYSQL_CLIENT_CONNECT
+echo "checking that flashback works as expected (to s2)"
+echo "select snapshot_location='${FST_SNAPSHOT_S2_ID_LOC}', format_version=2 from fuse_snapshot('default', 'fuse_test_compaction') limit 1" | $MYSQL_CLIENT_CONNECT
+
+echo "checking that after flashback to s2,  the table contains {1,2}"
+echo "select c  from fuse_test_compaction order by c" | $MYSQL_CLIENT_CONNECT
+
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- more fuse compact test cases
- test cases for issue #11204 

which verifies that table of old table metadata, after compaction, the history showed by `fuse_snapshot` is correct, and can be flashedback to. 

Closes #issue
