### PR TITLE
fix: permission error on DROP USER with account_admin

### DIFF
--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -84,9 +84,6 @@ impl AuthMgr {
                 let tenant = session.get_current_tenant();
                 let identity = UserIdentity::new(&user_name, "%");
 
-                // ensure the builtin roles like ACCOUNT_ADMIN, PUBLIC exists
-                user_api.ensure_builtin_roles(&tenant).await?;
-
                 // create a new user for this identity if not exists
                 let user = match user_api.get_user(&tenant, identity.clone()).await {
                     Ok(user_info) => match user_info.auth_info {

--- a/src/query/service/src/interpreters/interpreter_role_create.rs
+++ b/src/query/service/src/interpreters/interpreter_role_create.rs
@@ -50,7 +50,6 @@ impl Interpreter for CreateRoleInterpreter {
         let plan = self.plan.clone();
         let tenant = self.ctx.get_tenant();
         let user_mgr = UserApiProvider::instance();
-        user_mgr.ensure_builtin_roles(&tenant).await?;
         user_mgr
             .add_role(&tenant, RoleInfo::new(&plan.role_name), plan.if_not_exists)
             .await?;

--- a/src/query/service/src/interpreters/interpreter_user_create.rs
+++ b/src/query/service/src/interpreters/interpreter_user_create.rs
@@ -53,7 +53,6 @@ impl Interpreter for CreateUserInterpreter {
         let tenant = self.ctx.get_tenant();
 
         let user_mgr = UserApiProvider::instance();
-        user_mgr.ensure_builtin_roles(&tenant).await?;
         let users = user_mgr.get_users(&tenant).await?;
 
         let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -323,9 +323,10 @@ impl Session {
         }
 
         Err(ErrorCode::PermissionDenied(format!(
-            "Permission denied, user {} requires {:?} privilege on {}",
-            &current_user.identity(),
+            "Permission denied, privilege {:?} is required on {} for user {} with role {}",
             privilege.clone(),
+            &current_user.identity(),
+            &current_role.identity(),
             object
         )))
     }

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -131,29 +131,6 @@ impl UserApiProvider {
     }
 
     #[async_backtrace::framed]
-    pub async fn ensure_builtin_roles(&self, tenant: &str) -> Result<()> {
-        let mut account_admin = RoleInfo::new(BUILTIN_ROLE_ACCOUNT_ADMIN);
-        account_admin.grants.grant_privileges(
-            &GrantObject::Global,
-            UserPrivilegeSet::available_privileges_on_global(),
-        );
-        self.add_role(tenant, account_admin, true).await?;
-
-        let mut public = RoleInfo::new(BUILTIN_ROLE_PUBLIC);
-        public.grants.grant_privileges(
-            &GrantObject::Table(
-                "default".to_string(),
-                "system".to_string(),
-                "one".to_string(),
-            ),
-            UserPrivilegeType::Select.into(),
-        );
-        self.add_role(tenant, public, true).await?;
-
-        Ok(())
-    }
-
-    #[async_backtrace::framed]
     pub async fn grant_privileges_to_role(
         &self,
         tenant: &str,

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -57,9 +57,6 @@ impl UserApiProvider {
         quota: Option<TenantQuota>,
     ) -> Result<()> {
         GlobalInstance::set(Self::try_create(conf, idm_config).await?);
-        UserApiProvider::instance()
-            .ensure_builtin_roles(tenant)
-            .await?;
         if let Some(q) = quota {
             let i = UserApiProvider::instance().get_tenant_quota_api_client(tenant)?;
             let res = i.get_quota(MatchSeq::GE(0)).await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The role `account_admin` is considered contains ALL the privileges by default. But this role is only initialized once on the initialization phase, after when any new privilege got added, the newly added privilege can not be included in `account_admin`.

This PR tries to make the builtin roles actually fake roles, which only produced on `get_role()` and `get_roles()`. This may also reduce some burden to management work about the builtin-roles.
