### PR TITLE
refactor: refactor order by clause analyzing and binding.

### DIFF
--- a/src/query/catalog/src/plan/pushdown.rs
+++ b/src/query/catalog/src/plan/pushdown.rs
@@ -121,7 +121,7 @@ impl PushDownInfo {
 
             if let RemoteExpr::<String>::ColumnRef { id, .. } = &order.0 {
                 // TODO: support sub column of nested type.
-                let field = schema.field_with_name(id).unwrap();
+                let field = schema.field_with_name(id).ok()?;
                 if !support(&field.data_type().into()) {
                     return None;
                 }

--- a/src/query/sql/src/planner/binder/bind_context.rs
+++ b/src/query/sql/src/planner/binder/bind_context.rs
@@ -264,6 +264,7 @@ impl BindContext {
         column: &str,
         span: Span,
         available_aliases: &[(String, ScalarExpr)],
+        allow_ambiguous: bool,
     ) -> Result<NameResolutionResult> {
         let mut result = vec![];
 
@@ -316,7 +317,7 @@ impl BindContext {
 
         if result.is_empty() {
             Err(ErrorCode::SemanticError(format!("column {column} doesn't exist")).set_span(span))
-        } else if result.len() > 1 {
+        } else if result.len() > 1 && !allow_ambiguous {
             Err(ErrorCode::SemanticError(format!(
                 "column {column} reference is ambiguous, got {result:?}"
             ))

--- a/src/query/sql/src/planner/binder/scalar.rs
+++ b/src/query/sql/src/planner/binder/scalar.rs
@@ -33,6 +33,7 @@ pub struct ScalarBinder<'a> {
     name_resolution_ctx: &'a NameResolutionContext,
     metadata: MetadataRef,
     aliases: &'a [(String, ScalarExpr)],
+    allow_ambiguous: bool,
 }
 
 impl<'a> ScalarBinder<'a> {
@@ -49,7 +50,12 @@ impl<'a> ScalarBinder<'a> {
             name_resolution_ctx,
             metadata,
             aliases,
+            allow_ambiguous: false,
         }
+    }
+
+    pub fn allow_ambiguity(&mut self) {
+        self.allow_ambiguous = true;
     }
 
     #[async_backtrace::framed]
@@ -60,6 +66,7 @@ impl<'a> ScalarBinder<'a> {
             self.name_resolution_ctx,
             self.metadata.clone(),
             self.aliases,
+            self.allow_ambiguous,
         );
         Ok(*type_checker.resolve(expr).await?)
     }

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -173,6 +173,7 @@ impl Binder {
             .analyze_order_items(
                 &mut from_context,
                 &mut scalar_items,
+                &select_list,
                 &projections,
                 order_by,
                 stmt.distinct,

--- a/src/query/sql/src/planner/binder/setting.rs
+++ b/src/query/sql/src/planner/binder/setting.rs
@@ -46,6 +46,7 @@ impl Binder {
             &self.name_resolution_ctx,
             self.metadata.clone(),
             &[],
+            false,
         );
         let variable = variable.name.clone();
 

--- a/src/query/sql/src/planner/binder/sort.rs
+++ b/src/query/sql/src/planner/binder/sort.rs
@@ -115,6 +115,7 @@ impl Binder {
                         self.metadata.clone(),
                         &aliases,
                     );
+                    scalar_binder.allow_ambiguity();
                     let (bound_expr, _) = scalar_binder.bind(&order.expr).await?;
 
                     if let Some((idx, (alias, _))) = aliases

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -759,6 +759,7 @@ impl Binder {
                     &self.name_resolution_ctx,
                     self.metadata.clone(),
                     &[],
+                    false,
                 );
                 let box (scalar, _) = type_checker.resolve(expr).await?;
                 let scalar_expr = scalar.as_expr_with_col_name()?;

--- a/src/query/sql/src/planner/expression_parser.rs
+++ b/src/query/sql/src/planner/expression_parser.rs
@@ -93,8 +93,14 @@ pub fn parse_exprs(
     }
 
     let name_resolution_ctx = NameResolutionContext::try_from(settings.as_ref())?;
-    let mut type_checker =
-        TypeChecker::new(&mut bind_context, ctx, &name_resolution_ctx, metadata, &[]);
+    let mut type_checker = TypeChecker::new(
+        &mut bind_context,
+        ctx,
+        &name_resolution_ctx,
+        metadata,
+        &[],
+        false,
+    );
 
     let sql_dialect = Dialect::MySQL;
     let tokens = tokenize_sql(sql)?;

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -118,6 +118,8 @@ pub struct TypeChecker<'a> {
     // true if current expr is inside an window function.
     // This is used to allow aggregation function in window's aggregate function.
     in_window_function: bool,
+
+    allow_ambiguous: bool,
 }
 
 impl<'a> TypeChecker<'a> {
@@ -127,6 +129,7 @@ impl<'a> TypeChecker<'a> {
         name_resolution_ctx: &'a NameResolutionContext,
         metadata: MetadataRef,
         aliases: &'a [(String, ScalarExpr)],
+        allow_ambiguous: bool,
     ) -> Self {
         let func_ctx = ctx.get_function_context().unwrap();
         Self {
@@ -138,6 +141,7 @@ impl<'a> TypeChecker<'a> {
             aliases,
             in_aggregate_function: false,
             in_window_function: false,
+            allow_ambiguous,
         }
     }
 
@@ -185,6 +189,7 @@ impl<'a> TypeChecker<'a> {
                     column.as_str(),
                     ident.span,
                     self.aliases,
+                    self.allow_ambiguous,
                 )?;
                 let (scalar, data_type) = match result {
                     NameResolutionResult::Column(column) => {
@@ -2434,6 +2439,7 @@ impl<'a> TypeChecker<'a> {
             inner_column_name.as_str(),
             span,
             self.aliases,
+            self.allow_ambiguous,
         ) {
             Ok(result) => {
                 let (scalar, data_type) = match result {

--- a/tests/sqllogictests/suites/base/03_common/03_0004_select_order_by_db_table_col
+++ b/tests/sqllogictests/suites/base/03_common/03_0004_select_order_by_db_table_col
@@ -43,11 +43,8 @@ SELECT DISTINCT(id) FROM a.t ORDER BY a.t.id2
 statement error
 SELECT SUM(id) as id2 FROM a.t ORDER BY a.t.id2
 
-query I
+statement error 1065
 SELECT DISTINCT(id) as id2 FROM a.t ORDER BY a.t.id2
-----
-1
-2
 
 query II
 SELECT * FROM a.t ORDER BY a.t.id ASC


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. Refactor: simplify the logic of `analyze_order_items`.
2. Improvement: If a select item is the same with an order by item, their indices allocated by the binder will be the same.

The point 2. brings two benefits:

1. A simple common expression elimination

```sql
-- this PR:
mysql> explain select salary+1 as a from empsalary order by salary+1;
+------------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                      |
+------------------------------------------------------------------------------------------------------------------------------+
| Sort                                                                                                                         |
| ├── sort keys: [a ASC NULLS LAST]                                                                                            |
| ├── estimated rows: 10.00                                                                                                    |
| └── EvalScalar                                                                                                               |
|     ├── expressions: [empsalary.salary (#2) + 1]                                                                             |
|     ├── estimated rows: 10.00                                                                                                |
|     └── TableScan                                                                                                            |
|         ├── table: default.default.empsalary                                                                                 |
|         ├── read rows: 10                                                                                                    |
|         ├── read bytes: 71                                                                                                   |
|         ├── partitions total: 1                                                                                              |
|         ├── partitions scanned: 1                                                                                            |
|         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]       |
|         ├── push downs: [filters: [], limit: NONE]                                                                           |
|         ├── output columns: [salary]                                                                                         |
|         └── estimated rows: 10.00                                                                                            |
+------------------------------------------------------------------------------------------------------------------------------+

-- before:
mysql> explain select salary+1 as a from empsalary order by salary+1;
+----------------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                          |
+----------------------------------------------------------------------------------------------------------------------------------+
| EvalScalar                                                                                                                       |
| ├── expressions: [empsalary.salary (#2) + 1]                                                                                     |
| ├── estimated rows: 10.00                                                                                                        |
| └── Sort                                                                                                                         |
|     ├── sort keys: [(salary + 1) ASC NULLS LAST]                                                                                 |
|     ├── estimated rows: 10.00                                                                                                    |
|     └── EvalScalar                                                                                                               |
|         ├── expressions: [empsalary.salary (#2) + 1]                                                                             |
|         ├── estimated rows: 10.00                                                                                                |
|         └── TableScan                                                                                                            |
|             ├── table: default.default.empsalary                                                                                 |
|             ├── read rows: 10                                                                                                    |
|             ├── read bytes: 71                                                                                                   |
|             ├── partitions total: 1                                                                                              |
|             ├── partitions scanned: 1                                                                                            |
|             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]       |
|             ├── push downs: [filters: [], limit: NONE]                                                                           |
|             ├── output columns: [salary]                                                                                         |
|             └── estimated rows: 10.00                                                                                            |
+----------------------------------------------------------------------------------------------------------------------------------+
```

2. Fix: distinct can be used for a complex expression.

```sql
-- this PR
mysql> select distinct salary+1 from empsalary order by salary+1;
+--------------+
| (salary + 1) |
+--------------+
|         3501 |
|         3901 |
|         4201 |
|         4501 |
|         4801 |
|         5001 |
|         5201 |
|         6001 |
+--------------+

-- before
mysql> select distinct salary+1 from empsalary order by salary+1;
ERROR 1105 (HY000): Code: 1006, Text = Unable to get field named "5". Valid fields: ["4"].
```