### PR TITLE
chore(ci): use larger runner for build aarch64 musl

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -20,19 +20,21 @@ queue_rules:
       - check-success=test_stateful_standalone
       - check-success=test_stateful_cluster
       # sqllogic standalone tests
-      - check-success=test_sqllogic_standalone_base
-      - check-success=test_sqllogic_standalone_query
-      - check-success=test_sqllogic_standalone_standalone
-      - check-success=test_sqllogic_standalone_ydb
-      - check-success=test_sqllogic_standalone_crdb
-      - check-success=test_sqllogic_standalone_duckdb
+      - check-success=sqllogic_standalone_base_parquet
+      - check-success=sqllogic_standalone_base_native
+      - check-success=sqllogic_standalone_ydb_parquet
+      - check-success=sqllogic_standalone_ydb_native
+      - check-success=sqllogic_standalone_query
+      - check-success=sqllogic_standalone_standalone
+      - check-success=sqllogic_standalone_crdb
+      - check-success=sqllogic_standalone_duckdb
       # sqllogic cluster tests
-      - check-success=test_sqllogic_cluster_base
-      - check-success=test_sqllogic_cluster_query
-      - check-success=test_sqllogic_cluster_cluster
-      - check-success=test_sqllogic_cluster_ydb
-      - check-success=test_sqllogic_cluster_crdb
-      - check-success=test_sqllogic_cluster_duckdb
+      - check-success=sqllogic_cluster_base
+      - check-success=sqllogic_cluster_query
+      - check-success=sqllogic_cluster_cluster
+      - check-success=sqllogic_cluster_ydb
+      - check-success=sqllogic_cluster_crdb
+      - check-success=sqllogic_cluster_duckdb
 
   - name: docs_queue
     merge_method: squash

--- a/.github/workflows/dev-linux.yml
+++ b/.github/workflows/dev-linux.yml
@@ -62,7 +62,7 @@ jobs:
   build_other:
     timeout-minutes: 30
     name: build_${{ matrix.arch }}_${{ matrix.libc }}
-    runs-on: [self-hosted, X64, Linux, 8c16g]
+    runs-on: [self-hosted, X64, Linux, 16c32g]
     strategy:
       matrix:
         include:
@@ -150,8 +150,8 @@ jobs:
       - uses: ./.github/actions/test_meta_cluster
         timeout-minutes: 10
 
-  test_sqllogic_standalone:
-    name: test_sqllogic_standalone_${{ matrix.dirs }}
+  sqllogic_standalone:
+    name: sqllogic_standalone_${{ matrix.dirs }}
     runs-on: [self-hosted, X64, Linux, 4c8g]
     needs: build
     strategy:
@@ -177,8 +177,8 @@ jobs:
         with:
           name: test-sqllogic-standalone-${{ matrix.handlers }}-${{ matrix.dirs }}
 
-  test_sqllogic_standalone_with_native:
-    name: test_sqllogic_standalone_${{ matrix.dirs }}_${{ matrix.format }}
+  sqllogic_standalone_with_native:
+    name: sqllogic_standalone_${{ matrix.dirs }}_${{ matrix.format }}
     runs-on: [self-hosted, X64, Linux, 4c8g]
     needs: build
     strategy:
@@ -205,10 +205,9 @@ jobs:
         with:
           name: test-sqllogic-standalone-${{ matrix.handlers }}-${{ matrix.dirs }}_${{ matrix.format }}
 
-
-  test_sqllogic_management_mode:
+  sqllogic_management_mode:
     timeout-minutes: 30
-    name: test_sqllogic_${{ matrix.dirs }}
+    name: sqllogic_${{ matrix.dirs }}
     runs-on: [self-hosted, X64, Linux, 4c8g]
     needs: build
     strategy:
@@ -224,8 +223,8 @@ jobs:
           dirs: ${{ matrix.dirs }}
           handlers: ${{ matrix.handlers }}
 
-  test_sqllogic_cluster:
-    name: test_sqllogic_cluster_${{ matrix.dirs }}
+  sqllogic_cluster:
+    name: sqllogic_cluster_${{ matrix.dirs }}
     runs-on: [self-hosted, X64, Linux, 4c8g]
     needs: build
     strategy:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Closes #issue
