### PR TITLE
fix: page reader should use num_values of chunk.

### DIFF
--- a/src/query/storages/parquet/src/parquet_part.rs
+++ b/src/query/storages/parquet/src/parquet_part.rs
@@ -32,6 +32,7 @@ use common_expression::Scalar;
 pub struct ColumnMeta {
     pub offset: u64,
     pub length: u64,
+    pub num_values: i64,
     pub compression: Compression,
     pub uncompressed_size: u64,
     pub min_max: Option<(Scalar, Scalar)>,

--- a/src/query/storages/parquet/src/parquet_reader/deserialize.rs
+++ b/src/query/storages/parquet/src/parquet_reader/deserialize.rs
@@ -154,7 +154,7 @@ impl ParquetReader {
                     std::io::Cursor::new(chunk),
                     PageMetaData {
                         column_start: meta.offset,
-                        num_values: rows as i64,
+                        num_values: meta.num_values,
                         compression: meta.compression,
                         descriptor: descriptor.descriptor.clone(),
                     },

--- a/src/query/storages/parquet/src/parquet_reader/deserialize.rs
+++ b/src/query/storages/parquet/src/parquet_reader/deserialize.rs
@@ -197,7 +197,7 @@ impl ParquetReader {
                     std::io::Cursor::new(chunk),
                     PageMetaData {
                         column_start: meta.offset,
-                        num_values: rows as i64,
+                        num_values: meta.num_values,
                         compression: meta.compression,
                         descriptor: descriptor.descriptor.clone(),
                     },

--- a/src/query/storages/parquet/src/pruning.rs
+++ b/src/query/storages/parquet/src/pruning.rs
@@ -163,6 +163,7 @@ impl PartitionPruner {
                 column_metas.insert(*index, ColumnMeta {
                     offset,
                     length,
+                    num_values: c.num_values(),
                     compression: c.compression(),
                     uncompressed_size: c.uncompressed_size() as u64,
                     min_max,

--- a/tests/sqllogictests/suites/base/03_common/03_0040_parquet_list_field
+++ b/tests/sqllogictests/suites/base/03_common/03_0040_parquet_list_field
@@ -1,0 +1,15 @@
+statement ok
+drop stage if exists r2_stage;
+
+statement ok
+CREATE STAGE r2_stage URL='s3://indexed-xyz/ethereum/decoded/logs/v1.2.0/partition_key=9d/dt=2016/' CONNECTION = ( ENDPOINT_URL = 'https://ed5d915e0259fcddb2ab1ce5592040c3.r2.cloudflarestorage.com/' REGION = 'auto' ACCESS_KEY_ID = '43c31ff797ec2387177cabab6d18f15a' SECRET_ACCESS_KEY = 'afb354f05026f2512557922974e9dd2fdb21e5c2f5cbf929b35f0645fb284cf7' );
+
+
+query I
+SELECT count(*) FROM @r2_stage;
+----
+1000
+
+statement ok
+drop stage if exists r2_stage;
+

--- a/tests/sqllogictests/suites/base/03_common/03_0040_parquet_list_field
+++ b/tests/sqllogictests/suites/base/03_common/03_0040_parquet_list_field
@@ -8,7 +8,7 @@ CREATE STAGE r2_stage URL='s3://indexed-xyz/ethereum/decoded/logs/v1.2.0/partiti
 query I
 SELECT count(*) FROM @r2_stage;
 ----
-1000
+17223
 
 statement ok
 drop stage if exists r2_stage;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

for List Type,  `num_values` of a leaf column may be larger then num_rows.

page reader currently use `num_values` to decide whether all pages is readn.

this bug may lead to some pages not read, and result in less rows in this column than others and report error.



see: 
https://github.com/jorgecarleitao/parquet2/blob/main/src/read/page/reader.rs#L53
https://github.com/jorgecarleitao/parquet2/blob/main/src/read/page/reader.rs#L179


Closes #issue
