### PR TITLE
chore: Add rust-analyzer in rust-toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2023-03-10"
-components = ["rustfmt", "clippy", "rust-src", "miri"]
+components = ["rustfmt", "clippy", "rust-src", "miri", "rust-analyzer"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Wait for new build-tool release