### PR TITLE
fix: truncate should commit new meta to meta-server first

### DIFF
--- a/src/query/storages/fuse/src/io/files.rs
+++ b/src/query/storages/fuse/src/io/files.rs
@@ -18,6 +18,7 @@ use common_base::runtime::execute_futures_in_parallel;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
 use opendal::Operator;
+use tracing::info;
 
 // File related operations.
 pub struct Files {
@@ -68,6 +69,7 @@ impl Files {
 
     #[async_backtrace::framed]
     async fn delete_files(op: Operator, locations: Vec<String>) -> Result<()> {
+        info!("deleting files: {:?}", &locations);
         op.remove(locations).await?;
         Ok(())
     }

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -728,11 +728,23 @@ mod utils {
                 let block_location = &block.location.0;
                 // if deletion operation failed (after DAL retried)
                 // we just left them there, and let the "major GC" collect them
+                info!(
+                    "aborting operation, delete block location: {:?}",
+                    block_location,
+                );
                 let _ = operator.delete(block_location).await;
                 if let Some(index) = &block.bloom_filter_index_location {
+                    info!(
+                        "aborting operation, delete bloom index location: {:?}",
+                        index.0
+                    );
                     let _ = operator.delete(&index.0).await;
                 }
             }
+            info!(
+                "aborting operation, delete segment location: {:?}",
+                entry.segment_location
+            );
             let _ = operator.delete(&entry.segment_location).await;
         }
         Ok(())

--- a/src/query/storages/fuse/src/operations/fuse_sink.rs
+++ b/src/query/storages/fuse/src/operations/fuse_sink.rs
@@ -39,6 +39,7 @@ use storages_common_table_meta::meta::Location;
 use storages_common_table_meta::meta::SegmentInfo;
 use storages_common_table_meta::meta::Statistics;
 use storages_common_table_meta::table::TableCompression;
+use tracing::info;
 
 use super::AppendOperationLogEntry;
 use crate::io;
@@ -371,6 +372,7 @@ impl Processor for FuseTableSink {
                 segment,
             } => {
                 self.data_accessor.write(&location, data).await?;
+                info!("fuse sink wrote down segment {} ", location);
 
                 self.state = State::PreCommitSegment { location, segment };
             }

--- a/src/query/storages/fuse/src/operations/truncate.rs
+++ b/src/query/storages/fuse/src/operations/truncate.rs
@@ -32,6 +32,7 @@ impl FuseTable {
     #[async_backtrace::framed]
     pub async fn do_truncate(&self, ctx: Arc<dyn TableContext>, purge: bool) -> Result<()> {
         if let Some(prev_snapshot) = self.read_table_snapshot().await? {
+            // 1. prepare new snapshot
             let prev_id = prev_snapshot.snapshot_id;
             let prev_format_version = self.snapshot_format_version().await?;
             let new_snapshot = TableSnapshot::new(
@@ -45,33 +46,32 @@ impl FuseTable {
                 // truncate MUST reset ts location
                 None,
             );
+
+            // 2. write down new snapshot
             let loc = self.meta_location_generator();
             let new_snapshot_loc =
                 loc.snapshot_location_from_uuid(&new_snapshot.snapshot_id, TableSnapshot::VERSION)?;
             let bytes = new_snapshot.to_bytes()?;
             self.operator.write(&new_snapshot_loc, bytes).await?;
 
-            if purge {
-                let snapshot_files = self.list_snapshot_files().await?;
-                let keep_last_snapshot = false;
-                self.do_purge(&ctx, snapshot_files, keep_last_snapshot)
-                    .await?
-            }
-
+            // 3. commit new meta to meta server
             let mut new_table_meta = self.table_info.meta.clone();
+
             // update snapshot location
             new_table_meta.options.insert(
                 OPT_KEY_SNAPSHOT_LOCATION.to_owned(),
                 new_snapshot_loc.clone(),
             );
-
-            // update table statistics, all zeros
+            // reset table statistics
             new_table_meta.statistics = TableStatistics::default();
 
             let table_id = self.table_info.ident.table_id;
             let table_version = self.table_info.ident.seq;
             let catalog = ctx.get_catalog(self.table_info.catalog())?;
 
+            // commit table meta to meta server.
+            // `truncate_table` is not supposed to be retry-able, thus we use
+            // `update_data_table_meta` directly.
             catalog
                 .update_table_meta(&self.table_info, UpdateTableMetaReq {
                     table_id,
@@ -81,6 +81,7 @@ impl FuseTable {
                 })
                 .await?;
 
+            // best effort to remove the table's copied files.
             catalog
                 .truncate_table(&self.table_info, TruncateTableReq { table_id })
                 .await?;
@@ -92,6 +93,17 @@ impl FuseTable {
                 new_snapshot_loc,
             )
             .await;
+
+            // best effort to remove historical data. if failed, let `vacuum` to do the job.
+            // TODO: consider remove the `purge` option from `truncate`
+            // - it is not a safe operation, there is NO retention interval protection here
+            // - it is incompatible with time travel features
+            if purge {
+                let snapshot_files = self.list_snapshot_files().await?;
+                let keep_last_snapshot = false;
+                self.do_purge(&ctx, snapshot_files, keep_last_snapshot)
+                    .await?
+            }
         }
 
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

truncate should commit the new meta to meta-server first.

the principle should be: 

publish the new meta first, let the effects of `truncate` be visible to all the subsequent  txs (and parallel txs while committing), and purge the data later(in a best-effort manner) if the `purge` option is specified.

also, please consider removing the `purge` option from `truncate`, since
 - it is not a safe operation, there is NO retention interval protection here
- it is somehow incompatible with time travel features


Closes #issue
