### PR TITLE
feat: optimize join by reducing blocking at probe phase

### DIFF
--- a/tests/sqllogictests/suites/query/join.test
+++ b/tests/sqllogictests/suites/query/join.test
@@ -526,7 +526,7 @@ statement ok
 insert into t2 values(1), (NULL), (3);
 
 query I
-select * from t1 join t2 on t1.a < t2.b;
+select * from t1 join t2 on t1.a < t2.b order by t1.a;
 ----
 1 3
 2 3


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

By limiting the size of the blocks processed by each probe thread, make the whole pipeline flow better and reduce the time of hash join blocking.


Closes #issue
