### PR TITLE
fix(planner): remove obsolete EOI token in insert probing

### DIFF
--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -125,7 +125,6 @@ impl Planner {
                     let iter = (&mut tokenizer)
                         .take(tokens.len() * 2)
                         .take_while(|token| token.is_ok())
-                        .chain(std::iter::once(Ok(Token::new_eoi(sql))))
                         .map(|token| token.unwrap())
                         // Make sure the tokens stream is always ended with EOI.
                         .chain(std::iter::once(Token::new_eoi(sql)));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
