### PR TITLE
chore: refactor snapshot_format_version function, fix possible snapshot version missmatch bug

### DIFF
--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -252,7 +252,7 @@ impl FuseTable {
     pub async fn read_table_snapshot(&self) -> Result<Option<Arc<TableSnapshot>>> {
         if let Some(loc) = self.snapshot_loc().await? {
             let reader = MetaReaders::table_snapshot_reader(self.get_operator());
-            let ver = self.snapshot_format_version().await?;
+            let ver = self.snapshot_format_version(Some(loc.clone())).await?;
             let params = LoadParams {
                 location: loc,
                 len_hint: None,
@@ -266,8 +266,13 @@ impl FuseTable {
     }
 
     #[async_backtrace::framed]
-    pub async fn snapshot_format_version(&self) -> Result<u64> {
-        match self.snapshot_loc().await? {
+    pub async fn snapshot_format_version(&self, location_opt: Option<String>) -> Result<u64> {
+        let location_opt = if location_opt.is_some() {
+            location_opt
+        } else {
+            self.snapshot_loc().await?
+        };
+        match location_opt {
             Some(loc) => Ok(TableMetaLocationGenerator::snapshot_version(loc.as_str())),
             None => {
                 // No snapshot location here, indicates that there are no data of this table yet
@@ -391,7 +396,7 @@ impl Table for FuseTable {
         let schema = self.schema().as_ref().clone();
 
         let prev = self.read_table_snapshot().await?;
-        let prev_version = self.snapshot_format_version().await?;
+        let prev_version = self.snapshot_format_version(None).await?;
         let prev_timestamp = prev.as_ref().and_then(|v| v.timestamp);
         let prev_snapshot_id = prev.as_ref().map(|v| (v.snapshot_id, prev_version));
         let prev_statistics_location = prev
@@ -442,7 +447,7 @@ impl Table for FuseTable {
         let schema = self.schema().as_ref().clone();
 
         let prev = self.read_table_snapshot().await?;
-        let prev_version = self.snapshot_format_version().await?;
+        let prev_version = self.snapshot_format_version(None).await?;
         let prev_timestamp = prev.as_ref().and_then(|v| v.timestamp);
         let prev_statistics_location = prev
             .as_ref()

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -212,7 +212,7 @@ impl FuseTable {
         overwrite: bool,
     ) -> Result<()> {
         let prev = self.read_table_snapshot().await?;
-        let prev_version = self.snapshot_format_version().await?;
+        let prev_version = self.snapshot_format_version(None).await?;
         let prev_timestamp = prev.as_ref().and_then(|v| v.timestamp);
         let prev_statistics_location = prev
             .as_ref()

--- a/src/query/storages/fuse/src/operations/truncate.rs
+++ b/src/query/storages/fuse/src/operations/truncate.rs
@@ -34,7 +34,7 @@ impl FuseTable {
         if let Some(prev_snapshot) = self.read_table_snapshot().await? {
             // 1. prepare new snapshot
             let prev_id = prev_snapshot.snapshot_id;
-            let prev_format_version = self.snapshot_format_version().await?;
+            let prev_format_version = self.snapshot_format_version(None).await?;
             let new_snapshot = TableSnapshot::new(
                 Uuid::new_v4(),
                 &prev_snapshot.timestamp,

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
@@ -73,7 +73,7 @@ impl<'a> FuseBlock<'a> {
             }
 
             // prepare the stream of snapshot
-            let snapshot_version = tbl.snapshot_format_version().await?;
+            let snapshot_version = tbl.snapshot_format_version(None).await?;
             let snapshot_location = tbl
                 .meta_location_generator
                 .snapshot_location_from_uuid(&snapshot.snapshot_id, snapshot_version)?;

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
@@ -55,7 +55,7 @@ impl<'a> FuseSegment<'a> {
         let maybe_snapshot = tbl.read_table_snapshot().await?;
         if let Some(snapshot) = maybe_snapshot {
             // prepare the stream of snapshot
-            let snapshot_version = tbl.snapshot_format_version().await?;
+            let snapshot_version = tbl.snapshot_format_version(None).await?;
             let snapshot_location = tbl
                 .meta_location_generator
                 .snapshot_location_from_uuid(&snapshot.snapshot_id, snapshot_version)?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore: refactor snapshot_format_version function, fix possible snapshot version missmatch bug


for shared-table, 

- the snapshot location and format version can not be determined at the time of construction (due to we do not support async table constructor yet).

- the method `Table::snapshot_loc` will read the table snapshot location from hint file **for each invocation**

- `snapshot_format_version` uses `snapshot_loc` method to get the location of snapshot, and parse the format version

- thus `read_table_snapshot` is taking the following risk

https://github.com/datafuselabs/databend/blob/aa97d2c5b57f1585abc8192e5fb76f9fc4157903/src/query/storages/fuse/src/fuse_table.rs#L252-L278

  the `loc` we get at line 253, may not be the `loc` that is used to parse the format version at line 255 (since hint file may have been changed),  if the format version changed, we may be  reading the snapshot file using incorrect(old) version
  
  

Closes #issue
