### PR TITLE
fix: enable kill query before pipeline started.

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -16,7 +16,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::net::SocketAddr;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -108,7 +107,8 @@ pub trait TableContext: Send + Sync {
     fn get_catalog(&self, catalog_name: &str) -> Result<Arc<dyn Catalog>>;
     fn get_id(&self) -> String;
     fn get_current_catalog(&self) -> String;
-    fn get_aborting(&self) -> Arc<AtomicBool>;
+    fn check_aborting(&self) -> Result<()>;
+    fn get_error(&self) -> Option<ErrorCode>;
     fn get_current_database(&self) -> String;
     fn get_current_user(&self) -> Result<UserInfo>;
     fn get_current_role(&self) -> Option<RoleInfo>;

--- a/src/query/service/src/interpreters/interpreter.rs
+++ b/src/query/service/src/interpreters/interpreter.rs
@@ -53,6 +53,11 @@ pub trait Interpreter: Sync + Send {
         InterpreterMetrics::record_query_start(&ctx);
         log_query_start(&ctx);
 
+        if let Err(err) = ctx.check_aborting() {
+            log_query_finished(&ctx, Some(err.clone()));
+            return Err(err);
+        }
+
         let mut build_res = match self.execute2().await {
             Ok(build_res) => build_res,
             Err(build_error) => {
@@ -91,18 +96,18 @@ pub trait Interpreter: Sync + Send {
 
             let complete_executor = PipelineCompleteExecutor::from_pipelines(pipelines, settings)?;
 
-            ctx.set_executor(Arc::downgrade(&complete_executor.get_inner()));
+            ctx.set_executor(complete_executor.get_inner())?;
             complete_executor.execute()?;
-            return Ok(Box::pin(DataBlockStream::create(None, vec![])));
+            Ok(Box::pin(DataBlockStream::create(None, vec![])))
+        } else {
+            let pulling_executor = PipelinePullingExecutor::from_pipelines(build_res, settings)?;
+
+            ctx.set_executor(pulling_executor.get_inner())?;
+            Ok(Box::pin(ProgressStream::try_create(
+                Box::pin(PullingExecutorStream::create(pulling_executor)?),
+                ctx.get_result_progress(),
+            )?))
         }
-
-        let pulling_executor = PipelinePullingExecutor::from_pipelines(build_res, settings)?;
-
-        ctx.set_executor(Arc::downgrade(&pulling_executor.get_inner()));
-        Ok(Box::pin(ProgressStream::try_create(
-            Box::pin(PullingExecutorStream::create(pulling_executor)?),
-            ctx.get_result_progress(),
-        )?))
     }
 
     /// The core of the databend processor which will execute the logical plan and build the pipeline

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -91,7 +91,7 @@ impl Interpreter for ReclusterTableInterpreter {
             let executor_settings = ExecutorSettings::try_create(&settings, query_id)?;
             let executor = PipelineCompleteExecutor::try_create(pipeline, executor_settings)?;
 
-            ctx.set_executor(Arc::downgrade(&executor.get_inner()));
+            ctx.set_executor(executor.get_inner())?;
             executor.execute()?;
             drop(executor);
 

--- a/src/query/service/src/interpreters/interpreter_user_stage_remove.rs
+++ b/src/query/service/src/interpreters/interpreter_user_stage_remove.rs
@@ -75,8 +75,7 @@ impl Interpreter for RemoveUserStageInterpreter {
                 error!("Failed to delete file: {:?}, error: {}", chunk, e);
             }
 
-            let aborting = self.ctx.get_aborting();
-            if aborting.load(std::sync::atomic::Ordering::SeqCst) {
+            if self.ctx.check_aborting().is_err() {
                 return Ok(PipelineBuildResult::create());
             }
         }

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -19,11 +19,9 @@ use std::collections::VecDeque;
 use std::future::Future;
 use std::net::SocketAddr;
 use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::sync::Weak;
 use std::time::SystemTime;
 
 use common_base::base::tokio::task::JoinHandle;
@@ -205,7 +203,7 @@ impl QueryContext {
         *self.shared.init_query_id.write() = id;
     }
 
-    pub fn set_executor(&self, weak_ptr: Weak<PipelineExecutor>) {
+    pub fn set_executor(&self, weak_ptr: Arc<PipelineExecutor>) -> Result<()> {
         self.shared.set_executor(weak_ptr)
     }
 
@@ -359,8 +357,12 @@ impl TableContext for QueryContext {
         self.shared.get_current_catalog()
     }
 
-    fn get_aborting(&self) -> Arc<AtomicBool> {
-        self.shared.get_aborting()
+    fn check_aborting(&self) -> Result<()> {
+        self.shared.check_aborting()
+    }
+
+    fn get_error(&self) -> Option<ErrorCode> {
+        self.shared.get_error()
     }
 
     fn get_current_database(&self) -> String {

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -134,6 +134,11 @@ impl QueryContextShared {
         *guard = Some(err);
     }
 
+    pub fn get_error(&self) -> Option<ErrorCode> {
+        let guard = self.error.lock();
+        (*guard).clone()
+    }
+
     pub fn set_on_error_map(&self, map: Arc<DashMap<String, HashMap<u16, InputError>>>) {
         let mut guard = self.on_error_map.write();
         *guard = Some(map);
@@ -172,6 +177,18 @@ impl QueryContextShared {
 
     pub fn get_aborting(&self) -> Arc<AtomicBool> {
         self.aborting.clone()
+    }
+
+    pub fn check_aborting(&self) -> Result<()> {
+        if self.aborting.load(Ordering::Acquire) {
+            Err(self.get_error().unwrap_or_else(|| {
+                ErrorCode::AbortedQuery(
+                    "Aborted query, because the server is shutting down or the query was killed.",
+                )
+            }))
+        } else {
+            Ok(())
+        }
     }
 
     pub fn get_current_database(&self) -> String {
@@ -328,9 +345,18 @@ impl QueryContextShared {
         *guard = Some(affect);
     }
 
-    pub fn set_executor(&self, weak_ptr: Weak<PipelineExecutor>) {
-        let mut executor = self.executor.write();
-        *executor = weak_ptr;
+    pub fn set_executor(&self, executor: Arc<PipelineExecutor>) -> Result<()> {
+        let mut guard = self.executor.write();
+        match self.check_aborting() {
+            Ok(_) => {
+                *guard = Arc::downgrade(&executor);
+                Ok(())
+            }
+            Err(err) => {
+                executor.finish(Some(err.clone()));
+                Err(err)
+            }
+        }
     }
 
     pub fn push_precommit_block(&self, block: DataBlock) {

--- a/src/query/service/src/stream/table_read_block_stream.rs
+++ b/src/query/service/src/stream/table_read_block_stream.rs
@@ -52,7 +52,7 @@ impl<T: ?Sized + Table> ReadDataBlockStream for T {
         let query_id = ctx.get_id();
         let executor_settings = ExecutorSettings::try_create(&settings, query_id)?;
         let executor = PipelinePullingExecutor::try_create(pipeline, executor_settings)?;
-        ctx.set_executor(Arc::downgrade(&executor.get_inner()));
+        ctx.set_executor(executor.get_inner())?;
         Ok(Box::pin(PullingExecutorStream::create(executor)?))
     }
 }

--- a/src/query/service/src/test_kits/table_test_fixture.rs
+++ b/src/query/service/src/test_kits/table_test_fixture.rs
@@ -379,7 +379,7 @@ pub fn execute_pipeline(ctx: Arc<QueryContext>, mut res: PipelineBuildResult) ->
     let mut pipelines = res.sources_pipelines;
     pipelines.push(res.main_pipeline);
     let executor = PipelineCompleteExecutor::from_pipelines(pipelines, executor_settings)?;
-    ctx.set_executor(Arc::downgrade(&executor.get_inner()));
+    ctx.set_executor(executor.get_inner())?;
     executor.execute()
 }
 

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -14,7 +14,6 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -465,7 +464,11 @@ impl TableContext for CtxDelegation {
         "default".to_owned()
     }
 
-    fn get_aborting(&self) -> Arc<AtomicBool> {
+    fn check_aborting(&self) -> Result<()> {
+        todo!()
+    }
+
+    fn get_error(&self) -> Option<ErrorCode> {
         todo!()
     }
 

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
@@ -117,7 +117,7 @@ async fn do_compact(ctx: Arc<QueryContext>, table: Arc<dyn Table>) -> Result<boo
         let query_id = ctx.get_id();
         let executor_settings = ExecutorSettings::try_create(&settings, query_id)?;
         let executor = PipelineCompleteExecutor::try_create(pipeline, executor_settings)?;
-        ctx.set_executor(Arc::downgrade(&executor.get_inner()));
+        ctx.set_executor(executor.get_inner())?;
         executor.execute()?;
         Ok(true)
     } else {

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/deletion.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/deletion.rs
@@ -109,7 +109,7 @@ pub async fn do_deletion(
         let query_id = ctx.get_id();
         let executor_settings = ExecutorSettings::try_create(&settings, query_id)?;
         let executor = PipelineCompleteExecutor::try_create(pipeline, executor_settings)?;
-        ctx.set_executor(Arc::downgrade(&executor.get_inner()));
+        ctx.set_executor(executor.get_inner())?;
         executor.execute()?;
     }
     Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

before this pr,  query can only be killed after pipeline is started(` ctx.set_executor()`).

it will be better if long  binding/read_parttiion can be interrupted, which needs another pr.  



Closes  https://github.com/datafuselabs/databend/issues/11302
