### PR TITLE
feat: Bump OpenDAL to 0.34.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,9 +3579,12 @@ dependencies = [
 
 [[package]]
 name = "dlv-list"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+checksum = "d529fd73d344663edfd598ccb3f344e46034db51ebd103518eae34338248ad73"
+dependencies = [
+ "const-random",
+]
 
 [[package]]
 name = "downcast"
@@ -6446,16 +6449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6915,9 +6908,9 @@ dependencies = [
 
 [[package]]
 name = "opendal"
-version = "0.33.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c582b11500656b4f6210f868a0a26395cdf30183c5597c45d0a34525dd94512"
+checksum = "005c877c4f788a7749825bbc61031ccc950217fac6bcf9965641fbf1bdf991b0"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -7125,12 +7118,12 @@ dependencies = [
 
 [[package]]
 name = "ordered-multimap"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
 dependencies = [
  "dlv-list",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -8203,14 +8196,13 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f753b768a9d691395e7db3dc74452cc39a5da55293c3fa2241e2aeaf9d94028"
+checksum = "5d36dae58fbc1db90e1cf14ca8fabcba92b7aa3c282d5e46bcdf16b9c28ab04c"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.0",
- "bytes",
  "chrono",
  "form_urlencoded",
  "hex",
@@ -8253,7 +8245,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -8468,7 +8459,6 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sha2",
  "signature 2.0.0",
  "subtle",
  "zeroize",
@@ -8487,9 +8477,9 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
 dependencies = [
  "cfg-if",
  "ordered-multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ members = [
 [workspace.dependencies]
 # databend maintains:
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
-opendal = { version = "0.33", features = [
+opendal = { version = "0.34", features = [
     "layers-tracing",
     "layers-metrics",
     "services-ipfs",

--- a/src/common/storage/src/metrics.rs
+++ b/src/common/storage/src/metrics.rs
@@ -30,7 +30,6 @@ use opendal::raw::Layer;
 use opendal::raw::LayeredAccessor;
 use opendal::raw::RpList;
 use opendal::raw::RpRead;
-use opendal::raw::RpScan;
 use opendal::raw::RpWrite;
 use opendal::Result;
 
@@ -197,11 +196,6 @@ impl<A: Accessor> LayeredAccessor for StorageMetricsAccessor<A> {
         self.inner.list(path, args).await
     }
 
-    #[async_backtrace::framed]
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        self.inner.scan(path, args).await
-    }
-
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
         self.inner
             .blocking_read(path, args)
@@ -216,10 +210,6 @@ impl<A: Accessor> LayeredAccessor for StorageMetricsAccessor<A> {
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         self.inner.blocking_list(path, args)
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        self.inner.blocking_scan(path, args)
     }
 }
 

--- a/src/common/storage/src/runtime_layer.rs
+++ b/src/common/storage/src/runtime_layer.rs
@@ -38,11 +38,10 @@ use opendal::raw::oio::ReadExt;
 use opendal::raw::Accessor;
 use opendal::raw::Layer;
 use opendal::raw::LayeredAccessor;
-use opendal::raw::RpCreate;
+use opendal::raw::RpCreateDir;
 use opendal::raw::RpDelete;
 use opendal::raw::RpList;
 use opendal::raw::RpRead;
-use opendal::raw::RpScan;
 use opendal::raw::RpStat;
 use opendal::raw::RpWrite;
 use opendal::Error;
@@ -107,7 +106,7 @@ impl<A: Accessor> LayeredAccessor for RuntimeAccessor<A> {
     }
 
     #[async_backtrace::framed]
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         let op = self.inner.clone();
         let path = path.to_string();
         let future = async move { op.create_dir(&path, args).await };
@@ -184,15 +183,6 @@ impl<A: Accessor> LayeredAccessor for RuntimeAccessor<A> {
         self.runtime.spawn(future).await.expect("join must success")
     }
 
-    #[async_backtrace::framed]
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        let op = self.inner.clone();
-        let path = path.to_string();
-        let future = async move { op.scan(&path, args).await };
-        let future = TrackedFuture::create(future);
-        self.runtime.spawn(future).await.expect("join must success")
-    }
-
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
         self.inner.blocking_read(path, args)
     }
@@ -203,10 +193,6 @@ impl<A: Accessor> LayeredAccessor for RuntimeAccessor<A> {
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         self.inner.blocking_list(path, args)
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        self.inner.blocking_scan(path, args)
     }
 }
 

--- a/src/query/service/tests/it/sessions/query_ctx.rs
+++ b/src/query/service/tests/it/sessions/query_ctx.rs
@@ -39,6 +39,8 @@ async fn test_get_storage_accessor_s3() -> Result<()> {
         region: "us-east-2".to_string(),
         endpoint_url: mock_server.uri(),
         bucket: "bucket".to_string(),
+        access_key_id: "access_key_id".to_string(),
+        secret_access_key: "secret_access_key".to_string(),
         disable_credential_loader: true,
         ..Default::default()
     });


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR will bump opendal to 0.34.0.

Release Note: https://github.com/apache/incubator-opendal/releases/tag/v0.34.0

Notable Changes:

- Fix S3's retry logic for credential not loaded
- Improve the memory/moka backend's perf up to 160000%
