### PR TITLE
62 copy file inc table seq

### DIFF
--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -47,8 +47,6 @@ use common_meta_app::schema::UndropTableReply;
 use common_meta_app::schema::UndropTableReq;
 use common_meta_app::schema::UpdateTableMetaReply;
 use common_meta_app::schema::UpdateTableMetaReq;
-use common_meta_app::schema::UpsertTableCopiedFileReply;
-use common_meta_app::schema::UpsertTableCopiedFileReq;
 use common_meta_app::schema::UpsertTableOptionReply;
 use common_meta_app::schema::UpsertTableOptionReq;
 use common_meta_types::GCDroppedDataReply;
@@ -125,11 +123,6 @@ pub trait SchemaApi: Send + Sync {
         &self,
         req: GetTableCopiedFileReq,
     ) -> Result<GetTableCopiedFileReply, KVAppError>;
-
-    async fn upsert_table_copied_file_info(
-        &self,
-        req: UpsertTableCopiedFileReq,
-    ) -> Result<UpsertTableCopiedFileReply, KVAppError>;
 
     async fn truncate_table(&self, req: TruncateTableReq)
     -> Result<TruncateTableReply, KVAppError>;

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -257,7 +257,7 @@ impl SchemaApiTestSuite {
         suite.truncate_table(&b.build().await).await?;
         suite.get_tables_from_share(&b.build().await).await?;
         suite
-            .upsert_table_copied_file_info(&b.build().await)
+            .update_table_with_copied_files(&b.build().await)
             .await?;
         Ok(())
     }
@@ -2388,6 +2388,7 @@ impl SchemaApiTestSuite {
         Ok(())
     }
 
+    /// Return table id and table meta
     #[tracing::instrument(level = "debug", skip_all)]
     async fn create_out_of_retention_time_table<
         MT: SchemaApi + kvapi::AsKVApi<Error = MetaError>,
@@ -2398,7 +2399,7 @@ impl SchemaApiTestSuite {
         dbid_tbname: DBIdTableName,
         drop_on: Option<DateTime<Utc>>,
         delete: bool,
-    ) -> anyhow::Result<u64> {
+    ) -> anyhow::Result<(u64, TableMeta)> {
         let created_on = Utc::now();
         let schema = || {
             Arc::new(TableSchema::new(vec![TableField::new(
@@ -2439,7 +2440,7 @@ impl SchemaApiTestSuite {
         if delete {
             delete_test_data(mt.as_kv_api(), &dbid_tbname).await?;
         }
-        Ok(table_id)
+        Ok((table_id, create_table_meta))
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
@@ -2484,7 +2485,7 @@ impl SchemaApiTestSuite {
             true,
         )
         .await?;
-        let table_id = self
+        let (table_id, table_meta) = self
             .create_out_of_retention_time_table(
                 mt,
                 tbl_name_ident.clone(),
@@ -2514,7 +2515,14 @@ impl SchemaApiTestSuite {
                 fail_if_duplicated: true,
             };
 
-            let _ = mt.upsert_table_copied_file_info(req).await?;
+            let req = UpdateTableMetaReq {
+                table_id,
+                seq: MatchSeq::Any,
+                new_table_meta: table_meta.clone(),
+                copied_files: Some(req),
+            };
+
+            let _ = mt.update_table_meta(req).await?;
 
             let key = TableCopiedFileNameIdent {
                 table_id,
@@ -3187,6 +3195,7 @@ impl SchemaApiTestSuite {
             created_on,
             ..TableMeta::default()
         };
+        let created_on = Utc::now();
 
         info!("--- prepare db and table");
         {
@@ -3203,7 +3212,6 @@ impl SchemaApiTestSuite {
             };
 
             let _ = mt.create_database(plan).await?;
-            let created_on = Utc::now();
 
             let req = CreateTableReq {
                 if_not_exists: false,
@@ -3235,7 +3243,14 @@ impl SchemaApiTestSuite {
                 fail_if_duplicated: true,
             };
 
-            let _ = mt.upsert_table_copied_file_info(req).await?;
+            let req = UpdateTableMetaReq {
+                table_id,
+                seq: MatchSeq::Any,
+                new_table_meta: table_meta(created_on),
+                copied_files: Some(req),
+            };
+
+            let _ = mt.update_table_meta(req).await?;
 
             let req = GetTableCopiedFileReq {
                 table_id,
@@ -3265,7 +3280,14 @@ impl SchemaApiTestSuite {
                 fail_if_duplicated: true,
             };
 
-            let _ = mt.upsert_table_copied_file_info(req).await?;
+            let req = UpdateTableMetaReq {
+                table_id,
+                seq: MatchSeq::Any,
+                new_table_meta: table_meta(created_on),
+                copied_files: Some(req),
+            };
+
+            let _ = mt.update_table_meta(req).await?;
 
             let req = GetTableCopiedFileReq {
                 table_id,
@@ -3302,6 +3324,7 @@ impl SchemaApiTestSuite {
             created_on,
             ..TableMeta::default()
         };
+        let created_on = Utc::now();
 
         info!("--- prepare db and table");
         {
@@ -3318,7 +3341,6 @@ impl SchemaApiTestSuite {
             };
 
             let _ = mt.create_database(plan).await?;
-            let created_on = Utc::now();
 
             let req = CreateTableReq {
                 if_not_exists: false,
@@ -3350,7 +3372,14 @@ impl SchemaApiTestSuite {
                 fail_if_duplicated: true,
             };
 
-            let _ = mt.upsert_table_copied_file_info(req).await?;
+            let req = UpdateTableMetaReq {
+                table_id,
+                seq: MatchSeq::Any,
+                new_table_meta: table_meta(created_on),
+                copied_files: Some(req),
+            };
+
+            let _ = mt.update_table_meta(req).await?;
 
             let req = GetTableCopiedFileReq {
                 table_id,
@@ -4147,7 +4176,7 @@ impl SchemaApiTestSuite {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn upsert_table_copied_file_info<MT: SchemaApi>(&self, mt: &MT) -> anyhow::Result<()> {
+    async fn update_table_with_copied_files<MT: SchemaApi>(&self, mt: &MT) -> anyhow::Result<()> {
         let tenant = "tenant1";
         let db_name = "db1";
         let tbl_name = "tb2";
@@ -4170,6 +4199,8 @@ impl SchemaApiTestSuite {
             ..TableMeta::default()
         };
 
+        let created_on = Utc::now();
+
         info!("--- prepare db and table");
         {
             let plan = CreateDatabaseReq {
@@ -4185,7 +4216,6 @@ impl SchemaApiTestSuite {
             };
 
             let _ = mt.create_database(plan).await?;
-            let created_on = Utc::now();
 
             let req = CreateTableReq {
                 if_not_exists: false,
@@ -4217,7 +4247,14 @@ impl SchemaApiTestSuite {
                 fail_if_duplicated: true,
             };
 
-            let _ = mt.upsert_table_copied_file_info(req).await?;
+            let req = UpdateTableMetaReq {
+                table_id,
+                seq: MatchSeq::Any,
+                new_table_meta: table_meta(created_on),
+                copied_files: Some(req),
+            };
+
+            let _ = mt.update_table_meta(req).await?;
 
             let req = GetTableCopiedFileReq {
                 table_id,
@@ -4256,7 +4293,14 @@ impl SchemaApiTestSuite {
                 fail_if_duplicated: true,
             };
 
-            let result = mt.upsert_table_copied_file_info(req).await;
+            let req = UpdateTableMetaReq {
+                table_id,
+                seq: MatchSeq::Any,
+                new_table_meta: table_meta(created_on),
+                copied_files: Some(req),
+            };
+
+            let result = mt.update_table_meta(req).await;
             let err = result.unwrap_err();
             let err = ErrorCode::from(err);
             assert_eq!(ErrorCode::DuplicatedUpsertFiles("").code(), err.code());
@@ -4292,7 +4336,15 @@ impl SchemaApiTestSuite {
                 fail_if_duplicated: false,
             };
 
-            mt.upsert_table_copied_file_info(req).await?;
+            let req = UpdateTableMetaReq {
+                table_id,
+                seq: MatchSeq::Any,
+                new_table_meta: table_meta(created_on),
+                copied_files: Some(req),
+            };
+
+            mt.update_table_meta(req).await?;
+
             let req = GetTableCopiedFileReq {
                 table_id,
                 files: vec!["file".to_string(), "file_not_exist".to_string()],

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -2440,7 +2440,7 @@ impl SchemaApiTestSuite {
         if delete {
             delete_test_data(mt.as_kv_api(), &dbid_tbname).await?;
         }
-        Ok((table_id, create_table_meta))
+        Ok((table_id, drop_data))
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
@@ -2473,7 +2473,9 @@ impl SchemaApiTestSuite {
         info!("create database res: {:?}", res);
 
         assert_eq!(1, res.db_id, "first database id is 1");
-        let drop_on = Some(Utc::now() - Duration::days(1));
+        let one_day_before = Some(Utc::now() - Duration::days(1));
+        let two_day_before = Some(Utc::now() - Duration::days(2));
+
         self.create_out_of_retention_time_table(
             mt,
             tbl_name_ident.clone(),
@@ -2481,7 +2483,7 @@ impl SchemaApiTestSuite {
                 db_id: res.db_id,
                 table_name: tb1_name.to_string(),
             },
-            drop_on,
+            one_day_before,
             true,
         )
         .await?;
@@ -2493,7 +2495,7 @@ impl SchemaApiTestSuite {
                     db_id: res.db_id,
                     table_name: tb1_name.to_string(),
                 },
-                Some(Utc::now() - Duration::days(2)),
+                two_day_before,
                 false,
             )
             .await?;

--- a/src/query/catalog/src/database.rs
+++ b/src/query/catalog/src/database.rs
@@ -32,8 +32,6 @@ use common_meta_app::schema::UndropTableReply;
 use common_meta_app::schema::UndropTableReq;
 use common_meta_app::schema::UpdateTableMetaReply;
 use common_meta_app::schema::UpdateTableMetaReq;
-use common_meta_app::schema::UpsertTableCopiedFileReply;
-use common_meta_app::schema::UpsertTableCopiedFileReq;
 use common_meta_app::schema::UpsertTableOptionReply;
 use common_meta_app::schema::UpsertTableOptionReq;
 use dyn_clone::DynClone;
@@ -164,17 +162,6 @@ pub trait Database: DynClone + Sync + Send {
     ) -> Result<GetTableCopiedFileReply> {
         Err(ErrorCode::Unimplemented(format!(
             "UnImplement get_table_copied_file_info in {} Database",
-            self.name()
-        )))
-    }
-
-    #[async_backtrace::framed]
-    async fn upsert_table_copied_file_info(
-        &self,
-        _req: UpsertTableCopiedFileReq,
-    ) -> Result<UpsertTableCopiedFileReply> {
-        Err(ErrorCode::Unimplemented(format!(
-            "UnImplement upsert_table_copied_file_info in {} Database",
             self.name()
         )))
     }

--- a/src/query/service/src/databases/default/default_database.rs
+++ b/src/query/service/src/databases/default/default_database.rs
@@ -34,8 +34,6 @@ use common_meta_app::schema::UndropTableReply;
 use common_meta_app::schema::UndropTableReq;
 use common_meta_app::schema::UpdateTableMetaReply;
 use common_meta_app::schema::UpdateTableMetaReq;
-use common_meta_app::schema::UpsertTableCopiedFileReply;
-use common_meta_app::schema::UpsertTableCopiedFileReq;
 use common_meta_app::schema::UpsertTableOptionReply;
 use common_meta_app::schema::UpsertTableOptionReq;
 
@@ -176,15 +174,6 @@ impl Database for DefaultDatabase {
         req: GetTableCopiedFileReq,
     ) -> Result<GetTableCopiedFileReply> {
         let res = self.ctx.meta.get_table_copied_file_info(req).await?;
-        Ok(res)
-    }
-
-    #[async_backtrace::framed]
-    async fn upsert_table_copied_file_info(
-        &self,
-        req: UpsertTableCopiedFileReq,
-    ) -> Result<UpsertTableCopiedFileReply> {
-        let res = self.ctx.meta.upsert_table_copied_file_info(req).await?;
         Ok(res)
     }
 

--- a/src/query/service/src/databases/share/share_database.rs
+++ b/src/query/service/src/databases/share/share_database.rs
@@ -34,8 +34,6 @@ use common_meta_app::schema::UndropTableReply;
 use common_meta_app::schema::UndropTableReq;
 use common_meta_app::schema::UpdateTableMetaReply;
 use common_meta_app::schema::UpdateTableMetaReq;
-use common_meta_app::schema::UpsertTableCopiedFileReply;
-use common_meta_app::schema::UpsertTableCopiedFileReq;
 use common_meta_app::schema::UpsertTableOptionReply;
 use common_meta_app::schema::UpsertTableOptionReq;
 use common_sharing::ShareEndpointManager;
@@ -181,15 +179,6 @@ impl Database for ShareDatabase {
         req: GetTableCopiedFileReq,
     ) -> Result<GetTableCopiedFileReply> {
         let res = self.ctx.meta.get_table_copied_file_info(req).await?;
-        Ok(res)
-    }
-
-    #[async_backtrace::framed]
-    async fn upsert_table_copied_file_info(
-        &self,
-        req: UpsertTableCopiedFileReq,
-    ) -> Result<UpsertTableCopiedFileReply> {
-        let res = self.ctx.meta.upsert_table_copied_file_info(req).await?;
         Ok(res)
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/


## Summary

### refactor(schema-api): remove unused upsert_table_copied_file_info from trait SchemaApi and trait Database
Updating copied files is actually done with `SchemaApi::update_table_meta()`

