### PR TITLE
chore(query): use prune cache only if enable result query cache

### DIFF
--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -122,17 +122,17 @@ impl FuseTable {
             segments_location.len()
         );
 
-        type CacheItem = (PartStatistics, Partitions);
-        let cache_key = format!(
-            "{:x}",
-            Sha256::digest(format!("{:?}_{:?}", segments_location, push_downs))
-        );
-
         let is_derterministic = push_downs
             .as_ref()
             .map(|p| p.is_deterministic)
             .unwrap_or_default();
-        if is_derterministic {
+        if is_derterministic && ctx.get_settings().get_enable_query_result_cache()? {
+            type CacheItem = (PartStatistics, Partitions);
+            let cache_key = format!(
+                "{:x}",
+                Sha256::digest(format!("{:?}_{:?}", segments_location, push_downs))
+            );
+
             if let Some(cache) = CacheItem::cache() {
                 if let Some(data) = cache.get(&cache_key) {
                     info!(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore(query): use prune cache only if enable result query cache

Closes #issue
