### PR TITLE
refactor(meta): remove UpsertTableCopiedFileReq.table_id

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -2088,6 +2088,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> SchemaApi for KV {
             if let Some(req) = &req.copied_files {
                 let (conditions, match_operations) =
                     build_upsert_table_copied_file_info_conditions(
+                        &tbid,
                         req,
                         tb_meta_seq,
                         req.fail_if_duplicated,
@@ -2742,14 +2743,12 @@ async fn get_table_id_from_share_by_name(
 }
 
 fn build_upsert_table_copied_file_info_conditions(
+    table_id: &TableId,
     req: &UpsertTableCopiedFileReq,
     tb_meta_seq: u64,
     fail_if_duplicated: bool,
 ) -> Result<(Vec<TxnCondition>, Vec<TxnOp>), KVAppError> {
-    let table_id = req.table_id;
-    let tbid = TableId { table_id };
-
-    let mut condition = vec![txn_cond_seq(&tbid, Eq, tb_meta_seq)];
+    let mut condition = vec![txn_cond_seq(table_id, Eq, tb_meta_seq)];
     let mut if_then = vec![];
 
     // `remove_table_copied_files` and `upsert_table_copied_file_info`
@@ -2767,7 +2766,7 @@ fn build_upsert_table_copied_file_info_conditions(
 
     for (file_name, file_info) in file_name_infos {
         let key = TableCopiedFileNameIdent {
-            table_id,
+            table_id: table_id.table_id,
             file: file_name.to_owned(),
         };
         if fail_if_duplicated {

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -1954,7 +1954,6 @@ impl SchemaApiTestSuite {
                 });
 
                 let upsert_source_table = UpsertTableCopiedFileReq {
-                    table_id,
                     file_info,
                     expire_at: None,
                     fail_if_duplicated: true,
@@ -1993,7 +1992,6 @@ impl SchemaApiTestSuite {
                 });
 
                 let upsert_source_table = UpsertTableCopiedFileReq {
-                    table_id,
                     file_info,
                     expire_at: None,
                     fail_if_duplicated: true,
@@ -2032,7 +2030,6 @@ impl SchemaApiTestSuite {
                 });
 
                 let upsert_source_table = UpsertTableCopiedFileReq {
-                    table_id,
                     file_info,
                     expire_at: None,
                     fail_if_duplicated: true,
@@ -2511,7 +2508,6 @@ impl SchemaApiTestSuite {
             file_info.insert("file".to_string(), stage_info.clone());
 
             let req = UpsertTableCopiedFileReq {
-                table_id,
                 file_info: file_info.clone(),
                 expire_at: Some((Utc::now().timestamp() + 86400) as u64),
                 fail_if_duplicated: true,
@@ -3239,7 +3235,6 @@ impl SchemaApiTestSuite {
             file_info.insert("file".to_string(), stage_info.clone());
 
             let req = UpsertTableCopiedFileReq {
-                table_id,
                 file_info: file_info.clone(),
                 expire_at: Some((Utc::now().timestamp() + 86400) as u64),
                 fail_if_duplicated: true,
@@ -3276,7 +3271,6 @@ impl SchemaApiTestSuite {
             file_info.insert("file2".to_string(), stage_info.clone());
 
             let req = UpsertTableCopiedFileReq {
-                table_id,
                 file_info: file_info.clone(),
                 expire_at: Some((Utc::now().timestamp() - 86400) as u64),
                 fail_if_duplicated: true,
@@ -3368,7 +3362,6 @@ impl SchemaApiTestSuite {
             file_info.insert("file".to_string(), stage_info.clone());
 
             let req = UpsertTableCopiedFileReq {
-                table_id,
                 file_info: file_info.clone(),
                 expire_at: Some((Utc::now().timestamp() + 86400) as u64),
                 fail_if_duplicated: true,
@@ -4243,7 +4236,6 @@ impl SchemaApiTestSuite {
             file_info.insert("file".to_string(), stage_info.clone());
 
             let req = UpsertTableCopiedFileReq {
-                table_id,
                 file_info: file_info.clone(),
                 expire_at: Some((Utc::now().timestamp() + 86400) as u64),
                 fail_if_duplicated: true,
@@ -4289,7 +4281,6 @@ impl SchemaApiTestSuite {
             file_info.insert("file_not_exist".to_string(), stage_info.clone());
 
             let req = UpsertTableCopiedFileReq {
-                table_id,
                 file_info: file_info.clone(),
                 expire_at: Some((Utc::now().timestamp() + 86400) as u64),
                 fail_if_duplicated: true,
@@ -4332,7 +4323,6 @@ impl SchemaApiTestSuite {
             file_info.insert("file_not_exist".to_string(), stage_info.clone());
 
             let req = UpsertTableCopiedFileReq {
-                table_id,
                 file_info: file_info.clone(),
                 expire_at: Some((Utc::now().timestamp() + 86400) as u64),
                 fail_if_duplicated: false,

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -712,7 +712,6 @@ pub struct GetTableCopiedFileReply {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct UpsertTableCopiedFileReq {
-    pub table_id: u64,
     pub file_info: BTreeMap<String, TableCopiedFileInfo>,
     pub expire_at: Option<u64>,
     pub fail_if_duplicated: bool,

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -61,7 +61,7 @@ pub static METACLI_COMMIT_SEMVER: Lazy<Version> = Lazy::new(|| {
 /// - 2023-02-17: since 0.9.42:
 ///   Meta service only responds with MetaAPIError.
 ///
-/// - 2023-05-07: since 1.1.29: (Fix the `since` when merged)
+/// - 2023-05-07: since 1.1.32:
 ///   TxnDeleteRequest provides a `match_seq` field to delete a record if its `seq` matches.
 pub static MIN_METASRV_SEMVER: Version = Version {
     major: 0,

--- a/src/query/service/src/interpreters/interpreter_copy.rs
+++ b/src/query/service/src/interpreters/interpreter_copy.rs
@@ -32,7 +32,6 @@ use common_expression::DataSchemaRefExt;
 use common_meta_app::principal::StageInfo;
 use common_meta_app::schema::TableCopiedFileInfo;
 use common_meta_app::schema::UpsertTableCopiedFileReq;
-use common_meta_types::MetaId;
 use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_sql::executor::table_read_plan::ToReadDataSourcePlan;
 use common_storage::StageFileInfo;
@@ -450,7 +449,6 @@ impl CopyInterpreter {
             // 1. Commit data to table.
             let operations = ctx.consume_precommit_blocks();
 
-            let table_id = to_table.get_id();
             let expire_hours = ctx.get_settings().get_load_file_metadata_expire_hours()?;
 
             let upsert_copied_files_request = {
@@ -462,7 +460,6 @@ impl CopyInterpreter {
                 } else {
                     let fail_if_duplicated = !force;
                     Self::upsert_copied_files_request(
-                        table_id,
                         expire_hours,
                         copied_file_tree,
                         fail_if_duplicated,
@@ -528,7 +525,6 @@ impl CopyInterpreter {
     }
 
     fn upsert_copied_files_request(
-        table_id: MetaId,
         expire_hours: u64,
         copy_stage_files: BTreeMap<String, TableCopiedFileInfo>,
         fail_if_duplicated: bool,
@@ -539,7 +535,6 @@ impl CopyInterpreter {
         tracing::debug!("upsert_copied_files_info: {:?}", copy_stage_files);
         let expire_at = expire_hours * 60 * 60 + Utc::now().timestamp() as u64;
         let req = UpsertTableCopiedFileReq {
-            table_id,
             file_info: copy_stage_files,
             expire_at: Some(expire_at),
             fail_if_duplicated,


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta): remove UpsertTableCopiedFileReq.table_id

`UpsertTableCopiedFileReq` is a sub-compoenent of `UpdateTableMetaReq`
and do not need `table_id`


##### chore(meta): update doc about the newly added TxnDeleteRequest.match_seq

## Changelog







## Related Issues