### PR TITLE
feat(query): Optimize read system.columns data

### DIFF
--- a/src/query/storages/system/src/catalogs_table.rs
+++ b/src/query/storages/system/src/catalogs_table.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use common_catalog::catalog::CatalogManager;
+use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -44,7 +45,11 @@ impl AsyncSystemTable for CatalogsTable {
     }
 
     #[async_backtrace::framed]
-    async fn get_full_data(&self, _ctx: Arc<dyn TableContext>) -> Result<DataBlock> {
+    async fn get_full_data(
+        &self,
+        _ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+    ) -> Result<DataBlock> {
         let cm = CatalogManager::instance();
 
         let catalog_names: Vec<Vec<u8>> = cm

--- a/src/query/storages/system/src/databases_table.rs
+++ b/src/query/storages/system/src/databases_table.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_catalog::catalog::Catalog;
 use common_catalog::catalog::CatalogManager;
+use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -47,7 +48,11 @@ impl AsyncSystemTable for DatabasesTable {
     }
 
     #[async_backtrace::framed]
-    async fn get_full_data(&self, ctx: Arc<dyn TableContext>) -> Result<DataBlock> {
+    async fn get_full_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+    ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
         let catalogs = CatalogManager::instance();
         let catalogs: Vec<(String, Arc<dyn Catalog>)> = catalogs

--- a/src/query/storages/system/src/engines_table.rs
+++ b/src/query/storages/system/src/engines_table.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use common_catalog::catalog_kind::CATALOG_DEFAULT;
+use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -44,7 +45,11 @@ impl AsyncSystemTable for EnginesTable {
     }
 
     #[async_backtrace::framed]
-    async fn get_full_data(&self, ctx: Arc<dyn TableContext>) -> Result<DataBlock> {
+    async fn get_full_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+    ) -> Result<DataBlock> {
         // TODO passing catalog name
         let table_engine_descriptors = ctx.get_catalog(CATALOG_DEFAULT)?.get_table_engines();
         let mut engine_name = Vec::with_capacity(table_engine_descriptors.len());

--- a/src/query/storages/system/src/functions_table.rs
+++ b/src/query/storages/system/src/functions_table.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -48,7 +49,11 @@ impl AsyncSystemTable for FunctionsTable {
     }
 
     #[async_backtrace::framed]
-    async fn get_full_data(&self, ctx: Arc<dyn TableContext>) -> Result<DataBlock> {
+    async fn get_full_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+    ) -> Result<DataBlock> {
         // TODO(andylokandy): add rewritable function names, e.g. database()
         let func_names = BUILTIN_FUNCTIONS.registered_names();
         let aggregate_function_factory = AggregateFunctionFactory::instance();

--- a/src/query/storages/system/src/query_cache_table.rs
+++ b/src/query/storages/system/src/query_cache_table.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -50,7 +51,11 @@ impl AsyncSystemTable for QueryCacheTable {
     }
 
     #[async_backtrace::framed]
-    async fn get_full_data(&self, ctx: Arc<dyn TableContext>) -> Result<DataBlock> {
+    async fn get_full_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+    ) -> Result<DataBlock> {
         let meta_client = UserApiProvider::instance().get_meta_store_client();
         let result_cache_mgr = ResultCacheMetaManager::create(meta_client, 0);
         let tenant = ctx.get_tenant();

--- a/src/query/storages/system/src/roles_table.rs
+++ b/src/query/storages/system/src/roles_table.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -46,7 +47,11 @@ impl AsyncSystemTable for RolesTable {
     }
 
     #[async_backtrace::framed]
-    async fn get_full_data(&self, ctx: Arc<dyn TableContext>) -> Result<DataBlock> {
+    async fn get_full_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+    ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
         let roles = UserApiProvider::instance().get_roles(&tenant).await?;
 

--- a/src/query/storages/system/src/stages_table.rs
+++ b/src/query/storages/system/src/stages_table.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 use std::vec;
 
+use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -49,7 +50,11 @@ impl AsyncSystemTable for StagesTable {
     }
 
     #[async_backtrace::framed]
-    async fn get_full_data(&self, ctx: Arc<dyn TableContext>) -> Result<DataBlock> {
+    async fn get_full_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+    ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
         let stages = UserApiProvider::instance().get_stages(&tenant).await?;
         let mut name: Vec<Vec<u8>> = Vec::with_capacity(stages.len());

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_catalog::catalog::Catalog;
 use common_catalog::catalog::CatalogManager;
+use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -90,7 +91,11 @@ where TablesTable<T>: HistoryAware
     }
 
     #[async_backtrace::framed]
-    async fn get_full_data(&self, ctx: Arc<dyn TableContext>) -> Result<DataBlock> {
+    async fn get_full_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+    ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
         let catalog_mgr = CatalogManager::instance();
         let ctls: Vec<(String, Arc<dyn Catalog>)> = catalog_mgr

--- a/src/query/storages/system/src/users_table.rs
+++ b/src/query/storages/system/src/users_table.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -44,7 +45,11 @@ impl AsyncSystemTable for UsersTable {
     }
 
     #[async_backtrace::framed]
-    async fn get_full_data(&self, ctx: Arc<dyn TableContext>) -> Result<DataBlock> {
+    async fn get_full_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+    ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
         let users = UserApiProvider::instance().get_users(&tenant).await?;
 

--- a/tests/sqllogictests/suites/base/01_system/01_0006_system_columns
+++ b/tests/sqllogictests/suites/base/01_system/01_0006_system_columns
@@ -1,4 +1,10 @@
 statement ok
+drop table if exists default.t;
+
+statement ok
+create table default.t(id int);
+
+statement ok
 DROP DATABASE IF EXISTS COLUMNTEST
 
 statement ok
@@ -8,11 +14,37 @@ statement ok
 CREATE TABLE COLUMNTEST.A(ID INT, ID2 INT DEFAULT 1, ID3 STRING, ID4 STRING DEFAULT 'ID4')
 
 statement ok
+CREATE TABLE COLUMNTEST.T(TID INT, TID2 INT DEFAULT 1, TID3 STRING, TID4 STRING DEFAULT 'ID4')
+
+statement ok
 SELECT lower(database), name, type, default_kind as default_type, default_expression, comment FROM system.columns  WHERE database LIKE 'columntest'
 
 statement ok
 SELECT lower(database), name FROM system.columns  WHERE table LIKE 'views'
 
+query TT
+SELECT lower(database), name FROM system.columns  WHERE table = 't' or database='columntest' order by name
+----
+columntest id
+default id
+columntest id2
+columntest id3
+columntest id4
+columntest tid
+columntest tid2
+columntest tid3
+columntest tid4
+
+query TT
+SELECT lower(database), name FROM system.columns  WHERE table = 't' and database='columntest' order by name
+----
+columntest tid
+columntest tid2
+columntest tid3
+columntest tid4
+
+statement ok
+drop table default.t;
 
 statement ok
 DROP DATABASE COLUMNTEST


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

If query `system.columns` with push down filter Expr FunctionCall eq

and the eq arg has column name 'table' like this:

```
where table='tb1' and table='tb2' and table='tb3' and table = 'tb4'
```

will only get these tables.

BTW, not use field database and Expr or as filter. Because there maybe have some bad case:

```
where database='db1' or table='db2_tb1'
where database='db1' and table='db1_tb1' or table='db2_tb1'
```

Closes #https://github.com/datafuselabs/databend/issues/11355
