### PR TITLE
fix(meta): upgrade openraft to 0.8.4-alpha.3; bug fix, improve performance, etc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyerror"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,17 +1327,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.8"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
- "bitflags",
- "clap_derive 4.1.8",
- "clap_lex 0.3.2",
- "is-terminal",
+ "clap_builder",
+ "clap_derive 4.2.0",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.4.1",
  "strsim 0.10.0",
- "termcolor",
 ]
 
 [[package]]
@@ -1306,15 +1364,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.8"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1328,12 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "clru"
@@ -1388,6 +1442,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -3441,7 +3501,7 @@ name = "databend-sqllogictests"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "clap 4.1.8",
+ "clap 4.2.7",
  "common-exception",
  "env_logger 0.10.0",
  "futures-util",
@@ -6134,7 +6194,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b603516767d1ab23d0de09d023e62966c3322f7148297c35cf3d97aa8b37fa"
 dependencies = [
- "clap 4.1.8",
+ "clap 4.2.7",
  "termcolor",
  "threadpool",
 ]
@@ -6971,13 +7031,13 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.8.4"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.2#17a658f41ba193609ee3ac626149ef50592d937c"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.3#5da9594d3658e5d1637d8e0a896f6724fdc918f9"
 dependencies = [
  "anyerror",
  "anyhow",
  "async-trait",
  "byte-unit",
- "clap 3.2.23",
+ "clap 4.2.7",
  "derive_more",
  "futures",
  "maplit",
@@ -10410,6 +10470,12 @@ name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ jsonb = { version = "0.2.2" }
 
 # openraft = { version = "0.8.2", features = ["compat-07"] }
 # For debugging
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.8.4-alpha.2", features = ["compat-07"] }
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.8.4-alpha.3", features = ["compat-07"] }
 
 # type helper
 derive_more = "0.99.17"

--- a/src/meta/service/src/store/store.rs
+++ b/src/meta/service/src/store/store.rs
@@ -32,6 +32,7 @@ use common_meta_types::Entry;
 use common_meta_types::LogId;
 use common_meta_types::MetaStartupError;
 use common_meta_types::Snapshot;
+use common_meta_types::SnapshotData;
 use common_meta_types::SnapshotMeta;
 use common_meta_types::StorageError;
 use common_meta_types::StoredMembership;
@@ -146,7 +147,7 @@ impl RaftLogReader<TypeConfig> for RaftStore {
 }
 
 #[async_trait]
-impl RaftSnapshotBuilder<TypeConfig, Cursor<Vec<u8>>> for RaftStore {
+impl RaftSnapshotBuilder<TypeConfig> for RaftStore {
     #[tracing::instrument(level = "debug", skip(self), fields(id=self.id))]
     async fn build_snapshot(&mut self) -> Result<Snapshot, StorageError> {
         self.do_build_snapshot().await
@@ -155,7 +156,6 @@ impl RaftSnapshotBuilder<TypeConfig, Cursor<Vec<u8>>> for RaftStore {
 
 #[async_trait]
 impl RaftStorage<TypeConfig> for RaftStore {
-    type SnapshotData = Cursor<Vec<u8>>;
     type LogReader = RaftStore;
     type SnapshotBuilder = RaftStore;
 
@@ -289,7 +289,7 @@ impl RaftStorage<TypeConfig> for RaftStore {
     }
 
     #[tracing::instrument(level = "debug", skip(self), fields(id=self.id))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<Self::SnapshotData>, StorageError> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotData>, StorageError> {
         server_metrics::incr_applying_snapshot(1);
         Ok(Box::new(Cursor::new(Vec::new())))
     }
@@ -298,7 +298,7 @@ impl RaftStorage<TypeConfig> for RaftStore {
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta,
-        snapshot: Box<Self::SnapshotData>,
+        snapshot: Box<SnapshotData>,
     ) -> Result<(), StorageError> {
         // TODO(xp): disallow installing a snapshot with smaller last_applied.
 

--- a/src/meta/types/src/raft_types.rs
+++ b/src/meta/types/src/raft_types.rs
@@ -25,7 +25,13 @@ pub type LogIndex = u64;
 pub type Term = u64;
 
 openraft::declare_raft_types!(
-    pub TypeConfig: D = LogEntry, R = AppliedState, NodeId = NodeId, Node = MembershipNode, Entry = openraft::entry::Entry<TypeConfig>
+    pub TypeConfig:
+        D = LogEntry,
+        R = AppliedState,
+        NodeId = NodeId,
+        Node = MembershipNode,
+        Entry = openraft::entry::Entry<TypeConfig>,
+        SnapshotData = Cursor<Vec<u8>>
 );
 
 pub type CommittedLeaderId = openraft::CommittedLeaderId<NodeId>;
@@ -40,7 +46,7 @@ pub type Entry = openraft::Entry<TypeConfig>;
 
 pub type SnapshotMeta = openraft::SnapshotMeta<NodeId, MembershipNode>;
 pub type SnapshotData = Cursor<Vec<u8>>;
-pub type Snapshot = openraft::Snapshot<NodeId, MembershipNode, SnapshotData>;
+pub type Snapshot = openraft::Snapshot<TypeConfig>;
 
 pub type RaftMetrics = openraft::RaftMetrics<NodeId, MembershipNode>;
 

--- a/tests/sqllogictests/Cargo.toml
+++ b/tests/sqllogictests/Cargo.toml
@@ -15,7 +15,7 @@ name = "databend-sqllogictests"
 
 [dependencies]
 async-trait = "0.1.53"
-clap = { version = "4.0.29", features = ["derive", "env"] }
+clap = { version = "4.1.11", features = ["derive", "env"] }
 common-exception = { path = "../../src/common/exception" }
 env_logger = "0.10.0"
 futures-util = "0.3.25"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### fix(meta): upgrade openraft to 0.8.4-alpha.3; bug fix, improve performance, etc

# Changes Summary:

- Fix: replication should be able to shutdown when replicating snapshot to unreachable node.
- Feature: new RaftNetwork API with argument RCPOption.
- Feature: add `RaftMetrics.vote`, `Wait::vote()`.
- Feature: add Wait::purged() to wait for purged to become the expected.
- Feature: add RaftMetrics::purged to report the last purged log id.
- Feature: add backoff strategy for unreachable nodes.
- Improve: build snapshot in anohter task.
- Improve: Better performance with two channel: `256 clients, 3 node: 1 million rps`.


# Detailed change log

## Fix: replication should be able to shutdown when replicating snapshot to unreachable node

If a replication is sending a snapshot, it should
periodically verify the input channel's status. When the input channel
is closed during replication rebuilding, it should immediately exit the
loop instead of attempting retries indefinitely.

## Change: move snapshot type definition from storage traits to `RaftTypeConfig`

Similar to `NodeId` or `Entry`, `SnapshotData` is also a data type that
is specified by the application and needs to be defined in
`RaftTypeConfig`, which is a collection of all application types.

Public types changes:

- Add `SnapshotData` to `RaftTypeConfig`:
  ```rust
  pub trait RaftTypeConfig {
      /// ...
      type SnapshotData: AsyncRead + AsyncWrite + AsyncSeek + Send + Sync + Unpin + 'static;
  }
  ```
- Remove associated type `SnapshotData` from `storage::RaftStorage`.
- Remove associated type `SnapshotData` from `storage::v2::RaftStateMachine`.

Corresponding API changes:

- Change `storage::RaftSnapshotBuilder<C: RaftTypeConfig, SNAPSHOT_DATA>` to `RaftSnapshotBuilder<C>`
- Change `storage::Snapshot<NID: NodeId, N: Node, SNAPSHOT_DATA>` to `storage::Snapshot<C>`

## Change: `RaftMetrics.replication` type to `BTreeMap<NodeId, Option<LogId>>`

The `RaftMetrics.replication` used to be of type
`ReplicationMetrics{ replication: BTreeMap<NodeId, ReplicationTargetMetrics> }`
which contained an atomic log index value for each
ReplicationTargetMetrics stored in the `BTreeMap`. The purpose of this
type was to reduce the cost of copying a metrics instance. However,
since the metrics report rate has been significantly reduced, this
cost is now negligible. As a result, these complicated implementations
have been removed. When reporting metrics, they can simply be cloned
from the progress information maintained by `Engine`.

## Feature: `RaftNetwork::send_append_entries()` can return PartialSuccess

If there are too many log entries and the `RPCOption.ttl` is not
sufficient, an application can opt to only send a portion of the
entries, with `AppendEntriesResponse::PartialSuccess(Option<LogId>)`, to
inform Openraft with the last replicated log id. Thus replication can
still make progress.

For example, it tries to send log entries `[1-2..3-10]`, the application
is allowed to send just `[1-2..1-3]` and return `PartialSuccess(1-3)`,

### Caution

The returned matching log id must be **greater than or equal to** the
first log id(`AppendEntriesRequest::prev_log_id`) of the entries to
send. If no RPC reply is received, `RaftNetwork::send_append_entries`
**must** return an `RPCError` to inform Openraft that the first log
id(`AppendEntriesRequest::prev_log_id`) may not match on the remote
target node.

## Feature: new RaftNetwork API with argument RCPOption

- `RaftNetwork` introduced 3 new API `append_entries`,
  `install_snapshot` and `vote` which accept an additional argument
  `RPCOption`, and deprecated the old API `send_append_entries`,
  `send_install_snapshot` and `send_vote`.

- The old API will be **removed** in `0.9`. An application can still
  implement the old API without any changes. Openraft calls only the new
  API and the default implementation will delegate to the old API.

- Implementing the new APIs will disable the old APIs.

- The new APIs accepts an additional argument `RPCOption`, to enable an
  application control the networking behaviors based on the parameters
  in `RPCOption`.

  The `hard_ttl()` and `soft_ttl()` in `RPCOption` sets the hard limit
  and the moderate limit of the duration for which an RPC should run.
  Once the `soft_ttl()` ends, the RPC implementation should start to
  gracefully cancel the RPC, and once the `hard_ttl()` ends, Openraft
  will terminate the ongoing RPC at once.

## Feature: add `RaftMetrics.vote`, `Wait::vote()`

The latest approved value of `Vote`, which has been saved to disk, is
referred to as `RaftMetrics.vote`. Additionally, a new `vote()` method
has been included in `Wait` to enable the application to wait for `vote`
to reach the anticipated value.

## Feature: add Wait::purged() to wait for purged to become the expected

## Feature: add RaftMetrics::purged to report the last purged log id

## Feature: add backoff strategy for unreachable nodes

Implements a backoff strategy for temporarily or permanently unreachable nodes.
If the `Network` implementation returns `Unreachable` error, Openraft
will backoff for a while before sending next RPC to this target.
This mechanism prevents error logging flood.

Adds a new method `backoff()` to `RaftNetwork` to let an application
return a customized backoff policy, the default provided backoff just
constantly sleep 500ms.

Adds an `unreachable_nodes` setting to the testing router `TypedRaftRouteryped` to emulate unreachable nodes.
Add new error `Unreachable` and an `RPCError` variant `Unreachable`.

## Improve: build snapshot in anohter task

Before this commit, snapshot is built in the `sm::Worker`, which blocks
other state-machine writes, such as applying log entries.

This commit parallels applying log entries and building snapshot: A
snapshot is built in another `tokio::task`.

Because building snapshot is a read operation, it does not have to
block the entire state machine. Instead, it only needs a consistent view
of the state machine or holding a lock of the state machine.

## Improve: move receiving snapshot chunk to sm::Worker

Receiving snapshot chunk should not be run in RaftCore task.
Otherwise it will block RaftCore.

In this commit this task is moved to sm::Worker, running in another
task. The corresponding responding command will not be run until
sm::Worker notify RaftCore receiving is finished.

## Changelog







## Related Issues