### PR TITLE
chore: http handler release context/session earlier.

### DIFF
--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -274,7 +274,6 @@ impl HttpQuery {
         let block_sender_closer = block_sender.closer();
         let state_clone = state.clone();
         let ctx_clone = ctx.clone();
-        let ctx_clone2 = ctx.clone();
         let sql = request.sql.clone();
         let query_id = id.clone();
         let query_id_clone = id.clone();
@@ -319,7 +318,6 @@ impl HttpQuery {
             block_receiver,
             schema,
             format_settings,
-            ctx_clone2,
         )));
         let query = HttpQuery {
             id,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

there is an extra instance of ctx to avoid dropping runtime when task on it is running,
this is solved better in https://github.com/datafuselabs/databend/pull/10501, so not need it any more.



Closes https://github.com/datafuselabs/databend/issues/11359
