### PR TITLE
fix(http): Don't print whole SQL for insert

### DIFF
--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -44,6 +45,7 @@ use crate::servers::http::v1::query::PageManager;
 use crate::servers::http::v1::query::ResponseData;
 use crate::servers::http::v1::query::Wait;
 use crate::servers::http::v1::HttpQueryManager;
+use crate::sessions::short_sql;
 use crate::sessions::QueryAffect;
 use crate::sessions::SessionType;
 use crate::sessions::TableContext;
@@ -52,7 +54,7 @@ fn default_as_true() -> bool {
     true
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
 pub struct HttpQueryRequest {
     pub session_id: Option<String>,
     pub session: Option<HttpSessionConf>,
@@ -62,6 +64,19 @@ pub struct HttpQueryRequest {
     #[serde(default = "default_as_true")]
     pub string_fields: bool,
     pub stage_attachment: Option<StageAttachmentConf>,
+}
+
+impl Debug for HttpQueryRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpQueryRequest")
+            .field("session_id", &self.session_id)
+            .field("session", &self.session)
+            .field("sql", &short_sql(self.sql.clone()))
+            .field("pagination", &self.pagination)
+            .field("string_fields", &self.string_fields)
+            .field("stage_attachment", &self.stage_attachment)
+            .finish()
+    }
 }
 
 const DEFAULT_MAX_ROWS_IN_BUFFER: usize = 5 * 1000 * 1000;

--- a/src/query/service/src/sessions/mod.rs
+++ b/src/query/service/src/sessions/mod.rs
@@ -26,6 +26,7 @@ mod session_type;
 pub use common_catalog::table_context::TableContext;
 pub use query_affect::QueryAffect;
 pub use query_ctx::QueryContext;
+pub use query_ctx_shared::short_sql;
 pub use query_ctx_shared::QueryContextShared;
 pub use session::Session;
 pub use session_ctx::SessionContext;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(http): Don't print whole SQL for insert
