### PR TITLE
feat(query): add func date_format and str_to_date and str_to_timestamp

### DIFF
--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -1120,6 +1120,8 @@ Functions overloads:
 1 cot(Float64 NULL) :: Float64 NULL
 0 crc32(String) :: UInt32
 1 crc32(String NULL) :: UInt32 NULL
+0 date_format(Timestamp, String) :: String NULL
+1 date_format(Timestamp NULL, String NULL) :: String NULL
 0 degrees(Float64) :: Float64
 1 degrees(Float64 NULL) :: Float64 NULL
 0 div(UInt8, UInt8) :: UInt8
@@ -2980,6 +2982,10 @@ Functions overloads:
 17 sqrt(Float32 NULL) :: Float64 NULL
 18 sqrt(Float64) :: Float64
 19 sqrt(Float64 NULL) :: Float64 NULL
+0 str_to_date(String, String) :: Date NULL
+1 str_to_date(String NULL, String NULL) :: Date NULL
+0 str_to_timestamp(String, String) :: Timestamp NULL
+1 str_to_timestamp(String NULL, String NULL) :: Timestamp NULL
 0 strcmp(String, String) :: Int8
 1 strcmp(String NULL, String NULL) :: Int8 NULL
 0 substr(String, Int64) :: String

--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -55,6 +55,7 @@ use tracing::info;
 use crate::interpreters::InterpreterFactory;
 use crate::interpreters::InterpreterPtr;
 use crate::servers::http::v1::HttpQueryContext;
+use crate::sessions::short_sql;
 use crate::sessions::QueryContext;
 use crate::sessions::SessionType;
 use crate::sessions::TableContext;
@@ -286,14 +287,11 @@ pub async fn clickhouse_handler_post(
         sql.push(' ');
     }
     sql.push_str(body.into_string().await?.as_str());
-    let n = 100;
+    let n = 64;
     // other parts of the request already logged in middleware
-    let msg = if sql.len() > n {
-        format!(
-            "{}...(omit {} bytes)",
-            &sql[0..n].to_string(),
-            sql.len() - n
-        )
+    let len = sql.len();
+    let msg = if len > n {
+        format!("{}...(omit {} bytes)", short_sql(sql.clone()), len - n)
     } else {
         sql.to_string()
     };

--- a/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes
+++ b/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes
@@ -893,3 +893,38 @@ select * from t order by b
 statement ok
 drop table t
 
+query T
+select date_format('2022-02-02', '精彩的%Y年，美丽的%mmonth,激动の%dd');
+----
+精彩的2022年，美丽的02month,激动の02d
+
+query T
+select str_to_date('精彩的2022年，美丽的02month,激动の02d', '精彩的%Y年，美丽的%mmonth,激动の%dd');
+----
+2022-02-02
+
+statement error 1001
+select date_format('', '');
+
+statement error 1001
+select date_format('2022-2-04T03:58:59', '%Y年%m月%d日，%H时%M分%S秒');
+
+query T
+select date_format('2022-02-04T03:58:59', '%Y年%m月%d日，%H时%M分%S秒');
+----
+2022年02月04日，03时58分59秒
+
+query T
+select str_to_timestamp('2022年02月04日，03时58分59秒', '%Y年%m月%d日，%H时%M分%S秒');
+----
+NULL
+
+query T
+select str_to_timestamp('2022年02月04日，8时58分59秒,时区：+0000', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-04 08:58:59.000000
+
+query T
+select str_to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-04 00:58:59.000000


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

support function:

date_format(Timestamp, String) :: String NULL
date_format(Timestamp NULL, String NULL) :: String NULL

str_to_date(String, String) :: Date NULL
str_to_date(String NULL, String NULL) :: Date NULL
str_to_timestamp(String, String) :: Timestamp NULL
str_to_timestamp(String NULL, String NULL) :: Timestamp NULL

### Note

* If use str_to_timestamp , the string must contains timezone. Because we need to unique date and time. If not contains timezone will return null.

Closes #11125
