### PR TITLE
chore(planner): fix a bug in require_property

### DIFF
--- a/src/query/sql/src/planner/optimizer/property/enforcer.rs
+++ b/src/query/sql/src/planner/optimizer/property/enforcer.rs
@@ -51,7 +51,7 @@ pub fn require_property(
                     .child(0)?
                     .children()
                     .iter()
-                    .all(check_partition)
+                    .any(check_partition)
                 {
                     children.push(optimized_expr.child(index)?.clone());
                     continue;
@@ -62,6 +62,9 @@ pub fn require_property(
                     })?;
                 children.push(enforced_child);
                 continue;
+            } else if index == 1 && required.distribution == Distribution::Broadcast {
+                let enforced_child = enforce_property(optimized_expr.child(index)?, &required)?;
+                children.push(enforced_child);
             }
         }
         if let RelOperator::UnionAll(_) = &s_expr.plan {

--- a/src/query/sql/src/planner/optimizer/property/enforcer.rs
+++ b/src/query/sql/src/planner/optimizer/property/enforcer.rs
@@ -44,9 +44,9 @@ pub fn require_property(
         let required = rel_expr.compute_required_prop_child(ctx.clone(), index, required)?;
         let physical = rel_expr.derive_physical_prop_child(index)?;
         if let RelOperator::Join(_) = &s_expr.plan {
-            // If the child is join probe side and join type is broadcast join
-            // We should wrap the child with Random exchange to make it partition to all nodes
             if index == 0 && required.distribution == Distribution::Broadcast {
+                // If the child is join probe side and join type is broadcast join
+                // We should wrap the child with Random exchange to make it partition to all nodes
                 if optimized_expr
                     .child(0)?
                     .children()
@@ -63,6 +63,8 @@ pub fn require_property(
                 children.push(enforced_child);
                 continue;
             } else if index == 1 && required.distribution == Distribution::Broadcast {
+                // If the child is join build side and join type is broadcast join
+                // We should wrap the child with Broadcast exchange to make it available to all nodes.
                 let enforced_child = enforce_property(optimized_expr.child(index)?, &required)?;
                 children.push(enforced_child);
             }

--- a/src/query/sql/src/planner/optimizer/property/enforcer.rs
+++ b/src/query/sql/src/planner/optimizer/property/enforcer.rs
@@ -51,7 +51,7 @@ pub fn require_property(
                     .child(0)?
                     .children()
                     .iter()
-                    .any(check_partition)
+                    .all(check_partition)
                 {
                     children.push(optimized_expr.child(index)?.clone());
                     continue;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR
If the child is join build side and join type is broadcast join, we should wrap the child with Broadcast exchange to make it available to all nodes.

Closes #issue
