### PR TITLE
feat(query): make date_format throw err

### DIFF
--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -7,6 +7,7 @@ array_slice -> slice
 bitmap_cardinality -> bitmap_count
 ceiling -> ceil
 character_length -> char_length
+date_format -> to_string
 intdiv -> div
 ipv4_num_to_string -> inet_ntoa
 ipv4_string_to_num -> inet_aton
@@ -22,6 +23,8 @@ remove_nullable -> assume_not_null
 rlike -> regexp
 sha1 -> sha
 siphash -> siphash64
+str_to_date -> to_date
+str_to_timestamp -> to_timestamp
 substring -> substr
 substring_utf8 -> substr_utf8
 subtract -> minus
@@ -1120,8 +1123,6 @@ Functions overloads:
 1 cot(Float64 NULL) :: Float64 NULL
 0 crc32(String) :: UInt32
 1 crc32(String NULL) :: UInt32 NULL
-0 date_format(Timestamp, String) :: String NULL
-1 date_format(Timestamp NULL, String NULL) :: String NULL
 0 degrees(Float64) :: Float64
 1 degrees(Float64 NULL) :: Float64 NULL
 0 div(UInt8, UInt8) :: UInt8
@@ -2982,10 +2983,6 @@ Functions overloads:
 17 sqrt(Float32 NULL) :: Float64 NULL
 18 sqrt(Float64) :: Float64
 19 sqrt(Float64 NULL) :: Float64 NULL
-0 str_to_date(String, String) :: Date NULL
-1 str_to_date(String NULL, String NULL) :: Date NULL
-0 str_to_timestamp(String, String) :: Timestamp NULL
-1 str_to_timestamp(String NULL, String NULL) :: Timestamp NULL
 0 strcmp(String, String) :: Int8
 1 strcmp(String NULL, String NULL) :: Int8 NULL
 0 substr(String, Int64) :: String
@@ -3056,12 +3053,14 @@ Functions overloads:
 19 to_boolean(Int64 NULL) :: Boolean NULL
 0 to_date(Variant) :: Date
 1 to_date(Variant NULL) :: Date NULL
-2 to_date(String) :: Date
-3 to_date(String NULL) :: Date NULL
-4 to_date(Timestamp) :: Date
-5 to_date(Timestamp NULL) :: Date NULL
-6 to_date(Int64) :: Date
-7 to_date(Int64 NULL) :: Date NULL
+2 to_date(String, String) :: Date NULL
+3 to_date(String NULL, String NULL) :: Date NULL
+4 to_date(String) :: Date
+5 to_date(String NULL) :: Date NULL
+6 to_date(Timestamp) :: Date
+7 to_date(Timestamp NULL) :: Date NULL
+8 to_date(Int64) :: Date
+9 to_date(Int64 NULL) :: Date NULL
 0 to_day_of_month(Date) :: UInt8
 1 to_day_of_month(Date NULL) :: UInt8 NULL
 2 to_day_of_month(Timestamp) :: UInt8
@@ -3301,20 +3300,24 @@ Functions overloads:
 22 to_string(Float64 NULL) :: String NULL
 23 to_string(Boolean) :: String
 24 to_string(Boolean NULL) :: String NULL
-25 to_string(Date) :: String
-26 to_string(Date NULL) :: String NULL
-27 to_string(Timestamp) :: String
-28 to_string(Timestamp NULL) :: String NULL
-29 to_string(Bitmap) :: String
-30 to_string(Bitmap NULL) :: String NULL
+25 to_string(Timestamp, String) :: String NULL
+26 to_string(Timestamp NULL, String NULL) :: String NULL
+27 to_string(Date) :: String
+28 to_string(Date NULL) :: String NULL
+29 to_string(Timestamp) :: String
+30 to_string(Timestamp NULL) :: String NULL
+31 to_string(Bitmap) :: String
+32 to_string(Bitmap NULL) :: String NULL
 0 to_timestamp(Variant) :: Timestamp
 1 to_timestamp(Variant NULL) :: Timestamp NULL
 2 to_timestamp(String) :: Timestamp
 3 to_timestamp(String NULL) :: Timestamp NULL
-4 to_timestamp(Date) :: Timestamp
-5 to_timestamp(Date NULL) :: Timestamp NULL
-6 to_timestamp(Int64) :: Timestamp
-7 to_timestamp(Int64 NULL) :: Timestamp NULL
+4 to_timestamp(String, String) :: Timestamp NULL
+5 to_timestamp(String NULL, String NULL) :: Timestamp NULL
+6 to_timestamp(Date) :: Timestamp
+7 to_timestamp(Date NULL) :: Timestamp NULL
+8 to_timestamp(Int64) :: Timestamp
+9 to_timestamp(Int64 NULL) :: Timestamp NULL
 0 to_uint16(Variant) :: UInt16
 1 to_uint16(Variant NULL) :: UInt16 NULL
 2 to_uint16(String) :: UInt16

--- a/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes
+++ b/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes
@@ -894,12 +894,17 @@ statement ok
 drop table t
 
 query T
-select date_format('2022-02-02', '精彩的%Y年，美丽的%mmonth,激动の%dd');
+select to_string('2022-02-02', '精彩的%Y年，美丽的%mmonth,激动の%dd');
 ----
 精彩的2022年，美丽的02month,激动の02d
 
 query T
 select str_to_date('精彩的2022年，美丽的02month,激动の02d', '精彩的%Y年，美丽的%mmonth,激动の%dd');
+----
+2022-02-02
+
+query T
+select to_date('精彩的2022年，美丽的02month,激动の02d', '精彩的%Y年，美丽的%mmonth,激动の%dd');
 ----
 2022-02-02
 
@@ -925,6 +930,6 @@ select str_to_timestamp('2022年02月04日，8时58分59秒,时区：+0000', '%Y
 2022-02-04 08:58:59.000000
 
 query T
-select str_to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
 ----
 2022-02-04 00:58:59.000000


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. rename func name to_date, to_timestamp, add alias str_to_date, str_to_timestamp
2. return throw err



REF: https://github.com/datafuselabs/databend/pull/11442#discussion_r1193236422
