### PR TITLE
feat(meta): add replication state to meta service API /v1/cluster/status

### DIFF
--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::net::Ipv4Addr;
@@ -98,24 +99,39 @@ use crate::Opened;
 pub struct MetaNodeStatus {
     pub id: NodeId,
 
+    /// The raft service endpoint for internal communication
     pub endpoint: String,
 
+    /// The size in bytes of the on disk data.
     pub db_size: u64,
 
+    /// Server state, one of "Follower", "Learner", "Candidate", "Leader".
     pub state: String,
 
+    /// Is this node a leader.
     pub is_leader: bool,
 
+    /// Current term.
     pub current_term: u64,
 
+    /// Last received log index
     pub last_log_index: u64,
 
+    /// Last log id that has been committed and applied to state machine.
     pub last_applied: LogId,
 
+    /// The last known leader node.
     pub leader: Option<Node>,
 
+    /// The replication state of all nodes.
+    ///
+    /// Only leader node has non-None data for this field, i.e., `is_leader` is true.
+    pub replication: Option<BTreeMap<NodeId, Option<LogId>>>,
+
+    /// Nodes that can vote in election can grant replication.
     pub voters: Vec<Node>,
 
+    /// Also known as `learner`s.
     pub non_voters: Vec<Node>,
 
     /// The last `seq` used by GenericKV sub tree.
@@ -901,6 +917,7 @@ impl MetaNode {
                 None => LogId::new(CommittedLeaderId::new(0, 0), 0),
             },
             leader,
+            replication: metrics.replication,
             voters,
             non_voters: learners,
             last_seq,


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feat(meta): add replication state to meta service API /v1/cluster/status

Usage: `curl localhost:28101/v1/cluster/status | yq -y -c`:

```yaml
id: 1
# ...
replication:
  '1':
    leader_id: {term: 1, node_id: 1}
    index: 18884
  '2':
    leader_id: {term: 1, node_id: 1}
    index: 18884
  '3':
    leader_id: {term: 1, node_id: 1}
    index: 18884
```

## Changelog







## Related Issues