### PR TITLE
chore: add more vacuum table test

### DIFF
--- a/tests/suites/5_ee/01_vacuum/01_0001_ee_vacuum_kill_randomly.sh
+++ b/tests/suites/5_ee/01_vacuum/01_0001_ee_vacuum_kill_randomly.sh
@@ -20,7 +20,8 @@ pid=$!
 # there is a new process introduced from background subshell, use ps -p $pid to checkout
 
 # kill query randomly
-sleep 5
+sleep_time=`expr $RANDOM % 5 + 5`
+sleep $sleep_time 
 killall databend-query > /dev/null 2>&1
 kill $pid
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore: add more vacuum table test
1. after enough time, all the orphan file which out of retention time will be purged; 
2. use a random sleep time in kill query vacuum tets.

Closes #issue
