### PR TITLE
docs: utc timezone for logs

### DIFF
--- a/docs/doc/100-faq/10-how-to-get-server-logs.md
+++ b/docs/doc/100-faq/10-how-to-get-server-logs.md
@@ -11,6 +11,10 @@ No connection. Trying to reconnect...
 
 You can get the server logs from the `system.tracing` table(level=50 only shows the ERROR logs):
 
+:::note
+Databend uses [tokio-tracing](https://github.com/tokio-rs/tracing) to trace logs, where the default timezone is UTC and cannot be changed through the Databend timezone setting, therefore the time in the traced log will always be in UTC, and not reflect your local time.
+:::
+
 ```sql
 SELECT * FROM system.tracing WHERE level=50;
 +------+----------------+----------------------------------------------------------------------------------------------------------------------------------+-------+----------+--------+-------------------------------------+

--- a/docs/doc/100-faq/20-how-to-tracing.md
+++ b/docs/doc/100-faq/20-how-to-tracing.md
@@ -23,6 +23,10 @@ SELECT sum(number+1)+1 FROM numbers(10000) WHERE number>0 GROUP BY number%3;
 
 ## Tracing log
 
+:::note
+Databend uses [tokio-tracing](https://github.com/tokio-rs/tracing) to trace logs, where the default timezone is UTC and cannot be changed through the Databend timezone setting, therefore the time in the traced log will always be in UTC, and not reflect your local time.
+:::
+
 ```sql
 [2021-06-10T08:40:36Z DEBUG clickhouse_srv::cmd] Got packet Query(QueryRequest { query_id: "bac2b254-6245-4cae-910d-3e5e979c8b68", client_info: QueryClientInfo { query_kind: 1, initial_user: "", initial_query_id: "", initial_address: "0.0.0.0:0", interface: 1, os_user: "bohu", client_hostname: "thinkpad", client_name: "ClickHouse ", client_version_major: 21, client_version_minor: 4, client_version_patch: 6, client_revision: 54447, http_method: 0, http_user_agent: "", quota_key: "" }, stage: 2, compression: 1, query: "SELECT sum(number+1)+1 from numbers(10000) where number>0 group by number%3;" })
 Jun 10 16:40:36.131 DEBUG ThreadId(16) databend_query::sql::plan_parser: query="SELECT sum(number+1)+1 from numbers(10000) where number>0 group by number%3;"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

added note: Databend uses [tokio-tracing](https://github.com/tokio-rs/tracing) to trace logs, where the default timezone is UTC and cannot be changed through the Databend timezone setting, therefore the time in the traced log will always be in UTC, and not reflect your local time.

Closes #11461
