### PR TITLE
chore: tune the error message on setting max_storage_io_requests

### DIFF
--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -127,7 +127,9 @@ impl Settings {
         if val > 0 {
             self.try_set_u64("max_storage_io_requests", val)
         } else {
-            Err(ErrorCode::BadArguments("Value must be greater than 0"))
+            Err(ErrorCode::BadArguments(
+                "max_storage_io_requests must be greater than 0",
+            ))
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

I got an error message like this when proxying to a databend intance:

```
time="2023-05-16T05:04:58Z" level=info msg="wrappedResponseWriter.Write: {\"error\":{\"code\":\"401\",\"message\":\"Value must be greater than 0\"}}"
```

after investigation, i found this error comes from:

https://github.com/datafuselabs/databend/blob/14871e27bf449c97277bb15dcc949e6281631610/src/query/settings/src/settings_getter_setter.rs#L130

i hope this pr may makes the error message more clear about what actually happens.