### PR TITLE
fix(query): fix SRF as arg of other function

### DIFF
--- a/src/query/sql/src/planner/binder/project_set.rs
+++ b/src/query/sql/src/planner/binder/project_set.rs
@@ -65,6 +65,10 @@ impl<'a> Visitor<'a> for SrfCollector {
                 params: params.to_vec(),
                 window: over.clone(),
             });
+        } else {
+            for arg in args.iter() {
+                self.visit_expr(arg);
+            }
         }
     }
 }

--- a/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
+++ b/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
@@ -292,12 +292,12 @@ select id, get(arr, 5) from t4
 statement error 1001
 select id, get(arr, 'a') from t4
 
-query IT
-select id, json_path_query(arr, '$[2, 1 to last -1]') from t1
+query ITS
+select id, json_path_query(arr, '$[2, 1 to last -1]'), typeof(json_path_query(arr, '$[2, 1 to last -1]')) from t1
 ----
-1 3
-1 2
-1 3
+1 3 VARIANT
+1 2 VARIANT
+1 3 VARIANT
 
 query IT
 select id, json_path_query(arr, '$[*]?(@ > 1 && @ <= 3)') from t1

--- a/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
+++ b/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
@@ -47,15 +47,15 @@ select unnest([1,2,3]), number from numbers(1);
 2 0
 3 0
 
-query II
-select unnest([1,2,3]), number from numbers(2);
+query III
+select unnest([1,2,3]), unnest([1,2,3]) + 1, number from numbers(2);
 ----
-1 0
-2 0
-3 0
-1 1
-2 1
-3 1
+1 2 0
+2 3 0
+3 4 0
+1 2 1
+2 3 1
+3 4 1
 
 query II
 select unnest([1,2,3]), number, unnest([1,2,3]) + number from numbers(2);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix SRF as arg of other function

Closes #11474
