### PR TITLE
feat(query): optimize show tables with pushdown filter only contain eq database

### DIFF
--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -236,7 +236,7 @@ pub fn find_eq_db_table(expr: &Expr<String>, visitor: &mut impl FnMut(&str, &Sca
             } else if function.signature.name == "and_filters" {
                 // only support this:
                 // 1. where xx and xx and xx
-                // 2. filter: Column `table`
+                // 2. filter: Column `table`, Column `database`
                 for arg in args {
                     find_eq_db_table(arg, visitor)
                 }

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -24,7 +24,6 @@ use common_expression::infer_table_schema;
 use common_expression::types::StringType;
 use common_expression::utils::FromData;
 use common_expression::DataBlock;
-use common_expression::Expr;
 use common_expression::Scalar;
 use common_expression::TableDataType;
 use common_expression::TableField;
@@ -39,6 +38,7 @@ use common_storages_view::view_table::VIEW_ENGINE;
 
 use crate::table::AsyncOneBlockSystemTable;
 use crate::table::AsyncSystemTable;
+use crate::util::find_eq_filter;
 
 pub struct ColumnsTable {
     table_info: TableInfo,
@@ -152,7 +152,7 @@ impl ColumnsTable {
         if let Some(push_downs) = push_downs {
             if let Some(filter) = push_downs.filter {
                 let expr = filter.as_expr(&BUILTIN_FUNCTIONS);
-                find_eq_db_table(&expr, &mut |col_name, scalar| {
+                find_eq_filter(&expr, &mut |col_name, scalar| {
                     if col_name == "database" {
                         if let Scalar::String(s) = scalar {
                             if let Ok(database) = String::from_utf8(s.clone()) {
@@ -217,30 +217,5 @@ impl ColumnsTable {
         }
 
         Ok(rows)
-    }
-}
-
-pub fn find_eq_db_table(expr: &Expr<String>, visitor: &mut impl FnMut(&str, &Scalar)) {
-    match expr {
-        Expr::Constant { .. } | Expr::ColumnRef { .. } => {}
-        Expr::Cast { expr, .. } => find_eq_db_table(expr, visitor),
-        Expr::FunctionCall { function, args, .. } => {
-            if function.signature.name == "eq" {
-                match args.as_slice() {
-                    [Expr::ColumnRef { id, .. }, Expr::Constant { scalar, .. }]
-                    | [Expr::Constant { scalar, .. }, Expr::ColumnRef { id, .. }] => {
-                        visitor(id, scalar);
-                    }
-                    _ => {}
-                }
-            } else if function.signature.name == "and_filters" {
-                // only support this:
-                // 1. where xx and xx and xx
-                // 2. filter: Column `table`, Column `database`
-                for arg in args {
-                    find_eq_db_table(arg, visitor)
-                }
-            }
-        }
     }
 }

--- a/src/query/storages/system/src/lib.rs
+++ b/src/query/storages/system/src/lib.rs
@@ -45,6 +45,7 @@ mod table_functions_table;
 mod tables_table;
 mod tracing_table;
 mod users_table;
+mod util;
 
 pub use build_options_table::BuildOptionsTable;
 pub use caches_table::CachesTable;

--- a/src/query/storages/system/src/util.rs
+++ b/src/query/storages/system/src/util.rs
@@ -1,0 +1,41 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_expression::Expr;
+use common_expression::Scalar;
+
+pub fn find_eq_filter(expr: &Expr<String>, visitor: &mut impl FnMut(&str, &Scalar)) {
+    match expr {
+        Expr::Constant { .. } | Expr::ColumnRef { .. } => {}
+        Expr::Cast { expr, .. } => find_eq_filter(expr, visitor),
+        Expr::FunctionCall { function, args, .. } => {
+            if function.signature.name == "eq" {
+                match args.as_slice() {
+                    [Expr::ColumnRef { id, .. }, Expr::Constant { scalar, .. }]
+                    | [Expr::Constant { scalar, .. }, Expr::ColumnRef { id, .. }] => {
+                        visitor(id, scalar);
+                    }
+                    _ => {}
+                }
+            } else if function.signature.name == "and_filters" {
+                // only support this:
+                // 1. where xx and xx and xx
+                // 2. filter: Column `table`, Column `database`
+                for arg in args {
+                    find_eq_filter(arg, visitor)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

optimize show tables with pushdown filter only contain eq database

## Result

```
select count() from system.tables;
+---------+
| count() |
+---------+
|    4082 |
+---------+
1 row in set (0.509 sec)

MySQL [(none)]> show tables from a;
+-------------+
| tables_in_a |
+-------------+
| a           |
+-------------+
1 row in set (0.043 sec)

MySQL [(none)]> show tables from tpch;
+----------------+
| tables_in_tpch |
+----------------+
| customer       |
| lineitem       |
| nation         |
| orders         |
| part           |
| partsupp       |
| region         |
| supplier       |
+----------------+
8 rows in set (0.045 sec)
```

Closes #issue
