### PR TITLE
fix(query): fix create table if not exists

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -1121,7 +1121,10 @@ impl<KV: kvapi::KVApi<Error = MetaError>> SchemaApi for KV {
             let (tb_id_seq, tb_id) = get_u64_value(self, &dbid_tbname).await?;
             if tb_id_seq > 0 {
                 return if req.if_not_exists {
-                    Ok(CreateTableReply { table_id: tb_id })
+                    Ok(CreateTableReply {
+                        table_id: tb_id,
+                        new_table: false,
+                    })
                 } else {
                     Err(KVAppError::AppError(AppError::TableAlreadyExists(
                         TableAlreadyExists::new(
@@ -1228,7 +1231,10 @@ impl<KV: kvapi::KVApi<Error = MetaError>> SchemaApi for KV {
                 );
 
                 if succ {
-                    return Ok(CreateTableReply { table_id });
+                    return Ok(CreateTableReply {
+                        table_id,
+                        new_table: true,
+                    });
                 }
             }
         }

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -448,6 +448,7 @@ impl Display for CreateTableReq {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct CreateTableReply {
     pub table_id: u64,
+    pub new_table: bool,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -23,6 +23,7 @@ use common_meta_app::schema::CreateDatabaseReply;
 use common_meta_app::schema::CreateDatabaseReq;
 use common_meta_app::schema::CreateIndexReply;
 use common_meta_app::schema::CreateIndexReq;
+use common_meta_app::schema::CreateTableReply;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::DropDatabaseReply;
 use common_meta_app::schema::DropDatabaseReq;
@@ -129,7 +130,7 @@ pub trait Catalog: DynClone + Send + Sync {
     async fn list_tables_history(&self, tenant: &str, db_name: &str)
     -> Result<Vec<Arc<dyn Table>>>;
 
-    async fn create_table(&self, req: CreateTableReq) -> Result<()>;
+    async fn create_table(&self, req: CreateTableReq) -> Result<CreateTableReply>;
 
     async fn drop_table_by_id(&self, req: DropTableByIdReq) -> Result<DropTableReply>;
 

--- a/src/query/catalog/src/database.rs
+++ b/src/query/catalog/src/database.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_app::schema::CreateTableReply;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::DatabaseInfo;
 use common_meta_app::schema::DropTableByIdReq;
@@ -105,7 +106,7 @@ pub trait Database: DynClone + Sync + Send {
     }
 
     #[async_backtrace::framed]
-    async fn create_table(&self, _req: CreateTableReq) -> Result<()> {
+    async fn create_table(&self, _req: CreateTableReq) -> Result<CreateTableReply> {
         Err(ErrorCode::Unimplemented(format!(
             "UnImplement create_table in {} Database",
             self.name()

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -25,6 +25,7 @@ use common_meta_app::schema::CreateDatabaseReply;
 use common_meta_app::schema::CreateDatabaseReq;
 use common_meta_app::schema::CreateIndexReply;
 use common_meta_app::schema::CreateIndexReq;
+use common_meta_app::schema::CreateTableReply;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::DropDatabaseReply;
 use common_meta_app::schema::DropDatabaseReq;

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -323,7 +323,7 @@ impl Catalog for DatabaseCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn create_table(&self, req: CreateTableReq) -> Result<()> {
+    async fn create_table(&self, req: CreateTableReq) -> Result<CreateTableReply> {
         if req.tenant().is_empty() {
             return Err(ErrorCode::TenantIsEmpty(
                 "Tenant can not empty(while create table)",

--- a/src/query/service/src/catalogs/default/immutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/immutable_catalog.rs
@@ -24,6 +24,7 @@ use common_meta_app::schema::CreateDatabaseReply;
 use common_meta_app::schema::CreateDatabaseReq;
 use common_meta_app::schema::CreateIndexReply;
 use common_meta_app::schema::CreateIndexReq;
+use common_meta_app::schema::CreateTableReply;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::DropDatabaseReply;
 use common_meta_app::schema::DropDatabaseReq;
@@ -179,7 +180,7 @@ impl Catalog for ImmutableCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn create_table(&self, _req: CreateTableReq) -> Result<()> {
+    async fn create_table(&self, _req: CreateTableReq) -> Result<CreateTableReply> {
         Err(ErrorCode::Unimplemented(
             "Cannot create table in system database",
         ))

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -24,6 +24,7 @@ use common_meta_app::schema::CreateDatabaseReply;
 use common_meta_app::schema::CreateDatabaseReq;
 use common_meta_app::schema::CreateIndexReply;
 use common_meta_app::schema::CreateIndexReq;
+use common_meta_app::schema::CreateTableReply;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::DatabaseIdent;
 use common_meta_app::schema::DatabaseInfo;

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -282,7 +282,7 @@ impl Catalog for MutableCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn create_table(&self, req: CreateTableReq) -> Result<()> {
+    async fn create_table(&self, req: CreateTableReq) -> Result<CreateTableReply> {
         let db = self
             .get_database(&req.name_ident.tenant, &req.name_ident.db_name)
             .await?;

--- a/src/query/service/src/databases/default/default_database.rs
+++ b/src/query/service/src/databases/default/default_database.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_catalog::table::Table;
 use common_exception::Result;
 use common_meta_api::SchemaApi;
+use common_meta_app::schema::CreateTableReply;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::DatabaseInfo;
 use common_meta_app::schema::DropTableByIdReq;
@@ -130,9 +131,9 @@ impl Database for DefaultDatabase {
     }
 
     #[async_backtrace::framed]
-    async fn create_table(&self, req: CreateTableReq) -> Result<()> {
-        self.ctx.meta.create_table(req).await?;
-        Ok(())
+    async fn create_table(&self, req: CreateTableReq) -> Result<CreateTableReply> {
+        let res = self.ctx.meta.create_table(req).await?;
+        Ok(res)
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/databases/share/share_database.rs
+++ b/src/query/service/src/databases/share/share_database.rs
@@ -19,6 +19,7 @@ use common_catalog::table::Table;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_api::SchemaApi;
+use common_meta_app::schema::CreateTableReply;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::DatabaseInfo;
 use common_meta_app::schema::DropTableByIdReq;
@@ -129,7 +130,7 @@ impl Database for ShareDatabase {
     }
 
     #[async_backtrace::framed]
-    async fn create_table(&self, _req: CreateTableReq) -> Result<()> {
+    async fn create_table(&self, _req: CreateTableReq) -> Result<CreateTableReply> {
         Err(ErrorCode::PermissionDenied(
             "Permission denied, cannot create table from a shared database".to_string(),
         ))

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -129,7 +129,10 @@ impl CreateTableInterpreter {
         let catalog = self.ctx.get_catalog(&self.plan.catalog)?;
 
         // TODO: maybe the table creation and insertion should be a transaction, but it may require create_table support 2pc.
-        catalog.create_table(self.build_request(None)?).await?;
+        let reply = catalog.create_table(self.build_request(None)?).await?;
+        if !reply.new_table {
+            return Ok(PipelineBuildResult::create());
+        }
         let table = catalog
             .get_table(tenant.as_str(), &self.plan.database, &self.plan.table)
             .await?;

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -46,6 +46,7 @@ use common_meta_app::schema::CreateDatabaseReply;
 use common_meta_app::schema::CreateDatabaseReq;
 use common_meta_app::schema::CreateIndexReply;
 use common_meta_app::schema::CreateIndexReq;
+use common_meta_app::schema::CreateTableReply;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::DropDatabaseReply;
 use common_meta_app::schema::DropDatabaseReq;
@@ -670,7 +671,7 @@ impl Catalog for FakedCatalog {
         todo!()
     }
 
-    async fn create_table(&self, _req: CreateTableReq) -> Result<()> {
+    async fn create_table(&self, _req: CreateTableReq) -> Result<CreateTableReply> {
         todo!()
     }
 

--- a/src/query/storages/hive/hive/src/hive_catalog.rs
+++ b/src/query/storages/hive/hive/src/hive_catalog.rs
@@ -33,6 +33,7 @@ use common_meta_app::schema::CreateDatabaseReply;
 use common_meta_app::schema::CreateDatabaseReq;
 use common_meta_app::schema::CreateIndexReply;
 use common_meta_app::schema::CreateIndexReq;
+use common_meta_app::schema::CreateTableReply;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::DropDatabaseReply;
 use common_meta_app::schema::DropDatabaseReq;
@@ -326,7 +327,7 @@ impl Catalog for HiveCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn create_table(&self, _req: CreateTableReq) -> Result<()> {
+    async fn create_table(&self, _req: CreateTableReq) -> Result<CreateTableReply> {
         Err(ErrorCode::Unimplemented(
             "Cannot create table in HIVE catalog",
         ))

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -30,6 +30,7 @@ use common_meta_app::schema::CreateDatabaseReply;
 use common_meta_app::schema::CreateDatabaseReq;
 use common_meta_app::schema::CreateIndexReply;
 use common_meta_app::schema::CreateIndexReq;
+use common_meta_app::schema::CreateTableReply;
 use common_meta_app::schema::CreateTableReq;
 use common_meta_app::schema::DropDatabaseReply;
 use common_meta_app::schema::DropDatabaseReq;
@@ -242,7 +243,7 @@ impl Catalog for IcebergCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn create_table(&self, _req: CreateTableReq) -> Result<()> {
+    async fn create_table(&self, _req: CreateTableReq) -> Result<CreateTableReply> {
         unimplemented!()
     }
 

--- a/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables
@@ -115,6 +115,12 @@ SELECT a FROM db2.test3
 statement ok
 CREATE TABLE db2.test4(a Varchar null, y Varchar null) ENGINE=fuse AS SELECT b, a FROM db1.test1
 
+statement ok
+CREATE TABLE if not exists db2.test4 AS SELECT b, a FROM db1.test1
+
+statement ok
+CREATE TABLE if not exists db2.test4 AS SELECT b, a FROM db1.test1
+
 query TTTTT
 DESCRIBE db2.test4
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Add `CreateTableReply` in meta_api_impl, if the table exists we will not apply the insert.

Closes #11430
