### PR TITLE
fix(query): fix show err with special name

### DIFF
--- a/src/query/sql/src/planner/binder/ddl/database.rs
+++ b/src/query/sql/src/planner/binder/ddl/database.rs
@@ -71,7 +71,7 @@ impl Binder {
         if *full {
             select_builder.with_column("catalog AS Catalog");
         }
-        select_builder.with_column(format!("name AS databases_in_{ctl}"));
+        select_builder.with_column(format!("name AS `databases_in_{ctl}`"));
         select_builder.with_order_by("catalog");
         select_builder.with_order_by("name");
         match limit {

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -149,7 +149,7 @@ impl Binder {
                 .with_column("data_compressed_size")
                 .with_column("index_size");
         } else {
-            select_builder.with_column(format!("name AS Tables_in_{database}"));
+            select_builder.with_column(format!("name AS `Tables_in_{database}`"));
             if *with_history {
                 select_builder.with_column("dropped_on AS drop_time");
             };

--- a/tests/sqllogictests/suites/base/06_show/06_0004_show_tables
+++ b/tests/sqllogictests/suites/base/06_show/06_0004_show_tables
@@ -77,3 +77,21 @@ SHOW TABLES FROM showtables WHERE name = 't2' AND 1 = 1
 
 statement ok
 DROP DATABASE showtable
+
+statement ok
+drop database if exists `rust-lang`
+
+statement ok
+create database `rust-lang`
+
+statement ok
+create table `rust-lang`.t(id int);
+
+statement ok
+use `rust-lang`
+
+statement ok
+show tables
+
+statement ok
+drop database `rust-lang`

--- a/tests/suites/0_stateless/14_clickhouse_http_handler/14_0001_clickhouse_http.result
+++ b/tests/suites/0_stateless/14_clickhouse_http_handler/14_0001_clickhouse_http.result
@@ -7,7 +7,7 @@ OK.
 databases_in_default
 String
 db2
-tables_in_db2
+Tables_in_db2
 String
 t2
 Table	Create Table


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

show tables and show databases will be rewrite to select query.

If db name or catalog name have special name will cause parser err.

```
MySQL [rust-lang]> use rust-lang
Database changed
MySQL [rust-lang]> show tables;
ERROR 1105 (HY000): Code: 1005, Text = error: 
  --> SQL:1:30
  |
1 | SELECT name AS Tables_in_rust-lang FROM system.tables where database = 'rust-lang' ORDER BY catalog,database,name 
  |                              ^ expected `,`, `FROM`, `WHERE`, `GROUP`, `HAVING`, `WINDOW`, or 12 more ...

```
need rewrite to 

```
SELECT name AS `Tables_in_rust-lang` FROM system.tables where database = 'rust-lang' ORDER BY catalog,database,name ;
```

Closes #11496
