### PR TITLE
feat: add bitmap logical operation functions

### DIFF
--- a/src/query/functions/src/scalars/bitmap.rs
+++ b/src/query/functions/src/scalars/bitmap.rs
@@ -12,13 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::BitAnd;
+use std::ops::BitOr;
+use std::ops::BitXor;
+use std::ops::Sub;
+
 use common_expression::types::bitmap::BitmapType;
+use common_expression::types::string::StringColumnBuilder;
 use common_expression::types::ArrayType;
 use common_expression::types::BooleanType;
 use common_expression::types::StringType;
 use common_expression::types::UInt64Type;
 use common_expression::vectorize_with_builder_1_arg;
 use common_expression::vectorize_with_builder_2_arg;
+use common_expression::EvalContext;
 use common_expression::FunctionDomain;
 use common_expression::FunctionRegistry;
 use itertools::join;
@@ -192,15 +199,20 @@ pub fn register(registry: &mut FunctionRegistry) {
         "bitmap_max",
         |_| FunctionDomain::MayThrow,
         vectorize_with_builder_1_arg::<BitmapType, UInt64Type>(|b, builder, ctx| {
-            match RoaringTreemap::deserialize_from(b) {
+            let val = match RoaringTreemap::deserialize_from(b) {
                 Ok(rb) => match rb.max() {
-                    Some(val) => builder.push(val),
-                    None => ctx.set_error(builder.len(), "The bitmap is empty"),
+                    Some(val) => val,
+                    None => {
+                        ctx.set_error(builder.len(), "The bitmap is empty");
+                        0
+                    }
                 },
                 Err(e) => {
                     ctx.set_error(builder.len(), e.to_string());
+                    0
                 }
-            }
+            };
+            builder.push(val);
         }),
     );
 
@@ -208,15 +220,94 @@ pub fn register(registry: &mut FunctionRegistry) {
         "bitmap_min",
         |_| FunctionDomain::MayThrow,
         vectorize_with_builder_1_arg::<BitmapType, UInt64Type>(|b, builder, ctx| {
-            match RoaringTreemap::deserialize_from(b) {
+            let val = match RoaringTreemap::deserialize_from(b) {
                 Ok(rb) => match rb.min() {
-                    Some(val) => builder.push(val),
-                    None => ctx.set_error(builder.len(), "The bitmap is empty"),
+                    Some(val) => val,
+                    None => {
+                        ctx.set_error(builder.len(), "The bitmap is empty");
+                        0
+                    }
                 },
                 Err(e) => {
                     ctx.set_error(builder.len(), e.to_string());
+                    0
                 }
-            }
+            };
+            builder.push(val);
         }),
     );
+
+    registry.register_passthrough_nullable_2_arg::<BitmapType, BitmapType, BitmapType, _, _>(
+        "bitmap_or",
+        |_, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<BitmapType, BitmapType, BitmapType>(
+            |arg1, arg2, builder, ctx| bitmap_logic_operate(arg1, arg2, builder, ctx, LogicOp::Or),
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<BitmapType, BitmapType, BitmapType, _, _>(
+        "bitmap_and",
+        |_, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<BitmapType, BitmapType, BitmapType>(
+            |arg1, arg2, builder, ctx| bitmap_logic_operate(arg1, arg2, builder, ctx, LogicOp::And),
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<BitmapType, BitmapType, BitmapType, _, _>(
+        "bitmap_xor",
+        |_, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<BitmapType, BitmapType, BitmapType>(
+            |arg1, arg2, builder, ctx| bitmap_logic_operate(arg1, arg2, builder, ctx, LogicOp::Xor),
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<BitmapType, BitmapType, BitmapType, _, _>(
+        "bitmap_not",
+        |_, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<BitmapType, BitmapType, BitmapType>(
+            |arg1, arg2, builder, ctx| bitmap_logic_operate(arg1, arg2, builder, ctx, LogicOp::Not),
+        ),
+    );
+
+    registry.register_aliases("bitmap_not", &["bitmap_and_not"]);
+}
+
+enum LogicOp {
+    Or,
+    And,
+    Xor,
+    Not,
+}
+
+/// perform a logical operation on two input bitmap, and write result bitmap to builder
+fn bitmap_logic_operate(
+    arg1: &[u8],
+    arg2: &[u8],
+    builder: &mut StringColumnBuilder,
+    ctx: &mut EvalContext,
+    op: LogicOp,
+) {
+    let Some(rb1) =  RoaringTreemap::deserialize_from(arg1).map_err(|e| {
+        ctx.set_error(builder.len(), e.to_string());
+        builder.commit_row();
+    }).ok() else {
+        return;
+    };
+
+    let Some(rb2) =  RoaringTreemap::deserialize_from(arg2).map_err(|e| {
+        ctx.set_error(builder.len(), e.to_string());
+        builder.commit_row();
+    }).ok() else {
+        return;
+    };
+
+    let rb = match op {
+        LogicOp::Or => rb1.bitor(rb2),
+        LogicOp::And => rb1.bitand(rb2),
+        LogicOp::Xor => rb1.bitxor(rb2),
+        LogicOp::Not => rb1.sub(rb2),
+    };
+
+    rb.serialize_into(&mut builder.data).unwrap();
+    builder.commit_row();
 }

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -4,6 +4,7 @@ array_contains -> contains
 array_get -> get
 array_length -> length
 array_slice -> slice
+bitmap_and_not -> bitmap_not
 bitmap_cardinality -> bitmap_count
 ceiling -> ceil
 character_length -> char_length
@@ -690,6 +691,8 @@ Functions overloads:
 125 bit_xor(Int64 NULL, Int32 NULL) :: Int64 NULL
 126 bit_xor(Int64, Int64) :: Int64
 127 bit_xor(Int64 NULL, Int64 NULL) :: Int64 NULL
+0 bitmap_and(Bitmap, Bitmap) :: Bitmap
+1 bitmap_and(Bitmap NULL, Bitmap NULL) :: Bitmap NULL
 0 bitmap_contains(Bitmap, UInt64) :: Boolean
 1 bitmap_contains(Bitmap NULL, UInt64 NULL) :: Boolean NULL
 0 bitmap_count(Bitmap) :: UInt64
@@ -702,6 +705,12 @@ Functions overloads:
 1 bitmap_max(Bitmap NULL) :: UInt64 NULL
 0 bitmap_min(Bitmap) :: UInt64
 1 bitmap_min(Bitmap NULL) :: UInt64 NULL
+0 bitmap_not(Bitmap, Bitmap) :: Bitmap
+1 bitmap_not(Bitmap NULL, Bitmap NULL) :: Bitmap NULL
+0 bitmap_or(Bitmap, Bitmap) :: Bitmap
+1 bitmap_or(Bitmap NULL, Bitmap NULL) :: Bitmap NULL
+0 bitmap_xor(Bitmap, Bitmap) :: Bitmap
+1 bitmap_xor(Bitmap NULL, Bitmap NULL) :: Bitmap NULL
 0 blake3(String) :: String
 1 blake3(String NULL) :: String NULL
 0 build_bitmap(Array(UInt64)) :: Bitmap

--- a/tests/sqllogictests/suites/query/02_function/02_0064_function_bitmap
+++ b/tests/sqllogictests/suites/query/02_function/02_0064_function_bitmap
@@ -35,3 +35,28 @@ SELECT bitmap_max(build_bitmap([1,4,5])), bitmap_min(build_bitmap([1,4,5]))
 
 statement error
 SELECT bitmap_max(build_bitmap([])), bitmap_min(build_bitmap([]))
+
+query TT
+SELECT bitmap_or(build_bitmap([1,4,5]), build_bitmap([6,7]))::String, bitmap_or(build_bitmap([1,4,5]), build_bitmap([1,5]))::String
+----
+1,4,5,6,7 1,4,5
+
+query TT
+SELECT bitmap_and(build_bitmap([1,4,5]), build_bitmap([4,5]))::String, bitmap_and(build_bitmap([1,3,5]), build_bitmap([2,4,6]))::String
+----
+4,5 (empty)
+
+query TT
+SELECT bitmap_xor(build_bitmap([1,4,5]), build_bitmap([5,6,7]))::String, bitmap_xor(build_bitmap([1,3,5]), build_bitmap([2,4,6]))::String
+----
+1,4,6,7 1,2,3,4,5,6
+
+query TT
+SELECT bitmap_not(build_bitmap([2,3]), build_bitmap([2,3,5]))::String, bitmap_not(build_bitmap([1,3,5]), build_bitmap([1,5]))::String
+----
+(empty) 3
+
+query TT
+SELECT bitmap_and_not(build_bitmap([2,3]), build_bitmap([2,3,5]))::String, bitmap_and_not(build_bitmap([1,3,5]), build_bitmap([1,5]))::String
+----
+(empty) 3


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add `bitmap_or`, `bitmap_and`, `bitmap_xor`, `bitmap_not`, `bitmap_and_not` function. And fixed panic when calling `bitmap_max` and `bitmap_min` with empty bitmap.

Part of #11219
