### PR TITLE
feat(python): support configuration from env

### DIFF
--- a/src/bendpy/README.md
+++ b/src/bendpy/README.md
@@ -73,6 +73,12 @@ maturin develop -E docs
 pdoc opendal
 ```
 
+## Storage configuration
+
+- Meta Storage directory(Catalogs, Databases, Tables, Partitions, etc.): `./.databend/meta`
+- Data Storage directory: `./.databend/data`
+- Cache Storage directory: `./.databend/cache`
+
 ## More
 
 Databend python api is inspired by [arrow-datafusion-python](https://github.com/apache/arrow-datafusion-python), thanks for their great work.

--- a/src/bendpy/README.md
+++ b/src/bendpy/README.md
@@ -75,9 +75,10 @@ pdoc opendal
 
 ## Storage configuration
 
-- Meta Storage directory(Catalogs, Databases, Tables, Partitions, etc.): `./.databend/meta`
-- Data Storage directory: `./.databend/data`
-- Cache Storage directory: `./.databend/cache`
+- Meta Storage directory(Catalogs, Databases, Tables, Partitions, etc.): `./.databend/_meta`
+- Data Storage directory: `./.databend/_data`
+- Cache Storage directory: `./.databend/_cache`
+- Logs directory: `./.databend/logs`
 
 ## More
 

--- a/src/bendpy/src/lib.rs
+++ b/src/bendpy/src/lib.rs
@@ -22,6 +22,7 @@ mod utils;
 
 use std::env;
 
+use common_config::Config;
 use common_config::InnerConfig;
 use common_license::license_manager::LicenseManager;
 use common_license::license_manager::OssLicenseManager;
@@ -37,7 +38,7 @@ use utils::RUNTIME;
 fn databend(_py: Python, m: &PyModule) -> PyResult<()> {
     env::set_var("META_EMBEDDED_DIR", ".databend/_meta");
 
-    let mut conf: InnerConfig = InnerConfig::load().unwrap();
+    let mut conf: InnerConfig = Config::load(false).unwrap().try_into().unwrap();
     conf.storage.allow_insecure = true;
     conf.storage.params = StorageParams::Fs(StorageFsConfig {
         root: ".databend/_data".to_string(),

--- a/src/bendpy/src/lib.rs
+++ b/src/bendpy/src/lib.rs
@@ -20,6 +20,8 @@ mod dataframe;
 mod schema;
 mod utils;
 
+use std::env;
+
 use common_config::InnerConfig;
 use common_license::license_manager::LicenseManager;
 use common_license::license_manager::OssLicenseManager;
@@ -33,20 +35,22 @@ use utils::RUNTIME;
 /// A Python module implemented in Rust.
 #[pymodule]
 fn databend(_py: Python, m: &PyModule) -> PyResult<()> {
-    let mut conf: InnerConfig = InnerConfig::default();
+    env::set_var("META_EMBEDDED_DIR", ".databend/_meta");
+
+    let mut conf: InnerConfig = InnerConfig::load().unwrap();
     conf.storage.allow_insecure = true;
     conf.storage.params = StorageParams::Fs(StorageFsConfig {
-        root: "_databend_data".to_string(),
+        root: ".databend/_data".to_string(),
     });
 
     RUNTIME.block_on(async {
-        MetaEmbedded::init_global_meta_store("_databend_meta".to_string())
+        MetaEmbedded::init_global_meta_store(".databend/_meta".to_string())
             .await
             .unwrap();
         GlobalServices::init(conf).await.unwrap();
-        // init oss license manager
     });
 
+    // init oss license manager
     OssLicenseManager::init().unwrap();
 
     m.add_class::<context::PySessionContext>()?;

--- a/src/bendpy/tests/basic.py
+++ b/src/bendpy/tests/basic.py
@@ -29,4 +29,3 @@ class TestBasic:
         self.ctx.sql("insert into aa select number, number, true, number from numbers(10)").collect()
         df = self.ctx.sql("select sum(a) x, max(b) y, max(d) z from aa where c").to_pandas()
         assert df.values.tolist() == [[90.0, b'9', 9.0]]
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Example to enable disk cache:

```
❯ python
Python 3.7.16 (default, May 11 2023, 12:45:25) 
[GCC 12.2.1 20230201] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os 
>>> os.environ["CACHE_DATA_CACHE_STORAGE"] = "disk"
>>> from databend import SessionContext 
>>> ctx = SessionContext()
>>> ctx.sql("select * from system.configs where name like '%data_cache%'")
┌────────────────────────────────────────────────────────────────────────────┐
│  group  │                   name                   │  value  │ description │
│  String │                  String                  │  String │    String   │
├─────────┼──────────────────────────────────────────┼─────────┼─────────────┤
│ 'cache' │ 'data_cache_storage'                     │ 'disk'  │ ''          │
│ 'cache' │ 'table_data_cache_population_queue_size' │ '65536' │ ''          │
└────────────────────────────────────────────────────────────────────────────┘
>>> ctx.sql("select * from system.configs where name like '%disk%'")
┌─────────────────────────────────────────────────────────────────┐
│  group  │       name       │         value        │ description │
│  String │      String      │        String        │    String   │
├─────────┼──────────────────┼──────────────────────┼─────────────┤
│ 'cache' │ 'disk.max_bytes' │ '21474836480'        │ ''          │
│ 'cache' │ 'disk.path'      │ './.databend/_cache' │ ''          │
└─────────────────────────────────────────────────────────────────┘
>>> 
```

Closes #11528

All configuration entries could be found by `./databend-query --help` (need the query binary)
