### PR TITLE
ci: checkout merge commit on benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,8 +39,14 @@ jobs:
       source_id: ${{ steps.metadata.outputs.source_id }}
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
+      - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request_target'
+        with:
+          fetch-depth: 0
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Build Release
         uses: ./.github/actions/build_linux
         if: github.event_name == 'pull_request_target'
@@ -79,6 +85,11 @@ jobs:
       max-parallel: 1
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request_target'
+      - uses: actions/checkout@v3
+        if: github.event_name == 'pull_request_target'
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - uses: ./.github/actions/setup_bendsql
       - name: Download artifact
         run: |
@@ -183,6 +194,11 @@ jobs:
       max-parallel: 1
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request_target'
+      - uses: actions/checkout@v3
+        if: github.event_name == 'pull_request_target'
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - uses: ./.github/actions/setup_bendsql
       - uses: ./.github/actions/benchmark_cloud
         timeout-minutes: 60

--- a/benchmark/clickbench/benchmark_cloud.sh
+++ b/benchmark/clickbench/benchmark_cloud.sh
@@ -30,16 +30,16 @@ bendsql --version
 
 echo "Preparing benchmark metadata..."
 echo '{}' >result.json
-yq -i ".date = \"$(date -u +%Y-%m-%d)\"" result.json
-yq -i '.tags = ["s3"]' result.json
+yq -i ".date = \"$(date -u +%Y-%m-%d)\"" -o json result.json
+yq -i '.tags = ["s3"]' -o json result.json
 case ${BENCHMARK_SIZE} in
 Medium)
-    yq -i '.cluster_size = "16"' result.json
-    yq -i '.machine = "Medium"' result.json
+    yq -i '.cluster_size = "16"' -o json result.json
+    yq -i '.machine = "Medium"' -o json result.json
     ;;
 Large)
-    yq -i '.cluster_size = "64"' result.json
-    yq -i '.machine = "Large"' result.json
+    yq -i '.cluster_size = "64"' -o json result.json
+    yq -i '.machine = "Large"' -o json result.json
     ;;
 *)
     echo "Unsupported benchmark size: ${BENCHMARK_SIZE}"
@@ -84,7 +84,7 @@ function run_query() {
     q_time=$(echo "$query" | bendsql --time)
     if [[ -n $q_time ]]; then
         echo "Q${query_num}[$seq] succeeded in $q_time seconds"
-        yq -i ".result[${query_num}] += [${q_time}]" result.json
+        yq -i ".result[${query_num}] += [${q_time}]" -o json result.json
     else
         echo "Q${query_num}[$seq] failed"
     fi
@@ -94,7 +94,7 @@ TRIES=3
 QUERY_NUM=0
 while read -r query; do
     echo "Running Q${QUERY_NUM}: ${query}"
-    yq -i ".result += [[]]" result.json
+    yq -i ".result += [[]]" -o json result.json
     for i in $(seq 1 $TRIES); do
         run_query "$QUERY_NUM" "$i" "$query"
     done

--- a/benchmark/clickbench/benchmark_local.sh
+++ b/benchmark/clickbench/benchmark_local.sh
@@ -63,11 +63,11 @@ echo "Data loaded in ${load_time}s."
 data_size=$(echo "select sum(data_compressed_size) from system.tables where database = '${BENCHMARK_DATASET}';" | bendsql -o tsv)
 
 echo '{}' >result.json
-yq -i ".date = \"$(date -u +%Y-%m-%d)\"" result.json
-yq -i ".load_time = ${load_time} | .data_size = ${data_size} | .result = []" result.json
-yq -i ".machine = \"${instance_type}\"" result.json
-yq -i '.cluster_size = 1' result.json
-yq -i '.tags = ["gp3"]' result.json
+yq -i ".date = \"$(date -u +%Y-%m-%d)\"" -o json result.json
+yq -i ".load_time = ${load_time} | .data_size = ${data_size} | .result = []" -o json result.json
+yq -i ".machine = \"${instance_type}\"" -o json result.json
+yq -i '.cluster_size = 1' -o json result.json
+yq -i '.tags = ["gp3"]' -o json result.json
 
 echo "Running queries..."
 
@@ -80,7 +80,7 @@ function run_query() {
     q_time=$(echo "$query" | bendsql --time)
     if [[ -n $q_time ]]; then
         echo "Q${query_num}[$seq] succeeded in $q_time seconds"
-        yq -i ".result[${query_num}] += [${q_time}]" result.json
+        yq -i ".result[${query_num}] += [${q_time}]" -o json result.json
     else
         echo "Q${query_num}[$seq] failed"
     fi
@@ -92,7 +92,7 @@ while read -r query; do
     echo "Running Q${QUERY_NUM}: ${query}"
     sync
     echo 3 | sudo tee /proc/sys/vm/drop_caches
-    yq -i ".result += [[]]" result.json
+    yq -i ".result += [[]]" -o json result.json
     for i in $(seq 1 $TRIES); do
         run_query "$QUERY_NUM" "$i" "$query"
     done


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Checking out merge commit on `pull_request_target` has security concerns, but we need this for benchmark.
Since only org members can label a pr to trigger a benchmark run, it is believed to be safe here.

Closes #issue
