### PR TITLE
fix: multi-cols pruning of `replace into`

### DIFF
--- a/src/query/storages/fuse/src/operations/merge_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/merge_into_mutator.rs
@@ -334,7 +334,7 @@ impl MergeIntoOperationAggregator {
     }
 
     // if any item of `column_min_max` does NOT overlap with the corresponding item of `column_stats`
-    // returns false, otherwise returns ture.
+    // returns false, otherwise returns true.
     fn check_overlap(
         on_conflict_fields: &[OnConflictField],
         column_stats: &HashMap<ColumnId, ColumnStatistics>,

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/merge_into_mutator.rs
@@ -333,11 +333,11 @@ impl MergeIntoOperationAggregator {
         for (idx, field) in self.on_conflict_fields.iter().enumerate() {
             let column_id = field.table_field.column_id();
             let (min, max) = &columns_min_max[idx];
-            if self.overlapped_by_stats(column_stats.get(&column_id), min, max) {
-                return true;
+            if !self.overlapped_by_stats(column_stats.get(&column_id), min, max) {
+                return false;
             }
         }
-        false
+        true
     }
 
     fn overlapped_by_stats(

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/merge_into_mutator.rs
@@ -330,18 +330,25 @@ impl MergeIntoOperationAggregator {
         column_stats: &HashMap<ColumnId, ColumnStatistics>,
         columns_min_max: &[(Scalar, Scalar)],
     ) -> bool {
-        for (idx, field) in self.on_conflict_fields.iter().enumerate() {
+        Self::check_overlap(&self.on_conflict_fields, column_stats, columns_min_max)
+    }
+
+    fn check_overlap(
+        on_conflict_fields: &[OnConflictField],
+        column_stats: &HashMap<ColumnId, ColumnStatistics>,
+        columns_min_max: &[(Scalar, Scalar)],
+    ) -> bool {
+        for (idx, field) in on_conflict_fields.iter().enumerate() {
             let column_id = field.table_field.column_id();
             let (min, max) = &columns_min_max[idx];
-            if !self.overlapped_by_stats(column_stats.get(&column_id), min, max) {
+            if !Self::check_overlapped_by_stats(column_stats.get(&column_id), min, max) {
                 return false;
             }
         }
         true
     }
 
-    fn overlapped_by_stats(
-        &self,
+    fn check_overlapped_by_stats(
         column_stats: Option<&ColumnStatistics>,
         key_min: &Scalar,
         key_max: &Scalar,
@@ -353,5 +360,129 @@ impl MergeIntoOperationAggregator {
         } else {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common_expression::types::NumberDataType;
+    use common_expression::types::NumberScalar;
+    use common_expression::TableDataType;
+    use common_expression::TableField;
+
+    use super::*;
+
+    #[test]
+    fn test_check_overlap() -> Result<()> {
+        // case description:
+        //
+        // - on conflict('xx_id', 'xx_type', 'xx_time');
+        //
+        // - range index of columns
+        //   'xx_id' : [1, 10]
+        //   'xx_type' : ["a", "z"]
+        //   'xx_time' : [100, 200]
+        //
+        // - min/max of input values (to be checked)
+        //
+        //  'xx_id' : [11, 12]
+        //  'xx_type' : ["b", "b"]
+        //  'xx_time' : [100, 100]
+        //
+        // - expected result: overlap
+        //   columns 'xx_type' and 'xx_time' do overlap, but 'xx_id' does not overlap
+        //   so the result is NOT overlap
+
+        // setup schema
+        let field_type_id = TableDataType::Number(NumberDataType::UInt64);
+        let field_type_string = TableDataType::String;
+        let field_type_time = TableDataType::Number(NumberDataType::UInt32);
+
+        let xx_id = TableField::new("xx_id", field_type_id);
+        let xx_type = TableField::new("xx_type", field_type_string);
+        let xx_time = TableField::new("xx_time", field_type_time);
+
+        let schema = TableSchema::new(vec![xx_id, xx_type, xx_time]);
+
+        let fields = schema.fields();
+
+        // setup on conflict fields
+        let on_conflict_fields = fields
+            .iter()
+            .enumerate()
+            .map(|(id, field)| OnConflictField {
+                table_field: field.clone(),
+                field_index: id,
+            })
+            .collect::<Vec<_>>();
+
+        let mut column_stats = HashMap::new();
+
+        let range = |min: Scalar, max: Scalar| {
+            ColumnStatistics {
+                min,
+                max,
+                // the following values do not matter in this case
+                null_count: 0,
+                in_memory_size: 0,
+                distinct_of_values: None,
+            }
+        };
+
+        // stats of xx_id [1, 10]
+        column_stats.insert(
+            0,
+            range(
+                Scalar::Number(NumberScalar::UInt64(1)),
+                Scalar::Number(NumberScalar::UInt64(10)),
+            ),
+        );
+
+        // stats of xx_type [a, z]
+        column_stats.insert(
+            1,
+            range(
+                Scalar::String("a".to_string().into_bytes()),
+                Scalar::String("z".to_string().into_bytes()),
+            ),
+        );
+
+        // stats of xx_time [100, 200]
+        column_stats.insert(
+            2,
+            range(
+                Scalar::Number(NumberScalar::UInt32(100)),
+                Scalar::Number(NumberScalar::UInt32(200)),
+            ),
+        );
+
+        let columns_min_max = [
+            // for xx_id column, NOT overlaps
+            (
+                Scalar::Number(NumberScalar::UInt64(11)),
+                Scalar::Number(NumberScalar::UInt64(12)),
+            ),
+            // for xx_type column, overlaps
+            (
+                Scalar::String("b".to_string().into_bytes()),
+                Scalar::String("b".to_string().into_bytes()),
+            ),
+            // for xx_time column, overlaps
+            (
+                Scalar::Number(NumberScalar::UInt32(100)),
+                Scalar::Number(NumberScalar::UInt32(100)),
+            ),
+        ];
+
+        let overlap = super::MergeIntoOperationAggregator::check_overlap(
+            &on_conflict_fields,
+            &column_stats,
+            &columns_min_max,
+        );
+
+        // any column that does NOT overlaps imply NOT overlaps
+        assert!(!overlap);
+
+        Ok(())
     }
 }

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0024_replace_into_issue_10861
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0024_replace_into_issue_10861
@@ -10,6 +10,7 @@ USE issue_10861
 statement ok
 create table s(id int);
 
+# setup: multiple segments and blocks
 statement ok
 insert into s values(1);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

For `replace into` stmt that specifies multiple `on conflicts` fields,  segments/blocks should be pruned if any of the fields could be pruned by range index (not all of them).

- [x] fix
- [x] unit test

Closes #11557
