### PR TITLE
chore: warning the unknown session settings

### DIFF
--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -251,7 +251,16 @@ impl HttpQuery {
             if let Some(conf_settings) = &session_conf.settings {
                 let settings = session.get_settings();
                 for (k, v) in conf_settings {
-                    settings.set_setting(k.to_string(), v.to_string())?;
+                    settings
+                        .set_setting(k.to_string(), v.to_string())
+                        .or_else(|e| {
+                            if e.code() == ErrorCode::UNKNOWN_VARIABLE {
+                                tracing::warn!("unknown session setting: {}", k);
+                                Ok(())
+                            } else {
+                                Err(e)
+                            }
+                        })?;
                 }
             }
             if let Some(secs) = session_conf.keep_server_session_secs {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

in the current design, the session settings will be persisted in the client side, and will be passed to the backend in the next request. 

but when we removed a setting, the memorized session settings from the client side will trigger an UnknownVariable error which breaks the query call.

this pr tries swallow the unknown variable error on we got a unknown session settings, and replaces it with a warning log. so this might make it easier for us to remove/change the session setting variables without being afraid of break the client calls.