### PR TITLE
refactor(merge-into-mutator): use dedicate thread pool to decode block data

### DIFF
--- a/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
@@ -17,11 +17,11 @@ use std::ops::Range;
 use std::time::Instant;
 
 use common_base::rangemap::RangeMerger;
+use common_base::runtime::execute_futures_in_parallel;
 use common_base::runtime::UnlimitedFuture;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::ColumnId;
-use futures::future::try_join_all;
 use opendal::Operator;
 use storages_common_cache::CacheAccessor;
 use storages_common_cache::TableDataCacheKey;
@@ -80,17 +80,31 @@ impl BlockReader {
                 metrics_inc_remote_io_read_bytes_after_merged(range.end - range.start);
             }
 
-            read_handlers.push(UnlimitedFuture::create(Self::read_range(
-                op.clone(),
-                location,
-                idx,
-                range.start,
-                range.end,
-            )));
+            read_handlers.push(UnlimitedFuture::create({
+                let path = location.to_owned();
+                let op = op.clone();
+                let range = range.clone();
+                async move { Self::read_range(op, path, idx, range.start, range.end).await }
+            }));
         }
 
         let start = Instant::now();
-        let owner_memory = OwnerMemory::create(try_join_all(read_handlers).await?);
+
+        // TODO: too much parallelism,  may cause OOM.
+        let threads_nums = read_settings.max_threads as usize;
+        let permit_nums = read_settings.max_storage_io_requests as usize;
+        let r = execute_futures_in_parallel(
+            read_handlers,
+            threads_nums,
+            permit_nums,
+            "merge-io-block-reader".to_owned(),
+        )
+        .await?
+        .into_iter()
+        .collect::<Result<_>>()?;
+
+        // let owner_memory = OwnerMemory::create(try_join_all(read_handlers).await?);
+        let owner_memory = OwnerMemory::create(r);
         let table_data_cache = CacheManager::instance().get_table_data_cache();
         let mut read_res = MergeIOReadResult::create(
             owner_memory,
@@ -174,7 +188,7 @@ impl BlockReader {
 
         let mut merge_io_read_res =
             Self::merge_io_read(settings, self.operator.clone(), location, ranges).await?;
-        // TODO set
+
         merge_io_read_res.cached_column_data = cached_column_data;
         merge_io_read_res.cached_column_array = cached_column_array;
         Ok(merge_io_read_res)
@@ -184,12 +198,12 @@ impl BlockReader {
     #[async_backtrace::framed]
     pub async fn read_range(
         op: Operator,
-        path: &str,
+        path: impl AsRef<str>,
         index: usize,
         start: u64,
         end: u64,
     ) -> Result<(usize, Vec<u8>)> {
-        let chunk = op.range_read(path, start..end).await?;
+        let chunk = op.range_read(path.as_ref(), start..end).await?;
         Ok((index, chunk))
     }
 }

--- a/src/query/storages/fuse/src/io/read/read_settings.rs
+++ b/src/query/storages/fuse/src/io/read/read_settings.rs
@@ -21,6 +21,8 @@ use common_exception::Result;
 pub struct ReadSettings {
     pub storage_io_min_bytes_for_seek: u64,
     pub storage_io_max_page_bytes_for_read: u64,
+    pub max_threads: u64,
+    pub max_storage_io_requests: u64,
 }
 
 impl ReadSettings {
@@ -32,15 +34,8 @@ impl ReadSettings {
             storage_io_max_page_bytes_for_read: ctx
                 .get_settings()
                 .get_storage_io_max_page_bytes_for_read()?,
+            max_threads: ctx.get_settings().get_max_threads()?,
+            max_storage_io_requests: ctx.get_settings().get_max_storage_io_requests()?,
         })
-    }
-}
-
-impl Default for ReadSettings {
-    fn default() -> Self {
-        ReadSettings {
-            storage_io_min_bytes_for_seek: 1024,
-            storage_io_max_page_bytes_for_read: 1024 * 1024,
-        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

If data blocks needed to be loaded during the execution of `replace into`,  submit the deserialization task to a dedicated thread pool, preventing async tasks from being blocked.

Closes #issue
