### PR TITLE
chore(planner): Replace owned structures with `Arc` to reduce memory consumption

### DIFF
--- a/src/query/service/tests/it/sql/planner/format/mod.rs
+++ b/src/query/service/tests/it/sql/planner/format/mod.rs
@@ -101,84 +101,88 @@ fn test_format() {
     );
 
     let s_expr = SExpr::create_binary(
-        Join {
-            right_conditions: vec![
-                FunctionCall {
-                    span: None,
-                    func_name: "plus".to_string(),
-                    params: vec![],
-                    arguments: vec![
-                        BoundColumnRef {
-                            span: None,
-                            column: ColumnBinding {
-                                database_name: None,
-                                table_name: None,
-                                table_index: None,
-                                column_name: "col1".to_string(),
-                                index: col1,
-                                data_type: Box::new(DataType::Boolean),
-                                visibility: Visibility::Visible,
-                            },
-                        }
-                        .into(),
-                        ConstantExpr {
-                            span: None,
-                            value: Scalar::Number(NumberScalar::UInt64(123u64)),
-                        }
-                        .into(),
-                    ],
-                }
-                .into(),
-            ],
-            left_conditions: vec![
-                BoundColumnRef {
-                    span: None,
-                    column: ColumnBinding {
-                        database_name: None,
-                        table_name: None,
-                        table_index: None,
-                        column_name: "col2".to_string(),
-                        index: col2,
-                        data_type: Box::new(DataType::Boolean),
-                        visibility: Visibility::Visible,
-                    },
-                }
-                .into(),
-            ],
-            non_equi_conditions: vec![],
-            join_type: JoinType::Inner,
-            marker_index: None,
-            from_correlated_subquery: false,
-            contain_runtime_filter: false,
-        }
-        .into(),
-        SExpr::create_unary(
-            Filter {
-                predicates: vec![
-                    ConstantExpr {
+        Arc::new(
+            Join {
+                right_conditions: vec![
+                    FunctionCall {
                         span: None,
-                        value: Scalar::Boolean(true),
+                        func_name: "plus".to_string(),
+                        params: vec![],
+                        arguments: vec![
+                            BoundColumnRef {
+                                span: None,
+                                column: ColumnBinding {
+                                    database_name: None,
+                                    table_name: None,
+                                    table_index: None,
+                                    column_name: "col1".to_string(),
+                                    index: col1,
+                                    data_type: Box::new(DataType::Boolean),
+                                    visibility: Visibility::Visible,
+                                },
+                            }
+                            .into(),
+                            ConstantExpr {
+                                span: None,
+                                value: Scalar::Number(NumberScalar::UInt64(123u64)),
+                            }
+                            .into(),
+                        ],
                     }
                     .into(),
                 ],
-                is_having: false,
+                left_conditions: vec![
+                    BoundColumnRef {
+                        span: None,
+                        column: ColumnBinding {
+                            database_name: None,
+                            table_name: None,
+                            table_index: None,
+                            column_name: "col2".to_string(),
+                            index: col2,
+                            data_type: Box::new(DataType::Boolean),
+                            visibility: Visibility::Visible,
+                        },
+                    }
+                    .into(),
+                ],
+                non_equi_conditions: vec![],
+                join_type: JoinType::Inner,
+                marker_index: None,
+                from_correlated_subquery: false,
+                contain_runtime_filter: false,
             }
             .into(),
-            SExpr::create_leaf(
+        ),
+        Arc::new(SExpr::create_unary(
+            Arc::new(
+                Filter {
+                    predicates: vec![
+                        ConstantExpr {
+                            span: None,
+                            value: Scalar::Boolean(true),
+                        }
+                        .into(),
+                    ],
+                    is_having: false,
+                }
+                .into(),
+            ),
+            Arc::new(SExpr::create_leaf(Arc::new(
                 Scan {
                     table_index: tab1,
                     ..Default::default()
                 }
                 .into(),
-            ),
-        ),
-        SExpr::create_leaf(
+            ))),
+        )),
+        Arc::new(SExpr::create_leaf(Arc::new(
             Scan {
                 table_index: tab1,
                 ..Default::default()
             }
             .into(),
-        ),
+        ))),
     );
 
     let metadata_ref = Arc::new(RwLock::new(metadata));

--- a/src/query/service/tests/it/sql/planner/optimizer/agg_index_query_rewrite.rs
+++ b/src/query/service/tests/it/sql/planner/optimizer/agg_index_query_rewrite.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs.
+// Copyright 2023 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -354,7 +354,7 @@ async fn test_query_rewrite() -> Result<()> {
         let optimzier = HeuristicOptimizer::new(func_ctx.clone(), bind_context, metadata.clone());
         let meta = metadata.read();
         let base_columns = meta.columns_by_table_index(0);
-        let result = agg_index::try_rewrite(&optimzier, &base_columns, &query, &vec![(
+        let result = agg_index::try_rewrite(&optimzier, &base_columns, &query, &[(
             0,
             suite.index.to_string(),
             index,

--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -15,6 +15,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use common_ast::ast::Expr;
 use common_ast::ast::GroupBy;
@@ -449,7 +450,7 @@ impl Binder {
             let eval_scalar = EvalScalar {
                 items: scalar_items,
             };
-            new_expr = SExpr::create_unary(eval_scalar.into(), new_expr);
+            new_expr = SExpr::create_unary(Arc::new(eval_scalar.into()), Arc::new(new_expr));
         }
 
         let aggregate_plan = Aggregate {
@@ -465,7 +466,7 @@ impl Binder {
                 .map(|g| g.index)
                 .unwrap_or(0),
         };
-        new_expr = SExpr::create_unary(aggregate_plan.into(), new_expr);
+        new_expr = SExpr::create_unary(Arc::new(aggregate_plan.into()), Arc::new(new_expr));
 
         Ok(new_expr)
     }

--- a/src/query/sql/src/planner/binder/delete.rs
+++ b/src/query/sql/src/planner/binder/delete.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_ast::ast::Expr;
 use common_ast::ast::TableReference;
 use common_exception::ErrorCode;
@@ -69,7 +71,8 @@ impl<'a> Binder {
                     predicates: vec![scalar],
                     is_having: false,
                 };
-                let filter_expr = SExpr::create_unary(filter.into(), table_expr);
+                let filter_expr =
+                    SExpr::create_unary(Arc::new(filter.into()), Arc::new(table_expr));
                 let mut rewriter = SubqueryRewriter::new(self.metadata.clone());
                 let filter_expr = rewriter.rewrite(&filter_expr)?;
                 (None, Some(filter_expr))

--- a/src/query/sql/src/planner/binder/distinct.rs
+++ b/src/query/sql/src/planner/binder/distinct.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_exception::Result;
 use common_exception::Span;
@@ -60,7 +61,7 @@ impl Binder {
             let eval_scalar = EvalScalar {
                 items: scalar_items,
             };
-            new_expr = SExpr::create_unary(eval_scalar.into(), new_expr);
+            new_expr = SExpr::create_unary(Arc::new(eval_scalar.into()), Arc::new(new_expr));
         }
 
         // Like aggregate, we just use scalar directly.
@@ -85,6 +86,9 @@ impl Binder {
             grouping_sets: vec![],
         };
 
-        Ok(SExpr::create_unary(distinct_plan.into(), new_expr))
+        Ok(SExpr::create_unary(
+            Arc::new(distinct_plan.into()),
+            Arc::new(new_expr),
+        ))
     }
 }

--- a/src/query/sql/src/planner/binder/having.rs
+++ b/src/query/sql/src/planner/binder/having.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_ast::ast::Expr;
 use common_exception::Result;
 use common_exception::Span;
@@ -76,6 +78,9 @@ impl Binder {
             is_having: true,
         };
 
-        Ok(SExpr::create_unary(filter.into(), child))
+        Ok(SExpr::create_unary(
+            Arc::new(filter.into()),
+            Arc::new(child),
+        ))
     }
 }

--- a/src/query/sql/src/planner/binder/join.rs
+++ b/src/query/sql/src/planner/binder/join.rs
@@ -204,9 +204,9 @@ impl Binder {
             contain_runtime_filter: false,
         };
         Ok(SExpr::create_binary(
-            logical_join.into(),
-            left_child,
-            right_child,
+            Arc::new(logical_join.into()),
+            Arc::new(left_child),
+            Arc::new(right_child),
         ))
     }
 
@@ -250,23 +250,27 @@ impl Binder {
 
         if !left_push_down.is_empty() {
             *left_child = SExpr::create_unary(
-                Filter {
-                    predicates: left_push_down,
-                    is_having: false,
-                }
-                .into(),
-                left_child.clone(),
+                Arc::new(
+                    Filter {
+                        predicates: left_push_down,
+                        is_having: false,
+                    }
+                    .into(),
+                ),
+                Arc::new(left_child.clone()),
             );
         }
 
         if !right_push_down.is_empty() {
             *right_child = SExpr::create_unary(
-                Filter {
-                    predicates: right_push_down,
-                    is_having: false,
-                }
-                .into(),
-                right_child.clone(),
+                Arc::new(
+                    Filter {
+                        predicates: right_push_down,
+                        is_having: false,
+                    }
+                    .into(),
+                ),
+                Arc::new(right_child.clone()),
             );
         }
 

--- a/src/query/sql/src/planner/binder/limit.rs
+++ b/src/query/sql/src/planner/binder/limit.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_ast::ast::Expr;
 use common_ast::ast::Literal;
 use common_exception::ErrorCode;
@@ -48,7 +50,7 @@ impl Binder {
 
     pub(super) fn bind_limit(child: SExpr, limit: Option<usize>, offset: usize) -> SExpr {
         let limit_plan = Limit { limit, offset };
-        SExpr::create_unary(limit_plan.into(), child)
+        SExpr::create_unary(Arc::new(limit_plan.into()), Arc::new(child))
     }
 
     /// So far, we only support integer literal as limit argument.

--- a/src/query/sql/src/planner/binder/project.rs
+++ b/src/query/sql/src/planner/binder/project.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use common_ast::ast::Identifier;
 use common_ast::ast::Indirection;
@@ -147,7 +148,7 @@ impl Binder {
         scalars.sort_by_key(|s| s.index);
         let eval_scalar = EvalScalar { items: scalars };
 
-        let new_expr = SExpr::create_unary(eval_scalar.into(), child);
+        let new_expr = SExpr::create_unary(Arc::new(eval_scalar.into()), Arc::new(child));
 
         // Set output columns
         bind_context.columns = columns.to_vec();

--- a/src/query/sql/src/planner/binder/project_set.rs
+++ b/src/query/sql/src/planner/binder/project_set.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_ast::ast::Expr;
 use common_ast::ast::Identifier;
 use common_ast::ast::Literal;
@@ -186,6 +188,9 @@ impl Binder {
 
         let project_set = ProjectSet { srfs: items };
 
-        Ok(SExpr::create_unary(project_set.into(), s_expr))
+        Ok(SExpr::create_unary(
+            Arc::new(project_set.into()),
+            Arc::new(s_expr),
+        ))
     }
 }

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use async_recursion::async_recursion;
 use common_ast::ast::BinaryOperator;
@@ -376,7 +377,7 @@ impl Binder {
             predicates: split_conjunctions(&scalar),
             is_having: false,
         };
-        let new_expr = SExpr::create_unary(filter_plan.into(), child);
+        let new_expr = SExpr::create_unary(Arc::new(filter_plan.into()), Arc::new(child));
         bind_context.set_expr_context(last_expr_context);
         Ok((new_expr, scalar))
     }
@@ -466,7 +467,11 @@ impl Binder {
             .collect();
 
         let union_plan = UnionAll { pairs };
-        let mut new_expr = SExpr::create_binary(union_plan.into(), left_expr, right_expr);
+        let mut new_expr = SExpr::create_binary(
+            Arc::new(union_plan.into()),
+            Arc::new(left_expr),
+            Arc::new(right_expr),
+        );
 
         if distinct {
             new_expr = self.bind_distinct(

--- a/src/query/sql/src/planner/binder/sort.rs
+++ b/src/query/sql/src/planner/binder/sort.rs
@@ -14,6 +14,7 @@
 
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_ast::ast::Expr;
 use common_ast::ast::Literal;
@@ -236,7 +237,7 @@ impl Binder {
 
         let mut new_expr = if !scalars.is_empty() {
             let eval_scalar = EvalScalar { items: scalars };
-            SExpr::create_unary(eval_scalar.into(), child)
+            SExpr::create_unary(Arc::new(eval_scalar.into()), Arc::new(child))
         } else {
             child
         };
@@ -245,7 +246,7 @@ impl Binder {
             items: order_by_items,
             limit: None,
         };
-        new_expr = SExpr::create_unary(sort_plan.into(), new_expr);
+        new_expr = SExpr::create_unary(Arc::new(sort_plan.into()), Arc::new(new_expr));
         Ok(new_expr)
     }
 
@@ -295,7 +296,10 @@ impl Binder {
             items: order_by_items,
             limit: None,
         };
-        Ok(SExpr::create_unary(sort_plan.into(), child))
+        Ok(SExpr::create_unary(
+            Arc::new(sort_plan.into()),
+            Arc::new(child),
+        ))
     }
 
     #[allow(clippy::only_used_in_recursion)]

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -745,7 +745,7 @@ impl Binder {
         let stat = table.table().table_statistics()?;
 
         Ok((
-            SExpr::create_leaf(
+            SExpr::create_leaf(Arc::new(
                 Scan {
                     table_index,
                     columns: columns
@@ -773,7 +773,7 @@ impl Binder {
                     ..Default::default()
                 }
                 .into(),
-            ),
+            )),
             bind_context,
         ))
     }

--- a/src/query/sql/src/planner/binder/window.rs
+++ b/src/query/sql/src/planner/binder/window.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -56,7 +57,10 @@ impl Binder {
             frame: window_info.frame.clone(),
         };
 
-        Ok(SExpr::create_unary(window_plan.into(), child))
+        Ok(SExpr::create_unary(
+            Arc::new(window_plan.into()),
+            Arc::new(child),
+        ))
     }
 }
 

--- a/src/query/sql/src/planner/optimizer/cascades/cascade.rs
+++ b/src/query/sql/src/planner/optimizer/cascades/cascade.rs
@@ -122,7 +122,7 @@ impl CascadesOptimizer {
         let children = m_expr
             .children
             .iter()
-            .map(|index| self.find_optimal_plan(*index))
+            .map(|index| Ok(Arc::new(self.find_optimal_plan(*index)?)))
             .collect::<Result<Vec<_>>>()?;
 
         let result = SExpr::create(m_expr.plan.clone(), children, None, None, None);

--- a/src/query/sql/src/planner/optimizer/cost/cost_model.rs
+++ b/src/query/sql/src/planner/optimizer/cost/cost_model.rs
@@ -38,7 +38,7 @@ impl CostModel for DefaultCostModel {
 }
 
 fn compute_cost_impl(memo: &Memo, m_expr: &MExpr) -> Result<Cost> {
-    match &m_expr.plan {
+    match m_expr.plan.as_ref() {
         RelOperator::Scan(plan) => compute_cost_scan(memo, m_expr, plan),
         RelOperator::DummyTableScan(_) => Ok(Cost(0.0)),
         RelOperator::Join(plan) => compute_cost_join(memo, m_expr, plan),

--- a/src/query/sql/src/planner/optimizer/distributed/distributed.rs
+++ b/src/query/sql/src/planner/optimizer/distributed/distributed.rs
@@ -39,7 +39,7 @@ pub fn optimize_distributed_query(ctx: Arc<dyn TableContext>, s_expr: &SExpr) ->
     };
     if !root_required.satisfied_by(&physical_prop) {
         // Manually enforce serial distribution.
-        result = SExpr::create_unary(Exchange::Merge.into(), result);
+        result = SExpr::create_unary(Arc::new(Exchange::Merge.into()), Arc::new(result));
     }
 
     Ok(result)
@@ -47,37 +47,40 @@ pub fn optimize_distributed_query(ctx: Arc<dyn TableContext>, s_expr: &SExpr) ->
 
 // Traverse the SExpr tree to find top_k, if find, push down it to Exchange::Merge
 fn push_down_topk_to_merge(s_expr: &SExpr, mut top_k: Option<TopK>) -> Result<SExpr> {
-    if let RelOperator::Exchange(Exchange::Merge) = s_expr.plan {
+    if let RelOperator::Exchange(Exchange::Merge) = *s_expr.plan {
         // A quick fix for Merge child is aggregate.
         // Todo: consider to push down topk to the above of aggregate.
-        if let RelOperator::Aggregate(_) = s_expr.child(0)?.plan {
+        if let RelOperator::Aggregate(_) = *s_expr.child(0)?.plan {
             return Ok(s_expr.clone());
         }
         if let Some(top_k) = top_k {
             let mut child = s_expr.children[0].clone();
-            child = SExpr::create_unary(top_k.sort.into(), child.clone());
+            child = Arc::new(SExpr::create_unary(Arc::new(top_k.sort.into()), child));
             let children = if s_expr.children.len() == 2 {
                 vec![child, s_expr.children[1].clone()]
             } else {
                 vec![child]
             };
-            return Ok(s_expr.replace_children(children));
+            return Ok(s_expr.replace_children(children.into_iter()));
         }
     }
 
     let mut s_expr_children = vec![];
     for child in s_expr.children.iter() {
         top_k = None;
-        if let RelOperator::Sort(sort) = &child.plan {
+        if let RelOperator::Sort(sort) = (*child.plan).clone() {
             if sort.limit.is_some() {
                 top_k = Some(TopK { sort: sort.clone() });
             }
         }
         let mut new_children = vec![];
         for child_child in child.children.iter() {
-            new_children.push(push_down_topk_to_merge(child_child, top_k.clone())?);
+            new_children.push(Arc::new(push_down_topk_to_merge(
+                child_child,
+                top_k.clone(),
+            )?));
         }
-        s_expr_children.push(child.replace_children(new_children));
+        s_expr_children.push(Arc::new(child.replace_children(new_children)));
     }
     Ok(s_expr.replace_children(s_expr_children))
 }

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -93,22 +94,26 @@ impl SubqueryRewriter {
         //      \
         //       Get
         let pattern = SExpr::create_unary(
-            PatternPlan {
-                plan_type: RelOp::EvalScalar,
-            }
-            .into(),
-            SExpr::create_unary(
+            Arc::new(
                 PatternPlan {
-                    plan_type: RelOp::Filter,
+                    plan_type: RelOp::EvalScalar,
                 }
                 .into(),
-                SExpr::create_leaf(
+            ),
+            Arc::new(SExpr::create_unary(
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::Filter,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_leaf(Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Scan,
                     }
                     .into(),
-                ),
-            ),
+                ))),
+            )),
         );
 
         if !subquery.subquery.match_pattern(&pattern) {
@@ -190,35 +195,45 @@ impl SubqueryRewriter {
         let mut left_child = input.clone();
         if !left_filters.is_empty() {
             left_child = SExpr::create_unary(
-                Filter {
-                    predicates: left_filters,
-                    is_having: false,
-                }
-                .into(),
-                left_child,
+                Arc::new(
+                    Filter {
+                        predicates: left_filters,
+                        is_having: false,
+                    }
+                    .into(),
+                ),
+                Arc::new(left_child),
             );
         }
 
         // Remove `Filter` from subquery.
         let mut right_child = SExpr::create_unary(
-            subquery.subquery.plan().clone(),
-            SExpr::create_unary(
-                subquery.subquery.plan().clone(),
-                SExpr::create_leaf(filter_tree.child(0)?.plan().clone()),
-            ),
+            Arc::new(subquery.subquery.plan().clone()),
+            Arc::new(SExpr::create_unary(
+                Arc::new(subquery.subquery.plan().clone()),
+                Arc::new(SExpr::create_leaf(Arc::new(
+                    filter_tree.child(0)?.plan().clone(),
+                ))),
+            )),
         );
         if !right_filters.is_empty() {
             right_child = SExpr::create_unary(
-                Filter {
-                    predicates: right_filters,
-                    is_having: false,
-                }
-                .into(),
-                right_child,
+                Arc::new(
+                    Filter {
+                        predicates: right_filters,
+                        is_having: false,
+                    }
+                    .into(),
+                ),
+                Arc::new(right_child),
             );
         }
 
-        let result = SExpr::create_binary(join.into(), left_child, right_child);
+        let result = SExpr::create_binary(
+            Arc::new(join.into()),
+            Arc::new(left_child),
+            Arc::new(right_child),
+        );
 
         Ok(Some(result))
     }
@@ -253,7 +268,11 @@ impl SubqueryRewriter {
                     from_correlated_subquery: true,
                     contain_runtime_filter: false,
                 };
-                let s_expr = SExpr::create_binary(join_plan.into(), left.clone(), flatten_plan);
+                let s_expr = SExpr::create_binary(
+                    Arc::new(join_plan.into()),
+                    Arc::new(left.clone()),
+                    Arc::new(flatten_plan),
+                );
                 Ok((s_expr, UnnestResult::SingleJoin))
             }
             SubqueryType::Exists | SubqueryType::NotExists => {
@@ -292,7 +311,11 @@ impl SubqueryRewriter {
                     from_correlated_subquery: true,
                     contain_runtime_filter: false,
                 };
-                let s_expr = SExpr::create_binary(join_plan.into(), left.clone(), flatten_plan);
+                let s_expr = SExpr::create_binary(
+                    Arc::new(join_plan.into()),
+                    Arc::new(left.clone()),
+                    Arc::new(flatten_plan),
+                );
                 Ok((s_expr, UnnestResult::MarkJoin { marker_index }))
             }
             SubqueryType::Any => {
@@ -350,7 +373,11 @@ impl SubqueryRewriter {
                 }
                 .into();
                 Ok((
-                    SExpr::create_binary(mark_join, left.clone(), flatten_plan),
+                    SExpr::create_binary(
+                        Arc::new(mark_join),
+                        Arc::new(left.clone()),
+                        Arc::new(flatten_plan),
+                    ),
                     UnnestResult::MarkJoin { marker_index },
                 ))
             }
@@ -388,14 +415,14 @@ impl SubqueryRewriter {
                     metadata.add_derived_column(name.to_string(), data_type.wrap_nullable()),
                 );
             }
-            let logical_get = SExpr::create_leaf(
+            let logical_get = SExpr::create_leaf(Arc::new(
                 Scan {
                     table_index,
                     columns: self.derived_columns.values().cloned().collect(),
                     ..Default::default()
                 }
                 .into(),
-            );
+            ));
             // Todo(xudong963): Wrap logical get with distinct to eliminate duplicates rows.
             let cross_join = Join {
                 left_conditions: vec![],
@@ -407,7 +434,11 @@ impl SubqueryRewriter {
                 contain_runtime_filter: false,
             }
             .into();
-            return Ok(SExpr::create_binary(cross_join, logical_get, plan.clone()));
+            return Ok(SExpr::create_binary(
+                Arc::new(cross_join),
+                Arc::new(logical_get),
+                Arc::new(plan.clone()),
+            ));
         }
 
         match plan.plan() {
@@ -454,8 +485,8 @@ impl SubqueryRewriter {
                     });
                 }
                 Ok(SExpr::create_unary(
-                    EvalScalar { items }.into(),
-                    flatten_plan,
+                    Arc::new(EvalScalar { items }.into()),
+                    Arc::new(flatten_plan),
                 ))
             }
             RelOperator::Filter(filter) => {
@@ -481,7 +512,10 @@ impl SubqueryRewriter {
                     is_having: filter.is_having,
                 }
                 .into();
-                Ok(SExpr::create_unary(filter_plan, flatten_plan))
+                Ok(SExpr::create_unary(
+                    Arc::new(filter_plan),
+                    Arc::new(flatten_plan),
+                ))
             }
             RelOperator::Join(join) => {
                 // Currently, we don't support join conditions contain subquery
@@ -505,18 +539,20 @@ impl SubqueryRewriter {
                     need_cross_join,
                 )?;
                 Ok(SExpr::create_binary(
-                    Join {
-                        left_conditions: join.left_conditions.clone(),
-                        right_conditions: join.right_conditions.clone(),
-                        non_equi_conditions: join.non_equi_conditions.clone(),
-                        join_type: join.join_type.clone(),
-                        marker_index: join.marker_index,
-                        from_correlated_subquery: false,
-                        contain_runtime_filter: false,
-                    }
-                    .into(),
-                    left_flatten_plan,
-                    right_flatten_plan,
+                    Arc::new(
+                        Join {
+                            left_conditions: join.left_conditions.clone(),
+                            right_conditions: join.right_conditions.clone(),
+                            non_equi_conditions: join.non_equi_conditions.clone(),
+                            join_type: join.join_type.clone(),
+                            marker_index: join.marker_index,
+                            from_correlated_subquery: false,
+                            contain_runtime_filter: false,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(left_flatten_plan),
+                    Arc::new(right_flatten_plan),
                 ))
             }
             RelOperator::Aggregate(aggregate) => {
@@ -595,17 +631,19 @@ impl SubqueryRewriter {
                     })
                 }
                 Ok(SExpr::create_unary(
-                    Aggregate {
-                        mode: AggregateMode::Initial,
-                        group_items,
-                        aggregate_functions: agg_items,
-                        from_distinct: aggregate.from_distinct,
-                        limit: aggregate.limit,
-                        grouping_id_index: aggregate.grouping_id_index,
-                        grouping_sets: aggregate.grouping_sets.clone(),
-                    }
-                    .into(),
-                    flatten_plan,
+                    Arc::new(
+                        Aggregate {
+                            mode: AggregateMode::Initial,
+                            group_items,
+                            aggregate_functions: agg_items,
+                            from_distinct: aggregate.from_distinct,
+                            limit: aggregate.limit,
+                            grouping_id_index: aggregate.grouping_id_index,
+                            grouping_sets: aggregate.grouping_sets.clone(),
+                        }
+                        .into(),
+                    ),
+                    Arc::new(flatten_plan),
                 ))
             }
             RelOperator::Sort(_) => {
@@ -616,7 +654,10 @@ impl SubqueryRewriter {
                     flatten_info,
                     need_cross_join,
                 )?;
-                Ok(SExpr::create_unary(plan.plan().clone(), flatten_plan))
+                Ok(SExpr::create_unary(
+                    Arc::new(plan.plan().clone()),
+                    Arc::new(flatten_plan),
+                ))
             }
 
             RelOperator::Limit(_) => {
@@ -627,7 +668,10 @@ impl SubqueryRewriter {
                     flatten_info,
                     need_cross_join,
                 )?;
-                Ok(SExpr::create_unary(plan.plan().clone(), flatten_plan))
+                Ok(SExpr::create_unary(
+                    Arc::new(plan.plan().clone()),
+                    Arc::new(flatten_plan),
+                ))
             }
 
             RelOperator::UnionAll(op) => {
@@ -651,9 +695,9 @@ impl SubqueryRewriter {
                     need_cross_join,
                 )?;
                 Ok(SExpr::create_binary(
-                    op.clone().into(),
-                    left_flatten_plan,
-                    right_flatten_plan,
+                    Arc::new(op.clone().into()),
+                    Arc::new(left_flatten_plan),
+                    Arc::new(right_flatten_plan),
                 ))
             }
 

--- a/src/query/sql/src/planner/optimizer/heuristic/heuristic.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/heuristic.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_expression::FunctionContext;
 use once_cell::sync::Lazy;
@@ -105,7 +107,7 @@ impl HeuristicOptimizer {
     pub fn optimize_expression(&self, s_expr: &SExpr, rules: &[RuleID]) -> Result<SExpr> {
         let mut optimized_children = Vec::with_capacity(s_expr.arity());
         for expr in s_expr.children() {
-            optimized_children.push(self.optimize_expression(expr, rules)?);
+            optimized_children.push(Arc::new(self.optimize_expression(expr, rules)?));
         }
         let optimized_expr = s_expr.replace_children(optimized_children);
         let result = self.apply_transform_rules(&optimized_expr, rules)?;

--- a/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -85,7 +86,7 @@ impl SubqueryRewriter {
                     item.scalar = res.0;
                 }
 
-                Ok(SExpr::create_unary(plan.into(), input))
+                Ok(SExpr::create_unary(Arc::new(plan.into()), Arc::new(input)))
             }
             RelOperator::Filter(mut plan) => {
                 let mut input = self.rewrite(s_expr.child(0)?)?;
@@ -95,7 +96,7 @@ impl SubqueryRewriter {
                     *pred = res.0;
                 }
 
-                Ok(SExpr::create_unary(plan.into(), input))
+                Ok(SExpr::create_unary(Arc::new(plan.into()), Arc::new(input)))
             }
             RelOperator::Aggregate(mut plan) => {
                 let mut input = self.rewrite(s_expr.child(0)?)?;
@@ -112,7 +113,7 @@ impl SubqueryRewriter {
                     item.scalar = res.0;
                 }
 
-                Ok(SExpr::create_unary(plan.into(), input))
+                Ok(SExpr::create_unary(Arc::new(plan.into()), Arc::new(input)))
             }
 
             RelOperator::Window(mut plan) => {
@@ -139,18 +140,18 @@ impl SubqueryRewriter {
                     }
                 }
 
-                Ok(SExpr::create_unary(plan.into(), input))
+                Ok(SExpr::create_unary(Arc::new(plan.into()), Arc::new(input)))
             }
 
             RelOperator::Join(_) | RelOperator::UnionAll(_) => Ok(SExpr::create_binary(
-                s_expr.plan().clone(),
-                self.rewrite(s_expr.child(0)?)?,
-                self.rewrite(s_expr.child(1)?)?,
+                Arc::new(s_expr.plan().clone()),
+                Arc::new(self.rewrite(s_expr.child(0)?)?),
+                Arc::new(self.rewrite(s_expr.child(1)?)?),
             )),
 
             RelOperator::Limit(_) | RelOperator::Sort(_) => Ok(SExpr::create_unary(
-                s_expr.plan().clone(),
-                self.rewrite(s_expr.child(0)?)?,
+                Arc::new(s_expr.plan().clone()),
+                Arc::new(self.rewrite(s_expr.child(0)?)?),
             )),
 
             RelOperator::DummyTableScan(_) | RelOperator::Scan(_) => Ok(s_expr.clone()),
@@ -342,8 +343,11 @@ impl SubqueryRewriter {
                     contain_runtime_filter: false,
                 }
                 .into();
-                let s_expr =
-                    SExpr::create_binary(join_plan, left.clone(), *subquery.subquery.clone());
+                let s_expr = SExpr::create_binary(
+                    Arc::new(join_plan),
+                    Arc::new(left.clone()),
+                    Arc::new(*subquery.subquery.clone()),
+                );
                 Ok((s_expr, UnnestResult::SingleJoin))
             }
             SubqueryType::Exists | SubqueryType::NotExists => {
@@ -353,7 +357,8 @@ impl SubqueryRewriter {
                     limit: Some(1),
                     offset: 0,
                 };
-                subquery_expr = SExpr::create_unary(limit.into(), subquery_expr.clone());
+                subquery_expr =
+                    SExpr::create_unary(Arc::new(limit.into()), Arc::new(subquery_expr.clone()));
 
                 // We will rewrite EXISTS subquery into the form `COUNT(*) = 1`.
                 // For example, `EXISTS(SELECT a FROM t WHERE a > 1)` will be rewritten into
@@ -422,8 +427,11 @@ impl SubqueryRewriter {
                 // Filter: COUNT(*) = 1 or COUNT(*) != 1
                 //     Aggregate: COUNT(*)
                 let rewritten_subquery = SExpr::create_unary(
-                    filter.into(),
-                    SExpr::create_unary(agg.into(), subquery_expr),
+                    Arc::new(filter.into()),
+                    Arc::new(SExpr::create_unary(
+                        Arc::new(agg.into()),
+                        Arc::new(subquery_expr),
+                    )),
                 );
                 let cross_join = Join {
                     left_conditions: vec![],
@@ -436,7 +444,11 @@ impl SubqueryRewriter {
                 }
                 .into();
                 Ok((
-                    SExpr::create_binary(cross_join, left.clone(), rewritten_subquery),
+                    SExpr::create_binary(
+                        Arc::new(cross_join),
+                        Arc::new(left.clone()),
+                        Arc::new(rewritten_subquery),
+                    ),
                     UnnestResult::SimpleJoin,
                 ))
             }
@@ -500,8 +512,11 @@ impl SubqueryRewriter {
                     contain_runtime_filter: false,
                 }
                 .into();
-                let s_expr =
-                    SExpr::create_binary(mark_join, left.clone(), *subquery.subquery.clone());
+                let s_expr = SExpr::create_binary(
+                    Arc::new(mark_join),
+                    Arc::new(left.clone()),
+                    Arc::new(*subquery.subquery.clone()),
+                );
                 Ok((s_expr, UnnestResult::MarkJoin { marker_index }))
             }
             _ => unreachable!(),

--- a/src/query/sql/src/planner/optimizer/hyper_dp/join_node.rs
+++ b/src/query/sql/src/planner/optimizer/hyper_dp/join_node.rs
@@ -93,12 +93,12 @@ impl JoinNode {
             .iter()
             .map(|child| {
                 if let Some(s_expr) = &child.s_expr {
-                    s_expr.clone()
+                    Arc::new(s_expr.clone())
                 } else {
-                    child.s_expr(join_relations)
+                    Arc::new(child.s_expr(join_relations))
                 }
             })
             .collect::<Vec<_>>();
-        SExpr::create(rel_op, children, None, None, None)
+        SExpr::create(Arc::new(rel_op), children, None, None, None)
     }
 }

--- a/src/query/sql/src/planner/optimizer/m_expr.rs
+++ b/src/query/sql/src/planner/optimizer/m_expr.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 
@@ -35,7 +37,7 @@ pub struct MExpr {
     // index of current `MExpr` within a `Group`
     pub index: IndexType,
 
-    pub plan: RelOperator,
+    pub plan: Arc<RelOperator>,
     pub children: Vec<IndexType>,
 
     // Disable rules for current `MExpr`
@@ -46,7 +48,7 @@ impl MExpr {
     pub fn create(
         group_index: IndexType,
         index: IndexType,
-        plan: RelOperator,
+        plan: Arc<RelOperator>,
         children: Vec<IndexType>,
         applied_rules: AppliedRules,
     ) -> Self {

--- a/src/query/sql/src/planner/optimizer/memo.rs
+++ b/src/query/sql/src/planner/optimizer/memo.rs
@@ -78,13 +78,13 @@ impl Memo {
         let mut children_group = vec![];
         for expr in s_expr.children() {
             // Insert children expressions recursively and collect their group indices
-            let group = self.insert(None, expr.clone())?;
+            let group = self.insert(None, (**expr).clone())?;
             children_group.push(group);
         }
 
         if let Some((group_index, _)) = self
             .m_expr_lookup_table
-            .get(&(s_expr.plan.clone(), children_group.clone()))
+            .get(&((*s_expr.plan).clone(), children_group.clone()))
         {
             // If the expression already exists, return the group index of the existing expression
             return Ok(*group_index);
@@ -126,7 +126,7 @@ impl Memo {
 
     pub fn insert_m_expr(&mut self, group_index: IndexType, m_expr: MExpr) -> Result<()> {
         self.m_expr_lookup_table.insert(
-            (m_expr.plan.clone(), m_expr.children.clone()),
+            ((*m_expr.plan).clone(), m_expr.children.clone()),
             (m_expr.group_index, m_expr.index),
         );
         self.group_mut(group_index)?.insert(m_expr)

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -153,7 +153,7 @@ pub fn optimize_query(
     let mut result = heuristic.optimize(s_expr)?;
     if ctx.get_settings().get_enable_dphyp()? {
         let (dp_res, optimized) =
-            DPhpy::new(ctx.clone(), metadata.clone(), false).optimize(result.clone())?;
+            DPhpy::new(ctx.clone(), metadata.clone(), false).optimize(&result)?;
         result = dp_res;
         if !optimized {
             // Callback to CascadesOptimizer

--- a/src/query/sql/src/planner/optimizer/pattern_extractor.rs
+++ b/src/query/sql/src/planner/optimizer/pattern_extractor.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 
 use crate::optimizer::group::Group;
@@ -99,9 +101,9 @@ impl PatternExtractor {
         }
 
         'LOOP: loop {
-            let mut children: Vec<SExpr> = vec![];
+            let mut children = vec![];
             for (index, cursor) in cursors.iter().enumerate() {
-                children.push(candidates[index][*cursor].clone());
+                children.push(Arc::new(candidates[index][*cursor].clone()));
             }
             results.push(SExpr::create(
                 m_expr.plan.clone(),

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/derive_filter.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/derive_filter.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_exception::Result;
 
@@ -80,26 +81,34 @@ pub fn try_derive_predicates(
 
     if !left_push_down.is_empty() {
         left_child = SExpr::create_unary(
-            Filter {
-                predicates: left_push_down,
-                is_having: false,
-            }
-            .into(),
-            left_child,
+            Arc::new(
+                Filter {
+                    predicates: left_push_down,
+                    is_having: false,
+                }
+                .into(),
+            ),
+            Arc::new(left_child),
         );
     }
 
     if !right_push_down.is_empty() {
         right_child = SExpr::create_unary(
-            Filter {
-                predicates: right_push_down,
-                is_having: false,
-            }
-            .into(),
-            right_child,
+            Arc::new(
+                Filter {
+                    predicates: right_push_down,
+                    is_having: false,
+                }
+                .into(),
+            ),
+            Arc::new(right_child),
         );
     }
-    Ok(SExpr::create_binary(join.into(), left_child, right_child))
+    Ok(SExpr::create_binary(
+        Arc::new(join.into()),
+        Arc::new(left_child),
+        Arc::new(right_child),
+    ))
 }
 
 fn derive_predicate(

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/mark_join_to_semi_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/mark_join_to_semi_join.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 
 use crate::optimizer::SExpr;
@@ -66,11 +68,11 @@ pub fn convert_mark_to_semi_join(s_expr: &SExpr) -> Result<SExpr> {
 
     let s_join_expr = s_expr.child(0)?;
     let mut result = SExpr::create_binary(
-        join.into(),
-        s_join_expr.child(0)?.clone(),
-        s_join_expr.child(1)?.clone(),
+        Arc::new(join.into()),
+        Arc::new(s_join_expr.child(0)?.clone()),
+        Arc::new(s_join_expr.child(1)?.clone()),
     );
 
-    result = SExpr::create_unary(filter.into(), result);
+    result = SExpr::create_unary(Arc::new(filter.into()), Arc::new(result));
     Ok(result)
 }

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/outer_join_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/outer_join_to_inner_join.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 
 use crate::optimizer::SExpr;
@@ -77,12 +79,12 @@ pub fn outer_to_inner(s_expr: &SExpr) -> Result<SExpr> {
 
             join.join_type = new_join_type;
             Ok(SExpr::create_unary(
-                filter.into(),
-                SExpr::create_binary(
-                    join.into(),
-                    s_expr.child(0)?.child(0)?.clone(),
-                    s_expr.child(0)?.child(1)?.clone(),
-                ),
+                Arc::new(filter.into()),
+                Arc::new(SExpr::create_binary(
+                    Arc::new(join.into()),
+                    Arc::new(s_expr.child(0)?.child(0)?.clone()),
+                    Arc::new(s_expr.child(0)?.child(1)?.clone()),
+                )),
             ))
         } else {
             Ok(s_expr.clone())

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_eliminate_eval_scalar.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_eliminate_eval_scalar.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 
 use crate::optimizer::rule::Rule;
@@ -35,16 +37,18 @@ impl RuleEliminateEvalScalar {
             //  \
             //   *
             patterns: vec![SExpr::create_unary(
-                PatternPlan {
-                    plan_type: RelOp::EvalScalar,
-                }
-                .into(),
-                SExpr::create_leaf(
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::EvalScalar,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_leaf(Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Pattern,
                     }
                     .into(),
-                ),
+                ))),
             )],
         }
     }

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_eliminate_filter.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_eliminate_filter.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use itertools::Itertools;
 
@@ -37,16 +39,18 @@ impl RuleEliminateFilter {
             //  \
             //   *
             patterns: vec![SExpr::create_unary(
-                PatternPlan {
-                    plan_type: RelOp::Filter,
-                }
-                .into(),
-                SExpr::create_leaf(
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::Filter,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_leaf(Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Pattern,
                     }
                     .into(),
-                ),
+                ))),
             )],
         }
     }
@@ -94,7 +98,10 @@ impl Rule for RuleEliminateFilter {
                 predicates,
                 is_having: eval_scalar.is_having,
             };
-            state.add_result(SExpr::create_unary(filter.into(), s_expr.child(0)?.clone()));
+            state.add_result(SExpr::create_unary(
+                Arc::new(filter.into()),
+                Arc::new(s_expr.child(0)?.clone()),
+            ));
         }
         Ok(())
     }

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_constant.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_constant.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_expression::ConstantFolder;
 use common_expression::FunctionContext;
@@ -41,76 +43,86 @@ impl RuleFoldConstant {
                 //  \
                 //   *
                 SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::Filter,
-                    }
-                    .into(),
-                    SExpr::create_leaf(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::Filter,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(SExpr::create_leaf(Arc::new(
                         PatternPlan {
                             plan_type: RelOp::Pattern,
                         }
                         .into(),
-                    ),
+                    ))),
                 ),
                 // EvalScalar
                 //  \
                 //   *
                 SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::EvalScalar,
-                    }
-                    .into(),
-                    SExpr::create_leaf(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::EvalScalar,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(SExpr::create_leaf(Arc::new(
                         PatternPlan {
                             plan_type: RelOp::Pattern,
                         }
                         .into(),
-                    ),
+                    ))),
                 ),
                 // ProjectSet
                 //  \
                 //   *
                 SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::ProjectSet,
-                    }
-                    .into(),
-                    SExpr::create_leaf(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::ProjectSet,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(SExpr::create_leaf(Arc::new(
                         PatternPlan {
                             plan_type: RelOp::Pattern,
                         }
                         .into(),
-                    ),
+                    ))),
                 ),
                 // Exchange
                 //  \
                 //   *
                 SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::Exchange,
-                    }
-                    .into(),
-                    SExpr::create_leaf(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::Exchange,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(SExpr::create_leaf(Arc::new(
                         PatternPlan {
                             plan_type: RelOp::Pattern,
                         }
                         .into(),
-                    ),
+                    ))),
                 ),
                 // Join
                 //  \
                 //   *
                 SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::Join,
-                    }
-                    .into(),
-                    SExpr::create_leaf(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::Join,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(SExpr::create_leaf(Arc::new(
                         PatternPlan {
                             plan_type: RelOp::Pattern,
                         }
                         .into(),
-                    ),
+                    ))),
                 ),
             ],
             func_ctx,

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_expression::types::NumberScalar;
 use common_expression::Scalar;
@@ -44,16 +46,18 @@ impl RuleFoldCountAggregate {
             //  \
             //   *
             patterns: vec![SExpr::create_unary(
-                PatternPlan {
-                    plan_type: RelOp::Aggregate,
-                }
-                .into(),
-                SExpr::create_leaf(
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::Aggregate,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_leaf(Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Pattern,
                     }
                     .into(),
-                ),
+                ))),
             )],
         }
     }
@@ -116,8 +120,8 @@ impl Rule for RuleFoldCountAggregate {
             let eval_scalar = EvalScalar { items: scalars };
             let dummy_table_scan = DummyTableScan;
             state.add_result(SExpr::create_unary(
-                eval_scalar.into(),
-                SExpr::create_leaf(dummy_table_scan.into()),
+                Arc::new(eval_scalar.into()),
+                Arc::new(SExpr::create_leaf(Arc::new(dummy_table_scan.into()))),
             ));
         }
         Ok(())

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_normalize_disjunctive_filter.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_normalize_disjunctive_filter.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_expression::Scalar;
 
@@ -100,16 +102,18 @@ impl RuleNormalizeDisjunctiveFilter {
             //  \
             //   *
             patterns: vec![SExpr::create_unary(
-                PatternPlan {
-                    plan_type: RelOp::Filter,
-                }
-                .into(),
-                SExpr::create_leaf(
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::Filter,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_leaf(Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Pattern,
                     }
                     .into(),
-                ),
+                ))),
             )],
         }
     }
@@ -140,12 +144,14 @@ impl Rule for RuleNormalizeDisjunctiveFilter {
         }
         if rewritten {
             state.add_result(SExpr::create_unary(
-                Filter {
-                    predicates: split_predicates,
-                    is_having: filter.is_having,
-                }
-                .into(),
-                s_expr.child(0)?.clone(),
+                Arc::new(
+                    Filter {
+                        predicates: split_predicates,
+                        is_having: filter.is_having,
+                    }
+                    .into(),
+                ),
+                Arc::new(s_expr.child(0)?.clone()),
             ));
         }
         Ok(())

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_normalize_scalar.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_normalize_scalar.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_expression::Scalar;
 
@@ -85,16 +87,18 @@ impl RuleNormalizeScalarFilter {
             //  \
             //   *
             patterns: vec![SExpr::create_unary(
-                PatternPlan {
-                    plan_type: RelOp::Filter,
-                }
-                .into(),
-                SExpr::create_leaf(
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::Filter,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_leaf(Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Pattern,
                     }
                     .into(),
-                ),
+                ))),
             )],
         }
     }
@@ -118,7 +122,10 @@ impl Rule for RuleNormalizeScalarFilter {
             .any(|p| is_true(p) || (is_falsy(p) && filter.predicates.len() > 1))
         {
             filter.predicates = normalize_predicates(filter.predicates);
-            state.add_result(SExpr::create_unary(filter.into(), s_expr.child(0)?.clone()));
+            state.add_result(SExpr::create_unary(
+                Arc::new(filter.into()),
+                Arc::new(s_expr.child(0)?.clone()),
+            ));
             Ok(())
         } else {
             Ok(())

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 
 use crate::binder::JoinPredicate;
@@ -50,28 +52,32 @@ impl RulePushDownFilterJoin {
             //   |  *
             //   *
             patterns: vec![SExpr::create_unary(
-                PatternPlan {
-                    plan_type: RelOp::Filter,
-                }
-                .into(),
-                SExpr::create_binary(
+                Arc::new(
                     PatternPlan {
-                        plan_type: RelOp::Join,
+                        plan_type: RelOp::Filter,
                     }
                     .into(),
-                    SExpr::create_leaf(
-                        PatternPlan {
-                            plan_type: RelOp::Pattern,
-                        }
-                        .into(),
-                    ),
-                    SExpr::create_leaf(
-                        PatternPlan {
-                            plan_type: RelOp::Pattern,
-                        }
-                        .into(),
-                    ),
                 ),
+                Arc::new(SExpr::create_binary(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::Join,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(SExpr::create_leaf(Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::Pattern,
+                        }
+                        .into(),
+                    ))),
+                    Arc::new(SExpr::create_leaf(Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::Pattern,
+                        }
+                        .into(),
+                    ))),
+                )),
             )],
             _metadata: metadata,
         }
@@ -178,12 +184,14 @@ pub fn try_push_down_filter_join(
 
     if !original_predicates.is_empty() {
         result = SExpr::create_unary(
-            Filter {
-                predicates: original_predicates,
-                is_having: false,
-            }
-            .into(),
-            result,
+            Arc::new(
+                Filter {
+                    predicates: original_predicates,
+                    is_having: false,
+                }
+                .into(),
+            ),
+            Arc::new(result),
         );
     }
     Ok((need_push, result))

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 
 use crate::optimizer::rule::Rule;
@@ -50,16 +52,18 @@ impl RulePushDownFilterScan {
             //  \
             //   LogicalGet
             patterns: vec![SExpr::create_unary(
-                PatternPlan {
-                    plan_type: RelOp::Filter,
-                }
-                .into(),
-                SExpr::create_leaf(
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::Filter,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_leaf(Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Scan,
                     }
                     .into(),
-                ),
+                ))),
             )],
             metadata,
         }
@@ -293,7 +297,10 @@ impl Rule for RulePushDownFilterScan {
             None => get.push_down_predicates = Some(add_filters),
         }
 
-        let mut result = SExpr::create_unary(filter.into(), SExpr::create_leaf(get.into()));
+        let mut result = SExpr::create_unary(
+            Arc::new(filter.into()),
+            Arc::new(SExpr::create_leaf(Arc::new(get.into()))),
+        );
         result.set_applied_rule(&self.id);
         state.add_result(result);
         Ok(())

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_limit_scan.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_limit_scan.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::cmp;
+use std::sync::Arc;
 
 use common_exception::Result;
 
@@ -45,16 +46,18 @@ impl RulePushDownLimitScan {
         Self {
             id: RuleID::PushDownLimitScan,
             patterns: vec![SExpr::create_unary(
-                PatternPlan {
-                    plan_type: RelOp::Limit,
-                }
-                .into(),
-                SExpr::create_leaf(
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::Limit,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_leaf(Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Scan,
                     }
                     .into(),
-                ),
+                ))),
             )],
         }
     }
@@ -72,9 +75,9 @@ impl Rule for RulePushDownLimitScan {
             let mut get: Scan = child.plan().clone().try_into()?;
             count += limit.offset;
             get.limit = Some(get.limit.map_or(count, |c| cmp::max(c, count)));
-            let get = SExpr::create_leaf(RelOperator::Scan(get));
+            let get = SExpr::create_leaf(Arc::new(RelOperator::Scan(get)));
 
-            let mut result = s_expr.replace_children(vec![get]);
+            let mut result = s_expr.replace_children(vec![Arc::new(get)]);
             result.set_applied_rule(&self.id);
             state.add_result(result);
         }

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_prewhere.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_prewhere.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::TableSchemaRef;
@@ -41,16 +43,18 @@ impl RulePushDownPrewhere {
         Self {
             id: RuleID::PushDownPrewhere,
             patterns: vec![SExpr::create_unary(
-                PatternPlan {
-                    plan_type: RelOp::Filter,
-                }
-                .into(),
-                SExpr::create_leaf(
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::Filter,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_leaf(Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Scan,
                     }
                     .into(),
-                ),
+                ))),
             )],
             metadata,
         }
@@ -146,7 +150,7 @@ impl RulePushDownPrewhere {
                 predicates: prewhere_pred,
             });
         }
-        Ok(SExpr::create_leaf(get.into()))
+        Ok(SExpr::create_leaf(Arc::new(get.into())))
     }
 }
 

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_split_aggregate.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_split_aggregate.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 
 use crate::optimizer::rule::Rule;
@@ -37,16 +39,18 @@ impl RuleSplitAggregate {
             //  \
             //   *
             patterns: vec![SExpr::create_unary(
-                PatternPlan {
-                    plan_type: RelOp::Aggregate,
-                }
-                .into(),
-                SExpr::create_leaf(
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::Aggregate,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_leaf(Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Pattern,
                     }
                     .into(),
-                ),
+                ))),
             )],
         }
     }
@@ -67,8 +71,11 @@ impl Rule for RuleSplitAggregate {
         let mut partial = agg.clone();
         partial.mode = AggregateMode::Partial;
         let result = SExpr::create_unary(
-            agg.into(),
-            SExpr::create_unary(partial.into(), s_expr.child(0)?.clone()),
+            Arc::new(agg.into()),
+            Arc::new(SExpr::create_unary(
+                Arc::new(partial.into()),
+                Arc::new(s_expr.child(0)?.clone()),
+            )),
         );
         state.add_result(result);
         Ok(())

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_try_apply_agg_index.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_try_apply_agg_index.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 use common_expression::FunctionContext;
 
@@ -46,16 +48,18 @@ impl RuleTryApplyAggIndex {
                 //     |
                 //    Scan
                 SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::EvalScalar,
-                    }
-                    .into(),
-                    SExpr::create_leaf(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::EvalScalar,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(SExpr::create_leaf(Arc::new(
                         PatternPlan {
                             plan_type: RelOp::Scan,
                         }
                         .into(),
-                    ),
+                    ))),
                 ),
                 // Expression
                 //     |
@@ -63,22 +67,26 @@ impl RuleTryApplyAggIndex {
                 //     |
                 //    Scan
                 SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::EvalScalar,
-                    }
-                    .into(),
-                    SExpr::create_unary(
+                    Arc::new(
                         PatternPlan {
-                            plan_type: RelOp::Filter,
+                            plan_type: RelOp::EvalScalar,
                         }
                         .into(),
-                        SExpr::create_leaf(
+                    ),
+                    Arc::new(SExpr::create_unary(
+                        Arc::new(
+                            PatternPlan {
+                                plan_type: RelOp::Filter,
+                            }
+                            .into(),
+                        ),
+                        Arc::new(SExpr::create_leaf(Arc::new(
                             PatternPlan {
                                 plan_type: RelOp::Scan,
                             }
                             .into(),
-                        ),
-                    ),
+                        ))),
+                    )),
                 ),
                 // Expression
                 //     |
@@ -88,34 +96,42 @@ impl RuleTryApplyAggIndex {
                 //     |
                 //    Scan
                 SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::EvalScalar,
-                    }
-                    .into(),
-                    SExpr::create_unary(
+                    Arc::new(
                         PatternPlan {
-                            plan_type: RelOp::Aggregate,
+                            plan_type: RelOp::EvalScalar,
                         }
                         .into(),
-                        SExpr::create_unary(
+                    ),
+                    Arc::new(SExpr::create_unary(
+                        Arc::new(
                             PatternPlan {
                                 plan_type: RelOp::Aggregate,
                             }
                             .into(),
-                            SExpr::create_unary(
+                        ),
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(
                                 PatternPlan {
-                                    plan_type: RelOp::EvalScalar,
+                                    plan_type: RelOp::Aggregate,
                                 }
                                 .into(),
-                                SExpr::create_leaf(
+                            ),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(
+                                    PatternPlan {
+                                        plan_type: RelOp::EvalScalar,
+                                    }
+                                    .into(),
+                                ),
+                                Arc::new(SExpr::create_leaf(Arc::new(
                                     PatternPlan {
                                         plan_type: RelOp::Scan,
                                     }
                                     .into(),
-                                ),
-                            ),
-                        ),
-                    ),
+                                ))),
+                            )),
+                        )),
+                    )),
                 ),
                 // Expression
                 //     |
@@ -127,40 +143,50 @@ impl RuleTryApplyAggIndex {
                 //     |
                 //    Scan
                 SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::EvalScalar,
-                    }
-                    .into(),
-                    SExpr::create_unary(
+                    Arc::new(
                         PatternPlan {
-                            plan_type: RelOp::Aggregate,
+                            plan_type: RelOp::EvalScalar,
                         }
                         .into(),
-                        SExpr::create_unary(
+                    ),
+                    Arc::new(SExpr::create_unary(
+                        Arc::new(
                             PatternPlan {
                                 plan_type: RelOp::Aggregate,
                             }
                             .into(),
-                            SExpr::create_unary(
+                        ),
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(
                                 PatternPlan {
-                                    plan_type: RelOp::EvalScalar,
+                                    plan_type: RelOp::Aggregate,
                                 }
                                 .into(),
-                                SExpr::create_unary(
+                            ),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(
                                     PatternPlan {
-                                        plan_type: RelOp::Filter,
+                                        plan_type: RelOp::EvalScalar,
                                     }
                                     .into(),
-                                    SExpr::create_leaf(
+                                ),
+                                Arc::new(SExpr::create_unary(
+                                    Arc::new(
+                                        PatternPlan {
+                                            plan_type: RelOp::Filter,
+                                        }
+                                        .into(),
+                                    ),
+                                    Arc::new(SExpr::create_leaf(Arc::new(
                                         PatternPlan {
                                             plan_type: RelOp::Scan,
                                         }
                                         .into(),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ),
+                                    ))),
+                                )),
+                            )),
+                        )),
+                    )),
                 ),
             ],
         }

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_commute_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_commute_join.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 
 use crate::optimizer::rule::Rule;
@@ -43,12 +45,14 @@ impl RuleCommuteJoin {
             // | \
             // *  *
             patterns: vec![SExpr::create_binary(
-                PatternPlan {
-                    plan_type: RelOp::Join,
-                }
-                .into(),
-                SExpr::create_pattern_leaf(),
-                SExpr::create_pattern_leaf(),
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::Join,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_pattern_leaf()),
+                Arc::new(SExpr::create_pattern_leaf()),
             )],
         }
     }
@@ -78,8 +82,11 @@ impl Rule for RuleCommuteJoin {
                 (join.left_conditions, join.right_conditions) =
                     (join.right_conditions, join.left_conditions);
                 join.join_type = join.join_type.opposite();
-                let mut result =
-                    SExpr::create_binary(join.into(), right_child.clone(), left_child.clone());
+                let mut result = SExpr::create_binary(
+                    Arc::new(join.into()),
+                    Arc::new(right_child.clone()),
+                    Arc::new(left_child.clone()),
+                );
 
                 // Disable the following rules for the generated expression
                 result.set_applied_rule(&RuleID::CommuteJoin);

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_commute_join_base_table.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_commute_join_base_table.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::Result;
 
 use crate::optimizer::rule::Rule;
@@ -40,12 +42,14 @@ impl RuleCommuteJoinBaseTable {
             // | \
             // *  *
             patterns: vec![SExpr::create_binary(
-                PatternPlan {
-                    plan_type: RelOp::Join,
-                }
-                .into(),
-                SExpr::create_pattern_leaf(),
-                SExpr::create_pattern_leaf(),
+                Arc::new(
+                    PatternPlan {
+                        plan_type: RelOp::Join,
+                    }
+                    .into(),
+                ),
+                Arc::new(SExpr::create_pattern_leaf()),
+                Arc::new(SExpr::create_pattern_leaf()),
             )],
         }
     }
@@ -80,8 +84,11 @@ impl Rule for RuleCommuteJoinBaseTable {
                 (join.left_conditions, join.right_conditions) =
                     (join.right_conditions, join.left_conditions);
                 join.join_type = join.join_type.opposite();
-                let mut result =
-                    SExpr::create_binary(join.into(), right_child.clone(), left_child.clone());
+                let mut result = SExpr::create_binary(
+                    Arc::new(join.into()),
+                    Arc::new(right_child.clone()),
+                    Arc::new(left_child.clone()),
+                );
 
                 // Disable the following rules for the generated expression
                 result.set_applied_rule(&RuleID::CommuteJoin);

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_eager_aggregation.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_eager_aggregation.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use common_expression::types::number::NumberDataType;
 use common_expression::types::DataType;
@@ -152,120 +153,40 @@ impl RuleEagerAggregation {
                 //       /    \
                 //      *      *
                 SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::EvalScalar,
-                    }
-                    .into(),
-                    SExpr::create_unary(
+                    Arc::new(
                         PatternPlan {
-                            plan_type: RelOp::Aggregate,
+                            plan_type: RelOp::EvalScalar,
                         }
                         .into(),
-                        SExpr::create_unary(
-                            PatternPlan {
-                                plan_type: RelOp::Aggregate,
-                            }
-                            .into(),
-                            SExpr::create_binary(
-                                PatternPlan {
-                                    plan_type: RelOp::Join,
-                                }
-                                .into(),
-                                SExpr::create_pattern_leaf(),
-                                SExpr::create_pattern_leaf(),
-                            ),
-                        ),
                     ),
-                ),
-                //     Expression
-                //         |
-                //  Aggregate(final)
-                //         |
-                // Aggregate(partial)
-                //         |
-                //     Expression
-                //         |
-                //        Join
-                //       /    \
-                //      *      *
-                SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::EvalScalar,
-                    }
-                    .into(),
-                    SExpr::create_unary(
-                        PatternPlan {
-                            plan_type: RelOp::Aggregate,
-                        }
-                        .into(),
-                        SExpr::create_unary(
+                    Arc::new(SExpr::create_unary(
+                        Arc::new(
                             PatternPlan {
                                 plan_type: RelOp::Aggregate,
                             }
                             .into(),
-                            SExpr::create_unary(
-                                PatternPlan {
-                                    plan_type: RelOp::EvalScalar,
-                                }
-                                .into(),
-                                SExpr::create_binary(
-                                    PatternPlan {
-                                        plan_type: RelOp::Join,
-                                    }
-                                    .into(),
-                                    SExpr::create_pattern_leaf(),
-                                    SExpr::create_pattern_leaf(),
-                                ),
-                            ),
                         ),
-                    ),
-                ),
-                //     Expression
-                //         |
-                //        Sort
-                //         |
-                //  Aggregate(final)
-                //         |
-                // Aggregate(partial)
-                //         |
-                //        Join
-                //       /    \
-                //      *      *
-                SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::EvalScalar,
-                    }
-                    .into(),
-                    SExpr::create_unary(
-                        PatternPlan {
-                            plan_type: RelOp::Sort,
-                        }
-                        .into(),
-                        SExpr::create_unary(
-                            PatternPlan {
-                                plan_type: RelOp::Aggregate,
-                            }
-                            .into(),
-                            SExpr::create_unary(
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(
                                 PatternPlan {
                                     plan_type: RelOp::Aggregate,
                                 }
                                 .into(),
-                                SExpr::create_binary(
+                            ),
+                            Arc::new(SExpr::create_binary(
+                                Arc::new(
                                     PatternPlan {
                                         plan_type: RelOp::Join,
                                     }
                                     .into(),
-                                    SExpr::create_pattern_leaf(),
-                                    SExpr::create_pattern_leaf(),
                                 ),
-                            ),
-                        ),
-                    ),
+                                Arc::new(SExpr::create_pattern_leaf()),
+                                Arc::new(SExpr::create_pattern_leaf()),
+                            )),
+                        )),
+                    )),
                 ),
                 //     Expression
-                //         |
-                //        Sort
                 //         |
                 //  Aggregate(final)
                 //         |
@@ -277,42 +198,162 @@ impl RuleEagerAggregation {
                 //       /    \
                 //      *      *
                 SExpr::create_unary(
-                    PatternPlan {
-                        plan_type: RelOp::EvalScalar,
-                    }
-                    .into(),
-                    SExpr::create_unary(
+                    Arc::new(
                         PatternPlan {
-                            plan_type: RelOp::Sort,
+                            plan_type: RelOp::EvalScalar,
                         }
                         .into(),
-                        SExpr::create_unary(
+                    ),
+                    Arc::new(SExpr::create_unary(
+                        Arc::new(
                             PatternPlan {
                                 plan_type: RelOp::Aggregate,
                             }
                             .into(),
-                            SExpr::create_unary(
+                        ),
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(
                                 PatternPlan {
                                     plan_type: RelOp::Aggregate,
                                 }
                                 .into(),
-                                SExpr::create_unary(
+                            ),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(
                                     PatternPlan {
                                         plan_type: RelOp::EvalScalar,
                                     }
                                     .into(),
-                                    SExpr::create_binary(
+                                ),
+                                Arc::new(SExpr::create_binary(
+                                    Arc::new(
                                         PatternPlan {
                                             plan_type: RelOp::Join,
                                         }
                                         .into(),
-                                        SExpr::create_pattern_leaf(),
-                                        SExpr::create_pattern_leaf(),
                                     ),
-                                ),
-                            ),
-                        ),
+                                    Arc::new(SExpr::create_pattern_leaf()),
+                                    Arc::new(SExpr::create_pattern_leaf()),
+                                )),
+                            )),
+                        )),
+                    )),
+                ),
+                //     Expression
+                //         |
+                //        Sort
+                //         |
+                //  Aggregate(final)
+                //         |
+                // Aggregate(partial)
+                //         |
+                //        Join
+                //       /    \
+                //      *      *
+                SExpr::create_unary(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::EvalScalar,
+                        }
+                        .into(),
                     ),
+                    Arc::new(SExpr::create_unary(
+                        Arc::new(
+                            PatternPlan {
+                                plan_type: RelOp::Sort,
+                            }
+                            .into(),
+                        ),
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(
+                                PatternPlan {
+                                    plan_type: RelOp::Aggregate,
+                                }
+                                .into(),
+                            ),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(
+                                    PatternPlan {
+                                        plan_type: RelOp::Aggregate,
+                                    }
+                                    .into(),
+                                ),
+                                Arc::new(SExpr::create_binary(
+                                    Arc::new(
+                                        PatternPlan {
+                                            plan_type: RelOp::Join,
+                                        }
+                                        .into(),
+                                    ),
+                                    Arc::new(SExpr::create_pattern_leaf()),
+                                    Arc::new(SExpr::create_pattern_leaf()),
+                                )),
+                            )),
+                        )),
+                    )),
+                ),
+                //     Expression
+                //         |
+                //        Sort
+                //         |
+                //  Aggregate(final)
+                //         |
+                // Aggregate(partial)
+                //         |
+                //     Expression
+                //         |
+                //        Join
+                //       /    \
+                //      *      *
+                SExpr::create_unary(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::EvalScalar,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(SExpr::create_unary(
+                        Arc::new(
+                            PatternPlan {
+                                plan_type: RelOp::Sort,
+                            }
+                            .into(),
+                        ),
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(
+                                PatternPlan {
+                                    plan_type: RelOp::Aggregate,
+                                }
+                                .into(),
+                            ),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(
+                                    PatternPlan {
+                                        plan_type: RelOp::Aggregate,
+                                    }
+                                    .into(),
+                                ),
+                                Arc::new(SExpr::create_unary(
+                                    Arc::new(
+                                        PatternPlan {
+                                            plan_type: RelOp::EvalScalar,
+                                        }
+                                        .into(),
+                                    ),
+                                    Arc::new(SExpr::create_binary(
+                                        Arc::new(
+                                            PatternPlan {
+                                                plan_type: RelOp::Join,
+                                            }
+                                            .into(),
+                                        ),
+                                        Arc::new(SExpr::create_pattern_leaf()),
+                                        Arc::new(SExpr::create_pattern_leaf()),
+                                    )),
+                                )),
+                            )),
+                        )),
+                    )),
                 ),
             ],
             metadata,
@@ -741,47 +782,51 @@ impl Rule for RuleEagerAggregation {
 
             join_exprs.push(if d == 0 {
                 eval_scalar_expr
-                    .replace_children(vec![join_expr.replace_children(vec![
-                        SExpr::create_unary(
-                            RelOperator::Aggregate(eager_group_by_and_eager_count[d].clone()),
-                            SExpr::create_unary(
-                                RelOperator::Aggregate(eager_group_by_count_partial),
+                    .replace_children(vec![Arc::new(join_expr.replace_children(vec![
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(RelOperator::Aggregate(
+                                eager_group_by_and_eager_count[d].clone(),
+                            )),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(RelOperator::Aggregate(eager_group_by_count_partial)),
                                 if !eager_extra_eval_scalar_expr[0].items.is_empty() {
-                                    SExpr::create_unary(
-                                        RelOperator::EvalScalar(
+                                    Arc::new(SExpr::create_unary(
+                                        Arc::new(RelOperator::EvalScalar(
                                             eager_extra_eval_scalar_expr[0].clone(),
-                                        ),
-                                        join_expr.child(0)?.clone(),
-                                    )
+                                        )),
+                                        Arc::new(join_expr.child(0)?.clone()),
+                                    ))
                                 } else {
-                                    join_expr.child(0)?.clone()
+                                    Arc::new(join_expr.child(0)?.clone())
                                 },
-                            ),
-                        ),
-                        join_expr.child(1)?.clone(),
-                    ])])
+                            )),
+                        )),
+                        Arc::new(join_expr.child(1)?.clone()),
+                    ]))])
                     .replace_plan(eager_groupby_count_count_sum.try_into()?)
             } else {
                 eval_scalar_expr
-                    .replace_children(vec![join_expr.replace_children(vec![
-                        join_expr.child(0)?.clone(),
-                        SExpr::create_unary(
-                            RelOperator::Aggregate(eager_group_by_and_eager_count[d].clone()),
-                            SExpr::create_unary(
-                                RelOperator::Aggregate(eager_group_by_count_partial),
+                    .replace_children(vec![Arc::new(join_expr.replace_children(vec![
+                        Arc::new(join_expr.child(0)?.clone()),
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(RelOperator::Aggregate(
+                                eager_group_by_and_eager_count[d].clone(),
+                            )),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(RelOperator::Aggregate(eager_group_by_count_partial)),
                                 if !eager_extra_eval_scalar_expr[1].items.is_empty() {
-                                    SExpr::create_unary(
-                                        RelOperator::EvalScalar(
+                                    Arc::new(SExpr::create_unary(
+                                        Arc::new(RelOperator::EvalScalar(
                                             eager_extra_eval_scalar_expr[1].clone(),
-                                        ),
-                                        join_expr.child(1)?.clone(),
-                                    )
+                                        )),
+                                        Arc::new(join_expr.child(1)?.clone()),
+                                    ))
                                 } else {
-                                    join_expr.child(1)?.clone()
+                                    Arc::new(join_expr.child(1)?.clone())
                                 },
-                            ),
-                        ),
-                    ])])
+                            )),
+                        )),
+                    ]))])
                     .replace_plan(eager_groupby_count_count_sum.try_into()?)
             });
 
@@ -802,44 +847,48 @@ impl Rule for RuleEagerAggregation {
 
             join_exprs.push(
                 eval_scalar_expr
-                    .replace_children(vec![join_expr.replace_children(vec![
-                        SExpr::create_unary(
-                            RelOperator::Aggregate(eager_group_by_and_eager_count[0].clone()),
-                            SExpr::create_unary(
-                                RelOperator::Aggregate(
+                    .replace_children(vec![Arc::new(join_expr.replace_children(vec![
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(RelOperator::Aggregate(
+                                eager_group_by_and_eager_count[0].clone(),
+                            )),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(RelOperator::Aggregate(
                                     eager_group_by_and_eager_count_partial[0].clone(),
-                                ),
+                                )),
                                 if !eager_extra_eval_scalar_expr[0].items.is_empty() {
-                                    SExpr::create_unary(
-                                        RelOperator::EvalScalar(
+                                    Arc::new(SExpr::create_unary(
+                                        Arc::new(RelOperator::EvalScalar(
                                             eager_extra_eval_scalar_expr[0].clone(),
-                                        ),
-                                        join_expr.child(0)?.clone(),
-                                    )
+                                        )),
+                                        Arc::new(join_expr.child(0)?.clone()),
+                                    ))
                                 } else {
-                                    join_expr.child(0)?.clone()
+                                    Arc::new(join_expr.child(0)?.clone())
                                 },
-                            ),
-                        ),
-                        SExpr::create_unary(
-                            RelOperator::Aggregate(eager_group_by_and_eager_count[1].clone()),
-                            SExpr::create_unary(
-                                RelOperator::Aggregate(
+                            )),
+                        )),
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(RelOperator::Aggregate(
+                                eager_group_by_and_eager_count[1].clone(),
+                            )),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(RelOperator::Aggregate(
                                     eager_group_by_and_eager_count_partial[1].clone(),
-                                ),
+                                )),
                                 if !eager_extra_eval_scalar_expr[1].items.is_empty() {
-                                    SExpr::create_unary(
-                                        RelOperator::EvalScalar(
+                                    Arc::new(SExpr::create_unary(
+                                        Arc::new(RelOperator::EvalScalar(
                                             eager_extra_eval_scalar_expr[1].clone(),
-                                        ),
-                                        join_expr.child(1)?.clone(),
-                                    )
+                                        )),
+                                        Arc::new(join_expr.child(1)?.clone()),
+                                    ))
                                 } else {
-                                    join_expr.child(1)?.clone()
+                                    Arc::new(join_expr.child(1)?.clone())
                                 },
-                            ),
-                        ),
-                    ])])
+                            )),
+                        )),
+                    ]))])
                     .replace_plan(eager_split_count_sum.try_into()?),
             );
         } else if can_push_down[d] && eager_aggregations[d ^ 1].is_empty() {
@@ -1009,43 +1058,43 @@ impl Rule for RuleEagerAggregation {
 
             join_exprs.push(if d == 0 {
                 join_expr.replace_children(vec![
-                    SExpr::create_unary(
-                        RelOperator::Aggregate(eager_group_by.clone()),
-                        SExpr::create_unary(
-                            RelOperator::Aggregate(eager_group_by_partial),
+                    Arc::new(SExpr::create_unary(
+                        Arc::new(RelOperator::Aggregate(eager_group_by.clone())),
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(RelOperator::Aggregate(eager_group_by_partial)),
                             if !eager_extra_eval_scalar_expr[0].items.is_empty() {
-                                SExpr::create_unary(
-                                    RelOperator::EvalScalar(
+                                Arc::new(SExpr::create_unary(
+                                    Arc::new(RelOperator::EvalScalar(
                                         eager_extra_eval_scalar_expr[0].clone(),
-                                    ),
-                                    join_expr.child(0)?.clone(),
-                                )
+                                    )),
+                                    Arc::new(join_expr.child(0)?.clone()),
+                                ))
                             } else {
-                                join_expr.child(0)?.clone()
+                                Arc::new(join_expr.child(0)?.clone())
                             },
-                        ),
-                    ),
-                    join_expr.child(1)?.clone(),
+                        )),
+                    )),
+                    Arc::new(join_expr.child(1)?.clone()),
                 ])
             } else {
                 join_expr.replace_children(vec![
-                    join_expr.child(0)?.clone(),
-                    SExpr::create_unary(
-                        RelOperator::Aggregate(eager_group_by.clone()),
-                        SExpr::create_unary(
-                            RelOperator::Aggregate(eager_group_by_partial),
+                    Arc::new(join_expr.child(0)?.clone()),
+                    Arc::new(SExpr::create_unary(
+                        Arc::new(RelOperator::Aggregate(eager_group_by.clone())),
+                        Arc::new(SExpr::create_unary(
+                            Arc::new(RelOperator::Aggregate(eager_group_by_partial)),
                             if !eager_extra_eval_scalar_expr[1].items.is_empty() {
-                                SExpr::create_unary(
-                                    RelOperator::EvalScalar(
+                                Arc::new(SExpr::create_unary(
+                                    Arc::new(RelOperator::EvalScalar(
                                         eager_extra_eval_scalar_expr[1].clone(),
-                                    ),
-                                    join_expr.child(1)?.clone(),
-                                )
+                                    )),
+                                    Arc::new(join_expr.child(1)?.clone()),
+                                ))
                             } else {
-                                join_expr.child(1)?.clone()
+                                Arc::new(join_expr.child(1)?.clone())
                             },
-                        ),
-                    ),
+                        )),
+                    )),
                 ])
             });
 
@@ -1062,29 +1111,29 @@ impl Rule for RuleEagerAggregation {
                 eager_count_partial.mode = AggregateMode::Partial;
                 join_exprs.push(if d == 0 {
                     eval_scalar_expr
-                        .replace_children(vec![join_expr.replace_children(vec![
-                            join_expr.child(0)?.clone(),
-                            SExpr::create_unary(
-                                RelOperator::Aggregate(eager_count.clone()),
-                                SExpr::create_unary(
-                                    RelOperator::Aggregate(eager_count_partial),
-                                    join_expr.child(1)?.clone(),
-                                ),
-                            ),
-                        ])])
+                        .replace_children(vec![Arc::new(join_expr.replace_children(vec![
+                            Arc::new(join_expr.child(0)?.clone()),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(RelOperator::Aggregate(eager_count.clone())),
+                                Arc::new(SExpr::create_unary(
+                                    Arc::new(RelOperator::Aggregate(eager_count_partial)),
+                                    Arc::new(join_expr.child(1)?.clone()),
+                                )),
+                            )),
+                        ]))])
                         .replace_plan(eager_count_sum.try_into()?)
                 } else {
                     eval_scalar_expr
-                        .replace_children(vec![join_expr.replace_children(vec![
-                            SExpr::create_unary(
-                                RelOperator::Aggregate(eager_count.clone()),
-                                SExpr::create_unary(
-                                    RelOperator::Aggregate(eager_count_partial),
-                                    join_expr.child(0)?.clone(),
-                                ),
-                            ),
-                            join_expr.child(1)?.clone(),
-                        ])])
+                        .replace_children(vec![Arc::new(join_expr.replace_children(vec![
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(RelOperator::Aggregate(eager_count.clone())),
+                                Arc::new(SExpr::create_unary(
+                                    Arc::new(RelOperator::Aggregate(eager_count_partial)),
+                                    Arc::new(join_expr.child(0)?.clone()),
+                                )),
+                            )),
+                            Arc::new(join_expr.child(1)?.clone()),
+                        ]))])
                         .replace_plan(eager_count_sum.try_into()?)
                 });
 
@@ -1102,59 +1151,59 @@ impl Rule for RuleEagerAggregation {
                 eager_count_partial.mode = AggregateMode::Partial;
                 join_exprs.push(if d == 0 {
                     eval_scalar_expr
-                        .replace_children(vec![join_expr.replace_children(vec![
-                            SExpr::create_unary(
-                                RelOperator::Aggregate(eager_group_by),
-                                SExpr::create_unary(
-                                    RelOperator::Aggregate(eager_agg_partial),
+                        .replace_children(vec![Arc::new(join_expr.replace_children(vec![
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(RelOperator::Aggregate(eager_group_by)),
+                                Arc::new(SExpr::create_unary(
+                                    Arc::new(RelOperator::Aggregate(eager_agg_partial)),
                                     if !eager_extra_eval_scalar_expr[0].items.is_empty() {
-                                        SExpr::create_unary(
-                                            RelOperator::EvalScalar(
+                                        Arc::new(SExpr::create_unary(
+                                            Arc::new(RelOperator::EvalScalar(
                                                 eager_extra_eval_scalar_expr[0].clone(),
-                                            ),
-                                            join_expr.child(0)?.clone(),
-                                        )
+                                            )),
+                                            Arc::new(join_expr.child(0)?.clone()),
+                                        ))
                                     } else {
-                                        join_expr.child(0)?.clone()
+                                        Arc::new(join_expr.child(0)?.clone())
                                     },
-                                ),
-                            ),
-                            SExpr::create_unary(
-                                RelOperator::Aggregate(eager_count),
-                                SExpr::create_unary(
-                                    RelOperator::Aggregate(eager_count_partial),
-                                    join_expr.child(1)?.clone(),
-                                ),
-                            ),
-                        ])])
+                                )),
+                            )),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(RelOperator::Aggregate(eager_count)),
+                                Arc::new(SExpr::create_unary(
+                                    Arc::new(RelOperator::Aggregate(eager_count_partial)),
+                                    Arc::new(join_expr.child(1)?.clone()),
+                                )),
+                            )),
+                        ]))])
                         .replace_plan(double_eager_count_sum.try_into()?)
                 } else {
                     eval_scalar_expr
-                        .replace_children(vec![join_expr.replace_children(vec![
-                            SExpr::create_unary(
-                                RelOperator::Aggregate(eager_count),
-                                SExpr::create_unary(
-                                    RelOperator::Aggregate(eager_count_partial),
-                                    join_expr.child(0)?.clone(),
-                                ),
-                            ),
-                            SExpr::create_unary(
-                                RelOperator::Aggregate(eager_group_by),
-                                SExpr::create_unary(
-                                    RelOperator::Aggregate(eager_agg_partial),
+                        .replace_children(vec![Arc::new(join_expr.replace_children(vec![
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(RelOperator::Aggregate(eager_count)),
+                                Arc::new(SExpr::create_unary(
+                                    Arc::new(RelOperator::Aggregate(eager_count_partial)),
+                                    Arc::new(join_expr.child(0)?.clone()),
+                                )),
+                            )),
+                            Arc::new(SExpr::create_unary(
+                                Arc::new(RelOperator::Aggregate(eager_group_by)),
+                                Arc::new(SExpr::create_unary(
+                                    Arc::new(RelOperator::Aggregate(eager_agg_partial)),
                                     if !eager_extra_eval_scalar_expr[1].items.is_empty() {
-                                        SExpr::create_unary(
-                                            RelOperator::EvalScalar(
+                                        Arc::new(SExpr::create_unary(
+                                            Arc::new(RelOperator::EvalScalar(
                                                 eager_extra_eval_scalar_expr[1].clone(),
-                                            ),
-                                            join_expr.child(1)?.clone(),
-                                        )
+                                            )),
+                                            Arc::new(join_expr.child(1)?.clone()),
+                                        ))
                                     } else {
-                                        join_expr.child(1)?.clone()
+                                        Arc::new(join_expr.child(1)?.clone())
                                     },
-                                ),
-                            ),
-                        ])])
+                                )),
+                            )),
+                        ]))])
                         .replace_plan(double_eager_count_sum.try_into()?)
                 });
             }
@@ -1175,19 +1224,21 @@ impl Rule for RuleEagerAggregation {
         // Generate final result.
         for idx in 0..final_agg_finals.len() {
             let temp_final_agg_expr = final_agg_expr
-                .replace_children(vec![
+                .replace_children(vec![Arc::new(
                     final_agg_partial_expr
-                        .replace_children(vec![join_exprs[idx].clone()])
+                        .replace_children(vec![Arc::new(join_exprs[idx].clone())])
                         .replace_plan(final_agg_partials[idx].clone().try_into()?),
-                ])
+                )])
                 .replace_plan(final_agg_finals[idx].clone().try_into()?);
             let mut result = if has_sort {
                 eval_scalar_expr
-                    .replace_children(vec![sort_expr.replace_children(vec![temp_final_agg_expr])])
+                    .replace_children(vec![Arc::new(
+                        sort_expr.replace_children(vec![Arc::new(temp_final_agg_expr)]),
+                    )])
                     .replace_plan(final_eval_scalars[idx].clone().try_into()?)
             } else {
                 eval_scalar_expr
-                    .replace_children(vec![temp_final_agg_expr])
+                    .replace_children(vec![Arc::new(temp_final_agg_expr)])
                     .replace_plan(final_eval_scalars[idx].clone().try_into()?)
             };
             result.set_applied_rule(&self.id);

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_left_associate_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_left_associate_join.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
+use std::sync::Arc;
 use std::vec;
 
 use common_exception::Result;
@@ -64,19 +66,23 @@ impl RuleLeftAssociateJoin {
             // |  *
             // *
             patterns: vec![SExpr::create_binary(
-                PatternPlan {
-                    plan_type: RelOp::Join,
-                }
-                .into(),
-                SExpr::create_binary(
+                Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Join,
                     }
                     .into(),
-                    SExpr::create_pattern_leaf(),
-                    SExpr::create_pattern_leaf(),
                 ),
-                SExpr::create_pattern_leaf(),
+                Arc::new(SExpr::create_binary(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::Join,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(SExpr::create_pattern_leaf()),
+                    Arc::new(SExpr::create_pattern_leaf()),
+                )),
+                Arc::new(SExpr::create_pattern_leaf()),
             )],
         }
     }
@@ -101,8 +107,8 @@ impl Rule for RuleLeftAssociateJoin {
         //  t1  join4
         //      /  \
         //     t2  t3
-        let join1: Join = s_expr.plan.clone().try_into()?;
-        let join2: Join = s_expr.child(0)?.plan.clone().try_into()?;
+        let join1: Join = s_expr.plan.deref().clone().try_into()?;
+        let join2: Join = s_expr.child(0)?.plan.deref().clone().try_into()?;
         let t1 = s_expr.child(0)?.child(0)?;
         let t2 = s_expr.child(0)?.child(1)?;
         let t3 = s_expr.child(1)?;
@@ -128,9 +134,9 @@ impl Rule for RuleLeftAssociateJoin {
         let t2_prop = RelExpr::with_s_expr(t2).derive_relational_prop()?;
         let t3_prop = RelExpr::with_s_expr(t3).derive_relational_prop()?;
         let join4_prop = RelExpr::with_s_expr(&SExpr::create_binary(
-            join_4.clone().into(),
-            t2.clone(),
-            t3.clone(),
+            Arc::new(join_4.clone().into()),
+            Arc::new(t2.clone()),
+            Arc::new(t3.clone()),
         ))
         .derive_relational_prop()?;
 
@@ -196,10 +202,14 @@ impl Rule for RuleLeftAssociateJoin {
         }
 
         let mut result = SExpr::create(
-            join_3.into(),
+            Arc::new(join_3.into()),
             vec![
-                t1.clone(),
-                SExpr::create_binary(join_4.into(), t2.clone(), t3.clone()),
+                Arc::new(t1.clone()),
+                Arc::new(SExpr::create_binary(
+                    Arc::new(join_4.into()),
+                    Arc::new(t2.clone()),
+                    Arc::new(t3.clone()),
+                )),
             ],
             None,
             None,

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_left_exchange_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_left_exchange_join.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
+use std::sync::Arc;
 use std::vec;
 
 use common_exception::Result;
@@ -62,19 +64,23 @@ impl RuleLeftExchangeJoin {
             // |  *
             // *
             patterns: vec![SExpr::create_binary(
-                PatternPlan {
-                    plan_type: RelOp::Join,
-                }
-                .into(),
-                SExpr::create_binary(
+                Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Join,
                     }
                     .into(),
-                    SExpr::create_pattern_leaf(),
-                    SExpr::create_pattern_leaf(),
                 ),
-                SExpr::create_pattern_leaf(),
+                Arc::new(SExpr::create_binary(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::Join,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(SExpr::create_pattern_leaf()),
+                    Arc::new(SExpr::create_pattern_leaf()),
+                )),
+                Arc::new(SExpr::create_pattern_leaf()),
             )],
         }
     }
@@ -99,8 +105,8 @@ impl Rule for RuleLeftExchangeJoin {
         //  join4 t2
         //  /  \
         // t1  t3
-        let join1: Join = s_expr.plan.clone().try_into()?;
-        let join2: Join = s_expr.child(0)?.plan.clone().try_into()?;
+        let join1: Join = s_expr.plan.deref().clone().try_into()?;
+        let join2: Join = s_expr.child(0)?.plan.deref().clone().try_into()?;
         let t1 = s_expr.child(0)?.child(0)?;
         let t2 = s_expr.child(0)?.child(1)?;
         let t3 = s_expr.child(1)?;
@@ -126,9 +132,9 @@ impl Rule for RuleLeftExchangeJoin {
         let t2_prop = RelExpr::with_s_expr(t2).derive_relational_prop()?;
         let t3_prop = RelExpr::with_s_expr(t3).derive_relational_prop()?;
         let join4_prop = RelExpr::with_s_expr(&SExpr::create_binary(
-            join_4.clone().into(),
-            t1.clone(),
-            t3.clone(),
+            Arc::new(join_4.clone().into()),
+            Arc::new(t1.clone()),
+            Arc::new(t3.clone()),
         ))
         .derive_relational_prop()?;
 
@@ -194,10 +200,14 @@ impl Rule for RuleLeftExchangeJoin {
         }
 
         let mut result = SExpr::create(
-            join_3.into(),
+            Arc::new(join_3.into()),
             vec![
-                SExpr::create_binary(join_4.into(), t1.clone(), t3.clone()),
-                t2.clone(),
+                Arc::new(SExpr::create_binary(
+                    Arc::new(join_4.into()),
+                    Arc::new(t1.clone()),
+                    Arc::new(t3.clone()),
+                )),
+                Arc::new(t2.clone()),
             ],
             None,
             None,

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_right_associate_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_right_associate_join.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
+use std::sync::Arc;
+
 use common_exception::Result;
 
 use super::util::get_join_predicates;
@@ -60,19 +63,23 @@ impl RuleRightAssociateJoin {
             //    | \
             //    *  *
             patterns: vec![SExpr::create_binary(
-                PatternPlan {
-                    plan_type: RelOp::Join,
-                }
-                .into(),
-                SExpr::create_pattern_leaf(),
-                SExpr::create_binary(
+                Arc::new(
                     PatternPlan {
                         plan_type: RelOp::Join,
                     }
                     .into(),
-                    SExpr::create_pattern_leaf(),
-                    SExpr::create_pattern_leaf(),
                 ),
+                Arc::new(SExpr::create_pattern_leaf()),
+                Arc::new(SExpr::create_binary(
+                    Arc::new(
+                        PatternPlan {
+                            plan_type: RelOp::Join,
+                        }
+                        .into(),
+                    ),
+                    Arc::new(SExpr::create_pattern_leaf()),
+                    Arc::new(SExpr::create_pattern_leaf()),
+                )),
             )],
         }
     }
@@ -97,8 +104,8 @@ impl Rule for RuleRightAssociateJoin {
         //  join4 t3
         //  /  \
         // t1  t2
-        let join1: Join = s_expr.plan.clone().try_into()?;
-        let join2: Join = s_expr.child(1)?.plan.clone().try_into()?;
+        let join1: Join = s_expr.plan.deref().clone().try_into()?;
+        let join2: Join = s_expr.child(1)?.plan.deref().clone().try_into()?;
         let t1 = s_expr.child(0)?;
         let t2 = s_expr.child(1)?.child(0)?;
         let t3 = s_expr.child(1)?.child(1)?;
@@ -124,9 +131,9 @@ impl Rule for RuleRightAssociateJoin {
         let t2_prop = RelExpr::with_s_expr(t2).derive_relational_prop()?;
         let t3_prop = RelExpr::with_s_expr(t3).derive_relational_prop()?;
         let join4_prop = RelExpr::with_s_expr(&SExpr::create_binary(
-            join_4.clone().into(),
-            t1.clone(),
-            t2.clone(),
+            Arc::new(join_4.clone().into()),
+            Arc::new(t1.clone()),
+            Arc::new(t2.clone()),
         ))
         .derive_relational_prop()?;
 
@@ -192,10 +199,14 @@ impl Rule for RuleRightAssociateJoin {
         }
 
         let mut result = SExpr::create(
-            join_3.into(),
+            Arc::new(join_3.into()),
             vec![
-                SExpr::create_binary(join_4.into(), t1.clone(), t2.clone()),
-                t3.clone(),
+                Arc::new(SExpr::create_binary(
+                    Arc::new(join_4.into()),
+                    Arc::new(t1.clone()),
+                    Arc::new(t2.clone()),
+                )),
+                Arc::new(t3.clone()),
             ],
             None,
             None,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Store the `RelOperator`s with shared pointer to reduce memory consumption and memory copy.