### PR TITLE
feat: support more than two predicates for iejoin

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/ie_join/ie_join_util.rs
+++ b/src/query/service/src/pipelines/processors/transforms/ie_join/ie_join_util.rs
@@ -1,0 +1,105 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::min;
+use std::cmp::Ordering;
+
+use common_exception::Result;
+use common_expression::types::BooleanType;
+use common_expression::types::DataType;
+use common_expression::Column;
+use common_expression::DataBlock;
+use common_expression::Evaluator;
+use common_expression::FunctionContext;
+use common_expression::RemoteExpr;
+use common_functions::BUILTIN_FUNCTIONS;
+use common_sql::executor::cast_expr_to_non_null_boolean;
+
+pub(crate) fn filter_block(block: DataBlock, filter: &RemoteExpr) -> Result<DataBlock> {
+    let filter = filter.as_expr(&BUILTIN_FUNCTIONS);
+    let other_predicate = cast_expr_to_non_null_boolean(filter)?;
+    assert_eq!(other_predicate.data_type(), &DataType::Boolean);
+
+    let func_ctx = FunctionContext::default();
+
+    let evaluator = Evaluator::new(&block, &func_ctx, &BUILTIN_FUNCTIONS);
+    let predicate = evaluator
+        .run(&other_predicate)?
+        .try_downcast::<BooleanType>()
+        .unwrap();
+    block.filter_boolean_value(&predicate)
+}
+
+pub(crate) fn order_match(op: &str, order: Ordering) -> bool {
+    match op {
+        "gt" => order == Ordering::Greater,
+        "gte" => order == Ordering::Equal || order == Ordering::Greater,
+        "lt" => order == Ordering::Less,
+        "lte" => order == Ordering::Less || order == Ordering::Equal,
+        _ => unreachable!(),
+    }
+}
+
+// Exponential search
+pub(crate) fn probe_l1(l1: &Column, pos: usize, op1: &str) -> usize {
+    let mut step = 1;
+    let n = l1.len();
+    let mut hi = pos;
+    let mut lo = pos;
+    let mut off1;
+    if matches!(op1, "gte" | "lte") {
+        lo -= min(step, lo);
+        step *= 2;
+        off1 = lo;
+        while lo > 0
+            && order_match(
+                op1,
+                unsafe { l1.index_unchecked(pos) }.cmp(&unsafe { l1.index_unchecked(off1) }),
+            )
+        {
+            hi = lo;
+            lo -= min(step, lo);
+            step *= 2;
+            off1 = lo;
+        }
+    } else {
+        hi += min(step, n - hi);
+        step *= 2;
+        off1 = hi;
+        while hi < n
+            && !order_match(
+                op1,
+                unsafe { l1.index_unchecked(pos) }.cmp(&unsafe { l1.index_unchecked(off1) }),
+            )
+        {
+            lo = hi;
+            hi += min(step, n - hi);
+            step *= 2;
+            off1 = hi;
+        }
+    }
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        off1 = mid;
+        if order_match(
+            op1,
+            unsafe { l1.index_unchecked(pos) }.cmp(&unsafe { l1.index_unchecked(off1) }),
+        ) {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    lo
+}

--- a/src/query/service/src/pipelines/processors/transforms/ie_join/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/ie_join/mod.rs
@@ -13,5 +13,6 @@
 // limitations under the License.
 
 mod ie_join_state;
+mod ie_join_util;
 
 pub use ie_join_state::IEJoinState;

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -1649,7 +1649,7 @@ impl PhysicalPlanBuilder {
     async fn try_ie_join(&mut self, join: &Join, s_expr: &SExpr) -> Result<Option<PhysicalPlan>> {
         if !join.left_conditions.is_empty()
             || join.non_equi_conditions.len() < 2
-            || join.join_type != JoinType::Inner
+            || !matches!(join.join_type, JoinType::Inner | JoinType::Cross)
         {
             // Use hash join if exists equi conditions
             return Ok(None);
@@ -1667,8 +1667,7 @@ impl PhysicalPlanBuilder {
                 other_conditions.push(condition);
             }
         }
-        if ie_conditions.len() != 2 || !other_conditions.is_empty() {
-            // Todo(xudong): support other conditions
+        if ie_conditions.len() != 2 {
             return Ok(None);
         }
         // Construct IEJoin

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -412,7 +412,7 @@ impl SubqueryRewriter {
                 let data_type = column_entry.data_type();
                 self.derived_columns.insert(
                     *correlated_column,
-                    metadata.add_derived_column(name.to_string(), data_type.wrap_nullable()),
+                    metadata.add_derived_column(name.to_string(), data_type),
                 );
             }
             let logical_get = SExpr::create_leaf(Arc::new(

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
@@ -166,6 +166,7 @@ pub fn try_push_down_filter_join(
                         need_push = true;
                     }
                 } else if matches!(join.join_type, JoinType::Inner | JoinType::Cross) {
+                    join.join_type = JoinType::Inner;
                     join.non_equi_conditions.push(predicate.clone());
                     need_push = true;
                 } else {

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
@@ -165,7 +165,7 @@ pub fn try_push_down_filter_join(
                         join.right_conditions.push(right.clone());
                         need_push = true;
                     }
-                } else if matches!(join.join_type, JoinType::Inner) {
+                } else if matches!(join.join_type, JoinType::Inner | JoinType::Cross) {
                     join.non_equi_conditions.push(predicate.clone());
                     need_push = true;
                 } else {

--- a/tests/sqllogictests/suites/query/iejoin.test
+++ b/tests/sqllogictests/suites/query/iejoin.test
@@ -15,25 +15,39 @@ insert into west values ('s1', 404, 100,  6, 4), ('s2', 400, 140, 11, 2), ('s3',
 
 query TT
 SELECT east.rid, west.rid
-FROM east join west
-ON east.dur < west.time AND east.rev > west.cost;
+FROM east, west
+WHERE east.dur < west.time AND east.rev > west.cost;
 ----
 r2	s2
 
 query TT
 SELECT s1.rid, s2.rid
-FROM west s1 join west s2
-on s1.time > s2.time AND s1.cost < s2.cost ORDER BY 1, 2;
+FROM west s1, west s2
+WHERE s1.time > s2.time AND s1.cost < s2.cost ORDER BY 1, 2;
 ----
 s1	s3
 s4	s3
 
 query TT
 SELECT east.rid, west.rid
-FROM east join west
-ON east.dur + east.rev < west.time AND east.rev > west.cost;
+FROM east, west
+WHERE east.dur + east.rev < west.time AND east.rev > west.cost;
 ----
 r2 s2
+
+query TT
+SELECT s1.rid, s2.rid
+FROM west s1, west s2
+WHERE s1.time > s2.time AND s1.cost < s2.cost AND s1.rid != 's1';
+----
+s4 s3
+
+query TT
+SELECT s1.rid, s2.rid
+FROM west s1, west s2
+WHERE s1.time > s2.time AND s1.cost < s2.cost AND s1.rid > s2.rid;
+----
+s4 s3
 
 statement ok
 drop table east;

--- a/tests/sqllogictests/suites/query/iejoin.test
+++ b/tests/sqllogictests/suites/query/iejoin.test
@@ -2,7 +2,7 @@ statement ok
 set max_block_size = 1;
 
 statement ok
-create table east(rid varchar, id int, dur int, rev int, cores int);
+create table east(rid varchar, id int, dur int null, rev int, cores int);
 
 statement ok
 insert into east values ('r1', 100, 140, 12, 2), ('r2', 99, 100, 12, 8), ('r3', 103,  90,  5, 4);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support more than two predicates for iejoin, such as

```sql
SELECT s1.rid, s2.rid
FROM west s1, west s2
WHERE s1.time > s2.time AND s1.cost < s2.cost AND s1.rid > s2.rid;
```
Predicates with more than two are placed in `other_conditions`

Closes #issue
